### PR TITLE
use build id instead of app id for the submit url

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2301,7 +2301,7 @@ class ApplicationBase(VersionedDoc, SnapshotMixin):
             url_name = 'receiver_secure_post_with_app_id'
         else:
             url_name = 'receiver_post_with_app_id'
-        return reverse(url_name, args=[self.domain, self.copy_of or self.get_id])
+        return reverse(url_name, args=[self.domain, self.get_id])
 
     @absolute_url_property
     def key_server_url(self):


### PR DESCRIPTION
The server already accepts a build id in this location. It recognizes it as such and uses it to look up the app_id, thus tagging the form submission with both an app id and a build id. This will let us do some nice stuff like detect which exact build a submission came from (and thus what build is on the phone). This will also be used in the upcoming "readable form data page" feature.
