### PR TITLE
Fix bug with cloudcare button on forms with no questions

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/form_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view.html
@@ -180,12 +180,13 @@
                     {% endif %}
                 });
                 casexml.init();
-
-                // tag the 'preview in cloudcare' button with the right url
-                // unfortunately, has to be done in javascript
-                var cloudCareUrl = getCloudCareUrl("{% url cloudcare_main domain '' %}", "{{ app.id }}", "{{ module.id }}", "{{ nav_form.id }}") + "?preview=true";
-                $("#cloudcare-preview-url").attr("href", cloudCareUrl);
             }
+
+            // tag the 'preview in cloudcare' button with the right url
+            // unfortunately, has to be done in javascript
+            var cloudCareUrl = getCloudCareUrl("{% url cloudcare_main domain '' %}", "{{ app.id }}", "{{ module.id }}", "{{ nav_form.id }}") + "?preview=true";
+            $("#cloudcare-preview-url").attr("href", cloudCareUrl);
+
             {% if app.application_version != '1.0' %}
                 var allFormsRequireACase = {{ module.all_forms_require_a_case|BOOL }};
                 var putInRoot = {{ module.put_in_root|BOOL }};


### PR DESCRIPTION
Fixes http://manage.dimagi.com/default.asp?63291

Edited title to be more accurate of what was changed since my original commit was pretty off topic.

Basically just always sets the url for the 'try in cloudcare' button so that forms with just labels and/or empty repeat questions will still be able to use this link.
