### PR TITLE
fix the dates

### DIFF
--- a/custom/opm/opm_reports/beneficiary.py
+++ b/custom/opm/opm_reports/beneficiary.py
@@ -287,10 +287,20 @@ class OPMCaseRow(object):
 
     @property
     def preg_weighed(self):
+
+        def _from_case(property):
+            return self.case_property(property, 0) == 'received'
+
+        def _from_forms(filter_kwargs):
+            return any(
+                form.xpath('form/pregnancy_questions/mother_weight') == '1'
+                for form in self.filtered_forms(BIRTH_PREP_XMLNS, **filter_kwargs)
+            )
+
         if self.preg_month == 6:
-            return self.case_property('weight_tri_1') == 'received'
+            return _from_case('weight_tri_1') or _from_forms({'explicit_start': self.preg_first_eligible_datetime})
         elif self.preg_month == 9:
-            return self.case_property('weight_tri_2') == 'received'
+            return _from_case('weight_tri_2') or _from_forms({'months_before': 3})
 
     def filtered_forms(self, xmlns_or_list=None, months_before=None, months_after=None, explicit_start=None):
         """

--- a/custom/opm/opm_reports/beneficiary.py
+++ b/custom/opm/opm_reports/beneficiary.py
@@ -217,18 +217,17 @@ class OPMCaseRow(object):
         else:
             xmlns_list = xmlns_or_list or []
 
-        reference_date = self.datespan.enddate
         if months_before is not None:
-            new_year, new_month = add_months(reference_date.year, reference_date.month, -months_before)
+            new_year, new_month = add_months(self.year, self.month, -months_before)
             start = first_of_next_month(datetime.datetime(new_year, new_month, 1))
         else:
             start = None
 
         if months_after is not None:
-            new_year, new_month = add_months(reference_date.year, reference_date.month, months_after)
+            new_year, new_month = add_months(self.year, self.month, months_after)
             end = first_of_next_month(datetime.datetime(new_year, new_month, 1))
         else:
-            end = first_of_next_month(reference_date)
+            end = datetime.datetime.combine(self.reporting_window_end, datetime.time())
 
         def check_form(form):
             if xmlns_list and form.xmlns not in xmlns_list:

--- a/custom/opm/opm_reports/beneficiary.py
+++ b/custom/opm/opm_reports/beneficiary.py
@@ -175,14 +175,22 @@ class OPMCaseRow(object):
             if not self.vhnd_available:
                 return True
             elif 9 > self.preg_month > 3:
-                vhnd_attendance = {
-                    4: self.case_property('attendance_vhnd_1', 0),
-                    5: self.case_property('attendance_vhnd_2', 0),
-                    6: self.case_property('attendance_vhnd_3', 0),
-                    7: self.case_property('month_7_attended', 0),
-                    8: self.case_property('month_8_attended', 0)
-                }
-                return vhnd_attendance[self.preg_month] == '1'
+                def _legacy_method():
+                    vhnd_attendance = {
+                        4: self.case_property('attendance_vhnd_1', 0),
+                        5: self.case_property('attendance_vhnd_2', 0),
+                        6: self.case_property('attendance_vhnd_3', 0),
+                        7: self.case_property('month_7_attended', 0),
+                        8: self.case_property('month_8_attended', 0)
+                    }
+                    return vhnd_attendance[self.preg_month] == '1'
+
+                def _new_method():
+                    return any(
+                        form.xpath('form/pregnancy_questions/attendance_vhnd') == '1'
+                        for form in self.filtered_forms(BIRTH_PREP_XMLNS, 1)
+                    )
+                return _legacy_method() or _new_method()
             else:
                 return False
 

--- a/custom/opm/opm_reports/beneficiary.py
+++ b/custom/opm/opm_reports/beneficiary.py
@@ -134,6 +134,18 @@ class OPMCaseRow(object):
         if self.status == 'mother':
             return len(months_between(self.dod, self.reporting_window_start)) - 1
 
+    @property
+    @memoized
+    def window(self):
+        if self.status == 'pregnant':
+            # 4, 5, 6 --> 1,
+            # 7, 8, 9 --> 2
+            return (self.preg_month - 1) / 3
+        else:
+            # 1, 2, 3 --> 3
+            # 4, 5, 6 --> 4...
+            return ((self.child_age - 1) / 3) + 3
+
     def set_case_properties(self):
         if self.child_age is None and self.preg_month is None:
             raise InvalidRow
@@ -473,7 +485,6 @@ class ConditionsMet(OPMCaseRow):
         super(ConditionsMet, self).__init__(case, report, child_index=child_index)
         if self.status == 'mother':
             self.child_name = self.case_property(indexed_child("child1_name", child_index), EMPTY_FIELD)
-            self.preg_month = EMPTY_FIELD
             self.one = self.condition_image(C_ATTENDANCE_Y, C_ATTENDANCE_N, self.child_attended_vhnd)
             self.two = self.condition_image(C_WEIGHT_Y, C_WEIGHT_N, self.child_growth_calculated)
             self.three = self.condition_image(ORSZNTREAT_Y, ORSZNTREAT_N, self.child_received_ors)

--- a/custom/opm/opm_reports/beneficiary.py
+++ b/custom/opm/opm_reports/beneficiary.py
@@ -271,7 +271,7 @@ class OPMCaseRow(object):
 
             return any(
                 _test(form)
-                for form in self.filtered_forms(CFU1_XMLNS, 2, 1)
+                for form in self.filtered_forms(CFU1_XMLNS, 3)
             )
 
     @property
@@ -282,7 +282,7 @@ class OPMCaseRow(object):
 
             return any(
                 _test(form)
-                for form in self.filtered_forms(CFU1_XMLNS, 2, 1)
+                for form in self.filtered_forms(CFU1_XMLNS, 3)
             )
 
     @property
@@ -293,7 +293,7 @@ class OPMCaseRow(object):
 
             return any(
                 _test(form)
-                for form in self.filtered_forms([CFU1_XMLNS, CFU2_XMLNS], 2, 1)
+                for form in self.filtered_forms([CFU1_XMLNS, CFU2_XMLNS],3)
             )
 
     @property

--- a/custom/opm/opm_reports/beneficiary.py
+++ b/custom/opm/opm_reports/beneficiary.py
@@ -256,9 +256,8 @@ class OPMCaseRow(object):
                 return True
             else:
                 return any(
-                    form.xpath('form/child1/child1_attendance_vhnd') == '1'
-                    for form in self.forms
-                    if form.xmlns in CHILDREN_FORMS and self.form_in_range(form)
+                    form.xpath('form/child_1/child1_attendance_vhnd') == '1'
+                    for form in self.filtered_forms(CHILDREN_FORMS, 1)
                 )
 
     @property
@@ -328,7 +327,7 @@ class OPMCaseRow(object):
     def child_weighed_once(self):
         if self.child_age == 3:
             def _test(form):
-                return form.xpath(indexed_child('form/child1/child1_child_weight', self.child_index)) == '1'
+                return form.xpath(indexed_child('form/child_1/child1_child_weight', self.child_index)) == '1'
 
             return any(
                 _test(form)
@@ -339,7 +338,7 @@ class OPMCaseRow(object):
     def child_birth_registered(self):
         if self.child_age == 6:
             def _test(form):
-                return form.xpath(indexed_child('form/child1/child1_child_register', self.child_index)) == '1'
+                return form.xpath(indexed_child('form/child_1/child1_child_register', self.child_index)) == '1'
 
             return any(
                 _test(form)
@@ -350,7 +349,7 @@ class OPMCaseRow(object):
     def child_received_measles_vaccine(self):
         if self.child_age == 12:
             def _test(form):
-                return form.xpath(indexed_child('form/child1/child1_child_measlesvacc', self.child_index)) == '1'
+                return form.xpath(indexed_child('form/child_1/child1_child_measlesvacc', self.child_index)) == '1'
 
             return any(
                 _test(form)

--- a/custom/opm/opm_reports/beneficiary.py
+++ b/custom/opm/opm_reports/beneficiary.py
@@ -146,8 +146,15 @@ class OPMCaseRow(object):
     @memoized
     def child_age(self):
         if self.status == 'mother':
-            return len(months_between(self.dod, self.reporting_window_start)) - 1
+            non_adjusted_month = len(months_between(self.dod, self.reporting_window_start)) - 1
+            # anchor date should be their one month birthday
+            anchor_date = add_months_to_date(self.dod, 1)
 
+            month = self._adjust_for_vhnd_presence(non_adjusted_month, anchor_date)
+            if month < 1:
+                raise InvalidRow('child month %s not valid' % month)
+
+            return month
 
     @property
     def child_age_display(self):

--- a/custom/opm/opm_reports/beneficiary.py
+++ b/custom/opm/opm_reports/beneficiary.py
@@ -129,10 +129,19 @@ class OPMCaseRow(object):
             return month
 
     @property
+    def preg_month_display(self):
+        return self.preg_month if self.preg_month is not None else EMPTY_FIELD
+
+    @property
     @memoized
     def child_age(self):
         if self.status == 'mother':
             return len(months_between(self.dod, self.reporting_window_start)) - 1
+
+
+    @property
+    def child_age_display(self):
+        return self.child_age if self.child_age is not None else EMPTY_FIELD
 
     @property
     @memoized
@@ -446,9 +455,9 @@ class ConditionsMet(OPMCaseRow):
             ('block_name', _("Block Name"), True),
             ('husband_name', _("Husband Name"), True),
             ('status', _("Current status"), True),
-            ('preg_month', _('Pregnancy Month'), True),
+            ('preg_month_display', _('Pregnancy Month'), True),
             ('child_name', _("Child Name"), True),
-            ('child_age', _("Child Age"), True),
+            ('child_age_display', _("Child Age"), True),
             ('window', _("Window"), True),
             ('one', _("1"), True),
             ('two', _("2"), True),
@@ -466,9 +475,9 @@ class ConditionsMet(OPMCaseRow):
             ('block_name', _("Block Name"), True),
             ('husband_name', _("Husband Name"), True),
             ('status', _("Current status"), True),
-            ('preg_month', _('Pregnancy Month'), True),
+            ('preg_month_display', _('Pregnancy Month'), True),
             ('child_name', _("Child Name"), True),
-            ('child_age', _("Child Age"), True),
+            ('child_age_display', _("Child Age"), True),
             ('window', _("Window"), True),
             ('one', _("1"), True),
             ('two', _("2"), True),

--- a/custom/opm/opm_reports/beneficiary.py
+++ b/custom/opm/opm_reports/beneficiary.py
@@ -168,35 +168,37 @@ class OPMCaseRow(object):
 
     @property
     def preg_attended_vhnd(self):
-        # in month 9 they always meet this condition
-        if self.preg_month == 9:
-            return True
-        elif not self.vhnd_available:
-            return True
-        elif 9 > self.preg_month > 3:
-            vhnd_attendance = {
-                4: self.case_property('attendance_vhnd_1', 0),
-                5: self.case_property('attendance_vhnd_2', 0),
-                6: self.case_property('attendance_vhnd_3', 0),
-                7: self.case_property('month_7_attended', 0),
-                8: self.case_property('month_8_attended', 0)
-            }
-            return vhnd_attendance[self.preg_month] == '1'
-        else:
-            return False
+        if self.status == 'pregnant':
+            # in month 9 they always meet this condition
+            if self.preg_month == 9:
+                return True
+            if not self.vhnd_available:
+                return True
+            elif 9 > self.preg_month > 3:
+                vhnd_attendance = {
+                    4: self.case_property('attendance_vhnd_1', 0),
+                    5: self.case_property('attendance_vhnd_2', 0),
+                    6: self.case_property('attendance_vhnd_3', 0),
+                    7: self.case_property('month_7_attended', 0),
+                    8: self.case_property('month_8_attended', 0)
+                }
+                return vhnd_attendance[self.preg_month] == '1'
+            else:
+                return False
 
     @property
     def child_attended_vhnd(self):
-        if self.child_age == 1:
-            return True
-        elif not self.vhnd_available:
-            return True
-        else:
-            return any(
-                form.form.get(indexed_child('child1_vhndattend_calc', self.child_index)) == 'received'
-                for form in self.forms
-                if form.xmlns in CHILDREN_FORMS and self.form_in_range(form)
-            )
+        if self.status == 'mother':
+            if self.child_age == 1:
+                return True
+            elif not self.vhnd_available:
+                return True
+            else:
+                return any(
+                    form.form.get(indexed_child('child1_vhndattend_calc', self.child_index)) == 'received'
+                    for form in self.forms
+                    if form.xmlns in CHILDREN_FORMS and self.form_in_range(form)
+                )
 
     @property
     def preg_weighed(self):

--- a/custom/opm/opm_reports/beneficiary.py
+++ b/custom/opm/opm_reports/beneficiary.py
@@ -386,9 +386,7 @@ class OPMCaseRow(object):
     @property
     @memoized
     def vhnd_available(self):
-        if self.owner_id not in self.data_provider.vhnd_availability:
-            raise InvalidRow
-        return self.data_provider.vhnd_availability[self.owner_id]
+        return self.owner_id in self.data_provider.vhnd_dates
 
     def add_extra_children(self):
         if self.child_index == 1:

--- a/custom/opm/opm_reports/beneficiary.py
+++ b/custom/opm/opm_reports/beneficiary.py
@@ -256,7 +256,7 @@ class OPMCaseRow(object):
                 return True
             else:
                 return any(
-                    form.form.get(indexed_child('child1_vhndattend_calc', self.child_index)) == 'received'
+                    form.xpath('form/child1/child1_attendance_vhnd') == '1'
                     for form in self.forms
                     if form.xmlns in CHILDREN_FORMS and self.form_in_range(form)
                 )

--- a/custom/opm/opm_reports/reports.py
+++ b/custom/opm/opm_reports/reports.py
@@ -297,7 +297,7 @@ class SharedDataProvider(object):
     @memoized
     def _vhnd_dates(self):
         # todo: this will load one row per every VHND in history.
-        # if this gets too big we'll have to make the queries more targeted (which would be
+        # If this gets too big we'll have to make the queries more targeted (which would be
         # easy to do in the get_dates_in_range function) but if the dataset is small this will
         # avoid significantly fewer DB trips.
         # If things start getting slow or memory intensive this would be a good place to look.

--- a/custom/opm/opm_reports/reports.py
+++ b/custom/opm/opm_reports/reports.py
@@ -171,10 +171,6 @@ class VhndAvailabilitySqlData(SqlData):
     @property
     def filter_values(self):
         return {}
-        return dict(
-            startdate=self.config['startdate'],
-            enddate=self.config['enddate'],
-        )
 
     @property
     def group_by(self):

--- a/custom/opm/opm_reports/reports.py
+++ b/custom/opm/opm_reports/reports.py
@@ -13,23 +13,19 @@ import simplejson
 import re
 from dateutil import parser
 from decimal import Decimal
-from numbers import Number
 
 from django.http import HttpResponse
 from django.template import RequestContext
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext_noop, ugettext as _
 
-from couchdbkit.exceptions import ResourceNotFound
-from sqlagg.filters import ANDFilter, BETWEEN
 from dimagi.utils.couch.database import iter_docs
 from dimagi.utils.dates import DateSpan
 from dimagi.utils.decorators.memoized import memoized
 from sqlagg.base import AliasColumn
-from sqlagg.columns import SimpleColumn, SumColumn, CountColumn
+from sqlagg.columns import SimpleColumn, SumColumn
 
 from corehq.apps.es import cases as case_es, filters as es_filters
-from corehq.apps.hqcase.utils import get_cases_in_domain
 from corehq.apps.reports.cache import request_cache
 from corehq.apps.reports.datatables import DataTablesHeader, DataTablesColumn
 from corehq.apps.reports.filters.dates import DatespanFilter
@@ -41,7 +37,6 @@ from corehq.apps.reports.standard.maps import ElasticSearchMapReport
 from corehq.apps.reports.tasks import export_all_rows_task
 from corehq.apps.users.models import CommCareCase, CouchUser, CommCareUser
 from corehq.elastic import es_query
-from corehq.pillows.mappings.reportcase_mapping import REPORT_CASE_INDEX
 from corehq.pillows.mappings.user_mapping import USER_INDEX
 from corehq.util.translation import localize
 

--- a/custom/opm/opm_reports/tests/case_reports.py
+++ b/custom/opm/opm_reports/tests/case_reports.py
@@ -31,11 +31,11 @@ class MockDataProvider(SharedDataProvider):
     Mock data provider to manually specify vhnd availability per user
     """
     def __init__(self, datespan, vhnd_map=None):
