### PR TITLE
add hotfix_deploy to fab

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -528,7 +528,8 @@ def record_successful_deploy():
 def hotfix_deploy():
     """ deploy code to remote host by checking out the latest via git """
     if not console.confirm('Are you sure you want to deploy {env.environment}?'.format(env=env), default=False) or \
-       not console.confirm('Did you run "fab {env.environment} preindex_views"? '.format(env=env), default=False):
+       not console.confirm('Did you run "fab {env.environment} preindex_views"? '.format(env=env), default=False) or \
+       not console.confirm('HEY!!!! YOU ARE ONLY DEPLOYING CODE. THIS IS NOT A NORMAL DEPLOY. COOL???', default=False):
         utils.abort('Deployment aborted.')
 
     require('root', provided_by=('staging', 'preview', 'production', 'india'))


### PR DESCRIPTION
this is a fab deploy target that ONLY updates code and restarts services.

useful if you know you aren't deploying anything major and just want to update code as it takes less than 10% as long as a normal deploy
