### PR TITLE
Delete cc review days

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1735,16 +1735,26 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
         return s
 
     def create_profile(self, is_odk=False, with_media=False, template='app_manager/profile.xml'):
+        self__profile = self.profile
         app_profile = defaultdict(dict)
-        app_profile.update(self.profile)
-        # the following code is to let HQ override CommCare defaults
-        # impetus: Weekly Logging should be Short (HQ override) instead of Never (CommCare default)
-        # setting.default is assumed to also be the CommCare default unless there's a setting.commcare_default
+
         for setting in commcare_settings.SETTINGS:
-            type = setting['type']
-            if type in ('properties', 'features') and setting['id'] not in app_profile[type]:
+            setting_type = setting['type']
+            setting_id = setting['id']
+
+            if setting_type not in ('properties', 'features'):
+                setting_value = None
+            elif setting_id not in self__profile.get(setting_type, {}):
                 if 'commcare_default' in setting and setting['commcare_default'] != setting['default']:
-                    app_profile[type][setting['id']] = setting['default']
+                    setting_value = setting['default']
+                else:
+                    setting_value = None
+            else:
+                setting_value = self__profile[setting_type][setting_id]
+            if setting_value:
+                app_profile[setting_type][setting_id] = setting_value
+            # assert that it gets explicitly set once per loop
+            del setting_value
 
         if self.case_sharing:
             app_profile['properties']['server-tether'] = 'sync'

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-profile-settings.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-profile-settings.yaml
@@ -16,15 +16,6 @@
   default: "0"
   values_txt: "Any positive integer. Represents period of purging in days."
 
-- disabled: true
-  name: "Days for Review"
-  description: "How long the phone will retain completed forms for review."
-  id: "cc-review-days"
-  values: ["1", "7",  "31", "92", "365"]
-  value_names: ["Just One Day", "One Week", "One Month", "Three Months", "One Year"]
-  default: "7"
-  values_txt: "Any positive integer. Represents period of purging in days."
-
 - name: "Logging Enabled"
   description: "Whether logging of incidents should be activated on the client."
   id: "logenabled"

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-settings-layout.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-settings-layout.yaml
@@ -68,4 +68,3 @@
     - properties.restore-tolerance  # OTA Restore Tolerance (disabled)
     - features.users  # No Users Mode (disabled)
     - properties.loose_media  # Loose Media Mode (disabled)
-    - properties.cc-review-days  # Days for Review (disabled)


### PR DESCRIPTION
Includes a necessary tightening up of profile generation to only add known properties—thus not adding cc-review-days even when it's been set in `self.profile`.
