### PR TITLE
Show case properties in the "Case History" table of the Case Export page by default

### DIFF
--- a/corehq/apps/export/custom_export_helpers.py
+++ b/corehq/apps/export/custom_export_helpers.py
@@ -433,6 +433,21 @@ class CaseCustomExportHelper(CustomExportHelper):
                 if col["index"] in self.properties_to_show:
                     col["show"] = True
 
+        # Show most of the Case History rows by default
+        dont_show_cols = {
+            "sync_log_id",
+        }
+        for table in table_conf:
+            if table.get("index", "") == "#.actions.#":
+                for col in table.get("column_configuration", []):
+                    index = col.get("index", "")
+                    if index not in dont_show_cols:
+                        col["show"] = True
+                    else:
+                        dont_show_cols.discard(index)
+                    print col
+                break
+
         print "[table_conf]"
         import pprint
         pp = pprint.PrettyPrinter(indent=4)

--- a/corehq/apps/export/custom_export_helpers.py
+++ b/corehq/apps/export/custom_export_helpers.py
@@ -386,7 +386,6 @@ class CaseCustomExportHelper(CustomExportHelper):
     def update_table_conf(self, table_conf):
         column_conf = table_conf[0].get("column_configuration", [])
         current_properties = set(self.custom_export.case_properties)
-
         remaining_properties = current_properties.copy()
 
         def is_special_type(p):

--- a/corehq/apps/export/custom_export_helpers.py
+++ b/corehq/apps/export/custom_export_helpers.py
@@ -387,11 +387,6 @@ class CaseCustomExportHelper(CustomExportHelper):
         column_conf = table_conf[0].get("column_configuration", [])
         current_properties = set(self.custom_export.case_properties)
 
-        print "['current_properties']"
-        import pprint
-        pp = pprint.PrettyPrinter(indent=4)
-        pp.pprint(current_properties)
-
         remaining_properties = current_properties.copy()
 
         def is_special_type(p):
@@ -412,11 +407,6 @@ class CaseCustomExportHelper(CustomExportHelper):
                 if self.creating_new_export:
                     col["selected"] = True
 
-        print "[column_conf]"
-        import pprint
-        pp = pprint.PrettyPrinter(indent=4)
-        pp.pprint(column_conf)
-
         column_conf.extend([
             ExportColumn(
                 index=prop,
@@ -434,9 +424,7 @@ class CaseCustomExportHelper(CustomExportHelper):
                     col["show"] = True
 
         # Show most of the Case History rows by default
-        dont_show_cols = {
-            "sync_log_id",
-        }
+        dont_show_cols = {"sync_log_id"}
         for table in table_conf:
             if table.get("index", "") == "#.actions.#":
                 for col in table.get("column_configuration", []):
@@ -445,13 +433,7 @@ class CaseCustomExportHelper(CustomExportHelper):
                         col["show"] = True
                     else:
                         dont_show_cols.discard(index)
-                    print col
                 break
-
-        print "[table_conf]"
-        import pprint
-        pp = pprint.PrettyPrinter(indent=4)
-        pp.pprint(table_conf)
 
         return table_conf
 

--- a/corehq/apps/export/custom_export_helpers.py
+++ b/corehq/apps/export/custom_export_helpers.py
@@ -386,6 +386,12 @@ class CaseCustomExportHelper(CustomExportHelper):
     def update_table_conf(self, table_conf):
         column_conf = table_conf[0].get("column_configuration", [])
         current_properties = set(self.custom_export.case_properties)
+
+        print "['current_properties']"
+        import pprint
+        pp = pprint.PrettyPrinter(indent=4)
+        pp.pprint(current_properties)
+
         remaining_properties = current_properties.copy()
 
         def is_special_type(p):
@@ -406,6 +412,11 @@ class CaseCustomExportHelper(CustomExportHelper):
                 if self.creating_new_export:
                     col["selected"] = True
 
+        print "[column_conf]"
+        import pprint
+        pp = pprint.PrettyPrinter(indent=4)
+        pp.pprint(column_conf)
+
         column_conf.extend([
             ExportColumn(
                 index=prop,
@@ -421,6 +432,11 @@ class CaseCustomExportHelper(CustomExportHelper):
             for col in table.get("column_configuration", []):
                 if col["index"] in self.properties_to_show:
                     col["show"] = True
+
+        print "[table_conf]"
+        import pprint
+        pp = pprint.PrettyPrinter(indent=4)
+        pp.pprint(table_conf)
 
         return table_conf
 

--- a/corehq/apps/export/templates/export/customize_export.html
+++ b/corehq/apps/export/templates/export/customize_export.html
@@ -488,7 +488,7 @@
                         </tr>
                         </thead>
                         <tbody data-bind="sortable: column_configuration">
-                            <tr data-bind="visible:  $root.show_deleted() || ($data.show() || selected)">
+                            <tr data-bind="visible: ($parent.index() == '#.actions.#') || $root.show_deleted() || ($data.show() || selected)">
                                 <td class="sortable-handle">
                                     <i class="icon-resize-vertical"></i>
                                 </td>

--- a/corehq/apps/export/templates/export/customize_export.html
+++ b/corehq/apps/export/templates/export/customize_export.html
@@ -488,7 +488,6 @@
                         </tr>
                         </thead>
                         <tbody data-bind="sortable: column_configuration">
-{#                            <tr data-bind="visible: ($parent.index() == '#.actions.#') || $root.show_deleted() || ($data.show() || selected)">#}
                             <tr data-bind="visible: $root.show_deleted() || ($data.show() || selected)">
                                 <td class="sortable-handle">
                                     <i class="icon-resize-vertical"></i>

--- a/corehq/apps/export/templates/export/customize_export.html
+++ b/corehq/apps/export/templates/export/customize_export.html
@@ -488,7 +488,8 @@
                         </tr>
                         </thead>
                         <tbody data-bind="sortable: column_configuration">
-                            <tr data-bind="visible: ($parent.index() == '#.actions.#') || $root.show_deleted() || ($data.show() || selected)">
+{#                            <tr data-bind="visible: ($parent.index() == '#.actions.#') || $root.show_deleted() || ($data.show() || selected)">#}
+                            <tr data-bind="visible: $root.show_deleted() || ($data.show() || selected)">
                                 <td class="sortable-handle">
                                     <i class="icon-resize-vertical"></i>
                                 </td>

--- a/corehq/apps/export/templates/export/customize_export.html
+++ b/corehq/apps/export/templates/export/customize_export.html
@@ -488,7 +488,7 @@
                         </tr>
                         </thead>
                         <tbody data-bind="sortable: column_configuration">
-                            <tr data-bind="visible: $root.show_deleted() || ($data.show() || selected)">
+                            <tr data-bind="visible:  $root.show_deleted() || ($data.show() || selected)">
                                 <td class="sortable-handle">
                                     <i class="icon-resize-vertical"></i>
                                 </td>


### PR DESCRIPTION
Previously, you had to check the "show advanced and deleted properties" box to see all properties in the case history table. Now, all of those properties will be shown regardless of whether the box is checked or not. (The "Cases" table is unaffected).

Addresses this ticket:
http://manage.dimagi.com/default.asp?123010#695770
