### PR TITLE
Update CommCare Version when App Version changes

### DIFF
--- a/corehq/apps/app_manager/const.py
+++ b/corehq/apps/app_manager/const.py
@@ -1,5 +1,9 @@
 APP_V1 = '1.0'
 APP_V2 = '2.0'
+MAJOR_RELEASE_TO_VERSION = {
+    "1": APP_V1,
+    "2": APP_V2,
+}
 
 CAREPLAN_GOAL = 'careplan_goal'
 CAREPLAN_TASK = 'careplan_task'

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yaml
@@ -20,6 +20,8 @@
   widget: build_spec
   # this depends on builds are available, and on application_version
   # values, value_names, and default are magically set elsewhere
+  # the build_spec widget depends on application_version coming before it in
+  # this file
 
 - id: platform
   name: "Java Phone Platform"


### PR DESCRIPTION
Reviewer note: I noticed that sometimes a widget subscribes to `visibleValue` and sometimes to `value`, but I don't really understand the semantic difference between the two. The build_spec widget binds to `value` of application_version, which follows the example set by other contingent computed defaults.
