### PR TITLE
Don't blow up if there's a null value

### DIFF
--- a/corehq/apps/consumption/shortcuts.py
+++ b/corehq/apps/consumption/shortcuts.py
@@ -14,7 +14,10 @@ def get_default_consumption(domain, product_id, location_type, case_id):
         keys=keys, reduce=False, limit=1, descending=True,
     )
     results = results.one()
-    return Decimal(results['value']) if results else None
+    if results and results['value']:
+        return Decimal(results['value'])
+    else:
+        return None
 
 
 def set_default_consumption_for_domain(domain, amount):


### PR DESCRIPTION
For some of the locations on Mike's project, `results['value']` was returning None and the `Decimal` call was blowing up.
