### PR TITLE
Fix try in cloudcare button

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/form_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view.html
@@ -180,12 +180,13 @@
                     {% endif %}
                 });
                 casexml.init();
-
-                // tag the 'preview in cloudcare' button with the right url
-                // unfortunately, has to be done in javascript
-                var cloudCareUrl = getCloudCareUrl("{% url cloudcare_main domain '' %}", "{{ app.id }}", "{{ module.id }}", "{{ nav_form.id }}") + "?preview=true";
-                $("#cloudcare-preview-url").attr("href", cloudCareUrl);
             }
+
+            // tag the 'preview in cloudcare' button with the right url
+            // unfortunately, has to be done in javascript
+            var cloudCareUrl = getCloudCareUrl("{% url cloudcare_main domain '' %}", "{{ app.id }}", "{{ module.id }}", "{{ nav_form.id }}") + "?preview=true";
+            $("#cloudcare-preview-url").attr("href", cloudCareUrl);
+
             {% if app.application_version != '1.0' %}
                 var allFormsRequireACase = {{ module.all_forms_require_a_case|BOOL }};
                 var putInRoot = {{ module.put_in_root|BOOL }};


### PR DESCRIPTION
'Try in cloudcare' url gets set if there are just labels and/or repeat questions now. Was previously just opening a link to the current page in a new tab.

http://manage.dimagi.com/default.asp?63291
