### PR TITLE
Export default consumptions with location export

### DIFF
--- a/corehq/apps/commtrack/forms.py
+++ b/corehq/apps/commtrack/forms.py
@@ -6,6 +6,7 @@ from crispy_forms.layout import Layout, Fieldset, ButtonHolder, Submit
 from corehq.apps.commtrack.models import Product, Program
 from corehq.apps.commtrack.util import all_sms_codes
 from corehq.apps.consumption.shortcuts import set_default_consumption_for_product, get_default_consumption
+from django.core.urlresolvers import reverse
 
 
 class CurrencyField(forms.DecimalField):
@@ -100,6 +101,10 @@ class AdvancedSettingsForm(forms.Form):
         label=ugettext_lazy("Minimum Window for Calculation (Days)"), required=False)
     consumption_optimal_window = forms.IntegerField(
         label=ugettext_lazy("Optimal Window for Calculation (Days)"), required=False)
+    individual_consumption_defaults = forms.BooleanField(
+        label=ugettext_lazy("Configure consumption defaults individually by supply point"),
+        required=False
+    )
 
     sync_location_fixtures = forms.BooleanField(
         label=ugettext_lazy("Sync location fixtures"), required=False)
@@ -142,6 +147,7 @@ class AdvancedSettingsForm(forms.Form):
                 'consumption_min_transactions',
                 'consumption_min_window',
                 'consumption_optimal_window',
+                'individual_consumption_defaults',
             ),
             Fieldset(
                 _('Phone Settings'),
@@ -153,7 +159,16 @@ class AdvancedSettingsForm(forms.Form):
             )
         )
 
+        from corehq.apps.locations.views import LocationImportView
+        url = reverse(
+            LocationImportView.urlname, args=[kwargs.pop('domain')]
+        )
+
         forms.Form.__init__(self, *args, **kwargs)
+
+        self.fields['individual_consumption_defaults'].help_text = _(
+            "This is configured on the <a href='{url}'>bulk location import page</a>."
+        ).format(url=url)
 
 
 class ConsumptionForm(forms.Form):

--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -372,6 +372,7 @@ class CommtrackConfig(Document):
     consumption_config = SchemaProperty(ConsumptionConfig)
     stock_levels_config = SchemaProperty(StockLevelsConfig)
     ota_restore_config = SchemaProperty(StockRestoreConfig)
+    individual_consumption_defaults = BooleanProperty(default=False)
 
     @property
     def multiaction_keyword(self):

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1558,8 +1558,8 @@ class AdvancedCommTrackSettingsView(BaseCommTrackAdminView):
             self.commtrack_settings.stock_levels_config.to_json().items()))
 
         if self.request.method == 'POST':
-            return AdvancedSettingsForm(self.request.POST, initial=initial)
-        return AdvancedSettingsForm(initial=initial)
+            return AdvancedSettingsForm(self.request.POST, initial=initial, domain=self.domain)
+        return AdvancedSettingsForm(initial=initial, domain=self.domain)
 
     def set_ota_restore_config(self):
         """
@@ -1591,6 +1591,7 @@ class AdvancedCommTrackSettingsView(BaseCommTrackAdminView):
             self.commtrack_settings.use_auto_consumption = bool(data.get('use_auto_consumption'))
             self.commtrack_settings.sync_location_fixtures = bool(data.get('sync_location_fixtures'))
             self.commtrack_settings.sync_consumption_fixtures = bool(data.get('sync_consumption_fixtures'))
+            self.commtrack_settings.individual_consumption_defaults = bool(data.get('individual_consumption_defaults'))
 
             self.set_ota_restore_config()
 

--- a/corehq/apps/locations/util.py
+++ b/corehq/apps/locations/util.py
@@ -1,4 +1,5 @@
 from corehq.apps.commtrack.psi_hacks import is_psi_domain
+from corehq.apps.commtrack.models import Product
 from corehq.apps.locations.models import Location, root_locations, CustomProperty
 from corehq.apps.domain.models import Domain
 from couchdbkit import ResourceNotFound
@@ -6,6 +7,7 @@ from django.utils.translation import ugettext as _
 from dimagi.utils.couch.loosechange import map_reduce
 from couchexport.writers import Excel2007ExportWriter
 from StringIO import StringIO
+from corehq.apps.consumption.shortcuts import get_default_consumption
 
 def load_locs_json(domain, selected_loc_id=None):
     """initialize a json location tree for drill-down controls on
