### PR TITLE
support ability to run tests in two stages

### DIFF
--- a/corehq/apps/app_manager/tests/test_form_versioning.py
+++ b/corehq/apps/app_manager/tests/test_form_versioning.py
@@ -1,4 +1,4 @@
-from django.utils.unittest.case import TestCase
+from django.test.testcases import TestCase
 from corehq.apps.app_manager import suite_xml
 from corehq.apps.app_manager.models import Application, Module, Form, import_app
 from corehq.apps.app_manager.tests import add_build

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -1,4 +1,4 @@
-from django.utils.unittest.case import TestCase
+from django.test import TestCase
 from corehq.apps.app_manager.models import Application
 from corehq.apps.app_manager.tests.util import TestFileMixin
 from corehq.apps.app_manager.suite_xml import dot_interpolate

--- a/corehq/apps/cloudcare/tests/test_api.py
+++ b/corehq/apps/cloudcare/tests/test_api.py
@@ -1,4 +1,4 @@
-from django.utils.unittest.case import TestCase
+from django.test import TestCase
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.util import post_case_blocks

--- a/corehq/apps/commtrack/tests/test_supply_points.py
+++ b/corehq/apps/commtrack/tests/test_supply_points.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+from django.test import TestCase
 
 from corehq.apps.commtrack.helpers import make_supply_point
 from corehq.apps.commtrack import const

--- a/corehq/apps/commtrack/tests/util.py
+++ b/corehq/apps/commtrack/tests/util.py
@@ -1,4 +1,5 @@
 from xml.etree import ElementTree
+from django.test import TestCase
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.tests import delete_all_cases, delete_all_xforms
 from casexml.apps.case.xml import V2
@@ -12,7 +13,6 @@ from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.commtrack.util import get_default_requisition_config
 from corehq.apps.commtrack.models import CommTrackUser, SupplyPointCase, CommtrackConfig
 from corehq.apps.sms.backend import test
-from django.utils.unittest.case import TestCase
 from corehq.apps.commtrack.helpers import make_supply_point
 from corehq.apps.commtrack.models import Product
 from couchforms.models import XFormInstance

--- a/corehq/apps/groups/tests/test_groups.py
+++ b/corehq/apps/groups/tests/test_groups.py
@@ -1,4 +1,4 @@
-from django.utils.unittest.case import TestCase
+from django.test import TestCase
 from corehq.apps.groups.models import Group
 from corehq.apps.users.models import CommCareUser
 

--- a/corehq/apps/hqcase/tests/test_case_assigment.py
+++ b/corehq/apps/hqcase/tests/test_case_assigment.py
@@ -1,5 +1,5 @@
 import uuid
-from django.utils.unittest.case import TestCase
+from django.test import TestCase
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.util import post_case_blocks

--- a/corehq/apps/hqcase/tests/test_case_sharing.py
+++ b/corehq/apps/hqcase/tests/test_case_sharing.py
@@ -1,4 +1,4 @@
-from django.utils.unittest.case import TestCase
+from django.test import TestCase
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.tests.util import check_user_has_case

--- a/corehq/apps/mobile_auth/tests.py
+++ b/corehq/apps/mobile_auth/tests.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from django.utils.unittest.case import TestCase
+from django.test import TestCase
 from casexml.apps.case.tests import check_xml_line_by_line
 from corehq.apps.mobile_auth.utils import new_key_record, get_mobile_auth_payload
 from dimagi.utils.parsing import json_format_datetime

--- a/corehq/apps/receiverwrapper/tests/test_auth.py
+++ b/corehq/apps/receiverwrapper/tests/test_auth.py
@@ -4,7 +4,7 @@ from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.util import normalize_username
 from couchforms.models import XFormInstance
 import django_digest.test
-from django.utils.unittest.case import TestCase
+from django.test import TestCase
 import os
 from corehq.apps.app_manager.models import Application
 from corehq.apps.domain.shortcuts import create_domain

--- a/corehq/apps/receiverwrapper/tests/test_submissions.py
+++ b/corehq/apps/receiverwrapper/tests/test_submissions.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.utils.unittest.case import TestCase
+from django.test import TestCase
 from corehq.apps.users.models import WebUser
 from corehq.apps.domain.shortcuts import create_domain
 from django.test.client import Client

--- a/corehq/apps/receiverwrapper/tests/test_submit_errors.py
+++ b/corehq/apps/receiverwrapper/tests/test_submit_errors.py
@@ -1,4 +1,4 @@
-from django.utils.unittest.case import TestCase
+from django.test import TestCase
 from corehq.apps.users.models import WebUser
 from corehq.apps.domain.shortcuts import create_domain
 from django.test.client import Client

--- a/corehq/apps/reports/tests/test_cache.py
+++ b/corehq/apps/reports/tests/test_cache.py
@@ -1,6 +1,6 @@
 import uuid
 from django.http import HttpRequest
-from django.utils.unittest.case import TestCase
+from django.test import TestCase
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.reports.cache import CacheableRequestMixIn, request_cache
 from corehq.apps.users.models import WebUser

--- a/corehq/apps/reports/tests/test_case_export.py
+++ b/corehq/apps/reports/tests/test_case_export.py
@@ -1,4 +1,4 @@
-from django.utils.unittest.case import TestCase
+from django.test import TestCase
 from corehq.apps.groups.models import Group
 from corehq.apps.reports.util import case_users_filter, case_group_filter
 from corehq.apps.users.models import CommCareUser

--- a/corehq/apps/reports/tests/test_form_export.py
+++ b/corehq/apps/reports/tests/test_form_export.py
@@ -1,7 +1,7 @@
 from StringIO import StringIO
 import json
 from django.core.urlresolvers import reverse
