### PR TITLE
Prevent commtrack bootstrap from running twice

### DIFF
--- a/corehq/apps/commtrack/util.py
+++ b/corehq/apps/commtrack/util.py
@@ -82,7 +82,7 @@ def get_or_make_def_program(domain):
 
 
 def bootstrap_commtrack_settings_if_necessary(domain, requisitions_enabled=False):
-    if not(domain and domain.commtrack_enabled and not domain.commtrack_settings):
+    if not(domain and domain.commtrack_enabled and not CommtrackConfig.for_domain(domain.name)):
         return
 
     c = CommtrackConfig(


### PR DESCRIPTION
When switching a domain to CommTrack, this method gets called twice and the settings reference on the domain hasn't been updated yet so duplicate data was being created.
