### PR TITLE
add support for requisition receipts + tests

### DIFF
--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -433,6 +433,20 @@ class RequisitionCase(CommCareCase):
         return [r['id'] for r in results]
 
 
+    @classmethod
+    def open_for_product_case(cls, domain, location, product_case_id):
+        """
+        For a given product case, return the IDs of all open requisitions at that location.
+        """
+        startkey = [domain, location, 'open', product_case_id]
+        results = cls.get_db().view('commtrack/requisitions',
+            endkey=startkey, # yes this is confusing, but i blame couch's descending=true rules
+            startkey=startkey + [{}],
+            descending=True,
+            reduce=False,
+        )
+        return [r['id'] for r in results]
+
     class Meta:
         app_label = "commtrack" # This is necessary otherwise syncdb will confuse this app with casexml
 

--- a/corehq/apps/commtrack/requisitions.py
+++ b/corehq/apps/commtrack/requisitions.py
@@ -55,7 +55,7 @@ class RequisitionState(object):
 
     @classmethod
     def from_transactions(cls, user_id, product_stock_case, transactions):
-        assert transactions, "can't make a requisition state from an empty transaciton list"
+        assert transactions, "can't make a requisition state from an empty transaction list"
 
         def _to_fields(transaction):
             ret = {'requisition_status': RequisitionStatus.by_action_type(transaction.action_config.action_type)}

--- a/corehq/apps/commtrack/requisitions.py
+++ b/corehq/apps/commtrack/requisitions.py
@@ -24,7 +24,7 @@ class RequisitionState(object):
     """
 
     def __init__(self, domain, id, user_id, username, product_stock_case_id,
-                 create=False, owner_id=None, **custom_fields):
+                 create=False, owner_id=None, close=False, **custom_fields):
         self.domain = domain
         self.id = id
         self.user_id = user_id
@@ -32,6 +32,7 @@ class RequisitionState(object):
         self.username = username
         self.product_stock_case_id = product_stock_case_id
         self.create = create
+        self.close = close
         self.custom_fields = custom_fields or {}
 
     def to_xml(self):
@@ -49,6 +50,7 @@ class RequisitionState(object):
                 const.PARENT_CASE_REF: (const.SUPPLY_POINT_PRODUCT_CASE_TYPE,
                                         self.product_stock_case_id),
             },
+            close=self.close,
             **extras
         )
         return ElementTree.tostring(caseblock.as_xml(format_datetime=json_format_datetime))
@@ -79,6 +81,13 @@ class RequisitionState(object):
                     'amount_filled': transaction.value,
                     'filled_by': user_id,
                     'filled_on': datetime.utcnow(),
+                })
+            elif transaction.action_config.action_type == RequisitionActions.RECEIPTS:
+                ret.update({
+                    'amount_received': transaction.value,
+                    'received_by': user_id,
+                    'received_on': datetime.utcnow(),
+                    'close': True,
                 })
             else:
                 raise ValueError("the type %s isn't yet supported." % transaction.action_config.action_type)

--- a/corehq/apps/commtrack/stockreport.py
+++ b/corehq/apps/commtrack/stockreport.py
@@ -169,7 +169,7 @@ class Requisition(StockTransaction):
             'product_id': tx.find(_('product')).text,
             'case_id': tx.find(_('product_entry')).text,
             'value': int(tx.find(_('value')).text),
-            'action_name': 'request',
+            'action_name': tx.find(_('action')).text,
         }
         return cls(config=config, **data)
 
@@ -177,10 +177,11 @@ class Requisition(StockTransaction):
         if not E:
             E = XML()
 
-        return E.request(
+        return E.requisition(
             E.product(self.product_id),
             E.product_entry(self.case_id),
             E.value(str(self.value)),
+            E.action(self.action_name)
         )
 
 class RequisitionResponse(Requisition):
@@ -266,7 +267,7 @@ def unpack_transactions(root, config):
     def transactions():
         types = {
             'transaction': StockTransaction,
-            'request': Requisition,
+            'requisition': Requisition,
             'response': BulkRequisitionResponse,
         }
         for tag, factory in types.iteritems():
@@ -287,7 +288,7 @@ def normalize_transactions(transactions):
 
 
 def replace_transactions(root, new_tx):
-    for tag in ('transaction', 'request', 'response'):
+    for tag in ('transaction', 'requisition', 'response'):
         for tx in root.findall(_(tag)):
             tx.getparent().remove(tx)
     for tx in new_tx:

--- a/corehq/apps/commtrack/tests/test_sms_reporting.py
+++ b/corehq/apps/commtrack/tests/test_sms_reporting.py
@@ -140,6 +140,7 @@ class StockRequisitionTest(CommTrackTest):
             req_case = RequisitionCase.get(req_ids_by_product_code[code])
             self.assertTrue(req_case.closed)
             self.assertEqual(str(amt), req_case.amount_received)
+            self.assertEqual(self.user._id, req_case.received_by)
             self.assertTrue(req_case._id in reqs, 'requisition %s should be in %s' % (req_case._id, reqs))
 
     def testReceiptsWithNoOpenRequisition(self):

--- a/corehq/apps/commtrack/tests/test_sms_reporting.py
+++ b/corehq/apps/commtrack/tests/test_sms_reporting.py
@@ -63,15 +63,16 @@ class StockRequisitionTest(CommTrackTest):
             spp = CommCareCase.get(self.spps[code]._id)
             # make sure the index was created
             [req_ref] = spp.reverse_indices
-            req_case = CommCareCase.get(req_ref.referenced_id)
+            req_case = RequisitionCase.get(req_ref.referenced_id)
             self.assertEqual(str(amt), req_case.amount_requested)
+            self.assertEqual(self.user._id, req_case.requested_by)
             self.assertEqual(req_case.location_, self.sp.location_)
             self.assertTrue(req_case._id in reqs)
 
     def testSimpleApproval(self):
         self.testRequisition()
 
-        # req loc1 pp 10 pq 20...
+        # approve loc1
         handled = handle(self.verified_number, 'approve {loc}'.format(
             loc='loc1',
             ))
@@ -90,7 +91,7 @@ class StockRequisitionTest(CommTrackTest):
     def testSimpleFill(self):
         self.testRequisition()
 
-        # req loc1 pp 10 pq 20...
+        # fill loc1
         handled = handle(self.verified_number, 'fill {loc}'.format(
             loc='loc1',
         ))

--- a/corehq/apps/commtrack/util.py
+++ b/corehq/apps/commtrack/util.py
@@ -114,8 +114,8 @@ def bootstrap_default(domain, requisitions_enabled=False):
                 CommtrackActionConfig(
                     action_type=RequisitionActions.RECEIPTS,
                     keyword='rec',
-                    caption='Stock on hand',
-                    name='stock_on_hand',
+                    caption='Requisition Receipts',
+                    name='req_received',
                 ),
             ],
         )


### PR DESCRIPTION
```
- receipts close the last open requisition and set updated properties
  on it.
- no major changes though small tweaks to sms transaction objects to
  make them aware of their own domain, location and location id
- add function to get open requisitions by case and for receipts use
  this to find the last requisition that should be updated and closed
- miscellaneous cleanup (see commits)
```
