### PR TITLE
Es flip

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -435,6 +435,7 @@ def deploy():
         execute(migrate)
         execute(_do_collectstatic)
         execute(version_static)
+        execute(flip_es_aliases)
     except Exception:
         execute(mail_admins, "Deploy failed", "You had better check the logs.")
         raise
@@ -567,6 +568,16 @@ def migrate():
         sudo('%(virtualenv_root)s/bin/python manage.py syncdb --noinput' % env, user=env.sudo_user)
         sudo('%(virtualenv_root)s/bin/python manage.py migrate --noinput' % env, user=env.sudo_user)
 
+
+@roles('django_celery','django_monolith')
+def flip_es_aliases():
+    """Flip elasticsearch aliases to the lastest version """
+    require('code_root', provided_by=('production', 'demo', 'staging', "india"))
+    with cd(env.code_root):
+        sudo('%(virtualenv_root)s/bin/python manage.py ptop_es_manage --flip_alias --pillow CasePillow' % env, user=env.sudo_user)
+        sudo('%(virtualenv_root)s/bin/python manage.py ptop_es_manage --flip_alias --pillow FullCasePillow' % env, user=env.sudo_user)
+        sudo('%(virtualenv_root)s/bin/python manage.py ptop_es_manage --flip_alias --pillow XFormPillow' % env, user=env.sudo_user)
+        sudo('%(virtualenv_root)s/bin/python manage.py ptop_es_manage --flip_alias --pillow FullXFormPillow' % env, user=env.sudo_user)
 
 @roles('staticfiles', 'django_monolith')
 def _do_collectstatic():


### PR DESCRIPTION
adding new directives to deploy to do es alias flips for all our main indices.
this will only do anything if and only if the alias in question is NOT set to what's in prod. so this should allow for the workflow to work a-la preindex+deploy. we just need to be careful with how we preindex (which we already are)