-        super(MockDataProvider, self).__init__(datespan)
+        super(MockDataProvider, self).__init__()
         self.vhnd_map = vhnd_map if vhnd_map is not None else AggressiveDefaultDict(lambda: set([datespan.enddate.date()]))
 
     @property
-    def vhnd_dates(self):
+    def _vhnd_dates(self):
         return self.vhnd_map
 
 
@@ -80,7 +80,7 @@ class MockCaseRow(OPMCaseRow):
         self.report = report
         self.report.snapshot = None
         self.report.is_rendered_as_email = None
-        self.report._data_provider = data_provider or MockDataProvider(self.report.datespan)
+        self.report._data_provider = data_provider or MockDataProvider(report.datespan)
         super(MockCaseRow, self).__init__(case, report)
 
 

--- a/custom/opm/opm_reports/tests/case_reports.py
+++ b/custom/opm/opm_reports/tests/case_reports.py
@@ -85,7 +85,7 @@ class OPMCaseReportTestBase(TestCase):
 
 
 def get_relative_edd_from_preg_month(report_date, month):
-    months_until_edd = 10 - month
+    months_until_edd = 9 - month
     new_year, new_month = add_months(report_date.year, report_date.month, months_until_edd)
     return type(report_date)(new_year, new_month, 1)
 
