### PR TITLE
bump jsonobject version to 0.4.2

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,7 +2,7 @@
 Cython==0.17.4
 restkit==4.2.0
 jsonobject-couchdbkit==0.6.5.2
-jsonobject==0.4.1
+jsonobject==0.4.2
 celery==3.0.24
 decorator==3.3.2
 django==1.5.5


### PR DESCRIPTION
Let's see if _this_ fixes the build. Just cleanup changes: https://github.com/dannyroberts/jsonobject/pull/90

For posterity, the issue I'm trying to fix is an apparent "staleness" of some sort where PyPi seems to be sending down old code despite being asked for the latest version. (That's the hypothesis anyway.) Currently, I'm trying to fix by making functionality-less code changes to jsonobject and bumping the version number. Doing a version bump with no changes seemed not to permanently fix the problem, even though it seemed to fix it "sometimes": https://github.com/dimagi/commcare-hq/pull/3101.
