### PR TITLE
more explictly force a zero

### DIFF
--- a/corehq/apps/commtrack/stockreport.py
+++ b/corehq/apps/commtrack/stockreport.py
@@ -347,8 +347,8 @@ class StockState(object):
         self.case = case
         self.last_reported = reported_on
         props = case.dynamic_properties()
-        self.current_stock = int(props.get('current_stock', 0)) # int
-        self.stocked_out_since = props.get('stocked_out_since') # date
+        self.current_stock = int(props.get('current_stock') or 0)  # int
+        self.stocked_out_since = props.get('stocked_out_since')  # date
 
     def update(self, action_type, value):
         """given the current stock state for a product at a location, update


### PR DESCRIPTION
wasn't caught before because couchdbkit removes None values from dynamic properties
