### PR TITLE
move the form validation error messages to be part of validate_for_build

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -389,6 +389,13 @@ class FormBase(DocumentSchema):
             logging.error("Failed: _parse_xml(string=%r)" % self.source)
             raise
         else:
+            try:
+                self.validate_form()
+            except XFormValidationError as e:
+                error = {'type': 'validation error', 'validation_message': unicode(e)}
+                error.update(meta)
+                errors.append(error)
+
             for error in self.check_actions():
                 error.update(meta)
                 errors.append(error)

--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -17,6 +17,10 @@
                             {% endif %}
                             {% include "app_manager/partials/form_error_message.html" %}
                         {% endif %}
+                        {% if error.type == "validation error" %}
+                            {{ error.validation_message|linebreaksbr }} in form
+                            {% include "app_manager/partials/form_error_message.html" %}
+                        {% endif %}
                         {% if error.type == "no ref detail" %}
                             Module
                             <a href="{% url view_module domain app.id error.module.id %}">{{ error.module.name|trans:langs }}</a>

--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -344,10 +344,8 @@ def get_form_view_context(request, form, langs, is_user_registration, messages=m
             form_errors.append("Syntax Error: %s" % e)
         except AppError as e:
             form_errors.append("Error in application: %s" % e)
-        except XFormValidationError as e:
-            message = unicode(e)
-            form_errors.append((html.escape(message).replace('\n', '<br/>'), {'extra_tags': 'html'}))
-
+        except XFormValidationError:
+            pass
         except XFormError as e:
             form_errors.append("Error in form: %s" % e)
         # any other kind of error should fail hard, but for now there are too many for that to be practical

--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -345,6 +345,7 @@ def get_form_view_context(request, form, langs, is_user_registration, messages=m
         except AppError as e:
             form_errors.append("Error in application: %s" % e)
         except XFormValidationError:
+            # showing these messages is handled by validate_form_for_build ajax
             pass
         except XFormError as e:
             form_errors.append("Error in form: %s" % e)


### PR DESCRIPTION
showing up both on the form view page and showing up in the list of build errors with a link to the correct form

fixes: http://manage.dimagi.com/default.asp?68089
