### PR TITLE
speed up loading form view up to 10x

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -659,6 +659,7 @@ class FormBase(DocumentSchema):
     def get_questions(self, langs, **kwargs):
         return XForm(self.source).get_questions(langs, **kwargs)
 
+    @memoized
     def get_case_property_name_formatter(self):
         """Get a function that formats case property names
 

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -121,7 +121,7 @@ class ParentCasePropertyBuilder(object):
         case_properties = set(self.defaults)
 
         for m_case_type, form in self.forms_info:
-            case_properties.update(form.get_case_updates(case_type))
+            case_properties.update(self.get_case_updates(form, case_type))
 
         parent_types, contributed_properties = \
             self.get_parent_types_and_contributed_properties(case_type)
@@ -131,6 +131,10 @@ class ParentCasePropertyBuilder(object):
                 case_properties.add('%s/%s' % (parent_type[1], property))
 
         return case_properties
+
+    @memoized
+    def get_case_updates(self, form, case_type):
+        return form.get_case_updates(case_type)
 
     def get_case_property_map(self, case_types):
         case_types = sorted(case_types)


### PR DESCRIPTION
by memoizing a few functions used to collect case property suggestions

My example went from 22 seconds to about 2. It was calling get_questions
800 times in the process. Now it's called once per form.
