### PR TITLE
make sha1 explicit default for password hashing

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -113,6 +113,17 @@ MIDDLEWARE_CLASSES = [
 
 SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
 
+PASSWORD_HASHERS = (
+    # this is the default list with SHA1 moved to the front
+    'django.contrib.auth.hashers.SHA1PasswordHasher',
+    'django.contrib.auth.hashers.PBKDF2PasswordHasher',
+    'django.contrib.auth.hashers.PBKDF2SHA1PasswordHasher',
+    'django.contrib.auth.hashers.BCryptPasswordHasher',
+    'django.contrib.auth.hashers.MD5PasswordHasher',
+    'django.contrib.auth.hashers.UnsaltedMD5PasswordHasher',
+    'django.contrib.auth.hashers.CryptPasswordHasher',
+)
+
 ROOT_URLCONF = "urls"
 
 TEMPLATE_CONTEXT_PROCESSORS = [


### PR DESCRIPTION
only takes effect on django 1.5 as this django setting was only added in 1.4

fixes: http://manage.dimagi.com/default.asp?87398
