### PR TITLE
adding explicit list of cacheable documents

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -871,6 +871,16 @@ for k, v in  LOCAL_PILLOWTOPS.items():
     plist.extend(v)
     PILLOWTOPS[k] = plist
 
+COUCH_CACHE_BACKENDS = [
+    'corehq.apps.cachehq.cachemodels.DomainGenerationCache',
+    'corehq.apps.cachehq.cachemodels.UserGenerationCache',
+    'corehq.apps.cachehq.cachemodels.GroupGenerationCache',
+    'corehq.apps.cachehq.cachemodels.UserRoleGenerationCache',
+    'corehq.apps.cachehq.cachemodels.TeamGenerationCache',
+    'corehq.apps.cachehq.cachemodels.ReportGenerationCache',
+    'dimagi.utils.couch.cache.cache_core.gen.GlobalCache',
+]
+
 #Custom workflow for indexing xform data beyond the standard properties
 XFORM_PILLOW_HANDLERS = ['pact.pillowhandler.PactHandler', ]
 


### PR DESCRIPTION
**subclasses** lookup didn't seem to work.
1: too magical (my bad)
and 2: celery bootstrap doesn't bootstrap the way we expect, so the assumptions for all the subclasses to show up wasn't right. this correctly now bootstraps and gets all generational caching bits working now in a celeyr environment.
