### PR TITLE
Archive form ga

### DIFF
--- a/corehq/apps/reports/templates/reports/form/partials/single_form.html
+++ b/corehq/apps/reports/templates/reports/form/partials/single_form.html
@@ -92,6 +92,20 @@ requires imports/proptable.html to be included in the main template
         showSkipped(false);
     });
 </script>
+<script type="text/javascript">
+    function archive_form() {
+        document.getElementById('archive-form-btn').disabled=true;
+        document.getElementById('archive-spinner').style.display='inline-block';
+        _gaq.push(['_trackEvent', 'Reports', 'Case History', 'Archive this form']);
+        document.getElementById('archive-form').submit();
+    }
+    function restore_form() {
+        document.getElementById('unarchive-form-btn').disabled=true;
+        document.getElementById('unarchive-spinner').style.display='inline-block';
+        _gaq.push(['_trackEvent', 'Reports', 'Case History', 'Restore this form']);
+        document.getElementById('unarchive-form').submit();
+    }
+</script>
 <style>
     .form-data-group-table {
         margin-bottom: 0;
@@ -201,7 +215,7 @@ requires imports/proptable.html to be included in the main template
                         <i class="icon icon-question-sign"></i>
                     </span>
                     <button type="submit" class="btn btn-danger" id="archive-form-btn"
-                            onclick="document.getElementById('archive-form-btn').disabled=true;document.getElementById('archive-form').submit();document.getElementById('archive-spinner').style.display='inline-block';">
+                            onclick="archive_form();">
                         {% trans "Archive this form" %}
                         <i class="icon-refresh icon-spin" id="archive-spinner" style="display:none"></i>
                     </button>
@@ -213,7 +227,7 @@ requires imports/proptable.html to be included in the main template
                         <i class="icon icon-question-sign"></i>
                     </span>
                     <button type="submit" class="btn btn-primary" id="unarchive-form-btn"
-                            onclick="document.getElementById('unarchive-form-btn').disabled=true;document.getElementById('unarchive-form').submit();document.getElementById('unarchive-spinner').style.display='inline-block';">
+                            onclick="restore_form();">
                         {% trans "Restore this form" %}
                         <i class="icon-refresh icon-spin" id="unarchive-spinner" style="display:none"></i>
                    </button>

--- a/corehq/apps/reports/templates/reports/form/partials/single_form.html
+++ b/corehq/apps/reports/templates/reports/form/partials/single_form.html
@@ -93,17 +93,18 @@ requires imports/proptable.html to be included in the main template
     });
 </script>
 <script type="text/javascript">
+    // TODO - upgrade to Universal Analytics, to avoid using setTimeout
     function archive_form() {
         document.getElementById('archive-form-btn').disabled=true;
         document.getElementById('archive-spinner').style.display='inline-block';
         _gaq.push(['_trackEvent', 'Reports', 'Case History', 'Archive this form']);
-        document.getElementById('archive-form').submit();
+        setTimeout("document.getElementById('archive-form').submit();", 300);
     }
     function restore_form() {
         document.getElementById('unarchive-form-btn').disabled=true;
         document.getElementById('unarchive-spinner').style.display='inline-block';
         _gaq.push(['_trackEvent', 'Reports', 'Case History', 'Restore this form']);
-        document.getElementById('unarchive-form').submit();
+        setTimeout("document.getElementById('unarchive-form').submit();", 300);
     }
 </script>
 <style>


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?114950#651164

Eventually should upgrade to Universal Analytics, which provides better handling of event tracking preceding a POST request (https://trello.com/c/19BjPlpx/64-upgrade-from-asynchronous-analytics-to-universal-analytics).  This avoids using setTimeout and is more reliable.  Since archive/restore form takes a while anyway, not a big deal to increase the total load time by 300 ms.
