### PR TITLE
added UI notifications if a build is flagged as broken

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases.js
@@ -21,6 +21,12 @@ function ReleasesMain(o) {
     self.deployAnyway = {};
     self.appVersion = ko.observable(self.options.appVersion);
     self.lastAppVersion = ko.observable();
+    self.brokenBuilds = ko.computed(function () {
+        var apps = self.savedApps();
+        return _.some(apps, function (app) {
+            return app.build_broken();
+        });
+    });
     self.savedApps.subscribe(function () {
         var lastApp = self.savedApps()[0];
         self.lastAppVersion(lastApp ? lastApp.version() : -1);

--- a/corehq/apps/app_manager/templates/app_manager/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/releases.html
@@ -108,6 +108,22 @@
 {% endblock %}
 {% block form-view %}
     <div id="releases-table">
+        <div class="alert alert-error" data-bind="visible: brokenBuilds">
+            <p>
+                <span class="icon icon-exclamation-sign"></span>
+                {% blocktrans %}
+                    One or more of your versions is broken, please make sure it is
+                    not marked as released. Make a new version if needed, and update
+                    any live deployments as soon as possible. 
+                {% endblocktrans %}
+            </p>
+            <p><small>
+                {% blocktrans %}
+                    All new builds should work, so if problems persist, please
+                    report the issue.
+                {% endblocktrans %}
+            </small></p>
+        </div>
         <button class="btn btn-primary" data-bind="
             click: makeNewBuild,
             attr: {disabled: !makeNewBuildEnabled() ? 'disabled' : undefined},
@@ -152,7 +168,8 @@
                 <tr class="build" data-bind="css: {
                     'build-released': is_released(),
                     'build-unreleased': !is_released(),
-                    'build-latest-release': id() === $root.latestReleaseId()
+                    'build-latest-release': id() === $root.latestReleaseId(),
+                    'error': build_broken
                 }">
                     <td>
                         {% if edit %}
@@ -181,7 +198,14 @@
                     </td>
                     <td class="nowrap">
                         <div class="btn-group">
-                            <a class="btn btn-primary" data-bind="openModal: 'deploy-build-modal-template'">Deploy</a>
+                            <a class="btn" data-bind="
+                                openModal: 'deploy-build-modal-template',
+                                css: {'btn-primary': !build_broken(), 'btn-danger': build_broken}
+                            ">
+                                <span class="icon icon-exclamation-sign" data-bind="
+                                visible: build_broken"></span>
+                                Deploy
+                            </a>
                         </div>
                     </td>
                     {% if edit %}


### PR DESCRIPTION
In light of our conversation today, what do y'all think of this error text?

> "One or more of your versions is broken, please make sure it is not marked as released.  Make a new version if needed, and update any live deployments as soon as possible."  "All new versions should work, so if problems persist, please report the issue."

fixes: http://manage.dimagi.com/default.asp?69701

![screen shot 2013-08-07 at 5 50 54 pm](https://f.cloud.github.com/assets/137212/928040/f262d8d8-ffab-11e2-922e-6c400c3a8b65.png)
