### PR TITLE
Fixed broken url reverse on form template for special "User Registration" form

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/form_view_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view_base.html
@@ -237,7 +237,12 @@
 
     {% if edit %}
     <div class="btn-group">
-        <a id="edit_label" href="{% url "form_source" domain app.id module.id form.id %}" class="btn btn-primary">
+        <a id="edit_label" href="{% if is_user_registration %}
+                                    {% url "user_registration_source" domain app.id %}
+                                 {% else %}
+                                    {% url "form_source" domain app.id module.id form.id %}
+                                 {% endif %}
+                                 " class="btn btn-primary">
             <i class="icon-pencil"></i>
             {% trans "Edit" %}
         </a>


### PR DESCRIPTION
Addresses this ticket: http://manage.dimagi.com/default.asp?127376#719249

This was causing the site to 500. I don't love the spacing I used for the conditional href value. All on one line is also a bit much. Any ideas on how to make it cleaner?
