### PR TITLE
Prevent app crashes when using sort only property

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1661,10 +1661,12 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
     def _create_custom_app_strings(self, lang):
         def trans(d):
             return clean_trans(d, langs)
+
         id_strings = IdStrings()
         langs = [lang] + self.langs
         yield id_strings.homescreen_title(), self.name
         yield id_strings.app_display_name(), self.name
+
         for module in self.get_modules():
             for detail in module.get_details():
                 if detail.type.startswith('case'):
@@ -1672,11 +1674,18 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
                 else:
                     label = trans(module.referral_label)
                 yield id_strings.detail_title_locale(module, detail), label
+
                 for column in detail.get_columns():
                     yield id_strings.detail_column_header_locale(module, detail, column), trans(column.header)
                     if column.format == 'enum':
                         for key, val in column.enum.items():
                             yield id_strings.detail_column_enum_variable(module, detail, column, key), trans(val)
+
+                if hasattr(detail, '_sort_only_columns'):
+                    for c in detail._sort_only_columns:
+                        field_text = {'en': str(c.field)}
+                        yield id_strings.detail_column_header_locale(module, detail, c), trans(field_text)
+
             yield id_strings.module_locale(module), trans(module.name)
             if module.case_list.show:
                 yield id_strings.case_list_locale(module), trans(module.case_list.label) or "Case List"

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -58,7 +58,7 @@ from corehq.apps.app_manager.const import APP_V1, APP_V2
 from corehq.apps.app_manager import fixtures, suite_xml, commcare_settings, build_error_utils
 from corehq.apps.app_manager.suite_xml import IdStrings
 from corehq.apps.app_manager.templatetags.xforms_extras import clean_trans
-from corehq.apps.app_manager.util import split_path, save_xform
+from corehq.apps.app_manager.util import split_path, save_xform, create_temp_sort_column
 from corehq.apps.app_manager.xform import XForm, parse_xml as _parse_xml, XFormError, XFormValidationError, WrappedNode, CaseXPath
 
 MISSING_DEPENDECY = \
@@ -1691,13 +1691,7 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
                 # everything left is a sort only option
                 for sort_element in sort_elements:
                     # create a fake column for it
-                    column = DetailColumn(
-                        model='case',
-                        field=sort_element,
-                        format='invisible',
-                        # ._i is exposed as .id, which is used in generating locale_ids
-                        _i=len(columns)
-                    )
+                    column = create_temp_sort_column(sort_element, len(columns))
 
                     # now mimic the normal translation
                     field_text = {'en': str(column.field)}

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1682,7 +1682,8 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
                 for column in columns:
                     yield id_strings.detail_column_header_locale(module, detail, column), trans(column.header)
 
-                    sort_elements.pop(column.header.values()[0], None)
+                    if column.header:
+                        sort_elements.pop(column.header.values()[0], None)
 
                     if column.format == 'enum':
                         for key, val in column.enum.items():

--- a/corehq/apps/app_manager/suite_xml.py
+++ b/corehq/apps/app_manager/suite_xml.py
@@ -375,8 +375,11 @@ def get_detail_column_infos(detail):
     for column in detail.get_columns():
         sort_element, order = sort_elements.pop(column.field, (None, None))
         columns.append(DetailColumnInfo(column, sort_element, order))
+
     # sort elements is now populated with only what's not in any column
-    # add invisible columns for these
+    # add invisible columns for these and store them on the detail
+    # object so that they are on hand for app strings
+    detail._sort_only_columns = []
     for field, (sort_element, order) in sort_elements.items():
         column = DetailColumn(
             model='case',
@@ -385,6 +388,7 @@ def get_detail_column_infos(detail):
             # ._i is exposed as .id, which is used in generating locale_ids
             _i=len(columns),
         )
+        detail._sort_only_columns.append(column)
         columns.append(DetailColumnInfo(column, sort_element, order))
     return columns
 

--- a/corehq/apps/app_manager/suite_xml.py
+++ b/corehq/apps/app_manager/suite_xml.py
@@ -377,9 +377,7 @@ def get_detail_column_infos(detail):
         columns.append(DetailColumnInfo(column, sort_element, order))
 
     # sort elements is now populated with only what's not in any column
