### PR TITLE
No migrate preview

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -442,6 +442,10 @@ def clone_repo():
 @task
 @roles('pg', 'django_monolith')
 def preindex_views():
+    if not env.should_migrate:
+        print 'Skipping preindex_views for "%s" because should_migrate = False' % env.environment
+        return
+        
     with cd(env.code_root_preindex):
         #update the codebase of the preindex dir...
         update_code(preindex=True)
@@ -506,7 +510,8 @@ def deploy():
             execute(migrate)
         execute(_do_collectstatic)
         execute(version_static)
-        execute(flip_es_aliases)
+        if env.should_migrate:
+            execute(flip_es_aliases)
     except Exception:
         execute(mail_admins, "Deploy failed", "You had better check the logs.")
         raise

--- a/fabfile.py
+++ b/fabfile.py
@@ -443,8 +443,7 @@ def clone_repo():
 @roles('pg', 'django_monolith')
 def preindex_views():
     if not env.should_migrate:
-        print 'Skipping preindex_views for "%s" because should_migrate = False' % env.environment
-        return
+        utils.abort('Skipping preindex_views for "%s" because should_migrate = False' % env.environment)
         
     with cd(env.code_root_preindex):
         #update the codebase of the preindex dir...

--- a/fabfile.py
+++ b/fabfile.py
@@ -47,7 +47,7 @@ if not hasattr(env, 'code_branch'):
 
 env.home = "/home/cchq"
 env.selenium_url = 'http://jenkins.dimagi.com/job/commcare-hq-post-deploy/buildWithParameters?token=%(token)s&TARGET=%(environment)s'
-
+env.should_migrate = False # Default to safety
 env.roledefs = {
         'django_celery': [],
         'django_app': [],
@@ -144,6 +144,7 @@ def staging():
     _setup_path()
     env.user = prompt("Username: ", default='dimagivm')
     env.es_endpoint = 'localhost'
+    env.should_migrate = True
 
 @task
 def india():
@@ -154,6 +155,7 @@ def india():
     env.hosts = ['220.226.209.82']
     env.user = prompt("Username: ", default=env.user)
     env.django_port = '8001'
+    env.should_migrate = True
 
     _setup_path()
     env.virtualenv_root = posixpath.join(env.home, '.virtualenvs/commcarehq')
@@ -184,6 +186,7 @@ def production():
     env.environment = 'production'
     env.django_port = '9010'
     env.code_branch = 'master'
+    env.should_migrate = True
 
     #env.hosts = None
     env.roledefs = {
@@ -225,6 +228,7 @@ def realstaging():
     env.environment = 'staging'
     env.django_port = '9010'
 
+    env.should_migrate = True
 
     #env.hosts = None
     env.roledefs = {
@@ -260,6 +264,7 @@ def preview():
     env.environment = 'preview'
     env.django_port = '7999'
     #env.hosts = None
+    env.should_migrate = False
 
     env.roledefs = {
         'couch': [],
@@ -497,7 +502,8 @@ def deploy():
         execute(update_virtualenv)
         execute(clear_services_dir)
         set_supervisor_config()
-        execute(migrate)
+        if env.should_migrate:
+            execute(migrate)
         execute(_do_collectstatic)
         execute(version_static)
         execute(flip_es_aliases)


### PR DESCRIPTION
This is to skip preindexing, db syncing, flipping of ES aliases, etc, when preview is deployed. It should be just the code.
