### PR TITLE
rename and restructure phonelog models

### DIFF
--- a/corehq/apps/hqadmin/views.py
+++ b/corehq/apps/hqadmin/views.py
@@ -62,7 +62,7 @@ from dimagi.utils.decorators.view import get_file
 from dimagi.utils.timezones import utils as tz_utils
 from dimagi.utils.django.email import send_HTML_email
 from pillowtop import get_all_pillows_json
-from phonelog.models import Log
+from phonelog.models import DeviceReportEntry
 from phonelog.reports import TAGS
 
 from .multimech import GlobalConfig
@@ -357,7 +357,7 @@ def submissions_errors(request, template="hqadmin/submissions_errors_report.html
         ).all()
         num_forms_submitted = data[0].get('value', 0) if data else 0
 
-        phonelogs = Log.objects.filter(domain__exact=domain.name,
+        phonelogs = DeviceReportEntry.objects.filter(domain__exact=domain.name,
             date__range=[datespan.startdate_param_utc, datespan.enddate_param_utc])
         num_errors = phonelogs.filter(type__in=TAGS["error"]).count()
         num_warnings = phonelogs.filter(type__in=TAGS["warning"]).count()
@@ -394,7 +394,7 @@ def mobile_user_reports(request):
 
     rows = []
 
-    logs = Log.objects.filter(type__exact="user-report").order_by('domain')
+    logs = DeviceReportEntry.objects.filter(type__exact="user-report").order_by('domain')
     for log in logs:
         seconds_since_epoch = int(time.mktime(log.date.timetuple()) * 1000)
         rows.append(dict(domain=log.domain,

--- a/corehq/apps/reports/filters/devicelog.py
+++ b/corehq/apps/reports/filters/devicelog.py
@@ -1,7 +1,7 @@
 from django.utils.translation import ugettext_noop
 from dimagi.utils.couch.database import get_db
 from corehq.apps.reports.filters.base import BaseReportFilter
-from phonelog.models import Log
+from phonelog.models import DeviceReportEntry
 import settings
 
 
@@ -19,7 +19,7 @@ class DeviceLogTagFilter(BaseReportFilter):
         show_all = bool(not selected_tags)
         tags = [dict(name=l['type'],
                     show=bool(show_all or l['type'] in selected_tags))
-                    for l in Log.objects.values('type').distinct()]
+                    for l in DeviceReportEntry.objects.values('type').distinct()]
         context = {
             'errors_only_slug': self.errors_only_slug,
             'default_on': show_all,
@@ -39,7 +39,7 @@ class BaseDeviceLogFilter(BaseReportFilter):
 
     def get_filters(self, selected):
         show_all = bool(not selected)
-        it = Log.objects.filter(domain__exact=self.domain).values(self.field).distinct()
+        it = DeviceReportEntry.objects.filter(domain__exact=self.domain).values(self.field).distinct()
         return [dict(name=f[self.field],
                     show=bool(show_all or f[self.field] in selected))
                     for f in it]

--- a/corehq/ex-submodules/phonelog/migrations/0003_auto__del_userlog__del_log__add_userentry__add_unique_userentry_xform_.py
+++ b/corehq/ex-submodules/phonelog/migrations/0003_auto__del_userlog__del_log__add_userentry__add_unique_userentry_xform_.py
@@ -1,0 +1,114 @@
+# encoding: utf-8
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        
+        # Deleting model 'UserLog'
+        db.delete_table(u'phonelog_userlog')
+
+        # Deleting model 'Log'
+        db.delete_table(u'phonelog_log')
+
+        # Adding model 'UserEntry'
+        db.create_table(u'phonelog_userentry', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('xform_id', self.gf('django.db.models.fields.CharField')(max_length=50, db_index=True)),
+            ('i', self.gf('django.db.models.fields.IntegerField')()),
+            ('user_id', self.gf('django.db.models.fields.CharField')(max_length=50)),
+            ('sync_token', self.gf('django.db.models.fields.CharField')(max_length=50)),
+            ('username', self.gf('django.db.models.fields.CharField')(max_length=100, db_index=True)),
+        ))
+        db.send_create_signal(u'phonelog', ['UserEntry'])
+
+        # Adding unique constraint on 'UserEntry', fields ['xform_id', 'i']
+        db.create_unique(u'phonelog_userentry', ['xform_id', 'i'])
+
+        # Adding model 'DeviceReportEntry'
+        db.create_table(u'phonelog_devicereportentry', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('xform_id', self.gf('django.db.models.fields.CharField')(max_length=50)),
+            ('i', self.gf('django.db.models.fields.IntegerField')()),
+            ('msg', self.gf('django.db.models.fields.TextField')()),
+            ('type', self.gf('django.db.models.fields.CharField')(max_length=32, db_index=True)),
+            ('date', self.gf('django.db.models.fields.DateTimeField')(db_index=True)),
+            ('domain', self.gf('django.db.models.fields.CharField')(max_length=100, db_index=True)),
+            ('device_id', self.gf('django.db.models.fields.CharField')(max_length=50, db_index=True)),
+            ('app_version', self.gf('django.db.models.fields.TextField')()),
+            ('username', self.gf('django.db.models.fields.CharField')(max_length=100, db_index=True)),
+        ))
+        db.send_create_signal(u'phonelog', ['DeviceReportEntry'])
+
+        # Adding unique constraint on 'DeviceReportEntry', fields ['xform_id', 'i']
+        db.create_unique(u'phonelog_devicereportentry', ['xform_id', 'i'])
+
+
+    def backwards(self, orm):
+        
+        # Removing unique constraint on 'DeviceReportEntry', fields ['xform_id', 'i']
+        db.delete_unique(u'phonelog_devicereportentry', ['xform_id', 'i'])
+
+        # Removing unique constraint on 'UserEntry', fields ['xform_id', 'i']
+        db.delete_unique(u'phonelog_userentry', ['xform_id', 'i'])
+
+        # Adding model 'UserLog'
+        db.create_table(u'phonelog_userlog', (
+            ('username', self.gf('django.db.models.fields.CharField')(max_length=100, db_index=True)),
+            ('xform_id', self.gf('django.db.models.fields.CharField')(max_length=50, db_index=True)),
+            ('user_id', self.gf('django.db.models.fields.CharField')(max_length=50)),
+            ('sync_token', self.gf('django.db.models.fields.CharField')(max_length=50)),
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+        ))
+        db.send_create_signal(u'phonelog', ['UserLog'])
+
+        # Adding model 'Log'
+        db.create_table(u'phonelog_log', (
+            ('username', self.gf('django.db.models.fields.CharField')(max_length=100, db_index=True)),
+            ('msg', self.gf('django.db.models.fields.TextField')()),
+            ('domain', self.gf('django.db.models.fields.CharField')(max_length=100, db_index=True)),
+            ('date', self.gf('django.db.models.fields.DateTimeField')(db_index=True)),
+            ('xform_id', self.gf('django.db.models.fields.CharField')(max_length=50, db_index=True)),
+            ('app_version', self.gf('django.db.models.fields.TextField')()),
+            ('type', self.gf('django.db.models.fields.CharField')(max_length=32, db_index=True)),
+            ('id', self.gf('django.db.models.fields.CharField')(max_length=50, primary_key=True)),
+            ('device_id', self.gf('django.db.models.fields.CharField')(max_length=50, db_index=True)),
+        ))
+        db.send_create_signal(u'phonelog', ['Log'])
+
+        # Deleting model 'UserEntry'
+        db.delete_table(u'phonelog_userentry')
+
+        # Deleting model 'DeviceReportEntry'
+        db.delete_table(u'phonelog_devicereportentry')
+
+
+    models = {
+        u'phonelog.devicereportentry': {
+            'Meta': {'unique_together': "[('xform_id', 'i')]", 'object_name': 'DeviceReportEntry'},
+            'app_version': ('django.db.models.fields.TextField', [], {}),
+            'date': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'}),
+            'device_id': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'i': ('django.db.models.fields.IntegerField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'msg': ('django.db.models.fields.TextField', [], {}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '32', 'db_index': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'xform_id': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'phonelog.userentry': {
+            'Meta': {'unique_together': "[('xform_id', 'i')]", 'object_name': 'UserEntry'},
+            'i': ('django.db.models.fields.IntegerField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'sync_token': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'user_id': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'username': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'xform_id': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'})
+        }
+    }
+
+    complete_apps = ['phonelog']

--- a/corehq/ex-submodules/phonelog/migrations/0004_auto__chg_field_devicereportentry_username.py
+++ b/corehq/ex-submodules/phonelog/migrations/0004_auto__chg_field_devicereportentry_username.py
@@ -1,0 +1,46 @@
+# encoding: utf-8
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        
+        # Changing field 'DeviceReportEntry.username'
+        db.alter_column(u'phonelog_devicereportentry', 'username', self.gf('django.db.models.fields.CharField')(max_length=100, null=True))
+
+
+    def backwards(self, orm):
+        
+        # Changing field 'DeviceReportEntry.username'
+        db.alter_column(u'phonelog_devicereportentry', 'username', self.gf('django.db.models.fields.CharField')(default='', max_length=100))
+
+
+    models = {
+        u'phonelog.devicereportentry': {
+            'Meta': {'unique_together': "[('xform_id', 'i')]", 'object_name': 'DeviceReportEntry'},
+            'app_version': ('django.db.models.fields.TextField', [], {}),
+            'date': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'}),
+            'device_id': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'i': ('django.db.models.fields.IntegerField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'msg': ('django.db.models.fields.TextField', [], {}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '32', 'db_index': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'db_index': 'True'}),
+            'xform_id': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'phonelog.userentry': {
+            'Meta': {'unique_together': "[('xform_id', 'i')]", 'object_name': 'UserEntry'},
+            'i': ('django.db.models.fields.IntegerField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'sync_token': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'user_id': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'username': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'xform_id': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'})
+        }
+    }
+
+    complete_apps = ['phonelog']

--- a/corehq/ex-submodules/phonelog/migrations/0005_auto.py
+++ b/corehq/ex-submodules/phonelog/migrations/0005_auto.py
@@ -1,0 +1,46 @@
+# encoding: utf-8
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        
+        # Adding index on 'DeviceReportEntry', fields ['xform_id']
+        db.create_index(u'phonelog_devicereportentry', ['xform_id'])
+
+
+    def backwards(self, orm):
+        
+        # Removing index on 'DeviceReportEntry', fields ['xform_id']
+        db.delete_index(u'phonelog_devicereportentry', ['xform_id'])
+
+
+    models = {
+        u'phonelog.devicereportentry': {
+            'Meta': {'unique_together': "[('xform_id', 'i')]", 'object_name': 'DeviceReportEntry'},
+            'app_version': ('django.db.models.fields.TextField', [], {}),
+            'date': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'}),
+            'device_id': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'i': ('django.db.models.fields.IntegerField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'msg': ('django.db.models.fields.TextField', [], {}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '32', 'db_index': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'db_index': 'True'}),
+            'xform_id': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'})
+        },
+        u'phonelog.userentry': {
+            'Meta': {'unique_together': "[('xform_id', 'i')]", 'object_name': 'UserEntry'},
+            'i': ('django.db.models.fields.IntegerField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'sync_token': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'user_id': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'username': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'xform_id': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'})
+        }
+    }
+
+    complete_apps = ['phonelog']

--- a/corehq/ex-submodules/phonelog/models.py
+++ b/corehq/ex-submodules/phonelog/models.py
@@ -5,31 +5,38 @@ from django.db import models
 COUCH_UUID_MAX_LEN = 50
 
 
-class Log(models.Model):
+class DeviceReportEntry(models.Model):
     xform_id = models.CharField(max_length=COUCH_UUID_MAX_LEN, db_index=True)
+    i = models.IntegerField()
     msg = models.TextField()
-    id = models.CharField(max_length=50, primary_key=True)
     type = models.CharField(max_length=32, db_index=True)
     date = models.DateTimeField(db_index=True)
     domain = models.CharField(max_length=100, db_index=True)
     device_id = models.CharField(max_length=COUCH_UUID_MAX_LEN, db_index=True)
     app_version = models.TextField()
-    username = models.CharField(max_length=100, db_index=True)
+    username = models.CharField(max_length=100, db_index=True, null=True)
+
+    class Meta:
+        unique_together = [('xform_id', 'i')]
 
     @property
     @memoized
     def device_users(self):
         return list(
-            UserLog.objects.filter(xform_id__exact=self.xform_id)
+            UserEntry.objects.filter(xform_id__exact=self.xform_id)
             .distinct('username').values_list('username', flat=True)
         )
 
 
-class UserLog(models.Model):
+class UserEntry(models.Model):
     xform_id = models.CharField(max_length=COUCH_UUID_MAX_LEN, db_index=True)
+    i = models.IntegerField()
     user_id = models.CharField(max_length=COUCH_UUID_MAX_LEN)
     sync_token = models.CharField(max_length=COUCH_UUID_MAX_LEN)
     username = models.CharField(max_length=100, db_index=True)
+
+    class Meta:
+        unique_together = [('xform_id', 'i')]
 
 
 class _(Document):

--- a/corehq/ex-submodules/phonelog/reports.py
+++ b/corehq/ex-submodules/phonelog/reports.py
@@ -23,7 +23,7 @@ from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.timezones import utils as tz_utils
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_noop
-from phonelog.models import Log
+from phonelog.models import DeviceReportEntry
 
 logger = logging.getLogger(__name__)
 
@@ -74,7 +74,7 @@ class FormErrorReport(PhonelogReport):
     @property
     @memoized
     def all_logs(self):
-        return Log.objects.filter(
+        return DeviceReportEntry.objects.filter(
             domain__exact=self.domain,
             date__range=[self.datespan.startdate_param_utc,
                          self.datespan.enddate_param_utc],
@@ -275,16 +275,16 @@ class DeviceLogDetailsReport(PhonelogReport):
     @property
     def rows(self):
         if self.goto_key:
-            log = Log.objects.get(pk=self.goto_key)
+            log = DeviceReportEntry.objects.get(pk=self.goto_key)
             assert log.domain == self.domain
-            logs = Log.objects.filter(
+            logs = DeviceReportEntry.objects.filter(
                 date__lte=log.date,
                 domain__exact=self.domain,
                 device_id__exact=log.device_id,
             )
             return self._create_rows(logs, matching_id=log.id)
         else:
-            logs = Log.objects.filter(
+            logs = DeviceReportEntry.objects.filter(
                 date__range=[self.datespan.startdate_param_utc,
                              self.datespan.enddate_param_utc],
                 domain__exact=self.domain,

--- a/corehq/pillows/log.py
+++ b/corehq/pillows/log.py
@@ -1,18 +1,19 @@
-import hashlib
-from django.db import IntegrityError
+import dateutil.parser
 from pillowtop.listener import SQLPillow
 from couchforms.models import XFormInstance
-from phonelog.models import UserLog, Log
-import dateutil.parser as dparser
+from phonelog.models import UserEntry, DeviceReportEntry
+
 
 def force_list(obj_or_list):
     return obj_or_list if isinstance(obj_or_list, list) else [obj_or_list]
+
 
 def get_logs(form, report_name, report_slug):
     report = form.get(report_name, {}) or {}
     if isinstance(report, list):
         return filter(None, [log.get(report_slug) for log in report])
     return report.get(report_slug, [])
+
 
 class PhoneLogPillow(SQLPillow):
     document_class = XFormInstance
@@ -22,25 +23,39 @@ class PhoneLogPillow(SQLPillow):
         xform_id = doc_dict.get('_id')
         form = doc_dict.get('form', {})
         userlogs = get_logs(form, 'user_subreport', 'user')
-        for log in force_list(userlogs):
-            u = UserLog(user_id=log["user_id"], username=log["username"],
-                        sync_token=log["sync_token"], xform_id=xform_id)
-            u.save()
+        UserEntry.objects.filter(xform_id=xform_id).delete()
+        DeviceReportEntry.objects.filter(xform_id=xform_id).delete()
+        to_save = []
+        for i, log in enumerate(force_list(userlogs)):
+            to_save.append(UserEntry(
+                xform_id=xform_id,
+                i=i,
+                user_id=log["user_id"],
+                username=log["username"],
+                sync_token=log["sync_token"],
+            ))
+        UserEntry.objects.bulk_create(to_save)
 
         domain = doc_dict.get('domain')
         logs = get_logs(form, 'log_subreport', 'log')
-        logged_in_user = 'unknown'
-        for log in filter(None, force_list(logs)):
+        logged_in_user = None
+        to_save = []
+        for i, log in enumerate(force_list(logs)):
+            if not log:
+                continue
             if log["type"] == 'login':
                 logged_in_user = log["msg"].split('-')[1]
 
-            uuid = hashlib.md5(log["type"] + log["@date"]).hexdigest()
-            try:
-                l, _ = Log.objects.get_or_create(id=uuid, xform_id=xform_id, domain=domain,
-                                         type=log["type"], msg=log["msg"],
-                                         date=dparser.parse(log["@date"]),
-                                         app_version=form.get('app_version'),
-                                         device_id=form.get('device_id'),
-                                         username=logged_in_user)
-            except IntegrityError:
-                pass
+            to_save.append(DeviceReportEntry(
+                xform_id=xform_id,
+                i=i,
+                domain=domain,
+                type=log["type"],
+                msg=log["msg"],
+                # must accept either date or datetime string
+                date=dateutil.parser.parse(log["@date"]).replace(tzinfo=None),
+                app_version=form.get('app_version'),
+                device_id=form.get('device_id'),
+                username=logged_in_user,
+            ))
+        DeviceReportEntry.objects.bulk_create(to_save)


### PR DESCRIPTION
- improve speed of pillow
- improve idempotent behavior of pillow
- fix bug where entries of the same type with the same second-rounded
  date were competing (only one would get saved)

will require restarting the phonelog pillow (which is broken anyway)
