### PR TITLE
add support for multiple subcases in same repeat

### DIFF
--- a/corehq/apps/app_manager/tests/data/form_preparation_v2/multiple_subcase_repeat.json
+++ b/corehq/apps/app_manager/tests/data/form_preparation_v2/multiple_subcase_repeat.json
@@ -1,0 +1,884 @@
+{
+    "_attachments": {
+        "3f0298d0fbad9360151d69615eedf5a3d9cc08fe.xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n<h:html xmlns:h=\"http://www.w3.org/1999/xhtml\" xmlns:orx=\"http://openrosa.org/jr/xforms\" xmlns=\"http://www.w3.org/2002/xforms\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:jr=\"http://openrosa.org/javarosa\">\n\t<h:head>\n\t\t<h:title>New Form</h:title>\n\t\t<model>\n\t\t\t<instance>\n\t\t\t\t<data xmlns:jrm=\"http://dev.commcarehq.org/jr/xforms\" xmlns=\"http://openrosa.org/formdesigner/18EA34D4-E1F4-4076-A850-544567376491\" uiVersion=\"1\" version=\"1\" name=\"New Form\">\n\t\t\t\t\t<question1 />\n\t\t\t\t</data>\n\t\t\t</instance>\n\t\t\t<bind nodeset=\"/data/question1\" type=\"xsd:string\" />\n\t\t\t<itext>\n\t\t\t\t<translation lang=\"en\" default=\"\">\n\t\t\t\t\t<text id=\"question1-label\">\n\t\t\t\t\t\t<value>question1</value>\n\t\t\t\t\t</text>\n\t\t\t\t</translation>\n\t\t\t</itext>\n\t\t</model>\n\t</h:head>\n\t<h:body>\n\t\t<input ref=\"/data/question1\">\n\t\t\t<label ref=\"jr:itext('question1-label')\" />\n\t\t</input>\n\t</h:body>\n</h:html>",
+        "40a728a98ae206690a1a648a8cca5b21403a078c.xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n<h:html xmlns:h=\"http://www.w3.org/1999/xhtml\" xmlns:orx=\"http://openrosa.org/jr/xforms\" xmlns=\"http://www.w3.org/2002/xforms\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:jr=\"http://openrosa.org/javarosa\">\n\t<h:head>\n\t\t<h:title>New Form</h:title>\n\t\t<model>\n\t\t\t<instance>\n\t\t\t\t<data xmlns:jrm=\"http://dev.commcarehq.org/jr/xforms\" xmlns=\"http://openrosa.org/formdesigner/E2F31438-4225-436E-9809-3196BE7F9295\" uiVersion=\"1\" version=\"1\" name=\"New Form\">\n\t\t\t\t\t<question1 />\n\t\t\t\t</data>\n\t\t\t</instance>\n\t\t\t<bind nodeset=\"/data/question1\" type=\"xsd:string\" />\n\t\t\t<itext>\n\t\t\t\t<translation lang=\"en\" default=\"\">\n\t\t\t\t\t<text id=\"question1-label\">\n\t\t\t\t\t\t<value>question1</value>\n\t\t\t\t\t</text>\n\t\t\t\t</translation>\n\t\t\t</itext>\n\t\t</model>\n\t</h:head>\n\t<h:body>\n\t\t<input ref=\"/data/question1\">\n\t\t\t<label ref=\"jr:itext('question1-label')\" />\n\t\t</input>\n\t</h:body>\n</h:html>",
+        "4cc6053c2e2eebf30ea8359be6b462656a307785.xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n<h:html xmlns:h=\"http://www.w3.org/1999/xhtml\" xmlns:orx=\"http://openrosa.org/jr/xforms\" xmlns=\"http://www.w3.org/2002/xforms\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:jr=\"http://openrosa.org/javarosa\">\n\t<h:head>\n\t\t<h:title>New Form</h:title>\n\t\t<model>\n\t\t\t<instance>\n\t\t\t\t<data xmlns:jrm=\"http://dev.commcarehq.org/jr/xforms\" xmlns=\"http://openrosa.org/formdesigner/ABD894EB-0E04-44DB-9558-915A13A72F49\" uiVersion=\"1\" version=\"1\" name=\"New Form\">\n\t\t\t\t\t<parent_name />\n\t\t\t\t\t<children jr:template=\"\">\n\t\t\t\t\t\t<which_child />\n\t\t\t\t\t\t<child_name />\n\t\t\t\t\t</children>\n\t\t\t\t</data>\n\t\t\t</instance>\n\t\t\t<bind nodeset=\"/data/parent_name\" type=\"xsd:string\" />\n\t\t\t<bind nodeset=\"/data/children\" />\n\t\t\t<bind nodeset=\"/data/children/which_child\" />\n\t\t\t<bind nodeset=\"/data/children/child_name\" type=\"xsd:string\" />\n\t\t\t<itext>\n\t\t\t\t<translation lang=\"en\" default=\"\">\n\t\t\t\t\t<text id=\"parent_name-label\">\n\t\t\t\t\t\t<value>parent name</value>\n\t\t\t\t\t</text>\n\t\t\t\t\t<text id=\"children-label\">\n\t\t\t\t\t\t<value>Children</value>\n\t\t\t\t\t</text>\n\t\t\t\t\t<text id=\"which_child-label\">\n\t\t\t\t\t\t<value>which child</value>\n\t\t\t\t\t</text>\n\t\t\t\t\t<text id=\"which_child-1-label\">\n\t\t\t\t\t\t<value>one</value>\n\t\t\t\t\t</text>\n\t\t\t\t\t<text id=\"which_child-2-label\">\n\t\t\t\t\t\t<value>two</value>\n\t\t\t\t\t</text>\n\t\t\t\t\t<text id=\"child_name-label\">\n\t\t\t\t\t\t<value>child name</value>\n\t\t\t\t\t</text>\n\t\t\t\t</translation>\n\t\t\t</itext>\n\t\t</model>\n\t</h:head>\n\t<h:body>\n\t\t<input ref=\"/data/parent_name\">\n\t\t\t<label ref=\"jr:itext('parent_name-label')\" />\n\t\t</input>\n\t\t<group>\n\t\t\t<label ref=\"jr:itext('children-label')\" />\n\t\t\t<repeat nodeset=\"/data/children\">\n\t\t\t\t<select1 ref=\"/data/children/which_child\">\n\t\t\t\t\t<label ref=\"jr:itext('which_child-label')\" />\n\t\t\t\t\t<item>\n\t\t\t\t\t\t<label ref=\"jr:itext('which_child-1-label')\" />\n\t\t\t\t\t\t<value>1</value>\n\t\t\t\t\t</item>\n\t\t\t\t\t<item>\n\t\t\t\t\t\t<label ref=\"jr:itext('which_child-2-label')\" />\n\t\t\t\t\t\t<value>2</value>\n\t\t\t\t\t</item>\n\t\t\t\t</select1>\n\t\t\t\t<input ref=\"/data/children/child_name\">\n\t\t\t\t\t<label ref=\"jr:itext('child_name-label')\" />\n\t\t\t\t</input>\n\t\t\t</repeat>\n\t\t</group>\n\t</h:body>\n</h:html>"
+    },
+    "admin_password": null,
+    "admin_password_charset": "n",
+    "application_version": "2.0",
+    "attribution_notes": null,
+    "build_broken": false,
+    "build_comment": null,
+    "build_langs": [
+        "en"
+    ],
+    "build_signed": true,
+    "build_spec": {
+        "build_number": null,
+        "doc_type": "BuildSpec",
+        "latest": true,
+        "version": "2.3.0"
+    },
+    "built_on": null,
+    "built_with": {
+        "build_number": null,
+        "datetime": null,
+        "doc_type": "BuildRecord",
+        "latest": null,
+        "signed": true,
+        "version": null
+    },
+    "cached_properties": {},
+    "case_sharing": false,
+    "cloudcare_enabled": false,
+    "comment_from": null,
+    "copy_history": [],
+    "deployment_date": null,
+    "description": null,
+    "doc_type": "Application",
+    "force_http": false,
+    "is_released": false,
+    "langs": [
+        "en"
+    ],
+    "modules": [
+        {
+            "case_label": {
+                "en": "Cases"
+            },
+            "case_list": {
+                "doc_type": "CaseList",
+                "label": {},
+                "show": false
+            },
+            "case_type": "parent",
+            "details": [
+                {
+                    "columns": [
+                        {
+                            "advanced": "",
+                            "doc_type": "DetailColumn",
+                            "enum": {},
+                            "field": "name",
+                            "filter_xpath": "",
+                            "format": "plain",
+                            "header": {
+                                "en": "Name"
+                            },
+                            "late_flag": 30,
+                            "model": "case",
+                            "time_ago_interval": 365.25
+                        }
+                    ],
+                    "doc_type": "Detail",
+                    "sort_elements": [],
+                    "type": "case_short"
+                },
+                {
+                    "columns": [
+                        {
+                            "advanced": "",
+                            "doc_type": "DetailColumn",
+                            "enum": {},
+                            "field": "name",
+                            "filter_xpath": "",
+                            "format": "plain",
+                            "header": {
+                                "en": "Name"
+                            },
+                            "late_flag": 30,
+                            "model": "case",
+                            "time_ago_interval": 365.25
+                        }
+                    ],
+                    "doc_type": "Detail",
+                    "sort_elements": [],
+                    "type": "case_long"
+                },
+                {
+                    "columns": [
+                        {
+                            "advanced": "",
+                            "doc_type": "DetailColumn",
+                            "enum": {},
+                            "field": "name",
+                            "filter_xpath": "",
+                            "format": "plain",
+                            "header": {
+                                "en": "Name"
+                            },
+                            "late_flag": 30,
+                            "model": "case",
+                            "time_ago_interval": 365.25
+                        }
+                    ],
+                    "doc_type": "Detail",
+                    "sort_elements": [],
+                    "type": "ref_short"
+                },
+                {
+                    "columns": [
+                        {
+                            "advanced": "",
+                            "doc_type": "DetailColumn",
+                            "enum": {},
+                            "field": "name",
+                            "filter_xpath": "",
+                            "format": "plain",
+                            "header": {
+                                "en": "Name"
+                            },
+                            "late_flag": 30,
+                            "model": "case",
+                            "time_ago_interval": 365.25
+                        }
+                    ],
+                    "doc_type": "Detail",
+                    "sort_elements": [],
+                    "type": "ref_long"
+                }
+            ],
+            "doc_type": "Module",
+            "forms": [
+                {
+                    "actions": {
+                        "case_preload": {
+                            "condition": {
+                                "answer": null,
+                                "doc_type": "FormActionCondition",
+                                "question": null,
+                                "type": "always"
+                            },
+                            "doc_type": "PreloadAction",
+                            "preload": {}
+                        },
+                        "close_case": {
+                            "condition": {
+                                "answer": null,
+                                "doc_type": "FormActionCondition",
+                                "question": null,
+                                "type": "never"
+                            },
+                            "doc_type": "FormAction"
+                        },
+                        "close_referral": {
+                            "condition": {
+                                "answer": null,
+                                "doc_type": "FormActionCondition",
+                                "question": null,
+                                "type": "never"
+                            },
+                            "doc_type": "FormAction"
+                        },
+                        "doc_type": "FormActions",
+                        "open_case": {
+                            "condition": {
+                                "answer": null,
+                                "doc_type": "FormActionCondition",
+                                "question": null,
+                                "type": "always"
+                            },
+                            "doc_type": "OpenCaseAction",
+                            "external_id": null,
+                            "name_path": "/data/parent_name"
+                        },
+                        "open_referral": {
+                            "condition": {
+                                "answer": null,
+                                "doc_type": "FormActionCondition",
+                                "question": null,
+                                "type": "never"
+                            },
+                            "doc_type": "OpenReferralAction",
+                            "followup_date": null,
+                            "name_path": null
+                        },
+                        "referral_preload": {
+                            "condition": {
+                                "answer": null,
+                                "doc_type": "FormActionCondition",
+                                "question": null,
+                                "type": "never"
+                            },
+                            "doc_type": "PreloadAction",
+                            "preload": {}
+                        },
+                        "subcases": [
+                            {
+                                "case_name": "/data/children/child_name",
+                                "case_properties": {},
+                                "case_type": "child1",
+                                "condition": {
+                                    "answer": "1",
+                                    "doc_type": "FormActionCondition",
+                                    "question": "/data/children/which_child",
+                                    "type": "if"
+                                },
+                                "doc_type": "OpenSubCaseAction",
+                                "repeat_context": "/data/children"
+                            },
+                            {
+                                "case_name": "/data/children/child_name",
+                                "case_properties": {},
+                                "case_type": "child2",
+                                "condition": {
+                                    "answer": "2",
+                                    "doc_type": "FormActionCondition",
+                                    "question": "/data/children/which_child",
+                                    "type": "if"
+                                },
+                                "doc_type": "OpenSubCaseAction",
+                                "repeat_context": "/data/children"
+                            }
+                        ],
+                        "update_case": {
+                            "condition": {
+                                "answer": null,
+                                "doc_type": "FormActionCondition",
+                                "question": null,
+                                "type": "always"
+                            },
+                            "doc_type": "UpdateCaseAction",
+                            "update": {}
+                        },
+                        "update_referral": {
+                            "condition": {
+                                "answer": null,
+                                "doc_type": "FormActionCondition",
+                                "question": null,
+                                "type": "never"
+                            },
+                            "doc_type": "UpdateReferralAction",
+                            "followup_date": null
+                        }
+                    },
+                    "doc_type": "Form",
+                    "form_filter": null,
+                    "media_audio": null,
+                    "media_image": null,
+                    "name": {
+                        "en": "Untitled Form"
+                    },
+                    "requires": "none",
+                    "show_count": false,
+                    "unique_id": "4cc6053c2e2eebf30ea8359be6b462656a307785",
+                    "version": null,
+                    "xmlns": "http://openrosa.org/formdesigner/ABD894EB-0E04-44DB-9558-915A13A72F49"
+                }
+            ],
+            "media_audio": null,
+            "media_image": null,
+            "name": {
+                "en": "Untitled Module"
+            },
+            "parent_select": {
+                "active": false,
+                "doc_type": "ParentSelect",
+                "module_id": null,
+                "relationship": "parent"
+            },
+            "put_in_root": false,
+            "referral_label": {
+                "en": "Referrals"
+            },
+            "referral_list": {
+                "doc_type": "CaseList",
+                "label": {},
+                "show": false
+            },
+            "task_list": {
+                "doc_type": "CaseList",
+                "label": {},
+                "show": false
+            },
+            "unique_id": "bca6ab262d8e0b8ba8a4aabf648b6f37ba6a2885"
+        },
+        {
+            "case_label": {
+                "en": "Cases"
+            },
+            "case_list": {
+                "doc_type": "CaseList",
+                "label": {},
+                "show": false
+            },
+            "case_type": "child1",
+            "details": [
+                {
+                    "columns": [
+                        {
+                            "advanced": "",
+                            "doc_type": "DetailColumn",
+                            "enum": {},
+                            "field": "name",
+                            "filter_xpath": "",
+                            "format": "plain",
+                            "header": {
+                                "en": "Name"
+                            },
+                            "late_flag": 30,
+                            "model": "case",
+                            "time_ago_interval": 365.25
+                        }
+                    ],
+                    "doc_type": "Detail",
+                    "sort_elements": [],
+                    "type": "case_short"
+                },
+                {
+                    "columns": [
+                        {
+                            "advanced": "",
+                            "doc_type": "DetailColumn",
+                            "enum": {},
+                            "field": "name",
+                            "filter_xpath": "",
+                            "format": "plain",
+                            "header": {
+                                "en": "Name"
+                            },
+                            "late_flag": 30,
+                            "model": "case",
+                            "time_ago_interval": 365.25
+                        }
+                    ],
+                    "doc_type": "Detail",
+                    "sort_elements": [],
+                    "type": "case_long"
+                },
+                {
+                    "columns": [
+                        {
+                            "advanced": "",
+                            "doc_type": "DetailColumn",
+                            "enum": {},
+                            "field": "name",
+                            "filter_xpath": "",
+                            "format": "plain",
+                            "header": {
+                                "en": "Name"
+                            },
+                            "late_flag": 30,
+                            "model": "case",
+                            "time_ago_interval": 365.25
+                        }
+                    ],
+                    "doc_type": "Detail",
+                    "sort_elements": [],
+                    "type": "ref_short"
+                },
+                {
+                    "columns": [
+                        {
+                            "advanced": "",
+                            "doc_type": "DetailColumn",
+                            "enum": {},
+                            "field": "name",
+                            "filter_xpath": "",
+                            "format": "plain",
+                            "header": {
+                                "en": "Name"
+                            },
+                            "late_flag": 30,
+                            "model": "case",
+                            "time_ago_interval": 365.25
+                        }
+                    ],
+                    "doc_type": "Detail",
+                    "sort_elements": [],
+                    "type": "ref_long"
+                }
+            ],
+            "doc_type": "Module",
+            "forms": [
+                {
+                    "actions": {
+                        "case_preload": {
+                            "condition": {
+                                "answer": null,
+                                "doc_type": "FormActionCondition",
+                                "question": null,
+                                "type": "always"
+                            },
+                            "doc_type": "PreloadAction",
+                            "preload": {}
+                        },
+                        "close_case": {
+                            "condition": {
+                                "answer": null,
+                                "doc_type": "FormActionCondition",
+                                "question": null,
+                                "type": "never"
+                            },
+                            "doc_type": "FormAction"
+                        },
+                        "close_referral": {
+                            "condition": {
+                                "answer": null,
+                                "doc_type": "FormActionCondition",
+                                "question": null,
+                                "type": "never"
+                            },
+                            "doc_type": "FormAction"
+                        },
+                        "doc_type": "FormActions",
+                        "open_case": {
+                            "condition": {
+                                "answer": null,
+                                "doc_type": "FormActionCondition",
+                                "question": null,
+                                "type": "never"
+                            },
+                            "doc_type": "OpenCaseAction",
+                            "external_id": null,
+                            "name_path": null
+                        },
+                        "open_referral": {
+                            "condition": {
+                                "answer": null,
+                                "doc_type": "FormActionCondition",
+                                "question": null,
+                                "type": "never"
+                            },
+                            "doc_type": "OpenReferralAction",
+                            "followup_date": null,
+                            "name_path": null
+                        },
+                        "referral_preload": {
+                            "condition": {
+                                "answer": null,
+                                "doc_type": "FormActionCondition",
+                                "question": null,
+                                "type": "never"
+                            },
+                            "doc_type": "PreloadAction",
+                            "preload": {}
+                        },
+                        "subcases": [],
+                        "update_case": {
+                            "condition": {
+                                "answer": null,
+                                "doc_type": "FormActionCondition",
+                                "question": null,
+                                "type": "always"
+                            },
+                            "doc_type": "UpdateCaseAction",
+                            "update": {}
+                        },
+                        "update_referral": {
+                            "condition": {
+                                "answer": null,
+                                "doc_type": "FormActionCondition",
+                                "question": null,
+                                "type": "never"
+                            },
+                            "doc_type": "UpdateReferralAction",
+                            "followup_date": null
+                        }
+                    },
+                    "doc_type": "Form",
+                    "form_filter": null,
+                    "media_audio": null,
+                    "media_image": null,
+                    "name": {
+                        "en": "Untitled Form"
+                    },
+                    "requires": "case",
+                    "show_count": false,
+                    "unique_id": "40a728a98ae206690a1a648a8cca5b21403a078c",
+                    "version": null,
+                    "xmlns": "http://openrosa.org/formdesigner/E2F31438-4225-436E-9809-3196BE7F9295"
+                }
+            ],
+            "media_audio": null,
+            "media_image": null,
+            "name": {
+                "en": "Child1"
+            },
+            "parent_select": {
+                "active": false,
+                "doc_type": "ParentSelect",
+                "module_id": null,
+                "relationship": "parent"
+            },
+            "put_in_root": false,
+            "referral_label": {
+                "en": "Referrals"
+            },
+            "referral_list": {
+                "doc_type": "CaseList",
+                "label": {},
+                "show": false
+            },
+            "task_list": {
+                "doc_type": "CaseList",
+                "label": {},
+                "show": false
+            },
+            "unique_id": "1409cde22d97d022100399cb7ccf19f335ea9d95"
+        },
+        {
+            "case_label": {
+                "en": "Cases"
+            },
+            "case_list": {
+                "doc_type": "CaseList",
+                "label": {},
+                "show": false
+            },
+            "case_type": "child2",
+            "details": [
+                {
+                    "columns": [
+                        {
+                            "advanced": "",
+                            "doc_type": "DetailColumn",
+                            "enum": {},
+                            "field": "name",
+                            "filter_xpath": "",
+                            "format": "plain",
+                            "header": {
+                                "en": "Name"
+                            },
+                            "late_flag": 30,
+                            "model": "case",
+                            "time_ago_interval": 365.25
+                        }
+                    ],
+                    "doc_type": "Detail",
+                    "sort_elements": [],
+                    "type": "case_short"
+                },
+                {
+                    "columns": [
+                        {
+                            "advanced": "",
+                            "doc_type": "DetailColumn",
+                            "enum": {},
+                            "field": "name",
+                            "filter_xpath": "",
+                            "format": "plain",
+                            "header": {
+                                "en": "Name"
+                            },
+                            "late_flag": 30,
+                            "model": "case",
+                            "time_ago_interval": 365.25
+                        }
+                    ],
+                    "doc_type": "Detail",
+                    "sort_elements": [],
+                    "type": "case_long"
+                },
+                {
+                    "columns": [
+                        {
+                            "advanced": "",
+                            "doc_type": "DetailColumn",
+                            "enum": {},
+                            "field": "name",
+                            "filter_xpath": "",
+                            "format": "plain",
+                            "header": {
+                                "en": "Name"
+                            },
+                            "late_flag": 30,
+                            "model": "case",
+                            "time_ago_interval": 365.25
+                        }
+                    ],
+                    "doc_type": "Detail",
+                    "sort_elements": [],
+                    "type": "ref_short"
+                },
+                {
+                    "columns": [
+                        {
+                            "advanced": "",
+                            "doc_type": "DetailColumn",
+                            "enum": {},
+                            "field": "name",
+                            "filter_xpath": "",
+                            "format": "plain",
+                            "header": {
+                                "en": "Name"
+                            },
+                            "late_flag": 30,
+                            "model": "case",
+                            "time_ago_interval": 365.25
+                        }
+                    ],
+                    "doc_type": "Detail",
+                    "sort_elements": [],
+                    "type": "ref_long"
+                }
+            ],
+            "doc_type": "Module",
+            "forms": [
+                {
+                    "actions": {
+                        "case_preload": {
+                            "condition": {
+                                "answer": null,
+                                "doc_type": "FormActionCondition",
+                                "question": null,
+                                "type": "always"
+                            },
+                            "doc_type": "PreloadAction",
+                            "preload": {}
+                        },
+                        "close_case": {
+                            "condition": {
+                                "answer": null,
+                                "doc_type": "FormActionCondition",
+                                "question": null,
+                                "type": "never"
+                            },
+                            "doc_type": "FormAction"
+                        },
+                        "close_referral": {
+                            "condition": {
+                                "answer": null,
+                                "doc_type": "FormActionCondition",
+                                "question": null,
+                                "type": "never"
+                            },
+                            "doc_type": "FormAction"
+                        },
+                        "doc_type": "FormActions",
+                        "open_case": {
+                            "condition": {
+                                "answer": null,
+                                "doc_type": "FormActionCondition",
+                                "question": null,
+                                "type": "never"
+                            },
+                            "doc_type": "OpenCaseAction",
+                            "external_id": null,
+                            "name_path": null
+                        },
+                        "open_referral": {
+                            "condition": {
+                                "answer": null,
+                                "doc_type": "FormActionCondition",
+                                "question": null,
+                                "type": "never"
+                            },
+                            "doc_type": "OpenReferralAction",
+                            "followup_date": null,
+                            "name_path": null
+                        },
+                        "referral_preload": {
+                            "condition": {
+                                "answer": null,
+                                "doc_type": "FormActionCondition",
+                                "question": null,
+                                "type": "never"
+                            },
+                            "doc_type": "PreloadAction",
+                            "preload": {}
+                        },
+                        "subcases": [],
+                        "update_case": {
+                            "condition": {
+                                "answer": null,
+                                "doc_type": "FormActionCondition",
+                                "question": null,
+                                "type": "always"
+                            },
+                            "doc_type": "UpdateCaseAction",
+                            "update": {}
+                        },
+                        "update_referral": {
+                            "condition": {
+                                "answer": null,
+                                "doc_type": "FormActionCondition",
+                                "question": null,
+                                "type": "never"
+                            },
+                            "doc_type": "UpdateReferralAction",
+                            "followup_date": null
+                        }
+                    },
+                    "doc_type": "Form",
+                    "form_filter": null,
+                    "media_audio": null,
+                    "media_image": null,
+                    "name": {
+                        "en": "Untitled Form"
+                    },
+                    "requires": "case",
+                    "show_count": false,
+                    "unique_id": "3f0298d0fbad9360151d69615eedf5a3d9cc08fe",
+                    "version": null,
+                    "xmlns": "http://openrosa.org/formdesigner/18EA34D4-E1F4-4076-A850-544567376491"
+                }
+            ],
+            "media_audio": null,
+            "media_image": null,
+            "name": {
+                "en": "Child2"
+            },
+            "parent_select": {
+                "active": false,
+                "doc_type": "ParentSelect",
+                "module_id": null,
+                "relationship": "parent"
+            },
+            "put_in_root": false,
+            "referral_label": {
+                "en": "Referrals"
+            },
+            "referral_list": {
+                "doc_type": "CaseList",
+                "label": {},
+                "show": false
+            },
+            "task_list": {
+                "doc_type": "CaseList",
+                "label": {},
+                "show": false
+            },
+            "unique_id": "43949260920eecb2b6e79f6554a13a1040a754e5"
+        }
+    ],
+    "multimedia_map": {},
+    "name": "Repeat subcases",
+    "phone_model": null,
+    "platform": "nokia/s40",
+    "profile": {
+        "features": {
+            "sense": "false",
+            "users": "true"
+        },
+        "properties": {
+            "ViewStyle": "v_chatterbox",
+            "cc-autoup-freq": "freq-never",
+            "cc-content-valid": "no",
+            "cc-days-form-retain": "-1",
+            "cc-entry-mode": "cc-entry-quick",
+            "cc-login-images": "No",
+            "cc-send-procedure": "cc-send-http",
+            "cc-send-unsent": "cc-su-auto",
+            "cc-user-mode": "cc-u-normal",
+            "extra_key_action": "audio",
+            "log_prop_daily": "log_never",
+            "log_prop_weekly": "log_short",
+            "logenabled": "Enabled",
+            "loose_media": "no",
+            "password_format": "n",
+            "purge-freq": "0",
+            "restore-tolerance": "loose",
+            "server-tether": "push-only",
+            "unsent-number-limit": "5",
+            "user_reg_server": "required"
+        }
+    },
+    "recipients": "",
+    "secure_submissions": false,
+    "show_user_registration": false,
+    "success_message": {},
+    "text_input": "roman",
+    "translation_strategy": "dump-known",
+    "translations": {},
+    "use_custom_suite": false,
+    "user_registration": {
+        "actions": {
+            "case_preload": {
+                "condition": {
+                    "answer": null,
+                    "doc_type": "FormActionCondition",
+                    "question": null,
+                    "type": "never"
+                },
+                "doc_type": "PreloadAction",
+                "preload": {}
+            },
+            "close_case": {
+                "condition": {
+                    "answer": null,
+                    "doc_type": "FormActionCondition",
+                    "question": null,
+                    "type": "never"
+                },
+                "doc_type": "FormAction"
+            },
+            "close_referral": {
+                "condition": {
+                    "answer": null,
+                    "doc_type": "FormActionCondition",
+                    "question": null,
+                    "type": "never"
+                },
+                "doc_type": "FormAction"
+            },
+            "doc_type": "FormActions",
+            "open_case": {
+                "condition": {
+                    "answer": null,
+                    "doc_type": "FormActionCondition",
+                    "question": null,
+                    "type": "never"
+                },
+                "doc_type": "OpenCaseAction",
+                "external_id": null,
+                "name_path": null
+            },
+            "open_referral": {
+                "condition": {
+                    "answer": null,
+                    "doc_type": "FormActionCondition",
+                    "question": null,
+                    "type": "never"
+                },
+                "doc_type": "OpenReferralAction",
+                "followup_date": null,
+                "name_path": null
+            },
+            "referral_preload": {
+                "condition": {
+                    "answer": null,
+                    "doc_type": "FormActionCondition",
+                    "question": null,
+                    "type": "never"
+                },
+                "doc_type": "PreloadAction",
+                "preload": {}
+            },
+            "subcases": [],
+            "update_case": {
+                "condition": {
+                    "answer": null,
+                    "doc_type": "FormActionCondition",
+                    "question": null,
+                    "type": "never"
+                },
+                "doc_type": "UpdateCaseAction",
+                "update": {}
+            },
+            "update_referral": {
+                "condition": {
+                    "answer": null,
+                    "doc_type": "FormActionCondition",
+                    "question": null,
+                    "type": "never"
+                },
+                "doc_type": "UpdateReferralAction",
+                "followup_date": null
+            }
+        },
+        "data_paths": {},
+        "doc_type": "UserRegistrationForm",
+        "name": {},
+        "password_path": "password",
+        "requires": "none",
+        "show_count": false,
+        "unique_id": "880b17c23fab965765ddce25562dab02c8f0eee9",
+        "username_path": "username",
+        "version": null,
+        "xmlns": null
+    },
+    "user_type": null,
+    "version": 3
+}

