### PR TITLE
make submit_forms_locally more flexible

### DIFF
--- a/corehq/apps/receiverwrapper/util.py
+++ b/corehq/apps/receiverwrapper/util.py
@@ -11,14 +11,13 @@ def get_submit_url(domain, app_id=None):
         return "/a/{domain}/receiver/".format(domain=domain)
 
 
-def submit_form_locally(instance, domain):
+def submit_form_locally(instance, domain, **kwargs):
+    # intentionally leave these unauth'd for now
+    kwargs['auth_context'] = kwargs.get('auth_context') or DefaultAuthContext()
     response = receiver.SubmissionPost(
-        app_id=None,
         domain=domain,
         instance=instance,
-        attachments={},
-        # intentionally leave these unauth'd for now
-        auth_context=DefaultAuthContext()
+        **kwargs
     ).get_response()
     if not 200 <= response.status_code < 300:
         raise LocalSubmissionError('Error submitting (status code %s): %s' % (


### PR DESCRIPTION
**wait for build to pass**
- allows you to pass in kwargs that get passed on, e.g. received_on
- does not force attachment to be {}; this is the default anyway
- does not force auth_context to be DefaultAuthContext()
