### PR TITLE
bump jsonobject version to 0.2.5

### DIFF
--- a/requirements/jsonobject-couchdbkit.txt
+++ b/requirements/jsonobject-couchdbkit.txt
@@ -1,2 +1,2 @@
 git+git://github.com/dannyroberts/couchdbkit.git@jsonobject-0.5.7.3#egg=couchdbkit
-jsonobject>=0.2.4
+jsonobject>=0.2.5

--- a/requirements/jsonobject-couchdbkit.txt
+++ b/requirements/jsonobject-couchdbkit.txt
@@ -1,2 +1,2 @@
 git+git://github.com/dannyroberts/couchdbkit.git@jsonobject-0.5.7.3#egg=couchdbkit
-jsonobject>=0.2.2
+jsonobject>=0.2.4


### PR DESCRIPTION
Includes
- modest optimization that prevents very redundant validation on wrap (but validation was super fast so overall gains are real but not huge)
- bug fix for inferring types from subclasses of recognized type, e.g. `SafeUnicode` for `unicode`
