### PR TITLE
Update requests lib to 2.0

### DIFF
--- a/requirements/docs-requirements.txt
+++ b/requirements/docs-requirements.txt
@@ -14,7 +14,7 @@ unittest2
 openpyxl==1.5.6
 Pillow==2.0.0
 simplejson==2.6.1
-requests==1.1.0
+requests==2.0.0
 lxml==3.2.1
 python-magic==0.4.2
 sorl-thumbnail==11.12

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -36,7 +36,7 @@ python-memcached==1.47
 pytz==2011b
 PyYAML==3.10
 raven==3.1.10
-requests==1.1.0
+requests==2.0.0
 south==0.7.3
 sorl-thumbnail==11.12
 tropo-webapi-python==0.1.3


### PR DESCRIPTION
I read the changelog and browsed through our uses of the lib, the version change didn't affect any of the API we use.
