### PR TITLE
validate Copy Application form

### DIFF
--- a/corehq/apps/app_manager/forms.py
+++ b/corehq/apps/app_manager/forms.py
@@ -1,0 +1,35 @@
+from crispy_forms.bootstrap import FormActions
+from crispy_forms.helper import FormHelper
+from crispy_forms.layout import ButtonHolder, Fieldset, Hidden, Layout, Submit
+from django import forms
+from django.utils.translation import ugettext as _
+from corehq import Domain
+
+
+class CopyApplicationForm(forms.Form):
+    domain = forms.CharField(label=_("Copy this app to project:"))
+    name = forms.CharField(required=False, label=_('Name'))
+
+    def __init__(self, app_id, *args, **kwargs):
+        super(CopyApplicationForm, self).__init__(*args, **kwargs)
+        self.helper = FormHelper()
+        self.helper.layout = Layout(
+            Fieldset(
+            '<h3>%s</h3>' % _('Copy Application'),
+                'domain',
+                'name',
+            ),
+            Hidden('app', app_id),
+            FormActions(
+                ButtonHolder(
+                    Submit('submit', '%s...' % _('Copy'))
+                )
+            )
+        )
+
+    def clean_domain(self):
+        domain_name = self.cleaned_data['domain']
+        domain = Domain.get_by_name(domain_name)
+        if domain is None:
+            raise forms.ValidationError("A valid project space is required.")
+        return domain_name

--- a/corehq/apps/app_manager/templates/app_manager/app_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/app_view.html
@@ -3,6 +3,7 @@
 {% load xforms_extras %}
 {% load hq_shared_tags %}
 {% load i18n %}
+{% load crispy_forms_tags %}
 {% block js %}{{ block.super }}
     <script src="{% static 'app_manager/js/commcaresettings.js' %}"></script>
     {% if app.get_doc_type == "Application" %}
@@ -252,15 +253,9 @@
 
         {% endif %}
         <div class="tab-pane" id="copy">
-            <h3>{% trans "Copy Application" %}</h3>
             <div>
-                <form class="form form-inline" method="get" action="{% url "copy_app" domain %}">
-                    <input type="hidden" name="app" value="{{ app.id }}"/>
-                    {% trans "Copy this app to project:" %} <input type="text" name="domain" />
-                    <br>
-                    {% trans "New name:" %} <input type="text" name="name" value="{{ app.name }}">
-                    <br>
-                    <button type="submit" class="btn btn-primary">{% trans "Copy..." %}</button>
+                <form class="form form-horizontal" method="post" action="{% url "copy_app" domain %}">
+                    {% crispy copy_app_form %}
                 </form>
             </div>
         </div>


### PR DESCRIPTION
Validates data submitted in the Copy Application form, so there's no 500 when the user leaves the domain field blank (http://manage.dimagi.com/default.asp?88783#528840)

This PR is 90% of the way there - when an invalid form is submitted, it redirects to application settings rather than staying on copy application, although the form validation error message still appears when you return to copy application.
