### PR TITLE
remove double import of corehq, plus update of supervisor files

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -4,6 +4,7 @@ import hashlib
 import random
 import threading
 
+
 from django.core.management import execute_manager
 import sys, os
 
@@ -17,7 +18,7 @@ for d in submodules_list:
     if d == "__init__.py" or d == '.' or d == '..':
         continue
     sys.path.append(os.path.join(filedir,'submodules',d))
-sys.path.append(os.path.join(filedir,'submodules','core-hq-src','corehq'))
+#sys.path.append(os.path.join(filedir,'submodules','core-hq-src','corehq'))
 sys.path.append(os.path.join(filedir,'submodules','core-hq-src','lib'))
 
 try:

--- a/manage.py
+++ b/manage.py
@@ -18,7 +18,6 @@ for d in submodules_list:
     if d == "__init__.py" or d == '.' or d == '..':
         continue
     sys.path.append(os.path.join(filedir,'submodules',d))
-#sys.path.append(os.path.join(filedir,'submodules','core-hq-src','corehq'))
 sys.path.append(os.path.join(filedir,'submodules','core-hq-src','lib'))
 
 try:

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -37,3 +37,4 @@ gitdb
 gevent
 rawes
 numpy
+socketpool

--- a/services/templates/supervisor_django.conf
+++ b/services/templates/supervisor_django.conf
@@ -1,7 +1,7 @@
 [program:%(project)s-%(environment)s-django]
 directory=%(code_root)s/
 ; gunicorn
-command=%(virtualenv_root)s/bin/python manage.py run_gunicorn --bind 0.0.0.0:%(server_port)s --preload --workers 3 --log-file %(log_dir)s/%(project)s.gunicorn.log --log-level debug --timeout 900
+command=%(virtualenv_root)s/bin/python manage.py run_gunicorn --bind 0.0.0.0:%(server_port)s --preload --workers 4 -k gevent --log-file %(log_dir)s/%(project)s.gunicorn.log --log-level debug --timeout 900
 user=%(sudo_user)s
 autostart=true
 autorestart=true

--- a/services/templates/supervisor_django_public.conf
+++ b/services/templates/supervisor_django_public.conf
@@ -1,7 +1,7 @@
 [program:%(project)s-%(environment)s-django_public]
 directory=%(code_root)s/
 environment=CUSTOMSETTINGS=demo
-command=%(virtualenv_root)s/bin/python manage.py run_gunicorn --bind 0.0.0.0:8021 --preload --workers 3 --log-file %(log_dir)s/%(project)s-public.gunicorn.log --log-level debug --timeout 300
+command=%(virtualenv_root)s/bin/python manage.py run_gunicorn --bind 0.0.0.0:8021 --preload --workers 3 -k gevent --log-file %(log_dir)s/%(project)s-public.gunicorn.log --log-level debug --timeout 300
 user=%(sudo_user)s
 autostart=true
 autorestart=true


### PR DESCRIPTION
small fix for requirements too

this is a blunt instrument for the supervisor file - but our proxy proportionally sends traffic to our machines so it's not going to destroy our worker machines
