### PR TITLE
Case importer fixes/changes

### DIFF
--- a/corehq/apps/importer/templates/importer/excel_config.html
+++ b/corehq/apps/importer/templates/importer/excel_config.html
@@ -15,9 +15,15 @@
                 } else {
                     $('#key_val_selection_fields').hide();
                 }
-            });
+            }).change();
 
-            $('#key_value_columns').change();
+            $('#create_new_cases').change(function() {
+                if ($(this).attr('checked') === 'checked') {
+                    $('#case_type').show();
+                } else {
+                    $('#case_type').hide();
+                }
+            }).change();
 
             $('#back_button').click(function() {
                 history.back();
@@ -34,32 +40,10 @@
         <input type="hidden" name="named_columns" value="{{named_columns}}" />
 
         <fieldset>
-            <legend>{% trans "Case Type to Update/Create" %}</legend>
-            <div class="control-group">
-                <label class="control-label" for="case_type">
-                    {% trans "Case type" %}
-                </label>
-                <div class="controls">
-                    <select name="case_type" id="case_type">
-                        <option disabled>{% trans "Used in existing applications:" %}</option>
-                        {% for case_type in case_types_from_apps %}
-                        <option value="{{case_type|escape}}">{{case_type|escape}}</option>
-                        {% endfor %}
-
-                        <option disabled>{% trans "From unknown or deleted applications:" %}</option>
-                        {% for case_type in case_types_from_cases %}
-                        <option value="{{case_type|escape}}">{{case_type|escape}}</option>
-                        {% endfor %}
-                    </select>
-                </div>
-            </div>
-        </fieldset>
-
-        <fieldset>
             <legend>{% trans "Identifying Cases to Update/Create" %}</legend>
             <div class="control-group">
                 <label class="control-label" for="search_column">
-                    {% trans "Excel Column" %}
+                    {% trans "Excel column" %}
                 </label>
                 <div class="controls">
                     <select name="search_column" id="search_column">
@@ -74,7 +58,7 @@
 
             <div class="control-group">
                 <label class="control-label" for="search_field">
-                    {% trans "Corresponding Case Field" %}
+                    {% trans "Corresponding case field" %}
                 </label>
                 <div class="controls">
                     <select name="search_field" id="search_field">
@@ -96,6 +80,24 @@
                                id="create_new_cases" />
                         {% trans "Create new records if there is no matching case" %}
                     </label>
+                </div>
+                <div id="case_type">
+                    <label class="control-label" for="case_type">
+                        {% trans "Case type for new cases" %}
+                    </label>
+                    <div class="controls">
+                        <select name="case_type" id="case_type">
+                            <option disabled>{% trans "Used in existing applications:" %}</option>
+                            {% for case_type in case_types_from_apps %}
+                            <option value="{{case_type|escape}}">{{case_type|escape}}</option>
+                            {% endfor %}
+
+                            <option disabled>{% trans "From unknown or deleted applications:" %}</option>
+                            {% for case_type in case_types_from_cases %}
+                            <option value="{{case_type|escape}}">{{case_type|escape}}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
                 </div>
             </div>
         </fieldset>

--- a/corehq/apps/importer/templates/importer/partials/import_status.html
+++ b/corehq/apps/importer/templates/importer/partials/import_status.html
@@ -9,7 +9,7 @@
                     updated.
                 {% endblocktrans %}
             </p>
-            {% ifnotequal result.created_count 0 %}
+            {% if result.created_count > 0 %}
                 <p>
                     {% blocktrans with created_count=result.created_count %}
                         <strong>{{ created_count }}</strong> rows did
@@ -17,7 +17,7 @@
                         for them.
                     {% endblocktrans %}
                 </p>
-            {% endifnotequal %}
+            {% endif %}
             <p>
                 {% blocktrans with too_many_matches=result.too_many_matches %}
                     <strong>{{ too_many_matches }}</strong> rows matched more
@@ -25,6 +25,16 @@
                     in your system with the same external ID.
                 {% endblocktrans %}
             </p>
+            {% if result.blank_externals|length > 0 %}
+                <p>
+                    {% blocktrans %}
+                        The following row numbers had blank external id's and 
+                        could not be created due to this:
+                    {% endblocktrans %}
+                    {{ result.blank_externals|join:", " }}
+                </p>
+            {% endif %}
+
         </div>
         <script type="text/javascript">
             $("#export-download-status .loading-indicator").addClass('hide');

--- a/corehq/apps/importer/templates/importer/partials/import_status.html
+++ b/corehq/apps/importer/templates/importer/partials/import_status.html
@@ -48,6 +48,18 @@
                 </p>
             {% endif %}
 
+            {% if result.invalid_dates|length > 0 %}
+                <p>
+                    {% blocktrans %}
+                        Date fields were specified that caused an error during
+                        conversion. This is likely caused by a value from
+                        excel having the wrong type or not being formatted
+                        properly. The following row numbers had this issue and
+                        were ignored:
+                    {% endblocktrans %}
+                    {{ result.invalid_dates|join:", " }}
+                </p>
+            {% endif %}
         </div>
         <script type="text/javascript">
             $("#export-download-status .loading-indicator").addClass('hide');

--- a/corehq/apps/importer/templates/importer/partials/import_status.html
+++ b/corehq/apps/importer/templates/importer/partials/import_status.html
@@ -3,12 +3,15 @@
     <div id="ready_{{ download_id }}">
         <legend>{% trans "Import complete." %}</legend>
         <div class="alert alert-success">
-            <p>
-                {% blocktrans with match_count=result.match_count %}
-                    <strong>{{ match_count }}</strong> rows were matched and
-                    updated.
-                {% endblocktrans %}
-            </p>
+            {% if result.match_count %}
+                <p>
+                    {% blocktrans with match_count=result.match_count %}
+                        <strong>{{ match_count }}</strong> rows were matched and
+                        updated.
+                    {% endblocktrans %}
+                </p>
+            {% endif %}
+
             {% if result.created_count > 0 %}
                 <p>
                     {% blocktrans with created_count=result.created_count %}
@@ -18,13 +21,23 @@
                     {% endblocktrans %}
                 </p>
             {% endif %}
-            <p>
-                {% blocktrans with too_many_matches=result.too_many_matches %}
-                    <strong>{{ too_many_matches }}</strong> rows matched more
-                    than one case at the same time - this means that there are cases
-                    in your system with the same external ID.
-                {% endblocktrans %}
-            </p>
+
+            {% if result.match_count == 0 and result.created_count == 0 %}
+                <p>
+                    {% trans "No cases were matched or updated during this import." %}
+                </p>
+            {% endif %}
+
+            {% if result.too_many_matches > 0 %}
+                <p>
+                    {% blocktrans with too_many_matches=result.too_many_matches %}
+                        <strong>{{ too_many_matches }}</strong> rows matched more
+                        than one case at the same time - this means that there are cases
+                        in your system with the same external ID.
+                    {% endblocktrans %}
+                </p>
+            {% endif %}
+
             {% if result.blank_externals|length > 0 %}
                 <p>
                     {% blocktrans %}

--- a/corehq/apps/importer/util.py
+++ b/corehq/apps/importer/util.py
@@ -135,9 +135,17 @@ def convert_custom_fields_to_struct(config):
 
     return field_map
 
+class InvalidDateException(Exception):
+    pass
+
 def parse_excel_date(date_val):
     """ Convert field value from excel to a date value """
-    return str(date(*xldate_as_tuple(date_val, 0)[:3]))
+    try:
+        parsed_date = str(date(*xldate_as_tuple(date_val, 0)[:3]))
+    except Exception:
+        raise InvalidDateException
+
+    return parsed_date
 
 def parse_search_id(config, columns, row):
     """ Find and convert the search id in an excel row """


### PR DESCRIPTION
These commits address feedback from Sheel's QA.
#### Only show case type select if creating new cases

Move case type selector below the "create new cases" link and hide it if not checked to make it more clear this is only for new cases, not updating.
#### Do not allow blank external ID's

Prevent the user from leaving external ID blank is they are matching cases based on this. Behavior was pretty weird otherwise and an empty string for an ID doesn't seem correct.
#### Hide some of importer success rows given 0 counts

It was showing stuff like "0 rows had duplicate matches found..." etc which didn't really make 
#### Fix issues with date conversion

Date conversion errors would cause the import to hang. Now it finishes and displays a message informing the user of the failed row.
