### PR TITLE
make archiving and unarchiving a form properly handle commtrack data

### DIFF
--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -17,6 +17,7 @@ from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.users.models import CommCareUser
 from casexml.apps.stock.utils import months_of_stock_remaining, state_stock_category
 from corehq.apps.domain.models import Domain
+from couchforms.signals import xform_archived, xform_unarchived
 from dimagi.utils.couch.loosechange import map_reduce
 from couchforms.models import XFormInstance
 from dimagi.utils import parsing as dateparse
@@ -31,8 +32,7 @@ from corehq.apps.commtrack.exceptions import LinkedSupplyPointNotFoundError
 from couchexport.models import register_column_type, ComplexExportColumn
 from dimagi.utils.dates import force_to_datetime
 from django.db import models
-from django.db.models.signals import post_save
-from corehq.apps.domain.models import Domain
+from django.db.models.signals import post_save, post_delete
 
 from dimagi.utils.decorators.memoized import memoized
 
@@ -1450,6 +1450,17 @@ def update_stock_state(sender, instance, *args, **kwargs):
     state.save()
 
 
+@receiver(post_delete, sender=DbStockTransaction)
+def stock_state_deleted(sender, instance, *args, **kwargs):
+    qs = DbStockTransaction.objects.filter(
+        section_id=instance.section_id,
+        case_id=instance.case_id,
+        product_id=instance.product_id,
+    ).order_by('-report__date')
+    if qs:
+        update_stock_state(sender, qs[0])
+
+
 @receiver(post_save, sender=StockState)
 def update_domain_mapping(sender, instance, *args, **kwargs):
     case_id = unicode(instance.case_id)
@@ -1470,6 +1481,16 @@ def post_loc_edited(sender, loc=None, **kwargs):
 @receiver(location_created)
 def post_loc_created(sender, loc=None, **kwargs):
     sync_location_supply_point(loc)
+
+
+@receiver(xform_archived)
+def remove_data(sender, xform, *args, **kwargs):
+    DbStockReport.objects.filter(form_id=xform._id).delete()
+
+@receiver(xform_unarchived)
+def reprocess_form(sender, xform, *args, **kwargs):
+    from corehq.apps.commtrack.processing import process_stock
+    process_stock(xform)
 
 # import signals
 from . import signals

--- a/corehq/apps/commtrack/processing.py
+++ b/corehq/apps/commtrack/processing.py
@@ -1,8 +1,8 @@
 import logging
 from casexml.apps.case.xform import is_device_report
-from casexml.apps.stock.const import TRANSACTION_SUBTYPE_INFERRED, COMMTRACK_REPORT_XMLNS
+from casexml.apps.stock.const import COMMTRACK_REPORT_XMLNS
 from dimagi.utils.decorators.log_exception import log_exception
-from corehq.apps.commtrack.models import CommtrackConfig, StockTransaction, NewStockReport
+from corehq.apps.commtrack.models import CommtrackConfig, NewStockReport
 from dimagi.utils.couch.loosechange import map_reduce
 from corehq.apps.commtrack.util import wrap_commtrack_case
 from casexml.apps.case.models import CommCareCaseAction, CommCareCase

--- a/corehq/apps/commtrack/tests/data/balances.py
+++ b/corehq/apps/commtrack/tests/data/balances.py
@@ -24,7 +24,7 @@ def balance_ota_block(sp, section_id, product_amounts, datestring):
     )
 
 
