### PR TITLE
remove a ton of unused imports

### DIFF
--- a/corehq/apps/accounting/decorators.py
+++ b/corehq/apps/accounting/decorators.py
@@ -1,5 +1,4 @@
 import json
-from corehq import toggles
 from corehq.apps.accounting.models import BillingAccountAdmin
 from django.http import Http404, HttpResponse
 from django_prbac.decorators import requires_privilege

--- a/corehq/apps/accounting/dispatcher.py
+++ b/corehq/apps/accounting/dispatcher.py
@@ -1,5 +1,5 @@
 from django.utils.decorators import method_decorator
-from corehq import toggles, privileges
+from corehq import privileges
 from corehq.apps.reports.dispatcher import ReportDispatcher
 from django_prbac.decorators import requires_privilege_raise404
 

--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -12,7 +12,7 @@ from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_noop, ugettext as _, ugettext
 
-from crispy_forms.bootstrap import FormActions, StrictButton, InlineField, InlineRadios
+from crispy_forms.bootstrap import FormActions, StrictButton, InlineField
 from crispy_forms.helper import FormHelper
 from crispy_forms import layout as crispy
 from django_countries.countries import COUNTRIES
@@ -22,16 +22,31 @@ from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.django.email import send_HTML_email
 from django_prbac.models import Role, Grant
 
-from corehq.apps.accounting.async_handlers import (FeatureRateAsyncHandler, SoftwareProductRateAsyncHandler)
+from corehq.apps.accounting.async_handlers import (
+    FeatureRateAsyncHandler,
+    SoftwareProductRateAsyncHandler,
+)
 from corehq.apps.accounting.utils import is_active_subscription
 from corehq.apps.hqwebapp.crispy import BootstrapMultiField, TextField
 from corehq.apps.domain.models import Domain
-from corehq.apps.users.models import WebUser
-from corehq.apps.accounting.models import (BillingContactInfo, Currency, SoftwarePlanVersion, BillingAccount,
-                                           Subscription, Subscriber, CreditLine, SoftwareProductRate,
-                                           FeatureRate, SoftwarePlanEdition, SoftwarePlanVisibility,
-                                           BillingAccountAdmin, SoftwarePlan, Feature, FeatureType,
-                                           SoftwareProduct, SoftwareProductType, CreditAdjustment)
+from corehq.apps.accounting.models import (
+    BillingAccount,
+    BillingContactInfo,
+    CreditAdjustment,
+    CreditLine,
+    Currency,
+    Feature,
+    FeatureRate,
+    FeatureType,
+    SoftwarePlan,
+    SoftwarePlanEdition,
+    SoftwarePlanVersion,
+    SoftwarePlanVisibility,
+    SoftwareProduct,
+    SoftwareProductRate,
+    SoftwareProductType,
+    Subscription,
+)
 
 
 class BillingAccountForm(forms.Form):

--- a/corehq/apps/accounting/generator.py
+++ b/corehq/apps/accounting/generator.py
@@ -7,8 +7,6 @@ import datetime
 from django.conf import settings
 from django.core.management import call_command
 
-from django_prbac import arbitrary as role_gen
-
 from dimagi.utils.dates import add_months
 from dimagi.utils.data import generator as data_gen
 

