### PR TITLE
Fix location coordinate importing

### DIFF
--- a/corehq/apps/locations/bulk.py
+++ b/corehq/apps/locations/bulk.py
@@ -99,6 +99,10 @@ def import_location(domain, location_type, location_data):
     form_data['name'] = data.pop('name')
     form_data['location_type'] = location_type
 
+    lat, lon = data.pop('latitude', None), data.pop('longitude', None)
+    if lat and lon:
+        form_data['coordinates'] = '%s, %s' % (lat, lon)
+
     properties = {}
     consumption = []
     for k, v in data.iteritems():

--- a/corehq/apps/locations/tests/test_location_import.py
+++ b/corehq/apps/locations/tests/test_location_import.py
@@ -183,3 +183,17 @@ class LocationImportTest(CommTrackTest):
             ),
             77
         )
+
+    def test_import_coordinates(self):
+        data = {
+            'name': 'importedloc',
+            'latitude': 55,
+            'longitude': -55,
+        }
+
+        loc_id = import_location(self.domain.name, 'state', data)['id']
+
+        loc = Location.get(loc_id)
+
+        self.assertEqual(data['latitude'], loc.latitude)
+        self.assertEqual(data['longitude'], loc.longitude)


### PR DESCRIPTION
I export `latitude`/`longitude` columns in the template, but the form expects `coordinates`..... did this ever work?
