### PR TITLE
Boost periodic queue's concurrency

### DIFF
--- a/services/templates/supervisor_celery_periodic.conf
+++ b/services/templates/supervisor_celery_periodic.conf
@@ -1,5 +1,5 @@
 [program:%(project)s-%(environment)s-celery_periodic]
-command=%(virtualenv_root)s/bin/python %(code_root)s/manage.py celery worker --queues=celery_periodic --events --loglevel=INFO --hostname=%(host_string)s_periodic --maxtasksperchild=50 --concurrency=4
+command=%(virtualenv_root)s/bin/python %(code_root)s/manage.py celery worker --queues=celery_periodic --events --loglevel=INFO --hostname=%(host_string)s_periodic --maxtasksperchild=50 --concurrency=6
 directory=%(code_root)s
 user=%(sudo_user)s
 numprocs=1


### PR DESCRIPTION
This used to be 8, and I reduced it to 4 to save on memory. But I didn't realize that we had periodic tasks that can take up to a few hours to complete. So this will put it to 6 since 4 is getting a little to close to having a clogged queue when those long running tasks pile up.