@@ -103,6 +103,6 @@ class MockDataTest(OPMCaseReportTestBase):
         case = OPMCase(
             forms=[form],
             # add/override any desired case properties here
-            edd=date(2014, 12, 10),
+            edd=date(2014, 11, 10),
         )
         row = MockCaseRow(case, report)

--- a/custom/opm/opm_reports/tests/case_reports.py
+++ b/custom/opm/opm_reports/tests/case_reports.py
@@ -18,13 +18,21 @@ class AggressiveDefaultDict(defaultdict):
     def __contains__(self, item):
         return True
 
+    def get(self, key, default=None):
+        key_miss = object()
+        result = super(AggressiveDefaultDict, self).get(key, key_miss)
+        if result == key_miss:
+            return self[key]
+        return result
+
+
 class MockDataProvider(SharedDataProvider):
     """
     Mock data provider to manually specify vhnd availability per user
     """
     def __init__(self, datespan, vhnd_map=None):
         super(MockDataProvider, self).__init__(datespan)
-        self.vhnd_map = vhnd_map if vhnd_map is not None else AggressiveDefaultDict(lambda: set(datespan.startdate))
+        self.vhnd_map = vhnd_map if vhnd_map is not None else AggressiveDefaultDict(lambda: set([datespan.enddate.date()]))
 
     @property
     def vhnd_dates(self):

