### PR TITLE
Stock models

### DIFF
--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -3,9 +3,12 @@ from xml.etree import ElementTree
 import collections
 from couchdbkit.exceptions import ResourceNotFound
 from couchdbkit.ext.django.schema import *
+from django.db import transaction
 from django.utils.translation import ugettext as _
 from casexml.apps.case.mock import CaseBlock
+from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.xml import V1, V2
+from casexml.apps.stock.models import StockReport as DbStockReport, StockTransaction as DbStockTransaction
 from corehq import Domain
 
 from corehq.apps.commtrack import const
@@ -15,7 +18,6 @@ from dimagi.utils.couch.loosechange import map_reduce
 from couchforms.models import XFormInstance
 from dimagi.utils import parsing as dateparse
 from datetime import datetime
-from casexml.apps.case.models import CommCareCase
 from copy import copy
 from django.dispatch import receiver
 from corehq.apps.locations.signals import location_created, location_edited
@@ -433,19 +435,45 @@ class NewStockReport(object):
     Intermediate class for dealing with stock XML
     """
     # todo: fix name, remove old stock report class
-    def __init__(self, tag, node, transactions):
+    def __init__(self, form, timestamp, tag, node, transactions):
+        self._form = form
+        self.form_id = form._id
+        self.timestamp = timestamp
         self.tag = tag
         self.node = node
         self.transactions = transactions
 
     @classmethod
-    def from_xml(cls, config, global_context, elem):
+    def from_xml(cls, form, config, elem):
         tag, node = elem
+        timestamp = node.get('@date', form.received_on)
         products = node['product']
         if not isinstance(products, collections.Sequence):
             products = [products]
-        transactions = [StockTransaction.from_xml(config, global_context, tag, node, prod_entry) for prod_entry in products]
-        return cls(tag, node, transactions)
+        transactions = [StockTransaction.from_xml(config, timestamp, tag, node, prod_entry)
+                        for prod_entry in products]
+
+        return cls(form, timestamp, tag, node, transactions)
+
+    @transaction.commit_on_success
+    def create_models(self):
+        report = DbStockReport.objects.create(form_id=self.form_id, date=self.timestamp, type=self.tag)
+        for txn in self.transactions:
+            db_txn = DbStockTransaction(
+                report=report,
+                case_id=txn.case_id,
+                product_id=txn.product_id,
+            )
+            previous_transaction = db_txn.get_previous_transaction()
+            if self.tag == 'balance':
+                db_txn.stock_on_hand = txn.quantity
+                db_txn.quantity = txn.quantity - (previous_transaction.stock_on_hand if previous_transaction else 0)
+            else:
+                assert self.tag == 'transfer'
+                db_txn.quantity = txn.quantity
+                db_txn.stock_on_hand = (previous_transaction.stock_on_hand if previous_transaction else 0) + txn.quantity
+
+            db_txn.save()
 
 
 class StockTransaction(Document):
@@ -526,9 +554,9 @@ class StockTransaction(Document):
 
     @classmethod
     # note: works on 'jsonified' xml as produced by couchforms
-    def from_xml(cls, config, global_context, action_tag, action_node, product_node):
+    def from_xml(cls, config, timestamp, action_tag, action_node, product_node):
         data = {
-            'timestamp': action_node.get('@date', global_context['timestamp']),
+            'timestamp': timestamp,
             'product_id': product_node.get('@id'),
             'quantity': float(product_node.get('@quantity')),
             # note: no location id

--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -489,7 +489,7 @@ class StockTransaction(Document):
     product_id = StringProperty()
     action = StringProperty()
     subaction = StringProperty()
-    quantity = FloatProperty()
+    quantity = DecimalProperty()
     processing_order = IntegerProperty()
 
     """
@@ -839,7 +839,7 @@ class SupplyPointProductCase(CommCareCase):
         app_label = "commtrack"
 
     # can flesh this out more as needed
-    product = StringProperty() # would be nice if this was product_id but is grandfathered in
+    product = StringProperty()  # would be nice if this was product_id but is grandfathered in
     current_stock = DecimalProperty()
     stocked_out_since = StringProperty()
 

