### PR TITLE
Disable broken XML format for XFormInstanceResource

### DIFF
--- a/corehq/apps/api/resources/v0_1.py
+++ b/corehq/apps/api/resources/v0_1.py
@@ -1,34 +1,33 @@
+
+# Standard library imports
 from functools import wraps
 import json
 
+# Django imports
 from django.http import Http404, HttpResponse
 from django.conf import settings
 
+# Tastypie imports
 from tastypie import fields
 from tastypie.authentication import Authentication
 from tastypie.authorization import ReadOnlyAuthorization, Authorization
 from tastypie.exceptions import BadRequest
-from tastypie.serializers import Serializer
 from tastypie.throttle import CacheThrottle
 
+# External imports
 from casexml.apps.case.models import CommCareCase
 from couchforms.models import XFormInstance
+
+# CCHQ imports
 from corehq.apps.domain.decorators import login_or_digest, domain_admin_required
 from corehq.apps.groups.models import Group
 from corehq.apps.users.models import CommCareUser, WebUser
 
+# API imports
+from corehq.apps.api.serializers import CustomXMLSerializer, XFormInstanceSerializer
 from corehq.apps.api.util import get_object_or_not_exist
 from corehq.apps.api.resources import JsonResource, DomainSpecificResourceMixin
 
-
-class CustomXMLSerializer(Serializer):
-    def to_etree(self, data, options=None, name=None, depth=0):
-        etree = super(CustomXMLSerializer, self).to_etree(data, options, name, depth)
-        id = etree.find('id')
-        if id is not None:
-            etree.attrib['id'] = id.findtext('.')
-            etree.remove(id)
-        return etree
 
 def api_auth(view_func):
     @wraps(view_func)
@@ -211,9 +210,6 @@ class CommCareCaseResource(JsonResource, DomainSpecificResourceMixin):
         resource_name = 'case'
 
 
-class XFormInstanceMeta(CustomResourceMeta):
-    serializer = CustomXMLSerializer(formats=['json'])
-
 class XFormInstanceResource(JsonResource, DomainSpecificResourceMixin):
     type = "form"
     id = fields.CharField(attribute='get_id', readonly=True, unique=True)
@@ -229,8 +225,9 @@ class XFormInstanceResource(JsonResource, DomainSpecificResourceMixin):
     def obj_get(self, bundle, **kwargs):
         return get_object_or_not_exist(XFormInstance, kwargs['pk'], kwargs['domain'])
 
-    class Meta(XFormInstanceMeta):
+    class Meta(CustomResourceMeta):
         object_class = XFormInstance        
         list_allowed_methods = []
         detail_allowed_methods = ['get']
         resource_name = 'form'
+        serializer = XFormInstanceSerializer()

--- a/corehq/apps/api/resources/v0_1.py
+++ b/corehq/apps/api/resources/v0_1.py
@@ -210,6 +210,10 @@ class CommCareCaseResource(JsonResource, DomainSpecificResourceMixin):
         detail_allowed_methods = ['get']
         resource_name = 'case'
 
+
+class XFormInstanceMeta(CustomResourceMeta):
+    serializer = CustomXMLSerializer(formats=['json'])
+
 class XFormInstanceResource(JsonResource, DomainSpecificResourceMixin):
     type = "form"
     id = fields.CharField(attribute='get_id', readonly=True, unique=True)
@@ -225,7 +229,7 @@ class XFormInstanceResource(JsonResource, DomainSpecificResourceMixin):
     def obj_get(self, bundle, **kwargs):
         return get_object_or_not_exist(XFormInstance, kwargs['pk'], kwargs['domain'])
 
-    class Meta(CustomResourceMeta):
+    class Meta(XFormInstanceMeta):
         object_class = XFormInstance        
         list_allowed_methods = []
         detail_allowed_methods = ['get']

--- a/corehq/apps/api/serializers.py
+++ b/corehq/apps/api/serializers.py
@@ -1,11 +1,16 @@
 
-import defusedxml.lxml as lxml
-from lxml.etree import Element, tostring, LxmlError
-from django.utils.encoding import force_unicode
-
+# Standard library imports
 from io import BytesIO
+
+# Django & Tastypie imports
+from django.utils.encoding import force_unicode
 from tastypie.bundle import Bundle
 from tastypie.serializers import Serializer, get_type_string
+
+# External imports
+import defusedxml.lxml as lxml
+from lxml.etree import Element, tostring, LxmlError
+
 
 class CommCareCaseSerializer(Serializer):
     '''
@@ -86,4 +91,20 @@ class CommCareCaseSerializer(Serializer):
                     element.text = force_unicode(simple_data)
 
         return element
-        
+
+
+class CustomXMLSerializer(Serializer):
+    def to_etree(self, data, options=None, name=None, depth=0):
+        etree = super(CustomXMLSerializer, self).to_etree(data, options, name, depth)
+        id = etree.find('id')
+        if id is not None:
+            etree.attrib['id'] = id.findtext('.')
+            etree.remove(id)
+        return etree
+
+class XFormInstanceSerializer(Serializer):
+    def to_xml(self, data, options=None):
+        if isinstance(data, Bundle):
+            return data.obj.get_xml()
+        else:
+            return super(XFormInstanceSerializer, self).to_xml(data, options=options)


### PR DESCRIPTION
I decided not to remove this from all resources since there is at least some chance of there being an XML-junkie out there that is consuming our JSON by first converting it to XML...
