### PR TITLE
capitalize titles, show percent with % format and decimals

### DIFF
--- a/corehq/apps/reports/commtrack/standard.py
+++ b/corehq/apps/reports/commtrack/standard.py
@@ -187,14 +187,14 @@ class CurrentStockStatusReport(GenericTabularReport, CommtrackReportMixin):
 
     def get_data_for_graph(self):
         ret = [
-            {"key": "stocked out", "color": "#e00707"},
-            {"key": "under stock", "color": "#ffb100"},
-            {"key": "adequate stock", "color": "#4ac925"},
-            {"key": "overstocked", "color": "#b536da"},
+            {"key": "Stocked Out", "color": "#e00707"},
+            {"key": "Under Stock", "color": "#ffb100"},
+            {"key": "Adequate Stock", "color": "#4ac925"},
+            {"key": "Overstocked", "color": "#b536da"},
 #            {"key": "nonreporting", "color": "#363636"},
-            {"key": "unknown", "color": "#ABABAB"}
+            {"key": "Unknown", "color": "#ABABAB"}
         ]
-        statuses = ['stocked out', 'under stock', 'adequate stock', 'overstocked', 'no data'] #'nonreporting', 'no data']
+        statuses = ['Stocked Out', 'Under Stock', 'Adequate Stock', 'Overstocked', 'No data'] #'nonreporting', 'no data']
 
         for r in ret:
             r["values"] = []
@@ -203,9 +203,6 @@ class CurrentStockStatusReport(GenericTabularReport, CommtrackReportMixin):
             for i, status in enumerate(statuses):
                 ret[i]['values'].append({"x": '%.1f%%' % pd[0], "y": pd[i+2]})
 
-        for row in ret:
-            row["key"] = row["key"].title()
-            
         return ret
 
     @property

--- a/corehq/apps/reports/commtrack/standard.py
+++ b/corehq/apps/reports/commtrack/standard.py
@@ -201,8 +201,11 @@ class CurrentStockStatusReport(GenericTabularReport, CommtrackReportMixin):
 
         for pd in self.product_data:
             for i, status in enumerate(statuses):
-                ret[i]['values'].append({"x": pd[0], "y": pd[i+2]})
+                ret[i]['values'].append({"x": '%.1f%%' % pd[0], "y": pd[i+2]})
 
+        for row in ret:
+            row["key"] = row["key"].title()
+            
         return ret
 
     @property


### PR DESCRIPTION
Use "75.0%" instead of "75" and "Under Stock" instead of "under stock" in chart labels in Stock Status report.
