### PR TITLE
Case importer cleanup

### DIFF
--- a/corehq/apps/importer/templates/importer/excel_config.html
+++ b/corehq/apps/importer/templates/importer/excel_config.html
@@ -9,19 +9,19 @@
     <script type="text/javascript">
         $(function() {
             $('#key_value_columns').change(function() {
-                if ($(this).val() == "yes") {                    
+                if ($(this).val() == "yes") {
                     $('#key_column').removeAttr('disabled');
                     $('#value_column').removeAttr('disabled');
                 } else {
-                	$('#key_column').attr('disabled', 'disabled');
+                    $('#key_column').attr('disabled', 'disabled');
                     $('#value_column').attr('disabled', 'disabled');
-                } //else
+                }
             });
 
             $('#key_value_columns').change();
 
             $('#back_button').click(function() {
-            	history.back();
+                history.back();
                 return false;
             });
         });
@@ -45,7 +45,7 @@
             </div>
         </div>
     </fieldset>
-    
+
     <fieldset>
         <legend>Which column should be used to identify cases?</legend>
         <div class="control-group">
@@ -56,16 +56,16 @@
                     <option value="{{column|escape}}">{{column|escape}}</option>
                     {% endfor %}
                 </select>
-                
+
                 <label for="search_field">Corresponding case field</label>
-                <select name="search_field" id="search_field">               
+                <select name="search_field" id="search_field">
                     <option value="case_id">case_id</option>
                     <option value="external_id">external_id</option>
-                </select>                
+                </select>
             </div>
         </div>
     </fieldset>
-    
+
     <fieldset>
         <legend>Are there columns in the file that contain key/value fields?</legend>
         <div class="control-group">
@@ -73,11 +73,11 @@
                 <select class="input-small" name="key_value_columns" id="key_value_columns">
                     <option selected>no</option>
                     <option >yes</option>
-                </select> 
-            </div>       
+                </select>
+            </div>
         </div>
-    </fieldset>    
-    
+    </fieldset>
+
     <fieldset>
         <legend>Which Excel columns correspond to the key/value fields?</legend>
         <div class="control-group">
@@ -88,7 +88,7 @@
                     <option value="{{column|escape}}">{{column|escape}}</option>
                     {% endfor %}
                 </select>
-                
+
                 <label for="value_column">Value column</label>
                 <select name="value_column" id="value_column">
                     {% for column in columns %}
@@ -98,7 +98,7 @@
             </div>
         </div>
     </fieldset>
-    
+
     <div class="form-actions">
         <button type="button" class="btn btn-primary btn-large" id="back_button"><i class="icon-backward icon-white"></i> Back</button>
         <button type="submit" class="btn btn-primary btn-large"><i class="icon-forward icon-white"></i> Next step</button>

--- a/corehq/apps/importer/templates/importer/excel_fields.html
+++ b/corehq/apps/importer/templates/importer/excel_fields.html
@@ -12,7 +12,7 @@
                 selectField = $(this).prev();
 
                 // check if field is valid for xml
-                
+
                 // TODO: this method seems pretty sketchy, should cleanup
                 var value = $(this).val();
                 var regx = new RegExp(/^xml/i); 
@@ -20,102 +20,114 @@
                 value = value.replace(/\s/g, "_"); // space to underscore
                 value = value.replace(/[^a-zA-Z0-9_\-]/g, ""); // remove other symbols
                 value = value.replace(regx, ""); // remove xml from beginning of string
-                
+
                 $(this).val(value);
-                
+
                 if ($(this).val() != '') {
-                	selectField.val('');
-                	selectField.attr('disabled', 'disabled');
+                    selectField.val('');
+                    selectField.attr('disabled', 'disabled');
                 } else {
-                	selectField.removeAttr('disabled');
-                } //else
+                    selectField.removeAttr('disabled');
+                }
             });
 
             $('.custom_field').change();
 
             $('#field_form').submit(function() {
-            	$('[disabled]').each(function() {
+                $('[disabled]').each(function() {
                     $(this).removeAttr('disabled');
-            	});
-
-            	$(this).find('input[type=checkbox]').each(function () {
-            	    $(this).prev().val($(this).is(':checked') ? '1' : '0');
                 });
-                
+
+                $(this).find('input[type=checkbox]').each(function () {
+                    $(this).prev().val($(this).is(':checked') ? '1' : '0');
+                });
+
                 return true;
             });
 
             $('#back_button').click(function() {
                 history.back();
                 return false;
-            });            
+            })
         });
     </script>
 {% endblock %}
 
 {% block main_column %}
