### PR TITLE
remove staticmedia/ dir, which is unused

### DIFF
--- a/staticmedia/.gitignore
+++ b/staticmedia/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
Right? I checked on hqproxy0 and it's totally empty there too. And our code has no references to it, only to `staticfiles/`