-def submission_wrap(products, user, sp, sp2, insides):
+def submission_wrap(instance_id, products, user, sp, sp2, insides):
     insides = insides() if callable(insides) else insides
     return ("""<?xml version="1.0" ?>
         <data uiVersion="1" version="33" name="New Form" xmlns="http://commtrack.org/test_form_submission">
@@ -49,7 +49,7 @@ def submission_wrap(products, user, sp, sp2, insides):
         product1=products[1]._id,
         product2=products[2]._id,
         user_id=user._id,
-        instance_id=uuid.uuid4().hex,
+        instance_id=instance_id,
         username=user.username,
         long_date=long_date(),
     )

--- a/corehq/apps/commtrack/tests/test_xml.py
+++ b/corehq/apps/commtrack/tests/test_xml.py
@@ -8,8 +8,9 @@ from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.xml import V2
 from casexml.apps.phone.restore import RestoreConfig
 from casexml.apps.phone.tests.utils import synclog_id_from_restore_payload
-from corehq.apps.commtrack.models import ConsumptionConfig, StockRestoreConfig, RequisitionCase, Product
+from corehq.apps.commtrack.models import ConsumptionConfig, StockRestoreConfig, RequisitionCase, Product, StockState
 from corehq.apps.consumption.shortcuts import set_default_consumption_for_domain
+from couchforms.models import XFormInstance
 from dimagi.utils.parsing import json_format_datetime
 from casexml.apps.stock import const as stockconst
 from casexml.apps.stock.models import StockReport, StockTransaction
@@ -167,7 +168,9 @@ class CommTrackSubmissionTest(CommTrackTest):
     def submit_xml_form(self, xml_method, **submit_extras):
         from casexml.apps.case import settings
         settings.CASEXML_FORCE_DOMAIN_CHECK = False
+        instance_id = uuid.uuid4().hex
         instance = submission_wrap(
+            instance_id,
             self.products,
             self.user,
             self.sp,
@@ -179,6 +182,7 @@ class CommTrackSubmissionTest(CommTrackTest):
             domain=self.domain.name,
             **submit_extras
         )
+        return instance_id
 
     def check_stock_models(self, case, product_id, expected_soh, expected_qty, section_id):
         if not isinstance(expected_qty, Decimal):
@@ -465,6 +469,45 @@ class CommTrackSyncTest(CommTrackSubmissionTest):
         # now restore should have the case
         check_user_has_case(self, self.casexml_user, self.sp_block, should_have=True,
                             restore_id=self.sync_log_id, version=V2, line_by_line=False)
+
+
+class CommTrackArchiveSubmissionTest(CommTrackSubmissionTest):
+
+    def testArchiveForm(self):
+        initial = float(100)
+        initial_amounts = [(p._id, initial) for p in self.products]
+        self.submit_xml_form(balance_submission(initial_amounts))
+
+        final_amounts = [(p._id, float(50)) for i, p in enumerate(self.products)]
+        second_form_id = self.submit_xml_form(balance_submission(final_amounts))
+
+        def _assert_initial_state():
+            self.assertEqual(1, StockReport.objects.filter(form_id=second_form_id).count())
+            # 6 = 3 stockonhand and 3 inferred consumption txns
+            self.assertEqual(6, StockTransaction.objects.filter(report__form_id=second_form_id).count())
+
+            for state in StockState.objects.filter(case_id=self.sp._id):
+                self.assertEqual(Decimal(50), state.stock_on_hand)
+                self.assertIsNotNone(state.daily_consumption)
+
+
+        # check initial setup
+        _assert_initial_state()
+
+        # archive and confirm commtrack data is deleted
+        form = XFormInstance.get(second_form_id)
+        form.archive()
+        self.assertEqual(0, StockReport.objects.filter(form_id=second_form_id).count())
+        self.assertEqual(0, StockTransaction.objects.filter(report__form_id=second_form_id).count())
+        for state in StockState.objects.filter(case_id=self.sp._id):
+            # balance should be reverted to 100 in the StockState
+            self.assertEqual(Decimal(100), state.stock_on_hand)
+            # consumption should be none since there will only be 1 data point
+            self.assertIsNone(state.daily_consumption)
+
+        # unarchive and confirm commtrack data is restored
+        form.unarchive()
+        _assert_initial_state()
 
 
 def _report_soh(amounts, case_id, section_id='stock', report=None):


### PR DESCRIPTION
this consists of 3 items:
1. deleting stock reports (and cascading transactions) when a form is archived
2. properly updating stock states whenever a stock transaction is deleted
3. reprocessing the commtrack part of the form when a form is unarchived to repopulate the standard models.
- a basic test
