### PR TITLE
fix secure_submissions field on domain page

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -376,8 +376,8 @@ class DomainMetadataForm(DomainGlobalSettingsForm, SnapshotSettingsMixin):
     secure_submissions = BooleanField(
         label=_("Only accept secure submissions"),
         required=False,
-        help_text=_("Turn this on to prevent others from impersonating your"
-                    "mobile workers. To use, all of your deployed applications"
+        help_text=_("Turn this on to prevent others from impersonating your "
+                    "mobile workers. To use, all of your deployed applications "
                     "must be using secure submissions."),
     )
 

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -207,6 +207,7 @@ class EditBasicProjectInfoView(BaseEditProjectInfoView):
                 'commtrack_enabled',
                 'restrict_superusers',
                 'ota_restore_caching',
+                'secure_submissions',
             ]:
                 initial[attr] = getattr(self.domain_object, attr)
             initial.update({


### PR DESCRIPTION
- text was funky
- checkbox didn't get checked in UI on reload
