### PR TITLE
upgrade dev couchdbkit and jsonobject

### DIFF
--- a/requirements/jsonobject-couchdbkit.txt
+++ b/requirements/jsonobject-couchdbkit.txt
@@ -1,2 +1,2 @@
-git+git://github.com/dannyroberts/couchdbkit.git@jsonobject-0.6.5.1#egg=couchdbkit
-jsonobject>=0.2.6
+git+git://github.com/dannyroberts/couchdbkit.git@jsonobject-0.6.5.3#egg=couchdbkit
+jsonobject>=0.2.7


### PR DESCRIPTION
This includes https://github.com/dannyroberts/couchdbkit/commit/06457fa42abc4415b7139312d6b1e73d39e8a535, which fixes all of our 0.6.5 "strict" wrapping woes
