### PR TITLE
Informative exception (instead of infinite regress) on unknown Repeater type

### DIFF
--- a/corehq/apps/receiverwrapper/models.py
+++ b/corehq/apps/receiverwrapper/models.py
@@ -94,7 +94,10 @@ class Repeater(Document, UnicodeMixIn):
     def wrap(cls, data):
         doc_type = data['doc_type'].replace(DELETED, '')
         if cls.__name__ == Repeater.__name__:
-            return repeater_types.get(doc_type, cls).wrap(data)
+            if doc_type in repeater_types:
+                return repeater_types[doc_type].wrap(data)
+            else:
+                raise Exception('Unknown repeater type: %s', data)
         else:
             return super(Repeater, cls).wrap(data)
 


### PR DESCRIPTION
This does not add crashes that I know of, since prior to this change it seems to 500 by blowing the stack anyhow.
