### PR TITLE
Change default mode in example settings to debug

### DIFF
--- a/localsettings.example.py
+++ b/localsettings.example.py
@@ -36,7 +36,7 @@ EXCHANGE_NOTIFICATION_RECIPIENTS = ['commcarehq-dev+exchange@dimagi.com']
 
 ####### Log/debug setup ########
 
-DEBUG = False
+DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 
 # log directories must exist and be writeable!


### PR DESCRIPTION
Defaulting to debug mode so static assets work out of the box when
running server locally.
