### PR TITLE
Try out CFLAGS=-O0 for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
  - "2.6"
+env:
+ - CFLAGS=-O0
 install:
  - "time bash -e .travis/quietly-run-install.sh"
  - "time python .travis/download-requirements-in-parallel.py requirements/requirements.txt requirements/dev-requirements.txt"


### PR DESCRIPTION
Build passed in ~30 min, which is a big longer than the high 20s that I'm seeing in recent history. This implies that we use these libraries enough that optimizing them is worthwhile? Very dubious.

I thought that last week it was more like 40 minutes, and just barely scraping by under 50?

Anyhow, submitting this PR and closing immediately... for posterity?
