### PR TITLE
support for configuration and better unicode handling in location fixture

### DIFF
--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -213,13 +213,20 @@ class CommtrackActionConfig(DocumentSchema):
 
 class LocationType(DocumentSchema):
     name = StringProperty()
+    code = StringProperty()
     allowed_parents = StringListProperty()
     administrative = BooleanProperty()
+
+    @classmethod
+    def wrap(cls, obj):
+        from corehq.apps.commtrack.util import unicode_slug
+        if not obj.get('code'):
+            obj['code'] = unicode_slug(obj['name'])
+        return super(LocationType, cls).wrap(obj)
 
 
 class CommtrackRequisitionConfig(DocumentSchema):
     # placeholder class for when this becomes fancier
-
     enabled = BooleanProperty(default=False)
 
     # requisitions have their own sets of actions
@@ -288,7 +295,6 @@ class StockRestoreConfig(DocumentSchema):
 
 
 class CommtrackConfig(Document):
-
     domain = StringProperty()
 
     # supported stock actions for this commtrack domain

--- a/corehq/apps/commtrack/tests/__init__.py
+++ b/corehq/apps/commtrack/tests/__init__.py
@@ -3,4 +3,5 @@ from .test_locations import *
 from .test_settings import *
 from .test_sms_reporting import *
 from .test_supply_points import *
+from .test_utils import *
 from .test_xml import *

--- a/corehq/apps/commtrack/tests/test_utils.py
+++ b/corehq/apps/commtrack/tests/test_utils.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+# vim: ai ts=4 sts=4 et sw=4 encoding=utf-8
+
+from django.test import TestCase
+from corehq.apps.commtrack.util import unicode_slug
+
+
+class CommtrackUtilsTest(TestCase):
+
+    def test_unicode_slug(self):
+        test_cases = (
+            ('normal', 'normal'),
+            (u'unicode', 'unicode'),
+            ('    with\n\t  whitespace   ', 'with-whitespace'),
+            (u'speçial çháracters', 'special-characters'),
+            (u'हिंदी', 'hindii'),
+        )
+        for input, output in test_cases:
+            self.assertEqual(output, unicode_slug(input))

--- a/corehq/apps/commtrack/util.py
+++ b/corehq/apps/commtrack/util.py
@@ -15,6 +15,8 @@ import bisect
 from corehq.apps.hqcase.utils import submit_case_blocks
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.xml import V2
+from django.utils.text import slugify
+from unidecode import unidecode
 
 
 def all_supply_point_types(domain):
@@ -273,3 +275,7 @@ def get_case_wrapper(data):
 
 def wrap_commtrack_case(case_json):
     return get_case_wrapper(case_json).wrap(case_json)
+
+
+def unicode_slug(text):
+    return slugify(unicode(unidecode(text)))

--- a/corehq/apps/domain/templates/domain/admin/commtrack_settings.html
+++ b/corehq/apps/domain/templates/domain/admin/commtrack_settings.html
@@ -93,6 +93,7 @@ var other_sms_codes = {{ other_sms_codes|JSON }};
                 <thead>
                     <tr>
                         <th>{% trans "Location Type" %}</th>
+                        <th>{% trans "Location Type Code" %}</th>
                         <th>{% trans "Allowed Parent Types" %}</th>
                         <th>{% trans "Administrative only?" %}</th>
                         <th></th>
@@ -103,6 +104,10 @@ var other_sms_codes = {{ other_sms_codes|JSON }};
                         <td class="control-group" data-bind="css: { 'error': name_error }">
                             <input class="loctype_name" data-bind="value: name" type="text" />
                             <div class="help-inline" data-bind="text: name_error"></div>
+                        </td>
+                        <td class="control-group" data-bind="css: { 'error': code_error }">
+                            <input class="loctype_code" data-bind="value: code" type="text" />
+                            <div class="help-inline" data-bind="text: code_error"></div>
                         </td>
                         <td class="control-group" data-bind="css: { 'error': allowed_parents_error }">
                             <select multiple="true" data-bind="options: $root.loc_types, optionsText: 'name', optionsValue: 'name', selectedOptions: allowed_parents, optionsCaption: '\u2013top level\u2013'"></select>

--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from xml.etree import ElementTree
+from corehq.apps.commtrack.util import unicode_slug
 from .models import Location
 
 
@@ -16,14 +17,19 @@ def location_fixture_generator(user, version, last_sync):
     # todo: eventually this needs to not load all locations for any given user
     # as this will have performance implications
     locs = Location.root_locations(user.domain)
-    _append_children(root, locs)
+    loc_types = project.commtrack_settings.location_types
+    type_to_slug_mapping = dict((ltype.name, ltype.code) for ltype in loc_types)
+    def location_type_lookup(location_type):
+        return type_to_slug_mapping.get(location_type, unicode_slug(location_type))
+
+    _append_children(root, locs, location_type_lookup)
     return [root]
 
 
-def _append_children(node, locations):
+def _append_children(node, locations, type_lookup_function):
     by_type = _group_by_type(locations)
     for type, locs in by_type.items():
-        node.append(_types_to_fixture(type, locs))
+        node.append(_types_to_fixture(type, locs, type_lookup_function))
 
 
 def _group_by_type(locations):
@@ -33,15 +39,15 @@ def _group_by_type(locations):
     return by_type
 
 
-def _types_to_fixture(type, locs):
-    type_node = ElementTree.Element('%ss' % _el_name(type))  # ghetto pluralization
+def _types_to_fixture(type, locs, type_lookup_function):
+    type_node = ElementTree.Element('%ss' % type_lookup_function(type))  # ghetto pluralization
     for loc in locs:
-        type_node.append(_location_to_fixture(loc))
+        type_node.append(_location_to_fixture(loc, type_lookup_function))
     return type_node
 
 
-def _location_to_fixture(location):
-    root = ElementTree.Element(_el_name(location.location_type), {'id': location._id})
+def _location_to_fixture(location, type_lookup_function):
+    root = ElementTree.Element(type_lookup_function(location.location_type), {'id': location._id})
     fixture_fields = [
         'name',
         'site_code',
@@ -55,10 +61,5 @@ def _location_to_fixture(location):
         field_node.text = unicode(val if val is not None else '')
         root.append(field_node)
 
-    _append_children(root, location.children)
+    _append_children(root, location.children, type_lookup_function)
     return root
-
-
-def _el_name(location_type):
-    # todo: add a better way to configure/manage this
-    return '_'.join((location_type.encode('ascii', errors='ignore') or 'unknown_type').split())


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?100728

adds a "code" field to the location type config UI, which is used for the XML tag.

also has built in setting of the code based on name that uses `unidecode` to choose smart defaults
