### PR TITLE
normalize itext when rendering xform

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -627,6 +627,7 @@ class FormBase(DocumentSchema):
         app = self.get_app()
         xform.exclude_languages(app.build_langs)
         xform.set_default_language(app.build_langs[0])
+        xform.normalize_itext()
         xform.set_version(self.get_version())
 
     def render_xform(self):

--- a/corehq/apps/app_manager/tests/data/form_preparation_careplan/update_goal.xml
+++ b/corehq/apps/app_manager/tests/data/form_preparation_careplan/update_goal.xml
@@ -80,12 +80,6 @@
 					<text id="update_description-label">
 						<value>Update the goal's description?</value>
 					</text>
-					<text id="update_description-yes-label">
-						<value>Yes</value>
-					</text>
-					<text id="update_description-no-label">
-						<value>No</value>
-					</text>
 					<text id="description-label">
 						<value>Goal Description</value>
 					</text>
@@ -147,11 +141,11 @@
 			<select1 ref="/data/description_group/update_description">
 				<label ref="jr:itext('update_description-label')" />
 				<item>
-					<label ref="jr:itext('update_description-yes-label')" />
+					<label ref="jr:itext('close_goal-yes-label')" />
 					<value>yes</value>
 				</item>
 				<item>
-					<label ref="jr:itext('update_description-no-label')" />
+					<label ref="jr:itext('close_goal-no-label')" />
 					<value>no</value>
 				</item>
 			</select1>

--- a/corehq/apps/app_manager/tests/data/form_preparation_careplan/update_task.xml
+++ b/corehq/apps/app_manager/tests/data/form_preparation_careplan/update_task.xml
@@ -43,9 +43,6 @@
 					<text id="task_complete-label">
 						<value>Has the task been completed?</value>
 					</text>
-					<text id="task_complete-yes-label">
-						<value>Yes</value>
-					</text>
 					<text id="task_complete-no-label">
 						<value>Not Yet</value>
 					</text>
@@ -96,7 +93,7 @@
 		<select1 ref="/data/task_complete">
 			<label ref="jr:itext('task_complete-label')" />
 			<item>
-				<label ref="jr:itext('task_complete-yes-label')" />
+				<label ref="jr:itext('progress_made-yes-label')" />
 				<value>yes</value>
 			</item>
 			<item>

--- a/corehq/apps/app_manager/tests/data/form_preparation_v2/subcase-repeat-sharing.xml
+++ b/corehq/apps/app_manager/tests/data/form_preparation_v2/subcase-repeat-sharing.xml
@@ -21,9 +21,6 @@
 					<text id="child-label">
 						<value>Child</value>
 					</text>
-					<text id="name-label">
-						<value>Name</value>
-					</text>
 				</translation>
 			</itext>
 		<bind calculate="/data/meta/timeEnd" nodeset="/data/case/@date_modified" type="xsd:dateTime"/><bind calculate="/data/meta/userID" nodeset="/data/case/@user_id"/><setvalue event="xforms-ready" ref="/data/case/@case_id" value="uuid()"/><bind calculate="/data/mother_name" nodeset="/data/case/create/case_name"/><setvalue event="xforms-ready" ref="/data/case/create/owner_id" value="instance('groups')/groups/group/@id"/><bind calculate="/data/meta/timeEnd" nodeset="/data/child/case/@date_modified" type="xsd:dateTime"/><bind calculate="/data/meta/userID" nodeset="/data/child/case/@user_id"/><bind calculate="uuid()" nodeset="/data/child/case/@case_id"/><bind calculate="/data/child/name" nodeset="/data/child/case/create/case_name"/><bind nodeset="/data/child/case/create/owner_id" calculate="instance('groups')/groups/group/@id"/><bind calculate="/data/case/@case_id" nodeset="/data/child/case/index/parent"/><setvalue event="xforms-ready" ref="/data/meta/deviceID" value="instance('commcaresession')/session/context/deviceid"/><setvalue event="xforms-ready" ref="/data/meta/timeStart" value="now()"/><bind nodeset="/data/meta/timeStart" type="xsd:dateTime"/><setvalue event="xforms-revalidate" ref="/data/meta/timeEnd" value="now()"/><bind nodeset="/data/meta/timeEnd" type="xsd:dateTime"/><setvalue event="xforms-ready" ref="/data/meta/username" value="instance('commcaresession')/session/context/username"/><setvalue event="xforms-ready" ref="/data/meta/userID" value="instance('commcaresession')/session/context/userid"/><setvalue event="xforms-ready" ref="/data/meta/instanceID" value="uuid()"/><setvalue event="xforms-ready" ref="/data/meta/appVersion" value="instance('commcaresession')/session/context/appversion"/></model>
