### PR TITLE
fix rebuildstaging edge-case having a read-only URL

### DIFF
--- a/scripts/rebuildstaging.py
+++ b/scripts/rebuildstaging.py
@@ -191,7 +191,18 @@ def rebuild_staging(config):
                 cwd=path,
                 name=config.name,
             )
-            git.push('origin', config.name, '--force')
+            force_push(git, config.name)
+
+
+def force_push(git, branch):
+    try:
+        git.push('origin', branch, '--force')
+    except sh.ErrorReturnCode_128 as e:
+        # oops we're using a read-only URL, so change to the suggested url
+        line = sh.grep('  Use ', _in=e.stderr)
+        edit_url = line.strip().split()[1]
+        git.remote('set-url', 'origin', edit_url)
+        git.push('origin', branch, '--force')
 
 
 def format_cwd(cwd):


### PR DESCRIPTION
This is a somewhat rare case, but it's super easy to automate away, so why not. It's for when you try and push and get

```
fatal: remote error: 
  You can't push to git://github.com/dimagi/django-no-exceptions.git
  Use https://github.com/dimagi/django-no-exceptions.git
```

instead (because you've never pushed to that repo before and git submodule update makes it read-only by default). This will now just silently change the url to be the suggested write-enabled url.
