### PR TITLE
Better error handling for submit failure in CloudCare

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/backbone/apps.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/backbone/apps.js
@@ -609,6 +609,23 @@ cloudCare.AppView = Backbone.View.extend({
                     self.showModule(selectedModule);
                     cloudCare.dispatch.trigger("form:submitted");
                     showSuccess(translatedStrings.saved, $("#cloudcare-notifications"), 2500);
+                },
+                error: function (resp, status, message) {
+                    if (message) {
+                        message = "Save failed. Details: " + message;
+                    } else {
+                        message = "Unknown error: " + status + " " + resp.status;
+                        if (resp.status === 0) {
+                            message = (message
+                                + ". This can happen if you loaded CloudCare "
+                                + "from a different address than the server "
+                                + "address (" + submitUrl + ")");
+                        }
+                    }
+                    data.onerror({message: message});
+                    // TODO change submit button text to something other than
+                    // "Submitting..." and prevent "All changes saved!" message
+                    // banner at top of the form.
                 }
             });
         };


### PR DESCRIPTION
The error message for a cross-site script error looks something like this (assuming the user loaded the site from http://localhost:8080/... and localsettings.py has BASE_ADDRESS = "127.0.0.1:8080"):

Unknown error: error 0. This can happen if you loaded CloudCare from a different address than the server address (http://127.0.0.1:8080/a/test/receiver/6717bd0cf4ada93d80ed2a41b67dee6b/)

NOTE I’m not sure why cloudcare has to use an address provided by the server. Why not submit to a path like /a/test/receiver/6717bd0cf4ada93d80ed2a41b67dee6b/ rather than the fully qualified URL?

@NoahCarnahan I heard that you have been working on CloudCare recently. Maybe you want to review this?
