### PR TITLE
A couple more places where restrict_superusers needs to be enforced

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -443,7 +443,7 @@ class _AuthorizableMixin(IsMemberOfMixin):
                 domain = self.current_domain
             else:
                 return False # no domain, no admin
-        if self.is_global_admin():
+        if self.is_global_admin() and not Domain.get_by_name(domain).restrict_superusers:
             return True
         dm = self.get_domain_membership(domain)
         if dm:
@@ -1698,7 +1698,7 @@ class WebUser(CouchUser, MultiMembershipMixin, OrgMembershipMixin, CommCareMobil
     @memoized
     def has_permission(self, domain, permission, data=None):
         # is_admin is the same as having all the permissions set
-        if self.is_global_admin():
+        if (self.is_global_admin() and not Domain.get_by_name(domain).restrict_superusers):
             return True
         elif self.is_domain_admin(domain):
             return True


### PR DESCRIPTION
Each of these checks exists outside of a `DomainMembership`. The only way to be an admin of a domain that restricts superusers is to have an explicit admin domain membership. This will all be tidied up by the upcoming permissions change.
