### PR TITLE
Fixture cleanup

### DIFF
--- a/corehq/apps/commtrack/fixtures.py
+++ b/corehq/apps/commtrack/fixtures.py
@@ -1,13 +1,10 @@
 from xml.etree import ElementTree
-from corehq import Domain
 from .models import Product
 
 
 def product_fixture_generator(user, version, last_sync):
-    if not user.domain:
-        return []
-    domain = Domain.get_by_name(user.domain)
-    if not domain or not Domain.get_by_name(user.domain).commtrack_enabled:
+    project = user.project
+    if not project or not project.commtrack_enabled:
         return []
 
     root = ElementTree.Element('fixture',

--- a/corehq/apps/commtrack/fixtures.py
+++ b/corehq/apps/commtrack/fixtures.py
@@ -1,0 +1,35 @@
+from xml.etree import ElementTree
+from corehq import Domain
+from .models import Product
+
+
+def product_fixture_generator(user, version, last_sync):
+    if not user.domain:
+        return []
+    domain = Domain.get_by_name(user.domain)
+    if not domain or not Domain.get_by_name(user.domain).commtrack_enabled:
+        return []
+
+    root = ElementTree.Element('fixture',
+                               attrib={'id': 'commtrack:products',
+                                       'user_id': user.user_id})
+    products = ElementTree.Element('products')
+    root.append(products)
+    for product_data in Product.by_domain(user.domain):
+        product = (ElementTree.Element('product',
+                                       {'id': product_data.get_id}))
+        products.append(product)
+        product_fields = ['name',
+                          'unit',
+                          'code',
+                          'description',
+                          'category',
+                          'program_id',
+                          'cost']
+        for product_field in product_fields:
+            field = ElementTree.Element(product_field)
+            val = getattr(product_data, product_field, None)
+            field.text = unicode(val if val is not None else '')
+            product.append(field)
+
+    return [root]

--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -11,7 +11,6 @@ from casexml.apps.stock import const as stockconst
 from casexml.apps.stock.consumption import ConsumptionConfiguration
 from casexml.apps.stock.models import StockReport as DbStockReport, StockTransaction as DbStockTransaction
 from casexml.apps.case.xml import V2
-from corehq import Domain
 from corehq.apps.commtrack import const
 from corehq.apps.consumption.shortcuts import get_default_consumption
 from corehq.apps.hqcase.utils import submit_case_blocks
@@ -160,38 +159,6 @@ class Product(Document):
             include_docs=False,
         )
         return [row['id'] for row in view_results]
-
-
-def product_fixture_generator(user, version, last_sync):
-    if not user.domain:
-        return []
-    domain = Domain.get_by_name(user.domain)
-    if not domain or not Domain.get_by_name(user.domain).commtrack_enabled:
-        return []
-
-    root = ElementTree.Element('fixture',
-                               attrib={'id': 'commtrack:products',
-                                       'user_id': user.user_id})
-    products = ElementTree.Element('products')
-    root.append(products)
-    for product_data in Product.by_domain(user.domain):
-        product = (ElementTree.Element('product',
-                                       {'id': product_data.get_id}))
-        products.append(product)
-        product_fields = ['name',
-                          'unit',
-                          'code',
-                          'description',
-                          'category',
-                          'program_id',
-                          'cost']
-        for product_field in product_fields:
-            field = ElementTree.Element(product_field)
-            val = getattr(product_data, product_field, None)
-            field.text = unicode(val if val is not None else '')
-            product.append(field)
-
-    return [root]
 
 
 class CommtrackActionConfig(DocumentSchema):

--- a/corehq/apps/commtrack/tests/test_fixture.py
+++ b/corehq/apps/commtrack/tests/test_fixture.py
@@ -4,7 +4,8 @@ from xml.etree import ElementTree
 
 from casexml.apps.case.xml import V1
 from corehq.apps.app_manager.tests import XmlTest
-from corehq.apps.commtrack.models import Product, product_fixture_generator
+from corehq.apps.commtrack.fixtures import product_fixture_generator
+from corehq.apps.commtrack.models import Product
 from corehq.apps.commtrack.tests.util import CommTrackTest
 from corehq.apps.commtrack.tests.util import bootstrap_user
 

--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -1,7 +1,20 @@
 from collections import defaultdict
 from xml.etree import ElementTree
+from django.conf import settings
 from corehq.apps.fixtures.models import FixtureDataItem, FixtureDataType
 from corehq.apps.users.models import CommCareUser
+from dimagi.utils.modules import to_function
+
+
+def hq_fixtures(user, version, last_sync):
+    if hasattr(user, "_hq_user") and user._hq_user is not None:
+        user = user._hq_user
+    if isinstance(user, CommCareUser):
+        for func_path in settings.HQ_FIXTURE_GENERATORS:
+            func = to_function(func_path)
+            if func:
+                for fixture in func(user, version, last_sync):
+                    yield fixture
 
 
 def item_lists(user, version, last_sync):

