### PR TITLE
fix collapse logic for app settings

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/commcaresettings.js
+++ b/corehq/apps/app_manager/static/app_manager/js/commcaresettings.js
@@ -197,7 +197,7 @@ function CommcareSettings(options) {
             });
         });
         section.reallyCollapse = ko.computed(function () {
-            return section.collapse || _(section.settings).some(function (setting) {
+            return section.collapse && !_(section.settings).some(function (setting) {
                 return setting.hasError();
             });
         });


### PR DESCRIPTION
will now stay open when there's an error in a section
(this was the original intended behavior anyway)
