### PR TITLE
Superuser invite

### DIFF
--- a/corehq/apps/hqwebapp/utils.py
+++ b/corehq/apps/hqwebapp/utils.py
@@ -77,7 +77,7 @@ class InvitationView():
 
         if request.user.is_authenticated():
             is_invited_user = request.couch_user.username == invitation.email
-            if self.is_invited(invitation, request.couch_user):
+            if self.is_invited(invitation, request.couch_user) and not request.couch_user.is_superuser:
                 if is_invited_user:
                     # if this invite was actually for this user, just mark it accepted
                     messages.info(request, _("You are already a member of {entity}.").format(


### PR DESCRIPTION
Fixes following fogbugz case http://manage.dimagi.com/default.asp?61877#351001 

Previously: Superuser can't be invited to join a new domain. Superuser gets "you are already a member of domain" message after accepting an invite for new domain.

With fix: Superuser can join any new domain with an invitation. 

At last, wrote a line of Python code, or half a line :)
