### PR TITLE
retire (don't delete) newly created users on api failures

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -138,7 +138,7 @@ class CommCareUserResource(v0_1.CommCareUserResource):
             self._update(bundle)
             bundle.obj.save()
         except Exception:
-            bundle.obj.delete()
+            bundle.obj.retire()
         return bundle
 
     def obj_update(self, bundle, **kwargs):


### PR DESCRIPTION
context in http://manage.dimagi.com/default.asp?120634
