### PR TITLE
Add app_id and  build_id to form API

### DIFF
--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -41,8 +41,8 @@ class XFormInstanceResource(SimpleSortableResourceMixin, v0_3.XFormInstanceResou
     uiversion = fields.CharField(attribute='uiversion', blank=True, null=True)
     metadata = fields.DictField(attribute='metadata', blank=True, null=True)
     domain = fields.CharField(attribute='domain')
-    app_id = fields.CharField(attribute='app_id')
-    build_id = fields.CharField(attribute='build_id')
+    app_id = fields.CharField(attribute='app_id', null=True)
+    build_id = fields.CharField(attribute='build_id', null=True)
 
     cases = UseIfRequested(ToManyDocumentsField('corehq.apps.api.resources.v0_4.CommCareCaseResource',
                                                 attribute=lambda xform: casexml_xform.cases_referenced_by_xform(xform)))

--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -41,6 +41,8 @@ class XFormInstanceResource(SimpleSortableResourceMixin, v0_3.XFormInstanceResou
     uiversion = fields.CharField(attribute='uiversion', blank=True, null=True)
     metadata = fields.DictField(attribute='metadata', blank=True, null=True)
     domain = fields.CharField(attribute='domain')
+    app_id = fields.CharField(attribute='app_id')
+    build_id = fields.CharField(attribute='build_id')
 
     cases = UseIfRequested(ToManyDocumentsField('corehq.apps.api.resources.v0_4.CommCareCaseResource',
                                                 attribute=lambda xform: casexml_xform.cases_referenced_by_xform(xform)))

--- a/corehq/pillows/mappings/xform_mapping.py
+++ b/corehq/pillows/mappings/xform_mapping.py
@@ -1,6 +1,6 @@
 from corehq.pillows.core import DATE_FORMATS_STRING, DATE_FORMATS_ARR
 
-XFORM_INDEX="xforms_6xx892jdu629mm9uj39rd95b8g2sd9hu"
+XFORM_INDEX="xforms_1cce1f049a1b4d864c9c25dc42648a45"
 
 
 XFORM_MAPPING = {
@@ -35,6 +35,7 @@ XFORM_MAPPING = {
         "path": {"type": "string", "index": "not_analyzed"},
         "submit_ip": {"type": "ip"},
         "app_id": {"type": "string", "index": "not_analyzed"},
+        "build_id": {"type": "string", "index": "not_analyzed"},
         "received_on": {
             "type": "date",
             "format": DATE_FORMATS_STRING


### PR DESCRIPTION
Data team needs this—and it's pretty unreasonable not to have it anyway.