--- a/corehq/apps/accounting/invoice_pdf.py
+++ b/corehq/apps/accounting/invoice_pdf.py
@@ -1,4 +1,3 @@
-import datetime
 import os
 from reportlab.lib.styles import ParagraphStyle
 from reportlab.lib.units import inch

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -9,7 +9,6 @@ from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
-from corehq import toggles
 from corehq.apps.accounting.invoice_pdf import Address, InvoiceTemplate
 from corehq.apps.accounting.utils import is_active_subscription, get_privileges
 from corehq.apps.accounting.subscription_changes import (

--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -8,7 +8,7 @@ from corehq.apps.app_manager.models import Application
 from corehq.apps.fixtures.models import FixtureDataType
 from corehq.apps.orgs.models import Organization
 from corehq.apps.reminders.models import CaseReminderHandler, METHOD_SMS_SURVEY, METHOD_IVR_SURVEY
-from corehq.apps.users.models import CommCareUser, UserRole, WebUser
+from corehq.apps.users.models import CommCareUser, UserRole
 from couchexport.models import SavedExportSchema
 from dimagi.utils.couch.database import iter_docs
 from dimagi.utils.decorators.memoized import memoized

--- a/corehq/apps/accounting/utils.py
+++ b/corehq/apps/accounting/utils.py
@@ -3,7 +3,7 @@ import datetime
 import json
 from django.utils.encoding import force_unicode
 from django.utils.functional import Promise
-from corehq import Domain, privileges, toggles
+from corehq import Domain, privileges
 from corehq.apps.accounting.exceptions import AccountingError
 from dimagi.utils.dates import add_months
 from django_prbac.models import Role

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -27,7 +27,7 @@ from corehq.apps.accounting.async_handlers import (FeatureRateAsyncHandler, Sele
 from corehq.apps.accounting.user_text import PricingTable
 from corehq.apps.accounting.utils import LazyEncoder, fmt_feature_rate_dict, fmt_product_rate_dict
 from corehq.apps.hqwebapp.views import BaseSectionPageView
-from corehq import toggles, privileges
+from corehq import privileges
 from django_prbac.decorators import requires_privilege_raise404
 
 

--- a/corehq/apps/adm/admin/forms.py
+++ b/corehq/apps/adm/admin/forms.py
@@ -2,7 +2,7 @@ from django import forms
 from django.forms.util import ErrorList
 from django.forms.widgets import Textarea
 from django.utils.safestring import mark_safe
-from corehq.apps.adm.models import BaseADMColumn, ReducedADMColumn, DaysSinceADMColumn, ConfigurableADMColumn,\
+from corehq.apps.adm.models import ReducedADMColumn, DaysSinceADMColumn,\
     CompareADMColumn, ADMReport, KEY_TYPE_OPTIONS, REPORT_SECTION_OPTIONS, \
     CASE_FILTER_OPTIONS, CASE_STATUS_OPTIONS, CaseCountADMColumn, ConfigurableADMColumn, CouchViewADMColumn, SORT_BY_DIRECTION_OPTIONS, UserDataADMColumn
 from corehq.apps.crud.models import BaseAdminCRUDForm

--- a/corehq/apps/announcements/forms.py
+++ b/corehq/apps/announcements/forms.py
@@ -1,6 +1,5 @@
 from django import forms
 from django.forms.widgets import Textarea
-from hqstyle.forms import fields as hq_fields
 from corehq.apps.announcements.models import HQAnnouncement, ReportAnnouncement
 from corehq.apps.crud.models import BaseAdminCRUDForm
 

--- a/corehq/apps/api/es.py
+++ b/corehq/apps/api/es.py
@@ -12,7 +12,7 @@ from dimagi.utils.logging import notify_exception
 
 from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.reports.filters.forms import FormsByApplicationFilter
-from corehq.elastic import get_es, es_query, ES_URLS
+from corehq.elastic import get_es
 from corehq.pillows.base import restore_property_dict, VALUE_TAG
 
 

--- a/corehq/apps/api/resources/v0_1.py
+++ b/corehq/apps/api/resources/v0_1.py
@@ -10,7 +10,7 @@ from django.conf import settings
 # Tastypie imports
 from tastypie import fields
 from tastypie.authentication import Authentication
-from tastypie.authorization import ReadOnlyAuthorization, Authorization
+from tastypie.authorization import ReadOnlyAuthorization
 from tastypie.exceptions import BadRequest
 from tastypie.throttle import CacheThrottle
 

--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -23,7 +23,7 @@ from corehq.apps.users.models import CouchUser, Permissions
 
 from corehq.apps.api.resources import v0_1, v0_3, JsonResource, DomainSpecificResourceMixin, dict_object, SimpleSortableResourceMixin
 from corehq.apps.api.es import XFormES, CaseES, ESQuerySet, es_search
-from corehq.apps.api.fields import ToManyDocumentsField, UseIfRequested, ToManyDictField, ToManyListDictField, CallableCharField
+from corehq.apps.api.fields import ToManyDocumentsField, UseIfRequested, ToManyDictField, ToManyListDictField
 from corehq.apps.api.serializers import CommCareCaseSerializer
 
 

--- a/corehq/apps/api/serializers.py
+++ b/corehq/apps/api/serializers.py
@@ -9,7 +9,7 @@ from tastypie.serializers import Serializer, get_type_string
 
 # External imports
 import defusedxml.lxml as lxml
-from lxml.etree import Element, tostring, LxmlError
+from lxml.etree import Element
 
 
 class CommCareCaseSerializer(Serializer):

--- a/corehq/apps/api/tests.py
+++ b/corehq/apps/api/tests.py
@@ -6,7 +6,6 @@ import dateutil.parser
 from django.utils.http import urlencode
 from django.test import TestCase
 from django.core.urlresolvers import reverse
-from tastypie.exceptions import BadRequest
 from tastypie.resources import Resource
 from tastypie import fields
 from corehq.apps.groups.models import Group

--- a/corehq/apps/api/urls.py
+++ b/corehq/apps/api/urls.py
@@ -1,4 +1,3 @@
-import re
 from corehq.apps.api.object_fetch_api import CaseAttachmentAPI
 
 from corehq.apps.api.domainapi import DomainAPI

--- a/corehq/apps/app_manager/detail_screen.py
+++ b/corehq/apps/app_manager/detail_screen.py
@@ -1,6 +1,5 @@
 from corehq.apps.app_manager import suite_xml as sx
 from corehq.apps.app_manager.util import is_sort_only_column
-from corehq.apps.app_manager.const import CT_LEDGER_STOCK
 from corehq.apps.app_manager.xpath import dot_interpolate, CaseXPath, IndicatorXpath, LedgerdbXpath
 
 CASE_PROPERTY_MAP = {

--- a/corehq/apps/app_manager/management/commands/build_apps.py
+++ b/corehq/apps/app_manager/management/commands/build_apps.py
@@ -1,5 +1,5 @@
 import json
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 from lxml import etree
 import os
 from corehq.apps.app_manager.models import Application, RemoteApp

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -9,7 +9,6 @@ import random
 import json
 import types
 import re
-import toggle
 from collections import defaultdict
 from datetime import datetime
 from functools import wraps

--- a/corehq/apps/app_manager/success_message.py
+++ b/corehq/apps/app_manager/success_message.py
@@ -1,6 +1,5 @@
 from datetime import timedelta, datetime
-import re
-from corehq.apps.users.models import CouchUser, CommCareUser
+from corehq.apps.users.models import CommCareUser
 from dimagi.utils.couch.database import get_db
 from dimagi.utils.parsing import json_format_datetime
 from string import Template

--- a/corehq/apps/app_manager/tests/test_xform_parsing.py
+++ b/corehq/apps/app_manager/tests/test_xform_parsing.py
@@ -1,4 +1,3 @@
-import os
 from django.test import TestCase
 from corehq.apps.app_manager.tests.util import TestFileMixin
 from corehq.apps.app_manager.xform import XForm, XFormError

--- a/corehq/apps/app_manager/tests/util.py
+++ b/corehq/apps/app_manager/tests/util.py
@@ -1,4 +1,3 @@
-from doctest import Example
 import json
 import os
 from corehq.apps.builds.models import CommCareBuild

--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -36,7 +36,13 @@ from django.utils.http import urlencode
 from django.views.decorators.http import require_GET
 from django.conf import settings
 from couchdbkit.resource import ResourceNotFound
-from corehq.apps.app_manager.const import APP_V1, CAREPLAN_GOAL, CAREPLAN_TASK, APP_V2, CT_REQUISITION_MODES, MAJOR_RELEASE_TO_VERSION
+from corehq.apps.app_manager.const import (
+    APP_V1,
+    APP_V2,
+    CAREPLAN_GOAL,
+    CAREPLAN_TASK,
+    MAJOR_RELEASE_TO_VERSION,
+)
 from corehq.apps.app_manager.success_message import SuccessMessage
 from corehq.apps.app_manager.util import is_valid_case_type, get_all_case_properties, add_odk_profile_after_build, ParentCasePropertyBuilder, commtrack_ledger_sections
 from corehq.apps.app_manager.util import save_xform, get_settings_values
@@ -54,7 +60,7 @@ from corehq.apps.app_manager.xform import XFormError, XFormValidationError, Case
     XForm
 from corehq.apps.builds.models import CommCareBuildConfig, BuildSpec
 from corehq.apps.users.decorators import require_permission
-from corehq.apps.users.models import Permissions, CommCareUser
+from corehq.apps.users.models import Permissions
 from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.decorators.view import get_file
 from dimagi.utils.django.cache import make_template_fragment_key

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from casexml.apps.case.xml import V2_NAMESPACE
 from corehq.apps.app_manager.const import APP_V1
 from lxml import etree as ET
-from .xpath import CaseIDXPath, session_var, XPath, CaseTypeXpath
+from .xpath import CaseIDXPath, session_var, CaseTypeXpath
 from .exceptions import XFormError, CaseError, XFormValidationError, BindNotFound
 import formtranslate.api
 

--- a/corehq/apps/appstore/forms.py
+++ b/corehq/apps/appstore/forms.py
@@ -1,8 +1,5 @@
 from django import forms
-from corehq.apps.domain.models import Domain
-import re
-from corehq.apps.domain.utils import new_domain_re
-from corehq.apps.orgs.models import Organization
+
 
 class AddReviewForm(forms.Form):
 

--- a/corehq/apps/appstore/interfaces.py
+++ b/corehq/apps/appstore/interfaces.py
@@ -1,15 +1,12 @@
 from corehq.apps.appstore.dispatcher import AppstoreDispatcher
 from corehq.apps.domain.models import Domain
-from corehq.apps.groups.models import Group
 from corehq.apps.reports.standard import DatespanMixin
 from django.core.urlresolvers import reverse
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.reports import util
 from corehq.apps.reports.datatables import DataTablesHeader, DataTablesColumn, DTSortType
 from corehq.apps.reports.generic import GenericReportView, GenericTabularReport
-from corehq.apps.reports.models import HQUserType
-from corehq.apps.users.models import WebUser
-from dimagi.utils.couch.database import get_db
+
 
 class AppstoreInterface(GenericReportView):
     section_name = "CommCare Exchange"

--- a/corehq/apps/appstore/views.py
+++ b/corehq/apps/appstore/views.py
@@ -15,8 +15,7 @@ from corehq.apps.app_manager.views import _clear_app_cache
 from corehq.apps.appstore.forms import AddReviewForm
 from corehq.apps.appstore.models import Review
 from corehq.apps.domain.decorators import require_superuser
-from corehq.apps.users.models import CouchUser
-from corehq.elastic import es_query, parse_args_for_es, generate_sortables_from_facets, fill_mapping_with_facets
+from corehq.elastic import es_query, parse_args_for_es, fill_mapping_with_facets
 from corehq.apps.domain.models import Domain
 from dimagi.utils.couch.database import apply_update
 

--- a/corehq/apps/builds/jadjar.py
+++ b/corehq/apps/builds/jadjar.py
@@ -1,5 +1,4 @@
 from StringIO import StringIO
-from datetime import datetime
 import itertools
 from zipfile import ZipFile, ZIP_DEFLATED
 from django.conf import settings
@@ -7,6 +6,7 @@ import shlex
 from subprocess import Popen, PIPE
 from tempfile import NamedTemporaryFile
 import os
+
 
 class JadDict(dict):
     @classmethod

--- a/corehq/apps/builds/management/commands/add_commcare_build.py
+++ b/corehq/apps/builds/management/commands/add_commcare_build.py
@@ -1,6 +1,6 @@
-from couchdbkit.exceptions import BadValueError
 from django.core.management.base import BaseCommand, CommandError
 from corehq.apps.builds.models import CommCareBuild
+
 
 class Command(BaseCommand):
     args = '<build_path> <version> <build_number>'

--- a/corehq/apps/builds/views.py
+++ b/corehq/apps/builds/views.py
@@ -1,11 +1,10 @@
-import json
 from couchdbkit import ResourceNotFound
 from django.http import HttpResponseBadRequest, HttpResponse, Http404
 from django.views.decorators.http import require_GET
 from django.views.generic import TemplateView
 from django.shortcuts import render
 from django.utils.decorators import method_decorator
-from dimagi.utils.web import json_response, json_request
+from dimagi.utils.web import json_request
 from dimagi.utils.couch.database import get_db
 
 from corehq.apps.api.models import require_api_user

--- a/corehq/apps/cleanup/management/commands/check_case_integrity.py
+++ b/corehq/apps/cleanup/management/commands/check_case_integrity.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 from optparse import make_option
-from couchdbkit import ResourceNotFound
 from django.core.management.base import BaseCommand
 from casexml.apps.case.cleanup import rebuild_case
 from casexml.apps.case.models import CommCareCase

--- a/corehq/apps/cleanup/management/commands/check_form_versions.py
+++ b/corehq/apps/cleanup/management/commands/check_form_versions.py
@@ -1,4 +1,4 @@
-from corehq.apps.app_manager.models import SavedAppBuild, Application
+from corehq.apps.app_manager.models import Application
 from django.core.management.base import BaseCommand
 
 

--- a/corehq/apps/cleanup/management/commands/migrate_repeat_records.py
+++ b/corehq/apps/cleanup/management/commands/migrate_repeat_records.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from dimagi.utils.couch.database import iter_docs
 from django.core.management.base import BaseCommand
 from corehq import Domain

--- a/corehq/apps/cloudcare/decorators.py
+++ b/corehq/apps/cloudcare/decorators.py
@@ -1,6 +1,5 @@
 from corehq.apps.users.models import Permissions
 from corehq.apps.domain.decorators import login_and_domain_required
-from django.http import HttpResponseForbidden
 from corehq.apps.users.decorators import require_permission
 
 def require_cloudcare_access_ex():

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -1,6 +1,6 @@
 from couchdbkit import ResourceConflict
 from django.utils.decorators import method_decorator
-from corehq.apps.accounting.decorators import requires_privilege_plaintext_response, requires_privilege_for_commcare_user, requires_privilege_with_fallback
+from corehq.apps.accounting.decorators import requires_privilege_for_commcare_user, requires_privilege_with_fallback
 from dimagi.utils.couch.database import iter_docs
 from django.views.decorators.cache import cache_page
 from casexml.apps.case.models import CommCareCase

--- a/corehq/apps/commtrack/helpers.py
+++ b/corehq/apps/commtrack/helpers.py
@@ -1,18 +1,11 @@
-import logging
-from casexml.apps.case.mock import CaseBlock
 from corehq.apps.commtrack.models import Product, CommtrackConfig,\
     CommtrackActionConfig, SupplyPointType, SupplyPointCase
-from corehq.apps.commtrack import const
-from casexml.apps.case.xml import V2
-import uuid
-from corehq.apps.hqcase.utils import submit_case_blocks
-from xml.etree import ElementTree
-from corehq.apps.users.cases import get_owner_id
 
 """
 helper code to populate the various commtrack models, for ease of
 development/testing, before we have proper UIs and imports
 """
+
 
 def make_product(domain, name, code):
     p = Product()

--- a/corehq/apps/commtrack/management/commands/bootstrap_psi.py
+++ b/corehq/apps/commtrack/management/commands/bootstrap_psi.py
@@ -1,12 +1,7 @@
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 from optparse import make_option
 from corehq.apps.domain.models import Domain
-from corehq.apps.locations.models import Location
-from corehq.apps.users.models import CommCareUser
-from corehq.apps.sms.mixin import MobileBackend
 from corehq.apps.commtrack.helpers import *
-import sys
-import random
 
 PRODUCTS = [
     ('PSI kit', 'k'),

--- a/corehq/apps/commtrack/management/commands/migrate_loc_code.py
+++ b/corehq/apps/commtrack/management/commands/migrate_loc_code.py
@@ -1,10 +1,8 @@
-from django.core.management.base import BaseCommand, CommandError
-from optparse import make_option
-from corehq.apps.domain.models import Domain
+from django.core.management.base import BaseCommand
 from corehq.apps.locations.models import Location
 from casexml.apps.case.models import CommCareCase
 from dimagi.utils.couch.loosechange import map_reduce
-import sys
+
 
 class Command(BaseCommand):
     args = 'domain'

--- a/corehq/apps/domain/middleware.py
+++ b/corehq/apps/domain/middleware.py
@@ -1,21 +1,11 @@
 # Use modern Python
 from __future__ import unicode_literals, print_function, absolute_import
 
-# Standard Library imports
-
-# Django imports
-from django.conf import settings
-import django.core.exceptions
-
 # External imports
-from redis_cache.exceptions import ConnectionInterrumped
 from corehq.apps.accounting.exceptions import AccountingError
 from corehq.apps.accounting.models import Subscription
-from dimagi.utils.couch.cache import cache_core
 from django_prbac.models import Role
 
-# CCHQ imports
-from corehq import toggles
 
 class CCHQPRBACMiddleware(object):
     """
@@ -53,5 +43,3 @@ class CCHQPRBACMiddleware(object):
             request.role = Role.objects.get(slug='community_plan_v0')
         except Role.DoesNotExist:
             request.role = Role()  # A fresh Role() has no privileges
-    
-############################################################################################################

--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -1,12 +1,9 @@
 from collections import defaultdict
 from xml.etree import ElementTree
 from django.conf import settings
-from corehq import toggles, privileges
-from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.fixtures.models import FixtureDataItem, FixtureDataType
 from corehq.apps.users.models import CommCareUser
 from dimagi.utils.modules import to_function
-import toggle
 
 
 def hq_fixtures(user, version, last_sync):

--- a/corehq/apps/hqcase/management/commands/ptop_make_reportcase_mapping.py
+++ b/corehq/apps/hqcase/management/commands/ptop_make_reportcase_mapping.py
@@ -1,13 +1,8 @@
-from datetime import datetime
-import hashlib
-import pprint
 from django.core.management.base import NoArgsCommand
 import sys
 import os
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.hqcase.management.commands.ptop_generate_mapping import MappingOutputCommand
-from corehq.pillows import dynamic
-from corehq.pillows.dynamic import DEFAULT_MAPPING_WRAPPER, case_special_types, case_nested_types
 from django.conf import settings
 from corehq.pillows.mappings import reportcase_mapping
 from corehq.pillows.reportcase import ReportCasePillow

--- a/corehq/apps/hqmedia/utils.py
+++ b/corehq/apps/hqmedia/utils.py
@@ -1,12 +1,4 @@
-from django.core.urlresolvers import reverse
-from django.utils.datastructures import SortedDict
-import os
-import sys
-import logging
 from corehq.apps.app_manager.xform import XFormValidationError, XFormError
-from corehq.apps.domain.models import Domain
-from corehq.apps.users.models import CouchUser
-from corehq.apps.hqmedia.models import CommCareMultimedia, CommCareAudio, CommCareImage, HQMediaMapItem
 from corehq.apps.domain.models import LICENSES
 
 MULTIMEDIA_PREFIX = "jr://file/"

--- a/corehq/apps/indicators/views.py
+++ b/corehq/apps/indicators/views.py
@@ -1,16 +1,15 @@
-from django.http import HttpResponse, Http404
+from django.http import Http404
 from django.shortcuts import render
 from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView
 from tastypie.http import HttpBadRequest
-from corehq.apps.crud.views import BaseAdminCRUDFormView, BaseCRUDFormView
+from corehq.apps.crud.views import BaseCRUDFormView
 from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.indicators.admin.crud import IndicatorCRUDFormRequestManager
 from corehq.apps.indicators.admin.forms import BulkCopyIndicatorsForm
 from corehq.apps.indicators.dispatcher import require_edit_indicators
-from corehq.apps.indicators.utils import get_namespaces, get_indicator_domains
+from corehq.apps.indicators.utils import get_indicator_domains
 from dimagi.utils.modules import to_function
-import settings
 
 
 @require_edit_indicators

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -1,4 +1,4 @@
-from django.http import HttpResponse, HttpResponseRedirect, Http404, HttpResponseServerError
+from django.http import HttpResponse, HttpResponseRedirect, Http404
 from django.utils.safestring import mark_safe
 from django.views.decorators.http import require_POST
 from corehq.apps.commtrack.views import BaseCommTrackManageView
@@ -19,12 +19,7 @@ from django.utils.translation import ugettext as _, ugettext_noop
 from dimagi.utils.decorators.memoized import memoized
 from custom.openlmis.tasks import bootstrap_domain_task
 from soil.util import expose_download, get_download_context
-import uuid
 from corehq.apps.commtrack.tasks import import_locations_async
-from soil import DownloadBase
-from django.shortcuts import render_to_response
-from django.template.context import RequestContext
-from soil.heartbeat import heartbeat_enabled, is_alive
 from couchexport.models import Format
 from corehq.apps.consumption.shortcuts import get_default_consumption
 

--- a/corehq/apps/reminders/management/commands/create_definitions_2012_07.py
+++ b/corehq/apps/reminders/management/commands/create_definitions_2012_07.py
@@ -1,6 +1,5 @@
-import hashlib
 from django.core.management.base import LabelCommand, CommandError
-from corehq.apps.reminders.models import CaseReminderHandler, CaseReminderEvent, MATCH_EXACT, MATCH_REGEX, EVENT_AS_SCHEDULE, RECIPIENT_CASE, REPEAT_SCHEDULE_INDEFINITELY
+from corehq.apps.reminders.models import CaseReminderHandler, CaseReminderEvent
 from datetime import time
 
 class Command(LabelCommand):

--- a/corehq/apps/reminders/views.py
+++ b/corehq/apps/reminders/views.py
@@ -9,7 +9,7 @@ from django.http import HttpResponseRedirect, Http404, HttpResponse
 from django.shortcuts import render
 
 from django.utils.translation import ugettext as _, ugettext_noop
-from corehq import privileges, toggles
+from corehq import privileges
 from corehq.apps.accounting.decorators import requires_privilege_with_fallback
 from corehq.apps.app_manager.models import Application
 from corehq.apps.app_manager.util import get_case_properties
@@ -53,15 +53,12 @@ from corehq.apps.reminders.models import (
     METHOD_STRUCTURED_SMS,
     RECIPIENT_USER_GROUP,
     RECIPIENT_SENDER,
-    RECIPIENT_OWNER,
     METHOD_IVR_SURVEY,
 )
 from corehq.apps.sms.views import BaseMessagingSectionView
 from corehq.apps.users.decorators import require_permission
-from corehq.apps.users.models import CommCareUser, Permissions, CouchUser
+from corehq.apps.users.models import CommCareUser, Permissions
 from dimagi.utils.decorators.memoized import memoized
-from django_prbac.exceptions import PermissionDenied
-from django_prbac.utils import ensure_request_has_privilege
 from .models import UI_SIMPLE_FIXED, UI_COMPLEX
 from .util import get_form_list, get_sample_list, get_recipient_name, get_form_name, can_use_survey_reminders
 from corehq.apps.sms.mixin import VerifiedNumber

--- a/corehq/apps/reports/commtrack/standard.py
+++ b/corehq/apps/reports/commtrack/standard.py
@@ -1,9 +1,6 @@
-from collections import deque
-from casexml.apps.case.models import CommCareCase
 from corehq.apps.api.es import CaseES
 from corehq.apps.commtrack.psi_hacks import is_psi_domain
-from corehq.apps.commtrack.util import supply_point_type_categories
-from corehq.apps.reports.commtrack.data_sources import StockStatusDataSource, ReportingStatusDataSource, is_timely
+from corehq.apps.reports.commtrack.data_sources import StockStatusDataSource, ReportingStatusDataSource
 from corehq.apps.reports.generic import GenericTabularReport
 from corehq.apps.reports.datatables import DataTablesHeader, DataTablesColumn
 from corehq.apps.commtrack.models import Product, CommtrackConfig, CommtrackActionConfig

--- a/corehq/apps/reports/standard/domains.py
+++ b/corehq/apps/reports/standard/domains.py
@@ -1,15 +1,16 @@
 from datetime import datetime
-from corehq.elastic import es_query, ADD_TO_ES_FILTER, ES_URLS, ES_MAX_CLAUSE_COUNT
+from corehq.elastic import es_query
 from django.core.urlresolvers import reverse
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_noop
 from corehq.apps.hqadmin.reports import AdminFacetedReport
 from corehq.apps.reports.datatables import DataTablesHeader, DataTablesColumn, DTSortType
-from corehq.apps.reports.dispatcher import BasicReportDispatcher, AdminReportDispatcher
-from corehq.apps.reports.generic import GenericTabularReport, ElasticTabularReport
+from corehq.apps.reports.dispatcher import BasicReportDispatcher
+from corehq.apps.reports.generic import GenericTabularReport
 from django.utils.translation import ugettext as _
 from corehq.apps.reports.util import numcell
 from corehq.pillows.mappings.domain_mapping import DOMAIN_INDEX
+
 
 def format_date(dstr, default):
     return datetime.strptime(dstr, '%Y-%m-%dT%H:%M:%SZ').strftime('%Y/%m/%d %H:%M:%S') if dstr else default

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -29,10 +29,10 @@ from corehq.apps.users.models import CouchUser, Permissions
 from corehq.apps.users import models as user_models
 from corehq.apps.users.views.mobile.users import EditCommCareUserView
 from corehq.apps.sms.models import (
-    SMSLog, INCOMING, OUTGOING, ForwardingRule, CommConnectCase,
+    SMSLog, INCOMING, OUTGOING, ForwardingRule,
     LastReadMessage,
 )
-from corehq.apps.sms.mixin import MobileBackend, SMSBackend, BackendMapping, VerifiedNumber
+from corehq.apps.sms.mixin import SMSBackend, BackendMapping, VerifiedNumber
 from corehq.apps.sms.forms import ForwardingRuleForm, BackendMapForm, InitiateAddSMSBackendForm, SMSSettingsForm, SubscribeSMSForm
 from corehq.apps.sms.util import get_available_backends, get_contact
 from corehq.apps.groups.models import Group
@@ -44,8 +44,6 @@ from dimagi.utils.timezones import utils as tz_utils
 from django.views.decorators.csrf import csrf_exempt
 from corehq.apps.domain.models import Domain
 from django.utils.translation import ugettext as _, ugettext_noop
-from couchdbkit.resource import ResourceNotFound
-from casexml.apps.case.models import CommCareCase
 from dimagi.utils.parsing import json_format_datetime, string_to_boolean
 from dateutil.parser import parse
 from dimagi.utils.decorators.memoized import memoized

--- a/corehq/apps/unicel/api.py
+++ b/corehq/apps/unicel/api.py
@@ -1,9 +1,8 @@
-from datetime import datetime, date, timedelta
+from datetime import datetime
 import logging
-from corehq.apps.sms.util import clean_phone_number, clean_outgoing_sms_text, create_billable_for_sms
+from corehq.apps.sms.util import clean_phone_number, create_billable_for_sms
 from corehq.apps.sms.api import incoming
 from corehq.apps.sms.mixin import SMSBackend
-from django.conf import settings
 from urllib2 import urlopen
 from urllib import urlencode
 import pytz

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -2,12 +2,10 @@ from __future__ import absolute_import
 import json
 import re
 import urllib
-from corehq.apps.accounting.decorators import requires_privilege_with_fallback
 from django.utils.decorators import method_decorator
-from corehq import Domain, toggles, privileges
+from corehq import Domain, privileges
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.domain.views import BaseDomainView
-from corehq.apps.locations.models import Location
 from corehq.apps.sms.mixin import BadSMSConfigException
 from corehq.apps.users.decorators import require_can_edit_web_users, require_permission_to_edit_user
 from dimagi.utils.decorators.memoized import memoized

--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -1,11 +1,11 @@
 from django.conf import settings
-from datetime import datetime
 
 # this isn't OR specific, but we like it to be included
 OPENROSA_ACCEPT_LANGUAGE = "HTTP_ACCEPT_LANGUAGE"
 OPENROSA_VERSION_HEADER = "HTTP_X_OPENROSA_VERSION"
 OPENROSA_DATE_HEADER = "HTTP_DATE"
 OPENROSA_HEADERS = [OPENROSA_VERSION_HEADER, OPENROSA_DATE_HEADER, OPENROSA_ACCEPT_LANGUAGE]
+
 
 class OpenRosaMiddleware(object):
     """

--- a/corehq/pillows/core.py
+++ b/corehq/pillows/core.py
@@ -1,15 +1,8 @@
-import hashlib
-import simplejson
 from auditcare.models import AuditEvent
 from couchforms.models import XFormInstance
 from couchlog.models import ExceptionRecord
-from pillowtop.listener import  LogstashMonitoringPillow, AliasedElasticPillow
-from pillowtop.listener import ElasticPillow
-from casexml.apps.case.models import CommCareCase
-from corehq.apps.domain.models import Domain
-import logging
+from pillowtop.listener import LogstashMonitoringPillow
 from django.conf import settings
-from datetime import datetime
 
 
 DATE_FORMATS_ARR = ["yyyy-MM-dd",

--- a/custom/apps/gsid/reports/__init__.py
+++ b/custom/apps/gsid/reports/__init__.py
@@ -1,14 +1,9 @@
 from corehq.apps.fixtures.models import FixtureDataItem, FixtureDataType
-from corehq.apps.reports.basic import Column, FunctionView, SummingTabularReport, BasicTabularReport
-from corehq.apps.reports.datatables import DataTablesHeader, DataTablesColumn, DataTablesColumnGroup
 from corehq.apps.reports.fields import ReportSelectField
-from corehq.apps.reports.filters.base import BaseSingleOptionFilter, BaseDrilldownOptionFilter
+from corehq.apps.reports.filters.base import BaseDrilldownOptionFilter
 from corehq.apps.reports.filters.dates import DatespanFilter
 from corehq.apps.reports.filters.fixtures import MultiLocationFilter
-from corehq.apps.reports.standard import CustomProjectReport, DatespanMixin
 from util import get_unique_combinations
-from couchdbkit_aggregate.fn import mean, min, max
-from dimagi.utils.decorators.memoized import memoized
 
 
 class AsyncClinicField(MultiLocationFilter):

--- a/custom/apps/gsid/reports/sql_reports.py
+++ b/custom/apps/gsid/reports/sql_reports.py
@@ -2,12 +2,10 @@ import functools
 from sqlagg.columns import *
 from sqlagg.base import AliasColumn
 from sqlagg.filters import *
-from sqlalchemy import func
 from corehq.apps.fixtures.models import FixtureDataItem, FixtureDataType
-from corehq.apps.reports.basic import Column
 from corehq.apps.reports.datatables import DataTablesColumn, DataTablesHeader, DataTablesColumnGroup, DTSortType
 from corehq.apps.reports.graph_models import MultiBarChart, LineChart, Axis
-from corehq.apps.reports.sqlreport import SqlTabularReport, DatabaseColumn, SummingSqlTabularReport, AggregateColumn, calculate_total_row
+from corehq.apps.reports.sqlreport import DatabaseColumn, SummingSqlTabularReport, AggregateColumn, calculate_total_row
 from corehq.apps.reports.standard import CustomProjectReport, DatespanMixin
 from corehq.apps.reports.standard.maps import GenericMapReport
 from corehq.apps.reports.util import format_datatables_data
@@ -15,8 +13,6 @@ from dimagi.utils.decorators.memoized import memoized
 from util import get_unique_combinations,  capitalize_fn
 
 from datetime import datetime, timedelta
-
-import hashlib
 
 
 class StaticColumn(AliasColumn):

--- a/custom/opm/opm_reports/tests/__init__.py
+++ b/custom/opm/opm_reports/tests/__init__.py
@@ -1,17 +1,13 @@
-from datetime import datetime
-import os, json, string
+import os
+import json
 
-from django.http import HttpRequest
 from django.test import TestCase
 
 from fluff.management.commands.ptop_fast_reindex_fluff import FluffPtopReindexer
 
-from corehq.apps.users.models import WebUser
-from corehq.apps.users.models import CommCareUser, CommCareCase
 from dimagi.utils.couch.database import get_db
 from dimagi.utils.modules import to_function
 
-from custom.opm.opm_tasks.tasks import save_report
 from custom.opm.opm_tasks.models import OpmReportSnapshot
 from ..constants import *
 from ..beneficiary import Beneficiary

--- a/custom/opm/opm_tasks/tasks.py
+++ b/custom/opm/opm_tasks/tasks.py
@@ -1,15 +1,11 @@
 """
 Celery tasks to save a snapshot of the reports each month
 """
-import datetime, logging
+import logging
 
 from celery.task import periodic_task
 from celery.schedules import crontab
-from django.http import HttpRequest
 from django.conf import settings
-
-from dimagi.utils.dates import DateSpan
-from dimagi.utils.couch.database import get_db
 
 from ..opm_reports.reports import (BeneficiaryPaymentReport,
     IncentivePaymentReport, get_report, last_if_none)

--- a/custom/penn_state/reports.py
+++ b/custom/penn_state/reports.py
@@ -1,7 +1,4 @@
-import datetime, copy
-
-from django.views.generic import TemplateView
-from django.http import HttpResponse
+import copy
 
 from couchdbkit.exceptions import ResourceNotFound
 from no_exceptions.exceptions import Http403, Http404
@@ -9,7 +6,6 @@ from no_exceptions.exceptions import Http403, Http404
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.groups.models import Group
 from corehq.apps.reports.standard import CustomProjectReport
-from dimagi.utils.couch.database import get_db
 
 from .models import LegacyWeeklyReport
 from .constants import *

--- a/hqscripts/generic_queue.py
+++ b/hqscripts/generic_queue.py
@@ -1,9 +1,6 @@
 from datetime import datetime
 from time import sleep
-from optparse import make_option
-from django.core.management.base import BaseCommand, CommandError
-from django.conf import settings
-from dimagi.utils.parsing import string_to_datetime, json_format_datetime
+from django.core.management.base import BaseCommand
 from dimagi.utils.couch.cache import cache_core
 from dimagi.utils.logging import notify_exception
 from redis_cache.cache import RedisCache


### PR DESCRIPTION
I did this on the off chance that it would improve the startup time of management commands. Not surprisingly, it didn't.

these aren't all of them, just the worst offenders from

``` bash
pyflakes . | grep 'imported but unused' | cut -d':' -f1 | uniq -c | sort -n | grep -v '\./submodules'
```
