### PR TITLE
have rebuildstaging show more details on a conflict

### DIFF
--- a/scripts/gitutils.py
+++ b/scripts/gitutils.py
@@ -1,0 +1,122 @@
+import sh
+from sh_verbose import ShVerbose
+
+
+def get_git(path=None):
+    return sh.git.bake('--no-pager', _cwd=path)
+
+
+class OriginalBranch(object):
+    def __init__(self, git=None):
+        self.git = git or get_git()
+        self.original_branch = None
+
+    def __enter__(self):
+        self.original_branch = git_current_branch(self.git)
+        return self.original_branch
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.git.checkout(self.original_branch)
+
+
+def git_current_branch(git=None):
+    git = git or get_git()
+    branch = sh.grep(git.branch('--no-color'), '^* ').strip()[2:]
+    if branch.startswith('('):
+        branch = sh.grep(
+            git.log('--no-color', n=1),
+            'commit'
+        ).strip().split(' ')[-1]
+    return branch
+
+
+def git_check_merge(branch1, branch2, git=None):
+    """
+    returns True if branch1 would auto-merge cleanly into branch2,
+    False if the merge requires human assistance
+
+    Thanks to http://stackoverflow.com/a/501461/240553
+
+    """
+    git = git or get_git()
+    with ShVerbose(False):
+        orig_branch = git_current_branch(git)
+        git.checkout(branch2)
+        is_behind = git.log('{0}..{1}'.format(branch2, branch1),
+                            max_count=1).strip()
+        if is_behind:
+            try:
+                git.merge('--no-commit', '--no-ff', branch1).strip()
+            except sh.ErrorReturnCode_1:
+                # git merge returns 1 when there's a conflict
+                return False
+            else:
+                return True
+            finally:
+                git.merge('--abort')
+                git.checkout(orig_branch)
+        else:
+            return True
+
+
+def git_bisect_merge_conflict(branch1, branch2, git=None):
+    """
+    return the branch2 commit that prevents branch1 from being merged in
+
+    """
+    git = git or get_git()
+    with OriginalBranch(git):
+        try:
+            base = git('merge-base', branch1, branch2).strip()
+            if git_check_merge(branch1, branch2, git):
+                return None
+            assert git_check_merge(branch1, base, git)
+            git.bisect('reset')
+            txt = git.bisect('start', branch2, base, '--')
+            while 'is the first bad commit' not in txt:
+                commit = git_current_branch(git)
+                if git_check_merge(branch1, commit, git):
+                    txt = git.bisect('good')
+                else:
+                    txt = git.bisect('bad')
+            return sh.grep(txt, '^commit ').strip().split(' ')[-1]
+        finally:
+            git.bisect('reset')
+
+
+def _left_pad(padding, text):
+    return padding + ('\n' + padding).join(text.split('\n'))
+
+
+def print_one_way_merge_details(branch1, branch2, git):
+    commit = git_bisect_merge_conflict(branch1, branch2, git)
+    if commit:
+        print '  * First conflicting commit on {0}:\n'.format(branch2)
+        print _left_pad(' ' * 4, git.log('-n1', commit))
+    else:
+        print '  * No conflicting commits on {0}'.format(branch2)
+
+
+def print_merge_details(branch1, branch2, git):
+    print_one_way_merge_details(branch1, branch2, git)
+    print_one_way_merge_details(branch2, branch1, git)
+
+
+if __name__ == '__main__':
+    import sys
+    args = sys.argv[1:]
+    options = ['show-conflict']
+    try:
+        option = args.pop(0)
+    except IndexError:
+        option = None
+    if option == 'show-conflict':
+        if len(args) == 2:
+            print_merge_details(*args, git=get_git())
+        else:
+            print ('usage: python scripts/gitutils.py '
+                   'show-conflict <branch1> <branch2>')
+    else:
+        print 'usage: python scripts/gitutils.py <command> [args...]\n'
+        print 'Available commands:'
+        print _left_pad('   ', '\n'.join(options))

--- a/scripts/rebuildstaging.py
+++ b/scripts/rebuildstaging.py
@@ -28,44 +28,17 @@ import sh
 import sys
 import gevent
 
+from sh_verbose import ShVerbose
+from gitutils import (
+    OriginalBranch,
+    get_git,
+    git_check_merge,
+    print_merge_details,
+)
+
 from gevent import monkey
 monkey.patch_httplib()
 
