### PR TITLE
jad version should default to old behavior before 2.8 (had done 2.1 originally)

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1351,7 +1351,7 @@ class ApplicationBase(VersionedDoc, SnapshotMixin):
             # e.g. 2011-Apr-11 20:45
             'CommCare-Release': "true",
         }
-        if LooseVersion(self.build_spec.version) < '2.1':
+        if LooseVersion(self.build_spec.version) < '2.8':
             settings['Build-Number'] = self.version
         return settings
 


### PR DESCRIPTION
This is upon Clayton's request because he realized 2.1-2.7 were responding not ideally to the change.
