### PR TITLE
Custom translations for system SMS responses

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/supported-languages.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/supported-languages.html
@@ -1,10 +1,11 @@
+{% load i18n %}
 <div data-bind="saveButton: saveButton, visible: editing"></div>
 <table class="table">
     <thead>
         <tr class="row control-group" data-bind="css: {error: validateGeneral()}">
             <th></th>
             <th></th>
-            <th>{% if not always_deploy %}Deploy{% endif %}</th>
+            <th>{% if not always_deploy %}{% trans "Deploy" %}{% endif %}</th>
             <th></th>
             <th></th>
             <th></th>

--- a/corehq/apps/app_manager/templates/app_manager/partials/supported-languages.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/supported-languages.html
@@ -4,7 +4,7 @@
         <tr class="row control-group" data-bind="css: {error: validateGeneral()}">
             <th></th>
             <th></th>
-            <th>Deploy</th>
+            <th>{% if not always_deploy %}Deploy{% endif %}</th>
             <th></th>
             <th></th>
             <th></th>
@@ -25,7 +25,11 @@
                 <span class="label label-info" data-bind="visible: $root.languages()[0] === $data">1. default</span>
             </td>
             <td>
+                {% if always_deploy %}
+                <input type="checkbox" checked="checked" data-bind="value: deploy, visible: false" />
+                {% else %}
                 <span data-bind="editableBool: deploy, editing: $root.editing"></span>
+                {% endif %}
             </td>
             <td>
                 <span data-bind="langcode: langcode, valueUpdate: 'textchange', editing: $root.editing, inputHandlers: {hasfocus: $root.seen}"></span>

--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -1509,6 +1509,27 @@ def edit_commcare_profile(request, domain, app_id):
     return json_response(response_json)
 
 
+def validate_langs(request, existing_langs, validate_build=True):
+    o = json.loads(request.raw_post_data)
+    langs = o['langs']
+    rename = o['rename']
+    build = o['build']
+
+    assert set(rename.keys()).issubset(existing_langs)
+    assert set(rename.values()).issubset(langs)
+    # assert that there are no repeats in the values of rename
+    assert len(set(rename.values())) == len(rename.values())
+    # assert that no lang is renamed to an already existing lang
+    for old, new in rename.items():
+        if old != new:
+            assert(new not in existing_langs)
+    # assert that the build langs are in the correct order
+    if validate_build:
+        assert sorted(build, key=lambda lang: langs.index(lang)) == build
+
+    return (langs, rename, build)
+
+
 @no_conflict_require_POST
 @require_can_edit_apps
 def edit_app_langs(request, domain, app_id):
