### PR TITLE
workaround for inconsistent usage of pack/fulfill in commtrack alerts

### DIFF
--- a/corehq/apps/commtrack/const.py
+++ b/corehq/apps/commtrack/const.py
@@ -47,6 +47,7 @@ RequisitionActions = enum(
     REQUEST='request',
     APPROVAL='approval',
     FULFILL='fulfill',
+    PACK='pack',  # todo: pack and fulfill are the same thing but both are used. should reconcile
     RECEIPTS='requisition-receipts',
 )
 
@@ -55,6 +56,7 @@ ORDERED_REQUISITION_ACTIONS = (
     RequisitionActions.REQUEST,
     RequisitionActions.APPROVAL,
     RequisitionActions.FULFILL,
+    RequisitionActions.PACK,
     RequisitionActions.RECEIPTS,
 )
 


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?132178
