### PR TITLE
have fixture API use work with complex fixtures

### DIFF
--- a/corehq/apps/fixtures/models.py
+++ b/corehq/apps/fixtures/models.py
@@ -167,6 +167,14 @@ class FixtureDataItem(Document):
         return fields
 
     @property
+    def try_fields_without_attributes(self):
+        """This is really just for the API"""
+        try:
+            return self.fields_without_attributes
+        except FixtureVersionError:
+            return self.fields
+
+    @property
     def data_type(self):
         if not hasattr(self, '_data_type'):
             self._data_type = FixtureDataType.get(self.data_type_id)

--- a/corehq/apps/fixtures/resources/v0_1.py
+++ b/corehq/apps/fixtures/resources/v0_1.py
@@ -14,7 +14,7 @@ def convert_fdt(fdi):
 
 class FixtureResource(JsonResource):
     type = "fixture"
-    fields = tp_f.DictField(attribute='fields_without_attributes', readonly=True, unique=True)
+    fields = tp_f.DictField(attribute='try_fields_without_attributes', readonly=True, unique=True)
     fixture_type = tp_f.CharField(attribute='fixture_type', readonly=True)
     id = tp_f.CharField(attribute='_id', readonly=True, unique=True)
 


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?114134

if you can use the old simple representation for fields do that
else show the complex version
