### PR TITLE
Also reindex the first row for each pillow

### DIFF
--- a/corehq/apps/hqcase/management/commands/ptop_fast_reindexer.py
+++ b/corehq/apps/hqcase/management/commands/ptop_fast_reindexer.py
@@ -255,7 +255,7 @@ class PtopReindexer(NoArgsCommand):
         print "done in %s seconds" % (end - start).seconds
 
     def process_row(self, row, count):
-        if count > self.start_num:
+        if count >= self.start_num:
             retries = 0
             while retries < MAX_TRIES:
                 try:


### PR DESCRIPTION
If you use the ptop_fast_reindexer, the first item for each pillow will be skipped, this fixes that.
