### PR TITLE
partial xml comparison

### DIFF
--- a/corehq/apps/app_manager/tests/data/suite/autoselect-case-entry.xml
+++ b/corehq/apps/app_manager/tests/data/suite/autoselect-case-entry.xml
@@ -1,0 +1,30 @@
+<partial>
+    <entry>
+    <form>http://openrosa.org/formdesigner/5FBED77B-E327-495D-97E8-0733B97D8EA5</form>
+    <command id="m1-f0">
+      <text>
+        <locale id="forms.m1f0"/>
+      </text>
+    </command>
+    <instance id="casedb" src="jr://instance/casedb"/>
+    <instance id="commcaresession" src="jr://instance/session"/>
+    <session>
+      <datum id="case_id_case_clinic" nodeset="instance('casedb')/casedb/case[@case_type='clinic'][@status='open']" value="./@case_id" detail-select="m1_case_short" detail-confirm="m1_case_long"/>
+      <datum id="case_id_auto_selected" function="instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id_case_clinic]/index/case_id_index"/>
+    </session>
+    <assertions>
+      <assert test="count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id_case_clinic]/index/case_id_index) = 1">
+        <text>
+          <locale id="case_autoload.case.property_missing">
+            <argument>case_id_index</argument>
+          </locale>
+        </text>
+      </assert>
+      <assert test="count(instance('casedb')/casedb/case[@case_id=instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/data/case_id_case_clinic]/index/case_id_index]) = 1">
+        <text>
+          <locale id="case_autoload.case.case_missing"/>
+        </text>
+      </assert>
+    </assertions>
+  </entry>
+</partial>

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -119,6 +119,11 @@ class SuiteTest(SimpleTestCase, TestFileMixin):
             )
         ))
         self.assertXmlEqual(self.get_xml('suite-advanced-autoselect-case'), app.create_suite())
+        self.assertXmlPartialEqual(
+            self.get_xml('autoselect-case-entry'),
+            app.create_suite(),
+            "./entry/command[@id='m1-f0']/.."
+        )
 
     def test_case_assertions(self):
         self._test_generic_suite('app_case_sharing', 'suite-case-sharing')

--- a/corehq/apps/app_manager/tests/util.py
+++ b/corehq/apps/app_manager/tests/util.py
@@ -26,12 +26,19 @@ class TestFileMixin(object):
     def get_xml(self, name):
         return self.get_file(name, 'xml')
 
+    def assertXmlPartialEqual(self, expected, actual, xpath):
+        """
+        Extracts a section of XML using the xpath and compares it to the expected
+        """
+        expected = parse_normalize(expected)
+        actual = extract_xml_partial(actual, xpath)
+        print actual
+        self.assertXmlEqual(expected, actual, normalize=False)
+
     def assertXmlEqual(self, expected, actual, normalize=True):
         if normalize:
-            parser = lxml.etree.XMLParser(remove_blank_text=True)
-            parse = lambda *args: normalize_attributes(lxml.etree.XML(*args))
-            expected = lxml.etree.tostring(parse(expected, parser), pretty_print=True)
-            actual = lxml.etree.tostring(parse(actual, parser), pretty_print=True)
+            expected = parse_normalize(expected)
+            actual = parse_normalize(actual)
 
         # snippet from http://stackoverflow.com/questions/321795/comparing-xml-in-a-unit-test-in-python/7060342#7060342
         checker = LXMLOutputChecker()
@@ -56,6 +63,22 @@ def normalize_attributes(xml):
             node.attrib.clear()
             node.attrib.update(attrs)
     return xml
+
+
+def parse_normalize(xml, to_string=True):
+    parser = lxml.etree.XMLParser(remove_blank_text=True)
+    parse = lambda *args: normalize_attributes(lxml.etree.XML(*args))
+    parsed = parse(xml, parser)
+    return lxml.etree.tostring(parsed, pretty_print=True) if to_string else parsed
+
+
+def extract_xml_partial(xml, xpath):
+    actual = parse_normalize(xml, to_string=False)
+    nodes = actual.findall(xpath)
+    root = lxml.etree.Element('partial')
+    for node in nodes:
+        root.append(node)
+    return lxml.etree.tostring(root, pretty_print=True)
 
 
 def add_build(version, build_number):


### PR DESCRIPTION
@dannyroberts @millerdev 
Do you guys think this is useful?

Pros:
- don't have to have entire XML in repo

Cons:
- Can hide errors elsewhere in XML

Could also do the inverse - compare XML after deleting some nodes. Combination of both options could reudce amount of test XML required e.g.:

``` python
self.assertXmlPartialEqual(expected_fixture, actual, './fixture')
self.assertXmlPartialEqual(expected_entry, actual, "./entry/command[@id='m1-f0']/..")
# removes sections matching xpath expressions before comparison
self.assertXmlReducedEqual(
    expected_rest, 
    actual, 
    ['./fixture', "./entry/command[@id='m1-f0']/.."]
)
```
