### PR TITLE
make V2 translations default

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2591,7 +2591,7 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
     profile = DictProperty()
     use_custom_suite = BooleanProperty(default=False)
     cloudcare_enabled = BooleanProperty(default=False)
-    translation_strategy = StringProperty(default='dump-known',
+    translation_strategy = StringProperty(default='select-known',
                                           choices=app_strings.CHOICES.keys())
     commtrack_enabled = BooleanProperty(default=False)
     commtrack_requisition_mode = StringProperty(choices=CT_REQUISITION_MODES)

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yaml
@@ -139,9 +139,10 @@
   name: 'Translations Strategy'
   values: ['dump-known', 'select-known', 'simple']
   value_names:
-   - 'Version 1 translations (old and reliable)'
-   - 'Version 2 translations (not well tested)'
+   - 'Version 1 translations (old)'
+   - 'Version 2 translations (recommended)'
    - 'Simple (FOR TESTING ONLY: crashes with any unrecognized user-defined translations)'
-  default: 'dump-known'
+  default: 'select-known'
   requires: "{$parent.doc_type}='Application'"
   preview: true
+  disabled: true


### PR DESCRIPTION
This will only impact new apps. (It'll also make the option not available except for people to upgrade to V2 if they haven't. The whole thing's preview-only anyway.)
