### PR TITLE
use a number of methods to try to find a build number in a form

### DIFF
--- a/corehq/apps/receiverwrapper/util.py
+++ b/corehq/apps/receiverwrapper/util.py
@@ -1,5 +1,46 @@
+import re
+
+
 def get_submit_url(domain, app_id=None):
     if app_id:
         return "/a/{domain}/receiver/{app_id}/".format(domain=domain, app_id=app_id)
     else:
         return "/a/{domain}/receiver/".format(domain=domain)
+
+
+def get_meta_appversion_text(xform):
+    form_data = xform.get_form
+    try:
+        text = form_data['meta']['appVersion']['#text']
+    except KeyError:
+        return None
+
+    # just make sure this is a longish string and not something like '2.0'
+    if isinstance(text, (str, unicode)) and len(text) > 5:
+        return text
+    else:
+        return None
+
+
+def get_build_version(xform):
+    """
+    there are a bunch of unreliable places to look for a build version
+    this abstracts that out
+
+    """
+    patterns = [
+        r' build (\d+) ',
+        r' #(\d+) '
+    ]
+
+    appversion_text = get_meta_appversion_text(xform)
+    if appversion_text:
+        for pattern in patterns:
+            match = re.search(pattern, appversion_text)
+            if match:
+                build_number, = match.groups()
+                return int(build_number)
+
+    xform_version = xform.version
+    if xform_version and xform_version != '1':
+        return int(xform_version)

--- a/corehq/apps/receiverwrapper/util.py
+++ b/corehq/apps/receiverwrapper/util.py
@@ -9,7 +9,7 @@ def get_submit_url(domain, app_id=None):
 
 
 def get_meta_appversion_text(xform):
-    form_data = xform.get_form
+    form_data = xform.form
     try:
         text = form_data['meta']['appVersion']['#text']
     except KeyError:


### PR DESCRIPTION
including pattern matching in the meta.appVersion.#text
and pull this out for reuse

The only difference here is that it now looks for the build version in the appVersion text first before looking at the form version. Potential issues are (1) that I could have overlooked something in the various formats of appVersion, which could result in pulling out the wrong number and (2) that the form version is often behind the build version (i.e. if the form didn't change the `@version` attribute won't change either), which means that this change will actually make that more correct.

fixes: http://manage.dimagi.com/default.asp?73618
