### PR TITLE
add commcaresession to all entries if form filtering in module

### DIFF
--- a/corehq/apps/app_manager/suite_xml.py
+++ b/corehq/apps/app_manager/suite_xml.py
@@ -665,7 +665,7 @@ class SuiteGenerator(SuiteGeneratorBase):
         datums = defaultdict(lambda: defaultdict(list))
         entries = {}
         for e in suite.entries:
-            command = e.node.find('command').get('id')
+            command = e.command.id
             module_id, form_id = command.split('-', 1)
             if form_id != 'case-list':
                 entries[command] = e
@@ -878,7 +878,7 @@ class SuiteGenerator(SuiteGeneratorBase):
         details = [details_by_id[detail_id] for detail_id in detail_ids
                    if detail_id]
 
-        entry_id = entry.node.find('command[@id]').get('id')
+        entry_id = entry.command.id
         if entry_id in relevance_by_id:
             xpaths.add(relevance_by_id[entry_id])
 

--- a/corehq/apps/app_manager/tests/data/suite/form-filter.xml
+++ b/corehq/apps/app_manager/tests/data/suite/form-filter.xml
@@ -187,6 +187,7 @@
       </text>
     </command>
     <instance id="casedb" src="jr://instance/casedb"/>
+    <instance id="commcaresession" src="jr://instance/session"/>
     <session>
       <datum id="case_id_case_clinic" nodeset="instance('casedb')/casedb/case[@case_type='clinic'][@status='open']" value="./@case_id" detail-select="m1_case_short" detail-confirm="m1_case_long"/>
     </session>
@@ -199,6 +200,7 @@
       </text>
     </command>
     <instance id="casedb" src="jr://instance/casedb"/>
+    <instance id="commcaresession" src="jr://instance/session"/>
     <session>
       <datum id="case_id_load_clinic0" nodeset="instance('casedb')/casedb/case[@case_type='clinic'][@status='open']" value="./@case_id" detail-select="m1_case_short" detail-confirm="m1_case_long"/>
     </session>
@@ -224,6 +226,7 @@
       </text>
     </command>
     <instance id="casedb" src="jr://instance/casedb"/>
+    <instance id="commcaresession" src="jr://instance/session"/>
     <session>
       <datum id="case_id_case_clinic" nodeset="instance('casedb')/casedb/case[@case_type='clinic'][@status='open']" value="./@case_id" detail-select="m1_case_short" detail-confirm="m1_case_long"/>
     </session>
@@ -236,7 +239,6 @@
       </text>
     </command>
     <instance id="casedb" src="jr://instance/casedb"/>
-    <instance id="commcaresession" src="jr://instance/session"/>
     <session>
       <datum id="case_id_case_requisition" nodeset="instance('casedb')/casedb/case[@case_type='requisition'][@status='open']" value="./@case_id" detail-select="m2_case_short" detail-confirm="m2_case_long"/>
     </session>
@@ -252,7 +254,7 @@
       <locale id="modules.m1"/>
     </text>
     <command id="m1-f0"/>
-    <command id="m1-f1"/>
+    <command id="m1-f1" relevant="instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id_load_clinic0]/edd = '123'"/>
     <command id="m1-f2"/>
     <command id="m1-case-list"/>
   </menu>
@@ -260,6 +262,6 @@
     <text>
       <locale id="modules.m2"/>
     </text>
-    <command id="m2-f0" relevant="instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id_case_requisition]/edd = '123'"/>
+    <command id="m2-f0"/>
   </menu>
 </suite>

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -172,7 +172,7 @@ class SuiteTest(SimpleTestCase, TestFileMixin):
         Ensure form filter gets added correctly and appropriate instances get added to the entry.
         """
         app = Application.wrap(self.get_json('suite-advanced'))
-        form = app.get_module(2).get_form(0)
+        form = app.get_module(1).get_form(1)
         form.form_filter = "./edd = '123'"
         self.assertXmlEqual(self.get_xml('form-filter'), app.create_suite())
 


### PR DESCRIPTION
P2 BUG: http://manage.dimagi.com/default.asp?121457

When a menu command has a 'relevance' xpath criteria that xpath is evaluated using instances from the first entry ([source](https://bitbucket.org/commcare/commcare/src/8a35c95b69c653d94fba7de762fb3cc7d187ec58/backend/src/org/commcare/util/CommCareSession.java?at=default#cl-394)).

This change adds any instances referenced in ANY of the menu commands to ALL of the entries for that menu.

Not sure if we want to make a smarter version that only adds extra instances to the first entry?

@dannyroberts 
