### PR TITLE
Adds "received_on" header in POST request for form forwarding.

### DIFF
--- a/corehq/apps/receiverwrapper/models.py
+++ b/corehq/apps/receiverwrapper/models.py
@@ -215,8 +215,6 @@ class RepeatRecord(Document, LockableMixIn):
         if self.repeater_type == "FormRepeater":
             form = XFormInstance.get(self.repeat_record.payload_id)
             headers = {
-                "content-type": "text/xml",
-                "content-length": len(payload),
                 "received-on": form.received_on.isoformat()+"Z",
             }
             post_fn = post_fn or simple_post_with_cached_timeout(headers=headers)

--- a/corehq/apps/receiverwrapper/models.py
+++ b/corehq/apps/receiverwrapper/models.py
@@ -213,7 +213,7 @@ class RepeatRecord(Document, LockableMixIn):
         payload = self.get_payload()
         post_fn = post_fn or simple_post_with_cached_timeout
         if self.repeater_type == "FormRepeater":
-            form = XFormInstance.get(self.repeat_record.payload_id)
+            form = XFormInstance.get(self.payload_id)
             headers = {
                 "received-on": form.received_on.isoformat()+"Z",
             }

--- a/corehq/apps/receiverwrapper/models.py
+++ b/corehq/apps/receiverwrapper/models.py
@@ -217,13 +217,13 @@ class RepeatRecord(Document, LockableMixIn):
             headers = {
                 "received-on": form.received_on.isoformat()+"Z",
             }
-            post_fn = post_fn or simple_post_with_cached_timeout(headers=headers)
+            post_fn = post_fn or simple_post_with_cached_timeout
         if self.try_now():
             # we don't use celery's version of retry because
             # we want to override the success/fail each try
             for i in range(max_tries):
                 try:
-                    resp = post_fn(payload, self.url)
+                    resp = post_fn(payload, self.url,headers=headers)
                     if 200 <= resp.status < 300:
                         self.update_success()
                         break

--- a/corehq/apps/receiverwrapper/models.py
+++ b/corehq/apps/receiverwrapper/models.py
@@ -217,7 +217,7 @@ class RepeatRecord(Document, LockableMixIn):
             headers = {
                 "content-type": "text/xml",
                 "content-length": len(payload),
-                "received-on": str(form.received_on.isoformat())+"Z",
+                "received-on": form.received_on.isoformat()+"Z",
             }
             post_fn = post_fn or simple_post_with_cached_timeout(headers=headers)
         if self.try_now():

--- a/corehq/apps/receiverwrapper/models.py
+++ b/corehq/apps/receiverwrapper/models.py
@@ -217,7 +217,7 @@ class RepeatRecord(Document, LockableMixIn):
             headers = {
                 "content-type": "text/xml",
                 "content-length": len(payload),
-                "received-on": form.received_on,
+                "received-on": str(form.received_on.isoformat())+"Z",
             }
             post_fn = post_fn or simple_post_with_cached_timeout(headers=headers)
         if self.try_now():

--- a/corehq/apps/receiverwrapper/models.py
+++ b/corehq/apps/receiverwrapper/models.py
@@ -217,7 +217,7 @@ class RepeatRecord(Document, LockableMixIn):
             headers = {
                 "content-type": "text/xml",
                 "content-length": len(payload),
-                "received_on": form.received_on,
+                "received-on": form.received_on,
             }
             post_fn = post_fn or simple_post_with_cached_timeout(headers=headers)
         if self.try_now():


### PR DESCRIPTION
Fixes following case http://manage.dimagi.com/default.asp?62551#353472, "Add "received_on" header to the form forwarding API". 
- Modified simple_post() in submodules/dimagi-utils-src/utils/post.py to accept an optional headers parameter. Added a separate commit (https://github.com/dimagi/dimagi-utils/pull/101)
- Added received_on header for form forwarding. 
  
  I have setup a simpleHttpServer to test the modification in POST request of form-forwarding. But I haven't been able to test, as form submission on localhost was not working. Code modification is trivial in any case. I hope somebody can test this. Following is the reason I am not able to test on local.
- After running jython xformserver and running multithreaded django server, form submission still gave 500 error, while xformserver received the form submission data. I have also added Touchforms user credentials as given in the README
