### PR TITLE
stay on Copy Application tab when form fails to validate

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/app_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/app_view.html
@@ -230,7 +230,7 @@
 {% endblock %}
 {% block form-view %}
     <div class="tab-content">
-        <div class="tab-pane active" id="app-settings">
+        <div class="tab-pane{% if not copy_app_form.is_bound %} active{% endif %}" id="app-settings">
             {% include "app_manager/partials/app-settings.html" %}
         </div>
         {% include 'app_manager/languages.html' %}
@@ -252,7 +252,7 @@
             </div>
 
         {% endif %}
-        <div class="tab-pane" id="copy">
+        <div class="tab-pane{% if copy_app_form.is_bound %} active{% endif %}" id="copy">
             <div>
                 <form class="form form-horizontal" method="post" action="{% url "copy_app" domain %}">
                     {% crispy copy_app_form %}

--- a/corehq/apps/app_manager/templates/app_manager/managed_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/managed_app.html
@@ -132,7 +132,9 @@
             </a>
         </li>
         <li class="divider"></li>
-        <li {% if not module and not form and not release_manager %}class="app-name-div active"{% endif %}>
+        <li {% if not module and not form and not release_manager %}class="app-name-div
+                {% if not copy_app_form or not copy_app_form.is_bound %}active{% endif %}"
+            {% endif %}>
             <a href="{% url "view_app" domain app.id %}?edit={{ edit|BOOL }}#app-settings" data-toggle="tab">
                 <i class="icon-cog"></i>
                 {% trans "Settings" %}
@@ -323,7 +325,7 @@
     {% endif %}
     {% if edit %}
         <li class="nav-header">Actions</li>
-        <li>
+        <li class="app-name-div{% if copy_app_form and copy_app_form.is_bound %} active{% endif %}">
             <a href="{% url "view_app" domain app.id %}copy/?edit={{ edit|BOOL }}#copy" data-toggle="tab">
                 <i class="icon-copy"></i>
                 {% trans "Copy Application" %}


### PR DESCRIPTION
fixes http://manage.dimagi.com/default.asp?94077#535996

Instead of redirecting to the Settings tab, stay on Copy Application tab
