### PR TITLE
Workaround admin party issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *.pyc
 *~
-local.ini*
+/local.ini*
 /localsettings*
 /loadtest/test_scripts/localsettings.py
 !localsettings.example.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ install:
  - "time (bash -e .travis/misc-setup.sh | ts)"
  - "cp .travis/localsettings.py localsettings.py"
  - "pip install coverage unittest2 mock --use-mirrors"
- - "pip install --upgrade couchdbkit==0.6.5"
 script: "coverage run manage.py test --noinput --failfast"
 after_success:
  - coverage report

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
  - "time (bash -e .travis/misc-setup.sh | ts)"
  - "cp .travis/localsettings.py localsettings.py"
  - "pip install coverage unittest2 mock --use-mirrors"
+ - "pip install --upgrade couchdbkit==0.6.5"
 script: "coverage run manage.py test --noinput --failfast"
 after_success:
  - coverage report

--- a/.travis/local.ini
+++ b/.travis/local.ini
@@ -1,0 +1,17 @@
+; CouchDB Configuration Settings
+
+; These are just the modifications necessary to run CCHQ tests on Travis-CI
+; Specifically, some of our tests rely on CouchDB being set up for authentication
+; rather than admin party (which sends a 401 when credentials are supplied)
+
+[couchdb]
+uuid = b558ce2854455290910bd76622115eed
+
+; To create an admin account uncomment the '[admins]' section below and add a
+; line in the format 'username = password'. When you next start CouchDB, it
+; will change the password to a hash (so that your passwords don't linger
+; around in plain-text files). You can add more admin accounts with more
+; 'username = password' lines. Don't forget to restart CouchDB after
+; changing this.
+[admins]
+commcarehq = not-a-real-password

--- a/.travis/localsettings.py
+++ b/.travis/localsettings.py
@@ -19,8 +19,8 @@ SQL_REPORTING_DATABASE_URL = "sqlite:////tmp/commcare_reporting_test.db"
 ####### Couch Config ######
 COUCH_HTTPS = False 
 COUCH_SERVER_ROOT = '127.0.0.1:5984' 
-COUCH_USERNAME = ''
-COUCH_PASSWORD = ''
+COUCH_USERNAME = 'commcarehq'
+COUCH_PASSWORD = 'not-a-real-password'
 COUCH_DATABASE_NAME = 'commcarehq'
 
 ######## Email setup ########

--- a/.travis/upgrade-couchdb.sh
+++ b/.travis/upgrade-couchdb.sh
@@ -2,6 +2,7 @@ curl http://127.0.0.1:5984/
 sudo add-apt-repository -y ppa:nilya/couchdb-1.3
 sudo apt-get update
 sudo apt-get install -qq -y couchdb
+sudo cp .travis/local.ini /etc/couchdb/local.ini
 sudo service couchdb restart 
 sleep 3
 curl http://127.0.0.1:5984/

--- a/settings.py
+++ b/settings.py
@@ -279,6 +279,9 @@ APPS_TO_EXCLUDE_FROM_TESTS = (
     'south',
 
     # submodules with tests that run on travis
+    'casexml.apps.case',
+    'casexml.apps.phone',
+    'couchforms',
     'ctable',
     'ctable_view',
     'dimagi.utils',


### PR DESCRIPTION
DO NOT MERGE - keeping open to run the tests as they only run against master and PRs

This PR is for whatever temporary stuff we have to do to get the build to work for now. Once we are caught up with couchdbkit 0.6.5 it should all be revertable.
