### PR TITLE
More importer post-QA changes

### DIFF
--- a/corehq/apps/importer/tasks.py
+++ b/corehq/apps/importer/tasks.py
@@ -80,9 +80,8 @@ def bulk_import_async(import_id, config, domain, excel_id):
             too_many_matches += 1
             continue
 
-
-        owner_id = get_property(fields_to_update, 'owner_id') or user_id
-        external_id = get_property(fields_to_update, 'external_id')
+        owner_id = fields_to_update.pop('owner_id', user_id)
+        external_id = fields_to_update.pop('external_id', None)
 
         if not case:
             id = uuid.uuid4().hex
@@ -118,14 +117,6 @@ def bulk_import_async(import_id, config, domain, excel_id):
         'blank_externals': blank_external_ids,
         'invalid_dates': invalid_dates,
     }
-
-def get_property(fields, property_name):
-    if property_name in fields:
-        prop = fields[property_name]
-        del fields[property_name]
-        return prop
-    else:
-        return None
 
 def submit_case_block(caseblock, domain, username, user_id):
     """ Convert a CaseBlock object to xml and submit for creation/update """

--- a/corehq/apps/importer/tasks.py
+++ b/corehq/apps/importer/tasks.py
@@ -81,11 +81,8 @@ def bulk_import_async(import_id, config, domain, excel_id):
             continue
 
 
-        if 'owner_id' in fields_to_update:
-            owner_id = fields_to_update['owner_id']
-            del fields_to_update['owner_id']
-        else:
-            owner_id = user_id
+        owner_id = get_property(fields_to_update, 'owner_id') or user_id
+        external_id = get_property(fields_to_update, 'external_id')
 
         if not case:
             id = uuid.uuid4().hex
@@ -109,6 +106,9 @@ def bulk_import_async(import_id, config, domain, excel_id):
                 version=V2,
                 update=fields_to_update
             )
+            if external_id:
+                caseblock['external_id'] = external_id
+
             submit_case_block(caseblock, domain, username, user_id)
 
     return {
@@ -119,6 +119,13 @@ def bulk_import_async(import_id, config, domain, excel_id):
         'invalid_dates': invalid_dates,
     }
 
+def get_property(fields, property_name):
+    if property_name in fields:
+        prop = fields[property_name]
+        del fields[property_name]
+        return prop
+    else:
+        return None
 
 def submit_case_block(caseblock, domain, username, user_id):
     """ Convert a CaseBlock object to xml and submit for creation/update """

--- a/corehq/apps/importer/views.py
+++ b/corehq/apps/importer/views.py
@@ -162,6 +162,13 @@ def excel_fields(request, domain):
     except:
         pass
 
+    # we can't actually update this so don't show it
+    try:
+        case_fields.remove('type')
+    except:
+        pass
+
+
     return render(request, "importer/excel_fields.html", {
                                 'named_columns': named_columns,
                                 'case_type': case_type,


### PR DESCRIPTION
#### Enable external_id updating

Allow users to update external_id when uploading cases matched on
case_id instead of external.
#### Remove option to update type

We can't update case type with the xml tool so don't give the user an option to select it.
