### PR TITLE
fix help link in domain registration emails

### DIFF
--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -166,7 +166,7 @@ The CommCareHQ Team
 """
 
 
-WIKI_LINK = 'http://wiki.commcarehq.org/display/commcarepublic/Home'
+WIKI_LINK = 'help.commcarehq.org'
 USERS_LINK = 'http://groups.google.com/group/commcare-users'
 PRICING_LINK = 'http://www.commcarehq.org/software-plans'
 


### PR DESCRIPTION
fix http://manage.dimagi.com/default.asp?114006
