### PR TITLE
change ReportField to use warnings.warn

### DIFF
--- a/corehq/apps/reports/fields.py
+++ b/corehq/apps/reports/fields.py
@@ -1,8 +1,8 @@
 import datetime
 from django.template.context import Context
 from django.template.loader import render_to_string
-import logging
 import pytz
+import warnings
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.domain.models import Domain, LICENSES
 from corehq.apps.fixtures.models import FixtureDataItem, FixtureDataType
@@ -34,7 +34,12 @@ class ReportField(CacheableRequestMixIn):
     template = ""
 
     def __init__(self, request, domain=None, timezone=pytz.utc, parent_report=None):
-        logging.warn("%s: ReportField is deprecated. Use ReportFilter instead." % self.__class__.__name__)
+        warnings.warn(
+            "ReportField (%s) is deprecated. Use ReportFilter instead." % (
+                self.__class__.__name__
+            ),
+            DeprecationWarning,
+        )
         self.context = Context()
         self.request = request
         self.domain = domain


### PR DESCRIPTION
As per Simon's suggestion, using the convention

``` python
warnings.warn(message, DeprecationWarning)
```

instead of logging. This (1) marks it as different from normal logging and (2) makes it easy to print when debugging and suppress in prod.
