### PR TITLE
use default django cache instead of couchdb

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -484,37 +484,7 @@ class CachedStringProperty(object):
 
     @classmethod
     def set(cls, key, value):
-        cache.set(key, value, 12*60*60)
-
-
-class CouchCache(Document):
-
-    value = StringProperty(default=None)
-
-
-class CouchCachedStringProperty(CachedStringProperty):
-
-    @classmethod
-    def _get(cls, key):
-        try:
-            c = CouchCache.get(key)
-            assert(c.doc_type == CouchCache.__name__)
-        except ResourceNotFound:
-            c = CouchCache(_id=key)
-        return c
-
-    @classmethod
-    def get(cls, key):
-        return cls._get(key).value
-
-    @classmethod
-    def set(cls, key, value):
-        c = cls._get(key)
-        c.value = value
-        try:
-            c.save()
-        except ResourceConflict:
-            cls.set(key, value)
+        cache.set(key, value, 7*24*60*60)  # cache for 7 days
 
 
 class FormBase(DocumentSchema):
@@ -531,7 +501,7 @@ class FormBase(DocumentSchema):
     xmlns = StringProperty()
     version = IntegerProperty()
     source = FormSource()
-    validation_cache = CouchCachedStringProperty(
+    validation_cache = CachedStringProperty(
         lambda self: "cache-%s-%s-validation" % (self.get_app().get_id, self.unique_id)
     )
 

--- a/corehq/apps/app_manager/tests/test_build_errors.py
+++ b/corehq/apps/app_manager/tests/test_build_errors.py
@@ -1,5 +1,5 @@
 import json
-from django.test import TestCase
+from django.test import SimpleTestCase as TestCase
 import os
 from corehq.apps.app_manager.models import Application
 

--- a/corehq/apps/app_manager/tests/test_commcare_settings.py
+++ b/corehq/apps/app_manager/tests/test_commcare_settings.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from django.test import TestCase
+from django.test import SimpleTestCase as TestCase
 from corehq.apps.app_manager.commcare_settings import parse_condition_string, check_condition, circular_dependencies, SETTINGS, SETTINGS_LOOKUP
 from corehq.apps.app_manager.models import Application
 

--- a/corehq/apps/app_manager/tests/test_days_ago_migration.py
+++ b/corehq/apps/app_manager/tests/test_days_ago_migration.py
@@ -1,8 +1,10 @@
 from corehq.apps.app_manager.models import Application
 from corehq.apps.app_manager.tests.util import TestFileMixin
+from django.test import SimpleTestCase as TestCase
 
 
-class DaysAgoMigrationTest(TestFileMixin):
+class DaysAgoMigrationTest(TestCase, TestFileMixin):
+    file_path = ['data']
 
     def setUp(self):
         self.app = Application.wrap(self.get_json('days_ago_migration'))

--- a/corehq/apps/app_manager/tests/test_form_preparation_v2.py
+++ b/corehq/apps/app_manager/tests/test_form_preparation_v2.py
@@ -3,7 +3,7 @@ import lxml
 from corehq.apps.app_manager.const import APP_V2, CAREPLAN_GOAL, CAREPLAN_TASK
 from corehq.apps.app_manager.models import Application, OpenCaseAction, UpdateCaseAction, PreloadAction, FormAction, Module, AdvancedModule, AdvancedForm, AdvancedOpenCaseAction, LoadUpdateAction, \
     AutoSelectCase
-from django.test import TestCase
+from django.test import SimpleTestCase as TestCase
 from corehq.apps.app_manager.tests.util import TestFileMixin
 from corehq.apps.app_manager.util import new_careplan_module
 

--- a/corehq/apps/app_manager/tests/test_get_questions.py
+++ b/corehq/apps/app_manager/tests/test_get_questions.py
@@ -1,6 +1,6 @@
 import os
 
-from django.test import TestCase
+from django.test import SimpleTestCase as TestCase
 
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.app_manager.models import Application, Module, APP_V2
@@ -98,8 +98,6 @@ class GetFormQuestionsTest(TestCase):
             with open(path) as f:
                 return f.read()
 
-        create_domain(self.domain)
-
         self.app = app = Application.new_app(
                 self.domain, "Test", application_version=APP_V2)
         app.add_module(Module.new_module("Module", 'en'))
@@ -110,7 +108,6 @@ class GetFormQuestionsTest(TestCase):
                 attachment=read('case_in_form.xml'))
 
         self.form_unique_id = form.unique_id
-        app.save()
 
     def test_get_questions(self):
         form = self.app.get_form(self.form_unique_id)

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -1,4 +1,4 @@
-from django.test import TestCase, SimpleTestCase
+from django.test import SimpleTestCase
 from corehq.apps.app_manager.models import Application, AutoSelectCase, AUTO_SELECT_USER, AUTO_SELECT_CASE, \
     LoadUpdateAction, AUTO_SELECT_FIXTURE, AUTO_SELECT_RAW
 from corehq.apps.app_manager.tests.util import TestFileMixin
@@ -119,7 +119,7 @@ class SuiteTest(SimpleTestCase, TestFileMixin):
         self._test_generic_suite('app_no_case_sharing', 'suite-no-case-sharing')
 
 
-class RegexTest(TestCase):
+class RegexTest(SimpleTestCase):
 
     def testRegex(self):
         replacement = "@case_id stuff"

--- a/corehq/apps/app_manager/tests/test_xml_parsing.py
+++ b/corehq/apps/app_manager/tests/test_xml_parsing.py
@@ -1,4 +1,4 @@
-from django.test import TestCase
+from django.test import SimpleTestCase as TestCase
 from corehq.apps.app_manager.models import _parse_xml
 import os
 


### PR DESCRIPTION
This change allows tests to run without the need for couchdb.

The couch cache never expires but I think a 7 day timeout is plenty long enough.
