### PR TITLE
lazy migrate old RepeatRecords

### DIFF
--- a/corehq/apps/receiverwrapper/models.py
+++ b/corehq/apps/receiverwrapper/models.py
@@ -219,6 +219,20 @@ class RepeatRecord(Document, LockableMixIn):
 
     payload_id = StringProperty()
 
+    @classmethod
+    def wrap(cls, data):
+        for attr in ('last_checked', 'next_checked'):
+            value = data.get(attr)
+            if not value:
+                continue
+            try:
+                dt = datetime.strptime(value, '%Y-%m-%dT%H:%M:%SZ')
+                data[attr] = dt.isoformat() + '.000000Z'
+                print data[attr]
+            except ValueError:
+                pass
+        return super(RepeatRecord, cls).wrap(data)
+
     @property
     @memoized
     def repeater(self):

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,7 +2,7 @@
 Cython==0.17.4
 restkit==4.2.0
 jsonobject-couchdbkit==0.6.5.5
-jsonobject==0.4.2
+jsonobject==0.4.3
 celery==3.0.24
 decorator==3.3.2
 django==1.5.5


### PR DESCRIPTION
- update to jsonobject to always use ".000000Z" when us=0: https://github.com/dannyroberts/jsonobject/pull/91
