### PR TITLE
allow selected operator for form action conditions

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -170,6 +170,7 @@ class FormActionCondition(DocumentSchema):
     type = StringProperty(choices=["if", "always", "never"], default="never")
     question = StringProperty()
     answer = StringProperty()
+    operator = StringProperty(choices=['=', 'selected'], default='=')
 
 
 class FormAction(DocumentSchema):

--- a/corehq/apps/app_manager/static/app_manager/js/case-config-ui-2.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case-config-ui-2.js
@@ -450,7 +450,8 @@ var CaseConfig = (function () {
     var DEFAULT_CONDITION = {
         type: 'always',
         question: null,
-        answer: null
+        answer: null,
+        operator: null
     };
 
     var propertyDictToArray = function (required, property_dict, caseConfig, keyIsPath) {
@@ -482,6 +483,15 @@ var CaseConfig = (function () {
             }
         });
         return [property_dict, extra_dict];
+    };
+
+    var cleanCondition = function(condition) {
+        if (condition.type !== 'if') {
+            condition.question = null;
+            condition.answer = null;
+            condition.operator = null;
+        }
+        return condition;
     };
 
     var HQFormActions = {
@@ -580,19 +590,19 @@ var CaseConfig = (function () {
 
             return {
                 open_case: {
-                    condition: open_condition,
+                    condition: cleanCondition(open_condition),
                     name_path: case_name
                 },
                 update_case: {
                     update: case_properties,
-                    condition: update_condition
+                    condition: cleanCondition(update_condition)
                 },
                 case_preload: {
                     preload: case_preload,
-                    condition: update_condition
+                    condition: cleanCondition(update_condition)
                 },
                 close_case: {
-                    condition: close_condition
+                    condition: cleanCondition(close_condition)
                 }
             };
         }
@@ -662,7 +672,7 @@ var CaseConfig = (function () {
                 case_type: o.case_type,
                 case_properties: case_properties,
                 reference_id: o.reference_id,
-                condition: o.condition,
+                condition: cleanCondition(o.condition),
                 repeat_context: case_transaction.repeat_context()
             };
         }

--- a/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
@@ -7,7 +7,8 @@ var AdvancedCase = (function () {
         return {
             type: type,
             question: null,
-            answer: null
+            answer: null,
+            operator: null
         };
     };
 
@@ -459,6 +460,7 @@ var AdvancedCase = (function () {
             if (condition.type() !== 'if') {
                 condition.question(null);
                 condition.answer(null);
+                condition.operator(null);
             }
         },
         header: function (action) {
@@ -729,7 +731,15 @@ var AdvancedCase = (function () {
     var OpenCaseAction = {
         mapping: function (self) {
             return {
-                include: ['case_type', 'name_path', 'case_tag', 'parent_tag', 'parent_reference_id', 'open_condition', 'close_condition'],
+                include: [
+                    'case_type',
+                    'name_path',
+                    'case_tag',
+                    'parent_tag',
+                    'parent_reference_id',
+                    'open_condition',
+                    'close_condition'
+                ],
                 case_properties: {
                     create: function (options) {
                         return CaseProperty.wrap(options.data,  self);
@@ -862,9 +872,9 @@ var AdvancedCase = (function () {
             if (self.parent_tag() && !self.allow_subcase()) {
                 self.parent_tag('');
             }
-            var action = ko.mapping.toJS(self, OpenCaseAction.mapping(self));
             ActionBase.clean_condition(self.open_condition);
             ActionBase.clean_condition(self.close_condition);
+            var action = ko.mapping.toJS(self, OpenCaseAction.mapping(self));
             var x = propertyArrayToDict(['name'], action.case_properties);
             action.case_properties = x[0];
             action.name_path = x[1].name;

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_config_shared.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_config_shared.html
@@ -10,12 +10,18 @@
         <a href="#" data-bind="click: function () {type('always')}, visible: $root.edit"><i class="icon-remove"></i></a>
         {% trans "Only if the answer to" %}
         <input class="input-large" type="hidden" data-bind="
-            questionsSelect: $root.getQuestions('select1', false, $parent.case_transaction.allow.repeats()),
+            questionsSelect: $root.getQuestions('select select1', false, $parent.case_transaction.allow.repeats()),
             value: question,
             optionsCaption: ' ',
             edit: $root.edit"
         />
-        {% trans "is" %}
+        <select class="input-medium" data-bind="
+                optstr: [
+                    {label:'{% trans "is" %}',value:'='},
+                    {label:'{% trans "has selected" %}',value:'selected'}
+                ],
+                value: operator,
+                edit: $root.edit"></select>
         <span data-bind="if: $root.getAnswers({question: question()}).length">
             <select data-bind="
                 optstr: $root.getAnswers({question: question()}),

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -988,7 +988,14 @@ class XForm(WrappedNode):
         if condition.type == 'always':
             return 'true()'
         elif condition.type == 'if':
-            return "%s = '%s'" % (self.resolve_path(condition.question), condition.answer)
+            if condition.operator == 'selected':
+                template = "selected({path}, '{answer}')"
+            else:
+                template = "{path} = '{answer}'"
+            return template.format(
+                path=self.resolve_path(condition.question),
+                answer=condition.answer
+            )
         else:
             return 'false()'
 


### PR DESCRIPTION
Works in all contexts of form action conditions (both in normal modules and advanced modules):
**Opening a case**

![image](https://cloud.githubusercontent.com/assets/249606/3257429/7acd7468-f22b-11e3-8e29-6bd9fc4d0c71.png)

**Closing a case**

![image](https://cloud.githubusercontent.com/assets/249606/3257437/927875ea-f22b-11e3-80f4-b44152c4782a.png)

Results in xpath like `selected(/data/question4, 'item6')`
