### PR TITLE
allow any form to contribute case properties

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -663,8 +663,11 @@ class Form(FormBase, IndexedSchema, NavMenuItemMediaMixin):
 
         return errors
 
-    def get_case_updates(self):
-        return self.actions.update_case.update.keys()
+    def get_case_updates(self, case_type):
+        if self.get_module().case_type == case_type:
+            return self.actions.update_case.update.keys()
+
+        return []
 
     @memoized
     def get_parent_types_and_contributed_properties(self, module_case_type, case_type):

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -103,8 +103,7 @@ class ParentCasePropertyBuilder(object):
         case_properties = set(self.defaults)
 
         for m_case_type, form in self.forms_info:
-            if m_case_type == case_type:
-                case_properties.update(form.get_case_updates())
+            case_properties.update(form.get_case_updates(case_type))
 
         parent_types, contributed_properties = \
             self.get_parent_types_and_contributed_properties(case_type)


### PR DESCRIPTION
Move case type checking to form. Mostly for the sake of
careplan forms which have a different case type from their
module.
