### PR TITLE
Fix 500 when deleting mobile numbers

### DIFF
--- a/corehq/apps/sms/mixin.py
+++ b/corehq/apps/sms/mixin.py
@@ -253,7 +253,7 @@ class CommCareMobileContactMixin(object):
         """
         Deletes this contact's phone number from the verified phone number list, freeing it up
         for use by other contacts.
-        
+
         return  void
         """
         v = self.get_verified_number(phone_number)

--- a/corehq/apps/sms/mixin.py
+++ b/corehq/apps/sms/mixin.py
@@ -151,27 +151,26 @@ class MobileBackend(Document):
         # for passing to functions, ensure the keys are all strings
         return dict((str(k), v) for k, v in self.outbound_params.items())
 
-
 class CommCareMobileContactMixin(object):
     """
     Defines a mixin to manage a mobile contact's information. This mixin must be used with
     a class which is a Couch Document.
     """
-    
+
     def get_time_zone(self):
         """
         This method should be implemented by all subclasses of CommCareMobileContactMixin,
         and must return a string representation of the time zone. For example, "America/New_York".
         """
         raise NotImplementedError("Subclasses of CommCareMobileContactMixin must implement method get_time_zone().")
-    
+
     def get_language_code(self):
         """
         This method should be implemented by all subclasses of CommCareMobileContactMixin,
         and must return the preferred language code of the contact. For example, "en".
         """
         raise NotImplementedError("Subclasses of CommCareMobileContactMixin must implement method get_language_code().")
-    
+
     def get_verified_numbers(self, include_pending=False):
         v = VerifiedNumber.view("sms/verified_number_by_doc_type_id",
             startkey=[self.doc_type, self._id],
@@ -184,7 +183,7 @@ class CommCareMobileContactMixin(object):
     def get_verified_number(self, phone=None):
         """
         Retrieves this contact's verified number entry by (self.doc_type, self._id).
-        
+
         return  the VerifiedNumber entry
         """
         verified = self.get_verified_numbers(True)
@@ -196,21 +195,21 @@ class CommCareMobileContactMixin(object):
                 return None
 
         return verified.get(strip_plus(phone))
-    
+
     def validate_number_format(self, phone_number):
         """
         Validates that the given phone number consists of all digits.
-        
+
         return  void
         raises  InvalidFormatException if the phone number format is invalid
         """
         if not phone_number_re.match(phone_number):
             raise InvalidFormatException("Phone number format must consist of only digits.")
-    
+
     def verify_unique_number(self, phone_number):
         """
         Verifies that the given phone number is not already in use by any other contacts.
-        
+
         return  void
         raises  InvalidFormatException if the phone number format is invalid
         raises  PhoneNumberInUseException if the phone number is already in use by another contact
@@ -222,11 +221,11 @@ class CommCareMobileContactMixin(object):
         ).one()
         if v is not None and (v.owner_doc_type != self.doc_type or v.owner_id != self._id):
             raise PhoneNumberInUseException("Phone number is already in use.")
-    
+
     def save_verified_number(self, domain, phone_number, verified, backend_id, ivr_backend_id=None, only_one_number_allowed=False):
         """
         Saves the given phone number as this contact's verified phone number.
-        
+
         return  void
         raises  InvalidFormatException if the phone number format is invalid
         raises  PhoneNumberInUseException if the phone number is already in use by another contact

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -596,7 +596,7 @@ class DjangoUserMixin(DocumentSchema):
         return dummy.check_password(password)
 
 
-class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn):
+class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, CommCareMobileContactMixin):
     """
     A user (for web and commcare)
     """
@@ -1032,7 +1032,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn):
         return super(CouchUser, self).__getattr__(item)
 
 
-class CommCareUser(CouchUser, CommCareMobileContactMixin, SingleMembershipMixin):
+class CommCareUser(CouchUser, SingleMembershipMixin):
 
     domain = StringProperty()
     registering_device_id = StringProperty()

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1531,7 +1531,7 @@ class WebUser(CouchUser, MultiMembershipMixin, OrgMembershipMixin, CommCareMobil
             return None
 
         timezone = report_utils.get_timezone(self.user_id, domain)
-        return timezone
+        return timezone.zone
 
     def get_language_code(self):
         return self.language

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -596,7 +596,7 @@ class DjangoUserMixin(DocumentSchema):
         return dummy.check_password(password)
 
 
-class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, CommCareMobileContactMixin):
+class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn):
     """
     A user (for web and commcare)
     """
