### PR TITLE
Fix off by one date errors on CT reports

### DIFF
--- a/corehq/apps/reports/commtrack/data_sources.py
+++ b/corehq/apps/reports/commtrack/data_sources.py
@@ -78,9 +78,9 @@ class CommtrackDataSourceMixin(object):
         the correct localized date so we need to manipulate the datetime
         object to be at the actual end of given day.
         """
-        config_date = self.config.get('enddate')
+        config_date = self.config.get('enddate') or datetime.now()
         if isinstance(config_date, datetime):
-            date = config_date.date() or datetime.now().date()
+            date = config_date.date()
             return datetime(date.year, date.month, date.day, 23, 59, 59)
         else:
             date = [int(x) for x in config_date.split('-')]

--- a/corehq/apps/reports/commtrack/data_sources.py
+++ b/corehq/apps/reports/commtrack/data_sources.py
@@ -50,18 +50,47 @@ class CommtrackDataSourceMixin(object):
 
     @property
     def start_date(self):
-        return self.config.get('startdate') or (datetime.now() - timedelta(30)).date()
+        """
+        Map reports send start date as a string formatted
+        as "yyyy-mm-dd" but with standard reports, it comes as a
+        datetime object, so these two must be treated differently.
+
+        The datetime variety is converted to UTC to make sure we have
+        the correct localized date so we need to manipulate the datetime
+        object to be at the actual start of given day.
+        """
+        config_date = self.config.get('startdate') or datetime.now() - timedelta(30)
+        if isinstance(config_date, datetime):
+            date = config_date.date()
+            return datetime(date.year, date.month, date.day, 0, 0, 0)
+        else:
+            date = [int(x) for x in config_date.split('-')]
+            return datetime(date[0], date[1], date[2], 0, 0, 0)
 
     @property
     def end_date(self):
-        return self.config.get('enddate') or datetime.now().date()
+        """
+        Map reports send end date as a string formatted
+        as "yyyy-mm-dd" but with standard reports, it comes as a
+        datetime object, so these two must be treated differently
+
+        The datetime variety is converted to UTC to make sure we have
+        the correct localized date so we need to manipulate the datetime
+        object to be at the actual end of given day.
+        """
+        config_date = self.config.get('enddate')
+        if isinstance(config_date, datetime):
+            date = config_date.date() or datetime.now().date()
+            return datetime(date.year, date.month, date.day, 23, 59, 59)
+        else:
+            date = [int(x) for x in config_date.split('-')]
+            return datetime(date[0], date[1], date[2], 23, 59, 59)
 
     @property
     def request(self):
         request = self.config.get('request')
         if request:
             return request
-
 
 
 class StockStatusDataSource(ReportDataSource, CommtrackDataSourceMixin):

--- a/corehq/apps/reports/commtrack/data_sources.py
+++ b/corehq/apps/reports/commtrack/data_sources.py
@@ -58,11 +58,9 @@ class CommtrackDataSourceMixin(object):
     @property
     def start_date(self):
         if self.config.get('startdate'):
-            start = parser.parse(self.config.get('startdate')).date()
+            return parser.parse(self.config.get('startdate')).date()
         else:
-            start = (datetime.now() - timedelta(30)).date()
-
-        return datetime(start.year, start.month, start.day, 0, 0, 0)
+            return (datetime.now() - timedelta(30)).date()
 
     @property
     def end_date(self):
@@ -71,7 +69,7 @@ class CommtrackDataSourceMixin(object):
         else:
             end = datetime.now().date()
 
-        return datetime(end.year, end.month, end.day, 23, 59, 59)
+        return end + timedelta(days=1)
 
 
 class StockStatusDataSource(ReportDataSource, CommtrackDataSourceMixin):

--- a/corehq/apps/reports/commtrack/standard.py
+++ b/corehq/apps/reports/commtrack/standard.py
@@ -79,26 +79,6 @@ class CommtrackReportMixin(ProjectReport, ProjectReportParametersMixin, Datespan
     def aggregate_by(self):
         return self.request.GET.get('agg_type')
 
-    @property
-    def start_date(self):
-        """
-        The datetime is converted to UTC to make sure we have
-        the correct localized date so we need to manipulate the datetime
-        object to be at the actual start of given day.
-        """
-        date = self.datespan.startdate_utc.date()
-        return datetime(date.year, date.month, date.day, 0, 0, 0)
-
-    @property
-    def end_date(self):
-        """
-        The datetime is converted to UTC to make sure we have
-        the correct localized date so we need to manipulate the datetime
-        object to be at the actual end of given day.
-        """
-        date = self.datespan.enddate_utc.date()
-        return datetime(date.year, date.month, date.day, 23, 59, 59)
-
 
 class CurrentStockStatusReport(GenericTabularReport, CommtrackReportMixin):
     name = ugettext_noop('Stock Status by Product')
@@ -158,8 +138,8 @@ class CurrentStockStatusReport(GenericTabularReport, CommtrackReportMixin):
 
         stock_states = StockState.objects.filter(
             case_id__in=sp_ids,
-            last_modified_date__lte=self.end_date,
-            last_modified_date__gte=self.start_date,
+            last_modified_date__lte=self.datespan.enddate_display,
+            last_modified_date__gte=self.datespan.startdate_display,
             section_id=STOCK_SECTION_TYPE
         ).order_by('product_id')
 
@@ -275,8 +255,8 @@ class AggregateStockStatusReport(GenericTabularReport, CommtrackReportMixin):
                 'domain': self.domain,
                 'location_id': self.request.GET.get('location_id'),
                 'program_id': self.request.GET.get('program'),
-                'startdate': self.start_date,
-                'enddate': self.end_date,
+                'startdate': self.datespan.startdate_display,
+                'enddate': self.datespan.enddate_display,
                 'aggregate': True
             }
             self.prod_data = self.prod_data + list(StockStatusDataSource(config).get_data())
@@ -339,8 +319,8 @@ class ReportingRatesReport(GenericTabularReport, CommtrackReportMixin):
             'domain': self.domain,
             'location_id': self.request.GET.get('location_id'),
             'program_id': self.request.GET.get('program'),
-            'startdate': self.start_date,
-            'enddate': self.end_date,
+            'startdate': self.datespan.startdate_display,
+            'enddate': self.datespan.enddate_display,
             'request': self.request,
         }
         statuses = list(ReportingStatusDataSource(config).get_data())


### PR DESCRIPTION
The utc conversion was causing it to cut off hours at the end of the
day as enddate would end up being a datetime object with 10pm today.
