### PR TITLE
use couchdbkit==0.6.5.5

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 # needed to build gevent from source
 Cython==0.17.4
 restkit==4.2.0
-jsonobject-couchdbkit==0.6.5.2
+jsonobject-couchdbkit==0.6.5.5
 jsonobject==0.4.2
 celery==3.0.24
 decorator==3.3.2


### PR DESCRIPTION
This seems to have been causing some issues. If I do the following,

```
pip uninstall jsonobject jsonobject-couchdbkit
pip install jsonobject==0.4.2 jsonobject-couchdbkit==0.6.5.2
./manage.py shell
```

I get an error. If I do

```
pip uninstall jsonobject jsonobject-couchdbkit
pip install jsonobject==0.4.2 jsonobject-couchdbkit==0.6.5.5
./manage.py shell
```

everything works great.

The diff between those two is just https://github.com/dannyroberts/couchdbkit/compare/7e8450b9e515366f0c2e4bcdf9552974103910fe...0994bbdad12c319c90000c734aa584a3c28d83cb, so it's like pip is getting confused and installing the wrong version of jsonobject (and a different one than it claims in the output!!!?)
