### PR TITLE
add requirements/jsonobject-couchdbkit.txt

### DIFF
--- a/requirements/jsonobject-couchdbkit.txt
+++ b/requirements/jsonobject-couchdbkit.txt
@@ -1,0 +1,1 @@
+git+git://github.com/dannyroberts/couchdbkit.git@jsonobject-0.5.7.3#egg=couchdbkit


### PR DESCRIPTION
will be removed once the transition is finalized.

To use jsonobject-backed couchdbkit locally, run

``` shell
pip install -r requirements/jsonobject-couchdbkit.txt
```
