### PR TITLE
guard against jankiness

### DIFF
--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -431,9 +431,15 @@ def datespan_from_beginning(domain, default_days, timezone):
     return datespan
 
 def get_installed_custom_modules_names():
+    # todo: don't depend on the django process being started from the django
+    # root directory
     path = os.path.dirname('custom/apps/')
+    if not os.path.exists(path):
+        return []
+
     installed_custom_module_names = []
 
+    # todo: don't inspect modules using file structure
     for module in os.listdir(path):
         if os.path.isdir(path + '/' + module) == True and os.path.exists(path + '/' + module + '/urls.py') and 'urlpatterns' in open(path + '/' + module + '/urls.py').read():
             installed_custom_module_names.append(module)


### PR DESCRIPTION
test.commcarehq.org no longer works because of this code, I presume
because the command that starts the django process isn't run from the
django root directory.

This change just guards against that.  We really should not be doing any
of this gleaning the available modules from the filesystem.

In addition, the existing report framework provides a reasonably good
interface for just making whatever sort of pages you want, and hooking
that into the URL dispatcher as an extension of the normal report
dispatching, and it also provides a central place to manage permissions
and such, so I'm a little worried that we're making a separate entry
point for other custom apps.

Even if we something separate from the report dispatcher it would be
better to have the interface be at a higher level of abstraction than
the URL router.
