### PR TITLE
fix the error when adding new locations without any metadata

### DIFF
--- a/corehq/apps/locations/forms.py
+++ b/corehq/apps/locations/forms.py
@@ -127,8 +127,12 @@ class LocationForm(forms.Form):
             if not subform.is_valid():
                 raise forms.ValidationError('Error in location properties')
             self.cleaned_data.update(('prop:%s' % k, v) for k, v in subform.cleaned_data.iteritems())
-        self.cleaned_data['metadata'] = json.loads(self.data['metadata'])\
-            if self.data.get('metadata', None) is not None else {}
+
+        try:
+            metadata = json.loads(self.data.get('metadata', '{}'))
+        except ValueError:
+            metadata = {}
+        self.cleaned_data['metadata'] = metadata
 
         return self.cleaned_data
 


### PR DESCRIPTION
There was an error with adding new locations, whereas clicking on the submit button without first editing custom data (even if nothing was changed) would result in an empty string, which would not be JSON-parsable.