-
-def get_git(path=None):
-    return sh.git.bake('--no-pager', _cwd=path)
-
-
-def git_current_branch(git):
-    return sh.grep(git.branch('--no-color'), '^* ').strip()[2:]
-
-
-def git_check_merge(branch1, branch2, git):
-    """
-    returns True if branch1 would auto-merge cleanly into branch2,
-    False if the merge requires human assistance
-
-    Thanks to http://stackoverflow.com/a/501461/240553
-
-    """
-    with ShVerbose(False):
-        orig_branch = git_current_branch(git)
-        git.checkout(branch2)
-        is_behind = git.log('{0}..{1}'.format(branch2, branch1),
-                            max_count=1).strip()
-        if is_behind:
-            try:
-                git.merge('--no-commit', '--no-ff', branch1).strip()
-            except sh.ErrorReturnCode_1:
-                # git merge returns 1 when there's a conflict
-                return False
-            else:
-                return True
-            finally:
-                git.merge('--abort')
-                git.checkout(orig_branch)
-        else:
-            return True
 
 class BranchConfig(jsonobject.JsonObject):
     trunk = jsonobject.StringProperty()
@@ -104,29 +77,29 @@ def sync_local_copies(config):
 
     for path, config in base_config.span_configs():
         git = get_git(path)
-
-        for branch in [config.trunk] + config.branches:
-            git.checkout(branch)
-            unpushed = _count_commits('origin/{0}..{0}'.format(branch))
-            unpulled = _count_commits('{0}..origin/{0}'.format(branch))
-            if unpulled or unpushed:
-                print ("  [{cwd}] {branch}: "
-                       "{unpushed} ahead and {unpulled} behind origin").format(
-                    cwd=path,
-                    branch=branch,
-                    unpushed=unpushed,
-                    unpulled=unpulled,
-                )
-            else:
-                print "  [{cwd}] {branch}: Everything up-to-date.".format(
-                    cwd=path,
-                    branch=branch,
-                )
-            if unpushed:
-                unpushed_branches.append((path, branch))
-            elif unpulled:
-                print "  Fastforwarding your branch to origin"
-                git.merge('--ff-only', 'origin/{0}'.format(branch))
+        with OriginalBranch(git):
+            for branch in [config.trunk] + config.branches:
+                git.checkout(branch)
+                unpushed = _count_commits('origin/{0}..{0}'.format(branch))
+                unpulled = _count_commits('{0}..origin/{0}'.format(branch))
+                if unpulled or unpushed:
+                    print ("  [{cwd}] {branch}: {unpushed} ahead "
+                           "and {unpulled} behind origin").format(
+                        cwd=path,
+                        branch=branch,
+                        unpushed=unpushed,
+                        unpulled=unpulled,
+                    )
+                else:
+                    print "  [{cwd}] {branch}: Everything up-to-date.".format(
+                        cwd=path,
+                        branch=branch,
+                    )
+                if unpushed:
+                    unpushed_branches.append((path, branch))
+                elif unpulled:
+                    print "  Fastforwarding your branch to origin"
+                    git.merge('--ff-only', 'origin/{0}'.format(branch))
     if unpushed_branches:
         print "The following branches have commits that need to be pushed:"
         for path, branch in unpushed_branches:
@@ -141,20 +114,20 @@ def check_merges(config):
     base_config = config
     for path, config in base_config.span_configs():
         git = get_git(path)
-
-        git.checkout(config.trunk)
-        for branch in config.branches:
-            git.checkout(branch)
-            print "  [{cwd}] {trunk} => {branch}".format(
-                cwd=format_cwd(path),
-                trunk=config.trunk,
-                branch=branch,
-            ),
-            if not git_check_merge(config.trunk, branch, git=git):
-                merge_conflicts.append((path, config.trunk, branch))
-                print "FAIL"
-            else:
-                print "ok"
+        with OriginalBranch(git):
+            git.checkout(config.trunk)
+            for branch in config.branches:
+                git.checkout(branch)
+                print "  [{cwd}] {trunk} => {branch}".format(
+                    cwd=format_cwd(path),
+                    trunk=config.trunk,
+                    branch=branch,
+                ),
+                if not git_check_merge(config.trunk, branch, git=git):
+                    merge_conflicts.append((path, config.trunk, branch))
+                    print "FAIL"
+                else:
+                    print "ok"
     if merge_conflicts:
         print "You must fix the following merge conflicts before rebuilding:"
         for cwd, trunk, branch in merge_conflicts:
@@ -163,6 +136,8 @@ def check_merges(config):
                 branch=branch,
                 trunk=trunk,
             )
+            git = get_git(cwd)
+            print_merge_details(branch, trunk, git)
         exit(1)
     else:
         print "No merge conflicts"
@@ -171,68 +146,32 @@ def check_merges(config):
 def rebuild_staging(config):
     for path, config in config.span_configs():
         git = get_git(path)