-    <form class="form-horizontal form-report" action="{% url corehq.apps.importer.views.excel_commit domain %}" method="post" id="field_form">
-    <input type="hidden" name="named_columns" value="{{named_columns}}" />
-    <input type="hidden" name="case_type" value="{{case_type}}" />
-    <input type="hidden" name="search_column" value="{{search_column}}" />
-    <input type="hidden" name="search_field" value="{{search_field}}" />
-    <input type="hidden" name="key_column" value="{{key_column}}" />
-    <input type="hidden" name="value_column" value="{{value_column}}" />    
-    
-    <fieldset>
-        <legend>Map columns to case fields</legend>
-        <div class="control-group">
-            <div class="controls">
+    <form class="form-horizontal form-report"
+          action="{% url corehq.apps.importer.views.excel_commit domain %}"
+          method="post"
+          id="field_form">
+        <input type="hidden" name="named_columns" value="{{named_columns}}" />
+        <input type="hidden" name="case_type" value="{{case_type}}" />
+        <input type="hidden" name="search_column" value="{{search_column}}" />
+        <input type="hidden" name="search_field" value="{{search_field}}" />
+        <input type="hidden" name="key_column" value="{{key_column}}" />
+        <input type="hidden" name="value_column" value="{{value_column}}" />
 
-                <label for="case-type">Excel data label
-                <!-- css this up -->
-                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-                &nbsp;&nbsp;&nbsp;&nbsp;               
-                Case field name
-                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 
-                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-                &nbsp;&nbsp;&nbsp;&nbsp;
-                or enter a new field name:
-                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;    
-                &nbsp;      
-                Is this a date field?      
-                </label>
-                
+        <fieldset>
+            <legend>Map columns to case fields</legend>
+            <table>
+                <tr>
+                    <th>
+                        Excel data label
+                    </th>
+                    <th>
+                        Case field name
+                    </th>
+                    <th>
+                        or enter a new field name
+                    </th>
+                    <th>
+                        Is this a date field?
+                    </th>
+                </tr>
+
                 {% for i in excel_fields_range %}
-                    <select name="excel_field[]">
-                        <option value=""></option>
-                        {% for excel_field in excel_fields %}
-                        <option value="{{excel_field|escape}}">{{excel_field|escape}}</option>
-                        {% endfor %}
-                    </select>
-                    
-                    <select name="case_field[]">
-                        <option value=""></option>
-                        {% for case_field in case_fields %}
-                        <option value="{{case_field|escape}}">{{case_field|escape}}</option>
-                        {% endfor %}
-                    </select>
-                    
-                    <input type="text" name="custom_field[]" class="custom_field" />
-                    
-                    <input type="hidden" name="date_yesno[]" value="0" />
-                    <input type="checkbox" />
-                    
-                    <br>
+                    <tr>
+                        <td>
+                            <select name="excel_field[]">
+                                <option value=""></option>
+                                {% for excel_field in excel_fields %}
+                                    <option value="{{excel_field|escape}}">
+                                        {{excel_field|escape}}
+                                    </option>
+                                {% endfor %}
+                            </select>
+                        </td>
+
+                        <td>
+                            <select name="case_field[]">
+                                <option value=""></option>
+                                {% for case_field in case_fields %}
+                                    <option value="{{case_field|escape}}">
+                                        {{case_field|escape}}
+                                    </option>
+                                {% endfor %}
+                            </select>
+                        </td>
+
+                        <td>
+                            <input type="text" name="custom_field[]" class="custom_field" />
+                        </td>
+
+                        <td style="text-align:center">
+                            <input type="checkbox" />
+                        </td>
+
+                        <input type="hidden" name="date_yesno[]" value="0" />
+                    </tr>
                 {% endfor %}
-            </div>
+            </table>
+        </fieldset>
+
+        <div class="form-actions">
+            <button type="button" class="btn btn-primary btn-large" id="back_button">
+                <i class="icon-backward icon-white"></i> Back
+            </button>
+            <button type="submit" class="btn btn-primary btn-large">
+                <i class="icon-forward icon-white"></i> Confirm import
+            </button>
         </div>
-    </fieldset>
-   
-    <div class="form-actions">
-        <button type="button" class="btn btn-primary btn-large" id="back_button"><i class="icon-backward icon-white"></i> Back</button>
-        <button type="submit" class="btn btn-primary btn-large"><i class="icon-forward icon-white"></i> Confirm import</button>
-    </div>
     </form>
 {% endblock %}

