### PR TITLE
show trial message as pop up instead of a django message

### DIFF
--- a/corehq/apps/accounting/migrations/0029_auto__add_field_defaultproductplan_is_trial.py
+++ b/corehq/apps/accounting/migrations/0029_auto__add_field_defaultproductplan_is_trial.py
@@ -1,0 +1,301 @@
+# encoding: utf-8
+import datetime
+from decimal import Decimal
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+from corehq.apps.accounting.models import FeatureType, SoftwareProductType, SoftwarePlanEdition, SoftwarePlanVisibility
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        
+        # Adding field 'DefaultProductPlan.is_trial'
+        db.add_column(u'accounting_defaultproductplan', 'is_trial', self.gf('django.db.models.fields.BooleanField')(default=False), keep_default=False)
+
+        user_community = orm.Feature.objects.get(
+            name="User Community"
+        ).featurerate_set.filter(is_active=True).latest('date_created')
+        sms_trial_feature = orm.Feature.objects.get_or_create(
+            name="SMS Trial",
+            feature_type=FeatureType.SMS,
+        )[0]
+        sms_trial = orm.FeatureRate.objects.get_or_create(
+            feature=sms_trial_feature,
+            monthly_limit=25,
+            per_excess_fee=Decimal('1.00'),
+        )[0]
+        advanced_role = orm['django_prbac.Role'].objects.get(slug='advanced_plan_v0')
+        for product_type in SoftwareProductType.CHOICES:
+            product_type = product_type[0]
+            product = orm.SoftwareProduct.objects.get_or_create(
+                name='%s %s' % (product_type, SoftwarePlanEdition.ADVANCED),
+                product_type=product_type
+            )[0]
+            product_rate = orm.SoftwareProductRate.objects.create(
+                product=product,
+            )
+            trial_plan = orm.SoftwarePlan.objects.get_or_create(
+                name="%s %s Trial" % (product_type, SoftwarePlanEdition.ADVANCED),
+                description="",
+                edition=SoftwarePlanEdition.ADVANCED,
+                visibility=SoftwarePlanVisibility.TRIAL,
+            )[0]
+            trial_plan_version = orm.SoftwarePlanVersion(
+                plan=trial_plan,
+                role=advanced_role,
+            )
+            trial_plan_version.save()
+            trial_plan_version.product_rates.add(product_rate)
+            trial_plan_version.feature_rates.add(user_community)
+            trial_plan_version.feature_rates.add(sms_trial)
+            trial_plan_version.save()
+            try:
+                default_trial_plan_advanced = orm.DefaultProductPlan.objects.get(
+                    product_type=product_type,
+                    edition=SoftwarePlanEdition.ADVANCED,
+                    is_trial=True
+                )
+            except orm.DefaultProductPlan.DoesNotExist:
+                default_trial_plan_advanced = orm.DefaultProductPlan(
+                    product_type=product_type,
+                    edition=SoftwarePlanEdition.ADVANCED,
+                    is_trial=True
+                )
+            default_trial_plan_advanced.plan = trial_plan
+            default_trial_plan_advanced.save()
+
+
+    def backwards(self, orm):
+        
+        # Deleting field 'DefaultProductPlan.is_trial'
+        db.delete_column(u'accounting_defaultproductplan', 'is_trial')
+
+
+    models = {
+        u'accounting.billingaccount': {
+            'Meta': {'object_name': 'BillingAccount'},
+            'account_type': ('django.db.models.fields.CharField', [], {'default': "'CONTRACT'", 'max_length': '25'}),
+            'billing_admins': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['accounting.BillingAccountAdmin']", 'null': 'True', 'symmetrical': 'False'}),
+            'created_by': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'created_by_domain': ('django.db.models.fields.CharField', [], {'max_length': '256', 'null': 'True', 'blank': 'True'}),
+            'currency': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Currency']"}),
+            'date_confirmed_extra_charges': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_auto_invoiceable': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'db_index': 'True'}),
+            'salesforce_account_id': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '80', 'null': 'True', 'blank': 'True'})
+        },
+        u'accounting.billingaccountadmin': {
+            'Meta': {'object_name': 'BillingAccountAdmin'},
+            'domain': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '256', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'web_user': ('django.db.models.fields.CharField', [], {'max_length': '80', 'db_index': 'True'})
+        },
+        u'accounting.billingcontactinfo': {
+            'Meta': {'object_name': 'BillingContactInfo'},
+            'account': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['accounting.BillingAccount']", 'unique': 'True', 'primary_key': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'company_name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'emails': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True'}),
+            'first_line': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'phone_number': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'postal_code': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'second_line': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'state_province_region': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'accounting.billingrecord': {
+            'Meta': {'object_name': 'BillingRecord'},
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'emailed_to': ('django.db.models.fields.CharField', [], {'max_length': '254', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'invoice': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Invoice']"}),
+            'pdf_data_id': ('django.db.models.fields.CharField', [], {'max_length': '48'}),
+            'skipped_email': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'accounting.creditadjustment': {
+            'Meta': {'object_name': 'CreditAdjustment'},
+            'amount': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'credit_line': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.CreditLine']"}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'invoice': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Invoice']", 'null': 'True'}),
+            'line_item': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.LineItem']", 'null': 'True'}),
+            'note': ('django.db.models.fields.TextField', [], {}),
+            'payment_record': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.PaymentRecord']", 'null': 'True'}),
+            'reason': ('django.db.models.fields.CharField', [], {'default': "'MANUAL'", 'max_length': '25'}),
+            'related_credit': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'creditadjustment_related'", 'null': 'True', 'to': u"orm['accounting.CreditLine']"}),
+            'web_user': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True'})
+        },
+        u'accounting.creditline': {
+            'Meta': {'object_name': 'CreditLine'},
+            'account': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.BillingAccount']"}),
+            'balance': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'feature_type': ('django.db.models.fields.CharField', [], {'max_length': '10', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'product_type': ('django.db.models.fields.CharField', [], {'max_length': '25', 'null': 'True', 'blank': 'True'}),
+            'subscription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Subscription']", 'null': 'True', 'blank': 'True'})
+        },
+        u'accounting.currency': {
+            'Meta': {'object_name': 'Currency'},
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '3'}),
+            'date_updated': ('django.db.models.fields.DateField', [], {'auto_now': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '25', 'db_index': 'True'}),
+            'rate_to_default': ('django.db.models.fields.DecimalField', [], {'default': "'1.0'", 'max_digits': '20', 'decimal_places': '9'}),
+            'symbol': ('django.db.models.fields.CharField', [], {'max_length': '10'})
+        },
+        u'accounting.defaultproductplan': {
+            'Meta': {'object_name': 'DefaultProductPlan'},
+            'edition': ('django.db.models.fields.CharField', [], {'default': "'Community'", 'max_length': '25'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_trial': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'plan': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwarePlan']"}),
+            'product_type': ('django.db.models.fields.CharField', [], {'max_length': '25'})
+        },
+        u'accounting.feature': {
+            'Meta': {'object_name': 'Feature'},
+            'feature_type': ('django.db.models.fields.CharField', [], {'max_length': '10', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '40'})
+        },
+        u'accounting.featurerate': {
+            'Meta': {'object_name': 'FeatureRate'},
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'feature': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Feature']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'monthly_fee': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '10', 'decimal_places': '2'}),
+            'monthly_limit': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'per_excess_fee': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '10', 'decimal_places': '2'})
+        },
+        u'accounting.invoice': {
+            'Meta': {'object_name': 'Invoice'},
+            'balance': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'date_due': ('django.db.models.fields.DateField', [], {'db_index': 'True'}),
+            'date_end': ('django.db.models.fields.DateField', [], {}),
+            'date_paid': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_received': ('django.db.models.fields.DateField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'date_start': ('django.db.models.fields.DateField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_hidden': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'subscription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Subscription']"}),
+            'tax_rate': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'})
+        },
+        u'accounting.lineitem': {
+            'Meta': {'object_name': 'LineItem'},
+            'base_cost': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'base_description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'feature_rate': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.FeatureRate']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'invoice': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Invoice']"}),
+            'product_rate': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwareProductRate']", 'null': 'True'}),
+            'quantity': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'unit_cost': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'unit_description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'accounting.paymentmethod': {
+            'Meta': {'object_name': 'PaymentMethod'},
+            'account': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.BillingAccount']"}),
+            'billing_admin': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.BillingAccountAdmin']"}),
+            'customer_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'method_type': ('django.db.models.fields.CharField', [], {'default': "'Stripe'", 'max_length': '50', 'db_index': 'True'})
+        },
+        u'accounting.paymentrecord': {
+            'Meta': {'object_name': 'PaymentRecord'},
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'payment_method': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.PaymentMethod']"}),
+            'transaction_id': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'accounting.softwareplan': {
+            'Meta': {'object_name': 'SoftwarePlan'},
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'edition': ('django.db.models.fields.CharField', [], {'default': "'Enterprise'", 'max_length': '25'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'visibility': ('django.db.models.fields.CharField', [], {'default': "'INTERNAL'", 'max_length': '10'})
+        },
+        u'accounting.softwareplanversion': {
+            'Meta': {'object_name': 'SoftwarePlanVersion'},
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'feature_rates': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['accounting.FeatureRate']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'plan': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwarePlan']"}),
+            'product_rates': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['accounting.SoftwareProductRate']", 'symmetrical': 'False', 'blank': 'True'}),
+            'role': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['django_prbac.Role']"})
+        },
+        u'accounting.softwareproduct': {
+            'Meta': {'object_name': 'SoftwareProduct'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '40'}),
+            'product_type': ('django.db.models.fields.CharField', [], {'max_length': '25', 'db_index': 'True'})
+        },
+        u'accounting.softwareproductrate': {
+            'Meta': {'object_name': 'SoftwareProductRate'},
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'monthly_fee': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '10', 'decimal_places': '2'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwareProduct']"})
+        },
+        u'accounting.subscriber': {
+            'Meta': {'object_name': 'Subscriber'},
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '256', 'null': 'True', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'organization': ('django.db.models.fields.CharField', [], {'max_length': '256', 'null': 'True', 'db_index': 'True'})
+        },
+        u'accounting.subscription': {
+            'Meta': {'object_name': 'Subscription'},
+            'account': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.BillingAccount']"}),
+            'auto_generate_credits': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'date_delay_invoicing': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_end': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_start': ('django.db.models.fields.DateField', [], {}),
+            'do_not_invoice': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_trial': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'plan_version': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwarePlanVersion']"}),
+            'salesforce_contract_id': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'subscriber': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Subscriber']"})
+        },
+        u'accounting.subscriptionadjustment': {
+            'Meta': {'object_name': 'SubscriptionAdjustment'},
+            'date_created': ('django.db.models.fields.DateField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'invoice': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Invoice']", 'null': 'True'}),
+            'method': ('django.db.models.fields.CharField', [], {'default': "'INTERNAL'", 'max_length': '50'}),
+            'new_date_delay_invoicing': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'new_date_end': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'new_date_start': ('django.db.models.fields.DateField', [], {}),
+            'new_salesforce_contract_id': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'note': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'reason': ('django.db.models.fields.CharField', [], {'default': "'CREATE'", 'max_length': '50'}),
+            'related_subscription': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'subscriptionadjustment_related'", 'null': 'True', 'to': u"orm['accounting.Subscription']"}),
+            'subscription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Subscription']"}),
+            'web_user': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True'})
+        },
+        u'django_prbac.role': {
+            'Meta': {'object_name': 'Role'},
+            'description': ('django.db.models.fields.TextField', [], {'default': "u''", 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'parameters': ('django_prbac.fields.StringSetField', [], {'default': '[]', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '256'})
+        }
+    }
+
+    complete_apps = ['accounting']

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -113,9 +113,11 @@ class SoftwarePlanEdition(object):
 class SoftwarePlanVisibility(object):
     PUBLIC = "PUBLIC"
     INTERNAL = "INTERNAL"
+    TRIAL = "TRIAL"
     CHOICES = (
         (PUBLIC, "Anyone can subscribe"),
         (INTERNAL, "Dimagi must create subscription"),
+        (TRIAL, "This is a Trial Plan"),
     )
 
 

--- a/corehq/apps/accounting/static/accounting/ko/accounting.credits.js
+++ b/corehq/apps/accounting/static/accounting/ko/accounting.credits.js
@@ -1,9 +1,11 @@
-var CreditsManager = function (products, features, paymentHandler, can_purchase_credits) {
+var CreditsManager = function (products, features, paymentHandler, can_purchase_credits, is_plan_trial) {
     'use strict';
     var self = this;
 
     self.products = ko.observableArray();
     self.features = ko.observableArray();
+
+    can_purchase_credits = can_purchase_credits && !is_plan_trial;
 
     self.init = function () {
         _.each(products, function (product) {

--- a/corehq/apps/domain/templates/domain/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/current_subscription.html
@@ -28,7 +28,7 @@
 
         var creditsHandler = new CreditsManager(
             {{ plan.products|JSON }}, {{ plan.features|JSON }},
-            paymentHandler, {{ can_purchase_credits|BOOL }}
+            paymentHandler, {{ can_purchase_credits|BOOL }}, {{ plan.is_trial|BOOL }}
         );
         $(function () {
             ko.applyBindings(creditsHandler, $('#subscriptionSummary').get(0));
@@ -59,19 +59,22 @@
                             {% endblocktrans %}
                             </div>
                         {% endif %}
-                        <a class="btn btn-primary" style="margin-top:10px;" href="{{ change_plan_url }}">
-                            {% trans "Change Plan" %}
-                        </a>
+                        <p>
+                            <a class="btn btn-primary" style="margin-top:10px;" href="{{ change_plan_url }}">
+                                {% trans "Change Plan" %}
+                            </a>
+                        </p>
+                        {% if plan.is_trial %}
+                            <div class="alert alert-info">
+                                <i class="icon-info-sign"></i>
+                                {% blocktrans with plan.date_end as date_end %}
+                                    Your trial expires on {{ date_end }}.
+                                {% endblocktrans %}
+                            </div>
+                        {% endif %}
                     </div>
                 </div>
-                {% if plan.is_trial %}
-                    <div class="alert alert-info">
-                        <i class="icon-info-sign"></i>
-                        {% blocktrans with plan.date_end as date_end %}
-                            Your trial expires on {{ date_end }}.
-                        {% endblocktrans %}
-                    </div>
-                {% else %}
+                {% if not plan.is_trial %}
                     {% if plan.date_start %}
                         <div class="control-group">
                             <label class="control-label">{% trans 'Date Started' %}</label>
@@ -139,40 +142,46 @@
                             </div>
                         </div>
                     {% endif %}
-                </div>
-                <h2>{% trans 'Usage Summary' %}</h2>
-                <table class="table table-bordered table-striped">
-                    <thead>
-                        <tr>
-                            <th>{% trans "Feature" %}</th>
-                            <th>{% trans "Current Use" %}</th>
-                            <th>{% trans "Remaining" %}</th>
-                            <th>{% trans "Credits Available" %}</th>
-                            {% if can_purchase_credits %}
-                            <th>{% trans "Add Credit" %}</th>
-                            {% endif %}
-                        </tr>
-                    </thead>
-                    <tbody data-bind="foreach: features">
-                        <tr>
-                            <td data-bind="text: name"></td>
-                            <td data-bind="text: usage"></td>
-                            <td data-bind="text: remaining"></td>
-                            <td data-bind="text: amount"></td>
-                            <td data-bind="visible: canPurchaseCredits">
-                                <button type="button"
-                                        class="btn"
-                                        data-toggle="modal"
-                                        data-target="#paymentModal"
-                                        data-bind="click: triggerPayment">
-                                    <i class="icon-plus"></i>
-                                    {% trans 'Add Credit' %}
-                                </button>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            {% endif %}
+                {% endif %}
+            </div>
+            <h2>{% trans 'Usage Summary' %}</h2>
+            <table class="table table-bordered table-striped">
+                <thead>
+                    <tr>
+                        <th>{% trans "Feature" %}</th>
+                        <th>{% trans "Current Use" %}</th>
+                        <th>{% trans "Remaining" %}</th>
+                        {% if not plan.is_trial %}
+                        <th>{% trans "Credits Available" %}</th>
+                        {% endif %}
+                        {% if can_purchase_credits and not plan.is_trial %}
+                        <th>{% trans "Add Credit" %}</th>
+                        {% endif %}
+                    </tr>
+                </thead>
+                <tbody data-bind="foreach: features">
+                    <tr>
+                        <td data-bind="text: name"></td>
+                        <td data-bind="text: usage"></td>
+                        <td data-bind="text: remaining"></td>
+                        {% if not plan.is_trial %}
+                        <td data-bind="text: amount"></td>
+                        {% endif %}
+                        {% if can_purchase_credits and not plan.is_trial %}
+                        <td data-bind="visible: canPurchaseCredits">
+                            <button type="button"
+                                    class="btn"
+                                    data-toggle="modal"
+                                    data-target="#paymentModal"
+                                    data-bind="click: triggerPayment">
+                                <i class="icon-plus"></i>
+                                {% trans 'Add Credit' %}
+                            </button>
+                        </td>
+                        {% endif %}
+                    </tr>
+                </tbody>
+            </table>
         </article>
     </div>
 </div>

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1054,7 +1054,9 @@ class SelectPlanView(DomainAccountingSettings):
         return {
             'pricing_table': PricingTable.get_table_by_product(self.product, domain=self.domain),
             'current_edition': (self.current_subscription.plan_version.plan.edition.lower()
-                                if self.current_subscription is not None else ""),
+                                if self.current_subscription is not None
+                                and not self.current_subscription.is_trial
+                                else ""),
             'is_non_ops_superuser': self.is_non_ops_superuser,
         }
 

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -288,6 +288,61 @@
                     </ul>
                 </div>
             </div>
+            {% if request.show_trial_notice %}
+            <div class="modal hide fade" id="trial-notice">
+                <div class="modal-header">
+                    <a class="close" data-dismiss="modal">&times;</a>
+                    <h3>{% trans 'Important Message' %}</h3>
+                </div>
+                <div class="modal-body">
+                    {% with request.trial_info.feature_name as feat_name %}
+                    {% with request.trial_info.required_plan as req_plan %}
+                    {% with request.trial_info.current_plan as current_plan %}
+                    {% with request.trial_info.date_end as date_end %}
+                        <p class="lead">
+                        {% blocktrans %}
+                            <strong>{{ feat_name }}</strong> is only available for the {{ req_plan }}
+                            Plan and higher. You are currently on a trial version
+                            of the {{ current_plan }} Plan.
+                        {% endblocktrans %}
+                        </p>
+                        <p>
+                        {% blocktrans %}
+                            We want you to have a chance to use and evaluate our
+                            pay-only features before deciding which plan to subscribe to.
+                            You will have access to <strong>{{ feat_name }}</strong> for a
+                            30 day trial period. <strong>This period is ending on {{ date_end }}.</strong>
+                            After {{ date_end }}, you will no longer have access to {{ feat_name }}.
+                        {% endblocktrans %}
+                        </p>
+                        <p>
+                        {% blocktrans %}
+                            To continue accessing {{ feat_name }} after the trial period,
+                            subscribe to the {{ req_plan }} Plan.
+                        {% endblocktrans %}
+                        </p>
+                    {% endwith %}
+                    {% endwith %}
+                    {% endwith %}
+                    {% endwith %}
+                    {% if request.is_billing_admin %}
+                        <p>
+                            <a class="btn btn-primary" href="{% url 'domain_select_plan' request.domain %}">
+                                {% blocktrans %}
+                                    Change my project's plan
+                                {% endblocktrans %}
+                            </a>
+                        </p>
+                    {% endif %}
+                </div>
+                <div class="modal-footer">
+                    <button class="btn"
+                            data-dismiss="modal">
+                        {% trans "Close" %}
+                    </button>
+                </div>
+            </div>
+            {% endif %}
         {% endblock %}
         </div>
         <!--Begin javascript -->
@@ -476,6 +531,14 @@
         {% endblock %}
         {% endif %}
         {% endblock %}
+
+        {% if request.show_trial_notice %}
+        <script>
+            $(function () {
+                $('#trial-notice').modal('show');
+            });
+        </script>
+        {% endif %}
 
         <script>
             $(function () {

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -86,7 +86,7 @@ def request_new_domain(request, form, org, domain_type=None, new_user=True):
         or toggles.ACCOUNTING_PREVIEW.enabled(new_domain.name)
     ):
         advanced_plan_version = DefaultProductPlan.get_default_plan_by_domain(
-            new_domain, edition=SoftwarePlanEdition.ADVANCED
+            new_domain, edition=SoftwarePlanEdition.ADVANCED, is_trial=True
         )
         expiration_date = date.today() + timedelta(days=30)
         trial_account = BillingAccount.objects.get_or_create(


### PR DESCRIPTION
![screen shot 2014-05-06 at 1 23 49 pm](https://cloud.githubusercontent.com/assets/716573/2892979/68356edc-d543-11e3-8e79-f7e487f1b005.png)

Also adds:
- trial default plans `is_trial` added to `DefaultProductPlan`
- Advanced trial is set up in migration for this...
