### PR TITLE
add an error message to detail page for forms whose cases didn't get processed

### DIFF
--- a/corehq/apps/reports/templates/reports/reportdata/form_data.html
+++ b/corehq/apps/reports/templates/reports/reportdata/form_data.html
@@ -32,5 +32,10 @@
 {% endblock %}
 
 {% block main_column %}
+    {% if not instance.initial_processing_complete and request|toggle_enabled:'CASE_REBUILD'%}
+    <div class="alert alert-error">
+        {% trans "This form's case changes were not processed because of errors that occurred during case processing." %}
+    </div>
+    {% endif %}
     {% render_form instance domain form_render_options %}
 {% endblock %}


### PR DESCRIPTION
- this is a terrible UI that is not clearly actionable
- but it is better than completely hiding this fact
