### PR TITLE
Creating new cases during case import

### DIFF
--- a/corehq/apps/importer/const.py
+++ b/corehq/apps/importer/const.py
@@ -1,0 +1,2 @@
+class LookupErrors:
+    NotFound, MultipleResults = range(2)

--- a/corehq/apps/importer/templates/importer/excel_config.html
+++ b/corehq/apps/importer/templates/importer/excel_config.html
@@ -1,5 +1,6 @@
 {% extends "hqwebapp/two_column.html" %}
 {% load report_tags %}
+{% load i18n %}
 
 {% block head %}
     {{ block.super }}
@@ -29,14 +30,16 @@
 {% endblock %}
 
 {% block main_column %}
-    <form class="form-horizontal form-report" action="{% url corehq.apps.importer.views.excel_fields domain %}" method="post">
+    <form class="form-horizontal form-report"
+          action="{% url corehq.apps.importer.views.excel_fields domain %}"
+          method="post">
     <input type="hidden" name="named_columns" value="{{named_columns}}" />
 
     <fieldset>
-        <legend>Which cases do you want to update?</legend>
+        <legend>{% trans "Which cases do you want to update?" %}</legend>
         <div class="control-group">
             <div class="controls">
-                <label for="case_type">Case type</label>
+                <label for="case_type">{% trans "Case type" %}</label>
                 <select name="case_type" id="case_type">
                     {% for case_type in case_types %}
                     <option value="{{case_type|escape}}">{{case_type|escape}}</option>
@@ -47,61 +50,61 @@
     </fieldset>
 
     <fieldset>
-        <legend>Which column should be used to identify cases?</legend>
+        <legend>{% trans "Which column should be used to identify cases?" %}</legend>
         <div class="control-group">
             <div class="controls">
-                <label for="search_column">Excel column</label>
+                <label for="search_column">{% trans "Excel column" %}</label>
                 <select name="search_column" id="search_column">
                     {% for column in columns %}
                     <option value="{{column|escape}}">{{column|escape}}</option>
                     {% endfor %}
                 </select>
 
-                <label for="search_field">Corresponding case field</label>
+                <label for="search_field">{% trans "Corresponding case field" %}</label>
                 <select name="search_field" id="search_field">
-                    <option value="case_id">case_id</option>
-                    <option value="external_id">external_id</option>
+                    <option value="case_id">{% trans "case_id" %}</option>
+                    <option value="external_id">{% trans "external_id" %}</option>
                 </select>
             </div>
         </div>
     </fieldset>
 
     <fieldset>
-        <legend>Do you want to create new cases if there isn't a match found to update?</legend>
+        <legend>{% trans "Do you want to create new cases if there isn't a match found to update?" %}</legend>
         <div class="control-group">
             <div class="controls">
                 <select class="input-small" name="create_new_cases" id="create_new_cases">
-                    <option selected>No</option>
-                    <option>Yes</option>
+                    <option selected>{% trans "No" %}</option>
+                    <option>{% trans "Yes" %}</option>
                 </select>
             </div>
         </div>
     </fieldset>
 
     <fieldset>
-        <legend>Are there columns in the file that contain key/value fields?</legend>
+        <legend>{% trans "Are there columns in the file that contain key/value fields?" %}</legend>
         <div class="control-group">
             <div class="controls">
                 <select class="input-small" name="key_value_columns" id="key_value_columns">
-                    <option selected>No</option>
-                    <option>Yes</option>
+                    <option selected>{% trans "No" %}</option>
+                    <option>{% trans "Yes" %}</option>
                 </select>
             </div>
         </div>
     </fieldset>
 
     <fieldset>
-        <legend>Which Excel columns correspond to the key/value fields?</legend>
+        <legend>{% trans "Which Excel columns correspond to the key/value fields?" %}</legend>
         <div class="control-group">
             <div class="controls">
-                <label for="key_column">Key column</label>
+                <label for="key_column">{% trans "Key column" %}</label>
                 <select name="key_column" id="key_column">
                     {% for column in columns %}
                     <option value="{{column|escape}}">{{column|escape}}</option>
                     {% endfor %}
                 </select>
 
