### PR TITLE
make some formatting and organizational improvemnts to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ python:
 env:
   global:
     - CFLAGS=-O0
-    - COUCHDB_USER=
-    - COUCHDB_PW=
+    - COUCHDB_USER=""
+    - COUCHDB_PW=""
   matrix:
     - TEST_RUNNER=testrunner.GroupTestRunnerCatchall
     - TEST_RUNNER=testrunner.GroupTestRunner0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,39 +1,43 @@
 language: python
 python:
- - "2.7"
+  - "2.7"
 env:
- - CFLAGS=-O0 TEST_RUNNER=testrunner.GroupTestRunnerCatchall
- - CFLAGS=-O0 TEST_RUNNER=testrunner.GroupTestRunner0
- - CFLAGS=-O0 TEST_RUNNER=testrunner.GroupTestRunner1
+  global:
+    - CFLAGS=-O0
+    - COUCHDB_USER=
+    - COUCHDB_PW=
+  matrix:
+    - TEST_RUNNER=testrunner.GroupTestRunnerCatchall
+    - TEST_RUNNER=testrunner.GroupTestRunner0
+    - TEST_RUNNER=testrunner.GroupTestRunner1
 branches:
   only:
-   - master
-   - django-1.5-build
+    - master
 before_install:
-   - "curl http://localhost:5984/"  # print couch info
+  - "curl http://localhost:5984/"  # print couch info
+  - "uname -a"
+  - "lsb_release -a"
 install:
- - "uname -a"
- - "lsb_release -a"
- - "sudo apt-get install moreutils libblas-dev liblapack-dev"
- - "git clone https://github.com/dimagi/commcarehq-venv.git"
- - "cp -r commcarehq-venv/hq_env/* ~/virtualenv/"
- - "source ~/virtualenv/bin/activate"
- - "time (bash -e scripts/uninstall-requirements.sh | ts)"
- # set env variables for couch username/password, used by install.sh, to blank
- - "export COUCHDB_USER= COUCHDB_PW= && time (bash -e .travis/quietly-run-install.sh | ts)"
- - "curl -X PUT http://localhost:5984/commcarehq_test"  # this is an auth test
- - "time (pip install --exists-action w -r requirements/requirements.txt --use-mirrors)"
- - "time (bash -e .travis/misc-setup.sh | ts)"
- - "cp .travis/localsettings.py localsettings.py"
- - "pip install coverage unittest2 mock --use-mirrors"
+  - "sudo apt-get install moreutils libblas-dev liblapack-dev"
+  - "git clone https://github.com/dimagi/commcarehq-venv.git"
+  - "cp -r commcarehq-venv/hq_env/* ~/virtualenv/"
+  - "source ~/virtualenv/bin/activate"
+  - "time (bash -e scripts/uninstall-requirements.sh | ts)"
+  # set env variables for couch username/password, used by install.sh, to blank
+  - "time (bash -e .travis/quietly-run-install.sh | ts)"
+  - "curl -X PUT http://localhost:5984/commcarehq_test"  # this is an auth test
+  - "time (pip install --exists-action w -r requirements/requirements.txt --use-mirrors)"
+  - "time (bash -e .travis/misc-setup.sh | ts)"
+  - "cp .travis/localsettings.py localsettings.py"
+  - "pip install coverage unittest2 mock --use-mirrors"
 script: "coverage run manage.py test --noinput --failfast --testrunner=$TEST_RUNNER"
 after_success:
- - coverage report
- - coveralls
+  - coverage report
+  - coveralls
 services:
- - postgresql
- - couchdb
- - rabbitmq
- - elasticsearch
- - memcache
- - redis-server
+  - postgresql
+  - couchdb
+  - rabbitmq
+  - elasticsearch
+  - memcache
+  - redis-server


### PR DESCRIPTION
mostly indentation, but also
- split `env` out into `global` and `matrix`
- remove `django-1.5-build` since that's not a thing anymore
- move some informational printouts into `before_install`
