### PR TITLE
fix security hole in user roles

### DIFF
--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -159,6 +159,7 @@ def post_user_role(request, domain):
     if role.get_id:
         old_role = UserRole.get(role.get_id)
         assert(old_role.doc_type == UserRole.__name__)
+        assert(old_role.domain == domain)
     role.save()
     return json_response(role)
 


### PR DESCRIPTION
would allow Mallory to edit a UserRole doc on another domain

she would have to know the original UserRole's doc_id, but that is not a secret