-        git.checkout(config.trunk)
-        git.checkout('-B', config.name, config.trunk)
-        for branch in config.branches:
-            print "  [{cwd}] Merging {branch} into {name}".format(
+        with OriginalBranch(git):
+            git.checkout(config.trunk)
+            git.checkout('-B', config.name, config.trunk)
+            for branch in config.branches:
+                print "  [{cwd}] Merging {branch} into {name}".format(
+                    cwd=path,
+                    branch=branch,
+                    name=config.name
+                )
+                git.merge(branch, '--no-edit')
+            if config.submodules:
+                for submodule in config.submodules:
+                    git.add(submodule)
+                git.commit('-m', "update submodule refs", '--no-edit')
+            # stupid safety check
+            assert config.name != 'master'
+            print "  [{cwd}] Force pushing to origin {name}".format(
                 cwd=path,
-                branch=branch,
-                name=config.name
+                name=config.name,
             )
-            git.merge(branch, '--no-edit')
-        if config.submodules:
-            for submodule in config.submodules:
-                git.add(submodule)
-            git.commit('-m', "update submodule refs", '--no-edit')
-        # stupid safety check
-        assert config.name != 'master'
-        print "  [{cwd}] Force pushing to origin {name}".format(
-            cwd=path,
-            name=config.name,
-        )
-        git.push('origin', config.name, '--force')
+            git.push('origin', config.name, '--force')
 
 
 def format_cwd(cwd):
     return os.path.join(cwd) if cwd else '.'
 
-_original_init = sh.RunningCommand.__init__
-
-
-def _verbose_init(self, cmd, call_args, stdin, stdout, stderr):
-    print u"[{cwd}]$ {command}".format(
-        cwd=format_cwd(call_args['cwd']),
-        command=' '.join(cmd[0].rsplit('/', 1)[1:] + cmd[1:]),
-    )
-    try:
-        _original_init(self, cmd, call_args, stdin, stdout, stderr)
-    except sh.ErrorReturnCode as e:
-        sys.stdout.write(e.stdout)
-        sys.stderr.write(e.stderr)
-        raise
-    else:
-        sys.stdout.write(self.stdout)
-        sys.stderr.write(self.stderr)
-
-
-def patch_sh_verbose():
-
-    sh.RunningCommand.__init__ = _verbose_init
-
-
-class ShVerbose(object):
-    def __init__(self, verbose=True):
-        self.verbose = verbose
-        self.start_init = None
-
-    def __enter__(self):
-        # record whatever the current __init__ is so we can reset it later
-        self.start_init = sh.RunningCommand.__init__
-        sh.RunningCommand.__init__ = (_verbose_init if self.verbose
-                                      else _original_init)
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        sh.RunningCommand.__init__ = self.start_init
 
 if __name__ == '__main__':
     from sys import stdin

--- a/scripts/sh_verbose.py
+++ b/scripts/sh_verbose.py
@@ -1,0 +1,45 @@
+import os
+import sh
+import sys
+
+
+def format_cwd(cwd):
+    return os.path.join(cwd) if cwd else '.'
+
+
+_original_init = sh.RunningCommand.__init__
+
+
+def _verbose_init(self, cmd, call_args, stdin, stdout, stderr):
+    print u"[{cwd}]$ {command}".format(
+        cwd=format_cwd(call_args['cwd']),
+        command=' '.join(cmd[0].rsplit('/', 1)[1:] + cmd[1:]),
+    )
+    try:
+        _original_init(self, cmd, call_args, stdin, stdout, stderr)
+    except sh.ErrorReturnCode as e:
+        sys.stdout.write(e.stdout)
+        sys.stderr.write(e.stderr)
+        raise
+    else:
+        sys.stdout.write(self.stdout)
+        sys.stderr.write(self.stderr)
+
+
+def patch_sh_verbose():
+    sh.RunningCommand.__init__ = _verbose_init
+
+
+class ShVerbose(object):
+    def __init__(self, verbose=True):
+        self.verbose = verbose
+        self.start_init = None
+
+    def __enter__(self):
+        # record whatever the current __init__ is so we can reset it later
+        self.start_init = sh.RunningCommand.__init__
+        sh.RunningCommand.__init__ = (_verbose_init if self.verbose
+                                      else _original_init)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        sh.RunningCommand.__init__ = self.start_init


### PR DESCRIPTION
- when there is a merge conflict rebuildstaging will find the
  first commit on each branch that prevents the other from being
  merged in
- this functionality is also accessible as a separate script:
  $ python scripts/gitutils.py show-conflict <branch1> <branch2>
- reusable git-related utilities are now in scripts/gitutils.py
- added OriginalBranch context manager that makes sure you end up
  on the branch you started out on, even if the code block
  throws an exception
- use OriginalBranch throughout to improve the experience of
  rebuildstaging
- git_current_branch now returns either a branch or a commit if not on
  any branch

Here's some example output from rebuildstaging:

![screen shot 2014-02-25 at 1 43 13 pm](https://f.cloud.github.com/assets/137212/2261972/2a4ab7a0-9e55-11e3-8e89-84366210f8ca.png)
