### PR TITLE
override tabs on 404 errors to hopefully avoid turning them into 500s

### DIFF
--- a/corehq/apps/hqwebapp/templates/404.html
+++ b/corehq/apps/hqwebapp/templates/404.html
@@ -1,5 +1,6 @@
 {% extends "error_base.html" %}
 {% block title %}404 Error {% endblock %}
+{% block tabs %}{% endblock tabs %}
 {% block centered-content %}
     <div class="page-header">
         <h1>404


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?100272

(wasn't actually able to reproduce locally and only fails on prod for a subset of users, but the stack suggests it's coming from somewhere in tab rendering)
