### PR TITLE
Move reports attachment url to to param

### DIFF
--- a/corehq/apps/reports/urls.py
+++ b/corehq/apps/reports/urls.py
@@ -43,7 +43,7 @@ urlpatterns = patterns('corehq.apps.reports.views',
     # Download and view form data
     url(r'^form_data/(?P<instance_id>[\w\-:]+)/$', 'form_data', name='render_form_data'),
     url(r'^form_data/(?P<instance_id>[\w\-:]+)/download/$', 'download_form', name='download_form'),
-    url(r'^form_data/(?P<instance_id>[\w\-:]+)/download/(?P<attachment>[\w._-]+)?$',
+    url(r'^form_data/(?P<instance_id>[\w\-:]+)/download-attachment/$',
         'download_attachment', name='download_attachment'),
     url(r'^form_data/(?P<instance_id>[\w\-:]+)/archive/$', 'archive_form', name='archive_form'),
     url(r'^form_data/(?P<instance_id>[\w\-:]+)/unarchive/$', 'unarchive_form', name='unarchive_form'),

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -915,7 +915,10 @@ def download_form(request, domain, instance_id):
 @require_form_view_permission
 @login_and_domain_required
 @require_GET
-def download_attachment(request, domain, instance_id, attachment):
+def download_attachment(request, domain, instance_id):
+    attachment = request.GET.get('attachment', False)
+    if not attachment:
+        return HttpResponseBadRequest("Invalid attachment.")
     instance = _get_form_or_404(instance_id)
     assert(domain == instance.domain)
     return couchforms_views.download_attachment(request, instance_id, attachment)


### PR DESCRIPTION
Previously was getting errors on filenames with characters that weren't
valid in the url. Moving to passing this via param will prevent that.

http://manage.dimagi.com/default.asp?60807
