### PR TITLE
Custom product data

### DIFF
--- a/corehq/apps/commtrack/bulk.py
+++ b/corehq/apps/commtrack/bulk.py
@@ -55,10 +55,10 @@ def import_stock_reports(domain, f):
 def import_products(domain, download, task):
     messages = []
     products = []
-    data = download.get_content().split('\n')[1:]
+    data = download.get_content().split('\n')
     processed = 0
-    total_rows = len(data)
-    reader = csv.reader(data)
+    total_rows = len(data) - 1
+    reader = csv.DictReader(data)
     for row in reader:
         try:
             p = Product.from_csv(row)

--- a/corehq/apps/commtrack/fixtures.py
+++ b/corehq/apps/commtrack/fixtures.py
@@ -24,9 +24,8 @@ def _simple_fixture_generator(user, name, fields, data_fn):
             val = getattr(data_item, field_name, None)
             if isinstance(val, dict):
                 for k, v in getattr(data_item, field_name, {}).items():
-                    sub_el = ElementTree.Element("data")
+                    sub_el = ElementTree.Element(k)
                     sub_el.text = unicode(v if v is not None else '')
-                    sub_el.attrib = {"key": k}
                     field_elem.append(sub_el)
             else:
                 field_elem.text = unicode(val if val is not None else '')

--- a/corehq/apps/commtrack/fixtures.py
+++ b/corehq/apps/commtrack/fixtures.py
@@ -24,7 +24,7 @@ def _simple_fixture_generator(user, name, fields, data_fn):
             val = getattr(data_item, field_name, None)
             if isinstance(val, dict):
                 if val:
-                    for k, v in getattr(data_item, field_name, {}).items():
+                    for k, v in val.items():
                         sub_el = ElementTree.Element(k)
                         sub_el.text = unicode(v if v is not None else '')
                         field_elem.append(sub_el)

--- a/corehq/apps/commtrack/fixtures.py
+++ b/corehq/apps/commtrack/fixtures.py
@@ -23,14 +23,16 @@ def _simple_fixture_generator(user, name, fields, data_fn):
 
             val = getattr(data_item, field_name, None)
             if isinstance(val, dict):
-                for k, v in getattr(data_item, field_name, {}).items():
-                    sub_el = ElementTree.Element(k)
-                    sub_el.text = unicode(v if v is not None else '')
-                    field_elem.append(sub_el)
+                if val:
+                    for k, v in getattr(data_item, field_name, {}).items():
+                        sub_el = ElementTree.Element(k)
+                        sub_el.text = unicode(v if v is not None else '')
+                        field_elem.append(sub_el)
+
+                    item_elem.append(field_elem)
             else:
                 field_elem.text = unicode(val if val is not None else '')
-
-            item_elem.append(field_elem)
+                item_elem.append(field_elem)
 
     return [root]
 

--- a/corehq/apps/commtrack/fixtures.py
+++ b/corehq/apps/commtrack/fixtures.py
@@ -20,8 +20,17 @@ def _simple_fixture_generator(user, name, fields, data_fn):
         list_elem.append(item_elem)
         for field_name in fields:
             field_elem = ElementTree.Element(field_name)
+
             val = getattr(data_item, field_name, None)
-            field_elem.text = unicode(val if val is not None else '')
+            if isinstance(val, dict):
+                for k, v in getattr(data_item, field_name, {}).items():
+                    sub_el = ElementTree.Element("data")
+                    sub_el.text = unicode(v if v is not None else '')
+                    sub_el.attrib = {"key": k}
+                    field_elem.append(sub_el)
+            else:
+                field_elem.text = unicode(val if val is not None else '')
+
             item_elem.append(field_elem)
 
     return [root]
@@ -35,7 +44,8 @@ def product_fixture_generator(user, version, last_sync):
         'description',
         'category',
         'program_id',
-        'cost'
+        'cost',
+        'product_data'
     ]
     data_fn = lambda: Product.by_domain(user.domain)
     return _simple_fixture_generator(user, "product", fields, data_fn)

