### PR TITLE
Correct EMWF users to display username_in_report

### DIFF
--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -17,7 +17,7 @@ from ..util import _report_user_dict
 def user_tuple(u):
     user = _report_user_dict(u)
     uid = "u__%s" % user['user_id']
-    name = "%s [user]" % user['username_in_report'].split('@')[0]
+    name = "%s [user]" % user['username_in_report']
     return (uid, name)
 
 
@@ -94,7 +94,7 @@ class EmwfOptionsView(LoginAndDomainMixin, JSONResponseMixin, View):
         return es_wrapper('users', domain=self.domain, q=self.user_query, **kwargs)
 
     def get_users(self, start, size):
-        fields = ['_id', 'username', 'first_name', 'last_name']
+        fields = ['_id', 'username', 'first_name', 'last_name', 'doc_type']
         users = self.user_es_call(fields=fields, start_at=start, size=size,
             sort_by='username.exact', order='asc')
         return [user_tuple(u) for u in users]

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -272,7 +272,7 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
             res = es_query(
                 es_url=ES_URLS["users"],
                 q=q,
-                fields = ['_id', 'username', 'first_name', 'last_name'],
+                fields = ['_id', 'username', 'first_name', 'last_name', 'doc_type'],
             )
             selected += [user_tuple(hit['fields']) for hit in res['hits']['hits']]
 

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -189,8 +189,9 @@ def get_username_from_forms(domain, user_id):
 
 def _report_user_dict(user):
     """
-    Accepts a user object or a dict such as that returned from elasticsearch
-    via CommCareUser.es_fakes
+    Accepts a user object or a dict such as that returned from elasticsearch.
+    Make sure the following fields are available:
+    ['_id', 'username', 'first_name', 'last_name', 'doc_type', 'is_active']
     """
     if not isinstance(user, dict):
         user_report_attrs = ['user_id', 'username_in_report', 'raw_username', 'is_active']


### PR DESCRIPTION
For a user "John Doe"
The filter originally displayed `jdoe@myproject.commcarehq.org "John Doe" [user]`
It was changed to display just `jdoe [user]`, in what looks like it was meant to strip the `@myproject.commcarehq.org`
This change makes the display the proper username_in_report display used elsewhere: `jdoe "John Doe" [user]`

http://manage.dimagi.com/default.asp?106857
