### PR TITLE
bump ctable version

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -56,5 +56,5 @@ amqp==1.0.8
 amqplib==1.0.2
 sqlagg==0.1.4
 -e submodules/fluff-src
-ctable==0.0.3
+ctable==0.0.4
 unittest2


### PR DESCRIPTION
depends on https://github.com/dimagi/ctable/pull/33 and new version pushed to PyPi
