### PR TITLE
Fix bug with users first/last name display

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -673,7 +673,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn):
 
     @property
     def full_name(self):
-        return ("%s %s" % (self.first_name, self.last_name)).strip()
+        return ("%s %s" % (self.first_name or '', self.last_name or '')).strip()
 
     formatted_name = full_name
     name = full_name


### PR DESCRIPTION
Was displaying "None None" for the name if the first_name and last_name
fields had null values. Now displays nothing in that case.

Case 60148
