### PR TITLE
Set v0.4 case API max_limit=100

### DIFF
--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -132,6 +132,9 @@ class CommCareCaseResource(v0_3.CommCareCaseResource, DomainSpecificResourceMixi
                           model = CommCareCase, #lambda jvalue: dict_object(CommCareCase.wrap(jvalue).get_json()),
                           es_client = CaseES(domain)) # Not that XFormES is used only as an ES client, for `run_query` against the proper index
 
+    class Meta(v0_3.CommCareCaseResource.Meta):
+        max_limit = 100 # Today, takes ~25 seconds for some domains
+
 class GroupResource(JsonResource, DomainSpecificResourceMixin):
     id = fields.CharField(attribute='get_id', unique=True, readonly=True)
     domain = fields.CharField(attribute='domain')


### PR DESCRIPTION
Unfortunate, but this is the best compromise between current performance and reasonable batch size.
