### PR TITLE
Responding to UAT for Features 4 and 5

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -664,15 +664,15 @@ class BillingAccountInfoForm(forms.ModelForm):
                 crispy.Field('country', css_class="input-large"),
             ),
             FormActions(
-                StrictButton(
-                    _("Subscribe to Plan"),
-                    type="submit",
-                    css_class='btn btn-primary',
-                ),
-                crispy.HTML('<a href="%(url)s" class="btn">%(title)s</a>' % {
+                crispy.HTML('<a href="%(url)s" style="margin-right:5px;" class="btn">%(title)s</a>' % {
                     'url': reverse(DomainSubscriptionView.urlname, args=[self.domain]),
                     'title': _("Cancel"),
                 }),
+                StrictButton(
+                    _("Subscribe to Plan"),
+                    type="submit",
+                    css_class='btn btn-success',
+                ),
             )
         )
 

--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -62,8 +62,8 @@
     {% endfor %}
     {% if show_community_notice %}
     <div class="form-actions">
-        <a href="{% url 'domain_subscription_view' domain %}" class="btn btn-primary">{% trans 'Stay with Community Plan' %}</a>
         <a href="{% url 'domain_select_plan' domain %}" class="btn">{% trans 'Select different plan' %}</a>
+        <a href="{% url 'domain_subscription_view' domain %}" class="btn btn-primary">{% trans 'Stay with Community Plan' %}</a>
     </div>
     {% else %}
     <form action="{% url 'confirm_billing_account_info' domain %}" method="post" class="form">
@@ -81,10 +81,10 @@
             {% endblocktrans %}
         </p>
         <div class="form-actions">
+            <a href="{% url 'domain_select_plan' domain %}" class="btn">{% trans 'Select different plan' %}</a>
             <button type="submit" class="btn btn-primary">
                 {% trans 'Select this Plan' %}
             </button>
-            <a href="{% url 'domain_select_plan' domain %}" class="btn">{% trans 'Select different plan' %}</a>
         </div>
     </form>
     {% endif %}

--- a/corehq/apps/domain/templates/domain/confirm_plan.html
+++ b/corehq/apps/domain/templates/domain/confirm_plan.html
@@ -33,7 +33,7 @@
     <hr />
     <div class="alert alert-error">
         {% blocktrans with current_plan.name as p %}
-        <h4>Note: Continuing will cancel your current subscription.</h4>
+        <h4>Note: Continuing will change your current subscription.</h4>
         <p>You are currently subscribed to the <strong>{{ p }} Software Plan</strong></p>
         {% endblocktrans %}
     </div>

--- a/corehq/apps/domain/templates/domain/select_plan.html
+++ b/corehq/apps/domain/templates/domain/select_plan.html
@@ -38,7 +38,7 @@
             <form action="{% url 'confirm_selected_plan' domain %}" method="post" class="form">
                 <input type="hidden" name="plan_edition" data-bind="value: selected_edition">
                 <div class="form-actions" data-bind="visible: isSubmitVisible">
-                    <button type="submit" class="btn btn-primary">{% trans 'Next' %}</button>
+                    <button type="submit" class="btn btn-primary btn-large">{% trans 'Next' %}</button>
                 </div>
                 <table class="table-pricing">
                 <thead>
@@ -101,7 +101,7 @@
                     <li data-bind="text: $data"></li>
                 </ul>
                 <div class="form-actions" data-bind="visible: isSubmitVisible">
-                    <button type="submit" class="btn btn-primary">{% trans 'Next' %}</button>
+                    <button type="submit" class="btn btn-primary btn-large">{% trans 'Next' %}</button>
                 </div>
             </form>
         </article>


### PR DESCRIPTION
- make "Next" button bigger
- on the "confirm plan" page, switch the order of the select plan & select a different plan buttons so that selecting a different plan is on the left (implying backwards)
- In the red box warning on subscription canceling, change the text from "cancel" to "change"
