### PR TITLE
really quick and not the best place to put a more friendly login message...

### DIFF
--- a/corehq/apps/domain/templates/login_and_password/partials/login_form.html
+++ b/corehq/apps/domain/templates/login_and_password/partials/login_form.html
@@ -3,12 +3,18 @@
     <h1>{% trans "Welcome back to " %}{% if domain %}{{ domain }}{% else %}CommCare HQ{% endif %}!<br />
         <small>
         {% if next %}
-            {% trans "You will be transferred to your original destination after you sign in." %}
+            {% trans "Looks like your CommCare session has expired. Please log-in again to continue working." %}
         {% else %}
             {% trans "Please sign in below to continue." %}
         {% endif %}
         </small>
     </h1>
+
+    {% if next %}
+    <p>
+        {% trans "You will be transferred to your original destination after you sign in." %}
+    </p>
+    {% endif %}
 </div>
 <form class="form-horizontal form-login" name="form" method="post" >
     {% csrf_token %}


### PR DESCRIPTION
....

without having an explicit way to detect session expiration in our login/logout redirection, using next param as way of determining intent.

on an expired or nonexistent session, next= will show up on url redirect.

![friendly_logout](https://f.cloud.github.com/assets/60140/717638/8e29fe48-df51-11e2-91cb-28e5a1ec27c9.png)
