### PR TITLE
Fix for subscription start date / end date issues...

### DIFF
--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -528,6 +528,7 @@ class SubscriptionForm(forms.Form):
             auto_generate_credits=auto_generate_credits,
             web_user=self.web_user,
         )
+        # this is likely temporary, see PR#3725
         sub.save()
         return sub
 

--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -517,7 +517,7 @@ class SubscriptionForm(forms.Form):
         is_active = is_active_subscription(date_start, date_end)
         do_not_invoice = self.cleaned_data['do_not_invoice']
         auto_generate_credits = self.cleaned_data['auto_generate_credits']
-        return Subscription.new_domain_subscription(
+        sub = Subscription.new_domain_subscription(
             account, domain, plan_version,
             date_start=date_start,
             date_end=date_end,
@@ -528,6 +528,8 @@ class SubscriptionForm(forms.Form):
             auto_generate_credits=auto_generate_credits,
             web_user=self.web_user,
         )
+        sub.save()
+        return sub
 
     def clean_active_accounts(self):
         transfer_account = self.cleaned_data.get('active_accounts')


### PR DESCRIPTION
For some reason, if I don't add the save line here and the end date is a year away, the subscription start and end date default to today, as if it was never set...

I tried digging into this and couldn't for the life of me figure out why, and why _specifically_ for an end date that was a year away, as the subscription IS saved in `new_domain_subscription` and `date_start` and `date_end` are set. If anyone has ideas, I'd love to hear. Otherwise, this is the fix.

This fixes http://manage.dimagi.com/default.asp?120385
