### PR TITLE
Make case type meaningful on import

### DIFF
--- a/corehq/apps/importer/tasks.py
+++ b/corehq/apps/importer/tasks.py
@@ -57,8 +57,12 @@ def bulk_import_async(import_id, config, domain, excel_id):
             blank_external_ids.append(i + 1)
             continue
 
-        case, error = importer_util.lookup_case(config.search_field,
-                                                search_id, domain)
+        case, error = importer_util.lookup_case(
+            config.search_field,
+            search_id,
+            domain,
+            config.case_type
+        )
 
         try:
             fields_to_update = importer_util.populate_updated_fields(

--- a/corehq/apps/importer/tasks.py
+++ b/corehq/apps/importer/tasks.py
@@ -102,15 +102,17 @@ def bulk_import_async(import_id, config, domain, excel_id):
             )
             submit_case_block(caseblock, domain, username, user_id)
         elif case and case.type == config.case_type:
+            extras = {}
+            if external_id:
+                extras['external_id'] = external_id
             caseblock = CaseBlock(
                 create=False,
                 case_id=case._id,
                 owner_id=owner_id,
                 version=V2,
-                update=fields_to_update
+                update=fields_to_update,
+                **extras
             )
-            if external_id:
-                caseblock['external_id'] = external_id
 
             submit_case_block(caseblock, domain, username, user_id)
 

--- a/corehq/apps/importer/templates/importer/excel_config.html
+++ b/corehq/apps/importer/templates/importer/excel_config.html
@@ -15,15 +15,9 @@
                 } else {
                     $('#key_val_selection_fields').hide();
                 }
-            }).change();
+            });
 
-            $('#create_new_cases').change(function() {
-                if ($(this).attr('checked') === 'checked') {
-                    $('#case_type').show();
-                } else {
-                    $('#case_type').hide();
-                }
-            }).change();
+            $('#key_value_columns').change();
 
             $('#back_button').click(function() {
                 history.back();
@@ -40,10 +34,32 @@
         <input type="hidden" name="named_columns" value="{{named_columns}}" />
 
         <fieldset>
+            <legend>{% trans "Case Type to Update/Create" %}</legend>
+            <div class="control-group">
+                <label class="control-label" for="case_type">
+                    {% trans "Case type" %}
+                </label>
+                <div class="controls">
+                    <select name="case_type" id="case_type">
+                        <option disabled>{% trans "Used in existing applications:" %}</option>
+                        {% for case_type in case_types_from_apps %}
+                        <option value="{{case_type|escape}}">{{case_type|escape}}</option>
+                        {% endfor %}
+
+                        <option disabled>{% trans "From unknown or deleted applications:" %}</option>
+                        {% for case_type in case_types_from_cases %}
+                        <option value="{{case_type|escape}}">{{case_type|escape}}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+            </div>
+        </fieldset>
+
+        <fieldset>
             <legend>{% trans "Identifying Cases to Update/Create" %}</legend>
             <div class="control-group">
                 <label class="control-label" for="search_column">
-                    {% trans "Excel column" %}
+                    {% trans "Excel Column" %}
                 </label>
                 <div class="controls">
                     <select name="search_column" id="search_column">
@@ -58,7 +74,7 @@
 
             <div class="control-group">
                 <label class="control-label" for="search_field">
-                    {% trans "Corresponding case field" %}
+                    {% trans "Corresponding Case Field" %}
                 </label>
                 <div class="controls">
                     <select name="search_field" id="search_field">
@@ -80,24 +96,6 @@
                                id="create_new_cases" />
                         {% trans "Create new records if there is no matching case" %}
                     </label>
-                </div>
-                <div id="case_type">
-                    <label class="control-label" for="case_type">
-                        {% trans "Case type for new cases" %}
-                    </label>
-                    <div class="controls">
-                        <select name="case_type" id="case_type">
-                            <option disabled>{% trans "Used in existing applications:" %}</option>
-                            {% for case_type in case_types_from_apps %}
-                            <option value="{{case_type|escape}}">{{case_type|escape}}</option>
-                            {% endfor %}
-
-                            <option disabled>{% trans "From unknown or deleted applications:" %}</option>
-                            {% for case_type in case_types_from_cases %}
-                            <option value="{{case_type|escape}}">{{case_type|escape}}</option>
-                            {% endfor %}
-                        </select>
-                    </div>
                 </div>
             </div>
         </fieldset>

--- a/corehq/apps/importer/templates/importer/excel_config.html
+++ b/corehq/apps/importer/templates/importer/excel_config.html
@@ -15,7 +15,7 @@
                 } else {
                     $('#key_val_selection_fields').hide();
                 }
-            });
+            }).change();
 
             $('#key_value_columns').change();
 
@@ -59,7 +59,7 @@
             <legend>{% trans "Identifying Cases to Update/Create" %}</legend>
             <div class="control-group">
                 <label class="control-label" for="search_column">
-                    {% trans "Excel Column" %}
+                    {% trans "Excel column" %}
                 </label>
                 <div class="controls">
                     <select name="search_column" id="search_column">
@@ -74,7 +74,7 @@
 
             <div class="control-group">
                 <label class="control-label" for="search_field">
-                    {% trans "Corresponding Case Field" %}
+                    {% trans "Corresponding case field" %}
                 </label>
                 <div class="controls">
                     <select name="search_field" id="search_field">

--- a/corehq/apps/importer/util.py
+++ b/corehq/apps/importer/util.py
@@ -185,7 +185,7 @@ def get_value_column_index(config, columns):
 
     return value_column_index
 
-def lookup_case(search_field, search_id, domain):
+def lookup_case(search_field, search_id, domain, case_type):
     """
     Attempt to find the case in CouchDB by the provided search_field and search_id.
 
@@ -196,7 +196,8 @@ def lookup_case(search_field, search_id, domain):
     if search_field == 'case_id':
         try:
             case = CommCareCase.get(search_id)
-            if case.domain == domain:
+
+            if case.domain == domain and case.type == case_type:
                 found = True
         except Exception:
             pass

--- a/corehq/apps/importer/util.py
+++ b/corehq/apps/importer/util.py
@@ -202,17 +202,20 @@ def lookup_case(search_field, search_id, domain, case_type):
         except Exception:
             pass
     elif search_field == 'external_id':
-        try:
-            case = CommCareCase.view(
-                'hqcase/by_domain_external_id',
-                key=[domain, search_id],
-                reduce=False,
-                include_docs=True).one()
-            found = bool(case)
-        except NoResultFound:
-            pass
-        except MultipleResultsFound:
-            return (None, LookupErrors.MultipleResults)
+        results = CommCareCase.view(
+            'hqcase/by_domain_external_id',
+            key=[domain, search_id],
+            reduce=False,
+            include_docs=True)
+        if results:
+            cases_by_type = [case for case in results
+                             if case.type == case_type]
+
+            if len(cases_by_type) > 1:
+                return (None, LookupErrors.MultipleResults)
+            else:
+                case = cases_by_type[0]
+                found = True
 
     if found:
         return (case, None)


### PR DESCRIPTION
These commits address some issues that came up during importer QA. Namely, case type wasn't being used properly.
1. We hid the case type for update only imports. This was reverted.
2. We never updated cases with the wrong type selected but we would tell the user that we did. Now we don't count those.
3. External ID updating in case updates was actually broken, oops.
4. External ID will only match on the specified case type, no longer requiring the external id to be unique across all apps.