-    # add invisible columns for these and store them on the detail
-    # object so that they are on hand for app strings
-    detail._sort_only_columns = []
+    # add invisible columns for these
     for field, (sort_element, order) in sort_elements.items():
         column = DetailColumn(
             model='case',
@@ -388,7 +386,6 @@ def get_detail_column_infos(detail):
             # ._i is exposed as .id, which is used in generating locale_ids
             _i=len(columns),
         )
-        detail._sort_only_columns.append(column)
         columns.append(DetailColumnInfo(column, sort_element, order))
     return columns
 

--- a/corehq/apps/app_manager/suite_xml.py
+++ b/corehq/apps/app_manager/suite_xml.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 from django.core.urlresolvers import reverse
 from lxml import etree
 from eulxml.xmlmap import StringField, XmlObject, IntegerField, NodeListField, NodeField
-from corehq.apps.app_manager.util import split_path
+from corehq.apps.app_manager.util import split_path, create_temp_sort_column
 from corehq.apps.app_manager.xform import SESSION_CASE_ID
 from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.web import get_url_base
@@ -379,13 +379,7 @@ def get_detail_column_infos(detail):
     # sort elements is now populated with only what's not in any column
     # add invisible columns for these
     for field, (sort_element, order) in sort_elements.items():
-        column = DetailColumn(
-            model='case',
-            field=field,
-            format='invisible',
-            # ._i is exposed as .id, which is used in generating locale_ids
-            _i=len(columns),
-        )
+        column = create_temp_sort_column(field, len(columns))
         columns.append(DetailColumnInfo(column, sort_element, order))
     return columns
 

