### PR TITLE
Invoice updates intermediate PR

### DIFF
--- a/corehq/apps/accounting/async_handlers.py
+++ b/corehq/apps/accounting/async_handlers.py
@@ -212,7 +212,6 @@ class Select2InvoiceTriggerHandler(BaseSelect2AsyncHandler):
 
     @property
     def domain_response(self):
-        print 'getting domain response'
         domain_names = [domain['key'] for domain in Domain.get_all(include_docs=False)]
         domain_names = filter(lambda x: toggles.ACCOUNTING_PREVIEW.enabled(x), domain_names)
         if self.search_string:

--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -444,33 +444,42 @@ class SubscriptionForm(forms.Form):
 
 
 class CreditForm(forms.Form):
-    amount = forms.DecimalField()
+    amount = forms.DecimalField(label="Amount (USD)")
     note = forms.CharField(required=False)
-    rate_type = forms.ChoiceField()
-    product_rate = forms.ChoiceField(required=False, label=_("Product Rate"))
-    feature_rate = forms.ChoiceField(required=False, label=_("Feature Rate"))
+    rate_type = forms.ChoiceField(
+        label=_("Rate Type"),
+        choices=(
+            ('', 'Any'),
+            ('Product', 'Product'),
+            ('Feature', 'Feature'),
+        ),
+        required=False,
+    )
+    product_type = forms.ChoiceField( required=False, label=_("Product Type"))
+    feature_type = forms.ChoiceField(required=False, label=_("Feature Type"))
 
-    def __init__(self, obj_id, is_account, *args, **kwargs):
+    def __init__(self, account, subscription, *args, **kwargs):
+        self.account = account
+        self.subscription = subscription
         super(CreditForm, self).__init__(*args, **kwargs)
-        if not kwargs:
-            self.fields['product_rate'].choices = \
-                self.get_product_rate_choices(obj_id, is_account)
-            self.fields['feature_rate'].choices = \
-                self.get_feature_choices(obj_id, is_account)
-            self.fields['rate_type'].choices = \
-                self.get_rate_type_choices(self.fields['product_rate'].choices,
-                                           self.fields['feature_rate'].choices)
-        self.fields['amount'].label = \
-            _("Amount (%s)") % self.get_currency_str(obj_id, is_account)
+
+        product_choices = [('', 'Any')]
+        product_choices.extend(SoftwareProductType.CHOICES)
+        self.fields['product_type'].choices = product_choices
+
+        feature_choices = [('', 'Any')]
+        feature_choices.extend(FeatureType.CHOICES)
+        self.fields['feature_type'].choices = feature_choices
+
         self.helper = FormHelper()
         self.helper.layout = crispy.Layout(
             crispy.Fieldset(
-            'Adjust %s Level Credit' % ('Account' if is_account else 'Subscription'),
+                'Add Credit',
                 'amount',
                 'note',
                 crispy.Field('rate_type', data_bind="value: rateType"),
-                crispy.Div('product_rate', data_bind="visible: showProduct"),
-                crispy.Div('feature_rate', data_bind="visible: showFeature"),
+                crispy.Div('product_type', data_bind="visible: showProduct"),
+                crispy.Div('feature_type', data_bind="visible: showFeature"),
             ),
             FormActions(
                 crispy.ButtonHolder(
@@ -479,100 +488,37 @@ class CreditForm(forms.Form):
             )
         )
 
-    def get_currency_str(self, obj_id, is_account):
-        account = BillingAccount.objects.get(
-            id=obj_id
-        ) if is_account else Subscription.objects.get(id=obj_id).account
-        symbol = account.currency.symbol
-        if len(symbol) != 0:
-            return symbol
-        else:
-            return account.currency.code
-
     def clean_amount(self):
         amount = self.cleaned_data['amount']
         field_metadata = CreditAdjustment._meta.get_field('amount')
         if amount >= 10 ** (field_metadata.max_digits - field_metadata.decimal_places):
-            raise ValidationError(mark_safe('Amount over maximum size.  If you need support '
-                                            'for quantities this large, please '
-                                            '<a data-toggle="modal" data-target="#reportIssueModal" '
-                                            'href="#reportIssueModal">Report an Issue</a>.'))
+            raise ValidationError(mark_safe(
+                'Amount over maximum size.  If you need support for '
+                'quantities this large, please <a data-toggle="modal" '
+                'data-target="#reportIssueModal" href="#reportIssueModal">'
+                'Report an Issue</a>.'
+            ))
         return amount
 
-    def get_subscriptions(self, obj_id, is_account):
-        return Subscription.objects.filter(
-            account=BillingAccount.objects.get(id=obj_id)
-        ) if is_account else [Subscription.objects.get(id=obj_id)]
-
-    def get_product_rate_choices(self, obj_id, is_account):
-        subscriptions = self.get_subscriptions(obj_id, is_account)
-        product_rate_sets = \
-            [sub.plan_version.product_rates for sub in subscriptions]
-        product_rates = set()
-        for product_rate_set in product_rate_sets:
-            for product_rate in product_rate_set.all():
-                product_rates.add(product_rate)
-        return [(product_rate.id, str(product_rate))
-                for product_rate in product_rates]
-
-    def get_feature_choices(self, obj_id, is_account):
-        subscriptions = self.get_subscriptions(obj_id, is_account)
-        feature_rate_sets = \
-            [sub.plan_version.feature_rates for sub in subscriptions]
-        feature_rates = set()
-        for feature_rate_set in feature_rate_sets:
-            for feature_rate in feature_rate_set.all():
-                feature_rates.add(feature_rate)
-        return [(feature_rate.id, str(feature_rate))
-                for feature_rate in feature_rates]
-
-    def get_rate_type_choices(self, product_choices, feature_choices):
-        choices = [('Any', 'Any')]
-        if len(product_choices) != 0:
-            choices.append(('Product', 'Product'))
-        if len(feature_choices) != 0:
-            choices.append(('Feature', 'Feature'))
-        return choices
-
-    def adjust_credit(self, account=None, subscription=None):
+    def adjust_credit(self):
         amount = self.cleaned_data['amount']
         note = self.cleaned_data['note']
 
-        def get_account_for_rate():
-            return account if account is not None else subscription.account
-
-        def add_product_rate():
-            CreditLine.add_rate_credit(amount, get_account_for_rate(),
-                                       product_rate=SoftwareProductRate.objects.get(
-                                           id=self.cleaned_data['product_rate']),
-                                       subscription=subscription,
-                                       note=note)
-
-        def add_feature_rate():
-            CreditLine.add_rate_credit(amount, get_account_for_rate(),
-                                       feature_rate=FeatureRate.objects.get(
-                                           id=self.cleaned_data['feature_rate']),
-                                       subscription=subscription,
-                                       note=note)
-
-        def add_account_level():
-            CreditLine.add_account_credit(amount, account,
-                                          note=note)
-
-        def add_subscription_level():
-            CreditLine.add_subscription_credit(amount, subscription,
-                                               note=note)
-
         if self.cleaned_data['rate_type'] == 'Product':
-            add_product_rate()
+            CreditLine.add_product_credit(
+                amount, self.account, self.cleaned_data['product_type'],
+                subscription=self.subscription, note=note,
+            )
         elif self.cleaned_data['rate_type'] == 'Feature':
-            add_feature_rate()
-        elif account is not None:
-            add_account_level()
-        elif self.is_existing:
-            add_subscription_level()
+            CreditLine.add_feature_credit(
+                amount, self.account, self.cleaned_data['feature_type'],
+                subscription=self.subscription, note=note,
+            )
+        elif self.subscription is not None:
+            CreditLine.add_subscription_credit(amount, self.subscription, note=note)
         else:
-            raise ValueError('invalid credit adjustment')
+            CreditLine.add_account_credit(amount, self.account, note=note)
+        return True
 
 
 class CancelForm(forms.Form):

--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -397,13 +397,13 @@ class SubscriptionForm(forms.Form):
         salesforce_contract_id = self.cleaned_data['salesforce_contract_id']
         is_active = is_active_subscription(date_start, date_end)
         do_not_invoice = self.cleaned_data['do_not_invoice']
-        return Subscription.new_domain_subscription(account, domain, plan_version,
-                                                    date_start=date_start,
-                                                    date_end=date_end,
-                                                    date_delay_invoicing=date_delay_invoicing,
-                                                    salesforce_contract_id=salesforce_contract_id,
-                                                    is_active=is_active,
-                                                    do_not_invoice=do_not_invoice)
+        return Subscription.new_domain_subscription(
+            account, domain, plan_version,
+            date_start=date_start,
+            salesforce_contract_id=salesforce_contract_id,
+            is_active=is_active,
+            do_not_invoice=do_not_invoice
+        )
 
     def update_subscription(self, subscription):
         kwargs = {

--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -335,9 +335,6 @@ class SubscriptionForm(forms.Form):
             if account_id is not None:
                 self.fields['account'].initial = account_id
 
-            self.fields['domain'].choices = [
-                (domain, domain) for domain in Domain.get_all()
-            ]
             domain_field = crispy.Field(
                 'domain', css_class="input-xxlarge",
                 placeholder="Search for Project Space"
@@ -348,7 +345,6 @@ class SubscriptionForm(forms.Form):
                 'plan_version', css_class="input-xxlarge",
                 placeholder="Search for Software Plan"
             )
-
 
         self.helper = FormHelper()
         self.helper.form_text_inline = True

--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -454,7 +454,7 @@ class CreditForm(forms.Form):
         ),
         required=False,
     )
-    product_type = forms.ChoiceField( required=False, label=_("Product Type"))
+    product_type = forms.ChoiceField(required=False, label=_("Product Type"))
     feature_type = forms.ChoiceField(required=False, label=_("Feature Type"))
 
     def __init__(self, account, subscription, *args, **kwargs):

--- a/corehq/apps/accounting/generator.py
+++ b/corehq/apps/accounting/generator.py
@@ -66,25 +66,29 @@ def billing_account(web_user_creator, web_user_contact, currency=None, save=True
     )
     if save:
         billing_account.save()
-        billing_contact = BillingContactInfo(
-            account=billing_account,
-            first_name=data_gen.arbitrary_firstname(),
-            last_name=data_gen.arbitrary_lastname(),
-            emails=web_user_creator.username,
-            phone_number="+15555555",
-            company_name="Company Name",
-            first_line="585 Mass Ave",
-            city="Cambridge",
-            state_province_region="MA",
-            postal_code="02139",
-            country="US",
-        )
+        billing_contact = arbitrary_contact_info(billing_account, web_user_creator)
         billing_contact.save()
         billing_account.billing_admins =\
             [BillingAccountAdmin.objects.get_or_create(web_user=web_user_contact.username)[0]]
         billing_account.save()
 
     return billing_account
+
+
+def arbitrary_contact_info(account, web_user_creator):
+    return BillingContactInfo(
+        account=account,
+        first_name=data_gen.arbitrary_firstname(),
+        last_name=data_gen.arbitrary_lastname(),
+        emails=web_user_creator.username,
+        phone_number="+15555555",
+        company_name="Company Name",
+        first_line="585 Mass Ave",
+        city="Cambridge",
+        state_province_region="MA",
+        postal_code="02139",
+        country="US",
+    )
 
 
 def delete_all_accounts():

--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -4,7 +4,7 @@ import datetime
 from django.db.models import ProtectedError
 
 from django.utils.translation import ugettext as _
-from corehq.apps.accounting.utils import assure_domain_instance
+from corehq.apps.accounting.utils import ensure_domain_instance
 from dimagi.utils.decorators.memoized import memoized
 
 from corehq import Domain
@@ -93,11 +93,11 @@ class SubscriptionInvoiceFactory(InvoiceFactory):
         self.date_end = self.subscription.date_end if self.subscription.date_end < date_end else date_end
 
 
-class CommunityInvoiceFactory(InvoiceFactory):
+class CommunityInvoiceFactory(DomainInvoiceFactory):
 
     def __init__(self, date_start, date_end, domain):
         super(CommunityInvoiceFactory, self).__init__(date_start, date_end)
-        self.domain = assure_domain_instance(domain)
+        self.domain = ensure_domain_instance(domain)
 
     @property
     @memoized

--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -1,7 +1,8 @@
 import calendar
 from decimal import Decimal
 import datetime
-from django.db.models import ProtectedError
+import logging
+from django.db.models import Q
 
 from django.utils.translation import ugettext as _
 from corehq.apps.accounting.utils import ensure_domain_instance
