### PR TITLE
Commtrack fix for bad API queries

### DIFF
--- a/corehq/apps/commtrack/views.py
+++ b/corehq/apps/commtrack/views.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from django.http import HttpResponse, HttpResponseRedirect, Http404
+from django.http import HttpResponse, HttpResponseRedirect, Http404, HttpResponseNotFound
 from django.shortcuts import render
 
 from corehq.apps.domain.decorators import require_superuser, domain_admin_required, require_previewer, login_and_domain_required
@@ -236,11 +236,13 @@ def api_query_supply_point(request, domain):
         return {'id': loc._id, 'name': loc.name}
 
     if id:
-        loc = Location.get(id)
-        if loc:
-            payload = loc_to_payload(loc)
-        else:
-            payload = None
+        try:
+            loc = Location.get(id)
+            return HttpResponse(json.dumps(loc_to_payload(loc)), 'text/json')
+
+        except ResourceNotFound:
+            return HttpResponseNotFound(json.dumps({'message': 'no location with is %s found' % id}, 'text/json'))
+
     else:
         LIMIT = 100
         loc_types = [loc_type.name for loc_type in Domain.get_by_name(domain).commtrack_settings.location_types if not loc_type.administrative]
@@ -259,7 +261,4 @@ def api_query_supply_point(request, domain):
             )
 
         locs = sorted(itertools.chain(*(get_locs(loc_type) for loc_type in loc_types)), key=lambda e: e.name)[:LIMIT]
-        payload = map(loc_to_payload, locs)
-
-    return HttpResponse(json.dumps(payload), 'text/json')
-
+        return HttpResponse(json.dumps(map(loc_to_payload, locs)), 'text/json')

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -172,7 +172,7 @@ class SupplyPointSelectWidget(forms.Widget):
     def render(self, name, value, attrs=None):
         return get_template('locations/manage/partials/autocomplete_select_widget.html').render(Context({
                     'name': name,
-                    'value': value,
+                    'value': value or '',
                     'query_url': reverse('corehq.apps.commtrack.views.api_query_supply_point', args=[self.domain]),
                 }))
 


### PR DESCRIPTION
two part fix (see commits) - don't query when no id, and don't 500 when a bad id
