### PR TITLE
process incoming messages asynchronously

### DIFF
--- a/corehq/apps/grapevine/tasks.py
+++ b/corehq/apps/grapevine/tasks.py
@@ -1,0 +1,6 @@
+from celery.task import task
+from corehq.apps.sms.api import incoming as incoming_sms
+
+@task
+def incoming_sms_async(phone_number, text, backend_api):
+    incoming_sms(phone_number, text, backend_api)

--- a/corehq/apps/grapevine/views.py
+++ b/corehq/apps/grapevine/views.py
@@ -1,5 +1,5 @@
 from corehq.apps.grapevine.api import GrapevineBackend
-from corehq.apps.sms.api import incoming as incoming_sms
+from corehq.apps.grapevine.tasks import incoming_sms_async
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.views.decorators.csrf import csrf_exempt
 from xml.etree import ElementTree as ET
@@ -60,7 +60,7 @@ def sms_in(request):
             content_text = root.find('content').text
             text = unescape(content_text) if content_text else ''
 
-            incoming_sms(phone_number, text, GrapevineBackend.get_api_id())
+            incoming_sms_async.delay(phone_number, text, GrapevineBackend.get_api_id())
         elif root.tag == 'gviSmsResponse':
             date_string = root.find('responseDateTime').text
             phone_number = root.find('recipient/msisdn').text
@@ -69,7 +69,7 @@ def sms_in(request):
             if resp_type == 'reply':
                 response_text = root.find('response').text
                 message_text = unescape(response_text) if response_text else ''
-                incoming_sms(phone_number, message_text, GrapevineBackend.get_api_id())
+                incoming_sms_async.delay(phone_number, message_text, GrapevineBackend.get_api_id())
 
         return HttpResponse()
     else:


### PR DESCRIPTION
Currently the requests from Grapevine timeout before a response is sent back resulting in retry attempts and messages being received multiple times by HQ.
