### PR TITLE
include the request object in build error

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -48,6 +48,7 @@ from dimagi.utils.web import get_url_base, parse_int
 from dimagi.utils.couch.database import get_db
 import commcare_translations
 from corehq.util import bitly
+from corehq.util import view_utils
 from corehq.apps.appstore.models import SnapshotMixin
 from corehq.apps.builds.models import BuildSpec, CommCareBuildConfig, BuildRecord
 from corehq.apps.hqmedia.models import HQMediaMixin
@@ -2588,7 +2589,11 @@ class ApplicationBase(VersionedDoc, SnapshotMixin,
         except Exception as e:
             if settings.DEBUG:
                 raise
-            logging.exception('Unexpected error building app')
+
+            # this is much less useful/actionable without a URL
+            # so make sure to include the request
+            logging.error('Unexpected error building app', exc_info=True,
+                          extra={'request': view_utils.get_request()})
             errors.append({'type': 'error', 'message': 'unexpected error: %s' % e})
         return errors
 

--- a/corehq/util/view_utils.py
+++ b/corehq/util/view_utils.py
@@ -1,2 +1,22 @@
+import inspect
+
+
 def set_file_download(response, filename):
     response["Content-Disposition"] = 'attachment; filename="%s"' % filename
+
+
+def get_request():
+    """
+    Walk up the stack, return the nearest first argument named "request".
+
+    taken from http://nedbatchelder.com/blog/201008/global_django_requests.html
+    """
+    frame = None
+    try:
+        for f in inspect.stack()[1:]:
+            frame = f[0]
+            code = frame.f_code
+            if code.co_varnames and code.co_varnames[0] in ("request", "req"):
+                return frame.f_locals[code.co_varnames[0]]
+    finally:
+        del frame


### PR DESCRIPTION
so that we will have the URL in sentry

Finds it form the stack frames, as suggested in http://nedbatchelder.com/blog/201008/global_django_requests.html.

Will make errors like http://logs.internal.dimagi.com:9000/commcare-hq-dev-team/hq-production/group/109420/ (requires VPN access + login) more useful
