### PR TITLE
create domain post save signal

### DIFF
--- a/corehq/apps/commtrack/signals.py
+++ b/corehq/apps/commtrack/signals.py
@@ -5,11 +5,12 @@ from corehq.apps.commtrack import const
 from corehq.apps.commtrack.const import is_commtrack_form, RequisitionStatus
 from corehq.apps.commtrack.models import (RequisitionCase, SupplyPointProductCase,
         CommtrackConfig)
-from corehq.apps.commtrack.util import bootstrap_default
+from corehq.apps.commtrack.util import bootstrap_commtrack_settings_if_necessary
 from corehq.apps.domain.signals import commcare_domain_post_save
 from corehq.apps.locations.models import Location
 from corehq.apps.sms.api import send_sms_to_verified_number
 from dimagi.utils import create_unique_filter
+
 
 def attach_locations(xform, cases):
     """
@@ -96,6 +97,7 @@ def send_notifications(xform, cases):
                     if phone:
                         send_sms_to_verified_number(phone, msg)
 
+
 def commtrack_processing(sender, xform, cases, **kwargs):
     if is_commtrack_form(xform):
         attach_locations(xform, cases)
@@ -104,7 +106,7 @@ def commtrack_processing(sender, xform, cases, **kwargs):
 cases_received.connect(commtrack_processing)
 
 
-def bootstrap_domain_signal(sender, **kwargs):
-    bootstrap_default(kwargs['domain'])
+def bootstrap_commtrack_settings_if_necessary_signal(sender, **kwargs):
+    bootstrap_commtrack_settings_if_necessary(kwargs['domain'])
 
-commcare_domain_post_save.connect(bootstrap_domain_signal)
+commcare_domain_post_save.connect(bootstrap_commtrack_settings_if_necessary_signal)

--- a/corehq/apps/commtrack/signals.py
+++ b/corehq/apps/commtrack/signals.py
@@ -5,6 +5,8 @@ from corehq.apps.commtrack import const
 from corehq.apps.commtrack.const import is_commtrack_form, RequisitionStatus
 from corehq.apps.commtrack.models import (RequisitionCase, SupplyPointProductCase,
         CommtrackConfig)
+from corehq.apps.commtrack.util import bootstrap_default
+from corehq.apps.domain.signals import commcare_domain_post_save
 from corehq.apps.locations.models import Location
 from corehq.apps.sms.api import send_sms_to_verified_number
 from dimagi.utils import create_unique_filter
@@ -100,3 +102,9 @@ def commtrack_processing(sender, xform, cases, **kwargs):
         send_notifications(xform, cases)
 
 cases_received.connect(commtrack_processing)
+
+
+def bootstrap_domain_signal(sender, **kwargs):
+    bootstrap_default(kwargs['domain'])
+
+commcare_domain_post_save.connect(bootstrap_domain_signal)

--- a/corehq/apps/commtrack/tests/util.py
+++ b/corehq/apps/commtrack/tests/util.py
@@ -3,7 +3,7 @@ from corehq.apps.commtrack import const
 from corehq.apps.groups.models import Group
 from corehq.apps.locations.models import Location
 from corehq.apps.domain.shortcuts import create_domain
-from corehq.apps.commtrack.util import bootstrap_default
+from corehq.apps.commtrack.util import bootstrap_commtrack_settings_if_necessary
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.sms.backend import test
 from django.utils.unittest.case import TestCase
@@ -70,7 +70,7 @@ def bootstrap_domain(domain_name=TEST_DOMAIN, requisitions_enabled=False):
     domain_obj = create_domain(domain_name)
     domain_obj.commtrack_enabled = True
     domain_obj.save(**get_safe_write_kwargs())
-    bootstrap_default(domain_obj, requisitions_enabled)
+    bootstrap_commtrack_settings_if_necessary(domain_obj, requisitions_enabled)
 
     return domain_obj
 

--- a/corehq/apps/commtrack/util.py
+++ b/corehq/apps/commtrack/util.py
@@ -56,7 +56,7 @@ def make_product(domain, name, code):
     p.save()
     return p
 
-def bootstrap_default(domain, requisitions_enabled=True):
+def bootstrap_commtrack_settings_if_necessary(domain, requisitions_enabled=True):
     if not(domain and domain.commtrack_enabled and not domain.commtrack_settings):
         return
 

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -19,8 +19,6 @@ from django.utils.translation import ugettext_noop
 from django.utils.translation import ugettext as _
 
 
-import corehq.apps.commtrack.util as commtrack_util
-
 def tf_choices(true_txt, false_txt):
     return (('false', false_txt), ('true', true_txt))
 
@@ -347,7 +345,6 @@ class DomainMetadataForm(DomainGlobalSettingsForm, SnapshotSettingsMixin):
                 domain.call_center_config.case_owner_id = self.cleaned_data.get('call_center_case_owner', None)
                 domain.call_center_config.case_type = self.cleaned_data.get('call_center_case_type', None)
             domain.restrict_superusers = self.cleaned_data.get('restrict_superusers', False)
-            commtrack_util.bootstrap_default(domain)
             domain.save()
             return True
         except Exception:

--- a/corehq/apps/domain/signals.py
+++ b/corehq/apps/domain/signals.py
@@ -1,0 +1,3 @@
+from django.dispatch import Signal
+
+commcare_domain_post_save = Signal(providing_args=["domain"])

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -3,7 +3,6 @@ import uuid
 from datetime import datetime
 from django.core.mail import send_mail
 from corehq.apps.registration.models import RegistrationRequest
-from corehq.apps.commtrack.util import bootstrap_default
 from dimagi.utils.web import get_ip, get_url_base
 from django.conf import settings
 from django.contrib.sites.models import Site
@@ -58,8 +57,6 @@ def request_new_domain(request, form, org, domain_type=None, new_user=True):
         date_created=datetime.utcnow(),
         commtrack_enabled=commtrack_enabled,
         creating_user=current_user.username)
-
-    bootstrap_default(new_domain)    
 
     if org:
         new_domain.organization = org


### PR DESCRIPTION
Not 100% sure if this is a _safe_ refactor since `domain.save()` gets called in quite a few other places but think its OK.

Plan is to use the signal for bootstrapping call center config to domain as well.
