### PR TITLE
use session storage for django messages

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -598,6 +598,8 @@ FLUFF_PILLOW_TYPES_TO_SQL = {
 
 PREVIEWER_RE = '^$'
 
+MESSAGE_STORAGE = 'django.contrib.messages.storage.session.SessionStorage'
+
 try:
     #try to see if there's an environmental variable set for local_settings
     if os.environ.get('CUSTOMSETTINGS', None) == "demo":


### PR DESCRIPTION
fixes india server cookie error that prevents people from using the site
indefinitely (until cookies are cleared) after a django message is set
that has html content

See: http://manage.dimagi.com/default.asp?98749
