### PR TITLE
don't import memory-heavy phonenumbers module unless it is needed

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -5,6 +5,7 @@ import re
 import io
 from PIL import Image
 import uuid
+from corehq.apps.sms.phonenumbers_helper import parse_phone_number
 import settings
 
 from django import forms
@@ -19,9 +20,7 @@ from django.forms.widgets import  Select
 from django.utils.encoding import smart_str
 from django.contrib.auth.forms import PasswordResetForm
 from django.utils.safestring import mark_safe
-from django_countries import CountryField
 from django_countries.countries import COUNTRIES
-import phonenumbers
 from corehq.apps.accounting.models import BillingContactInfo, BillingAccountAdmin, SubscriptionAdjustmentMethod, Subscription, SoftwarePlanEdition
 from corehq.apps.app_manager.models import Application, FormBase
 
@@ -681,10 +680,7 @@ class EditBillingAccountInfoForm(forms.ModelForm):
         return result
 
     def _parse_number(self, number, country):
-        try:
-            return phonenumbers.parse(number, country)
-        except phonenumbers.NumberParseException:
-            pass
+        return parse_phone_number(number, country, failhard=False)
 
     def clean_phone_number(self):
         data = self.cleaned_data['phone_number']

--- a/corehq/apps/sms/phonenumbers_helper.py
+++ b/corehq/apps/sms/phonenumbers_helper.py
@@ -1,0 +1,16 @@
+
+
+class PhoneNumberParseException(Exception):
+    pass
+
+
+def parse_phone_number(number, region=None, keep_raw_input=False,
+                      numobj=None, _check_region=True, failhard=True):
+    from phonenumbers.phonenumberutil import parse as phonenumbers_parse, NumberParseException
+    try:
+        return phonenumbers_parse(number, region, keep_raw_input, numobj, _check_region)
+    except NumberParseException:
+        if failhard:
+            raise PhoneNumberParseException()
+        else:
+            return None

--- a/corehq/apps/smsbillables/management/commands/retrobill.py
+++ b/corehq/apps/smsbillables/management/commands/retrobill.py
@@ -1,5 +1,5 @@
-import phonenumbers
 from corehq import Domain
+from corehq.apps.sms.phonenumbers_helper import parse_phone_number, PhoneNumberParseException
 from corehq.apps.smsbillables.models import SmsBillable
 from django.core.management.base import LabelCommand
 from corehq.apps.sms.models import SMSLog
@@ -25,8 +25,8 @@ class Command(LabelCommand):
                 sms_log = SMSLog.get(sms_doc['id'])
                 try:
                     if sms_log.phone_number is not None:
-                        phonenumbers.parse(sms_log.phone_number)
-                except phonenumbers.NumberParseException:
+                        parse_phone_number(sms_log.phone_number)
+                except PhoneNumberParseException:
                     billables = SmsBillable.objects.filter(log_id=sms_log._id)
                     if len(billables) == 0:
                         SmsBillable.create(sms_log)

--- a/corehq/apps/smsbillables/models.py
+++ b/corehq/apps/smsbillables/models.py
@@ -1,4 +1,3 @@
-import phonenumbers
 import logging
 from decimal import Decimal
 from django.core.exceptions import ObjectDoesNotExist
@@ -8,6 +7,7 @@ from corehq.apps.accounting import models as accounting
 from corehq.apps.accounting.models import Currency
 from corehq.apps.accounting.utils import EXCHANGE_RATE_DECIMAL_PLACES
 from corehq.apps.sms.models import DIRECTION_CHOICES
+from corehq.apps.sms.phonenumbers_helper import parse_phone_number
 from corehq.apps.sms.util import clean_phone_number
 
 
@@ -229,12 +229,9 @@ class SmsBillable(models.Model):
         # Fetch gateway_fee
         backend_api_id = message_log.backend_api
         backend_instance = message_log.backend_id
-        try:
-            parsed_number = phonenumbers.parse(phone_number)
-        except phonenumbers.NumberParseException:
-            country_code = None
-        else:
-            country_code = parsed_number.country_code
+
+        parsed_number = parse_phone_number(phone_number, failhard=False)
+        country_code = parsed_number.country_code if parsed_number else None
 
         billable.gateway_fee = SmsGatewayFee.get_by_criteria(
             backend_api_id, direction, backend_instance=backend_instance, country_code=country_code


### PR DESCRIPTION
the GEOCODE_DATA is 6MB and gets imported with `import phonenumbers`

codependent with https://github.com/dimagi/payments/pull/40