--- a/corehq/apps/commtrack/forms.py
+++ b/corehq/apps/commtrack/forms.py
@@ -79,7 +79,9 @@ class ProductForm(forms.Form):
         for field in ('name', 'code', 'program_id', 'unit', 'description', 'cost'):
             setattr(product, field, self.cleaned_data[field])
 
-        product.product_data = json.loads(self.data['product_data'])
+        product_data = self.data.get('product_data')
+        if product_data:
+            product.product_data = json.loads(product_data)
 
         if commit:
             product.save()

--- a/corehq/apps/commtrack/forms.py
+++ b/corehq/apps/commtrack/forms.py
@@ -7,6 +7,7 @@ from corehq.apps.commtrack.models import Product, Program
 from corehq.apps.commtrack.util import all_sms_codes
 from corehq.apps.consumption.shortcuts import set_default_consumption_for_product, get_default_monthly_consumption
 from django.core.urlresolvers import reverse
+import json
 
 
 class CurrencyField(forms.DecimalField):
@@ -77,6 +78,8 @@ class ProductForm(forms.Form):
 
         for field in ('name', 'code', 'program_id', 'unit', 'description', 'cost'):
             setattr(product, field, self.cleaned_data[field])
+
+        product.product_data = json.loads(self.data['product_data'])
 
         if commit:
             product.save()

--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -165,7 +165,6 @@ class Product(Document):
         )
         return [row['id'] for row in view_results]
 
