### PR TITLE
Adds auto-complete for sms-deploy

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1386,6 +1386,11 @@ class ApplicationBase(VersionedDoc, SnapshotMixin):
             # I'm putting this assert here if copy._id is ever None
             # which makes tests error
             assert copy._id
+            """
+            #Hardcode variables for testing purpose to avoid BitlyError. CHANGE_BEFORE_COMMIT.
+            copy.short_url = "http://SET_IN_CODE_UPDATE"
+            copy.short_odk_url = "http:/SET_IN_CODE_UPDATE"
+            """
             copy.short_url = bitly.shorten(
                 get_url_base() + reverse('corehq.apps.app_manager.views.download_jad', args=[copy.domain, copy._id])
             )

--- a/corehq/apps/app_manager/static/app_manager/js/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases.js
@@ -143,6 +143,12 @@ function ReleasesMain(o) {
                 self.buildState('error');
             });
     };
+    self.group_deploy = function() { 
+        var json_contacts = $('.tabbable').find("input[name]='recipients'").attr("data-contacts").replace(/'/g,'"');
+        $('.tabbable').find("input[name]='recipients'").multiTypeahead({ 
+            source: jQuery.parseJSON(json_contacts),
+        }).focus();
+    };
     // init
     setTimeout(function () {
         self.getMoreSavedApps();

--- a/corehq/apps/app_manager/templates/app_manager/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/releases.html
@@ -180,7 +180,7 @@
                     </td>
                     <td class="nowrap">
                         <div class="btn-group">
-                            <a class="btn btn-primary" data-bind="openModal: 'deploy-build-modal-template'">Deploy</a>
+                            <a class="btn btn-primary" data-bind="openModal: 'deploy-build-modal-template', click: $root.group_deploy">Deploy</a>
                         </div>
                     </td>
                     {% if edit %}
@@ -365,7 +365,7 @@
                                                 <div data-bind="visible: $data">
                                                     <form method="post" action="{% url corehq.apps.sms.views.send_to_recipients domain %}">
                                                         <label>{% trans "Send to:" %}</label>
-                                                        <input type="text" name="recipients" value=""/>
+                                                        <input type="text" name="recipients" data-contacts='{{ sms_contacts|JSON }}' value=""/>
                                                         <br />
                                                         <textarea name="message" data-bind="text: 'Update to CommCare: ' +
                                                             $data + ' (&quot;' + $parent.short_name() + '&quot; v. ' + $parent.version() + ')'"></textarea>

--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -14,6 +14,7 @@ from django.utils.translation import ugettext as _
 from django.views.decorators.cache import cache_control
 from corehq import ApplicationsTab
 from corehq.apps.app_manager import commcare_settings
+from corehq.apps.sms.views import get_sms_autocomplete_context
 from django.utils import html
 from django.utils.http import urlencode as django_urlencode
 from couchdbkit.exceptions import ResourceConflict
@@ -561,6 +562,7 @@ def release_manager(request, domain, app_id, template='app_manager/releases.html
     app = get_app(domain, app_id)
     latest_release = get_app(domain, app_id, latest=True)
     context = get_apps_base_context(request, domain, app)
+    context['sms_contacts'] = get_sms_autocomplete_context(request, domain)["sms_contacts"]
 
     saved_apps = []
 


### PR DESCRIPTION
Implements this [fogbugz case](http://manage.dimagi.com/default.asp?55903). Adds auto-complete(groups, users, send-to-all) for 'Send to Phone via SMS' input in App-Deploy dialog. 

Note on testing: Auto-fill feature is functional, deploying makes a successful POST request to send_sms handler, but I could not actually test the SMS going through, as I don't have the SMS-CONFIG credentials.
