### PR TITLE
admin restore utility for superusers

### DIFF
--- a/corehq/apps/hqadmin/urls.py
+++ b/corehq/apps/hqadmin/urls.py
@@ -20,6 +20,7 @@ urlpatterns = patterns('corehq.apps.hqadmin.views',
     url(r'^commcare_settings/$', 'all_commcare_settings', name="all_commcare_settings"),
     url(r'^management_commands/$', 'management_commands', name="management_commands"),
     url(r'^run_command/$', 'run_command', name="run_management_command"),
+    url(r'^phone/restore/$', 'admin_restore', name="admin_restore"),
     AdminReportDispatcher.url_pattern(),
 )
 

--- a/corehq/apps/hqadmin/views.py
+++ b/corehq/apps/hqadmin/views.py
@@ -5,10 +5,10 @@ import logging
 from collections import defaultdict
 from StringIO import StringIO
 import os
-from django.views.decorators.http import require_POST
+from django.views.decorators.http import require_POST, require_GET
 from pytz import timezone
 
-from django.http import HttpResponseRedirect, HttpResponse
+from django.http import HttpResponseRedirect, HttpResponse, HttpResponseBadRequest, HttpResponseNotFound
 from django.core.urlresolvers import reverse
 from django.shortcuts import render
 from django.views.decorators.cache import cache_page
@@ -23,13 +23,15 @@ from corehq.apps.hqadmin.models import HqDeploy
 from corehq.apps.builds.models import CommCareBuildConfig, BuildSpec
 from corehq.apps.domain.models import Domain
 from corehq.apps.hqadmin.escheck import check_cluster_health, check_case_index, check_xform_index, check_exchange_index
+from corehq.apps.ota.views import get_restore_response, get_restore_params
 from corehq.apps.reports.datatables import DataTablesColumn, DataTablesHeader, DTSortType
 from corehq.apps.reports.util import make_form_couch_key
 from corehq.apps.sms.models import SMSLog
 from corehq.apps.users.models import  CommCareUser, WebUser
+from corehq.apps.users.util import format_username
 from couchforms.models import XFormInstance
 from dimagi.utils.couch.database import get_db, is_bigcouch
-from corehq.apps.domain.decorators import  require_superuser, login_or_digest
+from corehq.apps.domain.decorators import  require_superuser
 from dimagi.utils.decorators.datespan import datespan_in_request
 from dimagi.utils.parsing import json_format_datetime, string_to_datetime
 from dimagi.utils.web import json_response
@@ -746,6 +748,21 @@ def all_commcare_settings(request):
                      if app_filter(s)]
     return json_response(settings_list)
 
+@require_superuser
+@require_GET
+def admin_restore(request):
+    full_username = request.GET.get('as', '')
+    if not full_username or '@' not in full_username:
+        return HttpResponseBadRequest('Please specify a user using ?as=user@domain')
+
+    username, domain = full_username.split('@')
+    if not domain.endswith(settings.HQ_ACCOUNT_ROOT):
+        full_username = format_username(username, domain)
+
+    user = CommCareUser.get_by_username(full_username)
+    if not user:
+        return HttpResponseNotFound('User %s not found.' % full_username)
+    return get_restore_response(user, **get_restore_params(request))
 
 @require_superuser
 def management_commands(request, template="hqadmin/management_commands.html"):

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -10,19 +10,27 @@ def restore(request, domain):
     We override restore because we have to supply our own 
     user model (and have the domain in the url)
     """
-    
     user = request.user
-    restore_id = request.GET.get('since')
-    api_version = request.GET.get('version', "1.0")
-    state_hash = request.GET.get('state')
-    username = user.username
     couch_user = CouchUser.from_django_user(user)
-    
+    return get_restore_response(couch_user, **get_restore_params(request))
+
+def get_restore_params(request):
+    """
+    Given a request, get the relevant restore parameters out with sensible defaults
+    """
+    # not a view just a view util
+    return {
+        'since': request.GET.get('since'),
+        'version': request.GET.get('version', "1.0"),
+        'state': request.GET.get('state'),
+    }
+
+def get_restore_response(couch_user, since=None, version='1.0', state=None):
+    # not a view just a view util
     if not couch_user.is_commcare_user():
-        response = HttpResponse("No linked chw found for %s" % username)
+        response = HttpResponse("No linked chw found for %s" % couch_user.username)
         response.status_code = 401 # Authentication Failure
         return response
-    
-    return generate_restore_response(couch_user.to_casexml_user(), restore_id, 
-                                         api_version, state_hash)
-    
+
+    return generate_restore_response(couch_user.to_casexml_user(), since,
+                                     version, state)


### PR DESCRIPTION
addresses long-standing Case:34696

let's you hit /hq/admin/phone/restore?as=someuser@domain and view that users ota restore payload.
this is only available to superusers.
supports the additional "since", "version", and "state" params as well
