### PR TITLE
Blank address invoice

### DIFF
--- a/corehq/apps/accounting/invoice_pdf.py
+++ b/corehq/apps/accounting/invoice_pdf.py
@@ -49,13 +49,13 @@ class Address(object):
     def __str__(self):
         return '''%(name)s
 %(first_line)s%(second_line)s
-%(city)s, %(region)s %(postal_code)s
+%(city)s%(region)s %(postal_code)s
 %(country)s%(phone_number)s%(email_address)s%(website)s
         ''' % {
             'name': self.name,
             'first_line': self.first_line,
             'second_line': prepend_newline_if_not_empty(self.second_line),
-            'city': self.city,
+            'city': "%s, " % self.city if self.city else "",
             'region': self.region,
             'postal_code': self.postal_code,
             'country': self.country,

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1210,8 +1210,13 @@ class InvoicePdf(SafeSaveDocument):
             pdf_data.name,
             invoice_number=invoice.invoice_number,
             to_address=Address(
-                name=("%s %s" %
-                      (contact_info.first_name, contact_info.last_name)),
+                name=(
+                    "%s %s" %
+                    (contact_info.first_name
+                     if contact_info.first_name is not None else "",
+                     contact_info.last_name
+                     if contact_info.last_name is not None else "")
+                ),
                 first_line=contact_info.first_line,
                 second_line=contact_info.second_line,
                 city=contact_info.city,


### PR DESCRIPTION
Now that we're allowing billing contact addresses to be blank, if address is blank, don't include any text in the Bill To field.

Before:
![screen shot 2014-04-01 at 12 54 22 pm](https://cloud.githubusercontent.com/assets/1757035/2581957/715c3004-b9be-11e3-8550-80fbe2f8197c.png)

After:
![screen shot 2014-04-01 at 12 54 13 pm](https://cloud.githubusercontent.com/assets/1757035/2581958/752fb34a-b9be-11e3-8441-a532f1344e5d.png)
