### PR TITLE
flag incomplete build when an expected resource is not found

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2161,6 +2161,10 @@ class ApplicationBase(VersionedDoc, SnapshotMixin):
     build_comment = StringProperty()
     comment_from = StringProperty()
     build_broken = BooleanProperty(default=False)
+    # not used yet, but nice for tagging/debugging
+    # currently only canonical value is 'incomplete-build',
+    # for when build resources aren't found where they should be
+    build_broken_reason = StringProperty()
 
     # watch out for a past bug:
     # when reverting to a build that happens to be released


### PR DESCRIPTION
fixes: http://manage.dimagi.com/default.asp?86733

This puts a red warning there for people so they know to delete and rebuild.

It also fixes the logging message to be more useful, in case there is actually something stranger going on.
