### PR TITLE
Enable last minute SP creation on location mapping

### DIFF
--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -1191,8 +1191,16 @@ class CommTrackUser(CommCareUser):
                 "There was no linked supply point for the location."
             )
 
-    def add_location(self, location):
+    def add_location(self, location, create_sp_if_missing=False):
         sp = location.linked_supply_point()
+
+        # hack: if location was created before administrative flag was
+        # removed there would be no SupplyPointCase already
+        if not sp and create_sp_if_missing:
+            sp = SupplyPointCase.create_from_location(
+                self.domain,
+                location
+            )
 
         from corehq.apps.commtrack.util import submit_mapping_case_block
         submit_mapping_case_block(self, self.supply_point_index_mapping(sp))

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -328,7 +328,7 @@ class CommtrackUserForm(forms.Form):
         if location_id:
             loc = Location.get(location_id)
             commtrack_user.clear_locations()
-            commtrack_user.add_location(loc)
+            commtrack_user.add_location(loc, create_sp_if_missing=True)
 
 
 class ConfirmExtraUserChargesForm(EditBillingAccountInfoForm):


### PR DESCRIPTION
Fairly temp solution to http://manage.dimagi.com/default.asp?101792 and http://manage.dimagi.com/default.asp?102641

Basically, if you create a location of an administrative type, then change the type to be a non-admin location type, the created location is usable as a supply point but does not have the appropriate case created.
