### PR TITLE
add forms, cases, and users viz to the global project space report

### DIFF
--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -31,7 +31,6 @@ class AdminFacetedReport(AdminReport, ElasticTabularReport):
         ctxt = super(AdminFacetedReport, self).template_context
 
         self.run_query() # this runs the es query and populates the necessary attributes
-
         ctxt.update({
             'layout_flush_content': True,
             'facet_map': self.es_facet_map,

--- a/corehq/apps/hqadmin/templates/hqadmin/domain_faceted_report.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/domain_faceted_report.html
@@ -1,0 +1,61 @@
+{% extends "hqadmin/faceted_report.html" %}
+{% load hq_shared_tags %}
+{% load hqstyle_tags %}
+{% load i18n %}
+
+{% block js %}{{ block.super }}
+    <link href="{% static 'hqwebapp/js/lib/nvd3/nv.d3.css' %}" rel="stylesheet">
+    <script src="{% static 'hqwebapp/js/lib/nvd3/lib/d3.v2.js' %}"></script>
+    <script src="{% static 'hqwebapp/js/lib/nvd3/lib/fisheye.js' %}"></script>
+    <script src="{% static 'hqwebapp/js/lib/nvd3/nv.d3.min.js' %}"></script>
+    <script src="{% static 'hqwebapp/js/lib/history-1.7.1.js' %}"></script>
+{% endblock %}
+
+{% block js-inline %} {{ block.super }}
+    <script src="{% static 'hqwebapp/js/hash-tab.js' %}"></script>
+    <script src='{% static 'hqadmin/js/nvd3_charts_helper.js' %}' type='text/javascript'></script>
+    <script src='{% static 'hqadmin/js/visualizations.js' %}' type='text/javascript'></script>
+    <script type="text/javascript">
+        var visualizations = {
+            forms: {name: "forms", xaxis_label: "# form submissions", viz: null},
+            cases: {name: "cases", xaxis_label: "# case creations", viz: null},
+            users: {name: "users", xaxis_label: "# mobile workers created", viz: null}
+        };
+
+        function parse_url_params() {
+            var result = {}, queryString = location.search.slice(1),
+                re = /([^&=]+)=([^&]*)/g, m;
+
+            while (m = re.exec(queryString)) {
+                result[decodeURIComponent(m[1])] = decodeURIComponent(m[2]);
+            }
+
+            return result;
+        }
+        var url_params = parse_url_params();
+
+        for (var key in visualizations) {
+            if (visualizations.hasOwnProperty(key)) {
+                visualizations[key].viz = new HQVisualizations({
+                    chart_name: key,
+                    histogram_type: key,
+                    xaxis_label: visualizations[key].xaxis_label,
+                    ajax_url: "{% url admin_stats_data %}",
+                    data: url_params,
+                    should_update_url: false,
+                    interval: "{{ interval }}"
+                });
+                visualizations[key].viz.init();
+            }
+        }
+    </script>
+{% endblock %}
+{% block main_column %}{{ block.super }}
+    <hr />
+    <h2>Visualize Forms</h2>
+    {% include "orgs/partials/visualizations.html" with chart_name="forms" %}
+    <h2>Visualize Cases</h2>
+    {% include "orgs/partials/visualizations.html" with chart_name="cases" %}
+    <h2>Visualize Users</h2>
+    {% include "orgs/partials/visualizations.html" with chart_name="users" %}
+{% endblock %}

--- a/corehq/apps/hqadmin/urls.py
+++ b/corehq/apps/hqadmin/urls.py
@@ -25,6 +25,7 @@ urlpatterns = patterns('corehq.apps.hqadmin.views',
     url(r'^run_command/$', 'run_command', name="run_management_command"),
     url(r'^phone/restore/$', 'admin_restore', name="admin_restore"),
     url(r'^flag_broken_builds/$', FlagBrokenBuilds.as_view(), name="flag_broken_builds"),
+    url(r'^stats_data/$', 'stats_data', name="admin_stats_data"),
     AdminReportDispatcher.url_pattern(),
 )
 

--- a/corehq/apps/hqadmin/views.py
+++ b/corehq/apps/hqadmin/views.py
@@ -893,7 +893,7 @@ ES_DOMAIN_QUERY_LIMIT = 500
 @datespan_in_request(from_param="startdate", to_param="enddate", default_days=365)
 def stats_data(request):
     histo_type = request.GET.get('histogram_type')
-    interval = request.GET.get("interval", "month")
+    interval = request.GET.get("interval", "week")
 
     params, __ = parse_args_for_es(request, prefix='es_')
     if params:

--- a/corehq/apps/hqadmin/views.py
+++ b/corehq/apps/hqadmin/views.py
@@ -26,14 +26,17 @@ from django.core import management
 
 from corehq.apps.app_manager.models import ApplicationBase
 from corehq.apps.app_manager.util import get_settings_values
+from corehq.apps.appstore.views import parse_args_for_es
 from corehq.apps.hqadmin.history import get_recent_changes
 from corehq.apps.hqadmin.models import HqDeploy
 from corehq.apps.hqadmin.forms import EmailForm, BrokenBuildsForm
 from corehq.apps.builds.models import CommCareBuildConfig, BuildSpec
 from corehq.apps.domain.models import Domain
 from corehq.apps.hqadmin.escheck import check_cluster_health, check_case_index, check_xform_index
+from corehq.apps.orgs.views import get_stats_data
 from corehq.apps.ota.views import get_restore_response, get_restore_params
 from corehq.apps.reports.datatables import DataTablesColumn, DataTablesHeader, DTSortType
+from corehq.apps.reports.standard.domains import es_domain_query
 from corehq.apps.reports.util import make_form_couch_key
 from corehq.apps.sms.models import SMSLog
 from corehq.apps.users.models import  CommCareUser, WebUser
@@ -882,3 +885,29 @@ class FlagBrokenBuilds(FormView):
                 docs.append(doc)
         db.bulk_save(docs)
         return HttpResponse("posted!")
+
+
+ES_DOMAIN_QUERY_LIMIT = 500
+
+@require_superuser
+@datespan_in_request(from_param="startdate", to_param="enddate", default_days=365)
+def stats_data(request):
+    histo_type = request.GET.get('histogram_type')
+    interval = request.GET.get("interval", "month")
+
+    params, __ = parse_args_for_es(request, prefix='es_')
+    if params:
+        domain_results = es_domain_query(params, fields=["name"], size=99999, show_stats=False)
+        domains = [d["fields"]["name"] for d in domain_results["hits"]["hits"]]
+
+        if len(domains) <= 10:
+            domain_info = [{"names": [d], "display_name": d} for d in domains]
+        elif len(domains) <= ES_DOMAIN_QUERY_LIMIT:
+            domain_info = [{"names": [d for d in domains], "display_name": _("Domains Matching Filter")}]
+        else:
+            domain_info = [{"names": None, "display_name": _("All Domains (NOT applying filters. > 500 projects)")}]
+    else:
+        domain_info = [{"names": None, "display_name": _("All Domains")}]
+
+    stats_data = get_stats_data(domain_info, histo_type, request.datespan, interval=interval)
+    return json_response(stats_data)

--- a/corehq/apps/reports/standard/domains.py
+++ b/corehq/apps/reports/standard/domains.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from dimagi.utils.decorators.memoized import memoized
 from django.core.urlresolvers import reverse
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_noop
@@ -194,12 +195,11 @@ FACET_MAPPING = [
     ]),
 ]
 
