### PR TITLE
include both the referenced build and the latest build in cache key

### DIFF
--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -1647,7 +1647,11 @@ def download_file(req, domain, app_id, path):
 
     try:
         assert req.app.copy_of
-        obj = CachedObject(str(app_id) + ":" + full_path)
+        obj = CachedObject('{primary}-{secondary}:{path}'.format(
+            primary=app_id,
+            secondary=req.app._id,
+            path=full_path,
+        ))
         if not obj.is_cached():
             payload = req.app.fetch_attachment(full_path)
             if type(payload) is unicode:


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?87253