@@ -12,147 +13,180 @@ from corehq.apps.accounting.exceptions import LineItemError, InvoiceError
 from corehq.apps.accounting.models import (
     LineItem, FeatureType, Invoice, DefaultProductPlan, Subscriber,
     Subscription, BillingAccount, SubscriptionAdjustment,
-    SubscriptionAdjustmentMethod, BillingRecord, InvoicePdf, BillingContactInfo)
+    SubscriptionAdjustmentMethod, BillingRecord, InvoicePdf, BillingContactInfo, SoftwarePlanEdition)
 from corehq.apps.smsbillables.models import SmsBillable
 from corehq.apps.users.models import CommCareUser
 
+logger = logging.getLogger(__name__)
 
-DEFAULT_DAYS_UNTIL_DUE = 10
+
+DEFAULT_DAYS_UNTIL_DUE = 30
 
 
-class InvoiceFactory(object):
+class DomainInvoiceFactory(object):
     """
     This handles all the little details when generating an Invoice.
     """
-    subscription = None
 
-    def __init__(self, date_start, date_end):
+    def __init__(self, date_start, date_end, domain):
         """
-        The Invoice generated will always be for the month preceding the invoicing_date.
+        The Invoice generated will always be for the month preceding the
+        invoicing_date.
         For example, if today is July 5, 2014 then the invoice will be from
-        June 1, 2014 to June 30, 2014
+        June 1, 2014 to June 30, 2014.
         """
         self.date_start = date_start
         self.date_end = date_end
+        self.domain = ensure_domain_instance(domain)
+        if self.domain is None:
+            raise InvoiceError("Domain '%s' is not a valid domain on HQ!"
+                               % domain)
+        self.is_community_invoice = False
 
-    def create(self):
-        if self.subscription is None:
-            raise InvoiceError("Cannot create an invoice without a subscription.")
+    @property
+    def subscriber(self):
+        return Subscriber.objects.get_or_create(domain=self.domain.name)[0]
 
+    def get_subscriptions(self):
+        subscriptions = Subscription.objects.filter(
+            subscriber=self.subscriber, date_start__lt=self.date_end
+        ).filter(Q(date_end=None) | Q(date_end__gte=self.date_start)
+        ).order_by('date_start').all()
+        return list(subscriptions)
+
+    def get_community_ranges(self, subscriptions):
+        community_ranges = []
+        prev_sub_end = self.date_end
+        if len(subscriptions) == 0:
+            community_ranges.append((self.date_start, self.date_end))
+        else:
+            for ind, sub in enumerate(subscriptions):
+                if ind == 0 and sub.date_start > self.date_start:
+                    # the first subscription started AFTER the beginning
+                    # of the invoicing period
+                    community_ranges.append((self.date_start, sub.date_start))
+
+                if prev_sub_end < self.date_end:
+                    community_ranges.append((prev_sub_end, sub.date_start))
+                prev_sub_end = sub.date_end
+
+                if (ind == len(subscriptions) - 1
+                    and sub.date_end is not None
+                    and sub.date_end <= self.date_end
+                ):
+                    # the last subscription ended BEFORE the end of
+                    # the invoicing period
+                    community_ranges.append(
+                        (sub.date_end, self.date_end + datetime.timedelta(days=1))
+                    )
+        return community_ranges
+
+    def ensure_full_coverage(self, subscriptions):
+        plan_version = DefaultProductPlan.get_default_plan_by_domain(
+            self.domain, edition=SoftwarePlanEdition.COMMUNITY
+        ).plan.get_version()
+        if not plan_version.feature_charges_exist_for_domain(self.domain):
+            return
+        community_ranges = self.get_community_ranges(subscriptions)
+        if not community_ranges:
+            return
+        do_not_invoice = any([s.do_not_invoice for s in subscriptions])
+        account = BillingAccount.get_or_create_account_by_domain(
+            self.domain.name, created_by=self.__class__.__name__)[0]
+        if account.date_confirmed_extra_charges is None:
+            logger.error(
+                "[BILLING] Domain '%s' is going to get charged on "
+                "Community, but they haven't formally acknowledged this. "
+                "Someone on ops should reconcile this soon. To be on the "
+                "safe side, we've marked the invoices as Do Not Invoice."
+                % self.domain.name
+            )
+            do_not_invoice = True
+        if not BillingContactInfo.objects.filter(account=account).exists():
+            # No contact information exists for this account.
+            # This shouldn't happen, but if it does, we can't continue
+            # with the invoice generation.
+            raise InvoiceError("No Billing Contact Info could be found "
+                               "for domain '%s'." % self.domain.name)
+        # First check to make sure none of the existing subscriptions is set
+        # to do not invoice. Let's be on the safe side and not send a
+        # community invoice out, if that's the case.
+        for c in community_ranges:
+            # create a new community subscription for each
+            # date range that the domain did not have a subscription
+            community_subscription = Subscription(
+                account=account,
+                plan_version=plan_version,
+                subscriber=self.subscriber,
+                date_start=c[0],
+                date_end=c[1],
+                do_not_invoice=do_not_invoice,
+            )
+            community_subscription.save()
+            subscriptions.append(community_subscription)
+
+    def create_invoices(self):
+        subscriptions = self.get_subscriptions()
+        self.ensure_full_coverage(subscriptions)
+        for subscription in subscriptions:
+            self.create_invoice_for_subscription(subscription)
+
+    def create_invoice_for_subscription(self, subscription):
         days_until_due = DEFAULT_DAYS_UNTIL_DUE
-        if self.subscription.date_delay_invoicing is not None:
-            td = self.subscription.date_delay_invoicing - self.date_end
+        if subscription.date_delay_invoicing is not None:
+            td = subscription.date_delay_invoicing - self.date_end
             days_until_due = max(days_until_due, td.days)
         date_due = self.date_end + datetime.timedelta(days_until_due)
 
-        invoice = Invoice(
-            subscription=self.subscription,
-            date_start=self.date_start,
-            date_end=self.date_end,
-            date_due=date_due,
-        )
-        invoice.save()
-        self.generate_line_items(invoice)
-        invoice.update_balance()
-        if invoice.balance == Decimal('0.0'):
-            invoice.billingrecord_set.all().delete()
-            invoice.lineitem_set.all().delete()
-            invoice.delete()
-            return None
-
-        invoice.calculate_credit_adjustments()
-        invoice.update_balance()
-        # generate PDF
-        invoice.save()
-
-        billing_record = BillingRecord(invoice=invoice)
-        invoice_pdf = InvoicePdf()
-        invoice_pdf.generate_pdf(billing_record)
-
-        return invoice
-
-    def generate_line_items(self, invoice):
-        for product_rate in self.subscription.plan_version.product_rates.all():
-            product_factory = ProductLineItemFactory(self.subscription, product_rate, invoice)
-            product_factory.create()
-
-        for feature_rate in self.subscription.plan_version.feature_rates.all():
-            feature_factory_class = FeatureLineItemFactory.get_factory_by_feature_type(
-                feature_rate.feature.feature_type
-            )
-            feature_factory = feature_factory_class(self.subscription, feature_rate, invoice)
-            feature_factory.create()
-
-
-class SubscriptionInvoiceFactory(InvoiceFactory):
-
-    def __init__(self, date_start, date_end, subscription):
-        super(SubscriptionInvoiceFactory, self).__init__(date_start, date_end)
-        self.subscription = subscription
-        self.date_start = self.subscription.date_start if self.subscription.date_start > date_start else date_start
-        self.date_end = self.subscription.date_end if self.subscription.date_end < date_end else date_end
-
-
-class CommunityInvoiceFactory(DomainInvoiceFactory):
-
-    def __init__(self, date_start, date_end, domain):
-        super(CommunityInvoiceFactory, self).__init__(date_start, date_end)
-        self.domain = ensure_domain_instance(domain)
-
-    @property
-    @memoized
-    def account(self):
-        """
-        First try to grab the account used for the last subscription.
-        If an account is not found, create it.
-        """
-        account, _ = BillingAccount.get_or_create_account_by_domain(self.domain.name, self.__class__.__name__)
-        # todo: fix so that contact_emails gets correctly populated.
-        BillingContactInfo.objects.get_or_create(
-            account=account
-        )
-        return account
-
-    @property
-    def software_plan_version(self):
-        return DefaultProductPlan.get_default_plan_by_domain(self.domain)
-
-    @property
-    @memoized
-    def subscription(self):
-        """
-        If we're arriving here, it's because there wasn't a subscription for the period of this invoice,
-        so let's create one.
-        """
-        subscriber, _ = Subscriber.objects.get_or_create(domain=self.domain.name)
-        subscription = Subscription(
-            account=self.account,
-            subscriber=subscriber,
-            plan_version=self.software_plan_version,
-            date_start=self.date_start,
-            date_end=self.date_end,
-        )
-        subscription.save()
-        return subscription
-
-    def create(self):
-        invoice = super(CommunityInvoiceFactory, self).create()
-        if invoice is None:
-            # no charges were created, so delete the temporary subscription to the community plan for this
-            # invoicing period
-            self.subscription.delete()
-            try:
-                # delete the account too (is only successful if no other subscriptions reference it)
-                self.account.delete()
-            except ProtectedError:
-                pass
+        if subscription.date_start > self.date_start:
+            invoice_start = subscription.date_start
         else:
+            invoice_start = self.date_start
+
+        if subscription.date_end <= self.date_end:
+            # Since the Subscription is actually terminated on date_end
+            # have the invoice period be until the day before date_end.
+            invoice_end = subscription.date_end - datetime.timedelta(days=1)
+        else:
+            invoice_end = self.date_end
+
+        invoice = Invoice(
+            subscription=subscription,
+            date_start=invoice_start,
+            date_end=invoice_end,
+            date_due=date_due,
+            is_hidden=subscription.do_not_invoice,
+        )
+        invoice.save()
+
+        if subscription.subscriptionadjustment_set.count() == 0:
+            # record that the subscription was created
             SubscriptionAdjustment.record_adjustment(
-                self.subscription,
+                subscription,
                 method=SubscriptionAdjustmentMethod.TASK,
                 invoice=invoice,
             )
+
+        self.generate_line_items(invoice, subscription)
+        invoice.calculate_credit_adjustments()
+        invoice.update_balance()
+        invoice.save()
+
+        BillingRecord.generate_record(invoice)
+
         return invoice
+
+    def generate_line_items(self, invoice, subscription):
+        for product_rate in subscription.plan_version.product_rates.all():
+            product_factory = ProductLineItemFactory(subscription, product_rate, invoice)
+            product_factory.create()
+
+        for feature_rate in subscription.plan_version.feature_rates.all():
+            feature_factory_class = FeatureLineItemFactory.get_factory_by_feature_type(
+                feature_rate.feature.feature_type
+            )
+            feature_factory = feature_factory_class(subscription, feature_rate, invoice)
+            feature_factory.create()
 
 
 class LineItemFactory(object):
@@ -308,9 +342,10 @@ class UserLineItemFactory(FeatureLineItemFactory):
     @property
     def unit_description(self):
         if self.num_excess_users > 0:
-            return _("Per User fee exceeding monthly limit of %(monthly_limit)s users." % {
-                'monthly_limit': self.rate.monthly_limit,
-            })
+            return _("Per User fee exceeding monthly limit of "
+                     "%(monthly_limit)s users." % {
+                        'monthly_limit': self.rate.monthly_limit,
+                    })
 
 
 class SmsLineItemFactory(FeatureLineItemFactory):
@@ -343,21 +378,23 @@ class SmsLineItemFactory(FeatureLineItemFactory):
     @memoized
     def unit_description(self):
         if self.is_within_monthly_limit:
-            return _("%(num_sms)d of %(monthly_limit)d included SMS messages") % {
-                'num_sms': self.num_sms,
-                'monthly_limit': self.rate.monthly_limit,
-            }
+            return _("%(num_sms)d of %(monthly_limit)d included SMS "
+                     "messages") % {
+                        'num_sms': self.num_sms,
+                        'monthly_limit': self.rate.monthly_limit,
+                    }
         if self.rate.monthly_limit == 0:
             return _("%(num_sms)d SMS Message(plural)s" % {
                 'num_sms': self.num_sms,
                 'plural': '' if self.num_sms == 1 else 's',
             })
         num_extra = self.rate.monthly_limit - self.num_sms
