### PR TITLE
Translation strategy option

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1557,6 +1557,8 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
     use_custom_suite = BooleanProperty(default=False)
     force_http = BooleanProperty(default=False)
     cloudcare_enabled = BooleanProperty(default=False)
+    translation_strategy = StringProperty(default='dump-known',
+                                          choices=['dump-known', 'simple'])
 
     @classmethod
     def wrap(cls, data):
@@ -1744,8 +1746,9 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
                 if name:
                     messages[lc] = name
 
-            cc_trans = commcare_translations.load_translations(lang)
-            messages.update(cc_trans)
+            if self.translation_strategy == 'dump-known':
+                cc_trans = commcare_translations.load_translations(lang)
+                messages.update(cc_trans)
 
             messages.update(non_empty_only(self.translations.get(lang, {})))
         else:

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1689,6 +1689,15 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
         yield id_strings.homescreen_title(), self.name
         yield id_strings.app_display_name(), self.name
 
+        yield 'cchq.case', "Case"
+        yield 'cchq.referral', "Referral"
+
+        # include language code names
+        for lc in self.langs:
+            name = langcodes.get_name(lc) or lc
+            if name:
+                yield lc, name
+
         for module in self.get_modules():
             for detail in module.get_details():
                 if detail.type.startswith('case'):
@@ -1728,36 +1737,32 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
             for form in module.get_forms():
                 yield id_strings.form_locale(form), trans(form.name) + ('${0}' if form.show_count else '')
 
-    def create_app_strings(self, lang, include_blank_custom=False):
+    def create_app_strings(self, lang, for_default=False):
         def non_empty_only(dct):
             return dict([(key, value) for key, value in dct.items() if value])
         if lang != "default":
-            messages = {"cchq.case": "Case", "cchq.referral": "Referral"}
+            messages = {}
 
             custom = dict(self._create_custom_app_strings(lang))
-            if include_blank_custom:
+            if for_default:
                 messages.update(custom)
             else:
                 messages.update(non_empty_only(custom))
 
-            # include language code names
-            for lc in self.langs:
-                name = langcodes.get_name(lc) or lc
-                if name:
-                    messages[lc] = name
-
             if self.translation_strategy == 'dump-known':
                 cc_trans = commcare_translations.load_translations(lang)
                 messages.update(cc_trans)
-
-            messages.update(non_empty_only(self.translations.get(lang, {})))
+            if self.translation_strategy == 'dump-known' or \
+                    (self.translation_strategy == 'simple' and not for_default):
+                messages.update(non_empty_only(self.translations.get(lang, {})))
         else:
             messages = {}
+
             for lc in reversed(self.langs):
                 if lc == "default":
                     continue
                 new_messages = commcare_translations.loads(
-                    self.create_app_strings(lc, include_blank_custom=True)
+                    self.create_app_strings(lc, for_default=True)
                 )
 
                 for key, val in new_messages.items():

