### PR TITLE
Output node text

### DIFF
--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -205,7 +205,7 @@ class ItextValue(unicode):
 
     @classmethod
     def from_node(cls, node):
-        parts = [node.text]
+        parts = [node.text or '']
         for sub in node.findall('*'):
             if sub.tag_name == 'output':
                 ref = sub.attrib.get('ref') or sub.attrib.get('value')

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -216,7 +216,7 @@ class ItextValue(unicode):
 
     @classmethod
     def _render(cls, parts, context=None, processor=None, escape=None):
-        escape = escape or (lambda x: x if x is not None else '')
+        escape = escape or (lambda x: x)
         processor = processor or (lambda x: x if x is not None else '____')
         context = context or {}
         return ''.join(


### PR DESCRIPTION
This reverts https://github.com/dimagi/commcare-hq/pull/3320, introduces the more fundamental fix, and adds a test for the (pretty common) edge case.

The test (which now passes) fails on the pre-fix code:

```
======================================================================
ERROR: test_output_ref_start (corehq.apps.app_manager.tests.test_xform_parsing.ItextValueTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/droberts/dimagi/commcare-hq/corehq/apps/app_manager/tests/test_xform_parsing.py", line 63, in test_output_ref_start
    '____ Test test')
  File "/Users/droberts/dimagi/commcare-hq/corehq/apps/app_manager/tests/test_xform_parsing.py", line 48, in _test
    escaped_itext
  File "/Users/droberts/dimagi/commcare-hq/corehq/apps/app_manager/xform.py", line 215, in from_node
    return cls(parts)
  File "/Users/droberts/dimagi/commcare-hq/corehq/apps/app_manager/xform.py", line 195, in __new__
    return super(ItextValue, cls).__new__(cls, cls._render(parts))
  File "/Users/droberts/dimagi/commcare-hq/corehq/apps/app_manager/xform.py", line 225, in _render
    for part in parts
TypeError: sequence item 0: expected string, NoneType found
```