--- a/corehq/apps/app_manager/tests/data/suite/sort-only-value.json
+++ b/corehq/apps/app_manager/tests/data/suite/sort-only-value.json
@@ -1,0 +1,371 @@
+{
+    "_attachments": {
+        "527e109bd10972030eb18fe895657629953f69eb.xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n<h:html xmlns:h=\"http://www.w3.org/1999/xhtml\" xmlns:orx=\"http://openrosa.org/jr/xforms\" xmlns=\"http://www.w3.org/2002/xforms\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:jr=\"http://openrosa.org/javarosa\">\n\t<h:head>\n\t\t<h:title>New Form</h:title>\n\t\t<model>\n\t\t\t<instance>\n\t\t\t\t<data xmlns:jrm=\"http://dev.commcarehq.org/jr/xforms\" xmlns=\"http://openrosa.org/formdesigner/85772309-F1B6-4D38-A49E-FA734433BE29\" uiVersion=\"1\" version=\"1\" name=\"New Form\">\n\t\t\t\t\t<test />\n\t\t\t\t</data>\n\t\t\t</instance>\n\t\t\t<bind nodeset=\"/data/test\" type=\"xsd:int\" />\n\t\t\t<itext>\n\t\t\t\t<translation lang=\"en\" default=\"\">\n\t\t\t\t\t<text id=\"test-label\">\n\t\t\t\t\t\t<value>question1</value>\n\t\t\t\t\t</text>\n\t\t\t\t</translation>\n\t\t\t</itext>\n\t\t</model>\n\t</h:head>\n\t<h:body>\n\t\t<input ref=\"/data/test\">\n\t\t\t<label ref=\"jr:itext('test-label')\" />\n\t\t</input>\n\t</h:body>\n</h:html>", 
+        "a644b8f62ed87bba25cf61858cec8db9eaefb314.xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n<h:html xmlns:h=\"http://www.w3.org/1999/xhtml\" xmlns:orx=\"http://openrosa.org/jr/xforms\" xmlns=\"http://www.w3.org/2002/xforms\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:jr=\"http://openrosa.org/javarosa\">\n\t<h:head>\n\t\t<h:title>New Form</h:title>\n\t\t<model>\n\t\t\t<instance>\n\t\t\t\t<data xmlns:jrm=\"http://dev.commcarehq.org/jr/xforms\" xmlns=\"http://openrosa.org/formdesigner/E9A1916C-5901-4C99-9EE8-894CE0C294BA\" uiVersion=\"1\" version=\"1\" name=\"New Form\">\n\t\t\t\t\t<question1 />\n\t\t\t\t</data>\n\t\t\t</instance>\n\t\t\t<bind nodeset=\"/data/question1\" type=\"xsd:string\" />\n\t\t\t<itext>\n\t\t\t\t<translation lang=\"en\" default=\"\">\n\t\t\t\t\t<text id=\"question1-label\">\n\t\t\t\t\t\t<value>question1</value>\n\t\t\t\t\t</text>\n\t\t\t\t</translation>\n\t\t\t</itext>\n\t\t</model>\n\t</h:head>\n\t<h:body>\n\t\t<input ref=\"/data/question1\">\n\t\t\t<label ref=\"jr:itext('question1-label')\" />\n\t\t</input>\n\t</h:body>\n</h:html>"
+    }, 
+    "admin_password": null, 
+    "admin_password_charset": "n", 
+    "application_version": "2.0", 
+    "attribution_notes": null, 
+    "build_broken": false, 
+    "build_comment": null, 
+    "build_langs": [
+        "en"
+    ], 
+    "build_signed": true, 
+    "build_spec": {
+        "build_number": null, 
+        "doc_type": "BuildSpec", 
+        "latest": true, 
+        "version": "2.6.0"
+    }, 
+    "built_on": null, 
+    "built_with": {
+        "build_number": null, 
+        "datetime": null, 
+        "doc_type": "BuildRecord", 
+        "latest": null, 
+        "signed": true, 
+        "version": null
+    }, 
+    "cached_properties": {}, 
+    "case_sharing": false, 
+    "cloudcare_enabled": false, 
+    "comment_from": null, 
+    "copy_history": [], 
+    "deployment_date": null, 
+    "description": null, 
+    "doc_type": "Application", 
+    "force_http": false, 
+    "is_released": false, 
+    "langs": [
+        "en"
+    ], 
+    "media_form_errors": false, 
+    "modules": [
+        {
+            "case_label": {
+                "en": "Cases"
+            }, 
+            "case_list": {
+                "doc_type": "CaseList", 
+                "label": {}, 
+                "show": false
+            }, 
+            "case_type": "asd", 
+            "details": [
+                {
+                    "columns": [
+                        {
+                            "advanced": "", 
+                            "enum": {}, 
+                            "field": "status", 
+                            "filter_xpath": "", 
+                            "format": "plain", 
+                            "header": {
+                                "en": "Status"
+                            }, 
+                            "late_flag": 30, 
+                            "model": "case", 
+                            "time_ago_interval": 365.25
+                        }
+                    ], 
+                    "doc_type": "Detail", 
+                    "sort_elements": [
+                        {
+                            "direction": "ascending", 
+                            "doc_type": "SortElement", 
+                            "field": "name", 
+                            "type": "plain"
+                        }
+                    ], 
+                    "type": "case_short"
+                }, 
+                {
+                    "columns": [
+                        {
+                            "advanced": "", 
+                            "enum": {}, 
+                            "field": "status", 
+                            "filter_xpath": "", 
+                            "format": "plain", 
+                            "header": {
+                                "en": "Status"
+                            }, 
+                            "late_flag": 30, 
+                            "model": "case", 
+                            "time_ago_interval": 365.25
+                        }
+                    ], 
+                    "doc_type": "Detail", 
+                    "sort_elements": [], 
+                    "type": "case_long"
+                }, 
+                {
+                    "columns": [], 
+                    "doc_type": "Detail", 
+                    "sort_elements": [], 
+                    "type": "ref_short"
+                }, 
+                {
+                    "columns": [], 
+                    "doc_type": "Detail", 
+                    "sort_elements": [], 
+                    "type": "ref_long"
+                }
+            ], 
+            "doc_type": "Module", 
+            "forms": [
+                {
+                    "actions": {
+                        "case_preload": {
+                            "condition": {
+                                "answer": null, 
+                                "question": null, 
+                                "type": "always"
+                            }, 
+                            "preload": {}
+                        }, 
+                        "close_case": {
+                            "condition": {
+                                "answer": null, 
+                                "doc_type": "FormActionCondition", 
+                                "question": null, 
+                                "type": "never"
+                            }
+                        }, 
+                        "close_referral": {
+                            "condition": {
+                                "answer": null, 
+                                "doc_type": "FormActionCondition", 
+                                "question": null, 
+                                "type": "never"
+                            }, 
+                            "doc_type": "FormAction"
+                        }, 
+                        "open_case": {
+                            "condition": {
+                                "answer": null, 
+                                "doc_type": "FormActionCondition", 
+                                "question": null, 
+                                "type": "always"
+                            }, 
+                            "external_id": null, 
+                            "name_path": "/data/test"
+                        }, 
+                        "open_referral": {
+                            "condition": {
+                                "answer": null, 
+                                "doc_type": "FormActionCondition", 
+                                "question": null, 
+                                "type": "never"
+                            }, 
+                            "doc_type": "OpenReferralAction", 
+                            "followup_date": null, 
+                            "name_path": null
+                        }, 
+                        "referral_preload": {
+                            "condition": {
+                                "answer": null, 
+                                "doc_type": "FormActionCondition", 
+                                "question": null, 
+                                "type": "never"
+                            }, 
+                            "doc_type": "PreloadAction", 
+                            "preload": {}
+                        }, 
+                        "subcases": [], 
+                        "update_case": {
+                            "condition": {
+                                "answer": null, 
+                                "question": null, 
+                                "type": "always"
+                            }, 
+                            "update": {}
+                        }, 
+                        "update_referral": {
+                            "condition": {
+                                "answer": null, 
+                                "doc_type": "FormActionCondition", 
+                                "question": null, 
+                                "type": "never"
+                            }, 
+                            "doc_type": "UpdateReferralAction", 
+                            "followup_date": null
+                        }
+                    }, 
+                    "doc_type": "Form", 
+                    "form_filter": "", 
+                    "media_audio": null, 
+                    "media_image": null, 
+                    "name": {
+                        "en": "test"
+                    }, 
+                    "requires": "none", 
+                    "show_count": false, 
+                    "unique_id": "527e109bd10972030eb18fe895657629953f69eb", 
+                    "version": null, 
+                    "xmlns": "http://openrosa.org/formdesigner/85772309-F1B6-4D38-A49E-FA734433BE29"
+                }
+            ], 
+            "media_audio": null, 
+            "media_image": null, 
+            "name": {
+                "en": "case sort"
+            }, 
+            "parent_select": {
+                "active": false, 
+                "module_id": null, 
+                "relationship": "parent"
+            }, 
+            "put_in_root": false, 
+            "referral_label": {
+                "en": "Referrals"
+            }, 
+            "referral_list": {
+                "doc_type": "CaseList", 
+                "label": {}, 
+                "show": false
+            }, 
+            "task_list": {
+                "doc_type": "CaseList", 
+                "label": {}, 
+                "show": false
+            }, 
+            "unique_id": "2ae584461bf71ca8b284b0a451da416b52afa7bd"
+        }
+    ], 
+    "multimedia_map": {}, 
+    "name": "testtest", 
+    "phone_model": null, 
+    "platform": "nokia/s40", 
+    "profile": {
+        "features": {
+            "sense": "false", 
+            "users": "true"
+        }, 
+        "properties": {
+            "ViewStyle": "v_chatterbox", 
+            "cc-autoup-freq": "freq-never", 
+            "cc-content-valid": "no", 
+            "cc-entry-mode": "cc-entry-quick", 
+            "cc-send-procedure": "cc-send-http", 
+            "cc-send-unsent": "cc-su-auto", 
+            "cc-user-mode": "cc-u-normal", 
+            "extra_key_action": "audio", 
+            "log_prop_daily": "log_never", 
+            "log_prop_weekly": "log_short", 
+            "logenabled": "Enabled", 
+            "loose_media": "no", 
+            "password_format": "n", 
+            "purge-freq": "0", 
+            "restore-tolerance": "loose", 
+            "server-tether": "push-only", 
+            "unsent-number-limit": "5", 
+            "user_reg_server": "required"
+        }
+    }, 
+    "recipients": "", 
+    "show_user_registration": false, 
+    "success_message": {}, 
+    "text_input": "roman", 
+    "translations": {}, 
+    "use_custom_suite": false, 
+    "user_registration": {
+        "actions": {
+            "case_preload": {
+                "condition": {
+                    "answer": null, 
+                    "doc_type": "FormActionCondition", 
+                    "question": null, 
+                    "type": "never"
+                }, 
+                "doc_type": "PreloadAction", 
+                "preload": {}
+            }, 
+            "close_case": {
+                "condition": {
+                    "answer": null, 
+                    "doc_type": "FormActionCondition", 
+                    "question": null, 
+                    "type": "never"
+                }, 
+                "doc_type": "FormAction"
+            }, 
+            "close_referral": {
+                "condition": {
+                    "answer": null, 
+                    "doc_type": "FormActionCondition", 
+                    "question": null, 
+                    "type": "never"
+                }, 
+                "doc_type": "FormAction"
+            }, 
+            "doc_type": "FormActions", 
+            "open_case": {
+                "condition": {
+                    "answer": null, 
+                    "doc_type": "FormActionCondition", 
+                    "question": null, 
+                    "type": "never"
+                }, 
+                "doc_type": "OpenCaseAction", 
+                "external_id": null, 
+                "name_path": null
+            }, 
+            "open_referral": {
+                "condition": {
+                    "answer": null, 
+                    "doc_type": "FormActionCondition", 
+                    "question": null, 
+                    "type": "never"
+                }, 
+                "doc_type": "OpenReferralAction", 
+                "followup_date": null, 
+                "name_path": null
+            }, 
+            "referral_preload": {
+                "condition": {
+                    "answer": null, 
+                    "doc_type": "FormActionCondition", 
+                    "question": null, 
+                    "type": "never"
+                }, 
+                "doc_type": "PreloadAction", 
+                "preload": {}
+            }, 
+            "subcases": [], 
+            "update_case": {
+                "condition": {
+                    "answer": null, 
+                    "doc_type": "FormActionCondition", 
+                    "question": null, 
+                    "type": "never"
+                }, 
+                "doc_type": "UpdateCaseAction", 
+                "update": {}
+            }, 
+            "update_referral": {
+                "condition": {
+                    "answer": null, 
+                    "doc_type": "FormActionCondition", 
+                    "question": null, 
+                    "type": "never"
+                }, 
+                "doc_type": "UpdateReferralAction", 
+                "followup_date": null
+            }
+        }, 
+        "data_paths": {}, 
+        "doc_type": "UserRegistrationForm", 
+        "name": {}, 
+        "password_path": "password", 
+        "requires": "none", 
+        "show_count": false, 
+        "unique_id": "f6699084be19a6688430fbecbe6d3ebbb74475cb", 
+        "username_path": "username", 
+        "version": null, 
+        "xmlns": null
+    }, 
+    "user_type": null
+}

