### PR TITLE
Preindex static resourcing

### DIFF
--- a/corehq/apps/hqwebapp/management/commands/resource_static.py
+++ b/corehq/apps/hqwebapp/management/commands/resource_static.py
@@ -1,0 +1,76 @@
+from gevent import monkey
+monkey.patch_all()
+from gevent.pool import Pool
+
+import simplejson
+import os
+from django.core.management.base import LabelCommand
+from django.contrib.staticfiles import finders
+from subprocess import Popen, PIPE
+from django.conf import settings
+from dimagi.utils import gitinfo
+from django.core import cache
+
+rcache = cache.get_cache('redis')
+RESOURCE_PREFIX = '#resource_%s'
+
+class Command(LabelCommand):
+    help = "Prints the paths of all the static files"
+    args = "clear"
+
+    def output_resources(self, resource_str):
+        with open(os.path.join(self.root_dir, 'resource_versions.py'), 'w') as fout:
+            fout.write("resource_versions = %s" % resource_str)
+
+    def handle(self, *args, **options):
+        self.root_dir = settings.FILEPATH
+
+        prefix = os.getcwd()
+        current_snapshot = gitinfo.get_project_snapshot(self.root_dir, submodules=False)
+        current_sha = current_snapshot['commits'][0]['sha']
+        print "Current commit SHA: %s" % current_sha
+
+        if 'clear' in args:
+            print "clearing resource cache"
+            rcache.delete_pattern(RESOURCE_PREFIX % '*')
+
+        existing_resource_str = rcache.get(RESOURCE_PREFIX % current_sha, None)
+        if existing_resource_str:
+            print "getting resource dict from cache"
+            self.output_resources(existing_resource_str)
+            return
+
+        pool = Pool(8)
+        self.resources = {}
+        for finder in finders.get_finders():
+            for path, storage in finder.list(['.*', '*~', '* *']):
+                if not storage.location.startswith(prefix):
+                    continue
+                url = os.path.join(storage.prefix, path) if storage.prefix else path
+                parts = (storage.location + '/' + path).split('/')
+                pool.spawn(self.generate_output, url, parts)
+        pool.join()
+        resource_str = simplejson.dumps(self.resources, indent=2)
+        rcache.set(RESOURCE_PREFIX % current_sha, resource_str, 3600)
+        self.output_resources(resource_str)
+
+    def generate_output(self, url, parts, dir_version=False):
+        filepath = '/'.join(parts[:-1]) + '/'
+        filename = parts[-1] if not dir_version else "."
+
+        if 'submodules' in parts:
+            sub_index = parts.index('submodules')
+            if parts[sub_index+1] == 'formdesigner' and filepath.count('/js/lib/xpath') > 0:
+                # hack to handle the formdesigner sub-sub
+                git_dir = '/'.join(parts[:sub_index+5]) + "/.git"
+            else:
+                git_dir = '/'.join(parts[:sub_index+2]) + "/.git"
+        else:
+            git_dir = os.path.join(settings.FILEPATH, '.git')
+        cmdstring = r"""git --git-dir %s log -n 1 --format=format:%%h %s""" % (git_dir, os.path.join(filepath, filename))
+        p = Popen(
+            cmdstring.split(' '),
+        stdout=PIPE, stderr=PIPE
+        )
+        hash = p.stdout.read()
+        self.resources[url] = hash

--- a/corehq/apps/hqwebapp/management/commands/resource_static.py
+++ b/corehq/apps/hqwebapp/management/commands/resource_static.py
@@ -51,7 +51,7 @@ class Command(LabelCommand):
                 pool.spawn(self.generate_output, url, parts)
         pool.join()
         resource_str = simplejson.dumps(self.resources, indent=2)
-        rcache.set(RESOURCE_PREFIX % current_sha, resource_str, 3600)
+        rcache.set(RESOURCE_PREFIX % current_sha, resource_str, 86400)
         self.output_resources(resource_str)
 
     def generate_output(self, url, parts, dir_version=False):

--- a/fabfile.py
+++ b/fabfile.py
@@ -599,6 +599,7 @@ def preindex_views():
         # no update to env - the actual deploy will do
         # this may break if a new dependency is introduced in preindex
         update_virtualenv(preindex=True)
+        version_static(preindex=True)
 
         sudo((
             'echo "%(virtualenv_root_preindex)s/bin/python '
@@ -880,16 +881,16 @@ def _do_collectstatic():
 
 @roles('django_app', 'django_monolith')
 @parallel
-def version_static():
+def version_static(preindex=False):
     """
     Put refs on all static references to prevent stale browser cache hits when things change.
     This needs to be run on the WEB WORKER since the web worker governs the actual static
     reference.
 
     """
+    cmd = 'resource_static' if not preindex else 'resource_static clear'
     with cd(env.code_root):
-        sudo('rm -f tmp.sh resource_versions.py; %(virtualenv_root)s/bin/python manage.py   \
-             printstatic > tmp.sh; bash tmp.sh > resource_versions.py' % env, user=env.sudo_user)
+        sudo('rm -f tmp.sh resource_versions.py; %(virtualenv_root)s/bin/python manage.py ' % env + cmd, user=env.sudo_user)
 
 
 


### PR DESCRIPTION
preindexing now will call new management command which does all the static resourcing.
however, the output will be now saved to a file AND a cache based upon the current git sha commit.

when deploying the command will check the cache first, or regenerate on its own if the cache somehow disappears.

the resource versions also use greenlets to multi-call all the commands (using a git-dir call instead of cd'ing) - results inconclusive on local SSD dev though.
