### PR TITLE
change behavior to only preindex NEW indices

### DIFF
--- a/corehq/apps/hqcase/management/commands/ptop_preindex.py
+++ b/corehq/apps/hqcase/management/commands/ptop_preindex.py
@@ -1,9 +1,8 @@
 from datetime import datetime
+from optparse import make_option
 from django.core.mail import mail_admins
-import sys
 from gevent import monkey;monkey.patch_all()
 import gevent
-from gevent import Greenlet
 from pillowtop.listener import AliasedElasticPillow
 from pillowtop.management.pillowstate import get_pillow_states
 from pillowtop.run_pillowtop import import_pillows
@@ -36,23 +35,48 @@ def do_reindex(pillow_class_name):
 
 
 class Command(BaseCommand):
-    help = "Preindex pillowtop ES"
-    option_list = NoArgsCommand.option_list + ()
+    help = "Preindex ES pillows. Only run reindexer if the index doesn't exist."
+    option_list = NoArgsCommand.option_list + (
+        make_option('--replace',
+                    action='store_true',
+                    dest='replace',
+                    default=False,
+                    help='Reindex existing indices even if they are already there.'),
+    )
 
     def handle(self, *args, **options):
         runs = []
-        pillows = import_pillows()
-        aliased_pillows = filter(lambda x: isinstance(x, AliasedElasticPillow), pillows)
+        pillow_classes = import_pillows(instantiate=False)
+        aliased_classes = filter(lambda x: issubclass(x, AliasedElasticPillow), pillow_classes)
+        aliasable_pillows = [p(create_index=False) for p in aliased_classes]
 
-        mapped_masters, unmapped_masters, stale_indices = get_pillow_states(pillows)
+        reindex_all = options['replace']
+
+        mapped_masters, unmapped_masters, stale_indices = get_pillow_states(aliasable_pillows)
+
+        # mapped masters: ES indices as known in the current running code state that
+        # correctly have the alias applied to them
+
+        # unmapped masters: ES indices as known in the current running code state that
+        # do not have the alias applied to them
+
+        # stale indices: ES indices running on ES that are not part of the current source control.
 
         print "Master indices missing aliases:"
-
         unmapped_indices = [x[0] for x in unmapped_masters]
+        print unmapped_indices
 
-        reindex_pillows = filter(lambda x: x.es_index in unmapped_indices, aliased_pillows)
+        if reindex_all:
+            print "Reindexing ALL master pillows that are not aliased"
+            preindexable_pillows = aliasable_pillows
+        else:
+            print "Reindexing master pillows that do not exist yet (ones with aliases skipped)"
+            preindexable_pillows = filter(lambda x: not x.index_exists(), aliasable_pillows)
 
-        print reindex_pillows
+
+        reindex_pillows = filter(lambda x: x.es_index in unmapped_indices, preindexable_pillows)
+
+        print "Reindexing:\n\t%s" % '\n\t'.join(x.es_index for x in reindex_pillows)
 
         if len(reindex_pillows) > 0:
             preindex_message = """
@@ -65,8 +89,6 @@ class Command(BaseCommand):
             """ % (settings.EMAIL_SUBJECT_PREFIX, ', '.join([x.__class__.__name__ for x in reindex_pillows]))
 
             mail_admins("Pillow preindexing starting", preindex_message)
-
-
 
         start = datetime.utcnow()
         for pillow in reindex_pillows:


### PR DESCRIPTION
that do not exist yet. separate flag to do wholesale replace.

this protects from double preindex before a new deploy.
