### PR TITLE
Added redis-server to file

### DIFF
--- a/requirements/apt-packages.txt
+++ b/requirements/apt-packages.txt
@@ -6,6 +6,7 @@ libevent-dev
 python-setuptools
 postgresql
 memcached
+redis-server
 gdebi-core
 apache2
 


### PR DESCRIPTION
redis-server was not included in requirements/apt-packages.txt. This is a dependency for the cache as suggested in the localsettings.example.py file