--- a/custom/opm/opm_reports/tests/case_reports.py
+++ b/custom/opm/opm_reports/tests/case_reports.py
@@ -24,10 +24,10 @@ class MockDataProvider(SharedDataProvider):
     """
     def __init__(self, datespan, vhnd_map=None):
         super(MockDataProvider, self).__init__(datespan)
-        self.vhnd_map = vhnd_map if vhnd_map is not None else AggressiveDefaultDict(lambda: True)
+        self.vhnd_map = vhnd_map if vhnd_map is not None else AggressiveDefaultDict(lambda: set(datespan.startdate))
 
     @property
-    def vhnd_availability(self):
+    def vhnd_dates(self):
         return self.vhnd_map
 
 

--- a/custom/opm/opm_reports/tests/test_birth_spacing.py
+++ b/custom/opm/opm_reports/tests/test_birth_spacing.py
@@ -24,7 +24,7 @@ class TestBirthSpacing(TestCase):
     def test_not_enough_time(self):
         case = OPMCase(
             forms=[],
-            dod=date(2014, 1, 10),
+            dod=date(2013, 12, 10),
         )
         report = Report(month=6, year=2014, block="Atri")
         row = MockCaseRow(case, report)
@@ -38,7 +38,7 @@ class TestBirthSpacing(TestCase):
                 self.not_pregnant_form(2012, 10, 12),
                 self.not_pregnant_form(2013, 10, 12),
             ],
-            dod=date(2012, 2, 10),
+            dod=date(2012, 1, 10),
         )
         report = Report(month=1, year=2014, block="Atri")
         row = MockCaseRow(case, report)
@@ -52,7 +52,7 @@ class TestBirthSpacing(TestCase):
                 self.not_pregnant_form(2013, 3, 12),
                 self.pregnant_form(2013, 10, 12),
             ],
-            dod=date(2012, 4, 10),
+            dod=date(2012, 3, 10),
         )
         report = Report(month=1, year=2014, block="Atri")
         row = MockCaseRow(case, report)
@@ -67,7 +67,7 @@ class TestBirthSpacing(TestCase):
                 self.not_pregnant_form(2013, 1, 12),
                 self.pregnant_form(2013, 10, 12),
             ],
-            dod=date(2012, 2, 10),
+            dod=date(2012, 1, 10),
         )
         report = Report(month=1, year=2014, block="Atri")
         row = MockCaseRow(case, report)

--- a/custom/opm/opm_reports/tests/test_child_condition_four.py
+++ b/custom/opm/opm_reports/tests/test_child_condition_four.py
@@ -97,7 +97,7 @@ class TestChildWeighedOnce(OPMCaseReportTestBase, ConditionFourTestMixin):
 def _valid_measles_form(received_on):
     return XFormInstance(
         form={
-            'child1': {
+            'child_1': {
                 'child1_child_measlesvacc': '1',
             }
         },
@@ -109,7 +109,7 @@ def _valid_measles_form(received_on):
 def _valid_birth_registration_form(received_on):
     return XFormInstance(
         form={
-            'child1': {
+            'child_1': {
                 'child1_child_register': '1',
             }
         },
@@ -121,7 +121,7 @@ def _valid_birth_registration_form(received_on):
 def _valid_child_weight_registration_form(received_on):
     return XFormInstance(
         form={
-            'child1': {
+            'child_1': {
                 'child1_child_weight': '1',
             }
         },

--- a/custom/opm/opm_reports/tests/test_child_condition_four.py
+++ b/custom/opm/opm_reports/tests/test_child_condition_four.py
@@ -13,7 +13,7 @@ class ConditionFourTestMixin(object):
 
     @property
     def valid_dod(self):
-        return offset_date(self.report_date, -(self.expected_window - 1))
+        return offset_date(self.report_date, -self.expected_window)
 
     def valid_form(self, received_on):
         return self.valid_form_function(received_on)
@@ -48,17 +48,8 @@ class ConditionFourTestMixin(object):
             row = MockCaseRow(case, self.report)
             self.assertEqual(True, self.get_condition(row))
 
-    def test_one_month_extension_valid(self):
+    def test_one_month_extension_not_valid(self):
         form_date = offset_date(self.report_datetime, 1)
-        case = OPMCase(
-            forms=[self.valid_form(form_date)],
-            dod=self.valid_dod,
-        )
-        row = MockCaseRow(case, self.report)
-        self.assertEqual(True, self.get_condition(row))
-
-    def test_two_month_extension_not_valid(self):
-        form_date = offset_date(self.report_datetime, 2)
         case = OPMCase(
             forms=[self.valid_form(form_date)],
             dod=self.valid_dod,

--- a/custom/opm/opm_reports/tests/test_child_conditions.py
+++ b/custom/opm/opm_reports/tests/test_child_conditions.py
@@ -33,7 +33,7 @@ class ChildConditionMixin(object):
     def check_condition(self, forms=None, child_age=None):
         child_age = child_age or 5
         report_year, report_month = 2014, 6
-        dod_year, dod_month = add_months(report_year, report_month, 1-child_age)
+        dod_year, dod_month = add_months(report_year, report_month, -child_age)
         report = Report(month=report_month, year=report_year, block="Atri")
         case = OPMCase(
             forms=forms or [],

--- a/custom/opm/opm_reports/tests/test_child_conditions.py
+++ b/custom/opm/opm_reports/tests/test_child_conditions.py
@@ -30,7 +30,7 @@ class ChildConditionMixin(object):
             xmlns=self.xmlns,
         )
 
-    def check_condition(self, forms=None, report=None, child_age=None):
+    def check_condition(self, forms=None, child_age=None):
         child_age = child_age or 5
         report_year, report_month = 2014, 6
         dod_year, dod_month = add_months(report_year, report_month, 1-child_age)
@@ -43,17 +43,17 @@ class ChildConditionMixin(object):
         self.assertEqual(row.child_age, child_age)
         return getattr(row, self.row_property)
 
-    def assertMeetsCondition(self, forms=None, report=None, child_age=None):
+    def assertMeetsCondition(self, forms=None, child_age=None):
         msg = "{} did not return True".format(self.row_property)
-        self.assertTrue(self.check_condition(forms, report, child_age), msg)
+        self.assertTrue(self.check_condition(forms, child_age), msg)
 
-    def assertFailsCondition(self, forms=None, report=None, child_age=None):
+    def assertFailsCondition(self, forms=None, child_age=None):
         msg = "{} did not return False".format(self.row_property)
-        self.assertEqual(False, self.check_condition(forms, report, child_age), msg)
+        self.assertEqual(False, self.check_condition(forms, child_age), msg)
 
-    def assertConditionIrrelevant(self, forms=None, report=None, child_age=None):
+    def assertConditionIrrelevant(self, forms=None, child_age=None):
         msg = "{} did not return None".format(self.row_property)
-        self.assertEqual(None, self.check_condition(forms, report, child_age), msg)
+        self.assertEqual(None, self.check_condition(forms, child_age), msg)
 
 
 

--- a/custom/opm/opm_reports/tests/test_preg_conditions.py
+++ b/custom/opm/opm_reports/tests/test_preg_conditions.py
@@ -1,7 +1,10 @@
-from datetime import date
+from datetime import date, time, datetime
 from unittest import TestCase
 
 from .case_reports import Report, OPMCase, MockCaseRow, OPMCaseReportTestBase
+from couchforms.models import XFormInstance
+from custom.opm.opm_reports.constants import BIRTH_PREP_XMLNS
+from dimagi.utils.dates import add_months_to_date
 
 
 class TestMotherWeightMonitored(TestCase):
@@ -33,10 +36,12 @@ class TestMotherWeightMonitored(TestCase):
 
 
 class TestMotherReceivedIFA(OPMCaseReportTestBase):
+    valid_edd = date(2014, 9, 15)
+
     def case(self, met=True):
         return OPMCase(
             forms=[],
-            edd=date(2014, 9, 15),
+            edd=self.valid_edd,
             ifa_tri_1='received' if met else 'not_taken',
        )
 
@@ -52,15 +57,54 @@ class TestMotherReceivedIFA(OPMCaseReportTestBase):
         row = MockCaseRow(self.case(), self.report)
         self.assertEqual(row.preg_month, 6)
 
-    def test_soft_block_n_a(self):
+    def test_soft_block_not_checked(self):
         report = Report(month=6, year=2014, block="Wazirganj")
         row = MockCaseRow(self.case(met=False), report)
         self.assertEqual(None, row.preg_received_ifa)
 
-    def test_never_received_ifa(self):
+    def test_legacy_never_received_ifa(self):
         row = MockCaseRow(self.case(met=False), self.report)
         self.assertEqual(False, row.preg_received_ifa)
 
-    def test_condition_met(self):
+    def test_legacy_received_ifa(self):
         row = MockCaseRow(self.case(met=True), self.report)
         self.assertTrue(row.preg_received_ifa)
+
+    def test_received_ifa_in_forms(self):
+        form = _form_with_ifa(self.report_datetime)
+        case = OPMCase(
+            forms=[form],
+            edd=self.valid_edd,
+        )
+        row = MockCaseRow(case, self.report)
+        self.assertTrue(row.preg_received_ifa)
+
+    def test_received_ifa_look_back(self):
+        form = _form_with_ifa(datetime.combine(add_months_to_date(self.valid_edd, -6), time()))
+        case = OPMCase(
+            forms=[form],
+            edd=self.valid_edd,
+        )
+        row = MockCaseRow(case, self.report)
+        self.assertTrue(row.preg_received_ifa)
+
+    def test_received_ifa_look_back_only_6_months(self):
+        form = _form_with_ifa(datetime.combine(add_months_to_date(self.valid_edd, -7), time()))
+        case = OPMCase(
+            forms=[form],
+            edd=self.valid_edd,
+        )
+        row = MockCaseRow(case, self.report)
+        self.assertFalse(row.preg_received_ifa)
+
+
+def _form_with_ifa(received_on):
+    return XFormInstance(
+        received_on=received_on,
+        xmlns=BIRTH_PREP_XMLNS,
+        form={
+            'pregnancy_questions': {
+                'ifa_receive': '1'
+            }
+        }
+    )

--- a/custom/opm/opm_reports/tests/test_preg_conditions.py
+++ b/custom/opm/opm_reports/tests/test_preg_conditions.py
@@ -8,7 +8,7 @@ class TestMotherWeightMonitored(TestCase):
     def setUp(self):
         self.case = OPMCase(
             forms=[],
-            edd=date(2014, 10, 15),
+            edd=date(2014, 9, 15),
             weight_tri_1="received",
             weight_tri_2="not_taken",
        )
@@ -36,7 +36,7 @@ class TestMotherReceivedIFA(OPMCaseReportTestBase):
     def case(self, met=True):
         return OPMCase(
             forms=[],
-            edd=date(2014, 10, 15),
+            edd=date(2014, 9, 15),
             ifa_tri_1='received' if met else 'not_taken',
        )
 

--- a/custom/opm/opm_reports/tests/test_preg_conditions.py
+++ b/custom/opm/opm_reports/tests/test_preg_conditions.py
@@ -1,4 +1,4 @@
-from datetime import date, time, datetime
+from datetime import date, time, datetime, timedelta
 from unittest import TestCase
 
 from .case_reports import Report, OPMCase, MockCaseRow, OPMCaseReportTestBase
@@ -7,14 +7,19 @@ from custom.opm.opm_reports.constants import BIRTH_PREP_XMLNS
 from dimagi.utils.dates import add_months_to_date
 
 
-class TestMotherWeightMonitored(TestCase):
+class TestMotherWeightMonitored(OPMCaseReportTestBase):
+    valid_edd = date(2014, 9, 15)
+
     def setUp(self):
+        super(TestMotherWeightMonitored, self).setUp()
         self.case = OPMCase(
             forms=[],
-            edd=date(2014, 9, 15),
+            edd=self.valid_edd,
             weight_tri_1="received",
             weight_tri_2="not_taken",
-       )
+        )
+        self.second_trimester_report = Report(month=9, year=2014, block="Atri")
+
 
     def test_inapplicable_month(self):
         report = Report(month=7, year=2014, block="Atri")
@@ -22,16 +27,60 @@ class TestMotherWeightMonitored(TestCase):
         self.assertEqual(row.preg_month, 7)
         self.assertEqual(None, row.preg_weighed)
 
-    def test_condition_met(self):
+    def test_legacy_condition_met(self):
         report = Report(month=6, year=2014, block="Atri")
         row = MockCaseRow(self.case, report)
         self.assertEqual(row.preg_month, 6)
         self.assertTrue(row.preg_weighed)
 
-    def test_condition_not_met(self):
-        report = Report(month=9, year=2014, block="Atri")
-        row = MockCaseRow(self.case, report)
+    def test_legacy_condition_not_met(self):
+        row = MockCaseRow(self.case, self.second_trimester_report)
         self.assertEqual(row.preg_month, 9)
+        self.assertFalse(row.preg_weighed)
+
+    def test_birth_weight_monitored_first_trimester(self):
+        form = _form_with_weight_monitor(self.report_datetime)
+        case = OPMCase(
+            forms=[form],
+            edd=self.valid_edd,
+        )
+        row = MockCaseRow(case, self.report)
+        self.assertTrue(row.preg_weighed)
+
+    def test_birth_weight_monitored_second_trimester(self):
+        form = _form_with_weight_monitor(datetime(2014, 8, 1))
+        case = OPMCase(
+            forms=[form],
+            edd=self.valid_edd,
+        )
+        row = MockCaseRow(case, self.second_trimester_report)
+        self.assertTrue(row.preg_weighed)
+
+    def test_birth_weight_monitored_first_trimester_lookback(self):
+        form = _form_with_weight_monitor(datetime.combine(add_months_to_date(self.valid_edd, -6), time()))
+        case = OPMCase(
+            forms=[form],
+            edd=self.valid_edd,
+        )
+        row = MockCaseRow(case, self.report)
+        self.assertTrue(row.preg_weighed)
+
+    def test_birth_weight_monitored_first_trimester_lookback_only_6_months(self):
+        form = _form_with_weight_monitor(datetime.combine(add_months_to_date(self.valid_edd, -7), time()))
+        case = OPMCase(
+            forms=[form],
+            edd=self.valid_edd,
+        )
+        row = MockCaseRow(case, self.report)
+        self.assertFalse(row.preg_weighed)
+
+    def test_birth_weight_monitored_second_trimester_no_lookback(self):
+        form = _form_with_weight_monitor(datetime.combine(add_months_to_date(self.valid_edd, -4), time()))
+        case = OPMCase(
+            forms=[form],
+            edd=self.valid_edd,
+        )
+        row = MockCaseRow(case, self.second_trimester_report)
         self.assertFalse(row.preg_weighed)
 
 
@@ -79,7 +128,7 @@ class TestMotherReceivedIFA(OPMCaseReportTestBase):
         row = MockCaseRow(case, self.report)
         self.assertTrue(row.preg_received_ifa)
 
-    def test_received_ifa_look_back(self):
+    def test_received_ifa_lookback(self):
         form = _form_with_ifa(datetime.combine(add_months_to_date(self.valid_edd, -6), time()))
         case = OPMCase(
             forms=[form],
@@ -88,7 +137,7 @@ class TestMotherReceivedIFA(OPMCaseReportTestBase):
         row = MockCaseRow(case, self.report)
         self.assertTrue(row.preg_received_ifa)
 
-    def test_received_ifa_look_back_only_6_months(self):
+    def test_received_ifa_lookback_only_6_months(self):
         form = _form_with_ifa(datetime.combine(add_months_to_date(self.valid_edd, -7), time()))
         case = OPMCase(
             forms=[form],
@@ -96,6 +145,18 @@ class TestMotherReceivedIFA(OPMCaseReportTestBase):
         )
         row = MockCaseRow(case, self.report)
         self.assertFalse(row.preg_received_ifa)
+
+
+def _form_with_weight_monitor(received_on):
+    return XFormInstance(
+        received_on=received_on,
+        xmlns=BIRTH_PREP_XMLNS,
+        form={
+            'pregnancy_questions': {
+                'mother_weight': '1'
+            }
+        }
+    )
 
 
 def _form_with_ifa(received_on):

--- a/custom/opm/opm_reports/tests/test_status.py
+++ b/custom/opm/opm_reports/tests/test_status.py
@@ -8,7 +8,7 @@ class TestPregnancyStatus(OPMCaseReportTestBase):
     def test_not_yet_delivered(self):
         case = OPMCase(
             forms=[],
-            edd=date(2014, 12, 10),
+            edd=date(2014, 11, 10),
         )
         row = MockCaseRow(case, self.report)
         self.assertEqual('pregnant', row.status)
@@ -49,6 +49,12 @@ class TestPregnancyStatus(OPMCaseReportTestBase):
             forms=[],
             edd=date(2014, 6, 10),
         )
-        # todo: is this really right? this person won't count to either status in the month
-        # is that valid given that people deliver late? (maybe yes since they have already had 6 months counting
+        row = MockCaseRow(case, self.report)
+        self.assertEqual('pregnant', row.status)
+
+    def test_due_after_period_not_delivered(self):
+        case = OPMCase(
+            forms=[],
+            edd=date(2014, 5, 10),
+        )
         self.assertRaises(InvalidRow, MockCaseRow, case, self.report)

--- a/custom/opm/opm_reports/tests/test_vhnd.py
+++ b/custom/opm/opm_reports/tests/test_vhnd.py
@@ -66,7 +66,7 @@ class TestChildVHND(OPMCaseReportTestBase):
     def test_always_positive_in_first_month(self):
         case = OPMCase(
             forms=[],
-            dod=date(2014, 6, 10),
+            dod=date(2014, 5, 10),
         )
         row = MockCaseRow(case, self.report)
         self.assertEqual(True, row.child_attended_vhnd)
@@ -105,7 +105,7 @@ class TestPregnancyVHND(OPMCaseReportTestBase):
     def test_no_data_not_match(self):
         case = OPMCase(
             forms=[],
-            edd=date(2014, 12, 10),
+            edd=date(2014, 11, 10),
         )
         row = MockCaseRow(case, self.report)
         self.assertEqual(False, row.preg_attended_vhnd)
@@ -146,7 +146,7 @@ class TestPregnancyVHND(OPMCaseReportTestBase):
     def test_positive_when_no_vhnd(self):
         case = OPMCase(
             forms=[],
-            edd=date(2014, 12, 10),
+            edd=date(2014, 11, 10),
         )
         data_provider = MockDataProvider(self.report.datespan, vhnd_map={
             'Sahora': False,
@@ -157,7 +157,7 @@ class TestPregnancyVHND(OPMCaseReportTestBase):
     def test_no_vhnd_specified(self):
         case = OPMCase(
             forms=[],
-            edd=date(2014, 12, 10),
+            edd=date(2014, 11, 10),
         )
         data_provider = MockDataProvider(self.report.datespan, vhnd_map={})
         row = MockCaseRow(case, self.report, data_provider=data_provider)

--- a/custom/opm/opm_reports/tests/test_vhnd.py
+++ b/custom/opm/opm_reports/tests/test_vhnd.py
@@ -113,6 +113,15 @@ class TestPregnancyVHNDNew(OPMCaseReportTestBase):
         row = MockCaseRow(case, self.report, data_provider=data_provider)
         self.assertEqual(True, row.preg_attended_vhnd)
 
+    def test_first_window_looks_back(self):
+        form = _preg_form_with_vhnd_attendance(datetime(2014, 5, 25))
+        edd = get_relative_edd_from_preg_month(self.report_date, 4)
+        case = OPMCase(
+            forms=[form],
+            edd=edd,
+        )
+        row = MockCaseRow(case, self.report)
+        self.assertEqual(True, row.preg_attended_vhnd)
 
 class TestPregnancyVHNDLegacy(OPMCaseReportTestBase):
     # mapping month of pregnancy to case properties that trigger vhnd attendance

--- a/custom/opm/opm_reports/tests/test_vhnd.py
+++ b/custom/opm/opm_reports/tests/test_vhnd.py
@@ -154,7 +154,7 @@ def _child_form_with_vhnd_attendance(received_on, xmlns=CFU1_XMLNS):
         received_on=received_on,
         xmlns=xmlns,
         form={
-            'child1': {
+            'child_1': {
                 'child1_attendance_vhnd': '1'
             }
         }
@@ -165,7 +165,7 @@ def _child_form_without_vhnd_attendance(received_on, xmlns=CFU1_XMLNS):
         received_on=received_on,
         xmlns=xmlns,
         form={
-            'child1': {
+            'child_1': {
                 'child1_attendance_vhnd': '0'
             }
         },

--- a/custom/opm/opm_reports/tests/test_vhnd.py
+++ b/custom/opm/opm_reports/tests/test_vhnd.py
@@ -1,6 +1,6 @@
 from datetime import date, datetime, timedelta
 from couchforms.models import XFormInstance
-from custom.opm.opm_reports.constants import InvalidRow, CFU2_XMLNS, CHILDREN_FORMS, BIRTH_PREP_XMLNS
+from custom.opm.opm_reports.constants import CFU2_XMLNS, CHILDREN_FORMS, BIRTH_PREP_XMLNS
 from custom.opm.opm_reports.tests.case_reports import OPMCaseReportTestBase, OPMCase, MockCaseRow, \
     get_relative_edd_from_preg_month, MockDataProvider
 
@@ -76,20 +76,9 @@ class TestChildVHND(OPMCaseReportTestBase):
             forms=[],
             dod=date(2014, 3, 10),
         )
-        data_provider = MockDataProvider(self.report.datespan, vhnd_map={
-            'Sahora': False,
-        })
-        row = MockCaseRow(case, self.report, data_provider=data_provider)
-        self.assertEqual(True, row.child_attended_vhnd)
-
-    def test_no_vhnd_specified(self):
-        case = OPMCase(
-            forms=[],
-            dod=date(2014, 3, 10),
-        )
         data_provider = MockDataProvider(self.report.datespan, vhnd_map={})
         row = MockCaseRow(case, self.report, data_provider=data_provider)
-        self.assertRaises(InvalidRow, lambda: row.child_attended_vhnd)
+        self.assertEqual(True, row.child_attended_vhnd)
 
 
 class TestPregnancyVHNDNew(OPMCaseReportTestBase):
@@ -136,20 +125,9 @@ class TestPregnancyVHNDNew(OPMCaseReportTestBase):
             forms=[],
             edd=date(2014, 11, 10),
         )
-        data_provider = MockDataProvider(self.report.datespan, vhnd_map={
-            'Sahora': False,
-        })
-        row = MockCaseRow(case, self.report, data_provider=data_provider)
-        self.assertEqual(True, row.preg_attended_vhnd)
-
-    def test_no_vhnd_specified(self):
-        case = OPMCase(
-            forms=[],
-            edd=date(2014, 11, 10),
-        )
         data_provider = MockDataProvider(self.report.datespan, vhnd_map={})
         row = MockCaseRow(case, self.report, data_provider=data_provider)
-        self.assertRaises(InvalidRow, lambda: row.preg_attended_vhnd)
+        self.assertEqual(True, row.preg_attended_vhnd)
 
 
 class TestPregnancyVHNDLegacy(OPMCaseReportTestBase):

--- a/custom/opm/opm_reports/tests/test_windows_and_months.py
+++ b/custom/opm/opm_reports/tests/test_windows_and_months.py
@@ -3,10 +3,6 @@ from datetime import date, datetime
 from couchforms.models import XFormInstance
 from custom.opm.opm_reports.constants import InvalidRow
 from custom.opm.opm_reports.tests import (OPMCaseReportTestBase, OPMCase, MockCaseRow, Report, offset_date)
-from dimagi.utils.dates import add_months
-
-
-
 
 
 class TestPregnancyWindowAndMonths(OPMCaseReportTestBase):
@@ -17,34 +13,15 @@ class TestPregnancyWindowAndMonths(OPMCaseReportTestBase):
         """
         return offset_date(self.report_date, offset)
 
