### PR TITLE
expose Owner Name in case list regardless of case-sharing flag

### DIFF
--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -711,9 +711,7 @@ def release_build(request, domain, app_id, saved_app_id):
 
 
 def get_module_view_context_and_template(app, module):
-    defaults = ('name', 'date-opened', 'status')
-    if app.case_sharing:
-        defaults += ('#owner_name',)
+    defaults = ('name', 'date-opened', 'status', '#owner_name')
     builder = ParentCasePropertyBuilder(app, defaults=defaults)
 
     def ensure_unique_ids():


### PR DESCRIPTION
supervisor apps, for which this is the main use-case, normally have case sharing flag off because they have to manage their more complex use case themselves.