-        return _("%(num_extra_sms)d SMS Message%(plural)s beyond %(monthly_limit)d messages included." % {
-            'num_extra_sms': num_extra,
-            'plural': '' if num_extra == 0 else 's',
-            'monthly_limit': self.rate.monthly_limit,
-        })
+        return _("%(num_extra_sms)d SMS Message%(plural)s beyond "
+                 "%(monthly_limit)d messages included." % {
+                    'num_extra_sms': num_extra,
+                    'plural': '' if num_extra == 0 else 's',
+                    'monthly_limit': self.rate.monthly_limit,
+                })
 
     @property
     @memoized

--- a/corehq/apps/accounting/management/commands/cchq_software_plan_bootstrap.py
+++ b/corehq/apps/accounting/management/commands/cchq_software_plan_bootstrap.py
@@ -44,6 +44,7 @@ class Command(BaseCommand):
         self.for_tests = testing
         if self.for_tests:
             logger.info("Initializing Plans and Roles for Testing")
+            logging.disable(logging.ERROR)
 
         if verbose:
             logger.setLevel(logging.DEBUG)

--- a/corehq/apps/accounting/migrations/0013_roles_and_plans_migration_p1m2.py
+++ b/corehq/apps/accounting/migrations/0013_roles_and_plans_migration_p1m2.py
@@ -53,7 +53,7 @@ class Migration(DataMigration):
                                     "still being used."
                                     % (version.pk, plan.name))
 
-        for credit_line in CreditLine.objects.filter(feature_rate__isnull=False).all():
+        for credit_line in orm.CreditLine.objects.filter(feature_rate__isnull=False).all():
             latest_rate = credit_line.feature_rate.feature.get_rate()
             if credit_line.feature_rate.pk != latest_rate.pk:
                 credit_line.feature_rate = latest_rate
@@ -68,7 +68,7 @@ class Migration(DataMigration):
                                 "%d because it was still being used."
                                 % feature_rate.pk)
 
-        for credit_line in CreditLine.objects.filter(product_rate__isnull=False).all():
+        for credit_line in orm.CreditLine.objects.filter(product_rate__isnull=False).all():
             latest_rate = credit_line.product_rate.product.get_rate()
             if credit_line.product_rate.pk != latest_rate.pk:
                 credit_line.product_rate = latest_rate

