### PR TITLE
fix a test by making CommCareUserResource disallow stale couch results

### DIFF
--- a/corehq/apps/api/resources/v0_1.py
+++ b/corehq/apps/api/resources/v0_1.py
@@ -126,7 +126,7 @@ class CommCareUserResource(UserResource):
                 raise BadRequest('Project %s has no group with id=%s' % (domain, group_id))
             return list(group.get_users(only_commcare=True))
         else:
-            return list(CommCareUser.by_domain(domain))
+            return list(CommCareUser.by_domain(domain, strict=True))
 
 
 class WebUserResource(UserResource):

--- a/corehq/apps/api/tests.py
+++ b/corehq/apps/api/tests.py
@@ -200,7 +200,6 @@ class TestCommCareUserResource(APIResourceTest):
         self.client.login(username=self.username, password=self.password)
 
         commcare_user = CommCareUser.create(domain=self.domain.name, username='fake_user', password='*****')
-
         backend_id = commcare_user.get_id
 
         response = self.client.get(self.list_endpoint)

--- a/corehq/apps/api/tests.py
+++ b/corehq/apps/api/tests.py
@@ -200,6 +200,7 @@ class TestCommCareUserResource(APIResourceTest):
         self.client.login(username=self.username, password=self.password)
 
         commcare_user = CommCareUser.create(domain=self.domain.name, username='fake_user', password='*****')
+
         backend_id = commcare_user.get_id
 
         response = self.client.get(self.list_endpoint)

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -787,7 +787,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn):
         return CouchUser.view("users/by_username", include_docs=True)
 
     @classmethod
-    def by_domain(cls, domain, is_active=True, reduce=False, limit=None, skip=0):
+    def by_domain(cls, domain, is_active=True, reduce=False, limit=None, skip=0, strict=False):
         flag = "active" if is_active else "inactive"
         if cls.__name__ == "CouchUser":
             key = [flag, domain]
@@ -806,7 +806,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn):
             reduce=reduce,
             startkey=key,
             endkey=key + [{}],
-            stale=settings.COUCH_STALE_QUERY,
+            stale=None if strict else settings.COUCH_STALE_QUERY,
             **extra_args
         ).all()
 


### PR DESCRIPTION
Failure looked like:

```
FAIL: test_get_list (corehq.apps.api.tests.TestCommCareUserResource)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/droberts/dimagi/commcare-hq/corehq/apps/api/tests.py", line 209, in test_get_list
    self.assertEqual(len(api_users), 1)
AssertionError: 0 != 1
```
