### PR TITLE
remove duplicated code

### DIFF
--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -186,28 +186,6 @@ def commcare_user():
 def hq_web_user():
     return _(settings.WEB_USER_TERM)
 
-
-@register.simple_tag
-def list_my_orgs(request):
-    org_list = request.couch_user.get_organizations()
-    lst = list()
-    lst.append('<ul class="nav nav-pills nav-stacked">')
-    for org in org_list:
-        default_url = reverse("orgs_landing", args=[org.name])
-        lst.append('<li><a href="%s">%s</a></li>' % (default_url, org.title))
-    lst.append('</ul>')
-
-    return "".join(lst)
-
-
-@register.simple_tag
-def commcare_user():
-    return _(settings.COMMCARE_USER_TERM)
-
-@register.simple_tag
-def hq_web_user():
-    return _(settings.WEB_USER_TERM)
-
 @register.filter
 def mod(value, arg):
     return value % arg


### PR DESCRIPTION
Looks like when @dmyung  was making some caching changes, he accidentally duplicated some code. I didn't fix all of the issues in that file as some of other duplicated code isn't an exact copy, so I'm not which version is the correct one

still needs to be fixed:
https://github.com/dimagi/commcare-hq/blob/f40ffbc19ae4fa598a70388e705291c45e395e1f/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py#L153 
https://github.com/dimagi/commcare-hq/blob/f40ffbc19ae4fa598a70388e705291c45e395e1f/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py#L133
