### PR TITLE
support trailing slashes in a few urls

### DIFF
--- a/corehq/apps/registration/urls.py
+++ b/corehq/apps/registration/urls.py
@@ -2,8 +2,8 @@ from django.conf.urls.defaults import *
 
 urlpatterns = patterns('corehq.apps.registration.views',
     url(r'^$', 'registration_default', name='registration_default'),
-    url(r'^user/(?P<domain_type>\w+)?$', 'register_user', name='register_user'),
-    url(r'^domain/(?P<domain_type>\w+)?$', 'register_domain', name='registration_domain'),
+    url(r'^user/(?P<domain_type>\w+)?/?$', 'register_user', name='register_user'),
+    url(r'^domain/(?P<domain_type>\w+)?/?$', 'register_domain', name='registration_domain'),
     url(r'^organization/$', 'register_org', name='registration_org'),
     url(r'^domain/confirm(?:/(?P<guid>\w+))?/$', 'confirm_domain', name='registration_confirm_domain'),
     url(r'^resend/$', 'resend_confirmation', name='registration_resend_domain_confirmation'),


### PR DESCRIPTION
was confused why this was 404ing: https://www.commcarehq.org/register/domain/commtrack/
