### PR TITLE
Don't clear product data on upload

### DIFF
--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -252,13 +252,7 @@ class Product(Document):
         if not p.name:
             raise InvalidProductException(_('Product name is a required field and cannot be blank!'))
 
-        # pack and add custom data items
-        product_data = {}
-        for k, v in row.iteritems():
-            if str(k).startswith('data: '):
-                product_data[k[6:]] = v
-
-        setattr(p, 'product_data', product_data)
+        p.product_data = row.get('data', {})
 
         return p
 


### PR DESCRIPTION
This fixes a bug that was introduced when switching from csv to excel, as the format of the inputs changed.
