### PR TITLE
make all exports default to csv and misc memory fixes

### DIFF
--- a/corehq/apps/export/templates/export/customize_export.html
+++ b/corehq/apps/export/templates/export/customize_export.html
@@ -412,9 +412,9 @@
                 <label for="format-select" class="control-label">{% trans "Default file type" %}</label>
                 <div class="controls">
                     <select id="format-select" data-bind="value: custom_export.default_format">
+                        <option value="csv">{% trans "CSV (Zip file)" %}</option>
                         <option value="xlsx">{% trans "Excel 2007" %}</option>
                         <option value="xls">{% trans "Excel (older versions)" %}</option>
-                        <option value="csv">{% trans "CSV (Zip file)" %}</option>
                     </select>
                 </div>
             </div>

--- a/corehq/apps/reports/export.py
+++ b/corehq/apps/reports/export.py
@@ -1,4 +1,3 @@
-from StringIO import StringIO
 from datetime import date
 import os
 import tempfile
@@ -39,7 +38,6 @@ class BulkExport(object):
         configs = list()
         schemas = list()
         checkpoints = list()
-        file = StringIO()
 
         for export_object in self.export_objects:
             config, schema, checkpoint = export_object.get_export_components(filter=self.export_filter)
@@ -52,22 +50,24 @@ class BulkExport(object):
         # generate the headers for the bulk excel file
         headers = self.generate_table_headers(schemas, checkpoints)
 
-        writer.open(headers, file)
+        fd, path = tempfile.mkstemp()
+        with os.fdopen(fd, 'wb') as tmp:
+            writer.open(headers, tmp)
 
-        # now that the headers are set, lets build the rows
-        for i, config in enumerate(configs):
-            for doc in config.get_docs():
-                if self.export_objects[i].transform:
-                    doc = self.export_objects[i].transform(doc)
-                table = format_tables(create_intermediate_tables(doc, schemas[i]),
-                                    include_headers=isinstance(self, CustomBulkExport), separator=self.separator)
-                if isinstance(self, CustomBulkExport):
-                    table = self.export_objects[i].trim(table, doc)
-                table = self.export_objects[i].parse_tables(table)
-                writer.write(table)
+            # now that the headers are set, lets build the rows
+            for i, config in enumerate(configs):
+                for doc in config.get_docs():
+                    if self.export_objects[i].transform:
+                        doc = self.export_objects[i].transform(doc)
+                    table = format_tables(create_intermediate_tables(doc, schemas[i]),
+                                        include_headers=isinstance(self, CustomBulkExport), separator=self.separator)
+                    if isinstance(self, CustomBulkExport):
+                        table = self.export_objects[i].trim(table, doc)
+                    table = self.export_objects[i].parse_tables(table)
+                    writer.write(table)
 
-        writer.close()
-        return file
+            writer.close()
+        return path
 
     def generate_table_headers(self, schemas, checkpoints):
         return []

--- a/corehq/apps/reports/export.py
+++ b/corehq/apps/reports/export.py
@@ -26,7 +26,7 @@ class BulkExport(object):
     def separator(self):
         return "."
 
-    def create(self, export_tags, export_filter, format=Format.XLS_2007, safe_only=False):
+    def create(self, export_tags, export_filter, format=Format.CSV, safe_only=False):
         self.export_filter = export_filter
         self.format = format
         self.safe_only = safe_only

--- a/corehq/apps/reports/standard/export.py
+++ b/corehq/apps/reports/standard/export.py
@@ -249,7 +249,9 @@ class CaseExportReport(ExportReport):
     icon = "icon-share"
 
     def get_filter_params(self):
-        return self.request.GET.copy()
+        params = self.request.GET.copy()
+        params['format'] = 'csv'
+        return params
 
     def get_saved_exports(self):
         startkey = json.dumps([self.domain, ""])[:-3]

--- a/corehq/apps/reports/static/reports/javascripts/reports.download_export.js
+++ b/corehq/apps/reports/static/reports/javascripts/reports.download_export.js
@@ -36,36 +36,4 @@ var HQExportDownloader = function (options) {
             });
         });
     };
-
-//    $('.export-action-download').click(function() {
-//        var $modalBody = $("#export-download-status .modal-body");
-//        $modalBody.find('.loading-indicator').removeClass('hide');
-//        $modalBody.find('.loaded-data').empty();
-//        $("#export-download-status .modal-header h3 span").text($(this).data("formname"));
-//        $.ajax({
-//            type: "GET",
-//            dataType: "json",
-//            url: $(this).data('dlocation'),
-//            success: function(d) {
-//                var autoRefresh = '';
-//                var pollDownloader = function () {
-//                    console.log($('#ready_'+d.download_id).length);
-//                    if ($('#ready_'+d.download_id).length == 0)
-//                    {
-//                        $.get(d.download_url, function(data) {
-//                            $modalBody.find('.loaded-data').html(data);
-//                        });
-//                    } else {
-//                        $modalBody.find('.loading-indicator').addClass('hide');
-//                        clearInterval(autoRefresh);
-//                    }
-//                };
-//                $("#export-download-status").on('hide', function () {
-//                    clearInterval(autoRefresh);
-//                });
-//
-//                autoRefresh = setInterval(pollDownloader, 2000);
-//            }
-//        });
-//    });
 };

