### PR TITLE
Fix bug in inventory aggregate report

### DIFF
--- a/corehq/apps/reports/commtrack/data_sources.py
+++ b/corehq/apps/reports/commtrack/data_sources.py
@@ -186,17 +186,27 @@ class StockStatusDataSource(ReportDataSource, CommtrackDataSourceMixin):
                 product = product_aggregation[state.product_id]
                 product['current_stock'] = self.format_decimal(
                     product['current_stock'] + state.stock_on_hand
-                ),
-                product['total_consumption'] += state.get_consumption()
+                )
+
+                if product['total_consumption'] is None:
+                    product['total_consumption'] = state.get_consumption()
+                elif state.get_consumption() is not None:
+                    product['total_consumption'] += state.get_consumption()
+
                 product['count'] += 1
-                product['consumption'] = product['total_consumption'] / product['count']
+
+                if product['total_consumption'] is not None:
+                    product['consumption'] = product['total_consumption'] / product['count']
+                else:
+                    product['consumption'] = None
+
                 product['category'] = stock_category(
-                    product['total_stock'],
-                    product['avg_consumption'],
+                    product['current_stock'],
+                    product['consumption'],
                     Domain.get_by_name(self.domain)
                 )
                 product['months_remaining'] = months_of_stock_remaining(
-                    product['total_stock'],
+                    product['current_stock'],
                     product['consumption']
                 )
             else:


### PR DESCRIPTION
When testing this, it looked like it was aggregating, but no supply point had more than one `StockStatus` per product, so this code wasn't getting hit on my local or staging domains...

Have done more thorough testing now.