--- a/corehq/apps/app_manager/tests/data/suite/sort-only-value.xml
+++ b/corehq/apps/app_manager/tests/data/suite/sort-only-value.xml
@@ -1,0 +1,90 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<suite>
+  <xform>
+    <resource id="527e109bd10972030eb18fe895657629953f69eb">
+      <location authority="local">./modules-0/forms-0.xml</location>
+      <location authority="remote">./modules-0/forms-0.xml</location>
+    </resource>
+  </xform>
+  <locale language="default">
+    <resource id="app_default_strings">
+      <location authority="local">./default/app_strings.txt</location>
+      <location authority="remote">./default/app_strings.txt</location>
+    </resource>
+  </locale>
+  <locale language="en">
+    <resource id="app_en_strings">
+      <location authority="local">./en/app_strings.txt</location>
+      <location authority="remote">./en/app_strings.txt</location>
+    </resource>
+  </locale>
+  <detail id="m0_case_short">
+    <title>
+      <text>
+        <locale id="m0.case_short.title"/>
+      </text>
+    </title>
+    <field>
+      <header>
+        <text>
+          <locale id="m0.case_short.case_status_1.header"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="@status"/>
+        </text>
+      </template>
+    </field>
+    <field>
+      <header width="0">
+        <text>
+          <locale id="m0.case_short.case_name_2.header"/>
+        </text>
+      </header>
+      <template width="0">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </template>
+      <sort type="string" order="1" direction="ascending">
+        <text>
+          <xpath function="case_name"/>
+        </text>
+      </sort>
+    </field>
+  </detail>
+  <detail id="m0_case_long">
+    <title>
+      <text>
+        <locale id="m0.case_long.title"/>
+      </text>
+    </title>
+    <field>
+      <header>
+        <text>
+          <locale id="m0.case_long.case_status_1.header"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="@status"/>
+        </text>
+      </template>
+    </field>
+  </detail>
+  <entry>
+    <form>http://openrosa.org/formdesigner/85772309-F1B6-4D38-A49E-FA734433BE29</form>
+    <command id="m0-f0">
+      <text>
+        <locale id="forms.m0f0"/>
+      </text>
+    </command>
+  </entry>
+  <menu id="m0">
+    <text>
+      <locale id="modules.m0"/>
+    </text>
+    <command id="m0-f0"/>
+  </menu>
+</suite>

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -1,6 +1,8 @@
 from django.utils.unittest.case import TestCase
 from corehq.apps.app_manager.models import Application
 from corehq.apps.app_manager.tests.util import TestFileMixin
