### PR TITLE
Add request data back to commtrack reports

### DIFF
--- a/corehq/apps/reports/commtrack/data_sources.py
+++ b/corehq/apps/reports/commtrack/data_sources.py
@@ -58,6 +58,13 @@ class CommtrackDataSourceMixin(object):
     def end_date(self):
         return self.config.get('end_date') or datetime.now().date()
 
+    @property
+    def request(self):
+        request = self.config.get('request')
+        if request:
+            return request
+
+
 
 class StockStatusDataSource(ReportDataSource, CommtrackDataSourceMixin):
     """

--- a/corehq/apps/reports/commtrack/standard.py
+++ b/corehq/apps/reports/commtrack/standard.py
@@ -296,6 +296,7 @@ class ReportingRatesReport(GenericTabularReport, CommtrackReportMixin):
             'program_id': self.request.GET.get('program'),
             'start_date': self.datespan.startdate_utc,
             'end_date': self.datespan.enddate_utc,
+            'request': self.request,
         }
         statuses = list(ReportingStatusDataSource(config).get_data())
 


### PR DESCRIPTION
Request was removed in this commit: https://github.com/dimagi/commcare-hq/commit/7e8bd6755945e178c1e80f3853a26aec59fbcae7 which changed the way the report date filters were done. Turns out it was needed for the form filtering, though.
