### PR TITLE
Download fixture data as excel file

### DIFF
--- a/corehq/apps/fixtures/templates/fixtures/view.html
+++ b/corehq/apps/fixtures/templates/fixtures/view.html
@@ -38,6 +38,8 @@
 {% endblock %}
 
 {% block content %}
+    <div class="span2">&nbsp;</div>
+    <a href="{% url download_fixtures domain %}">Download all fixtures in excel format</a>
     <div class="row-fluid hidden" style="margin-top: 25px;" id="fixtures-ui">
         <div class="span2">&nbsp;</div>
         <div class="span9">

--- a/corehq/apps/fixtures/templates/fixtures/view.html
+++ b/corehq/apps/fixtures/templates/fixtures/view.html
@@ -39,7 +39,7 @@
 
 {% block content %}
     <div class="span2">&nbsp;</div>
-    <a href="{% url download_fixtures domain %}">Download all fixtures in excel format</a>
+    <a href="{% url download_fixtures domain %}">{% trans "Download all fixtures in excel format" %}</a>
     <div class="row-fluid hidden" style="margin-top: 25px;" id="fixtures-ui">
         <div class="span2">&nbsp;</div>
         <div class="span9">

--- a/corehq/apps/fixtures/urls.py
+++ b/corehq/apps/fixtures/urls.py
@@ -10,4 +10,5 @@ urlpatterns = patterns('corehq.apps.fixtures.views',
     url(r'^groups/$', 'groups'),
     url(r'^users/$', 'users'),
     url(r'^item-lists/upload/$', UploadItemLists.as_view(), name='upload_item_lists'),
+    url(r'^item-lists/download/$', 'download_item_lists', name="download_fixtures"),
 )

--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -221,9 +221,9 @@ def download_item_lists(request, domain):
         for item_row in FixtureDataItem.by_data_type(domain, type_id):
             group_1 = ",".join([group.name for group in item_row.get_groups()])
             user_1 = ",".join([user.raw_username for user in item_row.get_users()])
-            data_row = tuple([str(_id_from_doc(item_row))]
-                            +[item_row.fields[field] for field in fields]
-                            +[group_1.strip(","),user_1.strip(","),"N"])
+            data_row = tuple([str(_id_from_doc(item_row))]+
+                             [item_row.fields[field] for field in fields]+
+                             [group_1.strip(","),user_1.strip(","),"N"])
             data_table_of_type.append(data_row)
         type_schema.extend(fields)
         data_type_schemas.append(tuple(type_schema))
@@ -235,9 +235,9 @@ def download_item_lists(request, domain):
     type_headers = ("types", tuple(type_headers))
     table_headers = [type_headers]    
     for type_schema in data_type_schemas:
-        item_header = (type_schema[1], tuple(["field: UID"]
-                                            +["field: "+x for x in type_schema[2:]]
-                                            +["group 1", "user 1","Delete(Y/N)"]))
+        item_header = (type_schema[1], tuple(["field: UID"]+
+                                             ["field: "+x for x in type_schema[2:]]+
+                                             ["group 1", "user 1","Delete(Y/N)"]))
         table_headers.append(item_header)
 
     table_headers = tuple(table_headers)

--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -10,7 +10,7 @@ from django.utils.decorators import method_decorator
 from django.views.generic.base import TemplateView
 from django.shortcuts import render
 
-from corehq.apps.fixtures.models import FixtureDataType, FixtureDataItem
+from corehq.apps.fixtures.models import FixtureDataType, FixtureDataItem, _id_from_doc
 from corehq.apps.groups.models import Group
 from corehq.apps.users.bulkupload import GroupMemoizer
 from corehq.apps.users.decorators import require_permission
@@ -209,48 +209,44 @@ def view(request, domain, template='fixtures/view.html'):
 @require_can_edit_fixtures
 def download_item_lists(request, domain):
     data_types = FixtureDataType.by_domain(domain)
-    data_type_rows = []
-    tables = [] 
-    """ 
-    [(("header_name","schema"),("header_name","rows"))]
-    [(("Districts", (x,y,z)),
-      ("Districts", ((v1,v2),
-        ))))]
+    data_type_schemas = []
+    max_fields = 0
+    data_tables = []
 
-
-    """
-    out = ""
-    max_columns = 0
-    tables_data = []
     for data_type in data_types:
-        row = [data_type.name, data_type.tag]
+        type_schema = [data_type.name, data_type.tag]
         fields = [field for field in data_type.fields]
-        row.extend(fields)
-        data_type_rows.append(tuple(row))
-        if max_columns<len(row):
-            max_columns = len(row)
         type_id = data_type.get_id
-        table_data = []
+        data_table_of_type = []
         for item_row in FixtureDataItem.by_data_type(domain, type_id):
