### PR TITLE
Save report for all individuals in a group

### DIFF
--- a/custom/penn_state/models.py
+++ b/custom/penn_state/models.py
@@ -57,5 +57,5 @@ class LegacyWeeklyReport(Document):
             key=[DOMAIN, site, str(date)],
             reduce=False,
             include_docs=True,
-        ).one()
+        ).first()
         return report

--- a/custom/penn_state/tasks.py
+++ b/custom/penn_state/tasks.py
@@ -39,16 +39,16 @@ class Site(object):
                 for days in range(4, -1, -1)]
 
     def process_user(self, user):
+        username = user.raw_username
+        if username not in self.individual:
+            self.emails.append(user.email)
+            self.individual[username] = {
+                'strategy': [0] * 5,
+                'game': [0] * 5,
+            }
         for form in XFormInstance.get_forms_by_user(
                 user, self.week[0], self.week[-1]):
             if form.xmlns == DAILY_DATA_XMLNS:
-                username = form.metadata.username
-                if username not in self.individual:
-                    self.emails.append(user.email)
-                    self.individual[username] = {
-                        'strategy': [0] * 5,
-                        'game': [0] * 5,
-                    }
                 self.process_form(form, username)
 
 


### PR DESCRIPTION
Regardless of whether or not they filled out any forms that week.
This PR will also prevent a 500 that occurs when there exist
multiple snapshots for a given group and week, although it doesn't
address WHY that happens (it shouldn't, and I'm looking into it).
