### PR TITLE
Provide hints for sort direction based on format

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/module_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/module_view.html
@@ -60,6 +60,40 @@
                     $(this).val(valueNoSpaces);
                 }
             });
+            $('.sort-format').change(function () {
+                // Using index is hacky but sort of needed. There are
+                // multiple items with the same value (plain and date) and
+                // translations could mean the text value is varying....
+                var idx = this.selectedIndex;
+                var options;
+
+                if (idx === 0) {
+                    options = [
+                        "{% trans 'Increasing (a, b, c)' %}",
+                        "{% trans 'Decreasing (c, b, a)' %}"
+                    ]
+                } else if (idx === 1) {
+                    options = [
+                        "{% trans 'Increasing (May 1st, May 2nd)' %}",
+                        "{% trans 'Decreasing (May 2nd, May 1st)' %}"
+                    ]
+                } else if (idx === 2) {
+                    options = [
+                        "{% trans 'Increasing (1, 2, 3)' %}",
+                        "{% trans 'Decreasing (3, 2, 1)' %}"
+                    ]
+                } else if (idx === 3) {
+                    options = [
+                        "{% trans 'Increasing (1.1, 1.2, 1.3)' %}",
+                        "{% trans 'Decreasing (1.3, 1.2, 1.1)' %}"
+                    ]
+                }
+
+                var $order = $(this).closest('tr').find('.sort-direction');
+                $order.find('option[value="ascending"]').text(options[0]);
+                $order.find('option[value="descending"]').text(options[1]);
+
+            }).change();
         });
         $(function () {
             COMMCAREHQ.app_manager.module_view = {
@@ -263,18 +297,15 @@
                                 </td>
 
                                 <td>
-                                    <select data-bind="value: direction">
-                                        <option value="ascending">
-                                            {% trans "Increasing" %}
-                                        </option>
-                                        <option value="descending">
-                                            {% trans "Decreasing" %}
-                                        </option>
+                                    <select class='sort-direction' data-bind="value: direction">
+                                        <!-- text for these guys is set in js -->
+                                        <option value="ascending"></option>
+                                        <option value="descending"></option>
                                     </select>
                                 </td>
 
                                 <td>
-                                    <select data-bind="value: type">
+                                    <select class='sort-format' data-bind="value: type">
                                         <option value="string">
                                             {% trans "Plain" %}
                                         </option>


### PR DESCRIPTION
Having sort by "Increasing" or "Decreasing" was not at all obvious to the user as to what this means, especially when it comes to dates. Now we add a bit of a description to the option text based on the currently selected format.
