### PR TITLE
Hide full sort header when there are no rows

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/module_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/module_view.html
@@ -219,7 +219,7 @@
         </div>
         <div id="detail-screen-config-body">
             {% if app.enable_multi_sort %}
-                <legend>
+                <legend data-bind="visible: rowCount() > 0">
                     {% trans "Sort Properties" %}
                     <span style="font-size: 13px">
                         <span class="hq-help-template"


### PR DESCRIPTION
I added extra header information but wasn't hiding that as well..