--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -472,7 +472,6 @@ class NewStockReport(object):
                 assert self.tag == 'transfer'
                 db_txn.quantity = txn.quantity
                 db_txn.stock_on_hand = (previous_transaction.stock_on_hand if previous_transaction else 0) + txn.quantity
-
             db_txn.save()
 
 
@@ -733,6 +732,13 @@ class SupplyPointCase(CommCareCase):
         else:
             return self
 
+    def get_product_subcases(self):
+        product_subcase_uuids = [ix.referenced_id for ix in self.reverse_indices if ix.identifier == const.PARENT_CASE_REF]
+        return SupplyPointProductCase.view('_all_docs', keys=product_subcase_uuids, include_docs=True)
+
+    def get_product_subcase(self, product_id):
+        filtered = filter(lambda spp: spp.product == product_id, self.get_product_subcases())
+        return filtered[0] if filtered else None
 
     def to_full_dict(self):
         data = super(SupplyPointCase, self).to_full_dict()

--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -1,5 +1,6 @@
 import uuid
 from xml.etree import ElementTree
+import collections
 from couchdbkit.exceptions import ResourceNotFound
 from couchdbkit.ext.django.schema import *
 from django.utils.translation import ugettext as _
@@ -425,6 +426,26 @@ class StockStatus(StringDataSchema):
         return [StockStatus.force_wrap(row["value"]) for row in _view_shared(
             'commtrack/current_stock_status', domain, location_id,
             skip=skip, limit=limit)]
+
+
+class NewStockReport(object):
+    """
+    Intermediate class for dealing with stock XML
+    """
+    # todo: fix name, remove old stock report class
+    def __init__(self, tag, node, transactions):
+        self.tag = tag
+        self.node = node
+        self.transactions = transactions
+
+    @classmethod
+    def from_xml(cls, config, global_context, elem):
+        tag, node = elem
+        products = node['product']
+        if not isinstance(products, collections.Sequence):
+            products = [products]
+        transactions = [StockTransaction.from_xml(config, global_context, tag, node, prod_entry) for prod_entry in products]
+        return cls(tag, node, transactions)
 
 
 class StockTransaction(Document):

--- a/corehq/apps/commtrack/processing.py
+++ b/corehq/apps/commtrack/processing.py
@@ -21,10 +21,11 @@ logger = logging.getLogger('commtrack.incoming')
 
 COMMTRACK_LEGACY_REPORT_XMLNS = 'http://commtrack.org/legacy/stock_report'
 
-# FIXME this decorator is causing me bizarre import issues
 @log_exception()
 def process_stock(sender, xform, config=None, **kwargs):
-    """process the commtrack xml constructs in an incoming submission"""
+    """
+    process the commtrack xml constructs in an incoming submission
+    """
     domain = xform.domain
 
     config = CommtrackConfig.for_domain(domain)

--- a/corehq/apps/commtrack/processing.py
+++ b/corehq/apps/commtrack/processing.py
@@ -118,6 +118,8 @@ def product_subcases(supply_point):
     return DefaultDict(create_product_subcase, product_subcase_mapping)
 
 def unpack_commtrack(xform, config):
+    # todo: I think this function has to be rewritten to work off the
+    # raw XML of the doc in order to preserve ordering
     namespace = xform.form['@xmlns']
     def commtrack_nodes(data):
         for tag, nodes in data.iteritems():
@@ -131,7 +133,6 @@ def unpack_commtrack(xform, config):
                         yield e
 
     for elem in commtrack_nodes(xform.form):
-        # FIXME deal with requisitions later
         yield NewStockReport.from_xml(xform, config, elem)
 
 

--- a/corehq/apps/commtrack/processing.py
+++ b/corehq/apps/commtrack/processing.py
@@ -117,12 +117,8 @@ def product_subcases(supply_point):
     return DefaultDict(create_product_subcase, product_subcase_mapping)
 
 def unpack_commtrack(xform, config):
