### PR TITLE
Some performance improvements to the App Report

### DIFF
--- a/corehq/elastic.py
+++ b/corehq/elastic.py
@@ -119,7 +119,8 @@ def es_histogram(histo_type, domains=None, startdate=None, enddate=None, tz_diff
 
 
 SIZE_LIMIT = 1000000
-def es_query(params=None, facets=None, terms=None, q=None, es_url=None, start_at=None, size=None, dict_only=False, fields=None):
+def es_query(params=None, facets=None, terms=None, q=None, es_url=None, start_at=None, size=None, dict_only=False,
+             fields=None, facet_size=None):
     if terms is None:
         terms = []
     if q is None:
@@ -154,7 +155,7 @@ def es_query(params=None, facets=None, terms=None, q=None, es_url=None, start_at
     if facets:
         q["facets"] = q.get("facets", {})
         for facet in facets:
-            q["facets"][facet] = {"terms": {"field": facet, "size": SIZE_LIMIT}}
+            q["facets"][facet] = {"terms": {"field": facet, "size": facet_size or SIZE_LIMIT}}
 
     if filter["and"]:
         query = q.pop("query", {})


### PR DESCRIPTION
Set a facet size limit to admin reports and don't include unnecessary facets to app report. 

This along with https://github.com/dimagi/commcare-hq/pull/1791 (which this depends on) fixes issues with querying elasticsearch current in the app report. This PR also fixes issues with the slow loading UI.

tested by running the generated queries live on the prod es index
- [x] Merge https://github.com/dimagi/commcare-hq/pull/1791