-                <label for="value_column">Value column</label>
+                <label for="value_column">{% trans "Value column" %}</label>
                 <select name="value_column" id="value_column">
                     {% for column in columns %}
                     <option value="{{column|escape}}">{{column|escape}}</option>
@@ -112,8 +115,12 @@
     </fieldset>
 
     <div class="form-actions">
-        <button type="button" class="btn btn-primary btn-large" id="back_button"><i class="icon-backward icon-white"></i> Back</button>
-        <button type="submit" class="btn btn-primary btn-large"><i class="icon-forward icon-white"></i> Next step</button>
+        <button type="button" class="btn btn-primary btn-large" id="back_button">
+            <i class="icon-backward icon-white"></i> {% trans "Back" %}
+        </button>
+        <button type="submit" class="btn btn-primary btn-large">
+            <i class="icon-forward icon-white"></i> {% trans "Next Step" %}
+        </button>
     </div>
     </form>
 {% endblock %}

--- a/corehq/apps/importer/templates/importer/excel_config.html
+++ b/corehq/apps/importer/templates/importer/excel_config.html
@@ -67,12 +67,24 @@
     </fieldset>
 
     <fieldset>
+        <legend>Do you want to create new cases if there isn't a match found to update?</legend>
+        <div class="control-group">
+            <div class="controls">
+                <select class="input-small" name="create_new_cases" id="create_new_cases">
+                    <option selected>No</option>
+                    <option>Yes</option>
+                </select>
+            </div>
+        </div>
+    </fieldset>
+
+    <fieldset>
         <legend>Are there columns in the file that contain key/value fields?</legend>
         <div class="control-group">
             <div class="controls">
                 <select class="input-small" name="key_value_columns" id="key_value_columns">
-                    <option selected>no</option>
-                    <option >yes</option>
+                    <option selected>No</option>
+                    <option>Yes</option>
                 </select>
             </div>
         </div>

