### PR TITLE
remove duplicates from saved custom form exports, if configured

### DIFF
--- a/corehq/apps/reports/models.py
+++ b/corehq/apps/reports/models.py
@@ -601,7 +601,24 @@ class HQGroupExportConfiguration(GroupExportConfiguration):
     HQ's version of a group export, tagged with a domain
     """
     domain = StringProperty()
-    
+
+    def get_custom_exports(self):
+
+        def _rewrap(export):
+            print 'rewrap'
+            # custom wrap if relevant
+            try:
+                return {
+                    'form': FormExportSchema,
+                }[export.type].wrap(export._doc)
+            except KeyError:
+                return export
+
+        for custom in list(self.custom_export_ids):
+            custom_export = self._get_custom(custom)
+            if custom_export:
+                yield _rewrap(custom_export)
+
     @classmethod
     def by_domain(cls, domain):
         return cache_core.cached_view(cls.get_db(), "groupexport/by_domain", key=domain, reduce=False, include_docs=True, wrapper=cls.wrap)

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -100,8 +100,9 @@ def weekly_reports():
 
 @periodic_task(run_every=crontab(hour=[0,12], minute="0", day_of_week="*"), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE','celery'))
 def saved_exports():    
-    for row in HQGroupExportConfiguration.view("groupexport/by_domain", reduce=False).all():
-        export_for_group(row["id"], "couch")
+    for group_config in HQGroupExportConfiguration.view("groupexport/by_domain", reduce=False,
+                                                        include_docs=True).all():
+        export_for_group(group_config, "couch")
 
 @periodic_task(run_every=crontab(hour="12, 22", minute="0", day_of_week="*"), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE','celery'))
 def update_calculated_properties():


### PR DESCRIPTION
does this by passing in a wrapped version of the group config
that applies additional filters

we should probably do this for archived/deleted users too

depends on https://github.com/dimagi/couchexport/pull/60/
