### PR TITLE
Refactor case details

### DIFF
--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -37,21 +37,21 @@ def _create_custom_app_strings(app, lang):
             yield lc, name
 
     for module in app.get_modules():
-        for detail in module.get_details():
-            if detail.type.startswith('case'):
+        for detail_type, detail in module.get_details():
+            if detail_type.startswith('case'):
                 label = trans(module.case_label)
             else:
                 label = trans(module.referral_label)
-            yield id_strings.detail_title_locale(module, detail), label
+            yield id_strings.detail_title_locale(module, detail_type), label
 
-            detail_column_infos = get_detail_column_infos(detail)
+            detail_column_infos = get_detail_column_infos(detail, include_sort=detail_type == 'case_short')
             for (column, sort_element, order) in detail_column_infos:
                 if not is_sort_only_column(column):
-                    yield id_strings.detail_column_header_locale(module, detail, column), trans(column.header)
+                    yield id_strings.detail_column_header_locale(module, detail_type, column), trans(column.header)
 
                 if column.format in ('enum', 'enum-image'):
                     for item in column.enum:
-                        yield id_strings.detail_column_enum_variable(module, detail, column, item.key), trans(item.value)
+                        yield id_strings.detail_column_enum_variable(module, detail_type, column, item.key), trans(item.value)
 
         yield id_strings.module_locale(module), numfirst(trans(module.name))
         if module.case_list.show:

--- a/corehq/apps/app_manager/build_error_utils.py
+++ b/corehq/apps/app_manager/build_error_utils.py
@@ -19,12 +19,12 @@ def get_case_errors(module, needs_case_type, needs_case_detail,
         }
 
     if needs_case_detail:
-        if not module.get_detail('case_short').columns:
+        if not module.case_details.short.columns:
             yield {
                 'type': 'no case detail',
                 'module': module_info,
             }
-        columns = module.get_detail('case_short').columns + module.get_detail('case_long').columns
+        columns = module.case_details.short.columns + module.case_details.long.columns
         for column in columns:
             if column.format in ('enum', 'enum-image'):
                 for item in column.enum:
@@ -36,7 +36,7 @@ def get_case_errors(module, needs_case_type, needs_case_detail,
                             'module': module_info,
                         }
 
-    if needs_referral_detail and not module.get_detail('ref_short').columns:
+    if needs_referral_detail and not module.ref_details.short.columns:
         yield {
             'type': 'no ref detail',
             'module': module_info,

--- a/corehq/apps/app_manager/detail_screen.py
+++ b/corehq/apps/app_manager/detail_screen.py
@@ -12,7 +12,7 @@ CASE_PROPERTY_MAP = {
     'name': 'case_name',
 }
 
-# todo: find usages
+
 def get_column_generator(app, module, detail, column, sort_element=None,
                          order=None, detail_type=None):
     cls = get_class_for_format(column.format)

--- a/corehq/apps/app_manager/detail_screen.py
+++ b/corehq/apps/app_manager/detail_screen.py
@@ -12,11 +12,11 @@ CASE_PROPERTY_MAP = {
     'name': 'case_name',
 }
 
-
+# todo: find usages
 def get_column_generator(app, module, detail, column, sort_element=None,
-                         order=None):
+                         order=None, detail_type=None):
     cls = get_class_for_format(column.format)
-    return cls(app, module, detail, column, sort_element, order)
+    return cls(app, module, detail, column, sort_element, order, detail_type=detail_type)
 
 
 def get_class_for_format(slug):
@@ -74,10 +74,11 @@ class FormattedDetailColumn(object):
     template_form = None
 
     def __init__(self, app, module, detail, column, sort_element=None,
-                 order=None):
+                 order=None, detail_type=None):
         self.app = app
         self.module = module
         self.detail = detail
+        self.detail_type = detail_type
         self.column = column
         self.sort_element = sort_element
         self.order = order
