### PR TITLE
Fixed a bug with empty ES "or" filters

### DIFF
--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -373,10 +373,13 @@ class ExpandedMobileWorkerFilter(EmwfMixin, BaseMultipleOptionFilter):
                 filters.term("_id", user_ids),
                 filters.term("__group_ids", group_ids),
             )
-            return q.OR(
-                id_filter,
-                filters.OR(*user_type_filters),
-            )
+            if user_type_filters:
+                return q.OR(
+                    id_filter,
+                    filters.OR(*user_type_filters),
+                )
+            else:
+                return q.filter(id_filter)
 
 
     @classmethod


### PR DESCRIPTION
If `user_type_filters` is an empty list, we get an empty or filter, which ES doesn't like. Perhaps a better thing to do would be to modify the `filters.OR` function to handle this situation itself. What do you think @esoergel ? (feel free to make the changes yourself if you think of something better)
