### PR TITLE
cleanup sms error handling

### DIFF
--- a/corehq/apps/commtrack/tests/test_sms_reporting.py
+++ b/corehq/apps/commtrack/tests/test_sms_reporting.py
@@ -3,7 +3,7 @@ from corehq.apps.commtrack.const import RequisitionStatus
 from corehq.apps.commtrack.models import RequisitionCase
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.commtrack.tests.util import CommTrackTest
-from corehq.apps.commtrack.sms import handle
+from corehq.apps.commtrack.sms import handle, SMSError
 
 
 class StockReportTest(CommTrackTest):
@@ -68,6 +68,21 @@ class StockRequisitionTest(CommTrackTest):
             self.assertEqual(self.user._id, req_case.requested_by)
             self.assertEqual(req_case.location_, self.sp.location_)
             self.assertTrue(req_case._id in reqs)
+
+    def testApprovalBadLocations(self):
+        self.testRequisition()
+
+        try:
+            handle(self.verified_number, 'approve')
+            self.fail("empty locations should fail")
+        except SMSError, e:
+            self.assertEqual('must specify a location code', str(e))
+
+        try:
+            handle(self.verified_number, 'approve notareallocation')
+            self.fail("unknown locations should fail")
+        except SMSError, e:
+            self.assertTrue('invalid location code' in str(e))
 
     def testSimpleApproval(self):
         self.testRequisition()


### PR DESCRIPTION
NOTE: this breaks multiaction submissions of the following format:
 loc keyword x y

these have been deemed to complicated to be useful
- don't fail hard on empty messages
- better error message for no location code on requisition messages
- use SMSError instead of RuntimeError
- add test
