### PR TITLE
extract common logic from xform.get_questions()

### DIFF
--- a/corehq/apps/app_manager/tests/__init__.py
+++ b/corehq/apps/app_manager/tests/__init__.py
@@ -12,6 +12,7 @@ try:
     from corehq.apps.app_manager.tests.test_views import *
     from corehq.apps.app_manager.tests.test_commcare_settings import *
     from corehq.apps.app_manager.tests.test_brief_view import *
+    from .test_get_questions import *
     from .test_repeater import *
 except ImportError, e:
     # for some reason the test harness squashes these so log them here for clarity

--- a/corehq/apps/app_manager/tests/data/case_in_form.xml
+++ b/corehq/apps/app_manager/tests/data/case_in_form.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/7C07141C-3131-4934-8461-E58F664DFDCC" uiVersion="1" version="1" name="Untitled Form">
+                    <question1 />
+                    <question2 />
+                    <question3 />
+
+
+                    <!-- repeat context test -->
+					<hi />
+					<question15 jr:template="">
+						<question16 />
+						<question21 />
+						<question25 />
+					</question15>
+                    <thing />
+
+                    <!-- a data node that doesn't have a control node 
+                    should show up as 'hidden' in get_questions() -->
+                    <datanode />
+				</data>
+            </instance>
+            <bind nodeset="/data/question1" type="xsd:string"
+                constraint="1 + instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id]/child_property_1"
+                jr:constraintMsg="jr:itext('question1-constraintMsg')"
+                relevant="instance('casedb')/casedb/case[@case_id=instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id]/index/parent]/parent_property_1 + 1 + instance('casedb')/casedb/case[@case_id=instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id]/index/parent]/parent_property_1" />
+            <bind nodeset="/data/question2" type="xsd:string" />
+            <bind nodeset="/data/question3" type="xsd:string" />
+
+            <!-- repeat context test -->
+            <bind nodeset="/data/hi" />
+			<bind nodeset="/data/question15" />
+			<bind nodeset="/data/question15/question16" type="xsd:string" constraint="@fellow/question25" jr:constraintMsg="jr:itext('question16-constraintMsg')" />
+			<bind nodeset="/data/question15/question21" />
+			<bind nodeset="/data/question15/question25" type="xsd:int" />
+            <bind nodeset="/data/thing" type="xsd:string" />
+            <bind nodeset="/data/datanode" />
+
+			<itext>
+                <translation lang="en" default="">
+                    <!-- tests reference parsing with various "edge" cases :-P -->
+					<text id="question1-label">
+                        <value>label en <output value="instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id]/nonexistent_child_property" /> label en</value>
+					</text>
+					<text id="question1-hint">
+                        <value><output value="instance('casedb')/casedb/case[@case_id=instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id]/index/parent]/parent_property_1" /> hint message en</value>
+                    </text>
+                    <text id="question1-constraintMsg">
+                        <value>constraint message en <output value="instance('casedb')/casedb/case[@case_id=instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id]/index/parent]/parent_property_1"/></value>>
+                    </text>
+                    <text id="question2-label">
+                        <value>label en <output value="instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id]/nonexistent_child_property" /> label en</value>
+                    </text>
+                    <text id="question3-label">
+                        <value>no references here!</value>
+                    </text>
+                    <text id="hi-label">
+                        <value>woo</value>
+                    </text>
+                    <text id="jr:itext('question15-label')">
+                        <value>woo</value>
+                    </text>
+                    <text id="jr:itext('question16-label')">
+                        <value>woo</value>
+                    </text>
+                    <text id="jr:itext('question21-label')">
+                        <value>woo</value>
+                    </text>
+                    <text id="jr:itext('question21-item22-label')">
+                        <value>woo</value>
+                    </text>
+                    <text id="jr:itext('question25-label')">
+                        <value>woo</value>
+                    </text>
+                    <text id="jr:itext('thing-label')">
+                        <value>woo</value>
+                    </text>
+				</translation>
+				<translation lang="es">
+                    <text id="question1-label">
+                        <!-- make sure multiple references to the same property in one message get replaced -->
+                        <!-- make sure output ref gets recognized as well as output value, from legacy handmade forms -->
+                        <value>label es <output value="instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id]/nonexistent_child_property" />
+                            <output value="instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id]/nonexistent_child_property" />
+                            <output ref="instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id]/child_property_1" />
+                        </value>
+					</text>
+					<text id="question1-hint">
+						<value>hint message</value>
+					</text>
+                    <text id="question1-constraintMsg">
+                        <value>constraint message en</value>>
+                    </text>>
+				</translation>
+			</itext>
+        </model>
+        <setvalue ref="/data/question3" event="xforms-ready" 
+            value="instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id]/child_property_1"/>
+	</h:head>
+	<h:body>
+		<input ref="/data/question1">
+			<label ref="jr:itext('question1-label')" />
+			<hint ref="jr:itext('question1-hint')" />
+        </input>
+        <input ref="/data/question2">
+            <label ref="jr:itext('question2-label')" />>
+        </input>
+        <input ref="/data/question3">
+            <label ref="jr:itext('question3-label')" />>
+        </input>
+
+        <!-- we didn't copy the itext for these questions.  But the reference
+             finder shouldn't fail on invalid itext ids -->
+        <trigger ref="/data/hi">
+			<label ref="jr:itext('hi-label')" />
+		</trigger>
+		<group>
+			<label ref="jr:itext('question15-label')" />
+			<repeat nodeset="/data/question15" jr:count="instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id]/gender">
+				<input ref="/data/question15/question16">
+					<label ref="jr:itext('question16-label')" />
+				</input>
+				<select1 ref="/data/question15/question21">
+					<label ref="jr:itext('question21-label')" />
+					<item>
+						<label ref="jr:itext('question21-item22-label')" />
+						<value>item22</value>
+					</item>
+				</select1>
+				<input ref="/data/question15/question25">
+					<label ref="jr:itext('question25-label')" />
+				</input>
+			</repeat>
+		</group>
+		<input ref="/data/thing">
+			<label ref="jr:itext('thing-label')" />
+		</input>
+
+	</h:body>
+</h:html>
+

