### PR TITLE
Help popover for the "Released" column on the application deploy page

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/releases.html
@@ -13,6 +13,22 @@
 {% block js-inline %}{{ block.super }}
 <script>
     $(function () {
+       var help_text = {
+           "Released": "This is used for automatically updating CommCare applications. If the \"Auto-update\" setting is " +
+                   "set to Daily or Weekly, any application versions that are marked as released will update to the latest" +
+                   "released version when checking for updates.",
+       };
+       $('.help_popover').popover({
+                placement: $(this).data('placement') || 'left',
+                title: function () {
+                    return $(this).attr('data-help-key');
+                },
+                content: function () {
+                    return help_text[$(this).attr('data-help-key')];
+                }
+            });
+    });
+    $(function () {
         // init releases
         {# The '___' in these urls will later be replaced by an app's _id ReleasesMain's url function #}
         var urls = {
@@ -119,7 +135,9 @@
                 <th></th>
                 {% endif %}
                 <th>{% trans "Comment" %}</th>
-                <th>{% trans "Released" %}</th>
+                <th class="help_popover" data-help-key="Released">
+                    <a href="#">{% trans "Released" %} <i class="icon icon-question-sign"></i></a>
+                </th>
 
             </tr>
             <tbody data-bind="visible: buildState, css: {hide: false}" class="hide">


### PR DESCRIPTION
Addresses this ticket:
http://manage.dimagi.com/default.asp?115954#682855

I replicated the javascript used in the `corehq/apps/users/templates/users/mobile/users_list.html` template to create the pop-over. Clicking the heading shows the pop-over, and clicking the heading again hides it. This is the same functionality as the [aforementioned page](http://www.commcarehq.org/a/noahtest/settings/users/commcare/). I noticed that on [some pages](http://www.commcarehq.org/a/noahtest/settings/users/web/) the pop-over is hover activated though. Is there a preferred method?
