### PR TITLE
Keepalive

### DIFF
--- a/services/templates/supervisor_django.conf
+++ b/services/templates/supervisor_django.conf
@@ -1,7 +1,7 @@
 [program:%(project)s-%(environment)s-django]
 directory=%(code_root)s/
 ; gunicorn
-command=%(virtualenv_root)s/bin/python manage.py run_gunicorn --bind 0.0.0.0:%(server_port)s --preload --workers 15 --log-file %(log_dir)s/%(project)s.gunicorn.log --log-level debug --timeout 900
+command=%(virtualenv_root)s/bin/python manage.py run_gunicorn --bind 0.0.0.0:%(server_port)s --preload --workers 5 -k gevent --keep-alive 30 --log-file %(log_dir)s/%(project)s.gunicorn.log --log-level debug --timeout 900
 user=%(sudo_user)s
 autostart=true
 autorestart=true


### PR DESCRIPTION
Turn on gevent and set keep-alive to 30 in prod setup.

If you're not Danny or Cory, don't deploy! We've set up a special time to test this.
