### PR TITLE
Move default sort option code

### DIFF
--- a/corehq/apps/app_manager/suite_xml.py
+++ b/corehq/apps/app_manager/suite_xml.py
@@ -430,6 +430,20 @@ class SuiteGenerator(object):
                                 )
                                 detail.append_column(dc)
 
+                            # need to add a default here so that it doesn't
+                            # get persisted
+                            if self.app.enable_multi_sort and \
+                               len(module.detail_sort_elements) == 0:
+                                from corehq.apps.app_manager.models import SortElement
+                                try:
+                                    se = SortElement()
+                                    se.field = detail.columns[0].field
+                                    se.type = 'string'
+                                    se.direction = 'ascending'
+                                    module.detail_sort_elements.append(se)
+                                except Exception:
+                                    pass
+
                         for column in detail.get_columns():
                             fields = get_column_generator(self.app, module, detail, column).fields
                             d.fields.extend(fields)

--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -970,21 +970,6 @@ def edit_module_detail_screens(req, domain, app_id, module_id):
 
         del screens['sort_elements']
 
-    if app.enable_multi_sort and len(detail.sort_elements) == 0:
-        # if we are using new sort style, we need to force a default
-        try:
-            default = screens['case_short'][0]
-            item = SortElement()
-            item.field = default['field']
-            item.type = ''
-            item.direction = 'ascending'
-            detail.sort_elements.append(item)
-        except Exception:
-            # if it errors, we don't have any thing to sort by so
-            # can just skip it
-            pass
-
-
     for detail_type in screens:
         if detail_type not in DETAIL_TYPES:
             return HttpResponseBadRequest("All detail types must be in %r"


### PR DESCRIPTION
In the original location this was persisting this default sort element.
So if you didn't sort by anything and saved the page it would show up as
a sort property the next time you load that page. In the new location it
generates the SortElement right before saving so we have it there to
write out the suite_xml but it won't be saved.
