### PR TITLE
New Billing Contact Info Form

### DIFF
--- a/corehq/apps/accounting/decorators.py
+++ b/corehq/apps/accounting/decorators.py
@@ -1,0 +1,21 @@
+from django.http import Http404
+from corehq import BillingAccountAdmin
+
+
+def require_billing_admin():
+    def decorate(fn):
+        """
+        Decorator to require the current logged in user to be a billing admin to access the decorated view.
+        """
+        def wrapped(request, *args, **kwargs):
+            if not hasattr(request, 'couch_user') and not hasattr(request, 'domain'):
+                raise Http404()
+            print request.domain
+            is_billing_admin = BillingAccountAdmin.get_admin_status_and_account(request.couch_user, request.domain)[0]
+            if not (is_billing_admin or request.couch_user.is_superuser):
+                raise Http404()
+            return fn(request, *args, **kwargs)
+
+        return wrapped
+
+    return decorate

--- a/corehq/apps/accounting/static/accounting/js/accounting.billing_info_handler.js
+++ b/corehq/apps/accounting/static/accounting/js/accounting.billing_info_handler.js
@@ -1,8 +1,15 @@
-var BillingContactInfoHandler = function (valid_email_text, domain) {
+var BillingContactInfoHandler = function (valid_email_text) {
     'use strict';
     var self = this;
 
     self.country = new AsyncSelect2Handler('country');
+    self.country.initSelection = function (element, callback) {
+        var data = {
+            text: element.data('countryname'),
+            id: element.val()
+        };
+        callback(data);
+    };
     self.billing_admins = new AsyncSelect2Handler('billing_admins', true);
     self.emails = new EmailSelect2Handler('emails', valid_email_text);
 
@@ -43,13 +50,15 @@ var AsyncSelect2Handler = function (field, multiple) {
                     }
                 },
                 multiple: self.multiple,
-                initSelection: function (element, callback) {
-                    var data = (self.multiple) ? billingInfoUtils.getMultiResultsFromElement(element) :
-                        billingInfoUtils.getSingleResultFromElement(element);
-                    callback(data);
-                }
+                initSelection: self.initSelection
             });
         });
+    };
+
+    self.initSelection = function (element, callback) {
+        var data = (self.multiple) ? billingInfoUtils.getMultiResultsFromElement(element) :
+            billingInfoUtils.getSingleResultFromElement(element);
+        callback(data);
     };
 };
 

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -627,6 +627,11 @@ class BillingAccountInfoForm(forms.ModelForm):
         self.creating_user = creating_user
 
         try:
+            self.current_country = self.account.billingcontactinfo.country
+        except Exception:
+            self.current_country = None
+
+        try:
             kwargs['instance'] = self.account.billingcontactinfo
         except BillingContactInfo.DoesNotExist:
             pass
@@ -661,7 +666,8 @@ class BillingAccountInfoForm(forms.ModelForm):
                 'city',
                 'state_province_region',
                 'postal_code',
