### PR TITLE
silently fail when attempting to send stripe purchase receipts

### DIFF
--- a/corehq/apps/accounting/payment_handlers.py
+++ b/corehq/apps/accounting/payment_handlers.py
@@ -117,12 +117,12 @@ class BaseStripePaymentHandler(object):
             self.update_credits(payment_record)
             try:
                 self.send_email(payment_record)
-            except Exception as e:
+            except Exception:
                 logger.error(
                     "[BILLING] Failed to send out an email receipt for "
                     "payment related to PaymentRecord No. %s. "
-                    "Everything else succeeded. Error was: %s"
-                    % (payment_record.id, e)
+                    "Everything else succeeded."
+                    % payment_record.id, exc_info=True
                 )
         except stripe.error.CardError as e:
             # card was declined

--- a/corehq/apps/accounting/payment_handlers.py
+++ b/corehq/apps/accounting/payment_handlers.py
@@ -115,7 +115,15 @@ class BaseStripePaymentHandler(object):
                 self.payment_method, charge.id, amount
             )
             self.update_credits(payment_record)
-            self.send_email(payment_record)
+            try:
+                self.send_email(payment_record)
+            except Exception as e:
+                logger.error(
+                    "[BILLING] Failed to send out an email receipt for "
+                    "payment related to PaymentRecord No. %s. "
+                    "Everything else succeeded. Error was: %s"
+                    % (payment_record.id, e)
+                )
         except stripe.error.CardError as e:
             # card was declined
             return e.json_body

--- a/settings.py
+++ b/settings.py
@@ -747,7 +747,7 @@ LOGGING = {
             'propagate': False,
         },
         'accounting': {
-            'handlers': ['accountinglog', 'sentry', 'console', 'couchlog'],
+            'handlers': ['accountinglog', 'sentry', 'console', 'couchlog', 'mail_admins'],
             'level': 'INFO',
             'propagate': False,
         },


### PR DESCRIPTION
(and the error is due to celery failing)
