### PR TITLE
Add "lost to followup" column

### DIFF
--- a/custom/reports/care_sa/models.py
+++ b/custom/reports/care_sa/models.py
@@ -260,13 +260,16 @@ class CareSAFluff(fluff.IndicatorDocument):
         property_value='deceased',
     )
 
-    #2b TODO
-    #hbc visit date >= today - 90
-    #lost_to_followup = xcalculators.filtered_form_calc(
-        #xmlns=HBC_XMLNS,
-        #property_path='form/visit_date',
-        #property_value='90',
-    #)
+    #2b
+    class VisitDateCalculator(fluff.Calculator):
+        from datetime import timedelta
+        window = timedelta(days=1)
+
+        @fluff.date_emitter
+        def total(self, form):
+            yield form.form['visit_date']
+
+    lost_to_followup = VisitDateCalculator(filter=xcalculators.FormPropertyFilter(xmlns=HBC_XMLNS))
 
     #2c TODO not in form
 


### PR DESCRIPTION
Only thing special here is this indicator has a custom calculator to emit a specific date field that is then used to filter all forms with visit dates within the last 90 days.