@@ -36,7 +33,7 @@
 			<label ref="jr:itext('child-label')"/>
 			<repeat nodeset="/data/child">
 				<input ref="/data/child/name">
-					<label ref="jr:itext('name-label')"/>
+					<label ref="jr:itext('mother_name-label')"/>
 				</input>
 			</repeat>
 		</group>

--- a/corehq/apps/app_manager/tests/data/form_preparation_v2/subcase-repeat.xml
+++ b/corehq/apps/app_manager/tests/data/form_preparation_v2/subcase-repeat.xml
@@ -21,9 +21,6 @@
 					<text id="child-label">
 						<value>Child</value>
 					</text>
-					<text id="name-label">
-						<value>Name</value>
-					</text>
 				</translation>
 			</itext>
 		<bind calculate="/data/meta/timeEnd" nodeset="/data/case/@date_modified" type="xsd:dateTime"/><bind calculate="/data/meta/userID" nodeset="/data/case/@user_id"/><setvalue event="xforms-ready" ref="/data/case/@case_id" value="uuid()"/><bind calculate="/data/mother_name" nodeset="/data/case/create/case_name"/><bind calculate="/data/meta/userID" nodeset="/data/case/create/owner_id"/><bind calculate="/data/meta/timeEnd" nodeset="/data/child/case/@date_modified" type="xsd:dateTime"/><bind calculate="/data/meta/userID" nodeset="/data/child/case/@user_id"/><bind calculate="uuid()" nodeset="/data/child/case/@case_id"/><bind calculate="/data/child/name" nodeset="/data/child/case/create/case_name"/><bind calculate="/data/meta/userID" nodeset="/data/child/case/create/owner_id"/><bind calculate="/data/case/@case_id" nodeset="/data/child/case/index/parent"/><setvalue event="xforms-ready" ref="/data/meta/deviceID" value="instance('commcaresession')/session/context/deviceid"/><setvalue event="xforms-ready" ref="/data/meta/timeStart" value="now()"/><bind nodeset="/data/meta/timeStart" type="xsd:dateTime"/><setvalue event="xforms-revalidate" ref="/data/meta/timeEnd" value="now()"/><bind nodeset="/data/meta/timeEnd" type="xsd:dateTime"/><setvalue event="xforms-ready" ref="/data/meta/username" value="instance('commcaresession')/session/context/username"/><setvalue event="xforms-ready" ref="/data/meta/userID" value="instance('commcaresession')/session/context/userid"/><setvalue event="xforms-ready" ref="/data/meta/instanceID" value="uuid()"/><setvalue event="xforms-ready" ref="/data/meta/appVersion" value="instance('commcaresession')/session/context/appversion"/></model>
@@ -36,7 +33,7 @@
 			<label ref="jr:itext('child-label')"/>
 			<repeat nodeset="/data/child">
 				<input ref="/data/child/name">
-					<label ref="jr:itext('name-label')"/>
+					<label ref="jr:itext('mother_name-label')"/>
 				</input>
 			</repeat>
 		</group>

--- a/corehq/apps/app_manager/tests/data/form_preparation_v2_advanced/subcase-open.xml
+++ b/corehq/apps/app_manager/tests/data/form_preparation_v2_advanced/subcase-open.xml
@@ -52,9 +52,6 @@
 					<text id="child-label">
 						<value>Child</value>
 					</text>
-					<text id="name-label">
-						<value>Name</value>
-					</text>
                     <text id="which_child-label">
 						<value>which child</value>
 					</text>
@@ -107,7 +104,7 @@
 					</item>
 				</select1>
 				<input ref="/data/child/name">
-					<label ref="jr:itext('name-label')"/>
+					<label ref="jr:itext('mother_name-label')"/>
 				</input>
 			</repeat>
 		</group>

--- a/corehq/apps/app_manager/tests/data/form_preparation_v2_advanced/subcase-repeat-multiple.xml
+++ b/corehq/apps/app_manager/tests/data/form_preparation_v2_advanced/subcase-repeat-multiple.xml
@@ -57,9 +57,6 @@
 					<text id="child-label">
 						<value>Child</value>
 					</text>
-					<text id="name-label">
-						<value>Name</value>
-					</text>
                     <text id="which_child-label">
 						<value>which child</value>
 					</text>