-    def test_valid_window_not_yet_delivered(self):
-        # maps number of months in the future your due date is to window
-        window_mapping = {
-            1: 2,
-            2: 2,
-            3: 2,
-            4: 1,
-            5: 1,
-            6: 1,
-        }
-        for i, window in window_mapping.items():
-            case = OPMCase(
-                forms=[],
-                edd=self._offset_date(i),
-            )
-            row = MockCaseRow(case, self.report)
-            self.assertEqual('pregnant', row.status)
-            self.assertEqual(window, row.window)
-
     def test_valid_month_not_yet_delivered(self):
         # maps number of months in the future your due date is to month of pregnancy
         month_mapping = {
-            1: 9,
-            2: 8,
-            3: 7,
-            4: 6,
-            5: 5,
-            6: 4,
+            0: 9,
+            1: 8,
+            2: 7,
+            3: 6,
+            4: 5,
+            5: 4,
         }
         for i, month in month_mapping.items():
             case = OPMCase(
@@ -59,51 +36,17 @@ class TestPregnancyWindowAndMonths(OPMCaseReportTestBase):
         # 7 or more months in the future you don't count
         case = OPMCase(
             forms=[],
-            edd=self._offset_date(7),
+            edd=self._offset_date(6),
         )
         self.assertRaises(InvalidRow, MockCaseRow, case, self.report)
 
     def test_past_range(self):
-        # anytime in the period or after you don't count
+        # anytime after the period you don't count
         case = OPMCase(
             forms=[],
-            edd=self.report_date,
+            edd=self._offset_date(-1),
         )
         self.assertRaises(InvalidRow, MockCaseRow, case, self.report)
-
-    def test_valid_child_window(self):
-        # maps number of months in the past your delivery date was to window of child calc
-        # todo: this seems really funny. Should 0-2 map to 3, 3-5 map to 4, etc.?
-        window_mapping = {
-            0: 1,
-            1: 1,
-            2: 1,
-            3: 2,
-            4: 2,
-            5: 2,
-            6: 3,
-            7: 3,
-            8: 3,
-            9: 4,
-            10: 4,
-            11: 4,
-            12: 5,
-            13: 5,
-            14: 5,
-            15: 6,
-            16: 6,
-            17: 6,
-        }
-        for i, window in window_mapping.items():
-            case = OPMCase(
-                forms=[],
-                dod=self._offset_date(-i),
-            )
-            row = MockCaseRow(case, self.report)
-            self.assertEqual('mother', row.status)
-            self.assertEqual(window, row.window, 'value {} expected window {} but was {}'.format(
-                i, window, row.window
-            ))
 
     def test_valid_child_month(self):
         for i in range(18):
@@ -113,7 +56,7 @@ class TestPregnancyWindowAndMonths(OPMCaseReportTestBase):
             )
             row = MockCaseRow(case, self.report)
             self.assertEqual('mother', row.status)
-            self.assertEqual(i + 1, row.child_age)
+            self.assertEqual(i, row.child_age)
 
 
 class TestFormFiltering(TestCase):


### PR DESCRIPTION
the main change is updating the window logic to be valid according to
the period that ends N months from the anchor date as per
https://docs.google.com/a/dimagi.com/document/d/1Wu3vZWTbVTYw_oFH10SwgOuY37e7iMyCuHDbyX2zM_E/edit

also includes a fairly sizeable refactor including:
- pull status, preg_month and child_age into properties
- make it clear in the row it is only one month/year
- make datespan calculated from the month/year
- get rid of window entirely
- make end be the first of the next period and update filters to not be inclusive
- fixing all tests
- updating calcs (that i knew about) to correctly handle the new date ranges

the meat is in 5d56c1618ab4b37874da258d29717e28f9917788 and then there's a long tail of test fixes
