### PR TITLE
separate receiverwrapper into its own db

### DIFF
--- a/.travis/localsettings.py
+++ b/.travis/localsettings.py
@@ -19,8 +19,8 @@ SQL_REPORTING_DATABASE_URL = "sqlite:////tmp/commcare_reporting_test.db"
 ####### Couch Config ######
 COUCH_HTTPS = False 
 COUCH_SERVER_ROOT = '127.0.0.1:5984' 
-COUCH_USERNAME = ''
-COUCH_PASSWORD = ''
+COUCH_USERNAME = None
+COUCH_PASSWORD = None
 COUCH_DATABASE_NAME = 'commcarehq'
 
 ######## Email setup ########

--- a/corehq/apps/api/tests.py
+++ b/corehq/apps/api/tests.py
@@ -378,6 +378,7 @@ class TestRepeaterResource(APIResourceTest):
             self.assertEqual(result['url'], repeater.url)
             self.assertEqual(result['domain'], repeater.domain)
             self.assertEqual(result['type'], cls.__name__)
+            repeater.delete()
 
     def test_get_list(self):
         self.client.login(username=self.username, password=self.password)
@@ -435,6 +436,7 @@ class TestRepeaterResource(APIResourceTest):
             self.assertEqual(repeater_json['domain'], repeater_back.domain)
             self.assertEqual(repeater_json['type'], repeater_back.doc_type)
             self.assertEqual(repeater_json['url'], repeater_back.url)
+            repeater_back.delete()
 
 
     def test_update(self):
@@ -457,6 +459,7 @@ class TestRepeaterResource(APIResourceTest):
             self.assertEqual(1, len(cls.by_domain(self.domain.name)))
             modified = cls.get(backend_id)
             self.assertTrue('modified' in modified.url)
