### PR TITLE
celerymon supervisor script quick fix

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -139,6 +139,8 @@ def india():
         'deploy': [],
         'django_monolith': ['220.226.209.82'],
     }
+    env.jython_home = '/usr/local/lib/jython'
+    env.roles = ['django_monolith']
 
 @task
 def production():
@@ -303,7 +305,7 @@ def clone_repo():
 
 
 @task
-@roles('pg')
+@roles('pg', 'django_monolith')
 def preindex_views():
     with cd(env.code_root):
         update_code()

--- a/services/templates/supervisor_celerymon.conf
+++ b/services/templates/supervisor_celerymon.conf
@@ -1,6 +1,6 @@
 [program:%(project)s-%(environment)s-celerymon]
-command=%(virtualenv_root)s/bin/python %(code_root)s/manage.py celerymon
-directory=%(code_root)s
+command=celerymon -B 0.0.0.0
+directory=%(root)s
 user=%(sudo_user)s
 numprocs=1
 autostart=true

--- a/settings.py
+++ b/settings.py
@@ -43,7 +43,7 @@ STATIC_ROOT = ''
 MEDIA_URL = '/media/'
 STATIC_URL = '/static/'
 
-filepath = os.path.abspath(os.path.dirname(__file__))
+FILEPATH = os.path.abspath(os.path.dirname(__file__))
 
 STATICFILES_FINDERS = (
     "django.contrib.staticfiles.finders.FileSystemFinder",
@@ -51,10 +51,10 @@ STATICFILES_FINDERS = (
 )
 
 STATICFILES_DIRS = (
-    ('formdesigner', os.path.join(filepath,'submodules', 'formdesigner')),
+    ('formdesigner', os.path.join(FILEPATH,'submodules', 'formdesigner')),
 )
 
-DJANGO_LOG_FILE = "%s/%s" % (filepath, "commcarehq.django.log")
+DJANGO_LOG_FILE = "%s/%s" % (FILEPATH, "commcarehq.django.log")
 
 # URL prefix for admin media -- CSS, JavaScript and images. Make sure to use a
 # trailing slash.


### PR DESCRIPTION
fixing celerymon command to work - celerymon doesn't work well with
virtualenv for some reason, so calling global celerymon command and
assumes you have a celeryconfig.py in the root (below code_root)
directory of config (which it is on production now)