--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -18,13 +18,7 @@ def hq_fixtures(user, version, last_sync):
 
 
 def item_lists(user, version, last_sync):
-    if isinstance(user, CommCareUser):
-        pass
-    elif hasattr(user, "_hq_user") and user._hq_user is not None:
-        user = user._hq_user
-    else:
-        return []
-
+    assert isinstance(user, CommCareUser)
     all_types = dict([(t._id, t) for t in FixtureDataType.by_domain(user.domain)])
     global_types = dict([(id, t) for id, t in all_types.items() if t.is_global])
 

--- a/corehq/apps/reportfixtures/fixturegenerators.py
+++ b/corehq/apps/reportfixtures/fixturegenerators.py
@@ -1,6 +1,5 @@
 import logging
 from xml.etree import ElementTree
-from corehq.apps.domain.models import Domain
 from corehq.apps.callcenter.indicator_sets import CallCenter
 from corehq.apps.users.models import CommCareUser
 
@@ -9,19 +8,12 @@ logger = logging.getLogger(__name__)
 
 
 def indicators(user, version, last_sync):
-    if isinstance(user, CommCareUser):
-        pass
-    elif hasattr(user, "_hq_user") and user._hq_user is not None:
-        user = user._hq_user
-    else:
-        return []
-
+    assert isinstance(user, CommCareUser)
     fixtures = []
     indicator_sets = []
-    for dom in user.get_domains():
-        domain = Domain.get_by_name(dom)
-        if hasattr(domain, 'call_center_config') and domain.call_center_config.enabled:
-            indicator_sets.append(CallCenter(domain, user))
+    domain = user.project
+    if domain and hasattr(domain, 'call_center_config') and domain.call_center_config.enabled:
+        indicator_sets.append(CallCenter(domain, user))
 
     for set in indicator_sets:
         try:

--- a/corehq/apps/users/fixturegenerators.py
+++ b/corehq/apps/users/fixturegenerators.py
@@ -8,6 +8,4 @@ def user_groups(user, version, last_sync):
     For a given user, return a fixture containing all the groups
     they are a part of.
     """
-    if hasattr(user, "_hq_user") and user._hq_user is not None:
-        return [user._hq_user.get_group_fixture()]
-    return []  # this user isn't made on HQ, and this also keeps tests happy
+    return [user.get_group_fixture()]

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1237,6 +1237,11 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
                             (self.username, str(result[1]))
                 )
 
+    @property
+    @memoized
+    def project(self):
+        return Domain.get_by_name(self.domain)
+
     def is_domain_admin(self, domain=None):
         # cloudcare workaround
         return False

--- a/custom/bihar/reports/indicators/fixtures.py
+++ b/custom/bihar/reports/indicators/fixtures.py
@@ -2,7 +2,6 @@ from xml.etree import ElementTree
 from django.utils import translation
 from django.utils.translation import ugettext as _
 from corehq.apps.groups.models import Group
-from corehq.apps.users.models import CommCareUser
 from custom.bihar import BIHAR_DOMAINS
 from custom.bihar.reports.indicators.indicators import IndicatorDataProvider, IndicatorConfig, INDICATOR_SETS
 
@@ -14,14 +13,6 @@ hard_coded_fixture_id = 'indicators:bihar-supervisor'
 
 
 def generator(user, version, last_sync):
-    # todo: this appears in the beginning of all fixture generators. should fix
-    if isinstance(user, CommCareUser):
-        pass
-    elif hasattr(user, "_hq_user") and user._hq_user is not None:
-        user = user._hq_user
-    else:
-        return []
-
     if user.domain in hard_coded_domains:
         groups = filter(hard_coded_group_filter, Group.by_user(user))
         if len(groups) == 1:

--- a/settings.py
+++ b/settings.py
@@ -417,7 +417,7 @@ FIXTURE_GENERATORS = [
     "corehq.apps.fixtures.fixturegenerators.item_lists",
     "corehq.apps.reportfixtures.fixturegenerators.indicators",
     "custom.bihar.reports.indicators.fixtures.generator",
-    "corehq.apps.commtrack.models.product_fixture_generator",
+    "corehq.apps.commtrack.fixtures.product_fixture_generator",
 ]
 
 GET_URL_BASE = 'dimagi.utils.web.get_url_base'

--- a/settings.py
+++ b/settings.py
@@ -413,6 +413,10 @@ OPENROSA_VERSION = "1.0"
 
 # OTA restore fixture generators
 FIXTURE_GENERATORS = [
+    "corehq.apps.fixtures.fixturegenerators.hq_fixtures",
+]
+
+HQ_FIXTURE_GENERATORS = [
     "corehq.apps.users.fixturegenerators.user_groups",
     "corehq.apps.fixtures.fixturegenerators.item_lists",
     "corehq.apps.reportfixtures.fixturegenerators.indicators",


### PR DESCRIPTION
this funnels all hq fixtures through a single method which does all the precondition checking so that the fixture generators themselves don't have to reproduce all the same error handling logic introduced by the fact that casexml doesn't know about `CommCareUser`.
