### PR TITLE
Revert Case List report behavior

### DIFF
--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -46,7 +46,7 @@ class CaseListMixin(ElasticProjectInspectionReport, ProjectReportParametersMixin
 
         def _filter_gen(key, flist):
             return {"terms": {
-                key: [item.lower() if item else "" for item in flist]
+                key: [item.lower() for item in flist if item]
             }}
 
         def _domain_term():

--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -45,9 +45,6 @@ class CaseListMixin(ElasticProjectInspectionReport, ProjectReportParametersMixin
         user_ids = user_ids or []
 
         def _filter_gen(key, flist):
-            if len(flist) == 0:
-                return None
-
             return {"terms": {
                 key: [item.lower() if item else "" for item in flist]
             }}


### PR DESCRIPTION
[3368](https://github.com/dimagi/commcare-hq/pull/3368) makes the case list report show unfiltered results if all options are removed.  I confirmed with Amelia and Sheel that this is not the desired behavior, as the other reports show no rows in this case.

The second commit is a small fix I noticed while reviewing that PR.
