### PR TITLE
simplify mobile worker username display

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -692,7 +692,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, EulaMi
             return self.username
 
     def html_username(self):
-        username = self.username
+        username = self.raw_username
         if '@' in username:
             html = "<span class='user_username'>%s</span><span class='user_domainname'>@%s</span>" % \
                    tuple(username.split('@'))


### PR DESCRIPTION
get rid of `@<domain>.commcarehq.org`

**Before**
![before](https://f.cloud.github.com/assets/137212/1229454/d2add922-27b8-11e3-93b8-303dbf9287ce.jpg)

**After**
![after](https://f.cloud.github.com/assets/137212/1229456/d810c23a-27b8-11e3-8fd8-828287f552fa.jpg)

(But don't worry, it's still the full form when a mobile worker logs in to CloudCare)
![top](https://f.cloud.github.com/assets/137212/1229457/e1874096-27b8-11e3-87b5-78a67353408f.png)
