### PR TITLE
Add new excel field type option for integers

### DIFF
--- a/corehq/apps/importer/templates/importer/excel_fields.html
+++ b/corehq/apps/importer/templates/importer/excel_fields.html
@@ -107,7 +107,7 @@
                 <thead>
                     <th class="span1"></th>
                     <th>{% trans "Excel Field" %}</th>
-                    <th></th>
+                    <th>{% trans "Data Type" %}</th>
                     <th></th>
                     <th>{% trans "Case Property" %}</th>
                     <th></th>

--- a/corehq/apps/importer/templates/importer/partials/excel_field_row.html
+++ b/corehq/apps/importer/templates/importer/partials/excel_field_row.html
@@ -26,12 +26,12 @@
 </td>
 
 <td class="span3">
-    <label class="checkbox">
-        <input type="checkbox"
-               class="is_date"
-               name="is_date[]" />
-        {% trans "This field is a date" %}
-    </label>
+    <select name="type_field[]">
+        <option value="plain">{% trans "Plain" %}</option>
+        <option value="date">{% trans "Date" %}</option>
+        <option value="integer">{% trans "Integer" %}</option>
+        <option value="decimal">{% trans "Decimal" %}</option>
+    </select>
 </td>
 
 <td>

--- a/corehq/apps/importer/util.py
+++ b/corehq/apps/importer/util.py
@@ -32,7 +32,7 @@ class ImporterConfig(object):
         self.excel_fields = request.POST.getlist('excel_field[]')
         self.case_fields = request.POST.getlist('case_field[]')
         self.custom_fields = request.POST.getlist('custom_field[]')
-        self.date_fields = request.POST.getlist('is_date_field[]')
+        self.type_fields = request.POST.getlist('type_field[]')
 
         self.search_column = request.POST['search_column']
 
@@ -123,14 +123,16 @@ def convert_custom_fields_to_struct(config):
     excel_fields = config.excel_fields
     case_fields = config.case_fields
     custom_fields = config.custom_fields
-    date_fields = config.date_fields
+    type_fields = config.type_fields
 
     field_map = {}
     for i, field in enumerate(excel_fields):
         if field and (case_fields[i] or custom_fields[i]):
-            field_map[field] = {'case': case_fields[i],
-                                'custom': custom_fields[i],
-                                'is_date_field': date_fields[i] == 'true'}
+            field_map[field] = {
+                'case': case_fields[i],
+                'custom': custom_fields[i],
+                'type_field': type_fields[i]
+            }
 
     return field_map
 
@@ -260,8 +262,13 @@ def populate_updated_fields(config, columns, row):
             update_field_name = field_map[key]['case']
 
         if update_value:
-            if field_map[key]['is_date_field']:
+            if field_map[key]['type_field'] == 'date':
                 update_value = parse_excel_date(update_value)
+            elif field_map[key]['type_field'] == 'integer':
+                try:
+                    update_value = str(int(update_value))
+                except ValueError:
+                    update_value = ''
             else:
                 update_value = convert_field_value(update_value)
 


### PR DESCRIPTION
Since excel stores all numbers as decimals, the importer can cause problems with applications that are expecting integer types. Options are: Plain/Date/Integer/Decimal, decided to make it consistent with case list sorting types. Plain and decimal treat things the same as always.

![screen shot 2013-10-25 at 1 12 52 pm](https://f.cloud.github.com/assets/152134/1409787/ee1d1b6e-3d98-11e3-8f91-970ddd79be47.png)
