### PR TITLE
Bug reports 500

### DIFF
--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -299,7 +299,6 @@ def bug_report(req):
     email = EmailMessage(
         subject=subject,
         body=message,
-        from_email=report['username'],
         to=settings.BUG_REPORT_RECIPIENTS,
         headers={'Reply-To': reply_to}
     )


### PR DESCRIPTION
(merge https://github.com/dimagi/commcare-hq/pull/273 first)

Not sure if this is the right solution, but amazon doesn't allow you to send from non-verified emails; a possible consequence of this is that people won't get the default fogbugz "here's the ticket" email.
