### PR TITLE
Add all_docs_of_type filter

### DIFF
--- a/corehq/apps/hqadmin/_design/filters/all_docs_of_type.js
+++ b/corehq/apps/hqadmin/_design/filters/all_docs_of_type.js
@@ -1,0 +1,3 @@
+function (doc, req) {
+    return (doc.doc_type && doc.doc_type === req.query.doc_type) 
+}


### PR DESCRIPTION
Super simple filter, didn't find it in our code base. One tool in the swiss army knife that will make it easy to move a django app to its own db (namely receiverwrapper).
