### PR TITLE
make commtrack wrapper helpers convert values explicitly

### DIFF
--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -276,7 +276,51 @@ def _view_shared(view_name, domain, location_id=None, skip=0, limit=100):
         view_name, startkey=startkey, endkey=endkey,
         reduce=False, skip=skip, **extras)
 
-class StockStatus(DocumentSchema):
+
+def force_int(value):
+    if value is None:
+        return None
+    else:
+        return int(value)
+
+
+def force_bool(value):
+    if value is None:
+        return None
+    elif value is 'false':
+        return False
+    else:
+        return bool(value)
+
+
+def force_empty_string_to_null(value):
+    if value == '':
+        return None
+    else:
+        return value
+
+
+class FormDataSchema(DocumentSchema):
+
+    @classmethod
+    def force_wrap(cls, data):
+        data = copy(data)
+        for property in cls.properties().values():
+            transform = {
+                IntegerProperty: force_int,
+                BooleanProperty: force_bool,
+                DateProperty: force_empty_string_to_null,
+                DateTimeProperty: force_empty_string_to_null,
+            }.get(property.__class__, lambda x: x)
+            data[property.name] = transform(data.get(property.name))
+        return super(FormDataSchema, cls).wrap(data)
+
+    @classmethod
+    def wrap(cls, data):
+        raise NotImplementedError()
+
+
+class StockStatus(FormDataSchema):
     """
     This is a wrapper/helper class to represent the current stock status
     of a commtrack case.
@@ -294,28 +338,21 @@ class StockStatus(DocumentSchema):
 
     @classmethod
     def from_case(cls, case):
-        return StockStatus.wrap(case._doc)
-
-    @classmethod
-    def wrap(cls, data):
-        # couchdbkit doesn't like passing empty strings (instead of nulls)
-        # to DateTimeProperty fields
-        if data.get('stocked_out_since', None) == '':
-            del data['stocked_out_since']
-        return super(StockStatus, cls).wrap(data) 
+        return StockStatus.force_wrap(case._doc)
 
     @classmethod
     def by_domain(cls, domain, skip=0, limit=100):
-        return [StockStatus.wrap(row["value"]) for row in _view_shared(
+        return [StockStatus.force_wrap(row["value"]) for row in _view_shared(
             'commtrack/current_stock_status', domain, skip=skip, limit=limit)]
 
     @classmethod
     def by_location(cls, domain, location_id, skip=0, limit=100):
-        return [StockStatus.wrap(row["value"]) for row in _view_shared(
+        return [StockStatus.force_wrap(row["value"]) for row in _view_shared(
             'commtrack/current_stock_status', domain, location_id,
             skip=skip, limit=limit)]
 
-class StockTransaction(DocumentSchema):
+
+class StockTransaction(FormDataSchema):
     """
     wrapper/helper for transactions
     """
@@ -331,12 +368,12 @@ class StockTransaction(DocumentSchema):
 
     @classmethod
     def by_domain(cls, domain, skip=0, limit=100):
-        return [StockTransaction.wrap(row["value"]) for row in _view_shared(
+        return [StockTransaction.force_wrap(row["value"]) for row in _view_shared(
             'commtrack/stock_transactions', domain, skip=skip, limit=limit)]
 
     @classmethod
     def by_location(cls, domain, location_id, skip=0, limit=100):
-        return [StockTransaction.wrap(row["value"]) for row in _view_shared(
+        return [StockTransaction.force_wrap(row["value"]) for row in _view_shared(
             'commtrack/stock_transactions', domain, location_id,
             skip=skip, limit=limit)]
 
@@ -345,8 +382,7 @@ class StockTransaction(DocumentSchema):
         q = CommCareCase.get_db().view('commtrack/stock_transactions_by_product',
                                        startkey=[product_case, start_date],
                                        endkey=[product_case, end_date, {}])
-        return [StockTransaction.wrap(row['value']) for row in q]
-
+        return [StockTransaction.force_wrap(row['value']) for row in q]
 
 
 def _get_single_index(case, identifier, type, wrapper=None):
@@ -358,6 +394,7 @@ def _get_single_index(case, identifier, type, wrapper=None):
         ref_id = matching[0].referenced_id
         return wrapper.get(ref_id) if wrapper else ref_id
     return None
+
 
 def get_case_wrapper(data):
     return {
@@ -943,7 +980,7 @@ class StockReport(object):
 
     @property
     def transactions(self):
-        return [StockTransaction.wrap(t) for t in \
+        return [StockTransaction.force_wrap(t) for t in \
                 self._form.form.get('transaction', [])]
 
     @property

--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -300,7 +300,7 @@ def force_empty_string_to_null(value):
         return value
 
 
-class FormDataSchema(DocumentSchema):
+class StringDataSchema(DocumentSchema):
 
     @classmethod
     def force_wrap(cls, data):
@@ -313,14 +313,14 @@ class FormDataSchema(DocumentSchema):
                 DateTimeProperty: force_empty_string_to_null,
             }.get(property.__class__, lambda x: x)
             data[property.name] = transform(data.get(property.name))
-        return super(FormDataSchema, cls).wrap(data)
+        return super(StringDataSchema, cls).wrap(data)
 
     @classmethod
     def wrap(cls, data):
         raise NotImplementedError()
 
 
-class StockStatus(FormDataSchema):
+class StockStatus(StringDataSchema):
     """
     This is a wrapper/helper class to represent the current stock status
     of a commtrack case.
