### PR TITLE
add really simple "search engine" to look up docs by id

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -6,7 +6,7 @@
         <title>{% block title %}{% endblock %} - {{ SITE_NAME }}</title>
         <meta name="application-name" content="{{ SITE_NAME }}">
         <meta http-equiv="content-language" content="en">
-
+        <link type="application/opensearchdescription+xml" rel="search" href="{% url 'osdd' %}"/>
         <link rel="shortcut icon" href="{% static 'hqwebapp/img/favicon2.png' %}" />
 
         <link rel="stylesheet" media="screen" href="{% static 'hqstyle/css/core/hqstyle-core.css' %}"/>

--- a/corehq/apps/hqwebapp/templates/osdd.xml
+++ b/corehq/apps/hqwebapp/templates/osdd.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+    <ShortName>Search My Site</ShortName>
+    <Description>Search My Site</Description>
+    <Url type="text/html" method="get" template="{{ url_base }}/search/?q={searchTerms}"/>
+</OpenSearchDescription>

--- a/corehq/apps/hqwebapp/urls.py
+++ b/corehq/apps/hqwebapp/urls.py
@@ -15,7 +15,8 @@ urlpatterns = patterns('corehq.apps.hqwebapp.views',
     (r'^reports/$', 'redirect_to_default'),
     url(r'^bug_report/$', 'bug_report', name='bug_report'),
     url(r'^debug/notify/$', 'debug_notify', name='debug_notify'),
-    url(r'^notifications/dismiss/$', 'dismiss_notification', name="dismiss_notification")
+    url(r'^notifications/dismiss/$', 'dismiss_notification', name="dismiss_notification"),
+    url(r'^search/$', 'quick_find', name="global_quick_find"),
 )
 
 urlpatterns += patterns('corehq.apps.orgs.views', url(r'^search_orgs/', 'search_orgs', name='search_orgs'))

--- a/corehq/apps/hqwebapp/urls.py
+++ b/corehq/apps/hqwebapp/urls.py
@@ -17,6 +17,7 @@ urlpatterns = patterns('corehq.apps.hqwebapp.views',
     url(r'^debug/notify/$', 'debug_notify', name='debug_notify'),
     url(r'^notifications/dismiss/$', 'dismiss_notification', name="dismiss_notification"),
     url(r'^search/$', 'quick_find', name="global_quick_find"),
+    url(r'^searchDescription.xml$', 'osdd', name="osdd"),
 )
 
 urlpatterns += patterns('corehq.apps.orgs.views', url(r'^search_orgs/', 'search_orgs', name='search_orgs'))

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -820,3 +820,9 @@ def quick_find(request):
         return deal_with_couch_doc(doc)
 
     raise Http404()
+
+
+def osdd(request, template='osdd.xml'):
+    response = render(request, template, {'url_base': get_url_base()})
+    response['Content-Type'] = 'application/xml'
+    return response


### PR DESCRIPTION
go to www.commcarehq.org/search/?q={doc_id}

and it'll either take you to the right page or give you json with just the domain, doc_type, and _id. Only works for superusers or for domain admins for the domain to which the doc belongs.

(doesn't work for users yet because doesn't deal with multiple domains.)