+from lxml import etree
+import commcare_translations
 
 
 # snippet from http://stackoverflow.com/questions/321795/comparing-xml-in-a-unit-test-in-python/7060342#7060342
@@ -21,10 +23,29 @@ class XmlTest(TestCase):
 class SuiteTest(XmlTest, TestFileMixin):
     file_path = ('data', 'suite')
 
+    def assertHasAllStrings(self, app, strings):
+        et = etree.XML(app)
+        locale_elems = et.findall(".//locale/[@id]")
+        locale_strings = [elem.attrib['id'] for elem in locale_elems]
+
+        app_strings = commcare_translations.loads(strings)
+
+        for string in locale_strings:
+            if string not in app_strings.keys():
+                raise AssertionError("App strings did not contain %s" % string)
+
     def _test_generic_suite(self, app_tag, suite_tag=None):
         suite_tag = suite_tag or app_tag
         app = Application.wrap(self.get_json(app_tag))
         self.assertXmlEqual(self.get_xml(suite_tag), app.create_suite())
+
+    def _test_app_strings(self, app_tag):
+        app = Application.wrap(self.get_json(app_tag))
+        app_xml = app.create_suite()
+        app_strings = app.create_app_strings('default')
+
+        self.assertHasAllStrings(app_xml, app_strings)
+
 
     def test_normal_suite(self):
         self._test_generic_suite('app', 'normal-suite')
