### PR TITLE
fix "click twice" behavior for save button in case config

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/case-config-ui-2.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case-config-ui-2.js
@@ -175,7 +175,9 @@ var CaseConfig = (function () {
             var $home = $('#case-config-ko');
             _.delay(function () {
                 ko.applyBindings(self, $home.get(0));
-                $home.on('change textchange', 'input, select', self.change)
+                $home.on('textchange', 'input', self.change)
+                     // all select2's are represented by an input[type="hidden"]
+                     .on('change', 'select, input[type="hidden"]', self.change)
                      .on('click', 'a', self.change);
                 self.ensureBlankProperties();
             });


### PR DESCRIPTION
keeping in mind that most "selects" in the UI are actually select2's
backed by an `<input type="hidden/>`
