### PR TITLE
Fixed missing pending invitations bug

### DIFF
--- a/corehq/apps/cachehq/cachemodels.py
+++ b/corehq/apps/cachehq/cachemodels.py
@@ -116,4 +116,5 @@ class DomainInvitationGenerationCache(GenerationCache):
     doc_types = ['Invitation']
     views = [
         'users/open_invitations_by_email',
+        'users/open_invitations_by_domain',
     ]


### PR DESCRIPTION
Adresses http://manage.dimagi.com/default.asp?125814#711893.

Pending invitations were missing from the "Web Users & Roles" page. It was caused by `DomainInvitationGenerationCache` missing the `'users/open_invitations_by_domain'` view in its `views` list.
