### PR TITLE
Remove log silencers from testing runs of bootstrap commands

### DIFF
--- a/corehq/apps/accounting/management/commands/cchq_software_plan_bootstrap.py
+++ b/corehq/apps/accounting/management/commands/cchq_software_plan_bootstrap.py
@@ -44,7 +44,6 @@ class Command(BaseCommand):
         self.for_tests = testing
         if self.for_tests:
             logger.info("Initializing Plans and Roles for Testing")
-            logging.disable(logging.ERROR)
 
         if verbose:
             logger.setLevel(logging.DEBUG)

--- a/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
+++ b/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
@@ -34,8 +34,6 @@ class Command(BaseCommand):
     )
 
     def handle(self, dry_run=False, verbose=False, fresh_start=False, testing=False, *args, **options):
-        if testing:
-            logging.disable(logging.ERROR)
 
         if verbose:
             logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
disabling logging on one test (for bootstrap commands) seems to be affecting the rest of the tests (worked fine locally, but travis seems unhappy)
