### PR TITLE
Make year filter show the year in request

### DIFF
--- a/corehq/apps/reports/filters/select.py
+++ b/corehq/apps/reports/filters/select.py
@@ -81,7 +81,7 @@ class YearFilter(BaseSingleOptionFilter):
     @property
     def options(self):
         start_year = getattr(settings, 'START_YEAR', 2008)
-        years = [(y, y) for y in range(start_year, datetime.datetime.utcnow().year + 1)]
+        years = [(unicode(y), y) for y in range(start_year, datetime.datetime.utcnow().year + 1)]
         years.reverse()
         return years
 


### PR DESCRIPTION
The URL param is unicode, so it doesn't match integer years and registers as invalid
