### PR TITLE
use cached query to lookup users by ID

### DIFF
--- a/corehq/apps/users/middleware.py
+++ b/corehq/apps/users/middleware.py
@@ -44,10 +44,14 @@ class UsersMiddleware(object):
 
                 # disable session based couch user caching - to be enabled later.
                 if cached_user_doc_id not in (MISSING, INTERRUPTED):
-                    #cache hit
-                    couch_user = CouchUser.wrap_correctly(cache_core.cached_open_doc(CouchUser.get_db(), cached_user_doc_id))
+                    # cache hit
+                    couch_user = CouchUser.wrap_correctly(
+                        cache_core.cached_open_doc(
+                            CouchUser.get_db(), cached_user_doc_id
+                        )
+                    )
                 else:
-                    #cache miss, write to cache
+                    # cache miss, write to cache
                     couch_user = CouchUser.from_django_user(request.user)
                     if couch_user:
                         cache_core.do_cache_doc(couch_user.to_json())

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -17,6 +17,7 @@ from django.template.loader import render_to_string
 from couchdbkit.ext.django.schema import *
 from couchdbkit.resource import ResourceNotFound
 from dimagi.utils.chunked import chunked
+from dimagi.utils.couch.cache import cache_core
 from dimagi.utils.couch.database import get_safe_write_kwargs, iter_docs
 from dimagi.utils.logging import notify_exception
 
@@ -1119,10 +1120,9 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, EulaMi
         """
         if domain is given, checks to make sure the user is a member of that domain
         returns None if there's no user found or if the domain check fails
-
         """
         try:
-            couch_user = cls.wrap_correctly(cls.get_db().get(userID))
+            couch_user = cls.wrap_correctly(cache_core.cached_open_doc(cls.get_db(), userID))
         except ResourceNotFound:
             return None
         if couch_user.doc_type != cls.__name__ and cls.__name__ != "CouchUser":


### PR DESCRIPTION
this was already the default in the middleware so should have been
enabled already.

this is properly invalidated on saves.
