### PR TITLE
parse async location hierarchy as JSON

### DIFF
--- a/corehq/apps/reports/templates/reports/fields/drillable_async.html
+++ b/corehq/apps/reports/templates/reports/fields/drillable_async.html
@@ -1,3 +1,4 @@
+{% load hq_shared_tags %}
 <label class="control-label">{{ control_name }}</label>
 <div class="controls">
     <div data-bind="foreach: selected_path" style="display: inline-block;">
@@ -10,7 +11,7 @@
 <script type="text/javascript">
 
     var LOAD_FDIS_URL = '{{ api_root }}';
-    var hierarchy = {{ hierarchy|safe }};
+    var hierarchy = {{ hierarchy|JSON }};
 
     function api_get_children(fdi_uuid, depth, callback) {
         var params = (fdi_uuid ? {parent_id: fdi_uuid} : {});

--- a/corehq/apps/reports/templates/reports/filters/drillable_async.html
+++ b/corehq/apps/reports/templates/reports/filters/drillable_async.html
@@ -1,4 +1,5 @@
 {# todo: clean this up to properly inherit from filters/base.html #}
+{% load hq_shared_tags %}
 
 <label class="control-label">{{ control_name }}</label> {# this is wrong, this should be inheriting the structure from filters/base.html, see base/drilldown_options #}
 <div class="controls">
@@ -12,7 +13,7 @@
 <script type="text/javascript">
 
     var LOAD_FDIS_URL = '{{ api_root }}';
-    var hierarchy = {{ hierarchy|safe }};
+    var hierarchy = {{ hierarchy|JSON }};
 
     function api_get_children(fdi_uuid, depth, callback) {
         var params = (fdi_uuid ? {parent_id: fdi_uuid} : {});

--- a/corehq/apps/reports/templates/reports/filters/multi_location.html
+++ b/corehq/apps/reports/templates/reports/filters/multi_location.html
@@ -2,6 +2,7 @@
 {#        Displays all fields simoltaneously, without needing to drilling-down, #}
 {#        where parent nodes are unknown.  #}
 {# todo: clean this up to properly inherit from filters/base.html #}
+{% load hq_shared_tags %}
 
 <label class="control-label">{{ control_name }}</label> {# this is wrong, this should be inheriting the structure from filters/base.html, see base/drilldown_options #}
 <div class="controls">
@@ -15,7 +16,7 @@
 <script type="text/javascript">
 
     var LOAD_FDIS_URL = '{{ api_root }}';
-    var hierarchy = {{ hierarchy|safe }};
+    var hierarchy = {{ hierarchy|JSON }};
     var selected = '{{ selected_fdi_id|safe }}';
 
     function api_get_children(fdi_uuid, depth, callback) {


### PR DESCRIPTION
@dannyroberts This change to jsonobject caused it to break (though it should have been JSON all along): https://github.com/dannyroberts/jsonobject/commit/baf31285ff187d855e4fe60f0d88d147221cd050