-                crispy.Field('country', css_class="input-large"),
+                crispy.Field('country', css_class="input-large",
+                             data_countryname=dict(COUNTRIES).get(self.current_country, '')),
             ),
             FormActions(
                 crispy.HTML('<a href="%(url)s" style="margin-right:5px;" class="btn">%(title)s</a>' % {

--- a/corehq/apps/domain/templates/domain/update_billing_contact_info.html
+++ b/corehq/apps/domain/templates/domain/update_billing_contact_info.html
@@ -1,0 +1,28 @@
+{% extends "settings/base_template.html" %}
+{% load crispy_forms_tags %}
+{% load hq_shared_tags %}
+{% load i18n %}
+
+{% block js %}{{ block.super }}
+    <script src="{% static 'hqwebapp/js/lib/select2/select2.js' %}"></script>
+    <script src="{% static 'accounting/js/accounting.billing_info_handler.js' %}"></script>
+{% endblock %}
+
+{% block head %}{{ block.super }}
+    <link href="{% static 'hqwebapp/js/lib/select2/select2.css' %}" rel="stylesheet"/>
+{% endblock %}
+
+{% block js-inline %}{{ block.super }}
+    <script>
+        var billingInfoHandler = new BillingContactInfoHandler(
+            '{% trans "Please enter a valid email." %}'
+        );
+        billingInfoHandler.init();
+    </script>
+{% endblock %}
+
+{% block main_column %}
+    <div id="billing-info">
+        {% crispy billing_account_info_form %}
+    </div>
+{% endblock %}

--- a/corehq/apps/domain/urls.py
+++ b/corehq/apps/domain/urls.py
@@ -12,7 +12,9 @@ from corehq.apps.domain.views import (EditBasicProjectInfoView, EditDeploymentPr
                                       ManageProjectMediaView, DomainForwardingOptionsView,
                                       AddRepeaterView, EditInternalDomainInfoView, EditInternalCalculationsView,
                                       BasicCommTrackSettingsView, AdvancedCommTrackSettingsView, OrgSettingsView,
-                                      DomainSubscriptionView, SelectPlanView, ConfirmSelectedPlanView, SelectedEnterprisePlanView, ConfirmBillingAccountInfoView, ProBonoView)
+                                      DomainSubscriptionView, SelectPlanView, ConfirmSelectedPlanView,
+                                      SelectedEnterprisePlanView, ConfirmBillingAccountInfoView, ProBonoView,
+                                      EditExistingBillingAccountView)
 
 #
 # After much reading, I discovered that Django matches URLs derived from the environment
@@ -87,6 +89,7 @@ domain_settings = patterns(
         name=ConfirmBillingAccountInfoView.urlname),
     url(r'^subscription/pro_bono/$', ProBonoView.as_view(), name=ProBonoView.urlname),
     url(r'^subscription/$', DomainSubscriptionView.as_view(), name=DomainSubscriptionView.urlname),
+    url(r'^billing_information/$', EditExistingBillingAccountView.as_view(), name=EditExistingBillingAccountView.urlname),
     url(r'^deployment/$', EditDeploymentProjectInfoView.as_view(), name=EditDeploymentProjectInfoView.urlname),
     url(r'^forwarding/$', DomainForwardingOptionsView.as_view(), name=DomainForwardingOptionsView.urlname),
     url(r'^forwarding/new/(?P<repeater_type>\w+)/$', AddRepeaterView.as_view(), name=AddRepeaterView.urlname),

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1,12 +1,12 @@
 import datetime
 from decimal import Decimal
 import logging
-from couchdbkit import ResourceNotFound
 import dateutil
 from corehq.apps.accounting.async_handlers import Select2BillingInfoHandler
 from corehq.apps.accounting.downgrade import DomainDowngradeStatusHandler
 from corehq.apps.accounting.forms import EnterprisePlanContactForm
 from corehq.apps.accounting.utils import get_change_status
+from corehq.apps.hqwebapp.async_handler import AsyncHandlerMixin
 from dimagi.utils.couch.resource_conflict import retry_resource
 from django.conf import settings
 from django.contrib.sites.models import Site
@@ -33,9 +33,9 @@ from corehq.apps.domain.decorators import (domain_admin_required,
     login_required, require_superuser, login_and_domain_required)
 from corehq.apps.domain.forms import (DomainGlobalSettingsForm, DomainMetadataForm, SnapshotSettingsForm,
                                       SnapshotApplicationForm, DomainDeploymentForm, DomainInternalForm,
-                                      BillingAccountInfoForm, ProBonoForm)
+                                      ConfirmNewSubscriptionForm, ProBonoForm, EditBillingAccountInfoForm)
 from corehq.apps.domain.models import Domain, LICENSES
-from corehq.apps.domain.utils import get_domained_url, normalize_domain_name
+from corehq.apps.domain.utils import normalize_domain_name
 from corehq.apps.hqwebapp.views import BaseSectionPageView, BasePageView
 from corehq.apps.orgs.models import Organization, OrgRequest, Team
 from corehq.apps.commtrack.util import all_sms_codes
@@ -398,6 +398,7 @@ def logo(request, domain):
 
 class DomainAccountingSettings(BaseAdminProjectSettingsView):
 
+    # todo replace decorator with require_billing_admin()
     @method_decorator(require_toggle(toggles.ACCOUNTING_PREVIEW))
     def dispatch(self, request, *args, **kwargs):
         return super(DomainAccountingSettings, self).dispatch(request, *args, **kwargs)
@@ -482,6 +483,57 @@ class DomainSubscriptionView(DomainAccountingSettings):
             'plan': self.plan,
             'change_plan_url': reverse(SelectPlanView.urlname, args=[self.domain]),
         }
