### PR TITLE
Awesome deploy

### DIFF
--- a/corehq/apps/hqadmin/management/commands/preindex_everything.py
+++ b/corehq/apps/hqadmin/management/commands/preindex_everything.py
@@ -5,6 +5,7 @@ from django.core.management import call_command
 
 from django.core.management.base import BaseCommand
 from django.core.mail import mail_admins
+from django.core import cache
 from django.conf import settings
 from dimagi.utils import gitinfo
 import gevent
@@ -18,6 +19,8 @@ class Command(BaseCommand):
     option_list = BaseCommand.option_list + (
         make_option('--mail', help='Mail confirmation', action='store_true',
                     default=False),
+        make_option('--check', help='Exit with 0 if preindex is complete',
+                    action='store_true', default=False)
     )
 
     def handle(self, *args, **options):
@@ -40,6 +43,12 @@ class Command(BaseCommand):
             log_count=1,
         )
         head = git_snapshot['commits'][0]
+
+        if options['check']:
+            exit(0 if get_preindex_complete(head) else 1)
+
+        if get_preindex_complete(head):
+            mail_admins('Already preindexed', "Skipping this step")
 
         commit_info = "\nCommit Info:\nOn Branch %s, SHA: %s" % (
             git_snapshot['current_branch'], head['sha'])
@@ -81,7 +90,23 @@ class Command(BaseCommand):
                 "but it's on you to check that all tasks are complete."
             )
 
+        set_preindex_complete(head)
+
         if email:
             mail_admins(subject, message)
         else:
             print '{}\n\n{}'.format(subject, message)
+
+rcache = cache.get_cache('redis')
+PREINDEX_COMPLETE_PREFIX = '#preindex_complete_%s'
+HELL_YEAH_IT_IS = 'hell yeah it is'
+
+
+def set_preindex_complete(head):
+    key = PREINDEX_COMPLETE_PREFIX % head
+    rcache.set(key, HELL_YEAH_IT_IS, 86400)
+
+
+def get_preindex_complete(head):
+    key = PREINDEX_COMPLETE_PREFIX % head
+    return rcache.get(key, None) == HELL_YEAH_IT_IS

--- a/fabfile.py
+++ b/fabfile.py
@@ -790,16 +790,13 @@ def awesome_deploy():
 
     @roles(*ROLES_DB_ONLY)
     def preindex_complete():
-        env.warn_only = True
-        try:
+        with settings(warn_only=True):
             return sudo(
                 '%(virtualenv_root_preindex)s/bin/python '
                 '%(code_root_preindex)s/manage.py preindex_everything '
                 '--check' % env,
                 user=env.sudo_user,
             ).succeeded
-        finally:
-            env.warn_only = False
 
     done = False
     while not done and datetime.datetime.utcnow() - start < max_wait:

--- a/fabfile.py
+++ b/fabfile.py
@@ -17,6 +17,7 @@ Server layout:
 """
 import sys
 from collections import defaultdict
+import datetime
 
 from fabric.context_managers import settings, cd
 
@@ -740,13 +741,16 @@ def hotfix_deploy():
 @task
 def deploy():
     """deploy code to remote host by checking out the latest via git"""
+    _require_target()
     if not console.confirm('Are you sure you want to deploy {env.environment}?'.format(env=env), default=False) or \
        not console.confirm('Did you run "fab {env.environment} preindex_views"? '.format(env=env), default=False):
         utils.abort('Deployment aborted.')
 
-    _require_target()
     run('echo ping!')  # workaround for delayed console response
+    _deploy_without_asking()
 
+
+def _deploy_without_asking():
     try:
         execute(update_code)
         execute(update_virtualenv)
@@ -769,6 +773,50 @@ def deploy():
     else:
         execute(services_restart)
         execute(record_successful_deploy)
+
+
+@task
+def awesome_deploy():
+    """preindex and deploy if it completes quickly enough, otherwise abort"""
+    if not console.confirm(
+            'Are you sure you want to preindex and deploy '
+            '{env.environment}?'.format(env=env), default=False):
+        utils.abort('Deployment aborted.')
+    max_wait = datetime.timedelta(minutes=5)
+    start = datetime.datetime.utcnow()
+    pause_length = datetime.timedelta(seconds=5)
+
+    execute(preindex_views)
+
+    @roles(*ROLES_DB_ONLY)
+    def preindex_complete():
+        env.warn_only = True
+        try:
+            return sudo(
+                '%(virtualenv_root_preindex)s/bin/python '
+                '%(code_root_preindex)s/manage.py preindex_everything '
+                '--check' % env,
+                user=env.sudo_user,
+            ).succeeded
+        finally:
+            env.warn_only = False
+
+    done = False
+    while not done and datetime.datetime.utcnow() - start < max_wait:
+        time.sleep(pause_length.seconds)
+        if preindex_complete():
+            done = True
+        pause_length *= 2
+
+    if done:
+        _deploy_without_asking()
+    else:
+        mail_admins(
+            " You can't deploy yet",
+            ("Preindexing is taking a while, so hold tight "
+             "and wait for an email saying it's done. "
+             "Thank you for using AWESOME DEPLOY.")
+        )
 
 
 @task

--- a/scripts/rebuildstaging
+++ b/scripts/rebuildstaging
@@ -18,7 +18,7 @@ function rebuildstaging() {
 }
 
 if [[ $deploy = "y" ]]; then
-    rebuildstaging && fab --linewise staging preindex_views && printf 'y\ny\n' | fab --linewise staging deploy
+    rebuildstaging && fab --linewise staging awesome_deploy
 else
     rebuildstaging
 fi


### PR DESCRIPTION
This commit introduces a new fab command, `awesome_deploy`, that preindexes and, provided preindex completes quickly, deploys. For 90% of deploys, this reduces deploy to a single step.

This PR touches functions used in current normal deploy only minimally: makes preindex log its completion to redis and adds a way to check for completion; splits deploy function up. Neither of these should affect normal deploy. I propose we keep using normal deploy for another few days, but use `awesome_deploy` on staging. To that affect, I've also changed the rebuildstaging `--deploy` option to use `awesome_deploy`.
