### PR TITLE
bump jsonobject requirement

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,7 +2,7 @@
 Cython==0.17.4
 restkit==4.2.0
 jsonobject-couchdbkit==0.6.5.2
-jsonobject==0.2.12
+jsonobject==0.3.0
 celery==3.0.24
 decorator==3.3.2
 django==1.5.5


### PR DESCRIPTION
I got a "can't import WrappingAttributeError" error which bumping this version fixed. @dannyroberts 
