### PR TITLE
Case importer

### DIFF
--- a/corehq/apps/importer/tasks.py
+++ b/corehq/apps/importer/tasks.py
@@ -98,14 +98,15 @@ def bulk_import_async(import_id, config, domain, excel_id):
                     user_id=user_id,
                     owner_id=owner_id,
                     case_type=config.case_type,
-                    external_id=search_id if config.search_field == 'external_id' else '',
                     update=fields_to_update
                 )
+                if config.search_field == 'external_id':
+                    caseblock['external_id'] = search_id
+
                 submit_case_block(caseblock, domain, username, user_id)
             except CaseBlockError:
                 created_count -= 1
                 errors += 1
-
         elif case and case.type == config.case_type:
             extras = {}
             if external_id:

--- a/corehq/apps/importer/tasks.py
+++ b/corehq/apps/importer/tasks.py
@@ -84,7 +84,14 @@ def bulk_import_async(import_id, config, domain, excel_id):
             too_many_matches += 1
             continue
 
-        owner_id = fields_to_update.pop('owner_id', user_id)
+        # make sure a valid owner id was supplied before using it
+        uploaded_owner_id = fields_to_update.pop('owner_id', None)
+        if uploaded_owner_id and \
+           CouchUser.get_by_user_id(uploaded_owner_id, domain):
+            owner_id = uploaded_owner_id
+        else:
+            owner_id = user_id
+
         external_id = fields_to_update.pop('external_id', None)
 
         if not case:

--- a/corehq/apps/importer/tasks.py
+++ b/corehq/apps/importer/tasks.py
@@ -32,11 +32,15 @@ def bulk_import_async(import_id, config, domain, excel_id):
     match_count = created_count = too_many_matches = errors = 0
     blank_external_ids = []
     invalid_dates = []
+    owner_id_errors = []
     prime_offset = 1  # used to prevent back-to-back priming
 
     user = CouchUser.get_by_user_id(config.couch_user_id, domain)
     username = user.username
     user_id = user._id
+
+    # keep a cache of id lookup successes to help performance
+    id_cache = {}
 
     for i in range(row_count):
         DownloadBase.set_progress(task, i, row_count)
@@ -75,11 +79,10 @@ def bulk_import_async(import_id, config, domain, excel_id):
             continue
 
         if case:
-            match_count += 1
+            pass
         elif error == LookupErrors.NotFound:
             if not config.create_new_cases:
                 continue
-            created_count += 1
         elif error == LookupErrors.MultipleResults:
             too_many_matches += 1
             continue
@@ -87,10 +90,13 @@ def bulk_import_async(import_id, config, domain, excel_id):
         # make sure a valid owner id was supplied before using it
         uploaded_owner_id = fields_to_update.pop('owner_id', None)
         if uploaded_owner_id and \
-           CouchUser.get_by_user_id(uploaded_owner_id, domain):
+           importer_util.is_valid_id(uploaded_owner_id, domain, id_cache):
             owner_id = uploaded_owner_id
+            id_cache[uploaded_owner_id] = True
         else:
-            owner_id = user_id
+            owner_id_errors.append(i + 1)
+            id_cache[uploaded_owner_id] = False
+            continue
 
         external_id = fields_to_update.pop('external_id', None)
 
@@ -111,8 +117,8 @@ def bulk_import_async(import_id, config, domain, excel_id):
                     caseblock['external_id'] = search_id
 
                 submit_case_block(caseblock, domain, username, user_id)
+                created_count += 1
             except CaseBlockError:
-                created_count -= 1
                 errors += 1
         elif case and case.type == config.case_type:
             extras = {}
@@ -129,8 +135,8 @@ def bulk_import_async(import_id, config, domain, excel_id):
                     **extras
                 )
                 submit_case_block(caseblock, domain, username, user_id)
+                match_count += 1
             except CaseBlockError:
-                match_count -= 1
                 errors += 1
 
     return {
@@ -139,6 +145,7 @@ def bulk_import_async(import_id, config, domain, excel_id):
         'too_many_matches': too_many_matches,
         'blank_externals': blank_external_ids,
         'invalid_dates': invalid_dates,
+        'owner_id_errors': owner_id_errors,
         'errors': errors,
     }
 

--- a/corehq/apps/importer/templates/importer/partials/import_status.html
+++ b/corehq/apps/importer/templates/importer/partials/import_status.html
@@ -61,6 +61,19 @@
                 </p>
             {% endif %}
 
+            {% if result.owner_id_errors|length > 0 %}
+                <p>
+                    {% blocktrans %}
+                        Owner ID was used in the mapping but there were errors
+                        when uploading because of these values. Make sure
+                        the values in this column are ID's for users or
+                        case sharing groups. The following row numbers had
+                        this issue and were ignored:
+                    {% endblocktrans %}
+                    {{ result.owner_id_errors|join:", " }}
+                </p>
+            {% endif %}
+
             {% if result.errors > 0 %}
                 <p>
                     {% blocktrans with errors=result.errors %}

--- a/corehq/apps/importer/util.py
+++ b/corehq/apps/importer/util.py
@@ -3,10 +3,10 @@ from dimagi.utils.couch.database import get_db
 from corehq.apps.importer.const import LookupErrors
 from datetime import date
 from casexml.apps.case.models import CommCareCase
-from couchdbkit.exceptions import MultipleResultsFound, NoResultFound
 from xlrd import xldate_as_tuple
-from soil import DownloadBase
-from corehq.apps import importer
+from corehq.apps.groups.models import Group
+from corehq.apps.users.models import CouchUser
+from couchdbkit.exceptions import ResourceNotFound
 
 def get_case_properties(domain, case_type=None):
     """
@@ -266,3 +266,18 @@ def get_spreadsheet(download_ref, column_headers=True):
     if not download_ref:
         return None
     return ExcelFile(download_ref.get_filename(), column_headers)
+
+def is_valid_id(uploaded_id, domain, cache):
+    if uploaded_id in cache:
+        return cache[uploaded_id]
+
+    # see if it's a user on this domain
+    if CouchUser.get_by_user_id(uploaded_id, domain):
+        return True
+
+    # or if it is a case sharing enabled group
+    try:
+        group = Group.get(uploaded_id)
+        return group.case_sharing
+    except ResourceNotFound:
+        return False


### PR DESCRIPTION
Two separate changes but didn't want to make two small PR's for this..

One commit stops submitting external_id = "" by default which made it possible for some funky stuff to happen.

The other forces a check on owner_id's submitted. Does a lookup to make sure the user exists on the domain, otherwise just throws it out and defaults to the current user_id.
