### PR TITLE
fix bug where newly added tables were not being added in "replace" mode

### DIFF
--- a/corehq/apps/fixtures/upload.py
+++ b/corehq/apps/fixtures/upload.py
@@ -234,7 +234,7 @@ def run_upload(domain, workbook, replace=False, task=None):
                 else:
                     data_type = new_data_type
 
-                if replace:
+                if replace and data_type != new_data_type:
                     data_type.recursive_delete(transaction)
                     data_type = new_data_type
 


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?116123

This is a pretty tricky bug that involves the interplay between what is a sub-optimal workflow of "replace" being delete everything and start from scratch, and `CouchTransaciton` having the same reference to a document being deleted and modified in the same transaction. Which then added `"_deleted": True` to the underlying dict, so the second save was just a noop repeat of the deletion.

A side effect of this is that it also created a bunch of dangling `FixtureDataItems` that point at a nonexistent type. I'm not sure whether that's a problem since all access is via the type, but we should clean them up at some point. 
