### PR TITLE
make Form.source return the property descriptor instead of crashing

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -211,6 +211,8 @@ class FormActions(DocumentSchema):
 
 class FormSource(object):
     def __get__(self, form, form_cls):
+        if not form:
+            return self
         unique_id = form.get_unique_id()
         app = form.get_app()
         filename = "%s.xml" % unique_id


### PR DESCRIPTION
In preparation for using jsonobject
