### PR TITLE
Add redis server to install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
   - "time (bash -e .travis/misc-setup.sh | ts)"
   - "cp .travis/localsettings.py localsettings.py"
   - "pip install coverage unittest2 mock --use-mirrors"
+  - "sudo service redis-server restart"
 script: "coverage run manage.py test --noinput --failfast --testrunner=$TEST_RUNNER"
 after_success:
   - coverage report

--- a/requirements/apt-packages.txt
+++ b/requirements/apt-packages.txt
@@ -6,6 +6,7 @@ libevent-dev
 python-setuptools
 postgresql
 memcached
+redis-server
 gdebi-core
 apache2
 


### PR DESCRIPTION
The redis-server was missing from requirements/apt-packages.txt. This causes errors when a fresh install is run. The Travis build server comes with a version of redis-server installed and simply adding redis-server to the apt-packages file caused a travis build error. Therefore, I had to add a line that restarts the redis-server just before the manage.py test is run to the travis.yml file.
