### PR TITLE
enable exporting the form ids in the call log report

### DIFF
--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -822,6 +822,14 @@ class GenericTabularReport(GenericReportView):
 
     @property
     def export_table(self):
+        """
+        Exports the report as excel.
+
+        When rendering a complex cell, it will assign a value in the following order:
+        1. cell['raw']
+        2. cell['sort_key']
+        3. str(cell)
+        """
         try:
             import xlwt
         except ImportError:
@@ -832,7 +840,12 @@ class GenericTabularReport(GenericReportView):
         formatted_rows = self.rows
 
         def _unformat_row(row):
-            return [col.get("sort_key", col) if isinstance(col, dict) else col for col in row]
+            def _unformat_val(val):
+                if isinstance(val, dict):
+                    return val.get('raw', val.get('sort_key', val))
+                return val
+
+            return [_unformat_val(val) for val in row]
 
         table = headers.as_table
         rows = [_unformat_row(row) for row in formatted_rows]

--- a/corehq/apps/reports/standard/ivr.py
+++ b/corehq/apps/reports/standard/ivr.py
@@ -146,7 +146,9 @@ class CallLogReport(ProjectReport, ProjectReportParametersMixin, GenericTabularR
     def _fmt_submission_link(self, submission_id):
         url = reverse("render_form_data", args=[self.domain, submission_id])
         display_text = _("View Submission")
-        return self.table_cell(display_text, '<a href="%s">%s</a>' % (url, display_text))
+        ret = self.table_cell(display_text, '<a href="%s">%s</a>' % (url, display_text))
+        ret['raw'] = submission_id
+        return ret
 
 class ExpectedCallbackReport(ProjectReport, ProjectReportParametersMixin, GenericTabularReport, DatespanMixin):
     """

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -203,7 +203,8 @@ def _report_user_dict(user):
 
 
 def format_datatables_data(text, sort_key):
-    # used below
+    # todo: this is redundant with report.table_cell()
+    # should remove/refactor one of them away
     data = {"html": text,
             "sort_key": sort_key}
     return data


### PR DESCRIPTION
adds a mechanism to override the export value + reference implementation
also add a todo
