### PR TITLE
this fixes the smtp credential issues where emails auto default to use s...

### DIFF
--- a/corehq/apps/domain/urls.py
+++ b/corehq/apps/domain/urls.py
@@ -4,6 +4,7 @@ from django.views.generic.simple import direct_to_template
 from django.contrib.auth.views import password_reset
 from django.shortcuts import render_to_response
 from django.template import RequestContext
+from django.conf import settings
 
 from corehq.apps.domain.forms import ConfidentialPasswordResetForm
 
@@ -54,8 +55,9 @@ urlpatterns =\
         url(r'^accounts/password_change/$', 'password_change', auth_pages_path('password_change_form.html'), name='password_change'),
         url(r'^accounts/password_change_done/$', 'password_change_done', auth_pages_path('password_change_done.html') ),
 
-        url(r'^accounts/password_reset_email/$', exception_safe_password_reset, extend(auth_pages_path('password_reset_form.html'), 
-                                                                                       { 'password_reset_form': ConfidentialPasswordResetForm }),
+        url(r'^accounts/password_reset_email/$', exception_safe_password_reset, extend(auth_pages_path('password_reset_form.html'),
+                                                                                       { 'password_reset_form': ConfidentialPasswordResetForm,
+                                                                                         'from_email':settings.HQ_NOTIFICATIONS_EMAIL}),
                                                                                 name='password_reset_email'),
         url(r'^accounts/password_reset_email/done/$', 'password_reset_done', auth_pages_path('password_reset_done.html') ),
 

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -543,7 +543,8 @@ def _notification_email_on_publish(domain, snapshot, published_by):
     subject = "New App on Exchange: %s" % snapshot.title
     try:
         for recipient in recipients:
-            send_HTML_email(subject, recipient, html_content, text_content=text_content, email_from=settings.HQ_NOTIFICATIONS_EMAIL)
+            send_HTML_email(subject, recipient, html_content, text_content=text_content,
+                            email_from=settings.HQ_NOTIFICATIONS_EMAIL)
     except Exception:
         logging.warning("Can't send notification email, but the message was:\n%s" % text_content)
 
@@ -694,6 +695,7 @@ def _send_request_notification_email(request, org, dom):
     subject = "New request to add a project to your organization! -- CommcareHQ"
     try:
         for recipient in recipients:
-            send_HTML_email(subject, recipient, html_content, text_content=text_content, email_from=settings.HQ_NOTIFICATIONS_EMAIL)
+            send_HTML_email(subject, recipient, html_content, text_content=text_content,
+                            email_from=settings.HQ_NOTIFICATIONS_EMAIL)
     except Exception:
         logging.warning("Can't send notification email, but the message was:\n%s" % text_content)

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -543,7 +543,7 @@ def _notification_email_on_publish(domain, snapshot, published_by):
     subject = "New App on Exchange: %s" % snapshot.title
     try:
         for recipient in recipients:
-            send_HTML_email(subject, recipient, html_content, text_content=text_content)
+            send_HTML_email(subject, recipient, html_content, text_content=text_content, email_from=settings.HQ_NOTIFICATIONS_EMAIL)
     except Exception:
         logging.warning("Can't send notification email, but the message was:\n%s" % text_content)
 
@@ -694,6 +694,6 @@ def _send_request_notification_email(request, org, dom):
     subject = "New request to add a project to your organization! -- CommcareHQ"
     try:
         for recipient in recipients:
-            send_HTML_email(subject, recipient, html_content, text_content=text_content)
+            send_HTML_email(subject, recipient, html_content, text_content=text_content, email_from=settings.HQ_NOTIFICATIONS_EMAIL)
     except Exception:
         logging.warning("Can't send notification email, but the message was:\n%s" % text_content)

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -296,7 +296,7 @@ def bug_report(req):
     # if the person looks like a commcare user, fogbugz can't reply
     # to their email, so just use the default
     if settings.HQ_ACCOUNT_ROOT in reply_to:
-        reply_to = settings.EMAIL_HOST_USER
+        reply_to = settings.HQ_NOTIFICATIONS_EMAIL
 
     if req.POST.get('five-hundred-report'):
         message = "%s \n\n This messge was reported from a 500 error page! Please fix this ASAP (as if you wouldn't anyway)..." % message

--- a/corehq/apps/orgs/models.py
+++ b/corehq/apps/orgs/models.py
@@ -108,7 +108,7 @@ class OrgInvitation(Invitation):
         text_content = render_to_string("orgs/email/org_invite.txt", params)
         html_content = render_to_string("orgs/email/org_invite.html", params)
         subject = 'Invitation from %s to join CommCareHQ' % self.get_inviter().formatted_name
-        send_HTML_email(subject, self.email, html_content, text_content=text_content)
+        send_HTML_email(subject, self.email, html_content, text_content=text_content, settings.HQ_NOTIFICATIONS_EMAIL)
 
 class OrgRequest(Document):
     doc_type = "OrgRequest"

--- a/corehq/apps/orgs/models.py
+++ b/corehq/apps/orgs/models.py
@@ -108,7 +108,9 @@ class OrgInvitation(Invitation):
         text_content = render_to_string("orgs/email/org_invite.txt", params)
         html_content = render_to_string("orgs/email/org_invite.html", params)
         subject = 'Invitation from %s to join CommCareHQ' % self.get_inviter().formatted_name
-        send_HTML_email(subject, self.email, html_content, text_content=text_content, settings.HQ_NOTIFICATIONS_EMAIL)
+        send_HTML_email(subject, self.email, html_content, text_content=text_content,
+                        email_from=settings.HQ_NOTIFICATIONS_EMAIL)
+
 
 class OrgRequest(Document):
     doc_type = "OrgRequest"

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -223,6 +223,6 @@ You can view the project here: %s""" % (
         get_url_base() + "/a/%s/" % domain_name)
     try:
         recipients = settings.NEW_DOMAIN_RECIPIENTS
-        send_mail("New Project: %s" % domain_name, message, settings.EMAIL_HOST_USER, recipients)
+        send_mail("New Project: %s" % domain_name, message, settings.HQ_NOTIFICATIONS_EMAIL, recipients)
     except Exception:
         logging.warning("Can't send email, but the message was:\n%s" % message)

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -144,8 +144,8 @@ The CommCareHQ Team
     subject = 'Welcome to CommCare HQ!'.format(**locals())
 
     try:
-        send_HTML_email(subject, recipient, message_html,
-                        text_content=message_plaintext)
+        send_HTML_email(subject, recipient, message_html, text_content=message_plaintext,
+                        email_from=settings.HQ_NOTIFICATIONS_EMAIL)
     except Exception:
         logging.warning("Can't send email, but the message was:\n%s" % message_plaintext)
 
@@ -198,7 +198,7 @@ The CommCareHQ Team
 
     try:
         send_HTML_email(subject, requesting_user.email, message_html,
-                        text_content=message_plaintext)
+                        text_content=message_plaintext, email_from=settings.HQ_NOTIFICATIONS_EMAIL)
     except Exception:
         logging.warning("Can't send email, but the message was:\n%s" % message_plaintext)
 

--- a/corehq/apps/reports/models.py
+++ b/corehq/apps/reports/models.py
@@ -488,7 +488,7 @@ class ReportNotification(Document):
             self.owner, self.domain, self._id).content
 
         for email in self.all_recipient_emails:
-            send_HTML_email(title, email, body)
+            send_HTML_email(title, email, body, email_from=settings.HQ_NOTIFICATIONS_EMAIL)
 
 
 class AppNotFound(Exception):

--- a/corehq/apps/reports/models.py
+++ b/corehq/apps/reports/models.py
@@ -472,7 +472,6 @@ class ReportNotification(Document):
         """Tuples for hour number and human-readable hour"""
         return tuple([(val, "%s:00" % val) for val in range(24)])
 
-
     def send(self):
         from dimagi.utils.django.email import send_HTML_email
         from corehq.apps.reports.views import get_scheduled_report_response

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta, date
 import json
 import tempfile
+from django.conf import settings
 from django.core.cache import cache
 from django.core.servers.basehttp import FileWrapper
 import os
@@ -517,11 +518,12 @@ def email_report(request, domain, report_slug, report_type=ProjectReportDispatch
     subject = form.cleaned_data['subject'] or _("Email report from CommCare HQ")
 
     if form.cleaned_data['send_to_owner']:
-        send_HTML_email(subject, request.couch_user.get_email(), body)
+        send_HTML_email(subject, request.couch_user.get_email(), body,
+                        email_from=settings.HQ_NOTIFICATIONS_EMAIL)
 
     if form.cleaned_data['recipient_emails']:
         for recipient in form.cleaned_data['recipient_emails']:
-            send_HTML_email(subject, recipient, body)
+            send_HTML_email(subject, recipient, body, email_from=settings.HQ_NOTIFICATIONS_EMAIL)
 
     return HttpResponse()
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1677,7 +1677,9 @@ class DomainInvitation(Invitation):
         text_content = render_to_string("domain/email/domain_invite.txt", params)
         html_content = render_to_string("domain/email/domain_invite.html", params)
         subject = 'Invitation from %s to join CommCareHQ' % self.get_inviter().formatted_name
-        send_HTML_email(subject, self.email, html_content, text_content=text_content, cc=[self.get_inviter().get_email()])
+        send_HTML_email(subject, self.email, html_content, text_content=text_content,
+                        cc=[self.get_inviter().get_email()],
+                        email_from=settings.HQ_NOTIFICATIONS_EMAIL)
 
     @classmethod
     def by_domain(cls, domain, is_active=True):

--- a/localsettings.example.py
+++ b/localsettings.example.py
@@ -37,6 +37,9 @@ BUG_REPORT_RECIPIENTS = ['commcarehq-support@dimagi.com']
 NEW_DOMAIN_RECIPIENTS = ['commcarehq-dev+newdomain@dimagi.com']
 EXCHANGE_NOTIFICATION_RECIPIENTS = ['commcarehq-dev+exchange@dimagi.com']
 
+HQ_NOTIFICATIONS_EMAIL = 'commcarehq-noreply@dimagi.com'
+SUPPORT_EMAIL = "commcarehq-support@dimagi.com"
+
 ####### Log/debug setup ########
 
 DEBUG = True

--- a/settings.py
+++ b/settings.py
@@ -314,6 +314,7 @@ XFORMS_PLAYER_URL = "http://localhost:4444/"  # touchform's setting
 
 ####### Couchlog config ######
 
+HQ_NOTIFICATIONS_EMAIL = 'commcarehq-noreply@dimagi.com'
 SUPPORT_EMAIL = "commcarehq-support@dimagi.com"
 COUCHLOG_BLUEPRINT_HOME = "%s%s" % (STATIC_URL, "hqwebapp/stylesheets/blueprint/")
 COUCHLOG_DATATABLES_LOC = "%s%s" % (

--- a/settings.py
+++ b/settings.py
@@ -285,6 +285,9 @@ EMAIL_SMTP_PORT = 587
 BUG_REPORT_RECIPIENTS = ()
 EXCHANGE_NOTIFICATION_RECIPIENTS = []
 
+HQ_NOTIFICATIONS_EMAIL = 'commcarehq-noreply@dimagi.com'
+SUPPORT_EMAIL = "commcarehq-support@dimagi.com"
+
 PAGINATOR_OBJECTS_PER_PAGE = 15
 PAGINATOR_MAX_PAGE_LINKS = 5
 
@@ -314,8 +317,6 @@ XFORMS_PLAYER_URL = "http://localhost:4444/"  # touchform's setting
 
 ####### Couchlog config ######
 
-HQ_NOTIFICATIONS_EMAIL = 'commcarehq-noreply@dimagi.com'
-SUPPORT_EMAIL = "commcarehq-support@dimagi.com"
 COUCHLOG_BLUEPRINT_HOME = "%s%s" % (STATIC_URL, "hqwebapp/stylesheets/blueprint/")
 COUCHLOG_DATATABLES_LOC = "%s%s" % (
     STATIC_URL, "hqwebapp/js/lib/datatables-1.9/js/jquery.dataTables.min.js")


### PR DESCRIPTION
...ettings.

however with using email services like SES, the SMTP login might not be a valid email address so it fails hard.

following examples from feature fix for django password reset from_email fixes (https://github.com/django/django/commit/4084bc7354), able to add new settings to auto default reply to.

first commit to merged hq codebase!
