### PR TITLE
setting for no html email text

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -524,6 +524,15 @@ EMAIL_HOST_USER = EMAIL_LOGIN
 EMAIL_HOST_PASSWORD = EMAIL_PASSWORD
 EMAIL_USE_TLS = True
 
+NO_HTML_EMAIL_MESSAGE = """This is an email from CommCare HQ. You're seeing
+this message because your email client chose to display the plaintext version
+of an email that CommCare HQ can only provide in HTML.  Please set your email
+client to view this email in HTML or read this email in a client that supports
+HTML email.
+
+Thanks,
+The CommCare HQ Team"""
+
 DATA_INTERFACE_MAP = {
     'Case Management' : [
         'corehq.apps.data_interfaces.interfaces.CaseReassignmentInterface',


### PR DESCRIPTION
This should be merged after https://github.com/dimagi/core-hq/pull/156, which depends on https://github.com/dimagi/dimagi-utils/pull/21.  Then the dimagi-utils submodule ref should be updated.
