### PR TITLE
Use the real consumption method

### DIFF
--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -1297,15 +1297,15 @@ class StockState(models.Model):
     def months_remaining(self):
         return months_of_stock_remaining(
             self.stock_on_hand,
-            self.daily_consumption
+            self.get_consumption()
         )
 
     @property
     def resupply_quantity_needed(self):
-        if self.daily_consumption is not None:
+        if self.get_consumption() is not None:
             stock_levels = self.get_domain().commtrack_settings.stock_levels_config
             needed_quantity = int(
-                self.daily_consumption * 30 * stock_levels.overstock_threshold
+                self.get_consumption() * 30 * stock_levels.overstock_threshold
             )
             return int(max(needed_quantity - self.stock_on_hand, 0))
         else:

--- a/corehq/apps/reports/commtrack/data_sources.py
+++ b/corehq/apps/reports/commtrack/data_sources.py
@@ -114,7 +114,7 @@ class StockStatusDataSource(ReportDataSource, CommtrackDataSourceMixin):
         SLUG_LOCATION_ID: lambda s: SupplyPointCase.get(s.case_id).location_[-1],
         # SLUG_LOCATION_LINEAGE: lambda p: list(reversed(p.location_[:-1])),
         SLUG_CURRENT_STOCK: 'stock_on_hand',
-        SLUG_CONSUMPTION: lambda s: s.daily_consumption * 30 if s.daily_consumption else None,
+        SLUG_CONSUMPTION: lambda s: s.get_consumption() * 30 if s.get_consumption() else None,
         SLUG_MONTHS_REMAINING: 'months_remaining',
         SLUG_CATEGORY: 'stock_category',
         # SLUG_STOCKOUT_SINCE: 'stocked_out_since',
@@ -175,7 +175,7 @@ class StockStatusDataSource(ReportDataSource, CommtrackDataSourceMixin):
             yield {
                 'category': state.stock_category,
                 'product_id': product._id,
-                'consumption': state.daily_consumption * 30 if state.daily_consumption else None,
+                'consumption': state.get_consumption() * 30 if state.get_consumption() else None,
                 'months_remaining': state.months_remaining,
                 'location_id': SupplyPointCase.get(state.case_id).location_id,
                 'product_name': product.name,


### PR DESCRIPTION
Depends on https://github.com/dimagi/casexml/pull/202

This method was added in a recent PR to abstract the consumption functionality some. Previously we stored defaults, now we store `None` and get the default at run time (so that it can be always up to date).

I drove the feature with tests and ... didn't check reports.

:poop:
