### PR TITLE
set django_templates.fast = True

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -72,11 +72,13 @@ SECRET_KEY = ''
 
 # List of callables that know how to import templates from various sources.
 TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.load_template_source',
-    'django.template.loaders.app_directories.load_template_source',
-    'django.template.loaders.eggs.Loader',
-    #     'django.template.loaders.eggs.load_template_source',
-    )
+    ('django.template.loaders.cached.Loader', (
+        'django.template.loaders.filesystem.load_template_source',
+        'django.template.loaders.app_directories.load_template_source',
+        'django.template.loaders.eggs.Loader',
+        #     'django.template.loaders.eggs.load_template_source',
+    )),
+)
 
 MIDDLEWARE_CLASSES = [
     'django.middleware.common.CommonMiddleware',


### PR DESCRIPTION
suggested by http://stackoverflow.com/a/9182798/240554
only concern is some warning of third party tags
and threadsafety that didn't sound like it applies to
us: https://docs.djangoproject.com/en/1.3/ref/templates/api/#loader-types
