### PR TITLE
switch auth context processor

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -93,7 +93,7 @@ MIDDLEWARE_CLASSES = [
 ROOT_URLCONF = "urls"
 
 TEMPLATE_CONTEXT_PROCESSORS = [
-    "django.core.context_processors.auth",
+    "django.contrib.auth.context_processors.auth",
     "django.core.context_processors.debug",
     "django.core.context_processors.i18n",
     "django.core.context_processors.media",


### PR DESCRIPTION
the one we reference was deprecated in django 1.2, and removed in 1.4
