### PR TITLE
report api

### DIFF
--- a/corehq/apps/reportfixtures/fixturegenerators.py
+++ b/corehq/apps/reportfixtures/fixturegenerators.py
@@ -86,13 +86,13 @@ def gen_fixture(user, indicator_set):
             group_id = group_data[group_name]
             xGroup = ElementTree.SubElement(xIndicators, elem_name, attrib={'id': group_id})
             for c in indicator_set.columns:
-                key = c.view.name
+                key = c.slug
                 if key != group_name:
                     xIndicator = ElementTree.SubElement(xGroup, c.header)
                     xIndicator.text = str(group_data.get(key, 0))
     elif data:
         for c in indicator_set.columns:
-            key = c.view.name
+            key = c.slug
             xIndicator = ElementTree.SubElement(xIndicators, c.header)
             xIndicator.text = str(data.get(key, 0))
 

--- a/corehq/apps/reportfixtures/tests/sql_fixture.py
+++ b/corehq/apps/reportfixtures/tests/sql_fixture.py
@@ -10,7 +10,8 @@ call_center_table = Table("call_center",
                           metadata,
                           Column("case", String(50), primary_key=True, autoincrement=False),
                           Column("date", DATE, primary_key=True, autoincrement=False),
-                          Column("cases_updated", INT))
+                          Column("cases_updated", INT),
+                          Column("duration", INT))
 
 
 def load_data():
@@ -20,10 +21,10 @@ def load_data():
     metadata.create_all()
 
     data = [
-        {"case": "123", "date": date.today(), "cases_updated": 1},
-        {"case": "123", "date": date.today() - timedelta(days=2), "cases_updated": 2},
-        {"case": "123", "date": date.today() - timedelta(days=7), "cases_updated": 1},
-        {"case": "123", "date": date.today() - timedelta(days=8), "cases_updated": 4},
+        {"case": "123", "date": date.today(), "cases_updated": 1, "duration": 10},
+        {"case": "123", "date": date.today() - timedelta(days=2), "cases_updated": 2, "duration": 15},
+        {"case": "123", "date": date.today() - timedelta(days=7), "cases_updated": 1, "duration": 6},
+        {"case": "123", "date": date.today() - timedelta(days=8), "cases_updated": 4, "duration": 50},
     ]
 
     connection = engine.connect()

--- a/corehq/apps/reports/api.py
+++ b/corehq/apps/reports/api.py
@@ -1,0 +1,43 @@
+class ReportDataSource(object):
+    def __init__(self, config=None):
+        """
+        :param config: dictionary containing configuration for this data source.
+         e.g.
+         {
+            'startdate': date(2013, 1, 1),
+            'enddate': date(2013, 1, 31),
+            'user_id': 'abc'
+         }
+        """
+        self.config = config or {}
+
+    def configure(self, config):
+        """
+        :param config: dictionary containing configuration for this data source.
+         Overrides any config supplied to the constructor.
+        """
+        self.config = config
+
+    def slugs(self):
+        """
+        Intention: Override
+
+        :return: A list of available slugs.
+        """
+        return []
+
+    def get_data(self, slugs=None):
+        """
+        Intention: Override
+
+        :param slugs: List of slugs to return for each row. Return all values if slugs = None or [].
+        :return: A list of dictionaries mapping slugs to values.
+            e.g. [{
+                'village': 'Mazu',
+                'births': 30,
+                'deaths': 28
+                },
+                {...}
+            ]
+        """
+        return {}

--- a/corehq/apps/reports/tests/__init__.py
+++ b/corehq/apps/reports/tests/__init__.py
@@ -4,6 +4,7 @@ try:
     from corehq.apps.reports.tests.test_household_verification import *
     from corehq.apps.reports.tests.test_sql_reports import *
     from corehq.apps.reports.tests.test_form_export import *
+    from corehq.apps.reports.tests.test_report_api import *
 except ImportError, e:
     # for some reason the test harness squashes these so log them here for clarity
     # otherwise debugging is a pain

--- a/corehq/apps/reports/tests/test_report_api.py
+++ b/corehq/apps/reports/tests/test_report_api.py
@@ -1,0 +1,99 @@
+from django import test as unittest
+from sqlagg.columns import SimpleColumn, SumColumn
+from sqlagg.filters import EQFilter
+from corehq.apps.reports.sqlreport import SqlData, DatabaseColumn, AggregateColumn
+
+from .sql_fixture import load_data
+from .sql_reports import combine_indicator
+
+DOMAIN = "test"
+format_string = "%Y-%m-%d"''
+
+unity = lambda x: x
+
+class UserDataSource(SqlData):
+    table_name = "user_report_data"
+
+    def __init__(self, config, keys=None, filters=None, group_by=None):
+        super(UserDataSource, self).__init__(config)
+        self._group_by = group_by
+        self._filters = filters
+        self._keys = keys
+
+    @property
+    def group_by(self):
+        return self._group_by
+
+    @property
+    def filters(self):
+        return self._filters
+
+    @property
+    def keys(self):
+        return self._keys
+
+    @property
+    def usernames_demo(self):
+        return {"user1": "Joe", "user2": "Bob", 'user3': "Gill"}
+
+    def username(self, key):
+        return self.usernames_demo[key]
+
+    @property
+    def columns(self):
+        user = DatabaseColumn("Username", SimpleColumn("user"), format_fn=self.username)
+        i_a = DatabaseColumn("Indicator A", SumColumn("indicator_a"), format_fn=unity)
+        i_b = DatabaseColumn("Indicator B", SumColumn("indicator_b"), format_fn=unity)
+
+        agg_c_d = AggregateColumn("C/D", combine_indicator,
+                                  [SumColumn("indicator_c"), SumColumn("indicator_d")],
+                                  format_fn=unity)
+
+        aggregate_cols = [
+            i_a,
+            i_b,
+            agg_c_d
+        ]
+
+        if self.group_by:
+            return [user] + aggregate_cols
+        else:
+            return aggregate_cols
+
+
+class ReportAPITest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        load_data()
+
+    def test_basic(self):
+        ds = UserDataSource({}, keys=[["user1"], ["user2"]], group_by=['user'])
+        data = ds.get_data()
+        self.assertEqual(data, [
+            {
+                'user': 'Bob',
+                'indicator_a': 1,
+                'indicator_b': 1,
+                'cd': 50
+            },
+            {
+                'user': 'Joe',
+                'indicator_a': 1,
+                'indicator_b': 1,
+                'cd': 100
+            }
+        ])
+
+    def test_filter(self):
+        ds = UserDataSource(
+            {'user_id': 'user2'},
+            filters=[EQFilter('user', 'user_id')],
+            keys=[["user2"]],
+            group_by=['user']
+        )
+        data = ds.get_data(['indicator_a'])
+        self.assertEqual(data, [
+            {
+                'indicator_a': 1,
+            }
+        ])


### PR DESCRIPTION
Hinges on the creation of `ReportDataSource` classes that basically allow retrieval of report data independently of the current report framework.

``` python
config = {
   'startdate': ...,
   'enddate': ...,
   'location_id': 'terminal_location_id',
   'product': '_all'
}
ds = StockOuts(config)
data = ds.get_data(['product', 'stockout_days'])
print data

data = [
   {
      'product': 'A',
      'stockout_days': 0
   },
   {...}
]
```
