### PR TITLE
initialize exports with a timestamp in the past instead of now

### DIFF
--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -247,6 +247,11 @@ BASIC_FORM_SCHEMA = {
 }
 
 def create_basic_form_checkpoint(index):
-    checkpoint = ExportSchema(seq="0", schema=BASIC_FORM_SCHEMA, timestamp=datetime.utcnow(), index=index)
+    checkpoint = ExportSchema(
+        seq="0",
+        schema=BASIC_FORM_SCHEMA,
+        timestamp=datetime.min,
+        index=index,
+    )
     checkpoint.save()
     return checkpoint


### PR DESCRIPTION
i think this could have caused certain properties to not show up
in exports if submitted before the initial export was made, though
didn't observe that specifically.
