### PR TITLE
Re added the days for review setting

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/json/commcare-profile-settings.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-profile-settings.yaml
@@ -19,10 +19,10 @@
 - name: "Days for Review"
   description: "How long the phone will retain completed forms for review."
   id: "cc-days-form-retain"
-  values: ["1", "7",  "31", "92", "365"]
-  value_names: ["Just One Day", "One Week", "One Month", "Three Months", "One Year"]
+  values: ["1", "7",  "31", "92", "365", "-1"]
+  value_names: ["Just One Day", "One Week", "One Month", "Three Months", "One Year", "Forms are Never Removed"]
   requires: "{features.sense}='false'"
-  default: "7"
+  default: "-1"
   values_txt: "Any positive integer. Represents period of purging in days." 
   since: "2.8"
 

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-profile-settings.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-profile-settings.yaml
@@ -16,6 +16,16 @@
   default: "0"
   values_txt: "Any positive integer. Represents period of purging in days."
 
+- name: "Days for Review"
+  description: "How long the phone will retain completed forms for review."
+  id: "cc-days-form-retain"
+  values: ["1", "7",  "31", "92", "365"]
+  value_names: ["Just One Day", "One Week", "One Month", "Three Months", "One Year"]
+  requires: "{features.sense}='false'"
+  default: "7"
+  values_txt: "Any positive integer. Represents period of purging in days." 
+  since: "2.8"
+
 - name: "Logging Enabled"
   description: "Whether logging of incidents should be activated on the client."
   id: "logenabled"

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-settings-layout.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-settings-layout.yaml
@@ -48,6 +48,12 @@
     - properties.cc-user-mode  # User Login Mode
     - properties.cc-login-images # Login Buttons
 
+- title: 'Android Settings'
+  id: app-settings-android
+  collapse: true
+  settings:
+    - properties.cc-days-form-retain # Days to Retain for Review
+
 - title: 'Advanced (Logging)'
   id: app-settings-advanced
   collapse: true


### PR DESCRIPTION
Currently visible on the test server under any app's settings, in the Android category.  Example: http://test.commcarehq.org/a/esoergel-test/apps/view/136ddd2d1808edb206fd3b56299dbb56/?edit=true