--- a/corehq/apps/importer/templates/importer/import_cases.html
+++ b/corehq/apps/importer/templates/importer/import_cases.html
@@ -2,25 +2,29 @@
 {% load report_tags %}
 
 {% block main_column %}
-    <form class="form-horizontal form-report" action="{% url corehq.apps.importer.views.excel_config domain %}" method="post" enctype="multipart/form-data">
+    <form class="form-horizontal form-report"
+          action="{% url corehq.apps.importer.views.excel_config domain %}"
+          method="post"
+          enctype="multipart/form-data">
+        <fieldset>
+            <legend>Select an Excel file from your computer to import</legend>
+            <div class="control-group">
+                <div class="controls">
+                    <input class="input-small" name="file" id="file" type="file" />
 
-    <fieldset>
-        <legend>Select an Excel file from your computer to import</legend>
-        <div class="control-group">
-            <div class="controls">
-                <input class="input-small" name="file" id="file" type="file" />
-                
-                <label for="named_columns">Are there column headers in this file?</label>
-                <select class="input-small" name="named_columns" id="named_columns">
-                    <option selected>yes</option>
-                    <option>no</option>
-                </select>
+                    <label for="named_columns">Are there column headers in this file?</label>
+                    <select class="input-small" name="named_columns" id="named_columns">
+                        <option selected>yes</option>
+                        <option>no</option>
+                    </select>
+                </div>
             </div>
+        </fieldset>
+
+        <div class="form-actions">
+            <button type="submit" class="btn btn-primary btn-large">
+                <i class="icon-forward icon-white"></i> Next step
+            </button>
         </div>
-    </fieldset>
-    
-    <div class="form-actions">
-        <button type="submit" class="btn btn-primary btn-large"><i class="icon-forward icon-white"></i> Next step</button>
-    </div>
     </form>
 {% endblock %}

--- a/corehq/apps/importer/util.py
+++ b/corehq/apps/importer/util.py
@@ -14,7 +14,7 @@ def get_case_properties(domain, case_type=None):
                          endkey=key + [{}],
                          reduce=True, group=True, group_level=3).all()
     return sorted(set([r['key'][2] for r in rows]))
-    
+
 # class to deal with Excel files
 class ExcelFile(object):
     # xlrd support for .xlsx isn't complete
@@ -22,47 +22,47 @@ class ExcelFile(object):
     # extension so if you fix this you should also fix these assumptions
     # (see _get_spreadsheet in views.py)
     ALLOWED_EXTENSIONS = ['xls']
-    
+
     file_path = ''
     workbook = None
     column_headers = False
     has_errors = False
-    
+
     def __init__(self, file_path, column_headers):
         self.file_path = file_path
         self.column_headers = column_headers
-        
+
         try:
             self.workbook = xlrd.open_workbook(self.file_path)
         except Exception:
             self.has_errors = True
-                
+
     def get_first_sheet(self):
         if self.workbook:
             return self.workbook.sheet_by_index(0)
         else:
             return None
-    
+
     def get_header_columns(self):
         sheet = self.get_first_sheet()
-        
+
         if sheet and sheet.ncols > 0:
             columns = []
-            
-            # get columns 
+
+            # get columns
             if self.column_headers:
                 columns = sheet.row_values(0)
             else:
                 for colnum in range(sheet.ncols):
                     columns.append("Column %i" % (colnum,))
-                    
+
             return columns
         else:
             return []
-        
+
     def get_column_values(self, column_index):
         sheet = self.get_first_sheet()
-        
+
         if sheet:
             if self.column_headers:
                 return sheet.col_values(column_index)[1:]
@@ -70,20 +70,19 @@ class ExcelFile(object):
                 return sheet.col_values(column_index)
         else:
             return []
-        
+
     def get_unique_column_values(self, column_index):
         return list(set(self.get_column_values(column_index)))
-    
+
     def get_num_rows(self):
         sheet = self.get_first_sheet()
-        
+
         if sheet:
             return sheet.nrows
-        
+
     def get_row(self, index):
         sheet = self.get_first_sheet()
-        
+
         if sheet:
             return sheet.row_values(index)
 
-    

--- a/corehq/apps/importer/views.py
+++ b/corehq/apps/importer/views.py
@@ -30,16 +30,16 @@ def excel_config(request, domain):
             named_columns = request.POST['named_columns']
             uses_headers = named_columns == 'yes'
             uploaded_file_handle = request.FILES['file']
-            
+
             extension = os.path.splitext(uploaded_file_handle.name)[1][1:].strip().lower()
