### PR TITLE
fixed links on 'Download to Java Phone'

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/releases.html
@@ -299,11 +299,11 @@
                                     </li>
                                     <li>
                                         {% trans "For help on how to install, see" %}
-                                        <a target="_blank" href="https://confluence.dimagi.com/display/commcarepublic/Set+Up+Mobile+Phone">{% trans "Set Up Mobile Phone" %}</a>.
+                                        <a target="_blank" href="https://confluence.dimagi.com/display/commcarepublic/Set+Up+Feature+Phones">{% trans "Set Up Feature Phones" %}</a>.
                                     </li>
                                     <li>
                                         {% trans "If you have any issues with the installation, please refer to" %}
-                                        <a target="_blank" href="https://confluence.dimagi.com/display/commcarepublic/Troubleshooting+Phone+Problems">{% trans "Troubleshooting Phone Problems" %}</a>.
+                                        <a target="_blank" href="https://confluence.dimagi.com/display/commcarepublic/Troubleshooting">{% trans "Troubleshooting Phone Problems" %}</a>.
                                     </li>
                                 </ol>
                             </div>


### PR DESCRIPTION
Please confirm target link:
I didn't see a page specifically about "troubleshooting phone problems", so I linked to https://confluence.dimagi.com/display/commcarepublic/Troubleshooting

Regarding bug: http://manage.dimagi.com/default.asp?68146
