### PR TITLE
Remove redundant merge checks

### DIFF
--- a/scripts/gitutils.py
+++ b/scripts/gitutils.py
@@ -20,7 +20,10 @@ class OriginalBranch(object):
         return self.original_branch
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.git.checkout(self.original_branch)
+        try:
+            self.git.checkout(self.original_branch)
+        except Exception as err:
+            print "cannot checkout '{}': {}".format(self.original_branch, err)
 
 
 def git_current_branch(git=None):

--- a/scripts/rebuildstaging
+++ b/scripts/rebuildstaging
@@ -2,13 +2,14 @@
 
 function usage() {
     cat << EOF
-usage: $0 [-h|--help] [-v|--verbose] [--deploy] [--skip-fetch]
+usage: $0 [-h|--help] [-v|--verbose] [--deploy|--no-push] [--skip-fetch]
 
 rebuild staging from yaml configuration (scripts/staging.yaml)
 
     -h --help       print this help text
     -v --verbose    display debugging output
     --deploy        deploy after rebuild is complete
+    --no-push       do not push changes (cannot be used with --deploy)
     --skip-fetch    assume local copy is already update date with remote
 EOF
 }
@@ -33,6 +34,10 @@ do
         skip_fetch=y
         echo skip-fetch
         ;;
+      --no-push)
+        no_push=y
+        echo no-push
+        ;;
       *)
         usage
         exit 1
@@ -47,8 +52,9 @@ function rebuildstaging() {
 args=''
 
 [[ $verbose = 'y' ]] && args="$args -v"
+[[ $no_push = 'y' ]] && args="$args --no-push"
 
-[[ $skip_fetch = 'y' ]] && args="$args sync check rebuild"
+[[ $skip_fetch = 'y' ]] && args="$args sync rebuild"
 
 # if staging.yaml isn't up-to-date, warn and quit
 git fetch origin master
@@ -59,7 +65,7 @@ then
     exit 1
 fi
 
-if [[ $deploy = 'y' ]]
+if [[ $deploy = 'y' && $no_push != 'y' ]]
 then
     rebuildstaging $args && git checkout autostaging && fab staging awesome_deploy:confirm=no
 else

--- a/scripts/rebuildstaging.py
+++ b/scripts/rebuildstaging.py
@@ -165,7 +165,7 @@ def rebuild_staging(config, print_details=True, push=True):
                 try:
                     git.merge(branch, '--no-edit')
                 except sh.ErrorReturnCode_1:
-                    merge_conflicts.append((path, origin(config.trunk), branch))
+                    merge_conflicts.append((path, branch, config.name))
                     git.merge("--abort")
                     print "FAIL"
                 else:
@@ -193,15 +193,15 @@ def rebuild_staging(config, print_details=True, push=True):
             )
     if merge_conflicts:
         print "You must fix the following merge conflicts before rebuilding:"
-        for cwd, trunk, branch in merge_conflicts:
-            print "  [{cwd}] {branch} => {trunk}".format(
+        for cwd, branch, name in merge_conflicts:
+            print "  [{cwd}] {branch} => {name}".format(
                 cwd=format_cwd(cwd),
                 branch=branch,
-                trunk=trunk,
+                name=name,
             )
             git = get_git(cwd)
             if print_details:
-                print_merge_details(branch, trunk, git)
+                print_merge_details(branch, name, git)
 
     if merge_conflicts or not_found:
         exit(1)

--- a/scripts/rebuildstaging.py
+++ b/scripts/rebuildstaging.py
@@ -136,7 +136,7 @@ def sync_local_copies(config):
         print "All branches up-to-date."
 
 
-def rebuild_staging(config, push=True):
+def rebuild_staging(config, print_details=True, push=True):
     merge_conflicts = []
     not_found = []
     all_configs = list(config.span_configs())
@@ -274,4 +274,4 @@ if __name__ == '__main__':
         if 'sync' in args:
             sync_local_copies(config)
         if 'rebuild' in args:
-            rebuild_staging(config, do_push)
+            rebuild_staging(config, push=do_push)


### PR DESCRIPTION
This should make rebuildstaging quite a bit faster by eliminating the reverse-merges.

@dannyroberts @czue 
