### PR TITLE
remove link to application summary while application summary page is bro...

### DIFF
--- a/corehq/apps/appstore/templates/appstore/project_info.html
+++ b/corehq/apps/appstore/templates/appstore/project_info.html
@@ -223,7 +223,7 @@
                         <dt>{% trans 'Attribution notes' %}</dt>
                         <dd>{{ app.attribution_notes }}</dd>
                     {% endif %}
-                    <dd><a class="btn" style="margin: .4em 0" href="{% url exchange_app_summary project app.id %}">{% trans "Application Summary" %}</a></dd>
+{#                    <dd><a class="btn" style="margin: .4em 0" href="{% url exchange_app_summary project app.id %}">{% trans "Application Summary" %}</a></dd>#}
                 </dl>
             </div>
         {% endfor %}


### PR DESCRIPTION
...ken

Due to some recent app-builder changes, the summary page is always blank. I'm removing the app summary link from a publications page on exchange until I have time to fix the summary page.
