### PR TITLE
removing devicelog, couchlog and auditcare pillows from settings for

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -807,9 +807,6 @@ INDICATOR_CONFIG = {
 
 PILLOWTOPS = [ 'corehq.pillows.CasePillow',
                'corehq.pillows.ExchangePillow',
-               'corehq.pillows.AuditcarePillow',
-               'corehq.pillows.CouchlogPillow',
-               'corehq.pillows.DevicelogPillow',
                ] + LOCAL_PILLOWTOPS
 
 REMOTE_APP_NAMESPACE = "%(domain)s.commcarehq.org"


### PR DESCRIPTION
pillowtop usage.

they were not used and the infrastructre to support it we don't have
quite working yet, and the exceptions it was throwing (connection,
timeout) was causing other pillows to not update.  removing until we can
refactor them correclty
