### PR TITLE
report api prototype

### DIFF
--- a/corehq/apps/api/resources/__init__.py
+++ b/corehq/apps/api/resources/__init__.py
@@ -1,3 +1,4 @@
+from tastypie.bundle import Bundle
 from tastypie.resources import Resource
 from tastypie.exceptions import InvalidSortError
 
@@ -27,6 +28,18 @@ class JsonResource(Resource):
             format = 'application/json'
 
         return format
+
+    def resource_uri_kwargs(self, bundle_or_obj=None):
+        kwargs = super(JsonResource, self).resource_uri_kwargs(bundle_or_obj)
+        try:
+            if isinstance(bundle_or_obj, Bundle):
+                kwargs['domain'] = bundle_or_obj.request.domain
+            else:
+                kwargs['domain'] = bundle_or_obj.domain
+        except AttributeError:
+            pass
+
+        return kwargs
 
 class SimpleSortableResourceMixin(object):
     '''

--- a/corehq/apps/api/urls.py
+++ b/corehq/apps/api/urls.py
@@ -10,6 +10,7 @@ from django.conf.urls.defaults import *
 from django.http import HttpResponseNotFound
 from tastypie.api import Api
 from corehq.apps.api.es import XFormES
+from corehq.apps.reports.resources.v0_1 import ReportResource
 from dimagi.utils.decorators import inline
 
 API_LIST = (
@@ -19,6 +20,7 @@ API_LIST = (
         v0_1.CommCareCaseResource,
         v0_1.XFormInstanceResource,
         FixtureResource,
+        ReportResource,
     )),
     ((0, 2), (
         v0_1.CommCareUserResource,
@@ -26,6 +28,7 @@ API_LIST = (
         v0_2.CommCareCaseResource,
         v0_1.XFormInstanceResource,
         FixtureResource,
+        ReportResource,
     )),
     ((0, 3), (
         v0_1.CommCareUserResource,
@@ -33,6 +36,7 @@ API_LIST = (
         v0_3.CommCareCaseResource,
         v0_3.XFormInstanceResource,
         FixtureResource,
+        ReportResource,
     )),
     ((0, 4), (
         v0_1.CommCareUserResource,
@@ -42,7 +46,8 @@ API_LIST = (
         v0_4.GroupResource,
         v0_4.XFormInstanceResource,
         v0_4.RepeaterResource,
-        FixtureResource
+        FixtureResource,
+        ReportResource,
     ))
 )
 

--- a/corehq/apps/reports/api.py
+++ b/corehq/apps/reports/api.py
@@ -1,0 +1,237 @@
+from datetime import datetime, date, time
+from dimagi.utils.dates import DateSpan
+
+CONFIG_TYPE_BOOLEAN = 'boolean'
+CONFIG_TYPE_STRING = 'string'
+CONFIG_TYPE_INTEGER = 'integer'
+CONFIG_TYPE_DATE = 'date'
+
+CONFIG_DATA_TYPES = [CONFIG_TYPE_BOOLEAN, CONFIG_TYPE_STRING,
+                     CONFIG_TYPE_INTEGER, CONFIG_TYPE_DATE]
+
+DATE_FORMAT = "%Y-%m-%d"
+
+
+class BaseMetaModel(object):
+    """
+    Assumes class will be instantiated with ``fields`` as 'args' and
+    ``optional_fields`` as 'kwargs'.
+
+    Ordering of args must match ordering in ``fields`` attribute.
+    """
+    fields = []
+    optional_fields = []
+
+    def __init__(self, *args, **kwargs):
+        if not len(args) == len(self.fields):
+            raise Exception("Unexpected fields. Expected '%s', got '%s'" % (self.fields, args))
+
+        for field, value in dict(zip(self.fields, args)).items():
+            setattr(self, field, value)
+
+        for field in self.optional_fields:
+            value = kwargs.pop(field, None)
+            setattr(self, field, value)
+
+        if kwargs:
+            raise Exception("Unexpected kwargs %s" % kwargs)
+
+        self.validate()
+
+    def validate(self):
+        pass
+
+    def to_json(self):
+        d = dict()
+        for f in self.fields:
+            d[f] = getattr(self, f)
+
+        for f in self.optional_fields:
+            val = getattr(self, f, None)
+            if val is not None:
+                d[f] = val
+
+        return d
+
+
+class ConfigItemMeta(BaseMetaModel):
+    fields = ['slug', 'name', 'data_type']
+    optional_fields = ['required', 'group_by', 'options', 'default', 'help_text']
+
+    def validate(self):
+        if self.data_type not in CONFIG_DATA_TYPES:
+            raise ValueError('Unexpected value for data_type: %s' % self.data_type)
+
+
+class IndicatorMeta(BaseMetaModel):
+    fields = ['slug', 'name']
+    optional_fields = ['group', 'help_text']
+
+
+class IndicatorGroupMeta(BaseMetaModel):
+    fields = ['slug', 'name']
+    optional_fields = ['help_text']
+
+
+class ReportApiSource(object):
+    _meta_fields = ['config', 'indicators', 'indicator_groups']
+    slug = ''
+    name = ''
+
+    def __init__(self, domain=None, request=None, config=None, meta_only=False):
+        """
+        One of request or config must be supplied.
+
+        :param domain: The domain requesting data.
+        :param request: The Django request object.
+        :param config: Dict containing the configuration. See ``self.config_meta``.
+        :param meta_only: If True just return the meta-data.
+        """
+        self.domain = domain
+        self.config = config or dict()
+        self.request = request
+        self.meta_only = meta_only
+
+        self.post_init()
+
+    def post_init(self):
+        if self.request:
+            self._build_config_from_request()
+        else:
+            for item in self.config_meta:
+                if item.slug not in self.config and item.default:
+                    self.config[item.slug] = item.default
+
+        self._convert_types()
+        self._build_datespan()
+
+    @property
+    def config_meta(self):
+        """
+        Return a list of ConfigItemMeta instances or dict with appropriate keys.
+        """
+        raise NotImplementedError()
+
+    @property
+    def indicators_meta(self):
+        """
+        Return a list of IndicatorMeta instances.
+        """
+        raise NotImplementedError()
+
+    @property
+    def indicator_groups_meta(self):
+        """
+        Return a list of IndicatorGroupMeta instances.
+        """
+        pass
+
+    @property
+    def config_complete(self):
+        """
+        Return True if ``self.meta_only`` is False AND all required config params are satisfied.
+        """
+        missing_params = self.get_missing_params()
+        print missing_params
+        return not self.meta_only and not missing_params
+
+    def get_missing_params(self):
+        """
+        Return a list of config params that are not satisfied.
+        """
+        if self.config is None:
+            return [item.slug for item in self.config_meta if item.required]
+
+        return [item.slug for item in self.config_meta if item.required and not self.config.get(item.slug)]
+
+    def get_results(self):
+        if self.config_complete:
+            return self.results()
+        else:
+            return None
+
+    def results(self):
+        """
+        Return a list of dicts mapping indicator slugs to values.
+
+        e.g.
+        [{
+            'user': 'a',
+            'indicator1': 10,
+            'indicator2': 4
+        },
+        {
+            'user': 'b,
+            'indicator1': 8,
+            'indicator2': 5
+        }]
+
+        """
+        pass
+
+    def api_meta(self, full=False):
+        meta = dict(slug=self.slug, name=self.name)
+
+        if full:
+            for field in self._meta_fields:
+                value = getattr(self, '%s_meta' % field) or []
+                meta[field] = [item.to_json() if isinstance(item, BaseMetaModel) else item for item in value]
+
+        return meta
+
+    def _build_config_from_request(self):
+        conf = dict([(item.slug, self.request.GET.get(item.slug, item.default)) for item in self.config_meta])
+        indicators_param = self.request.GET.get('indicators')
+        indicators = indicators_param.split(',') if indicators_param else None
+        conf['indicator_slugs'] = indicators
+        conf['domain'] = self.domain
+
+        self.config = dict(conf)
+
+    def _build_datespan(self):
+        def date_or_nothing(param):
+            if param in self.config and self.config[param]:
+                val = self.config[param]
+                if isinstance(val, date):
+                    return datetime.combine(val, time())
+                elif isinstance(val, datetime):
+                    return val
+                else:
+                    return datetime.strptime(val, DATE_FORMAT)
+
+        startdate = date_or_nothing('startdate')
+        enddate = date_or_nothing('enddate')
+
+        if startdate or enddate:
+            self.config['datespan'] = DateSpan(startdate, enddate, DATE_FORMAT)
+
+    def _convert_types(self):
+        for item in self.config_meta:
+            self.config[item.slug] = self._convert_type(item.data_type, self.config.get(item.slug, None))
+
+    def _convert_type(self, data_type, param):
+        if param is None or not isinstance(param, basestring):
+            return param
+        else:
+            if data_type == CONFIG_TYPE_DATE:
+                return datetime.strptime(param, DATE_FORMAT)
+            elif data_type == CONFIG_TYPE_BOOLEAN:
+                return param in ('True', 'true', 1)
+            elif data_type == CONFIG_TYPE_INTEGER:
+                return int(param)
+            return param
+
+
+def get_report_results(klass, domain, config, indicator_slugs=None, include_meta=False, meta_full=False):
+    config['indicator_slugs'] = indicator_slugs
+    report = klass(domain=domain, config=config)
+    if not report.config_complete:
+        raise ValueError('Report config incomplete. Missing config params: %s' % report.get_missing_params())
+
+    data = report.get_results()
+
+    ret = dict(results=data)
+    if include_meta:
+        ret.update(report.api_meta(full=meta_full))
+
+    return ret

--- a/corehq/apps/reports/resources/v0_1.py
+++ b/corehq/apps/reports/resources/v0_1.py
@@ -1,0 +1,79 @@
+from django.core.exceptions import ObjectDoesNotExist
+from corehq.apps.reports.api import ReportApiSource
+from tastypie import fields
+from tastypie.bundle import Bundle
+from corehq.apps.api.resources import JsonResource
+from corehq.apps.api.resources.v0_1 import CustomResourceMeta
+
+
+class DetailURIResource(object):
+    def detail_uri_kwargs(self, bundle_or_obj):
+        """
+        Given a ``Bundle`` or an object (typically a ``Model`` instance),
+        it returns the extra kwargs needed to generate a detail URI.
+        """
+        kwargs = {}
+
+        try:
+            if isinstance(bundle_or_obj, Bundle):
+                kwargs[self._meta.detail_uri_name] = getattr(bundle_or_obj.obj, self._meta.detail_uri_name)
+            else:
+                kwargs[self._meta.detail_uri_name] = getattr(bundle_or_obj, self._meta.detail_uri_name)
+        except AttributeError:
+            pass
+
+        return kwargs
+
+
+class ReportResource(DetailURIResource, JsonResource):
+    meta_fields = ['config', 'indicators', 'indicator_groups']
+    type = "report"
+    slug = fields.CharField(attribute='slug', readonly=True, unique=True)
+    name = fields.CharField(attribute='name', readonly=True)
+    config = fields.ListField(attribute='config_meta', readonly=True)
+    indicators = fields.ListField(attribute='indicators_meta', readonly=True)
+    indicator_groups = fields.ListField(attribute='indicator_groups_meta', readonly=True, null=True)
+    results = fields.ListField(attribute='get_results', readonly=True, null=True)
+
+    def dehydrate(self, bundle):
+        full = bundle.request.GET.get('full')
+
+        config_complete = bundle.obj.config_complete
+
+        full = full or not config_complete
+        bundle.data.update(bundle.obj.api_meta(full=full))
+
+        if not full:
+            for f in self.meta_fields:
+                del bundle.data[f]
+
+        if not config_complete:
+            del bundle.data['results']
+
+        return bundle
+
+    def obj_get(self, bundle, **kwargs):
+        domain = kwargs['domain']
+        slug = kwargs['slug']
+        source = self.get_source(slug, bundle.request, domain)
+        if not source:
+            raise ObjectDoesNotExist("Couldn't find a report which matched slug='%s'." % slug)
+
+    def obj_get_list(self, bundle, **kwargs):
+        domain = kwargs['domain']
+        return self.get_api_sources(bundle.request, domain)
+
+    def get_api_sources(self, request, domain=None):
+        # TODO: implement method. See corehq.apps.reports.dispatcher.ReportDispatcher#get_reports
+        return []
+
+    def get_source(self, slug, request, domain):
+        # TODO: implement method
+        return None
+
+    class Meta(CustomResourceMeta):
+        object_class = ReportApiSource
+        resource_name = 'report'
+        detail_uri_name = 'slug'
+        allowed_methods = ['get']
+        collection_name = 'reports'

--- a/corehq/apps/reports/tests/__init__.py
+++ b/corehq/apps/reports/tests/__init__.py
@@ -4,6 +4,7 @@ try:
     from corehq.apps.reports.tests.test_household_verification import *
     from corehq.apps.reports.tests.test_sql_reports import *
     from corehq.apps.reports.tests.test_form_export import *
+    from corehq.apps.reports.tests.test_api import *
 except ImportError, e:
     # for some reason the test harness squashes these so log them here for clarity
     # otherwise debugging is a pain

--- a/corehq/apps/reports/tests/test_api.py
+++ b/corehq/apps/reports/tests/test_api.py
@@ -1,0 +1,97 @@
+from datetime import date
+from django import test as unittest
+from sqlagg.columns import SimpleColumn, SumColumn
+from corehq.apps.reports.api import ReportApiSource, ConfigItemMeta, IndicatorMeta, get_report_results
+from corehq.apps.reports.datatables import DataTablesColumnGroup
+from corehq.apps.reports.sqlreport import SqlReportApiSource, SqlData, DatabaseColumn
+from corehq.apps.reports.tests.sql_fixture import load_data
+
+DOMAIN = "test"
+
+
+class TestReport(ReportApiSource):
+    slug = 'test'
+    name = 'Test'
+
+    @property
+    def config_meta(self):
+        return [ConfigItemMeta('date', 'Date', 'date', required=True)]
+
+    @property
+    def indicators_meta(self):
+        return [IndicatorMeta('test', 'Test')]
+
+    def results(self):
+        return [dict(test=1)]
+
+
+class TestSqlData(SqlData):
+    name = 'Test SQL report API test'
+    slug = 'sql_test'
+    table_name = 'user_report_data'
+
+    @property
+    def filters(self):
+        return ['date between :startdate and :enddate']
+
+    @property
+    def filter_values(self):
+        return dict(startdate=self.datespan.startdate_param_utc,
+                    enddate=self.datespan.enddate_param_utc)
+
+    @property
+    def group_by(self):
+        return ['user']
+
+    @property
+    def columns(self):
+        test_group = DataTablesColumnGroup("Category of abuse")
+        return [
+            DatabaseColumn("User", SimpleColumn("user")),
+            DatabaseColumn("Indicator A", SumColumn("indicator_a")),
+            DatabaseColumn("Indicator B", SumColumn("indicator_b")),
+            DatabaseColumn("Indicator B", SumColumn("indicator_c"), header_group=test_group),
+            DatabaseColumn("Indicator B", SumColumn("indicator_d"), header_group=test_group)
+        ]
+
+
+class TestSqlReport(SqlReportApiSource):
+    sqldata_class = TestSqlData
+
+    @property
+    def config_meta(self):
+        return [
+            ConfigItemMeta('startdate', 'Start Date', 'date', default=date(2013, 1, 1)),
+            ConfigItemMeta('enddate', 'End Date', 'date', default=date(2013, 2, 1)),
+            ConfigItemMeta('user', 'User', 'string', group_by=True),
+        ]
+
+
+class ReportApiTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        load_data()
+
+    def test_api_config_complete(self):
+        result = get_report_results(TestReport, DOMAIN, dict(date='2013-01-01'))
+        self.assertEqual(result, dict(results=[dict(test=1)]))
+
+    def test_api_config_incomplete(self):
+        with self.assertRaisesRegexp(ValueError, "Report config incomplete. Missing config params: \['date'\]"):
+            get_report_results(TestReport, DOMAIN, dict())
+
+    def test_sql_report_api(self):
+        result = get_report_results(TestSqlReport, DOMAIN, dict())
+        expected = {'results': [
+            {'indicator_a': 1L, 'indicator_b': 1L,
+             'indicator_c': 2L, 'indicator_d': 4L, 'user': 'user2'},
+            {'indicator_a': 1L, 'indicator_b': 1L,
+             'indicator_c': 2L, 'indicator_d': 2L, 'user': 'user1'}]}
+        self.assertEqual(result, expected)
+
+    def test_sql_report_api_select_indicators(self):
+        result = get_report_results(TestSqlReport, DOMAIN, dict(), indicator_slugs=['indicator_a'])
+        expected = {'results': [
+            {'indicator_a': 1L, 'user': 'user2'},
+            {'indicator_a': 1L, 'user': u'user1'}]}
+        self.assertEqual(result, expected)


### PR DESCRIPTION
docs: https://docs.google.com/a/dimagi.com/document/d/1MFk_7cNXl4FYji3Q50AGGUx9VorrnARBuftCd_1gfVA/edit#heading=h.wuy47rvevj3

**Overview**
- Base class `ReportApiSource` provides methods to get meta data and results from config `dict` or `request`.
- `SqlReportApiSource` wraps `SqlData` - implementation feels a bit clunky
- Tastypie resource class `ReportResource` makes `ReportApiSource` class data available via HTTP.