@@ -115,7 +112,7 @@
 					</item>
 				</select1>
 				<input ref="/data/child/name">
-					<label ref="jr:itext('name-label')"/>
+					<label ref="jr:itext('mother_name-label')"/>
 				</input>
 			</repeat>
 		</group>

--- a/corehq/apps/app_manager/tests/data/form_preparation_v2_advanced/subcase-repeat-sharing.xml
+++ b/corehq/apps/app_manager/tests/data/form_preparation_v2_advanced/subcase-repeat-sharing.xml
@@ -44,9 +44,6 @@
 					<text id="child-label">
 						<value>Child</value>
 					</text>
-					<text id="name-label">
-						<value>Name</value>
-					</text>
                     <text id="which_child-label">
 						<value>which child</value>
 					</text>
@@ -94,7 +91,7 @@
 					</item>
 				</select1>
 				<input ref="/data/child/name">
-					<label ref="jr:itext('name-label')"/>
+					<label ref="jr:itext('mother_name-label')"/>
 				</input>
 			</repeat>
 		</group>

--- a/corehq/apps/app_manager/tests/data/form_preparation_v2_advanced/subcase-repeat.xml
+++ b/corehq/apps/app_manager/tests/data/form_preparation_v2_advanced/subcase-repeat.xml
@@ -43,9 +43,6 @@
 					<text id="child-label">
 						<value>Child</value>
 					</text>
-					<text id="name-label">
-						<value>Name</value>
-					</text>
                     <text id="which_child-label">
 						<value>which child</value>
 					</text>
@@ -93,7 +90,7 @@
 					</item>
 				</select1>
 				<input ref="/data/child/name">
-					<label ref="jr:itext('name-label')"/>
+					<label ref="jr:itext('mother_name-label')"/>
 				</input>
 			</repeat>
 		</group>

--- a/corehq/apps/app_manager/tests/data/form_preparation_v2_advanced/subcase.xml
+++ b/corehq/apps/app_manager/tests/data/form_preparation_v2_advanced/subcase.xml
@@ -45,9 +45,6 @@
 					<text id="child-label">
 						<value>Child</value>
 					</text>
-					<text id="name-label">
-						<value>Name</value>
-					</text>
                     <text id="which_child-label">
 						<value>which child</value>
 					</text>
@@ -95,7 +92,7 @@
 					</item>
 				</select1>
 				<input ref="/data/child/name">
-					<label ref="jr:itext('name-label')"/>
+					<label ref="jr:itext('mother_name-label')"/>
 				</input>
 			</repeat>
 		</group>

--- a/corehq/apps/app_manager/tests/data/itext_form_normalized.xml
+++ b/corehq/apps/app_manager/tests/data/itext_form_normalized.xml
@@ -26,14 +26,8 @@
           <text id="question3">
             <value>q3-en</value>
           </text>
-          <text id="question4">
-            <value>q3-en</value>
-          </text>
           <text id="question4-1-label">
             <value>q4-1-label-en</value>
-          </text>
-          <text id="question4-2-label">
-            <value>q2-en</value>
           </text>
           <text id="question4-3-label">
             <value>q4-3-en</value>
@@ -53,11 +47,6 @@
             <value form="image">q4-5-en-audio</value>
             <value form="audio">q4-5-en-audio</value>
           </text>
-          <text id="question4-7-label">
-            <value>q4-5-en</value>
-            <value form="image">q4-5-en-image</value>
-            <value form="audio">q4-5-en-audio</value>
-          </text>
         </translation>
         <translation lang="pt">
           <text id="question1">
@@ -69,13 +58,7 @@
           <text id="question3">
             <value>q3-pt</value>
           </text>
-          <text id="question4">
-            <value>q3-pt</value>
-          </text>
           <text id="question4-1-label">
-            <value>q2-pt</value>
-          </text>
-          <text id="question4-2-label">
             <value>q2-pt</value>
           </text>
           <text id="question4-3-label">
@@ -96,11 +79,6 @@
             <value form="image">q4-5-pt-image</value>
             <value form="audio">q4-5-pt-audio</value>
           </text>
-          <text id="question4-7-label">
-            <value>q4-5-pt</value>
-            <value form="image">q4-5-pt-image</value>
-            <value form="audio">q4-5-pt-audio</value>
-          </text>
         </translation>
       </itext>
     </model>
@@ -116,13 +94,13 @@
       <label ref="jr:itext('question3')"/>
     </input>
     <select1 ref="/data/question4">
