### PR TITLE
Make case importer public

### DIFF
--- a/corehq/apps/importer/base.py
+++ b/corehq/apps/importer/base.py
@@ -7,10 +7,3 @@ class ImportCases(DataInterface):
     report_template_path = "importer/import_cases.html"
     gide_filters = True
     asynchronous = False
-
-    @classmethod
-    def show_in_navigation(cls, domain=None, project=None, user=None):
-        if domain == 'khayelitsha':
-            return True
-
-        return user.is_superuser or user.is_previewer()

--- a/corehq/apps/importer/templates/importer/excel_config.html
+++ b/corehq/apps/importer/templates/importer/excel_config.html
@@ -28,6 +28,8 @@
 {% endblock %}
 
 {% block main_column %}
+    {% include 'importer/partials/help_message.html' %}
+
     <form class="form-horizontal form-report"
           action="{% url corehq.apps.importer.views.excel_fields domain %}"
           method="post">

--- a/corehq/apps/importer/templates/importer/excel_fields.html
+++ b/corehq/apps/importer/templates/importer/excel_fields.html
@@ -87,6 +87,8 @@
 {% endblock %}
 
 {% block main_column %}
+    {% include 'importer/partials/help_message.html' %}
+
     <form action="{% url corehq.apps.importer.views.excel_commit domain %}"
           method="post"
           id="field_form">

--- a/corehq/apps/importer/templates/importer/import_cases.html
+++ b/corehq/apps/importer/templates/importer/import_cases.html
@@ -11,6 +11,17 @@
             <legend>
                 {% trans "Upload an Excel File From Your Computer to Import From" %}
             </legend>
+            <div class="alert">
+                <p>
+                    {% blocktrans %}
+                        Case importer is a tool for advanced users that
+                        allows you to bulk upload new cases or modify existing
+                        ones. This tool can make changes to your data that
+                        might confuse your reports or applications. Please
+                        exercise caution.
+                    {% endblocktrans %}
+                </p>
+            </div>
             <div class="control-group">
                 <label class="control-label" for="file">
                     {% trans "Select a file to upload" %}

--- a/corehq/apps/importer/templates/importer/import_cases.html
+++ b/corehq/apps/importer/templates/importer/import_cases.html
@@ -3,6 +3,8 @@
 {% load i18n %}
 
 {% block main_column %}
+    {% include 'importer/partials/help_message.html' %}
+
     <form class="form-horizontal form-report"
           action="{% url corehq.apps.importer.views.excel_config domain %}"
           method="post"
@@ -11,17 +13,7 @@
             <legend>
                 {% trans "Upload an Excel File From Your Computer to Import From" %}
             </legend>
-            <div class="alert">
-                <p>
-                    {% blocktrans %}
-                        Case importer is a tool for advanced users that
-                        allows you to bulk upload new cases or modify existing
-                        ones. This tool can make changes to your data that
-                        might confuse your reports or applications. Please
-                        exercise caution.
-                    {% endblocktrans %}
-                </p>
-            </div>
+
             <div class="control-group">
                 <label class="control-label" for="file">
                     {% trans "Select a file to upload" %}

--- a/corehq/apps/importer/templates/importer/partials/help_message.html
+++ b/corehq/apps/importer/templates/importer/partials/help_message.html
@@ -1,0 +1,22 @@
+{% load i18n %}
+
+<div class="alert">
+    <p>
+        {% blocktrans %}
+            Case importer is a tool for advanced users that
+            allows you to bulk upload new cases or modify existing
+            ones. This tool can make changes to your data that
+            might confuse your reports or applications. Please
+            exercise caution.
+        {% endblocktrans %}
+    </p>
+
+    <p>
+        {% blocktrans %}
+            Documentation and instructions can be found on our
+            <a href="https://help.commcarehq.org/display/commcarepublic/Excel+Importer+Instructions">
+                help pages for this feature.
+            </a>
+        {% endblocktrans %}
+    </p>
+</div>


### PR DESCRIPTION
This commit removes the restrictions hiding the case importer tool and adds a hopefully helpful warning for the page.

![screen shot 2013-07-25 at 6 29 44 pm](https://f.cloud.github.com/assets/152134/859243/be5229ae-f579-11e2-8410-9b4a6400066c.png)
