### PR TITLE
change import style

### DIFF
--- a/corehq/apps/importer/tasks.py
+++ b/corehq/apps/importer/tasks.py
@@ -6,7 +6,7 @@ from casexml.apps.case.mock import CaseBlock, CaseBlockError
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.importer.const import LookupErrors
-import corehq.apps.importer.util as importer_util
+from corehq.apps.importer import util as importer_util
 from corehq.apps.users.models import CouchUser
 from soil import DownloadBase
 from casexml.apps.case.xml import V2

--- a/corehq/apps/importer/views.py
+++ b/corehq/apps/importer/views.py
@@ -2,8 +2,7 @@ import os.path
 from django.http import HttpResponseRedirect, HttpResponseServerError
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.importer import base
-from corehq.apps.importer.util import ExcelFile, ImporterConfig
-import corehq.apps.importer.util as importer_util
+from corehq.apps.importer import util as importer_util
 from corehq.apps.importer.tasks import bulk_import_async
 from django.views.decorators.http import require_POST
 from corehq.apps.users.decorators import require_permission
@@ -44,7 +43,7 @@ def excel_config(request, domain):
     # views if your worker changes, so we have to store it elsewhere
     # using the soil framework.
 
-    if extension not in ExcelFile.ALLOWED_EXTENSIONS:
+    if extension not in importer_util.ExcelFile.ALLOWED_EXTENSIONS:
         return render_error(request, domain,
                             'The Excel file you chose could not be processed. '
                             'Please check that it is saved as a Microsoft '
@@ -185,7 +184,7 @@ def excel_fields(request, domain):
 @require_POST
 @require_can_edit_data
 def excel_commit(request, domain):
-    config = ImporterConfig.from_request(request)
+    config = importer_util.ImporterConfig.from_request(request)
 
     excel_id = request.session.get(EXCEL_SESSION_ID)
 


### PR DESCRIPTION
@twymer this was giving me the following error when I tried to do anything in the django shell:

```
  File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/home/skelly/dev/projects/commcare-hq/corehq/apps/importer/tasks.py", line 9, in <module>
    import corehq.apps.importer.util as importer_util
AttributeError: 'module' object has no attribute 'apps'
```
