### PR TITLE
Cancel subscription bug

### DIFF
--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -26,7 +26,9 @@ from corehq.apps.accounting.async_handlers import (
     FeatureRateAsyncHandler,
     SoftwareProductRateAsyncHandler,
 )
-from corehq.apps.accounting.utils import is_active_subscription
+from corehq.apps.accounting.utils import (
+    is_active_subscription, has_subscription_already_ended
+)
 from corehq.apps.hqwebapp.crispy import BootstrapMultiField, TextField
 from corehq.apps.domain.models import Domain
 from corehq.apps.accounting.models import (
@@ -307,8 +309,7 @@ class SubscriptionForm(forms.Form):
                     "%(start_date)s (already started)" % {
                     'start_date': self.fields['start_date'].initial,
                 })
-            if (subscription.date_end is not None
-                and subscription.date_end <= today):
+            if has_subscription_already_ended(subscription):
                 end_date_field = TextField(
                     'end_date',
                     "%(end_date)s (already ended)" % {

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -8,6 +8,7 @@ from corehq.apps.accounting import utils
 from corehq.apps.accounting.invoicing import SubscriptionInvoiceFactory, CommunityInvoiceFactory
 
 from corehq.apps.accounting.models import Subscription
+from corehq.apps.accounting.utils import has_subscription_already_ended
 from corehq.apps.orgs.models import Organization
 from dimagi.utils.couch.database import iter_docs
 
@@ -22,8 +23,9 @@ def activate_subscriptions(based_on_date=None):
     starting_date = based_on_date or datetime.date.today()
     starting_subscriptions = Subscription.objects.filter(date_start=starting_date)
     for subscription in starting_subscriptions:
-        subscription.is_active = True
-        subscription.save()
+        if not has_subscription_already_ended(subscription):
+            subscription.is_active = True
+            subscription.save()
 
 
 @periodic_task(run_every=crontab(minute=0, hour=0))

--- a/corehq/apps/accounting/templates/accounting/subscriptions.html
+++ b/corehq/apps/accounting/templates/accounting/subscriptions.html
@@ -37,8 +37,7 @@
             </form>
             {% if subscription_canceled %}
                 Subscription has been canceled.
-            {% endif %}
-            {% if disable_cancel %}
+            {% elif disable_cancel %}
                 Subscription has already ended.
             {% endif %}
         </div>

--- a/corehq/apps/accounting/utils.py
+++ b/corehq/apps/accounting/utils.py
@@ -121,6 +121,12 @@ def domain_has_privilege(domain, privilege_slug, **assignment):
     return False
 
 
+def has_subscription_already_ended(subscription):
+    return (subscription.date_end is not None
+            and subscription.date_end <= datetime.date.today()
+            and not subscription.is_active)
+
+
 def get_money_str(amount):
     if amount is not None:
         if amount < 0:

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -260,7 +260,9 @@ class EditSubscriptionView(AccountingSectionView):
             'credit_list': CreditLine.objects.filter(subscription=self.subscription),
             'disable_cancel': (
                 self.subscription.date_end is not None
-                and self.subscription.date_end < datetime.date.today()),
+                and self.subscription.date_end <= datetime.date.today()
+                and not self.subscription.is_active
+            ),
             'form': self.get_appropriate_subscription_form(self.subscription),
             'subscription': self.subscription,
             'subscription_canceled': self.subscription_canceled if hasattr(self, 'subscription_canceled') else False,

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -25,7 +25,10 @@ from corehq.apps.accounting.async_handlers import (FeatureRateAsyncHandler, Sele
                                                    SoftwareProductRateAsyncHandler, Select2BillingInfoHandler,
                                                    Select2SubscriptionInfoHandler)
 from corehq.apps.accounting.user_text import PricingTable
-from corehq.apps.accounting.utils import LazyEncoder, fmt_feature_rate_dict, fmt_product_rate_dict
+from corehq.apps.accounting.utils import (
+    LazyEncoder, fmt_feature_rate_dict, fmt_product_rate_dict,
+    has_subscription_already_ended
+)
 from corehq.apps.hqwebapp.views import BaseSectionPageView
 from corehq import privileges
 from django_prbac.decorators import requires_privilege_raise404
@@ -258,11 +261,7 @@ class EditSubscriptionView(AccountingSectionView):
             'cancel_form': CancelForm(),
             'credit_form': self.get_appropriate_credit_form(self.subscription),
             'credit_list': CreditLine.objects.filter(subscription=self.subscription),
-            'disable_cancel': (
-                self.subscription.date_end is not None
-                and self.subscription.date_end <= datetime.date.today()
-                and not self.subscription.is_active
-            ),
+            'disable_cancel': has_subscription_already_ended(self.subscription),
             'form': self.get_appropriate_subscription_form(self.subscription),
             'subscription': self.subscription,
             'subscription_canceled': self.subscription_canceled if hasattr(self, 'subscription_canceled') else False,


### PR DESCRIPTION
fixes http://manage.dimagi.com/default.asp?102989#584031

Disable the Cancel subscription button on page reload after it has been clicked.  Also fixes other issues found: don't activate a subscription if an admin creates a subscription in the future and then chooses to cancel it before it has begun, and only disable the end date field if the subscription end date is in the past or if the subscription was canceled.