+
+
+class EditExistingBillingAccountView(DomainAccountingSettings, AsyncHandlerMixin):
+    template_name = 'domain/update_billing_contact_info.html'
+    urlname = 'domain_update_billing_info'
+    page_title = ugettext_noop("Billing Contact Information")
+    async_handlers = [
+        Select2BillingInfoHandler,
+    ]
+
+    @property
+    @memoized
+    def account(self):
+        return BillingAccount.get_account_by_domain(self.domain)
+
+    @property
+    @memoized
+    def billing_info_form(self):
+        if self.request.method == 'POST':
+            return EditBillingAccountInfoForm(
+                self.account, self.domain, self.request.couch_user.username, data=self.request.POST
+            )
+        return EditBillingAccountInfoForm(self.account, self.domain, self.request.couch_user.username)
+
+    def dispatch(self, request, *args, **kwargs):
+        if self.account is None:
+            raise Http404()
+        return super(EditExistingBillingAccountView, self).dispatch(request, *args, **kwargs)
+
+    @property
+    def page_context(self):
+        return {
+            'billing_account_info_form': self.billing_info_form,
+        }
+
+    def post(self, request, *args, **kwargs):
+        if self.async_response is not None:
+            return self.async_response
+        if self.billing_info_form.is_valid():
+            is_saved = self.billing_info_form.save()
+            if not is_saved:
+                messages.error(
+                    request, _("It appears that there was an issue updating your contact information. "
+                               "We've been notified of the issue. Please try submitting again, and if the problem "
+                               "persists, please try in a few hours."))
+            else:
+                messages.success(
+                    request, _("Billing contact information was successfully updated.")
+                )
+                return HttpResponseRedirect(reverse(EditExistingBillingAccountView.urlname, args=[self.domain]))
+        return self.get(request, *args, **kwargs)
 
 
 class SelectPlanView(DomainAccountingSettings):
@@ -641,7 +693,7 @@ class ConfirmSelectedPlanView(SelectPlanView):
         return super(ConfirmSelectedPlanView, self).get(request, *args, **kwargs)
 
 
-class ConfirmBillingAccountInfoView(ConfirmSelectedPlanView):
+class ConfirmBillingAccountInfoView(ConfirmSelectedPlanView, AsyncHandlerMixin):
     template_name = 'domain/confirm_billing_info.html'
     urlname = 'confirm_billing_account_info'
     step_title = ugettext_noop("Confirm Billing Information")
@@ -678,12 +730,12 @@ class ConfirmBillingAccountInfoView(ConfirmSelectedPlanView):
     @memoized
     def billing_account_info_form(self):
         if self.request.method == 'POST' and self.is_form_post:
-            return BillingAccountInfoForm(
-                self.account, self.domain, self.selected_plan_version, self.current_subscription,
-                self.request.couch_user.username, data=self.request.POST
+            return ConfirmNewSubscriptionForm(
+                self.account, self.domain, self.request.couch_user.username,
+                self.selected_plan_version, self.current_subscription, data=self.request.POST
             )
-        return BillingAccountInfoForm(self.account, self.domain, self.selected_plan_version, self.current_subscription,
-                                      self.request.couch_user.username)
+        return ConfirmNewSubscriptionForm(self.account, self.domain, self.request.couch_user.username,
+                                          self.selected_plan_version, self.current_subscription)
 
     @property
     def page_context(self):
@@ -691,15 +743,9 @@ class ConfirmBillingAccountInfoView(ConfirmSelectedPlanView):
             'billing_account_info_form': self.billing_account_info_form,
         }
 
-    @property
-    def async_handler(self):
-        return self.request.POST.get('handler')
-
     def post(self, request, *args, **kwargs):
-        if self.async_handler in [h.slug for h in self.async_handlers]:
-            slug_to_handler = dict([(h.slug, h) for h in self.async_handlers])
-            handler = slug_to_handler[self.async_handler](request)
-            return handler.get_response()
+        if self.async_response is not None:
+            return self.async_response
         if self.is_form_post and self.billing_account_info_form.is_valid():
             is_saved = self.billing_account_info_form.save()
             software_plan_name = DESC_BY_EDITION[self.selected_plan_version.plan.edition]['name'].encode('utf-8')

--- a/corehq/apps/hqwebapp/async_handler.py
+++ b/corehq/apps/hqwebapp/async_handler.py
@@ -1,5 +1,28 @@
 import json
 from django.http import HttpResponse, HttpRequest