-
-    global_context = {
-        'timestamp': xform.received_on,
-    }
-
     namespace = xform.form['@xmlns']
+
     def commtrack_nodes(data):
         for tag, nodes in data.iteritems():
             for node in (nodes if isinstance(nodes, collections.Sequence) else [nodes]):
@@ -133,9 +129,10 @@ def unpack_commtrack(xform, config):
                 else:
                     for e in commtrack_nodes(node):
                         yield e
+
     for elem in commtrack_nodes(xform.form):
         # FIXME deal with requisitions later
-        yield NewStockReport.from_xml(config, global_context, elem)
+        yield NewStockReport.from_xml(xform, config, elem)
 
 
 def set_transactions(root, new_tx, E):

--- a/corehq/apps/commtrack/processing.py
+++ b/corehq/apps/commtrack/processing.py
@@ -9,10 +9,9 @@ from casexml.apps.case.models import CommCareCaseAction
 from casexml.apps.case.xml.parser import AbstractAction
 
 from casexml.apps.case.mock import CaseBlock
-from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.xml import V2
 from xml import etree as legacy_etree
-from datetime import datetime, date
+from datetime import date
 from lxml import etree
 from corehq.apps.receiverwrapper.util import get_submit_url
 from receiver.util import spoof_submission
@@ -141,7 +140,8 @@ def set_transactions(root, new_tx, E):
         root.append(tx.to_legacy_xml(E))
 
 def process_product_transactions(user_id, timestamp, case, txs):
-    """process all the transactions from a stock report for an individual
+    """
+    process all the transactions from a stock report for an individual
     product. we have to apply them in bulk because each one may update
     the case state that the next one works off of. therefore we have to
     keep track of the updated case state ourselves

--- a/corehq/apps/commtrack/processing.py
+++ b/corehq/apps/commtrack/processing.py
@@ -84,7 +84,6 @@ def process_stock(sender, xform, config=None, **kwargs):
         report.create_models()
 
 
-
 # TODO retire this with move to new data model
 def product_subcases(supply_point):
     """
@@ -94,9 +93,8 @@ def product_subcases(supply_point):
     """
     from helpers import make_supply_point_product
 
-    product_subcase_uuids = [ix.referenced_id for ix in supply_point.reverse_indices if ix.identifier == const.PARENT_CASE_REF]
-    product_subcases = CommCareCase.view('_all_docs', keys=product_subcase_uuids, include_docs=True)
-    product_subcase_mapping = dict((subcase.dynamic_properties().get('product'), subcase) for subcase in product_subcases)
+    product_subcases = supply_point.get_product_subcases()
+    product_subcase_mapping = dict((subcase.product, subcase) for subcase in product_subcases)
 
     def create_product_subcase(product_uuid):
         return make_supply_point_product(supply_point, product_uuid)
@@ -121,7 +119,6 @@ def product_subcases(supply_point):
 
 def unpack_commtrack(xform, config):
     namespace = xform.form['@xmlns']
-
     def commtrack_nodes(data):
         for tag, nodes in data.iteritems():
             for node in (nodes if isinstance(nodes, collections.Sequence) else [nodes]):

--- a/corehq/apps/commtrack/processing.py
+++ b/corehq/apps/commtrack/processing.py
@@ -79,6 +79,9 @@ def process_stock(sender, xform, config=None, **kwargs):
                      headers={'HTTP_X_SUBMIT_TIME': submit_time},
                      hqsubmission=False)
 
+    # create the django models
+    for report in stock_reports:
+        report.create_models()
 
 
 

--- a/corehq/apps/commtrack/processing.py
+++ b/corehq/apps/commtrack/processing.py
@@ -1,5 +1,5 @@
 import logging
-from dimagi.utils.logging import log_exception
+from dimagi.utils.decorators.log_exception import log_exception
 from corehq.apps.commtrack.models import CommtrackConfig, StockTransaction, SupplyPointCase, NewStockReport
 from corehq.apps.commtrack import const
 import collections
