### PR TITLE
memoize group.get_user_ids

### DIFF
--- a/corehq/apps/groups/models.py
+++ b/corehq/apps/groups/models.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from functools import partial
 from couchdbkit.ext.django.schema import *
+from dimagi.utils.decorators.memoized import memoized
 from corehq.apps.users.models import CouchUser, CommCareUser
 from dimagi.utils.couch.undo import UndoableDocument, DeleteDocRecord
 from django.conf import settings
@@ -90,6 +91,7 @@ class Group(UndoableDocument):
         self.path = self.path[index:]
         self.save()
 
+    @memoized
     def get_user_ids(self, is_active=True):
         return [user.user_id for user in self.get_users(is_active)]
 

--- a/corehq/apps/groups/models.py
+++ b/corehq/apps/groups/models.py
@@ -91,7 +91,6 @@ class Group(UndoableDocument):
         self.path = self.path[index:]
         self.save()
 
-    @memoized
     def get_user_ids(self, is_active=True):
         return [user.user_id for user in self.get_users(is_active)]
 
@@ -107,7 +106,16 @@ class Group(UndoableDocument):
             return [user for user in users if user.is_active]
         else:
             return users
-    
+
+    @memoized
+    def get_static_user_ids(self, is_active=True):
+        return [user.user_id for user in self.get_static_users(is_active)]
+
+    @memoized
+    def get_static_users(self, is_active=True):
+        return self.get_users()
+
+
     @classmethod
     def by_domain(cls, domain):
         return cls.view('groups/by_domain',

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -251,7 +251,7 @@ def case_users_filter(doc, users):
 
 def case_group_filter(doc, group):
     if group:
-        user_ids = set(group.get_user_ids())
+        user_ids = set(group.get_static_user_ids())
         try:
             return doc['user_id'] in user_ids
         except KeyError:
@@ -268,7 +268,7 @@ def users_filter(doc, users):
 
 def group_filter(doc, group):
     if group:
-        user_ids = set(group.get_user_ids())
+        user_ids = set(group.get_static_user_ids())
         try:
             return doc['form']['meta']['userID'] in user_ids
         except KeyError:


### PR DESCRIPTION
among other things, this will prevent hitting the db to get all users
in the group once per document during a group-filtered export (Case:63991)
