### PR TITLE
don't do any extra filtering if using a case footprint

### DIFF
--- a/corehq/apps/cloudcare/api.py
+++ b/corehq/apps/cloudcare/api.py
@@ -117,7 +117,7 @@ class CaseAPIHelper(object):
         else:
             base_results = [CaseAPIResult(id=id, id_only=True) for id in case_id_list]
 
-        if self.filters:
+        if self.filters and not self.footprint:
             base_results = filter(_filter, base_results)
 
         link_locations(base_results)

--- a/corehq/apps/cloudcare/tests/test_api.py
+++ b/corehq/apps/cloudcare/tests/test_api.py
@@ -185,10 +185,11 @@ class CaseAPITest(TestCase):
         list = get_filtered_cases(self.domain, user_id=self.test_user_id, status=CASE_STATUS_ALL,
                                   footprint=True,
                                   filters={"properties/case_name": name})
-        self.assertEqual(2, len(list))
-        # make sure at least one doesn't actually have the right property
-        # but was included in the footprint
-        self.assertEqual(1, len([c for c in list if c['properties']['case_name'] != name]))
+        # when filtering with footprint, the filters get intentionally ignored
+        # so just ensure the whole footprint including open and closed is available
+        self.assertEqual(self.expectedOpenByUserWithFootprint + self.expectedClosedByUserWithFootprint, len(list))
+
+
 def _child_case_type(type):
     return "%s-child" % type
 


### PR DESCRIPTION
fixes http://manage.dimagi.com/default.asp?104213

basically the previous footprint behavior was misleading and designed specifically to support parent-child case references in a single form. so when you said `footprint=True` you got all the filtered child cases, and then the footprint (the parents) got added.

however for the commtrack workflow you want the supply point cases, but those are only "owned" by an index reference from the user-location-mapping case, so the initial filter removes that and then the footprint doesn't go find them.

the right behavior (which is what the phone would do) is to just provide the whole casedb, including the footprint, and then let the additional filtering happen in touchforms (which it already does).

this might make certain touchforms usage slower (apps leveraging multiple case types and parent/child case references) but can revisit that if it becomes an issue.
