### PR TITLE
HTML escape causes the title to be double-escaped

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/form_designer.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_designer.html
@@ -61,7 +61,7 @@
                 saveType: 'patch',
                 form: formSrc,
                 langs: {{ app.langs|JSON }},
-                formName: "{{ form.name|trans:app.langs }}",
+                formName: "{{ form.name|trans:app.langs|escapejs }}",
                 displayLanguage: {{ lang|JSON }},
                 sessionid: {{ sessionid|JSON }}
             });


### PR DESCRIPTION
...once here (see https://docs.djangoproject.com/en/dev/ref/templates/builtins/#escape) and then & chars are escaped again by Vellum when rendering the form XML. `escapejs` avoids that because it uses a different type of escaping.

http://manage.dimagi.com/default.asp?112308