@@ -1524,23 +1545,9 @@ def edit_app_langs(request, domain, app_id):
         build: ["es", "hin"]
     }
     """
-    o = json.loads(request.raw_post_data)
     app = get_app(domain, app_id)
-    langs = o['langs']
-    rename = o['rename']
-    build = o['build']
-
     try:
-        assert set(rename.keys()).issubset(app.langs)
-        assert set(rename.values()).issubset(langs)
-        # assert that there are no repeats in the values of rename
-        assert len(set(rename.values())) == len(rename.values())
-        # assert that no lang is renamed to an already existing lang
-        for old, new in rename.items():
-            if old != new:
-                assert(new not in app.langs)
-        # assert that the build langs are in the correct order
-        assert sorted(build, key=lambda lang: langs.index(lang)) == build
+        langs, rename, build = validate_langs(request, app.langs)
     except AssertionError:
         return HttpResponse(status=400)
 

--- a/corehq/apps/hqwebapp/models.py
+++ b/corehq/apps/hqwebapp/models.py
@@ -790,6 +790,8 @@ class MessagingTab(UITab):
                 (_("Settings"), [
                     {'title': ugettext_lazy("General Settings"),
                      'url': reverse('sms_settings', args=[self.domain])},
+                    {'title': ugettext_lazy("Languages"),
+                     'url': reverse('sms_languages', args=[self.domain])},
                 ])
             )
 

--- a/corehq/apps/sms/handlers/keyword.py
+++ b/corehq/apps/sms/handlers/keyword.py
@@ -75,11 +75,11 @@ def global_keyword_start(v, text, msg, text_words, open_sessions):
                 return False
             process_survey_keyword_actions(v, sk, text[6:].strip(), msg)
         else:
-            message = get_message(MSG_KEYWORD_NOT_FOUND, v, {"keyword": keyword})
+            message = get_message(MSG_KEYWORD_NOT_FOUND, v, (keyword,))
             send_sms_to_verified_number(v, message, metadata=outbound_metadata)
     else:
         message = get_message(MSG_START_KEYWORD_USAGE, v, 
-            {"start_keyword": text_words[0]})
+            (text_words[0],))
         send_sms_to_verified_number(v, message, metadata=outbound_metadata)
     return True
 
@@ -102,7 +102,7 @@ def global_keyword_current(v, text, msg, text_words, open_sessions):
     return True
 
 def global_keyword_unknown(v, text, msg, text_words, open_sessions):
-    message = get_message(MSG_UNKNOWN_GLOBAL_KEYWORD, v, {"keyword": text_words[0]})
+    message = get_message(MSG_UNKNOWN_GLOBAL_KEYWORD, v, (text_words[0],))
     send_sms_to_verified_number(v, message)
     return True
 
@@ -203,7 +203,7 @@ def parse_structured_sms_named_args(args, action, verified_number=None):
             answer_parts = answer.partition(action.named_args_separator)
             if answer_parts[1] != action.named_args_separator:
                 error_msg = get_message(MSG_EXPECTED_NAMED_ARGS_SEPARATOR,
-                    verified_number, {"separator": action.named_args_separator})
+                    verified_number, (action.named_args_separator,))
                 raise StructuredSMSException(response_text=error_msg)
             else:
                 arg_name = answer_parts[0].upper().strip()
@@ -212,7 +212,7 @@ def parse_structured_sms_named_args(args, action, verified_number=None):
                     if xpath in xpath_answer:
                         error_msg = get_message(MSG_MULTIPLE_ANSWERS_FOUND,
                             verified_number,
-                            {"arg_name": arg_name})
+                            (arg_name,))
                         raise StructuredSMSException(response_text=error_msg)
 
                     xpath_answer[xpath] = answer_parts[2].strip()
@@ -229,13 +229,13 @@ def parse_structured_sms_named_args(args, action, verified_number=None):
                     if matches > 1:
                         error_msg = get_message(MSG_MULTIPLE_QUESTIONS_MATCH,
                             verified_number,
-                            {"answer": answer})
+                            (answer,))
                         raise StructuredSMSException(response_text=error_msg)
 
                     if v in xpath_answer:
                         error_msg = get_message(MSG_MULTIPLE_ANSWERS_FOUND,
                             verified_number,
-                            {"arg_name": k})
+                            (k,))
                         raise StructuredSMSException(response_text=error_msg)
 
                     xpath_answer[v] = answer[len(k):].strip()
@@ -315,7 +315,7 @@ def handle_structured_sms(survey_keyword, survey_keyword_action, contact,
                     {v: k for k, v in survey_keyword_action.named_args.items()}
             field_name = get_question_id(sse.xformsresponse, xpath_arg)
             error_msg = get_message(MSG_FIELD_DESCRIPTOR, verified_number,
-                {"field_name": field_name})
+                (field_name,))
         error_msg = "%s%s" % (error_msg, sse.response_text)
     except Exception:
         logging.exception("Could not process structured sms for contact %s, "

--- a/corehq/apps/sms/messages.py
+++ b/corehq/apps/sms/messages.py
@@ -49,7 +49,11 @@ _MESSAGES = {
 def get_message(msg_id, verified_number=None, context=None):
     default_msg = _MESSAGES.get(msg_id, "")
 
-    tdoc = StandaloneTranslationDoc.get_obj(verified_number.domain, "sms")
+    if verified_number:
+        tdoc = StandaloneTranslationDoc.get_obj(verified_number.domain, "sms")
+    else:
+        tdoc = None
+
     try:
         user_lang = verified_number.owner.get_language_code()
     except:
@@ -93,7 +97,7 @@ def get_message(msg_id, verified_number=None, context=None):
     )
 
     if context:
-        msg = msg.format(context)
+        msg = msg.format(*context)
 
     return msg
 

--- a/corehq/apps/sms/messages.py
+++ b/corehq/apps/sms/messages.py
@@ -1,23 +1,23 @@
-MSG_MULTIPLE_SESSIONS = "SURVEY_ERROR"
-MSG_TOUCHFORMS_DOWN = "TOUCHFORMS_DOWN"
-MSG_TOUCHFORMS_ERROR = "TOUCHFORMS_ERROR"
-MSG_CHOICE_OUT_OF_RANGE = "SELECT_OUT_OF_RANGE"
-MSG_INVALID_CHOICE = "SELECT_INVALID_CHOICE"
-MSG_INVALID_INT = "INVALID_INT"
-MSG_INVALID_FLOAT = "INVALID_FLOAT"
-MSG_INVALID_LONG = "INVALID_LONG"
-MSG_INVALID_DATE = "INVALID_DATE"
-MSG_INVALID_TIME = "INVALID_TIME"
-MSG_KEYWORD_NOT_FOUND = "KEYWORD_NOT_FOUND"
-MSG_START_KEYWORD_USAGE = "START_KEYWORD_USAGE"
-MSG_UNKNOWN_GLOBAL_KEYWORD = "UNKNOWN_GLOBAL_KEYWORD"
-MSG_FIELD_REQUIRED = "FIELD_REQUIRED"
-MSG_EXPECTED_NAMED_ARGS_SEPARATOR = "SS_NAMED_ARGS_SEPARATOR"
-MSG_MULTIPLE_ANSWERS_FOUND = "SS_MULTIPLE_ANSWERS_FOUND"
-MSG_MULTIPLE_QUESTIONS_MATCH = "SS_MULTIPLE_QUESTIONS_MATCH"
-MSG_MISSING_EXTERNAL_ID = "MISSING_EXTERNAL_ID"
-MSG_CASE_NOT_FOUND = "CASE_NOT_FOUND"
-MSG_FIELD_DESCRIPTOR = "FIELD_DESCRIPTOR"
+MSG_MULTIPLE_SESSIONS = "sms.survey.restart"
+MSG_TOUCHFORMS_DOWN = "sms.survey.temporarilydown"
+MSG_TOUCHFORMS_ERROR = "sms.survey.internalerror"
+MSG_CHOICE_OUT_OF_RANGE = "sms.validation.outofrange"
+MSG_INVALID_CHOICE = "sms.validation.invalidchoice"
+MSG_INVALID_INT = "sms.validation.invalidint"
+MSG_INVALID_FLOAT = "sms.validation.invalidfloat"
+MSG_INVALID_LONG = "sms.validation.invalidlong"
+MSG_INVALID_DATE = "sms.validation.invaliddate"
+MSG_INVALID_TIME = "sms.validation.invalidtime"
+MSG_KEYWORD_NOT_FOUND = "sms.keyword.notfound"
+MSG_START_KEYWORD_USAGE = "sms.keyword.startusage"
+MSG_UNKNOWN_GLOBAL_KEYWORD = "sms.keyword.unknownglobal"
+MSG_FIELD_REQUIRED = "sms.survey.fieldrequired"
+MSG_EXPECTED_NAMED_ARGS_SEPARATOR = "sms.structured.missingseparator"
+MSG_MULTIPLE_ANSWERS_FOUND = "sms.structured.multipleanswers"
+MSG_MULTIPLE_QUESTIONS_MATCH = "sms.structured.ambiguousanswer"
+MSG_MISSING_EXTERNAL_ID = "sms.caselookup.missingexternalid"
+MSG_CASE_NOT_FOUND = "sms.caselookup.casenotfound"
+MSG_FIELD_DESCRIPTOR = "sms.survey.fielddescriptor"
 
 _MESSAGES = {
     MSG_MULTIPLE_SESSIONS: "An error has occurred. Please try restarting the survey.",
@@ -30,19 +30,21 @@ _MESSAGES = {
     MSG_INVALID_LONG: "Invalid long integer entered.",
     MSG_INVALID_DATE: "Invalid date format: expected YYYYMMDD.",
     MSG_INVALID_TIME: "Invalid time format: expected HHMM (24-hour).",
-    MSG_KEYWORD_NOT_FOUND: "Keyword not found: '%(keyword)s'",
-    MSG_START_KEYWORD_USAGE: "Usage: %(start_keyword)s <keyword>",
-    MSG_UNKNOWN_GLOBAL_KEYWORD: "Unknown command: '%(keyword)s'",
+    MSG_KEYWORD_NOT_FOUND: "Keyword not found: '{0}'",
+    MSG_START_KEYWORD_USAGE: "Usage: {0} <keyword>",
+    MSG_UNKNOWN_GLOBAL_KEYWORD: "Unknown command: '{0}'",
     MSG_FIELD_REQUIRED: "This field is required.",
-    MSG_EXPECTED_NAMED_ARGS_SEPARATOR: "Expected name and value to be joined by '%(separator)s'.",
-    MSG_MULTIPLE_ANSWERS_FOUND: "More than one answer found for '%(arg_name)s'",
-    MSG_MULTIPLE_QUESTIONS_MATCH: "More than one question matches '%(answer)s'",
+    MSG_EXPECTED_NAMED_ARGS_SEPARATOR: "Expected name and value to be joined by '{0}'.",
+    MSG_MULTIPLE_ANSWERS_FOUND: "More than one answer found for '{0}'",
+    MSG_MULTIPLE_QUESTIONS_MATCH: "More than one question matches '{0}'",
     MSG_MISSING_EXTERNAL_ID: "Expected case external id.",
     MSG_CASE_NOT_FOUND: "Case with the given external id was not found.",
-    MSG_FIELD_DESCRIPTOR: "Field '%(field_name)s': ",
+    MSG_FIELD_DESCRIPTOR: "Field '{0}': ",
 }
 
 def get_message(msg_id, verified_number=None, context=None):
-    context = context or {}
-    return _MESSAGES.get(msg_id, "") % context
+    msg = _MESSAGES.get(msg_id, "")
+    if context:
+        msg = msg.format(context)
+    return msg
 

--- a/corehq/apps/sms/messages.py
+++ b/corehq/apps/sms/messages.py
@@ -1,3 +1,7 @@
+from corehq.apps.translations.models import StandaloneTranslationDoc
+from corehq.util.translation import localize
+from django.utils.translation import ugettext as _, ugettext_noop
+
 MSG_MULTIPLE_SESSIONS = "sms.survey.restart"
 MSG_TOUCHFORMS_DOWN = "sms.survey.temporarilydown"
 MSG_TOUCHFORMS_ERROR = "sms.survey.internalerror"
@@ -20,31 +24,76 @@ MSG_CASE_NOT_FOUND = "sms.caselookup.casenotfound"
 MSG_FIELD_DESCRIPTOR = "sms.survey.fielddescriptor"
 
 _MESSAGES = {
-    MSG_MULTIPLE_SESSIONS: "An error has occurred. Please try restarting the survey.",
-    MSG_TOUCHFORMS_DOWN: "An error has occurred. Please try again later. If the problem persists, try restarting the survey.",
-    MSG_TOUCHFORMS_ERROR: "Internal server error.",
-    MSG_CHOICE_OUT_OF_RANGE: "Choice is out of range.",
-    MSG_INVALID_CHOICE: "Invalid choice.",
-    MSG_INVALID_INT: "Invalid integer entered.",
-    MSG_INVALID_FLOAT: "Invalid floating point number entered.",
-    MSG_INVALID_LONG: "Invalid long integer entered.",
-    MSG_INVALID_DATE: "Invalid date format: expected YYYYMMDD.",
-    MSG_INVALID_TIME: "Invalid time format: expected HHMM (24-hour).",
-    MSG_KEYWORD_NOT_FOUND: "Keyword not found: '{0}'",
-    MSG_START_KEYWORD_USAGE: "Usage: {0} <keyword>",
-    MSG_UNKNOWN_GLOBAL_KEYWORD: "Unknown command: '{0}'",
-    MSG_FIELD_REQUIRED: "This field is required.",
-    MSG_EXPECTED_NAMED_ARGS_SEPARATOR: "Expected name and value to be joined by '{0}'.",
-    MSG_MULTIPLE_ANSWERS_FOUND: "More than one answer found for '{0}'",
-    MSG_MULTIPLE_QUESTIONS_MATCH: "More than one question matches '{0}'",
-    MSG_MISSING_EXTERNAL_ID: "Expected case external id.",
-    MSG_CASE_NOT_FOUND: "Case with the given external id was not found.",
-    MSG_FIELD_DESCRIPTOR: "Field '{0}': ",
+    MSG_MULTIPLE_SESSIONS: ugettext_noop("An error has occurred. Please try restarting the survey."),
+    MSG_TOUCHFORMS_DOWN: ugettext_noop("An error has occurred. Please try again later. If the problem persists, try restarting the survey."),
+    MSG_TOUCHFORMS_ERROR: ugettext_noop("Internal server error."),
+    MSG_CHOICE_OUT_OF_RANGE: ugettext_noop("Answer is out of range."),
+    MSG_INVALID_CHOICE: ugettext_noop("Invalid choice."),
+    MSG_INVALID_INT: ugettext_noop("Invalid integer entered."),
+    MSG_INVALID_FLOAT: ugettext_noop("Invalid decimal number entered."),
+    MSG_INVALID_LONG: ugettext_noop("Invalid long integer entered."),
+    MSG_INVALID_DATE: ugettext_noop("Invalid date format: expected YYYYMMDD."),
+    MSG_INVALID_TIME: ugettext_noop("Invalid time format: expected HHMM (24-hour)."),
+    MSG_KEYWORD_NOT_FOUND: ugettext_noop("Keyword not found: '{0}'"),
+    MSG_START_KEYWORD_USAGE: ugettext_noop("Usage: {0} <keyword>"),
+    MSG_UNKNOWN_GLOBAL_KEYWORD: ugettext_noop("Unknown command: '{0}'"),
+    MSG_FIELD_REQUIRED: ugettext_noop("This field is required."),
+    MSG_EXPECTED_NAMED_ARGS_SEPARATOR: ugettext_noop("Expected name and value to be joined by '{0}'."),
+    MSG_MULTIPLE_ANSWERS_FOUND: ugettext_noop("More than one answer found for '{0}'"),
+    MSG_MULTIPLE_QUESTIONS_MATCH: ugettext_noop("More than one question matches '{0}'"),
+    MSG_MISSING_EXTERNAL_ID: ugettext_noop("Please provide an external id for the case."),
+    MSG_CASE_NOT_FOUND: ugettext_noop("Case with the given external id was not found."),
+    MSG_FIELD_DESCRIPTOR: ugettext_noop("Field '{0}': "),
 }
 
 def get_message(msg_id, verified_number=None, context=None):
-    msg = _MESSAGES.get(msg_id, "")
+    default_msg = _MESSAGES.get(msg_id, "")
+
+    tdoc = StandaloneTranslationDoc.get_obj(verified_number.domain, "sms")
+    try:
+        user_lang = verified_number.owner.get_language_code()
+    except:
+        user_lang = None
+
+    def get_translation(lang):
+        return tdoc.translations.get(lang, {}).get(msg_id, None)
+
+    def domain_msg_user_lang():
+        if tdoc and user_lang in tdoc.langs:
+            return get_translation(user_lang)
+        else:
+            return None
+
+    def domain_msg_domain_lang():
+        if tdoc and tdoc.default_lang:
+            return get_translation(tdoc.default_lang)
+        else:
+            return None
+
+    def global_msg_user_lang():
+        result = None
+        if user_lang:
+            with localize(user_lang):
+                result = _(default_msg)
+        return result if result != default_msg else None
+
+    def global_msg_domain_lang():
+        result = None
+        if tdoc and tdoc.default_lang:
+            with localize(tdoc.default_lang):
+                result = _(default_msg)
+        return result if result != default_msg else None
+
+    msg = (
+        domain_msg_user_lang() or
+        domain_msg_domain_lang() or
+        global_msg_user_lang() or
+        global_msg_domain_lang() or
+        default_msg
+    )
+
     if context:
         msg = msg.format(context)
+
     return msg
 

--- a/corehq/apps/sms/templates/sms/languages.html
+++ b/corehq/apps/sms/templates/sms/languages.html
@@ -1,0 +1,116 @@
+{% extends 'hqwebapp/two_column.html' %}
+{% load i18n %}
+{% load hq_shared_tags %}
+
+{% block title %}
+    {% trans "SMS Languages" %}
+{% endblock %}
+
+{% block page-title %}
+    <ul class="breadcrumb">
+        <li>
+            <a href="{% url "messaging" domain %}"><strong>{% trans "Messaging" %}</strong></a> <span class="divider">&gt;</span>
+        </li>
+        <li class="active">
+            <a href="{% url "sms_languages" domain %}"><strong>{% trans "Languages" %}</strong></a>
+        </li>
+    </ul>
+{% endblock %}
+
+{% block js %}{{ block.super }}
+    <script src="{% static 'hqwebapp/js/lib/jquery-ui/jquery-ui-1.8.16.min.js' %}"></script>
+    <script src="{% static 'hqwebapp/js/knockout-bindings.js' %}"></script>
+    <script src="{% static 'hqwebapp/js/main.js' %}"></script>
+    <script src="{% static 'langcodes/js/langcodes.js' %}"></script>
+    <script src="{% static 'app_manager/js/supported-languages.js' %}"></script>
+{% endblock %}
+
+{% block head %}{{ block.super }}
+    <link rel="stylesheet" href="{% static 'hqwebapp/js/lib/jquery-ui/jquery-ui-redmond-1.8.16.css' %}"/>
+    <style>
+        .sortable-handle {
+            cursor: move;
+        }
+    </style>
+{% endblock %}
+
+{% block js-inline %}{{ block.super }}
+<script>
+    $(function () {
+        var langs = {{ sms_langs|JSON }};
+        var buildLangs = {{ sms_langs|JSON }};
+        var saveURL = "{% url "edit_sms_languages" domain %}";
+        var edit = true;
+        var validate = true;
+        var sl = new SupportedLanguages({
+            langs: langs,
+            buildLangs: buildLangs,
+            saveURL: saveURL,
+            edit: edit,
+            validate: validate
+        });
+        ko.applyBindings(sl, $("#supported-languages").get(0));
+        ko.applyBindings({file: ko.observable(null)}, $("#translations-upload-form").get(0));
+    });
+</script>
+{% endblock %}
+
+{% block main_column %}
+    <div class="tab-pane">
+        <div class="tabbable">
+            <ul class="nav nav-tabs">
+                <li class="active"><a href="#supported-languages" data-toggle="tab">{% trans "Language List" %}</a></li>
+                <li><a href="#translations-tab" data-toggle="tab">{% trans "Messaging Translations" %}</a></li>
+            </ul>
+        </div>
+        <div class="tab-content">
+            <div id="supported-languages" class="tab-pane active">
+                {% include "app_manager/partials/supported-languages.html" %}
+            </div>
+            <div id="translations-tab" class="tab-pane">
+                <div>
+                    <section>
+                        <h2>{% trans "Bulk Download/Upload Messaging Translations" %}</h2>
+                        <p>
+                            <ol>
+                                <li>
+                                    {% trans "Download your translations" %}:
+                                    <a href="{% url "download_sms_translations" domain %}">translations.xls</a>
+                                </li>
+                                <li>
+                                    {% trans "Update it with new information." %}
+                                </li>
+                                <li>
+                                    {% trans "Use the form below to upload your completed file." %}
+                                </li>
+                            </ol>
+                        </p>
+                        <p class="alert alert-info">
+                            {% trans "Your translations will be completely replaced with the translations found in this file." %}
+                        </p>
+                        <form id="translations-upload-form" class="form form-horizontal" action="{% url "upload_sms_translations" domain %}" method="post" enctype="multipart/form-data">
+                            <legend>{% trans "Choose a file for upload" %}</legend>
+                            <div class="form-actions" style="padding-left: 1em;">
+                                <fieldset>
+                                    <div class="control-group">
+                                        <label for="bulk_upload_file" class="control-label">{% trans "Translation File" %}</label>
+                                        <div class="controls">
+                                            <input id="bulk_upload_file" type="file" name="file" data-bind="value: file"/>
+                                        </div>
+                                    </div>
+                                    <div class="control-group">
+                                        <div class="controls">
+                                            <button type="submit" class="btn btn-primary" data-bind="visible: file()">
+                                                {% trans "Update Translations" %}
+                                            </button>
+                                        </div>
+                                    </div>
+                                </fieldset>
+                            </div>
+                        </form>
+                    </section>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/corehq/apps/sms/tests/inbound_handlers.py
+++ b/corehq/apps/sms/tests/inbound_handlers.py
@@ -329,7 +329,7 @@ class KeywordTestCase(TouchformsTestCase):
 
         def get_field_and_message(field_name, msg_id):
             msg1 = get_message(MSG_FIELD_DESCRIPTOR,
-                context={"field_name": field_name})
+                context=(field_name,))
             msg2 = get_message(msg_id)
             return "%s%s" % (msg1, msg2)
 
@@ -564,11 +564,11 @@ class KeywordTestCase(TouchformsTestCase):
         self.assertNoNewSubmission(form)
 
         incoming("999123", "mod_ss_3,pid1235,arm a", "TEST")
-        self.assertLastOutboundSMSEquals(self.user1, get_message(MSG_EXPECTED_NAMED_ARGS_SEPARATOR, context={"separator":"="}))
+        self.assertLastOutboundSMSEquals(self.user1, get_message(MSG_EXPECTED_NAMED_ARGS_SEPARATOR, context=("=",)))
         self.assertNoNewSubmission(form)
 
         incoming("999123", "mod_ss_3,pid1235,arm=a,arm=b", "TEST")
-        self.assertLastOutboundSMSEquals(self.user1, get_message(MSG_MULTIPLE_ANSWERS_FOUND, context={"arg_name":"ARM"}))
+        self.assertLastOutboundSMSEquals(self.user1, get_message(MSG_MULTIPLE_ANSWERS_FOUND, context=("ARM",)))
         self.assertNoNewSubmission(form)
 
         incoming("999123", "mod_ss_3 ,  pid1235  ,  arm = a", "TEST")
@@ -581,15 +581,15 @@ class KeywordTestCase(TouchformsTestCase):
 
         # Test global keywords
         incoming("999123", "#start unknownkeyword", "TEST")
-        self.assertLastOutboundSMSEquals(self.user1, get_message(MSG_KEYWORD_NOT_FOUND, context={"keyword":"UNKNOWNKEYWORD"}))
+        self.assertLastOutboundSMSEquals(self.user1, get_message(MSG_KEYWORD_NOT_FOUND, context=("UNKNOWNKEYWORD",)))
         self.assertNoNewSubmission(form)
 
         incoming("999123", "#start", "TEST")
-        self.assertLastOutboundSMSEquals(self.user1, get_message(MSG_START_KEYWORD_USAGE, context={"start_keyword":"#START"}))
+        self.assertLastOutboundSMSEquals(self.user1, get_message(MSG_START_KEYWORD_USAGE, context=("#START",)))
         self.assertNoNewSubmission(form)
 
         incoming("999123", "#unknown", "TEST")
-        self.assertLastOutboundSMSEquals(self.user1, get_message(MSG_UNKNOWN_GLOBAL_KEYWORD, context={"keyword":"#UNKNOWN"}))
+        self.assertLastOutboundSMSEquals(self.user1, get_message(MSG_UNKNOWN_GLOBAL_KEYWORD, context=("#UNKNOWN",)))
         self.assertNoNewSubmission(form)
 
         # Mobile worker creates a case

--- a/corehq/apps/sms/urls.py
+++ b/corehq/apps/sms/urls.py
@@ -28,6 +28,10 @@ urlpatterns = patterns('corehq.apps.sms.views',
     url(r'^api/last_read_message/$', 'api_last_read_message', name='api_last_read_message'),
     url(r'^settings/$', 'sms_settings', name='sms_settings'),
     url(r'^subscribe_sms/$', SubscribeSMSView.as_view(), name=SubscribeSMSView.urlname),
+    url(r'^languages/$', 'sms_languages', name='sms_languages'),
+    url(r'^languages/edit/$', 'edit_sms_languages', name='edit_sms_languages'),
+    url(r'^translations/download/$', 'download_sms_translations', name='download_sms_translations'),
+    url(r'^translations/upload/$', 'upload_sms_translations', name='upload_sms_translations'),
 )
 
 sms_admin_interface_urls = patterns('corehq.apps.sms.views',

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # vim: ai ts=4 sts=4 et sw=4 encoding=utf-8
+from StringIO import StringIO
 import logging
 from datetime import datetime, timedelta, time
 import re
@@ -36,6 +37,7 @@ from corehq.apps.sms.models import (
 from corehq.apps.sms.mixin import SMSBackend, BackendMapping, VerifiedNumber
 from corehq.apps.sms.forms import ForwardingRuleForm, BackendMapForm, InitiateAddSMSBackendForm, SMSSettingsForm, SubscribeSMSForm
 from corehq.apps.sms.util import get_available_backends, get_contact
+from corehq.apps.sms.messages import _MESSAGES
 from corehq.apps.groups.models import Group
 from corehq.apps.domain.decorators import login_and_domain_required, login_or_digest, domain_admin_required, require_superuser
 from corehq.apps.translations.models import StandaloneTranslationDoc
@@ -49,9 +51,15 @@ from django.utils.translation import ugettext as _, ugettext_noop
 from dimagi.utils.parsing import json_format_datetime, string_to_boolean
 from dateutil.parser import parse
 from dimagi.utils.decorators.memoized import memoized
+from dimagi.utils.decorators.view import get_file
 from dimagi.utils.logging import notify_exception
 from dimagi.utils.web import json_response
+from dimagi.utils.excel import WorkbookJSONReader
 from django.conf import settings
+from couchexport.models import Format
+from couchexport.export import export_raw
+from couchexport.shortcuts import export_response
+
 
 DEFAULT_MESSAGE_COUNT_THRESHOLD = 50
 
@@ -1054,13 +1062,57 @@ def edit_sms_languages(request, domain):
 @domain_admin_required
 @requires_privilege_with_fallback(privileges.OUTBOUND_SMS)
 def download_sms_translations(request, domain):
-    pass
+    tdoc = StandaloneTranslationDoc.get_obj(domain, "sms")
+    columns = ["property"] + tdoc.langs + ["default"]
+
+    msg_ids = sorted(_MESSAGES.keys())
+    rows = []
+    for msg_id in msg_ids:
+        rows.append([msg_id])
+
+    for lang in tdoc.langs:
+        for row in rows:
+            row.append(tdoc.translations[lang].get(row[0], ""))
+
+    for row in rows:
+        row.append(_MESSAGES.get(row[0]))
+
+    temp = StringIO()
+    headers = (("translations", tuple(columns)),)
+    data = (("translations", tuple(rows)),)
+    export_raw(headers, data, temp)
+    return export_response(temp, Format.XLS_2007, "translations")
 
 
 @domain_admin_required
 @requires_privilege_with_fallback(privileges.OUTBOUND_SMS)
+@get_file("file")
 def upload_sms_translations(request, domain):
-    pass
+    try:
+        workbook = WorkbookJSONReader(request.file)
+        translations = workbook.get_worksheet(title='translations')
+
+        with StandaloneTranslationDoc.get_locked_obj(domain, "sms") as tdoc:
+            msg_ids = sorted(_MESSAGES.keys())
+            result = {}
+            for lang in tdoc.langs:
+                result[lang] = {}
+
+            for row in translations:
+                for lang in tdoc.langs:
+                    if row.get(lang):
+                        msg_id = row["property"]
+                        if msg_id in msg_ids:
+                            result[lang][msg_id] = str(row[lang]).strip()
+
+            tdoc.translations = result
+            tdoc.save()
+        messages.success(request, _("SMS Translations Updated."))
+    except Exception:
+        notify_exception(request, 'SMS Upload Translations Error')
+        messages.error(request, _("Update failed. We're looking into it."))
+
+    return HttpResponseRedirect(reverse('sms_languages', args=[domain]))
 
 
 @domain_admin_required

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -1043,8 +1043,9 @@ def edit_sms_languages(request, domain):
             return HttpResponse(status=400)
 
         for old, new in rename.items():
-            tdoc.translations[new] = tdoc.translations[old]
-            del tdoc.translations[old]
+            if old != new:
+                tdoc.translations[new] = tdoc.translations[old]
+                del tdoc.translations[old]
 
         for lang in langs:
             if lang not in tdoc.translations:

--- a/corehq/apps/translations/_design/views/standalone/map.js
+++ b/corehq/apps/translations/_design/views/standalone/map.js
@@ -1,0 +1,5 @@
+function (doc) {
+    if (doc.doc_type === 'StandaloneTranslationDoc') {
+        emit([doc.domain, doc.area], null);
+    }
+}

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1657,12 +1657,11 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         return time_zone
 
     def get_language_code(self):
-        try:
-            lang = self.user_data["language_code"]
-        except Exception as e:
-            # Gracefully handle when user_data is None, or does not have a "language_code" entry
-            lang = None
-        return lang
+        if self.user_data and "language_code" in self.user_data:
+            # Old way
+            return self.user_data["language_code"]
+        else:
+            return self.language
 
     def __repr__(self):
         return ("{class_name}(username={self.username!r})".format(


### PR DESCRIPTION
Similar to custom translations in CommCare apps, this allows for custom translations of system-generated SMS messages, such as responses to invalid choices in an SMS survey.

![translations-1](https://cloud.githubusercontent.com/assets/1028814/2890915/a5d2ae82-d52d-11e3-88ce-6fbc2f495ffb.png)
![translations-2](https://cloud.githubusercontent.com/assets/1028814/2890916/a7e87580-d52d-11e3-9168-e4d78e775b03.png)
