### PR TITLE
Fixtures update

### DIFF
--- a/corehq/apps/fixtures/templates/fixtures/upload_item_lists.html
+++ b/corehq/apps/fixtures/templates/fixtures/upload_item_lists.html
@@ -18,7 +18,7 @@
 {% endblock %}
 
 {% block content %}
-    <div id="import-export" class="accordion-body">
+    <div id="import-export" class="accordion-body container">
         <div class="accordion-inner">
             <section>
                 <h2>{% trans "Bulk Download/Upload of Fixtures" %}</h2>

--- a/corehq/apps/fixtures/templates/fixtures/upload_item_lists.html
+++ b/corehq/apps/fixtures/templates/fixtures/upload_item_lists.html
@@ -1,5 +1,6 @@
 {% extends base_template %}
 {% load hq_shared_tags %}
+{% load i18n %}
 
 {% block oldstyle_tag %}{% endblock %}
 {% block oldstyle_imports %}{% endblock %}
@@ -17,10 +18,50 @@
 {% endblock %}
 
 {% block content %}
-    <div>
-        <form action="" method="post" enctype="multipart/form-data" id="upload-item-lists">
-            <input type="file" name="file" data-bind="value: file"/>
-            <button class="btn btn-primary" type="submit" data-bind="visible: file">Upload</button>
-        </form>
+    <div id="import-export" class="accordion-body">
+        <div class="accordion-inner">
+            <section>
+                <h2>{% trans "Bulk Download/Upload of Fixtures" %}</h2>
+                <p>
+                    <ol>
+                        <li>
+                            {% trans "Download your " %}
+                            <a href="{% url download_fixtures domain %}">{% trans "fixtures file" %}</a>
+                        </li>
+                        <li>
+                            {% trans "To modify fixture data, edit the document according to these " %}
+                            <a href="https://confluence.dimagi.com/pages/viewpage.action?pageId=18907967" target="_blank">{% trans "instructions."%}</a>
+                        </li>
+                        <li>
+                            {% trans "Use the form below to update fixtures."%}
+                        </li>
+                    </ol>
+                </p>
+                <p class="alert alert-info">
+                    {% trans "Fixtures will be updated according to changes in the uploaded document." %}
+                </p>
+                <form class="form form-horizontal" action="{% url upload_fixtures domain%}" method="post" enctype="multipart/form-data">
+                    <legend>{% trans "Choose a file for upload" %}</legend>
+                    <div class="form-actions" style="padding-left: 1em;">
+                        <fieldset>
+                            <div class="control-group">
+                                <label for="bulk_upload_file" class="control-label">{% trans "Fixtures File" %}</label>
+                                <div class="controls">
+                                    <input id="bulk_upload_file" type="file" name="file" data-bind="value: file"/>
+                                </div>
+                            </div>
+                            <div class="control-group">
+                                <div class="controls">
+                                    <button type="submit" class="btn btn-primary" data-bind="visible: file()">
+                                        {% trans "Update Fixtures" %}
+                                    </button>
+                                </div>
+                            </div>
+                        </fieldset>
+                    </div>
+                </form>
+            </section>
+            <a href="{% url fixture_view domain %}">{% trans "Go back to Fixtures" %}</a>
+        </div>
     </div>
 {% endblock %}

--- a/corehq/apps/fixtures/templates/fixtures/view.html
+++ b/corehq/apps/fixtures/templates/fixtures/view.html
@@ -14,16 +14,6 @@
 <script src="{% static 'hqwebapp/js/knockout-bindings.js' %}"></script>
 <script src="{% static 'fixtures/js/item-lists.js' %}"></script>
 {% endblock %}
