### PR TITLE
make cache invalidate pillow use the right signature

### DIFF
--- a/corehq/pillows/cacheinvalidate.py
+++ b/corehq/pillows/cacheinvalidate.py
@@ -31,7 +31,7 @@ class CacheInvalidatePillow(BasicPillow):
     def reset_checkpoint(self):
         pass
 
-    def get_checkpoint(self):
+    def get_checkpoint(self, verify_unchanged=False):
         doc_name = self.get_checkpoint_doc_name()
         current_db_seq = self.couch_db.info()['update_seq']
         checkpoint_doc = {


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?131015

looks like this has been broken since https://github.com/dimagi/pillowtop/commit/f70c02c8c1b0de9ab15144c02e145a12c3ba08a5
