### PR TITLE
Last of the Feature Limiting Requests (for now)

### DIFF
--- a/corehq/__init__.py
+++ b/corehq/__init__.py
@@ -59,23 +59,35 @@ def REPORTS(project):
             cp_reports = tuple(make_careplan_reports(config))
             reports.insert(0, (ugettext_lazy("Care Plans"), cp_reports))
 
-    messaging_reports = (
-        sms.MessagesReport,
-        sms.MessageLogReport,
-        ivr.CallLogReport,
-        ivr.ExpectedCallbackReport,
-        system_overview.SystemOverviewReport,
-        system_overview.SystemUsersReport
-    )
+    from corehq.apps.accounting.utils import domain_has_privilege
+    messaging_reports = []
+    project_can_use_sms = True
+    if toggles.ACCOUNTING_PREVIEW.enabled(project.name, namespace=toggles.NAMESPACE_DOMAIN):
+        project_can_use_sms = domain_has_privilege(project.name, privileges.OUTBOUND_SMS)
+    if project_can_use_sms:
+        messaging_reports.extend([
+           sms.MessagesReport,
+            sms.MessageLogReport,
+        ])
+    project_can_use_inbound_sms = True
+    if toggles.ACCOUNTING_PREVIEW.enabled(project.name, namespace=toggles.NAMESPACE_DOMAIN):
+        project_can_use_inbound_sms = domain_has_privilege(project.name, privileges.INBOUND_SMS)
+    if project_can_use_inbound_sms:
+        messaging_reports.extend([
+            ivr.CallLogReport,
+            ivr.ExpectedCallbackReport,
+            system_overview.SystemOverviewReport,
+            system_overview.SystemUsersReport,
+        ])
 
     messaging_reports += getattr(Domain.get_module_by_name(project.name), 'MESSAGING_REPORTS', ())
 
     messaging = (lambda project, user: (
         ugettext_lazy("Logs") if project.commtrack_enabled else ugettext_lazy("Messaging")), messaging_reports)
 
-    if project.commconnect_enabled:
+    if project.commconnect_enabled and messaging_reports:
         reports.insert(0, messaging)
-    else:
+    elif messaging_reports:
         reports.append(messaging)
 
     reports.extend(dynamic_reports(project))

--- a/corehq/apps/accounting/decorators.py
+++ b/corehq/apps/accounting/decorators.py
@@ -1,7 +1,6 @@
 import json
 from corehq import toggles
 from corehq.apps.accounting.models import BillingAccountAdmin
-from django.contrib import messages
 from django.http import Http404, HttpResponse
 from django_prbac.decorators import requires_privilege
 from django_prbac.exceptions import PermissionDenied
@@ -19,12 +18,15 @@ def is_accounting_previewer(request):
 def require_billing_admin():
     def decorate(fn):
         """
-        Decorator to require the current logged in user to be a billing admin to access the decorated view.
+        Decorator to require the current logged in user to be a billing
+        admin to access the decorated view.
         """
         def wrapped(request, *args, **kwargs):
-            if not hasattr(request, 'couch_user') or not hasattr(request, 'domain'):
+            if (not hasattr(request, 'couch_user')
+                    or not hasattr(request, 'domain')):
                 raise Http404()
-            is_billing_admin = BillingAccountAdmin.get_admin_status_and_account(request.couch_user, request.domain)[0]
+            is_billing_admin = BillingAccountAdmin.get_admin_status_and_account(
+                request.couch_user, request.domain)[0]
             if not (is_billing_admin or request.couch_user.is_superuser):
                 raise Http404()
             return fn(request, *args, **kwargs)
@@ -34,53 +36,65 @@ def require_billing_admin():
     return decorate
 
 
-def requires_privilege_alert(slug, **assignment):
+def requires_privilege_with_fallback(slug, **assignment):
     """
-    A version of the requires_privilege decorator which inserts an info message into the request
-    alerting the user that they will soon loose access to this privilege.
+    A version of the requires_privilege decorator which falls back
+    to the insufficient privileges page with an HTTP Status Code
+    of 402 that means "Payment Required"
     """
     def decorate(fn):
         def wrapped(request, *args, **kwargs):
             try:
-                return requires_privilege(slug, **assignment)(fn)(request, *args, **kwargs)
+                return requires_privilege(slug, **assignment)(fn)(
+                    request, *args, **kwargs
+                )
             except PermissionDenied:
-                if is_accounting_previewer(request):
-                    messaged_slugs = [m.extra_tags for m in messages.get_messages(request)]
-                    if slug not in messaged_slugs:
-                        messages.info(request, "You will soon lose access to this feature %s" % slug, extra_tags=slug)
-                return fn(request, *args, **kwargs)
+                from corehq.apps.domain.views import SubscriptionUpgradeRequiredView
+                return SubscriptionUpgradeRequiredView().get(request, slug)
         return wrapped
     return decorate
 
 
-def requires_privilege_plaintext_response(slug, http_status_code=None, **assignment):
+def requires_privilege_plaintext_response(slug,
+                                          http_status_code=None, **assignment):
     """
-    A version of the requires_privilege decorator which returns an HttpResponse object
-    with HTTP Status Code of 412 by default and content_type of tex/plain if the privilege is not found.
+    A version of the requires_privilege decorator which returns an
+    HttpResponse object with HTTP Status Code of 412 by default and
+    content_type of tex/plain if the privilege is not found.
     """
     def decorate(fn):
         def wrapped(request, *args, **kwargs):
             if not is_accounting_previewer(request):
                 return fn(request, *args, **kwargs)
             try:
-                return requires_privilege(slug, **assignment)(fn)(request, *args, **kwargs)
+                return requires_privilege(slug, **assignment)(fn)(
+                    request, *args, **kwargs
+                )
             except PermissionDenied:
-                return HttpResponse("You have lost access to this feature.",
-                                    status=http_status_code or 412, content_type="text/plain")
+                return HttpResponse(
+                    "You have lost access to this feature.",
+                    status=http_status_code or 412, content_type="text/plain",
+                )
         return wrapped
     return decorate
 
 
-def requires_privilege_json_response(slug, http_status_code=None, get_response=None, **assignment):
+def requires_privilege_json_response(slug, http_status_code=None,
+                                     get_response=None, **assignment):
     """
-    A version of the requires privilege decorator which returns an HttpResponse object
-    with an HTTP Status Code of 405 by default and content_type application/json if the privilege is not found.
-    get_response is an optional parameter where you can specify the format of response given an error
-    message and status code. The default response is:
+    A version of the requires privilege decorator which returns an
+    HttpResponse object with an HTTP Status Code of 405 by default
+    and content_type application/json if the privilege is not found.
+
+    `get_response` is an optional parameter where you can specify the
+    format of response given an error message and status code.
+    The default response is:
+    ```
     {
         'code': http_status_Code,
         'message': error_message
     }
+    ```
     todo accounting for API requests
     """
     http_status_code = http_status_code or 405
