### PR TITLE
only include the latest open requisition per spp when approving/filling

### DIFF
--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -346,7 +346,6 @@ class SupplyPointProductCase(CommCareCase):
         return _get_single_index(self, const.PARENT_CASE_REF, const.SUPPLY_POINT_CASE_TYPE,
                                  wrapper=SupplyPointCase)
 
-    @memoized
     def get_supply_point_case_id(self):
         return _get_single_index(self, const.PARENT_CASE_REF, const.SUPPLY_POINT_CASE_TYPE)
 
@@ -402,7 +401,6 @@ class RequisitionCase(CommCareCase):
                                  const.SUPPLY_POINT_PRODUCT_CASE_TYPE,
                                  wrapper=SupplyPointProductCase)
 
-    @memoized
     def get_product_case_id(self):
         return _get_single_index(self, const.PARENT_CASE_REF,
                                  const.SUPPLY_POINT_PRODUCT_CASE_TYPE)

--- a/corehq/apps/commtrack/stockreport.py
+++ b/corehq/apps/commtrack/stockreport.py
@@ -7,6 +7,7 @@ from lxml.builder import ElementMaker
 from xml import etree as legacy_etree
 from datetime import date, timedelta
 from corehq.apps.commtrack.const import RequisitionActions
+from dimagi.utils.create_unique_filter import create_unique_filter
 from dimagi.utils.decorators.memoized import memoized
 from receiver.util import spoof_submission
 from corehq.apps.receiverwrapper.util import get_submit_url
@@ -232,7 +233,9 @@ class BulkRequisitionResponse(object):
 
     @memoized
     def get_case_ids(self):
-        for c in RequisitionCase.open_for_location(self.domain, self.location_id):
+        # todo: too many couch requests
+        for c in filter(create_unique_filter(lambda id: RequisitionCase.get(id).get_product_case_id()),
+                        RequisitionCase.open_for_location(self.domain, self.location_id)):
             yield c
 
     def get_transactions(self):


### PR DESCRIPTION
- change default sort order of getting open requisitions to return recent first.
- add utility functions to get just referenced ids from commtrack models
