### PR TITLE
Multimedia hotfixes for bad attachment errors

### DIFF
--- a/corehq/apps/hqmedia/controller.py
+++ b/corehq/apps/hqmedia/controller.py
@@ -50,12 +50,6 @@ class MultimediaBulkUploadController(BaseMultimediaUploadController):
     details_template = "hqmedia/uploader/details_multi.html"
 
     @property
-    def upload_params(self):
-        return {
-            'replace_existing': False,
-        }
-
-    @property
     def supported_files(self):
         return [
             {

--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -3,12 +3,11 @@ import mimetypes
 from PIL import Image
 from datetime import datetime
 import hashlib
-from couchdbkit.exceptions import ResourceConflict, ResourceNotFound
+from couchdbkit.exceptions import ResourceConflict
 from couchdbkit.ext.django.schema import *
 from couchdbkit.schema import LazyDict
 from django.contrib import messages
 from django.core.urlresolvers import reverse
-import logging
 import magic
 from corehq.apps.app_manager.xform import XFormValidationError
 from couchforms.models import XFormError

--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -1,4 +1,5 @@
 from StringIO import StringIO
+import logging
 import mimetypes
 from PIL import Image
 from datetime import datetime
@@ -103,7 +104,13 @@ class CommCareMultimedia(SafeSaveDocument):
 
         if not self._attachments or attachment_id not in self._attachments:
             if not getattr(self, '_id'):
-                self.save()  # let's just make sure an id has been assigned to this guy before we try to put_attachment
+                # put attchment blows away existing data, so make sure an id has been
+                # assigned to this guy before we do it. this is the expected path
+                self.save()
+            else:
+                # this should only be files that had attachments deleted while the bug
+                # was in effect, so hopefully we will stop seeing it after a few days
+                logging.error('someone is uploading a file that should have existed for multimedia %s' % self._id)
             self.put_attachment(data, attachment_id, content_type=self.get_mime_type(data, filename=original_filename))
         new_media = AuxMedia()
         new_media.uploaded_date = datetime.utcnow()

--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -93,7 +93,7 @@ class CommCareMultimedia(SafeSaveDocument):
         return reverse("hqmedia_download", args=[self.doc_type, self._id])
 
     def attach_data(self, data, original_filename=None, username=None, attachment_id=None,
-                    media_meta=None, replace_attachment=False):
+                    media_meta=None):
         """
         This creates the auxmedia attachment with the downloaded data.
         """
@@ -295,8 +295,7 @@ class CommCareImage(CommCareMultimedia):
     class Config(object):
         search_view = 'hqmedia/image_search'
 
-    def attach_data(self, data, original_filename=None, username=None, attachment_id=None, media_meta=None,
-                    replace_attachment=False):
+    def attach_data(self, data, original_filename=None, username=None, attachment_id=None, media_meta=None):
         image = self.get_image_object(data)
         attachment_id = "%dx%d" % image.size
         attachment_id = "%s-%s.%s" % (self.file_hash, attachment_id, image.format)
@@ -307,8 +306,7 @@ class CommCareImage(CommCareMultimedia):
             "height": image.size[1]
         }
         return super(CommCareImage, self).attach_data(data, original_filename=original_filename, username=username,
-                                                      attachment_id=attachment_id, media_meta=media_meta,
-                                                      replace_attachment=replace_attachment)
+                                                      attachment_id=attachment_id, media_meta=media_meta)
 
     @classmethod
     def get_image_object(cls, data):

--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -40,7 +40,7 @@ class HQMediaLicense(DocumentSchema):
 
 class CommCareMultimedia(SafeSaveDocument):
     """
-        The base object of all CommCare Multimedia
+    The base object of all CommCare Multimedia
     """
     file_hash = StringProperty()  # use this to search for multimedia in couch
     aux_media = SchemaListProperty(AuxMedia)
@@ -94,37 +94,28 @@ class CommCareMultimedia(SafeSaveDocument):
     def attach_data(self, data, original_filename=None, username=None, attachment_id=None,
                     media_meta=None, replace_attachment=False):
         """
-            This creates the auxmedia attachment with the downloaded data.
+        This creates the auxmedia attachment with the downloaded data.
         """
         self.last_modified = datetime.utcnow()
-        is_update = False
 
         if not attachment_id:
             attachment_id = self.file_hash
 
-        if (attachment_id in self.current_attachments) and replace_attachment:
-            self.delete_attachment(attachment_id)
-            for aux in self.aux_media:
-                if aux.attachment_id == attachment_id:
-                    self.aux_media.remove(aux)
-
-        if not attachment_id in self.current_attachments:
+        if not self._attachments or attachment_id not in self._attachments:
             if not getattr(self, '_id'):
                 self.save()  # let's just make sure an id has been assigned to this guy before we try to put_attachment
             self.put_attachment(data, attachment_id, content_type=self.get_mime_type(data, filename=original_filename))
-            new_media = AuxMedia()
-            new_media.uploaded_date = datetime.utcnow()
-            new_media.attachment_id = attachment_id
-            new_media.uploaded_filename = original_filename
-            new_media.uploaded_by = username
-            new_media.checksum = self.file_hash
-            if media_meta:
-                new_media.media_meta = media_meta
-            self.aux_media.append(new_media)
-            self.save()
-            is_update = True
-
-        return is_update
+        new_media = AuxMedia()
+        new_media.uploaded_date = datetime.utcnow()
+        new_media.attachment_id = attachment_id
+        new_media.uploaded_filename = original_filename
+        new_media.uploaded_by = username
+        new_media.checksum = self.file_hash
+        if media_meta:
+            new_media.media_meta = media_meta
+        self.aux_media.append(new_media)
+        self.save()
+        return True
 
     def add_domain(self, domain, owner=None, **kwargs):
         if len(self.owners) == 0:

--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -151,12 +151,10 @@ class CommCareMultimedia(SafeSaveDocument):
         self.save()
 
     def get_display_file(self, return_type=True):
-        all_ids = self.current_attachments
-        if all_ids:
-            first_id = all_ids[0]
-            data = self.fetch_attachment(first_id, True).read()
+        if self.attachment_id:
+            data = self.fetch_attachment(self.attachment_id, True).read()
             if return_type:
-                content_type = self._attachments[first_id]['content_type']
+                content_type = self._attachments[self.attachment_id]['content_type']
                 return data, content_type
             else:
                 return data
@@ -175,8 +173,12 @@ class CommCareMultimedia(SafeSaveDocument):
         }
 
     @property
-    def current_attachments(self):
-        return [aux.attachment_id for aux in self.aux_media]
+    def attachment_id(self):
+        if not self.aux_media:
+            return None
+        ids = set([aux.attachment_id for aux in self.aux_media])
+        assert len(ids) == 1
+        return ids.pop()
 
     @classmethod
     def get_mime_type(cls, data, filename=None):

--- a/corehq/apps/hqmedia/tasks.py
+++ b/corehq/apps/hqmedia/tasks.py
@@ -90,8 +90,7 @@ def process_bulk_upload_zip(processing_id, domain, app_id, username=None, share_
             is_new = not form_path in app.multimedia_map.keys()
             is_updated = multimedia.attach_data(data,
                                                 original_filename=file_name,
-                                                username=username,
-                                                replace_attachment=replace_existing)
+                                                username=username)
 
             if not is_updated and not getattr(multimedia, '_id'):
                 status.add_unmatched_path(form_path,

--- a/corehq/apps/hqmedia/tasks.py
+++ b/corehq/apps/hqmedia/tasks.py
@@ -14,7 +14,7 @@ logging = get_task_logger(__name__)
 
 @task
 def process_bulk_upload_zip(processing_id, domain, app_id, username=None, share_media=False,
-                            license_name=None, author=None, attribution_notes=None, replace_existing=False):
+                            license_name=None, author=None, attribution_notes=None):
     """
         Responsible for processing the uploaded zip from Bulk Upload.
     """

--- a/corehq/apps/hqmedia/templates/hqmedia/bulk_upload.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/bulk_upload.html
@@ -47,7 +47,7 @@
             </div>
             <div class="form-horizontal hqm-upload-form">
                 <div class="modal-body">
-                    {% include 'hqmedia/partials/hqm_upload_form_multi.html' %}
+                    {% include 'hqmedia/partials/hqm_upload_form.html' %}
                 </div>
                 <div class="modal-footer">
                     <a class="hqm-upload hqm-upload-confirm btn disabled">

--- a/corehq/apps/hqmedia/templates/hqmedia/partials/hqm_upload_form_multi.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/partials/hqm_upload_form_multi.html
@@ -2,13 +2,4 @@
 
 {% load i18n %}
 {% block additional_options %}
-    <div class="control-group">
-        <label class="control-label">{% trans 'Override Existing' %}</label>
-        <div class="controls">
-            <label class="checkbox">
-                <input name="replace_existing" type="checkbox" />
-                {% trans 'Yes, replace any existing multimedia with media from this upload.' %}
-            </label>
-        </div>
-    </div>
 {% endblock %}

--- a/corehq/apps/hqmedia/templates/hqmedia/partials/hqm_upload_form_multi.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/partials/hqm_upload_form_multi.html
@@ -1,5 +1,0 @@
-{% extends 'hqmedia/partials/hqm_upload_form.html' %}
-
-{% load i18n %}
-{% block additional_options %}
-{% endblock %}

--- a/corehq/apps/hqmedia/views.py
+++ b/corehq/apps/hqmedia/views.py
@@ -263,10 +263,6 @@ class ProcessBulkUploadView(BaseProcessUploadedView):
     name = "hqmedia_uploader_bulk"
 
     @property
-    def replace_existing(self):
-        return self.request.POST.get('replace_existing') == 'true'
-
-    @property
     @memoized
     def uploaded_zip(self):
         try:
@@ -297,8 +293,7 @@ class ProcessBulkUploadView(BaseProcessUploadedView):
                                       share_media=self.share_media,
                                       license_name=self.license_used,
                                       author=self.author,
-                                      attribution_notes=self.attribution_notes,
-                                      replace_existing=self.replace_existing)
+                                      attribution_notes=self.attribution_notes)
         return status.get_response()
 
     @classmethod

--- a/corehq/apps/hqmedia/views.py
+++ b/corehq/apps/hqmedia/views.py
@@ -343,8 +343,7 @@ class BaseProcessFileUploadView(BaseProcessUploadedView):
         multimedia = self.media_class.get_by_data(data)
         multimedia.attach_data(data,
                                original_filename=self.uploaded_file.name,
-                               username=self.username,
-                               replace_attachment=True)
+                               username=self.username)
         multimedia.add_domain(self.domain, owner=True)
         if self.share_media:
             multimedia.update_or_add_license(self.domain,


### PR DESCRIPTION
This should fix Case:78348 from getting triggered again (though we still have to reupload the bad files). was a pretty hilarious set of circumstances causing it to fail.

probably easiest to read commit by commit. the second commit has the fix, and the rest is cleanup
