### PR TITLE
csv export fixes

### DIFF
--- a/corehq/apps/reports/standard/export.py
+++ b/corehq/apps/reports/standard/export.py
@@ -249,9 +249,7 @@ class CaseExportReport(ExportReport):
     icon = "icon-share"
 
     def get_filter_params(self):
-        params = self.request.GET.copy()
-        params['format'] = 'csv'
-        return params
+        return self.request.GET.copy()
 
     def get_saved_exports(self):
         startkey = json.dumps([self.domain, ""])[:-3]

--- a/corehq/apps/reports/static/reports/ko/export.manager.js
+++ b/corehq/apps/reports/static/reports/ko/export.manager.js
@@ -189,10 +189,7 @@ var ExportManager = function (o) {
         if ($button.data('modulename')) {
             modalTitle  = $button.data('modulename') + " > " + modalTitle;
         }
-        var downloadParams = {
-            export_tag: ["'+self.domain+'","'+$button.data('xmlns')+'","'+$button.data('formname')+'"],
-            filename: $button.data('formname')
-        }
+        var downloadParams = {};
         if (!self.is_custom) {
             downloadParams.app_id = $button.data('appid');
         }

--- a/corehq/apps/reports/static/reports/ko/export.manager.js
+++ b/corehq/apps/reports/static/reports/ko/export.manager.js
@@ -167,11 +167,15 @@ var ExportManager = function (o) {
         var $button = $(event.srcElement || event.currentTarget);
         var downloadUrl = self.downloadUrl || $button.data('dlocation');
         resetModal("'" + options.modalTitle + "'", true);
+        var format = self.format;
+        if ($button.data('format')) {
+            format = $button.data('format');
+        }
         downloadUrl = downloadUrl +
             "?" + self.exportFilters +
             '&async=true' +
-            '&format=' + self.format +
             '&export_tag=["'+self.domain+'","'+$button.data('xmlns')+'","'+$button.data('formname')+'"]' +
+            '&format=' + format +
             '&filename='+$button.data('formname');
 
         for (var k in options.downloadParams) {

--- a/corehq/apps/reports/templates/reports/partials/saved_custom_exports.html
+++ b/corehq/apps/reports/templates/reports/partials/saved_custom_exports.html
@@ -58,6 +58,7 @@
                    data-exportid="{{ export.get_id }}"
                    data-exporttype="form"
                    data-dlocation='{% url "export_custom_data" domain export.get_id %}'
+                   data-format="{{ export.default_format }}"
                    data-bind="click: requestDownload"
                    class="dl-export btn btn-primary"><i class="icon-download-alt icon-white"></i> {% trans "Download" %}</a>
             </td>

--- a/corehq/apps/reports/templates/reports/reportdata/case_export_data.html
+++ b/corehq/apps/reports/templates/reports/reportdata/case_export_data.html
@@ -47,7 +47,7 @@
     </div>
 
     <div class="hq-generic-report form-horizontal">
-        <h2>{% trans "Daily Saved Exports" %}</h2>
+        <h2>{% trans "Saved Custom Exports" %}</h2>
 
         {% if saved_exports %}
         <table class="export_data table table-striped">


### PR DESCRIPTION
turns out auto-defaulting custom form and case exports to csv was actually a bad idea, since they already specify a default type in the UI.

this restores that functionality (and fixes a couple small things that appear to be unrelated bugs introduced).

thanks @amsagoff for the feedback
