### PR TITLE
Downgrade concurrency on main and periodic workers

### DIFF
--- a/services/templates/supervisor_celery_main.conf
+++ b/services/templates/supervisor_celery_main.conf
@@ -1,5 +1,5 @@
 [program:%(project)s-%(environment)s-celery_main]
-command=%(virtualenv_root)s/bin/python %(code_root)s/manage.py celery worker --queues=celery --events --loglevel=INFO --hostname=%(host_string)s_main --maxtasksperchild=20 --concurrency=16
+command=%(virtualenv_root)s/bin/python %(code_root)s/manage.py celery worker --queues=celery --events --loglevel=INFO --hostname=%(host_string)s_main --maxtasksperchild=20 --concurrency=8
 directory=%(code_root)s
 user=%(sudo_user)s
 numprocs=1

--- a/services/templates/supervisor_celery_periodic.conf
+++ b/services/templates/supervisor_celery_periodic.conf
@@ -1,5 +1,5 @@
 [program:%(project)s-%(environment)s-celery_periodic]
-command=%(virtualenv_root)s/bin/python %(code_root)s/manage.py celery worker --queues=celery_periodic --events --loglevel=INFO --hostname=%(host_string)s_periodic --maxtasksperchild=50 --concurrency=6
+command=%(virtualenv_root)s/bin/python %(code_root)s/manage.py celery worker --queues=celery_periodic --events --loglevel=INFO --hostname=%(host_string)s_periodic --maxtasksperchild=50 --concurrency=4
 directory=%(code_root)s
 user=%(sudo_user)s
 numprocs=1


### PR DESCRIPTION
@dannyroberts @czue Looks like we're hitting the limit again on the celery machine, most likely because of the addition of 12 new processes for the reminders firing queue and reminders case update queue. Since that stuff used to run on main and periodic, I think we can downgrade those.
