### PR TITLE
add CachedCouchDocumentMixin and use for default consumption values

### DIFF
--- a/corehq/apps/cachehq/cachemodels.py
+++ b/corehq/apps/cachehq/cachemodels.py
@@ -90,3 +90,11 @@ class ReportGenerationCache(GenerationCache):
         "reportconfig/daily_notifications",
         'groupexport/by_domain',
     ]
+
+
+class DefaultConsumptionGenerationCache(GenerationCache):
+    generation_key = '#gen#default_consumption#'
+    doc_types = ['DefaultConsumption']
+    views = [
+        'consumption/consumption_index',
+    ]

--- a/corehq/apps/cachehq/mixins.py
+++ b/corehq/apps/cachehq/mixins.py
@@ -1,0 +1,45 @@
+import logging
+from couchdbkit import ResourceNotFound
+from corehq.apps.cachehq.invalidate import invalidate_document
+from dimagi.utils.couch.cache import cache_core
+from dimagi.utils.couch.cache.cache_core import cached_open_doc
+
+
+class CachedCouchDocumentMixin(object):
+    """
+    A mixin for Documents that's meant to be used to enable generationally cached
+    access in front of couch.
+    """
+
+    def save(self, **params):
+        super(CachedCouchDocumentMixin, self).save(**params)
+        invalidate_document(self)
+
+    def delete(self):
+        id = self._id
+        try:
+            super(CachedCouchDocumentMixin, self).delete()
+        except ResourceNotFound:
+            # it was already deleted. this isn't a problem, but might be a caching bug
+            logging.exception('Tried to delete cached doc %s but it was already deleted' % id)
+
+        self._doc['_id'] = id
+        invalidate_document(self, deleted=True)
+
+    @classmethod
+    def get(cls, docid, rev=None, db=None, dynamic_properties=True):
+        if rev is None and db is None and dynamic_properties:
+            doc_json = cached_open_doc(cls.get_db(), docid)
+            return cls.wrap(doc_json)
+        else:
+            return super(CachedCouchDocumentMixin, cls).get(docid, rev, db, dynamic_properties)
+
+    @classmethod
+    def view(cls, view_name, wrapper=None, dynamic_properties=None, wrap_doc=True, classes=None, **params):
+        wrapper = wrapper or cls.wrap
+        if dynamic_properties is None and wrap_doc and classes is None:
+            return cache_core.cached_view(cls.get_db(), view_name, wrapper, **params)
+        else:
+            return super(CachedCouchDocumentMixin, cls).view(
+                view_name, wrapper, dynamic_properties, wrap_doc, classes, **params
+            )

--- a/corehq/apps/consumption/models.py
+++ b/corehq/apps/consumption/models.py
@@ -1,4 +1,5 @@
 from couchdbkit.ext.django.schema import Document, StringProperty, DecimalProperty
+from corehq.apps.cachehq.mixins import CachedCouchDocumentMixin
 
 
 TYPE_DOMAIN = 'domain'
@@ -7,7 +8,7 @@ TYPE_SUPPLY_POINT_TYPE = 'supply-point-type'
 TYPE_SUPPLY_POINT = 'supply-point'
 
 
-class DefaultConsumption(Document):
+class DefaultConsumption(CachedCouchDocumentMixin, Document):
     """
     Model for setting the default consumption value of an entity
     """

--- a/corehq/apps/consumption/shortcuts.py
+++ b/corehq/apps/consumption/shortcuts.py
@@ -1,5 +1,6 @@
 from decimal import Decimal
 from corehq.apps.consumption.models import DefaultConsumption, TYPE_DOMAIN, TYPE_PRODUCT, TYPE_SUPPLY_POINT
+from dimagi.utils.couch.cache import cache_core
 
 
 def get_default_consumption(domain, product_id, location_type, case_id):
@@ -9,11 +10,11 @@ def get_default_consumption(domain, product_id, location_type, case_id):
         [domain, product_id, None, None],
         [domain, None, None, None],
     ]
-    results = DefaultConsumption.get_db().view(
-        'consumption/consumption_index',
+
+    results = cache_core.cached_view(DefaultConsumption.get_db(), 'consumption/consumption_index',
         keys=keys, reduce=False, limit=1, descending=True,
     )
-    results = results.one()
+    results = results[0] if results else None
     if results and results['value']:
         return Decimal(results['value'])
     else:

--- a/corehq/apps/consumption/tests.py
+++ b/corehq/apps/consumption/tests.py
@@ -1,5 +1,7 @@
 from django.test import TestCase
-from corehq.apps.consumption.shortcuts import get_default_consumption, set_default_consumption_for_domain, set_default_consumption_for_product, set_default_consumption_for_supply_point
+from corehq.apps.consumption.shortcuts import (get_default_consumption, set_default_consumption_for_domain,
+    set_default_consumption_for_product, set_default_consumption_for_supply_point
+)
 from .models import DefaultConsumption, TYPE_DOMAIN, TYPE_PRODUCT, TYPE_SUPPLY_POINT_TYPE, TYPE_SUPPLY_POINT
 
 domain = 'consumption-test'
@@ -149,5 +151,5 @@ def _count_consumptions():
 
 def _delete_all_consumptions():
     for consumption in DefaultConsumption.view('consumption/consumption_index',
-                                                   reduce=False, include_docs=True):
+                                               reduce=False, include_docs=True):
         consumption.delete()

--- a/settings.py
+++ b/settings.py
@@ -1059,6 +1059,7 @@ COUCH_CACHE_BACKENDS = [
     'corehq.apps.cachehq.cachemodels.UserRoleGenerationCache',
     'corehq.apps.cachehq.cachemodels.TeamGenerationCache',
     'corehq.apps.cachehq.cachemodels.ReportGenerationCache',
+    'corehq.apps.cachehq.cachemodels.DefaultConsumptionGenerationCache',
     'dimagi.utils.couch.cache.cache_core.gen.GlobalCache',
 ]
 


### PR DESCRIPTION
This builds off the work that was started in https://github.com/dimagi/dimagi-utils/pull/192 (which i later removed and moved here - switching to the existing caching framework).

I'm not 100% confident in `CachedCouchDocumentMixin`'s handling of all cases but I am as close to 100% confident in this change as is reasonable. The tests hit every use case and I have run them extensively with caching both on and off.

This makes OTA restores in CommTrack significantly faster, at least when default consumption fires a lot.
