### PR TITLE
build SQL_REPORTING_DATABASE_URL off django database settings

### DIFF
--- a/.travis/localsettings.py
+++ b/.travis/localsettings.py
@@ -14,8 +14,6 @@ DATABASES = {
     }
 }
 
-SQL_REPORTING_DATABASE_URL = "sqlite:////tmp/commcare_reporting_test.db"
-
 ####### Couch Config ######
 COUCH_HTTPS = False 
 COUCH_SERVER_ROOT = '127.0.0.1:5984' 

--- a/corehq/apps/reportfixtures/tests/sql_fixture.py
+++ b/corehq/apps/reportfixtures/tests/sql_fixture.py
@@ -35,3 +35,4 @@ def load_data():
             connection.execute(insert)
     finally:
         connection.close()
+        engine.dispose()

--- a/corehq/apps/reports/sqlreport.py
+++ b/corehq/apps/reports/sqlreport.py
@@ -258,6 +258,7 @@ class SqlData(ReportDataSource):
             data = qc.resolve(conn, self.filter_values)
         finally:
             conn.close()
+            engine.dispose()
 
         return data
 

--- a/corehq/apps/reports/tests/sql_fixture.py
+++ b/corehq/apps/reports/tests/sql_fixture.py
@@ -67,3 +67,4 @@ def load_data():
             connection.execute(insert)
     finally:
         connection.close()
+        engine.dispose()

--- a/custom/opm/opm_reports/tests/__init__.py
+++ b/custom/opm/opm_reports/tests/__init__.py
@@ -59,6 +59,10 @@ class OPMTestBase(object):
                 self.reindex_fluff(pillow)
         print "Finished setup, on to tests!"
 
+    def tearDown(self):
+        for pillow in [OpmCaseFluffPillow, OpmUserFluffPillow, OpmFormFluffPillow]:
+            pillow.get_sql_engine().dispose()
+
     def the_same(self, a, b):
         # for some reason types aren't consistent
         # so there's this beautiful kludge

--- a/settings.py
+++ b/settings.py
@@ -348,10 +348,6 @@ INSTALLED_APPS = DEFAULT_APPS + HQ_APPS
 # rather than the default 'accounts/profile'
 LOGIN_REDIRECT_URL = '/'
 
-
-# Default reporting database should be overridden in localsettings.
-SQL_REPORTING_DATABASE_URL = "sqlite:////tmp/commcare_reporting_test.db"
-
 REPORT_CACHE = 'default'  # or e.g. 'redis'
 
 ####### Domain settings  #######
@@ -806,6 +802,15 @@ else:
     TEMPLATE_LOADERS = [
         ('django.template.loaders.cached.Loader', TEMPLATE_LOADERS),
     ]
+
+### Reporting database - use same DB as main database
+db_settings = DATABASES["default"].copy()
+db_settings['PORT'] = db_settings.get('PORT', '5432')
+if UNIT_TESTING:
+    db_settings['NAME'] = 'test_{}'.format(db_settings['NAME'])
+SQL_REPORTING_DATABASE_URL = "postgresql://{USER}:{PASSWORD}@{HOST}:{PORT}/{NAME}".format(
+    **db_settings
+)
 
 ####### South Settings #######
 #SKIP_SOUTH_TESTS=True

--- a/settings.py
+++ b/settings.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 
 import sys
 import os
+from urllib import urlencode
 from django.contrib import messages
 
 # odd celery fix
@@ -806,9 +807,13 @@ else:
 ### Reporting database - use same DB as main database
 db_settings = DATABASES["default"].copy()
 db_settings['PORT'] = db_settings.get('PORT', '5432')
+options = db_settings.get('OPTIONS')
+db_settings['OPTIONS'] = '?{}'.format(urlencode(options)) if options else ''
+
 if UNIT_TESTING:
     db_settings['NAME'] = 'test_{}'.format(db_settings['NAME'])
-SQL_REPORTING_DATABASE_URL = "postgresql://{USER}:{PASSWORD}@{HOST}:{PORT}/{NAME}".format(
+
+SQL_REPORTING_DATABASE_URL = "postgresql+psycopg2://{USER}:{PASSWORD}@{HOST}:{PORT}/{NAME}{OPTIONS}".format(
     **db_settings
 )
 


### PR DESCRIPTION
Incremental change to not having to specify this at all. 

Also required for call-center unit tests.
