### PR TITLE
Fix group filtering bug in Reassign Cases and Case List reports

### DIFF
--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -94,7 +94,7 @@ class CaseListMixin(ElasticProjectInspectionReport, ProjectReportParametersMixin
         case_es = self.case_es
         user_ids, owner_ids = self.case_users_and_owners
         query = self.build_query(case_type=self.case_type, afilter=self.case_filter,
-                                 status=self.case_status, owner_ids=owner_ids+user_ids, user_ids=user_ids,
+                                 status=self.case_status, owner_ids=owner_ids+user_ids,
                                  search_string=SearchFilter.get_value(self.request, self.domain))
         query_results = case_es.run_query(query)
 


### PR DESCRIPTION
If you filtered by group in either of these reports, all cases with a `user_id` that matches a user in the group will be shown in the report. `user_id` corresponds to the last user to modify a case. We care about ownership (`owner_id`) here, so I removed this part of the query.
