### PR TITLE
rename case details sections to include type name

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -617,13 +617,12 @@ var DetailScreenConfig = (function () {
                         column.duplicate();
                     };
                 }
-
                 if (!this.edit && _.isEmpty(this.columns)) {
                     $('<p/>').text(DetailScreenConfig.message.EMPTY_SCREEN).appendTo($box);
                 } else {
                     if (this.edit) {
                         if (window.enableNewSort) {
-                            var $detailBody = $('#detail-screen-config-body');
+                            var $detailBody = $('#' + this.type + '-detail-screen-config-body');
                             $('<div id="saveBtn" class="clearfix">')
                                 .append(this.saveButton.ui)
                                 .prependTo($detailBody);
@@ -737,8 +736,9 @@ var DetailScreenConfig = (function () {
         };
         DetailScreenConfig.init = function ($home, spec) {
             var ds = new DetailScreenConfig($home, spec);
-            var $sortRowsHome = $('#detail-screen-sort');
-            var $parentSelectHome = $('#detail-screen-parent');
+            var type = spec.state.type;
+            var $sortRowsHome = $('#' + type + '-detail-screen-sort');
+            var $parentSelectHome = $('#' + type + '-detail-screen-parent');
             ko.applyBindings(ds.sortRows, $sortRowsHome.get(0));
             ko.applyBindings(ds.parentSelect, $parentSelectHome.get(0));
             $parentSelectHome.on('change', '*', function () {

--- a/corehq/apps/app_manager/templates/app_manager/module_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/module_view.html
@@ -33,6 +33,7 @@
             var $home = $("#detail-screen-config");
             var detailScreenConfig = DetailScreenConfig.init($home, {
                 state: {
+                    type: 'case',
                     short: {{ module.case_details.short|JSON }},
                     long: {{ module.case_details.long|JSON }}
                 },
@@ -230,8 +231,8 @@
                 </ol>
             {% endblocktrans %}
         </div>
-        <div id="detail-screen-config-body">
-            <div id="detail-screen-sort">
+        <div id="case-detail-screen-config-body">
+            <div id="case-detail-screen-sort">
             {% if app.enable_multi_sort %}
                 <legend data-bind="visible: rowCount() > 0">
                     {% trans "Sort Properties" %}
@@ -322,12 +323,12 @@
                 </div>
             {% endif %}
             </div>
-            <div id="detail-screen-config">
+            <div id="case-detail-screen-config">
                 <legend>
                     {% trans "Display Properties" %}
                 </legend>
             </div>
-            <div id="detail-screen-parent" data-bind="visible: moduleOptions().length">
+            <div id="case-detail-screen-parent" data-bind="visible: moduleOptions().length">
                 <legend>{% trans "Parent Child Selection" %}</legend>
                 <label class="checkbox">
                     <input type="checkbox" data-bind="checked: active"/>


### PR DESCRIPTION
Prep work for careplan having two case list configs on a page,
