### PR TITLE
Fix extra download incrementing in exchange.

### DIFF
--- a/corehq/apps/appstore/templates/appstore/project_info.html
+++ b/corehq/apps/appstore/templates/appstore/project_info.html
@@ -52,7 +52,6 @@
             $('#agree-button').click(function() {
                 var form = $("#" + $(this).attr('data-form'));
                 form.submit();
-                $(this).prop('disabled', true).addClass('disabled')
             });
 
             // show downloads info div


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?112463#640044

With the property 'disabled' set to true on the <a> tag,
the modal stuck around too long, allowing users to re-submit
a POST request, and falsely increment the download count
for the project.