@@ -352,7 +352,7 @@ class StockStatus(FormDataSchema):
             skip=skip, limit=limit)]
 
 
-class StockTransaction(FormDataSchema):
+class StockTransaction(StringDataSchema):
     """
     wrapper/helper for transactions
     """

--- a/corehq/apps/commtrack/tests/__init__.py
+++ b/corehq/apps/commtrack/tests/__init__.py
@@ -3,3 +3,4 @@ from .test_sms_reporting import *
 from .test_supply_point_products import *
 from .test_supply_points import *
 from .test_consumption import *
+from .test_wrapping import *

--- a/corehq/apps/commtrack/tests/test_wrapping.py
+++ b/corehq/apps/commtrack/tests/test_wrapping.py
@@ -1,0 +1,29 @@
+import datetime
+from django.test import TestCase
+from corehq.apps.commtrack.models import StockTransaction
+
+
+class WrappingTest(TestCase):
+    def test_stock_transaction(self):
+        stock_transaction = StockTransaction.force_wrap({
+            "action": "consumption",
+            "product_entry": "9d14b21ab5ae6fb39d00d575c54d406b",
+            "product": "a660733caacc170577445d13755b3be0",
+            "@inferred": "true",
+            "value": "5",
+            "location_id": "6da439e2eb717e6b80a2d871956273f9",
+            "received_on": "2013-01-11T00:00:00Z"
+        })
+
+        result = {
+            "action": "consumption",
+            "product_entry": "9d14b21ab5ae6fb39d00d575c54d406b",
+            "product": "a660733caacc170577445d13755b3be0",
+            "inferred": True,
+            "value": 5,
+            "location_id": "6da439e2eb717e6b80a2d871956273f9",
+            "received_on": datetime.datetime(2013, 01, 11, 00, 00, 00),
+        }
+
+        for key, value in result.items():
+            self.assertEqual(getattr(stock_transaction, key), value)


### PR DESCRIPTION
NOTE: I'd like the eyes of @czue or @mrgriscom before merging this

Make `StockStatus` and `StockTransaction` subclass a new `FormDataSchema` that has a `force_wrap` function and disables the `wrap` function. `force_wrap` modifies the values passed in based on the property type, forcing them to the proper type if they're a string.

fixes: http://manage.dimagi.com/default.asp?73921
