### PR TITLE
don't reassign anm_review cases for bihar

### DIFF
--- a/corehq/apps/hqcase/tests/test_case_assigment.py
+++ b/corehq/apps/hqcase/tests/test_case_assigment.py
@@ -92,8 +92,9 @@ class CaseAssignmentTest(TestCase):
 
     def test_assign_exclusion(self):
         self._make_tree()
+        exclude_fn = lambda case: case._id in (self.grandfather._id, self.primary._id, self.grandson._id)
         assign_case(self.primary, self.primary_user._id, include_subcases=True, include_parent_cases=True,
-                    exclude=(self.grandfather._id, self.primary._id, self.grandson._id))
+                    exclude_function=exclude_fn)
         self._check_state(new_owner_id=self.primary_user._id, expected_changed=[
             self.grandmother, self.parent, self.son, self.daughter,self.granddaughter, self.grandson2
         ])

--- a/corehq/apps/hqcase/utils.py
+++ b/corehq/apps/hqcase/utils.py
@@ -114,8 +114,9 @@ def get_cases_in_domain(domain, type=None):
     return (CommCareCase.wrap(doc) for doc in iter_docs(CommCareCase.get_db(),
                                                         get_case_ids_in_domain(domain, type=type)))
 
+
 def assign_case(case_or_case_id, owner_id, acting_user=None, include_subcases=True,
-                include_parent_cases=False, exclude=(), update=None):
+                include_parent_cases=False, exclude_function=None, update=None):
     """
     Assigns a case to an owner. Optionally traverses through subcases and parent cases
     and reassigns those to the same owner.
@@ -129,8 +130,8 @@ def assign_case(case_or_case_id, owner_id, acting_user=None, include_subcases=Tr
         cases_to_assign.extend(get_related_cases([primary_case], primary_case.domain, search_up=False).values())
     if include_parent_cases:
         cases_to_assign.extend(get_related_cases([primary_case], primary_case.domain, search_up=True).values())
-    if exclude:
-        cases_to_assign = filter(lambda case: case._id not in exclude, cases_to_assign)
+    if exclude_function:
+        cases_to_assign = [c for c in cases_to_assign if not exclude_function(c)]
     return assign_cases(cases_to_assign, owner_id, acting_user, update=update)
 
 

--- a/custom/bihar/signals.py
+++ b/custom/bihar/signals.py
@@ -18,7 +18,7 @@ def bihar_reassignment(sender, xform, cases, **kwargs):
     if hasattr(xform, 'domain') and xform.domain in BIHAR_DOMAINS and xform.metadata and xform.metadata.userID != SYSTEM_USERID:
         owner_ids = set(c.owner_id for c in cases)
         if len(owner_ids) != 1:
-            logging.error('form {form} had mismatched case owner ids'.format(form=xform._id))
+            logging.warning('form {form} had mismatched case owner ids'.format(form=xform._id))
         else:
             [owner_id] = owner_ids
             if owner_id not in DEMO_OWNER_IDS:

--- a/custom/bihar/signals.py
+++ b/custom/bihar/signals.py
@@ -23,11 +23,16 @@ def bihar_reassignment(sender, xform, cases, **kwargs):
             [owner_id] = owner_ids
             if owner_id not in DEMO_OWNER_IDS:
                 form_cases = set(c._id for c in cases)
+
+                def bihar_exclude(case):
+                    return case._id in form_cases or case.type == 'anm_review'
+
                 for case in cases:
                     if case.type in ('cc_bihar_pregnancy', 'cc_bihar_newborn'):
+
                         assign_case(case, owner_id, BiharMockUser(),
                                     include_subcases=True, include_parent_cases=True,
-                                    exclude=form_cases, update={'reassignment_form_id': xform._id})
+                                    exclude_function=bihar_exclude, update={'reassignment_form_id': xform._id})
 
 
 cases_received.connect(bihar_reassignment)


### PR DESCRIPTION
also make exclusion in case assignment more flexible, using a function instead of a list, and downgrade error messages to stop spamming us in legitimate workflows.

http://manage.dimagi.com/default.asp?112648

wait for tests
