### PR TITLE
Now passing submitted files to the DomainGlobalSettingsForm so that user uploaded logos will be saved

### DIFF
--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -314,7 +314,9 @@ class EditBasicProjectInfoView(BaseEditProjectInfoView):
                     can_use_custom_logo=self.can_use_custom_logo,
                 )
             return DomainGlobalSettingsForm(
-                self.request.POST, can_use_custom_logo=self.can_use_custom_logo
+                self.request.POST,
+                self.request.FILES,
+                can_use_custom_logo=self.can_use_custom_logo
             )
 
         if self.can_user_see_meta:


### PR DESCRIPTION
`self.request.FILES` was not being passed to the `DomainGlobalSettingsForm`. As a result, the logo was never set on `self.cleaned_data` and the conditional black at `commcare-hq/corehq/apps/domain/forms.py:302` (where the logo is set) was never being entered.

Will resolve http://manage.dimagi.com/default.asp?120034
