### PR TITLE
change order of auth decorators

### DIFF
--- a/corehq/apps/api/resources/v0_1.py
+++ b/corehq/apps/api/resources/v0_1.py
@@ -99,8 +99,8 @@ class DomainAdminAuthentication(LoginAndDomainAuthentication):
         PASSED_AUTH = 'is_authenticated'
 
         @api_auth
-        @domain_admin_required
         @login_or_digest
+        @domain_admin_required
         def dummy(request, domain, **kwargs):
             return PASSED_AUTH
 


### PR DESCRIPTION
@czue 

`domain_admin_required` requires `couch_user` on `request` which gets set by `login_or_digest`

Introduced here: https://github.com/dimagi/commcare-hq/commit/22739abfff04dc24154aee317b8a94be80eba51c#diff-d76c5e3466d0c10be90787ea041b317cR97