@@ -691,6 +691,14 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, CommCa
         except User.DoesNotExist:
             pass
         super(CouchUser, self).delete() # Call the "real" delete() method.
+
+    def delete_phone_number(self, phone_number):
+        for i in range(0,len(self.phone_numbers)):
+            if self.phone_numbers[i] == phone_number:
+                del self.phone_numbers[i]
+                break
+        self.save()
+        self.delete_verified_number(phone_number)
 
     def get_django_user(self):
         return User.objects.get(username__iexact=self.username)
@@ -1042,7 +1050,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, CommCa
         return super(CouchUser, self).__getattr__(item)
 
 
-class CommCareUser(CouchUser, SingleMembershipMixin):
+class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin):
 
     domain = StringProperty()
     registering_device_id = StringProperty()
@@ -1470,7 +1478,7 @@ class OrgMembershipMixin(DocumentSchema):
         if om:
             om.team_ids.remove(team_id)
 
-class WebUser(CouchUser, MultiMembershipMixin, OrgMembershipMixin):
+class WebUser(CouchUser, MultiMembershipMixin, OrgMembershipMixin, CommCareMobileContactMixin):
     #do sync and create still work?
 
     def sync_from_old_couch_user(self, old_couch_user):
@@ -1511,6 +1519,22 @@ class WebUser(CouchUser, MultiMembershipMixin, OrgMembershipMixin):
 
     def get_email(self):
         return self.email or self.username
+
+    def get_time_zone(self):
+        from corehq.apps.reports import util as report_utils
+
+        if hasattr(self, 'current_domain'):
+            domain = self.current_domain
+        elif len(self.domains) > 0:
+            domain = self.domains[0]
+        else:
+            return None
+
+        timezone = report_utils.get_timezone(self.user_id, domain)
+        return timezone
+
+    def get_language_code(self):
+        return self.language
 
     @property
     def projects(self):
@@ -1589,8 +1613,6 @@ class WebUser(CouchUser, MultiMembershipMixin, OrgMembershipMixin):
             return self.total_domain_membership(dm_list, domain)
         else:
             raise DomainMembershipError()
-
-
 
     def total_domain_membership(self, domain_memberships, domain):
         #sort out the permissions

--- a/corehq/apps/users/tests/phone_users.py
+++ b/corehq/apps/users/tests/phone_users.py
@@ -1,6 +1,5 @@
 from django.test import TestCase
 from corehq.apps.users.models import CouchUser, WebUser
-import pytz
 
 class PhoneUsersTestCase(TestCase):
 
@@ -58,7 +57,7 @@ class PhoneUsersTestCase(TestCase):
 
     def testWebUserImplementsMobileMixIn(self):
         time_zone = self.couch_user.get_time_zone()
-        self.assertEquals(time_zone, pytz.utc)
+        self.assertEquals(time_zone, 'UTC')
 
         lang_code = self.couch_user.get_language_code()
         self.assertEquals(lang_code, 'en')

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -309,12 +309,7 @@ def delete_phone_number(request, domain, couch_user_id):
     if 'phone_number' not in request.GET:
         return Http404('Must include phone number in request.')
     phone_number = urllib.unquote(request.GET['phone_number'])
-    for i in range(0,len(user.phone_numbers)):
-        if user.phone_numbers[i] == phone_number:
-            del user.phone_numbers[i]
-            break
-    user.save()
-    user.delete_verified_number(phone_number)
+    user.delete_phone_number(phone_number)
     return HttpResponseRedirect(reverse("user_account", args=(domain, couch_user_id )))
 
 @require_permission_to_edit_user


### PR DESCRIPTION
CommCareMobileContactMixin is moved from CommCareUser to CouchUser so that delete_verified_number method can be found when deleting a mobile number.