@@ -23,7 +23,7 @@ logger = logging.getLogger('commtrack.incoming')
 COMMTRACK_LEGACY_REPORT_XMLNS = 'http://commtrack.org/legacy/stock_report'
 
 # FIXME this decorator is causing me bizarre import issues
-#@log_exception()
+@log_exception()
 def process_stock(sender, xform, config=None, **kwargs):
     """process the commtrack xml constructs in an incoming submission"""
     domain = xform.domain

--- a/corehq/apps/commtrack/tests/data/balances.py
+++ b/corehq/apps/commtrack/tests/data/balances.py
@@ -7,64 +7,19 @@ def long_date():
     return datetime(today.year, today.month, today.day).isoformat()
 
 
-def blank_balances(sp, products):
+def balances_with_adequate_values(sp, products, datestring=None):
+    if datestring is None:
+        datestring = long_date() + 'Z'
+
     return """
         <ns0:balance xmlns:ns0="http://commtrack.org/stock_report" xmlns="http://openrosa.org/http/response" date="{long_date}" entity-id="{sp_id}">
-            <ns0:product consumption_rate="10.0" id="{product0}" quantity="" stock_category="nodata" stockout_since=""/>
-            <ns0:product consumption_rate="10.0" id="{product1}" quantity="" stock_category="nodata" stockout_since=""/>
-            <ns0:product consumption_rate="10.0" id="{product2}" quantity="" stock_category="nodata" stockout_since=""/>
+            <ns0:product id="{product0}" quantity="10" />
+            <ns0:product id="{product1}" quantity="10" />
+            <ns0:product id="{product2}" quantity="10" />
         </ns0:balance>
     """.format(
         sp_id=sp._id,
-        long_date=long_date() + 'Z',
-        product0=products[0]._id,
-        product1=products[1]._id,
-        product2=products[2]._id,
-    )
-
-
-def balances_with_adequate_values(sp, products):
-    return """
-        <ns0:balance xmlns:ns0="http://commtrack.org/stock_report" xmlns="http://openrosa.org/http/response" date="{long_date}" entity-id="{sp_id}">
-            <ns0:product consumption_rate="10.0" id="{product0}" quantity="10" stock_category="adequate" stockout_since=""/>
-            <ns0:product consumption_rate="10.0" id="{product1}" quantity="" stock_category="nodata" stockout_since=""/>
-            <ns0:product consumption_rate="10.0" id="{product2}" quantity="" stock_category="nodata" stockout_since=""/>
-        </ns0:balance>
-    """.format(
-        sp_id=sp._id,
-        long_date=long_date() + 'Z',
-        product0=products[0]._id,
-        product1=products[1]._id,
-        product2=products[2]._id,
-    )
-
-
-def balances_with_overstock_values(sp, products):
-    return """
-        <ns0:balance xmlns:ns0="http://commtrack.org/stock_report" xmlns="http://openrosa.org/http/response" date="{long_date}" entity-id="{sp_id}">
-            <ns0:product consumption_rate="10.0" id="{product0}" quantity="9001" stock_category="overstock" stockout_since=""/>
-            <ns0:product consumption_rate="10.0" id="{product1}" quantity="" stock_category="nodata" stockout_since=""/>
-            <ns0:product consumption_rate="10.0" id="{product2}" quantity="" stock_category="nodata" stockout_since=""/>
-        </ns0:balance>
-    """.format(
-        sp_id=sp._id,
-        long_date=long_date() + 'Z',
-        product0=products[0]._id,
-        product1=products[1]._id,
-        product2=products[2]._id,
-    )
-
-
-def balances_with_stockout(sp, products):
-    return """
-        <ns0:balance xmlns:ns0="http://commtrack.org/stock_report" xmlns="http://openrosa.org/http/response" date="{long_date}" entity-id="{sp_id}">
-            <ns0:product consumption_rate="10.0" id="{product0}" quantity="0" stock_category="stockout" stockout_since="{long_date}"/>
-            <ns0:product consumption_rate="10.0" id="{product1}" quantity="" stock_category="nodata" stockout_since=""/>
-            <ns0:product consumption_rate="10.0" id="{product2}" quantity="" stock_category="nodata" stockout_since=""/>
-        </ns0:balance>
-    """.format(
-        sp_id=sp._id,
-        long_date=long_date() + 'Z',
+        long_date=datestring,
         product0=products[0]._id,
         product1=products[1]._id,
         product2=products[2]._id,

--- a/corehq/apps/commtrack/tests/data/balances.py
+++ b/corehq/apps/commtrack/tests/data/balances.py
@@ -27,8 +27,7 @@ def balances_with_adequate_values(sp, products, datestring=None):
 
 
 def submission_wrap(products, user, sp, sp2, insides):
-    return ("""
-        <?xml version="1.0" encoding="UTF-8"?>
+    return ("""<?xml version="1.0" encoding="UTF-8"?>
         <data uiVersion="1" version="33" name="New Form">
             <products>{product0} {product1} {product2}</products>
             <meta>

--- a/corehq/apps/commtrack/tests/data/balances.py
+++ b/corehq/apps/commtrack/tests/data/balances.py
@@ -1,15 +1,14 @@
-from datetime import date, datetime
+from datetime import datetime
+from dimagi.utils.parsing import json_format_datetime
 
 
 def long_date():
-    return '' # TODO delete this line when date is on the balance node
-    today = date.today()
-    return datetime(today.year, today.month, today.day).isoformat()
+    return json_format_datetime(datetime.utcnow())
 
 
 def balances_with_adequate_values(sp, products, datestring=None):
     if datestring is None:
-        datestring = long_date() + 'Z'
+        datestring = long_date()
 
     return """
         <ns0:balance xmlns:ns0="http://commtrack.org/stock_report" xmlns="http://openrosa.org/http/response" date="{long_date}" entity-id="{sp_id}">
@@ -28,7 +27,7 @@ def balances_with_adequate_values(sp, products, datestring=None):
 
 def submission_wrap(products, user, sp, sp2, insides):
     return ("""<?xml version="1.0" encoding="UTF-8"?>
-        <data uiVersion="1" version="33" name="New Form">
+        <data uiVersion="1" version="33" name="New Form" xmlns="http://commtrack.org/test_form_submission">
             <products>{product0} {product1} {product2}</products>
             <meta>
                 <deviceID>351746051189879</deviceID>
@@ -57,11 +56,11 @@ def submission_wrap(products, user, sp, sp2, insides):
 
 def balance_submission():
     return """
-        <balance entity-id="{sp_id}" date="{long_date}">
-            <product index="0" id="{product0}" quantity="35" />
-            <product index="1" id="{product1}" quantity="46" />
-            <product index="2" id="{product2}" quantity="25" />
-        </balance>
+        <ns0:balance xmlns:ns0="http://commtrack.org/stock_report" date="{long_date}" entity-id="{sp_id}">
+            <ns0:product index="0" id="{product0}" quantity="35" />
+            <ns0:product index="1" id="{product1}" quantity="46" />
+            <ns0:product index="2" id="{product2}" quantity="25" />
+        </ns0:balance>
     """
 
 

--- a/corehq/apps/commtrack/tests/test_xml.py
+++ b/corehq/apps/commtrack/tests/test_xml.py
@@ -67,8 +67,8 @@ class CommTrackSubmissionTest(CommTrackTest):
 
     def check_product_stock(self, supply_point, product_id, expected_soh, expected_qty):
         # check the case
-        # spp = supply_point.get_product_subcase(product_id)
-        # self.assertEqual(expected_soh, spp.current_stock)
+        spp = supply_point.get_product_subcase(product_id)
+        self.assertEqual(expected_soh, spp.current_stock)
 
         # and the django model
         latest_trans = StockTransaction.latest(supply_point._id, product_id)
@@ -96,8 +96,6 @@ class CommTrackSubmissionTest(CommTrackTest):
             self.check_product_stock(self.sp, product, amt, amt)
 
     def test_transfer_source_only(self):
-        # this test correctly fails due to a bug in the code
-        # first set balance of everything to 100
         initial = float(100)
         initial_amounts = [(p._id, initial) for p in self.products]
         self.submit_xml_form(balance_submission(initial_amounts))

--- a/corehq/apps/commtrack/tests/test_xml.py
+++ b/corehq/apps/commtrack/tests/test_xml.py
@@ -5,10 +5,8 @@ from casexml.apps.stock.const import TRANSACTION_TYPE_BALANCE
 from casexml.apps.stock.models import StockReport, StockTransaction
 from corehq.apps.commtrack.tests.util import CommTrackTest, get_ota_balance_xml
 from casexml.apps.case.tests.util import check_xml_line_by_line
-from corehq.apps.commtrack.models import Product, SupplyPointProductCase, SupplyPointCase
+from corehq.apps.commtrack.models import Product
 from corehq.apps.receiverwrapper import submit_form_locally
-from couchforms.util import post_xform_to_couch
-from casexml.apps.case.signals import process_cases
 from corehq.apps.commtrack.tests.util import make_loc, make_supply_point, make_supply_point_product
 from corehq.apps.commtrack.tests.data.balances import (
     balances_with_adequate_values,

--- a/corehq/apps/commtrack/tests/test_xml.py
+++ b/corehq/apps/commtrack/tests/test_xml.py
@@ -69,9 +69,9 @@ class CommTrackSubmissionTest(CommTrackTest):
 
     def check_product_stock(self, supply_point, product_id, expected_soh, expected_qty):
         # check the case
-        # supply_point = SupplyPointCase.wrap(supply_point.to_json())
-        spp = supply_point.get_product_subcase(product_id)
-        self.assertEqual(expected_soh, spp.current_stock)
+        # spp = supply_point.get_product_subcase(product_id)
+        # self.assertEqual(expected_soh, spp.current_stock)
+
         # and the django model
         latest_trans = StockTransaction.latest(supply_point._id, product_id)
         self.assertEqual(expected_soh, latest_trans.stock_on_hand)

--- a/corehq/apps/commtrack/tests/test_xml.py
+++ b/corehq/apps/commtrack/tests/test_xml.py
@@ -5,7 +5,7 @@ from casexml.apps.stock.const import TRANSACTION_TYPE_BALANCE
 from casexml.apps.stock.models import StockReport, StockTransaction
 from corehq.apps.commtrack.tests.util import CommTrackTest, get_ota_balance_xml
 from casexml.apps.case.tests.util import check_xml_line_by_line
-from corehq.apps.commtrack.models import Product, SupplyPointProductCase
+from corehq.apps.commtrack.models import Product, SupplyPointProductCase, SupplyPointCase
 from corehq.apps.receiverwrapper import submit_form_locally
 from couchforms.util import post_xform_to_couch
 from casexml.apps.case.signals import process_cases
@@ -56,7 +56,7 @@ class CommTrackSubmissionTest(CommTrackTest):
         from casexml.apps.case import settings
         settings.CASEXML_FORCE_DOMAIN_CHECK = False
         instance = submission_wrap(
-            Product.by_domain(self.domain.name).all(),
+            self.products,
             self.reporters['fixed'],
             self.sp,
             self.sp2,
@@ -67,49 +67,58 @@ class CommTrackSubmissionTest(CommTrackTest):
             domain=self.domain.name,
         )
 
-    def check_product_stock(self, expected, spp=None, check_stock=True):
+    def check_product_stock(self, supply_point, product_id, expected_soh, expected_qty):
         # check the case
-        id = spp._id if spp is not None else self.first_spp._id
-        spp = SupplyPointProductCase.get(id)
-        self.assertEqual(spp.current_stock, expected)
-        if check_stock:
-            # and the django model
-            latest_trans = StockTransaction.objects.filter(case_id=spp.get_supply_point_case_id(),
-                                                           product_id=spp.product).order_by('-report__date')[0]
-            self.assertEqual(expected, latest_trans.stock_on_hand)
+        # supply_point = SupplyPointCase.wrap(supply_point.to_json())
+        spp = supply_point.get_product_subcase(product_id)
+        self.assertEqual(expected_soh, spp.current_stock)
+        # and the django model
+        latest_trans = StockTransaction.latest(supply_point._id, product_id)
+        self.assertEqual(expected_soh, latest_trans.stock_on_hand)
+        self.assertEqual(expected_qty, latest_trans.quantity)
 
     def setUp(self):
         super(CommTrackSubmissionTest, self).setUp()
-        self.first_spp = self.spps[self.products.first().code]
-        self.first_spp.current_stock = 10
-        self.first_spp.save()
+        self.first_spp = self.spps[self.products[0].code]
 
         loc2 = make_loc('loc1')
         self.sp2 = make_supply_point(self.domain.name, loc2)
-        self.second_spp = make_supply_point_product(self.sp2, self.products.first()._id)
-        self.second_spp.current_stock = 10
-        self.second_spp.save()
-
-        # make sure we are starting from an expected state
-        self.check_product_stock(10, self.first_spp, check_stock=False)
-        self.check_product_stock(10, self.second_spp, check_stock=False)
+        self.second_spp = make_supply_point_product(self.sp2, self.products[0]._id)
 
     def test_balance_submit(self):
-        self.submit_xml_form(balance_submission)
-        self.check_product_stock(35)
+        amounts = [(p._id, float(i*10)) for i, p in enumerate(self.products)]
+        self.submit_xml_form(balance_submission(amounts))
+        for product, amt in amounts:
+            self.check_product_stock(self.sp, product, amt, amt)
 
     def test_transfer_dest_only(self):
-        self.submit_xml_form(transfer_dest_only)
-        self.check_product_stock(48)
+        amounts = [(p._id, float(i*10)) for i, p in enumerate(self.products)]
+        self.submit_xml_form(transfer_dest_only(amounts))
+        for product, amt in amounts:
+            self.check_product_stock(self.sp, product, amt, amt)
 
     def test_transfer_source_only(self):
-        self.submit_xml_form(transfer_source_only)
-        self.check_product_stock(6)
+        # this test correctly fails due to a bug in the code
+        # first set balance of everything to 100
+        initial = float(100)
+        initial_amounts = [(p._id, initial) for p in self.products]
+        self.submit_xml_form(balance_submission(initial_amounts))
+
+        deductions = [(p._id, float(50 - 10*i)) for i, p in enumerate(self.products)]
+        self.submit_xml_form(transfer_source_only(deductions))
+        for product, amt in deductions:
+            self.check_product_stock(self.sp, product, initial-amt, -amt)
 
     def test_transfer_both(self):
-        self.submit_xml_form(transfer_both)
-        self.check_product_stock(6, self.first_spp)
-        self.check_product_stock(14, self.second_spp)
+        initial = float(100)
+        initial_amounts = [(p._id, initial) for p in self.products]
+        self.submit_xml_form(balance_submission(initial_amounts))
+
+        transfers = [(p._id, float(50 - 10*i)) for i, p in enumerate(self.products)]
+        self.submit_xml_form(transfer_both(transfers))
+        for product, amt in transfers:
+            self.check_product_stock(self.sp, product, initial-amt, -amt)
+            self.check_product_stock(self.sp2, product, amt, amt)
 
     def test_transfer_neither(self):
         # TODO this one should error
@@ -117,9 +126,25 @@ class CommTrackSubmissionTest(CommTrackTest):
         pass
 
     def test_balance_first_doc_order(self):
-        self.submit_xml_form(balance_first)
-        self.check_product_stock(73)
+        initial = float(100)
+        balance_amounts = [(p._id, initial) for p in self.products]
+        transfers = [(p._id, float(50 - 10*i)) for i, p in enumerate(self.products)]
+        self.submit_xml_form(balance_first(balance_amounts, transfers))
+        for product, amt in transfers:
+            self.check_product_stock(self.sp, product, initial+amt, amt)
+
 
     def test_transfer_first_doc_order(self):
-        self.submit_xml_form(transfer_first)
-        self.check_product_stock(35)
+        # first set to 100
+        initial = float(100)
+        initial_amounts = [(p._id, initial) for p in self.products]
+        self.submit_xml_form(balance_submission(initial_amounts))
+
+        # then mark some receipts
+        transfers = [(p._id, float(50 - 10*i)) for i, p in enumerate(self.products)]
+        # then set to 50
+        final = float(50)
+        balance_amounts = [(p._id, final) for p in self.products]
+        self.submit_xml_form(transfer_first(transfers, balance_amounts))
+        for product, amt in transfers:
+            self.check_product_stock(self.sp, product, final, initial + amt - final)

--- a/corehq/apps/commtrack/tests/util.py
+++ b/corehq/apps/commtrack/tests/util.py
@@ -3,6 +3,7 @@ from xml.etree import ElementTree
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.tests import delete_all_cases, delete_all_xforms
 from casexml.apps.case.xml import V2
+from casexml.apps.stock.models import StockReport, StockTransaction
 from corehq.apps.commtrack import const
 from corehq.apps.groups.models import Group
 from corehq.apps.hqcase.utils import submit_case_blocks
@@ -138,6 +139,8 @@ class CommTrackTest(TestCase):
         # might as well clean house before doing anything
         delete_all_xforms()
         delete_all_cases()
+        StockReport.objects.all().delete()
+        StockTransaction.objects.all().delete()
 
         self.backend = test.bootstrap(TEST_BACKEND, to_console=True)
         self.domain = bootstrap_domain(requisitions_enabled=self.requisitions_enabled)

--- a/corehq/apps/commtrack/tests/util.py
+++ b/corehq/apps/commtrack/tests/util.py
@@ -160,7 +160,6 @@ class CommTrackTest(TestCase):
         self.group.save()
         self.sp.owner_id = self.group._id
         self.sp.save()
-
         self.products = Product.by_domain(self.domain.name)
         self.assertEqual(3, len(self.products))
         self.spps = {}

--- a/corehq/apps/commtrack/tests/util.py
+++ b/corehq/apps/commtrack/tests/util.py
@@ -185,4 +185,6 @@ class CommTrackTest(TestCase):
 def get_ota_balance_xml(user):
     xml = generate_restore_payload(user.to_casexml_user(), version=V2)
     balance_block = etree.fromstring(xml).find('{http://commtrack.org/stock_report}balance')
-    return etree.tostring(balance_block)
+    if balance_block is not None:
+        return etree.tostring(balance_block)
+    return ''

--- a/corehq/apps/commtrack/tests/util.py
+++ b/corehq/apps/commtrack/tests/util.py
@@ -163,7 +163,7 @@ class CommTrackTest(TestCase):
         self.group.save()
         self.sp.owner_id = self.group._id
         self.sp.save()
-        self.products = Product.by_domain(self.domain.name)
+        self.products = sorted(Product.by_domain(self.domain.name), key=lambda p: p._id)
         self.assertEqual(3, len(self.products))
         self.spps = {}
         for p in self.products:

--- a/settings.py
+++ b/settings.py
@@ -6,7 +6,7 @@ import sys, os
 from django.contrib import messages
 
 # odd celery fix
-import djcelery;
+import djcelery
 
 djcelery.setup_loader()
 
@@ -170,6 +170,7 @@ HQ_APPS = (
     'hqscripts',
     'casexml.apps.case',
     'casexml.apps.phone',
+    'casexml.apps.stock',
     'corehq.apps.cleanup',
     'corehq.apps.cloudcare',
     'corehq.apps.appstore',


### PR DESCRIPTION
this is a minor refactor of the commtrack processing code, and a significant update of the xml parsing tests.

big thing is that we now save duplicately to the stock django models, which also generate the OTA restore payload.

four of the submission tests are failing due to what look to be real bugs in the code.

depends on https://github.com/dimagi/casexml/pull/141 (and the prior merged PRs into the casexml commtrack branch)
