### PR TITLE
Xml serialization for API

### DIFF
--- a/corehq/apps/api/resources/__init__.py
+++ b/corehq/apps/api/resources/__init__.py
@@ -10,21 +10,23 @@ class dict_object(object):
     def __repr__(self):
         return 'dict_object(%r)' % self.dict
 
-class JsonDefaultResourceMixIn(object):
-    """
-    Mixin to avoid having to get the "please append format=json to your url"
-    message and always default to json.
-    """
-
-    def determine_format(self, request):
-        return "application/json"
-
-class JsonResource(JsonDefaultResourceMixIn, Resource):
+class JsonResource(Resource):
     """
     This can be extended to default to json formatting. 
     """
     # This exists in addition to the mixin since the order of the class
     # definitions actually matters
+
+    def determine_format(self, request):
+        format = super(JsonResource, self).determine_format(request)
+
+        # Tastypie does _not_ support text/html but also does not raise the appropriate UnsupportedFormat exception
+        # for all other unsupported formats, Tastypie has correct behavior, so we only hack around this one.
+        if format == 'text/html':
+            format = 'application/json'
+
+        return format
+
     
 class DomainSpecificResourceMixin(object):
     def get_list(self, request, **kwargs):

--- a/corehq/apps/api/resources/v0_1.py
+++ b/corehq/apps/api/resources/v0_1.py
@@ -84,6 +84,7 @@ class CustomResourceMeta(object):
     authorization = ReadOnlyAuthorization()
     authentication = LoginAndDomainAuthentication()
     serializer = CustomXMLSerializer()
+    default_format='application/json'
 
 class UserResource(JsonResource, DomainSpecificResourceMixin):
     type = "user"

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -10,6 +10,7 @@ django-celery==3.0.11
 django-crispy-forms==1.2.0
 kombu==2.5.6
 billiard==2.7.3.21
+defusedxml==0.4.1
 diff-match-patch==20120106
 django-kombu==0.9.1
 django-digest==1.13

--- a/settings.py
+++ b/settings.py
@@ -23,6 +23,14 @@ except IndexError:
 ADMINS = ()
 MANAGERS = ADMINS
 
+# Ensure that extraneous Tastypie formats are not actually used
+# Curiously enough, browsers prefer html, then xml, lastly (or not at all) json
+# so removing html from the this variable annoyingly makes it render as XML
+# in the browser, when we want JSON. So I've added this commented
+# to document intent, but it should only really be activated
+# when we have logic in place to treat direct browser access specially.
+#TASTYPIE_DEFAULT_FORMATS=['json', 'xml', 'yaml']
+
 # default to the system's timezone settings
 TIME_ZONE = "UTC"
 


### PR DESCRIPTION
Mostly this removes a hardcoding of `application/json` that was added to make it easier to work with the API in a browser. The problem is that a browser does _not_ use a "default" encoding - it specifically requests `text/html,application/xhtml+xml,application/xml` so you always get crappy in-browser output. Added to this, Tastypie does not really support HTML but instead of raising the unsupported exception that it does for other formats, it returns a silly string to the browser. This patch works around it in a way that is better than what we did before, though not perfect.
