### PR TITLE
Allow users to specify owner names (not just ids) in excel case importer

### DIFF
--- a/corehq/apps/importer/tasks.py
+++ b/corehq/apps/importer/tasks.py
@@ -37,6 +37,7 @@ def do_import(spreadsheet, config, domain, task=None, chunksize=CASEBLOCK_CHUNKS
     blank_external_ids = []
     invalid_dates = []
     owner_id_errors = []
+    owner_name_errors = []
     prime_offset = 1  # used to prevent back-to-back priming
 
     user = CouchUser.get_by_user_id(config.couch_user_id, domain)
@@ -45,6 +46,7 @@ def do_import(spreadsheet, config, domain, task=None, chunksize=CASEBLOCK_CHUNKS
 
     # keep a cache of id lookup successes to help performance
     id_cache = {}
+    name_cache = {}
     caseblocks = []
     ids_seen = set()
 
@@ -127,17 +129,16 @@ def do_import(spreadsheet, config, domain, task=None, chunksize=CASEBLOCK_CHUNKS
             too_many_matches += 1
             continue
 
-        try:
-            uploaded_owner_name = row[columns.index('owner_name')]
-        except ValueError:
-            uploaded_owner_name = None
-
+        uploaded_owner_name = fields_to_update.pop('owner_name', None)
         uploaded_owner_id = fields_to_update.pop('owner_id', None)
 
         if uploaded_owner_name:
             # If an owner name was provided, replace the provided
-            # uploaded_owner_id with the id of the provided group or owner name
-            uploaded_owner_id = importer_util.get_id_from_name(uploaded_owner_name, domain, id_cache)
+            # uploaded_owner_id with the id of the provided group or owner
+            uploaded_owner_id = importer_util.get_id_from_name(uploaded_owner_name, domain, name_cache)
+            if not uploaded_owner_id:
+                owner_name_errors.append(i + 1)
+                continue
         if uploaded_owner_id:
             # If an owner_id mapping exists, verify it is a valid user
             # or case sharing group
@@ -238,6 +239,7 @@ def do_import(spreadsheet, config, domain, task=None, chunksize=CASEBLOCK_CHUNKS
         'blank_externals': blank_external_ids,
         'invalid_dates': invalid_dates,
         'owner_id_errors': owner_id_errors,
+        'owner_name_errors': owner_name_errors,
         'errors': errors,
         'num_chunks': num_chunks,
     }

--- a/corehq/apps/importer/tasks.py
+++ b/corehq/apps/importer/tasks.py
@@ -127,7 +127,17 @@ def do_import(spreadsheet, config, domain, task=None, chunksize=CASEBLOCK_CHUNKS
             too_many_matches += 1
             continue
 
+        try:
+            uploaded_owner_name = row[columns.index('owner_name')]
+        except ValueError:
+            uploaded_owner_name = None
+
         uploaded_owner_id = fields_to_update.pop('owner_id', None)
+
+        if uploaded_owner_name:
+            # If an owner name was provided, replace the provided
+            # uploaded_owner_id with the id of the provided group or owner name
+            uploaded_owner_id = importer_util.get_id_from_name(uploaded_owner_name, domain, id_cache)
         if uploaded_owner_id:
             # If an owner_id mapping exists, verify it is a valid user
             # or case sharing group

--- a/corehq/apps/importer/templates/importer/partials/import_status.html
+++ b/corehq/apps/importer/templates/importer/partials/import_status.html
@@ -74,6 +74,18 @@
                 </p>
             {% endif %}
 
+            {% if result.owner_name_errors|length > 0 %}
+                <p>
+                    {% blocktrans %}
+                        Owner name was used in the mapping but there were errors
+                        when uploading because of these values. Make sure the
+                        usernames are in the form
+                        &lt;username&gt;@&lt;project_name&gt;.commcarehq.org .
+                        The following row numbers had this issue and were ignored:
+                    {% endblocktrans %}
+                    {{ result.owner_name_errors|join:", " }}
+                </p>
+            {% endif %}
             {% if result.errors > 0 %}
                 <p>
                     {% blocktrans with errors=result.errors %}

--- a/corehq/apps/importer/util.py
+++ b/corehq/apps/importer/util.py
@@ -1,5 +1,6 @@
 import json
 import xlrd
+from couchdbkit import NoResultFound
 from dimagi.utils.couch.database import get_db
 from corehq.apps.importer.const import LookupErrors
 from datetime import date
@@ -7,6 +8,8 @@ from casexml.apps.case.models import CommCareCase
 from xlrd import xldate_as_tuple
 from corehq.apps.groups.models import Group
 from corehq.apps.users.cases import get_wrapped_owner
+from corehq.apps.users.models import CouchUser
+
 
 def get_case_properties(domain, case_type=None):
     """
@@ -353,3 +356,26 @@ def is_valid_id(uploaded_id, domain, cache):
 
     owner = get_wrapped_owner(uploaded_id)
     return owner and is_user_or_case_sharing_group(owner) and owner.is_member_of(domain)
+
+def get_id_from_name(uploaded_name, domain, cache):
+    '''
+    :param uploaded_name: A username or group name
+    :param domain:
+    :param cache:
+    :return: Looks for the given name and returns the corresponding id if the
+    user or group exists and None otherwise. Searches for user first, then
+    group.
+    '''
+    if uploaded_name in cache:
+        return cache[uploaded_name]
+    try:
+        user = CouchUser.get_by_username(uploaded_name)
+        id = getattr(user, 'couch_id', None)
+    except NoResultFound:
+        pass
+    if not id:
+        group = Group.by_name(domain, uploaded_name, one=True)
+        id = getattr(group, 'get_id', None)
+
+    cache[uploaded_name] = id
+    return id

--- a/corehq/apps/importer/util.py
+++ b/corehq/apps/importer/util.py
@@ -372,7 +372,7 @@ def get_id_from_name(uploaded_name, domain, cache):
         user = CouchUser.get_by_username(uploaded_name)
         id = getattr(user, 'couch_id', None)
     except NoResultFound:
-        pass
+        id = None
     if not id:
         group = Group.by_name(domain, uploaded_name, one=True)
         id = getattr(group, 'get_id', None)


### PR DESCRIPTION
Specifying owner names works just like specifying owner ids. A user can assign ownership to users or groups by assigning one of his or her excel columns to the special "owner_name" case property. If an owner_name and owner_id are present, the owner_name will take precedence.

Adresses this ticket: http://manage.dimagi.com/default.asp?115347
