### PR TITLE
removing old case sharing warning

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases.js
@@ -54,7 +54,6 @@ function ReleasesMain(o) {
     /* {fetchUrl, deleteUrl} */
     var self = this;
     self.options = o;
-    self.users_cannot_share = self.options.users_cannot_share;
     self.recipients = self.options.recipient_contacts;
     self.savedApps = ko.observableArray();
     self.doneFetching = ko.observable(false);

--- a/corehq/apps/app_manager/templates/app_manager/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/releases.html
@@ -259,27 +259,7 @@
                 <h3>{% trans "Deploying version" %} <span data-bind="text: version"></span></h3>
             </div>
             <div class="modal-body">
-                <div data-bind="visible: case_sharing() && $root.users_cannot_share.length">
-                    <p>
-                        <span class="label label-important">{% trans "Warning!" %}</span>
-                        {% blocktrans %}
-                        The following users cannot use this case sharing app because they have either more or less than one group.
-                        To fix this, please 
-                        {% endblocktrans %}
-                        <a href="{% url "commcare_users" domain %}?cannot_share=true&more_columns=true">{% trans "edit their group settings" %}</a>
-                        {% trans "so that they all belong to exactly one group." %}
-                    </p>
-                    <ul data-bind="foreach: $root.users_cannot_share">
-                        <li data-bind="text: username"></li>
-                    </ul>
-                    <p>
-                        <a href="{% url "commcare_users" domain %}?cannot_share=true&more_columns=true" class="btn">{% trans "Edit mobile users" %}</a>
-                        <a class="btn" data-bind="click: function () {return $root.deployAnyway[id()](true);}">{% trans "Deploy anyway" %}</a>
-                    </p>
-                </div>
-                <div class="accordion" data-bind="bootstrapCollapse: true,
-                    visible: $root.deployAnyway[id()]() || !(case_sharing() && $root.users_cannot_share.length)
-                ">
+                <div class="accordion" data-bind="bootstrapCollapse: true">
                     <div class="accordion-group">
                         <div class="accordion-heading">
                             <a class="accordion-toggle" data-bind="attr: {href: $root.url('emulator', id)}">

--- a/corehq/apps/app_manager/templates/app_manager/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/releases.html
@@ -32,7 +32,6 @@
             currentVersion: '{% url "corehq.apps.app_manager.views.current_app_version" domain app.id %}',
         };
         var o = {
-            users_cannot_share: {{ users_cannot_share|JSON }},
             urls: urls,
             currentAppVersion: {% if app.version %}{{ app.version }}{% else %}-1{% endif %},
             recipient_contacts: {{ sms_contacts|JSON }}

--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -534,12 +534,10 @@ def release_manager(request, domain, app_id, template='app_manager/releases.html
 
     saved_apps = []
 
-    users_cannot_share = CommCareUser.cannot_share(domain)
     context.update({
         'release_manager': True,
         'saved_apps': saved_apps,
         'latest_release': latest_release,
-        'users_cannot_share': users_cannot_share,
     })
     if not app.is_remote_app():
         # Multimedia is not supported for remote applications at this time.


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?85271#487751

Since case sharing errors are dealt with in the application, we're removing the case sharing error that comes up at "Deploy".
