### PR TITLE
Don't submit CT/call center forms as the user

### DIFF
--- a/corehq/apps/callcenter/utils.py
+++ b/corehq/apps/callcenter/utils.py
@@ -61,7 +61,7 @@ def sync_user_cases(commcare_user):
         )
 
     casexml = ElementTree.tostring(caseblock.as_xml())
-    submit_case_blocks(casexml, domain.name, commcare_user.username, commcare_user._id)
+    submit_case_blocks(casexml, domain.name)
 
 
 def bootstrap_callcenter(domain):

--- a/corehq/apps/commtrack/util.py
+++ b/corehq/apps/commtrack/util.py
@@ -253,8 +253,6 @@ def submit_mapping_case_block(user, index):
     submit_case_blocks(
         ElementTree.tostring(caseblock.as_xml()),
         user.domain,
-        user.username,
-        user._id
     )
 
 


### PR DESCRIPTION
This was causing saves on the user page to add form counts to worker history reports.
