### PR TITLE
Don't 500 on user uploads page

### DIFF
--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -585,11 +585,14 @@ class UploadCommCareUsers(BaseManageCommCareUserView):
         except WorksheetNotFound:
             self.group_specs = []
 
+        self.location_specs = []
         if Domain.get_by_name(self.domain).commtrack_enabled:
             try:
                 self.location_specs = self.workbook.get_worksheet(title='locations')
             except WorksheetNotFound:
-                self.location_specs = []
+                # if there is no sheet for locations (since this was added
+                # later and is optional) we don't error
+                pass
 
         try:
             check_headers(self.user_specs)


### PR DESCRIPTION
Previously errored if commtrack wasn't enabled because the variable
wasn't getting set.

Re: http://manage.dimagi.com/default.asp?87489
