### PR TITLE
Email notifications tweaks

### DIFF
--- a/corehq/apps/domain/urls.py
+++ b/corehq/apps/domain/urls.py
@@ -57,7 +57,7 @@ urlpatterns =\
 
         url(r'^accounts/password_reset_email/$', exception_safe_password_reset, extend(auth_pages_path('password_reset_form.html'),
                                                                                        { 'password_reset_form': ConfidentialPasswordResetForm,
-                                                                                         'from_email':settings.HQ_NOTIFICATIONS_EMAIL}),
+                                                                                         'from_email':settings.DEFAULT_FROM_EMAIL}),
                                                                                 name='password_reset_email'),
         url(r'^accounts/password_reset_email/done/$', 'password_reset_done', auth_pages_path('password_reset_done.html') ),
 

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -544,7 +544,7 @@ def _notification_email_on_publish(domain, snapshot, published_by):
     try:
         for recipient in recipients:
             send_HTML_email(subject, recipient, html_content, text_content=text_content,
-                            email_from=settings.HQ_NOTIFICATIONS_EMAIL)
+                            email_from=settings.DEFAULT_FROM_EMAIL)
     except Exception:
         logging.warning("Can't send notification email, but the message was:\n%s" % text_content)
 
@@ -696,6 +696,6 @@ def _send_request_notification_email(request, org, dom):
     try:
         for recipient in recipients:
             send_HTML_email(subject, recipient, html_content, text_content=text_content,
-                            email_from=settings.HQ_NOTIFICATIONS_EMAIL)
+                            email_from=settings.DEFAULT_FROM_EMAIL)
     except Exception:
         logging.warning("Can't send notification email, but the message was:\n%s" % text_content)

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -296,7 +296,7 @@ def bug_report(req):
     # if the person looks like a commcare user, fogbugz can't reply
     # to their email, so just use the default
     if settings.HQ_ACCOUNT_ROOT in reply_to:
-        reply_to = settings.HQ_NOTIFICATIONS_EMAIL
+        reply_to = settings.SERVER_EMAIL
 
     if req.POST.get('five-hundred-report'):
         message = "%s \n\n This messge was reported from a 500 error page! Please fix this ASAP (as if you wouldn't anyway)..." % message

--- a/corehq/apps/orgs/models.py
+++ b/corehq/apps/orgs/models.py
@@ -109,7 +109,7 @@ class OrgInvitation(Invitation):
         html_content = render_to_string("orgs/email/org_invite.html", params)
         subject = 'Invitation from %s to join CommCareHQ' % self.get_inviter().formatted_name
         send_HTML_email(subject, self.email, html_content, text_content=text_content,
-                        email_from=settings.HQ_NOTIFICATIONS_EMAIL)
+                        email_from=settings.DEFAULT_FROM_EMAIL)
 
 
 class OrgRequest(Document):

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -145,7 +145,7 @@ The CommCareHQ Team
 
     try:
         send_HTML_email(subject, recipient, message_html, text_content=message_plaintext,
-                        email_from=settings.HQ_NOTIFICATIONS_EMAIL)
+                        email_from=settings.DEFAULT_FROM_EMAIL)
     except Exception:
         logging.warning("Can't send email, but the message was:\n%s" % message_plaintext)
 
@@ -198,7 +198,7 @@ The CommCareHQ Team
 
     try:
         send_HTML_email(subject, requesting_user.email, message_html,
-                        text_content=message_plaintext, email_from=settings.HQ_NOTIFICATIONS_EMAIL)
+                        text_content=message_plaintext, email_from=settings.DEFAULT_FROM_EMAIL)
     except Exception:
         logging.warning("Can't send email, but the message was:\n%s" % message_plaintext)
 
