### PR TITLE
CloudCare API / case list optimizations

### DIFF
--- a/corehq/apps/cloudcare/api.py
+++ b/corehq/apps/cloudcare/api.py
@@ -36,10 +36,11 @@ class CaseAPIResult(object):
     The result of a case API query. Useful for abstracting out the difference
     between an id-only representation and a full_blown one.
     """
-    def __init__(self, id=None, couch_doc=None, id_only=False):
+    def __init__(self, id=None, couch_doc=None, id_only=False, lite=True):
         self._id = id
         self._couch_doc = couch_doc
         self.id_only = id_only
+        self.lite = lite
 
     def __getitem__(self, key):
         if key == 'case_id':
@@ -61,7 +62,7 @@ class CaseAPIResult(object):
 
     @property
     def case_json(self):
-        return self.couch_doc.get_json()
+        return self.couch_doc.get_json(lite=self.lite)
 
     def to_json(self):
         return self.id if self.id_only else self.case_json


### PR DESCRIPTION
default all cloudcare api access to not include reverse indices

(nothing in touchforms or maps - the only two 'certified' consumers
uses them, and we always told any unspported consumers we would change
them at any time with no warning, and ray is already totally off them)

also use iterdocs instead of hitting the DB for every case.

depends on https://github.com/dimagi/casexml/pull/96/
