### PR TITLE
Fix case mismatch error in domain invitations

### DIFF
--- a/corehq/apps/hqwebapp/utils.py
+++ b/corehq/apps/hqwebapp/utils.py
@@ -101,7 +101,7 @@ class InvitationView():
         self.validate_invitation(invitation)
 
         if request.user.is_authenticated():
-            is_invited_user = request.couch_user.username == invitation.email
+            is_invited_user = request.couch_user.username.lower() == invitation.email.lower()
             if self.is_invited(invitation, request.couch_user) and not request.couch_user.is_superuser:
                 if is_invited_user:
                     # if this invite was actually for this user, just mark it accepted


### PR DESCRIPTION
Addresses this ticket: http://manage.dimagi.com/default.asp?114017#687642

If the email address in a domain invitation has different capitalization than the user's email address in the database, then that user sees an error message when he or she accepts the invitation (but he or she is still added to the domain). This change lower cases both addresses before comparing them for equality.

@dimagi/team-commcare-hq 
According to this [SO answer](http://stackoverflow.com/a/9808332), it is up to each email host to decide if they want the part of the email address before the '@' to be case sensitive or not. Although apparently no widely used email providers treat it as case sensitive. So, there is a small security risk here. (It also looks like CommcareHQ login ignores case).
