### PR TITLE
two scripts that make local app building by hand quite a bit more pleasant

### DIFF
--- a/corehq/apps/app_manager/management/commands/download_app_forms.py
+++ b/corehq/apps/app_manager/management/commands/download_app_forms.py
@@ -1,0 +1,35 @@
+from django.core.management.base import BaseCommand, CommandError
+
+import os
+from corehq.apps.app_manager.models import Application, RemoteApp
+from corehq.apps.commtrack.util import unicode_slug
+
+
+class Command(BaseCommand):
+    args = '<app_id> <path_to_dir>'
+    help = """
+        Downloads an app's forms in a more convenient directory structure for working with offline.
+        See also: upload_app_forms
+    """
+    def handle(self, *args, **options):
+        # todo: would be nice if this worked off remote servers too
+        if len(args) != 2:
+            raise CommandError('Usage: %s\n%s' % (self.args, self.help))
+        app_id, path = args
+
+        # setup directory
+        if not os.path.exists(path):
+            os.mkdir(path)
+
+        app = Application.get(app_id)
+        for module_index, module in enumerate(app.get_modules()):
+            module_dir_name = '{index} - {name}'.format(index=module_index, name=unicode_slug(module.default_name()))
+            module_dir = os.path.join(path, module_dir_name)
+            if not os.path.exists(module_dir):
+                os.mkdir(module_dir)
+            for form_index, form in enumerate(module.get_forms()):
+                form_name = ('{index} - {name}.xml'.format(index=form_index, name=unicode_slug(form.default_name())))
+                form_path = os.path.join(module_dir, form_name)
+                with open(form_path, 'w') as f:
+                    f.write(form.source.encode('utf-8'))
+                    print 'wrote {}'.format(form_path)

--- a/corehq/apps/app_manager/management/commands/upload_app_forms.py
+++ b/corehq/apps/app_manager/management/commands/upload_app_forms.py
@@ -1,0 +1,69 @@
+from optparse import make_option
+from django.core.management.base import BaseCommand, CommandError
+
+import os
+from corehq.apps.app_manager.models import Application
+from corehq.apps.app_manager.util import save_xform
+from datetime import datetime
+from corehq.apps.users.models import CouchUser
+
+
+class Command(BaseCommand):
+    args = '<path_to_dir> <app_id>'
+    help = """
+        Uploads a a directory of forms to an app. See also: download_app_forms
+    """
+    option_list = BaseCommand.option_list + (
+        make_option('--deploy',
+                    action='store_true',
+                    dest='deploy',
+                    default=False,
+                    help="Deploy application, by making a new build and starring it."),
+        make_option('--user',
+                    action='store',
+                    dest='user',
+                    default=None,
+                    help="Username to use for deployer."),
+        make_option('--comment',
+                    action='store',
+                    dest='comment',
+                    default=None,
+                    help="Comment (used for if you deploy the application)"),
+    )
+
+    def handle(self, *args, **options):
+        if len(args) != 2:
+            raise CommandError('Usage: %s\n%s' % (self.args, self.help))
+        if options['deploy'] and not options['user']:
+            raise CommandError('Deploy argument requires a user')
+        elif options['deploy']:
+            user = CouchUser.get_by_username(options['user'])
+            if not user:
+                raise CommandError("Couldn't find user with username {}".format(options['user']))
+
+        # todo: would be nice if this worked off remote servers too
+        path, app_id = args
+
+        app = Application.get(app_id)
+        for module_dir in os.listdir(path):
+            module_index, name = module_dir.split(' - ')
+            module = app.get_module(int(module_index))
+            for form_name in os.listdir(os.path.join(path, module_dir)):
+                form_index, name = form_name.split(' - ')
+                form = module.get_form(int(form_index))
+                with open(os.path.join(path, module_dir, form_name)) as f:
+                    save_xform(app, form, f.read())
+
+        app.save()
+        print 'successfully updated {}'.format(app.name)
+        if options['deploy']:
+            # make build and star it
+            comment = options.get('comment', 'form changes from {0}'.format(datetime.now().strftime("%Y-%m-%d %H:%M")))
+            copy = app.make_build(
+                comment=comment,
+                user_id=user._id,
+                previous_version=app.get_latest_app(released_only=False),
+            )
+            copy.is_released = True
+            copy.save(increment_version=False)
+            print 'successfully released new version'


### PR DESCRIPTION
one will download all your forms in an app to a directory structure
based on the module configuration.

the other takes forms in that directory tree, reuploads them, then saves
(and optionally releases and stars) an application.

works great for fast iteration on a phone with auto-update.
