### PR TITLE
add commtrack login flow

### DIFF
--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -256,6 +256,17 @@ class Domain(Document, HQBillingDomainMixin, SnapshotMixin):
     # to be eliminated from projects and related documents when they are copied for the exchange
     _dirty_fields = ('admin_password', 'admin_password_charset', 'city', 'country', 'region', 'customer_type')
 
+    @property
+    def domain_type(self):
+        """
+        The primary type of this domain.  Used to determine site-specific
+        branding.
+        """
+        if self.commtrack_enabled:
+            return 'commtrack'
+        else:
+            return 'commcare'
+
     @classmethod
     def wrap(cls, data):
         # for domains that still use original_doc

--- a/corehq/apps/domain/templates/login_and_password/login.html
+++ b/corehq/apps/domain/templates/login_and_password/login.html
@@ -1,5 +1,5 @@
 {% extends "hqwebapp/centered.html" %}
-{% block title %}Login to CommCareHQ{% endblock title %}
+{% block title %}Login to {{ SITE_NAME }}{% endblock title %}
 
 {% block centered-content %}
     {% block login-content %}

--- a/corehq/apps/domain/templates/login_and_password/partials/login_form.html
+++ b/corehq/apps/domain/templates/login_and_password/partials/login_form.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 <div class="page-header">
-    <h1>{% trans "Welcome back to " %}{% if domain %}{{ domain }}{% else %}CommCare HQ{% endif %}!<br />
+    <h1>{% trans "Welcome back to " %}{% if domain %}{{ domain }}{% else %}{{ SITE_NAME }}{% endif %}!<br />
         <small>
         {% if next %}
             {% trans "Looks like your CommCare session has expired. Please log-in again to continue working." %}

--- a/corehq/apps/domain/templates/login_and_password/partials/login_full.html
+++ b/corehq/apps/domain/templates/login_and_password/partials/login_full.html
@@ -4,10 +4,10 @@
     </div>
     <div class="span4">
         <aside class="well">
-            <h2>Are you new to CommCare HQ?<br /><small>Sign up today. It's free!</small></h2>
-            <p><a href="http://www.commcarehq.org/home">Learn more</a> about how CommCare HQ can be your mobile health solution.</p>
-            <p>Don't have an account with CommCare HQ yet? Sign up and check out our features.</p>
-            <div class="row"><a style="float: right; margin-top: 7px;" class="btn btn-success btn-large" href="{% url register_user %}">Sign Up</a></div>
+            <h2>Are you new to {{ SITE_NAME }}?<br /><small>Sign up today. It's free!</small></h2>
+            <p><a href="{{ PUBLIC_SITE }}/home">Learn more</a> about how {{ SITE_NAME }} can be your {{ CAN_BE_YOUR }}.</p>
+            <p>Don't have an account with {{ SITE_NAME }} yet? Sign up and check out our features.</p>
+            <div class="row"><a style="float: right; margin-top: 7px;" class="btn btn-success btn-large" href="{% url register_user DOMAIN_TYPE %}">Sign Up</a></div>
         </aside>
     </div>
 </div>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -2,8 +2,8 @@
 <html lang="en">
     <head>
         <meta charset="utf-8"/>
-        <title>{% block title %}{% endblock %} - CommCare HQ</title>
-        <meta name="application-name" content="CommCare HQ">
+        <title>{% block title %}{% endblock %} - {{ SITE_NAME }}</title>
+        <meta name="application-name" content="{{ SITE_NAME }}">
         <meta http-equiv="content-language" content="en">
 
         <link rel="shortcut icon" href="{% static 'hqwebapp/img/favicon2.png' %}" />

