### PR TITLE
Have CloudCare use secure url when appropriate

### DIFF
--- a/corehq/apps/cloudcare/api.py
+++ b/corehq/apps/cloudcare/api.py
@@ -339,9 +339,12 @@ def get_cloudcare_apps(domain):
                ApplicationBase.view('cloudcare/cloudcare_apps', 
                                     startkey=[domain], endkey=[domain, {}]))
 
+def get_app_json(app):
+    app_json = app.to_json()
+    app_json['post_url'] = app.post_url
+    return app_json
+
 def get_app(domain, app_id):
     app = Application.get(app_id)
     assert(app.domain == domain)
-    return app._doc
-
-
+    return get_app_json(app)

--- a/corehq/apps/cloudcare/api.py
+++ b/corehq/apps/cloudcare/api.py
@@ -344,7 +344,7 @@ def get_app_json(app):
     app_json['post_url'] = app.post_url
     return app_json
 
-def get_app(domain, app_id):
+def look_up_app_json(domain, app_id):
     app = Application.get(app_id)
     assert(app.domain == domain)
     return get_app_json(app)

--- a/corehq/apps/cloudcare/static/cloudcare/js/backbone/apps.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/backbone/apps.js
@@ -464,7 +464,7 @@ cloudCare.AppView = Backbone.View.extend({
             dataType: "json"
         });
         resp.done(function (data) {
-            data["onsubmit"] = function (xml) {
+            data.onsubmit = function (xml) {
                 // post to receiver
                 $.ajax({
                     type: 'POST',
@@ -477,13 +477,13 @@ cloudCare.AppView = Backbone.View.extend({
                     }
                 });
             };
-            data["onerror"] = function (resp) {
+            data.onerror = function (resp) {
                 showError(resp.message, $("#cloudcare-notifications"));
                 cloudCare.dispatch.trigger("form:error", form, caseModel);
             };
-            data["onload"] = function (adapter, resp) {
+            data.onload = function (adapter, resp) {
                 cloudCare.dispatch.trigger("form:ready", form, caseModel);
-            }
+            };
             var sess = new WebFormSession(data);
             // TODO: probably shouldn't hard code these divs
             sess.load($('#webforms'), $('#loading'), self.options.language);

--- a/corehq/apps/cloudcare/static/cloudcare/js/backbone/apps.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/backbone/apps.js
@@ -104,7 +104,7 @@ cloudCare.App = LocalizableModel.extend({
     initialize: function () {
         var self = this;
         self.constructor.__super__.initialize.apply(self, [self.options]);
-        _.bindAll(self, "updateModules", "url", "urlRoot", "getSubmitId");
+        _.bindAll(self, "updateModules", "url", "urlRoot", "getSubmitUrl");
 
         self.updateModules();
         self.on("change", function () {
@@ -120,8 +120,8 @@ cloudCare.App = LocalizableModel.extend({
     urlRoot: function () {
         return this.get("urlRoot");
     },
-    getSubmitId: function () {
-        return this.get("copy_of") || this.id
+    getSubmitUrl: function () {
+        return this.get('post_url');
     },
     updateModules: function () {
         var self = this;
@@ -452,7 +452,7 @@ cloudCare.AppView = Backbone.View.extend({
         cloudCare.dispatch.trigger("form:enter", form, caseModel);
         var formUrl = self.getFormUrl(module, form, caseModel);
         var selectedModule = self.formListView.model;
-        var submitUrl = getSubmitUrl(self.options.submitUrlRoot, self.model.getSubmitId());
+        var submitUrl = self.model.getSubmitUrl();
 
         // clear current case information
         self._clearCaseView();

--- a/corehq/apps/cloudcare/static/cloudcare/js/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/util.js
@@ -54,7 +54,10 @@ var getFormEntryPath = function(appId, moduleId, formId, caseId) {
 };
 
 var getSubmitUrl = function (urlRoot, appId) {
-    // TODO: make this cleaner
+    // deprecated but still called from "touchforms-inline"
+    // which is used to fill out forms from within case details view
+    // use app.getSubmitUrl instead
+    // todo: replace and remove
     return urlRoot + "/" + appId + "/";
 };
 

--- a/corehq/apps/cloudcare/templates/cloudcare/cloudcare_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/cloudcare_home.html
@@ -48,7 +48,7 @@
         var caseUrlRoot = "{% url "cloudcare_get_cases" domain %}";
         var submitUrlRoot = "{% url "receiver_post" domain %}";
         var language = "{{ language }}";
-        var apps = {{ apps|safe }};
+        var apps = {{ apps|JSON }};
         var initialApp = {{ app|JSON }};
         var initialCase = {{ case|JSON }};
         window.mainView = new cloudCare.AppMainView({

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -17,7 +17,7 @@ from django.shortcuts import render
 from corehq.apps.app_manager.models import Application, ApplicationBase
 import json
 from corehq.apps.cloudcare.api import get_app, get_cloudcare_apps, get_filtered_cases, get_filters_from_request,\
-    api_closed_to_status, CaseAPIResult, CASE_STATUS_OPEN
+    api_closed_to_status, CaseAPIResult, CASE_STATUS_OPEN, get_app_json
 from dimagi.utils.parsing import string_to_boolean
 from django.conf import settings
 from corehq.apps.cloudcare import touchforms_api 
@@ -53,17 +53,16 @@ def cloudcare_main(request, domain, urlPath):
                                      endkey=[domain, app_id],
                                      descending=True,
                                      limit=1).one()
-        return build._doc if build else None
+        return get_app_json(build) if build else None
 
     if not preview:
         apps = get_cloudcare_apps(domain)
         # replace the apps with the last build of each app
         apps = [_app_latest_build_json(app["_id"]) for app in apps]
-    
     else:
         apps = ApplicationBase.view('app_manager/applications_brief', startkey=[domain], endkey=[domain, {}])
-        apps = [app._doc for app in apps if app and app.application_version == "2.0"]
-    
+        apps = [get_app_json(app) for app in apps if app and app.application_version == "2.0"]
+
     # trim out empty apps
     apps = filter(lambda app: app, apps)
     apps = filter(lambda app: app_access.user_can_access_app(request.couch_user, app), apps)
@@ -106,7 +105,7 @@ def cloudcare_main(request, domain, urlPath):
             else:
                 messages.info(request, _("That app is no longer valid. Try using the "
                                          "navigation links to select an app."))
-        if app == None and len(apps) == 1:
+        if app is None and len(apps) == 1:
             app = get_app(domain, apps[0]['_id'])
 
         def _get_case(domain, case_id):
@@ -116,14 +115,14 @@ def cloudcare_main(request, domain, urlPath):
         
         case = _get_case(domain, case_id) if case_id else None
         return {
-            "app": app, 
+            "app": app,
             "case": case
         }
 
     context = {
        "domain": domain,
        "language": language,
-       "apps": json.dumps(apps),
+       "apps": apps,
        "apps_raw": apps,
        "preview": preview,
        "maps_api_key": settings.GMAPS_API_KEY

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -16,7 +16,7 @@ from django.http import HttpResponseRedirect, HttpResponse, HttpResponseBadReque
 from django.shortcuts import render
 from corehq.apps.app_manager.models import Application, ApplicationBase
 import json
-from corehq.apps.cloudcare.api import get_app, get_cloudcare_apps, get_filtered_cases, get_filters_from_request,\
+from corehq.apps.cloudcare.api import look_up_app_json, get_cloudcare_apps, get_filtered_cases, get_filters_from_request,\
     api_closed_to_status, CaseAPIResult, CASE_STATUS_OPEN, get_app_json
 from dimagi.utils.parsing import string_to_boolean
 from django.conf import settings
@@ -101,12 +101,12 @@ def cloudcare_main(request, domain, urlPath):
         app = None
         if app_id:
             if app_id in [a['_id'] for a in apps]:
-                app = get_app(domain, app_id)
+                app = look_up_app_json(domain, app_id)
             else:
                 messages.info(request, _("That app is no longer valid. Try using the "
                                          "navigation links to select an app."))
         if app is None and len(apps) == 1:
-            app = get_app(domain, apps[0]['_id'])
+            app = look_up_app_json(domain, apps[0]['_id'])
 
         def _get_case(domain, case_id):
             case = CommCareCase.get(case_id)
@@ -267,7 +267,7 @@ def get_apps_api(request, domain):
 
 @cloudcare_api
 def get_app_api(request, domain, app_id):
-    return json_response(get_app(domain, app_id))
+    return json_response(look_up_app_json(domain, app_id))
 
 @cloudcare_api
 @cache_page(60 * 30)


### PR DESCRIPTION
And to change the way the url is gotten: it's now passed in instead of constructed from the app id

I tested by submitting forms on cloudcare on apps with both values for Use Secure Submissions with network tab open, and made sure that they submitted to urls with and without `/secure/` as appropriate.
