### PR TITLE
Reporting rates simple fix

### DIFF
--- a/corehq/apps/reports/commtrack/data_sources.py
+++ b/corehq/apps/reports/commtrack/data_sources.py
@@ -12,16 +12,8 @@ from django.db.models import Sum, Avg
 from corehq.apps.reports.commtrack.util import get_relevant_supply_point_ids, product_ids_filtered_by_program
 from corehq.apps.reports.commtrack.const import STOCK_SECTION_TYPE
 from casexml.apps.stock.utils import months_of_stock_remaining, stock_category
-
-# TODO make settings
 from corehq.apps.reports.standard.monitoring import MultiFormDrilldownMixin
 
-REPORTING_PERIOD = 'weekly'
-REPORTING_PERIOD_ARGS = (1,)
-
-
-def is_timely(case, limit=0):
-    return num_periods_late(case, REPORTING_PERIOD, *REPORTING_PERIOD_ARGS) <= limit
 
 def reporting_status(transaction, start_date, end_date):
     if transaction:

--- a/corehq/apps/reports/commtrack/data_sources.py
+++ b/corehq/apps/reports/commtrack/data_sources.py
@@ -18,7 +18,7 @@ def reporting_status(transaction, start_date, end_date):
     # for now we have decided to remove the "late" distinction
     # so we are only checking if a time even exists in this period
     if transaction:
-        return 'ontime'
+        return 'reporting'
     else:
         return 'nonreporting'
 

--- a/corehq/apps/reports/commtrack/data_sources.py
+++ b/corehq/apps/reports/commtrack/data_sources.py
@@ -15,15 +15,10 @@ from corehq.apps.reports.standard.monitoring import MultiFormDrilldownMixin
 
 
 def reporting_status(transaction, start_date, end_date):
+    # for now we have decided to remove the "late" distinction
+    # so we are only checking if a time even exists in this period
     if transaction:
-        last_reported = transaction.report.date.date()
-    else:
-        last_reported = None
-
-    if last_reported and last_reported < start_date:
         return 'ontime'
-    elif last_reported and start_date <= last_reported <= end_date:
-        return 'late'
     else:
         return 'nonreporting'
 
@@ -275,6 +270,10 @@ class ReportingStatusDataSource(ReportDataSource, CommtrackDataSourceMixin, Mult
             loc = SupplyPointCase.get(sp_id).location
             transactions = StockTransaction.objects.filter(
                 case_id=sp_id,
+            ).exclude(
+                report__date__lte=self.start_date
+            ).exclude(
+                report__date__gte=self.end_date
             )
 
             if transactions:

--- a/corehq/apps/reports/commtrack/data_sources.py
+++ b/corehq/apps/reports/commtrack/data_sources.py
@@ -1,4 +1,3 @@
-from corehq.apps.commtrack.util import num_periods_late
 from dimagi.utils.decorators.memoized import memoized
 from corehq.apps.locations.models import Location
 from corehq.apps.commtrack.models import Product, SupplyPointCase, StockState
@@ -276,7 +275,6 @@ class ReportingStatusDataSource(ReportDataSource, CommtrackDataSourceMixin, Mult
             loc = SupplyPointCase.get(sp_id).location
             transactions = StockTransaction.objects.filter(
                 case_id=sp_id,
-                section_id=STOCK_SECTION_TYPE,
             )
 
             if transactions:

--- a/corehq/apps/reports/commtrack/maps.py
+++ b/corehq/apps/reports/commtrack/maps.py
@@ -152,8 +152,7 @@ class ReportingStatusMapReport(GenericMapReport, CommtrackReportMixin):
         },
         'enum_captions': {
             'reporting_status': {
-                'ontime': 'On-time',
-                'late': 'Late',
+                'reporting': 'Reporting',
                 'nonreporting': 'Non-reporting',
             },
         },
@@ -168,8 +167,7 @@ class ReportingStatusMapReport(GenericMapReport, CommtrackReportMixin):
                 'color': {
                     'column': 'reporting_status',
                     'categories': {
-                        'ontime': 'rgba(0, 200, 0, .8)',
-                        'late': 'rgba(255, 255, 0, .8)',
+                        'reporting': 'rgba(0, 200, 0, .8)',
                         'nonreporting': 'rgba(255, 0, 0, .8)',
                     },
                 },

--- a/corehq/apps/reports/commtrack/standard.py
+++ b/corehq/apps/reports/commtrack/standard.py
@@ -296,8 +296,7 @@ class ReportingRatesReport(GenericTabularReport, CommtrackReportMixin):
         return DataTablesHeader(*(DataTablesColumn(text) for text in [
                     _('Location'),
                     _('# Sites'),
-                    _('On-time'),
-                    _('Late'),
+                    _('Reporting'),
                     _('Non-reporting'),
                 ]))
 
@@ -349,7 +348,7 @@ class ReportingRatesReport(GenericTabularReport, CommtrackReportMixin):
         def _rows():
             for loc in locs:
                 num_sites = len(sites_by_agg_site[loc._id])
-                yield [loc.name, len(sites_by_agg_site[loc._id])] + [fmt_col(loc, k) for k in ('ontime', 'late', 'nonreporting')]
+                yield [loc.name, len(sites_by_agg_site[loc._id])] + [fmt_col(loc, k) for k in ('reporting', 'nonreporting')]
 
         return master_tally, _rows()
 
@@ -360,11 +359,10 @@ class ReportingRatesReport(GenericTabularReport, CommtrackReportMixin):
     def master_pie_chart_data(self):
         tally = self._data[0]
         labels = {
-            'ontime': _('On-time'),
-            'late': _('Late'),
+            'reporting': _('Reporting'),
             'nonreporting': _('Non-reporting'),
         }
-        return [{'label': labels[k], 'value': tally.get(k, {'count': 0.})['count']} for k in ('ontime', 'late', 'nonreporting')]
+        return [{'label': labels[k], 'value': tally.get(k, {'count': 0.})['count']} for k in ('reporting', 'nonreporting')]
 
     @property
     def charts(self):


### PR DESCRIPTION
After extensive back and forth with Rowena/Chester, this is the temporary-ish fix to make the report useful to WFP (or anyone, for that matter).

This way instead of doing unclear things with the dates and what "late" means, for now this just shows who has reported during a time period.

The restriction to only `stock` ledgers was also dropped in this, because it would make filtering by form useless as there are forms that don't submit these ledger types.
