### PR TITLE
don't make 'all groups' checked by default; fix datespan bug

### DIFF
--- a/corehq/apps/reports/fields.py
+++ b/corehq/apps/reports/fields.py
@@ -707,8 +707,7 @@ class CombinedSelectUsersField(ReportField):
                 self.show_group_field and (ctxt["sgf"]["select"]["selected"] or all_groups)))
 
         if self.show_group_field:
-            ctxt["sgf"]["checked"] = all_groups or (not ctxt["sgf"]["select"]["selected"] and not (
-                self.show_mobile_worker_field and (ctxt["smwf"]["select"]["selected"] or all_mws)))
+            ctxt["sgf"]["checked"] = all_groups
 
         self.context.update(ctxt)
 

--- a/corehq/apps/reports/standard/inspect.py
+++ b/corehq/apps/reports/standard/inspect.py
@@ -84,7 +84,8 @@ class SubmitHistory(ElasticProjectInspectionReport, ProjectReport, ProjectReport
                     "range": {
                         "form.meta.timeEnd": {
                             "from": self.datespan.startdate_param,
-                            "to": self.datespan.enddate_param}}},
+                            "to": self.datespan.enddate_param,
+                            "include_upper": False}}},
                 "filter": {"and": []}}
 
             xmlnss = filter(None, [f["xmlns"] for f in self.all_relevant_forms.values()])


### PR DESCRIPTION
Not sure that this line should be necessary any longer: https://github.com/dimagi/dimagi-utils/blob/master/dimagi/utils/dates.py#L207

Decided not to touch that until Danny and I refactor the datespan class.
