### PR TITLE
make case list icons a little bit wider

### DIFF
--- a/corehq/apps/app_manager/detail_screen.py
+++ b/corehq/apps/app_manager/detail_screen.py
@@ -282,7 +282,7 @@ class Enum(FormattedDetailColumn):
 @register_format_type('enum-image')
 class EnumImage(Enum):
     template_form = 'image'
-    template_width = '10%'
+    template_width = '13%'
 
 
 @register_format_type('late-flag')


### PR DESCRIPTION
changing to 13% which is what gates uses
would ideally be either smart or configurable
but not a big issue now
