### PR TITLE
don't apply bindings if element doesn't exist

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/ko/bulk_upload_file.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/ko/bulk_upload_file.js
@@ -1,6 +1,12 @@
-ko.applyBindings(
-    {
-        file: ko.observable(null)
-    },
-    $("#bulk_upload_form").get(0)
-);
+/* globals ko */
+$(function () {
+    "use strict";
+    if ($("#bulk_upload_form").get(0)) {
+        ko.applyBindings(
+            {
+                file: ko.observable(null)
+            },
+            $("#bulk_upload_form").get(0)
+        );
+    }
+});


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?114019#643577

New to KnockoutJS 2.3 is that it will error if you attempt to apply bindings more than once on the same element. Prior to 2.3 the outcome was undefined.

Also note that if you apply bindings to an undefined element it will apply the bindings to the entire document.
e.g.

```
ko.applyBindings(viewModel, $("#element_id").get(0));
```

If the element with ID "element_id" does not exist the bindings will get applied to the entire document.

@dimagi/team-commcare-hq 