-            
+
             if extension in ExcelFile.ALLOWED_EXTENSIONS:
                 # NOTE: this is kinda messy and needs to be cleaned up but
                 # just trying to get something functional in place.
                 # We may not always be able to reference files from subsequent
                 # views if your worker changes, so we have to store it elsewhere
                 # using the soil framework.
-                
+
                 # stash content in the default storage for subsequent views
                 file_ref = expose_download(uploaded_file_handle.read(),
                                            expiry=1*60*60)
@@ -65,7 +65,7 @@ def excel_config(request, domain):
 
                     if len(case_types) > 0:
                         return render(request, "importer/excel_config.html", {
-                                                    'named_columns': named_columns, 
+                                                    'named_columns': named_columns,
                                                     'columns': columns,
                                                     'case_types': case_types,
                                                     'domain': domain,
@@ -86,7 +86,7 @@ def excel_config(request, domain):
     #TODO show bad/invalid file error on this page
     return HttpResponseRedirect(base.ImportCases.get_url(domain=domain))
 
-      
+
 @require_POST
 @require_can_edit_data
 def excel_fields(request, domain):
@@ -98,53 +98,53 @@ def excel_fields(request, domain):
     key_value_columns = request.POST['key_value_columns']
     key_column = ''
     value_column = ''
-    
+
     download_ref = DownloadBase.get(request.session.get(EXCEL_SESSION_ID))
-    
+
     spreadsheet = _get_spreadsheet(download_ref, uses_headers)
     if not spreadsheet:
         return _spreadsheet_expired(request, domain)
 
     columns = spreadsheet.get_header_columns()
-    
+
     if key_value_columns == 'yes':
         key_column = request.POST['key_column']
         value_column = request.POST['value_column']
-        
+
         excel_fields = []
-        key_column_index = columns.index(key_column)        
-        
+        key_column_index = columns.index(key_column)
+
         # if key/value columns were specified, get all the unique keys listed
-        if key_column_index:        
+        if key_column_index:
             excel_fields = spreadsheet.get_unique_column_values(key_column_index)
-                
+
         # concatenate unique key fields with the rest of the columns
         excel_fields = columns + excel_fields
         # remove key/value column names from list
         excel_fields.remove(key_column)
         if value_column in excel_fields:
-            excel_fields.remove(value_column)                 
+            excel_fields.remove(value_column)
     else:
         excel_fields = columns
-                  
+
     case_fields = get_case_properties(domain, case_type)
-    
+
     # hide search column and matching case fields from the update list
-    try:    
+    try:
         excel_fields.remove(search_column)
     except:
         pass
-    
-    try:    
+
+    try:
         case_fields.remove(search_field)
     except:
-        pass                    
-    
+        pass
+
     return render(request, "importer/excel_fields.html", {
                                 'named_columns': named_columns,
-                                'case_type': case_type,                                                               
-                                'search_column': search_column, 
-                                'search_field': search_field,                                                        
+                                'case_type': case_type,
+                                'search_column': search_column,
+                                'search_field': search_field,
                                 'key_column': key_column,
                                 'value_column': value_column,
                                 'columns': columns,
@@ -159,7 +159,7 @@ def excel_fields(request, domain):
 
 @require_POST
 @require_can_edit_data
-def excel_commit(request, domain):  
+def excel_commit(request, domain):
     named_columns = request.POST['named_columns']
     uses_headers = named_columns == 'yes'
     case_type = request.POST['case_type']
@@ -167,7 +167,7 @@ def excel_commit(request, domain):
     search_field = request.POST['search_field']
     key_column = request.POST['key_column']
     value_column = request.POST['value_column']
-    
+
     # TODO musn't be able to select an excel_field twice (in html)
     excel_fields = request.POST.getlist('excel_field[]')
     case_fields = request.POST.getlist('case_field[]')
@@ -179,7 +179,7 @@ def excel_commit(request, domain):
     for i, field in enumerate(excel_fields):
         if field and (case_fields[i] or custom_fields[i]):
             field_map[field] = {'case': case_fields[i], 'custom': custom_fields[i], 'date': int(date_yesno[i])}
-        
+
     download_ref = DownloadBase.get(request.session.get(EXCEL_SESSION_ID))
     spreadsheet = _get_spreadsheet(download_ref, uses_headers)
     if not spreadsheet:
@@ -190,17 +190,17 @@ def excel_commit(request, domain):
                                   'uploaded has expired - please upload '
                                   'a new one.'))
         return HttpResponseRedirect(base.ImportCases.get_url(domain=domain) + "?error=cache")
-    
-    columns = spreadsheet.get_header_columns()        
-    
+
+    columns = spreadsheet.get_header_columns()
+
     # find indexes of user selected columns
     search_column_index = columns.index(search_column)
-    
+
     try:
         key_column_index = columns.index(key_column)
     except ValueError:
         key_column_index = False
-    
+
     try:
         value_column_index = columns.index(value_column)
     except ValueError:
@@ -209,18 +209,18 @@ def excel_commit(request, domain):
     no_match_count = 0
     match_count = 0
     too_many_matches = 0
-    
+
     cases = {}
-   
+
     # start looping through all the rows
     for i in range(spreadsheet.get_num_rows()):
         # skip first row if it is a header field
         if i == 0 and named_columns:
             continue
-        
+
         row = spreadsheet.get_row(i)
         found = False
-        
+
         search_id = row[search_column_index]
 
         # see what has come out of the spreadsheet
@@ -232,10 +232,10 @@ def excel_commit(request, domain):
         except ValueError:
             # error, so probably a string
             pass
-        
-        # couchdb wants a string 
-        search_id = str(search_id)    
-                
+
+        # couchdb wants a string
+        search_id = str(search_id)
+
         if search_field == 'case_id':
             try:
                 case = CommCareCase.get(search_id)
@@ -245,37 +245,37 @@ def excel_commit(request, domain):
                 pass
         elif search_field == 'external_id':
             try:
-                case = CommCareCase.view('hqcase/by_domain_external_id', 
-                                         key=[domain, search_id], 
-                                         reduce=False, 
+                case = CommCareCase.view('hqcase/by_domain_external_id',
+                                         key=[domain, search_id],
+                                         reduce=False,
                                          include_docs=True).one()
                 found = True if case else False
             except NoResultFound:
                 pass
             except MultipleResultsFound:
-                too_many_matches += 1     
-               
+                too_many_matches += 1
+
         if found:
             match_count += 1
         else:
             no_match_count += 1
             continue
-        
+
         # here be monsters
         fields_to_update = {}
-        
-        for key in field_map:          
+
+        for key in field_map:
             update_value = False
-            
+
             if key_column_index and key == row[key_column_index]:
                 update_value = row[value_column_index]
-            else:                
+            else:
                 # nothing was set so maybe it is a regular column
                 try:
                     update_value = row[columns.index(key)]
                 except Exception:
                     pass
-            
+
             if update_value:
                 # case field to update
                 if field_map[key]['custom']:
@@ -284,35 +284,35 @@ def excel_commit(request, domain):
                 else:
                     # existing case field was chosen
                     update_field_name = field_map[key]['case']
-                
+
                 if field_map[key]['date'] == 1:
                     update_value = date(*xldate_as_tuple(update_value, 0)[:3])
-                                    
+
                 fields_to_update[update_field_name] = update_value
-    
-        if case.type == case_type:      
+
+        if case.type == case_type:
             if cases.has_key(search_id):
                 cases[search_id]['fields'].update(fields_to_update)
             else:
                 cases[search_id] = {'obj': case, 'fields': fields_to_update}
-            
+
     # run updates
     for id, case in cases.iteritems():
         for name, value in case['fields'].iteritems():
             case['obj'].set_case_property(name, value)
-                                               
+
         case['obj'].modified_on = datetime.utcnow()
-                
+
         # spoof case update xform submission
         case_block = get_case_xml(case['obj'], (const.CASE_ACTION_UPDATE,), version='2.0')
         submit_case_blocks(case_block, domain)
-            
+
     # unset filename session var
     try:
         del request.session[EXCEL_SESSION_ID]
     except KeyError:
-        pass            
-    
+        pass
+
     return render(request, "importer/excel_commit.html", {
                                 'match_count': match_count,
                                 'no_match_count': no_match_count,


### PR DESCRIPTION
This PR is entirely code cleanup.

Largely addressing code style concerns by cleaning up extraneous spaces on lines, replacing tab characters with appropriate spacing and fixing indentation issues.

Also redid the column mapping table to move from using &nbsp; positioned table headers to using a properly formatted table (see changes in corehq/apps/importer/templates/importer/excel_fields.html).

Before:

![screen shot 2013-05-13 at 3 32 32 pm](https://f.cloud.github.com/assets/152134/497754/e05c51d2-bc03-11e2-91cc-a67ca1f3ee80.png)

After:

![screen shot 2013-05-13 at 3 28 33 pm](https://f.cloud.github.com/assets/152134/497751/d7e058be-bc03-11e2-8f5a-2019ac3cc2b6.png)
