### PR TITLE
workaround for translations 500

### DIFF
--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -1595,9 +1595,9 @@ def get_app_translations(request, domain):
     key = params.get('key', None)
     one = params.get('one', False)
     translations = Translation.get_translations(lang, key, one)
-
-    translations = {k: v for k, v in translations.items()
-                    if not id_strings.is_custom_app_string(k)}
+    if isinstance(translations, dict):
+        translations = {k: v for k, v in translations.items()
+                        if not id_strings.is_custom_app_string(k)}
     return json_response(translations)
 
 


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?111525

this appears to have been introduced by https://github.com/dimagi/commcare-hq/commit/d165581746f82ed19ebb27b189f811223aa6f1e6
which made the incorrect assumption that the result of
`Translation.get_translations` was always a dict. Not knowing why the
change was made, this just works around the error
