### PR TITLE
Update care iact indicators

### DIFF
--- a/custom/reports/care_sa/models.py
+++ b/custom/reports/care_sa/models.py
@@ -382,23 +382,43 @@ class CareSAFluff(fluff.IndicatorDocument):
         property_path='form/last_session',
         property_value='not_complete',
     )
+    internal_iact_ipt = xcalculators.filtered_form_calc(
+        xmlns=IACT_XMLNS,
+        property_path='form/on_ipt',
+        property_value='yes',
+    )
     iact_participant_ipt = xcalculators.and_calc(
-        [internal_iact_not_complete, internal_on_ipt]
+        [internal_iact_not_complete, internal_iact_ipt]
     )
 
     #3g
+    internal_iact_bactrim = xcalculators.filtered_form_calc(
+        xmlns=IACT_XMLNS,
+        property_path='form/on_bactrim',
+        property_value='yes',
+    )
     iact_participant_bactrim = xcalculators.and_calc(
-        [internal_iact_not_complete, internal_on_bactrim]
+        [internal_iact_not_complete, internal_iact_bactrim]
     )
 
     #3h
+    internal_iact_pre_art = xcalculators.filtered_form_calc(
+        xmlns=IACT_XMLNS,
+        property_path='form/pre_art',
+        property_value='yes',
+    )
     iact_participant_art = xcalculators.and_calc(
-        [internal_iact_not_complete, internal_pre_art]
+        [internal_iact_not_complete, internal_iact_pre_art]
     )
 
     #3i
+    internal_iact_arv = xcalculators.filtered_form_calc(
+        xmlns=IACT_XMLNS,
+        property_path='form/on_arv',
+        property_value='yes',
+    )
     iact_participant_arv = xcalculators.and_calc(
-        [internal_iact_not_complete, internal_on_arv]
+        [internal_iact_not_complete, internal_iact_arv]
     )
 
     #3j

--- a/custom/reports/care_sa/reports/sql.py
+++ b/custom/reports/care_sa/reports/sql.py
@@ -453,7 +453,7 @@ class TestingAndCounseling(CareReport):
         ['Individuals HIV infected provided with CD4 count test results',
          'new_hiv_cd4_results'],  # 1i
         ['Individuals HIV infected provided with CD4 count test results from previous months',
-         'new_hiv_in_care_program'],  # 1k TODO empty?
+         'new_hiv_in_care_program'],  # 1k
         ['People tested as individuals', 'individual_tests'],  # 1l
         ['People tested as couples', 'couple_tests', 'SumColumn'],  # 1m
         ['People tested at the community', 'hiv_community'],
@@ -487,13 +487,15 @@ class IACT(CareReport):
         ['HIV+ client completed I-ACT', 'hiv_pos_completed'],  # 3b
         ['HIV+ clients registered for I-ACT & in the pipeline (5th session)', 'hiv_pos_pipeline'],  # 3c
         #['HIV+client registered for I-ACT after diagnosis', #TODO],  # 3d
-        ['I-ACT participants receiving INH/IPT prophylaxis', 'iact_participant_ipt'],  # 3f TODO empty?
-        ['I-ACT participants receiving Cotrimoxizole prophylaxis/Dapsone', 'iact_participant_bactrim'],  # 3g TODO empty?
-        ['I-ACT participant on Pre-ART', 'iact_participant_art'],  # 3h TODO empty?
-        ['I-ACT participant on ARV', 'iact_participant_arv'],  # 3i TODO empty?
+        ['I-ACT participants receiving INH/IPT prophylaxis',
+         'iact_participant_ipt'],  # 3f
+        ['I-ACT participants receiving Cotrimoxizole prophylaxis/Dapsone',
+         'iact_participant_bactrim'],  # 3g
+        ['I-ACT participant on Pre-ART', 'iact_participant_art'],  # 3h
+        ['I-ACT participant on ARV', 'iact_participant_arv'],  # 3i
         ['I-ACT registered client with CD4 count <200', 'cd4lt200'],  # 3j
         ['I-ACT registered client with CD4 count 200 - 350', 'cd4lt350'],  # 3k
         ['I-ACT registered client with CD4 cont higher than 350', 'cd4gt350'],  # 3l
         #['Unknown CD4 count at registration', ''],  # 3m
-        ['I-ACT Support groups completed (all 6 sessions)', 'iact_support_groups'],  # 3n TODO empty?
+        ['I-ACT Support groups completed (all 6 sessions)', 'iact_support_groups'],  # 3n
     ]


### PR DESCRIPTION
IPT/Bactrim/etc values show up on two seperate form types, I was
previously using the wrong ones.

Also removed a bunch of remaining TODO comments that I was using to
track which indicators I added but was unable to get data out of (as I'm
getting data from everything at this point).
