### PR TITLE
Fix reports crashing based on date compare type

### DIFF
--- a/corehq/apps/reports/commtrack/data_sources.py
+++ b/corehq/apps/reports/commtrack/data_sources.py
@@ -229,7 +229,7 @@ class ReportingStatusDataSource(ReportDataSource, CommtrackDataSourceMixin):
             product_cases = filter(lambda c: Product.get(c.product).program_id == self.program_id, product_cases)
         def latest_case(cases):
             # getting last report date should probably be moved to a util function in a case wrapper class
-            return max(cases, key=lambda c: getattr(c, 'last_reported', '2000-01-01'))
+            return max(cases, key=lambda c: getattr(c, 'last_reported', datetime(2000, 1, 1)))
         cases_by_site = map_reduce(lambda c: [(tuple(c.location_),)],
                                    lambda v: reporting_status(latest_case(v), self.start_date, self.end_date),
                                    data=product_cases, include_docs=True)


### PR DESCRIPTION
These worked locally yesterday, but today they did not...

Anyway, it was attempting to compare a datetime object to a string, which doesn't work.
