### PR TITLE
increase poll interval before counting polling attempts

### DIFF
--- a/corehq/apps/hqmedia/static/hqmedia/js/hqmedia.upload_controller.js
+++ b/corehq/apps/hqmedia/static/hqmedia/js/hqmedia.upload_controller.js
@@ -42,10 +42,11 @@ function BaseHQMediaUploadController (uploader_name, marker, options) {
     self.uploadURL = options.uploadURL;
     self.processingURL = options.processingURL;
 
-    // Other
-    self.pollInterval = 2000;
+    // Polling
+    self.pollInterval = 2000;  // 2 sec
+    self.maxPollInterval = 20000;  // 20 seconds
     self.currentPollAttempts = 0;
-    self.maxPollAttempts = 30;
+    self.maxPollAttempts = 20;
 
 
     self.getActiveUploadSelectors = function (file) {
@@ -433,7 +434,13 @@ function HQMediaBulkUploadController (uploader_name, marker, options) {
 
     self.processingError = function (processing_id) {
         return function (data, status) {
-            self.currentPollAttempts += 1;
+            if (self.pollInterval < self.maxPollInterval) {
+                // first try increasing their timeout, maybe the connection is poor
+                self.pollInterval = Math.min(self.pollInterval + 2000, self.maxPollInterval);
+            } else {
+                self.currentPollAttempts += 1;
+            }
+
             if (self.currentPollAttempts > self.maxPollAttempts) {
                 var processingFile = self.processingIdToFile[processing_id];
                 delete self.processingIdToFile[processing_id];


### PR DESCRIPTION
- 2 seconds is apparently too short of a timeout for many of our users' internet connections
- as a result, false failures are reported while the task continues to successfully run in the background
- instead of attempts, first try to increase the timeout for the user (max at 20 seconds) and then record failed attempts.

Related Case: http://manage.dimagi.com/default.asp?76827
