### PR TITLE
fix opm fluff

### DIFF
--- a/custom/opm/opm_reports/case_calcs.py
+++ b/custom/opm/opm_reports/case_calcs.py
@@ -26,14 +26,7 @@ def block_type(form):
 
 
 def case_date_group(form):
-    return { 
-        'date': form.received_on,
-        'value': 1,
-        'group_by': [
-            form.domain,
-            form.form['case']['@case_id'],
-        ],
-    }
+    return form.received_on
 
 class BirthPreparedness(fluff.Calculator):
     """

--- a/custom/opm/opm_reports/models.py
+++ b/custom/opm/opm_reports/models.py
@@ -32,7 +32,7 @@ class OpmCaseFluff(fluff.IndicatorDocument):
 
     document_class = CommCareCase
     domains = ('opm',)
-    group_by = ('domain', )
+    group_by = ('domain', 'user_id')
 
     name = flat_field(lambda case: case.name)
     husband_name = case_property('husband_name')
@@ -73,7 +73,10 @@ class OpmFormFluff(fluff.IndicatorDocument):
     document_class = XFormInstance
 
     domains = ('opm',)
-    # group_by = ('domain', )
+    group_by = (
+        'domain',
+        fluff.AttributeGetter('case_id', lambda form: form.form['case']['@case_id']),
+    )
 
     name = flat_field(lambda form: form.name)
 

--- a/custom/opm/opm_reports/user_calcs.py
+++ b/custom/opm/opm_reports/user_calcs.py
@@ -39,14 +39,7 @@ class WomenRegistered(fluff.Calculator):
                     children = form.form.get('live_birth_amount')
                     if children:
                         total += int(children)
-            yield { 
-                'date': None,
-                'value': total,
-                'group_by': [
-                    case.domain,
-                    case.user_id,
-                ],
-            }
+            yield [None, total]
 
 
 class ServiceForms(fluff.Calculator):


### PR DESCRIPTION
Calculator `group_by` must be same length as IndicatorDoc `group_by` so:
- simplified most common emitter `case_date_group` to just emit date (value is auto set to '1') by moving `group_by` to IndicatorDoc
- similar for OpmUserFluff
