### PR TITLE
Sort users by role on the "Web Users & Roles" page

### DIFF
--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -80,24 +80,9 @@ class BaseUserSettingsView(BaseDomainView):
         return user
 
     @property
-    @memoized
-    def web_users(self):
-        web_users = WebUser.by_domain(self.domain)
-        teams = Team.get_by_domain(self.domain)
-        for team in teams:
-            for user in team.get_members():
-                if user.get_id not in [web_user.get_id for web_user in web_users]:
-                    user.from_team = True
-                    web_users.append(user)
-        for user in web_users:
-            user.current_domain = self.domain
-        return web_users
-
-    @property
     def main_context(self):
         context = super(BaseUserSettingsView, self).main_context
         context.update({
-            'web_users': self.web_users,
             'couch_user': self.couch_user,
         })
         return context
@@ -347,8 +332,17 @@ class ListWebUsersView(BaseUserSettingsView):
     @property
     @memoized
     def web_users(self):
-        users = super(ListWebUsersView, self).web_users
-        return sorted(users, key=lambda x: (x.role_label(), x.email))
+        web_users = WebUser.by_domain(self.domain)
+        teams = Team.get_by_domain(self.domain)
+        for team in teams:
+            for user in team.get_members():
+                if user.get_id not in [web_user.get_id for web_user in web_users]:
+                    user.from_team = True
+                    web_users.append(user)
+        for user in web_users:
+            user.current_domain = self.domain
+        web_users.sort(key=lambda x: (x.role_label(), x.email))
+        return web_users
 
     @property
     @memoized
@@ -392,6 +386,7 @@ class ListWebUsersView(BaseUserSettingsView):
     @property
     def page_context(self):
         return {
+            'web_users': self.web_users,
             'user_roles': self.user_roles,
             'can_edit_roles': self.can_edit_roles,
             'default_role': UserRole.get_default(),

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -346,6 +346,12 @@ class ListWebUsersView(BaseUserSettingsView):
 
     @property
     @memoized
+    def web_users(self):
+        users = super(ListWebUsersView, self).web_users
+        return sorted(users, key=lambda x: (x.role_label(), x.email))
+
+    @property
+    @memoized
     def user_roles(self):
         user_roles = [AdminUserRole(domain=self.domain)]
         user_roles.extend(sorted(UserRole.by_domain(self.domain),


### PR DESCRIPTION
Addresses this ticket: http://manage.dimagi.com/default.asp?115971

This change sorts the list of web users on the "Web Users & Roles" page by alphabetically by role and then by email address. This is accomplished by overriding the `web_users` method of the `ListWebUsersView`. `web_users` is originally defined on `BaseUserSettingsView`, the immediate ancestor of `ListWebUsersView` (see `corehq/apps/users/views/__init__.py:84`). I chose not to alter this method so as not to change the behavior of other pages.

I'm definitely not sure if there is another place that might be more appropriate to do this sorting, so feedback would be appreciated. It might be possible to sort in the template itself?
