### PR TITLE
fix off by one error in worker activity times

### DIFF
--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -744,10 +744,10 @@ class WorkerActivityTimes(WorkerMonitoringChartBase,
         chart.add_data(d)
 
         # mapping between numbers 0..6 and its day of the week label
-        day_names = "Sun Mon Tue Wed Thu Fri Sat".split(" ")
+        day_names = "Mon Tue Wed Thu Fri Sat Sun".split(" ")
         # the order, bottom-to-top, in which the days should appear
         # i.e. Sun, Sat, Fri, Thu, etc
-        days = (0, 6, 5, 4, 3, 2, 1)
+        days = (6, 5, 4, 3, 2, 1, 0)
 
         sizes=[]
         for d in days:


### PR DESCRIPTION
Fixed off by one error, where data submitted on a monday would show up as being submitted on Sunday. 

pretty sure this report always gave incorrect information
