### PR TITLE
Add minimum version for django-dev-server

### DIFF
--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -1,5 +1,5 @@
 django-debug-toolbar
-django-devserver
+django-devserver>=0.7.0
 coverage
 guppy
 werkzeug


### PR DESCRIPTION
Anything lower than this causes the server to not start with Django
1.5.5 or higher.