+            repeater.delete()
 
 class TestESQuerySet(TestCase):
     '''

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2436,7 +2436,3 @@ Module.get_referral_list_command_id = lambda self: "m{module.id}-referral-list".
 Module.get_referral_list_locale_id = lambda self: "referral_lists.m{module.id}".format(module=self)
 import corehq.apps.app_manager.signals
 
-@register_repeater_type
-class AppStructureRepeater(Repeater):
-    def get_payload(self, repeat_record):
-        return repeat_record.payload_id # This is the id of the application, currently all we forward

--- a/corehq/apps/app_manager/signals.py
+++ b/corehq/apps/app_manager/signals.py
@@ -41,7 +41,7 @@ def get_custom_response_message(sender, xform, **kwargs):
                     Certainty.STRONG)
 
 def create_app_structure_repeat_records(sender, application, **kwargs):
-    from corehq.apps.app_manager.models import AppStructureRepeater
+    from corehq.apps.receiverwrapper.models import AppStructureRepeater
     domain = application.domain
     if domain:
         repeaters = AppStructureRepeater.by_domain(domain)

--- a/corehq/apps/app_manager/tests/test_repeater.py
+++ b/corehq/apps/app_manager/tests/test_repeater.py
@@ -5,8 +5,8 @@ from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.client import Client
 
-from corehq.apps.receiverwrapper.models import RepeatRecord
-from corehq.apps.app_manager.models import AppStructureRepeater, Application
+from corehq.apps.receiverwrapper.models import RepeatRecord, AppStructureRepeater
+from corehq.apps.app_manager.models import Application
 
 class TestAppStructureRepeater(TestCase):
     def setUp(self):

--- a/corehq/apps/domain/tests/test_views.py
+++ b/corehq/apps/domain/tests/test_views.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 from django.test.client import Client
 
 from corehq.apps.users.models import WebUser
-from corehq.apps.app_manager.models import AppStructureRepeater
+from corehq.apps.receiverwrapper.models import AppStructureRepeater
 from corehq.apps.domain.models import Domain
 
 class TestDomainViews(TestCase):

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -26,8 +26,7 @@ from dimagi.utils.django.email import send_HTML_email
 from dimagi.utils.web import get_ip, json_response
 from corehq.apps.users.views import require_can_edit_web_users
 from corehq.apps.receiverwrapper.forms import FormRepeaterForm
-from corehq.apps.receiverwrapper.models import FormRepeater, CaseRepeater, ShortFormRepeater
-from corehq.apps.app_manager.models import AppStructureRepeater
+from corehq.apps.receiverwrapper.models import FormRepeater, CaseRepeater, ShortFormRepeater, AppStructureRepeater
 from django.contrib import messages
 from django.views.decorators.http import require_POST
 import json

--- a/corehq/apps/receiverwrapper/models.py
+++ b/corehq/apps/receiverwrapper/models.py
@@ -195,6 +195,11 @@ class ShortFormRepeater(Repeater):
     def __unicode__(self):
         return "forwarding short form to: %s" % self.url
 
+@register_repeater_type
+class AppStructureRepeater(Repeater):
+    def get_payload(self, repeat_record):
+        return repeat_record.payload_id # This is the id of the application, currently all we forward
+
 class RepeatRecord(Document, LockableMixIn):
     """
     An record of a particular instance of something that needs to be forwarded

--- a/corehq/apps/receiverwrapper/tests/test_submit_errors.py
+++ b/corehq/apps/receiverwrapper/tests/test_submit_errors.py
@@ -10,7 +10,7 @@ from couchforms.models import SubmissionErrorLog, XFormInstance
 from couchforms.signals import xform_saved
 
 def _clear_all_forms(domain):
-    for item in SubmissionErrorLog.view("receiverwrapper/all_submissions_by_domain",
+    for item in SubmissionErrorLog.view("couchforms/all_submissions_by_domain",
                                   reduce=False,
                                   include_docs=True,
                                   startkey=[domain, "by_type"],
@@ -67,7 +67,7 @@ class SubmissionErrorTest(TestCase):
             self.assertTrue("Form is a duplicate" in res.content)
         
         # make sure we logged it
-        log = SubmissionErrorLog.view("receiverwrapper/all_submissions_by_domain",
+        log = SubmissionErrorLog.view("couchforms/all_submissions_by_domain",
                                       reduce=False,
                                       include_docs=True,
                                       startkey=[self.domain.name, "by_type", "XFormDuplicate"],
@@ -98,7 +98,7 @@ class SubmissionErrorTest(TestCase):
                 self.assertTrue(evil_laugh in res.content)
             
             # make sure we logged it
-            log = SubmissionErrorLog.view("receiverwrapper/all_submissions_by_domain",
+            log = SubmissionErrorLog.view("couchforms/all_submissions_by_domain",
                                           reduce=False,
                                           include_docs=True,
                                           startkey=[self.domain.name, "by_type", "XFormError"],
@@ -125,7 +125,7 @@ class SubmissionErrorTest(TestCase):
             self.assertTrue("render_error" in res.content)
         
         # make sure we logged it
-        log = SubmissionErrorLog.view("receiverwrapper/all_submissions_by_domain",
+        log = SubmissionErrorLog.view("couchforms/all_submissions_by_domain",
                                       reduce=False,
                                       include_docs=True,
                                       startkey=[self.domain.name, "by_type", "SubmissionErrorLog"],

--- a/settings.py
+++ b/settings.py
@@ -655,7 +655,6 @@ COUCHDB_APPS = [
     'migration',
     'mobile_auth',
     'phone',
-    'receiverwrapper',
     'reminders',
     'reportfixtures',
     'prescriptions',
@@ -695,6 +694,7 @@ COUCHDB_DATABASES += [
     ('care_sa', COUCH_DATABASE + '__fluff-care_sa'),
     ('cvsu', COUCH_DATABASE + '__fluff-cvsu'),
     ('mc', COUCH_DATABASE + '__fluff-mc'),
+    ('receiverwrapper', COUCH_DATABASE + '__receiverwrapper'),
 ]
 
 INSTALLED_APPS += LOCAL_APPS

--- a/settings.py
+++ b/settings.py
@@ -267,6 +267,7 @@ APPS_TO_EXCLUDE_FROM_TESTS = (
     'corehq.apps.tropo',
     'corehq.apps.yo',
     'crispy_forms',
+    'django_extensions',
     'djcelery',
     'djtables',
     'djkombu',
@@ -279,12 +280,17 @@ APPS_TO_EXCLUDE_FROM_TESTS = (
     'south',
 
     # submodules with tests that run on travis
+    'couchforms',
+    'casexml.apps.case',
+    'casexml.apps.phone',
     'ctable',
     'ctable_view',
     'dimagi.utils',
     'fluff',
     'fluff_filter',
+    'freddy',
     'pillowtop',
+    'receiver',
 )
 
 INSTALLED_APPS = DEFAULT_APPS + HQ_APPS


### PR DESCRIPTION
This requires a syncdb to put the design docs into the new database, and then a couple of pretty trivial curl commands to copy over the existing docs.

I welcome feedback about QA or non-obvious issues.

Depends on dimagi/couchforms#64
