### PR TITLE
bump gunicorn max_requests to 600

### DIFF
--- a/services/gunicorn_conf.py
+++ b/services/gunicorn_conf.py
@@ -4,7 +4,7 @@ workers = multiprocessing.cpu_count() * 2 + 1
 worker_class = 'gevent'
 keepalive = 60
 timeout = 900
-max_requests = 120
+max_requests = 600
 # defaults to 30 sec, setting to 5 minutes to fight `GreenletExit`s
 graceful_timeout = 5*60
 # cryptically, setting forwarded_allow_ips (to the ip of the hqproxy0)


### PR DESCRIPTION
Back of the napkin estimate:

We had 260,000 requests that went to gunicorn workers on Aug 25, 2014.† That amounts to 3 requests per second.
There are 5 worker processes per worker machine and 3 worker machines, so 15 processes
Processes restart every 600 requests (was 120).

(600 req / worker / restart) / ((3 req / sec) / (15 worker)) = 3000 sec / restart = 50 min / restart

(With 120 it's, a restart every 10 minutes instead.)

†`grep '25/Aug/2014' cchq-apache.log | grep -v 'GET /static/' | wc`
