### PR TITLE
add --deploy option to rebuildstaging

### DIFF
--- a/scripts/rebuildstaging
+++ b/scripts/rebuildstaging
@@ -14,7 +14,7 @@ if [[ $1 = "--deploy" ]]; then
 fi
 
 function rebuildstaging() {
-    python scripts/rebuildstaging.py < $f $@
+    python scripts/rebuildstaging.py < $f "$@"
 }
 
 if [[ $deploy = "y" ]]; then

--- a/scripts/rebuildstaging
+++ b/scripts/rebuildstaging
@@ -1,11 +1,24 @@
 #!/bin/bash
 
-if [ -z "$1" ]; then
-    echo "usage: $0 path/to/staging.yaml"
+if [[ -z "$1" ]]; then
+    echo "usage: $0 path/to/staging.yaml [--deploy]"
     exit
 fi
 
 f=$1
 shift
 
-python scripts/rebuildstaging.py < $f $@
+if [[ $1 = "--deploy" ]]; then
+    deploy='y'
+    shift
+fi
+
+function rebuildstaging() {
+    python scripts/rebuildstaging.py < $f $@
+}
+
+if [[ $deploy = "y" ]]; then
+    rebuildstaging && fab --linewise staging preindex_views && printf 'y\ny\n' | fab --linewise staging deploy
+else
+    rebuildstaging
+fi


### PR DESCRIPTION
runs preindex and deploy to staging if rebuildstaging goes through

I think people are really gonna love this! To do the whole process of rebuilding and deploying, you can now just run:

```
scripts/rebuildstaging staging.yaml --deploy
```

Features:
- uses the `--linewise` option of fab, which makes **whole lines** (!) get printed instead of one byte
  at a time—which prevents the garbled text caused by parallel commands
- automatically runs the preindex
- passes `y\ny\n` into fab deploy so you don't have to type it yourself
- if any command fails, none of the other ones get executed (bash `&&`)
