### PR TITLE
support device logs in exports again

### DIFF
--- a/corehq/apps/reports/exportfilters.py
+++ b/corehq/apps/reports/exportfilters.py
@@ -1,4 +1,4 @@
-
+from casexml.apps.case.xform import is_device_report
 
 
 def form_matches_users(form, users):
@@ -12,3 +12,10 @@ def is_commconnect_form(form):
     Checks if something is a commconnect form, by manually inspecting the deviceID property
     """
     return form.get('form', {}).get('meta', {}).get('deviceID', None) == 'commconnect'
+
+def default_form_filter(form, filter):
+    # hack: all the other filters we use completely break on device logs
+    # which don't have standard meta blocks, so just always force them
+    # to be accepted, since the only time they are relevant is when they're
+    # explicitly wanted
+    return is_device_report(form) or filter(form)

--- a/corehq/apps/reports/models.py
+++ b/corehq/apps/reports/models.py
@@ -10,7 +10,7 @@ from corehq.apps.app_manager.models import get_app
 from corehq.apps.app_manager.util import ParentCasePropertyBuilder
 from corehq.apps.reports.display import xmlns_to_name
 from couchdbkit.ext.django.schema import *
-from corehq.apps.reports.exportfilters import form_matches_users, is_commconnect_form
+from corehq.apps.reports.exportfilters import form_matches_users, is_commconnect_form, default_form_filter
 from corehq.apps.users.models import WebUser, CommCareUser, CouchUser
 from couchexport.models import SavedExportSchema, GroupExportConfiguration
 from couchexport.transforms import couch_to_excel_datetime, identity
@@ -543,6 +543,7 @@ class HQExportSchema(SavedExportSchema):
             self.domain = self.index[0]
         return self
 
+
 class FormExportSchema(HQExportSchema):
     doc_type = 'SavedExportSchema'
     app_id = StringProperty()
@@ -577,7 +578,6 @@ class FormExportSchema(HQExportSchema):
     def filter(self):
         user_ids = set(CouchUser.ids_by_domain(self.domain))
         user_ids.update(CouchUser.ids_by_domain(self.domain, is_active=False))
-
         def _top_level_filter(form):
             # careful, closures used
             return form_matches_users(form, user_ids) or is_commconnect_form(form)
@@ -587,7 +587,8 @@ class FormExportSchema(HQExportSchema):
             f.add(reports.util.app_export_filter, app_id=self.app_id)
         if not self.include_errors:
             f.add(couchforms.filters.instances)
-        return f
+        actual = SerializableFunction(default_form_filter, filter=f)
+        return actual
 
     @property
     def domain(self):

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -23,6 +23,7 @@ from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.templatetags.case_tags import case_inline_display
 from couchdbkit.exceptions import ResourceNotFound
 from casexml.apps.case.xml import V2
+from corehq.apps.reports.exportfilters import default_form_filter
 import couchexport
 from couchexport import views as couchexport_views
 from couchexport.export import SchemaMismatchException
@@ -275,7 +276,12 @@ def _export_default_or_custom_data(request, domain, export_id=None, bulk_export=
         # look more like a FormExportSchema
         if export_type == 'form':
             filter &= SerializableFunction(instances)
+
         export_object = FakeSavedExportSchema(index=export_tag)
+
+    if export_type == 'form':
+        _filter = filter
+        filter = SerializableFunction(default_form_filter, filter=_filter)
 
     if not filename:
         filename = export_object.name


### PR DESCRIPTION
@dannyroberts curious if you have any feedback on this. felt pretty dirty.

the alternative would be to explicitly put the `is_device_log` logic in every filter function.

or add `or` support to `SerializableFunction` which felt like a larger lift
