### PR TITLE
fix default consumption inconsistencies

### DIFF
--- a/corehq/__init__.py
+++ b/corehq/__init__.py
@@ -46,7 +46,7 @@ def REPORTS(project):
 
     if project.commtrack_enabled:
         reports.insert(0, (ugettext_lazy("Commtrack"), (
-            commtrack_reports.AggregateStockStatusReport,
+            commtrack_reports.InventoryReport,
             commtrack_reports.CurrentStockStatusReport,
             commtrack_maps.StockStatusMapReport,
             commtrack_reports.ReportingRatesReport,

--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -1379,7 +1379,7 @@ class StockState(models.Model):
                 self.case_id,
                 self.product_id,
                 config
-            )
+            ) / DAYS_IN_MONTH
 
     def get_monthly_consumption(self):
         consumption = self.get_daily_consumption()

--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -1344,10 +1344,11 @@ class StockState(models.Model):
 
     @property
     def resupply_quantity_needed(self):
-        if self.get_daily_consumption() is not None:
+        monthly_consumption = self.get_monthly_consumption()
+        if monthly_consumption is not None:
             stock_levels = self.get_domain().commtrack_settings.stock_levels_config
             needed_quantity = int(
-                self.get_daily_consumption() * 30 * stock_levels.overstock_threshold
+                monthly_consumption * stock_levels.overstock_threshold
             )
             return int(max(needed_quantity - self.stock_on_hand, 0))
         else:

--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -448,7 +448,7 @@ class CommtrackConfig(Document):
         return dict((a.keyword, a) for a in actions).get(keyword)
 
     def get_consumption_config(self):
-        def _default_consumption_function(case_id, product_id):
+        def _default_monthly_consumption(case_id, product_id):
             # note: for now as an optimization hack, per-supply point type is not supported
             # unless explicitly configured, because it will require looking up the case
             facility_type = None
@@ -464,7 +464,7 @@ class CommtrackConfig(Document):
             min_periods=self.consumption_config.min_transactions,
             min_window=self.consumption_config.min_window,
             max_window=self.consumption_config.optimal_window,
-            default_consumption_function=_default_consumption_function,
+            default_monthly_consumption_function=_default_monthly_consumption,
         )
 
     def get_ota_restore_settings(self):

--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -1339,15 +1339,15 @@ class StockState(models.Model):
     def months_remaining(self):
         return months_of_stock_remaining(
             self.stock_on_hand,
-            self.get_consumption()
+            self.get_daily_consumption()
         )
 
     @property
     def resupply_quantity_needed(self):
-        if self.get_consumption() is not None:
+        if self.get_daily_consumption() is not None:
             stock_levels = self.get_domain().commtrack_settings.stock_levels_config
             needed_quantity = int(
-                self.get_consumption() * 30 * stock_levels.overstock_threshold
+                self.get_daily_consumption() * 30 * stock_levels.overstock_threshold
             )
             return int(max(needed_quantity - self.stock_on_hand, 0))
         else:
@@ -1363,7 +1363,7 @@ class StockState(models.Model):
             DocDomainMapping.objects.get(doc_id=self.case_id).domain_name
         )
 
-    def get_consumption(self):
+    def get_daily_consumption(self):
         if self.daily_consumption is not None:
             return self.daily_consumption
         else:
@@ -1381,7 +1381,7 @@ class StockState(models.Model):
             )
 
     def get_monthly_consumption(self):
-        consumption = self.get_consumption()
+        consumption = self.get_daily_consumption()
         if consumption is not None:
             return consumption * Decimal(DAYS_IN_MONTH)
         else:

--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -8,7 +8,7 @@ from django.utils.translation import ugettext as _
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.stock import const as stockconst
-from casexml.apps.stock.consumption import ConsumptionConfiguration, compute_default_consumption
+from casexml.apps.stock.consumption import ConsumptionConfiguration, compute_default_monthly_consumption
 from casexml.apps.stock.models import StockReport as DbStockReport, StockTransaction as DbStockTransaction, DocDomainMapping
 from casexml.apps.case.xml import V2
 from corehq.apps.commtrack import const
@@ -1375,7 +1375,7 @@ class StockState(models.Model):
             else:
                 config = None
 
