### PR TITLE
enable configuring openlmis integration from the UI

### DIFF
--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -162,6 +162,17 @@ class StockLevelsConfig(DocumentSchema):
     overstock_threshold = DecimalProperty(default=3)  # in months
 
 
+class OpenLMISConfig(DocumentSchema):
+    # placeholder class for when this becomes fancier
+    enabled = BooleanProperty(default=False)
+
+    url = StringProperty()
+    username = StringProperty()
+    password = StringProperty() # todo: hash?
+
+    using_requisitions = BooleanProperty(default=False) # whether openlmis handles our requisitions for us
+
+
 class CommtrackConfig(Document):
 
     domain = StringProperty()
@@ -179,6 +190,7 @@ class CommtrackConfig(Document):
     supply_point_types = SchemaListProperty(SupplyPointType)
 
     requisition_config = SchemaProperty(CommtrackRequisitionConfig)
+    openlmis_config = SchemaProperty(OpenLMISConfig)
 
     # configured on Advanced Settings page
     use_auto_emergency_levels = BooleanProperty(default=False)
@@ -244,6 +256,10 @@ class CommtrackConfig(Document):
     @property
     def requisitions_enabled(self):
         return self.requisition_config.enabled
+
+    @property
+    def openlmis_enabled(self):
+        return self.openlmis_config.enabled
 
 def _view_shared(view_name, domain, location_id=None, skip=0, limit=100):
     extras = {"limit": limit} if limit else {}

--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -168,7 +168,9 @@ class OpenLMISConfig(DocumentSchema):
 
     url = StringProperty()
     username = StringProperty()
-    password = StringProperty() # todo: hash?
+    # we store passwords in cleartext right now, but in the future may want
+    # to leverage something like oauth to manage this better
+    password = StringProperty()
 
     using_requisitions = BooleanProperty(default=False) # whether openlmis handles our requisitions for us
 

--- a/corehq/apps/commtrack/static/commtrack/ko/settings.js
+++ b/corehq/apps/commtrack/static/commtrack/ko/settings.js
@@ -16,6 +16,7 @@ function CommtrackSettingsViewModel() {
     this.actions = ko.observableArray();
     this.loc_types = ko.observableArray();
     this.requisition_config = ko.observable();
+    this.openlmis_config = ko.observable();
 
     this.json_payload = ko.observable();
 
@@ -40,6 +41,7 @@ function CommtrackSettingsViewModel() {
             return new LocationTypeModel(e);
         }));
         this.requisition_config(new RequisitionConfigModel(data.requisition_config));
+        this.openlmis_config(new OpenLMISConfigModel(data.openlmis_config));
     };
 
     var settings = this;
@@ -156,7 +158,8 @@ function CommtrackSettingsViewModel() {
             keyword: this.keyword(),
             actions: $.map(this.actions(), function(e) { return e.to_json(); }),
             loc_types: $.map(this.loc_types(), function(e) { return e.to_json(); }),
-            requisition_config: this.requisition_config().to_json()
+            requisition_config: this.requisition_config().to_json(),
+            openlmis_config: this.openlmis_config().to_json()
         };
     };
 }
@@ -274,6 +277,25 @@ function RequisitionConfigModel(data) {
         return {
             enabled: this.enabled(),
             actions: $.map(this.actions(), function(e) { return e.to_json(); })
+        };
+    };
+}
+
+
+function OpenLMISConfigModel(data) {
+    this.enabled = ko.observable(data.enabled);
+    this.url = ko.observable(data.url);
+    this.username = ko.observable(data.username);
+    this.password = ko.observable(data.password);
+    this.using_requisitions = ko.observable(data.using_requisitions);
+
+    this.to_json = function() {
+        return {
+            enabled: this.enabled(),
+            url: this.url(),
+            username: this.username(),
+            password: this.password(),
+            using_requisitions: this.using_requisitions()
         };
     };
 }

