### PR TITLE
remove JS cruft adding properties to UserRole docs

### DIFF
--- a/corehq/apps/users/static/users/js/roles.js
+++ b/corehq/apps/users/static/users/js/roles.js
@@ -43,24 +43,6 @@ $(function () {
             }
         };
 
-        function wrapRole(role) {
-            role.permissions.viewReportList = ko.computed({
-                read: function () {
-                    return ko.utils.arrayMap(role.permissions.view_report_list(), function (reportPath) {
-                        return self.getReportObject(reportPath);
-                    });
-                },
-                write: function (reports) {
-                    var reportPaths = ko.utils.arrayMap(reports, function (report) {
-                        return report.path;
-                    });
-                    role.permissions.view_report_list.removeAll();
-                    ko.utils.arrayForEach(reportPaths, function (path) {
-                        role.permissions.view_report_list.push(path);
-                    });
-                }
-            });
-        }
         self.allowEdit = o.allowEdit;
         self.reportOptions = o.reportOptions;
         self.getReportObject = function (path) {
@@ -81,7 +63,6 @@ $(function () {
 
         self.addOrReplaceRole = function (role) {
             var newRole = UserRole.wrap(role);
-            wrapRole(newRole);
             var i;
             for (i = 0; i < self.userRoles().length; i++) {
                 if (ko.utils.unwrapObservable(self.userRoles()[i]._id) === newRole._id()) {


### PR DESCRIPTION
For any role that is edited / created and then edited again (without re-loading the page) this code was adding a `viewReportList` property to the UserRole couch doc.

Code not used though. Seems to be a hangover from here: https://github.com/dimagi/commcare-hq/commit/a8fc52aa286e27853cb1eacd476e221569f0eba3#diff-d019cf4fde5f7774ba81888a0ea57e94L150
