### PR TITLE
Add --failfast to Travis-CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
  - "bash -e .travis/misc-setup.sh"
  - "cp .travis/localsettings.py localsettings.py"
  - pip install coveralls
-script: "cat .travis/apps_under_test | grep -v '^#' | xargs coverage run manage.py test --noinput"
+script: "cat .travis/apps_under_test | grep -v '^#' | xargs coverage run manage.py test --noinput --failfast"
 after_success:
  - coveralls
 services:


### PR DESCRIPTION
This is a debatable move. I had removed it previously under the assumption that we might want a report of all the various errors that have occurred. However, I think the output is voluminous enough and we have enough failures that are caused by funky interactions that there is more value is saving time and minimizing what we have to scan through.
