### PR TITLE
fix exponential recursion in detail screen config

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -443,7 +443,7 @@ var DetailScreenConfig = (function () {
             }
 
             var longColumns = spec.long ? spec.long.columns : [];
-            columns = lcsMerge(spec.short.columns, longColumns, _.isEqual).merge;
+            columns = lcsMerge(spec.short.columns, longColumns, _.isEqual);
 
             // set up the columns
             for (i = 0; i < columns.length; i += 1) {

--- a/corehq/apps/app_manager/static/app_manager/js/lcs-merge.js
+++ b/corehq/apps/app_manager/static/app_manager/js/lcs-merge.js
@@ -1,30 +1,37 @@
+/*
+    Implemented (I think) directly from the pseudocode at
+    http://en.wikipedia.org/wiki/Longest_common_substring_problem
+ */
 function lcsMerge(X, Y, isEqual) {
     'use strict';
     isEqual = isEqual || function (a, b) {
         return a === b;
     };
-    function recLcsMerge(X, Y, i, j) {
-        var val, val1, val2, recur = recLcsMerge;
-
+    var cache = {};
+    function recLcsMerge(i, j) {
+        var val, val1, val2, recur = recLcsMerge, cache_key = i + ' ' + j;
+        if (cache[cache_key]) {
+            return cache[cache_key];
+        }
         if (i === 0 && j === 0) {
             val = {
-                lcs: [],
+                lcs_length: 0,
                 merge: []
             };
         } else if (i === 0) {
-            val = recur(X, Y, i, j - 1);
+            val = recur(i, j - 1);
             val.merge.push({x: false, y: true, token: Y[j - 1]});
         } else if (j === 0) {
-            val = recur(X, Y, i - 1, j);
+            val = recur(i - 1, j);
             val.merge.push({x: true, y: false, token: X[i - 1]});
         } else if (isEqual(X[i - 1], Y[j - 1])) {
-            val = recur(X, Y, i - 1, j - 1);
-            val.lcs.push(X[i - 1]);
+            val = recur(i - 1, j - 1);
+            val.lcs_length++;
             val.merge.push({x: true, y: true, token: X[i - 1]});
         } else {
-            val1 = recur(X, Y, i, j - 1);
-            val2 = recur(X, Y, i - 1, j);
-            if (val2.lcs.length > val1.lcs.length) {
+            val1 = recur(i, j - 1);
+            val2 = recur(i - 1, j);
+            if (val2.lcs_length > val1.lcs_length) {
                 val = val2;
                 val.merge.push({x: true, y: false, token: X[i - 1]});
             } else {
@@ -32,8 +39,12 @@ function lcsMerge(X, Y, isEqual) {
                 val.merge.push({x: false, y: true, token: Y[j - 1]});
             }
         }
+        cache[cache_key] = {
+            lcs_length: val.lcs_length,
+            merge: val.merge.slice(0)
+        };
         return val;
     }
 
-    return recLcsMerge(X, Y, X.length, Y.length);
+    return recLcsMerge(X.length, Y.length).merge;
 }


### PR DESCRIPTION
by memoizing `lcsMerge`. Also:
- simplify it to return the merged result rather than an internal data
  structure
- do not keep track of the whole longest submatch, just its length, for
  simplicity

fixes http://manage.dimagi.com/default.asp?125416
