### PR TITLE
Add redis-server and [travis_ignore]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
     - CFLAGS=-O0
     - COUCHDB_USER=""
     - COUCHDB_PW=""
+    - TRAVIS_INSTALL="y"
   matrix:
     - TEST_RUNNER=testrunner.GroupTestRunnerCatchall
     - TEST_RUNNER=testrunner.GroupTestRunner0

--- a/install.sh
+++ b/install.sh
@@ -73,7 +73,12 @@ if [ $? -eq 0 ]; then
     fi
     sudo apt-get update
 
-    cat requirements/apt-packages.txt | sed 's/#.*$//g' | xargs sudo apt-get install -y
+    ## Ignore packages that have the [travis_ignore] hashtag from the apt-packages.txt file if TRAVIS_INSTALL = yes
+    if [ "$TRAVIS_INSTALL" == "y" ]; then
+        grep -v '\[travis_ignore\]' requirements/apt-packages.txt | sed 's/#.*$//g' | xargs sudo apt-get install -y
+    else
+        cat requirements/apt-packages.txt | sed 's/#.*$//g' | xargs sudo apt-get install -y
+    fi
 
 else
     command -v yum > /dev/null 2>&1

--- a/requirements/apt-packages.txt
+++ b/requirements/apt-packages.txt
@@ -9,6 +9,10 @@ memcached
 gdebi-core
 apache2
 
+# packages ignored by travis install
+# note: you have to incude the hashtag after each package to ensure they are ignored
+redis-server # [travis_ignore]
+
 # dependencies for the pip modules
 libxml2-dev
 libxslt-dev 


### PR DESCRIPTION
These changes allow the install.sh file to do a full clean install on a new machine. The travis build environment already contains a redis-server package that is a more recent version than that which is available from the Ubuntu 12.04 packages. Prior attempts ( Dimagi pull request #4112) caused the stock redis-server on the travis build to have to be restarted. This change allows travis to ignore the redis-server apt-get package, but fully installs on a new machine.
