### PR TITLE
Added an Auto fill transaltions help popover

### DIFF
--- a/corehq/apps/translations/static/translations/js/translations.js
+++ b/corehq/apps/translations/static/translations/js/translations.js
@@ -113,7 +113,7 @@ var mk_translation_ui = function (spec) {
         $table = $("<table></table>"),
         $list_tbody = $('<tbody/>').appendTo($table),
         $adder_tbody = $('<tbody/>').appendTo($table),
-        $bootstrap = $('<a/>').attr('href', '').text('Auto fill translations ').click(function (e) {
+        $bootstrap = $('<a/>').attr('href', '').text('Auto fill translations').click(function (e) {
             e.preventDefault();
             $.ajax({
                 type: "get",
@@ -132,7 +132,7 @@ var mk_translation_ui = function (spec) {
                     }
                 }
             });
-        }).after($('<a><i class="icon-question-sign" data-trigger="click"></i></a>')).popover({
+        }).after($('<span> <a><i class="icon-question-sign" data-trigger="click"></i></a><span>')).popover({
             placement: 'right',
             title: 'Auto Fill translations',
             content: 'This will pick the most common translations for your selected language.  You can then edit them as needed.'

--- a/corehq/apps/translations/static/translations/js/translations.js
+++ b/corehq/apps/translations/static/translations/js/translations.js
@@ -132,7 +132,11 @@ var mk_translation_ui = function (spec) {
                     }
                 }
             });
-        }).after($('<i class="icon-question-sign" data-trigger="hover" data-original-title=""></i>'));
+        }).after($('<a><i class="icon-question-sign" data-trigger="click"></i></a>')).popover({
+            placement: 'right',
+            title: 'Auto Fill translations',
+            content: 'This will pick the most common translations for your selected language.  You can then edit them as needed.'
+        });
 
     for (key in spec.translations) {
         if (spec.translations.hasOwnProperty(key)) {

--- a/corehq/apps/translations/static/translations/js/translations.js
+++ b/corehq/apps/translations/static/translations/js/translations.js
@@ -113,7 +113,7 @@ var mk_translation_ui = function (spec) {
         $table = $("<table></table>"),
         $list_tbody = $('<tbody/>').appendTo($table),
         $adder_tbody = $('<tbody/>').appendTo($table),
-        $bootstrap = $('<a/>').attr('href', '').text('Auto fill translations').click(function (e) {
+        $bootstrap = $('<a/>').attr('href', '').text('Auto fill translations ').click(function (e) {
             e.preventDefault();
             $.ajax({
                 type: "get",
@@ -132,7 +132,7 @@ var mk_translation_ui = function (spec) {
                     }
                 }
             });
-        });
+        }).after($('<i class="icon-question-sign" data-trigger="hover" data-original-title=""></i>'));
 
     for (key in spec.translations) {
         if (spec.translations.hasOwnProperty(key)) {


### PR DESCRIPTION
Addresses this ticket: http://manage.dimagi.com/default.asp?115345#689444

I've added a question mark icon to the "Auto Fill translations" link on application language pages. The popover help text reads "This will pick the most common translations for your selected language.  You can then edit them as needed." as suggested in the FB ticket.
