### PR TITLE
Reportcase xform dict handling fix

### DIFF
--- a/corehq/apps/hqcase/tests/__init__.py
+++ b/corehq/apps/hqcase/tests/__init__.py
@@ -3,7 +3,6 @@ try:
     from .test_bugs import *
     from .test_force_close import *
     from .test_case_sharing import *
-    from .test_pillows import *
     from .test_object_cache import *
 except ImportError, e:
     # for some reason the test harness squashes these so log them here for clarity

--- a/corehq/apps/reports/tests/__init__.py
+++ b/corehq/apps/reports/tests/__init__.py
@@ -7,6 +7,7 @@ try:
     from corehq.apps.reports.tests.test_form_export import *
     from corehq.apps.reports.tests.test_report_api import *
     from corehq.apps.reports.tests.test_data_sources import *
+    from .test_pillows import *
 except ImportError, e:
     # for some reason the test harness squashes these so log them here for clarity
     # otherwise debugging is a pain

--- a/corehq/apps/reports/tests/__init__.py
+++ b/corehq/apps/reports/tests/__init__.py
@@ -7,7 +7,8 @@ try:
     from corehq.apps.reports.tests.test_form_export import *
     from corehq.apps.reports.tests.test_report_api import *
     from corehq.apps.reports.tests.test_data_sources import *
-    from .test_pillows import *
+    from .test_pillows_xforms import *
+    from .test_pillows_cases import *
 except ImportError, e:
     # for some reason the test harness squashes these so log them here for clarity
     # otherwise debugging is a pain

