### PR TITLE
have enums sort by the order they're in

### DIFF
--- a/corehq/apps/app_manager/detail_screen.py
+++ b/corehq/apps/app_manager/detail_screen.py
@@ -258,17 +258,34 @@ class Phone(FormattedDetailColumn):
 @register_format_type('enum')
 class Enum(FormattedDetailColumn):
 
-    @property
-    def xpath_function(self):
+    def _make_xpath(self, type):
+        if type == 'sort':
+            xpath_fragment_template = u"if({xpath} = '{key}', {i}, "
+        elif type == 'display':
+            xpath_fragment_template = u"if({xpath} = '{key}', $k{key}, "
+        else:
+            raise ValueError('type must be in sort, display')
+
         parts = []
-        for item in self.column.enum:
+        for i, item in enumerate(self.column.enum):
             parts.append(
-                u"if({xpath} = '{key}', $k{key}, ".format(key=item.key,
-                                                          xpath=self.xpath)
+                xpath_fragment_template.format(
+                    key=item.key,
+                    xpath=self.xpath,
+                    i=i,
+                )
             )
         parts.append(u"''")
         parts.append(u")" * len(self.column.enum))
         return ''.join(parts)
+
+    @property
+    def xpath_function(self):
+        return self._make_xpath(type='display')
+
+    @property
+    def sort_xpath_function(self):
+        return self._make_xpath(type='sort')
 
     @property
     def variables(self):

--- a/corehq/apps/app_manager/tests/data/suite/call-center.xml
+++ b/corehq/apps/app_manager/tests/data/suite/call-center.xml
@@ -69,6 +69,11 @@
           </xpath>
         </text>
       </template>
+      <sort type="string">
+        <text>
+          <xpath function="if(debug_level = 'admin', 0, if(debug_level = 'call_center', 1, if(debug_level = 'ict_coord', 2, '')))"/>
+        </text>
+      </sort>
     </field>
     <field>
       <header width="0">

--- a/corehq/apps/app_manager/tests/data/suite/normal-suite.xml
+++ b/corehq/apps/app_manager/tests/data/suite/normal-suite.xml
@@ -99,6 +99,16 @@
                 <locale id="m0.case_short.case_enum_5.header"/>
             </text>
         </header>
+        <template width="0">
+            <text>
+                <xpath function="if(enum = 'a', 0, if(enum = 'b', 1, ''))"/>
+            </text>
+        </template>
+    </field>
+    <field>
+        <header width="0">
+            <text/>
+        </header>
         <template>
             <text>
                 <xpath function="if(enum = 'a', $ka, if(enum = 'b', $kb, ''))">


### PR DESCRIPTION
(now that they're stored as a list not a dict)
previous behavior was to sort by the text that shows up
