### PR TITLE
Include unknown age forms

### DIFF
--- a/custom/reports/care_sa/models.py
+++ b/custom/reports/care_sa/models.py
@@ -36,7 +36,7 @@ class CareSAForm(XFormInstance):
         except (AttributeError, ValueError):
             # catch fun things like no age being found or age not being
             # a number
-            return -1
+            return '3'
 
         if age < 15:
             return '0'
@@ -99,7 +99,6 @@ class CareSAFluff(fluff.IndicatorDocument):
         NOTFilter(xcalculators.FormPropertyFilter(xmlns='http://openrosa.org/user-registration')),
         NOTFilter(xcalculators.FormPropertyFilter(xmlns='http://openrosa.org/user/registration')),
         NOTFilter(xcalculators.FormPropertyFilter(xmlns='http://code.javarosa.org/devicereport')),
-        CustomFilter(lambda f: f.age_group >= 0),
         CustomFilter(lambda f: f.gender in ['male', 'female']),
         CustomFilter(lambda f: f.cbo),
     ])

--- a/custom/reports/care_sa/reports/sql.py
+++ b/custom/reports/care_sa/reports/sql.py
@@ -238,7 +238,7 @@ class CareReport(SqlTabularReport,
 
     def age_seperated_dict(self, default):
         """ Build a dictionary with a copy of default for each age group """
-        return dict((str(i), copy(default)) for i in range(3))
+        return dict((str(i), copy(default)) for i in range(4))
 
     def initialize_user_stuff(self):
         """
@@ -350,6 +350,8 @@ class CareReport(SqlTabularReport,
             return '15-24 years'
         elif age_group_val == '2':
             return '25+ years'
+        else:
+            return 'Unknown'
 
     def get_grouping_name(self, user):
         """

--- a/custom/reports/care_sa/templates/care_sa/reports/grouped.html
+++ b/custom/reports/care_sa/templates/care_sa/reports/grouped.html
@@ -26,11 +26,13 @@
 
     {% for group in report_table.rows %}
         {% if group.username == 'TOTAL_ROW' %}
-            <tr style="background-color: #3a87ad">
+            <tr>
                 {% if group.row_data %}
-                    <td colspan="{{ group.total_width }}">Total:</td>
+                    <td colspan="{{ group.total_width }}" style="background-color: #3a87ad">Total:</td>
                     {% for col in group.row_data %}
-                        {% include 'reports/async/partials/tabular_cell.html' %}
+                        <td style="background-color: #3a87ad">
+                            {{ col }}
+                        </td>
                     {% endfor %}
                 {% else %}
                     {% if group.gender %}


### PR DESCRIPTION
Don't discard forms that had no patient age. Instead, display them as an "unknown" row.
