### PR TITLE
auto-include instances in <entry>

### DIFF
--- a/corehq/apps/app_manager/tests/data/suite/suite-advanced-commtrack.xml
+++ b/corehq/apps/app_manager/tests/data/suite/suite-advanced-commtrack.xml
@@ -349,6 +349,7 @@
     <instance id="casedb" src="jr://instance/casedb"/>
     <instance id="products" src="jr://fixture/commtrack:products"/>
     <instance id="ledgerdb" src="jr://instance/ledgerdb"/>
+    <instance id="commcaresession" src="jr://instance/session"/>
     <session>
       <datum id="case_id_case_clinic" nodeset="instance('casedb')/casedb/case[@case_type='clinic'][@status='open']" value="./@case_id" detail-select="m1_case_short" detail-confirm="m1_case_long"/>
       <datum id="product_id" nodeset="instance('products')/products/product" value="./@id" detail-select="m1_product_short"/>


### PR DESCRIPTION
include all instances that are referenced
from an xpath within the referenced `<detail>`s

Rather than trying to keep track of which types of case list columns add instance references and adding them using separate but parallel code while generating the `Entry` that references a `Detail`, any instance that shows up in any `Detail` that an `Entry` references now gets added to the `Entry` automatically.

Part of http://manage.dimagi.com/default.asp?117591.
