### PR TITLE
add versioning to multimedia files

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1426,6 +1426,7 @@ class ApplicationBase(VersionedDoc, SnapshotMixin):
             copy._id = copy.get_db().server.next_uuid()
 
         copy.set_form_versions(previous_version)
+        copy.set_media_versions(previous_version)
         copy.create_jadjar(save=True)
 
         try:
@@ -1465,6 +1466,9 @@ class ApplicationBase(VersionedDoc, SnapshotMixin):
 
     def set_form_versions(self, previous_version):
         # by default doing nothing here is fine.
+        pass
+
+    def set_media_versions(self, previous_version):
         pass
 
 #class Profile(DocumentSchema):
@@ -1620,6 +1624,17 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
                     my_hash = _hash(self.fetch_xform(form=form))
                     if previous_hash != my_hash:
                         form.version = self.version
+
+    def set_media_versions(self, previous_version):
+        for path, map_item in self.multimedia_map.items():
+            if previous_version:
+                pre_map_item = previous_version.multimedia_map.get(path, None)
+                if pre_map_item and pre_map_item.version and pre_map_item.multimedia_id == map_item.multimedia_id:
+                    map_item.version = pre_map_item.version
+                else:
+                    map_item.version = self.version
+            else:
+                map_item.version = self.version
 
     def _create_custom_app_strings(self, lang):
         def trans(d):

--- a/corehq/apps/app_manager/suite_xml.py
+++ b/corehq/apps/app_manager/suite_xml.py
@@ -402,7 +402,7 @@ class SuiteGenerator(object):
             yield MediaResource(
                 id=self.id_strings.media_resource(multimedia_id, name),
                 path=path,
-                version=1,
+                version=m.version,
                 local=None,
                 remote=get_url_base() + reverse(
                     'hqmedia_download',

--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -375,6 +375,7 @@ class HQMediaMapItem(DocumentSchema):
     multimedia_id = StringProperty()
     media_type = StringProperty()
     output_size = DictProperty()
+    version = IntegerProperty()
 
     @staticmethod
     def format_match_map(path, media_type=None, media_id=None, upload_path=""):


### PR DESCRIPTION
This adds a "version" (similar to form version) to the multimedia map upon build, letting the mobile client know whether to remote update each multimedia file. (Without this it would either update every image every time or never update.)