-def es_domain_query(params=None, facets=None, terms=None, domains=None, return_q_dict=False, start_at=None, size=None, sort=None):
+def es_domain_query(params=None, facets=None, domains=None, start_at=None, size=None, sort=None, fields=None, show_stats=True):
     from corehq.apps.appstore.views import es_query
     if params is None:
         params = {}
-    if terms is None:
-        terms = ['search']
+    terms = ['search']
     if facets is None:
         facets = []
     q = {"query": {"match_all":{}}}
@@ -227,13 +227,17 @@ def es_domain_query(params=None, facets=None, terms=None, domains=None, return_q
                             "operator" : "or", }}}}}
 
     q["facets"] = {}
-    stats = ['cp_n_active_cases', 'cp_n_inactive_cases', 'cp_n_active_cc_users', 'cp_n_cc_users', 'cp_n_60_day_cases', 'cp_n_web_users', 'cp_n_forms', 'cp_n_cases']
-    for prop in stats:
-        q["facets"].update({"%s-STATS" % prop: {"statistical": {"field": prop}}})
+    if show_stats:
+        stats = ['cp_n_active_cases', 'cp_n_inactive_cases', 'cp_n_active_cc_users', 'cp_n_cc_users', 'cp_n_60_day_cases', 'cp_n_web_users', 'cp_n_forms', 'cp_n_cases']
+        for prop in stats:
+            q["facets"].update({"%s-STATS" % prop: {"statistical": {"field": prop}}})
 
     q["sort"] = sort if sort else [{"name" : {"order": "asc"}},]
 
-    return es_query(params, facets, terms, q, DOMAIN_INDEX + '/hqdomain/_search', start_at, size, dict_only=return_q_dict)
+    if fields:
+        q["fields"] = fields
+
+    return es_query(params, facets, terms, q, DOMAIN_INDEX + '/hqdomain/_search', start_at, size)
 
 ES_PREFIX = "es_"
 class AdminDomainStatsReport(AdminFacetedReport, DomainStatsReport):
@@ -243,7 +247,13 @@ class AdminDomainStatsReport(AdminFacetedReport, DomainStatsReport):
     name = ugettext_noop('Project Space List')
     facet_title = ugettext_noop("Project Facets")
     search_for = ugettext_noop("projects...")
+    base_template = "hqadmin/domain_faceted_report.html"
 
+    @property
+    def template_context(self):
+        ctxt = super(AdminDomainStatsReport, self).template_context
+        ctxt["interval"] = "month"
+        return ctxt
 
     def es_query(self, params=None):
         return es_domain_query(params, self.es_facet_list, sort=self.get_sorting_block(),


### PR DESCRIPTION
Visualizations in global project report.

Behavior:
Shows visualizations with project space filters if the report returned 10 or fewer project spaces.
Shows aggregate visualizations for project spaces matched by facets it < 500 project spaces
Shows aggregate visualizations for total project spaces (not just those matched in report) if > 500 project spaces

![screen shot 2013-09-03 at 1 37 27 pm](https://f.cloud.github.com/assets/1201876/1074681/eb60925e-14bf-11e3-8f00-1e47600724c7.png)
