### PR TITLE
first data migration for accounting

### DIFF
--- a/corehq/apps/accounting/migrations/0013_roles_and_plans_migration_p1m2.py
+++ b/corehq/apps/accounting/migrations/0013_roles_and_plans_migration_p1m2.py
@@ -1,0 +1,289 @@
+# encoding: utf-8
+import datetime
+import logging
+from django.core.management import call_command
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+from corehq.apps.accounting.models import (
+    FeatureType, Subscription, SoftwarePlanEdition, SoftwarePlan, FeatureRate,
+    CreditLine, SoftwareProductRate, DefaultProductPlan
+)
+
+logger = logging.getLogger(__name__)
+
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        call_command('cchq_prbac_bootstrap')
+        call_command('cchq_software_plan_bootstrap')
+
+        # Reset Subscription plan_version to the latest version for that plan
+        for subscription in Subscription.objects.all():
+            software_plan = subscription.plan_version.plan
+            latest_version = software_plan.get_version()
+            if subscription.plan_version.pk != latest_version.pk:
+                logger.info("%s reset to newest version."
+                            % subscription.subscriber.domain)
+                subscription.plan_version = latest_version
+                subscription.save()
+
+        # make sure that the default standard plan SMS FeatureRate
+        # has the monthly_limit set to 100
+        standard_plans = DefaultProductPlan.objects.filter(
+            edition=SoftwarePlanEdition.STANDARD)
+        for std_plan in standard_plans:
+            feature_rate = std_plan.plan.get_version().feature_rates.filter(
+                feature__feature_type=FeatureType.SMS
+            )[0]
+            if feature_rate.monthly_limit != 100:
+                feature_rate.monthly_limit = 100
+                feature_rate.save()
+
+        for plan in SoftwarePlan.objects.all():
+            default_version = plan.get_version()
+            for version in plan.softwareplanversion_set.all():
+                if version.pk != default_version.pk:
+                    try:
+                        version.delete()
+                    except models.ProtectedError:
+                        logger.info("Skipped deleting SoftwarePlanVersion "
+                                    "with id %d for plan %s because it was "
+                                    "still being used."
+                                    % (version.pk, plan.name))
+
+        for credit_line in CreditLine.objects.filter(feature_rate__isnull=False).all():
+            latest_rate = credit_line.feature_rate.feature.get_rate()
+            if credit_line.feature_rate.pk != latest_rate.pk:
+                credit_line.feature_rate = latest_rate
+                credit_line.save()
+
+        for feature_rate in FeatureRate.objects.all():
+            if feature_rate.softwareplanversion_set.count() == 0:
+                try:
+                    feature_rate.delete()
+                except models.ProtectedError:
+                    logger.info("Skipped deleting FeatureRate with id "
+                                "%d because it was still being used."
+                                % feature_rate.pk)
+
+        for credit_line in CreditLine.objects.filter(product_rate__isnull=False).all():
+            latest_rate = credit_line.product_rate.product.get_rate()
+            if credit_line.product_rate.pk != latest_rate.pk:
+                credit_line.product_rate = latest_rate
+                credit_line.save()
+
+        for product_rate in SoftwareProductRate.objects.all():
+            if product_rate.softwareplanversion_set.count() == 0:
+                try:
+                    product_rate.delete()
+                except models.ProtectedError:
+                    logger.info("Skipped deleting ProductRate with id "
+                                "%d because it was still being used."
+                                % product_rate.pk)
+
+    def backwards(self, orm):
+        pass
+
+    models = {
+        u'accounting.billingaccount': {
+            'Meta': {'object_name': 'BillingAccount'},
+            'account_type': ('django.db.models.fields.CharField', [], {'default': "'CONTRACT'", 'max_length': '25'}),
+            'billing_admins': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['accounting.BillingAccountAdmin']", 'null': 'True', 'symmetrical': 'False'}),
+            'created_by': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'created_by_domain': ('django.db.models.fields.CharField', [], {'max_length': '25', 'null': 'True', 'blank': 'True'}),
+            'currency': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Currency']"}),
+            'date_confirmed_extra_charges': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_auto_invoiceable': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'db_index': 'True'}),
+            'salesforce_account_id': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '80', 'null': 'True', 'blank': 'True'})
+        },
+        u'accounting.billingaccountadmin': {
+            'Meta': {'object_name': 'BillingAccountAdmin'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'web_user': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80', 'db_index': 'True'})
+        },
+        u'accounting.billingcontactinfo': {
+            'Meta': {'object_name': 'BillingContactInfo'},
+            'account': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['accounting.BillingAccount']", 'unique': 'True', 'primary_key': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'company_name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'emails': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'first_line': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'phone_number': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'postal_code': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'second_line': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'state_province_region': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'accounting.billingrecord': {
+            'Meta': {'object_name': 'BillingRecord'},
+            'date_emailed': ('django.db.models.fields.DateField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'emailed_to': ('django.db.models.fields.CharField', [], {'max_length': '254', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'invoice': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Invoice']"}),
+            'pdf_data_id': ('django.db.models.fields.CharField', [], {'max_length': '48'})
+        },
+        u'accounting.creditadjustment': {
+            'Meta': {'object_name': 'CreditAdjustment'},
+            'amount': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'credit_line': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.CreditLine']"}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'invoice': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Invoice']", 'null': 'True'}),
+            'line_item': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.LineItem']", 'null': 'True'}),
+            'note': ('django.db.models.fields.TextField', [], {}),
+            'reason': ('django.db.models.fields.CharField', [], {'default': "'MANUAL'", 'max_length': '25'}),
+            'web_user': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True'})
+        },
+        u'accounting.creditline': {
+            'Meta': {'object_name': 'CreditLine'},
+            'account': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.BillingAccount']"}),
+            'balance': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'feature_rate': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.FeatureRate']", 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'product_rate': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwareProductRate']", 'null': 'True', 'blank': 'True'}),
+            'subscription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Subscription']", 'null': 'True', 'blank': 'True'})
+        },
+        u'accounting.currency': {
+            'Meta': {'object_name': 'Currency'},
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '3'}),
+            'date_updated': ('django.db.models.fields.DateField', [], {'auto_now': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '25', 'db_index': 'True'}),
+            'rate_to_default': ('django.db.models.fields.DecimalField', [], {'default': "'1.0'", 'max_digits': '20', 'decimal_places': '9'}),
+            'symbol': ('django.db.models.fields.CharField', [], {'max_length': '10'})
+        },
+        u'accounting.defaultproductplan': {
+            'Meta': {'object_name': 'DefaultProductPlan'},
+            'edition': ('django.db.models.fields.CharField', [], {'default': "'Community'", 'max_length': '25'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'plan': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwarePlan']"}),
+            'product_type': ('django.db.models.fields.CharField', [], {'max_length': '25'})
+        },
+        u'accounting.feature': {
+            'Meta': {'object_name': 'Feature'},
+            'feature_type': ('django.db.models.fields.CharField', [], {'max_length': '10', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '40'})
+        },
+        u'accounting.featurerate': {
+            'Meta': {'object_name': 'FeatureRate'},
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'feature': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Feature']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'monthly_fee': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '10', 'decimal_places': '2'}),
+            'monthly_limit': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'per_excess_fee': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '10', 'decimal_places': '2'})
+        },
+        u'accounting.invoice': {
+            'Meta': {'object_name': 'Invoice'},
+            'balance': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'date_due': ('django.db.models.fields.DateField', [], {'db_index': 'True'}),
+            'date_end': ('django.db.models.fields.DateField', [], {}),
+            'date_paid': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_received': ('django.db.models.fields.DateField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'date_start': ('django.db.models.fields.DateField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'subscription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Subscription']"}),
+            'tax_rate': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'})
+        },
+        u'accounting.lineitem': {
+            'Meta': {'object_name': 'LineItem'},
+            'base_cost': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'base_description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'feature_rate': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.FeatureRate']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'invoice': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Invoice']"}),
+            'product_rate': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwareProductRate']", 'null': 'True'}),
+            'quantity': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'unit_cost': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'unit_description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'accounting.softwareplan': {
+            'Meta': {'object_name': 'SoftwarePlan'},
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'edition': ('django.db.models.fields.CharField', [], {'default': "'Enterprise'", 'max_length': '25'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'visibility': ('django.db.models.fields.CharField', [], {'default': "'INTERNAL'", 'max_length': '10'})
+        },
+        u'accounting.softwareplanversion': {
+            'Meta': {'object_name': 'SoftwarePlanVersion'},
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'feature_rates': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['accounting.FeatureRate']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'plan': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwarePlan']"}),
+            'product_rates': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['accounting.SoftwareProductRate']", 'symmetrical': 'False', 'blank': 'True'}),
+            'role': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['django_prbac.Role']"})
+        },
+        u'accounting.softwareproduct': {
+            'Meta': {'object_name': 'SoftwareProduct'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '40'}),
+            'product_type': ('django.db.models.fields.CharField', [], {'max_length': '25', 'db_index': 'True'})
+        },
+        u'accounting.softwareproductrate': {
+            'Meta': {'object_name': 'SoftwareProductRate'},
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'monthly_fee': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '10', 'decimal_places': '2'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwareProduct']"})
+        },
+        u'accounting.subscriber': {
+            'Meta': {'object_name': 'Subscriber'},
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '25', 'null': 'True', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'organization': ('django.db.models.fields.CharField', [], {'max_length': '25', 'null': 'True', 'db_index': 'True'})
+        },
+        u'accounting.subscription': {
+            'Meta': {'object_name': 'Subscription'},
+            'account': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.BillingAccount']"}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'date_delay_invoicing': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_end': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_start': ('django.db.models.fields.DateField', [], {}),
+            'do_not_invoice': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'plan_version': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwarePlanVersion']"}),
+            'salesforce_contract_id': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'subscriber': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Subscriber']"})
+        },
+        u'accounting.subscriptionadjustment': {
+            'Meta': {'object_name': 'SubscriptionAdjustment'},
+            'date_created': ('django.db.models.fields.DateField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'invoice': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Invoice']", 'null': 'True'}),
+            'method': ('django.db.models.fields.CharField', [], {'default': "'INTERNAL'", 'max_length': '50'}),
+            'new_date_delay_invoicing': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'new_date_end': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'new_date_start': ('django.db.models.fields.DateField', [], {}),
+            'new_salesforce_contract_id': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'note': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'reason': ('django.db.models.fields.CharField', [], {'default': "'CREATE'", 'max_length': '50'}),
+            'related_subscription': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'subscriptionadjustment_related'", 'null': 'True', 'to': u"orm['accounting.Subscription']"}),
+            'subscription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Subscription']"}),
+            'web_user': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True'})
+        },
+        u'django_prbac.role': {
+            'Meta': {'object_name': 'Role'},
+            'description': ('django.db.models.fields.TextField', [], {'default': "u''", 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'parameters': ('django_prbac.fields.StringSetField', [], {'default': '[]', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '256'})
+        }
+    }
+
+    complete_apps = ['accounting']


### PR DESCRIPTION
so that everyone is on the same roles and software plans

In short this:
- resets all plan versions of current subscriptions to the latest version
- makes sure that all `FeatureRates` and `SoftwareProductRates` are the latest version
- makes sure that all `CreditLines` point to the latest `FeatureRate` and `SoftwareProductRate` (although `CreditLines` will eventually be migrated to point to `SoftwareProduct` or `Feature` to be version independent)