--- a/corehq/apps/app_manager/tests/test_get_questions.py
+++ b/corehq/apps/app_manager/tests/test_get_questions.py
@@ -1,0 +1,91 @@
+import os
+
+from django.test import TestCase
+
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.app_manager.models import Application, APP_V2
+
+class GetFormQuestionsTest(TestCase):
+    domain = 'test-domain'
+
+    def setUp(self):
+        def read(filename):
+            path = os.path.join(os.path.dirname(__file__), "data", filename)
+            with open(path) as f:
+                return f.read()
+
+        create_domain(self.domain)
+
+        self.app = app = Application.new_app(
+                self.domain, "Test", application_version=APP_V2)
+        module = app.new_module("Module", 'en')
+        module = app.get_module(0)
+        module.case_type = 'test'
+
+        form = app.new_form(module.id, name="Form", lang='en',
+                attachment=read('case_in_form.xml'))
+
+        self.form_unique_id = form.unique_id
+        app.save()
+
+    def test_get_questions(self):
+        form = self.app.get_form(self.form_unique_id)
+        questions = form.wrapped_xform().get_questions(['en', 'es'])
+        
+        self.assertEqual(questions, [
+            {
+                'tag': 'input',
+                'repeat': '',
+                'value': '/data/question1',
+                'label': 'label en ____ label en'
+            },
+            {
+                'tag': 'input',
+                'repeat': '',
+                'value': '/data/question2',
+                'label': 'label en ____ label en'
+            },
+            {
+                'tag': 'input',
+                'repeat': '',
+                'value': '/data/question3',
+                'label': 'no references here!'
+            },
+            {
+                'tag': 'input',
+                'repeat': '/data/question15',
+                'value': '/data/question15/question16',
+                'label': None
+            },
+            {
+                'tag': 'select1',
+                'repeat': '/data/question15',
+                'options': [
+                    {'value': 'item22',
+                     'label': None}
+                ],
+                'value': '/data/question15/question21',
+                'label': None
+            },
+            {
+                'tag': 'input',
+                'repeat': '/data/question15',
+                'value': '/data/question15/question25',
+                'label': None
+            },
+            {
+                'tag': 'input',
+                'repeat': '',
+                'value': '/data/thing',
+                'label': None
+            },
+            {
+                'tag': 'hidden',
+                'repeat': '',
+                'value': '/data/datanode',
+                'label': '/data/datanode'
+            },
+        ])
+
+
+        


### PR DESCRIPTION
For the case property reference stuff, I needed to be able to walk over
all of the questions in the form in order to inspect their attributes.
xform.get_questions() already did that, so I've extracted the generic
parts into xform.for_each_leaf_control_node() and
xform.for_each_leaf_data_node().

I've added a test for xform.get_questions() with a form that covers the
basic scenarios.

This change also includes a couple related changes:
- change the wrapped methods on WrappedNode to be actual methods instead
  of dynamic attributes.  I find it slightly easier to read now (at
  least if you didn't already know what it was doing), but more
  importantly you won't be dynamically creating these methods for every
  single node that you traverse, which in a large form could take a
  non-trivial amount of time.
- add a WrappedAttribs class that wraps node.attribs so you can access
  namespaced attributes using the same namespace abbreviations (need
  this for getting itext stuff with the 'jr' namespace).