--- a/corehq/apps/accounting/migrations/0015_auto__add_field_invoice_is_hidden__add_field_billingrecord_skipped_ema.py
+++ b/corehq/apps/accounting/migrations/0015_auto__add_field_invoice_is_hidden__add_field_billingrecord_skipped_ema.py
@@ -1,0 +1,235 @@
+# encoding: utf-8
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        
+        # Adding field 'Invoice.is_hidden'
+        db.add_column(u'accounting_invoice', 'is_hidden', self.gf('django.db.models.fields.BooleanField')(default=False), keep_default=False)
+
+        # Adding field 'BillingRecord.skipped_email'
+        db.add_column(u'accounting_billingrecord', 'skipped_email', self.gf('django.db.models.fields.BooleanField')(default=False), keep_default=False)
+
+        # Rename 'BillingRecord.date_emailed' to 'BillingRecord.date_created'
+        db.rename_column(u'accounting_billingrecord', 'date_emailed', 'date_created')
+
+
+    def backwards(self, orm):
+        
+        # Deleting field 'Invoice.is_hidden'
+        db.delete_column(u'accounting_invoice', 'is_hidden')
+
+        # Deleting field 'BillingRecord.skipped_email'
+        db.delete_column(u'accounting_billingrecord', 'skipped_email')
+
+        # Rename 'BillingRecord.date_created' to 'BillingRecord.date_emailed'
+        db.rename_column(u'accounting_billingrecord', 'date_created', 'date_emailed')
+
+
+    models = {
+        u'accounting.billingaccount': {
+            'Meta': {'object_name': 'BillingAccount'},
+            'account_type': ('django.db.models.fields.CharField', [], {'default': "'CONTRACT'", 'max_length': '25'}),
+            'billing_admins': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['accounting.BillingAccountAdmin']", 'null': 'True', 'symmetrical': 'False'}),
+            'created_by': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'created_by_domain': ('django.db.models.fields.CharField', [], {'max_length': '25', 'null': 'True', 'blank': 'True'}),
+            'currency': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Currency']"}),
+            'date_confirmed_extra_charges': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_auto_invoiceable': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'db_index': 'True'}),
+            'salesforce_account_id': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '80', 'null': 'True', 'blank': 'True'})
+        },
+        u'accounting.billingaccountadmin': {
+            'Meta': {'object_name': 'BillingAccountAdmin'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'web_user': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80', 'db_index': 'True'})
+        },
+        u'accounting.billingcontactinfo': {
+            'Meta': {'object_name': 'BillingContactInfo'},
+            'account': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['accounting.BillingAccount']", 'unique': 'True', 'primary_key': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'company_name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'emails': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'first_line': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'phone_number': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'postal_code': ('django.db.models.fields.CharField', [], {'max_length': '20', 'blank': 'True'}),
+            'second_line': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'state_province_region': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'})
+        },
+        u'accounting.billingrecord': {
+            'Meta': {'object_name': 'BillingRecord'},
+            'date_created': ('django.db.models.fields.DateField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'emailed_to': ('django.db.models.fields.CharField', [], {'max_length': '254', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'invoice': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Invoice']"}),
+            'pdf_data_id': ('django.db.models.fields.CharField', [], {'max_length': '48'}),
+            'skipped_email': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'accounting.creditadjustment': {
+            'Meta': {'object_name': 'CreditAdjustment'},
+            'amount': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'credit_line': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.CreditLine']"}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'invoice': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Invoice']", 'null': 'True'}),
+            'line_item': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.LineItem']", 'null': 'True'}),
+            'note': ('django.db.models.fields.TextField', [], {}),
+            'reason': ('django.db.models.fields.CharField', [], {'default': "'MANUAL'", 'max_length': '25'}),
+            'web_user': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True'})
+        },
+        u'accounting.creditline': {
+            'Meta': {'object_name': 'CreditLine'},
+            'account': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.BillingAccount']"}),
+            'balance': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'feature_rate': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.FeatureRate']", 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'product_rate': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwareProductRate']", 'null': 'True', 'blank': 'True'}),
+            'subscription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Subscription']", 'null': 'True', 'blank': 'True'})
+        },
+        u'accounting.currency': {
+            'Meta': {'object_name': 'Currency'},
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '3'}),
+            'date_updated': ('django.db.models.fields.DateField', [], {'auto_now': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '25', 'db_index': 'True'}),
+            'rate_to_default': ('django.db.models.fields.DecimalField', [], {'default': "'1.0'", 'max_digits': '20', 'decimal_places': '9'}),
+            'symbol': ('django.db.models.fields.CharField', [], {'max_length': '10'})
+        },
+        u'accounting.defaultproductplan': {
+            'Meta': {'object_name': 'DefaultProductPlan'},
+            'edition': ('django.db.models.fields.CharField', [], {'default': "'Community'", 'max_length': '25'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'plan': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwarePlan']"}),
+            'product_type': ('django.db.models.fields.CharField', [], {'max_length': '25'})
+        },
+        u'accounting.feature': {
+            'Meta': {'object_name': 'Feature'},
+            'feature_type': ('django.db.models.fields.CharField', [], {'max_length': '10', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '40'})
+        },
+        u'accounting.featurerate': {
+            'Meta': {'object_name': 'FeatureRate'},
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'feature': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Feature']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'monthly_fee': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '10', 'decimal_places': '2'}),
+            'monthly_limit': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'per_excess_fee': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '10', 'decimal_places': '2'})
+        },
+        u'accounting.invoice': {
+            'Meta': {'object_name': 'Invoice'},
+            'balance': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'date_due': ('django.db.models.fields.DateField', [], {'db_index': 'True'}),
+            'date_end': ('django.db.models.fields.DateField', [], {}),
+            'date_paid': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_received': ('django.db.models.fields.DateField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'date_start': ('django.db.models.fields.DateField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_hidden': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'subscription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Subscription']"}),
+            'tax_rate': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'})
+        },
+        u'accounting.lineitem': {
+            'Meta': {'object_name': 'LineItem'},
+            'base_cost': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'base_description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'feature_rate': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.FeatureRate']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'invoice': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Invoice']"}),
+            'product_rate': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwareProductRate']", 'null': 'True'}),
+            'quantity': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'unit_cost': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'unit_description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'accounting.softwareplan': {
+            'Meta': {'object_name': 'SoftwarePlan'},
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'edition': ('django.db.models.fields.CharField', [], {'default': "'Enterprise'", 'max_length': '25'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'visibility': ('django.db.models.fields.CharField', [], {'default': "'INTERNAL'", 'max_length': '10'})
+        },
+        u'accounting.softwareplanversion': {
+            'Meta': {'object_name': 'SoftwarePlanVersion'},
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'feature_rates': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['accounting.FeatureRate']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'plan': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwarePlan']"}),
+            'product_rates': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['accounting.SoftwareProductRate']", 'symmetrical': 'False', 'blank': 'True'}),
+            'role': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['django_prbac.Role']"})
+        },
+        u'accounting.softwareproduct': {
+            'Meta': {'object_name': 'SoftwareProduct'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '40'}),
+            'product_type': ('django.db.models.fields.CharField', [], {'max_length': '25', 'db_index': 'True'})
+        },
+        u'accounting.softwareproductrate': {
+            'Meta': {'object_name': 'SoftwareProductRate'},
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'monthly_fee': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '10', 'decimal_places': '2'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwareProduct']"})
+        },
+        u'accounting.subscriber': {
+            'Meta': {'object_name': 'Subscriber'},
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '256', 'null': 'True', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'organization': ('django.db.models.fields.CharField', [], {'max_length': '256', 'null': 'True', 'db_index': 'True'})
+        },
+        u'accounting.subscription': {
+            'Meta': {'object_name': 'Subscription'},
+            'account': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.BillingAccount']"}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'date_delay_invoicing': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_end': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_start': ('django.db.models.fields.DateField', [], {}),
+            'do_not_invoice': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'plan_version': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwarePlanVersion']"}),
+            'salesforce_contract_id': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'subscriber': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Subscriber']"})
+        },
+        u'accounting.subscriptionadjustment': {
+            'Meta': {'object_name': 'SubscriptionAdjustment'},
+            'date_created': ('django.db.models.fields.DateField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'invoice': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Invoice']", 'null': 'True'}),
+            'method': ('django.db.models.fields.CharField', [], {'default': "'INTERNAL'", 'max_length': '50'}),
+            'new_date_delay_invoicing': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'new_date_end': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'new_date_start': ('django.db.models.fields.DateField', [], {}),
+            'new_salesforce_contract_id': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'note': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'reason': ('django.db.models.fields.CharField', [], {'default': "'CREATE'", 'max_length': '50'}),
+            'related_subscription': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'subscriptionadjustment_related'", 'null': 'True', 'to': u"orm['accounting.Subscription']"}),
+            'subscription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Subscription']"}),
+            'web_user': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True'})
+        },
+        u'django_prbac.role': {
+            'Meta': {'object_name': 'Role'},
+            'description': ('django.db.models.fields.TextField', [], {'default': "u''", 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'parameters': ('django_prbac.fields.StringSetField', [], {'default': '[]', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '256'})
+        }
+    }
+
+    complete_apps = ['accounting']

--- a/corehq/apps/accounting/migrations/0016_auto__add_field_creditline_product_type__add_field_creditline_feature_.py
+++ b/corehq/apps/accounting/migrations/0016_auto__add_field_creditline_product_type__add_field_creditline_feature_.py
@@ -1,0 +1,247 @@
+# encoding: utf-8
+import datetime
+import logging
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+logger = logging.getLogger(__name__)
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        
+        # Adding field 'CreditLine.product_type'
+        db.add_column(u'accounting_creditline', 'product_type', self.gf('django.db.models.fields.CharField')(max_length=25, null=True, blank=True), keep_default=False)
+
+        # Adding field 'CreditLine.feature_type'
+        db.add_column(u'accounting_creditline', 'feature_type', self.gf('django.db.models.fields.CharField')(max_length=10, null=True, blank=True), keep_default=False)
+
+        # make sure we maintain the correct feature type and product type
+        # given an existing credit line.
+        for credit_line in orm.CreditLine.objects.all():
+            if credit_line.feature_rate is not None:
+                credit_line.feature_type = credit_line.feature_rate.feature.feature_type
+                logger.info("Transferred feature credit for account %d" % credit_line.account.id)
+                credit_line.save()
+            if credit_line.product_rate is not None:
+                credit_line.product_type = credit_line.product_rate.product.product_type
+                logger.info("Transferred product credit for account %d" % credit_line.account.id)
+                credit_line.save()
+
+
+    def backwards(self, orm):
+        
+        # Deleting field 'CreditLine.product_type'
+        db.delete_column(u'accounting_creditline', 'product_type')
+
+        # Deleting field 'CreditLine.feature_type'
+        db.delete_column(u'accounting_creditline', 'feature_type')
+
+
+    models = {
+        u'accounting.billingaccount': {
+            'Meta': {'object_name': 'BillingAccount'},
+            'account_type': ('django.db.models.fields.CharField', [], {'default': "'CONTRACT'", 'max_length': '25'}),
+            'billing_admins': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['accounting.BillingAccountAdmin']", 'null': 'True', 'symmetrical': 'False'}),
+            'created_by': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'created_by_domain': ('django.db.models.fields.CharField', [], {'max_length': '25', 'null': 'True', 'blank': 'True'}),
+            'currency': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Currency']"}),
+            'date_confirmed_extra_charges': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_auto_invoiceable': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'db_index': 'True'}),
+            'salesforce_account_id': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '80', 'null': 'True', 'blank': 'True'})
+        },
+        u'accounting.billingaccountadmin': {
+            'Meta': {'object_name': 'BillingAccountAdmin'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'web_user': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80', 'db_index': 'True'})
+        },
+        u'accounting.billingcontactinfo': {
+            'Meta': {'object_name': 'BillingContactInfo'},
+            'account': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['accounting.BillingAccount']", 'unique': 'True', 'primary_key': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'company_name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'emails': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'first_line': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'phone_number': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'postal_code': ('django.db.models.fields.CharField', [], {'max_length': '20', 'blank': 'True'}),
+            'second_line': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'state_province_region': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'})
+        },
+        u'accounting.billingrecord': {
+            'Meta': {'object_name': 'BillingRecord'},
+            'date_created': ('django.db.models.fields.DateField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'emailed_to': ('django.db.models.fields.CharField', [], {'max_length': '254', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'invoice': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Invoice']"}),
+            'pdf_data_id': ('django.db.models.fields.CharField', [], {'max_length': '48'}),
+            'skipped_email': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'accounting.creditadjustment': {
+            'Meta': {'object_name': 'CreditAdjustment'},
+            'amount': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'credit_line': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.CreditLine']"}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'invoice': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Invoice']", 'null': 'True'}),
+            'line_item': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.LineItem']", 'null': 'True'}),
+            'note': ('django.db.models.fields.TextField', [], {}),
+            'reason': ('django.db.models.fields.CharField', [], {'default': "'MANUAL'", 'max_length': '25'}),
+            'web_user': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True'})
+        },
+        u'accounting.creditline': {
+            'Meta': {'object_name': 'CreditLine'},
+            'account': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.BillingAccount']"}),
+            'balance': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'feature_rate': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.FeatureRate']", 'null': 'True', 'blank': 'True'}),
+            'feature_type': ('django.db.models.fields.CharField', [], {'max_length': '10', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'product_rate': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwareProductRate']", 'null': 'True', 'blank': 'True'}),
+            'product_type': ('django.db.models.fields.CharField', [], {'max_length': '25', 'null': 'True', 'blank': 'True'}),
+            'subscription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Subscription']", 'null': 'True', 'blank': 'True'})
+        },
+        u'accounting.currency': {
+            'Meta': {'object_name': 'Currency'},
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '3'}),
+            'date_updated': ('django.db.models.fields.DateField', [], {'auto_now': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '25', 'db_index': 'True'}),
+            'rate_to_default': ('django.db.models.fields.DecimalField', [], {'default': "'1.0'", 'max_digits': '20', 'decimal_places': '9'}),
+            'symbol': ('django.db.models.fields.CharField', [], {'max_length': '10'})
+        },
+        u'accounting.defaultproductplan': {
+            'Meta': {'object_name': 'DefaultProductPlan'},
+            'edition': ('django.db.models.fields.CharField', [], {'default': "'Community'", 'max_length': '25'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'plan': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwarePlan']"}),
+            'product_type': ('django.db.models.fields.CharField', [], {'max_length': '25'})
+        },
+        u'accounting.feature': {
+            'Meta': {'object_name': 'Feature'},
+            'feature_type': ('django.db.models.fields.CharField', [], {'max_length': '10', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '40'})
+        },
+        u'accounting.featurerate': {
+            'Meta': {'object_name': 'FeatureRate'},
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'feature': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Feature']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'monthly_fee': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '10', 'decimal_places': '2'}),
+            'monthly_limit': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'per_excess_fee': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '10', 'decimal_places': '2'})
+        },
+        u'accounting.invoice': {
+            'Meta': {'object_name': 'Invoice'},
+            'balance': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'date_due': ('django.db.models.fields.DateField', [], {'db_index': 'True'}),
+            'date_end': ('django.db.models.fields.DateField', [], {}),
+            'date_paid': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_received': ('django.db.models.fields.DateField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'date_start': ('django.db.models.fields.DateField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_hidden': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'subscription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Subscription']"}),
+            'tax_rate': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'})
+        },
+        u'accounting.lineitem': {
+            'Meta': {'object_name': 'LineItem'},
+            'base_cost': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'base_description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'feature_rate': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.FeatureRate']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'invoice': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Invoice']"}),
+            'product_rate': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwareProductRate']", 'null': 'True'}),
+            'quantity': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'unit_cost': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'unit_description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'accounting.softwareplan': {
+            'Meta': {'object_name': 'SoftwarePlan'},
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'edition': ('django.db.models.fields.CharField', [], {'default': "'Enterprise'", 'max_length': '25'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'visibility': ('django.db.models.fields.CharField', [], {'default': "'INTERNAL'", 'max_length': '10'})
+        },
+        u'accounting.softwareplanversion': {
+            'Meta': {'object_name': 'SoftwarePlanVersion'},
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'feature_rates': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['accounting.FeatureRate']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'plan': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwarePlan']"}),
+            'product_rates': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['accounting.SoftwareProductRate']", 'symmetrical': 'False', 'blank': 'True'}),
+            'role': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['django_prbac.Role']"})
+        },
+        u'accounting.softwareproduct': {
+            'Meta': {'object_name': 'SoftwareProduct'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '40'}),
+            'product_type': ('django.db.models.fields.CharField', [], {'max_length': '25', 'db_index': 'True'})
+        },
+        u'accounting.softwareproductrate': {
+            'Meta': {'object_name': 'SoftwareProductRate'},
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'monthly_fee': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '10', 'decimal_places': '2'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwareProduct']"})
+        },
+        u'accounting.subscriber': {
+            'Meta': {'object_name': 'Subscriber'},
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '256', 'null': 'True', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'organization': ('django.db.models.fields.CharField', [], {'max_length': '256', 'null': 'True', 'db_index': 'True'})
+        },
+        u'accounting.subscription': {
+            'Meta': {'object_name': 'Subscription'},
+            'account': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.BillingAccount']"}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'date_delay_invoicing': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_end': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_start': ('django.db.models.fields.DateField', [], {}),
+            'do_not_invoice': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'plan_version': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwarePlanVersion']"}),
+            'salesforce_contract_id': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'subscriber': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Subscriber']"})
+        },
+        u'accounting.subscriptionadjustment': {
+            'Meta': {'object_name': 'SubscriptionAdjustment'},
+            'date_created': ('django.db.models.fields.DateField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'invoice': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Invoice']", 'null': 'True'}),
+            'method': ('django.db.models.fields.CharField', [], {'default': "'INTERNAL'", 'max_length': '50'}),
+            'new_date_delay_invoicing': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'new_date_end': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'new_date_start': ('django.db.models.fields.DateField', [], {}),
+            'new_salesforce_contract_id': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'note': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'reason': ('django.db.models.fields.CharField', [], {'default': "'CREATE'", 'max_length': '50'}),
+            'related_subscription': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'subscriptionadjustment_related'", 'null': 'True', 'to': u"orm['accounting.Subscription']"}),
+            'subscription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Subscription']"}),
+            'web_user': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True'})
+        },
+        u'django_prbac.role': {
+            'Meta': {'object_name': 'Role'},
+            'description': ('django.db.models.fields.TextField', [], {'default': "u''", 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'parameters': ('django_prbac.fields.StringSetField', [], {'default': '[]', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '256'})
+        }
+    }
+
+    complete_apps = ['accounting']

--- a/corehq/apps/accounting/migrations/0017_auto__del_field_creditline_product_rate__del_field_creditline_feature_.py
+++ b/corehq/apps/accounting/migrations/0017_auto__del_field_creditline_product_rate__del_field_creditline_feature_.py
@@ -1,0 +1,229 @@
+# encoding: utf-8
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        
+        # Deleting field 'CreditLine.product_rate'
+        db.delete_column(u'accounting_creditline', 'product_rate_id')
+
+        # Deleting field 'CreditLine.feature_rate'
+        db.delete_column(u'accounting_creditline', 'feature_rate_id')
+
+
+    def backwards(self, orm):
+        
+        # Adding field 'CreditLine.product_rate'
+        db.add_column(u'accounting_creditline', 'product_rate', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['accounting.SoftwareProductRate'], null=True, blank=True), keep_default=False)
+
+        # Adding field 'CreditLine.feature_rate'
+        db.add_column(u'accounting_creditline', 'feature_rate', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['accounting.FeatureRate'], null=True, blank=True), keep_default=False)
+
+
+    models = {
+        u'accounting.billingaccount': {
+            'Meta': {'object_name': 'BillingAccount'},
+            'account_type': ('django.db.models.fields.CharField', [], {'default': "'CONTRACT'", 'max_length': '25'}),
+            'billing_admins': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['accounting.BillingAccountAdmin']", 'null': 'True', 'symmetrical': 'False'}),
+            'created_by': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'created_by_domain': ('django.db.models.fields.CharField', [], {'max_length': '25', 'null': 'True', 'blank': 'True'}),
+            'currency': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Currency']"}),
+            'date_confirmed_extra_charges': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_auto_invoiceable': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'db_index': 'True'}),
+            'salesforce_account_id': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '80', 'null': 'True', 'blank': 'True'})
+        },
+        u'accounting.billingaccountadmin': {
+            'Meta': {'object_name': 'BillingAccountAdmin'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'web_user': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80', 'db_index': 'True'})
+        },
+        u'accounting.billingcontactinfo': {
+            'Meta': {'object_name': 'BillingContactInfo'},
+            'account': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['accounting.BillingAccount']", 'unique': 'True', 'primary_key': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'company_name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'emails': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'first_line': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'phone_number': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'postal_code': ('django.db.models.fields.CharField', [], {'max_length': '20', 'blank': 'True'}),
+            'second_line': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'state_province_region': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'})
+        },
+        u'accounting.billingrecord': {
+            'Meta': {'object_name': 'BillingRecord'},
+            'date_created': ('django.db.models.fields.DateField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'emailed_to': ('django.db.models.fields.CharField', [], {'max_length': '254', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'invoice': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Invoice']"}),
+            'pdf_data_id': ('django.db.models.fields.CharField', [], {'max_length': '48'}),
+            'skipped_email': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'accounting.creditadjustment': {
+            'Meta': {'object_name': 'CreditAdjustment'},
+            'amount': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'credit_line': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.CreditLine']"}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'invoice': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Invoice']", 'null': 'True'}),
+            'line_item': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.LineItem']", 'null': 'True'}),
+            'note': ('django.db.models.fields.TextField', [], {}),
+            'reason': ('django.db.models.fields.CharField', [], {'default': "'MANUAL'", 'max_length': '25'}),
+            'web_user': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True'})
+        },
+        u'accounting.creditline': {
+            'Meta': {'object_name': 'CreditLine'},
+            'account': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.BillingAccount']"}),
+            'balance': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'feature_type': ('django.db.models.fields.CharField', [], {'max_length': '10', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'product_type': ('django.db.models.fields.CharField', [], {'max_length': '25', 'null': 'True', 'blank': 'True'}),
+            'subscription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Subscription']", 'null': 'True', 'blank': 'True'})
+        },
+        u'accounting.currency': {
+            'Meta': {'object_name': 'Currency'},
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '3'}),
+            'date_updated': ('django.db.models.fields.DateField', [], {'auto_now': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '25', 'db_index': 'True'}),
+            'rate_to_default': ('django.db.models.fields.DecimalField', [], {'default': "'1.0'", 'max_digits': '20', 'decimal_places': '9'}),
+            'symbol': ('django.db.models.fields.CharField', [], {'max_length': '10'})
+        },
+        u'accounting.defaultproductplan': {
+            'Meta': {'object_name': 'DefaultProductPlan'},
+            'edition': ('django.db.models.fields.CharField', [], {'default': "'Community'", 'max_length': '25'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'plan': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwarePlan']"}),
+            'product_type': ('django.db.models.fields.CharField', [], {'max_length': '25'})
+        },
+        u'accounting.feature': {
+            'Meta': {'object_name': 'Feature'},
+            'feature_type': ('django.db.models.fields.CharField', [], {'max_length': '10', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '40'})
+        },
+        u'accounting.featurerate': {
+            'Meta': {'object_name': 'FeatureRate'},
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'feature': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Feature']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'monthly_fee': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '10', 'decimal_places': '2'}),
+            'monthly_limit': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'per_excess_fee': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '10', 'decimal_places': '2'})
+        },
+        u'accounting.invoice': {
+            'Meta': {'object_name': 'Invoice'},
+            'balance': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'date_due': ('django.db.models.fields.DateField', [], {'db_index': 'True'}),
+            'date_end': ('django.db.models.fields.DateField', [], {}),
+            'date_paid': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_received': ('django.db.models.fields.DateField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'date_start': ('django.db.models.fields.DateField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_hidden': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'subscription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Subscription']"}),
+            'tax_rate': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'})
+        },
+        u'accounting.lineitem': {
+            'Meta': {'object_name': 'LineItem'},
+            'base_cost': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'base_description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'feature_rate': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.FeatureRate']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'invoice': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Invoice']"}),
+            'product_rate': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwareProductRate']", 'null': 'True'}),
+            'quantity': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'unit_cost': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'unit_description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'accounting.softwareplan': {
+            'Meta': {'object_name': 'SoftwarePlan'},
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'edition': ('django.db.models.fields.CharField', [], {'default': "'Enterprise'", 'max_length': '25'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'visibility': ('django.db.models.fields.CharField', [], {'default': "'INTERNAL'", 'max_length': '10'})
+        },
+        u'accounting.softwareplanversion': {
+            'Meta': {'object_name': 'SoftwarePlanVersion'},
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'feature_rates': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['accounting.FeatureRate']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'plan': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwarePlan']"}),
+            'product_rates': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['accounting.SoftwareProductRate']", 'symmetrical': 'False', 'blank': 'True'}),
+            'role': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['django_prbac.Role']"})
+        },
+        u'accounting.softwareproduct': {
+            'Meta': {'object_name': 'SoftwareProduct'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '40'}),
+            'product_type': ('django.db.models.fields.CharField', [], {'max_length': '25', 'db_index': 'True'})
+        },
+        u'accounting.softwareproductrate': {
+            'Meta': {'object_name': 'SoftwareProductRate'},
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'monthly_fee': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '10', 'decimal_places': '2'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwareProduct']"})
+        },
+        u'accounting.subscriber': {
+            'Meta': {'object_name': 'Subscriber'},
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '256', 'null': 'True', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'organization': ('django.db.models.fields.CharField', [], {'max_length': '256', 'null': 'True', 'db_index': 'True'})
+        },
+        u'accounting.subscription': {
+            'Meta': {'object_name': 'Subscription'},
+            'account': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.BillingAccount']"}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'date_delay_invoicing': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_end': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_start': ('django.db.models.fields.DateField', [], {}),
+            'do_not_invoice': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'plan_version': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwarePlanVersion']"}),
+            'salesforce_contract_id': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'subscriber': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Subscriber']"})
+        },
+        u'accounting.subscriptionadjustment': {
+            'Meta': {'object_name': 'SubscriptionAdjustment'},
+            'date_created': ('django.db.models.fields.DateField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'invoice': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Invoice']", 'null': 'True'}),
+            'method': ('django.db.models.fields.CharField', [], {'default': "'INTERNAL'", 'max_length': '50'}),
+            'new_date_delay_invoicing': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'new_date_end': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'new_date_start': ('django.db.models.fields.DateField', [], {}),
+            'new_salesforce_contract_id': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'note': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'reason': ('django.db.models.fields.CharField', [], {'default': "'CREATE'", 'max_length': '50'}),
+            'related_subscription': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'subscriptionadjustment_related'", 'null': 'True', 'to': u"orm['accounting.Subscription']"}),
+            'subscription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Subscription']"}),
+            'web_user': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True'})
+        },
+        u'django_prbac.role': {
+            'Meta': {'object_name': 'Role'},
+            'description': ('django.db.models.fields.TextField', [], {'default': "u''", 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'parameters': ('django_prbac.fields.StringSetField', [], {'default': '[]', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '256'})
+        }
+    }
+
+    complete_apps = ['accounting']

--- a/corehq/apps/accounting/migrations/0018_auto__chg_field_billingrecord_date_created.py
+++ b/corehq/apps/accounting/migrations/0018_auto__chg_field_billingrecord_date_created.py
@@ -1,0 +1,223 @@
+# encoding: utf-8
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        
+        # Changing field 'BillingRecord.date_created'
+        db.alter_column(u'accounting_billingrecord', 'date_created', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True))
+
+
+    def backwards(self, orm):
+        
+        # Changing field 'BillingRecord.date_created'
+        db.alter_column(u'accounting_billingrecord', 'date_created', self.gf('django.db.models.fields.DateField')(auto_now_add=True))
+
+
+    models = {
+        u'accounting.billingaccount': {
+            'Meta': {'object_name': 'BillingAccount'},
+            'account_type': ('django.db.models.fields.CharField', [], {'default': "'CONTRACT'", 'max_length': '25'}),
+            'billing_admins': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['accounting.BillingAccountAdmin']", 'null': 'True', 'symmetrical': 'False'}),
+            'created_by': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'created_by_domain': ('django.db.models.fields.CharField', [], {'max_length': '25', 'null': 'True', 'blank': 'True'}),
+            'currency': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Currency']"}),
+            'date_confirmed_extra_charges': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_auto_invoiceable': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'db_index': 'True'}),
+            'salesforce_account_id': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '80', 'null': 'True', 'blank': 'True'})
+        },
+        u'accounting.billingaccountadmin': {
+            'Meta': {'object_name': 'BillingAccountAdmin'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'web_user': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80', 'db_index': 'True'})
+        },
+        u'accounting.billingcontactinfo': {
+            'Meta': {'object_name': 'BillingContactInfo'},
+            'account': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['accounting.BillingAccount']", 'unique': 'True', 'primary_key': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'company_name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'emails': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'first_line': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'phone_number': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'postal_code': ('django.db.models.fields.CharField', [], {'max_length': '20', 'blank': 'True'}),
+            'second_line': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'state_province_region': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'})
+        },
+        u'accounting.billingrecord': {
+            'Meta': {'object_name': 'BillingRecord'},
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'emailed_to': ('django.db.models.fields.CharField', [], {'max_length': '254', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'invoice': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Invoice']"}),
+            'pdf_data_id': ('django.db.models.fields.CharField', [], {'max_length': '48'}),
+            'skipped_email': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'accounting.creditadjustment': {
+            'Meta': {'object_name': 'CreditAdjustment'},
+            'amount': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'credit_line': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.CreditLine']"}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'invoice': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Invoice']", 'null': 'True'}),
+            'line_item': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.LineItem']", 'null': 'True'}),
+            'note': ('django.db.models.fields.TextField', [], {}),
+            'reason': ('django.db.models.fields.CharField', [], {'default': "'MANUAL'", 'max_length': '25'}),
+            'web_user': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True'})
+        },
+        u'accounting.creditline': {
+            'Meta': {'object_name': 'CreditLine'},
+            'account': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.BillingAccount']"}),
+            'balance': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'feature_type': ('django.db.models.fields.CharField', [], {'max_length': '10', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'product_type': ('django.db.models.fields.CharField', [], {'max_length': '25', 'null': 'True', 'blank': 'True'}),
+            'subscription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Subscription']", 'null': 'True', 'blank': 'True'})
+        },
+        u'accounting.currency': {
+            'Meta': {'object_name': 'Currency'},
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '3'}),
+            'date_updated': ('django.db.models.fields.DateField', [], {'auto_now': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '25', 'db_index': 'True'}),
+            'rate_to_default': ('django.db.models.fields.DecimalField', [], {'default': "'1.0'", 'max_digits': '20', 'decimal_places': '9'}),
+            'symbol': ('django.db.models.fields.CharField', [], {'max_length': '10'})
+        },
+        u'accounting.defaultproductplan': {
+            'Meta': {'object_name': 'DefaultProductPlan'},
+            'edition': ('django.db.models.fields.CharField', [], {'default': "'Community'", 'max_length': '25'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'plan': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwarePlan']"}),
+            'product_type': ('django.db.models.fields.CharField', [], {'max_length': '25'})
+        },
+        u'accounting.feature': {
+            'Meta': {'object_name': 'Feature'},
+            'feature_type': ('django.db.models.fields.CharField', [], {'max_length': '10', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '40'})
+        },
+        u'accounting.featurerate': {
+            'Meta': {'object_name': 'FeatureRate'},
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'feature': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Feature']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'monthly_fee': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '10', 'decimal_places': '2'}),
+            'monthly_limit': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'per_excess_fee': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '10', 'decimal_places': '2'})
+        },
+        u'accounting.invoice': {
+            'Meta': {'object_name': 'Invoice'},
+            'balance': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'date_due': ('django.db.models.fields.DateField', [], {'db_index': 'True'}),
+            'date_end': ('django.db.models.fields.DateField', [], {}),
+            'date_paid': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_received': ('django.db.models.fields.DateField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'date_start': ('django.db.models.fields.DateField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_hidden': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'subscription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Subscription']"}),
+            'tax_rate': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'})
+        },
+        u'accounting.lineitem': {
+            'Meta': {'object_name': 'LineItem'},
+            'base_cost': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'base_description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'feature_rate': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.FeatureRate']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'invoice': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Invoice']"}),
+            'product_rate': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwareProductRate']", 'null': 'True'}),
+            'quantity': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'unit_cost': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'unit_description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'accounting.softwareplan': {
+            'Meta': {'object_name': 'SoftwarePlan'},
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'edition': ('django.db.models.fields.CharField', [], {'default': "'Enterprise'", 'max_length': '25'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'visibility': ('django.db.models.fields.CharField', [], {'default': "'INTERNAL'", 'max_length': '10'})
+        },
+        u'accounting.softwareplanversion': {
+            'Meta': {'object_name': 'SoftwarePlanVersion'},
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'feature_rates': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['accounting.FeatureRate']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'plan': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwarePlan']"}),
+            'product_rates': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['accounting.SoftwareProductRate']", 'symmetrical': 'False', 'blank': 'True'}),
+            'role': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['django_prbac.Role']"})
+        },
+        u'accounting.softwareproduct': {
+            'Meta': {'object_name': 'SoftwareProduct'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '40'}),
+            'product_type': ('django.db.models.fields.CharField', [], {'max_length': '25', 'db_index': 'True'})
+        },
+        u'accounting.softwareproductrate': {
+            'Meta': {'object_name': 'SoftwareProductRate'},
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'monthly_fee': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '10', 'decimal_places': '2'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwareProduct']"})
+        },
+        u'accounting.subscriber': {
+            'Meta': {'object_name': 'Subscriber'},
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '256', 'null': 'True', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'organization': ('django.db.models.fields.CharField', [], {'max_length': '256', 'null': 'True', 'db_index': 'True'})
+        },
+        u'accounting.subscription': {
+            'Meta': {'object_name': 'Subscription'},
+            'account': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.BillingAccount']"}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'date_delay_invoicing': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_end': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_start': ('django.db.models.fields.DateField', [], {}),
+            'do_not_invoice': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'plan_version': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwarePlanVersion']"}),
+            'salesforce_contract_id': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'subscriber': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Subscriber']"})
+        },
+        u'accounting.subscriptionadjustment': {
+            'Meta': {'object_name': 'SubscriptionAdjustment'},
+            'date_created': ('django.db.models.fields.DateField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'invoice': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Invoice']", 'null': 'True'}),
+            'method': ('django.db.models.fields.CharField', [], {'default': "'INTERNAL'", 'max_length': '50'}),
+            'new_date_delay_invoicing': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'new_date_end': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'new_date_start': ('django.db.models.fields.DateField', [], {}),
+            'new_salesforce_contract_id': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'note': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'reason': ('django.db.models.fields.CharField', [], {'default': "'CREATE'", 'max_length': '50'}),
+            'related_subscription': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'subscriptionadjustment_related'", 'null': 'True', 'to': u"orm['accounting.Subscription']"}),
+            'subscription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Subscription']"}),
+            'web_user': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True'})
+        },
+        u'django_prbac.role': {
+            'Meta': {'object_name': 'Role'},
+            'description': ('django.db.models.fields.TextField', [], {'default': "u''", 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'parameters': ('django_prbac.fields.StringSetField', [], {'default': '[]', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '256'})
+        }
+    }
+
+    complete_apps = ['accounting']

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -818,6 +818,11 @@ class Invoice(models.Model):
         credit_lines = CreditLine.get_credits_for_invoice(self)
         CreditLine.apply_credits_toward_balance(credit_lines, current_total, dict(invoice=self))
 
+    @classmethod
+    def exists_for_domain(cls, domain):
+        # todo return cls.objects.filter(subscription__subscriber__domain=domain).exists()
+        return True
+
 
 class SubscriptionAdjustment(models.Model):
     """

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -171,7 +171,9 @@ class BillingAccountAdmin(models.Model):
         if account is None:
             return web_user.is_domain_admin(domain), None
         admin = account.billing_admins.filter(web_user=web_user.username)
-        return admin.count() > 0, account
+        is_billing_admin = (admin.count() > 0
+                            and web_user.is_domainB_admin(domain))
+        return is_billing_admin, account
 
 
 class BillingAccount(models.Model):

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -995,8 +995,6 @@ class CreditLine(models.Model):
     """
     account = models.ForeignKey(BillingAccount, on_delete=models.PROTECT)
     subscription = models.ForeignKey(Subscription, on_delete=models.PROTECT, null=True, blank=True)
-    product_rate = models.ForeignKey(SoftwareProductRate, on_delete=models.PROTECT, null=True, blank=True)
-    feature_rate = models.ForeignKey(FeatureRate, on_delete=models.PROTECT, null=True, blank=True)
     product_type = models.CharField(max_length=25, null=True, blank=True,
                                     choices=SoftwareProductType.CHOICES)
     feature_type = models.CharField(max_length=10, null=True, blank=True,

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -22,7 +22,7 @@ from dimagi.utils.couch.database import SafeSaveDocument
 
 from corehq.apps.accounting.exceptions import (CreditLineError, AccountingError, SubscriptionAdjustmentError,
                                                SubscriptionChangeError, NewSubscriptionError)
-from corehq.apps.accounting.utils import EXCHANGE_RATE_DECIMAL_PLACES, assure_domain_instance, get_change_status
+from corehq.apps.accounting.utils import EXCHANGE_RATE_DECIMAL_PLACES, ensure_domain_instance, get_change_status
 
 global_logger = logging.getLogger(__name__)
 integer_field_validators = [MaxValueValidator(2147483647), MinValueValidator(-2147483648)]
@@ -444,7 +444,7 @@ class DefaultProductPlan(models.Model):
 
     @classmethod
     def get_default_plan_by_domain(cls, domain, edition=None):
-        domain = assure_domain_instance(domain)
+        domain = ensure_domain_instance(domain)
         edition = edition or SoftwarePlanEdition.COMMUNITY
         product_type = SoftwareProductType.get_type_by_domain(domain)
         try:
@@ -706,7 +706,7 @@ class Subscription(models.Model):
         """
         Returns SoftwarePlanVersion, Subscription for the given domain.
         """
-        domain_obj = assure_domain_instance(domain)
+        domain_obj = ensure_domain_instance(domain)
         if domain_obj is None:
             plan_version = DefaultProductPlan.objects.get(edition=SoftwarePlanEdition.COMMUNITY,
                                                           product_type=SoftwareProductType.COMMCARE).plan.get_version()

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -769,6 +769,7 @@ class Invoice(models.Model):
     date_received = models.DateField(blank=True, db_index=True, null=True)
     date_start = models.DateField()
     date_end = models.DateField()
+    is_hidden = models.BooleanField(default=False)
 
     @property
     def subtotal(self):
@@ -872,8 +873,9 @@ class BillingRecord(models.Model):
     This stores any interaction we have with the client in sending a physical / pdf invoice to their contact email.
     """
     invoice = models.ForeignKey(Invoice, on_delete=models.PROTECT)
-    date_emailed = models.DateField(auto_now_add=True, db_index=True)
+    date_created = models.DateField(auto_now_add=True, db_index=True)
     emailed_to = models.CharField(max_length=254, db_index=True)
+    skipped_email = models.BooleanField(default=False)
     pdf_data_id = models.CharField(max_length=48)
 
     @property

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1052,7 +1052,8 @@ class CreditLine(models.Model):
                     'balance': self.balance,
                 })
 
-    def adjust_credit_balance(self, amount, is_new=False, note=None, line_item=None, invoice=None):
+    def adjust_credit_balance(self, amount, is_new=False, note=None,
+                              line_item=None, invoice=None):
         reason = CreditAdjustmentReason.MANUAL
         note = note or ""
         if line_item is not None and invoice is not None:
@@ -1156,7 +1157,9 @@ class CreditLine(models.Model):
             if balance == Decimal('0.0000'):
                 return
             if balance <= Decimal('0.0000'):
-                raise CreditLineError("A balance went below zero dollars when applying credits.")
+                raise CreditLineError(
+                    "A balance went below zero dollars when applying credits."
+                )
             adjustment_amount = min(credit_line.balance, balance)
             if adjustment_amount > Decimal('0.0000'):
                 credit_line.adjust_credit_balance(-adjustment_amount, **adjust_balance_kwarg)

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -172,7 +172,7 @@ class BillingAccountAdmin(models.Model):
             return web_user.is_domain_admin(domain), None
         admin = account.billing_admins.filter(web_user=web_user.username)
         is_billing_admin = (admin.count() > 0
-                            and web_user.is_domainB_admin(domain))
+                            and web_user.is_domain_admin(domain))
         return is_billing_admin, account
 
 

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1065,8 +1065,10 @@ class CreditLine(models.Model):
     def get_credits_for_line_item(cls, line_item):
         return cls.get_credits_by_subscription_and_features(
             line_item.invoice.subscription,
-            product_type=line_item.product_rate.product.product_type,
-            feature_type=line_item.feature_rate.feature.feature_type,
+            product_type=(line_item.product_rate.product.product_type
+                          if line_item.product_rate is not None else None),
+            feature_type=(line_item.feature_rate.feature.feature_type
+                          if line_item.feature_rate is not None else None),
         )
 
     @classmethod

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -739,8 +739,10 @@ class Subscription(models.Model):
         return plan_version, subscription
     
     @classmethod
-    def new_domain_subscription(cls, account, domain, plan_version, date_start=None, adjustment_method=None,
-                                note=None, web_user=None, **kwargs):
+    def new_domain_subscription(cls, account, domain, plan_version,
+                                date_start=None, date_end=None, note=None,
+                                web_user=None, adjustment_method=None,
+                                **kwargs):
         subscriber = Subscriber.objects.get_or_create(domain=domain, organization=None)[0]
         today = datetime.date.today()
         future_subscriptions = Subscription.objects.filter(
@@ -765,6 +767,7 @@ class Subscription(models.Model):
             plan_version=plan_version,
             subscriber=subscriber,
             date_start=date_start or datetime.date.today(),
+            date_end=date_end,
             **kwargs
         )
         subscription.save()

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1032,9 +1032,9 @@ class CreditLine(models.Model):
                     'level': credit_level,
                     'account_id': self.account.id,
                     'feature': (' for Feature %s' % self.feature_type
-                                if self.feature_type is None else ""),
+                                if self.feature_type is not None else ""),
                     'product': (' for Product %s' % self.product_type
-                                if self.product_type is None else ""),
+                                if self.product_type is not None else ""),
                     'balance': self.balance,
                 })
 

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1127,7 +1127,6 @@ class CreditLine(models.Model):
     def add_feature_credit(cls, amount, account, feature_type,
                            subscription=None, note=None):
         cls._validate_add_amount(amount)
-        print "adding feature credit %s" % feature_type
         credit_line, is_created = cls.objects.get_or_create(
             account=account,
             subscription=subscription,

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -895,7 +895,7 @@ class BillingRecord(models.Model):
     This stores any interaction we have with the client in sending a physical / pdf invoice to their contact email.
     """
     invoice = models.ForeignKey(Invoice, on_delete=models.PROTECT)
-    date_created = models.DateField(auto_now_add=True, db_index=True)
+    date_created = models.DateTimeField(auto_now_add=True, db_index=True)
     emailed_to = models.CharField(max_length=254, db_index=True)
     skipped_email = models.BooleanField(default=False)
     pdf_data_id = models.CharField(max_length=48)

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -546,6 +546,23 @@ class SoftwarePlanVersion(models.Model):
         if self.user_feature is not None:
             return "USD %d" % self.user_feature.per_excess_fee
 
+    def feature_charges_exist_for_domain(self, domain,
+                                         start_date=None, end_date=None):
+        domain = ensure_domain_instance(domain)
+        if domain is None:
+            return False
+        from corehq.apps.accounting.usage import FeatureUsageCalculator
+        for feature_rate in self.feature_rates.all():
+            # -1 is the special infinity charge
+            if feature_rate.monthly_limit != -1:
+                calc = FeatureUsageCalculator(
+                    feature_rate, domain.name, start_date=start_date,
+                    end_date=end_date
+                )
+                if calc.get_usage() > feature_rate.monthly_limit:
+                    return True
+        return False
+
 
 class SubscriberManager(models.Manager):
 

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -2,17 +2,16 @@ from celery.schedules import crontab
 from celery.task import task, periodic_task
 from celery.utils.log import get_task_logger
 import datetime
-from django.core.exceptions import ObjectDoesNotExist
 from corehq import Domain
 from corehq.apps.accounting import utils
-from corehq.apps.accounting.invoicing import SubscriptionInvoiceFactory, CommunityInvoiceFactory
+from corehq.apps.accounting.exceptions import InvoiceError, CreditLineError
+from corehq.apps.accounting.invoicing import DomainInvoiceFactory
 
 from corehq.apps.accounting.models import Subscription
 from corehq.apps.accounting.utils import has_subscription_already_ended
-from corehq.apps.orgs.models import Organization
 from dimagi.utils.couch.database import iter_docs
 
-logging = get_task_logger(__name__)
+logger = get_task_logger(__name__)
 
 
 @periodic_task(run_every=crontab(minute=0, hour=0))
@@ -47,35 +46,18 @@ def generate_invoices(based_on_date=None):
     """
     today = based_on_date or datetime.date.today()
     invoice_start, invoice_end = utils.get_previous_month_date_range(today)
-    invoiceable_subscriptions = Subscription.objects.filter(date_start__lt=invoice_end,
-                                                            date_end__gt=invoice_start).all()
-
-    def _create_invoice(sub):
-        invoice_factory = SubscriptionInvoiceFactory(invoice_start, invoice_end, sub)
-        invoice_factory.create()
-
-    invoiced_orgs = []
-    orgs = Organization.get_db().view('orgs/by_name', group=True, group_level=1).all()
-    org_names = [o['key'] for o in orgs]
-    for org_name in org_names:
-        try:
-            subscription = invoiceable_subscriptions.get(subscriber__organization=org_name)
-        except ObjectDoesNotExist:
-            continue
-        _create_invoice(subscription)
-        invoiced_orgs.append(org_name)
 
     all_domain_ids = [d['id'] for d in Domain.get_all(include_docs=False)]
     for domain_doc in iter_docs(Domain.get_db(), all_domain_ids):
-        domain_name = domain_doc['name']
-        domain_org = domain_doc['organization']
+        domain = Domain.wrap(domain_doc)
         try:
-            subscription = invoiceable_subscriptions.get(subscriber__domain=domain_name)
-        except ObjectDoesNotExist:
-            if domain_org not in invoiced_orgs:
-                domain = Domain.wrap(domain_doc)
-                invoice_factory = CommunityInvoiceFactory(invoice_start, invoice_end, domain)
-                invoice_factory.create()
-            continue
-        _create_invoice(subscription)
+            invoice_factory = DomainInvoiceFactory(invoice_start, invoice_end, domain)
+            invoice_factory.create_invoices()
+        except CreditLineError as e:
+            logger.error("There was an error utilizing credits for "
+                         "domain %s: %s" % (domain.name, e))
+        except InvoiceError as e:
+            logger.error("Could not create invoice for domain %s: %s" % (
+                domain.name, e
+            ))
 

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -32,7 +32,7 @@ def deactivate_subscriptions(based_on_date=None):
     """
     Deactivates all subscriptions ending yesterday (or, for testing, based on the date specified)
     """
-    ending_date = based_on_date or (datetime.date.today() - datetime.timedelta(hours=24))
+    ending_date = based_on_date or datetime.date.today()
     ending_subscriptions = Subscription.objects.filter(date_end=ending_date)
     for subscription in ending_subscriptions:
         subscription.is_active = False

--- a/corehq/apps/accounting/templates/accounting/credits_tab.html
+++ b/corehq/apps/accounting/templates/accounting/credits_tab.html
@@ -26,15 +26,15 @@
                     </td>
                     {% endif %}
                     <td>
-                        {% if credit.product_rate %}
-                        {{ credit.product_rate }}
+                        {% if credit.product_type %}
+                        {{ credit.product_type }}
                         {% else %}
                         --
                         {% endif %}
                     </td>
                     <td>
-                        {% if credit.feature_rate %}
-                        {{ credit.feature_rate }}
+                        {% if credit.feature_type %}
+                        {{ credit.feature_type }}
                         {% else %}
                         --
                         {% endif %}

--- a/corehq/apps/accounting/templates/accounting/trigger_invoice.html
+++ b/corehq/apps/accounting/templates/accounting/trigger_invoice.html
@@ -1,0 +1,24 @@
+{% extends 'hqwebapp/base_section.html' %}
+{% load crispy_forms_tags %}
+{% load hq_shared_tags %}
+
+{% block head %} {{ block.super }}
+    <link rel="stylesheet" href="{% static 'hqwebapp/js/lib/jquery-ui-datepicker/datepicker-theme/jquery-ui-1.8.17.custom.css' %}" />
+    <link href="{% static 'hqwebapp/js/lib/select2/select2.css' %}" rel="stylesheet"/>
+{% endblock %}
+
+{% block js %}{{ block.super }}
+    <script src="{% static 'hqwebapp/js/lib/select2/select2.js' %}"></script>
+    <script src="{% static 'accounting/js/accounting.billing_info_handler.js' %}"></script>
+{% endblock %}
+
+{% block js-inline %}{{ block.super }}
+    <script type="text/javascript">
+        var domain_handler = new AsyncSelect2Handler('domain');
+        domain_handler.init();
+    </script>
+{% endblock %}
+
+{% block main_column %}
+    {% crispy trigger_form %}
+{% endblock %}

--- a/corehq/apps/accounting/tests/__init__.py
+++ b/corehq/apps/accounting/tests/__init__.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from .test_models import *
 from .test_invoicing import *
+from .test_invoice_factory import *
 from .test_credit_lines import *
 from .test_subscription_changes import *
 

--- a/corehq/apps/accounting/tests/test_invoice_factory.py
+++ b/corehq/apps/accounting/tests/test_invoice_factory.py
@@ -1,0 +1,115 @@
+import datetime
+from corehq.apps.accounting import generator
+from corehq.apps.accounting.invoicing import DomainInvoiceFactory
+from corehq.apps.accounting.models import DefaultProductPlan, BillingAccount, Subscription, SubscriptionAdjustment
+from corehq.apps.accounting.tests.base_tests import BaseAccountingTest
+from corehq.apps.accounting.utils import get_previous_month_date_range
+
+
+class TestDomainInvoiceFactory(BaseAccountingTest):
+
+    def setUp(self):
+        super(TestDomainInvoiceFactory, self).setUp()
+        self.invoice_start, self.invoice_end = get_previous_month_date_range()
+
+        self.domain = generator.arbitrary_domain()
+        self.account = BillingAccount.get_or_create_account_by_domain(
+            domain=self.domain.name, created_by="TEST"
+        )[0]
+        self.community = DefaultProductPlan.get_default_plan_by_domain(
+            self.domain).plan.get_version()
+        generator.arbitrary_commcare_users_for_domain(
+            self.domain.name, self.community.user_limit + 1
+        )
+
+        self.invoice_factory = DomainInvoiceFactory(
+            self.invoice_start, self.invoice_end, self.domain
+        )
+
+    def _clean_subs(self):
+        SubscriptionAdjustment.objects.all().delete()
+        Subscription.objects.all().delete()
+
+    def test_feature_charges(self):
+        domain_under_limits = generator.arbitrary_domain()
+        self.assertTrue(self.community.feature_charges_exist_for_domain(self.domain))
+        self.assertFalse(self.community.feature_charges_exist_for_domain(domain_under_limits))
+
+    def test_incomplete_starting_coverage(self):
+        some_plan = generator.arbitrary_subscribable_plan()
+        subscription = Subscription.new_domain_subscription(
+            self.account, self.domain, some_plan,
+            date_start=self.invoice_start + datetime.timedelta(days=3)
+        )
+        subscriptions = self.invoice_factory.get_subscriptions()
+        community_ranges = self.invoice_factory.get_community_ranges(subscriptions)
+        self.assertEqual(len(community_ranges), 1)
+        self.assertEqual(community_ranges[0][0], self.invoice_start)
+        self.assertEqual(community_ranges[0][1], subscription.date_start)
+        self._clean_subs()
+
+    def test_incomplete_ending_coverage(self):
+        some_plan = generator.arbitrary_subscribable_plan()
+        subscription = Subscription.new_domain_subscription(
+            self.account, self.domain, some_plan,
+            date_start=self.invoice_start,
+            date_end=self.invoice_end - datetime.timedelta(days=3)
+        )
+        subscriptions = self.invoice_factory.get_subscriptions()
+        community_ranges = self.invoice_factory.get_community_ranges(subscriptions)
+        self.assertEqual(len(community_ranges), 1)
+        self.assertEqual(community_ranges[0][0], subscription.date_end)
+        self.assertEqual(community_ranges[0][1],
+                         self.invoice_end + datetime.timedelta(days=1))
+        self._clean_subs()
+
+    def test_patchy_coverage(self):
+        some_plan = generator.arbitrary_subscribable_plan()
+        middle_date = self.invoice_end - datetime.timedelta(days=15)
+        Subscription.new_domain_subscription(
+            self.account, self.domain, some_plan,
+            date_start=self.invoice_start + datetime.timedelta(days=1),
+            date_end=middle_date
+        )
+        next_start = middle_date + datetime.timedelta(days=2)
+        next_end = next_start + datetime.timedelta(days=2)
+        Subscription.new_domain_subscription(
+            self.account, self.domain, some_plan,
+            date_start=next_start,
+            date_end=next_end,
+        )
+        final_start = next_end + datetime.timedelta(days=2)
+        Subscription.new_domain_subscription(
+            self.account, self.domain, some_plan,
+            date_start=final_start,
+            date_end=self.invoice_end - datetime.timedelta(days=1),
+        )
+        subscriptions = self.invoice_factory.get_subscriptions()
+        self.assertEqual(len(subscriptions), 3)
+        community_ranges = self.invoice_factory.get_community_ranges(subscriptions)
+        self.assertEqual(len(community_ranges), 4)
+        self._clean_subs()
+
+    def test_full_coverage(self):
+        some_plan = generator.arbitrary_subscribable_plan()
+        Subscription.new_domain_subscription(
+            self.account, self.domain, some_plan,
+            date_start=self.invoice_start,
+            date_end=self.invoice_end + datetime.timedelta(days=1),
+        )
+        subscriptions = self.invoice_factory.get_subscriptions()
+        community_ranges = self.invoice_factory.get_community_ranges(subscriptions)
+        self.assertEqual(len(community_ranges), 0)
+        self._clean_subs()
+
+    def test_no_coverage(self):
+        subscriptions = self.invoice_factory.get_subscriptions()
+        self.assertEqual(len(subscriptions), 0)
+        community_ranges = self.invoice_factory.get_community_ranges(subscriptions)
+        self.assertEqual(len(community_ranges), 1)
+
+
+
+
+
+

--- a/corehq/apps/accounting/tests/test_invoicing.py
+++ b/corehq/apps/accounting/tests/test_invoicing.py
@@ -13,7 +13,7 @@ from corehq.apps.accounting import generator, tasks, utils
 from corehq.apps.accounting.models import (
     Invoice, FeatureType, LineItem, Subscriber, DefaultProductPlan,
     CreditAdjustment, CreditLine, SubscriptionAdjustment, SoftwareProductType,
-    SoftwarePlanEdition, BillingRecord,
+    SoftwarePlanEdition, BillingRecord, BillingAccount,
 )
 
 
@@ -109,7 +109,10 @@ class TestInvoice(BaseInvoiceTestCase):
         """
         domain = generator.arbitrary_domain()
         generator.create_excess_community_users(domain)
-
+        account = BillingAccount.get_or_create_account_by_domain(
+            domain, created_by=self.dimagi_user)[0]
+        billing_contact = generator.arbitrary_contact_info(account, self.dimagi_user)
+        billing_contact.save()
         tasks.generate_invoices()
         subscriber = Subscriber.objects.get(domain=domain.name)
         invoices = Invoice.objects.filter(subscription__subscriber=subscriber)
@@ -117,52 +120,11 @@ class TestInvoice(BaseInvoiceTestCase):
         invoice = invoices.get()
         self.assertEqual(invoice.subscription.subscriber.domain, domain.name)
         self.assertEqual(invoice.subscription.date_start, invoice.date_start)
-        self.assertEqual(invoice.subscription.date_end, invoice.date_end)
+        self.assertEqual(
+            invoice.subscription.date_end - datetime.timedelta(days=1),
+            invoice.date_end
+        )
         domain.delete()
-
-    def test_use_prev_billing_account_for_community_invoice(self):
-        """
-        Make sure that if a billing account was already auto generated for a previous community invoice,
-        that a new one is not created.
-        """
-        domain = generator.arbitrary_domain()
-        generator.create_excess_community_users(domain)
-
-        second_invoicing_date = datetime.date.today()
-        second_invoice_start, second_invoice_end = utils.get_previous_month_date_range(second_invoicing_date)
-        first_invoicing_date = second_invoice_start - datetime.timedelta(days=random.randint(0, 365))
-
-        tasks.generate_invoices(first_invoicing_date)
-        tasks.generate_invoices(second_invoicing_date)
-        subscriber = Subscriber.objects.get(domain=domain.name)
-        invoices = Invoice.objects.filter(subscription__subscriber=subscriber)
-        self.assertEqual(invoices.count(), 2)
-        invoices = invoices.all()
-        self.assertNotEqual(invoices[0].subscription, invoices[1].subscription)
-        self.assertEqual(invoices[0].subscription.account, invoices[1].subscription.account)
-        for invoice in invoices:
-            self.assertEqual(invoice.subscription.subscriber.domain, domain.name)
-        domain.delete()
-
-    def test_product_plan_for_community_invoices(self):
-        """
-        Make sure that the different product domains get the different community plans by product type.
-        """
-        domains_by_product = generator.arbitrary_domains_by_product_type()
-        for domain in domains_by_product.values():
-            generator.create_excess_community_users(domain)
-
-        tasks.generate_invoices()
-        for product_type, domain in domains_by_product.items():
-            subscriber = Subscriber.objects.get(domain=domain.name)
-            self.assertEqual(subscriber.subscription_set.count(), 1)
-            subscription = subscriber.subscription_set.get()
-            self.assertEqual(subscription.invoice_set.count(), 1)
-            expected_community_plan = DefaultProductPlan.get_default_plan_by_domain(domain)
-            self.assertEqual(
-                subscription.plan_version.plan, expected_community_plan.plan
-            )
-            domain.delete()
 
 
 class TestProductLineItem(BaseInvoiceTestCase):
@@ -237,35 +199,6 @@ class TestProductLineItem(BaseInvoiceTestCase):
 
             # no adjustments
             self.assertEqual(product_line_item.total, product_line_item.unit_cost * product_line_item.quantity)
-
-    def test_community(self):
-        """
-        For Community plans (plan monthly fee is 0.0) that incur other rate charges, like users or SMS messages,
-        make sure that the following is true:
-        - base_description is None
-        - unit_description is None
-        - unit_cost is equal to 0
-        - quantity is equal to 0
-        - total and subtotal are 0.0
-        """
-        domain = generator.arbitrary_domain()
-        generator.create_excess_community_users(domain)
-
-        tasks.generate_invoices()
-        subscriber = Subscriber.objects.get(domain=domain.name)
-        invoice = Invoice.objects.filter(subscription__subscriber=subscriber).get()
-
-        product_line_items = invoice.lineitem_set.filter(feature_rate__exact=None)
-        self.assertEqual(product_line_items.count(), 1)
-        product_line_item = product_line_items.get()
-        self.assertIsNotNone(product_line_item.base_description)
-        self.assertIsNone(product_line_item.unit_description)
-        self.assertEqual(product_line_item.unit_cost, Decimal('0.0000'))
-        self.assertEqual(product_line_item.quantity, 1)
-        self.assertEqual(product_line_item.subtotal, Decimal('0.0000'))
-        self.assertEqual(product_line_item.total, Decimal('0.0000'))
-
-        domain.delete()
 
 
 class TestUserLineItem(BaseInvoiceTestCase):
@@ -351,6 +284,11 @@ class TestUserLineItem(BaseInvoiceTestCase):
         """
         domain = generator.arbitrary_domain()
         num_active = generator.create_excess_community_users(domain)
+
+        account = BillingAccount.get_or_create_account_by_domain(
+            domain, created_by=self.dimagi_user)[0]
+        billing_contact = generator.arbitrary_contact_info(account, self.dimagi_user)
+        billing_contact.save()
 
         tasks.generate_invoices()
         subscriber = Subscriber.objects.get(domain=domain.name)
@@ -449,44 +387,6 @@ class TestSmsLineItem(BaseInvoiceTestCase):
         self.assertGreater(sms_line_item.total, Decimal('0.0000'))
 
         self._delete_sms_billables()
-
-    def test_community_over_limit(self):
-        """
-        For a domain under community (no subscription) with SMS over the community limit, make sure that:
-        - base_description is None
-        - base_cost is 0.0
-        - unit_description is not None
-        - unit_cost is greater than 0.0
-        - quantity is equal to 1
-        - total and subtotals are greater than zero
-        """
-        domain = generator.arbitrary_domain()
-        invoice_date = datetime.date.today()
-        sms_date = utils.months_from_date(invoice_date, -1)
-
-        num_sms = random.randint(1, 5)
-        generator.arbitrary_sms_billables_for_domain(
-            domain.name, INCOMING, sms_date, num_sms
-        )
-
-        tasks.generate_invoices(invoice_date)
-        subscriber = Subscriber.objects.get(domain=domain.name)
-        invoice = Invoice.objects.filter(subscription__subscriber=subscriber).get()
-        sms_line_item = invoice.lineitem_set.get_feature_by_type(FeatureType.SMS).get()
-
-        # there is no base cost
-        self.assertIsNone(sms_line_item.base_description)
-        self.assertEqual(sms_line_item.base_cost, Decimal('0.0000'))
-
-        self.assertEqual(sms_line_item.quantity, 1)
-        self.assertGreater(sms_line_item.unit_cost, Decimal('0.0000'))
-        self.assertIsNotNone(sms_line_item.unit_description)
-
-        self.assertGreater(sms_line_item.subtotal, Decimal('0.0000'))
-        self.assertGreater(sms_line_item.total, Decimal('0.0000'))
-
-        self._delete_sms_billables()
-        domain.delete()
 
     def _delete_sms_billables(self):
         SmsBillable.objects.all().delete()

--- a/corehq/apps/accounting/urls.py
+++ b/corehq/apps/accounting/urls.py
@@ -5,6 +5,8 @@ from corehq.apps.accounting.views import *
 
 urlpatterns = patterns('corehq.apps.accounting.views',
     url(r'^$', 'accounting_default', name='accounting_default'),
+    url(r'^trigger_invoice/$', TriggerInvoiceView.as_view(),
+        name=TriggerInvoiceView.urlname),
     url(r'^accounts/(\d+)/$', ManageBillingAccountView.as_view(), name=ManageBillingAccountView.urlname),
     url(r'^accounts/new/$', NewBillingAccountView.as_view(), name=NewBillingAccountView.urlname),
     url(r'^subscriptions/(\d+)/$', EditSubscriptionView.as_view(), name=EditSubscriptionView.urlname),

--- a/corehq/apps/accounting/usage.py
+++ b/corehq/apps/accounting/usage.py
@@ -5,10 +5,10 @@ from corehq.apps.smsbillables.models import SmsBillable
 from corehq.apps.users.models import CommCareUser
 
 
-class FeatureUsage(object):
+class FeatureUsageCalculator(object):
 
     def __init__(self, feature_rate, domain_name):
-        super(FeatureUsage, self).__init__()
+        super(FeatureUsageCalculator, self).__init__()
         self.feature_rate = feature_rate
         self.domain = domain_name
 

--- a/corehq/apps/accounting/usage.py
+++ b/corehq/apps/accounting/usage.py
@@ -7,10 +7,17 @@ from corehq.apps.users.models import CommCareUser
 
 class FeatureUsageCalculator(object):
 
-    def __init__(self, feature_rate, domain_name):
+    def __init__(self, feature_rate, domain_name,
+                 start_date=None, end_date=None):
         super(FeatureUsageCalculator, self).__init__()
         self.feature_rate = feature_rate
         self.domain = domain_name
+        today = datetime.date.today()
+        last_day = calendar.monthrange(today.year, today.month)[1]
+        self.start_date = start_date or datetime.date(
+            today.year, today.month, 1)
+        self.end_date = end_date or datetime.date(
+            today.year, today.month, last_day)
 
     def get_usage(self):
         try:
@@ -25,12 +32,8 @@ class FeatureUsageCalculator(object):
         return CommCareUser.total_by_domain(self.domain, is_active=True)
 
     def _get_sms_usage(self):
-        today = datetime.date.today()
-        _, last_day = calendar.monthrange(today.year, today.month)
-        first_of_month = datetime.date(today.year, today.month, 1)
-        last_of_month = datetime.date(today.year, today.month, last_day)
         return SmsBillable.objects.filter(
             domain__exact=self.domain,
             is_valid=True,
-            date_sent__range=[first_of_month, last_of_month]
+            date_sent__range=[self.start_date, self.end_date]
         ).count()

--- a/corehq/apps/accounting/utils.py
+++ b/corehq/apps/accounting/utils.py
@@ -28,7 +28,7 @@ def months_from_date(reference_date, months_from_date):
     return datetime.date(year, month, 1)
 
 
-def assure_domain_instance(domain):
+def ensure_domain_instance(domain):
     if not isinstance(domain, Domain):
         domain = Domain.get_by_name(domain)
     return domain

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -793,8 +793,8 @@ class ConfirmNewSubscriptionForm(EditBillingAccountInfoForm):
             else:
                 subscription = Subscription.new_domain_subscription(
                     self.account, self.domain, self.plan_version,
-                    web_user=self.creating_user, adjustment_method=SubscriptionAdjustmentMethod.USER
-                )
+                    web_user=self.creating_user,
+                    adjustment_method=SubscriptionAdjustmentMethod.USER)
                 subscription.is_active = True
                 if subscription.plan_version.plan.edition == SoftwarePlanEdition.ENTERPRISE:
                     # this point can only be reached if the initiating user was a superuser

--- a/corehq/apps/domain/templates/domain/billing_statements.html
+++ b/corehq/apps/domain/templates/domain/billing_statements.html
@@ -1,0 +1,7 @@
+{% extends "settings/base_template.html" %}
+{% load hq_shared_tags %}
+{% load i18n %}
+
+{% block main_column %}
+Billing Statements!
+{% endblock %}

--- a/corehq/apps/domain/urls.py
+++ b/corehq/apps/domain/urls.py
@@ -14,7 +14,7 @@ from corehq.apps.domain.views import (EditBasicProjectInfoView, EditDeploymentPr
                                       BasicCommTrackSettingsView, AdvancedCommTrackSettingsView, OrgSettingsView,
                                       DomainSubscriptionView, SelectPlanView, ConfirmSelectedPlanView,
                                       SelectedEnterprisePlanView, ConfirmBillingAccountInfoView, ProBonoView,
-                                      EditExistingBillingAccountView)
+                                      EditExistingBillingAccountView, DomainBillingStatementsView)
 
 #
 # After much reading, I discovered that Django matches URLs derived from the environment
@@ -88,6 +88,8 @@ domain_settings = patterns(
     url(r'^subscription/change/account/$', ConfirmBillingAccountInfoView.as_view(),
         name=ConfirmBillingAccountInfoView.urlname),
     url(r'^subscription/pro_bono/$', ProBonoView.as_view(), name=ProBonoView.urlname),
+    url(r'^billing/statements/$', DomainBillingStatementsView.as_view(),
+        name=DomainBillingStatementsView.urlname),
     url(r'^subscription/$', DomainSubscriptionView.as_view(), name=DomainSubscriptionView.urlname),
     url(r'^billing_information/$', EditExistingBillingAccountView.as_view(), name=EditExistingBillingAccountView.urlname),
     url(r'^deployment/$', EditDeploymentProjectInfoView.as_view(), name=EditDeploymentProjectInfoView.urlname),

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -29,7 +29,7 @@ from corehq.apps.accounting.models import (
     DefaultProductPlan, SoftwarePlanEdition, BillingAccount,
     BillingAccountType, BillingAccountAdmin
 )
-from corehq.apps.accounting.usage import FeatureUsage
+from corehq.apps.accounting.usage import FeatureUsageCalculator
 from corehq.apps.accounting.user_text import get_feature_name, PricingTable, DESC_BY_EDITION, PricingTableFeatures
 from corehq.apps.hqwebapp.models import ProjectSettingsTab
 from corehq.apps import receiverwrapper
@@ -572,7 +572,7 @@ class DomainSubscriptionView(DomainAccountingSettings):
     def get_feature_summary(self, plan_version, subscription):
         feature_summary = []
         for feature_rate in plan_version.feature_rates.all():
-            usage = FeatureUsage(feature_rate, self.domain).get_usage()
+            usage = FeatureUsageCalculator(feature_rate, self.domain).get_usage()
             feature_info = {
                 'name': get_feature_name(feature_rate.feature.feature_type, self.product),
                 'usage': usage,

--- a/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
+++ b/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
@@ -29,9 +29,14 @@ class Command(BaseCommand):
                     help='Enable debug output'),
         make_option('--fresh-start', action='store_true',  default=False,
                     help='We changed the core v0 plans, wipe all existing plans and start over. USE CAUTION.'),
+        make_option('--testing', action='store_true',  default=False,
+                    help='Run this command for tests.'),
     )
 
-    def handle(self, dry_run=False, verbose=False, fresh_start=False, *args, **options):
+    def handle(self, dry_run=False, verbose=False, fresh_start=False, testing=False, *args, **options):
+        if testing:
+            logging.disable(logging.ERROR)
+
         if verbose:
             logger.setLevel(logging.DEBUG)
 

--- a/corehq/apps/hqwebapp/models.py
+++ b/corehq/apps/hqwebapp/models.py
@@ -1155,6 +1155,21 @@ class AccountingTab(UITab):
         except UserRole.DoesNotExist:
             return False
 
+    @property
+    @memoized
+    def sidebar_items(self):
+        items = super(AccountingTab, self).sidebar_items
+
+        if toggles.INVOICE_TRIGGER.enabled(self.couch_user.username):
+            from corehq.apps.accounting.views import TriggerInvoiceView
+            items.append(('Other Actions', (
+                {
+                    'title': TriggerInvoiceView.page_title,
+                    'url': reverse(TriggerInvoiceView.urlname),
+                },
+            )))
+        return items
+
 
 class SMSAdminTab(UITab):
     title = ugettext_noop("SMS Connectivity")

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -68,6 +68,12 @@ ACCOUNTING_PREVIEW = StaticToggle(
     [NAMESPACE_DOMAIN, NAMESPACE_USER]
 )
 
+INVOICE_TRIGGER = StaticToggle(
+    'invoice_trigger',
+    'Accounting Trigger Invoices',
+    [NAMESPACE_USER]
+)
+
 OFFLINE_CLOUDCARE = StaticToggle(
     'offline-cloudcare',
     'Offline Cloudcare'


### PR DESCRIPTION
Figure I should make a PR before this feature gets any larger.
- fixes some edge cases for incomplete coverage months and community invoice generation
- changes how community invoices are generated
- adds a skeleton view for user-facing invoices page (view in another PR)
- adds hook for email (implementation in another PR)
- adds migrations for CreditLines being according to product or feature types rather than a specific rate
- fixes tests to reflect above changes
