### PR TITLE
Enable faking from address for @dimagi.com users

### DIFF
--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -34,6 +34,7 @@ from couchforms.models import XFormInstance
 from soil import heartbeat
 from soil import views as soil_views
 import os
+import re
 
 from django.utils.http import urlencode
 
@@ -302,6 +303,11 @@ def bug_report(req):
         to=settings.BUG_REPORT_RECIPIENTS,
         headers={'Reply-To': reply_to}
     )
+
+    # only fake the from email if it's an @dimagi.com account
+    if re.search('@dimagi\.com$', report['username']):
+        email.from_email = report['username']
+
     email.send(fail_silently=False)
 
     if req.POST.get('five-hundred-report'):


### PR DESCRIPTION
If bug submitter has a dimagi email account fake the from address so they will receive a fogbugz confirmation email.

http://manage.dimagi.com/default.asp?58292
