### PR TITLE
location fixture support in app builder

### DIFF
--- a/corehq/apps/app_manager/detail_screen.py
+++ b/corehq/apps/app_manager/detail_screen.py
@@ -1,6 +1,7 @@
+from corehq import Domain
 from corehq.apps.app_manager import suite_xml as sx
 from corehq.apps.app_manager.util import is_sort_only_column
-from corehq.apps.app_manager.xpath import dot_interpolate, CaseXPath, IndicatorXpath, LedgerdbXpath
+from corehq.apps.app_manager.xpath import dot_interpolate, CaseXPath, IndicatorXpath, LedgerdbXpath, LocationXpath
 
 CASE_PROPERTY_MAP = {
     # IMPORTANT: if you edit this you probably want to also edit
@@ -370,6 +371,16 @@ class IndicatorXpathGenerator(BaseXpathGenerator):
         indicator_set, indicator = self.column.field_property.split('/', 1)
         instance_id = self.id_strings.indicator_instance(indicator_set)
         return IndicatorXpath(instance_id).indicator(indicator)
+
+
+@register_type_processor(sx.FIELD_TYPE_LOCATION)
+class LocationXpathGenerator(BaseXpathGenerator):
+    @property
+    def xpath(self):
+        from corehq.apps.locations.util import parent_child
+        hierarchy = parent_child(self.app.domain)
+        return LocationXpath('commtrack:locations').location(self.column.field_property, hierarchy)
+
 
 @register_type_processor(sx.FIELD_TYPE_LEDGER)
 class LedgerXpathGenerator(BaseXpathGenerator):

--- a/corehq/apps/app_manager/exceptions.py
+++ b/corehq/apps/app_manager/exceptions.py
@@ -90,3 +90,7 @@ class SuiteValidationError(SuiteError):
 
 class XFormIdNotUnique(AppManagerException, couchdbkit.MultipleResultsFound):
     pass
+
+
+class LocationXpathValidationError(AppManagerException):
+    pass

--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -125,7 +125,7 @@ var DetailScreenConfig = (function () {
     "use strict";
     var DetailScreenConfig, Screen, Column, sortRows;
     var word = '[a-zA-Z][\\w_-]*';
-    var field_val_re = RegExp('^('+word+':)?'+word+'(\\/'+word+')*$');
+    var field_val_re = RegExp('^('+word+':)*'+word+'(\\/'+word+')*$');
     var field_format_warning = $('<span/>').addClass('help-inline')
         .text("Must begin with a letter and contain only letters, numbers, '-', and '_'");
 
@@ -164,7 +164,7 @@ var DetailScreenConfig = (function () {
             this.includeInLong = uiElement.checkbox().val(orDefault(this.original.includeInLong, true));
 
             this.model = uiElement.select([
-                {label: "Case", value: "case"},
+                {label: "Case", value: "case"}
             ]).val(this.original.model);
             this.field = uiElement.input().val(this.original.field);
             this.format_warning = field_format_warning.clone().hide();
@@ -218,7 +218,7 @@ var DetailScreenConfig = (function () {
                 {label: DetailScreenConfig.message.TIME_AGO_INTERVAL.DAYS, value: DetailScreenConfig.TIME_AGO.day},
                 {label: DetailScreenConfig.message.TIME_AGO_INTERVAL.DAYS_UNTIL, value: -DetailScreenConfig.TIME_AGO.day},
                 {label: DetailScreenConfig.message.TIME_AGO_INTERVAL.WEEKS_UNTIL, value: -DetailScreenConfig.TIME_AGO.week},
-                {label: DetailScreenConfig.message.TIME_AGO_INTERVAL.MONTHS_UNTIL, value: -DetailScreenConfig.TIME_AGO.month},
+                {label: DetailScreenConfig.message.TIME_AGO_INTERVAL.MONTHS_UNTIL, value: -DetailScreenConfig.TIME_AGO.month}
             ]).val(this.original.time_ago_interval.toString());
             this.time_ago_extra.ui.prepend($('<div/>').text(DetailScreenConfig.message.TIME_AGO_EXTRA_LABEL));
 

--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -73,6 +73,11 @@
                             {% endif %}
                             <a href="{% url "view_module" domain app.id error.module.id %}">{{ error.module.name|trans:langs }}</a>
                         {% endif %}
+                        {% if error.type == "invalid location xpath" %}
+                            Case List has invalid location reference <code>{{ error.column.field_property}}</code>.
+                            Details: {{ error.details }}
+                            <a href="{% url "view_module" domain app.id error.module.id %}">{{ error.module.name|trans:langs }}</a>
+                        {% endif %}
                         {% if error.type == "subcase has no case type" %}
                             Child case specifies no module
                             in form {% include "app_manager/partials/form_error_message.html" %}

--- a/corehq/apps/app_manager/tests/__init__.py
+++ b/corehq/apps/app_manager/tests/__init__.py
@@ -13,6 +13,7 @@ try:
     from corehq.apps.app_manager.tests.test_views import *
     from corehq.apps.app_manager.tests.test_commcare_settings import *
     from corehq.apps.app_manager.tests.test_brief_view import *
+    from .test_location_xpath import *
     from .test_get_questions import *
     from .test_repeater import *
 except ImportError, e:

--- a/corehq/apps/app_manager/tests/test_location_xpath.py
+++ b/corehq/apps/app_manager/tests/test_location_xpath.py
@@ -1,0 +1,63 @@
+from django.test import SimpleTestCase
+from corehq.apps.app_manager.exceptions import LocationXpathValidationError
+from corehq.apps.app_manager.xpath import LocationXpath
+
+
+class LocationXpathTest(SimpleTestCase):
+
+    def setUp(self):
+        self.hierarchy = {
+            None: ["state"],
+            "state": ["district"],
+            "district": ["block"],
+            "block": ["outlet"],
+        }
+
+    def testValidXpathExpressions(self):
+        test_cases = [
+            ("outlet:outlet/location_type", "instance('commtrack:locations')/states/state/districts/district/blocks/block/outlets/outlet[@id = current()/location_id]/location_type"),
+            ("outlet:block/name", "instance('commtrack:locations')/states/state/districts/district/blocks/block[count(outlets/outlet[@id = current()/location_id]) > 0]/name"),
+            ("outlet:district/name", "instance('commtrack:locations')/states/state/districts/district[count(blocks/block/outlets/outlet[@id = current()/location_id]) > 0]/name"),
+            ("district:district/location_type", "instance('commtrack:locations')/states/state/districts/district[@id = current()/location_id]/location_type"),
+            ("district:state/name", "instance('commtrack:locations')/states/state[count(districts/district[@id = current()/location_id]) > 0]/name"),
+        ]
+        for input, expected in test_cases:
+            self.assertEqual(expected, LocationXpath('commtrack:locations').location(input, self.hierarchy))
+
+    def testFormatErrorCases(self):
+        test_cases = [
+            'badformatalloneword',
+            'badformat:noslash',
+            'badformat/nocolon'
+            'badformat:too:many/colons'
+            'badformat:too/many/slashes'
+        ]
+        for input in test_cases:
+            self.assertRaises(
+                LocationXpathValidationError,
+                LocationXpath('commtrack:locations').validate,
+                input, self.hierarchy,
+            )
+            self.assertRaises(
+                LocationXpathValidationError,
+                LocationXpath('commtrack:locations').location,
+                input, self.hierarchy,
+            )
+
+    def testStructureErrorCases(self):
+        test_cases = [
+            'unknowntype:outlet/location_type',
+            'outlet:unknowntype/location_type',
+            'state:outlet/location_type',  # can only point to parents
+        ]
+        for input in test_cases:
+            self.assertRaises(
+                LocationXpathValidationError,
+                LocationXpath('commtrack:locations').validate,
+                input, self.hierarchy,
+            )
+            self.assertRaises(
+                LocationXpathValidationError,
+                LocationXpath('commtrack:locations').location,
+                input, self.hierarchy,
+            )

--- a/corehq/apps/app_manager/xpath.py
+++ b/corehq/apps/app_manager/xpath.py
@@ -1,4 +1,6 @@
 import re
+from corehq.apps.app_manager.exceptions import LocationXpathValidationError
+from django.utils.translation import ugettext as _
 
 
 def dot_interpolate(string, replacement):
@@ -66,6 +68,88 @@ class IndicatorXpath(XPath):
         return XPath(u"instance('%s')/indicators/case[@id = current()/@case_id]" % self).slash(indicator_name)
 
 
+class LocationXpath(XPath):
+
+    def location(self, ref, hierarchy):
+
+        def gen_path(types):
+            def _gen():
+                for type in types:
+                    yield '%ss' % type
+                    yield type
+
+            return '/'.join(_gen())
+
+        def gen_expr(path):
+            query = '[@id = current()/location_id]'
+            if not path:
+                return query
+            else:
+                return '[count({path}{query}) > 0]'.format(
+                    path=gen_path(path),
+                    query=query,
+                )
+
+        def ref_to_xpath(input, hierarchy):
+            my_type, ref_type, property = self._parse_input(input)
+            types = self._ordered_types(hierarchy)
+            prefix_path = types[0:types.index(ref_type) + 1]
+            prefix = gen_path(prefix_path)
+            my_path = types[types.index(ref_type) + 1:types.index(my_type) + 1]
+            my_expr = gen_expr(my_path)
+            return '{prefix}{expr}/{property}'.format(prefix=prefix, expr=my_expr, property=property)
+
+        self.validate(ref, hierarchy)
+        return XPath(u"instance('{instance}')/{ref}").format(instance=self, ref=ref_to_xpath(ref, hierarchy))
+
+    def validate(self, ref, hierarchy):
+        my_type, ref_type, property = self._parse_input(ref)
+        types = self._ordered_types(hierarchy)
+        for type in [my_type, ref_type]:
+            if type not in types:
+                raise LocationXpathValidationError(
+                    _('Type {type} must be in list of domain types: {list}').format(
+                        type=type,
+                        list=', '.join(types)
+                    )
+                )
+
+        if types.index(ref_type) > types.index(my_type):
+            raise LocationXpathValidationError(
+                _('Reference type {ref} cannot be a child of primary type {main}.'.format(
+                    ref=ref_type,
+                    main=my_type,
+                ))
+            )
+
+    def _parse_input(self, input):
+        try:
+            my_type, ref = input.split(':')
+            ref_type, property = ref.split('/')
+            return my_type, ref_type, property
+        except ValueError:
+            raise LocationXpathValidationError(_(
+                'Property not correctly formatted. '
+                'Must be formatted like: loacation:mytype:referencetype/property. '
+                'For example: location:outlet:state/name'
+            ))
+
+    def _ordered_types(self, hierarchy):
+        from corehq.apps.commtrack.util import unicode_slug
+
+        def _gen(hierarchy):
+            next_types = set([None])
+            while next_types:
+                next_type = next_types.pop()
+                if next_type is not None:
+                    yield next_type
+                new_children = hierarchy.get(next_type, [])
+                for child in new_children:
+                    next_types.add(child)
+
+        return [unicode_slug(t) for t in _gen(hierarchy)]
+
+
 class LedgerdbXpath(XPath):
 
     def ledger(self):
@@ -82,4 +166,3 @@ class LedgerSectionXpath(XPath):
 
     def entry(self, id):
         return XPath(self.slash(u'entry').select(u'@id', id, quote=False))
-


### PR DESCRIPTION
there's some semblance of a spec here: https://docs.google.com/a/dimagi.com/document/d/1n6CI725XA5eJ0p8Vt-PMBz_8yyZ1EZDwmhwGtMUBYOw/edit

the tests are more accurate in terms of the behavior though.

basically allows you to type: `location:type:reftype/property` and reference the location fixture in the app builder. so you can query commtrack parent names and other types of things
