### PR TITLE
Hover over released star with pointer

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/releases.html
@@ -71,6 +71,9 @@
         background-size: 80%;
         background-position: center;
     }
+    .pointer {
+        cursor: pointer;
+    }
     .released {
         color: #ffff00;
         text-shadow: 1px 0px #ffa500, -1px 0px #ffa500, 0px 1px #ffa500, 0px -1px #ffa500;

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/knockout-bindings.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/knockout-bindings.js
@@ -262,7 +262,7 @@ ko.bindingHandlers.starred = {
         var value = ko.utils.unwrapObservable(valueAccessor()),
             $element = $(element);
         value = value + '';
-        $element.addClass('icon');
+        $element.addClass('icon pointer');
 
         var unselected = 'icon-star-empty';
         var selected = 'icon-star icon-large released';

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/knockout-bindings.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/knockout-bindings.js
@@ -266,7 +266,7 @@ ko.bindingHandlers.starred = {
 
         var unselected = 'icon-star-empty';
         var selected = 'icon-star icon-large released';
-        var pending = 'icon-refresh';
+        var pending = 'icon-refresh icon-spin';
         var error = 'icon-ban-circle';
 
         var suffix = error;


### PR DESCRIPTION
Screenshot omitted because OSX doesn't include cursors in screenshots by default
