### PR TITLE
Use crispy forms for creating new mobile worker

### DIFF
--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -1,5 +1,6 @@
+from crispy_forms.bootstrap import FormActions
 from crispy_forms.helper import FormHelper
-from crispy_forms.layout import Submit
+from crispy_forms.layout import ButtonHolder, Fieldset, HTML, Layout, Submit
 from django import forms
 from django.core.validators import EmailValidator, email_re
 from django.core.urlresolvers import reverse
@@ -162,6 +163,31 @@ class CommCareAccountForm(forms.Form):
 
     class Meta:
         app_label = 'users'
+
+    def __init__(self, *args, **kwargs):
+        super(forms.Form, self).__init__(*args, **kwargs)
+        self.helper = FormHelper()
+        self.helper.layout = Layout(
+            Fieldset(
+                'Create new Mobile Worker account',
+                'username',
+                'password',
+                HTML("{% if only_numeric %}"
+                     "<div class=\"control-group\"><div class=\"controls\">"
+                     "To enable alphanumeric passwords, go to the "
+                     "applications this user will use, go to CommCare "
+                     "Settings, and change Password Format to Alphanumeric."
+                     "</div></div>"
+                     "{% endif %}"),
+                'password_2',
+                'phone_number'
+            ),
+            FormActions(
+                ButtonHolder(
+                    Submit('submit', 'Create Mobile Worker')
+                )
+            )
+        )
 
     def clean_phone_number(self):
         phone_number = self.cleaned_data['phone_number']

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -1,6 +1,6 @@
 from crispy_forms.bootstrap import FormActions
 from crispy_forms.helper import FormHelper
-from crispy_forms.layout import ButtonHolder, Fieldset, HTML, Layout, Submit
+from crispy_forms.layout import ButtonHolder, Div, Fieldset, HTML, Layout, Submit
 from django import forms
 from django.core.validators import EmailValidator, email_re
 from django.core.urlresolvers import reverse
@@ -178,9 +178,15 @@ class CommCareAccountForm(forms.Form):
                      "applications this user will use, go to CommCare "
                      "Settings, and change Password Format to Alphanumeric."
                      "</div></div>"
-                     "{% endif %}"),
+                     "{% endif %}"
+                ),
                 'password_2',
-                'phone_number'
+                'phone_number',
+                Div(
+                    Div(HTML("Please enter number, including international code, in digits only."),
+                        css_class="controls"),
+                    css_class="control-group"
+                )
             ),
             FormActions(
                 ButtonHolder(

--- a/corehq/apps/users/templates/users/add_commcare_account.html
+++ b/corehq/apps/users/templates/users/add_commcare_account.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 {% load hqstyle_tags %}
+{% load crispy_forms_tags %}
 
 {% block js %}{{ block.super }}
     <script src="{% static 'users/js/key_filters.js' %}"></script>
@@ -30,24 +31,7 @@
 
 {% block main_column %}
     <form class="form form-horizontal" method="post" id="add_commcare_account_form">
-        {% bootstrap_form_errors form %}
         <input id="id_domain" name="domain" type="hidden" value="{{ domain }}" />
-        {% bootstrap_fieldset form "Create new Mobile Worker account" %}
-        <div class="control-group" id="enable_all_passwords_control">
-            <div class="controls">
-                <p class="help-block">
-                    {% blocktrans %}
-                        To enable alphanumeric passwords, go to the
-                        applications this user will use, go to CommCare
-                        Settings, and change Password Format to Alphanumeric.
-                    {% endblocktrans %}
-                </p>
-            </div>
-        </div>
-        <div class="form-actions">
-            <button type="submit" class="btn btn-primary">
-                {% trans "Create" %} {% commcare_user %}
-            </button>
-        </div>
+        {% crispy form %}
     </form>
 {% endblock %}


### PR DESCRIPTION
Uses crispy forms.  Adds help text when alphanumerics passwords are disabled and for acceptable phone numbers.
