### PR TITLE
properly lock down APIs by role

### DIFF
--- a/corehq/apps/api/resources/__init__.py
+++ b/corehq/apps/api/resources/__init__.py
@@ -1,6 +1,7 @@
 from tastypie.resources import Resource
 from tastypie.exceptions import InvalidSortError
 
+
 class dict_object(object):
     def __init__(self, dict):
         self.dict = dict
@@ -10,6 +11,7 @@ class dict_object(object):
 
     def __repr__(self):
         return 'dict_object(%r)' % self.dict
+
 
 class JsonResource(Resource):
     """
@@ -27,6 +29,7 @@ class JsonResource(Resource):
             format = 'application/json'
 
         return format
+
 
 class SimpleSortableResourceMixin(object):
     '''

--- a/corehq/apps/api/resources/v0_1.py
+++ b/corehq/apps/api/resources/v0_1.py
@@ -221,10 +221,10 @@ class CommCareCaseResource(JsonResource, DomainSpecificResourceMixin):
     def obj_get_list(self, bundle, **kwargs):
         domain = kwargs['domain']
         closed_only = {
-                          'true': True,
-                          'false': False,
-                          'any': True
-                      }[bundle.request.GET.get('closed', 'false')]
+            'true': True,
+            'false': False,
+            'any': True
+        }[bundle.request.GET.get('closed', 'false')]
         case_type = bundle.request.GET.get('case_type')
 
         key = [domain]

--- a/corehq/apps/api/resources/v0_1.py
+++ b/corehq/apps/api/resources/v0_1.py
@@ -91,27 +91,26 @@ class RequirePermissionAuthentication(LoginAndDomainAuthentication):
             return response
 
 
-class DomainAdminAuthorization(Authorization):
-    # todo: this class doesn't work at all!
-    # is_authorized was removed from tastypie long before our current version
+class DomainAdminAuthentication(LoginAndDomainAuthentication):
 
-    def is_authorized(self, request, object=None, **kwargs):
-        PASSED_AUTHORIZATION = 'is_authorized'
+    def is_authenticated(self, request, **kwargs):
+        PASSED_AUTH = 'is_authenticated'
 
         @api_auth
         @domain_admin_required
+        @login_or_digest
         def dummy(request, domain, **kwargs):
-            return PASSED_AUTHORIZATION
+            return PASSED_AUTH
 
         if not kwargs.has_key('domain'):
             kwargs['domain'] = request.domain
 
         response = dummy(request, **kwargs)
-
-        if response == PASSED_AUTHORIZATION:
+        if response == PASSED_AUTH:
             return True
         else:
             return response
+
 
 class CustomResourceMeta(object):
     authorization = ReadOnlyAuthorization()

--- a/corehq/apps/api/resources/v0_1.py
+++ b/corehq/apps/api/resources/v0_1.py
@@ -44,7 +44,6 @@ def api_auth(view_func):
 
 class LoginAndDomainAuthentication(Authentication):
     def is_authenticated(self, request, **kwargs):
-        print 'is authenticated'
         PASSED_AUTH = 'is_authenticated'
 
         @api_auth

--- a/corehq/apps/api/resources/v0_2.py
+++ b/corehq/apps/api/resources/v0_2.py
@@ -3,9 +3,11 @@ from tastypie import fields
 from casexml.apps.case.models import CommCareCase
 
 from corehq.apps.cloudcare.api import get_filtered_cases, get_filters_from_request, api_closed_to_status
-from corehq.apps.api.resources.v0_1 import CustomResourceMeta
+from corehq.apps.api.resources.v0_1 import CustomResourceMeta, RequirePermissionAuthentication
 from corehq.apps.api.util import get_object_or_not_exist
 from corehq.apps.api.resources import JsonResource, DomainSpecificResourceMixin, dict_object
+from corehq.apps.users.models import Permissions
+
 
 class CommCareCaseResource(JsonResource, DomainSpecificResourceMixin):
     type = "case"
@@ -44,7 +46,8 @@ class CommCareCaseResource(JsonResource, DomainSpecificResourceMixin):
                                   filters=filters))
 
     class Meta(CustomResourceMeta):
-        object_class = CommCareCase    
+        authentication = RequirePermissionAuthentication(Permissions.edit_data)
+        object_class = CommCareCase
         resource_name = 'case'
         list_allowed_methods = ['get']
         detail_allowed_methods = ['get']

--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -5,6 +5,7 @@ from django.http import HttpResponseForbidden, HttpResponse, HttpResponseBadRequ
 from tastypie import fields
 from tastypie.bundle import Bundle
 from tastypie.authentication import Authentication
+from corehq.apps.api.resources.v0_1 import CustomResourceMeta, RequirePermissionAuthentication
 
 from couchforms.models import XFormInstance
 from casexml.apps.case.models import CommCareCase
@@ -18,7 +19,7 @@ from corehq.apps.receiverwrapper.models import Repeater, repeater_types
 from corehq.apps.groups.models import Group
 from corehq.apps.cloudcare.api import ElasticCaseQuery
 from corehq.apps.users.util import format_username
-from corehq.apps.users.models import CouchUser, CommCareUser
+from corehq.apps.users.models import CouchUser, CommCareUser, Permissions
 
 from corehq.apps.api.resources import v0_1, v0_3, JsonResource, DomainSpecificResourceMixin, dict_object, SimpleSortableResourceMixin
 from corehq.apps.api.es import XFormES, CaseES, ESQuerySet, es_search
@@ -116,7 +117,7 @@ class RepeaterResource(JsonResource, DomainSpecificResourceMixin):
         bundle = self.full_hydrate(bundle)
         return bundle
 
-    class Meta(v0_1.CustomResourceMeta):
+    class Meta(CustomResourceMeta):
         object_class = Repeater
         resource_name = 'data-forwarding'
         detail_allowed_methods = ['get', 'put', 'delete']
@@ -209,9 +210,11 @@ class GroupResource(JsonResource, DomainSpecificResourceMixin):
         groups = Group.by_domain(domain)
         return groups
 
-    class Meta(v0_3.XFormInstanceResource.Meta):
+    class Meta(CustomResourceMeta):
+        authentication = RequirePermissionAuthentication(Permissions.edit_commcare_users)
         object_class = Group
         list_allowed_methods = ['get']
+        detail_allowed_methods = ['get']
         resource_name = 'group'
 
 
@@ -260,7 +263,7 @@ class SingleSignOnResource(JsonResource, DomainSpecificResourceMixin):
     def get_detail(self, bundle, **kwargs):
         return HttpResponseForbidden()
 
-    class Meta(v0_1.CustomResourceMeta):
+    class Meta(CustomResourceMeta):
         authentication = Authentication()
         resource_name = 'sso'
         detail_allowed_methods = []
@@ -321,7 +324,8 @@ class ApplicationResource(JsonResource, DomainSpecificResourceMixin):
     def obj_get(self, bundle, **kwargs):
         return get_object_or_not_exist(Application, kwargs['domain'], kwargs['pk'])
 
-    class Meta(v0_1.CustomResourceMeta):
+    class Meta(CustomResourceMeta):
+        authentication = RequirePermissionAuthentication(Permissions.edit_apps)
         object_class = Application
         list_allowed_methods = ['get']
         detail_allowed_methods = ['get']

--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -118,11 +118,12 @@ class RepeaterResource(JsonResource, DomainSpecificResourceMixin):
         return bundle
 
     class Meta(CustomResourceMeta):
+        authentication = v0_1.DomainAdminAuthentication()
         object_class = Repeater
         resource_name = 'data-forwarding'
         detail_allowed_methods = ['get', 'put', 'delete']
         list_allowed_methods = ['get', 'post']
-        authorization = v0_1.DomainAdminAuthorization
+
 
 
 def group_by_dict(objs, fn):

--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 
-from django.core.urlresolvers import NoReverseMatch, reverse
+from django.core.urlresolvers import reverse
 from django.http import HttpResponseForbidden, HttpResponse, HttpResponseBadRequest
 from tastypie import fields
 from tastypie.bundle import Bundle
@@ -19,7 +19,7 @@ from corehq.apps.receiverwrapper.models import Repeater, repeater_types
 from corehq.apps.groups.models import Group
 from corehq.apps.cloudcare.api import ElasticCaseQuery
 from corehq.apps.users.util import format_username
-from corehq.apps.users.models import CouchUser, CommCareUser, Permissions
+from corehq.apps.users.models import CouchUser, Permissions
 
 from corehq.apps.api.resources import v0_1, v0_3, JsonResource, DomainSpecificResourceMixin, dict_object, SimpleSortableResourceMixin
 from corehq.apps.api.es import XFormES, CaseES, ESQuerySet, es_search
@@ -399,9 +399,10 @@ class HOPECaseResource(CommCareCaseResource):
         if 'size' in query:
             del query['size']
 
-        return ESQuerySet(payload = query,
-                          model = HOPECase,
-                          es_client = self.case_es(domain)).order_by('server_modified_on') # Not that CaseES is used only as an ES client, for `run_query` against the proper index
+        # Note that CaseES is used only as an ES client, for `run_query` against the proper index
+        return ESQuerySet(payload=query,
+                          model=HOPECase,
+                          es_client=self.case_es(domain)).order_by('server_modified_on')
 
     class Meta(CommCareCaseResource.Meta):
         resource_name = 'hope-case'

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -9,10 +9,11 @@ from django.core.urlresolvers import reverse
 
 from tastypie import fields
 from tastypie.bundle import Bundle
+from corehq.apps.api.resources.v0_1 import RequirePermissionAuthentication
 
 from corehq.apps.groups.models import Group
 from corehq.apps.sms.util import strip_plus
-from corehq.apps.users.models import CommCareUser, WebUser
+from corehq.apps.users.models import CommCareUser, WebUser, Permissions
 from corehq.elastic import es_wrapper
 
 from . import v0_1, v0_4
@@ -43,6 +44,7 @@ class BulkUserResource(JsonResource, DomainSpecificResourceMixin):
         return namedtuple('user', user.keys())(**user)
 
     class Meta(v0_1.CustomResourceMeta):
+        authentication = RequirePermissionAuthentication(Permissions.edit_commcare_users)
         list_allowed_methods = ['get']
         detail_allowed_methods = ['get']
         object_class = object


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?99308

for users, web users and apps, the role was clear

for cases and forms, currently requiring edit data permission, though we may want to consider breaking this out to new permissions.

also fixed the repeater authorization not actually checking what it was supposed to be checking.
