### PR TITLE
Remove email opt in field from mobile user pages

### DIFF
--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -89,9 +89,6 @@ class UserForm(RoleForm):
     first_name = forms.CharField(max_length=50, required=False)
     last_name = forms.CharField(max_length=50, required=False)
     email = forms.EmailField(label=_("E-mail"), max_length=75, required=False)
-    email_opt_in = forms.BooleanField(required=False,
-                                      label="",
-                                      help_text=_("Join the mailing list to receive important announcements."))
     language = forms.ChoiceField(choices=(), initial=None, required=False, help_text=_(
         "Set the default language this user "
         "sees in CloudCare applications and in reports (if applicable). "
@@ -123,7 +120,7 @@ class CommCareAccountForm(forms.Form):
     password = forms.CharField(widget=PasswordInput(), required=True, min_length=1, help_text="Only numbers are allowed in passwords")
     password_2 = forms.CharField(label='Password (reenter)', widget=PasswordInput(), required=True, min_length=1)
     domain = forms.CharField(widget=HiddenInput())
-    
+
     class Meta:
         app_label = 'users'
 
@@ -132,7 +129,7 @@ class CommCareAccountForm(forms.Form):
         if username == 'admin' or username == 'demo_user':
             raise forms.ValidationError("The username %s is reserved for CommCare." % username)
         return username
-    
+
     def clean(self):
         try:
             password = self.cleaned_data['password']
@@ -163,5 +160,4 @@ class CommCareAccountForm(forms.Form):
         return self.cleaned_data
 
 validate_username = EmailValidator(email_re, _(u'Username contains invalid characters.'), 'invalid')
-
 


### PR DESCRIPTION
Not sure how the email opt in field ended up still on the generic user form, but it has been removed again so it will only display for web users.