--- a/corehq/apps/app_manager/tests/data/form_preparation_v2/multiple_subcase_repeat.xml
+++ b/corehq/apps/app_manager/tests/data/form_preparation_v2/multiple_subcase_repeat.xml
@@ -1,0 +1,66 @@
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa">
+	<h:head>
+		<h:title>New Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/ABD894EB-0E04-44DB-9558-915A13A72F49" uiVersion="1" version="3" name="New Form">
+					<parent_name/>
+					<children jr:template="">
+						<which_child/>
+						<child_name/>
+					<subcase_0><case xmlns="http://commcarehq.org/case/transaction/v2" case_id="" date_modified="" user_id=""><create><case_name/><owner_id/><case_type>child1</case_type></create><update/><index><parent case_type="parent"/></index></case></subcase_0><subcase_1><case xmlns="http://commcarehq.org/case/transaction/v2" case_id="" date_modified="" user_id=""><create><case_name/><owner_id/><case_type>child2</case_type></create><update/><index><parent case_type="parent"/></index></case></subcase_1></children>
+				<case xmlns="http://commcarehq.org/case/transaction/v2" case_id="" date_modified="" user_id=""><create><case_name/><owner_id/><case_type>parent</case_type></create><update/></case><orx:meta xmlns:cc="http://commcarehq.org/xforms"><orx:deviceID/><orx:timeStart/><orx:timeEnd/><orx:username/><orx:userID/><orx:instanceID/><cc:appVersion/></orx:meta></data>
+			</instance><instance id="commcaresession" src="jr://instance/session"/>
+			<bind nodeset="/data/parent_name" type="xsd:string" required="true()"/>
+			<bind nodeset="/data/children"/>
+			<bind nodeset="/data/children/which_child"/>
+			<bind nodeset="/data/children/child_name" type="xsd:string" required="true()"/>
+			<itext>
+				<translation lang="en" default="">
+					<text id="parent_name-label">
+						<value>parent name</value>
+					</text>
+					<text id="children-label">
+						<value>Children</value>
+					</text>
+					<text id="which_child-label">
+						<value>which child</value>
+					</text>
+					<text id="which_child-1-label">
+						<value>one</value>
+					</text>
+					<text id="which_child-2-label">
+						<value>two</value>
+					</text>
+					<text id="child_name-label">
+						<value>child name</value>
+					</text>
+				</translation>
+			</itext>
+		<bind calculate="/data/meta/timeEnd" nodeset="/data/case/@date_modified" type="dateTime"/><bind calculate="/data/meta/userID" nodeset="/data/case/@user_id"/><setvalue event="xforms-ready" ref="/data/case/@case_id" value="uuid()"/><bind calculate="/data/parent_name" nodeset="/data/case/create/case_name"/><bind calculate="/data/meta/userID" nodeset="/data/case/create/owner_id"/><bind calculate="/data/meta/timeEnd" nodeset="/data/children/subcase_0/case/@date_modified" type="dateTime"/><bind calculate="/data/meta/userID" nodeset="/data/children/subcase_0/case/@user_id"/><bind nodeset="/data/children/subcase_0/case" relevant="/data/children/which_child = '1'"/><bind calculate="uuid()" nodeset="/data/children/subcase_0/case/@case_id"/><bind calculate="/data/children/child_name" nodeset="/data/children/subcase_0/case/create/case_name"/><bind calculate="/data/meta/userID" nodeset="/data/children/subcase_0/case/create/owner_id"/><bind calculate="/data/case/@case_id" nodeset="/data/children/subcase_0/case/index/parent"/><bind calculate="/data/meta/timeEnd" nodeset="/data/children/subcase_1/case/@date_modified" type="dateTime"/><bind calculate="/data/meta/userID" nodeset="/data/children/subcase_1/case/@user_id"/><bind nodeset="/data/children/subcase_1/case" relevant="/data/children/which_child = '2'"/><bind calculate="uuid()" nodeset="/data/children/subcase_1/case/@case_id"/><bind calculate="/data/children/child_name" nodeset="/data/children/subcase_1/case/create/case_name"/><bind calculate="/data/meta/userID" nodeset="/data/children/subcase_1/case/create/owner_id"/><bind calculate="/data/case/@case_id" nodeset="/data/children/subcase_1/case/index/parent"/><setvalue event="xforms-ready" ref="/data/meta/deviceID" value="instance('commcaresession')/session/context/deviceid"/><setvalue event="xforms-ready" ref="/data/meta/timeStart" value="now()"/><bind nodeset="/data/meta/timeStart" type="xsd:dateTime"/><setvalue event="xforms-revalidate" ref="/data/meta/timeEnd" value="now()"/><bind nodeset="/data/meta/timeEnd" type="xsd:dateTime"/><setvalue event="xforms-ready" ref="/data/meta/username" value="instance('commcaresession')/session/context/username"/><setvalue event="xforms-ready" ref="/data/meta/userID" value="instance('commcaresession')/session/context/userid"/><setvalue event="xforms-ready" ref="/data/meta/instanceID" value="uuid()"/><setvalue event="xforms-ready" ref="/data/meta/appVersion" value="instance('commcaresession')/session/context/appversion"/></model>
+	</h:head>
+	<h:body>
+		<input ref="/data/parent_name">
+			<label ref="jr:itext('parent_name-label')"/>
+		</input>
+		<group>
+			<label ref="jr:itext('children-label')"/>
+			<repeat nodeset="/data/children">
+				<select1 ref="/data/children/which_child">
+					<label ref="jr:itext('which_child-label')"/>
+					<item>
+						<label ref="jr:itext('which_child-1-label')"/>
+						<value>1</value>
+					</item>
+					<item>
+						<label ref="jr:itext('which_child-2-label')"/>
+						<value>2</value>
+					</item>
+				</select1>
+				<input ref="/data/children/child_name">
+					<label ref="jr:itext('child_name-label')"/>
+				</input>
+			</repeat>
+		</group>
+	</h:body>
+</h:html>

