### PR TITLE
show last 5 deploys on hq system page

### DIFF
--- a/corehq/apps/hqadmin/models.py
+++ b/corehq/apps/hqadmin/models.py
@@ -8,16 +8,17 @@ class HqDeploy(Document):
     code_snapshot = DictProperty()
 
     @classmethod
-    def get_latest(cls, environment):
-        return HqDeploy.view(
+    def get_latest(cls, environment, limit=1):
+        result = HqDeploy.view(
             'hqadmin/deploy_history',
             startkey=[environment, {}],
             endkey=[environment],
             reduce=False,
-            limit=1,
+            limit=limit,
             descending=True,
             include_docs=True
-        ).one()
+        )
+        return result.all()
 
     @classmethod
     def get_list(cls, environment, startdate, enddate, limit=50):

--- a/corehq/apps/hqadmin/templates/hqadmin/partials/commit.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/partials/commit.html
@@ -1,0 +1,7 @@
+<div class="well well-small">
+    {% if commit.subject %}<strong>{{ commit.subject }}</strong><br>{% endif %}{{ commit.message }}
+    authored by {{ commit.author }} on {{ commit.date }}<br/>
+    <small>
+        <a href="{{ commit.commit_url }}">View</a> | <a href="{{ commit.compare_master }}">Compare</a>
+    </small>
+</div>

--- a/corehq/apps/hqadmin/templates/hqadmin/partials/deploy_history.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/partials/deploy_history.html
@@ -1,0 +1,51 @@
+{% load humanize %}
+<h3>Deploy History</h3>
+<table class="table table-striped">
+    <thead>
+    <tr>
+        <th>Date</th>
+        <th>User</th>
+        <th>Branch</th>
+        <th>Last Commit</th>
+        <th></th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for deploy in deploy_history %}
+        {% with deploy.code_snapshot.commits|first as commit%}
+        <tr>
+            <td>
+                {{ deploy.date|naturaltime }}<br/>
+                <small>{{ deploy.date }}</small>
+            </td>
+            <td>{{ deploy.user }}</td>
+            <td>{{ deploy.code_snapshot.current_branch }}</td>
+            <td>
+                {% include "hqadmin/partials/commit.html" %}
+            </td>
+            <td><a href="#{{ deploy.get_id }}" role="button" class="btn btn-small" data-toggle="modal">Details</a></td>
+        </tr>
+        {% endwith %}
+    {% endfor %}
+    </tbody>
+</table>
+{% for deploy in deploy_history %}
+    <div id="{{ deploy.get_id }}" class="modal hide fade">
+        <div class="modal-header">
+            <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+            <h3>Submodule Details</h3>
+            Deploy of branch {{ deploy.code_snapshot.current_branch }} by {{ deploy.user }} {{ deploy.date|naturaltime }}
+        </div>
+        <div class="modal-body">
+            {% for sub in deploy.code_snapshot.submodules %}
+                <h4>{{ sub.path }} {{ sub.branch }}</h4>
+                {% with sub.commits|first as commit %}
+                    {% include "hqadmin/partials/commit.html" %}
+                {% endwith %}
+            {% endfor %}
+        </div>
+        <div class="modal-footer">
+            <a href="#" class="btn" data-dismiss="modal">Close</a>
+        </div>
+    </div>
+{% endfor %}

--- a/corehq/apps/hqadmin/templates/hqadmin/system_info.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/system_info.html
@@ -157,8 +157,10 @@
 {% endblock js-inline %}
 {% block reportcontent %}
     <div class="row-fluid">
+        {% with deploy_history|first as last_deploy %}
         <span class="label label-info pull-right">Last deployed on {{ last_deploy.date|date:"d M Y" }}
          at {{ last_deploy.date|date:"H:i:s"}} UTC by {{ last_deploy.user }}</span>
+        {% endwith %}
     </div>
     <div class="row-fluid">
         <table class="table table-striped">
@@ -342,7 +344,7 @@
     </div>
 
     <div class="row-fluid">
-    {% include "hqadmin/partials/project_snapshot.html" %}
+    {% include "hqadmin/partials/deploy_history.html" %}
     </div>
     <div class="row-fluid">
         <h3>Recent Database Changes</h3>

--- a/corehq/apps/hqadmin/views.py
+++ b/corehq/apps/hqadmin/views.py
@@ -649,8 +649,7 @@ def system_info(request):
     context['rabbitmq_url'] = get_rabbitmq_management_url()
     context['hide_filters'] = True
     context['current_system'] = socket.gethostname()
-    context['last_deploy'] = HqDeploy.get_latest(environment)
-    context['snapshot'] = context['last_deploy'].code_snapshot if context['last_deploy'] else {}
+    context['deploy_history'] = HqDeploy.get_latest(environment, limit=5)
 
     context.update(check_redis())
     context.update(check_rabbitmq())

--- a/settings.py
+++ b/settings.py
@@ -153,6 +153,7 @@ DEFAULT_APPS = (
     'django.contrib.sessions',
     'django.contrib.sites',
     'django.contrib.staticfiles',
+    'django.contrib.humanize',
     'south',
     'djcelery',
     'djtables',


### PR DESCRIPTION
Useful in a few situations e.g. over what time period was a bug present (often between most recent deploy and deploy before that). 