@@ -37,6 +58,10 @@ class SuiteTest(XmlTest, TestFileMixin):
 
     def test_multisort_suite(self):
         self._test_generic_suite('multi-sort', 'multi-sort')
+
+    def test_sort_only_value_suite(self):
+        self._test_generic_suite('sort-only-value', 'sort-only-value')
+        self._test_app_strings('sort-only-value')
 
     def test_callcenter_suite(self):
         self._test_generic_suite('call-center')

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -175,3 +175,18 @@ def add_odk_profile_after_build(app_build):
     app_build.lazy_put_attachment(profile, 'files/profile.ccpr')
     # hack this in for records
     app_build.odk_profile_created_after_build = True
+
+def create_temp_sort_column(field, index):
+    """
+    Used to create a column for the sort only properties to
+    add the field to the list of properties and app strings but
+    not persist anything to the detail data.
+    """
+    from corehq.apps.app_manager.models import DetailColumn
+    return DetailColumn(
+        model='case',
+        field=field,
+        format='invisible',
+        # ._i is exposed as .id, which is used in generating locale_ids
+        _i=index
+    )


### PR DESCRIPTION
Previously loading the mobile app would crash if there was a property in the sort elements list that wasn't in the display list since there would be no related app strings line.

fixes: http://manage.dimagi.com/default.asp?70010