--- a/corehq/apps/hqwebapp/urls.py
+++ b/corehq/apps/hqwebapp/urls.py
@@ -9,7 +9,7 @@ urlpatterns = patterns('corehq.apps.hqwebapp.views',
 
     url(r'^no_permissions/$', 'no_permissions', name='no_permissions'),
 
-    url(r'^accounts/login/$', 'login', name="login"),
+    url(r'^accounts/login/(?P<domain_type>\w+)?$', 'login', name="login"),
     url(r'^accounts/logout/$', 'logout', name="logout"),
     (r'^$', 'redirect_to_default'),
     (r'^reports/$', 'redirect_to_default'),

--- a/corehq/apps/registration/templates/registration/confirmation_sent.html
+++ b/corehq/apps/registration/templates/registration/confirmation_sent.html
@@ -31,7 +31,7 @@
         {% endblocktrans %}</strong>
         {% blocktrans %}
             Please visit the link provided in the email to activate your account,
-            so you can start using your new CommCare HQ project!
+            so you can start using your new {{ SITE_NAME }} project!
         {% endblocktrans %}
     </div>
     {% include "registration/partials/confirmation_waiting_actions.html" %}

--- a/corehq/apps/registration/templates/registration/domain_request.html
+++ b/corehq/apps/registration/templates/registration/domain_request.html
@@ -5,7 +5,7 @@
 
 {% block step-title %}
     {% if is_new %}
-        {% blocktrans %}Welcome to CommCare HQ! <small>It's time to create your first project.</small>{% endblocktrans %}
+        {% blocktrans %}Welcome to {{ SITE_NAME }}! <small>It's time to create your first project.</small>{% endblocktrans %}
     {% else %}
         {% blocktrans %}Create a New Project Space{% endblocktrans %}
     {% endif %}
@@ -32,11 +32,21 @@
 {% block registration-content %}
 <div class="span8">
     {% if is_new %}
-    <p>{% blocktrans with request.couch_user.first_name as first_name %}
-      Congratulations, {{ first_name }}&mdash;you've successfully joined CommCare HQ.
-    {% endblocktrans %}</p>
-    <p>Your CommCare HQ Project will contain all form submissions from your CommCare mobile applications, as well as tools that help you easily create, deploy, and monitor your applications and workers.</p>
-    <p>Before you can view any of your own data from CommCare, you will need to request a project space.</p>
+    <p>
+    {% blocktrans with request.couch_user.first_name as first_name %}
+    Congratulations, {{ first_name }}&mdash;you've successfully joined {{ SITE_NAME }}.
+    {% endblocktrans %}
+    </p>
+    <p>
+    {% blocktrans %}
+    Your {{ SITE_NAME }} project will contain all form submissions from your CommCare mobile applications, as well as tools that help you easily create, deploy, and monitor your applications and workers.
+    {% endblocktrans %}
+    </p>
+    <p>
+    {% blocktrans %}
+    Before you can view any of your own data from CommCare, you will need to request a project space.
+    {% endblocktrans %}
+    </p>
     {% endif %}
     <form class="form-horizontal" method="post" action="{{ request.get_full_path }}">
         <fieldset>

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from functools import partial
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import authenticate, login
@@ -23,7 +22,7 @@ DOMAIN_TYPES = (
     'commtrack'
 )
 
-def render_registration_view(request, template, context, domain_type='commcare', *args, **kwargs):
+def get_domain_context(domain_type='commcare'):
     """
     Set context variables that are normally set based on the domain type
     according to what user/domain type is being registered.
@@ -32,10 +31,7 @@ def render_registration_view(request, template, context, domain_type='commcare',
 
     dummy_domain = Dummy()
     dummy_domain.commtrack_enabled = (domain_type == 'commtrack')
-    context.update(get_per_domain_context(dummy_domain))
-
-    return render(request, template, context, *args, **kwargs)
-
+    return get_per_domain_context(dummy_domain)
 
 def registration_default(request):
     return redirect(register_user)
@@ -44,7 +40,8 @@ def registration_default(request):
 def register_user(request, domain_type=None):
     domain_type = domain_type or 'commcare'
     assert domain_type in DOMAIN_TYPES
-    _render = partial(render_registration_view, domain_type=domain_type)
+
+    context = get_domain_context(domain_type)
 
     if request.user.is_authenticated():
         # Redirect to a page which lets user choose whether or not to create a new account
@@ -61,17 +58,17 @@ def register_user(request, domain_type=None):
                 new_user = authenticate(username=form.cleaned_data['email'],
                                         password=form.cleaned_data['password'])
                 login(request, new_user)
-
                 return redirect(
                     'registration_domain', domain_type=domain_type)
         else:
             form = NewWebUserRegistrationForm(
                     initial={'domain_type': domain_type})
 
-        return _render(request, 'registration/create_new_user.html', {
+        context.update({
             'form': form,
             'domain_type': domain_type
         })
+        return render(request, 'registration/create_new_user.html', context)
 
 
 @transaction.commit_on_success
@@ -113,7 +110,7 @@ def register_org(request, template="registration/org_request.html"):
 def register_domain(request, domain_type=None):
     domain_type = domain_type or 'commcare'
     assert domain_type in DOMAIN_TYPES
-    _render = partial(render_registration_view, domain_type=domain_type)
+    context = get_domain_context(domain_type)
 
     is_new = False
     referer_url = request.GET.get('referer', '')
@@ -123,10 +120,9 @@ def register_domain(request, domain_type=None):
         is_new = True
         domains_for_user = Domain.active_for_user(request.user, is_active=False)
         if len(domains_for_user) > 0:
-            vals = dict(requested_domain=domains_for_user[0])
-            return _render(request, 'registration/confirmation_waiting.html', {
-                'requested_domain': domains_for_user[0]
-            })
+            context['requested_domain'] = domains_for_user[0]
+            return render(request, 'registration/confirmation_waiting.html',
+                    context)
 
     if request.method == 'POST':
         nextpage = request.POST.get('next')
@@ -136,17 +132,23 @@ def register_domain(request, domain_type=None):
             reqs_today = RegistrationRequest.get_requests_today()
             max_req = settings.DOMAIN_MAX_REGISTRATION_REQUESTS_PER_DAY
             if reqs_today >= max_req:
-                vals = {'error_msg':'Number of domains requested today exceeds limit ('+str(max_req)+') - contact Dimagi',
-                        'show_homepage_link': 1 }
-                return _render(request, 'error.html', vals)
+                context.update({
+                    'error_msg':'Number of domains requested today exceeds limit ('+str(max_req)+') - contact Dimagi',
+                    'show_homepage_link': 1
+                })
+                return render(request, 'error.html', context)
 
             request_new_domain(
                 request, form, org, new_user=is_new, domain_type=domain_type)
 
             requested_domain = form.cleaned_data['domain_name']
             if is_new:
-                vals = dict(alert_message="An email has been sent to %s." % request.user.username, requested_domain=requested_domain)
-                return _render(request, 'registration/confirmation_sent.html', vals)
+                context.update({
+                    'alert_message': "An email has been sent to %s." % request.user.username,
+                    'requested_domain': requested_domain
+                })
+                return render(request, 'registration/confirmation_sent.html',
+                        context)
             else:
                 messages.success(request, '<strong>The project {project_name} was successfully created!</strong> An email has been sent to {username} for your records.'.format(
                     username=request.user.username,
@@ -164,10 +166,11 @@ def register_domain(request, domain_type=None):
     else:
         form = DomainRegistrationForm(initial={'domain_type': domain_type})
 
-    return _render(request, 'registration/domain_request.html', {
+    context.update({
         'form': form,
         'is_new': is_new,
     })
+    return render(request, 'registration/domain_request.html', context)
 
 @transaction.commit_on_success
 @login_required_late_eval_of_LOGIN_URL
@@ -185,25 +188,30 @@ def resend_confirmation(request):
                 domain.save()
         return redirect('domain_select')
 
-    _render = partial(
-        render_registration_view, 
-        domain_type='commtrack' if dom_req.project.commtrack_enabled else None)
+    context = get_domain_context(dom_req.project.domain_type)
 
     if request.method == 'POST':
         try:
             send_domain_registration_email(dom_req.new_user_username, dom_req.domain, dom_req.activation_guid)
         except Exception:
-            vals = {'error_msg':'There was a problem with your request',
-                    'error_details':sys.exc_info(),
-                    'show_homepage_link': 1 }
-            return _render(request, 'error.html', vals)
+            context.update({
+                'error_msg': 'There was a problem with your request',
+                'error_details': sys.exc_info(),
+                'show_homepage_link': 1,
+            })
+            return render(request, 'error.html', context)
         else:
-            vals = dict(alert_message="An email has been sent to %s." % dom_req.new_user_username, requested_domain=dom_req.domain)
-            return _render(request, 'registration/confirmation_sent.html', vals)
+            context.update({
+                'alert_message': "An email has been sent to %s." % dom_req.new_user_username,
+                'requested_domain': dom_req.domain
+            })
+            return render(request, 'registration/confirmation_sent.html',
+                context)
 
-    return _render(request, 'registration/confirmation_resend.html', {
+    context.update({
         'requested_domain': dom_req.domain
     })
+    return render(request, 'registration/confirmation_resend.html', context)
 
 @transaction.commit_on_success
 def confirm_domain(request, guid=None):
@@ -226,19 +234,18 @@ def confirm_domain(request, guid=None):
         return render(request, 'registration/confirmation_complete.html', vals)
 
     # Has guid already been confirmed?
-    vals['requested_domain'] = req.domain
-    requested_domain = Domain.get_by_name(req.domain)
     
-    _render = partial(
-        render_registration_view, 
-        domain_type='commtrack' if requested_domain.commtrack_enabled else None)
+    requested_domain = Domain.get_by_name(req.domain)
+    context = get_domain_context(requested_domain.domain_type)
+    context['requested_domain'] = req.domain
 
     if requested_domain.is_active:
         assert(req.confirm_time is not None and req.confirm_ip is not None)
-        vals['message_title'] = 'Already Activated'
-        vals['message_body'] = 'Your account %s has already been activated. No further validation is required.' % req.new_user_username
-        vals['is_error'] = False
-        return _render(request, 'registration/confirmation_complete.html', vals)
+        context['message_title'] = 'Already Activated'
+        context['message_body'] = 'Your account %s has already been activated. No further validation is required.' % req.new_user_username
+        context['is_error'] = False
+        return render(request, 'registration/confirmation_complete.html',
+                context)
 
     # Set confirm time and IP; activate domain and new user who is in the
     req.confirm_time = datetime.utcnow()
@@ -250,11 +257,11 @@ def confirm_domain(request, guid=None):
 
     send_new_request_update_email(requesting_user, get_ip(request), requested_domain.name, is_confirming=True)
 
-    vals['message_title'] = 'Account Confirmed'
-    vals['message_subtitle'] = 'Thank you for activating your account, %s!' % requesting_user.first_name
-    vals['message_body'] = 'Your account has been successfully activated. Thank you for taking the time to confirm your email address: %s.' % requesting_user.username
-    vals['is_error'] = False
-    return _render(request, 'registration/confirmation_complete.html', vals)
+    context['message_title'] = 'Account Confirmed'
+    context['message_subtitle'] = 'Thank you for activating your account, %s!' % requesting_user.first_name
+    context['message_body'] = 'Your account has been successfully activated. Thank you for taking the time to confirm your email address: %s.' % requesting_user.username
+    context['is_error'] = False
+    return render(request, 'registration/confirmation_complete.html', context)
 
 @retry_resource(3)
 def eula_agreement(request):

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -16,15 +16,24 @@ def base_template(request):
 
 def get_per_domain_context(project):
     if project and project.commtrack_enabled:
+        domain_type = 'commtrack'
         logo = 'hqstyle/img/commtrack-logo.png'
         site_name = "CommTrack"
+        public_site = "http://www.commtrack.org"
+        can_be_your = "mobile logistics solution"
     else:
+        domain_type = 'commcare'
         logo = 'hqstyle/img/commcare-logo.png'
         site_name = "CommCare HQ"
+        public_site = "http://www.commcarehq.org"
+        can_be_your = "mobile health solution"
 
     return {
+        'DOMAIN_TYPE': domain_type,
         'LOGO': logo,
-        'SITE_NAME': site_name
+        'SITE_NAME': site_name,
+        'CAN_BE_YOUR': can_be_your,
+        'PUBLIC_SITE': public_site,
     }
 
 

--- a/settings.py
+++ b/settings.py
@@ -262,6 +262,11 @@ REPORT_CACHE = 'default' # or e.g. 'redis'
 DOMAIN_MAX_REGISTRATION_REQUESTS_PER_DAY = 99
 DOMAIN_SELECT_URL = "/domain/select/"
 
+# This is not used by anything in CommCare HQ, leaving it here in case anything
+# in Django unexpectedly breaks without it.  When you need the login url, you
+# should use reverse('login', kwargs={'domain_type': domain_type}) in order to
+# maintain CommCare HQ/CommTrack distinction.
+LOGIN_URL = "/accounts/login/"
 # If a user tries to access domain admin pages but isn't a domain
 # administrator, here's where he/she is redirected
 DOMAIN_NOT_ADMIN_REDIRECT_PAGE_NAME = "homepage"

--- a/settings.py
+++ b/settings.py
@@ -261,7 +261,7 @@ REPORT_CACHE = 'default' # or e.g. 'redis'
 
 DOMAIN_MAX_REGISTRATION_REQUESTS_PER_DAY = 99
 DOMAIN_SELECT_URL = "/domain/select/"
-LOGIN_URL = "/accounts/login/"
+
 # If a user tries to access domain admin pages but isn't a domain
 # administrator, here's where he/she is redirected
 DOMAIN_NOT_ADMIN_REDIRECT_PAGE_NAME = "homepage"


### PR DESCRIPTION
this adds a commtrack-specific login page (including for after you have confirmed a domain but are not yet logged in) using an optional parameter in the urlpattern, i.e. accounts/login/commtrack (in the same way as the existing user and domain registration pages) and ensures that CommTrack appears instead of CommCare HQ and the correct domain type is preserved in any navigation links throughout the registration and login processes.

I didn't completely process the fact that we're using commtrack.org as an entry point for HQ.  We should probably switch to using the django sites framework using the domain name to determine the site for these pages where a logged-in domain isn't present, instead of passing around the domain type in the URLs.  But this will work fine for now.

Tested this pretty extensively by going through every page for both types.
