### PR TITLE
create a better exception & message for repeated form ids

### DIFF
--- a/corehq/apps/app_manager/exceptions.py
+++ b/corehq/apps/app_manager/exceptions.py
@@ -1,3 +1,6 @@
+import couchdbkit
+
+
 class AppManagerException(Exception):
     pass
 
@@ -82,4 +85,8 @@ class ParentModuleReferenceError(SuiteError):
 
 
 class SuiteValidationError(SuiteError):
+    pass
+
+
+class XFormIdNotUnique(AppManagerException, couchdbkit.MultipleResultsFound):
     pass


### PR DESCRIPTION
I think this part of the code isn't covered, but in the case where there's no MultipleResultsFound exception this continues to work. (In the other case this 500'd anyways, so this can't be worse.)
