### PR TITLE
Add ability to restrict superuser access by domain

### DIFF
--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -74,7 +74,7 @@ def login_and_domain_required_ex(redirect_field_name=REDIRECT_FIELD_NAME, login_
                         couch_user = CouchUser.from_django_user(user)
                     if couch_user.is_member_of(domain) or domain.is_public:
                         return view_func(req, domain_name, *args, **kwargs)
-                    elif user.is_superuser:
+                    elif user.is_superuser and not domain.restrict_superusers:
                         # superusers can circumvent domain permissions.
                         return view_func(req, domain_name, *args, **kwargs)
                     elif domain.is_snapshot:
@@ -86,7 +86,6 @@ def login_and_domain_required_ex(redirect_field_name=REDIRECT_FIELD_NAME, login_
                     return _redirect_for_login_or_domain(req, redirect_field_name, login_url)
             else:
                 raise Http404
-        
         return _inner
     return _outer
 

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -206,6 +206,7 @@ class Domain(Document, HQBillingDomainMixin, SnapshotMixin):
     is_shared = BooleanProperty(default=False)
     commtrack_enabled = BooleanProperty(default=False)
     call_center_config = SchemaProperty(CallCenterProperties)
+    restrict_superusers = BooleanProperty(default=False)
 
     case_display = SchemaProperty(CaseDisplaySettings)
 

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -180,7 +180,8 @@ def project_settings(request, domain, template="domain/admin/project_settings.ht
                 'commtrack_enabled': domain.commtrack_enabled,
                 'call_center_enabled': domain.call_center_config.enabled,
                 'call_center_case_owner': domain.call_center_config.case_owner_id,
-                'call_center_case_type': domain.call_center_config.case_type
+                'call_center_case_type': domain.call_center_config.case_type,
+                'restrict_superusers': domain.restrict_superusers,
             })
         else:
             form = DomainGlobalSettingsForm(initial={
@@ -235,6 +236,7 @@ def project_settings(request, domain, template="domain/admin/project_settings.ht
             # view whose template extends users_base.html); mike says he's refactoring all of this imminently, so
             # i will not worry about it until he is done
         call_center_enabled=domain.call_center_config.enabled,
+        restrict_superusers=domain.restrict_superusers,
         autocomplete_fields=('project_type', 'phone_model', 'user_type', 'city', 'country', 'region'),
         billing_info_form=billing_info_form,
         billing_info_partial=billing_info_partial,

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -353,7 +353,9 @@ class CustomDomainMembership(DomainMembership):
 
 class IsMemberOfMixin(DocumentSchema):
     def _is_member_of(self, domain):
-        return self.is_global_admin() or domain in self.get_domains()
+        domain_obj = Domain.get_by_name(domain)
+        return domain in self.get_domains() or \
+            (self.is_global_admin() and not domain_obj.restrict_superusers)
 
     def is_member_of(self, domain_qs):
         """


### PR DESCRIPTION
Adds an option to the project settings page (viewable only by staff) to prevent superusers (not in the project) from being able to access it.

For: http://manage.dimagi.com/default.asp?63471

![screen_shot_2013-06-13_at_8 11 19_pm](https://f.cloud.github.com/assets/152134/651898/70b0ad32-d487-11e2-84f9-843fb5dd35a1.png)
