### PR TITLE
don't 500 when new Software Plan is created

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -330,7 +330,10 @@ class SoftwarePlan(models.Model):
     )
 
     def get_version(self):
-        return self.softwareplanversion_set.filter(is_active=True).latest('date_created')
+        try:
+            return self.softwareplanversion_set.filter(is_active=True).latest('date_created')
+        except SoftwarePlanVersion.DoesNotExist:
+            return None
 
 
 class DefaultProductPlan(models.Model):

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -313,8 +313,8 @@ class EditSoftwarePlanView(AccountingSectionView):
     @memoized
     def software_plan_version_form(self):
         if self.request.method == 'POST':
-            return SoftwarePlanVersionForm(self.plan.get_version(), self.request.POST)
-        return SoftwarePlanVersionForm(self.plan.get_version())
+            return SoftwarePlanVersionForm(self.plan, self.plan.get_version(), self.request.POST)
+        return SoftwarePlanVersionForm(self.plan, self.plan.get_version())
 
     @property
     def page_context(self):


### PR DESCRIPTION
Creating a new Software Plan causes a 500 error because it tries to display in Roles and Features data for the most recent plan, which doesn't exist yet.  This fix causes Roles and Features to load empty forms when a Software Plan doesn't have a version yet.
