### PR TITLE
make es_query raise an exception if there is an error

### DIFF
--- a/corehq/apps/callcenter/signals.py
+++ b/corehq/apps/callcenter/signals.py
@@ -9,7 +9,7 @@ from corehq.apps.callcenter.utils import sync_user_cases, bootstrap_callcenter
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.signals import commcare_domain_post_save
 from corehq.apps.users.signals import commcare_user_post_save
-from corehq.elastic import es_query
+from corehq.elastic import es_query, ESError
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +52,7 @@ def catch_signal(app, **kwargs):
                 except ResourceNotFound:
                     _log("Couldn't find domain {dom} during call center sync".format(dom=hit['_id']))
 
-        except RequestException:
+        except (RequestException, ESError):
             _log('Unable to query ES for call-center domains during syncdb')
 
 signals.post_syncdb.connect(catch_signal)

--- a/corehq/elastic.py
+++ b/corehq/elastic.py
@@ -189,9 +189,13 @@ def es_query(params=None, facets=None, terms=None, q=None, es_url=None, start_at
     es_url = es_url or DOMAIN_INDEX + '/hqdomain/_search'
 
     es = get_es()
-    ret_data = es.get(es_url, data=q)
+    result = es.get(es_url, data=q)
 
-    return ret_data
+    if 'error' in result:
+        msg = result['error']
+        raise ESError(msg)
+
+    return result
 
 
 def es_wrapper(index, domain=None, q=None, doc_type=None, fields=None,
@@ -255,9 +259,6 @@ def es_wrapper(index, domain=None, q=None, doc_type=None, fields=None,
     )
 
     # parse results
-    if 'error' in res:
-        msg = res['error']
-        raise ESError(msg)
     if fields is not None:
         hits = [r['fields'] for r in res['hits']['hits']]
     else:


### PR DESCRIPTION
moving this pretty core functionality into es_query from es_wrapper

I did a good faith check at usages of es_query and none of them
check for an error field; so this just makes the exception that is raised
much more useful

Instead of `KeyError 'hits'`, it'll give you the actual es error
