### PR TITLE
Case importer fixes

### DIFF
--- a/corehq/apps/groups/models.py
+++ b/corehq/apps/groups/models.py
@@ -204,6 +204,9 @@ class Group(UndoableDocument):
                 "has the user in there twice"
             )
 
+    def is_member_of(self, domain):
+        return self.domain == domain
+
     def __repr__(self):
         return ("Group(domain={self.domain!r}, name={self.name!r}, "
                 + "case_sharing={self.case_sharing!r}, users={users!r})"

--- a/corehq/apps/importer/util.py
+++ b/corehq/apps/importer/util.py
@@ -292,4 +292,4 @@ def is_valid_id(uploaded_id, domain, cache):
         return cache[uploaded_id]
 
     owner = get_wrapped_owner(uploaded_id)
-    return owner and domain in owner.get_domains() and is_user_or_case_sharing_group(owner)
+    return owner and is_user_or_case_sharing_group(owner) and owner.is_member_of(domain)

--- a/corehq/apps/importer/util.py
+++ b/corehq/apps/importer/util.py
@@ -264,7 +264,7 @@ def populate_updated_fields(config, columns, row):
             # existing case field was chosen
             update_field_name = field_map[key]['case']
 
-        if update_value:
+        if update_value is not None:
             if field_map[key]['type_field'] == 'date':
                 update_value = parse_excel_date(update_value)
             elif field_map[key]['type_field'] == 'integer':


### PR DESCRIPTION
Fixes two bugs Derek found during imports.

1) Somehow you could never import the value zero, how did this not cause a problem yet??

2) A recent fix broke owner_id mapping for groups, this now works for both users/groups.
