### PR TITLE
Allow loading and saving of custom properties to careplan cases

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -696,7 +696,7 @@ class Form(FormBase, IndexedSchema, NavMenuItemMediaMixin):
                         self.actions.open_case.is_active() or
                         self.actions.update_case.is_active() or
                         self.actions.close_case.is_active()):
-                    parent_types.add(module_case_type)
+                    parent_types.add((module_case_type, 'parent'))
         return parent_types, case_properties
 
 
@@ -931,6 +931,9 @@ class ModuleBase(IndexedSchema, NavMenuItemMediaMixin):
     def requires_case_details(self):
         return False
 
+    def get_case_types(self):
+        return set([self.case_type])
+
     def get_module_info(self):
         return {
             'id': self.id,
@@ -1115,6 +1118,7 @@ class Module(ModuleBase):
 class CareplanForm(FormBase, IndexedSchema, NavMenuItemMediaMixin):
     mode = StringProperty(required=True, choices=['create', 'update'])
     custom_case_updates = DictProperty()
+    case_preload = DictProperty()
 
     @classmethod
     def wrap(cls, data):
@@ -1156,9 +1160,9 @@ class CareplanForm(FormBase, IndexedSchema, NavMenuItemMediaMixin):
         case_properties = set()
         if case_type == self.case_type:
             if case_type == CAREPLAN_GOAL:
-                parent_types.add(module_case_type)
+                parent_types.add((module_case_type, 'parent'))
             elif case_type == CAREPLAN_TASK:
-                parent_types.add(CAREPLAN_GOAL)
+                parent_types.add((CAREPLAN_GOAL, 'goal'))
             case_properties.update(self.case_updates().keys())
 
         return parent_types, case_properties
@@ -1191,20 +1195,21 @@ class CareplanGoalForm(CareplanForm):
         return changes
 
     def get_fixed_questions(self):
-        def q(name, label):
+        def q(name, case_key, label):
             return {
                 'name': name,
+                'key': case_key,
                 'label': label,
                 'path': self[name]
             }
         questions = [
-            q('description_path', _('Description')),
-            q('date_followup_path', _('Followup date')),
+            q('description_path', 'description', _('Description')),
+            q('date_followup_path', 'date_followup', _('Followup date')),
         ]
         if self.mode == 'create':
-            return [q('name_path', _('Name'))] + questions
+            return [q('name_path', 'name', _('Name'))] + questions
         else:
-            return questions + [q('close_path', _('Close if'))]
+            return questions + [q('close_path', 'close', _('Close if'))]
 
 
 class CareplanTaskForm(CareplanForm):
@@ -1239,24 +1244,25 @@ class CareplanTaskForm(CareplanForm):
         return changes
 
     def get_fixed_questions(self):
-        def q(name, label):
+        def q(name, case_key, label):
             return {
                 'name': name,
+                'key': case_key,
                 'label': label,
                 'path': self[name]
             }
         questions = [
-            q('date_followup_path', _('Followup date')),
+            q('date_followup_path', 'date_followup', _('Followup date')),
         ]
         if self.mode == 'create':
             return [
-                q('name_path', _('Name')),
-                q('description_path', _('Description')),
+                q('name_path', 'name', _('Name')),
+                q('description_path', 'description', _('Description')),
             ] + questions
         else:
             return questions + [
-                q('latest_report_path', _('Latest report')),
-                q('close_path', _('Close if')),
+                q('latest_report_path', 'latest_report', _('Latest report')),
+                q('close_path', 'close', _('Close if')),
             ]
 
 
@@ -1324,6 +1330,9 @@ class CareplanModule(ModuleBase):
 
     def requires_case_details(self):
         return True
+
+    def get_case_types(self):
+        return set(f.case_type for f in self.forms)
 
     def get_form_by_type(self, case_type, mode):
         for form in self.forms:

--- a/corehq/apps/app_manager/static/app_manager/js/careplan-config-ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/careplan-config-ui.js
@@ -1,19 +1,133 @@
 
 var CareplanConfig = (function(){
+    var PropertyBase = {
+        mapping: {
+            include: ['key', 'path']
+        },
+        wrap: function (data, transaction) {
+            var self = ko.mapping.fromJS(data, PropertyBase.mapping);
+            self.case_transaction = transaction;
+
+            self.isBlank = ko.computed(function () {
+                return !self.key() && !self.path();
+            });
+
+            // for compatibility with templates
+            self.required = function() {
+                return false;
+            }
+
+            return self;
+        }
+    };
+
     var Question = {
         wrap: function (data, transaction) {
-            var self = ko.mapping.fromJS(data);
-            self.transaction = transaction;
+            var self = PropertyBase.wrap(data, transaction);
 
             self.validateQuestion = ko.computed(function () {
                 if (self.path()) {
-                    if (transaction.propertyCounts()[self.path()] > 1) {
+                    if (transaction.propertyPathCounts()[self.path()] > 1) {
                         return "Question is being used twice.";
+                    } else if (transaction.preloadCounts()[self.path()] > 1){
+                        return "Two properties load to the same question";
+                    }
+                }
+                return null;
+            });
+            self.validateProperty = ko.computed(function () {
+                if (self.path() || self.key()) {
+                    if (transaction.propertyKeyCounts()[self.key()] > 1) {
+                        return "Property updated by two questions";
                     }
                 }
                 return null;
             });
 
+            self.validate = ko.computed(function(){
+                return self.validateProperty() || self.validateQuestion();
+            });
+            return self;
+        }
+    };
+
+    var CaseProperty = {
+        wrap: function (data, transaction) {
+            var self = PropertyBase.wrap(data, transaction);
+
+            self.defaultKey = ko.computed(function () {
+                var path = self.path() || '';
+                var value = path.split('/');
+                value = value[value.length-1];
+                return value;
+            });
+            self.repeat_context = function () {
+                return transaction.careplanConfig.get_repeat_context(self.path());
+            };
+            self.validateQuestion = ko.computed(function () {
+                if (self.path()) {
+                    if (transaction.propertyPathCounts()[self.path()] > 1) {
+                        return "Question is being used twice.";
+                    }
+                }
+            });
+            self.validateProperty = ko.computed(function () {
+                if (self.path() || self.key()) {
+                    if (transaction.propertyKeyCounts()[self.key()] > 1) {
+                        return "Property updated by two questions";
+                    } else if (transaction.careplanConfig.reserved_words.indexOf(self.key()) !== -1) {
+                        return '<strong>' + self.key() + '</strong> is a reserved word';
+                    } else if (self.repeat_context() && self.repeat_context() !== transaction.repeat_context()) {
+                        return 'Inside the wrong repeat!'
+                    } else if (self.key().indexOf('/') != -1) {
+                        return 'Updating properties in the parent case is not supported';
+                    }
+                }
+
+                return null;
+            });
+
+            self.validate = ko.computed(function(){
+                return self.validateProperty() || self.validateQuestion();
+            });
+
+            return self;
+        }
+    };
+
+    var CasePreload = {
+        wrap: function (data, transaction) {
+            var self = PropertyBase.wrap(data, transaction);
+            self.defaultKey = ko.computed(function () {
+                var path = self.path() || '';
+                var value = path.split('/');
+                value = value[value.length-1];
+                return value;
+            });
+
+            self.validateQuestion = ko.computed(function () {
+                if (self.path()) {
+                    if (transaction.preloadCounts()[self.path()] > 1) {
+                        return "Two properties load to the same question";
+                    }
+                }
+                return null;
+            });
+            self.validateProperty = ko.computed(function () {
+                if (self.key()) {
+                    if (transaction.careplanConfig.reserved_words.indexOf(self.key()) !== -1) {
+                        return '<strong>' + self.key() + '</strong> is a reserved word';
+                    } else if (transaction.careplanConfig.mode === 'create' &&
+                        self.key().indexOf('/') == -1) {
+                        return 'Only parent properties can be loaded here.';
+                    }
+                }
+                return null;
+            });
+
+            self.validate = ko.computed(function(){
+                return self.validateProperty() || self.validateQuestion();
+            });
             return self;
         }
     };
@@ -22,11 +136,23 @@ var CareplanConfig = (function(){
         mapping: function (self) {
             return {
                 include: [
-                    'fixedQuestions'
+                    'fixedQuestions',
+                    'case_properties',
+                    'case_preload'
                 ],
                 fixedQuestions: {
                     create: function (options) {
                         return Question.wrap(options.data, self);
+                    }
+                },
+                case_properties: {
+                    create: function(options) {
+                        return CaseProperty.wrap(options.data, self);
+                    }
+                },
+                case_preload: {
+                    create: function(options) {
+                        return CasePreload.wrap(options.data, self);
                     }
                 }
             }
@@ -34,18 +160,136 @@ var CareplanConfig = (function(){
         wrap: function (data, careplanConfig) {
             var self = {};
             ko.mapping.fromJS(data, CareplanTransaction.mapping(self), self);
+            self.careplanConfig = careplanConfig;
 
-            self.propertyCounts = ko.computed(function () {
+            // link self.case_name to corresponding path observable
+            // in case_properties for convenience
+            try {
+                self.case_name = _(self.fixedQuestions()).find(function (p) {
+                    return p.name() === 'name_path';
+                }).path;
+            } catch (e) {
+                self.case_name = null;
+            }
+
+            var count = function(itemLists, accessor) {
                 var count = {};
-                _(self.fixedQuestions()).each(function (p) {
-                    var path = p.path();
-                    if (!count.hasOwnProperty(path)) {
-                        count[path] = 0;
+                var update_count = function(p) {
+                    var key = p[accessor]();
+                    if (!count.hasOwnProperty(key)) {
+                        count[key] = 0;
                     }
-                    return count[path] += 1;
+                    return count[key] += 1;
+                }
+                _(itemLists).each(function(list){
+                    _(list()).each(function (p) {
+                        return update_count(p);
+                    });
                 });
                 return count;
+            }
+
+            self.suggestedProperties = ko.computed(function() {
+                var properties = {
+                    all: [],
+                    preload: [],
+                    save: []
+                };
+                var propertiesMap = self.careplanConfig.propertiesMap;
+                var caseType = self.careplanConfig.caseType;
+                if (_(propertiesMap).has(caseType)) {
+                    properties.all = propertiesMap[caseType]();
+                    if (self.careplanConfig.mode === 'create') {
+                        properties.preload = _.filter(properties.all, function(p) {
+                            return p.indexOf('/') != -1;
+                        });
+                    } else {
+                        properties.preload = properties.all;
+                    }
+                    properties.save = _.filter(properties.all, function(p) {
+                        return p.indexOf('/') == -1;
+                    });
+                }
+                return properties;
             });
+
+            self.suggestedPreloadProperties = ko.computed(function () {
+                return self.suggestedProperties().preload;
+            });
+
+            self.suggestedSaveProperties = ko.computed(function() {
+                return self.suggestedProperties().save;
+            });
+
+            var updates = [self.fixedQuestions, self.case_properties];
+            self.propertyPathCounts = ko.computed(function () {
+                return count(updates, 'path');
+            });
+
+            self.propertyKeyCounts = ko.computed(function () {
+                return count(updates, 'key');
+            });
+
+            self.preloadCounts = ko.computed(function (){
+                return count([self.fixedQuestions, self.case_preload], 'path');
+            })
+
+            self.addProperty = function () {
+                var property = CaseProperty.wrap({
+                    path: '',
+                    key: ''
+                }, self);
+
+                self.case_properties.push(property);
+            };
+
+            self.removeProperty = function (property) {
+                self.case_properties.remove(property);
+            };
+
+            self.addPreload = function () {
+                var property = CasePreload.wrap({
+                    path: '',
+                    key: ''
+                }, self);
+
+                self.case_preload.push(property);
+            };
+
+            self.removePreload = function (property) {
+                self.case_preload.remove(property);
+            };
+
+            self.repeat_context = function () {
+                return self.careplanConfig.get_repeat_context(self.case_name);
+            };
+
+            self.ensureBlankProperties = function () {
+                var items = [{
+                    properties: self.case_properties(),
+                    addProperty: self.addProperty
+                }];
+                if (self.case_preload) {
+                    items.push({
+                        properties: self.case_preload(),
+                        addProperty: self.addPreload
+                    });
+                }
+                _(items).each(function (item) {
+                    var properties = item.properties;
+                    var last = properties[properties.length-1];
+                    if (last && !last.isBlank()) {
+                        item.addProperty();
+                    }
+                });
+            };
+
+            // for compatibility with templates
+            self.allow = {
+                repeats: function(){
+                    return true;
+                }
+            }
 
             self.unwrap = function () {
                 CareplanTransaction.unwrap(self);
@@ -54,19 +298,55 @@ var CareplanConfig = (function(){
             return self;
         },
         unwrap: function (self) {
-            return ko.mapping.toJS(self, CareplanTransaction.mapping(self));
+            var unwrap = function(list, filter) {
+                if (filter) {
+                    list = _.filter(list, function(p) {
+                        return !p.isBlank();
+                    });
+                }
+                return ko.mapping.toJS(list, PropertyBase.mapping);
+            }
+            return {
+                fixedQuestions: unwrap(self.fixedQuestions()),
+                case_preload: unwrap(self.case_preload(), true),
+                case_properties: unwrap(self.case_properties(), true)
+            }
         }
     }
 
     var Careplan = function(params){
         var self = this;
-        self.home = params.home,
+        self.mode = params.mode;
+        self.caseType = params.caseType;
+        self.home = params.home;
         self.edit = params.edit;
         self.save_url = params.save_url;
         self.questions = params.questions;
+        self.reserved_words = params.reserved_words;
+        self.moduleCaseTypes = params.moduleCaseTypes;
+        self.propertiesMap = ko.mapping.fromJS(params.propertiesMap);
+
         self.transaction = CareplanTransaction.wrap({
-            fixedQuestions: params.fixedQuestions
+            fixedQuestions: params.fixedQuestions,
+            case_properties: params.customCaseUpdates,
+            case_preload: params.case_preload
+        }, self);
+
+        var questionMap = {};
+        _(self.questions).each(function (question) {
+            questionMap[question.value] = question;
         });
+        self.get_repeat_context = function(path) {
+            if (path && questionMap[path]) {
+                return questionMap[path].repeat;
+            } else {
+                return undefined;
+            }
+        };
+
+        self.getQuestions = function (filter, excludeHidden, includeRepeat) {
+            return CC_UTILS.getQuestions(self.questions, filter, excludeHidden, includeRepeat);
+        };
 
         self.saveButton = COMMCAREHQ.SaveButton.init({
             unsavedMessage: "You have unsaved changes",
@@ -76,7 +356,7 @@ var CareplanConfig = (function(){
                     type: 'post',
                     url: self.save_url,
                     data: {
-                        fixedQuestions: JSON.stringify(transaction.fixedQuestions)
+                        transaction: JSON.stringify(transaction)
                     },
                     dataType: 'json',
                     success: function (data) {
@@ -87,9 +367,15 @@ var CareplanConfig = (function(){
         });
 
         self.validate = ko.computed(function(){
-            var duplicate = _.find(_.values(self.transaction.propertyCounts()), function(count){
-                return count > 1;
-            });
+            var has_dups = function(list) {
+                 return _.find(_.values(list), function(count){
+                    return count > 1;
+                });
+            }
+            var duplicate = has_dups(self.transaction.propertyPathCounts()) ||
+                has_dups(self.transaction.propertyKeyCounts()) ||
+                has_dups(self.transaction.preloadCounts());
+
             var isValid = duplicate === undefined;
             self.saveButton.fire(isValid ? 'enable' : 'disable');
             return  isValid;
@@ -97,6 +383,7 @@ var CareplanConfig = (function(){
 
         self.change = function () {
             self.saveButton.fire('change');
+            self.transaction.ensureBlankProperties();
         };
 
         self.init = function () {
@@ -107,6 +394,7 @@ var CareplanConfig = (function(){
                      .on('change', 'select, input[type="hidden"]', self.change)
                      .on('click', 'a', self.change);
             });
+            self.transaction.ensureBlankProperties();
         }
     };
 

--- a/corehq/apps/app_manager/static/app_manager/js/case-config-ui-2.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case-config-ui-2.js
@@ -218,7 +218,8 @@ var CaseConfig = (function () {
             } catch (e) {
                 self.case_name = null;
             }
-            self.suggestedProperties = ko.computed(self.suggestedProperties, self);
+            self.suggestedPreloadProperties = ko.computed(self.suggestedProperties, self);
+            self.suggestedSaveProperties = ko.computed(self.suggestedProperties, self);
 
             self.addProperty = function () {
                 var property = CaseProperty.wrap({

--- a/corehq/apps/app_manager/templates/app_manager/form_view_careplan.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view_careplan.html
@@ -10,6 +10,7 @@
     <script src="{% static 'hqwebapp/js/knockout-bindings.js' %}"></script>
 
     <script src="{% static 'app_manager/js/case-knockout-bindings.js' %}"></script>
+    <script src="{% static 'app_manager/js/case-config-utils.js' %}"></script>
     <script src="{% static 'app_manager/js/careplan-config-ui.js' %}"></script>
     <script src="{% static 'cloudcare/js/util.js' %}"></script>
 {% endblock %}
@@ -23,13 +24,18 @@
             var form_empty = {% if form.source and xform_questions %}false{% else %}true{% endif %};
 
             var careplan = new CareplanConfig.Careplan({
-                home: $('#casexml_home'),
+                home: $('#case-config-ko'),
                 edit: edit,
+                mode: "{{ mode }}",
+                caseType: {{ form.get_case_type|JSON }},
                 questions: {{ xform_questions|JSON }},
                 fixedQuestions: {{ fixed_questions|JSON }},
-                customCaseUpdates: {{ custom_case_updates|JSON }},
+                customCaseUpdates: {{ custom_case_properties|JSON }},
+                case_preload: {{ case_preload|JSON }},
+                reserved_words: {{ case_reserved_words_json|JSON }},
                 caseType: {{ form.get_case_type|JSON }},
                 save_url: "{% url "corehq.apps.app_manager.views.edit_careplan_form_actions" app.domain app.id module.id nav_form.id %}",
+                moduleCaseTypes: {{ module_case_types|JSON }},
                 propertiesMap: {{ case_properties|JSON }}
             });
             careplan.init();
@@ -110,32 +116,7 @@
         {% else %}
             {% if form.source %}
                 <div class="casexml" id="casexml_home">
-                    <div data-bind="saveButton: saveButton, visible: edit, css: {disabled: validate}"></div>
-                    <table class="table table-condensed">
-                        <thead>
-                            <tr>
-                                <th>{% trans "Question" %}</th>
-                                <th>{% trans "Case Property" %}</th>
-                            </tr>
-                        </thead>
-
-                        <tbody data-bind="foreach: transaction.fixedQuestions">
-                            <tr class="control-group" data-bind="css: {error: validateQuestion}">
-                                <td data-bind="text: label">
-                                </td>
-                                <td>
-                                    <div>
-                                        <input class="input-xxlarge" type="hidden" data-bind="
-                                            questionsSelect: $root.questions,
-                                            value: path,
-                                            optionsCaption: ' '"
-                                        />
-                                    </div>
-                                    <p class="help-inline" data-bind="html: validateQuestion, visible: validateQuestion"></p>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
+                    {% include 'app_manager/partials/case_config_careplan.html' %}
                 </div>
             {% else %}
                 <p class="alert alert-warning">

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_config.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_config.html
@@ -1,5 +1,7 @@
 {% load i18n %}
 
+{% include 'app_manager/partials/case_config_shared.html' %}
+
 <script type="text/html" id="remove-subcase-modal-template">
     <div class="modal-header">
         <a href="#" class="close" data-dismiss="modal">×</a>
@@ -40,118 +42,6 @@
         </span>
     </div>
     <!--/ko-->
-</script>
-
-<script type="text/html" id="case-config:case-properties:question">
-    <input class="input-large" type="hidden" data-bind="
-        questionsSelect: $root.getQuestions('all', false, case_transaction.allow.repeats()),
-        value: path,
-        optionsCaption: ' ',
-        edit: $root.edit"
-    />
-    <p class="help-inline" data-bind="visible: required() && !path()">{% trans "Required" %}</p>
-</script>
-
-<script type="text/html" id="case-config:case-properties:property">
-    <span data-bind="visible: !required()">
-        <input type="text" class="input-medium" data-bind="
-            valueDefault: key,
-            default: defaultKey,
-            edit: $root.edit,
-            typeahead: case_transaction.suggestedProperties
-        "/>
-    </span>
-    <span data-bind="visible: required()">
-        <code data-bind="text: key"></code>
-    </span>
-</script>
-
-<script type="text/html" id="case-config:case-transaction:case-preload">
-    <em>{% trans "Load the following case properties into the form" %}</em>
-    <div class="alert alert-block alert-info" data-bind="visible: !case_preload().length">
-        {% trans "No case properties will be loaded" %}
-    </div>
-    <table class="table table-condensed" data-bind="visible: case_preload().length">
-        <thead>
-            <tr>
-                <th></th>
-                <th>{% trans "Case Property" %}</th>
-                <th></th>
-                <th>{% trans "Question" %}</th>
-            </tr>
-        </thead>
-
-        <tbody data-bind="foreach: case_preload">
-            <tr class="control-group" data-bind="css: {error: validateProperty() || validateQuestion}">
-                <td>
-                    <a href="#" data-bind="
-                        click: $parent.removePreload,
-                        visible: $root.edit && !(isBlank() && $index() === $parent.case_preload().length - 1)">
-                        <i class="icon-remove"></i>
-                    </a>
-                </td>
-                <td>
-                    <div data-bind="template: 'case-config:case-properties:property'"></div>
-                    <p class="help-inline" data-bind="html: validateProperty, visible: validateProperty"></p>
-                </td>
-                <td>
-                    <i class="icon-arrow-right"></i>
-                </td>
-                <td>
-                    <div data-bind="template: 'case-config:case-properties:question'"></div>
-                    <p class="help-inline" data-bind="html: validateQuestion, visible: validateQuestion"></p>
-                </td>
-            </tr>
-        </tbody>
-    </table>
-    <a href="#" data-bind="click: addPreload, visible: $root.edit && !case_preload().length">
-        <i class="icon-plus"></i>
-        {% trans "Load properties" %}
-    </a>
-</script>
-
-<script type="text/html" id="case-config:case-transaction:case-properties">
-    <em>{% trans "Save data to the following case properties" %}</em>
-    <div class="alert alert-block alert-info" data-bind="visible: !case_properties().length">
-        {% trans "No case properties will be saved" %}
-    </div>
-    <table class="table table-condensed" data-bind="visible: case_properties().length">
-        <thead>
-            <tr>
-                <th></th>
-                <th>{% trans "Question" %}</th>
-                <th></th>
-                <th>{% trans "Case Property" %}</th>
-            </tr>
-        </thead>
-
-        <tbody data-bind="foreach: case_properties">
-            <tr class="control-group" data-bind="css: {error: validate, warning: !validate() && required() && !path()}">
-                <td>
-                    <a href="#" data-bind="
-                        click: $parent.removeProperty,
-                        visible: $root.edit && !required() && !(isBlank() && $index() === $parent.case_properties().length - 1)
-                    ">
-                        <i class="icon-remove"></i>
-                    </a>
-                </td>
-                <td>
-                    <div data-bind="template: 'case-config:case-properties:question'"></div>
-                </td>
-                <td>
-                    <i class="icon-arrow-right"></i>
-                </td>
-                <td>
-                    <div data-bind="template: 'case-config:case-properties:property'"></div>
-                    <p class="help-inline" data-bind="html: validate, visible: validate"></p>
-                </td>
-            </tr>
-        </tbody>
-    </table>
-    <a href="#" data-bind="click: addProperty, visible: $root.edit && !case_properties().length">
-        <i class="icon-plus"></i>
-        {% trans "Save properties" %}
-    </a>
 </script>
 
 <script type="text/html" id="case-config:case-transaction">

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_config_careplan.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_config_careplan.html
@@ -1,0 +1,52 @@
+{% load i18n %}
+
+{% include 'app_manager/partials/case_config_shared.html' %}
+
+<script type="text/html" id="case-config:case-transaction">
+    <div class="row-fluid">
+        <div class="well span6">
+            <div data-bind="template: 'case-config:case-transaction:case-preload'"></div>
+        </div>
+        <div class="well span6">
+            <div data-bind="template: 'case-config:case-transaction:case-properties'"></div>
+        </div>
+    </div>
+</script>
+
+<div id="case-config-ko">
+    <div data-bind="saveButton: saveButton, visible: edit, css: {disabled: validate}"></div>
+    <div data-bind="with: transaction">
+        <table class="table table-condensed">
+            <thead>
+                <tr>
+                    <th>{% trans "Question" %}</th>
+                    <th>{% trans "Case Property" %}</th>
+                </tr>
+            </thead>
+
+            <tbody data-bind="foreach: fixedQuestions">
+                <tr class="control-group" data-bind="css: {error: validate}">
+                    <td>
+                        <div><span data-bind="text: label"></span></div>
+                        <p class="help-inline" data-bind="html: validateProperty, visible: validateProperty"></p>
+                    </td>
+                    <td>
+                        <div>
+                            <input class="input-xxlarge" type="hidden" data-bind="
+                                questionsSelect: $root.questions,
+                                value: path,
+                                optionsCaption: ' ',
+                                edit: $root.edit"
+                            />
+                        </div>
+                        <p class="help-inline" data-bind="html: validateQuestion, visible: validateQuestion"></p>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+        <div>
+            <strong>{% trans "Extra fields to load into the form or save to the case" %}</strong>
+            <div data-bind="template: {name: 'case-config:case-transaction'}"></div>
+        </div>
+    </div>
+</div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_config_shared.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_config_shared.html
@@ -1,0 +1,119 @@
+{% load i18n %}
+
+<script type="text/html" id="case-config:case-properties:question">
+    <input class="input-large" type="hidden" data-bind="
+        questionsSelect: $root.getQuestions('all', false, case_transaction.allow.repeats()),
+        value: path,
+        optionsCaption: ' ',
+        edit: $root.edit"
+    />
+    <p class="help-inline" data-bind="visible: required() && !path()">{% trans "Required" %}</p>
+</script>
+
+<script type="text/html" id="case-config:case-properties:property">
+    <span data-bind="visible: !property.required()">
+        <input type="text" class="input-medium" data-bind="
+            valueDefault: property.key,
+            default: property.defaultKey,
+            edit: $root.edit,
+            typeahead: suggestedProperties
+        "/>
+    </span>
+    <span data-bind="visible: property.required()">
+        <code data-bind="text: property.key"></code>
+    </span>
+</script>
+
+<script type="text/html" id="case-config:case-transaction:case-preload">
+    <em>{% trans "Load the following case properties into the form" %}</em>
+    <div class="alert alert-block alert-info" data-bind="visible: !case_preload().length">
+        {% trans "No case properties will be loaded" %}
+    </div>
+    <table class="table table-condensed" data-bind="visible: case_preload().length">
+        <thead>
+            <tr>
+                <th></th>
+                <th>{% trans "Case Property" %}</th>
+                <th></th>
+                <th>{% trans "Question" %}</th>
+            </tr>
+        </thead>
+
+        <tbody data-bind="foreach: case_preload">
+            <tr class="control-group" data-bind="css: {error: validateProperty || validateQuestion}">
+                <td>
+                    <a href="#" data-bind="
+                        click: $parent.removePreload,
+                        visible: $root.edit && !(isBlank() && $index() === $parent.case_preload().length - 1)">
+                        <i class="icon-remove"></i>
+                    </a>
+                </td>
+                <td>
+                    <div data-bind="template: {
+                        name: 'case-config:case-properties:property',
+                        data: {'property': $data, 'suggestedProperties': case_transaction.suggestedPreloadProperties}
+                    }"></div>
+                    <p class="help-inline" data-bind="html: validateProperty, visible: validateProperty"></p>
+                </td>
+                <td>
+                    <i class="icon-arrow-right"></i>
+                </td>
+                <td>
+                    <div data-bind="template: 'case-config:case-properties:question'"></div>
+                    <p class="help-inline" data-bind="html: validateQuestion, visible: validateQuestion"></p>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+    <a href="#" data-bind="click: addPreload, visible: $root.edit && !case_preload().length">
+        <i class="icon-plus"></i>
+        {% trans "Load properties" %}
+    </a>
+</script>
+
+<script type="text/html" id="case-config:case-transaction:case-properties">
+    <em>{% trans "Save data to the following case properties" %}</em>
+    <div class="alert alert-block alert-info" data-bind="visible: !case_properties().length">
+        {% trans "No case properties will be saved" %}
+    </div>
+    <table class="table table-condensed" data-bind="visible: case_properties().length">
+        <thead>
+            <tr>
+                <th></th>
+                <th>{% trans "Question" %}</th>
+                <th></th>
+                <th>{% trans "Case Property" %}</th>
+            </tr>
+        </thead>
+
+        <tbody data-bind="foreach: case_properties">
+            <tr class="control-group" data-bind="css: {error: validate, warning: !validate() && required() && !path()}">
+                <td>
+                    <a href="#" data-bind="
+                        click: $parent.removeProperty,
+                        visible: $root.edit && !required() && !(isBlank() && $index() === $parent.case_properties().length - 1)
+                    ">
+                        <i class="icon-remove"></i>
+                    </a>
+                </td>
+                <td>
+                    <div data-bind="template: 'case-config:case-properties:question'"></div>
+                </td>
+                <td>
+                    <i class="icon-arrow-right"></i>
+                </td>
+                <td>
+                    <div data-bind="template: {
+                        name: 'case-config:case-properties:property',
+                        data: {property: $data, suggestedProperties: case_transaction.suggestedSaveProperties}
+                    }"></div>
+                    <p class="help-inline" data-bind="html: validate, visible: validate"></p>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+    <a href="#" data-bind="click: addProperty, visible: $root.edit && !case_properties().length">
+        <i class="icon-plus"></i>
+        {% trans "Save properties" %}
+    </a>
+</script>

--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -384,8 +384,10 @@ def get_form_view_context_and_template(request, form, langs, is_user_registratio
 
     if isinstance(form, CareplanForm):
         context.update({
+            'mode': form.mode,
             'fixed_questions': form.get_fixed_questions(),
-            'custom_case_properties': form.custom_case_updates,
+            'custom_case_properties': [{'key': key, 'path': path} for key, path in form.custom_case_updates.items()],
+            'case_preload': [{'key': key, 'path': path} for key, path in form.case_preload.items()],
         })
         return "app_manager/form_view_careplan.html", context
     else:
@@ -1242,9 +1244,17 @@ def edit_form_actions(req, domain, app_id, module_id, form_id):
 def edit_careplan_form_actions(req, domain, app_id, module_id, form_id):
     app = get_app(domain, app_id)
     form = app.get_module(module_id).get_form(form_id)
-    fixed_questions = json.loads(req.POST.get('fixed_questions'))
-    for question in fixed_questions:
+    transaction = json.loads(req.POST.get('transaction'))
+
+    for question in transaction['fixedQuestions']:
         setattr(form, question['name'], question['path'])
+
+    def to_dict(properties):
+        return dict((p['key'], p['path']) for p in properties)
+
+    form.custom_case_updates = to_dict(transaction['case_properties'])
+    form.case_preload = to_dict(transaction['case_preload'])
+
     response_json = {}
     app.save(response_json)
     return json_response(response_json)


### PR DESCRIPTION
New Goal / New Task
- Can load case properties from parents
- Can save additional properties to the case
- Can NOT update properties in the parent case (easier not to support this)

Update Goal / Update Task
- Can load case properties from the case or its parents
- Can save additional properties to the case
- Can NOT update properties in the parent case (easier not to support this)
