### PR TITLE
use user_id or owner_id when matching exports (Case:43724)

### DIFF
--- a/corehq/apps/reports/templates/reports/reportdata/case_export_data.html
+++ b/corehq/apps/reports/templates/reports/reportdata/case_export_data.html
@@ -27,7 +27,7 @@
 {% block reportcontent %}
     <div id="full-case-export" class="form-horizontal hq-form-report">
         <fieldset style="margin-top: 2em;">
-            <legend>Download Settings</legend>
+            <legend>{% trans "Download Settings" %}</legend>
             <div class="control-group">
                 <label for="include-closed-select" class="control-label">{% trans "Download" %}</label>
                 <div class="controls">


### PR DESCRIPTION
This is not the most elegant fix but it is a minimal change that works. The behavior is still odd when the case gets reassigned by a web user into a group, but that's a separate issue.
