### PR TITLE
Send app_id as query parameter in form forwards

### DIFF
--- a/corehq/apps/receiverwrapper/models.py
+++ b/corehq/apps/receiverwrapper/models.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timedelta
 import json
+import urllib
+import urlparse
 
 from couchdbkit.ext.django.schema import *
 from couchdbkit.exceptions import ResourceNotFound
@@ -118,6 +120,10 @@ class Repeater(Document, UnicodeMixIn):
             self['base_doc'] += DELETED
         self.save()
 
+    def get_url(self, repeate_record):
+        # to be overridden
+        return self.url
+
     def get_headers(self, repeat_record):
         # to be overridden
         return {}
@@ -137,6 +143,15 @@ class FormRepeater(Repeater):
 
     def get_payload(self, repeat_record):
         return self._payload_doc(repeat_record).get_xml()
+
+    def get_url(self, repeat_record):
+        url = super(FormRepeater, self).get_url(repeat_record)
+        # adapted from http://stackoverflow.com/a/2506477/10840
+        url_parts = list(urlparse.urlparse(url))
+        query = urlparse.parse_qsl(url_parts[4])
+        query.append(("app_id", self._payload_doc(repeat_record).app_id))
+        url_parts[4] = urllib.urlencode(query)
+        return urlparse.urlunparse(url_parts)
 
     def get_headers(self, repeat_record):
         return {
@@ -243,7 +258,7 @@ class RepeatRecord(Document, LockableMixIn):
 
     @property
     def url(self):
-        return self.repeater.url
+        return self.repeater.get_url(self)
 
     @classmethod
     def all(cls, domain=None, due_before=None, limit=None):

--- a/corehq/apps/receiverwrapper/tests/test_repeater.py
+++ b/corehq/apps/receiverwrapper/tests/test_repeater.py
@@ -128,9 +128,11 @@ class RepeaterTest(TestCase):
 
         self.clear_log()
 
+        records_by_repeater_id = {}
         for repeat_record in repeat_records:
             repeat_record.fire(post_fn=self.make_post_fn([404, 404, 404]))
             repeat_record.save()
+            records_by_repeater_id[repeat_record.repeater_id] = repeat_record
 
         for (url, status, data, headers) in self.log:
             self.assertEqual(status, 404)
@@ -166,13 +168,15 @@ class RepeaterTest(TestCase):
         # This is deterministic but easily affected by minor code changes
 
         # check case stuff
-        self.assertEqual(self.log[1][:2], (self.case_repeater.url, 200))
+        rec = records_by_repeater_id[self.case_repeater.get_id]
+        self.assertEqual(self.log[1][:2], (self.case_repeater.get_url(rec), 200))
         self.assertIn('server-modified-on', self.log[1][3])
         check_xml_line_by_line(self, self.log[1][2], case_block)
 
         # check form stuff
+        rec = records_by_repeater_id[self.form_repeater.get_id]
         self.assertEqual(self.log[3][:3],
-                         (self.form_repeater.url, 200, xform_xml))
+                         (self.form_repeater.get_url(rec), 200, xform_xml))
         self.assertIn('received-on', self.log[3][3])
 
         repeat_records = RepeatRecord.all(


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?123057

Depends on https://github.com/dimagi/dimagi-utils/pull/212 to send the new parameter, but will work without it.
