### PR TITLE
Validate '|' cannot be in a password

### DIFF
--- a/corehq/apps/userhack/models.py
+++ b/corehq/apps/userhack/models.py
@@ -19,6 +19,7 @@
 
 from django.contrib.auth.models import User
 from django.core.validators import MaxLengthValidator
+from corehq.apps.users.util import validate_password
 
 NEW_USERNAME_LENGTH = 128
 
@@ -30,3 +31,11 @@ def monkey_patch_username(model, field):
             v.limit_value = NEW_USERNAME_LENGTH
 
 monkey_patch_username(User, 'username')
+
+old_set_password = User.set_password
+
+def set_password(self, raw_password):
+    validate_password(raw_password)
+    old_set_password(self, raw_password)
+
+User.set_password = set_password

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -4,6 +4,7 @@ from crispy_forms import layout as crispy
 from crispy_forms.layout import ButtonHolder, Div, Fieldset, HTML, Layout, Submit
 import datetime
 from django import forms
+from django.contrib.auth.forms import SetPasswordForm
 from django.core.validators import EmailValidator, email_re
 from django.core.urlresolvers import reverse
 from django.forms.widgets import PasswordInput, HiddenInput
@@ -419,3 +420,8 @@ class ConfirmExtraUserChargesForm(EditBillingAccountInfoForm):
         self.account.date_confirmed_extra_charges = datetime.datetime.today()
         self.account.save()
         return True
+
+class ValidateSetPasswordForm(SetPasswordForm):
+    def clean_new_password1(self):
+        new_password1 = self.cleaned_data['new_password1']
+        validate_password(new_password1)

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -16,7 +16,7 @@ from corehq.apps.domain.forms import EditBillingAccountInfoForm
 from corehq.apps.locations.models import Location
 from corehq.apps.registration.utils import handle_changed_mailchimp_email
 from corehq.apps.users.models import CouchUser
-from corehq.apps.users.util import format_username
+from corehq.apps.users.util import format_username, validate_password
 from corehq.apps.app_manager.models import validate_lang
 from corehq.apps.commtrack.models import CommTrackUser, Program
 import re
@@ -261,6 +261,7 @@ class CommCareAccountForm(forms.Form):
                 raise forms.ValidationError("Passwords do not match")
             if self.password_format == 'n' and not password.isnumeric():
                 raise forms.ValidationError("Password is not numeric")
+            validate_password(password)
 
         try:
             username = self.cleaned_data['username']

--- a/corehq/apps/users/util.py
+++ b/corehq/apps/users/util.py
@@ -2,6 +2,7 @@ import re
 
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
 
 from couchdbkit.resource import ResourceNotFound
 from corehq import toggles, privileges
@@ -137,3 +138,7 @@ def can_add_extra_mobile_workers(request):
         if account is None or account.date_confirmed_extra_charges is None:
             return False
     return True
+
+def validate_password(raw_password):
+    if '|' in raw_password:
+        raise ValidationError("'|' is not allowed in a password")

--- a/corehq/apps/users/util.py
+++ b/corehq/apps/users/util.py
@@ -140,5 +140,5 @@ def can_add_extra_mobile_workers(request):
     return True
 
 def validate_password(raw_password):
-    if '|' in raw_password:
+    if raw_password and '|' in raw_password:
         raise ValidationError("'|' is not allowed in a password")

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -30,8 +30,12 @@ from corehq.apps.users.util import can_add_extra_mobile_workers
 from corehq.elastic import es_query, ES_URLS, ADD_TO_ES_FILTER
 
 from couchexport.models import Format
-from corehq.apps.users.forms import (CommCareAccountForm, UpdateCommCareUserInfoForm, CommtrackUserForm,
-                                     MultipleSelectionForm, ConfirmExtraUserChargesForm)
+from corehq.apps.users.forms import (CommCareAccountForm,
+                                     UpdateCommCareUserInfoForm,
+                                     CommtrackUserForm,
+                                     MultipleSelectionForm,
+                                     ConfirmExtraUserChargesForm,
+                                     ValidateSetPasswordForm)
 from corehq.apps.users.models import CommCareUser, UserRole, CouchUser
 from corehq.apps.groups.models import Group
 from corehq.apps.domain.models import Domain
@@ -87,7 +91,7 @@ class EditCommCareUserView(BaseFullEditUserView):
     @property
     @memoized
     def reset_password_form(self):
-        return SetPasswordForm(user="")
+        return ValidateSetPasswordForm(user="")
 
     @property
     def commtrack_user_roles(self):


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?60104

Monkey patches set_password. Displays "'|' is not allowed in a password" as the error in all three possible locations.