-      <label ref="jr:itext('question4')"/>
+      <label ref="jr:itext('question3')"/>
       <item>
         <label ref="jr:itext('question4-1-label')"/>
         <value>1</value>
       </item>
       <item>
-        <label ref="jr:itext('question4-2-label')"/>
+        <label ref="jr:itext('question2')"/>
         <value>2</value>
       </item>
       <item>
@@ -142,7 +120,7 @@
         <value>6</value>
       </item>
       <item>
-        <label ref="jr:itext('question4-7-label')"/>
+        <label ref="jr:itext('question4-5-label')"/>
         <value>7</value>
       </item>
     </select1>

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -144,6 +144,44 @@ class WrappedNode(object):
         return ET.tostring(self.xml)
 
 
+class ItextNodeGroup(object):
+    def __init__(self, nodes):
+        self.id = nodes[0].id
+        assert all(node.id == self.id for node in nodes)
+        self.nodes = dict((n.lang, n) for n in nodes)
+
+    def add_node(self, node):
+        if self.nodes.get(node.lang):
+            raise Exception("Group already has node for lang: {}".format(node.lang))
+        else:
+            self.nodes[node.lang] = node
+
+    def __eq__(self, other):
+        for lang, node in self.nodes.items():
+            other_node = other.nodes.get(lang)
+            if node.values != other_node.values:
+                return False
+
+        return True
+
+    def __hash__(self):
+        return ''.join(["{}{}".format(n.lang, n.values) for n in self.nodes.values()]).__hash__()
+
+    def __repr__(self):
+        return "{}, {}".format(self.id, self.nodes)
+
+
+class ItextNode(object):
+    def __init__(self, lang, itext_node):
+        self.lang = lang
+        self.id = itext_node.attrib['id']
+        values = itext_node.findall('{f}value')
+        self.values = sorted([str.strip(ET.tostring(v.xml)) for v in values])
+
+    def __repr__(self):
+        return self.id
+
+
 def raise_if_none(message):
     """
     raise_if_none("message") is a decorator that turns a function that returns a WrappedNode
@@ -379,6 +417,60 @@ class XForm(WrappedNode):
     @property
     def video_references(self):
         return self.media_references(form="video")
+
+    def normalize_itext(self):
+        """
+        Convert this:
+            id1: en => 'yes', sp => 'si'
+            id2: en => 'yes', sp => 'si'
+            id3: en => 'if', sp => 'si'
+
+        to this:
+            id1: en => 'yes', sp => 'si'
+            id3: en => 'if', sp => 'si'
+
+        and rename the appropriate label references.
+        """
+        try:
+            itext = self.itext_node
+        except:
+            return
+        node_groups = {}
+        translations = {}
+        for translation in itext.findall('{f}translation'):
+            lang = translation.attrib['lang']
+            translations[lang] = translation
+            text_nodes = translation.findall('{f}text')
+            for text in text_nodes:
+                node = ItextNode(lang, text)
+                group = node_groups.get(node.id)
+                if not group:
+                    group = ItextNodeGroup([node])
+                else:
+                    group.add_node(node)
+                node_groups[node.id] = group
+
+        duplicate_dict = defaultdict(list)
+        for g in node_groups.values():
+            duplicate_dict[g].append(g)
+
+        duplicates = [g for g in duplicate_dict.values() if len(g) > 1]
+        for d in duplicates:
+            d = sorted(d, key=lambda ng: ng.id)
+            reference = d[0]
+            new_ref = "jr:itext('{}')".format(reference.id)
+
+            for group in d[1:]:
+                itext_ref = '{{f}}text[@id="{}"]'.format(group.id)
+                for lang in group.nodes.keys():
+                    translation = translations[lang]
+                    node = translation.find(itext_ref)
+                    translation.remove(node.xml)
+
+                old_ref_xpath = './/*[@ref="jr:itext(\'{}\')"]'.format(group.id)
+                for ref in self.findall(old_ref_xpath):
+                    if ref.xml is not None:
+                        ref.attrib['ref'] = new_ref
 
     def rename_language(self, old_code, new_code):
         trans_node = self.itext_node.find('{f}translation[@lang="%s"]' % old_code)


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?97349
Convert this:

```
    id1: en => 'yes', sp => 'si'
    id2: en => 'yes', sp => 'si'
    id3: en => 'if', sp => 'si'
```

to this:

```
    id1: en => 'yes', sp => 'si'
    id3: en => 'if', sp => 'si'
```

and rename the appropriate label references in the form.
