### PR TITLE
Make icon option appear when enabled in Feature Previews and get rid of is_previewer check

### DIFF
--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -871,7 +871,6 @@ def view_generic(req, domain, app_id=None, module_id=None, form_id=None, is_user
             feature_previews.CALC_XPATHS.enabled(getattr(req, 'domain', None))
         )
         module_context["enable_enum_image"] = (
-            req.couch_user.is_previewer or
             feature_previews.ENUM_IMAGE.enabled(getattr(req, 'domain', None))
         )
         context.update(module_context)

--- a/corehq/apps/hqwebapp/models.py
+++ b/corehq/apps/hqwebapp/models.py
@@ -474,6 +474,8 @@ class ProjectDataTab(UITab):
             edit_section = EditDataInterfaceDispatcher.navigation_sections(context)
 
             from corehq.apps.data_interfaces.views import CaseGroupListView, CaseGroupCaseManagementView
+            # FIXME: This will always evaluate to True, for more, see
+            # http://manage.dimagi.com/default.asp?125511
             if self.couch_user.is_previewer:
                 edit_section[0][1].append({
                     'title': CaseGroupListView.page_title,

--- a/corehq/apps/reminders/views.py
+++ b/corehq/apps/reminders/views.py
@@ -569,6 +569,10 @@ class CreateScheduledReminderView(BaseMessagingSectionView):
 
     @property
     def is_previewer(self):
+        # FIXME: is_previewer is a callable, this is currently passing around
+        # a reference to the function, so it will always evaluate to True
+        # except in templates, where it's evaluated.  For more, see
+        # http://manage.dimagi.com/default.asp?125511
         return self.request.couch_user.is_previewer
 
     @property


### PR DESCRIPTION
@dimagi/team-commcare-hq You might find this interesting.  It's a really wacky bug.

http://manage.dimagi.com/default.asp?124325

This was a pretty straightforward-looking issue, I just removed the line checking `is_previewer` and it worked.  Except it didn't really make sense that non-previewers weren't able to see the feature with that line there, `user.is_previewer or feature.is_enabled` should evaluate to true if it's `False or True`.

I did some digging, turns out that `is_previewer` is a callable, so this evaluated to `is_previewer_fn or True`, and because `bool(any_function) == True`, then this should always be True.

Except bool() is never explicitly called, so instead this returns the first truthy value from the or expression, or `is_previewer_fn`.  This is passed around until it ends up in a [template](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/app_manager/templates/app_manager/module_view.html#L12), and because django templates will call functions for you, that function was at last being called.  In effect, `user.is_previewer or feature.is_enabled` resolved to `user.is_previewer()`.

I decided to look for other times when is_previewer is used but not called, and found these other two instances.  This will be tracked here: http://manage.dimagi.com/default.asp?125511  It's easy to just add `()` after it, but that means for example, that the "Case Groups" view will no longer appear in the sidebar for people who can currently see it, so Amelia will decide whether that's acceptable or not.
