### PR TITLE
New tactic for drop-in-env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,16 +12,17 @@ install:
  - "sudo apt-get install moreutils libblas-dev liblapack-dev"
  - "bash -ex .travis/upgrade-couchdb.sh | ts"
  - "git clone https://github.com/dimagi/commcarehq-venv.git"
- - "source commcarehq-venv/hq_env/bin/activate"
- - "commcarehq-venv/hq_env/bin/pip install distribute"
+ - "cp -r commcarehq-venv/hq_env/* ~/virtualenv/"
+ - "source ~/virtualenv/bin/activate"
  - "time (bash -e .travis/quietly-run-install.sh | ts)"
- - "time (commcarehq-venv/hq_env/bin/pip install --exists-action w -r requirements/requirements.txt -r requirements/dev-requirements.txt --use-mirrors | ts)"
+ - "time (pip install --exists-action w -r requirements/requirements.txt -r requirements/dev-requirements.txt --use-mirrors | ts)"
  - "time (bash -e .travis/misc-setup.sh | ts)"
  - "cp .travis/localsettings.py localsettings.py"
- - "commcarehq-venv/hq_env/bin/pip install coverage unittest2 mock --use-mirrors"
-script: "cat .travis/apps_under_test | grep -v '^#' | xargs commcarehq-venv/hq_env/bin/coverage run manage.py test --noinput --failfast"
+ - "pip install coverage unittest2 mock --use-mirrors"
+script: "cat .travis/apps_under_test | grep -v '^#' | xargs coverage run manage.py test --noinput --failfast"
 after_success:
  - coverage report
+ - coveralls
 services:
  - postgresql
  - couchdb


### PR DESCRIPTION
Instead of trying to make a relocatable virtualenv and activate it - which is deprecated and/or not that functional, as it turns out - we use a VM to build exactly with the paths that Travis expects and then copy it over the existing virtualenv.
