### PR TITLE
make available custom reports able to differ between domains

### DIFF
--- a/corehq/apps/reports/dispatcher.py
+++ b/corehq/apps/reports/dispatcher.py
@@ -1,11 +1,8 @@
 from django.core.urlresolvers import reverse
 from django.http import Http404, HttpResponseRedirect
-from django.template.loader import render_to_string
-from django.utils.safestring import mark_safe
 from django.views.generic.base import View
 from corehq.apps.domain.decorators import login_and_domain_required, cls_to_view
 from dimagi.utils.decorators.datespan import datespan_in_request
-from django.utils.translation import ugettext as _
 
 from corehq.apps.domain.models import Domain
 
@@ -63,8 +60,15 @@ class ReportDispatcher(View):
     def get_reports(self, domain=None):
         attr_name = self.map_name
         import corehq
-        return getattr(corehq, attr_name, ()) + \
-               getattr(Domain.get_module_by_name(domain), attr_name, ())
+        domain_module = Domain.get_module_by_name(domain)
+        corehq_reports = tuple(getattr(corehq, attr_name, ()))
+        custom_reports = getattr(domain_module, attr_name, ())
+
+        if isinstance(custom_reports, dict):
+            custom_reports = custom_reports[domain]
+        custom_reports = tuple(custom_reports)
+
+        return corehq_reports + custom_reports
 
     def get_reports_dict(self, domain=None):
         return dict((report.slug, report)


### PR DESCRIPTION
 for domains that all map to the same submodule, by specifying a report_map (e.g.
CUSTOM_REPORTS) as a dict of lists of reports, keyed by domain, instead of a simple
list of reports

Scenario:

HSPH has hsph, hsph-dev, hsph-betterbirth-pilot-2 domains.
hsph-dev and hsph-betterbirth-pilot-2 use the same reports, and they are
evolutions of those used earlier in hsph, but have diverged
substantially.  Rather than make a separate submodule for the new
reports, let's just allow them to be in the same subdomain because:
- potential for reuse of CouchDB and Python code is still high
- it takes a lot of effort to create a new submodule
