### PR TITLE
Auto replaces spaces with underscores in case property fields

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/case_config_shared.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_config_shared.html
@@ -52,7 +52,13 @@
             valueDefault: property.key,
             default: property.defaultKey,
             edit: $root.edit,
-            casePropertyTypeahead: suggestedProperties
+            casePropertyTypeahead: suggestedProperties,
+            event: { keyup: function(data, event){
+                if (event.keyCode == 32) {
+                    $element.value =  $element.value.replace(/ /g,'_');
+                }
+                return true;
+            }}
         "/>
     </span>
     <span data-bind="visible: property.required()">

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_config_shared.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_config_shared.html
@@ -53,10 +53,8 @@
             default: property.defaultKey,
             edit: $root.edit,
             casePropertyTypeahead: suggestedProperties,
-            event: { keyup: function(data, event){
-                if (event.keyCode == 32) {
+            event: { change: function(){
                     $element.value =  $element.value.replace(/ /g,'_');
-                }
                 return true;
             }}
         "/>


### PR DESCRIPTION
Addresses this ticket: http://manage.dimagi.com/default.asp?122825#701898

Auto replaces spaces with underscores in case property fields of the save/load case management sections. It might be better if the javascript function I wrote here wasn't in the template, but I'm not sure where exactly is best. Any guidelines @biyeun ? 
