### PR TITLE
drastically speed up resource_static

### DIFF
--- a/corehq/apps/hqwebapp/management/commands/resource_static.py
+++ b/corehq/apps/hqwebapp/management/commands/resource_static.py
@@ -1,11 +1,8 @@
-from gevent import monkey
-monkey.patch_all(subprocess=True)
-from gevent.pool import Pool
-import simplejson
+import hashlib
+import json
 import os
 from django.core.management.base import LabelCommand
 from django.contrib.staticfiles import finders
-from subprocess import Popen, PIPE
 from django.conf import settings
 from dimagi.utils import gitinfo
 from django.core import cache
@@ -18,13 +15,13 @@ class Command(LabelCommand):
     help = "Prints the paths of all the static files"
     args = "clear"
 
+    root_dir = settings.FILEPATH
+
     def output_resources(self, resource_str):
         with open(os.path.join(self.root_dir, 'resource_versions.py'), 'w') as fout:
             fout.write("resource_versions = %s" % resource_str)
 
     def handle(self, *args, **options):
-        self.root_dir = settings.FILEPATH
-
         prefix = os.getcwd()
         current_snapshot = gitinfo.get_project_snapshot(self.root_dir, submodules=False)
         current_sha = current_snapshot['commits'][0]['sha']
@@ -40,38 +37,20 @@ class Command(LabelCommand):
             self.output_resources(existing_resource_str)
             return
 
-        pool = Pool(10)
-
-        self.resources = {}
+        resources = {}
         for finder in finders.get_finders():
             for path, storage in finder.list(['.*', '*~', '* *']):
                 if not storage.location.startswith(prefix):
                     continue
                 url = os.path.join(storage.prefix, path) if storage.prefix else path
-                parts = (storage.location + '/' + path).split('/')
-                pool.spawn(self.generate_output, url, parts)
-        pool.join()
-        resource_str = simplejson.dumps(self.resources, indent=2)
+                filename = os.path.join(storage.location, path)
+                resources[url] = self.get_hash(filename)
+        resource_str = json.dumps(resources, indent=2)
         rcache.set(RESOURCE_PREFIX % current_sha, resource_str, 86400)
         self.output_resources(resource_str)
 
-    def generate_output(self, url, parts, dir_version=False):
-        filepath = '/'.join(parts[:-1]) + '/'
-        filename = parts[-1] if not dir_version else "."
-
-        if 'submodules' in parts:
-            sub_index = parts.index('submodules')
-            if parts[sub_index+1] == 'formdesigner' and filepath.count('/js/lib/xpath') > 0:
-                # hack to handle the formdesigner sub-sub
-                git_dir = '/'.join(parts[:sub_index+5]) + "/.git"
-            else:
-                git_dir = '/'.join(parts[:sub_index+2]) + "/.git"
-        else:
-            git_dir = os.path.join(settings.FILEPATH, '.git')
-        cmdstring = r"""git --git-dir %s log -n 1 --format=format:%%h %s""" % (git_dir, os.path.join(filepath, filename))
-        p = Popen(
-            cmdstring.split(' '),
-        stdout=PIPE, stderr=PIPE
-        )
-        hash = p.stdout.read()
-        self.resources[url] = hash
+    def get_hash(self, filename):
+        with open(filename) as f:
+            hash = hashlib.sha1(f.read()).hexdigest()[:7]
+        print filename, hash
+        return hash

--- a/corehq/apps/hqwebapp/management/commands/resource_static.py
+++ b/corehq/apps/hqwebapp/management/commands/resource_static.py
@@ -52,5 +52,4 @@ class Command(LabelCommand):
     def get_hash(self, filename):
         with open(filename) as f:
             hash = hashlib.sha1(f.read()).hexdigest()[:7]
-        print filename, hash
         return hash


### PR DESCRIPTION
- use sha1 hash bypassing git altogether
  - this means _all_ hashes will change upon first deploy, and thus all
    caches will be invalidated, but behavior will return to normal
    thereafter
- goes from many minutes to 3 seconds
