### PR TITLE
fix api for forms w/o 'openrosa_headers' attr

### DIFF
--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -46,12 +46,17 @@ class XFormInstanceResource(SimpleSortableResourceMixin, v0_3.XFormInstanceResou
                                                 attribute=lambda xform: [dict_object(case.get_json()) for case in casexml_xform.cases_referenced_by_xform(xform)]))
 
     is_phone_submission = fields.BooleanField(readonly=True)
+
     def dehydrate_is_phone_submission(self, bundle):
-        return bundle.obj.openrosa_headers and bool(bundle.obj.openrosa_headers.get('HTTP_X_OPENROSA_VERSION'))
+        return (
+            getattr(bundle.obj, 'openrosa_headers', None)
+            and bundle.obj.openrosa_headers.get('HTTP_X_OPENROSA_VERSION')
+        )
 
     # Prevent hitting Couch to md5 the attachment. However, there is no way to
     # eliminate a tastypie field defined in a parent class.
     md5 = fields.CharField(attribute='uiversion', blank=True, null=True)
+
     def dehydrate_md5(self, bundle):
         return 'OBSOLETED'
 


### PR DESCRIPTION
I think this only fixes it for tests, where full processing may not have
occurred