--- a/corehq/apps/reports/static/reports/ko/export.manager.js
+++ b/corehq/apps/reports/static/reports/ko/export.manager.js
@@ -163,38 +163,52 @@ var ExportManager = function (o) {
         self.downloadExport(downloadUrl);
     };
 
-    self.requestDownload = function(data, event) {
+    self._requestDownload = function(options) {
         var $button = $(event.srcElement || event.currentTarget);
-        var modalTitle = $button.data('formname') || $button.data('xmlns');
         var downloadUrl = self.downloadUrl || $button.data('dlocation');
-
-        if ($button.data('modulename'))
-            modalTitle  = $button.data('modulename')+" > "+modalTitle;
-        resetModal("'"+modalTitle+"'", true);
-
+        resetModal("'" + options.modalTitle + "'", true);
         downloadUrl = downloadUrl +
-            "?"+self.exportFilters+
-            '&export_tag=["'+self.domain+'","'+$button.data('xmlns')+'","'+$button.data('formname')+'"]' +
-            '&filename='+$button.data('formname') +
+            "?" + self.exportFilters +
             '&async=true' +
-            '&format=' + self.format;
-        if (!self.is_custom)
-            downloadUrl = downloadUrl+'&app_id='+$button.data('appid');
+            '&format=' + self.format +
+            '&export_tag=["'+self.domain+'","'+$button.data('xmlns')+'","'+$button.data('formname')+'"]' +
+            '&filename='+$button.data('formname');
 
+        for (var k in options.downloadParams) {
+            if (options.downloadParams.hasOwnProperty(k)) {
+                var v = options.downloadParams[k];
+                downloadUrl += '&' + k + '=' + v;
+            }
+        }
         self.downloadExport(downloadUrl);
     };
 
-    self.requestCaseDownload = function(data, event) {
+    self.requestDownload = function(data, event) {
         var $button = $(event.srcElement || event.currentTarget);
-        var downloadUrl = self.downloadUrl || $button.data('dlocation');
-        var modalTitle = "Case List";
-        resetModal(modalTitle, true);
+        var modalTitle = $button.data('formname') || $button.data('xmlns');
+        if ($button.data('modulename')) {
+            modalTitle  = $button.data('modulename') + " > " + modalTitle;
+        }
+        var downloadParams = {
+            export_tag: ["'+self.domain+'","'+$button.data('xmlns')+'","'+$button.data('formname')+'"],
+            filename: $button.data('formname')
+        }
+        if (!self.is_custom) {
+            downloadParams.app_id = $button.data('appid');
+        }
+        return self._requestDownload({
+            modalTitle: modalTitle,
+            downloadParams: downloadParams
+        });
+    };
 
-        downloadUrl += '?'+self.exportFilters;
-        downloadUrl += '&include_closed=' + $('#include-closed-select').val();
-        downloadUrl += '&async=true'
-
-        self.downloadExport(downloadUrl);
+    self.requestCaseDownload = function(data, event) {
+        return self._requestDownload({
+            modalTitle: "Case List",
+            downloadParams: {
+                include_closed: $('#include-closed-select').val()
+            }
+        });
     };
 
     self.checkCustomSheetNameLength = function(data, event) {
@@ -306,5 +320,3 @@ ko.bindingHandlers.updateCustomSheetName = {
         }
     }
 };
-
-

--- a/corehq/apps/reports/static/reports/ko/export.manager.js
+++ b/corehq/apps/reports/static/reports/ko/export.manager.js
@@ -4,6 +4,7 @@ var ExportManager = function (o) {
     self.export_type = o.export_type || "form";
     self.is_custom = o.is_custom || false;
 
+    self.format = o.format || "csv";
     self.domain = o.domain;
     self.downloadUrl = o.downloadUrl;
     self.bulkDownloadUrl = o.bulkDownloadUrl;
@@ -175,7 +176,8 @@ var ExportManager = function (o) {
             "?"+self.exportFilters+
             '&export_tag=["'+self.domain+'","'+$button.data('xmlns')+'","'+$button.data('formname')+'"]' +
             '&filename='+$button.data('formname') +
-            '&async=true';
+            '&async=true' +
+            '&format=' + self.format;
         if (!self.is_custom)
             downloadUrl = downloadUrl+'&app_id='+$button.data('appid');
 


### PR DESCRIPTION
probably easiest to read commit-by-commit

the different ways this ended up getting implemented for the various types of exports is a testament to how badly our export code (particularly UI and bulk exports) could use some tech debt love.

changed and tested all of the following:
- download saved custom exports
- download full form exports
- download bulk custom form export
- download bulk full form export
- create custom form export
- download cases, users, and referrals
- download saved custom case exports
- create custom case export

also thrown in was not using StringIO for all bulk exports. anyone want to see me bring down the server by clicking a button 10 times?

depends on https://github.com/dimagi/couchexport/pull/85/
