### PR TITLE
Update readme/settings for running cloudcare local

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Then run the following separately:
     > jython submodules/touchforms-src/touchforms/backend/xformserver.py
 
     # On Mac / Linux use Gunicorn as the multi-threaded server
-    ./manage.py run_gunicorn
+    ./manage.py run_gunicorn -w 3
 
     # on Windows use CherryPy
     > manage.py runcpserver port=8000

--- a/localsettings.example.py
+++ b/localsettings.example.py
@@ -105,7 +105,7 @@ TOUCHFORMS_API_PASSWORD = 'password'
 
 ####### Misc / HQ-specific Config ########
 
-DEFAULT_PROTOCOL = "https" # or http
+DEFAULT_PROTOCOL = "http" # or https
 OVERRIDE_LOCATION="https://www.commcarehq.org"
 
 #Set your analytics IDs here for GA and pingdom RUM


### PR DESCRIPTION
Local settings example using https for default protocol causes cloudcare to not work locally. Also updated readme for correct gunicorn server command.
