### PR TITLE
avoid UnicodeEncodeErrors in the bookkeeper email

### DIFF
--- a/corehq/apps/accounting/interface.py
+++ b/corehq/apps/accounting/interface.py
@@ -512,7 +512,7 @@ class InvoiceInterface(GenericTabularReport):
                     '<a href="%s" class="btn">Go to Invoice</a>'
                     % reverse(InvoiceSummaryView.urlname, args=(invoice.id,))))
             else:
-                column.append(get_address_from_invoice(invoice))
+                column.append(unicode(get_address_from_invoice(invoice)))
             rows.append(column)
         return rows
 


### PR DESCRIPTION
fixes http://manage.dimagi.com/default.asp?111530#629467

the export writer automatically converts unicode values into UTF-8 encoding, so the Address should be converted to a unicode value before being passed in order to do the automatic encoding check.