@@ -223,6 +223,6 @@ You can view the project here: %s""" % (
         get_url_base() + "/a/%s/" % domain_name)
     try:
         recipients = settings.NEW_DOMAIN_RECIPIENTS
-        send_mail("New Project: %s" % domain_name, message, settings.HQ_NOTIFICATIONS_EMAIL, recipients)
+        send_mail("New Project: %s" % domain_name, message, settings.SERVER_EMAIL, recipients)
     except Exception:
         logging.warning("Can't send email, but the message was:\n%s" % message)

--- a/corehq/apps/reports/models.py
+++ b/corehq/apps/reports/models.py
@@ -487,7 +487,7 @@ class ReportNotification(Document):
             self.owner, self.domain, self._id).content
 
         for email in self.all_recipient_emails:
-            send_HTML_email(title, email, body, email_from=settings.HQ_NOTIFICATIONS_EMAIL)
+            send_HTML_email(title, email, body, email_from=settings.DEFAULT_FROM_EMAIL)
 
 
 class AppNotFound(Exception):

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -523,11 +523,11 @@ def email_report(request, domain, report_slug, report_type=ProjectReportDispatch
 
     if form.cleaned_data['send_to_owner']:
         send_HTML_email(subject, request.couch_user.get_email(), body,
-                        email_from=settings.HQ_NOTIFICATIONS_EMAIL)
+                        email_from=settings.DEFAULT_FROM_EMAIL)
 
     if form.cleaned_data['recipient_emails']:
         for recipient in form.cleaned_data['recipient_emails']:
-            send_HTML_email(subject, recipient, body, email_from=settings.HQ_NOTIFICATIONS_EMAIL)
+            send_HTML_email(subject, recipient, body, email_from=settings.DEFAULT_FROM_EMAIL)
 
     return HttpResponse()
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1712,7 +1712,7 @@ class DomainInvitation(Invitation):
         subject = 'Invitation from %s to join CommCareHQ' % self.get_inviter().formatted_name
         send_HTML_email(subject, self.email, html_content, text_content=text_content,
                         cc=[self.get_inviter().get_email()],
-                        email_from=settings.HQ_NOTIFICATIONS_EMAIL)
+                        email_from=settings.DEFAULT_FROM_EMAIL)
 
     @classmethod
     def by_domain(cls, domain, is_active=True):

--- a/localsettings.example.py
+++ b/localsettings.example.py
@@ -37,8 +37,10 @@ BUG_REPORT_RECIPIENTS = ['commcarehq-support@dimagi.com']
 NEW_DOMAIN_RECIPIENTS = ['commcarehq-dev+newdomain@dimagi.com']
 EXCHANGE_NOTIFICATION_RECIPIENTS = ['commcarehq-dev+exchange@dimagi.com']
 
-HQ_NOTIFICATIONS_EMAIL = 'commcarehq-noreply@dimagi.com'
+SERVER_EMAIL = 'commcarehq-noreply@dimagi.com' #the physical server emailing - differentiate if needed
+DEFAULT_FROM_EMAIL = 'commcarehq-noreply@dimagi.com'
 SUPPORT_EMAIL = "commcarehq-support@dimagi.com"
+EMAIL_SUBJECT_PREFIX = '[commcarehq] '
 
 ####### Log/debug setup ########
 

--- a/settings.py
+++ b/settings.py
@@ -287,8 +287,10 @@ EMAIL_SMTP_PORT = 587
 BUG_REPORT_RECIPIENTS = ()
 EXCHANGE_NOTIFICATION_RECIPIENTS = []
 
-HQ_NOTIFICATIONS_EMAIL = 'commcarehq-noreply@dimagi.com'
+SERVER_EMAIL = 'commcarehq-noreply@dimagi.com' #the physical server emailing - differentiate if needed
+DEFAULT_FROM_EMAIL = 'commcarehq-noreply@dimagi.com'
 SUPPORT_EMAIL = "commcarehq-support@dimagi.com"
+EMAIL_SUBJECT_PREFIX = '[commcarehq] '
 
 PAGINATOR_OBJECTS_PER_PAGE = 15
 PAGINATOR_MAX_PAGE_LINKS = 5


### PR DESCRIPTION
adding SERVER_EMAIL and DEFAULT_FROM_EMAIL as these are django aware.

removing HQ_NOTIFICATION_EMAIL setting.

adding SUBJECT prefix for emails now so it's easier to identify emails.

any dev/internal facing emails use SERVER_EMAIL, any customer facing emails use DEFAULT_FROM_EMAIL