@@ -87,7 +88,7 @@ class FormattedDetailColumn(object):
     def locale_id(self):
         if not is_sort_only_column(self.column):
             return self.id_strings.detail_column_header_locale(
-                self.module, self.detail, self.column,
+                self.module, self.detail_type, self.column,
             )
         else:
             return None
@@ -293,7 +294,7 @@ class Enum(FormattedDetailColumn):
         for item in self.column.enum:
             v_key = u"k{key}".format(key=item.key)
             v_val= self.id_strings.detail_column_enum_variable(self.module,
-                                                               self.detail,
+                                                               self.detail_type,
                                                                self.column,
                                                                item.key)
             variables[v_key] = v_val

--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -68,7 +68,6 @@ var SortRows = function () {
     self.rowCount = ko.computed(function () {
         return self.sortRows().length;
     });
-
 };
 
 // http://www.knockmeout.net/2011/05/dragging-dropping-and-sorting-with.html
@@ -164,7 +163,6 @@ var DetailScreenConfig = (function () {
 
             this.model = uiElement.select([
                 {label: "Case", value: "case"},
-                {label: "Referral", value: "referral"}
             ]).val(this.original.model);
             this.field = uiElement.input().val(this.original.field);
             this.format_warning = field_format_warning.clone().hide();
@@ -337,10 +335,6 @@ var DetailScreenConfig = (function () {
         return Column;
     }());
     Screen = (function () {
-        var sectionLabels = {
-            'case': "",
-            referral: "Referral Details"
-        };
         function Screen($home, spec, config, options) {
             var i, column, model, property, header,
                 that = this, columns;
@@ -351,7 +345,7 @@ var DetailScreenConfig = (function () {
             this.edit = options.edit;
             this.columns = [];
             this.suggestedColumns = [];
-            this.model = spec.short.type === "ref_short" ? "referral" : "case";
+            this.model = 'case';
             this.lang = options.lang;
             this.langs = options.langs || [];
             this.properties = options.properties;
@@ -423,7 +417,7 @@ var DetailScreenConfig = (function () {
                 }
             }).$edit_view.autocomplete({
                 source: function (request, response) {
-                    var availableTags = that.properties[that.customColumn.model.val()];
+                    var availableTags = that.properties;
                     response(
                         $.ui.autocomplete.filter(availableTags,  request.term)
                     );
@@ -440,26 +434,21 @@ var DetailScreenConfig = (function () {
             });
 
             // set up suggestion columns
-            for (model in this.properties) {
-                if (this.properties.hasOwnProperty(model) && !(this.model === 'case' && model === 'referral')) {
-                    for (i = 0; i < this.properties[model].length; i += 1) {
-                        property = this.properties[model][i];
-                        header = {};
-                        header[this.lang] = toTitleCase(property);
-                        column = Column.init({
-                            model: model,
-                            field: property,
-                            header: header,
-                            includeInShort: false
-                        }, this);
-                        initColumnAsSuggestion(column);
-                        this.suggestedColumns.push(column);
-                    }
-                }
+            for (i = 0; i < this.properties.length; i += 1) {
+                property = this.properties[i];
+                header = {};
+                header[this.lang] = toTitleCase(property);
+                column = Column.init({
+                    model: model,
+                    field: property,
+                    header: header,
+                    includeInShort: false
+                }, this);
+                initColumnAsSuggestion(column);
+                this.suggestedColumns.push(column);
             }
             this.suggestedColumns = _(this.suggestedColumns).sortBy(function (column) {
                 return [
-                    column.model.val() === 'referral' ? 1 : 2,
                     /\//.test(column.field.val()) ? 2 : 1,
                     column.field.val()
                 ];
@@ -517,8 +506,8 @@ var DetailScreenConfig = (function () {
                 });
             });
         }
-        Screen.init = function ($home, spec, config, lang) {
-            return new Screen($home, spec, config, lang);
+        Screen.init = function ($home, spec, config, options) {
+            return new Screen($home, spec, config, options);
         };
         Screen.prototype = {
             save: function () {
@@ -553,19 +542,11 @@ var DetailScreenConfig = (function () {
                         longColumns.push(column.serialize());
                     }
                 }
-
-                if (this.model === 'case') {
-                    return {
-                        'case_short': shortColumns,
-                        'case_long': longColumns,
-                        'sort_elements': ko.toJSON(this.config.sortRows.sortRows)
-                    };
-                } else {
-                    return {
-                        'ref_short': shortColumns,
-                        'ref_long': longColumns
-                    };
-                }
+                return {
+                    short: shortColumns,
+                    long: longColumns,
+                    sort_elements: ko.toJS(this.config.sortRows.sortRows)
+                };
             },
             addColumn: function (column, $tbody, i, suggested) {
                 var $tr = $('<tr/>').data('index', i).appendTo($tbody);
@@ -581,9 +562,6 @@ var DetailScreenConfig = (function () {
                 $('<td/>').addClass('detail-screen-checkbox').append(column.includeInShort.ui).appendTo($tr);
                 $('<td/>').addClass('detail-screen-checkbox').append(column.includeInLong.ui).appendTo($tr);
 
-                if (this.model === 'referral') {
-                    $('<td/>').addClass('detail-screen-model').append(column.model.ui).appendTo($tr);
-                }
                 if (!column.field.edit) {
                     var text = column.field.ui.text();
                     var parts = text.split('/');
@@ -629,9 +607,6 @@ var DetailScreenConfig = (function () {
             },
             render: function () {
                 var $table, $columns, $suggestedColumns, $thead, $tr, i, $box;
-                if (sectionLabels[this.model]) {
-                    $('<h4/>').text(sectionLabels[this.model]).appendTo(this.$home);
-                }
                 $box = $("<div/>").appendTo(this.$home);
 
                 // this is a not-so-elegant way to get the styling right
@@ -669,9 +644,6 @@ var DetailScreenConfig = (function () {
 
                     $('<th/>').addClass('detail-screen-checkbox').text(DetailScreenConfig.message.SHORT).appendTo($tr).popover(DetailScreenConfig.message.SHORT_POPOVER);
                     $('<th/>').addClass('detail-screen-checkbox').text(DetailScreenConfig.message.LONG).appendTo($tr).popover(DetailScreenConfig.message.LONG_POPOVER);
-                    if (this.model === "referral") {
-                        $('<th/>').addClass('detail-screen-model').text(DetailScreenConfig.message.MODEL).appendTo($tr);
-                    }
                     $('<th/>').addClass('detail-screen-field').text(DetailScreenConfig.message.FIELD).appendTo($tr);
                     $('<th/>').addClass('detail-screen-header').text(DetailScreenConfig.message.HEADER).appendTo($tr);
                     $('<th/>').addClass('detail-screen-format').text(DetailScreenConfig.message.FORMAT).appendTo($tr);
@@ -744,10 +716,10 @@ var DetailScreenConfig = (function () {
             this.edit = spec.edit;
             this.saveUrl = spec.saveUrl;
 
-            function addScreen(short, long) {
+            function addScreen(pair) {
                 var screen = Screen.init(
                     $('<div/>'),
-                    {'short': short, 'long': long},
+                    pair,
                     that,
                     {
                         lang: that.lang,
@@ -761,10 +733,7 @@ var DetailScreenConfig = (function () {
                 that.$home.append(screen.$home);
             }
 
-            addScreen(spec.state.case_short, spec.state.case_long);
-            if (spec.applicationVersion === '1.0') {
-                addScreen(spec.state.ref_short, spec.state.ref_long);
-            }
+            addScreen(spec.state);
         };
         DetailScreenConfig.init = function ($home, spec) {
             var ds = new DetailScreenConfig($home, spec);

--- a/corehq/apps/app_manager/templates/app_manager/module_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/module_view.html
@@ -32,12 +32,7 @@
         $(function () {
             var $home = $("#detail-screen-config");
             var detailScreenConfig = DetailScreenConfig.init($home, {
-                state: {
-                    case_short: {{ module.details.0|JSON }},
-                    case_long: {{ module.details.1|JSON }},
-                    ref_short: {{ module.details.2|JSON }},
-                    ref_long: {{ module.details.3|JSON }}
-                },
+                state: {{ module.get_details|JSON }},
                 properties: {
                     'case': {{ case_properties|JSON }},
                     referral: ["id", "type", "date-due", "date-created"]

--- a/corehq/apps/app_manager/templates/app_manager/module_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/module_view.html
@@ -32,11 +32,11 @@
         $(function () {
             var $home = $("#detail-screen-config");
             var detailScreenConfig = DetailScreenConfig.init($home, {
-                state: {{ module.get_details|JSON }},
-                properties: {
-                    'case': {{ case_properties|JSON }},
-                    referral: ["id", "type", "date-due", "date-created"]
+                state: {
+                    short: {{ module.case_details.short|JSON }},
+                    long: {{ module.case_details.long|JSON }}
                 },
+                properties: {{ case_properties|JSON }},
                 lang: {{ lang|JSON }},
                 langs: {{ app.langs|JSON }},
                 edit: {{ edit|JSON }},

--- a/corehq/apps/app_manager/templates/app_manager/suite-1.0.xml
+++ b/corehq/apps/app_manager/templates/app_manager/suite-1.0.xml
@@ -32,10 +32,10 @@
  {% endfor %}
 {% if not app.use_custom_suite %}
  {% for module in app.get_modules %}
-  {% for detail in module.details %}
+  {% for detail_type, detail in module.get_details %}
    {% if detail.columns %}
-    <detail id="m{{ module.id }}_{{ detail.type }}">
-        <title><text><locale id="m{{ module.id }}.{{ detail.type }}.title"/></text></title>
+    <detail id="m{{ module.id }}_{{ detail_type }}">
+        <title><text><locale id="m{{ module.id }}.{{ detail_type }}.title"/></text></title>
         <filter>
             {% if detail.filter_xpath %}
             <raw function="{{ detail.filter_xpath }}"/>
@@ -53,9 +53,9 @@
         {% if d.format != 'filter' %}
         <field>
             <header{% if d.format == "late-flag" or d.format == "invisible" %}{% if detail.display == "short" %} width="0"{% endif %}{% endif %}>
-                <text><locale id="m{{ module.id }}.{{ detail.type }}.{{ d.model }}_{{ d.field }}_{{ forloop.counter }}.header"/></text>
+                <text><locale id="m{{ module.id }}.{{ detail_type }}.{{ d.model }}_{{ d.field }}_{{ forloop.counter }}.header"/></text>
             </header>
-         {% if d.format == "plain" or d.format == "phone" and detail.type == "case_short" or d.format == "phone" and detail.type == "ref_short" %}
+         {% if d.format == "plain" or d.format == "phone" and detail_type == "case_short" or d.format == "phone" and detail_type == "ref_short" %}
             <template><text><xpath function="/data/{{ d.model }}_{{ d.field }}_{{ forloop.counter }}"/></text></template>
          {% else %}{% ifequal d.format "date" %}
 {#            <template><text><xpath function="format_date(/data/{{ d.model }}_{{ d.field }}_{{ forloop.counter }}, 'short')"/></text></template>#}
@@ -75,7 +75,7 @@
                  ">
                   {% for key, val in d.enum_dict.items|sort %}
                      <variable name="k{{ key }}">
-                         <locale id="m{{ module.id }}.{{ detail.type }}.{{ d.model }}_{{ d.field }}_{{ forloop.parentloop.counter }}.enum.k{{ key }}{% if d.format == "enum-image" %}.image{% endif %}"/>
+                         <locale id="m{{ module.id }}.{{ detail_type }}.{{ d.model }}_{{ d.field }}_{{ forloop.parentloop.counter }}.enum.k{{ key }}{% if d.format == "enum-image" %}.image{% endif %}"/>
                      </variable>
                   {% endfor %}
                  </xpath>

--- a/corehq/apps/app_manager/tests/test_app_manager.py
+++ b/corehq/apps/app_manager/tests/test_app_manager.py
@@ -22,7 +22,7 @@ class AppManagerTest(TestCase):
             for j in range(3):
                 self.app.new_form(module.id, name="Form%s-%s" % (i,j), attachment=self.xform_str, lang="en")
             module = self.app.get_module(i)
-            detail = module.get_detail("ref_short")
+            detail = module.ref_details.short
             detail.columns.append(
                 DetailColumn(header={"en": "test"}, model="case", field="test", format="plain")
             )
@@ -71,18 +71,6 @@ class AppManagerTest(TestCase):
     def testDeleteModule(self):
         self.app.delete_module(0)
         self.assertEqual(len(self.app.modules), 2)
-
-    def testSwapDetailColumns(self):
-        module = self.app.get_module(0)
-        detail = module.get_detail("ref_short")
-        self.assertEqual(len(detail.columns), 3)
-        self.assertEqual(detail.columns[0].header['en'], 'Name')
-        self.assertEqual(detail.columns[1].header['en'], 'test')
-        self.assertEqual(detail.columns[2].header['en'], 'age')
-        self.app.rearrange_detail_columns(module.id, "ref_short", 0, 1)
-        self.assertEqual(detail.columns[0].header['en'], 'test')
-        self.assertEqual(detail.columns[1].header['en'], 'Name')
-        self.assertEqual(detail.columns[2].header['en'], 'age')
 
     def testSwapModules(self):
         m0 = self.app.modules[0].name['en']

--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -970,6 +970,7 @@ def edit_module_detail_screens(req, domain, app_id, module_id):
     params = json_request(req.POST)
     screens = params.get('screens')
     parent_select = params.get('parent_select')
+    sort_elements = screens['sort_elements']
 
     if not screens:
         return HttpResponseBadRequest("Requires JSON encoded param 'screens'")
@@ -979,26 +980,17 @@ def edit_module_detail_screens(req, domain, app_id, module_id):
     detail = module.case_details.short
 
     detail.sort_elements = []
-    if 'sort_elements' in screens:
-        for sort_element in json.load(StringIO(screens['sort_elements'])):
-            item = SortElement()
-            item.field = sort_element['field']
-            item.type = sort_element['type']
-            item.direction = sort_element['direction']
-            detail.sort_elements.append(item)
 
-        del screens['sort_elements']
+    module.case_details.short.columns = map(DetailColumn.wrap, screens['short'])
+    module.case_details.long.columns = map(DetailColumn.wrap, screens['long'])
 
-    for detail_type in screens:
-        if detail_type not in DETAIL_TYPES:
-            return HttpResponseBadRequest("All detail types must be in %r"
-                                          % DETAIL_TYPES)
+    for sort_element in sort_elements:
+        item = SortElement()
+        item.field = sort_element['field']
+        item.type = sort_element['type']
+        item.direction = sort_element['direction']
+        detail.sort_elements.append(item)
 
-    # todo: fix js so it sends down screens in new format
-    module.case_details.short.columns = DetailColumn.wrap(screens['case']['short'])
-    module.case_details.long.columns = DetailColumn.wrap(screens['case']['long'])
-    module.ref_details.short.columns = DetailColumn.wrap(screens['ref']['short'])
-    module.ref_details.long.columns = DetailColumn.wrap(screens['ref']['long'])
 
     module.parent_select = ParentSelect.wrap(parent_select)
     resp = {}


### PR DESCRIPTION
used to be

``` python
module.details = [case_short, case_long, ref_short, ref_long]
```

now it's 

``` python
module.case_details = DetailPair(short=case_short, long=case_long)
module.ref_details = DetailPair(short=ref_short, long=ref_long)
```