-            data_row = tuple([item_row.fields[field] for field in fields])
-            table_data.append(data_row)
-        tables_data.append((data_type.tag,tuple(table_data)))
+            group_1 = ",".join([group.name for group in item_row.get_groups()])
+            user_1 = ",".join([user.raw_username for user in item_row.get_users()])
+            data_row = tuple([str(_id_from_doc(item_row))]
+                            +[item_row.fields[field] for field in fields]
+                            +[group_1.strip(","),user_1.strip(","),"N"])
+            data_table_of_type.append(data_row)
+        type_schema.extend(fields)
+        data_type_schemas.append(tuple(type_schema))
+        if max_fields<len(type_schema):
+            max_fields = len(type_schema)
+        data_tables.append((data_type.tag,tuple(data_table_of_type)))
 
-    data_type_headers = ["name", "tag"] + ["field %d" % x for x in range(1,max_columns-1)]
-
-    type_headers = ("types", tuple(data_type_headers))
-    type_rows = ("types", tuple(data_type_rows))
-    table_headers = [type_headers]
-    for item_row in data_type_rows:
-        item_header = (item_row[1], tuple(["field: "+x for x in item_row[2:]]))
+    type_headers = ["name", "tag"] + ["field %d" % x for x in range(1,max_fields-1)]
+    type_headers = ("types", tuple(type_headers))
+    table_headers = [type_headers]    
+    for type_schema in data_type_schemas:
+        item_header = (type_schema[1], tuple(["field: UID"]
+                                            +["field: "+x for x in type_schema[2:]]
+                                            +["group 1", "user 1","Delete(Y/N)"]))
         table_headers.append(item_header)
+
     table_headers = tuple(table_headers)
-    tables_data = tuple([type_rows]+tables_data)
+    type_rows = ("types", tuple(data_type_schemas))
+    data_tables = tuple([type_rows]+data_tables)
     
-    #return HttpResponse(str(tables_data)+"<br/>"+str(tuple(table_headers)))
     fd, path = tempfile.mkstemp()
     with os.fdopen(fd, 'w') as temp:
-        export_raw((table_headers), (tables_data), temp)
+        export_raw((table_headers), (data_tables), temp)
     format = Format.XLS_2007
     return export_response(open(path), format, "%s_fixtures" % domain)
 
@@ -321,19 +317,23 @@ class UploadItemLists(TemplateView):
                         sort_key=sort_key
                     )
                     transaction.save(data_item)
-                    for group_name in di.get('group', []):
-                        group = group_memoizer.by_name(group_name)
-                        if group:
-                            data_item.add_group(group, transaction=transaction)
-                        else:
-                            messages.error(request, "Unknown group: %s" % group_name)
-                    for raw_username in di.get('user', []):
-                        username = normalize_username(raw_username, self.domain)
-                        user = CommCareUser.get_by_username(username)
-                        if user:
-                            data_item.add_user(user)
-                        else:
-                            messages.error(request, "Unknown user: %s" % raw_username)
+                    for group_names in di.get('group', []):
+                        for group_name in group_names.split(","):
+                            group_name = group_name.strip()
+                            group = group_memoizer.by_name(group_name)
+                            if group:
+                                data_item.add_group(group, transaction=transaction)
+                            else:
+                                messages.error(request, "Unknown group: %s" % group_name)
+                    for raw_usernames in di.get('user', []):
+                        for raw_username in raw_usernames.split(","):
+                            raw_username = raw_username.strip()
+                            username = normalize_username(raw_username, self.domain)
+                            user = CommCareUser.get_by_username(username)
+                            if user:
+                                data_item.add_user(user)
+                            else:
+                                messages.error(request, "Unknown user: %s" % raw_username)
             for data_type in transaction.preview_save(cls=FixtureDataType):
                 for duplicate in FixtureDataType.by_domain_tag(domain=self.domain, tag=data_type.tag):
                     duplicate.recursive_delete(transaction)


### PR DESCRIPTION
[Fogbugz: Download, edit and re-upload fixture data.](http://manage.dimagi.com/default.asp?63330)
- Adds the ability to download all fixture data as an excel-sheet.
- Adds ability to add multiple comma-separated user and group list while uploading through excel-sheet.
  - Currently multiple users or groups can be added by having extra column for each user/group. There can be any extra number of columns needed. Now a single column with comma-separated user/group list can be uploaded.
- Added extra fields (UID, Delete(Y/N)) in excel-sheet for deleting and modifying items.

TO-DO: 
- Currently, only download is supported.  Modifying data using re-uploaded edited excel file is not yet supported. Re-upload of the file deletes and creates entire fixtures, similar to current behavior. 
- Needs UI tweaks and help-text on how to use excel edit-upload feature

[A sample excel-sheet that is downloaded this way, which can be uploaded back](https://docs.google.com/a/dimagi.com/spreadsheet/ccc?key=0Amg6qlUhNSXndFQ4WGtxZnZJQVFvbm92TWxTQ1ozSUE&hl=en#gid=1)
