### PR TITLE
Case api dates

### DIFF
--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -116,6 +116,13 @@ class CommCareCaseResource(v0_3.CommCareCaseResource, DomainSpecificResourceMixi
     parent_cases = UseIfRequested(ToManyDictField('corehq.apps.api.resources.v0_4.CommCareCaseResource',
                                                   attribute=lambda case: dict([ (index.identifier, CommCareCase.get(index.referenced_id)) for index in case.reverse_indices])))
 
+    # Fields that v0.2 assumed were pre-transformed but we are now operating on straight CommCareCase objects again
+    date_modified = fields.CharField(attribute='modified_on', default="1900-01-01")
+    server_date_modified = fields.CharField(attribute='server_modified_on', default="1900-01-01")
+
+    def case_es(self, domain):
+        return MOCK_CASE_ES or CaseES(domain)
+
     def obj_get_list(self, bundle, domain, **kwargs):
         filters = v0_3.CaseListFilters(bundle.request.GET).filters
 
@@ -130,7 +137,7 @@ class CommCareCaseResource(v0_3.CommCareCaseResource, DomainSpecificResourceMixi
         
         return ESQuerySet(payload = query,
                           model = CommCareCase, #lambda jvalue: dict_object(CommCareCase.wrap(jvalue).get_json()),
-                          es_client = CaseES(domain)) # Not that XFormES is used only as an ES client, for `run_query` against the proper index
+                          es_client = self.case_es(domain)) # Not that XFormES is used only as an ES client, for `run_query` against the proper index
 
     class Meta(v0_3.CommCareCaseResource.Meta):
         max_limit = 100 # Today, takes ~25 seconds for some domains

--- a/corehq/apps/api/tests.py
+++ b/corehq/apps/api/tests.py
@@ -2,6 +2,8 @@ import simplejson
 import time
 from datetime import datetime
 
+import dateutil.parser
+
 from django.utils.http import urlencode
 from django.test import TestCase
 from django.core.urlresolvers import reverse
@@ -9,8 +11,10 @@ from tastypie.resources import Resource
 from tastypie import fields
 
 from couchforms.models import XFormInstance
+from casexml.apps.case.models import CommCareCase
 
 from corehq.pillows.xform import XFormPillow
+from corehq.pillows.case import CasePillow
 from corehq.apps.users.models import CommCareUser, WebUser
 from corehq.apps.domain.models import Domain
 from corehq.apps.receiverwrapper.models import FormRepeater, CaseRepeater, ShortFormRepeater
@@ -193,6 +197,46 @@ class TestXFormInstanceResource(APIResourceTest):
 
         self.assertEqual(response.status_code, 200)
 
+class TestCommCareCaseResource(APIResourceTest):
+    """
+    Tests the CommCareCaseREsource, currently only v0_4
+    """
+    resource = v0_4.CommCareCaseResource
+
+    def test_get_list(self):
+        """
+        Any case in the appropriate domain should be in the list from the API.
+        """
+
+        # The actual infrastructure involves saving to CouchDB, having PillowTop
+        # read the changes and write it to ElasticSearch.
+
+        #the pillow is set to offline mode - elasticsearch not needed to validate
+        pillow = CasePillow(online=False)
+        fake_case_es = FakeXFormES()
+        v0_4.MOCK_CASE_ES = fake_case_es
+
+        modify_date = datetime.utcnow()
+
+        backend_case = CommCareCase(server_modified_on = modify_date)
+        backend_case.save()
+
+        translated_doc = pillow.change_transform(backend_case.to_json())
+        
+        fake_case_es.add_doc(translated_doc['_id'], translated_doc)
+
+        self.client.login(username=self.username, password=self.password)
+
+        response = self.client.get(self.list_endpoint)
+        self.assertEqual(response.status_code, 200)
+
+        api_cases = simplejson.loads(response.content)['objects']
+        self.assertEqual(len(api_cases), 1)
+
+        api_case = api_cases[0]
+        self.assertEqual(dateutil.parser.parse(api_case['server_date_modified']), backend_case.server_modified_on)
+
+        backend_case.delete()
 
 class TestCommCareUserResource(APIResourceTest):
     """


### PR DESCRIPTION
Fixes a problem where the fields were mapped in an obsoleted way, resulting in the default date of "the beginning of time" being returned.
