### PR TITLE
don't show parent properties for case types that aren't actual parents

### DIFF
--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -85,7 +85,11 @@ class ParentCasePropertyBuilder(object):
                     case_properties.update(
                         subcase.case_properties.keys()
                     )
-                    parent_types.add(m_case_type)
+                    if case_type != m_case_type and (
+                            f_actions.open_case.is_active() or
+                            f_actions.update_case.is_active() or
+                            f_actions.close_case.is_active()):
+                        parent_types.add(m_case_type)
         return parent_types, case_properties
 
     def get_parent_types(self, case_type):


### PR DESCRIPTION
`get_parent_types_and_contributed_properties` returns two things which are somewhat related but not intrinsically tied. The contributed properties returned here don't require that the case_type of the contributor refer to an actual parent case_type. The contributor only needs to open a case in a different module. 

This might merit splitting this function out into two, but I'm not sure of the best way to do.