-
     @classmethod
     def count_by_domain(cls, domain):
         """
@@ -174,11 +173,9 @@ class Product(Document):
         # todo: we should add a reduce so we can get this out of couch
         return len(cls.ids_by_domain(domain))
 
-
     @classmethod
     def _csv_attrs(cls):
         return [
-            '_id',
             'name',
             'unit',
             'code_',
@@ -188,32 +185,60 @@ class Product(Document):
             ('cost', lambda a: Decimal(a) if a else None),
         ]
 
-    def to_csv(self):
-        def _encode_if_needed(val):
-            return val.encode("utf8") if isinstance(val, unicode) else val
+    def to_dict(self):
+        from corehq.apps.commtrack.util import encode_if_needed
+        product_dict = {}
 
-        return [_encode_if_needed(getattr(self, attr[0] if isinstance(attr, tuple) else attr))
-                for attr in self._csv_attrs()]
+        product_dict['id'] = self._id
+
+        for attr in self._csv_attrs():
+            real_attr = attr[0] if isinstance(attr, tuple) else attr
+            product_dict[real_attr] = encode_if_needed(
+                getattr(self, real_attr)
+            )
+
+        return product_dict
+
+    def custom_property_dict(self):
+        from corehq.apps.commtrack.util import encode_if_needed
+        property_dict = {}
+
+        if hasattr(self, 'product_data'):
+            for prop, val in self.product_data.iteritems():
+                property_dict['data: ' + prop] = encode_if_needed(
+                    self.product_data[prop]
+                )
+
+        return property_dict
 
     @classmethod
     def from_csv(cls, row):
         if not row:
             return None
-        id, row = row[0], row[1:]
+
+        id = row.get('id')
         if id:
             p = cls.get(id)
         else:
             p = cls()
-        for i, attr in enumerate(cls._csv_attrs()[1:]):
-            try:
-                val = row[i].decode('utf-8')
-            except IndexError:
-                break
-            else:
+
+        for attr in cls._csv_attrs():
+            if attr in row or (isinstance(attr, tuple) and attr[0] in row):
+                val = row.get(attr, '').decode('utf-8')
                 if isinstance(attr, tuple):
                     attr, f = attr
                     val = f(val)
                 setattr(p, attr, val)
+            else:
+                break
+
+        # pack and add custom data items
+        product_data = {}
+        for k, v in row.iteritems():
+            if str(k).startswith('data: '):
+                product_data[k[6:]] = v
+
+        setattr(p, 'product_data', product_data)
 
         return p
 

--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -106,6 +106,7 @@ class Product(Document):
     category = StringProperty()
     program_id = StringProperty()
     cost = DecimalProperty()
+    product_data = DictProperty()
 
     @property
     def code(self):
@@ -203,11 +204,8 @@ class Product(Document):
         from corehq.apps.commtrack.util import encode_if_needed
         property_dict = {}
 
-        if hasattr(self, 'product_data'):
-            for prop, val in self.product_data.iteritems():
-                property_dict['data: ' + prop] = encode_if_needed(
-                    self.product_data[prop]
-                )
+        for prop, val in self.product_data.iteritems():
+            property_dict['data: ' + prop] = encode_if_needed(val)
 
         return property_dict
 

--- a/corehq/apps/commtrack/templates/commtrack/manage/product.html
+++ b/corehq/apps/commtrack/templates/commtrack/manage/product.html
@@ -10,6 +10,7 @@
 {% endblock %}
 
 {% block js-inline %} {{ block.super }}
+{% if custom_product_data_enabled %}
 <script>
     $(function () {
         var customDataEditor;
@@ -28,12 +29,15 @@
 
     });
 </script>
+{% endif %}
 {% endblock %}
 
 {% block main_column %}
     <form class="form form-horizontal" name="product" method="post">
         {% bootstrap_form_errors form %}
         {% bootstrap_fieldset form "Product Information" %}
+
+        {% if custom_product_data_enabled %}
         <input name="product_data" id="product-data-input" type="hidden" />
 
         <fieldset>
@@ -43,6 +47,7 @@
                 <div class="controls custom-data-controls"></div>
             </div>
         </fieldset>
+        {% endif %}
 
         <div class="form-actions"><button type="submit" class="btn btn-primary">
             {% if product.get_id %}

--- a/corehq/apps/commtrack/templates/commtrack/manage/product.html
+++ b/corehq/apps/commtrack/templates/commtrack/manage/product.html
@@ -9,10 +9,41 @@
     <script src="{% static 'hqwebapp/js/ui-element.js' %}"></script>
 {% endblock %}
 
+{% block js-inline %} {{ block.super }}
+<script>
+    $(function () {
+        var customDataEditor;
+
+        function handleChange() {
+            var data = customDataEditor.val();
+
+            $("input#product-data-input").val(JSON.stringify(data));
+        }
+
+        customDataEditor = uiElement.map_list('{{ product.get_id }}', '{% trans 'Product Data' %}');
+        customDataEditor.val({{ custom_product_data|JSON }});
+        customDataEditor.on('change', handleChange);
+
+        $("form .custom-data-controls").append(customDataEditor.ui);
+
+    });
+</script>
+{% endblock %}
+
 {% block main_column %}
     <form class="form form-horizontal" name="product" method="post">
         {% bootstrap_form_errors form %}
         {% bootstrap_fieldset form "Product Information" %}
+        <input name="product_data" id="product-data-input" type="hidden" />
+
+        <fieldset>
+            <legend>{% trans "Custom Product Data" %}</legend>
+            <div class="control-group">
+                <label class="control-label">{% trans 'Current Data' %}</label>
+                <div class="controls custom-data-controls"></div>
+            </div>
+        </fieldset>
+
         <div class="form-actions"><button type="submit" class="btn btn-primary">
             {% if product.get_id %}
                 {% trans 'Update Product' %}

--- a/corehq/apps/commtrack/tests/test_fixture.py
+++ b/corehq/apps/commtrack/tests/test_fixture.py
@@ -31,13 +31,29 @@ class FixtureTest(CommTrackTest, TestFileMixin):
         self._initialize_product_names(len(product_list))
         for i, product in enumerate(product_list):
             product_id = product._id
-            product_name  = self.product_names.next()
+            product_name = self.product_names.next()
             product_unit = self._random_string(20)
             product_code = self._random_string(20)
             product_description = self._random_string(20)
             product_category = self._random_string(20)
             product_program_id = self._random_string(20)
             product_cost = 0 if i == 0 else float('%g' % random.uniform(1, 100))
+
+            # only set this on one product, so we can also test that
+            # this node doesn't get sent down on every product
+            if i == 0:
+                product_data = {
+                    'special_number': '555111'
+                }
+
+                custom_data_xml = '''
+                    <product_data>
+                        <special_number>555111</special_number>
+                    </product_data>
+                '''
+            else:
+                product_data = {}
+                custom_data_xml = ''
 
             products += '''
                 <product id="{id}">
@@ -48,6 +64,7 @@ class FixtureTest(CommTrackTest, TestFileMixin):
                     <category>{category}</category>
                     <program_id>{program_id}</program_id>
                     <cost>{cost}</cost>
+                    {custom_data}
                 </product>
             '''.format(
                 id=product_id,
@@ -57,7 +74,8 @@ class FixtureTest(CommTrackTest, TestFileMixin):
                 description=product_description,
                 category=product_category,
                 program_id=product_program_id,
-                cost=product_cost
+                cost=product_cost,
+                custom_data=custom_data_xml
             )
 
             product.name = product_name
@@ -67,6 +85,7 @@ class FixtureTest(CommTrackTest, TestFileMixin):
             product.category = product_category
             product.program_id = product_program_id
             product.cost = product_cost
+            product.product_data = product_data
             product.save()
         fixture = product_fixture_generator(user, V1, None)
 

--- a/corehq/apps/commtrack/util.py
+++ b/corehq/apps/commtrack/util.py
@@ -285,3 +285,7 @@ def wrap_commtrack_case(case_json):
 
 def unicode_slug(text):
     return slugify(unicode(unidecode(text)))
+
+
+def encode_if_needed(val):
+    return val.encode("utf8") if isinstance(val, unicode) else val

--- a/corehq/apps/commtrack/views.py
+++ b/corehq/apps/commtrack/views.py
@@ -16,6 +16,7 @@ from corehq.apps.hqwebapp.forms import BulkUploadForm
 from corehq.apps.hqwebapp.utils import get_bulk_upload_form
 from corehq.apps.locations.models import Location
 from dimagi.utils.decorators.memoized import memoized
+from corehq import feature_previews
 from soil.util import expose_download, get_download_context
 import uuid
 from django.core.urlresolvers import reverse
@@ -176,6 +177,7 @@ class NewProductView(BaseCommTrackManageView):
             'product': self.product,
             'form': self.new_product_form,
             'custom_product_data': copy.copy(dict(self.product.product_data)),
+            'custom_product_data_enabled': feature_previews.PRODUCT_DATA.enabled(self.domain),
         }
 
     def post(self, request, *args, **kwargs):

--- a/corehq/apps/commtrack/views.py
+++ b/corehq/apps/commtrack/views.py
@@ -26,6 +26,7 @@ from couchdbkit import ResourceNotFound
 import csv
 from dimagi.utils.couch.database import iter_docs
 import itertools
+import copy
 
 @domain_admin_required
 def default(request, domain):
@@ -174,6 +175,7 @@ class NewProductView(BaseCommTrackManageView):
         return {
             'product': self.product,
             'form': self.new_product_form,
+            'custom_product_data': copy.copy(dict(self.product.product_data)),
         }
 
     def post(self, request, *args, **kwargs):

--- a/corehq/feature_previews.py
+++ b/corehq/feature_previews.py
@@ -74,6 +74,16 @@ ENUM_IMAGE = FeaturePreview(
     help_link='https://help.commcarehq.org/display/commcarepublic/Adding+Icons+in+Case+List+and+Case+Detail+screen'
 )
 
+PRODUCT_DATA = FeaturePreview(
+    slug='product_data',
+    label=_('Enable Custom Product Data'),
+    description=_(
+        "Enables custom product data, similar to custom user registration "
+        "data, that can be configured on the product page and "
+        "accessed via the product fixture on the phone."
+    ),
+)
+
 
 def commtrackify(domain_name, checked):
     from corehq.apps.domain.models import Domain


### PR DESCRIPTION
Enable custom product data from the csv import/export tools. Required a good bit of refactoring from the previous style.
