### PR TITLE
fix deprecation error on every manage.py call

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -623,6 +623,11 @@ LOGGING = {
             'format': '%(asctime)s %(levelname)s %(module)s %(message)s'
         },
     },
+    'filters': {
+        'require_debug_false': {
+            '()': 'django.utils.log.RequireDebugFalse'
+        }
+    },
     'handlers': {
         'pillowtop': {
             'level': 'INFO',
@@ -646,6 +651,7 @@ LOGGING = {
         },
         'mail_admins': {
             'level': 'ERROR',
+            'filters': ['require_debug_false'],
             'class': 'django.utils.log.AdminEmailHandler',
         },
         'sentry': {


### PR DESCRIPTION
http://docs.djangoproject.com/en/dev/releases/1.4/#request-exceptions-are-now-always-logged
