### PR TITLE
Move case importer work to celery

### DIFF
--- a/corehq/apps/importer/tasks.py
+++ b/corehq/apps/importer/tasks.py
@@ -1,0 +1,89 @@
+from celery.task import task
+from xml.etree import ElementTree
+from dimagi.utils.parsing import json_format_datetime
+from corehq.apps.hqcase.utils import submit_case_blocks
+from corehq.apps.importer.const import LookupErrors
+import corehq.apps.importer.util as importer_util
+from corehq.apps.users.models import CouchUser
+from soil import DownloadBase
+from casexml.apps.case.tests.util import CaseBlock
+from casexml.apps.case.xml import V2
+import uuid
+
+@task
+def bulk_import_async(import_id, config, domain, excel_id):
+    task = bulk_import_async
+
+    excel_ref = DownloadBase.get(excel_id)
+
+    spreadsheet = importer_util.get_spreadsheet(excel_ref, config.named_columns)
+
+    if not spreadsheet:
+        return {'error': 'EXPIRED'}
+    if spreadsheet.has_errors:
+        return {'error': 'HAS_ERRORS'}
+
+    row_count = spreadsheet.get_num_rows()
+    columns = spreadsheet.get_header_columns()
+    match_count = created_count = too_many_matches = 0
+
+    for i in range(row_count):
+        DownloadBase.set_progress(task, i, row_count)
+        # skip first row if it is a header field
+        if i == 0 and config.named_columns:
+            continue
+
+        row = spreadsheet.get_row(i)
+        search_id = importer_util.parse_search_id(config, columns, row)
+        case, error = importer_util.lookup_case(config.search_field,
+                                                search_id, domain)
+
+        if case:
+            match_count += 1
+        elif error == LookupErrors.NotFound:
+            if not config.create_new_cases:
+                continue
+            created_count += 1
+        elif error == LookupErrors.MultipleResults:
+            too_many_matches += 1
+            continue
+
+        fields_to_update = importer_util.populate_updated_fields(config,
+                                                                 columns, row)
+
+        user = CouchUser.get_by_user_id(config.couch_user_id, domain)
+        username = user.username
+        user_id = user._id
+
+        if not case:
+            id = uuid.uuid4().hex
+            owner_id = user_id
+
+            caseblock = CaseBlock(
+                create = True,
+                case_id = id,
+                version = V2,
+                user_id = user_id,
+                owner_id = owner_id,
+                case_type = config.case_type,
+                external_id = search_id if config.search_field == 'external_id' else '',
+                update = fields_to_update
+            )
+            submit_case_block(caseblock, domain, username, user_id)
+        elif case and case.type == config.case_type:
+            caseblock = CaseBlock(
+                create = False,
+                case_id = case._id,
+                version = V2,
+                update = fields_to_update
+            )
+            submit_case_block(caseblock, domain, username, user_id)
+
+    return {'created_count': created_count,
+            'match_count': match_count,
+            'too_many_matches': too_many_matches}
+
+def submit_case_block(caseblock, domain, username, user_id):
+    """ Convert a CaseBlock object to xml and submit for creation/update """
+    casexml = ElementTree.tostring(caseblock.as_xml(format_datetime=json_format_datetime))
+    submit_case_blocks(casexml, domain, username, user_id)

--- a/corehq/apps/importer/tasks.py
+++ b/corehq/apps/importer/tasks.py
@@ -29,6 +29,7 @@ def bulk_import_async(import_id, config, domain, excel_id):
     row_count = spreadsheet.get_num_rows()
     columns = spreadsheet.get_header_columns()
     match_count = created_count = too_many_matches = 0
+    prime_offset = 1 # used to prevent back-to-back priming
 
     for i in range(row_count):
         DownloadBase.set_progress(task, i, row_count)
@@ -36,8 +37,11 @@ def bulk_import_async(import_id, config, domain, excel_id):
         if i == 0 and config.named_columns:
             continue
 
-        if i != 0 and i % PRIME_VIEW_FREQUENCY == 0:
+        priming_progress = match_count + created_count + prime_offset
+        if priming_progress % PRIME_VIEW_FREQUENCY == 0:
             prime_pools()
+            # increment so we can't possibly prime on next iteration
+            prime_offset += 1
 
         row = spreadsheet.get_row(i)
         search_id = importer_util.parse_search_id(config, columns, row)

--- a/corehq/apps/importer/templates/importer/excel_commit.html
+++ b/corehq/apps/importer/templates/importer/excel_commit.html
@@ -1,22 +1,35 @@
 {% extends "hqwebapp/two_column.html" %}
 {% load report_tags %}
+{% load i18n %}
 
 {% block head %}
     {{ block.super }}
 {% endblock %}
 
 {% block main_column %}
-    <form class="form-horizontal form-report" action="#" method="post">
+    {% block extrahead %}
+        <script type="text/javascript">
+            var autoRefresh = '';
+            var pollDownloader = function () {
+                if ($('#ready_{{ download_id }}').length == 0)
+                    {
+                        $.get("{% url importer_job_poll domain download_id %}", function(data) {
+                            $("#display_{{ download_id }}").html(data);
+                        });
+                    } else {
+                        clearInterval(autoRefresh);
+                    }
+            };
+            $(document).ready(function () {
+                pollDownloader();
+                autoRefresh = setInterval(pollDownloader, 2000);
+            });
+        </script>
+    {% endblock extrahead %}
 