-            return compute_default_consumption(
+            return compute_default_monthly_consumption(
                 self.case_id,
                 self.product_id,
                 config

--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -956,13 +956,9 @@ class SupplyPointCase(CommCareCase):
             }
         ]
 
-DAYS_PER_MONTH = 365.2425 / 12.
-
-# TODO make settings
 
 UNDERSTOCK_THRESHOLD = 0.5  # months
 OVERSTOCK_THRESHOLD = 2.  # months
-
 DEFAULT_CONSUMPTION = 10.  # per month
 
 

--- a/corehq/apps/commtrack/tests/test_settings.py
+++ b/corehq/apps/commtrack/tests/test_settings.py
@@ -26,7 +26,7 @@ class CommTrackSettingsTest(TestCase):
         self.assertEqual(10, restore_settings.consumption_config.min_periods)
         self.assertEqual(20, restore_settings.consumption_config.min_window)
         self.assertEqual(60, restore_settings.consumption_config.max_window)
-        self.assertEqual(150, restore_settings.consumption_config.default_consumption_function('foo', 'bar'))
+        self.assertEqual(150, restore_settings.consumption_config.default_monthly_consumption_function('foo', 'bar'))
         self.assertFalse(restore_settings.force_consumption_case_filter(CommCareCase(type='force-type')))
         self.assertEqual(0, len(restore_settings.default_product_list))
 

--- a/corehq/apps/commtrack/tests/test_settings.py
+++ b/corehq/apps/commtrack/tests/test_settings.py
@@ -3,7 +3,7 @@ from casexml.apps.case.models import CommCareCase
 from corehq.apps.commtrack.models import CommtrackConfig, ConsumptionConfig, StockRestoreConfig
 from corehq.apps.commtrack.tests.util import bootstrap_domain
 from corehq.apps.commtrack.const import DAYS_IN_MONTH
-from corehq.apps.consumption.shortcuts import set_default_consumption_for_domain
+from corehq.apps.consumption.shortcuts import set_default_monthly_consumption_for_domain
 
 
 class CommTrackSettingsTest(TestCase):
@@ -19,7 +19,7 @@ class CommTrackSettingsTest(TestCase):
         ct_settings.ota_restore_config = StockRestoreConfig(
             section_to_consumption_types={'stock': 'consumption'},
         )
-        set_default_consumption_for_domain(domain.name, 5 * DAYS_IN_MONTH)
+        set_default_monthly_consumption_for_domain(domain.name, 5 * DAYS_IN_MONTH)
         restore_settings = ct_settings.get_ota_restore_settings()
         self.assertEqual(1, len(restore_settings.section_to_consumption_types))
         self.assertEqual('consumption', restore_settings.section_to_consumption_types['stock'])

--- a/corehq/apps/commtrack/tests/test_stock_state.py
+++ b/corehq/apps/commtrack/tests/test_stock_state.py
@@ -64,7 +64,7 @@ class StockStateConsumptionTest(StockStateTest):
         self.assertEqual(None, state.get_daily_consumption())
 
     def test_pre_set_defaults(self):
-        set_default_monthly_consumption_for_domain(self.domain.name, 50)
+        set_default_monthly_consumption_for_domain(self.domain.name, 5 * 30)
         self.report(25, 0)
 
         state = StockState.objects.get(
@@ -73,11 +73,11 @@ class StockStateConsumptionTest(StockStateTest):
             product_id=self.products[0]._id,
         )
 
-        self.assertEqual(50, float(state.get_daily_consumption()))
+        self.assertEqual(5, float(state.get_daily_consumption()))
 
     def test_defaults_set_after_report(self):
         self.report(25, 0)
-        set_default_monthly_consumption_for_domain(self.domain.name, 50)
+        set_default_monthly_consumption_for_domain(self.domain.name, 5 * 30)
 
         state = StockState.objects.get(
             section_id='stock',
@@ -85,4 +85,4 @@ class StockStateConsumptionTest(StockStateTest):
             product_id=self.products[0]._id,
         )
 
-        self.assertEqual(50, float(state.get_daily_consumption()))
+        self.assertEqual(5, float(state.get_daily_consumption()))

--- a/corehq/apps/commtrack/tests/test_stock_state.py
+++ b/corehq/apps/commtrack/tests/test_stock_state.py
@@ -4,7 +4,7 @@ from casexml.apps.stock.tests.base import _stock_report
 from corehq.apps.commtrack.tests.util import CommTrackTest
 from corehq.apps.commtrack.const import DAYS_IN_MONTH
 from datetime import datetime
