### PR TITLE
Birth Spacing Bonus -> Bonus Payment

### DIFF
--- a/custom/opm/opm_reports/beneficiary.py
+++ b/custom/opm/opm_reports/beneficiary.py
@@ -659,7 +659,7 @@ class Beneficiary(OPMCaseRow):
         ('bp2_cash', _("Birth Preparedness Form 2"), True),
         ('delivery_cash', _("Delivery Form"), True),
         ('child_cash', _("Child Followup Form"), True),
-        ('year_end_bonus_cash', _("Birth Spacing Bonus"), True),
+        ('year_end_bonus_cash', _("Bonus Payment"), True),
         ('total', _("Amount to be paid to beneficiary"), True),
         ('owner_id', _("Owner ID"), False)
     ]


### PR DESCRIPTION
> 1. For bonus payment right now the column in the BPR says "Birth
>    Spacing Bonus", which is where we assume the "Weight Grade Normal"
>    payment should also go. Should it be renamed it to "Year-end total" or
>    would you prefer to have two separate columns for it?

Can you rename it as bonus payment?