--- a/corehq/apps/reports/tests/test_pillows.py
+++ b/corehq/apps/reports/tests/test_pillows.py
@@ -1,0 +1,206 @@
+from django.utils.unittest.case import TestCase
+from django.conf import settings
+import simplejson
+from corehq.pillows.base import restore_property_dict
+
+from corehq.pillows.reportxform import ReportXFormPillow
+
+
+CONCEPT_XFORM =  {
+   "_id": "concept_xform",
+   "domain": "test-domain",
+   "form": {
+       "@xmlns": "http://openrosa.org/formdesigner/test_concepts",
+       "@uiVersion": "1",
+       "@name": "Visit",
+       "last_visit": "2013-09-01",
+       "any_other_sick": {
+           "#text": "no",
+           "@concept_id": "1907"
+       },
+       "cur_num_fp": "2",
+       "#type": "data",
+       "cur_counsel_topics": "bednet handwashing",
+       "case": {
+           "@xmlns": "http://commcarehq.org/case/transaction/v2",
+           "@date_modified": "2013-09-01T11:02:34Z",
+           "@user_id": "abcde",
+           "@case_id": "test_case_123345",
+           "update": {
+               "location_code": "",
+               "last_visit_counsel_topics": "bednet handwashing",
+               "last_visit": "2013-10-09",
+               "num_ec": "2"
+           }
+       },
+       "member_available": {
+           "#text": "yes",
+           "@concept_id": "1890"
+       },
+       "modern_fp": [
+           {
+               "fp_type": {
+                   "#text": "iud",
+                   "@concept_id": "374"
+               }
+           },
+           {
+               "fp_type": {
+                   "#text": "ij",
+                   "@concept_id": "374"
+               }
+           }
+       ],
+       "meta": {
+           "@xmlns": "http://openrosa.org/jr/xforms",
+           "username": "airene",
+           "instanceID": "some_form",
+           "userID": "some_user",
+           "timeEnd": "2013-09-09T11:02:34Z",
+           "appVersion": {
+               "@xmlns": "http://commcarehq.org/xforms",
+               "#text": "some version"
+           },
+           "timeStart": "2013-09-01T11:22:40Z",
+           "deviceID": "unittests"
+       },
+       "num_using_fp": {
+           "#text": "2",
+           "@concept_id": "1902"
+       },
+       "location_code_1": "",
+       "counseling": {
+           "sanitation_counseling": {
+               "handwashing_importance": "",
+               "handwashing_instructions": "",
+               "when_to_wash_hands": ""
+           },
+           "counsel_type_ec": "bednet handwashing",
+           "previous_counseling": "OK",
+           "bednet_counseling": {
+               "bednets_reduce_risk": "",
+               "wash_bednet": "",
+               "all_people_bednet": ""
+           }
+       },
+       "prev_location_code": "",
+       "@version": "234",
+       "num_ec": {
+           "#text": "2",
+           "@concept_id": "1901"
+       },
+       "prev_counsel_topics": "handwashing"
+   },
+   "initial_processing_complete": True,
+   "computed_modified_on_": "2013-10-01T23:13:38Z",
+   "app_id": "some_app",
+   "auth_context": {
+       "user_id": None,
+       "domain": "some-domain",
+       "authenticated": False,
+       "doc_type": "AuthContext"
+   },
+   "doc_type": "XFormInstance",
+   "xmlns": "http://openrosa.org/formdesigner/something",
+   "partial_submission": False,
+   "#export_tag": [
+       "domain",
+       "xmlns"
+   ],
+   "received_on": "2013-10-09T14:21:56Z",
+   "submit_ip": "105.230.106.73",
+   "computed_": {},
+   "openrosa_headers": {
+       "HTTP_X_OPENROSA_VERSION": "1.0"
+   },
+   "history": [
+   ]
+}
+
+
+
+class testReportPillows(TestCase):
+
+    def testConvertAndRestoreReportXFormDicts(self):
+        pillow = ReportXFormPillow(online=False)
+        orig = CONCEPT_XFORM
+        orig['domain'] = settings.ES_XFORM_FULL_INDEX_DOMAINS[0]
+        for_indexing = pillow.change_transform(orig)
+
+        restored = restore_property_dict(for_indexing)
+
+        #appVersion might be munged in meta, so swapping it out
+        orig_appversion = orig['form']['meta']['appVersion']
+        restored_appversion = restored['form']['meta']['appVersion']
+        if isinstance(orig_appversion, dict):
+            self.assertEqual(restored_appversion, orig_appversion['#text'])
+        else:
+            self.assertEqual(restored_appversion, orig_appversion)
+
+        del(orig['form']['meta']['appVersion'])
+        del(restored['form']['meta']['appVersion'])
+
+        self.assertNotEqual(for_indexing, orig)
+        self.assertNotEqual(for_indexing, restored)
+
+        self.assertEqual(orig, restored)
+
+
+    def testConceptReportConversion(self):
+        pillow = ReportXFormPillow(online=False)
+        orig = CONCEPT_XFORM
+        orig['domain'] = settings.ES_XFORM_FULL_INDEX_DOMAINS[0]
+        for_indexing = pillow.change_transform(orig)
+
+        self.assertTrue(isinstance(for_indexing['form']['last_visit'], dict))
+        self.assertTrue('#value' in for_indexing['form']['last_visit'])
+
+        self.assertTrue(isinstance(for_indexing['form']['member_available'], dict))
+        self.assertTrue(isinstance(for_indexing['form']['member_available']['#text'], dict))
+        self.assertTrue(isinstance(for_indexing['form']['member_available']['@concept_id'], dict))
+
+        self.assertEqual(for_indexing['form']['member_available'],
+                         {
+                             "#text": {
+                                 "#value": "yes"
+                             },
+                             "@concept_id": {
+                                 "#value": "1890"
+                             }
+                         }
+        )
+        self.assertEqual(for_indexing['form']['modern_fp'],
+                         [
+                             {
+                                 "fp_type": {
+                                     "#text": {
+                                         "#value": "iud"
+                                     },
+                                     "@concept_id": {
+                                         "#value": "374"
+                                     }
+                                 }
+                             },
+                             {
+                                 "fp_type": {
+                                     "#text": {
+                                         "#value": "ij"
+                                     },
+                                     "@concept_id": {
+                                         "#value": "374"
+                                     }
+                                 }
+                             }
+                         ]
+        )
+
+
+
+
+
+
+
+
+
+
+

--- a/corehq/apps/reports/tests/test_pillows_cases.py
+++ b/corehq/apps/reports/tests/test_pillows_cases.py
@@ -1,6 +1,7 @@
 from django.utils.unittest.case import TestCase
 import simplejson
 from casexml.apps.case.xform import extract_case_blocks
