### PR TITLE
Only show case type select if creating new cases

### DIFF
--- a/corehq/apps/importer/templates/importer/excel_config.html
+++ b/corehq/apps/importer/templates/importer/excel_config.html
@@ -15,9 +15,15 @@
                 } else {
                     $('#key_val_selection_fields').hide();
                 }
-            });
+            }).change();
 
-            $('#key_value_columns').change();
+            $('#create_new_cases').change(function() {
+                if ($(this).attr('checked') === 'checked') {
+                    $('#case_type').show();
+                } else {
+                    $('#case_type').hide();
+                }
+            }).change();
 
             $('#back_button').click(function() {
                 history.back();
@@ -34,32 +40,10 @@
         <input type="hidden" name="named_columns" value="{{named_columns}}" />
 
         <fieldset>
-            <legend>{% trans "Case Type to Update/Create" %}</legend>
-            <div class="control-group">
-                <label class="control-label" for="case_type">
-                    {% trans "Case type" %}
-                </label>
-                <div class="controls">
-                    <select name="case_type" id="case_type">
-                        <option disabled>{% trans "Used in existing applications:" %}</option>
-                        {% for case_type in case_types_from_apps %}
-                        <option value="{{case_type|escape}}">{{case_type|escape}}</option>
-                        {% endfor %}
-
-                        <option disabled>{% trans "From unknown or deleted applications:" %}</option>
-                        {% for case_type in case_types_from_cases %}
-                        <option value="{{case_type|escape}}">{{case_type|escape}}</option>
-                        {% endfor %}
-                    </select>
-                </div>
-            </div>
-        </fieldset>
-
-        <fieldset>
             <legend>{% trans "Identifying Cases to Update/Create" %}</legend>
             <div class="control-group">
                 <label class="control-label" for="search_column">
-                    {% trans "Excel Column" %}
+                    {% trans "Excel column" %}
                 </label>
                 <div class="controls">
                     <select name="search_column" id="search_column">
@@ -74,7 +58,7 @@
 
             <div class="control-group">
                 <label class="control-label" for="search_field">
-                    {% trans "Corresponding Case Field" %}
+                    {% trans "Corresponding case field" %}
                 </label>
                 <div class="controls">
                     <select name="search_field" id="search_field">
@@ -96,6 +80,24 @@
                                id="create_new_cases" />
                         {% trans "Create new records if there is no matching case" %}
                     </label>
+                </div>
+                <div id="case_type">
+                    <label class="control-label" for="case_type">
+                        {% trans "Case type for new cases" %}
+                    </label>
+                    <div class="controls">
+                        <select name="case_type" id="case_type">
+                            <option disabled>{% trans "Used in existing applications:" %}</option>
+                            {% for case_type in case_types_from_apps %}
+                            <option value="{{case_type|escape}}">{{case_type|escape}}</option>
+                            {% endfor %}
+
+                            <option disabled>{% trans "From unknown or deleted applications:" %}</option>
+                            {% for case_type in case_types_from_cases %}
+                            <option value="{{case_type|escape}}">{{case_type|escape}}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
                 </div>
             </div>
         </fieldset>


### PR DESCRIPTION
This just moves the case type selection down below the "create new cases" checkbox and only shows it if the box is checked.
