### PR TITLE
Pathfinder/m4change - add user_data to locations

### DIFF
--- a/corehq/apps/locations/forms.py
+++ b/corehq/apps/locations/forms.py
@@ -1,3 +1,4 @@
+import json
 from django import forms
 from corehq.apps.locations.models import Location, root_locations
 from django.template.loader import get_template
@@ -42,7 +43,7 @@ class LocationForm(forms.Form):
 
         super(LocationForm, self).__init__(bound_data, *args, **kwargs)
         self.fields['parent_id'].widget.domain = self.location.domain
-        
+
         # custom properties
         self.sub_forms = {}
         # TODO think i need to change this to iterate over all types, since the parent
@@ -126,6 +127,8 @@ class LocationForm(forms.Form):
             if not subform.is_valid():
                 raise forms.ValidationError('Error in location properties')
             self.cleaned_data.update(('prop:%s' % k, v) for k, v in subform.cleaned_data.iteritems())
+        self.cleaned_data['metadata'] = json.loads(self.data['metadata'])\
+            if self.data.get('metadata', None) is not None else {}
 
         return self.cleaned_data
 
@@ -142,6 +145,7 @@ class LocationForm(forms.Form):
         setattr(location, 'latitude', coords[0] if coords else None)
         setattr(location, 'longitude', coords[1] if coords else None)
         location.lineage = Location(parent=self.cleaned_data['parent_id']).lineage
+        location.metadata = self.cleaned_data.get('metadata', {})
 
         for k, v in self.cleaned_data.iteritems():
             if k.startswith('prop:'):
@@ -193,4 +197,3 @@ class LocationCustomPropertiesSubForm(forms.Form):
                         raise forms.ValidationError(mark_safe(str(e)))
                 return clean_custom
         raise AttributeError
-

--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -11,6 +11,7 @@ class Location(Document):
     site_code = StringProperty() # should be unique, not yet enforced
     # unique id from some external data source
     external_id = StringProperty()
+    metadata = DictProperty()
 
     latitude = FloatProperty()
     longitude = FloatProperty()

--- a/corehq/apps/locations/templates/locations/manage/location.html
+++ b/corehq/apps/locations/templates/locations/manage/location.html
@@ -5,6 +5,7 @@
 
 {% block js %}{{ block.super }}
     <script src="{% static 'users/js/key_filters.js' %}"></script>
+    <script src="{% static 'hqwebapp/js/ui-element.js' %}"></script>
     <script type="text/javascript" src="{% static 'locations/ko/location_drilldown.async.js' %}"></script>
 {% endblock %}
 
@@ -42,6 +43,15 @@
             });
         });
 
+      function handleChange() {
+          var data = customDataEditor.val();
+          $("input#metadata-input").val(JSON.stringify(data));
+      }
+      customDataEditor = uiElement.map_list('{{ location.get_id}}', '{% trans 'Location Data' %}');
+      customDataEditor.val({{ metadata|JSON }});
+      customDataEditor.on('change', handleChange);
+      $("#loc_form .custom-data-controls").append(customDataEditor.ui);
+
       $("#loc_form :button[type='submit']").click(function(e) {
           if (loc_id != null && model.selected_locid() != model.orig_parent_id) {
               e.preventDefault();
@@ -67,6 +77,15 @@
     <div style="display: none;" class="custom_subform" loctype="{{ loc_type }}">
       {% include 'hqstyle/forms/basic_fieldset.html' with form=subform %}
     </div>
+    <input name="metadata" id="metadata-input" type="hidden"/>
+    <fieldset>
+        <legend>{% trans "Custom Location Data" %}</legend>
+        <div class="control-group">
+            <label class="control-label">{% trans 'Current Data' %}</label>
+
+            <div class="controls custom-data-controls"></div>
+        </div>
+    </fieldset>
     {% endfor %}
 
     {% if consumption %}

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -1,3 +1,4 @@
+import copy
 from django.http import HttpResponse, HttpResponseRedirect, Http404
 from django.utils.safestring import mark_safe
 from django.views.decorators.http import require_POST
@@ -135,6 +136,11 @@ class NewLocationView(BaseLocationView):
 
     @property
     @memoized
+    def metadata(self):
+        return copy.copy(dict(self.location.metadata))
+
+    @property
+    @memoized
     def location_form(self):
         if self.request.method == 'POST':
             return LocationForm(self.location, self.request.POST)
@@ -146,6 +152,7 @@ class NewLocationView(BaseLocationView):
             'form': self.location_form,
             'location': self.location,
             'consumption': self.consumption,
+            'metadata': self.metadata
         }
 
     def post(self, request, *args, **kwargs):


### PR DESCRIPTION
Added user data to locations, because it makes sense for our CCT site use case. The way we have it now lets two separate users assigned to the same location have different CCT status, and CCT should be enabled/disabled per site, not per user. This solution allows us to do so, and `user_data` is generic enough to possibly be of some use to others in the future.

@czue I am not entirely sure which would be the best place to put the code inside the location form. If there's a better way to approach this, then please elaborate.
