### PR TITLE
Consumption bug fixes

### DIFF
--- a/corehq/apps/commtrack/const.py
+++ b/corehq/apps/commtrack/const.py
@@ -17,6 +17,7 @@ FULFILLMENT_CASE_TYPE = 'commtrack-fulfillment'
 RECEIVED_CASE_TYPE = 'commtrack-received'
 ORDER_CASE_TYPE = 'commtrack-order'
 
+DAYS_IN_MONTH = 30.0
 
 def is_commtrack_case(case):
     return case.type in [

--- a/corehq/apps/commtrack/templates/commtrack/manage/default_consumption.html
+++ b/corehq/apps/commtrack/templates/commtrack/manage/default_consumption.html
@@ -8,16 +8,16 @@
         <div class="span6">
                 <p>
                     {% blocktrans %}
-                        Use this page to edit the default consumption values
-                        for your products. These will be used if there is
-                        not enough information to compute an accurate value.
+                        Use this page to edit the default monthly consumption
+                        values for your products. These will be used if there
+                        is not enough information to compute an accurate value.
                     {% endblocktrans %}
                 </p>
         </div>
     </div>
     <form class="form-horizontal" method="post">
         <fieldset>
-            <legend>{% trans 'Edit Default Consumption' %}</legend>
+            <legend>{% trans 'Edit Default Monthly Consumption' %}</legend>
             {% crispy form %}
             <div class="form-actions">
                 <button type="submit" class="btn btn-primary">

--- a/corehq/apps/commtrack/tests/test_settings.py
+++ b/corehq/apps/commtrack/tests/test_settings.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.commtrack.models import CommtrackConfig, ConsumptionConfig, StockRestoreConfig
-from corehq.apps.commtrack.tests.util import bootstrap_domain
+from corehq.apps.commtrack.tests.util import bootstrap_domain, DAYS_IN_MONTH
 from corehq.apps.consumption.shortcuts import set_default_consumption_for_domain
 
 
@@ -18,7 +18,7 @@ class CommTrackSettingsTest(TestCase):
         ct_settings.ota_restore_config = StockRestoreConfig(
             section_to_consumption_types={'stock': 'consumption'},
         )
-        set_default_consumption_for_domain(domain.name, 5)
+        set_default_consumption_for_domain(domain.name, 5 * DAYS_IN_MONTH)
         restore_settings = ct_settings.get_ota_restore_settings()
         self.assertEqual(1, len(restore_settings.section_to_consumption_types))
         self.assertEqual('consumption', restore_settings.section_to_consumption_types['stock'])

--- a/corehq/apps/commtrack/tests/test_settings.py
+++ b/corehq/apps/commtrack/tests/test_settings.py
@@ -1,7 +1,8 @@
 from django.test import TestCase
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.commtrack.models import CommtrackConfig, ConsumptionConfig, StockRestoreConfig
-from corehq.apps.commtrack.tests.util import bootstrap_domain, DAYS_IN_MONTH
+from corehq.apps.commtrack.tests.util import bootstrap_domain
+from corehq.apps.commtrack.const import DAYS_IN_MONTH
 from corehq.apps.consumption.shortcuts import set_default_consumption_for_domain
 
 

--- a/corehq/apps/commtrack/tests/test_stock_state.py
+++ b/corehq/apps/commtrack/tests/test_stock_state.py
@@ -1,7 +1,8 @@
 from corehq.apps.commtrack.models import StockState
 from casexml.apps.stock.models import DocDomainMapping
 from casexml.apps.stock.tests.base import _stock_report
-from corehq.apps.commtrack.tests.util import CommTrackTest, DAYS_IN_MONTH
+from corehq.apps.commtrack.tests.util import CommTrackTest
+from corehq.apps.commtrack.const import DAYS_IN_MONTH
 from datetime import datetime
 from corehq.apps.consumption.shortcuts import set_default_consumption_for_domain
 

--- a/corehq/apps/commtrack/tests/test_stock_state.py
+++ b/corehq/apps/commtrack/tests/test_stock_state.py
@@ -1,11 +1,9 @@
 from corehq.apps.commtrack.models import StockState
 from casexml.apps.stock.models import DocDomainMapping
-from casexml.apps.stock.tests.base import StockTestBase, _stock_report
-from corehq.apps.commtrack.tests.util import CommTrackTest
+from casexml.apps.stock.tests.base import _stock_report
+from corehq.apps.commtrack.tests.util import CommTrackTest, DAYS_IN_MONTH
 from datetime import datetime
 from corehq.apps.consumption.shortcuts import set_default_consumption_for_domain
-from casexml.apps.stock.consumption import ConsumptionConfiguration
-from corehq.apps.commtrack.models import CommtrackConfig, ConsumptionConfig, StockRestoreConfig
 
 
 class StockStateTest(CommTrackTest):
@@ -74,7 +72,7 @@ class StockStateConsumptionTest(StockStateTest):
             product_id=self.products[0]._id,
         )
 