-{% block js-inline %}
-    <script>
-        $(function () {
-            function FileUpload() {
-                this.file = ko.observable();
-            }
-            ko.applyBindings(new FileUpload(), $('#upload-item-lists').get(0));
-        });
-    </script>
-{% endblock %}
 {% block head %}
 <style>
     .selected, .table tr.selected, .table tr.selected:hover, .table tr.selected > td {
@@ -48,54 +38,7 @@
 {% endblock %}
 
 {% block content %}
-    <div id="import-export" class="accordion-body">
-        <div class="accordion-inner">
-            <section>
-                <h2>{% trans "Bulk Download/Upload of Fixtures" %}</h2>
-                <p>
-                    <ol>
-                        <li>
-                            {% trans "Download your " %}
-                            <a href="{% url download_fixtures domain %}">{% trans "fixtures file" %}</a>
-                        </li>
-                        <li>
-                            {% trans "To add new fixture types/items, insert new rows with UID-column as blank." %}
-                        </li>
-                        <li>
-                            {% trans "To delete any fixture type/itemm, mark 'Y' in the 'Delete(Y/N)' column." %}
-                        </li>
-                        <li>
-                            {% trans "Use the form below to update fixtures."%}
-                        </li>
-                    </ol>
-                </p>
-                <p class="alert alert-info">
-                    {% trans "Fixtures will be updated according to changes in the uploaded document." %}
-                </p>
-                <form class="form form-horizontal" action="{% url upload_item_lists domain%}" method="post" enctype="multipart/form-data">
-                    <legend>{% trans "Choose a file for upload" %}</legend>
-                    <div class="form-actions" style="padding-left: 1em;">
-                        <fieldset>
-                            <div class="control-group">
-                                <label for="bulk_upload_file" class="control-label">{% trans "Fixtures File" %}</label>
-                                <div class="controls">
-                                    <input id="bulk_upload_file" type="file" name="file" data-bind="value: file"/>
-                                </div>
-                            </div>
-                            <div class="control-group">
-                                <div class="controls">
-                                    <button type="submit" class="btn btn-primary" data-bind="visible: file()">
-                                        {% trans "Update Fixtures" %}
-                                    </button>
-                                </div>
-                            </div>
-                        </fieldset>
-                    </div>
-                </form>
-            </section>
-        </div>
-    </div>
-
+    <button class="btn btn-primary" onClick="window.location='{% url upload_fixtures domain %}'">Bulk upload/download Fixtures</button>
     <div class="span2">&nbsp;</div>
     <div class="row-fluid hidden" style="margin-top: 25px;" id="fixtures-ui">
         <div class="span2">&nbsp;</div>

--- a/corehq/apps/fixtures/templates/fixtures/view.html
+++ b/corehq/apps/fixtures/templates/fixtures/view.html
@@ -14,6 +14,16 @@
 <script src="{% static 'hqwebapp/js/knockout-bindings.js' %}"></script>
 <script src="{% static 'fixtures/js/item-lists.js' %}"></script>
 {% endblock %}
+{% block js-inline %}
+    <script>
+        $(function () {
+            function FileUpload() {
+                this.file = ko.observable();
+            }
+            ko.applyBindings(new FileUpload(), $('#upload-item-lists').get(0));
+        });
+    </script>
+{% endblock %}
 {% block head %}
 <style>
     .selected, .table tr.selected, .table tr.selected:hover, .table tr.selected > td {
@@ -38,13 +48,59 @@
 {% endblock %}
 
 {% block content %}
+    <div id="import-export" class="accordion-body">
+        <div class="accordion-inner">
+            <section>
+                <h2>{% trans "Bulk Download/Upload of Fixtures" %}</h2>
+                <p>
+                    <ol>
+                        <li>
+                            {% trans "Download your " %}
+                            <a href="{% url download_fixtures domain %}">{% trans "fixtures file" %}</a>
+                        </li>
+                        <li>
+                            {% trans "To add new fixture types/items, insert new rows with UID-column as blank." %}
+                        </li>
+                        <li>
+                            {% trans "To delete any fixture type/itemm, mark 'Y' in the 'Delete(Y/N)' column." %}
+                        </li>
+                        <li>
+                            {% trans "Use the form below to update fixtures."%}
+                        </li>
+                    </ol>
+                </p>
+                <p class="alert alert-info">
+                    {% trans "Fixtures will be updated according to changes in the uploaded document." %}
+                </p>
+                <form class="form form-horizontal" action="{% url upload_item_lists domain%}" method="post" enctype="multipart/form-data">
+                    <legend>{% trans "Choose a file for upload" %}</legend>
+                    <div class="form-actions" style="padding-left: 1em;">
+                        <fieldset>
+                            <div class="control-group">
+                                <label for="bulk_upload_file" class="control-label">{% trans "Fixtures File" %}</label>
+                                <div class="controls">
+                                    <input id="bulk_upload_file" type="file" name="file" data-bind="value: file"/>
+                                </div>
+                            </div>
+                            <div class="control-group">
+                                <div class="controls">
+                                    <button type="submit" class="btn btn-primary" data-bind="visible: file()">
+                                        {% trans "Update Fixtures" %}
+                                    </button>
+                                </div>
+                            </div>
+                        </fieldset>
+                    </div>
+                </form>
+            </section>
+        </div>
+    </div>
+
     <div class="span2">&nbsp;</div>
-     {% trans "To edit following items lists " %}
-    <a href="{% url download_fixtures domain %}">{% trans "download all fixtures in excel format" %}</a> and reupload
     <div class="row-fluid hidden" style="margin-top: 25px;" id="fixtures-ui">
         <div class="span2">&nbsp;</div>
         <div class="span9">
-            <a href="{% url upload_item_lists domain %}">Upload Item Lists</a>
+            <div>Fixtures</div>
             <div class="well" data-bind="visible: !data_types().length && loading" style="text-align: center;">Loading...</div>
             <div data-bind="visible: data_types().length">
                 {% trans "Number of fixtures types: " %}<span data-bind="text: data_types().length"></span>

--- a/corehq/apps/fixtures/templates/fixtures/view.html
+++ b/corehq/apps/fixtures/templates/fixtures/view.html
@@ -38,12 +38,11 @@
 {% endblock %}
 
 {% block content %}
-    <button class="btn btn-primary" onClick="window.location='{% url upload_fixtures domain %}'">Bulk upload/download Fixtures</button>
     <div class="span2">&nbsp;</div>
     <div class="row-fluid hidden" style="margin-top: 25px;" id="fixtures-ui">
         <div class="span2">&nbsp;</div>
         <div class="span9">
-            <div>Fixtures</div>
+            <h1>{% trans "Fixtures" %} <a href="{% url upload_fixtures domain %}" class="btn btn-primary pull-right">Bulk upload/download Fixtures</a></h1>
             <div class="well" data-bind="visible: !data_types().length && loading" style="text-align: center;">Loading...</div>
             <div data-bind="visible: data_types().length">
                 {% trans "Number of fixtures types: " %}<span data-bind="text: data_types().length"></span>

--- a/corehq/apps/fixtures/urls.py
+++ b/corehq/apps/fixtures/urls.py
@@ -9,7 +9,7 @@ urlpatterns = patterns('corehq.apps.fixtures.views',
     url(r'^$', 'view', name='fixture_view'),
     url(r'^groups/$', 'groups'),
     url(r'^users/$', 'users'),
-    url(r'^item-lists/upload/$', UploadItemLists.as_view(), name='upload_item_lists'),
+    url(r'^item-lists/upload/$', UploadItemLists.as_view(), name='upload_fixtures'),
     url(r'^fixapi/', 'upload_fixture_api'),
     url(r'^item-lists/download/$', 'download_item_lists', name="download_fixtures"),
 )

--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -320,16 +320,16 @@ class UploadItemLists(TemplateView):
             upload_result = run_upload(request, self.domain, workbook)
             if upload_result["unknown_groups"]:
                 for group_name in upload_result["unknown_groups"]:
-                    messages.error(request, _("Unknown group: '%(name)s'" % {'name': group_name}))
+                    messages.error(request, _("Unknown group: '%(name)s'") % {'name': group_name})
             if upload_result["unknown_users"]:
                 for user_name in upload_result["unknown_users"]:
-                    messages.error(request, _("Unknown user: '%(name)s'" % {'name': user_name}))
+                    messages.error(request, _("Unknown user: '%(name)s'") % {'name': user_name})
         except WorksheetNotFound as e:
-            messages.error(request, _("Workbook does not contain a sheet called '%(title)s'" % {'title': e.title}))
+            messages.error(request, _("Workbook does not contain a sheet called '%(title)s'") % {'title': e.title})
             return error_redirect()
         except Exception as e:
             notify_exception(request)
-            messages.error(request, _("Fixture upload could not complete due to the following error: '%(e)s'" % {'e': e}))
+            messages.error(request, _("Fixture upload could not complete due to the following error: '%(e)s'") % {'e': e})
             return error_redirect()
 
         return HttpResponseRedirect(reverse('fixture_view', args=[self.domain]))
@@ -488,19 +488,19 @@ def run_upload(request, domain, workbook):
                         if group:
                             old_data_item.add_group(group, transaction=transaction)
                         else:
-                            messages.error(request, _("Unknown group: '%(name)s'. But the row is successfully added" % {'name': group_name}))
+                            messages.error(request, _("Unknown group: '%(name)s'. But the row is successfully added") % {'name': group_name})
 
                 for raw_username in di.get('user', []):
                         try:
                             username = normalize_username(raw_username, domain)
                         except ValidationError:
-                            messages.error(request, _("Invalid username: '%(name)s'. Row is not added" % {'name': raw_username}))
+                            messages.error(request, _("Invalid username: '%(name)s'. Row is not added") % {'name': raw_username})
                             continue
                         user = CommCareUser.get_by_username(username)
                         if user:
                             old_data_item.add_user(user)
                         else:
-                            messages.error(request, _("Unknown user: '%(name)s'. But the row is successfully added" % {'name': raw_username}))
+                            messages.error(request, _("Unknown user: '%(name)s'. But the row is successfully added") % {'name': raw_username})
 
     return_val["number_of_fixtures"] = number_of_fixtures + 1
     return return_val

--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -304,6 +304,9 @@ class UploadItemLists(TemplateView):
         except AttributeError:
             messages.error(request, "Error processing your Excel (.xlsx) file")
             return error_redirect()
+        except Exception as e:
+            messages.error(request, "Invalid file-format. Please upload a valid xlsx file.")
+            return error_redirect()
 
         try:
             upload_result = run_upload(request, self.domain, workbook)

--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -5,8 +5,10 @@ from couchdbkit import ResourceNotFound
 
 from django.contrib import messages
 from django.core.urlresolvers import reverse
+from django.core.validators import ValidationError
 from django.http import HttpResponseBadRequest, HttpResponseRedirect, Http404, HttpResponse
 from django.utils.decorators import method_decorator
+from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_POST
 from django.views.generic.base import TemplateView
 from django.shortcuts import render
@@ -238,8 +240,8 @@ def download_item_lists(request, domain):
         for item_row in FixtureDataItem.by_data_type(domain, type_id):
             groups = [group.name for group in item_row.get_groups()] + _get_empty_list(max_groups - len(item_row.get_groups()))
             users = [user.raw_username for user in item_row.get_users()] + _get_empty_list(max_users - len(item_row.get_users()))
-            data_row = tuple([str(_id_from_doc(item_row)),"N"]+
-                             ["" if item_row.fields[field] is None else item_row.fields[field] for field in fields]+
+            data_row = tuple([str(_id_from_doc(item_row)), "N"] +
+                             [item_row.fields[field] or "" for field in fields] +
                              groups + users)
             data_table_of_type.append(data_row)
         type_schema.extend(fields)
@@ -256,10 +258,10 @@ def download_item_lists(request, domain):
     type_headers = ("types", tuple(type_headers))
     table_headers = [type_headers]    
     for type_schema in data_type_schemas:
-        item_header = (type_schema[3], tuple(["UID",DELETE_HEADER]+
-                                             ["field: "+x for x in type_schema[4:]]+
-                                             ["group %d" % x for x in range(1, mmax_groups+1)]+
-                                             ["user %d" % x for x in range(1, mmax_users+1)]))
+        item_header = (type_schema[3], tuple(["UID", DELETE_HEADER] +
+                                             ["field: " + x for x in type_schema[4:]] +
+                                             ["group %d" % x for x in range(1, mmax_groups + 1)] +
+                                             ["user %d" % x for x in range(1, mmax_users + 1)]))
         table_headers.append(item_header)
 
     table_headers = tuple(table_headers)
@@ -308,26 +310,26 @@ class UploadItemLists(TemplateView):
         try:
             workbook = WorkbookJSONReader(request.file)
         except AttributeError:
-            messages.error(request, "Error processing your Excel (.xlsx) file")
+            messages.error(request, _("Error processing your Excel (.xlsx) file"))
             return error_redirect()
         except Exception as e:
-            messages.error(request, "Invalid file-format. Please upload a valid xlsx file.")
+            messages.error(request, _("Invalid file-format. Please upload a valid xlsx file."))
             return error_redirect()
 
         try:
             upload_result = run_upload(request, self.domain, workbook)
             if upload_result["unknown_groups"]:
                 for group_name in upload_result["unknown_groups"]:
-                    messages.error(request, "Unknown group: %s" % group_name)
+                    messages.error(request, _("Unknown group: '%(name)s'" % {'name': group_name}))
             if upload_result["unknown_users"]:
                 for user_name in upload_result["unknown_users"]:
-                    messages.error(request, "Unknown user: %s" % user_name)
+                    messages.error(request, _("Unknown user: '%(name)s'" % {'name': user_name}))
         except WorksheetNotFound as e:
-            messages.error(request, "Workbook does not have a sheet called '%s'" % e.title)
+            messages.error(request, _("Workbook does not contain a sheet called '%(title)s'" % {'title': e.title}))
             return error_redirect()
         except Exception as e:
             notify_exception(request)
-            messages.error(request, "Fixture upload could not complete due to the following error: %s" % e)
+            messages.error(request, _("Fixture upload could not complete due to the following error: '%(e)s'" % {'e': e}))
             return error_redirect()
 
         return HttpResponseRedirect(reverse('fixture_view', args=[self.domain]))
@@ -369,9 +371,8 @@ def upload_fixture_api(request, domain, **kwargs):
     except Exception:
         return _return_response(response_codes["fail"], error_messages["invalid_file"])
 
-
     try:
-        upload_resp = run_upload(request, domain, workbook) #error handle for other files
+        upload_resp = run_upload(request, domain, workbook) # error handle for other files
     except WorksheetNotFound as e:
         error_message = error_messages["has_no_sheet"].format(attr=e.title)
         return _return_response(response_codes["fail"], error_message)
@@ -429,29 +430,32 @@ def run_upload(request, domain, workbook):
                     name=_get_or_raise(dt, 'name'),
                     tag=_get_or_raise(dt, 'tag'),
                     fields=type_definition_fields,
-                )
+            )
             try:
                 data_type = FixtureDataType.get(dt['UID'])
+                assert data_type.domain == domain
+                assert data_type.doc_type == FixtureDataType._doc_type
                 if dt[DELETE_HEADER] == "Y" or dt[DELETE_HEADER] == "y":
                     data_type.recursive_delete(transaction)
                     continue
                 data_type.fields = type_definition_fields
-            except ResourceNotFound:
+            except (ResourceNotFound, KeyError) as e:
                 data_type = new_data_type
             transaction.save(data_type)
 
             data_items = workbook.get_worksheet(data_type.tag)
             for sort_key, di in enumerate(data_items):
-                #Check that type definitions in 'types' sheet vs corresponding columns in the item-sheet MATCH
+                # Check that type definitions in 'types' sheet vs corresponding columns in the item-sheet MATCH
                 item_fields = di['field']
                 for field in type_definition_fields:
                     if not item_fields.has_key(field):
-                        raise Exception("Workbook '{attr}' does not contain the column '{field}' specified in it's 'types' definition".format(attr=tag, field=field))
+                        raise Exception(_("Workbook '%(tag)s' does not contain the column " +
+                                          "'%(field)s' specified in its 'types' definition") % {'tag': tag, 'field': field})
                 item_fields_list = di['field'].keys()
                 for field in item_fields_list:
                     if not field in type_definition_fields:
-                        raise Exception("Workbook '{attr}' has an extra column '{field}' that's not defined in it's 'types' definition".format(attr=tag, field=field))
-                
+                        raise Exception(_("""Workbook '%(tag)s' has an extra column 
+                                          '%(field)s' that's not defined in its 'types' definition""") % {'tag': tag, 'field': field})                
                 new_data_item = FixtureDataItem(
                     domain=domain,
                     data_type_id=data_type.get_id,
@@ -463,12 +467,12 @@ def run_upload(request, domain, workbook):
                     assert old_data_item.domain == domain
                     assert old_data_item.doc_type == FixtureDataItem._doc_type
                     assert old_data_item.data_type_id == data_type.get_id
-                    if di[DELETE_HEADER]=="Y" or di[DELETE_HEADER]=="y":
+                    if di[DELETE_HEADER] == "Y" or di[DELETE_HEADER] == "y":
                         old_data_item.recursive_delete(transaction)
                         continue   
                     old_data_item.fields = di['field']
                     transaction.save(old_data_item)                 
-                except ResourceNotFound:
+                except (ResourceNotFound, KeyError) as e:
                     old_data_item = new_data_item
                     transaction.save(old_data_item)
 
@@ -484,15 +488,19 @@ def run_upload(request, domain, workbook):
                         if group:
                             old_data_item.add_group(group, transaction=transaction)
                         else:
-                            messages.error(request, "Unknown group: %s. But the row is successfully added" % group_name)
+                            messages.error(request, _("Unknown group: '%(name)s'. But the row is successfully added" % {'name': group_name}))
 
                 for raw_username in di.get('user', []):
-                        username = normalize_username(raw_username, domain)
+                        try:
+                            username = normalize_username(raw_username, domain)
+                        except ValidationError:
+                            messages.error(request, _("Invalid username: '%(name)s'. Row is not added" % {'name': raw_username}))
+                            continue
                         user = CommCareUser.get_by_username(username)
                         if user:
                             old_data_item.add_user(user)
                         else:
-                            messages.error(request, "Unknown user: %s. But the row is successfully added" % raw_username)
+                            messages.error(request, _("Unknown user: '%(name)s'. But the row is successfully added" % {'name': raw_username}))
 
     return_val["number_of_fixtures"] = number_of_fixtures + 1
     return return_val

--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -297,7 +297,7 @@ class UploadItemLists(TemplateView):
         """View's dispatch method automatically calls this"""
 
         def error_redirect():
-            return HttpResponseRedirect(reverse('upload_item_lists', args=[self.domain]))
+            return HttpResponseRedirect(reverse('upload_fixtures', args=[self.domain]))
 
         try:
             workbook = WorkbookJSONReader(request.file)


### PR DESCRIPTION
This update corresponds to 'fixes to Fixtures upload through API'. All of the [issues](http://manage.dimagi.com/default.asp?64973#371706) from the previous PR are fixed and tested.
- Fixed malformed document uploads giving 500 errors. Added a strict Fixture schema consistency check across all sheets
- Added the ability to add new Types, modify and delete using excel-file.
- Updated messages to be more helpful and relevent
- Linked upload/download instructions to a documentation page.

Few notes for future modifications
- In case of large fixture data, upload is successful, but takes lot of time (more than 30 minutes for a 18402 row fixture). So it's better, in case of large files, to add the upload task to a queue and notify the user once the upload is finished.
- Viewing large fixture data using webpage times out. So it's a good idea to not to display Fixtures with more than few 100 rows.
- Add a collapsible error-message holder. 
