### PR TITLE
Upgrade lxml

### DIFF
--- a/corehq/apps/app_manager/tests/test_form_preparation_v2.py
+++ b/corehq/apps/app_manager/tests/test_form_preparation_v2.py
@@ -1,4 +1,9 @@
 # coding=utf-8
+
+import io
+
+import lxml.etree
+
 from casexml.apps.case.tests.util import check_xml_line_by_line
 from corehq.apps.app_manager.const import APP_V2
 from corehq.apps.app_manager.models import Application, OpenCaseAction, UpdateCaseAction, PreloadAction, FormAction, Detail
@@ -15,31 +20,43 @@ class FormPreparationV2Test(TestCase, TestFileMixin):
         self.module.case_type = 'test_case_type'
         self.form.source = self.get_xml('original')
 
+    def assert_xml_equiv(self, actual, expected):
+        actual_canonicalized = io.BytesIO()
+        expected_canonicalized = io.BytesIO()
+
+        parser = lxml.etree.XMLParser(remove_blank_text=True)
+
+        lxml.etree.fromstring(actual, parser=parser).getroottree().write_c14n(actual_canonicalized)
+        lxml.etree.fromstring(expected, parser=parser).getroottree().write_c14n(expected_canonicalized)
+        
+        if actual_canonicalized.getvalue() != expected_canonicalized.getvalue():
+            check_xml_line_by_line(self, actual, expected)
+
     def test_no_actions(self):
-        check_xml_line_by_line(self, self.get_xml('no_actions'), self.form.render_xform())
+        self.assert_xml_equiv(self.get_xml('no_actions'), self.form.render_xform())
 
     def test_open_case(self):
         self.form.actions.open_case = OpenCaseAction(name_path="/data/question1", external_id=None)
         self.form.actions.open_case.condition.type = 'always'
-        check_xml_line_by_line(self, self.get_xml('open_case'), self.form.render_xform())
+        self.assert_xml_equiv(self.get_xml('open_case'), self.form.render_xform())
 
     def test_open_case_external_id(self):
         self.form.actions.open_case = OpenCaseAction(name_path="/data/question1", external_id='/data/question1')
         self.form.actions.open_case.condition.type = 'always'
-        check_xml_line_by_line(self, self.get_xml('open_case_external_id'), self.form.render_xform())
+        self.assert_xml_equiv(self.get_xml('open_case_external_id'), self.form.render_xform())
 
     def test_update_case(self):
         self.form.requires = 'case'
         self.form.actions.update_case = UpdateCaseAction(update={'question1': '/data/question1'})
         self.form.actions.update_case.condition.type = 'always'
-        check_xml_line_by_line(self, self.get_xml('update_case'), self.form.render_xform())
+        self.assert_xml_equiv(self.get_xml('update_case'), self.form.render_xform())
 
     def test_open_update_case(self):
         self.form.actions.open_case = OpenCaseAction(name_path="/data/question1", external_id=None)
         self.form.actions.open_case.condition.type = 'always'
         self.form.actions.update_case = UpdateCaseAction(update={'question1': '/data/question1'})
         self.form.actions.update_case.condition.type = 'always'
-        check_xml_line_by_line(self, self.get_xml('open_update_case'), self.form.render_xform())
+        self.assert_xml_equiv(self.get_xml('open_update_case'), self.form.render_xform())
 
     def test_update_preload_case(self):
         self.form.requires = 'case'
@@ -47,10 +64,10 @@ class FormPreparationV2Test(TestCase, TestFileMixin):
         self.form.actions.update_case.condition.type = 'always'
         self.form.actions.case_preload = PreloadAction(preload={'/data/question1': 'question1'})
         self.form.actions.case_preload.condition.type = 'always'
-        check_xml_line_by_line(self, self.get_xml('update_preload_case'), self.form.render_xform())
+        self.assert_xml_equiv(self.get_xml('update_preload_case'), self.form.render_xform())
 
     def test_close_case(self):
         self.form.requires = 'case'
         self.form.actions.close_case = FormAction()
         self.form.actions.close_case.condition.type = 'always'
-        check_xml_line_by_line(self, self.get_xml('close_case'), self.form.render_xform())
+        self.assert_xml_equiv(self.get_xml('close_case'), self.form.render_xform())

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -19,7 +19,7 @@ djtables==0.1.1
 egenix-mx-base==3.2.6
 eulxml==0.18.0
 gunicorn==0.17.4
-lxml==2.3
+lxml==3.2.1
 mock==0.8.0
 mocker==1.1.1
 openpyxl==1.5.6


### PR DESCRIPTION
This brings CCHQ up to date on lxml, as we've had some problems in the tests that cannot be attributed to our code and are likely already-fixed lxml bugs.

Note that CCHQ's test coverage is low enough that I do not have perfect confidence that this does not introduce any issues. However both casexml and couchforms depend on "lxml" with no version so their Travis-CI builds have been tested against the latest lxml for some time.
