### PR TITLE
Revert force execv setting

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -447,7 +447,6 @@ SMS_GATEWAY_PARAMS = "user=my_username&password=my_password&id=%(phone_number)s&
 
 # celery
 BROKER_URL = 'django://'  # default django db based
-CELERYD_FORCE_EXECV = True
 
 # this is the default celery queue
 # for periodic tasks on a separate queue override this to something else


### PR DESCRIPTION
@czue @dannyroberts Despite what https://celery.readthedocs.org/en/3.0/configuration.html says, the force execv setting seems to have made the deadlock issue worse, so am thinking we should revert.
