### PR TITLE
send deploy successful email after restart finishes

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -606,13 +606,12 @@ def deploy():
             execute(flip_es_aliases)
     except Exception:
         execute(mail_admins, "Deploy failed", "You had better check the logs.")
+        # hopefully bring the server back to life
+        execute(services_restart)
         raise
     else:
-        execute(record_successful_deploy)
-    finally:
-        # hopefully bring the server back to life if anything goes wrong
         execute(services_restart)
-
+        execute(record_successful_deploy)
 
 
 @task

--- a/fabfile.py
+++ b/fabfile.py
@@ -563,7 +563,10 @@ def record_successful_deploy():
 
 @task
 def hotfix_deploy():
-    """ deploy code to remote host by checking out the latest via git """
+    """ deploy ONLY the code with no extra cleanup or syncing
+
+    for small python-only hotfixes
+    """
     if not console.confirm('Are you sure you want to deploy {env.environment}?'.format(env=env), default=False) or \
        not console.confirm('Did you run "fab {env.environment} preindex_views"? '.format(env=env), default=False) or \
        not console.confirm('HEY!!!! YOU ARE ONLY DEPLOYING CODE. THIS IS NOT A NORMAL DEPLOY. COOL???', default=False):
@@ -576,12 +579,13 @@ def hotfix_deploy():
         execute(update_code)
     except Exception:
         execute(mail_admins, "Deploy failed", "You had better check the logs.")
+        # hopefully bring the server back to life
+        execute(services_restart)
         raise
     else:
-        execute(record_successful_deploy)
-    finally:
-        # hopefully bring the server back to life if anything goes wrong
         execute(services_restart)
+        execute(record_successful_deploy)
+
 
 @task
 def deploy():


### PR DESCRIPTION
(made this a couple days ago and forgot to PR)

The diff is a tad confusing, because I'm changing the control flow to not use finally, but in either the exception or normal cases, the commands getting executed are the same; only now if things go normally, service restart and success email were being done in the wrong order, and this fixes it.