-from django.utils.unittest.case import TestCase
+from django.test import TestCase
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.reports.models import FormExportSchema
 from corehq.apps.users.models import CommCareUser

--- a/corehq/apps/users/tests/case_utils.py
+++ b/corehq/apps/users/tests/case_utils.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+from django.test import TestCase
 import uuid
 from dimagi.utils.parsing import json_format_datetime
 from casexml.apps.case.mock import CaseBlock

--- a/settings.py
+++ b/settings.py
@@ -444,7 +444,7 @@ CELERY_PERIODIC_QUEUE = 'celery'
 
 SKIP_SOUTH_TESTS = True
 #AUTH_PROFILE_MODULE = 'users.HqUserProfile'
-TEST_RUNNER = 'testrunner.HqTestSuiteRunner'
+TEST_RUNNER = 'testrunner.TwoStageTestRunner'
 # this is what gets appended to @domain after your accounts
 HQ_ACCOUNT_ROOT = "commcarehq.org"
 

--- a/testrunner.py
+++ b/testrunner.py
@@ -1,6 +1,11 @@
+from couchdbkit.ext.django import loading
 from couchdbkit.ext.django.testrunner import CouchDbKitTestSuiteRunner
 from django.conf import settings
+from django.utils import unittest
 import settingshelper
+
+from django.test import TransactionTestCase
+from mock import patch, Mock
 
 
 class HqTestSuiteRunner(CouchDbKitTestSuiteRunner):
@@ -41,14 +46,105 @@ class HqTestSuiteRunner(CouchDbKitTestSuiteRunner):
 
         return super(HqTestSuiteRunner, self).setup_databases(**kwargs)
 
-    def run_tests(self, test_labels, extra_tests=None, **kwargs):
+    def filter_test_labels(self, test_labels):
         if not test_labels:
             test_labels = [self._strip(app) for app in settings.INSTALLED_APPS
                            if not app in settings.APPS_TO_EXCLUDE_FROM_TESTS
-                           and not app.startswith('django.')]
+                and not app.startswith('django.')]
+        return test_labels
+
+    def run_tests(self, test_labels, extra_tests=None, **kwargs):
+        test_labels = self.filter_test_labels(test_labels)
         return super(HqTestSuiteRunner, self).run_tests(
             test_labels, extra_tests, **kwargs
         )
 
     def _strip(self, app_name):
         return app_name.split('.')[-1]
+
+
+class TwoStageTestRunner(HqTestSuiteRunner):
+    """
+    Test runner which splits testing into two stages:
+     - Stage 1 runs all test that don't require DB access (test that don't inherit from TransactionTestCase)
+     - Stage 2 runs all DB tests (test that do inherit from TransactionTestCase)
+
+    Based off http://www.caktusgroup.com/blog/2013/10/02/skipping-test-db-creation/
+    """
+
+    def build_suite(self, *args, **kwargs):
+        """
+        Check if any of the tests to run subclasses TransactionTestCase.
+        """
+        suite = super(TwoStageTestRunner, self).build_suite(*args, **kwargs)
+        simple_tests = unittest.TestSuite()
+        db_tests = unittest.TestSuite()
+        for test in suite:
+            if isinstance(test, TransactionTestCase):
+                db_tests.addTest(test)
+            else:
+                simple_tests.addTest(test)
+        return simple_tests, db_tests
+
+    def setup_mock_database(self):
+        """
+        Ensure that touching the DB raises and error.
+        """
+        self._db_patch = patch('django.db.backends.util.CursorWrapper')
+        db_mock = self._db_patch.start()
+        db_mock.side_effect = RuntimeError('No database present during SimpleTestCase run.')
+
+        mock_couch = Mock(side_effect=RuntimeError('No database present during SimpleTestCase run.'), spec=[])
+
+        # register our dbs with the extension document classes
+        old_handler = loading.couchdbkit_handler
+        for app, value in old_handler.app_schema.items():
+            for name, cls in value.items():
+                cls.set_db(mock_couch)
+
+    def teardown_mock_database(self):
+        """
+        Remove cursor patch.
+        """
+        self._db_patch.stop()
+
+    def run_non_db_tests(self, suite):
+        print("Running {0} tests without database".format(suite.countTestCases()))
+        self.setup_mock_database()
+        result = self.run_suite(suite)
+        self.teardown_mock_database()
+        return self.suite_result(suite, result)
+
+    def run_db_tests(self, suite):
+        print("Running {0} tests with database".format(suite.countTestCases()))
+        old_config = self.setup_databases()
+        result = self.run_suite(suite)
+        self.teardown_databases(old_config)
+        return self.suite_result(suite, result)
+
+    def run_tests(self, test_labels, extra_tests=None, **kwargs):
+        """
+        Run the unit tests in two groups, those that don't need db access
+        first and those that require db access afterwards.
+        """
+        test_labels = self.filter_test_labels(test_labels)
+        self.setup_test_environment()
+        simple_suite, db_suite = self.build_suite(test_labels, extra_tests)
+        failures = 0
+        if simple_suite.countTestCases():
+            failures += self.run_non_db_tests(simple_suite)
+
+        if db_suite.countTestCases():
+            failures += self.run_db_tests(db_suite)
+
+        self.teardown_test_environment()
+        return failures
+
+
+class NonDbOnlyTestRunner(TwoStageTestRunner):
+    """
+    Override run_db_test to do nothing.
+    """
+    def run_db_tests(self, suite):
+        print("Skipping {0} database tests".format(suite.countTestCases()))
+        return 0


### PR DESCRIPTION
Split testing into two stages, first stage runs test that don't require any DB access, second stage runs all DB tests.

I thought this would allow us to develop a test suite that run really fast without any need for DB access but currently we only have 16 tests that pass without needing to touch the DB. 

depends on https://github.com/dimagi/auditcare/pull/15