--- a/corehq/apps/app_manager/static/app_manager/js/commcaresettings.js
+++ b/corehq/apps/app_manager/static/app_manager/js/commcaresettings.js
@@ -3,6 +3,7 @@ function CommcareSettings(options) {
     var initialValues = options.values;
     self.sections = options.sections;
     self.edit = ko.observable(options.edit);
+    self.user = options.user;
 
     self.settings = [];
     self.settingsIndex = {};
@@ -159,7 +160,8 @@ function CommcareSettings(options) {
         setting.visible = ko.computed(function () {
             return !(
                 (setting.disabled && setting.visibleValue() === setting['default']) ||
-                    (setting.hide_if_not_enabled && !setting.enabled())
+                    (setting.hide_if_not_enabled && !setting.enabled()) ||
+                    (setting.preview && !self.user.is_previewer)
                 );
         });
         setting.disabledButHasValue = ko.computed(function () {

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yaml
@@ -94,3 +94,11 @@
   default: false
   requires: "{$parent.doc_type}='Application'"
   hide_if_not_enabled: true
+
+- id: translation_strategy
+  name: 'Translations Strategy'
+  values: ['dump-known', 'simple']
+  value_names: ['Dump known (old and reliable)', 'Simple (but not tested)']
+  default: 'dump-known'
+  requires: "{$parent.doc_type}='Application'"
+  disabled: true

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yaml
@@ -101,4 +101,4 @@
   value_names: ['Dump known (old and reliable)', 'Simple (but not tested)']
   default: 'dump-known'
   requires: "{$parent.doc_type}='Application'"
-  disabled: true
+  preview: true

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-settings-layout.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-settings-layout.yaml
@@ -54,13 +54,14 @@
   settings:
     - properties.cc-days-form-retain # Days to Retain for Review
 
-- title: 'Advanced (Logging)'
+- title: 'Advanced'
   id: app-settings-advanced
   collapse: true
   settings:
     - properties.logenabled  # Logging Enabled
     - properties.log_prop_weekly  # Weekly Log Sending Frequency
     - properties.log_prop_daily  # Daily Log Sending Frequency
+    - hq.translation_strategy
 
 - title: 'Disabled'
   id: app-settings-disabled
@@ -72,9 +73,3 @@
     - properties.restore-tolerance  # OTA Restore Tolerance (disabled)
     - features.users  # No Users Mode (disabled)
     - properties.loose_media  # Loose Media Mode (disabled)
-- title: 'Settings in Preview'
-  id: app-settings-preview
-  collapse: true
-  always_show: false
-  settings:
-    - hq.translation_strategy

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-settings-layout.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-settings-layout.yaml
@@ -72,3 +72,9 @@
     - properties.restore-tolerance  # OTA Restore Tolerance (disabled)
     - features.users  # No Users Mode (disabled)
     - properties.loose_media  # Loose Media Mode (disabled)
+- title: 'Settings in Preview'
+  id: app-settings-preview
+  collapse: true
+  always_show: false
+  settings:
+    - hq.translation_strategy

--- a/corehq/apps/app_manager/templates/app_manager/app_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/app_view.html
@@ -21,7 +21,10 @@
                 urls: {
                     save: '{% url edit_commcare_settings domain app.id %}'
                 },
-                edit: {{ edit|BOOL }}
+                edit: {{ edit|BOOL }},
+                user: {
+                    is_previewer: {{ request.couch_user.is_previewer|BOOL }}
+                }
             }
         };
         $(function () {

--- a/corehq/apps/app_manager/templates/app_manager/partials/app-settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/app-settings.html
@@ -128,6 +128,7 @@ todo fix
                     <label class="control-label" data-bind="attr: {for: inputId}">
                         <span data-bind="text: name"></span>
                         <span data-bind="makeHqHelp: {name: name, description: $data.description, format: $data.description_format}, visible: $data.description"></span>
+                        <span class="label label-info" data-bind="visible: $data.preview">{% trans "Preview" %}</span>
                     </label>
                     <div class="controls">
                         <span data-bind="template: $data.widget_template || 'CommcareSettings.widgets.' + widget"></span>

--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -1451,6 +1451,7 @@ def edit_app_attr(request, domain, app_id, attr):
         'cloudcare_enabled',
         'application_version',
         'case_sharing',
+        'translation_strategy'
         # RemoteApp only
         'profile_url',
         'manage_urls'
@@ -1474,6 +1475,7 @@ def edit_app_attr(request, domain, app_id, attr):
         ('show_user_registration', None),
         ('text_input', None),
         ('use_custom_suite', None),
+        ('translation_strategy', None),
     )
     for attribute, transformation in easy_attrs:
         if should_edit(attribute):


### PR DESCRIPTION
Option will be available only to previewers and will look like this:

![screen shot 2013-09-04 at 4 05 13 pm](https://f.cloud.github.com/assets/137212/1083617/60f0e34c-159d-11e3-885f-df977f7e72f6.png)

Should wait for tests as always, but I also ran

``` shell
bash app_builder_live_test/diff master translation-strategy
```

which makes sure there are no changes in building an app between those two branches
