### PR TITLE
fix parsing of @bind (instead of @nodeset) on xform inputs

### DIFF
--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -765,7 +765,7 @@ class XForm(WrappedNode):
         elif 'bind' in node.attrib:
             bind_id = node.attrib['bind']
             bind = self.model_node.find('{f}bind[@id="%s"]' % bind_id)
-            if not bind.xml:
+            if not bind.exists():
                 raise BindNotFound('No binding found for %s' % bind_id)
             path = bind.attrib['nodeset']
         elif node.tag_name == "group":


### PR DESCRIPTION
Fixes pact form data 500

```
  File "/home/cchq/www/production/code_root/corehq/apps/app_manager/xform.py", line 769, in get_path
    raise BindNotFound('No binding found for %s' % bind_id)

BindNotFound: No binding found for clients_phone_number_1
```

Using `@bind` is much less common than using `@nodeset` (can only happen if you write a form by hand), and the parsing of that way of referencing a bind seems to have broken in this commit: https://github.com/dimagi/commcare-hq/commit/be2a6b903c57e376b4c171cb211866eb3a532e16#diff-2741d99380866b8e6c54177b973c696cR580

`bind.xml` returned an `Element` that was falsy because binds don't contain any subnodes; what I really wanted to check for wasn't truthiness but whether any bind was found at all. `not bind.exists()` is equivalent to `bind.xml is None`.