--- a/corehq/apps/app_manager/tests/test_form_preparation_v2.py
+++ b/corehq/apps/app_manager/tests/test_form_preparation_v2.py
@@ -79,15 +79,19 @@ class FormPreparationV2Test(FormPrepBase):
 class SubcaseRepeatTest(FormPrepBase):
     file_path = ('data', 'form_preparation_v2')
 
-    def setUp(self):
-        self.app = Application.wrap(self.get_json('subcase-repeat'))
-
     def test_subcase_repeat(self):
+        self.app = Application.wrap(self.get_json('subcase-repeat'))
         self.app.case_sharing = False
         self.assert_xml_equiv(self.app.get_module(0).get_form(0).render_xform(),
                               self.get_xml('subcase-repeat'))
 
     def test_subcase_repeat_sharing(self):
+        self.app = Application.wrap(self.get_json('subcase-repeat'))
         self.app.case_sharing = True
         self.assert_xml_equiv(self.app.get_module(0).get_form(0).render_xform(),
                               self.get_xml('subcase-repeat-sharing'))
+
+    def test_subcase_multiple_repeats(self):
+        self.app = Application.wrap(self.get_json('multiple_subcase_repeat'))
+        self.assert_xml_equiv(self.app.get_module(0).get_form(0).render_xform(),
+                              self.get_xml('multiple_subcase_repeat'))


### PR DESCRIPTION
This is useful if you want to have a repeat that is as follows:
- What kind of subcase would you like to open
- questions specific to that case type

And case config like
- if "What kind of subcase would you like to open" is "foo" then open into module Foo
- if "What kind of subcase would you like to open" is "bar" then open into module Bar
- etc.

Each of those case types will have different configuration and so the case block will need to be stored at separate paths. I chose to continue the `subcase_0`, `subcase_1`, etc convention.
