### PR TITLE
temporarily disable some user role downgrade functionality

### DIFF
--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -116,16 +116,18 @@ class DomainDowngradeActionHandler(BaseModifySubscriptionActionHandler):
         custom_roles = [r.get_id for r in UserRole.get_custom_roles_by_domain(self.domain.name)]
         if not custom_roles:
             return True
-        read_only_role = UserRole.get_read_only_role_by_domain(self.domain.name)
-        web_users = WebUser.by_domain(self.domain.name)
-        for web_user in web_users:
-            if web_user.get_domain_membership(self.domain.name).role_id in custom_roles:
-                web_user.set_role(self.domain.name, read_only_role.get_qualified_id())
-                web_user.save()
-        for cc_user in CommCareUser.by_domain(self.domain.name):
-            if cc_user.get_domain_membership(self.domain.name).role_id in custom_roles:
-                cc_user.set_role(self.domain.name, 'none')
-                cc_user.save()
+        # temporarily disable this part of the downgrade until we
+        # have a better user experience for notifying the downgraded user
+        # read_only_role = UserRole.get_read_only_role_by_domain(self.domain.name)
+        # web_users = WebUser.by_domain(self.domain.name)
+        # for web_user in web_users:
+        #     if web_user.get_domain_membership(self.domain.name).role_id in custom_roles:
+        #         web_user.set_role(self.domain.name, read_only_role.get_qualified_id())
+        #         web_user.save()
+        # for cc_user in CommCareUser.by_domain(self.domain.name):
+        #     if cc_user.get_domain_membership(self.domain.name).role_id in custom_roles:
+        #         cc_user.set_role(self.domain.name, 'none')
+        #         cc_user.save()
         UserRole.archive_custom_roles_for_domain(self.domain.name)
         UserRole.reset_initial_roles_for_domain(self.domain.name)
         return True

--- a/corehq/apps/accounting/tests/test_subscription_changes.py
+++ b/corehq/apps/accounting/tests/test_subscription_changes.py
@@ -71,17 +71,20 @@ class TestUserRoleSubscriptionChanges(BaseAccountingTest):
         subscription.cancel_subscription(web_user=self.admin_user.username)
 
         custom_role = UserRole.get(self.custom_role.get_id)
-        custom_web_user = WebUser.get(self.web_users[0].get_id)
-        custom_commcare_user = CommCareUser.get(self.commcare_users[0].get_id)
-
         self.assertTrue(custom_role.is_archived)
-        self.assertEqual(
-            custom_web_user.get_domain_membership(self.domain.name).role_id,
-            self.read_only_role.get_id
-        )
-        self.assertIsNone(
-            custom_commcare_user.get_domain_membership(self.domain.name).role_id
-        )
+
+        # disable this part of the test until we improve the UX for notifying
+        # downgraded users of their privilege changes
+        # custom_web_user = WebUser.get(self.web_users[0].get_id)
+        # custom_commcare_user = CommCareUser.get(self.commcare_users[0].get_id)
+        # self.assertEqual(
+        #     custom_web_user.get_domain_membership(self.domain.name).role_id,
+        #     self.read_only_role.get_id
+        # )
+        # self.assertIsNone(
+        #     custom_commcare_user.get_domain_membership(self.domain.name).role_id
+        # )
+        
         self.assertInitialRoles()
         self.assertStdUsers()
 
@@ -101,15 +104,17 @@ class TestUserRoleSubscriptionChanges(BaseAccountingTest):
         custom_role = UserRole.get(self.custom_role.get_id)
         self.assertFalse(custom_role.is_archived)
 
-        custom_web_user = WebUser.get(self.web_users[0].get_id)
-        custom_commcare_user = CommCareUser.get(self.commcare_users[0].get_id)
-        self.assertEqual(
-            custom_web_user.get_domain_membership(self.domain.name).role_id,
-            self.read_only_role.get_id
-        )
-        self.assertIsNone(
-            custom_commcare_user.get_domain_membership(self.domain.name).role_id
-        )
+        # disable this part of the test until we improve the UX for notifying
+        # downgraded users of their privilege changes
+        # custom_web_user = WebUser.get(self.web_users[0].get_id)
+        # custom_commcare_user = CommCareUser.get(self.commcare_users[0].get_id)
+        # self.assertEqual(
+        #     custom_web_user.get_domain_membership(self.domain.name).role_id,
+        #     self.read_only_role.get_id
+        # )
+        # self.assertIsNone(
+        #     custom_commcare_user.get_domain_membership(self.domain.name).role_id
+        # )
 
         self.assertInitialRoles()
         self.assertStdUsers()


### PR DESCRIPTION
-don't reassign custom roles to read only or none