--- a/corehq/apps/domain/templates/domain/admin/commtrack_settings.html
+++ b/corehq/apps/domain/templates/domain/admin/commtrack_settings.html
@@ -56,9 +56,9 @@ var other_sms_codes = {{ other_sms_codes|JSON }};
 
 <hr />
 
-<h3>Stock Actions</h3>
+<h3>{% trans "Stock Actions" %}</h3>
 
-<p class="help">For a given incoming stock report, stock actions will be applied in the order listed below.</p>
+<p class="help">{% trans "For a given incoming stock report, stock actions will be applied in the order listed below." %}</p>
 {% include "domain/admin/commtrack_action_table.html" %}
 <button type="button" class="btn btn-primary" data-bind="click: new_action"><i class="icon-plus icon-white"></i> {% trans "New Action" %}</button>
 <hr />
@@ -110,6 +110,43 @@ var other_sms_codes = {{ other_sms_codes|JSON }};
 </table>
 <button type="button" class="btn btn-primary" data-bind="click: new_loctype"><i class="icon-plus icon-white"></i> {% trans "New Location Type" %}</button>
 
+{% if request.couch_user.is_previewer %}
+<h3>{% trans "OpenLMIS Integration" %}</h3>
+<fieldset>
+    <div class="control-group" >
+        <label class="control-label" for="openlmis_enabled">{% trans "Enable OpenLMIS Integration?" %}</label>
+        <div class="controls">
+          <input id="openlmis_enabled" type="checkbox" data-bind="checked: openlmis_config().enabled">
+        </div>
+    </div>
+</fieldset>
+<fieldset data-bind="with: openlmis_config(), visible: openlmis_config().enabled">
+    <div class="control-group" >
+        <label class="control-label" for="openlmis_url">{% trans "API URL" %}</label>
+        <div class="controls">
+          <input id="openlmis_url" type="text" data-bind="value: url">
+        </div>
+    </div>
+    <div class="control-group" >
+        <label class="control-label" for="openlmis_username">{% trans "Username" %}</label>
+        <div class="controls">
+          <input id="openlmis_username" type="text" data-bind="value: username">
+        </div>
+    </div>
+    <div class="control-group" >
+        <label class="control-label" for="openlmis_password">{% trans "Password" %}</label>
+        <div class="controls">
+          <input id="openlmis_password" type="password" data-bind="value: password">
+        </div>
+    </div>
+    <div class="control-group" >
+        <label class="control-label" for="openlmis_using_requisitions">{% trans "Use OpenLMIS for Requisitions?" %}</label>
+        <div class="controls">
+          <input id="openlmis_using_requisitions" type="checkbox" data-bind="checked: using_requisitions">
+        </div>
+    </div>
+</fieldset>
+{% endif %}
 
 <!--
 

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -665,6 +665,11 @@ def commtrack_settings(request, domain):
         settings.location_types = [mk_loctype(l) for l in payload['loc_types']]
         settings.requisition_config.enabled = payload['requisition_config']['enabled']
         settings.requisition_config.actions =  [mk_action(a) for a in payload['requisition_config']['actions']]
+
+        if 'openlmis_config' in payload:
+            for item in payload['openlmis_config']:
+                setattr(settings.openlmis_config, item, payload['openlmis_config'][item])
+
         settings.save()
 
     def settings_to_json(config):
@@ -675,9 +680,10 @@ def commtrack_settings(request, domain):
             'requisition_config': {
                 'enabled': config.requisition_config.enabled,
                 'actions': [action_to_json(a) for a in config.requisition_config.actions],
-            }
-
+            },
+            'openlmis_config': config.openlmis_config._doc,
         }
+
     def action_to_json(action):
         return {
             'type': action.action_type,


### PR DESCRIPTION
this change just follows the same config-ui pattern used by the rest of the commtrack settings area.

integration doesn't do anything yet, but this is previewer-only so shouldn't be a big deal. just PRing in since it's a small and isolated change.
