### PR TITLE
fix python 2.6 error

### DIFF
--- a/corehq/apps/smsbillables/tests/test_gateway_fees.py
+++ b/corehq/apps/smsbillables/tests/test_gateway_fees.py
@@ -13,7 +13,7 @@ class TestGatewayFee(TestCase):
             code=settings.DEFAULT_CURRENCY,
             name="Default Currency",
             symbol="$",
-            rate_to_default=1.0
+            rate_to_default=Decimal('1.0')
         )
         self.available_backends = get_available_backends().values()
 


### PR DESCRIPTION
TypeError: Cannot convert float to Decimal.  First convert the float to a string
