### PR TITLE
force user auditing in travis for auditcare tests

### DIFF
--- a/.travis/localsettings.py
+++ b/.travis/localsettings.py
@@ -64,6 +64,8 @@ CACHES = {
     }
 }
 
+AUDIT_MODEL_SAVE = ['django.contrib.auth.models.User']
+
 ELASTICSEARCH_HOST = 'localhost' 
 ELASTICSEARCH_PORT = 9200
 


### PR DESCRIPTION
this is rather unfortunate, but auditcare depends on this being set, and it's not trivial to fix that dependency within the tests since it's necessary at module load time.

wait for build.
