### PR TITLE
silence pillowtop and south logs in tests.

### DIFF
--- a/.travis/localsettings.py
+++ b/.travis/localsettings.py
@@ -85,6 +85,16 @@ LOGGING = {
             'level': 'CRITICAL',
             'handler': 'null',
             'propagate': False,
+        },
+        'south': {
+            'level': 'CRITICAL',
+            'handler': 'null',
+            'propagate': False,
+        },
+        'pillowtop': {
+            'level': 'CRITICAL',
+            'handler': 'null',
+            'propagate': False,
         }
     }
 }


### PR DESCRIPTION
i think this is necessary because celery is hijacking the root logger.

this workaround is sufficient for now though.

http://stackoverflow.com/questions/13366312/django-celery-logging-best-practice
