### PR TITLE
catch and print banned emails

### DIFF
--- a/corehq/apps/registration/management/commands/add_mass_emails_to_mailchimp.py
+++ b/corehq/apps/registration/management/commands/add_mass_emails_to_mailchimp.py
@@ -32,6 +32,8 @@ class Command(BaseCommand):
                     print 'subscribed %s' % email_address
                 except mailchimp.ListAlreadySubscribedError:
                     print 'already subscribed %s' % email_address
+                except mailchimp.ListInvalidImportError as e:
+                    print e.message
                 except mailchimp.Error as e:
                     raise e
             else:


### PR DESCRIPTION
some emails are blocked from joining mailchimp lists - that's ok, so print these errors but continue with the management command.
