### PR TITLE
Adds 'upload fixtures through API' functionality

### DIFF
--- a/corehq/apps/fixtures/templates/fixtures/view.html
+++ b/corehq/apps/fixtures/templates/fixtures/view.html
@@ -38,6 +38,9 @@
 {% endblock %}
 
 {% block content %}
+    <div class="span2">&nbsp;</div>
+     {% trans "To edit following items lists " %}
+    <a href="{% url download_fixtures domain %}">{% trans "download all fixtures in excel format" %}</a> and reupload
     <div class="row-fluid hidden" style="margin-top: 25px;" id="fixtures-ui">
         <div class="span2">&nbsp;</div>
         <div class="span9">

--- a/corehq/apps/fixtures/urls.py
+++ b/corehq/apps/fixtures/urls.py
@@ -11,4 +11,5 @@ urlpatterns = patterns('corehq.apps.fixtures.views',
     url(r'^users/$', 'users'),
     url(r'^item-lists/upload/$', UploadItemLists.as_view(), name='upload_item_lists'),
     url(r'^fixapi/', 'upload_fixture_api'),
+    url(r'^item-lists/download/$', 'download_item_lists', name="download_fixtures"),
 )

--- a/corehq/apps/fixtures/urls.py
+++ b/corehq/apps/fixtures/urls.py
@@ -10,4 +10,5 @@ urlpatterns = patterns('corehq.apps.fixtures.views',
     url(r'^groups/$', 'groups'),
     url(r'^users/$', 'users'),
     url(r'^item-lists/upload/$', UploadItemLists.as_view(), name='upload_item_lists'),
+    url(r'^fixapi/', 'upload_fixture_api'),
 )

--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -1,4 +1,6 @@
 import json
+import os
+import tempfile
 from couchdbkit import ResourceNotFound
 
 from django.contrib import messages
@@ -10,12 +12,15 @@ from django.views.generic.base import TemplateView
 from django.shortcuts import render
 
 from corehq.apps.domain.decorators import login_or_digest
-from corehq.apps.fixtures.models import FixtureDataType, FixtureDataItem
+from corehq.apps.fixtures.models import FixtureDataType, FixtureDataItem, _id_from_doc
 from corehq.apps.groups.models import Group
 from corehq.apps.users.bulkupload import GroupMemoizer
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import CommCareUser, Permissions
 from corehq.apps.users.util import normalize_username
+from couchexport.export import UnsupportedExportFormat, export_raw
+from couchexport.models import Format
+from couchexport.shortcuts import export_response
 from dimagi.utils.couch.bulk import CouchTransaction
 from dimagi.utils.excel import WorkbookJSONReader, WorksheetNotFound
 from dimagi.utils.logging import notify_exception
@@ -202,6 +207,49 @@ def view(request, domain, template='fixtures/view.html'):
     return render(request, template, {
         'domain': domain
     })
+@require_can_edit_fixtures
+def download_item_lists(request, domain):
+    data_types = FixtureDataType.by_domain(domain)
+    data_type_schemas = []
+    max_fields = 0
+    data_tables = []
+
+    for data_type in data_types:
+        type_schema = [data_type.name, data_type.tag]
+        fields = [field for field in data_type.fields]
+        type_id = data_type.get_id
+        data_table_of_type = []
+        for item_row in FixtureDataItem.by_data_type(domain, type_id):
+            group_1 = ",".join([group.name for group in item_row.get_groups()])
+            user_1 = ",".join([user.raw_username for user in item_row.get_users()])
+            data_row = tuple([str(_id_from_doc(item_row))]+
+                             [item_row.fields[field] for field in fields]+
+                             [group_1.strip(","),user_1.strip(","),"N"])
+            data_table_of_type.append(data_row)
+        type_schema.extend(fields)
+        data_type_schemas.append(tuple(type_schema))
+        if max_fields<len(type_schema):
+            max_fields = len(type_schema)
+        data_tables.append((data_type.tag,tuple(data_table_of_type)))
+
+    type_headers = ["name", "tag"] + ["field %d" % x for x in range(1,max_fields-1)]
+    type_headers = ("types", tuple(type_headers))
+    table_headers = [type_headers]    
+    for type_schema in data_type_schemas:
+        item_header = (type_schema[1], tuple(["field: UID"]+
+                                             ["field: "+x for x in type_schema[2:]]+
+                                             ["group 1", "user 1","Delete(Y/N)"]))
+        table_headers.append(item_header)
+
+    table_headers = tuple(table_headers)
+    type_rows = ("types", tuple(data_type_schemas))
+    data_tables = tuple([type_rows]+data_tables)
+    
+    fd, path = tempfile.mkstemp()
+    with os.fdopen(fd, 'w') as temp:
+        export_raw((table_headers), (data_tables), temp)
+    format = Format.XLS_2007
+    return export_response(open(path), format, "%s_fixtures" % domain)
 
 
 class UploadItemLists(TemplateView):


### PR DESCRIPTION
Adds following functionality http://manage.dimagi.com/default.asp?61884#357275. Implements a view to upload fixtures.

I haven't yet added proper URL structure that agree with current API. I am looking forward to change this after discussing with you. Currently following is the URL structure to upload fixtures.

> curl -F "file-to-upload=@sample_fixture.xlsx" -v --digest -u sreddy@dimagi.com:password http://127.0.0.1:8000/a/{domain}/fixtures/fixapi/ 

It responds with a json output of the format {"code": (depending on success/failure/warning), "message": (helpful message to debug)}
Currently the codes are randomly chosen just to exemplify the implementation.

Also merged another [feature to download & re-upload fixture data as excel](https://github.com/dimagi/commcare-hq/pull/454)
