### PR TITLE
Don't reapply bindings if they already exist

### DIFF
--- a/corehq/apps/data_interfaces/templates/data_interfaces/interfaces/case_management.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/interfaces/case_management.html
@@ -24,8 +24,9 @@
             var caseManagementModel = new CaseManagement(OPTIONS);
             var $caseManagement = $('#case-management');
             var element = $caseManagement[0];
-            ko.cleanNode(element);
-            ko.applyBindings(caseManagementModel, element);
+            if (!ko.dataFor(element)) {
+                ko.applyBindings(caseManagementModel, element);
+            }
 
             $caseManagement.find('a.select-all').click(function () {
                 $caseManagement.find('input.selected-commcare-case').attr('checked', true).change();


### PR DESCRIPTION
before the knockout upgrade, this would fail silently, so I'm trying to essentially revert to that behavior.

http://manage.dimagi.com/default.asp?115312
http://manage.dimagi.com/default.asp?115274
