### PR TITLE
initial version of generic graph report template

### DIFF
--- a/corehq/apps/reports/graph_models.py
+++ b/corehq/apps/reports/graph_models.py
@@ -1,0 +1,56 @@
+class Axis(object):
+    def __init__(self, label=None, format=None):
+        self.label = label
+        self.format = format
+
+
+class Chart(object):
+    template_partial = ''
+
+
+class MultiBarChart(Chart):
+    template_partial = 'reports/partials/graphs/multibar_chart.html'
+
+    def __init__(self, x_axis, y_axis):
+        self.x_axis = x_axis
+        self.y_axis = y_axis
+        self.data = []
+        self.margin = {'top': 30, 'right': 20, 'bottom': 50, 'left': 80}
+        self.showControls = True
+        self.showLegend = True
+        self.reduceXTicks = True
+        self.rotateLabels = 0
+        self.tooltips = True
+        self.stacked = False
+
+    def add_dataset(self, key, values, color=None):
+        d = dict(key=key, values=values)
+        if color:
+            d['color'] = color
+        self.data.append(d)
+
+    def config_dict(self):
+        return dict(margin=self.margin,
+                    showControls=self.showControls,
+                    showLegend=self.showLegend,
+                    reduceXTicks=self.reduceXTicks,
+                    rotateLabels=self.rotateLabels,
+                    tooltips=self.tooltips,
+                    stacked=self.stacked)
+
+
+class PieChart(Chart):
+    template_partial = 'reports/partials/graphs/pie_chart.html'
+
+    def __init__(self, data):
+        self.data = data
+        self.margin = {'top': 30, 'right': 20, 'bottom': 50, 'left': 80}
+        self.showLabels = True
+        self.donut = False
+        self.tooltips = True
+
+    def config_dict(self):
+        return dict(margin=self.margin,
+                    showLabels=self.showLabels,
+                    tooltips=self.tooltips,
+                    donut=self.donut)

--- a/corehq/apps/reports/templates/reports/async/tabular_graph_generic.html
+++ b/corehq/apps/reports/templates/reports/async/tabular_graph_generic.html
@@ -1,0 +1,28 @@
+{% extends "reports/async/tabular.html" %}
+{% load hq_shared_tags %}
+{% load hqstyle_tags %}
+{% load i18n %}
+
+{% block pretable %}
+    {% for chart in charts %}
+    <div id='chart_{{ forloop.counter }}' class="hide">
+        <svg style='height:320px'> </svg>
+    </div>
+    {% endfor %}
+{% endblock %}
+
+{% block js %}{{ block.super }}
+{#    {% if has_chart %}#}
+    <link href="{% static 'hqwebapp/js/lib/nvd3/nv.d3.css' %}" rel="stylesheet">
+    <script src="{% static 'hqwebapp/js/lib/nvd3/lib/d3.v2.js' %}"></script>
+    <script src="{% static 'hqwebapp/js/lib/nvd3/nv.d3.js' %}"></script>
+{#    {% endif %}#}
+{% endblock %}
+
+{% block js-inline %}{{ block.super }}
+    {% for chart in charts %}
+        {% with id=forloop.counter|stringformat:"s" %}
+            {% include chart.template_partial with chart=chart chart_id='chart_'|add:id %}
+        {% endwith %}
+    {% endfor %}
+{% endblock %}

--- a/corehq/apps/reports/templates/reports/partials/graphs/multibar_chart.html
+++ b/corehq/apps/reports/templates/reports/partials/graphs/multibar_chart.html
@@ -1,0 +1,38 @@
+{% load hq_shared_tags %}
+<script type="text/javascript">
+    nv.addGraph(function() {
+        var chart_config = {{ chart.config_dict|JSON }};
+        var chart_data = {{ chart.data|JSON }}
+        var chart_id = '#{{ chart_id }}';
+
+        $(chart_id).show();
+
+        var chart = nv.models.multiBarChart();
+
+        chart.xAxis.axisLabel({{ chart.x_axis.label|JSON }});
+        {% if chart.x_axis.format %}
+            chart.xAxis.tickFormat({{ chart.x_axis.format|JSON }});
+        {% endif %}
+
+        chart.yAxis.axisLabel({{ chart.y_axis.label|JSON }});
+        {% if chart.y_axis.format %}
+            chart.yAxis.tickFormat({{ chart.y_axis.format|JSON }});
+        {% endif %}
+
+        chart.showControls(chart_config.showControls);
+        chart.showLegend(chart_config.showLegend);
+        chart.reduceXTicks(chart_config.reduceXTicks);
+        chart.rotateLabels(chart_config.rotateLabels);
+        chart.tooltips(chart_config.tooltips);
+        chart.stacked(chart_config.stacked);
+        chart.margin(chart_config.margin);
+
+        d3.select(chart_id + ' svg')
+                .datum(chart_data)
+                .transition().duration(500).call(chart);
+
+        nv.utils.windowResize(chart.update);
+
+        return chart;
+    });
+</script>

--- a/corehq/apps/reports/templates/reports/partials/graphs/pie_chart.html
+++ b/corehq/apps/reports/templates/reports/partials/graphs/pie_chart.html
@@ -1,0 +1,27 @@
+{% load hq_shared_tags %}
+<script type="text/javascript">
+    nv.addGraph(function() {
+        var chart_config = {{ chart.config_dict|JSON }};
+        var chart_data = {{ chart.data|JSON }}
+        var chart_id = '#{{ chart_id }}';
+
+        $(chart_id).show();
+
+        var chart = nv.models.pieChart()
+          .x(function(d) { return d.label })
+          .y(function(d) { return d.value });
+
+        chart.showLabels(chart_config.showLabels);
+        chart.donut(chart_config.donut);
+        chart.tooltips(chart_config.tooltips);
+        chart.margin(chart_config.margin);
+
+        d3.select(chart_id + ' svg')
+                .datum(chart_data)
+                .transition().duration(500).call(chart);
+
+        nv.utils.windowResize(chart.update);
+
+        return chart;
+    });
+</script>


### PR DESCRIPTION
Example report:

``` python
class GraphDemoReport(GenericTabularReport, CustomProjectReport, ProjectReportParametersMixin):
    name = 'Graph demo'
    slug = 'graph_demo'

    report_template_path = 'reports/async/tabular_graph_generic.html'

    extra_context_providers = [charts]

    @property
    def headers(self):
        return DataTablesHeader(DataTablesColumn("a"),
                                DataTablesColumn("b"),
                                DataTablesColumn("c"))

    @property
    def rows(self):
        return [[1, 2, 3]]

    def charts(self):
        x = Axis('x-label')
        y = Axis('y-label')
        c1 = MultiBarChart(x_axis=x, y_axis=y)
        c1.stacked = True
        c1.add_dataset('scheme a', [{'x': x, 'y': x} for x in range(0, 100)])
        c1.add_dataset('scheme b', [{'x': 100-x, 'y': x} for x in range(0, 100)])

        c2 = PieChart([{'key': "Cumulative Return", 'values': [
            {"label": "One", "value": 29},
            {"label": "Two", "value": 50},
            {"label": "Three", "value": 32}
        ]}])

        return [c1, c2]
```