+from corehq.pillows.base import VALUE_TAG
 from corehq.pillows.case import CasePillow
 from corehq.pillows.reportcase import ReportCasePillow
 from corehq.pillows.reportxform import ReportXFormPillow
@@ -446,7 +447,7 @@ EXAMPLE_CASE = {
 }
 
 
-class testPillowTopProcessing(TestCase):
+class testReportCaseProcessing(TestCase):
     def testXFormMapping(self):
         """
         Verify that a simple case doc will yield the basic mapping
@@ -538,8 +539,11 @@ class testPillowTopProcessing(TestCase):
         self.assertEqual(processed_case['actions'][0]['doc_type'], case['actions'][0]['doc_type'])
 
         #dynamic case properties #valued
-        self.assertEqual(processed_case['last_poop'].get('#value'), case['last_poop'])
-        self.assertEqual(processed_case['diaper_type'].get('#value'), case['diaper_type'])
-        self.assertTrue(isinstance(processed_case['prior_diapers'].get('#value', None), list))
-        self.assertEqual(processed_case['prior_diapers'].get('#value', None), case['prior_diapers'])
+        self.assertEqual(processed_case['last_poop'].get(VALUE_TAG), case['last_poop'])
+        self.assertEqual(processed_case['diaper_type'].get(VALUE_TAG), case['diaper_type'])
+        self.assertTrue(isinstance(processed_case['prior_diapers'], list))
+        for diaper in processed_case['prior_diapers']:
+            self.assertTrue(VALUE_TAG in diaper)
+
+        self.assertEqual(case['prior_diapers'], [x[VALUE_TAG] for x in processed_case['prior_diapers']])
 

--- a/corehq/apps/reports/tests/test_pillows_xforms.py
+++ b/corehq/apps/reports/tests/test_pillows_xforms.py
@@ -119,8 +119,7 @@ CONCEPT_XFORM =  {
 
 
 
-class testReportPillows(TestCase):
-
+class testReportXFormProcessing(TestCase):
     def testConvertAndRestoreReportXFormDicts(self):
         pillow = ReportXFormPillow(online=False)
         orig = CONCEPT_XFORM

--- a/corehq/pillows/base.py
+++ b/corehq/pillows/base.py
@@ -5,7 +5,15 @@ from django.conf import settings
 
 VALUE_TAG = '#value'
 
-def convert_properties(sub_dict, mapping, override_root_keys=None):
+def map_types(item, mapping):
+    if isinstance(item, dict):
+        return convert_property_dict(item, mapping)
+    elif isinstance(item, list):
+        return [map_types(x, mapping) for x in item]
+    elif isinstance:
+        return {VALUE_TAG: item}
+
+def convert_property_dict(sub_dict, mapping, override_root_keys=None):
     """
     For mapping out ALL nested properties on cases, convert everything to a dict so as to
     prevent string=>object and object=>string mapping errors.
@@ -20,14 +28,35 @@ def convert_properties(sub_dict, mapping, override_root_keys=None):
     for k, v in sub_dict.items():
         if k in mapping.get('properties', {}) or k in override_root_keys:
             continue
-
-        if isinstance(v, dict):
-            if mapping.get('dynamic', False):
-                #only transmogrify stuff if it's explicitly set to dynamic
-                sub_dict[k] = convert_properties(v, mapping.get('properties', {}).get(k, {}))
-        else:
-            sub_dict[k] = {VALUE_TAG: v}
+        dynamic_mapping = mapping.get('dynamic', 'notset')
+        sub_mapping = mapping.get('properties', {}).get(k, {})
+        if dynamic_mapping is not False:
+            sub_dict[k] = map_types(v, sub_mapping)
     return sub_dict
+
+def restore_property_dict(report_dict_item):
+    """
+    Revert a converted/retrieved document from Report<index> and deconvert all its properties
+    back from {#value: <val>} to just <val>
+    """
+    restored = {}
+    if not isinstance(report_dict_item, dict):
+        return report_dict_item
+
+    for k, v in report_dict_item.items():
+        if isinstance(v, list):
+            restored[k] = [restore_property_dict(x) for x in v]
+        elif isinstance(v, dict):
+            if VALUE_TAG in v:
+                restored[k] = v[VALUE_TAG]
+            else:
+                restored[k] = restore_property_dict(v)
+        else:
+            #not a dict, so it's the "passed over" types
+            restored[k] = v
+
+    return restored
+
 
 
 class HQPillow(AliasedElasticPillow):

