### PR TITLE
Prevent double saving new mobile users

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1098,6 +1098,8 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         return self
 
     def save(self, **params):
+        super(CommCareUser, self).save(**params)
+
         from corehq.apps.users.signals import commcare_user_post_save
         results = commcare_user_post_save.send_robust(sender='couch_user',
                                                      couch_user=self)
@@ -1109,8 +1111,6 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
                     message="Error occured while syncing user %s: %s" %
                             (self.username, str(result[1]))
                 )
-
-        super(CommCareUser, self).save(**params)
 
     def is_domain_admin(self, domain=None):
         # cloudcare workaround

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -195,7 +195,7 @@ def add_commcare_account(request, domain, template="users/add_commcare_account.h
             password = form.cleaned_data["password"]
 
             couch_user = CommCareUser.create(domain, username, password, device_id='Generated from HQ')
-            couch_user.save()
+
             return HttpResponseRedirect(reverse("user_account", args=[domain, couch_user.userID]))
     else:
         form = CommCareAccountForm()


### PR DESCRIPTION
To be able to remove the second save and still have everything sync
properly I also had to move the post save signal to happen after the
save... like it should have been doing anyways.

Fixes http://manage.dimagi.com/default.asp?65662
