### PR TITLE
fix http/https double redirects; move gunicorn options into config file

### DIFF
--- a/services/gunicorn.cfg
+++ b/services/gunicorn.cfg
@@ -1,0 +1,11 @@
+import multiprocessing
+preload_app = True
+workers = multiprocessing.cpu_count() * 2 + 1
+worker_class = 'gevent'
+timeout = 900
+max_requests = 1500
+# cryptically, setting forwarded_allow_ips (to the ip of the hqproxy0)
+# gets gunicorn to set https on redirects when appropriate. See:
+# http://docs.gunicorn.org/en/latest/configure.html#secure-scheme-headers
+# http://docs.gunicorn.org/en/latest/configure.html#forwarded-allow-ips
+forwarded_allow_ips = '10.176.162.109'

--- a/services/templates/supervisor_django.conf
+++ b/services/templates/supervisor_django.conf
@@ -1,7 +1,7 @@
 [program:%(project)s-%(environment)s-django]
 directory=%(code_root)s/
 ; gunicorn
-command=%(virtualenv_root)s/bin/python manage.py run_gunicorn --bind 0.0.0.0:%(server_port)s --preload --workers 5 -k gevent --keep-alive 60 --log-file %(log_dir)s/%(project)s.gunicorn.log --log-level debug --timeout 900 --max-requests 1500
+command=%(virtualenv_root)s/bin/python manage.py run_gunicorn -c services/gunicorn.cfg --bind 0.0.0.0:%(server_port)s --log-file %(log_dir)s/%(project)s.gunicorn.log --log-level debug
 user=%(sudo_user)s
 autostart=true
 autorestart=true

--- a/services/templates/supervisor_django_public.conf
+++ b/services/templates/supervisor_django_public.conf
@@ -1,7 +1,7 @@
 [program:%(project)s-%(environment)s-django_public]
 directory=%(code_root)s/
 environment=CUSTOMSETTINGS=demo
-command=%(virtualenv_root)s/bin/python manage.py run_gunicorn --bind 0.0.0.0:8021 --preload --workers 15 -k gevent --log-file %(log_dir)s/%(project)s-public.gunicorn.log --log-level debug --timeout 300
+command=%(virtualenv_root)s/bin/python manage.py run_gunicorn -c services/gunicorn.cfg --bind 0.0.0.0:8021 --log-file %(log_dir)s/%(project)s-public.gunicorn.log --log-level debug
 user=%(sudo_user)s
 autostart=true
 autorestart=true


### PR DESCRIPTION
I also set --keep-alive back to the default (2 sec), since we don't need that anymore.
