### PR TITLE
add post-checkout git-hook to delete .pyc files

### DIFF
--- a/git-hooks/install.sh
+++ b/git-hooks/install.sh
@@ -37,8 +37,12 @@ function git-submodule-list() {
     git submodule | sed 's/^+/ /' | cut -f3 -d' '
 }
 
-cp git-hooks/pre-commit.sh .git/hooks/pre-commit
-for submodule in $(git-submodule-list)
+for hook in 'pre-commit' 'post-checkout'
 do
-    cp $CP_OPT git-hooks/pre-commit.sh .git/modules/$submodule/hooks/pre-commit
+
+    cp git-hooks/$hook.sh .git/hooks/$hook
+    for submodule in $(git-submodule-list)
+    do
+        cp $CP_OPT git-hooks/$hook.sh .git/modules/$submodule/hooks/$hook
+    done
 done

--- a/git-hooks/post-checkout.sh
+++ b/git-hooks/post-checkout.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# do this in the background so your prompt doesn't hang
+find . -name '*.pyc' -delete &


### PR DESCRIPTION
this is a common source of confusion when trying to reproduce
an error on another branch
