### PR TITLE
Updated egenix-mx-base to 3.2.8

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -18,7 +18,7 @@ django-kombu==0.9.1
 django-rosetta==0.7.1
 django-tastypie==0.9.14
 djtables==0.1.1
-egenix-mx-base==3.2.7
+egenix-mx-base==3.2.8
 eulxml==0.18.0
 feedparser==5.1.3
 gunicorn==18.0


### PR DESCRIPTION
egenix-mx-base 3.2.8 was released on 11 Jul 2014. Pip throws an error when trying to install packages with version 3.2.7. Passed all Travis tests.
