### PR TITLE
Attempts to resolve faulty validation when copying a project.

### DIFF
--- a/corehq/apps/appstore/views.py
+++ b/corehq/apps/appstore/views.py
@@ -279,7 +279,7 @@ def copy_snapshot(request, domain):
                 return project_info(request, domain)
 
             if form.is_valid():
-                new_domain = dom.save_copy(form.clean_domain_name(), user=user)
+                new_domain = dom.save_copy(form.cleaned_data['domain_name'], user=user)
             else:
                 messages.error(request, form.errors)
                 return project_info(request, domain)


### PR DESCRIPTION
_Fix coming from [this FogBugz](http://manage.dimagi.com/default.asp?108982#631214) issue, which details how a 500 error was raised by somebody entering the same domain name while trying to copy an app._ 

The original error was thrown from line 282, where `form.clean_domain_name()` was being explicitly called.  There's no need to do that, as that method is already called once when `form.is_valid()` is called on 281  (Instead of calling again we can just drop in the cleaned value.

So, we won't get a `ValidationError` outside of Django's normal process, and the error is properly being raised to the user, but that doesn't really explain how the error actually happened -- if `clean_domain_name()` raised this `ValidationError` on 282, why didn't it catch it when it was run by `is_valid()` on 281?  **I could use some help brainstorming this -- can anybody imagine any reason why this would happen?**  This code has been explicitly calling `clean_domain_name()` since 2012, and presumably this is the first time this has come up?
