### PR TITLE
Added a try except to handle unicode in domain lookup. Solves FB:120611

### DIFF
--- a/corehq/apps/app_manager/forms.py
+++ b/corehq/apps/app_manager/forms.py
@@ -29,7 +29,10 @@ class CopyApplicationForm(forms.Form):
 
     def clean_domain(self):
         domain_name = self.cleaned_data['domain']
-        domain = Domain.get_by_name(domain_name)
+        try:
+            domain = Domain.get_by_name(domain_name)
+        except UnicodeEncodeError:
+            domain = None
         if domain is None:
             raise forms.ValidationError("A valid project space is required.")
         return domain_name


### PR DESCRIPTION
Warns the user of an invalid domain name if unicode is passed into form instead of returning a 500 error.
Solves http://manage.dimagi.com/default.asp?120611
