### PR TITLE
Catch weird case block building errors

### DIFF
--- a/corehq/apps/importer/templates/importer/partials/import_status.html
+++ b/corehq/apps/importer/templates/importer/partials/import_status.html
@@ -24,7 +24,7 @@
 
             {% if result.match_count == 0 and result.created_count == 0 %}
                 <p>
-                    {% trans "No cases were matched or updated during this import." %}
+                    {% trans "No cases were created or updated during this import." %}
                 </p>
             {% endif %}
 
@@ -58,6 +58,15 @@
                         were ignored:
                     {% endblocktrans %}
                     {{ result.invalid_dates|join:", " }}
+                </p>
+            {% endif %}
+
+            {% if result.errors > 0 %}
+                <p>
+                    {% blocktrans with errors=result.errors %}
+                        <strong>{{ errors }}</strong> rows had unknown case
+                        submission errors.
+                    {% endblocktrans %}
                 </p>
             {% endif %}
         </div>


### PR DESCRIPTION
This prevents any crash during case block creation/submission from
causing the importer to hang. Specifically, this was added to prevent
people from doing things like specifying internal case property names
during field selection (so assigning a name normally and also manually
entering case_name).
