### PR TITLE
Updates to Admin UI

### DIFF
--- a/corehq/apps/accounting/async_handlers.py
+++ b/corehq/apps/accounting/async_handlers.py
@@ -176,6 +176,7 @@ class Select2SubscriptionInfoHandler(BaseSelect2AsyncHandler):
         'domain',
         'account',
         'plan_version',
+        'new_plan_version',
     ]
 
     @property
@@ -203,6 +204,13 @@ class Select2SubscriptionInfoHandler(BaseSelect2AsyncHandler):
             plan_versions = plan_versions.filter(
                 plan__name__contains=self.search_string)
         return [(p.id, p.__str__()) for p in plan_versions.order_by('plan__name')]
+
+    @property
+    def new_plan_version_response(self):
+        current_version = int(self.data.get('additionalData[current_version]'))
+        plan_versions = filter(lambda x: x[0] != current_version,
+                               self.plan_version_response)
+        return plan_versions
 
 
 class Select2InvoiceTriggerHandler(BaseSelect2AsyncHandler):

--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -416,40 +416,19 @@ class SubscriptionForm(forms.Form):
             web_user=self.web_user,
         )
 
-    def update_subscription(self, subscription):
-        kwargs = {
-            'salesforce_contract_id': self.cleaned_data['salesforce_contract_id'],
-            'do_not_invoice': self.cleaned_data['do_not_invoice'],
-            'web_user': self.web_user,
-        }
+    def update_subscription(self):
+        self.subscription.update_subscription(
+            date_end=self.cleaned_data['end_date'],
+            date_delay_invoicing=self.cleaned_data['delay_invoice_until'],
+            do_not_invoice=self.cleaned_data['do_not_invoice'],
+            salesforce_contract_id=self.cleaned_data['salesforce_contract_id'],
+            web_user=self.web_user
+        )
 
-        if self.fields['start_date'].required:
-            kwargs.update({
-                'date_start': self.cleaned_data['start_date'],
-            })
 
-        if subscription.date_end is None or subscription.date_end > datetime.date.today():
-            kwargs.update({
-                'date_end': self.cleaned_data['end_date'],
-            })
-        else:
-           kwargs.update({
-                'date_end': subscription.date_end,
-            })
 
-        if (subscription.date_delay_invoicing is None
-            or subscription.date_delay_invoicing > datetime.date.today()):
-            kwargs.update({
-                'date_delay_invoicing': self.cleaned_data['delay_invoice_until'],
-            })
-        else:
-            kwargs.update({
-                'date_delay_invoicing': subscription.date_delay_invoicing,
-            })
 
-        new_plan_version = SoftwarePlanVersion.objects.get(id=self.cleaned_data['plan_version'])
 
-        return subscription.change_plan(new_plan_version, **kwargs)
 
 
 class CreditForm(forms.Form):

--- a/corehq/apps/accounting/templates/accounting/subscriptions.html
+++ b/corehq/apps/accounting/templates/accounting/subscriptions.html
@@ -9,15 +9,42 @@
 
 {% block js-inline %}{{ block.super }}
     {% if disable_cancel %}
-        <script>
-            $("#cancel_form :input").attr("disabled", true);
+        <script type="text/javascript">
+            $(function () {
+                $("#cancel_form :input").attr("disabled", true);
+            });
         </script>
     {% endif %}
+    <script type="text/javascript">
+        var new_plan_version = new AsyncSelect2Handler('new_plan_version');
+        new_plan_version.init();
+        new_plan_version.getAdditionalData = function () {
+            return {
+                'product': $('#id_new_plan_product').val(),
+                'edition': $('#id_new_plan_edition').val(),
+                'current_version': '{{ subscription.plan_version.id }}'
+            }
+        };
+        $(function () {
+            var deselectPlanVersion = function () {
+                var $planVer = $('#id_new_plan_version');
+                $planVer.val('');
+                $planVer.select2('val', '');
+            };
+            $('#id_new_plan_product').change(deselectPlanVersion);
+            $('#id_new_plan_edition').change(deselectPlanVersion);
+        });
+    </script>
 {% endblock %}
 
 {% block main_column %}
     <ul class="nav nav-tabs" id="user-settings-tabs">
         <li><a href="#subscription" data-toggle="tab">{% trans "Subscription" %}</a></li>
+        {% if can_change_subscription %}
+        <li><a href="#change-subscription-plan"
+               data-toggle="tab">{% trans "Upgrade / Downgrade" %}</a>
+        </li>
+        {% endif %}
         <li><a href="#credits" data-toggle="tab">{% trans "Credits" %}</a></li>
         <li><a href="#actions" data-toggle="tab">{% trans "Permanent Actions" %}</a></li>
     </ul>
@@ -26,6 +53,18 @@
         <div class="tab-pane" id="subscription">
             {{ block.super }}
         </div>
+
+        {% if can_change_subscription %}
+        <div class="tab-pane" id="change-subscription-plan">
+            <div class="alert alert-info">
+                Note that changing the software plan will cancel the current
+                subscription and create a new one with the new plan information.
+                It will also apply upgrades / downgrades of features
+                between the currently subscribed plan and the plan selected.
+            </div>
+            {% crispy change_subscription_form %}
+        </div>
+        {% endif %}
 
         <div class="tab-pane" id="credits">
             {% include 'accounting/credits_tab.html' %}


### PR DESCRIPTION
- allow ops to change the plan for a subscription without cancellation
- fixes the update plan workflow so that it doesn't create a new subscription if any of the editable dates are updated (that's what `SubscriptionAdjustment` is for)