-from corehq.apps.consumption.shortcuts import set_default_consumption_for_domain
+from corehq.apps.consumption.shortcuts import set_default_monthly_consumption_for_domain
 
 
 class StockStateTest(CommTrackTest):
@@ -64,7 +64,7 @@ class StockStateConsumptionTest(StockStateTest):
         self.assertEqual(None, state.get_daily_consumption())
 
     def test_pre_set_defaults(self):
-        set_default_consumption_for_domain(self.domain.name, 50)
+        set_default_monthly_consumption_for_domain(self.domain.name, 50)
         self.report(25, 0)
 
         state = StockState.objects.get(
@@ -77,7 +77,7 @@ class StockStateConsumptionTest(StockStateTest):
 
     def test_defaults_set_after_report(self):
         self.report(25, 0)
-        set_default_consumption_for_domain(self.domain.name, 50)
+        set_default_monthly_consumption_for_domain(self.domain.name, 50)
 
         state = StockState.objects.get(
             section_id='stock',

--- a/corehq/apps/commtrack/tests/test_stock_state.py
+++ b/corehq/apps/commtrack/tests/test_stock_state.py
@@ -30,7 +30,7 @@ class StockStateBehaviorTest(StockStateTest):
         )
 
         self.assertEqual(10, state.stock_on_hand)
-        self.assertEqual(3.0, state.get_consumption())
+        self.assertEqual(3.0, state.get_daily_consumption())
 
     def test_domain_mapping(self):
         # make sure there's a fake case setup for this
@@ -61,7 +61,7 @@ class StockStateConsumptionTest(StockStateTest):
             product_id=self.products[0]._id,
         )
 
-        self.assertEqual(None, state.get_consumption())
+        self.assertEqual(None, state.get_daily_consumption())
 
     def test_pre_set_defaults(self):
         set_default_consumption_for_domain(self.domain.name, 50)
@@ -73,7 +73,7 @@ class StockStateConsumptionTest(StockStateTest):
             product_id=self.products[0]._id,
         )
 
-        self.assertEqual(50, float(state.get_consumption()))
+        self.assertEqual(50, float(state.get_daily_consumption()))
 
     def test_defaults_set_after_report(self):
         self.report(25, 0)
@@ -85,4 +85,4 @@ class StockStateConsumptionTest(StockStateTest):
             product_id=self.products[0]._id,
         )
 
-        self.assertEqual(50, float(state.get_consumption()))
+        self.assertEqual(50, float(state.get_daily_consumption()))

--- a/corehq/apps/commtrack/tests/test_xml.py
+++ b/corehq/apps/commtrack/tests/test_xml.py
@@ -9,7 +9,7 @@ from casexml.apps.case.xml import V2
 from casexml.apps.phone.restore import RestoreConfig
 from casexml.apps.phone.tests.utils import synclog_id_from_restore_payload
 from corehq.apps.commtrack.models import ConsumptionConfig, StockRestoreConfig, RequisitionCase, Product, StockState
-from corehq.apps.consumption.shortcuts import set_default_consumption_for_domain
+from corehq.apps.consumption.shortcuts import set_default_monthly_consumption_for_domain
 from couchforms.models import XFormInstance
 from dimagi.utils.parsing import json_format_datetime
 from casexml.apps.stock import const as stockconst
@@ -99,7 +99,7 @@ class CommTrackOTATest(CommTrackTest):
         self.ct_settings.ota_restore_config = StockRestoreConfig(
             section_to_consumption_types={'stock': 'consumption'}
         )
-        set_default_consumption_for_domain(self.domain.name, 5 * DAYS_IN_MONTH)
+        set_default_monthly_consumption_for_domain(self.domain.name, 5 * DAYS_IN_MONTH)
 
         amounts = [(p._id, i*10) for i, p in enumerate(self.products)]
         report = _report_soh(amounts, self.sp._id, 'stock')
@@ -136,7 +136,7 @@ class CommTrackOTATest(CommTrackTest):
         self.ct_settings.ota_restore_config = StockRestoreConfig(
             section_to_consumption_types={'stock': 'consumption'},
         )
