### PR TITLE
fix start calcs when new month has fewer days than previous one

### DIFF
--- a/custom/opm/opm_reports/beneficiary.py
+++ b/custom/opm/opm_reports/beneficiary.py
@@ -6,7 +6,7 @@ import re
 import datetime
 from decimal import Decimal
 from django.core.urlresolvers import reverse
-from dimagi.utils.dates import months_between
+from dimagi.utils.dates import months_between, first_of_next_month
 
 from dimagi.utils.dates import add_months
 from dimagi.utils.decorators.memoized import memoized
@@ -193,7 +193,7 @@ class OPMCaseRow(object):
         end = self.datespan.enddate
         if num_months is not None:
             new_year, new_month = add_months(end.year, end.month, -num_months)
-            start = end.replace(month=new_month, year=new_year)
+            start = first_of_next_month(datetime.datetime(new_year, new_month, 1))
         else:
             start = None
         def check_form(form):

--- a/custom/opm/opm_reports/tests/case_reports.py
+++ b/custom/opm/opm_reports/tests/case_reports.py
@@ -97,7 +97,7 @@ def get_relative_edd_from_preg_month(report_date, month):
 
 def offset_date(reference_date, offset):
     new_year, new_month = add_months(reference_date.year, reference_date.month, offset)
-    return date(new_year, new_month, 1)
+    return type(reference_date)(new_year, new_month, 1)
 
 
 class MockDataTest(OPMCaseReportTestBase):

--- a/custom/opm/opm_reports/tests/case_reports.py
+++ b/custom/opm/opm_reports/tests/case_reports.py
@@ -95,6 +95,11 @@ def get_relative_edd_from_preg_month(report_date, month):
     return type(report_date)(new_year, new_month, 1)
 
 
+def offset_date(reference_date, offset):
+    new_year, new_month = add_months(reference_date.year, reference_date.month, offset)
+    return date(new_year, new_month, 1)
+
+
 class MockDataTest(OPMCaseReportTestBase):
 
     def test_mock_data(self):

--- a/custom/opm/opm_reports/tests/test_windows_and_months.py
+++ b/custom/opm/opm_reports/tests/test_windows_and_months.py
@@ -1,8 +1,11 @@
 from unittest import TestCase
 from datetime import date, datetime
 from custom.opm.opm_reports.constants import InvalidRow
-from custom.opm.opm_reports.tests import (OPMCaseReportTestBase, OPMCase, MockCaseRow, Report, Form)
+from custom.opm.opm_reports.tests import (OPMCaseReportTestBase, OPMCase, MockCaseRow, Report, Form, offset_date)
 from dimagi.utils.dates import add_months
+
+
+
 
 
 class TestPregnancyWindowAndMonths(OPMCaseReportTestBase):
@@ -11,8 +14,7 @@ class TestPregnancyWindowAndMonths(OPMCaseReportTestBase):
         """
         For a given offset, return a date that many months offset from the report date
         """
-        new_year, new_month = add_months(self.report_date.year, self.report_date.month, offset)
-        return date(new_year, new_month, 1)
+        return offset_date(self.report_date, offset)
 
     def test_valid_window_not_yet_delivered(self):
         # maps number of months in the future your due date is to window


### PR DESCRIPTION
changes the start from the very end of the previous month to the very beginning of the next month. i think this is more correct, but @esoergel should confirm
