### PR TITLE
Improve Application Status report

### DIFF
--- a/corehq/apps/receiverwrapper/tests/__init__.py
+++ b/corehq/apps/receiverwrapper/tests/__init__.py
@@ -1,4 +1,6 @@
 import logging
+from corehq.apps.receiverwrapper.util import get_version_from_appversion_text
+
 try:
     from .test_repeater import *
     from .test_submissions import *
@@ -10,3 +12,7 @@ except ImportError, e:
     # otherwise debugging is a pain
     logging.exception(e)
     raise(e)
+
+__test__ = {
+    'get_version_from_appversion_text': get_version_from_appversion_text,
+}

--- a/corehq/apps/receiverwrapper/util.py
+++ b/corehq/apps/receiverwrapper/util.py
@@ -77,28 +77,56 @@ def _get_version_from_build_id(domain, build_id):
         return build.version
 
 
-def get_build_version(xform):
+def get_version_from_appversion_text(appversion_text):
     """
-    there are a bunch of unreliable places to look for a build version
-    this abstracts that out
+    >>> # these first two could certainly be replaced
+    >>> # with more realistic examples, but I didn't have any on hand
+    >>> get_version_from_appversion_text('foofoo #102 barbar')
+    102
+    >>> get_version_from_appversion_text('foofoo b[99] barbar')
+    99
+    >>> get_version_from_appversion_text(
+    ...     'CommCare ODK, version "2.11.0"(29272). App v65. '
+    ...     'CommCare Version 2.11. Build 29272, built on: February-14-2014'
+    ... )
+    65
+    >>> get_version_from_appversion_text(
+    ...     'CommCare ODK, version "2.4.1"(10083). App v19.'
+    ...     'CommCare Version 2.4. Build 10083, built on: March-12-2013'
+    ... )
+    19
 
     """
+
     patterns = [
         r' #(\d+) ',
         'b\[(\d+)\]',
+        r'App v(\d+).',
     ]
-
-    version = get_version_from_build_id(xform.domain, xform.build_id)
-    if version:
-        return version
-
-    appversion_text = get_meta_appversion_text(xform)
     if appversion_text:
         for pattern in patterns:
             match = re.search(pattern, appversion_text)
             if match:
                 build_number, = match.groups()
                 return int(build_number)
+
+
+def get_build_version(xform):
+    """
+    there are a bunch of unreliable places to look for a build version
+    this abstracts that out
+
+    """
+
+    version = get_version_from_build_id(xform.domain, xform.build_id)
+    if version:
+        return version
+
+    version = get_version_from_appversion_text(
+        get_meta_appversion_text(xform)
+    )
+    if version:
+        return version
 
     xform_version = xform.version
     if xform_version and xform_version != '1':

--- a/corehq/apps/receiverwrapper/util.py
+++ b/corehq/apps/receiverwrapper/util.py
@@ -111,6 +111,13 @@ def get_version_from_appversion_text(appversion_text):
                 return int(build_number)
 
 
