### PR TITLE
Encode unicode as utf-8 in domain lookup

### DIFF
--- a/corehq/apps/app_manager/forms.py
+++ b/corehq/apps/app_manager/forms.py
@@ -29,10 +29,7 @@ class CopyApplicationForm(forms.Form):
 
     def clean_domain(self):
         domain_name = self.cleaned_data['domain']
-        try:
-            domain = Domain.get_by_name(domain_name)
-        except UnicodeEncodeError:
-            domain = None
+        domain = Domain.get_by_name(domain_name)
         if domain is None:
             raise forms.ValidationError("A valid project space is required.")
         return domain_name

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -1046,4 +1046,4 @@ class DomainCounter(Document):
 
 
 def _domain_cache_key(name):
-    return hashlib.md5(u'cchq:domain:{name}'.format(name=name)).hexdigest()
+    return hashlib.md5(u'cchq:domain:{name}'.format(name=name).encode('utf-8')).hexdigest()


### PR DESCRIPTION
`_domain_cache_key` now encodes strings as utf-8 to prevent hashlib.md5() from raising an `UnicodeDecodeError`. This change was discussed here: https://github.com/dimagi/commcare-hq/pull/372
