### PR TITLE
Make summing the default option for fluff calculators

### DIFF
--- a/corehq/fluff/calculators/xform.py
+++ b/corehq/fluff/calculators/xform.py
@@ -39,7 +39,7 @@ class FilteredFormPropertyCalculator(fluff.Calculator):
     indicator_calculator = None
     window = timedelta(days=1)
 
-    @fluff.custom_date_emitter(reduce_type="sum")
+    @fluff.date_emitter
     def total(self, form):
         if self.indicator_calculator:
             yield default_date(form)
@@ -93,7 +93,7 @@ class FormORCalculator(ORCalculator):
 class FormSUMCalculator(ORCalculator):
     window = timedelta(days=1)
 
-    @fluff.custom_date_emitter(reduce_type='sum')
+    @fluff.date_emitter
     def total(self, form):
         for calc in self.calculators:
             if calc.passes_filter(form):

--- a/corehq/fluff/calculators/xform.py
+++ b/corehq/fluff/calculators/xform.py
@@ -39,11 +39,12 @@ class FilteredFormPropertyCalculator(fluff.Calculator):
     indicator_calculator = None
     window = timedelta(days=1)
 
-    @fluff.date_emitter
+    @fluff.custom_date_emitter(reduce_type="sum")
     def total(self, form):
-        if self.indicator_calculator is not None:
+        if self.indicator_calculator:
+            yield default_date(form)
+        else:
             yield [default_date(form), self.indicator_calculator(form)]
-        yield default_date(form)
 
     def __init__(self, xmlns=None, property_path=None, property_value=None,
                  operator=EQUAL, indicator_calculator=None, window=None):
@@ -72,6 +73,7 @@ class FilteredFormPropertyCalculator(fluff.Calculator):
                 self.operator(form.xpath(self.property_path), self.property_value)
             )
         )
+
 
 # meh this is a little redundant but convenient
 class FormANDCalculator(ANDCalculator):


### PR DESCRIPTION
This changes the default "total" to use the sum option. Without an indicator calculator, the "sum" and "count" values are always going to be the same (since 1 is used by default).
