### PR TITLE
{{ doc_info|pretty_doc_info }}

### DIFF
--- a/corehq/apps/hqwebapp/doc_info.py
+++ b/corehq/apps/hqwebapp/doc_info.py
@@ -1,0 +1,102 @@
+from couchdbkit import ResourceNotFound
+from django.core.urlresolvers import reverse
+from django.utils.translation import ugettext as _
+from jsonobject import *
+from corehq.apps.users.models import CouchUser
+from corehq.apps.users.util import raw_username
+
+
+class DocInfo(JsonObject):
+    id = StringProperty()
+    domain = StringProperty()
+    type = StringProperty()
+
+    display = StringProperty()
+    link = StringProperty()
+    type_display = StringProperty()
+
+
+def get_doc_info_by_id(domain, id):
+    not_found_value = DocInfo(display=id, link=None, owner_type=None)
+    if not id:
+        return not_found_value
+    try:
+        doc = CouchUser.get_db().get(id)
+    except ResourceNotFound:
+        return not_found_value
+
+    if doc.get('domain') != domain and domain not in doc.get('domains', ()):
+        return not_found_value
+
+    return get_doc_info(doc, domain_hint=domain)
+
+
+def get_doc_info(doc, domain_hint=None):
+    domain = doc.get('domain') or domain_hint
+    doc_type = doc.get('doc_type')
+    doc_id = doc.get('_id')
+
+    assert doc.get('domain') == domain or domain in doc.get('domains', ())
+
+    if doc_type in ('Application', 'RemoteApp'):
+        if doc.get('copy_of'):
+            doc_info = DocInfo(
+                display=u'%s (#%s)' % (doc['name'], doc['version']),
+                type_display=_('Application Build'),
+                link=reverse(
+                    'corehq.apps.app_manager.views.download_index',
+                    args=[domain, doc_id],
+                ),
+            )
+        else:
+            doc_info = DocInfo(
+                display=doc['name'],
+                type_display=_('Application'),
+                link=reverse(
+                    'corehq.apps.app_manager.views.view_app',
+                    args=[domain, doc_id],
+                ),
+            )
+    elif doc_type in ('CommCareCase',):
+        doc_info = DocInfo(
+            display=doc['name'],
+            type_display=_('Case'),
+            link=reverse(
+                'case_details',
+                args=[domain, doc_id],
+            ),
+        )
+    elif doc_type in ('XFormInstance',):
+        doc_info = DocInfo(
+            type_display=_('Form'),
+            link=reverse(
+                'render_form_data',
+                args=[domain, doc_id],
+            ),
+        )
+    elif doc_type in ('CommCareUser',):
+        doc_info = DocInfo(
+            display=raw_username(doc['username']),
+            type_display=_('Mobile Worker'),
+            link=reverse(
+                'edit_commcare_user',
+                args=[domain, doc_id],
+            ),
+        )
+    elif doc_type in ('WebUser',):
+        doc_info = DocInfo(
+            type_display=_('Web User'),
+            display=doc['username'],
+            link=reverse(
+                'user_account',
+                args=[domain, doc_id],
+            ),
+        )
+    else:
+        doc_info = DocInfo()
+
+    doc_info.id = doc_id
+    doc_info.domain = domain
+    doc_info.type = doc_type
+
+    return doc_info

--- a/corehq/apps/hqwebapp/templates/hqwebapp/pretty_doc_info.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/pretty_doc_info.html
@@ -1,0 +1,2 @@
+{{ doc_info.type_display|default_if_none:doc_info.type|default_if_none:'' }}
+{% if doc_info.link %}<a href="{{ doc_info.link }}">{% endif %}{{ doc_info.display|default_if_none:doc_info.id }}{% if doc_info.link %}</a>{% endif %}

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -3,6 +3,7 @@ import json
 from django import template
 from django.conf import settings
 from django.core.urlresolvers import reverse
+from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 from corehq.apps.domain.models import Domain
@@ -237,3 +238,10 @@ def get_attribute(obj, arg):
     Usage: {{ couch_user|getattr:"full_name" }}
     """
     return getattr(obj, arg, None)
+
+
+@register.filter
+def pretty_doc_info(doc_info):
+    return render_to_string('hqwebapp/pretty_doc_info.html', {
+        'doc_info': doc_info,
+    })


### PR DESCRIPTION
Introducing a new template filter called `pretty_doc_info`, and it's code counterparts `get_doc_info` and `get_doc_info_by_id`. These are used to solve the problem of having just an id and wanting to behave nicely whether it's the id of a mobile worker, web user, or case (for example).

`get_doc_info` returns a DocInfo object that contains useful metadata about the doc in a consistent format. Interesting fields are

`display` --- like the username for a mobile worker
`link` --- link to main page for that doc, like a mobile worker's page in settings for a mobile worker
`type_display` --- like "Mobile Worker" for a mobile worker. This is translated text.

`{{ doc_info|pretty_doc_info %}` then gives a nice html display format that you can dump inline. See https://github.com/dimagi/couchforms/pull/72 for an example.
