### PR TITLE
Es robust

### DIFF
--- a/corehq/pillows/case.py
+++ b/corehq/pillows/case.py
@@ -17,7 +17,7 @@ class CasePillow(AliasedElasticPillow):
     couch_filter = "case/casedocs"
     es_host = settings.ELASTICSEARCH_HOST
     es_port = settings.ELASTICSEARCH_PORT
-    es_timeout = 600
+    es_timeout = 60
     es_index_prefix = "hqcases"
     es_alias = "hqcases"
     es_type = "case"

--- a/corehq/pillows/domain.py
+++ b/corehq/pillows/domain.py
@@ -14,7 +14,7 @@ class DomainPillow(AliasedElasticPillow):
     couch_filter = "domain/not_snapshots"
     es_host = settings.ELASTICSEARCH_HOST
     es_port = settings.ELASTICSEARCH_PORT
-    es_timeout = 600
+    es_timeout = 60
     es_index_prefix = "hqdomains"
     es_alias = "hqdomains"
     es_type = "hqdomain"

--- a/corehq/pillows/fullxform.py
+++ b/corehq/pillows/fullxform.py
@@ -32,7 +32,6 @@ class FullXFormPillow(XFormPillow):
     es_alias = "full_xforms"
     es_type = "fullxform"
     es_index = FULL_XFORM_INDEX
-    es_timeout = 600
 
     #for simplicity, the handlers are managed on the domain level
     handler_domain_map = {}

--- a/corehq/pillows/xform.py
+++ b/corehq/pillows/xform.py
@@ -25,7 +25,7 @@ class XFormPillow(AliasedElasticPillow):
     es_alias = "xforms"
     es_type = "xform"
     es_index = XFORM_INDEX
-    es_timeout = 600
+    es_timeout = 60
 
     es_meta = {
     }

--- a/settings.py
+++ b/settings.py
@@ -415,10 +415,19 @@ LOGGING = {
             'format': '%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d %(message)s'
         },
         'simple': {
-            'format': '%(levelname)s %(message)s'
+            'format': '%(asctime)s %(levelname)s %(message)s'
+        },
+
+        'pillowtop': {
+            'format': '%(asctime)s %(levelname)s %(module)s %(message)s'
         },
     },
     'handlers': {
+        'pillowtop': {
+            'level': 'INFO',
+            'class': 'logging.StreamHandler',
+            'formatter': 'pillowtop'
+        },
         'console': {
             'level': 'INFO',
             'class': 'logging.StreamHandler',
@@ -459,6 +468,11 @@ LOGGING = {
             'handlers': ['console', 'file', 'couchlog'],
             'level': 'INFO',
             'propagate': True
+        },
+        'pillowtop': {
+            'handlers': ['pillowtop'],
+            'level': 'ERROR',
+            'propagate': False,
         }
     }
 }


### PR DESCRIPTION
new logging settings for console only for pillowtop logging.
also adding timestamp to default logging output, cuz it'd be kinda useful to have when scanning logfiles. not sure why we didn't do this from the get go...oy.
