### PR TITLE
Added a couple util methods to FixtureDataItem

### DIFF
--- a/corehq/apps/fixtures/models.py
+++ b/corehq/apps/fixtures/models.py
@@ -201,13 +201,17 @@ class FixtureDataItem(Document):
         return cls.by_data_type(domain, data_type).all()
 
     @classmethod
-    def get_key_value_map(cls, domain, tag, key_field, value_field):
+    def get_indexed_items(cls, domain, tag, index_field):
         """
-        Turns an item list into a flat dictionary, mapping
-        the value in `key_field` to the value in `value_field`.
+        Looks up an item list and converts to mapping from `index_field`
+        to a dict of all fields for that item.
+
+            fixtures = FixtureDataItem.get_indexed_items('my_domain',
+                'item_list_tag', 'index_field')
+            result = fixtures['index_val']['result_field']
         """
         fixtures = cls.get_item_list(domain, tag)
-        return {f.fields[key_field]: f.fields[value_field] for f in fixtures}
+        return dict((f.fields[key_field], f.fields) for f in fixtures)
 
     def delete_ownerships(self, transaction):
         ownerships = FixtureOwnership.by_item_id(self.get_id, self.domain)

--- a/corehq/apps/fixtures/models.py
+++ b/corehq/apps/fixtures/models.py
@@ -195,6 +195,20 @@ class FixtureDataItem(Document):
         return cls.view('fixtures/data_items_by_field_value', key=[domain, data_type_id, field_name, field_value],
                         reduce=False, include_docs=True)
 
+    @classmethod
+    def get_item_list(cls, domain, tag):
+        data_type = FixtureDataType.by_domain_tag(domain, tag).one()
+        return cls.by_data_type(domain, data_type).all()
+
+    @classmethod
+    def get_key_value_map(cls, domain, tag, key_field, value_field):
+        """
+        Turns an item list into a flat dictionary, mapping
+        the value in `key_field` to the value in `value_field`.
+        """
+        fixtures = cls.get_item_list(domain, tag)
+        return {f.fields[key_field]: f.fields[value_field] for f in fixtures}
+
     def delete_ownerships(self, transaction):
         ownerships = FixtureOwnership.by_item_id(self.get_id, self.domain)
         transaction.delete_all(ownerships)

--- a/corehq/apps/fixtures/models.py
+++ b/corehq/apps/fixtures/models.py
@@ -211,7 +211,7 @@ class FixtureDataItem(Document):
             result = fixtures['index_val']['result_field']
         """
         fixtures = cls.get_item_list(domain, tag)
-        return dict((f.fields[key_field], f.fields) for f in fixtures)
+        return dict((f.fields[index_field], f.fields) for f in fixtures)
 
     def delete_ownerships(self, transaction):
         ownerships = FixtureOwnership.by_item_id(self.get_id, self.domain)

--- a/corehq/apps/fixtures/tests.py
+++ b/corehq/apps/fixtures/tests.py
@@ -9,10 +9,11 @@ from django.test import TestCase
 class FixtureDataTest(TestCase):
     def setUp(self):
         self.domain = 'qwerty'
+        self.tag = "contact"
 
         self.data_type = FixtureDataType(
             domain=self.domain,
-            tag="contact",
+            tag=self.tag,
             name="Contact",
             fields=['name', 'number']
         )
@@ -27,6 +28,18 @@ class FixtureDataTest(TestCase):
             }
         )
         self.data_item.save()
+
+        for name, number in [('Michael', '+16666666666'),
+            ('Eric', '+17777777777')]:
+            data_item = FixtureDataItem(
+                domain=self.domain,
+                data_type_id=self.data_type.get_id,
+                fields={
+                    'name': name,
+                    'number': number,
+                }
+            )
+            data_item.save()
 
         self.user = CommCareUser.create(self.domain, 'rudolph', '***')
 
@@ -74,3 +87,9 @@ class FixtureDataTest(TestCase):
 
         self.fixture_ownership = self.data_item.add_user(self.user)
         self.assertItemsEqual([self.user.get_id], self.data_item.get_all_users(wrap=False))
+
+    def test_get_indexed_items(self):
+        fixtures = FixtureDataItem.get_indexed_items(self.domain,
+            self.tag, 'name')
+        john_num = fixtures['John']['number']
+        self.assertEqual(john_num, '+15555555555')


### PR DESCRIPTION
I think the first method (`get_item_list`) is definitely useful - it lets you avoid looking up the data type, just pass the tag.

The second method `get_key_value_map` is useful for what I'm currently working on, but I'd welcome some feedback on its general utility.

```
>>> from corehq.apps.fixtures.models import FixtureDataItem
>>> FixtureDataItem.get_item_list('opm', 'birth_spacing')
[FixtureDataItem(_attachments=None, _id='412eb5220c757e08355e9c259b81886d', _rev='4-f8ddde9e97ee2de7e6aa598818589c30', data_type_id='2a84957505efa22f5fdaea9a1cf56e88', doc_type='FixtureDataItem', domain='opm', fields={'Amount (Rs.)': '20
00', 'Time Difference': '2 years'}, sort_key=None), FixtureDataItem(_attachments=None, _id='ce608ae75e60283b939bb32be19ad25a', _rev='4-6bc01ddc03f9451fc9a79ed609570de7', data_type_id='2a84957505efa22f5fdaea9a1cf56e88', doc_type='FixtureD
ataItem', domain='opm', fields={'Amount (Rs.)': '3000', 'Time Difference': '3 years'}, sort_key=None)]
>>> FixtureDataItem.get_indexed_items('opm', 'birth_spacing', 'Time Difference')
{'3 years': { 'Time Difference': '3 years', 'Amount (Rs.)': '3000'}, '2 years': { 'Time Difference': '2 years',
'Amount (Rs.)': '2000'}}
>>> FixtureDataItem.get_key_value_map('opm', 'birth_spacing', 'Time Difference', 'Amount (Rs.)')
{'3 years': '3000', '2 years': '2000'}
```
