### PR TITLE
Latest numpy so we do not rebuild when it is already there on travis

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -48,7 +48,7 @@ gitdb==0.5.4
 #-e git+git://github.com/SiteSupport/gevent.git@1.0rc2#egg=gevent
 gevent==0.13.8
 rawes==0.3.6
-numpy==1.7.0
+numpy==1.7.1
 six==1.2.0
 socketpool==0.5.2
 markdown==2.2.1


### PR DESCRIPTION
Technically, Travis-CI pre-installs numpy to the virtualenv with no version number, so they will always once in a while get ahead of us. Long-lasting solutions TBD.
