### PR TITLE
Allow omission of start_build parameter

### DIFF
--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -482,7 +482,7 @@ def get_apps_base_context(request, domain, app):
 def paginate_releases(request, domain, app_id):
     limit = request.GET.get('limit', 10)
     start_build_param = request.GET.get('start_build')
-    if start_build_param:
+    if start_build_param and json.loads(start_build_param):
         start_build = json.loads(start_build_param)
         assert isinstance(start_build, int)
     else:

--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -7,6 +7,7 @@ import re
 import json
 from collections import defaultdict
 from xml.dom.minidom import parseString
+from no_exceptions.exceptions import Http400
 
 from diff_match_patch import diff_match_patch
 from django.core.cache import cache
@@ -481,7 +482,10 @@ def get_apps_base_context(request, domain, app):
 @login_and_domain_required
 def paginate_releases(request, domain, app_id):
     limit = request.GET.get('limit', 10)
-    start_build = json.loads(request.GET.get('start_build'))
+    start_build_param = request.GET.get('start_build')
+    if not start_build_param:
+        raise Http400("You must pass in a start_build parameter")
+    start_build = json.loads(start_build_param)
     if start_build:
         assert isinstance(start_build, int)
     else:

--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -7,7 +7,6 @@ import re
 import json
 from collections import defaultdict
 from xml.dom.minidom import parseString
-from no_exceptions.exceptions import Http400
 
 from diff_match_patch import diff_match_patch
 from django.core.cache import cache
@@ -483,10 +482,8 @@ def get_apps_base_context(request, domain, app):
 def paginate_releases(request, domain, app_id):
     limit = request.GET.get('limit', 10)
     start_build_param = request.GET.get('start_build')
-    if not start_build_param:
-        raise Http400("You must pass in a start_build parameter")
-    start_build = json.loads(start_build_param)
-    if start_build:
+    if start_build_param:
+        start_build = json.loads(start_build_param)
         assert isinstance(start_build, int)
     else:
         start_build = {}


### PR DESCRIPTION
At first I raised a 400 if the parameter was omitted, but it makes more sense to just default to {}, which also appears to have been the original intention.

Addresses http://manage.dimagi.com/default.asp?82570