--- a/corehq/pillows/base.py
+++ b/corehq/pillows/base.py
@@ -10,7 +10,7 @@ def map_types(item, mapping):
         return convert_property_dict(item, mapping)
     elif isinstance(item, list):
         return [map_types(x, mapping) for x in item]
-    elif isinstance:
+    else:
         return {VALUE_TAG: item}
 
 def convert_property_dict(sub_dict, mapping, override_root_keys=None):
@@ -28,7 +28,7 @@ def convert_property_dict(sub_dict, mapping, override_root_keys=None):
     for k, v in sub_dict.items():
         if k in mapping.get('properties', {}) or k in override_root_keys:
             continue
-        dynamic_mapping = mapping.get('dynamic', 'notset')
+        dynamic_mapping = mapping.get('dynamic', True)
         sub_mapping = mapping.get('properties', {}).get(k, {})
         if dynamic_mapping is not False:
             sub_dict[k] = map_types(v, sub_mapping)
@@ -52,7 +52,6 @@ def restore_property_dict(report_dict_item):
             else:
                 restored[k] = restore_property_dict(v)
         else:
-            #not a dict, so it's the "passed over" types
             restored[k] = v
 
     return restored

--- a/corehq/pillows/reportcase.py
+++ b/corehq/pillows/reportcase.py
@@ -2,7 +2,7 @@ import copy
 from corehq.pillows.case import CasePillow
 from corehq.pillows.mappings.reportcase_mapping import REPORT_CASE_MAPPING, REPORT_CASE_INDEX
 from django.conf import settings
-from .base import convert_properties
+from .base import convert_property_dict
 
 
 class ReportCasePillow(CasePillow):
@@ -23,5 +23,5 @@ class ReportCasePillow(CasePillow):
             #full indexing is only enabled for select domains on an opt-in basis
             return None
         doc_ret = copy.deepcopy(doc_dict)
-        convert_properties(doc_ret, self.default_mapping, override_root_keys=['_id', 'doc_type', '_rev', '#export_tag'])
+        convert_property_dict(doc_ret, self.default_mapping, override_root_keys=['_id', 'doc_type', '_rev', '#export_tag'])
         return doc_ret

--- a/corehq/pillows/reportxform.py
+++ b/corehq/pillows/reportxform.py
@@ -1,9 +1,5 @@
-import copy
-
 from django.conf import settings
 
-from casexml.apps.case.xform import extract_case_blocks
-from corehq.pillows.base import convert_properties
 from corehq.pillows.base import convert_property_dict
 from .mappings.reportxform_mapping import REPORT_XFORM_INDEX, REPORT_XFORM_MAPPING
 from .xform import XFormPillow
@@ -35,7 +31,7 @@ class ReportXFormPillow(XFormPillow):
                 return None
 
             #after basic transforms for stupid type mistakes are done, walk all properties.
-            convert_properties(doc_ret['form'], self.default_mapping['properties']['form'], override_root_keys=['case'])
+            convert_property_dict(doc_ret['form'], self.default_mapping['properties']['form'], override_root_keys=['case'])
             return doc_ret
         else:
             return None

--- a/corehq/pillows/reportxform.py
+++ b/corehq/pillows/reportxform.py
@@ -4,6 +4,7 @@ from django.conf import settings
 
 from casexml.apps.case.xform import extract_case_blocks
 from corehq.pillows.base import convert_properties
+from corehq.pillows.base import convert_property_dict
 from .mappings.reportxform_mapping import REPORT_XFORM_INDEX, REPORT_XFORM_MAPPING
 from .xform import XFormPillow
 


### PR DESCRIPTION
basic issue was that arrays of dicts were not handled well when trying to "make everything a dict" for elasticsearch indexing.

Also adding conversion back. aim is to replace fullxforms and fullcases.
