### PR TITLE
use infinite timeouts for application assets

### DIFF
--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -1654,7 +1654,7 @@ def download_file(req, domain, app_id, path):
                 payload = payload.encode('utf-8')
             buffer = StringIO(payload)
             metadata = {'content_type': mimetype}
-            obj.cache_put(buffer, metadata)
+            obj.cache_put(buffer, metadata, timeout=0)
         else:
             _, buffer = obj.get()
             payload = buffer.getvalue()

--- a/corehq/apps/hqmedia/views.py
+++ b/corehq/apps/hqmedia/views.py
@@ -511,7 +511,7 @@ class ViewMultimediaFile(View):
                 data = CommCareImage.get_thumbnail_data(data, self.thumb)
             buffer = StringIO(data)
             metadata = {'content_type': content_type}
-            obj.cache_put(buffer, metadata)
+            obj.cache_put(buffer, metadata, timeout=0)
         else:
             metadata, buffer = obj.get()
             data = buffer.getvalue()


### PR DESCRIPTION
Application assets stored in redis should have an infinite timeout, with replacement handled by LRU.

Depends on https://github.com/dimagi/dimagi-utils/pull/168/files
