### PR TITLE
Fixed the has_datespan calculation in reports

### DIFF
--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -404,7 +404,7 @@ class GenericReportView(CacheableRequestMixIn):
         default_config = ReportConfig.default()
 
         def is_datespan(field):
-            field_fn = to_function(field) if type(field) == str else field
+            field_fn = to_function(field) if type(field) == basestring else field
             return issubclass(field_fn, (DatespanFilter, DatespanField))
         has_datespan = any([is_datespan(field) for field in self.fields])
 

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -403,8 +403,10 @@ class GenericReportView(CacheableRequestMixIn):
         current_config_id = self.request.GET.get('config_id', '')
         default_config = ReportConfig.default()
 
-        has_datespan = any([ issubclass(to_function(field), (DatespanFilter, DatespanField)) 
-                           for field in self.fields])
+        def is_datespan(field):
+            field_fn = to_function(field) if type(field) == str else field
+            return issubclass(field_fn, (DatespanFilter, DatespanField))
+        has_datespan = any([is_datespan(field) for field in self.fields])
 
         self.context.update(
             report=dict(

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -404,7 +404,7 @@ class GenericReportView(CacheableRequestMixIn):
         default_config = ReportConfig.default()
 
         def is_datespan(field):
-            field_fn = to_function(field) if type(field) == basestring else field
+            field_fn = to_function(field) if isinstance(field, basestring) else field
             return issubclass(field_fn, (DatespanFilter, DatespanField))
         has_datespan = any([is_datespan(field) for field in self.fields])
 


### PR DESCRIPTION
It would error if the filter was an explicit reference to a field and not a
string reference.
