### PR TITLE
Cancel subscription text

### DIFF
--- a/corehq/apps/accounting/templates/accounting/subscriptions.html
+++ b/corehq/apps/accounting/templates/accounting/subscriptions.html
@@ -42,7 +42,9 @@
                 {% crispy cancel_form %}
             </form>
             {% if subscription_canceled %}
-                Subscription has been canceled.
+                <div class="alert">
+                  Subscription has been canceled.
+                </div>
             {% elif disable_cancel %}
                 Subscription has already ended.
             {% endif %}

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -296,7 +296,6 @@ class EditSubscriptionView(AccountingSectionView):
         elif ('cancel_subscription' in self.request.POST
               and self.cancel_form.is_valid()):
             self.cancel_subscription()
-            return HttpResponseRedirect(self.page_url)
         return self.get(request, *args, **kwargs)
 
     def cancel_subscription(self):


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?104201#590987

Fixes a bug where the wrong text gets shown after a subscription is cancelled