+class BuildVersionSource:
+    BUILD_ID = object()
+    APPVERSION_TEXT = object()
+    XFORM_VERSION = object()
+    NONE = object()
+
+
 def get_build_version(xform):
     """
     there are a bunch of unreliable places to look for a build version
@@ -120,17 +127,19 @@ def get_build_version(xform):
 
     version = get_version_from_build_id(xform.domain, xform.build_id)
     if version:
-        return version
+        return version, BuildVersionSource.BUILD_ID
 
     version = get_version_from_appversion_text(
         get_meta_appversion_text(xform)
     )
     if version:
-        return version
+        return version, BuildVersionSource.APPVERSION_TEXT
 
     xform_version = xform.version
     if xform_version and xform_version != '1':
-        return int(xform_version)
+        return int(xform_version), BuildVersionSource.XFORM_VERSION
+
+    return None, BuildVersionSource.NONE
 
 
 def get_app_and_build_ids(domain, build_or_app_id):

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -1,4 +1,10 @@
-from corehq.apps.receiverwrapper.util import get_meta_appversion_text, get_build_version
+# coding=utf-8
+import functools
+from pydoc import html
+from django.utils.html import format_html
+from django.utils.safestring import mark_safe
+from corehq.apps.receiverwrapper.util import get_meta_appversion_text, get_build_version, \
+    BuildVersionSource
 from couchdbkit import ResourceNotFound
 from corehq.apps.app_manager.models import get_app
 from corehq.apps.reports import util
@@ -24,6 +30,34 @@ class DeploymentsReport(GenericTabularReport, ProjectReport, ProjectReportParame
             return user and (user.is_superuser or user.has_permission(domain, 'edit_apps'))
         return super(DeploymentsReport, cls).show_in_navigation(domain, project, user)
 
+
+def _build_html(version, version_source):
+    version = version or _("Unknown")
+
+    def fmt(title, extra_class=u'', extra_text=u''):
+        return format_html(
+            u'<span class="label{extra_class}" title="{title}">'
+            u'{extra_text}{version}</span>',
+            version=version,
+            title=title,
+            extra_class=extra_class,
+            extra_text=extra_text,
+        )
+    if version_source == BuildVersionSource.BUILD_ID:
+        return fmt(title=_("This was taken from build id"),
+                   extra_class=u' label-success')
+    elif version_source == BuildVersionSource.APPVERSION_TEXT:
+        return fmt(title=_("This was taken from appversion text"))
+    elif version_source == BuildVersionSource.XFORM_VERSION:
+        return fmt(title=_("This was taken from xform version"),
+                   extra_text=u'≥ ')
+    elif version_source == BuildVersionSource.NONE:
+        return fmt(title=_("Unable to determine the build version"))
+    else:
+        raise AssertionError('version_source must be '
+                             'a BuildVersionSource constant')
+
+
 class ApplicationStatusReport(DeploymentsReport):
     name = ugettext_noop("Application Status")
     slug = "app_status"
@@ -33,22 +67,25 @@ class ApplicationStatusReport(DeploymentsReport):
 
     @property
     def headers(self):
-        return DataTablesHeader(DataTablesColumn(_("Username")),
-            DataTablesColumn(_("Last Seen (UTC)"),sort_type=DTSortType.NUMERIC),
-            DataTablesColumn(_("Application (Deployed Build)")))
+        return DataTablesHeader(
+            DataTablesColumn(_("Username")),
+            DataTablesColumn(_("Last Seen (UTC)"),
+                             sort_type=DTSortType.NUMERIC),
+            DataTablesColumn(_("Application (Deployed Build)"))
+        )
 
     @property
     def rows(self):
         rows = []
         selected_app = self.request_params.get(SelectApplicationFilter.slug, '')
-        UNKNOWN = _("unknown")
 
         for user in self.users:
             last_seen = self.table_cell(-1, _("Never"))
             app_name = None
 
-            key = make_form_couch_key(self.domain, user_id=user.get('user_id'), app_id=selected_app if selected_app else None)
-            data = XFormInstance.view(
+            key = make_form_couch_key(self.domain, user_id=user.get('user_id'),
+                                      app_id=selected_app or None)
+            xform = XFormInstance.view(
                 "reports_forms/all_forms",
                 startkey=key+[{}],
                 endkey=key,
@@ -58,24 +95,29 @@ class ApplicationStatusReport(DeploymentsReport):
                 limit=1,
             ).first()
 
-            if data:
-                last_seen = util.format_relative_date(data.received_on)
-                build_version = get_build_version(data) or UNKNOWN
+            if xform:
+                last_seen = util.format_relative_date(xform.received_on)
+                build_version, build_version_source = get_build_version(xform)
 
-                if getattr(data, 'app_id', None):
+                if xform.app_id:
                     try:
-                        app = get_app(self.domain, data.app_id)
+                        app = get_app(self.domain, xform.app_id)
                     except ResourceNotFound:
                         pass
                     else:
-                        app_name = "%s [%s]" % (app.name, build_version)
+                        app_name = app.name
                 else:
-                    app_name = get_meta_appversion_text(data)
-                    
+                    app_name = get_meta_appversion_text(xform)
+
+                build_html = _build_html(build_version, build_version_source)
                 app_name = app_name or _("Unknown App")
+                app_name = format_html(
+                    u'{} {}', app_name, mark_safe(build_html),
+                )
 
             if app_name is None and selected_app:
                 continue
 
-            rows.append([user.get('username_in_report'), last_seen, app_name or "---"])
+            rows.append([user.get('username_in_report'),
+                         last_seen, app_name or "---"])
         return rows

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -83,7 +83,7 @@ class ApplicationStatusReport(DeploymentsReport):
             last_seen = self.table_cell(-1, _("Never"))
             app_name = None
 
-            key = make_form_couch_key(self.domain, user_id=user.get('user_id'),
+            key = make_form_couch_key(self.domain, user_id=user.user_id,
                                       app_id=selected_app or None)
             xform = XFormInstance.view(
                 "reports_forms/all_forms",
@@ -118,6 +118,7 @@ class ApplicationStatusReport(DeploymentsReport):
             if app_name is None and selected_app:
                 continue
 
-            rows.append([user.get('username_in_report'),
-                         last_seen, app_name or "---"])
+            rows.append(
+                [user.username_in_report, last_seen, app_name or "---"]
+            )
         return rows


### PR DESCRIPTION
fixes http://manage.dimagi.com/default.asp?111552
(https://github.com/dimagi/commcare-hq/issues/3345)
- improve accuracy and availability of version number
  - now checking `build_id` first, which was will only be in forms from apps built in the last month or so
  - added another pattern to check for in appversion text
- improve display of version number in report
  - nice html labels
  - explicitly say where it comes from in the hover (not very discoverable and only useful for advanced users)

![screen shot 2014-05-30 at 2 33 01 pm](https://cloud.githubusercontent.com/assets/137212/3134681/ff9116bc-e828-11e3-8f7d-dae85aa26cdd.png)
