### PR TITLE
Limit the case API to GET requests

### DIFF
--- a/corehq/apps/api/resources/v0_2.py
+++ b/corehq/apps/api/resources/v0_2.py
@@ -46,3 +46,5 @@ class CommCareCaseResource(JsonResource, DomainSpecificResourceMixin):
     class Meta(CustomResourceMeta):
         object_class = CommCareCase    
         resource_name = 'case'
+        list_allowed_methods = ['get']
+        detail_allowed_methods = ['get']


### PR DESCRIPTION
There was a 500 based on a POST with who-knows-what in it. Either way, I don't think this resource could ever have worked except for GET requests.
