### PR TITLE
Make owner_id select a little less brittle

### DIFF
--- a/corehq/apps/reports/standard/inspect.py
+++ b/corehq/apps/reports/standard/inspect.py
@@ -213,7 +213,12 @@ class CaseDisplay(object):
 
     @property
     def owner_id(self):
-        return self.case['owner_id'] if self.case['owner_id'] else self.case['user_id']
+        if 'owner_id' in self.case:
+            return self.case['owner_id']
+        elif 'user_id' in self.case:
+            return self.case['user_id']
+        else:
+            return ''
 
     @property
     @memoized


### PR DESCRIPTION
Don't crash if a case has no owner_id and/or user_id set

Fixes http://manage.dimagi.com/default.asp?62676