-        set_default_consumption_for_domain(self.domain.name, 5)
+        set_default_monthly_consumption_for_domain(self.domain.name, 5)
 
         balance_blocks = _get_ota_balance_blocks(self.ct_settings, self.user)
         self.assertEqual(0, len(balance_blocks))
@@ -448,7 +448,7 @@ class CommTrackSyncTest(CommTrackSubmissionTest):
         self.ct_settings.ota_restore_config = StockRestoreConfig(
             section_to_consumption_types={'stock': 'consumption'}
         )
-        set_default_consumption_for_domain(self.domain.name, 5)
+        set_default_monthly_consumption_for_domain(self.domain.name, 5)
         self.ota_settings = self.ct_settings.get_ota_restore_settings()
 
         # get initial restore token

--- a/corehq/apps/consumption/shortcuts.py
+++ b/corehq/apps/consumption/shortcuts.py
@@ -36,7 +36,7 @@ def get_default_consumption(domain, product_id, location_type, case_id):
         return None
 
 
-def set_default_consumption_for_domain(domain, amount):
+def set_default_monthly_consumption_for_domain(domain, amount):
     default = DefaultConsumption.get_domain_default(domain)
     return _update_or_create_default(domain, amount, default, TYPE_DOMAIN)
 

--- a/corehq/apps/consumption/tests.py
+++ b/corehq/apps/consumption/tests.py
@@ -1,5 +1,5 @@
 from django.test import TestCase
-from corehq.apps.consumption.shortcuts import (get_default_consumption, set_default_consumption_for_domain,
+from corehq.apps.consumption.shortcuts import (get_default_consumption, set_default_monthly_consumption_for_domain,
     set_default_consumption_for_product, set_default_consumption_for_supply_point
 )
 from .models import DefaultConsumption, TYPE_DOMAIN, TYPE_PRODUCT, TYPE_SUPPLY_POINT_TYPE, TYPE_SUPPLY_POINT
@@ -98,10 +98,10 @@ class ConsumptionShortcutsTestCase(ConsumptionTestBase):
 
     def testSetForDomain(self):
         self.assertEqual(None, DefaultConsumption.get_domain_default(domain))
-        default = set_default_consumption_for_domain(domain, 50)
+        default = set_default_monthly_consumption_for_domain(domain, 50)
         self.assertEqual(50, DefaultConsumption.get_domain_default(domain).default_consumption)
         self.assertEqual(1, _count_consumptions())
-        updated = set_default_consumption_for_domain(domain, 40)
+        updated = set_default_monthly_consumption_for_domain(domain, 40)
         self.assertEqual(default._id, updated._id)
         self.assertEqual(40, DefaultConsumption.get_domain_default(domain).default_consumption)
         self.assertEqual(1, _count_consumptions())

--- a/corehq/apps/reports/commtrack/standard.py
+++ b/corehq/apps/reports/commtrack/standard.py
@@ -212,7 +212,7 @@ class CurrentStockStatusReport(GenericTabularReport, CommtrackReportMixin):
             chart.data = self.get_data_for_graph()
             return [chart]
 
-class AggregateStockStatusReport(GenericTabularReport, CommtrackReportMixin):
+class InventoryReport(GenericTabularReport, CommtrackReportMixin):
     name = ugettext_noop('Inventory')
     slug = StockStatusDataSource.slug
     fields = ['corehq.apps.reports.filters.fixtures.AsyncLocationFilter',
@@ -224,7 +224,7 @@ class AggregateStockStatusReport(GenericTabularReport, CommtrackReportMixin):
     # temporary
     @classmethod
     def show_in_navigation(cls, domain=None, project=None, user=None):
-        return super(AggregateStockStatusReport, cls).show_in_navigation(domain, project, user) and _enabled_hack(domain)
+        return super(InventoryReport, cls).show_in_navigation(domain, project, user) and _enabled_hack(domain)
 
     @property
     def headers(self):


### PR DESCRIPTION
and a bunch of renaming to make things harder to screw up in the future.

should fix http://manage.dimagi.com/default.asp?122095

fix is in 494408b58d49334c54ccac6f5615d710d11a55d2 and then test update is in a9508f3709365e47e5c1429026d5676afb476ae0. the rest is renaming

codependent with https://github.com/dimagi/casexml/pull/234