+from dimagi.utils.decorators.memoized import memoized
+
+
+class AsyncHandlerMixin(object):
+    """
+    To be mixed in with a TemplateView.
+    todo write better documentation on this (biyeun)
+    """
+    async_handlers = []
+
+    @property
+    def handler_slug(self):
+        return self.request.POST.get('handler')
+
+    def get_async_handler(self):
+        handler_class = dict([(h.slug, h) for h in self.async_handlers])[self.handler_slug]
+        return handler_class(self.request)
+
+    @property
+    @memoized
+    def async_response(self):
+        if self.handler_slug in [h.slug for h in self.async_handlers]:
+            return self.get_async_handler().get_response()
 
 
 class AsyncHandlerError(Exception):

--- a/corehq/apps/hqwebapp/models.py
+++ b/corehq/apps/hqwebapp/models.py
@@ -6,6 +6,7 @@ from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_noop, ugettext_lazy
 from corehq import toggles
 from corehq.apps.accounting.dispatcher import AccountingAdminInterfaceDispatcher
+from corehq.apps.accounting.models import BillingAccountAdmin
 from corehq.apps.domain.utils import get_adm_enabled_domains
 from corehq.apps.indicators.dispatcher import IndicatorAdminInterfaceDispatcher
 from corehq.apps.indicators.utils import get_indicator_domains
@@ -822,16 +823,7 @@ class ProjectSettingsTab(UITab):
             from corehq.apps.domain.views import (
                 BasicCommTrackSettingsView,
                 AdvancedCommTrackSettingsView,
-                DomainSubscriptionView,
-                SelectPlanView,
             )
-
-            subscription = [
-                {
-                    'title': DomainSubscriptionView.page_title,
-                    'url': reverse(DomainSubscriptionView.urlname, args=[self.domain]),
-                },
-            ]
 
             if self.project.commtrack_enabled:
                 commtrack_settings = [
@@ -874,6 +866,19 @@ class ProjectSettingsTab(UITab):
                  ]}
             ])
             items.append((_('Project Administration'), administration))
+
+        user_is_billing_admin, billing_account = BillingAccountAdmin.get_admin_status_and_account(
+            self.couch_user, self.domain)
+        if user_is_billing_admin or self.couch_user.is_superuser:
+            from corehq.apps.domain.views import DomainSubscriptionView
+            subscription = [
+                {
+                    'title': DomainSubscriptionView.page_title,
+                    'url': reverse(DomainSubscriptionView.urlname, args=[self.domain]),
+                },
+            ]
+            if billing_account is not None:
+                print "add billing form!"
             if toggle.shortcuts.toggle_enabled(toggles.ACCOUNTING_PREVIEW, self.couch_user.username):
                 items.append((_('Subscription'), subscription))
 
@@ -888,6 +893,8 @@ class ProjectSettingsTab(UITab):
                 'url': reverse(EditInternalCalculationsView.urlname, args=[self.domain])
             }]
             items.append((_('Internal Data (Dimagi Only)'), internal_admin))
+
+
 
         return items
 

--- a/corehq/apps/hqwebapp/models.py
+++ b/corehq/apps/hqwebapp/models.py
@@ -870,7 +870,7 @@ class ProjectSettingsTab(UITab):
         user_is_billing_admin, billing_account = BillingAccountAdmin.get_admin_status_and_account(
             self.couch_user, self.domain)
         if user_is_billing_admin or self.couch_user.is_superuser:
-            from corehq.apps.domain.views import DomainSubscriptionView
+            from corehq.apps.domain.views import DomainSubscriptionView, EditExistingBillingAccountView
             subscription = [
                 {
                     'title': DomainSubscriptionView.page_title,
@@ -878,7 +878,12 @@ class ProjectSettingsTab(UITab):
                 },
             ]
             if billing_account is not None:
-                print "add billing form!"
+                subscription.append(
+                    {
+                        'title':  EditExistingBillingAccountView.page_title,
+                        'url': reverse(EditExistingBillingAccountView.urlname, args=[self.domain]),
+                    },
+                )
             if toggle.shortcuts.toggle_enabled(toggles.ACCOUNTING_PREVIEW, self.couch_user.username):
                 items.append((_('Subscription'), subscription))
 


### PR DESCRIPTION
- for editing existing billing contact info
- only shows up if a domain has subscribed to a plan other than community or has been previously invoiced for extra charges (SMS / users) on the community plan
- also fixes issue where the country code instead of the translated country name was showing up in the select2 country field

![screen shot 2014-02-14 at 5 06 49 pm](https://f.cloud.github.com/assets/716573/2176159/d3f0ad64-95cc-11e3-98ba-abeca185fdf7.png)