-        self.assertEqual(50, state.get_consumption())
+        self.assertEqual(50 / DAYS_IN_MONTH, state.get_consumption())
 
     def test_defaults_set_after_report(self):
         self.report(25, 0)
@@ -86,4 +84,4 @@ class StockStateConsumptionTest(StockStateTest):
             product_id=self.products[0]._id,
         )
 
-        self.assertEqual(50, state.get_consumption())
+        self.assertEqual(50 / DAYS_IN_MONTH, state.get_consumption())

--- a/corehq/apps/commtrack/tests/test_xml.py
+++ b/corehq/apps/commtrack/tests/test_xml.py
@@ -19,7 +19,7 @@ from corehq.apps.commtrack.tests.util import CommTrackTest, get_ota_balance_xml,
 from casexml.apps.case.tests.util import check_xml_line_by_line, check_user_has_case
 from corehq.apps.hqcase.utils import get_cases_in_domain
 from corehq.apps.receiverwrapper import submit_form_locally
-from corehq.apps.commtrack.tests.util import make_loc, make_supply_point
+from corehq.apps.commtrack.tests.util import make_loc, make_supply_point, DAYS_IN_MONTH
 from corehq.apps.commtrack.requisitions import get_notification_message
 from corehq.apps.commtrack.tests.data.balances import (
     balance_ota_block,
@@ -98,7 +98,7 @@ class CommTrackOTATest(CommTrackTest):
         self.ct_settings.ota_restore_config = StockRestoreConfig(
             section_to_consumption_types={'stock': 'consumption'}
         )
-        set_default_consumption_for_domain(self.domain.name, 5)
+        set_default_consumption_for_domain(self.domain.name, 5 * DAYS_IN_MONTH)
 
         amounts = [(p._id, i*10) for i, p in enumerate(self.products)]
         report = _report_soh(amounts, self.sp._id, 'stock')

--- a/corehq/apps/commtrack/tests/test_xml.py
+++ b/corehq/apps/commtrack/tests/test_xml.py
@@ -19,7 +19,8 @@ from corehq.apps.commtrack.tests.util import CommTrackTest, get_ota_balance_xml,
 from casexml.apps.case.tests.util import check_xml_line_by_line, check_user_has_case
 from corehq.apps.hqcase.utils import get_cases_in_domain
 from corehq.apps.receiverwrapper import submit_form_locally
-from corehq.apps.commtrack.tests.util import make_loc, make_supply_point, DAYS_IN_MONTH
+from corehq.apps.commtrack.tests.util import make_loc, make_supply_point
+from corehq.apps.commtrack.const import DAYS_IN_MONTH
 from corehq.apps.commtrack.requisitions import get_notification_message
 from corehq.apps.commtrack.tests.data.balances import (
     balance_ota_block,

--- a/corehq/apps/commtrack/tests/util.py
+++ b/corehq/apps/commtrack/tests/util.py
@@ -28,6 +28,8 @@ TEST_NUMBER = '5551234'
 TEST_PASSWORD = 'secret'
 TEST_BACKEND = 'test-backend'
 
+DAYS_IN_MONTH = 30.0
+
 ROAMING_USER = {
     'username': TEST_USER + '-roaming',
     'phone_number': TEST_NUMBER,

--- a/corehq/apps/commtrack/tests/util.py
+++ b/corehq/apps/commtrack/tests/util.py
@@ -28,8 +28,6 @@ TEST_NUMBER = '5551234'
 TEST_PASSWORD = 'secret'
 TEST_BACKEND = 'test-backend'
 
-DAYS_IN_MONTH = 30.0
-
 ROAMING_USER = {
     'username': TEST_USER + '-roaming',
     'phone_number': TEST_NUMBER,

--- a/corehq/apps/consumption/const.py
+++ b/corehq/apps/consumption/const.py
@@ -1,0 +1,1 @@
+DAYS_IN_MONTH = 30.0

--- a/corehq/apps/consumption/shortcuts.py
+++ b/corehq/apps/consumption/shortcuts.py
@@ -16,7 +16,7 @@ def get_default_consumption(domain, product_id, location_type, case_id):
     )
     results = results[0] if results else None
     if results and results['value']:
-        return Decimal(results['value'])
+        return Decimal(float(results['value']) / 30)
     else:
         return None
 

--- a/corehq/apps/consumption/shortcuts.py
+++ b/corehq/apps/consumption/shortcuts.py
@@ -1,5 +1,6 @@
 from decimal import Decimal
 from corehq.apps.consumption.models import DefaultConsumption, TYPE_DOMAIN, TYPE_PRODUCT, TYPE_SUPPLY_POINT
+from corehq.apps.consumption.const import DAYS_IN_MONTH
 from dimagi.utils.couch.cache import cache_core
 
 
@@ -16,7 +17,7 @@ def get_default_consumption(domain, product_id, location_type, case_id):
     )
     results = results[0] if results else None
     if results and results['value']:
-        return Decimal(float(results['value']) / 30)
+        return Decimal(float(results['value']) / DAYS_IN_MONTH)
     else:
         return None
 

--- a/corehq/apps/consumption/tests.py
+++ b/corehq/apps/consumption/tests.py
@@ -3,13 +3,13 @@ from corehq.apps.consumption.shortcuts import (get_default_consumption, set_defa
     set_default_consumption_for_product, set_default_consumption_for_supply_point
 )
 from .models import DefaultConsumption, TYPE_DOMAIN, TYPE_PRODUCT, TYPE_SUPPLY_POINT_TYPE, TYPE_SUPPLY_POINT
+from corehq.apps.consumption.const import DAYS_IN_MONTH
 
 domain = 'consumption-test'
 product_id = 'test-product'
 type_id = 'facilities'
 supply_point_id = 'test-facility'
 
-DAYS_IN_MONTH = 30
 
 class ConsumptionTestBase(TestCase):
     def setUp(self):

--- a/corehq/apps/consumption/tests.py
+++ b/corehq/apps/consumption/tests.py
@@ -9,6 +9,7 @@ product_id = 'test-product'
 type_id = 'facilities'
 supply_point_id = 'test-facility'
 
+DAYS_IN_MONTH = 30
 
 class ConsumptionTestBase(TestCase):
     def setUp(self):
@@ -127,20 +128,20 @@ class ConsumptionShortcutsTestCase(ConsumptionTestBase):
 
 
 def _create_domain_consumption(amt, domain=domain):
-    DefaultConsumption(domain=domain, default_consumption=amt, type=TYPE_DOMAIN).save()
+    DefaultConsumption(domain=domain, default_consumption=amt * DAYS_IN_MONTH, type=TYPE_DOMAIN).save()
 
 
 def _create_product_consumption(amt, domain=domain, product_id=product_id):
-    DefaultConsumption(domain=domain, default_consumption=amt, type=TYPE_PRODUCT, product_id=product_id).save()
+    DefaultConsumption(domain=domain, default_consumption=amt * DAYS_IN_MONTH, type=TYPE_PRODUCT, product_id=product_id).save()
 
 
 def _create_type_consumption(amt, domain=domain, product_id=product_id, type_id=type_id):
-    DefaultConsumption(domain=domain, default_consumption=amt, type=TYPE_SUPPLY_POINT_TYPE, product_id=product_id,
+    DefaultConsumption(domain=domain, default_consumption=amt * DAYS_IN_MONTH, type=TYPE_SUPPLY_POINT_TYPE, product_id=product_id,
                        supply_point_type=type_id).save()
 
 
 def _create_id_consumption(amt, domain=domain, product_id=product_id, supply_point_id=supply_point_id):
-    DefaultConsumption(domain=domain, default_consumption=amt, type=TYPE_SUPPLY_POINT, product_id=product_id,
+    DefaultConsumption(domain=domain, default_consumption=amt * DAYS_IN_MONTH, type=TYPE_SUPPLY_POINT, product_id=product_id,
                        supply_point_id=supply_point_id).save()
 
 

--- a/corehq/apps/locations/templates/locations/manage/location.html
+++ b/corehq/apps/locations/templates/locations/manage/location.html
@@ -89,7 +89,7 @@
     </fieldset>
 
     {% if consumption %}
-      <legend>{% trans "Default consumption values" %}</legend>
+      <legend>{% trans "Default monthly consumption values" %}</legend>
       {% for code, amount in consumption %}
         <div class="control-group">
           <label class="control-label">{{ code }}</label>

--- a/corehq/apps/locations/tests/test_location_import.py
+++ b/corehq/apps/locations/tests/test_location_import.py
@@ -1,5 +1,6 @@
 from corehq.apps.commtrack.helpers import make_supply_point
-from corehq.apps.commtrack.tests.util import CommTrackTest, make_loc, DAYS_IN_MONTH
+from corehq.apps.commtrack.tests.util import CommTrackTest, make_loc
+from corehq.apps.commtrack.const import DAYS_IN_MONTH
 from corehq.apps.locations.models import Location
 from corehq.apps.locations.bulk import import_location
 from mock import patch

--- a/corehq/apps/locations/tests/test_location_import.py
+++ b/corehq/apps/locations/tests/test_location_import.py
@@ -1,5 +1,5 @@
 from corehq.apps.commtrack.helpers import make_supply_point
-from corehq.apps.commtrack.tests.util import CommTrackTest, make_loc
+from corehq.apps.commtrack.tests.util import CommTrackTest, make_loc, DAYS_IN_MONTH
 from corehq.apps.locations.models import Location
 from corehq.apps.locations.bulk import import_location
 from mock import patch
@@ -214,7 +214,7 @@ class LocationImportTest(CommTrackTest):
                 'state',
                 sp._id,
             ),
-            77
+            77 / DAYS_IN_MONTH
         )
 
     def test_import_coordinates(self):

--- a/corehq/apps/reports/commtrack/data_sources.py
+++ b/corehq/apps/reports/commtrack/data_sources.py
@@ -9,6 +9,7 @@ from casexml.apps.stock.models import StockTransaction
 from couchforms.models import XFormInstance
 from corehq.apps.reports.commtrack.util import get_relevant_supply_point_ids, product_ids_filtered_by_program
 from corehq.apps.reports.commtrack.const import STOCK_SECTION_TYPE
+from corehq.apps.commtrack.const import DAYS_IN_MONTH
 from casexml.apps.stock.utils import months_of_stock_remaining, stock_category
 from corehq.apps.reports.standard.monitoring import MultiFormDrilldownMixin
 from decimal import Decimal
@@ -105,7 +106,7 @@ class StockStatusDataSource(ReportDataSource, CommtrackDataSourceMixin):
         SLUG_LOCATION_ID: lambda s: SupplyPointCase.get(s.case_id).location_[-1],
         # SLUG_LOCATION_LINEAGE: lambda p: list(reversed(p.location_[:-1])),
         SLUG_CURRENT_STOCK: 'stock_on_hand',
-        SLUG_CONSUMPTION: lambda s: s.get_consumption() * 30 if s.get_consumption() is not None else None,
+        SLUG_CONSUMPTION: lambda s: s.get_consumption() * DAYS_IN_MONTH if s.get_consumption() is not None else None,
         SLUG_MONTHS_REMAINING: 'months_remaining',
         SLUG_CATEGORY: 'stock_category',
         # SLUG_STOCKOUT_SINCE: 'stocked_out_since',
@@ -169,7 +170,7 @@ class StockStatusDataSource(ReportDataSource, CommtrackDataSourceMixin):
             yield {
                 'category': state.stock_category,
                 'product_id': product._id,
-                'consumption': state.get_consumption() * 30 if state.get_consumption() is not None else None,
+                'consumption': state.get_consumption() * Decimal(DAYS_IN_MONTH) if state.get_consumption() is not None else None,
                 'months_remaining': state.months_remaining,
                 'location_id': SupplyPointCase.get(state.case_id).location_id,
                 'product_name': product.name,
@@ -188,9 +189,9 @@ class StockStatusDataSource(ReportDataSource, CommtrackDataSourceMixin):
                 )
 
                 if product['consumption'] is None:
-                    product['consumption'] = state.get_consumption() * 30
+                    product['consumption'] = state.get_consumption() * Decimal(DAYS_IN_MONTH)
                 elif state.get_consumption() is not None:
-                    product['consumption'] += state.get_consumption() * 30
+                    product['consumption'] += state.get_consumption() * Decimal(DAYS_IN_MONTH)
 
                 product['count'] += 1
 
@@ -205,7 +206,7 @@ class StockStatusDataSource(ReportDataSource, CommtrackDataSourceMixin):
                 )
             else:
                 product = Product.get(state.product_id)
-                consumption = state.get_consumption() * 30
+                consumption = state.get_consumption() * Decimal(DAYS_IN_MONTH)
 
                 product_aggregation[state.product_id] = {
                     'product_id': product._id,


### PR DESCRIPTION
Fixes a few issues with consumption stuff:

1 - Language isn't clear as to what the time frame on the consumption value is.
2 - `get_consumption` was returning daily consumption for computations, and monthly for defaults
3 - Only leaf location location values were converted back to monthly consumption quantities
