### PR TITLE
remove mock Form class

### DIFF
--- a/custom/opm/opm_reports/tests/case_reports.py
+++ b/custom/opm/opm_reports/tests/case_reports.py
@@ -6,6 +6,7 @@ from jsonobject import (JsonObject, DictProperty, DateTimeProperty,
     StringProperty, IntegerProperty, BooleanProperty)
 
 from casexml.apps.case.models import CommCareCase
+from couchforms.models import XFormInstance
 from custom.opm.opm_reports.reports import SharedDataProvider
 from dimagi.utils.dates import DateSpan, add_months
 
@@ -43,12 +44,6 @@ class Report(JsonObject):
     @property
     def datespan(self):
         return DateSpan.from_month(self.month, self.year, inclusive=True)
-
-
-class Form(JsonObject):
-    xmlns = StringProperty('something')
-    form = DictProperty(required=True)
-    received_on = DateTimeProperty(required=True)
 
 
 class OPMCase(CommCareCase):
@@ -104,7 +99,7 @@ class MockDataTest(OPMCaseReportTestBase):
 
     def test_mock_data(self):
         report = Report(month=6, year=2014, block="Atri")
-        form = Form(form={'foo': 'bar'}, received_on=datetime(2014, 6, 15))
+        form = XFormInstance(form={'foo': 'bar'}, received_on=datetime(2014, 6, 15))
         case = OPMCase(
             forms=[form],
             # add/override any desired case properties here

--- a/custom/opm/opm_reports/tests/test_birth_spacing.py
+++ b/custom/opm/opm_reports/tests/test_birth_spacing.py
@@ -2,19 +2,20 @@ from datetime import datetime, date
 from unittest import TestCase
 
 from ..constants import *
-from .case_reports import Report, Form, OPMCase, MockCaseRow
+from .case_reports import Report, OPMCase, MockCaseRow
+from couchforms.models import XFormInstance
 
 
 class TestBirthSpacing(TestCase):
     def pregnant_form(self, y, m, d):
-        return Form(
+        return XFormInstance(
             form={'birth_spacing_prompt': '1'},
             received_on=datetime(y, m, d),
             xmlns=CFU3_XMLNS,
         )
 
     def not_pregnant_form(self, y, m, d):
-        return Form(
+        return XFormInstance(
             form={'birth_spacing_prompt': '2'},
             received_on=datetime(y, m, d),
             xmlns=CFU3_XMLNS,

--- a/custom/opm/opm_reports/tests/test_child_conditions.py
+++ b/custom/opm/opm_reports/tests/test_child_conditions.py
@@ -2,19 +2,20 @@ from datetime import datetime, date
 from unittest import TestCase
 
 from ..constants import *
-from .case_reports import Report, Form, OPMCase, MockCaseRow
+from .case_reports import Report, OPMCase, MockCaseRow
+from couchforms.models import XFormInstance
 
 
 class TestChildGrowthMonitored(TestCase):
     def form_with_condition(self, y, m, d):
-        return Form(
+        return XFormInstance(
             form={'child1_growthmon_calc': 'received'},
             received_on=datetime(y, m, d),
             xmlns=CFU2_XMLNS,
         )
 
     def form_without_condition(self, y, m, d):
-        return Form(
+        return XFormInstance(
             form={'child1_growthmon_calc': 'not_taken'},
             received_on=datetime(y, m, d),
             xmlns=CFU2_XMLNS,
@@ -51,14 +52,14 @@ class TestChildGrowthMonitored(TestCase):
 
 class TestChildExclusivelyBreastfed(TestCase):
     def breastfed_form(self, y, m, d):
-        return Form(
+        return XFormInstance(
             form={'child1_child_excbreastfed': '1'},
             received_on=datetime(y, m, d),
             xmlns=CFU1_XMLNS,
         )
 
     def not_breastfed_form(self, y, m, d):
-        return Form(
+        return XFormInstance(
             form={'child1_child_excbreastfed': '0'},
             received_on=datetime(y, m, d),
             xmlns=CFU1_XMLNS,

--- a/custom/opm/opm_reports/tests/test_preg_conditions.py
+++ b/custom/opm/opm_reports/tests/test_preg_conditions.py
@@ -1,7 +1,7 @@
 from datetime import date
 from unittest import TestCase
 
-from .case_reports import Report, Form, OPMCase, MockCaseRow
+from .case_reports import Report, OPMCase, MockCaseRow
 
 
 class TestMotherWeightMonitored(TestCase):

--- a/custom/opm/opm_reports/tests/test_vhnd.py
+++ b/custom/opm/opm_reports/tests/test_vhnd.py
@@ -1,6 +1,7 @@
 from datetime import date, datetime, timedelta
+from couchforms.models import XFormInstance
 from custom.opm.opm_reports.constants import InvalidRow, CFU2_XMLNS, CHILDREN_FORMS, BIRTH_PREP_XMLNS
-from custom.opm.opm_reports.tests.case_reports import OPMCaseReportTestBase, OPMCase, MockCaseRow, Form, \
+from custom.opm.opm_reports.tests.case_reports import OPMCaseReportTestBase, OPMCase, MockCaseRow, \
     get_relative_edd_from_preg_month, MockDataProvider
 
 
@@ -16,7 +17,7 @@ class TestChildVHND(OPMCaseReportTestBase):
 
     def test_single_match_in_all_forms(self):
         for xmlns in CHILDREN_FORMS:
-            form = Form(
+            form = XFormInstance(
                 form={'child1_vhndattend_calc': 'received'},
                 received_on=self.report_datetime,
                 xmlns=xmlns,
@@ -32,7 +33,7 @@ class TestChildVHND(OPMCaseReportTestBase):
         for received_on in (self.report_datetime - timedelta(days=32),
                             self.report_datetime + timedelta(days=32)):
             for xmlns in CHILDREN_FORMS:
-                form = Form(
+                form = XFormInstance(
                     form={'child1_vhndattend_calc': 'received'},
                     received_on=received_on,
                     xmlns=xmlns,
@@ -45,12 +46,12 @@ class TestChildVHND(OPMCaseReportTestBase):
                 self.assertEqual(False, row.child_attended_vhnd)
 
     def test_multiple_forms_in_window(self):
-        form1 = Form(
+        form1 = XFormInstance(
             form={'child1_vhndattend_calc': 'received'},
             received_on=self.report_datetime,
             xmlns=CFU2_XMLNS,
         )
-        form2 = Form(
+        form2 = XFormInstance(
             form={'child1_vhndattend_calc': 'not_taken'},
             received_on=self.report_datetime + timedelta(days=1),
             xmlns=CFU2_XMLNS,

--- a/custom/opm/opm_reports/tests/test_windows_and_months.py
+++ b/custom/opm/opm_reports/tests/test_windows_and_months.py
@@ -1,7 +1,8 @@
 from unittest import TestCase
 from datetime import date, datetime
+from couchforms.models import XFormInstance
 from custom.opm.opm_reports.constants import InvalidRow
-from custom.opm.opm_reports.tests import (OPMCaseReportTestBase, OPMCase, MockCaseRow, Report, Form, offset_date)
+from custom.opm.opm_reports.tests import (OPMCaseReportTestBase, OPMCase, MockCaseRow, Report, offset_date)
 from dimagi.utils.dates import add_months
 
 
@@ -117,7 +118,7 @@ class TestPregnancyWindowAndMonths(OPMCaseReportTestBase):
 
 class TestFormFiltering(TestCase):
     def check_form(self, received=None, num_months=None, xmlns=None):
-        form = Form(received_on=received or datetime(2014, 6, 15),
+        form = XFormInstance(received_on=received or datetime(2014, 6, 15),
                     form={'foo': 'bar'},
                     xmlns=xmlns or 'moodys://falafel.palace')
         case = OPMCase([form], dod=date(2014, 1, 10))


### PR DESCRIPTION
i couldn't see any reason why this was necessary, and i wanted to leverage other functions on XFormInstance
