### PR TITLE
add link to Try-in-cloudcare in tools-menu of form-designer

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/form_designer.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_designer.html
@@ -35,6 +35,7 @@
     <script src="{% static 'formdesigner/js/controller.js' %}"></script>
     <script src="{% static 'formdesigner/js/ui.js' %}"></script>
     <script src="{% static 'formdesigner/js/window.js' %}"></script>
+    <script src="{% static 'cloudcare/js/util.js' %}"></script>
 
     {% include 'hqmedia/partials/multimedia_js.html' %} {# todo We should have a discussion at some point how we'd like to organize this in the future. #}
 {% endblock %}
@@ -84,7 +85,12 @@
                 langs: {{ app.langs|JSON }},
                 formName: "{{ form.name|trans:app.langs }}",
                 displayLanguage: {{ lang|JSON }},
-                sessionid: {{ sessionid|JSON }}
+                sessionid: {{ sessionid|JSON }},
+                {% if app.application_version == '2.0' %}
+                    {% if form.source and not is_user_registration %}
+                        cloudCareUrl: getCloudCareUrl("{% url "cloudcare_main" domain '' %}", "{{ app.id }}", "{{ module.id }}", "{{ nav_form.id }}") + "?preview=true"
+                    {% endif %}
+                {% endif %}
             });
             formdesigner.on('form-saved', function (args) {
                 var response = args.response;


### PR DESCRIPTION
Puts 'Try in CloudCare' as a dropdown-item in the Tools menu. Don't have to open an extra page to find "Try in CloudCare" button. Depends on https://github.com/dimagi/Vellum/pull/206/commits

Option in Tools
![cloudcare in formdesigner](https://cloud.githubusercontent.com/assets/829142/2692369/bd1c0802-c3a0-11e3-9e3d-ca35012b9cac.png)

If there are any unsaved changes.
![cloudcare in formdesigner](https://cloud.githubusercontent.com/assets/829142/2733202/cb772a12-c643-11e3-92bb-954c149d15a7.png)
