### PR TITLE
Easily enable ADM

### DIFF
--- a/corehq/apps/adm/README.md
+++ b/corehq/apps/adm/README.md
@@ -1,0 +1,17 @@
+# Active Data Management Reports
+
+## Enabling Projects
+
+You can enable projects to view ADM reports in the Reports section of HQ
+by adding the following document to your couchdb:
+
+```{
+    "_id": "ADM_ENABLED_DOMAINS",
+    "domains": []
+}```
+
+Specify what domains you'd like to see ADM reports in the array `domains`.
+
+## Configuring HQ
+
+Visit `http://<CCHQ Instance>/adm` to configure ADM reports and columns available to HQ domains.

--- a/corehq/apps/domain/utils.py
+++ b/corehq/apps/domain/utils.py
@@ -36,3 +36,11 @@ def get_domain_module_map():
 
     hardcoded.update(dynamic)
     return hardcoded
+
+
+def get_adm_enabled_domains():
+    try:
+        domains = get_db().get('ADM_ENABLED_DOMAINS').get('domains', [])
+    except ResourceNotFound:
+        domains = []
+    return domains

--- a/corehq/apps/hqwebapp/models.py
+++ b/corehq/apps/hqwebapp/models.py
@@ -4,6 +4,7 @@ from django.utils.safestring import mark_safe, mark_for_escaping
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_noop
+from corehq.apps.domain.utils import get_adm_enabled_domains
 from corehq.apps.indicators.dispatcher import IndicatorAdminInterfaceDispatcher
 from corehq.apps.indicators.utils import get_indicator_domains
 
@@ -186,7 +187,7 @@ class ADMReportsTab(UITab):
         if not self.project or self.project.commtrack_enabled:
             return False
 
-        adm_enabled_projects = getattr(settings, 'ADM_ENABLED_PROJECTS', [])
+        adm_enabled_projects = get_adm_enabled_domains()
 
         return (not self.project.is_snapshot and
                 self.domain in adm_enabled_projects and


### PR DESCRIPTION
- ADM_ENABLED_PROJECTS is a setting that currently in localsettings.py
- We we don't necessarily want to make public what domains have ADM enabled. this is a pain to update. grabbing the info from a couch doc now with ID ADM_ENABLED_DOMAINS
- already updated india's couch to have the same settings, so don't worry there