@@ -146,11 +148,15 @@ def location_custom_properties(domain, loc_type):
     except KeyError:
         properties = []
 
-    loc_config = dict((lt.name, lt) for lt in Domain.get_by_name(domain).commtrack_settings.location_types)
+    loc_config = get_loc_config(domain)
     if not loc_config[loc_type].administrative:
         properties.insert(0, prop_site_code)
 
     return properties
+
+
+def get_loc_config(domain):
+    return dict((lt.name, lt) for lt in Domain.get_by_name(domain).commtrack_settings.location_types)
 
 
 def lookup_by_property(domain, prop_name, val, scope, root=None):
@@ -202,16 +208,54 @@ def get_custom_property_names(domain, loc_type):
     return [prop.name for prop in location_custom_properties(domain, loc_type)]
 
 
+def get_default_column_data(domain, location_types):
+    data = {
+        'headers': {},
+        'values': {}
+    }
+
+    if Domain.get_by_name(domain).commtrack_settings.individual_consumption_defaults:
+        products = Product.by_domain(domain, wrap=False)
+
+        for loc_type in location_types:
+            loc = get_loc_config(domain)[loc_type]
+            if not loc.administrative:
+                data['headers'][loc_type] = [
+                    'default_' +
+                    p['code_'] for p in products
+                ]
+
+                locations = Location.filter_by_type(domain, loc_type)
+                for loc in locations:
+                    data['values'][loc._id] = [
+                        get_default_consumption(
+                            domain,
+                            p['_id'],
+                            loc_type,
+                            loc._id
+                        ) or '' for p in products
+                    ]
+            else:
+                data['headers'][loc_type] = []
+    return data
+
+
 def dump_locations(response, domain):
     file = StringIO()
     writer = Excel2007ExportWriter()
 
     location_types = defined_location_types(domain)
 
+    defaults = get_default_column_data(domain, location_types)
+
     common_types = ['id', 'name', 'parent_id', 'latitude', 'longitude']
     writer.open(
         header_table=[
-            (loc_type, [common_types + get_custom_property_names(domain, loc_type)])
+            (loc_type, [
+                common_types +
+                get_custom_property_names(domain, loc_type) +
+                defaults['headers'].get(loc_type, [])
+            ])
             for loc_type in location_types
         ],
         file=file,
@@ -222,9 +266,22 @@ def dump_locations(response, domain):
         locations = Location.filter_by_type(domain, loc_type)
         for loc in locations:
             parent_id = loc.parent._id if loc.parent else ''
+
             custom_prop_values = [loc[prop.name] or '' for prop in location_custom_properties(domain, loc.location_type)]
+
+            if loc._id in defaults['values']:
+                default_column_values = defaults['values'][loc._id]
+            else:
+                default_column_values = []
+
             tab_rows.append(
-                [loc._id, loc.name, parent_id, loc.latitude or '', loc.longitude or ''] + custom_prop_values
+                [
+                    loc._id,
+                    loc.name,
+                    parent_id,
+                    loc.latitude or '',
+                    loc.longitude or ''
+                ] + custom_prop_values + default_column_values
             )
         writer.write([(loc_type, tab_rows)])
 


### PR DESCRIPTION
Add the ability to export the default consumption data during bulk location export. This is configured using a toggle on the consumption settings section in advanced CT settings. This was added to prevent this from being a mess for an upcoming project that will have 1500 products.