-    <fieldset>
-        <legend>Success!</legend>
-        <br>
-        Import complete. <strong>{{match_count}}</strong> rows were matched and updated, <strong>{{no_match_count}}</strong>
-        rows did not match any cases.<br>
-        <br>
-        <strong>{{too_many_matches}}</strong> rows matched more than one case at the same time - this means that there
-        are cases in your system with the same external ID.       
-    </fieldset>    
-    
-    </form>
+    <div class="downloader_container" id="display_{{ download_id }}">
+        <legend>
+            {% trans "Importing your data. This may take some time..." %}
+        </legend>
+    </div>
 {% endblock %}

--- a/corehq/apps/importer/templates/importer/partials/import_status.html
+++ b/corehq/apps/importer/templates/importer/partials/import_status.html
@@ -1,0 +1,57 @@
+{% load i18n %}
+{% if is_ready %}
+    <div id="ready_{{ download_id }}">
+        <legend>{% trans "Import complete." %}</legend>
+        <div class="alert alert-success">
+            <p>
+                {% blocktrans with match_count=result.match_count %}
+                    <strong>{{ match_count }}</strong> rows were matched and
+                    updated.
+                {% endblocktrans %}
+            </p>
+            {% ifnotequal result.created_count 0 %}
+                <p>
+                    {% blocktrans with created_count=result.created_count %}
+                        <strong>{{ created_count }}</strong> rows did
+                        not match any existing cases and had new cases created
+                        for them.
+                    {% endblocktrans %}
+                </p>
+            {% endifnotequal %}
+            <p>
+                {% blocktrans with too_many_matches=result.too_many_matches %}
+                    <strong>{{ too_many_matches }}</strong> rows matched more
+                    than one case at the same time - this means that there are cases
+                    in your system with the same external ID.
+                {% endblocktrans %}
+            </p>
+        </div>
+        <script type="text/javascript">
+            $("#export-download-status .loading-indicator").addClass('hide');
+        </script>
+    </div>
+{% else %}
+    <legend>
+        {% trans "Importing your data. This may take some time..." %}
+    </legend>
+    {% if not is_alive %}
+        <p class="alert alert-error">
+        {% blocktrans %}
+            Task processor not detected.
+            There may be something wrong with your system.
+            If the download takes longer than normal to complete
+            please contact support for help.
+        {% endblocktrans %}
+        </p>
+    {% endif %}
+    {% if progress.percent %}
+        <div class="progress progress-striped active">
+            <div class="bar" style="width: {{ progress.percent }}%;"></div>
+        </div>
+    {% endif %}
+    {% if progress.total %}
+        <p class="help-inline">
+            {% trans "Imported" %} {{ progress.percent }}%
+        </p>
+    {% endif %}
+{% endif %}

--- a/corehq/apps/importer/urls.py
+++ b/corehq/apps/importer/urls.py
@@ -4,6 +4,6 @@ urlpatterns = patterns('corehq.apps.importer.views',
     url(r'^excel/config/$', 'excel_config', name='excel_config'),
     url(r'^excel/fields/$', 'excel_fields', name='excel_fields'),
     url(r'^excel/commit/$', 'excel_commit', name='excel_commit'),
-    url(r'^importer_ajax/(?P<download_id>[0-9a-fA-Z]{25,32})$',
+    url(r'^importer_ajax/(?P<download_id>[0-9a-fA-Z]{25,32})/$',
         'importer_job_poll', name='importer_job_poll'),
 )

--- a/corehq/apps/importer/urls.py
+++ b/corehq/apps/importer/urls.py
@@ -4,5 +4,6 @@ urlpatterns = patterns('corehq.apps.importer.views',
     url(r'^excel/config/$', 'excel_config', name='excel_config'),
     url(r'^excel/fields/$', 'excel_fields', name='excel_fields'),
     url(r'^excel/commit/$', 'excel_commit', name='excel_commit'),
+    url(r'^importer_ajax/(?P<download_id>[0-9a-fA-Z]{25,32})$',
+        'importer_job_poll', name='importer_job_poll'),
 )
-

--- a/corehq/apps/importer/views.py
+++ b/corehq/apps/importer/views.py
@@ -25,7 +25,6 @@ from django.utils.translation import ugettext as _
 require_can_edit_data = require_permission(Permissions.edit_data)
 
 EXCEL_SESSION_ID = "excel_id"
-MAX_ALLOWED_ROWS = 500
 
 def render_error(request, domain, message):
     """ Load error message and reload page for excel file load errors """
@@ -66,10 +65,6 @@ def excel_config(request, domain):
     columns = spreadsheet.get_header_columns()
     row_count = spreadsheet.get_num_rows()
 
-    if row_count > MAX_ALLOWED_ROWS:
-        return render_error(request, domain,
-                            'Sorry, your spreadsheet is too big. Please reduce the '
-                            'number of rows to less than %s and try again.' % MAX_ALLOWED_ROWS)
     if row_count == 0:
         return render_error(request, domain,
                             'Your spreadsheet is empty. '

--- a/services/templates/supervisor_celery.conf
+++ b/services/templates/supervisor_celery.conf
@@ -1,5 +1,5 @@
 [program:%(project)s-%(environment)s-celeryd]
-command=%(virtualenv_root)s/bin/python %(code_root)s/manage.py celeryd --events --verbosity 2 --loglevel=INFO
+command=%(virtualenv_root)s/bin/python %(code_root)s/manage.py celeryd --events --verbosity 2 --loglevel=INFO -P gevent
 directory=%(code_root)s
 user=%(sudo_user)s
 numprocs=1


### PR DESCRIPTION
Make use of Soil to offload the importing of cases to a backround task
and be able to provide the user with a progress bar while the work is
happening.
