### PR TITLE
don't send admin_password hash to the client

### DIFF
--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -153,6 +153,8 @@ def get_settings_values(app):
         hq_settings.update({'custom_suite': app.custom_suite})
 
     hq_settings['build_spec'] = app.build_spec.to_string()
+    # the admin_password hash shouldn't be sent to the client
+    hq_settings.pop('admin_password', None)
 
     return {
         'properties': profile.get('properties', {}),


### PR DESCRIPTION
the client interprets it as the **password**, and if you save unrelated settings,
it'll set the password to this hash which is obviously not what's intended

fixes: http://manage.dimagi.com/default.asp?67115
