### PR TITLE
Crash with a validation error instead of type error

### DIFF
--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -179,7 +179,7 @@ class XForm(WrappedNode):
             self.namespaces.update(x="{%s}" % xmlns)
 
     def validate(self, version='1.0'):
-        validation_results = formtranslate.api.validate(ET.tostring(self.xml), version=version)
+        validation_results = formtranslate.api.validate(ET.tostring(self.xml) if self.xml else '', version=version)
         if not validation_results.success:
             raise XFormValidationError(validation_results.fatal_error, version, validation_results.problems)
         return self


### PR DESCRIPTION
`self.xml` is deliberately left as `None` in some cases; this ensures that we crash with a `ValidationError` in those cases.