--- a/corehq/apps/importer/templates/importer/excel_config.html
+++ b/corehq/apps/importer/templates/importer/excel_config.html
@@ -10,7 +10,7 @@
     <script type="text/javascript">
         $(function() {
             $('#key_value_columns').change(function() {
-                if ($(this).val() == "yes") {
+                if ($(this).val().toLowerCase() == "yes") {
                     $('#key_column').removeAttr('disabled');
                     $('#value_column').removeAttr('disabled');
                 } else {
@@ -74,8 +74,8 @@
         <div class="control-group">
             <div class="controls">
                 <select class="input-small" name="create_new_cases" id="create_new_cases">
-                    <option selected>{% trans "No" %}</option>
-                    <option>{% trans "Yes" %}</option>
+                    <option selected>No</option>
+                    <option>Yes</option>
                 </select>
             </div>
         </div>
@@ -86,8 +86,8 @@
         <div class="control-group">
             <div class="controls">
                 <select class="input-small" name="key_value_columns" id="key_value_columns">
-                    <option selected>{% trans "No" %}</option>
-                    <option>{% trans "Yes" %}</option>
+                    <option selected>No</option>
+                    <option>Yes</option>
                 </select>
             </div>
         </div>

--- a/corehq/apps/importer/templates/importer/excel_fields.html
+++ b/corehq/apps/importer/templates/importer/excel_fields.html
@@ -62,6 +62,7 @@
         <input type="hidden" name="case_type" value="{{case_type}}" />
         <input type="hidden" name="search_column" value="{{search_column}}" />
         <input type="hidden" name="search_field" value="{{search_field}}" />
+        <input type="hidden" name="create_new_cases" value="{{create_new_cases}}" />
         <input type="hidden" name="key_column" value="{{key_column}}" />
         <input type="hidden" name="value_column" value="{{value_column}}" />
 

--- a/corehq/apps/importer/templates/importer/excel_fields.html
+++ b/corehq/apps/importer/templates/importer/excel_fields.html
@@ -1,5 +1,6 @@
 {% extends "hqwebapp/two_column.html" %}
 {% load report_tags %}
+{% load i18n %}
 
 {% block head %}
     {{ block.super }}
@@ -67,21 +68,13 @@
         <input type="hidden" name="value_column" value="{{value_column}}" />
 
         <fieldset>
-            <legend>Map columns to case fields</legend>
+            <legend>{% trans "Map columns to case fields" %}</legend>
             <table>
                 <tr>
-                    <th>
-                        Excel data label
-                    </th>
-                    <th>
-                        Case field name
-                    </th>
-                    <th>
-                        or enter a new field name
-                    </th>
-                    <th>
-                        Is this a date field?
-                    </th>
+                    <th>{% trans "Excel data label"%}</th>
+                    <th>{% trans "Case field name"%}</th>
+                    <th>{% trans "or enter a new field name"%}</th>
+                    <th>{% trans "Is this a date field?"%}</th>
                 </tr>
 
                 {% for i in excel_fields_range %}
@@ -124,10 +117,10 @@
 
         <div class="form-actions">
             <button type="button" class="btn btn-primary btn-large" id="back_button">
-                <i class="icon-backward icon-white"></i> Back
+                <i class="icon-backward icon-white"></i> {% trans "Back" %}
             </button>
             <button type="submit" class="btn btn-primary btn-large">
-                <i class="icon-forward icon-white"></i> Confirm import
+                <i class="icon-forward icon-white"></i> {% trans "Confirm Import" %}
             </button>
         </div>
     </form>

--- a/corehq/apps/importer/templates/importer/import_cases.html
+++ b/corehq/apps/importer/templates/importer/import_cases.html
@@ -1,5 +1,6 @@
 {% extends 'reports/async/basic.html' %}
 {% load report_tags %}
+{% load i18n %}
 
 {% block main_column %}
     <form class="form-horizontal form-report"
@@ -7,15 +8,15 @@
           method="post"
           enctype="multipart/form-data">
         <fieldset>
-            <legend>Select an Excel file from your computer to import</legend>
+            <legend>{% trans "Select an Excel file from your computer to import" %}</legend>
             <div class="control-group">
                 <div class="controls">
                     <input class="input-small" name="file" id="file" type="file" />
 
-                    <label for="named_columns">Are there column headers in this file?</label>
+                    <label for="named_columns">{% trans "Are there column headers in this file?" %}</label>
                     <select class="input-small" name="named_columns" id="named_columns">
-                        <option selected>yes</option>
-                        <option>no</option>
+                        <option selected>{% trans "Yes" %}</option>
+                        <option>{% trans "No" %}</option>
                     </select>
                 </div>
             </div>
@@ -23,7 +24,7 @@
 
         <div class="form-actions">
             <button type="submit" class="btn btn-primary btn-large">
-                <i class="icon-forward icon-white"></i> Next step
+                <i class="icon-forward icon-white"></i> {% trans "Next step" %}
             </button>
         </div>
     </form>

--- a/corehq/apps/importer/util.py
+++ b/corehq/apps/importer/util.py
@@ -1,5 +1,10 @@
 import xlrd
 from dimagi.utils.couch.database import get_db
+from corehq.apps.importer.const import LookupErrors
+from xml.etree import ElementTree
+from dimagi.utils.parsing import json_format_datetime
+from corehq.apps.hqcase.utils import submit_case_blocks
+from casexml.apps.case.models import CommCareCase
 
 def get_case_properties(domain, case_type=None):
     """
@@ -85,4 +90,134 @@ class ExcelFile(object):
 
         if sheet:
             return sheet.row_values(index)
+
+def convert_custom_fields_to_struct(request):
+    excel_fields = request.POST.getlist('excel_field[]')
+    case_fields = request.POST.getlist('case_field[]')
+    custom_fields = request.POST.getlist('custom_field[]')
+    date_yesno = request.POST.getlist('date_yesno[]')
+
+    field_map = {}
+    for i, field in enumerate(excel_fields):
+        if field and (case_fields[i] or custom_fields[i]):
+            field_map[field] = {'case': case_fields[i],
+                                'custom': custom_fields[i],
+                                'date': int(date_yesno[i])}
+
+    return field_map
+
+def parse_excel_date(date):
+    """ Convert field value from excel to a date value """
+    return date(*xldate_as_tuple(date, 0)[:3])
+
+def parse_search_id(request, columns, row):
+    """ Find and convert the search id in an excel row """
+
+    # Find index of user specified search column
+    search_column = request.POST['search_column']
+    search_column_index = columns.index(search_column)
+
+    search_id = row[search_column_index]
+    try:
+        # if the spreadsheet gives a number, strip any decimals off
+        # float(x) is more lenient in conversion from string so both
+        # are used
+        search_id = int(float(search_id))
+    except ValueError:
+        # if it's not a number that's okay too
+        pass
+
+    # need a string no matter what the type was
+    return str(search_id)
+
+def submit_case_block(caseblock, domain, username, user_id):
+    """ Convert a CaseBlock object to xml and submit for creation/update """
+    casexml = ElementTree.tostring(caseblock.as_xml(format_datetime=json_format_datetime))
+    submit_case_blocks(casexml, domain, username, user_id)
+
+def get_key_column_index(request, columns):
+    key_column = request.POST['key_column']
+    try:
+        key_column_index = columns.index(key_column)
+    except ValueError:
+        key_column_index = False
+
+    return key_column_index
+
+def get_value_column_index(request, columns):
+    value_column = request.POST['value_column']
+    try:
+        value_column_index = columns.index(value_column)
+    except ValueError:
+        value_column_index = False
+
+    return value_column_index
+
+def lookup_case(search_field, search_id, domain):
+    """
+    Attempt to find the case in CouchDB by the provided search_field and search_id.
+
+    Returns a tuple with case (if found) and an
+    error code (if there was an error in lookup).
+    """
+    found = False
+    if search_field == 'case_id':
+        try:
+            import pdb; pdb.set_trace()
+            case = CommCareCase.get(search_id)
+            if case.domain == domain:
+                found = True
+        except Exception:
+            pass
+    elif search_field == 'external_id':
+        try:
+            case = CommCareCase.view('hqcase/by_domain_external_id',
+                                     key=[domain, search_id],
+                                     reduce=False,
+                                     include_docs=True).one()
+            found = bool(case)
+        except NoResultFound:
+            pass
+        except MultipleResultsFound:
+            return (None, LookupErrors.MultipleResults)
+
+    if found:
+        return (case, None)
+    else:
+        return (None, LookupErrors.NotFound)
+
+def populate_updated_fields(request, columns, row):
+    """
+    Returns a dict map of fields that were marked to be updated
+    due to the import. This can be then used to pass to the CaseBlock
+    to trigger updates.
+    """
+
+    field_map = convert_custom_fields_to_struct(request)
+    key_column_index = get_key_column_index(request, columns)
+    value_column_index = get_value_column_index(request, columns)
+    fields_to_update = {}
+
+    for key in field_map:
+        try:
+            if key_column_index and key == row[key_column_index]:
+                update_value = row[value_column_index]
+            else:
+                update_value = row[columns.index(key)]
+        except:
+            continue
+
+        if field_map[key]['custom']:
+            # custom (new) field was entered
+            update_field_name = field_map[key]['custom']
+        else:
+            # existing case field was chosen
+            update_field_name = field_map[key]['case']
+
+        if field_map[key]['date'] == 1:
+            update_value = parse_excel_date(update_value)
+
+        fields_to_update[update_field_name] = update_value
+
+    return fields_to_update
 

--- a/corehq/apps/importer/views.py
+++ b/corehq/apps/importer/views.py
@@ -106,6 +106,7 @@ def excel_fields(request, domain):
     case_type = request.POST['case_type']
     search_column = request.POST['search_column']
     search_field = request.POST['search_field']
+    create_new_cases = request.POST['create_new_cases']
     key_value_columns = request.POST['key_value_columns']
     key_column = ''
     value_column = ''
@@ -156,6 +157,7 @@ def excel_fields(request, domain):
                                 'case_type': case_type,
                                 'search_column': search_column,
                                 'search_field': search_field,
+                                'create_new_cases': create_new_cases,
                                 'key_column': key_column,
                                 'value_column': value_column,
                                 'columns': columns,
@@ -252,8 +254,6 @@ def lookup_case(search_field, search_id, domain):
         return (case, None)
     else:
         return (None, LookupErrors.NotFound)
-        # TYLER TODO: check if we are allowed to create new entries
-        # continue
 
 def populate_updated_fields(request, columns, row):
     field_map = convert_custom_fields_to_struct(request)
@@ -291,6 +291,7 @@ def excel_commit(request, domain):
     uses_headers = named_columns == 'yes'
     case_type = request.POST['case_type']
     search_field = request.POST['search_field']
+    create_new_cases = True if request.POST['create_new_cases'] == 'Yes' else False
 
     download_ref = DownloadBase.get(request.session.get(EXCEL_SESSION_ID))
     spreadsheet = _get_spreadsheet(download_ref, uses_headers)
@@ -320,8 +321,11 @@ def excel_commit(request, domain):
             match_count += 1
         elif error == LookupErrors.NotFound:
             no_match_count += 1
+            if not create_new_cases:
+                continue
         elif error == LookupErrors.MultipleResults:
             too_many_matches += 1
+            continue
 
         fields_to_update = populate_updated_fields(request, columns, row)
 

--- a/corehq/apps/importer/views.py
+++ b/corehq/apps/importer/views.py
@@ -34,7 +34,7 @@ MAX_ALLOWED_ROWS = 500
 def excel_config(request, domain):
     if request.method == 'POST':
         if request.FILES:
-            named_columns = request.POST['named_columns']
+            named_columns = request.POST['named_columns'].lower()
             uses_headers = named_columns == 'yes'
             uploaded_file_handle = request.FILES['file']
 
@@ -101,13 +101,13 @@ def excel_config(request, domain):
 @require_POST
 @require_can_edit_data
 def excel_fields(request, domain):
-    named_columns = request.POST['named_columns']
+    named_columns = request.POST['named_columns'].lower()
     uses_headers = named_columns == 'yes'
     case_type = request.POST['case_type']
     search_column = request.POST['search_column']
     search_field = request.POST['search_field']
     create_new_cases = request.POST['create_new_cases']
-    key_value_columns = request.POST['key_value_columns']
+    key_value_columns = request.POST['key_value_columns'].lower()
     key_column = ''
     value_column = ''
 
@@ -291,7 +291,7 @@ def excel_commit(request, domain):
     uses_headers = named_columns == 'yes'
     case_type = request.POST['case_type']
     search_field = request.POST['search_field']
-    create_new_cases = True if request.POST['create_new_cases'] == 'Yes' else False
+    create_new_cases = True if request.POST['create_new_cases'].lower() == 'yes' else False
 
     download_ref = DownloadBase.get(request.session.get(EXCEL_SESSION_ID))
     spreadsheet = _get_spreadsheet(download_ref, uses_headers)

--- a/corehq/apps/importer/views.py
+++ b/corehq/apps/importer/views.py
@@ -1,22 +1,20 @@
 import os.path
 from django.http import HttpResponseRedirect
-from casexml.apps.case.models import CommCareCase, const
+from casexml.apps.case.models import CommCareCase
 from casexml.apps.phone.xml import get_case_xml
 from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.importer import base
 from corehq.apps.importer.const import LookupErrors
-from corehq.apps.importer.util import ExcelFile, get_case_properties
+from corehq.apps.importer.util import *
 from couchdbkit.exceptions import MultipleResultsFound, NoResultFound
 from django.views.decorators.http import require_POST
 from datetime import datetime, date
-from dimagi.utils.parsing import json_format_datetime
 from xlrd import xldate_as_tuple
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
 from soil.util import expose_download
 from soil import DownloadBase
 
-from xml.etree import ElementTree
 from casexml.apps.case.tests.util import CaseBlock
 import uuid
 
@@ -169,120 +167,6 @@ def excel_fields(request, domain):
                                     'name': 'Import: Match columns to fields'
                                  },
                                 'slug': base.ImportCases.slug})
-
-def convert_custom_fields_to_struct(request):
-    # TODO musn't be able to select an excel_field twice (in html)
-    excel_fields = request.POST.getlist('excel_field[]')
-    case_fields = request.POST.getlist('case_field[]')
-    custom_fields = request.POST.getlist('custom_field[]')
-    date_yesno = request.POST.getlist('date_yesno[]')
-
-    field_map = {}
-    for i, field in enumerate(excel_fields):
-        if field and (case_fields[i] or custom_fields[i]):
-            field_map[field] = {'case': case_fields[i],
-                                'custom': custom_fields[i],
-                                'date': int(date_yesno[i])}
-
-    return field_map
-
-def parse_excel_date(date):
-    return date(*xldate_as_tuple(date, 0)[:3])
-
-def parse_search_id(request, columns, row):
-    # Find index of user specified search column
-    search_column = request.POST['search_column']
-    search_column_index = columns.index(search_column)
-
-    search_id = row[search_column_index]
-    try:
-        # if the spreadsheet gives a number, strip any decimals off
-        # float(x) is more lenient in conversion from string so both
-        # are used
-        search_id = int(float(search_id))
-    except ValueError:
-        # if it's not a number that's okay too
-        pass
-
-    # need a string no matter what the type was
-    return str(search_id)
-
-def submit_case_block(caseblock, domain, username, user_id):
-    casexml = ElementTree.tostring(caseblock.as_xml(format_datetime=json_format_datetime))
-    submit_case_blocks(casexml, domain, username, user_id)
-
-def get_key_column_index(request, columns):
-    key_column = request.POST['key_column']
-    try:
-        key_column_index = columns.index(key_column)
-    except ValueError:
-        key_column_index = False
-
-    return key_column_index
-
-def get_value_column_index(request, columns):
-    value_column = request.POST['value_column']
-    try:
-        value_column_index = columns.index(value_column)
-    except ValueError:
-        value_column_index = False
-
-    return value_column_index
-
-def lookup_case(search_field, search_id, domain):
-    found = False
-    if search_field == 'case_id':
-        try:
-            case = CommCareCase.get(search_id)
-            if case.domain == domain:
-                found = True
-        except Exception:
-            pass
-    elif search_field == 'external_id':
-        try:
-            case = CommCareCase.view('hqcase/by_domain_external_id',
-                                     key=[domain, search_id],
-                                     reduce=False,
-                                     include_docs=True).one()
-            found = bool(case)
-        except NoResultFound:
-            pass
-        except MultipleResultsFound:
-            return (None, LookupErrors.MultipleResults)
-
-    if found:
-        return (case, None)
-    else:
-        return (None, LookupErrors.NotFound)
-
-def populate_updated_fields(request, columns, row):
-    field_map = convert_custom_fields_to_struct(request)
-    key_column_index = get_key_column_index(request, columns)
-    value_column_index = get_value_column_index(request, columns)
-    fields_to_update = {}
-
-    for key in field_map:
-        try:
-            if key_column_index and key == row[key_column_index]:
-                update_value = row[value_column_index]
-            else:
-                update_value = row[columns.index(key)]
-        except:
-            continue
-
-        if field_map[key]['custom']:
-            # custom (new) field was entered
-            update_field_name = field_map[key]['custom']
-        else:
-            # existing case field was chosen
-            update_field_name = field_map[key]['case']
-
-        if field_map[key]['date'] == 1:
-            update_value = parse_excel_date(update_value)
-
-        fields_to_update[update_field_name] = update_value
-
-    return fields_to_update
 
 @require_POST
 @require_can_edit_data


### PR DESCRIPTION
Previously case import (from excel file) would only update existing
cases. This commit will allow it to create new cases if one does not
match.

Heavy refactoring was done to the view method to clean up the code and
provide better logging of changes. Originally the xml for the whole case
was submitted to update (which marked all fields as updated) but now we
only submit the changed fields.