@@ -92,24 +106,29 @@ def requires_privilege_json_response(slug, http_status_code=None, get_response=N
             if not is_accounting_previewer(request):
                 return fn(request, *args, **kwargs)
             try:
-                return requires_privilege(slug, **assignment)(fn)(request, *args, **kwargs)
+                return requires_privilege(slug, **assignment)(fn)(
+                    request, *args, **kwargs)
             except PermissionDenied:
                 error_message = "You have lost access to this feature."
                 response = get_response(error_message, http_status_code)
-                return HttpResponse(json.dumps(response), content_type="application/json")
+                return HttpResponse(json.dumps(response),
+                                    content_type="application/json")
         return wrapped
     return decorate
 
 
 def requires_privilege_for_commcare_user(slug, **assignment):
     """
-    A version of the requires_privilege decorator which requires the specified privilege
-    only for CommCareUsers.
+    A version of the requires_privilege decorator which requires
+    the specified privilege only for CommCareUsers.
     """
     def decorate(fn):
         def wrapped(request, *args, **kwargs):
-            if hasattr(request, 'couch_user') and request.couch_user.is_web_user():
+            if (hasattr(request, 'couch_user')
+                    and request.couch_user.is_web_user()):
                 return fn(request, *args, **kwargs)
-            return requires_privilege_alert(slug, **assignment)(fn)(request, *args, **kwargs)
+            return requires_privilege_with_fallback(slug, **assignment)(fn)(
+                request, *args, **kwargs
+            )
         return wrapped
     return decorate

--- a/corehq/apps/accounting/decorators.py
+++ b/corehq/apps/accounting/decorators.py
@@ -44,13 +44,17 @@ def requires_privilege_with_fallback(slug, **assignment):
     """
     def decorate(fn):
         def wrapped(request, *args, **kwargs):
+            if not is_accounting_previewer(request):
+                return fn(request, *args, **kwargs)
             try:
                 return requires_privilege(slug, **assignment)(fn)(
                     request, *args, **kwargs
                 )
             except PermissionDenied:
                 from corehq.apps.domain.views import SubscriptionUpgradeRequiredView
-                return SubscriptionUpgradeRequiredView().get(request, slug)
+                return SubscriptionUpgradeRequiredView().get(
+                    request, request.domain, slug
+                )
         return wrapped
     return decorate
 

--- a/corehq/apps/accounting/utils.py
+++ b/corehq/apps/accounting/utils.py
@@ -3,7 +3,7 @@ import datetime
 import json
 from django.utils.encoding import force_unicode
 from django.utils.functional import Promise
-from corehq import Domain, privileges
+from corehq import Domain, privileges, toggles
 from corehq.apps.accounting.exceptions import AccountingError
 from dimagi.utils.dates import add_months
 from django_prbac.models import Role
@@ -107,15 +107,17 @@ def is_active_subscription(date_start, date_end):
 
 
 def domain_has_privilege(domain, privilege_slug, **assignment):
-    from corehq.apps.accounting.models import Subscription
-    try:
-        plan_version = Subscription.get_subscribed_plan_by_domain(domain)[0]
-        roles = Role.objects.filter(slug=privilege_slug)
-        if not roles:
-            return False
-        privilege = roles[0].instantiate(assignment)
-        if plan_version.role.has_privilege(privilege):
-            return True
-    except AccountingError:
-        pass
-    return False
+    if toggles.ACCOUNTING_PREVIEW.enabled(domain, namespace=toggles.NAMESPACE_DOMAIN):
+        from corehq.apps.accounting.models import Subscription
+        try:
+            plan_version = Subscription.get_subscribed_plan_by_domain(domain)[0]
+            roles = Role.objects.filter(slug=privilege_slug)
+            if not roles:
+                return False
+            privilege = roles[0].instantiate(assignment)
+            if plan_version.role.has_privilege(privilege):
+                return True
+        except AccountingError:
+            pass
+        return False
+    return True

--- a/corehq/apps/app_manager/static/app_manager/js/commcaresettings.js
+++ b/corehq/apps/app_manager/static/app_manager/js/commcaresettings.js
@@ -4,6 +4,7 @@ function CommcareSettings(options) {
     self.sections = options.sections;
     self.edit = ko.observable(options.edit);
     self.user = options.user;
+    self.permissions = options.permissions;
 
     self.settings = [];
     self.settingsIndex = {};
@@ -161,7 +162,8 @@ function CommcareSettings(options) {
             return !(
                 (setting.disabled && setting.visibleValue() === setting['default']) ||
                     (setting.hide_if_not_enabled && !setting.enabled()) ||
-                    (setting.preview && !self.user.is_previewer)
+                    (setting.preview && !self.user.is_previewer) ||
+                    (setting.permission && !self.permissions[setting.permission])
                 );
         });
         setting.disabledButHasValue = ko.computed(function () {

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yaml
@@ -70,6 +70,7 @@
   requires: "{$parent.doc_type}='Application'"
   hide_if_not_enabled: true
   since: "2.0"
+  permission: "cloudcare"
 
 - id: use_custom_suite
   name: "Custom Suite File"

--- a/corehq/apps/app_manager/templates/app_manager/app_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/app_view.html
@@ -26,6 +26,9 @@
                 edit: {{ edit|BOOL }},
                 user: {
                     is_previewer: {{ request.couch_user.is_previewer|BOOL }}
+                },
+                permissions: {
+                    cloudcare: {{ is_cloudcare_allowed|BOOL }}
                 }
             }
         };

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -1,6 +1,6 @@
 from couchdbkit import ResourceConflict
 from django.utils.decorators import method_decorator
-from corehq.apps.accounting.decorators import requires_privilege_plaintext_response, requires_privilege_for_commcare_user
+from corehq.apps.accounting.decorators import requires_privilege_plaintext_response, requires_privilege_for_commcare_user, requires_privilege_with_fallback
 from dimagi.utils.couch.database import iter_docs
 from django.views.decorators.cache import cache_page
 from casexml.apps.case.models import CommCareCase
@@ -321,6 +321,7 @@ class EditCloudcareUserPermissionsView(BaseUserSettingsView):
     page_title = ugettext_noop("CloudCare Permissions")
 
     @method_decorator(domain_admin_required)
+    @method_decorator(requires_privilege_with_fallback(privileges.CLOUDCARE))
     def dispatch(self, request, *args, **kwargs):
         return super(EditCloudcareUserPermissionsView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/data_interfaces/dispatcher.py
+++ b/corehq/apps/data_interfaces/dispatcher.py
@@ -1,6 +1,6 @@
 from django.utils.decorators import method_decorator
 from corehq import privileges, toggles
-from corehq.apps.accounting.decorators import requires_privilege_alert
+from corehq.apps.accounting.decorators import requires_privilege_with_fallback
 from corehq.apps.reports.dispatcher import ReportDispatcher, ProjectReportDispatcher, datespan_default
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
@@ -20,7 +20,7 @@ class DataInterfaceDispatcher(ProjectReportDispatcher):
             return self.deid_dispatch(request, *args, **kwargs)
         return super(DataInterfaceDispatcher, self).dispatch(request, *args, **kwargs)
 
-    @method_decorator(requires_privilege_alert(privileges.DEIDENTIFIED_DATA))
+    @method_decorator(requires_privilege_with_fallback(privileges.DEIDENTIFIED_DATA))
     def deid_dispatch(self, request, *args, **kwargs):
         return super(DataInterfaceDispatcher, self).dispatch(request, *args, **kwargs)
 
@@ -47,7 +47,7 @@ class EditDataInterfaceDispatcher(ReportDispatcher):
             return self.bulk_dispatch(request, *args, **kwargs)
         return super(EditDataInterfaceDispatcher, self).dispatch(request, *args, **kwargs)
 
-    @method_decorator(requires_privilege_alert(privileges.BULK_CASE_MANAGEMENT))
+    @method_decorator(requires_privilege_with_fallback(privileges.BULK_CASE_MANAGEMENT))
     def bulk_dispatch(self, request, *args, **kwargs):
         return super(EditDataInterfaceDispatcher, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -9,6 +9,7 @@ from couchdbkit.ext.django.schema import (Document, StringProperty, BooleanPrope
                                           StringListProperty, SchemaListProperty, SchemaDictProperty, TimeProperty)
 from django.core.cache import cache
 from django.utils.safestring import mark_safe
+from corehq import privileges
 from corehq.apps.appstore.models import Review, SnapshotMixin
 from dimagi.utils.couch.cache import cache_core
 from dimagi.utils.decorators.memoized import memoized
@@ -563,6 +564,11 @@ class Domain(Document, HQBillingDomainMixin, SnapshotMixin):
             reduce=False,
             include_docs=True,
             wrapper=cls.wrap
+        )
+        from corehq.apps.accounting.utils import domain_has_privilege
+        result = filter(
+            lambda x: domain_has_privilege(x.name, privileges.CROSS_PROJECT_REPORTS),
+            result
         )
         return result
 

--- a/corehq/apps/domain/templates/domain/insufficient_privilege_notification.html
+++ b/corehq/apps/domain/templates/domain/insufficient_privilege_notification.html
@@ -15,6 +15,6 @@
            class="btn" target="_blank">{% trans 'Read more about our pricing plans' %}</a>
     </div>
     <div class="pull-right">
-        <a href="#" class="btn btn-primary">{% trans 'Change My Subscription' %}</a>
+        <a href="{{ change_subscription_url }}" class="btn btn-primary">{% trans 'Change My Subscription' %}</a>
     </div>
 {% endblock %}

--- a/corehq/apps/domain/templates/domain/insufficient_privilege_notification.html
+++ b/corehq/apps/domain/templates/domain/insufficient_privilege_notification.html
@@ -1,0 +1,20 @@
+{% extends 'hqwebapp/base_page.html' %}
+{% load i18n %}
+
+{% block page_content %}
+    <p class="lead">
+        {% blocktrans %}
+            <strong>{{ feature_name }}</strong> is only available to projects
+            subscribed to <strong>{{ plan_name }}</strong> plan or higher.
+            To access this feature, you must subscribe to the
+            <strong>{{ plan_name }}</strong> plan.
+        {% endblocktrans %}
+    </p>
+    <div class="pull-left">
+        <a href="https://wiki.commcarehq.org/display/commcarepublic/CommCare+Plan+Details"
+           class="btn" target="_blank">{% trans 'Read more about our pricing plans' %}</a>
+    </div>
+    <div class="pull-right">
+        <a href="#" class="btn btn-primary">{% trans 'Change My Subscription' %}</a>
+    </div>
+{% endblock %}

--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -14,7 +14,7 @@ from django.views.decorators.http import require_POST
 from django.views.generic.base import TemplateView
 from django.shortcuts import render
 from corehq import privileges
-from corehq.apps.accounting.decorators import requires_privilege_alert
+from corehq.apps.accounting.decorators import requires_privilege_with_fallback
 
 from corehq.apps.domain.decorators import login_or_digest
 from corehq.apps.fixtures.models import FixtureDataType, FixtureDataItem, _id_from_doc
@@ -35,7 +35,7 @@ from dimagi.utils.decorators.view import get_file
 
 require_can_edit_fixtures = lambda *args, **kwargs: (
     require_permission(Permissions.edit_data)(
-        requires_privilege_alert(privileges.LOOKUP_TABLES)(*args, **kwargs)
+        requires_privilege_with_fallback(privileges.LOOKUP_TABLES)(*args, **kwargs)
     )
 )
 

--- a/corehq/apps/hqwebapp/models.py
+++ b/corehq/apps/hqwebapp/models.py
@@ -765,6 +765,15 @@ class ProjectUsersTab(UITab):
                 or full_path.startswith(cloudcare_settings_url))
 
     @property
+    def can_view_cloudcare(self):
+        if toggles.ACCOUNTING_PREVIEW.enabled(self.couch_user.username):
+            try:
+                ensure_request_has_privilege(self._request, privileges.CLOUDCARE)
+            except PermissionDenied:
+                return False
+        return self.couch_user.is_domain_admin()
+
+    @property
     def sidebar_items(self):
         items = []
 
@@ -807,7 +816,7 @@ class ProjectUsersTab(UITab):
                  ]}
             ]
 
-            if self.couch_user.is_domain_admin():
+            if self.can_view_cloudcare:
                 mobile_users_menu.append({
                     'title': _('CloudCare Permissions'),
                     'url': reverse('cloudcare_app_settings',

--- a/corehq/apps/reminders/views.py
+++ b/corehq/apps/reminders/views.py
@@ -10,7 +10,7 @@ from django.shortcuts import render
 
 from django.utils.translation import ugettext as _, ugettext_noop
 from corehq import privileges, toggles
-from corehq.apps.accounting.decorators import requires_privilege_alert
+from corehq.apps.accounting.decorators import requires_privilege_with_fallback
 from corehq.apps.app_manager.models import Application
 from corehq.apps.app_manager.util import get_case_properties
 from corehq.apps.hqwebapp.views import CRUDPaginatedViewMixin
@@ -75,7 +75,17 @@ from dimagi.utils.timezones import utils as tz_utils
 from corehq.apps.reports import util as report_utils
 from dimagi.utils.couch.database import is_bigcouch, bigcouch_quorum_count, iter_docs
 
-reminders_permission = require_permission(Permissions.edit_data)
+reminders_framework_permission = lambda *args, **kwargs: (
+    require_permission(Permissions.edit_data)(
+        requires_privilege_with_fallback(privileges.REMINDERS_FRAMEWORK)(*args, **kwargs)
+    )
+)
+
+survey_reminders_permission = lambda *args, **kwargs: (
+    require_permission(Permissions.edit_data)(
+        requires_privilege_with_fallback(privileges.INBOUND_SMS)(*args, **kwargs)
+    )
+)
 
 def get_project_time_info(domain):
     timezone = report_utils.get_timezone(None, domain)
@@ -83,12 +93,11 @@ def get_project_time_info(domain):
     timezone_now = now.astimezone(timezone)
     return (timezone, now, timezone_now)
 
-@reminders_permission
+@reminders_framework_permission
 def default(request, domain):
     return HttpResponseRedirect(reverse('list_reminders', args=[domain]))
 
-@requires_privilege_alert(privileges.OUTBOUND_SMS)
-@reminders_permission
+@reminders_framework_permission
 def list_reminders(request, domain, reminder_type=REMINDER_TYPE_DEFAULT):
     all_handlers = CaseReminderHandler.get_handlers(domain=domain).all()
     all_handlers = filter(lambda x : x.reminder_type == reminder_type, all_handlers)
@@ -139,8 +148,7 @@ def list_reminders(request, domain, reminder_type=REMINDER_TYPE_DEFAULT):
         'timezone_now' : timezone_now,
     })
 
-@requires_privilege_alert(privileges.OUTBOUND_SMS)
-@reminders_permission
+@reminders_framework_permission
 def add_reminder(request, domain, handler_id=None, template="reminders/partial/add_reminder.html"):
 
     if handler_id:
@@ -205,8 +213,7 @@ def render_one_time_reminder_form(request, domain, form, handler_id):
 
     return render(request, "reminders/partial/add_one_time_reminder.html", context)
 
-@requires_privilege_alert(privileges.OUTBOUND_SMS)
-@reminders_permission
+@reminders_framework_permission
 def add_one_time_reminder(request, domain, handler_id=None):
     if handler_id:
         handler = CaseReminderHandler.get(handler_id)
@@ -271,8 +278,7 @@ def add_one_time_reminder(request, domain, handler_id=None):
 
     return render_one_time_reminder_form(request, domain, form, handler_id)
 
-@requires_privilege_alert(privileges.OUTBOUND_SMS)
-@reminders_permission
+@reminders_framework_permission
 def copy_one_time_reminder(request, domain, handler_id):
     handler = CaseReminderHandler.get(handler_id)
     initial = {
@@ -286,8 +292,7 @@ def copy_one_time_reminder(request, domain, handler_id):
     }
     return render_one_time_reminder_form(request, domain, OneTimeReminderForm(initial=initial), None)
 
-@requires_privilege_alert(privileges.OUTBOUND_SMS)
-@reminders_permission
+@reminders_framework_permission
 def delete_reminder(request, domain, handler_id):
     handler = CaseReminderHandler.get(handler_id)
     if handler.doc_type != 'CaseReminderHandler' or handler.domain != domain:
@@ -296,8 +301,7 @@ def delete_reminder(request, domain, handler_id):
     view_name = "one_time_reminders" if handler.reminder_type == REMINDER_TYPE_ONE_TIME else "list_reminders"
     return HttpResponseRedirect(reverse(view_name, args=[domain]))
 
-@requires_privilege_alert(privileges.OUTBOUND_SMS)
-@reminders_permission
+@reminders_framework_permission
 def scheduled_reminders(request, domain, template="reminders/partial/scheduled_reminders.html"):
     timezone = Domain.get_by_name(domain).default_timezone
     reminders = CaseReminderHandler.get_all_reminders(domain)
@@ -367,8 +371,7 @@ def get_events_scheduling_info(events):
         })
     return result
 
-@requires_privilege_alert(privileges.OUTBOUND_SMS)
-@reminders_permission
+@reminders_framework_permission
 def add_complex_reminder_schedule(request, domain, handler_id=None):
     if handler_id:
         h = CaseReminderHandler.get(handler_id)
@@ -644,7 +647,7 @@ class CreateScheduledReminderView(BaseMessagingSectionView):
     def _format_response(self, resp_list):
         return [{'text': r, 'id': r} for r in resp_list]
 
-    @method_decorator(reminders_permission)
+    @method_decorator(reminders_framework_permission)
     def dispatch(self, request, *args, **kwargs):
         return super(CreateScheduledReminderView, self).dispatch(request, *args, **kwargs)
 
@@ -744,8 +747,7 @@ class EditScheduledReminderView(CreateScheduledReminderView):
         self.schedule_form.save(self.reminder_handler)
 
 
-@requires_privilege_alert(privileges.OUTBOUND_SMS)
-@reminders_permission
+@reminders_framework_permission
 def manage_keywords(request, domain):
     context = {
         "domain" : domain,
@@ -754,8 +756,7 @@ def manage_keywords(request, domain):
     return render(request, "reminders/partial/manage_keywords.html", context)
 
 
-@requires_privilege_alert(privileges.INBOUND_SMS)
-@reminders_permission
+@survey_reminders_permission
 def add_keyword(request, domain, keyword_id=None):
     sk = None
     if keyword_id is not None:
@@ -874,8 +875,7 @@ def add_keyword(request, domain, keyword_id=None):
     return render(request, "reminders/partial/add_keyword.html", context)
 
 
-@requires_privilege_alert(privileges.OUTBOUND_SMS)
-@reminders_permission
+@reminders_framework_permission
 def delete_keyword(request, domain, keyword_id):
     s = SurveyKeyword.get(keyword_id)
     if s.domain != domain or s.doc_type != "SurveyKeyword":
@@ -884,8 +884,7 @@ def delete_keyword(request, domain, keyword_id):
     return HttpResponseRedirect(reverse("manage_keywords", args=[domain]))
 
 
-@requires_privilege_alert(privileges.INBOUND_SMS)
-@reminders_permission
+@survey_reminders_permission
 def add_survey(request, domain, survey_id=None):
     survey = None
     
@@ -1116,8 +1115,7 @@ def add_survey(request, domain, survey_id=None):
     return render(request, "reminders/partial/add_survey.html", context)
 
 
-@requires_privilege_alert(privileges.INBOUND_SMS)
-@reminders_permission
+@survey_reminders_permission
 def survey_list(request, domain):
     context = {
         "domain" : domain,
@@ -1126,8 +1124,7 @@ def survey_list(request, domain):
     return render(request, "reminders/partial/survey_list.html", context)
 
 
-@requires_privilege_alert(privileges.INBOUND_SMS)
-@reminders_permission
+@survey_reminders_permission
 def add_sample(request, domain, sample_id=None):
     sample = None
     if sample_id is not None:
@@ -1225,8 +1222,7 @@ def add_sample(request, domain, sample_id=None):
     return render(request, "reminders/partial/add_sample.html", context)
 
 
-@requires_privilege_alert(privileges.INBOUND_SMS)
-@reminders_permission
+@survey_reminders_permission
 def sample_list(request, domain):
     context = {
         "domain" : domain,
@@ -1235,8 +1231,7 @@ def sample_list(request, domain):
     return render(request, "reminders/partial/sample_list.html", context)
 
 
-@requires_privilege_alert(privileges.OUTBOUND_SMS)
-@reminders_permission
+@reminders_framework_permission
 def edit_contact(request, domain, sample_id, case_id):
     case = CommCareCase.get(case_id)
     if case.domain != domain:
@@ -1268,8 +1263,7 @@ def edit_contact(request, domain, sample_id, case_id):
     return render(request, "reminders/partial/edit_contact.html", context)
 
 
-@requires_privilege_alert(privileges.OUTBOUND_SMS)
-@reminders_permission
+@reminders_framework_permission
 def reminders_in_error(request, domain):
     handler_map = {}
     if request.method == "POST":

--- a/corehq/apps/reports/dispatcher.py
+++ b/corehq/apps/reports/dispatcher.py
@@ -11,7 +11,7 @@ from django_prbac.utils import ensure_request_has_privilege
 from corehq.apps.domain.models import Domain
 from corehq.apps.reports.exceptions import BadRequestError
 from corehq import privileges, toggles
-from corehq.apps.accounting.decorators import requires_privilege_alert
+from corehq.apps.accounting.decorators import requires_privilege_with_fallback
 
 datespan_default = datespan_in_request(
     from_param="startdate",
@@ -228,7 +228,7 @@ class CustomProjectReportDispatcher(ProjectReportDispatcher):
     prefix = 'custom_project_report'
     map_name = 'CUSTOM_REPORTS'
 
-    @method_decorator(requires_privilege_alert(privileges.CUSTOM_REPORTS))
+    @method_decorator(requires_privilege_with_fallback(privileges.CUSTOM_REPORTS))
     def dispatch(self, request, *args, **kwargs):
         return super(CustomProjectReportDispatcher, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 import json
 import re
 import urllib
-from corehq.apps.accounting.decorators import requires_privilege_alert
+from corehq.apps.accounting.decorators import requires_privilege_with_fallback
 from django.utils.decorators import method_decorator
 from corehq import Domain, toggles, privileges
 from corehq.apps.domain.views import BaseDomainView
@@ -418,7 +418,7 @@ def undo_remove_web_user(request, domain, record_id):
 # to change the permissions of your own role such that you could do anything, and would thus be equivalent to having
 # domain admin permissions.
 @domain_admin_required
-@method_decorator(requires_privilege_alert(privileges.ROLE_BASED_ACCESS))
+@method_decorator(requires_privilege_with_fallback(privileges.ROLE_BASED_ACCESS))
 @require_POST
 def post_user_role(request, domain):
     role_data = json.loads(request.raw_post_data)

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -19,7 +19,7 @@ from django.views.decorators.http import require_POST
 from django.contrib import messages
 from corehq import toggles, privileges
 from corehq.apps.accounting.async_handlers import Select2BillingInfoHandler
-from corehq.apps.accounting.decorators import requires_privilege_alert, require_billing_admin
+from corehq.apps.accounting.decorators import requires_privilege_with_fallback, require_billing_admin
 from corehq.apps.accounting.models import BillingAccount, BillingAccountType, BillingAccountAdmin
 from corehq.apps.hqwebapp.async_handler import AsyncHandlerMixin
 from corehq.apps.users.util import can_add_extra_mobile_workers
@@ -645,7 +645,7 @@ class UploadCommCareUsers(BaseManageCommCareUserView):
     urlname = 'upload_commcare_users'
     page_title = ugettext_noop("Bulk Upload Mobile Workers")
 
-    @method_decorator(requires_privilege_alert(privileges.BULK_USER_MANAGEMENT))
+    @method_decorator(requires_privilege_with_fallback(privileges.BULK_USER_MANAGEMENT))
     def dispatch(self, request, *args, **kwargs):
         return super(UploadCommCareUsers, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/privileges.py
+++ b/corehq/privileges.py
@@ -1,3 +1,5 @@
+from django.utils.translation import ugettext_lazy as _
+
 LOOKUP_TABLES = 'lookup_tables'
 API_ACCESS = 'api_access'
 
@@ -50,3 +52,27 @@ MOBILE_WORKER_CREATION = 'mobile_worker_creation'
 
 # Other privileges related specifically to accounting processes
 ACCOUNTING_ADMIN = 'accounting_admin'
+
+
+class Titles(object):
+
+    @classmethod
+    def get_name_from_privilege(cls, privilege):
+        return {
+            LOOKUP_TABLES: _("Lookup Tables"),
+            API_ACCESS: _("API Access"),
+            CLOUDCARE: _("Web-Based Apps (CloudCare)"),
+            ACTIVE_DATA_MANAGEMENT: _("Active Data Management"),
+            CUSTOM_BRANDING: _("Custom Branding"),
+            CROSS_PROJECT_REPORTS: _("Cross-Project Reports"),
+            ROLE_BASED_ACCESS: _("Advanced Role-Based Access"),
+            OUTBOUND_SMS: _("Outgoing Messaging"),
+            INBOUND_SMS: _("Incoming Messaging"),
+            REMINDERS_FRAMEWORK: _("Reminders Framework"),
+            CUSTOM_SMS_GATEWAY: _("Custom Android Gateway"),
+            BULK_CASE_MANAGEMENT: _("Bulk Case Management"),
+            BULK_USER_MANAGEMENT: _("Bulk User Management"),
+            ALLOW_EXCESS_USERS: _("Add Mobile Workers Above Limit"),
+            DEIDENTIFIED_DATA: _("De-Identified Data"),
+            HIPAA_COMPLIANCE_ASSURANCE: _("HIPAA Compliance Assurance"),
+        }.get(privilege, privilege)


### PR DESCRIPTION
- limit some messaging related reports based on `OUTBOUND_SMS`, `REMINDERS_FRAMEWORK``, and`INBOUND_SMS` privs
- refactor accounting decorators to use fallback view
- provide an insufficient privileges view according when trying to access URLs with insufficient privileges for pricing related features
- hide enable cloudcare checkbox in app builder and never allow `app.cloudcare_enabled` to be set to `True` on save
