### PR TITLE
Fixed a problem in apache/local_apache.conf

### DIFF
--- a/apache/local_apache.conf
+++ b/apache/local_apache.conf
@@ -17,7 +17,7 @@
     # ProxyPass /static !
 
 
-    ProxyPass / http://localhost:8000/ timeout=0
+    ProxyPass / http://localhost:8000/ timeout=1
     ProxyPassReverse / http://localhost:8000/
 
 </VirtualHost>


### PR DESCRIPTION
@czue , I fixed the issue that we were running up against trying to set up apache in my dev environment.

I discovered the `apachectl configtest` command, which gave me the following error message:

```
Syntax error on line 20 of /private/etc/apache2/other/cchq.conf:
ProxyPass Timeout must be at least one second
```

I don't know if this issue was a quirk of my setup of not, but I changed that value from `0` to `1` and made this PR incase updated the repository is appropriate.

I'm running Apache/2.2.26 (Unix) fyi.
