### PR TITLE
Handle UserRole changes on upgrades and downgrades

### DIFF
--- a/corehq/apps/accounting/exceptions.py
+++ b/corehq/apps/accounting/exceptions.py
@@ -18,7 +18,7 @@ class SubscriptionAdjustmentError(Exception):
     pass
 
 
-class SubscriptionDowngradeError(Exception):
+class SubscriptionChangeError(Exception):
     pass
 
 

--- a/corehq/apps/accounting/generator.py
+++ b/corehq/apps/accounting/generator.py
@@ -301,7 +301,7 @@ def arbitrary_commcare_user(domain, is_active=True):
         commcare_user.is_active = is_active
         commcare_user.save()
         return commcare_user
-    except AlreadyExistsError:
+    except Exception:
         pass
 
 

--- a/corehq/apps/accounting/generator.py
+++ b/corehq/apps/accounting/generator.py
@@ -35,6 +35,20 @@ def instantiate_accounting_for_tests():
     call_command('cchq_software_plan_bootstrap', testing=True)
 
 
+def teardown_accounting_for_tests():
+    print ('Tearing down accounting.')
+    DefaultProductPlan.objects.all().delete()
+
+    SoftwarePlanVersion.objects.all().delete()
+    SoftwarePlan.objects.all().delete()
+
+    FeatureRate.objects.all().delete()
+    Feature.objects.all().delete()
+
+    SoftwareProductRate.objects.all().delete()
+    SoftwareProduct.objects.all().delete()
+
+
 def init_default_currency():
     currency, _ = Currency.objects.get_or_create(
         code=settings.DEFAULT_CURRENCY,

--- a/corehq/apps/accounting/generator.py
+++ b/corehq/apps/accounting/generator.py
@@ -81,8 +81,10 @@ def delete_all_accounts():
 
 
 def arbitrary_subscribable_plan():
-    return DefaultProductPlan.objects.get(edition=random.choice(SUBSCRIBABLE_EDITIONS),
-                                          product_type=SoftwareProductType.COMMCARE).plan.get_version()
+    return DefaultProductPlan.objects.get(
+        edition=random.choice(SUBSCRIBABLE_EDITIONS),
+        product_type=SoftwareProductType.COMMCARE
+    ).plan.get_version()
 
 
 def generate_domain_subscription_from_date(date_start, billing_account, domain,
@@ -195,8 +197,11 @@ def arbitrary_sms_billables_for_domain(domain, direction, message_month_date, nu
 
 
 def create_excess_community_users(domain):
-    community_plan = DefaultProductPlan.objects.get(product_type=SoftwareProductType.COMMCARE,
-                                                    edition=SoftwarePlanEdition.COMMUNITY).get_version()
-    num_active_users = random.randint(community_plan.user_limit + 1, community_plan.user_limit + 4)
+    community_plan = DefaultProductPlan.objects.get(
+        product_type=SoftwareProductType.COMMCARE,
+        edition=SoftwarePlanEdition.COMMUNITY
+    ).plan.get_version()
+    num_active_users = random.randint(community_plan.user_limit + 1,
+                                      community_plan.user_limit + 4)
     arbitrary_commcare_users_for_domain(domain.name, num_active_users)
     return num_active_users

--- a/corehq/apps/accounting/generator.py
+++ b/corehq/apps/accounting/generator.py
@@ -12,10 +12,11 @@ from django_prbac import arbitrary as role_gen
 from dimagi.utils.dates import add_months
 from dimagi.utils.data import generator as data_gen
 
-from corehq.apps.accounting.models import (FeatureType, Currency, BillingAccount, FeatureRate, SoftwarePlanVersion,
-                                           SoftwarePlan, SoftwareProductRate, Subscription, Subscriber, SoftwareProduct,
-                                           Feature, SoftwareProductType, DefaultProductPlan, BillingAccountAdmin,
-                                           SubscriptionAdjustment, SoftwarePlanEdition)
+from corehq.apps.accounting.models import (
+    Currency, BillingAccount, Subscription, Subscriber, SoftwareProductType,
+    DefaultProductPlan, BillingAccountAdmin, SubscriptionAdjustment,
+    SoftwarePlanEdition,
+)
 from corehq.apps.domain.models import Domain
 from corehq.apps.users.models import WebUser, CommCareUser
 

--- a/corehq/apps/accounting/generator.py
+++ b/corehq/apps/accounting/generator.py
@@ -35,20 +35,6 @@ def instantiate_accounting_for_tests():
     call_command('cchq_software_plan_bootstrap', testing=True)
 
 
-def teardown_accounting_for_tests():
-    print ('Tearing down accounting.')
-    DefaultProductPlan.objects.all().delete()
-
-    SoftwarePlanVersion.objects.all().delete()
-    SoftwarePlan.objects.all().delete()
-
-    FeatureRate.objects.all().delete()
-    Feature.objects.all().delete()
-
-    SoftwareProductRate.objects.all().delete()
-    SoftwareProduct.objects.all().delete()
-
-
 def init_default_currency():
     currency, _ = Currency.objects.get_or_create(
         code=settings.DEFAULT_CURRENCY,

--- a/corehq/apps/accounting/generator.py
+++ b/corehq/apps/accounting/generator.py
@@ -34,20 +34,6 @@ def instantiate_accounting_for_tests():
     call_command('cchq_software_plan_bootstrap', testing=True)
 
 
-def teardown_accounting_for_tests():
-    print ('Tearing down accounting.')
-    DefaultProductPlan.objects.all().delete()
-
-    SoftwarePlanVersion.objects.all().delete()
-    SoftwarePlan.objects.all().delete()
-
-    FeatureRate.objects.all().delete()
-    Feature.objects.all().delete()
-
-    SoftwareProductRate.objects.all().delete()
-    SoftwareProduct.objects.all().delete()
-
-
 def init_default_currency():
     currency, _ = Currency.objects.get_or_create(
         code=settings.DEFAULT_CURRENCY,

--- a/corehq/apps/accounting/generator.py
+++ b/corehq/apps/accounting/generator.py
@@ -5,6 +5,7 @@ import random
 import datetime
 
 from django.conf import settings
+from django.core.management import call_command
 
 from django_prbac import arbitrary as role_gen
 
@@ -20,115 +21,31 @@ from corehq.apps.users.models import WebUser, CommCareUser
 
 # don't actually use the plan lists below for initializing new plans! the amounts have been changed to make
 # it easier for testing:
-MAX_COMMUNITY_USERS = 2
 
-COMMUNITY_COMMCARE_PLANS = [
-    {
-        'name': "CommCare Community",
-        'product_type': SoftwareProductType.COMMCARE,
-        'fee': Decimal('0.0'),
-        'rates': [
-            {
-                'name': "User Community",
-                'limit': MAX_COMMUNITY_USERS,
-                'excess': Decimal('1.00'),
-                'type': FeatureType.USER,
-            },
-            {
-                'name': "SMS Community",
-                'type': FeatureType.SMS,
-            },
-        ],
-    },
-    {
-        'name': "CommTrack Community",
-        'product_type': SoftwareProductType.COMMTRACK,
-        'fee': Decimal('0.0'),
-        'rates': [
-            {
-                'name': "User CommTrack Community",
-                'limit': MAX_COMMUNITY_USERS,
-                'excess': Decimal('1.00'),
-                'type': FeatureType.USER,
-            },
-            {
-                'name': "SMS CommTrack Community",
-                'type': FeatureType.SMS,
-            },
-        ],
-    },
-    {
-        'name': "CommConnect Community",
-        'product_type': SoftwareProductType.COMMCONNECT,
-        'fee': Decimal('0.0'),
-        'rates': [
-            {
-                'name': "User CommConnect Community",
-                'limit': MAX_COMMUNITY_USERS,
-                'excess': Decimal('1.00'),
-                'type': FeatureType.USER,
-            },
-            {
-                'name': "SMS CommConnect Community",
-                'type': FeatureType.SMS,
-            },
-        ],
-    },
+SUBSCRIBABLE_EDITIONS = [
+    SoftwarePlanEdition.ADVANCED,
+    SoftwarePlanEdition.PRO,
+    SoftwarePlanEdition.STANDARD,
 ]
 
-SUBSCRIBABLE_COMMCARE_PLANS = [
-    {
-        'name': "CommCare Standard",
-        'fee': Decimal('100.00'),
-        'rates': [
-            {
-                'name': "User Standard",
-                'limit': 4,
-                'excess': Decimal('1.00'),
-                'type': FeatureType.USER,
-            },
-            {
-                'name': "SMS Standard",
-                'limit': 10,
-                'type': FeatureType.SMS,
-            },
-        ],
-    },
-    {
-        'name': "CommCare Pro",
-        'fee': Decimal('500.00'),
-        'rates': [
-            {
-                'name': "User Pro",
-                'limit': 6,
-                'excess': Decimal('1.00'),
-                'type': FeatureType.USER,
-            },
-            {
-                'name': "SMS Pro",
-                'limit': 16,
-                'type': FeatureType.SMS,
-            },
-        ],
-    },
-    {
-        'name': "CommCare Advanced",
-        'fee': Decimal('1000.00'),
-        'rates': [
-            {
-                'name': "User Advanced",
-                'limit': 8,
-                'excess': Decimal('1.00'),
-                'type': FeatureType.USER,
-            },
-            {
-                'name': "SMS Advanced",
-                'limit': 20,
-                'type': FeatureType.SMS,
-            },
-        ],
-    },
-]
+
+def instantiate_accounting_for_tests():
+    call_command('cchq_prbac_bootstrap', testing=True)
+    call_command('cchq_software_plan_bootstrap', testing=True)
+
+
+def teardown_accounting_for_tests():
+    print ('Tearing down accounting.')
+    DefaultProductPlan.objects.all().delete()
+
+    SoftwarePlanVersion.objects.all().delete()
+    SoftwarePlan.objects.all().delete()
+
+    FeatureRate.objects.all().delete()
+    Feature.objects.all().delete()
+
+    SoftwareProductRate.objects.all().delete()
+    SoftwareProduct.objects.all().delete()
 
 
 def init_default_currency():
@@ -144,7 +61,11 @@ def init_default_currency():
 def arbitrary_web_user(save=True, is_dimagi=False):
     domain = data_gen.arbitrary_unique_name().lower()[:25]
     username = "%s@%s.com" % (data_gen.arbitrary_username(), 'dimagi' if is_dimagi else 'gmail')
-    web_user = WebUser.create(domain, username, 'test123')
+    try:
+        web_user = WebUser.create(domain, username, 'test123')
+    except Exception:
+        web_user = WebUser.get_by_username(username)
+    web_user.is_active = True
     if save:
         web_user.save()
     return web_user
@@ -172,61 +93,9 @@ def delete_all_accounts():
     Currency.objects.all().delete()
 
 
-def _instantiate_plans_from_list(plan_list):
-    plans = []
-    for plan in plan_list:
-        software_plan, created = SoftwarePlan.objects.get_or_create(name=plan['name'])
-        plan_version = SoftwarePlanVersion(
-            plan=software_plan,
-            role=role_gen.arbitrary_role(),
-        )
-        plan_version.save()
-        plan_version.product_rates.add(SoftwareProductRate.new_rate(plan['name'], plan['fee']))
-        for rate in plan['rates']:
-            plan_version.feature_rates.add(
-                FeatureRate.new_rate(
-                    rate['name'],
-                    rate['type'],
-                    monthly_fee=rate.get('fee'),
-                    monthly_limit=rate.get('limit'),
-                    per_excess_fee=rate.get('excess'),
-                )
-            )
-        plan_version.save()
-        plans.append(software_plan)
-    return plans
-
-
-def instantiate_subscribable_plans():
-    _instantiate_plans_from_list(SUBSCRIBABLE_COMMCARE_PLANS)
-
-
-def instantiate_community_plans():
-    plans = _instantiate_plans_from_list(COMMUNITY_COMMCARE_PLANS)
-    for ind, plan in enumerate(plans):
-        DefaultProductPlan.objects.get_or_create(
-            product_type=COMMUNITY_COMMCARE_PLANS[ind]['product_type'],
-            edition=SoftwarePlanEdition.COMMUNITY,
-            plan=plan,
-        )
-
-
-def delete_all_plans():
-    DefaultProductPlan.objects.all().delete()
-    SoftwarePlanVersion.objects.all().delete()
-    SoftwarePlan.objects.all().delete()
-
-    SoftwareProductRate.objects.all().delete()
-    SoftwareProduct.objects.all().delete()
-
-    FeatureRate.objects.all().delete()
-    Feature.objects.all().delete()
-
-
 def arbitrary_subscribable_plan():
-    subscribable_plans = [plan['name'] for plan in SUBSCRIBABLE_COMMCARE_PLANS]
-    plan = SoftwarePlan.objects.get(name=random.choice(subscribable_plans))
-    return plan.get_version()
+    return DefaultProductPlan.objects.get(edition=random.choice(SUBSCRIBABLE_EDITIONS),
+                                          product_type=SoftwareProductType.COMMCARE).plan.get_version()
 
 
 def generate_domain_subscription_from_date(date_start, billing_account, domain,
@@ -339,6 +208,8 @@ def arbitrary_sms_billables_for_domain(domain, direction, message_month_date, nu
 
 
 def create_excess_community_users(domain):
-    num_active_users = random.randint(MAX_COMMUNITY_USERS + 1, MAX_COMMUNITY_USERS + 4)
+    community_plan = DefaultProductPlan.objects.get(product_type=SoftwareProductType.COMMCARE,
+                                                    edition=SoftwarePlanEdition.COMMUNITY).get_version()
+    num_active_users = random.randint(community_plan.user_limit + 1, community_plan.user_limit + 4)
     arbitrary_commcare_users_for_domain(domain.name, num_active_users)
     return num_active_users

--- a/corehq/apps/accounting/management/commands/cchq_software_plan_bootstrap.py
+++ b/corehq/apps/accounting/management/commands/cchq_software_plan_bootstrap.py
@@ -34,10 +34,17 @@ class Command(BaseCommand):
         make_option('--force-reset', action='store_true',  default=False,
                     help='Assign latest version of all DefaultProductPlans to current '
                          'subscriptions and delete older versions.'),
+        make_option('--testing', action='store_true',  default=False,
+                    help='Run this command for testing purposes.'),
     )
 
-    def handle(self, dry_run=False, verbose=False, fresh_start=False, flush=False, force_reset=False, *args, **options):
+    def handle(self, dry_run=False, verbose=False, fresh_start=False, flush=False, force_reset=False,
+               testing=False, *args, **options):
         logging.info('Bootstrapping standard plans. Enterprise plans will have to be created via the admin UIs.')
+
+        self.for_tests = testing
+        if self.for_tests:
+            logger.info("Initializing Plans and Roles for Testing")
 
         if verbose:
             logger.setLevel(logging.DEBUG)
@@ -229,20 +236,24 @@ class Command(BaseCommand):
         feature_rates = []
         BOOTSTRAP_FEATURE_RATES = {
             SoftwarePlanEdition.COMMUNITY: {
-                FeatureType.USER: FeatureRate(monthly_limit=50, per_excess_fee=Decimal('1.00')),
+                FeatureType.USER: FeatureRate(monthly_limit=2 if self.for_tests else 50,
+                                              per_excess_fee=Decimal('1.00')),
                 FeatureType.SMS: FeatureRate(monthly_limit=0),  # use defaults here
             },
             SoftwarePlanEdition.STANDARD: {
-                FeatureType.USER: FeatureRate(monthly_limit=100, per_excess_fee=Decimal('1.00')),
-                FeatureType.SMS: FeatureRate(monthly_limit=250),
+                FeatureType.USER: FeatureRate(monthly_limit=4 if self.for_tests else 100,
+                                              per_excess_fee=Decimal('1.00')),
+                FeatureType.SMS: FeatureRate(monthly_limit=3 if self.for_tests else 100),
             },
             SoftwarePlanEdition.PRO: {
-                FeatureType.USER: FeatureRate(monthly_limit=500, per_excess_fee=Decimal('1.00')),
-                FeatureType.SMS: FeatureRate(monthly_limit=500),
+                FeatureType.USER: FeatureRate(monthly_limit=6 if self.for_tests else 500,
+                                              per_excess_fee=Decimal('1.00')),
+                FeatureType.SMS: FeatureRate(monthly_limit=5 if self.for_tests else 500),
             },
             SoftwarePlanEdition.ADVANCED: {
-                FeatureType.USER: FeatureRate(monthly_limit=1000, per_excess_fee=Decimal('1.00')),
-                FeatureType.SMS: FeatureRate(monthly_limit=1000),
+                FeatureType.USER: FeatureRate(monthly_limit=8 if self.for_tests else 1000,
+                                              per_excess_fee=Decimal('1.00')),
+                FeatureType.SMS: FeatureRate(monthly_limit=7 if self.for_tests else 1000),
             },
             SoftwarePlanEdition.ENTERPRISE: {
                 FeatureType.USER: FeatureRate(monthly_limit=-1, per_excess_fee=Decimal('0.00')),

--- a/corehq/apps/accounting/tests/__init__.py
+++ b/corehq/apps/accounting/tests/__init__.py
@@ -4,3 +4,6 @@ from .test_models import *
 from .test_invoicing import *
 from .test_credit_lines import *
 from .test_subscription_changes import *
+
+
+

--- a/corehq/apps/accounting/tests/__init__.py
+++ b/corehq/apps/accounting/tests/__init__.py
@@ -3,3 +3,4 @@ from __future__ import absolute_import
 from .test_models import *
 from .test_invoicing import *
 from .test_credit_lines import *
+from .test_subscription_changes import *

--- a/corehq/apps/accounting/tests/base_tests.py
+++ b/corehq/apps/accounting/tests/base_tests.py
@@ -1,0 +1,11 @@
+from django.test import TestCase
+from corehq.apps.accounting import generator
+
+
+class BaseAccountingTest(TestCase):
+
+    def setUp(self):
+        generator.instantiate_accounting_for_tests()
+
+    def tearDown(self):
+        generator.teardown_accounting_for_tests()

--- a/corehq/apps/accounting/tests/base_tests.py
+++ b/corehq/apps/accounting/tests/base_tests.py
@@ -6,6 +6,3 @@ class BaseAccountingTest(TestCase):
 
     def setUp(self):
         generator.instantiate_accounting_for_tests()
-
-    def tearDown(self):
-        generator.teardown_accounting_for_tests()

--- a/corehq/apps/accounting/tests/test_invoicing.py
+++ b/corehq/apps/accounting/tests/test_invoicing.py
@@ -156,8 +156,10 @@ class TestInvoice(BaseInvoiceTestCase):
             self.assertEqual(subscriber.subscription_set.count(), 1)
             subscription = subscriber.subscription_set.get()
             self.assertEqual(subscription.invoice_set.count(), 1)
-            expected_community_plan = DefaultProductPlan.objects.get(product_type=product_type)
-            self.assertEqual(subscription.plan_version.plan, expected_community_plan.plan)
+            expected_community_plan = DefaultProductPlan.get_default_plan_by_domain(domain)
+            self.assertEqual(
+                subscription.plan_version.plan, expected_community_plan.plan
+            )
             domain.delete()
 
 

--- a/corehq/apps/accounting/tests/test_invoicing.py
+++ b/corehq/apps/accounting/tests/test_invoicing.py
@@ -50,7 +50,6 @@ class BaseInvoiceTestCase(BaseAccountingTest):
         Invoice.objects.all().delete()
         generator.delete_all_subscriptions()
         generator.delete_all_accounts()
-        super(BaseInvoiceTestCase, self).tearDown()
 
 
 class TestInvoice(BaseInvoiceTestCase):

--- a/corehq/apps/accounting/tests/test_invoicing.py
+++ b/corehq/apps/accounting/tests/test_invoicing.py
@@ -2,7 +2,7 @@ from decimal import Decimal
 import random
 import datetime
 from django.core.exceptions import ObjectDoesNotExist
-from django.test import TestCase
+from corehq.apps.accounting.tests.base_tests import BaseAccountingTest
 
 from corehq.apps.sms.models import INCOMING, OUTGOING
 from corehq.apps.smsbillables.models import (
@@ -17,10 +17,11 @@ from corehq.apps.accounting.models import (
 )
 
 
-class BaseInvoiceTestCase(TestCase):
+class BaseInvoiceTestCase(BaseAccountingTest):
     min_subscription_length = 3
 
     def setUp(self):
+        super(BaseInvoiceTestCase, self).setUp()
         self.billing_contact = generator.arbitrary_web_user()
         self.dimagi_user = generator.arbitrary_web_user(is_dimagi=True)
         self.currency = generator.init_default_currency()
@@ -49,6 +50,7 @@ class BaseInvoiceTestCase(TestCase):
         Invoice.objects.all().delete()
         generator.delete_all_subscriptions()
         generator.delete_all_accounts()
+        super(BaseInvoiceTestCase, self).tearDown()
 
 
 class TestInvoice(BaseInvoiceTestCase):

--- a/corehq/apps/accounting/tests/test_models.py
+++ b/corehq/apps/accounting/tests/test_models.py
@@ -34,7 +34,6 @@ class TestSubscription(TestCase):
         self.dimagi_user = generator.arbitrary_web_user(is_dimagi=True)
         self.currency = generator.init_default_currency()
         self.account = generator.billing_account(self.dimagi_user, self.billing_contact)
-        generator.instantiate_subscribable_plans()
         self.subscription, self.subscription_length = generator.generate_domain_subscription_from_date(
             datetime.date.today(), self.account, 'test'
         )
@@ -73,5 +72,4 @@ class TestSubscription(TestCase):
         self.dimagi_user.delete()
 
         generator.delete_all_subscriptions()
-        generator.delete_all_plans()
         generator.delete_all_accounts()

--- a/corehq/apps/accounting/tests/test_models.py
+++ b/corehq/apps/accounting/tests/test_models.py
@@ -26,7 +26,6 @@ class TestBillingAccount(BaseAccountingTest):
         self.dimagi_user.delete()
         BillingAccount.objects.all().delete()
         Currency.objects.all().delete()
-        super(TestBillingAccount, self).tearDown()
 
 
 class TestSubscription(BaseAccountingTest):
@@ -76,4 +75,3 @@ class TestSubscription(BaseAccountingTest):
 
         generator.delete_all_subscriptions()
         generator.delete_all_accounts()
-        super(TestSubscription, self).tearDown()

--- a/corehq/apps/accounting/tests/test_models.py
+++ b/corehq/apps/accounting/tests/test_models.py
@@ -1,14 +1,15 @@
 import datetime
 from django.db import models
-from django.test import TestCase
 
 from corehq.apps.accounting import generator, tasks
 from corehq.apps.accounting.models import BillingAccount, Currency, Subscription
+from corehq.apps.accounting.tests.base_tests import BaseAccountingTest
 
 
-class TestBillingAccount(TestCase):
+class TestBillingAccount(BaseAccountingTest):
 
     def setUp(self):
+        super(TestBillingAccount, self).setUp()
         self.billing_contact = generator.arbitrary_web_user()
         self.dimagi_user = generator.arbitrary_web_user(is_dimagi=True)
         self.currency = generator.init_default_currency()
@@ -25,11 +26,13 @@ class TestBillingAccount(TestCase):
         self.dimagi_user.delete()
         BillingAccount.objects.all().delete()
         Currency.objects.all().delete()
+        super(TestBillingAccount, self).tearDown()
 
 
-class TestSubscription(TestCase):
+class TestSubscription(BaseAccountingTest):
 
     def setUp(self):
+        super(TestSubscription, self).setUp()
         self.billing_contact = generator.arbitrary_web_user()
         self.dimagi_user = generator.arbitrary_web_user(is_dimagi=True)
         self.currency = generator.init_default_currency()
@@ -73,3 +76,4 @@ class TestSubscription(TestCase):
 
         generator.delete_all_subscriptions()
         generator.delete_all_accounts()
+        super(TestSubscription, self).tearDown()

--- a/corehq/apps/accounting/tests/test_subscription_changes.py
+++ b/corehq/apps/accounting/tests/test_subscription_changes.py
@@ -14,6 +14,7 @@ class TestUserRoleSubscriptionChanges(BaseAccountingTest):
     min_subscription_length = 3
 
     def setUp(self):
+        super(TestUserRoleSubscriptionChanges, self).setUp()
         self.domain = generator.arbitrary_domain()
         UserRole.init_domain_with_presets(self.domain.name)
         self.user_roles = UserRole.by_domain(self.domain.name)

--- a/corehq/apps/accounting/tests/test_subscription_changes.py
+++ b/corehq/apps/accounting/tests/test_subscription_changes.py
@@ -1,0 +1,148 @@
+from django.test import TestCase
+from toggle.models import Toggle
+from corehq import toggles
+from corehq.apps.accounting import generator
+from corehq.apps.accounting.models import (
+    Subscription, BillingAccount, DefaultProductPlan, SoftwarePlanEdition,
+)
+from corehq.apps.users.models import (
+    Permissions, UserRole, UserRolePresets, WebUser, CommCareUser,
+)
+
+
+class TestUserRoleSubscriptionChanges(TestCase):
+    min_subscription_length = 3
+
+    def setUp(self):
+        self.domain = generator.arbitrary_domain()
+        UserRole.init_domain_with_presets(self.domain.name)
+        self.user_roles = UserRole.by_domain(self.domain.name)
+        self.custom_role = UserRole.get_or_create_with_permissions(
+            self.domain.name,
+            Permissions(edit_apps=True, edit_web_users=True),
+            "Custom Role"
+        )
+        self.custom_role.save()
+        self.read_only_role = UserRole.get_read_only_role_by_domain(self.domain.name)
+
+        self.admin_user = generator.arbitrary_web_user()
+        self.admin_user.add_domain_membership(self.domain.name, is_admin=True)
+        self.admin_user.save()
+
+        self.web_users = []
+        self.commcare_users = []
+        for role in [self.custom_role] + self.user_roles:
+            web_user = generator.arbitrary_web_user()
+            web_user.add_domain_membership(self.domain.name, role_id=role.get_id)
+            web_user.save()
+            self.web_users.append(web_user)
+
+            commcare_user = generator.arbitrary_commcare_user(
+                domain=self.domain.name)
+            commcare_user.set_role(self.domain.name, role.get_qualified_id())
+            commcare_user.save()
+            self.commcare_users.append(commcare_user)
+
+        # toggle until release
+        self.toggle = Toggle(
+            slug=toggles.ACCOUNTING_PREVIEW.slug,
+            enabled_users=[self.admin_user.username],
+        )
+        self.toggle.save()
+
+        self.account = BillingAccount.get_or_create_account_by_domain(
+            self.domain.name,created_by=self.admin_user.username)[0]
+        self.advanced_plan = DefaultProductPlan.get_default_plan_by_domain(
+            self.domain.name,edition=SoftwarePlanEdition.ADVANCED)
+
+    def test_cancellation(self):
+        subscription = Subscription.new_domain_subscription(
+            self.account, self.domain.name, self.advanced_plan,
+            web_user=self.admin_user.username
+        )
+        self._change_std_roles()
+        subscription.cancel_subscription(web_user=self.admin_user.username)
+
+        custom_role = UserRole.get(self.custom_role.get_id)
+        custom_web_user = WebUser.get(self.web_users[0].get_id)
+        custom_commcare_user = CommCareUser.get(self.commcare_users[0].get_id)
+
+        self.assertTrue(custom_role.is_archived)
+        self.assertEqual(
+            custom_web_user.get_domain_membership(self.domain.name).role_id,
+            self.read_only_role.get_id
+        )
+        self.assertIsNone(
+            custom_commcare_user.get_domain_membership(self.domain.name).role_id
+        )
+        self.assertInitialRoles()
+        self.assertStdUsers()
+
+    def test_resubscription(self):
+        subscription = Subscription.new_domain_subscription(
+            self.account, self.domain.name, self.advanced_plan,
+            web_user=self.admin_user.username
+        )
+        self._change_std_roles()
+        subscription.cancel_subscription(web_user=self.admin_user.username)
+        custom_role = UserRole.get(self.custom_role.get_id)
+        self.assertTrue(custom_role.is_archived)
+        subscription = Subscription.new_domain_subscription(
+            self.account, self.domain.name, self.advanced_plan,
+            web_user=self.admin_user.username
+        )
+        custom_role = UserRole.get(self.custom_role.get_id)
+        self.assertFalse(custom_role.is_archived)
+
+        custom_web_user = WebUser.get(self.web_users[0].get_id)
+        custom_commcare_user = CommCareUser.get(self.commcare_users[0].get_id)
+        self.assertEqual(
+            custom_web_user.get_domain_membership(self.domain.name).role_id,
+            self.read_only_role.get_id
+        )
+        self.assertIsNone(
+            custom_commcare_user.get_domain_membership(self.domain.name).role_id
+        )
+
+        self.assertInitialRoles()
+        self.assertStdUsers()
+        subscription.cancel_subscription(web_user=self.admin_user.username)
+
+    def _change_std_roles(self):
+        for u in self.user_roles:
+            user_role = UserRole.get(u.get_id)
+            user_role.permissions = Permissions(
+                view_reports=True, edit_commcare_users=True, edit_apps=True,
+                edit_data=True
+            )
+            user_role.save()
+
+    def assertInitialRoles(self):
+        for u in self.user_roles:
+            user_role = UserRole.get(u.get_id)
+            self.assertEqual(
+                user_role.permissions,
+                UserRolePresets.get_permissions(user_role.name)
+            )
+
+    def assertStdUsers(self):
+        for ind, wu in enumerate(self.web_users[1:]):
+            web_user = WebUser.get(wu.get_id)
+            self.assertEqual(
+                web_user.get_domain_membership(self.domain.name).role_id,
+                self.user_roles[ind].get_id
+            )
+
+        for ind, cc in enumerate(self.commcare_users[1:]):
+            commcare_user = CommCareUser.get(cc.get_id)
+            self.assertEqual(
+                commcare_user.get_domain_membership(self.domain.name).role_id,
+                self.user_roles[ind].get_id
+            )
+
+    def tearDown(self):
+        self.domain.delete()
+        self.admin_user.delete()
+        self.toggle.delete()
+        generator.delete_all_subscriptions()
+        generator.delete_all_accounts()

--- a/corehq/apps/accounting/tests/test_subscription_changes.py
+++ b/corehq/apps/accounting/tests/test_subscription_changes.py
@@ -1,4 +1,4 @@
-from django.test import TestCase
+from corehq.apps.accounting.tests.base_tests import BaseAccountingTest
 from toggle.models import Toggle
 from corehq import toggles
 from corehq.apps.accounting import generator
@@ -10,7 +10,7 @@ from corehq.apps.users.models import (
 )
 
 
-class TestUserRoleSubscriptionChanges(TestCase):
+class TestUserRoleSubscriptionChanges(BaseAccountingTest):
     min_subscription_length = 3
 
     def setUp(self):
@@ -146,3 +146,4 @@ class TestUserRoleSubscriptionChanges(TestCase):
         self.toggle.delete()
         generator.delete_all_subscriptions()
         generator.delete_all_accounts()
+        super(TestUserRoleSubscriptionChanges, self).tearDown()

--- a/corehq/apps/accounting/tests/test_subscription_changes.py
+++ b/corehq/apps/accounting/tests/test_subscription_changes.py
@@ -143,6 +143,5 @@ class TestUserRoleSubscriptionChanges(BaseAccountingTest):
     def tearDown(self):
         self.domain.delete()
         self.admin_user.delete()
-        self.toggle.delete()
         generator.delete_all_subscriptions()
         generator.delete_all_accounts()

--- a/corehq/apps/accounting/tests/test_subscription_changes.py
+++ b/corehq/apps/accounting/tests/test_subscription_changes.py
@@ -146,4 +146,3 @@ class TestUserRoleSubscriptionChanges(BaseAccountingTest):
         self.toggle.delete()
         generator.delete_all_subscriptions()
         generator.delete_all_accounts()
-        super(TestUserRoleSubscriptionChanges, self).tearDown()

--- a/corehq/apps/accounting/utils.py
+++ b/corehq/apps/accounting/utils.py
@@ -77,7 +77,7 @@ def get_change_status(from_plan_version, to_plan_version):
     to_privs = get_privileges(to_plan_version)
 
     downgraded_privs = all_privs.difference(to_privs)
-    upgraded_privs = to_privs.difference(from_privs)
+    upgraded_privs = to_privs
 
     from corehq.apps.accounting.models import SubscriptionAdjustmentReason as Reason
     if from_plan_version is None:

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -7,7 +7,7 @@ from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.xml import V2
 from corehq.apps.accounting.async_handlers import Select2BillingInfoHandler
 from corehq.apps.accounting.decorators import require_billing_admin, requires_privilege_alert
-from corehq.apps.accounting.downgrade import DomainDowngradeStatusHandler
+from corehq.apps.accounting.subscription_changes import DomainDowngradeStatusHandler
 from corehq.apps.accounting.forms import EnterprisePlanContactForm
 from corehq.apps.accounting.utils import get_change_status
 from corehq.apps.hqwebapp.async_handler import AsyncHandlerMixin

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -177,30 +177,66 @@ class Permissions(DocumentSchema):
             view_reports=True,
         )
 
+
+class UserRolePresets(object):
+    READ_ONLY_NO_REPORTS = "Read Only (No Reports)"
+    APP_EDITOR = "App Editor"
+    READ_ONLY = "Read Only"
+    FIELD_IMPLEMENTER = "Field Implementer"
+    INITIAL_ROLES = (
+        READ_ONLY,
+        APP_EDITOR,
+        FIELD_IMPLEMENTER,
+    )
+
+    @classmethod
+    def get_preset_map(cls):
+        return {
+            cls.READ_ONLY_NO_REPORTS: lambda: Permissions(),
+            cls.READ_ONLY: lambda: Permissions(view_reports=True),
+            cls.FIELD_IMPLEMENTER: lambda: Permissions(edit_commcare_users=True, view_reports=True),
+            cls.APP_EDITOR: lambda: Permissions(edit_apps=True, view_reports=True),
+        }
+
+    @classmethod
+    def get_permissions(cls, preset):
+        preset_map = cls.get_preset_map()
+        if preset not in preset_map.keys():
+            return None
+        return preset_map[preset]()
+
+
 class UserRole(Document):
     domain = StringProperty()
     name = StringProperty()
     permissions = SchemaProperty(Permissions)
+    is_archived = BooleanProperty(default=False)
 
     def get_qualified_id(self):
         return 'user-role:%s' % self.get_id
 
     @classmethod
-    def by_domain(cls, domain):
-        return cls.view('users/roles_by_domain',
+    def by_domain(cls, domain, is_archived=False):
+        # todo change this view to show is_archived status or move to PRBAC UserRole
+        all_roles = cls.view(
+            'users/roles_by_domain',
             startkey=[domain],
             endkey=[domain, {}],
             include_docs=True,
             reduce=False,
         )
+        return filter(lambda x: x.is_archived == is_archived, all_roles)
 
     @classmethod
-    def by_domain_and_name(cls, domain, name):
-        return cls.view('users/roles_by_domain',
+    def by_domain_and_name(cls, domain, name, is_archived=False):
+        # todo change this view to show is_archived status or move to PRBAC UserRole
+        all_roles = cls.view(
+            'users/roles_by_domain',
             key=[domain, name],
             include_docs=True,
             reduce=False,
         )
+        return filter(lambda x: x.is_archived == is_archived, all_roles)
 
     @classmethod
     def get_or_create_with_permissions(cls, domain, permissions, name=None):
@@ -215,23 +251,61 @@ class UserRole(Document):
         def get_name():
             if name:
                 return name
-            elif permissions == Permissions():
-                return "Read Only (No Reports)"
-            elif permissions == Permissions(edit_apps=True, view_reports=True):
-                return "App Editor"
-            elif permissions == Permissions(view_reports=True):
-                return "Read Only"
-            elif permissions == Permissions(edit_commcare_users=True, view_reports=True):
-                return "Field Implementer"
+            preset_match = filter(
+                lambda x: x[1]() == permissions,
+                UserRolePresets.get_preset_map().items()
+            )
+            if preset_match:
+                return preset_match[0][0]
         role = cls(domain=domain, permissions=permissions, name=get_name())
         role.save()
         return role
 
     @classmethod
+    def get_read_only_role_by_domain(cls, domain):
+        try:
+            return cls.by_domain_and_name(domain, UserRolePresets.READ_ONLY)[0]
+        except (IndexError, TypeError):
+            return cls.get_or_create_with_permissions(
+                domain, UserRolePresets.get_permissions(
+                    UserRolePresets.READ_ONLY), UserRolePresets.READ_ONLY)
+
+    @classmethod
+    def get_custom_roles_by_domain(cls, domain):
+        return filter(
+            lambda x: x.name not in UserRolePresets.INITIAL_ROLES,
+            cls.by_domain(domain)
+        )
+
+    @classmethod
+    def reset_initial_roles_for_domain(cls, domain):
+        initial_roles = filter(
+            lambda x: x.name in UserRolePresets.INITIAL_ROLES,
+            cls.by_domain(domain)
+        )
+        for role in initial_roles:
+            role.permissions = UserRolePresets.get_permissions(role.name)
+            role.save()
+
+    @classmethod
+    def archive_custom_roles_for_domain(cls, domain):
+        custom_roles = cls.get_custom_roles_by_domain(domain)
+        for role in custom_roles:
+            role.is_archived = True
+            role.save()
+
+    @classmethod
+    def unarchive_roles_for_domain(cls, domain):
+        archived_roles = cls.by_domain(domain, is_archived=True)
+        for role in archived_roles:
+            role.is_archived = False
+            role.save()
+
+    @classmethod
     def init_domain_with_presets(cls, domain):
-        cls.get_or_create_with_permissions(domain, Permissions(edit_apps=True, view_reports=True), 'App Editor')
-        cls.get_or_create_with_permissions(domain, Permissions(edit_commcare_users=True, view_reports=True), 'Field Implementer')
-        cls.get_or_create_with_permissions(domain, Permissions(view_reports=True), 'Read Only')
+        for role_name in UserRolePresets.INITIAL_ROLES:
+            cls.get_or_create_with_permissions(
+                domain, UserRolePresets.get_permissions(role_name), role_name)
 
     @classmethod
     def get_default(cls, domain=None):

--- a/testrunner.py
+++ b/testrunner.py
@@ -1,6 +1,6 @@
 from couchdbkit.ext.django.testrunner import CouchDbKitTestSuiteRunner
 from django.conf import settings
-from corehq.apps.accounting.generator import instantiate_accounting_for_tests
+from corehq.apps.accounting.generator import instantiate_accounting_for_tests, teardown_accounting_for_tests
 import settingshelper
 
 

--- a/testrunner.py
+++ b/testrunner.py
@@ -1,6 +1,5 @@
 from couchdbkit.ext.django.testrunner import CouchDbKitTestSuiteRunner
 from django.conf import settings
-from corehq.apps.accounting.generator import instantiate_accounting_for_tests, teardown_accounting_for_tests
 import settingshelper
 
 
@@ -40,9 +39,7 @@ class HqTestSuiteRunner(CouchDbKitTestSuiteRunner):
             setattr(settings, setting, value)
             print "set %s settting to %s" % (setting, value)
 
-        result = super(HqTestSuiteRunner, self).setup_databases(**kwargs)
-        instantiate_accounting_for_tests()
-        return result
+        return super(HqTestSuiteRunner, self).setup_databases(**kwargs)
 
     def run_tests(self, test_labels, extra_tests=None, **kwargs):
         if not test_labels:

--- a/testrunner.py
+++ b/testrunner.py
@@ -1,5 +1,6 @@
 from couchdbkit.ext.django.testrunner import CouchDbKitTestSuiteRunner
 from django.conf import settings
+from corehq.apps.accounting.generator import instantiate_accounting_for_tests, teardown_accounting_for_tests
 import settingshelper
 
 
@@ -39,7 +40,9 @@ class HqTestSuiteRunner(CouchDbKitTestSuiteRunner):
             setattr(settings, setting, value)
             print "set %s settting to %s" % (setting, value)
 
-        return super(HqTestSuiteRunner, self).setup_databases(**kwargs)
+        result = super(HqTestSuiteRunner, self).setup_databases(**kwargs)
+        instantiate_accounting_for_tests()
+        return result
 
     def run_tests(self, test_labels, extra_tests=None, **kwargs):
         if not test_labels:

--- a/testrunner.py
+++ b/testrunner.py
@@ -1,6 +1,6 @@
 from couchdbkit.ext.django.testrunner import CouchDbKitTestSuiteRunner
 from django.conf import settings
-from corehq.apps.accounting.generator import instantiate_accounting_for_tests, teardown_accounting_for_tests
+from corehq.apps.accounting.generator import instantiate_accounting_for_tests
 import settingshelper
 
 


### PR DESCRIPTION
On Downgrade:
- archives all custom `corehq.apps.users.UserRole` (not to be confused with `django_prbac`)
- sets all `WebUsers` `domain_membership.role_id` to the Read Only `role_id` if they were using this custom role
- sets all `CommCareUsers` `domain_membership.role_id` to `None`
- resets all non-custom roles to have the same permissions as when the domain was initialized.

On Upgrade:
- un-archives all custom `UserRole`s on upgrade
