### PR TITLE
Force stock on hand stuff to int

### DIFF
--- a/corehq/apps/reports/commtrack/data_sources.py
+++ b/corehq/apps/reports/commtrack/data_sources.py
@@ -165,7 +165,7 @@ class StockStatusDataSource(ReportDataSource, CommtrackDataSourceMixin):
                 'months_remaining': state.months_remaining,
                 'location_id': SupplyPointCase.get(state.case_id).location_id,
                 'product_name': product.name,
-                'current_stock': state.stock_on_hand,
+                'current_stock': int(state.stock_on_hand) if state.stock_on_hand is not None else None,
                 'location_lineage': None,
                 'resupply_quantity_needed': state.resupply_quantity_needed
             }
@@ -184,7 +184,7 @@ class StockStatusDataSource(ReportDataSource, CommtrackDataSourceMixin):
                 'months_remaining': months_of_stock_remaining(state['total_stock'], state['avg_consumption']),
                 'location_id': None,
                 'product_name': product.name,
-                'current_stock': state['total_stock'],
+                'current_stock': int(state['total_stock']) if state['total_stock'] is not None else None,
                 'location_lineage': None,
                 'resupply_quantity_needed': None
             }

--- a/corehq/apps/reports/commtrack/data_sources.py
+++ b/corehq/apps/reports/commtrack/data_sources.py
@@ -12,6 +12,7 @@ from corehq.apps.reports.commtrack.util import get_relevant_supply_point_ids, pr
 from corehq.apps.reports.commtrack.const import STOCK_SECTION_TYPE
 from casexml.apps.stock.utils import months_of_stock_remaining, stock_category
 from corehq.apps.reports.standard.monitoring import MultiFormDrilldownMixin
+from decimal import Decimal
 
 
 def reporting_status(transaction, start_date, end_date):
@@ -155,6 +156,13 @@ class StockStatusDataSource(ReportDataSource, CommtrackDataSourceMixin):
             else:
                 return self.raw_product_states(stock_states, slugs)
 
+    def format_decimal(self, d):
+        # https://docs.python.org/2/library/decimal.html#decimal-faq
+        if d is not None:
+            return d.quantize(Decimal(1)) if d == d.to_integral() else d.normalize()
+        else:
+            return None
+
     def leaf_node_data(self, stock_states):
         for state in stock_states:
             product = Product.get(state.product_id)
@@ -165,7 +173,7 @@ class StockStatusDataSource(ReportDataSource, CommtrackDataSourceMixin):
                 'months_remaining': state.months_remaining,
                 'location_id': SupplyPointCase.get(state.case_id).location_id,
                 'product_name': product.name,
-                'current_stock': int(state.stock_on_hand) if state.stock_on_hand is not None else None,
+                'current_stock': self.format_decimal(state.stock_on_hand),
                 'location_lineage': None,
                 'resupply_quantity_needed': state.resupply_quantity_needed
             }
@@ -184,7 +192,7 @@ class StockStatusDataSource(ReportDataSource, CommtrackDataSourceMixin):
                 'months_remaining': months_of_stock_remaining(state['total_stock'], state['avg_consumption']),
                 'location_id': None,
                 'product_name': product.name,
-                'current_stock': int(state['total_stock']) if state['total_stock'] is not None else None,
+                'current_stock': self.format_decimal(state['total_stock']),
                 'location_lineage': None,
                 'resupply_quantity_needed': None
             }


### PR DESCRIPTION
Currently ledgers only support integer values (though the sql table column is a decimal field). I think it is better to tack on a generic solution here for the time being, rather than changing the table, and handle more reasonable formatting in the future when decimals are supported.
