### PR TITLE
If user doesn't have name, default to username

### DIFF
--- a/corehq/apps/callcenter/utils.py
+++ b/corehq/apps/callcenter/utils.py
@@ -21,7 +21,7 @@ def sync_user_cases(commcare_user):
     # language or phone_number can be null and will break
     # case submission
     fields = {
-        'name': commcare_user.name,
+        'name': commcare_user.name or commcare_user.raw_username,
         'email': commcare_user.email,
         'language': commcare_user.language or '',
         'phone_number': commcare_user.phone_number or ''


### PR DESCRIPTION
There's some weird stuff going on in callcenter apps with blank user names. This is only half of the problem, but the other half I haven't been able to track down yet.
