### PR TITLE
updated README and install.sh to include updated java link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Please note that these instructions are targeted toward UNIX-based systems.
 
 ### Installing dependencies
 
-For Ubuntu 12.04, you can use the included `install.sh` script to install all
+For Ubuntu 12.04, download the JDK tar.gz from http://www.oracle.com/technetwork/java/javase/downloads/index.html and rename it jdk.tar.gz in the same directory as install.sh.
+Run the included `install.sh` script to install all
 dependencies, set them up to run at startup, and set up required databases.
 Then skip to "Setting up a virtualenv". 
 

--- a/install.sh
+++ b/install.sh
@@ -145,11 +145,11 @@ fi
 # from http://onabai.wordpress.com/2012/05/10/installing-couchdb-1-2-in-ubuntu-12-04/
 if [ ! -f /etc/init.d/couchdb ]; then
     if [ ! -f apache-couchdb-1.2.1.tar.gz ]; then
-        wget http://apache.mirrors.pair.com/couchdb/1.2.1/apache-couchdb-1.2.1.tar.gz
+        wget http://mirrors.ibiblio.org/apache/couchdb/source/1.3.1/apache-couchdb-1.3.1.tar.gz
     fi
 
-    tar xzf apache-couchdb-1.2.1.tar.gz
-    cd apache-couchdb-1.2.1
+    tar xzf apache-couchdb-1.3.1.tar.gz
+    cd apache-couchdb-1.3.1
     if [ "$PM" = "apt-ubuntu" ]; then
         ./configure
     elif  [ "$PM" = "yum-rhel" ]; then
@@ -162,7 +162,7 @@ if [ ! -f /etc/init.d/couchdb ]; then
     fi
     make 
     sudo make install
-    cd .. && rm -r apache-couchdb-1.2.1
+    cd .. && rm -r apache-couchdb-1.3.1
 
     if [ "$PM" = "apt-ubuntu" ]; then
         sudo adduser --disabled-login --disabled-password --no-create-home couchdb


### PR DESCRIPTION
I linked to the first mirror for downloading the jdk tarball.  Ideally that'd be some dynamic link that points to a working mirror of the latest version, but I'm not sure if such a thing exists.
