### PR TITLE
enough of that nonsense (add freddy as a submodule)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -100,3 +100,6 @@
 [submodule "submodules/psi-reports"]
 	path = submodules/psi-reports
 	url = git://github.com/dimagi/psi-reports.git
+[submodule "submodules/freddy"]
+	path = submodules/freddy
+	url = git://github.com/dimagi/freddy.git

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -50,6 +50,5 @@ numpy==1.6.2
 six==1.2.0
 socketpool==0.5.2
 markdown==2.2.1
--e git://github.com/dimagi/freddy.git@a6d24d201f3595a6be767f3679547d5de76b344a#egg=freddy
 amqp==1.0.8
 amqplib==1.0.2


### PR DESCRIPTION
add freddy as a submodule.  since it was a pip git requirement that gets put in the virtualenv's src/ folder as the canonical location for that library, hopefully there won't be any precedence issues if that folder doesn't get automatically deleted.  If there are, it shouldn't affect anything because the facilities functionality isn't really live yet.
