### PR TITLE
Make including consumption not the default option

### DIFF
--- a/corehq/apps/commtrack/static/commtrack/ko/location_bulk_upload_file.js
+++ b/corehq/apps/commtrack/static/commtrack/ko/location_bulk_upload_file.js
@@ -1,0 +1,29 @@
+/* globals ko */
+$(function () {
+    "use strict";
+    if ($("#bulk_upload_form").get(0)) {
+        ko.applyBindings(
+            {
+                file: ko.observable(null)
+            },
+            $("#bulk_upload_form").get(0)
+        );
+    }
+
+    // modify download url to pass extra option
+    function ConsumptionOptionsViewModel(base_url) {
+        this.base_url = base_url;
+        this.include_consumption = ko.observable(false);
+        self = this;
+        this.url = ko.computed(function() {
+            // ternary prevents adding include_consumption=false to other
+            // bulk pages
+            return self.base_url + (self.include_consumption() ? "?include_consumption=true" : "")
+        });
+    }
+
+    ko.applyBindings(
+        new ConsumptionOptionsViewModel($("#download_link").get(0).href),
+        $("#download_block").get(0)
+    );
+});

--- a/corehq/apps/hqwebapp/static/hqwebapp/ko/bulk_upload_file.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/ko/bulk_upload_file.js
@@ -9,4 +9,21 @@ $(function () {
             $("#bulk_upload_form").get(0)
         );
     }
+
+    // modify download url to pass extra option
+    function ConsumptionOptionsViewModel(base_url) {
+        this.base_url = base_url;
+        this.include_consumption = ko.observable(false);
+        self = this;
+        this.url = ko.computed(function() {
+            // ternary prevents adding include_consumption=false to other
+            // bulk pages
+            return self.base_url + (self.include_consumption() ? "?include_consumption=true" : "")
+        });
+    }
+
+    ko.applyBindings(
+        new ConsumptionOptionsViewModel($("#download_link").get(0).href),
+        $("#download_block").get(0)
+    );
 });

--- a/corehq/apps/hqwebapp/static/hqwebapp/ko/bulk_upload_file.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/ko/bulk_upload_file.js
@@ -9,21 +9,4 @@ $(function () {
             $("#bulk_upload_form").get(0)
         );
     }
-
-    // modify download url to pass extra option
-    function ConsumptionOptionsViewModel(base_url) {
-        this.base_url = base_url;
-        this.include_consumption = ko.observable(false);
-        self = this;
-        this.url = ko.computed(function() {
-            // ternary prevents adding include_consumption=false to other
-            // bulk pages
-            return self.base_url + (self.include_consumption() ? "?include_consumption=true" : "")
-        });
-    }
-
-    ko.applyBindings(
-        new ConsumptionOptionsViewModel($("#download_link").get(0).href),
-        $("#download_block").get(0)
-    );
 });

--- a/corehq/apps/hqwebapp/templates/hqwebapp/partials/bulk_upload.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/partials/bulk_upload.html
@@ -5,12 +5,14 @@
 <h2>{% blocktrans with plural_noun=bulk_upload.plural_noun|title %}Upload {{ plural_noun }} Using Excel{% endblocktrans %}</h2>
 <p>
     <ol>
-        <li>
+        <li id="download_block">
             <p>
                 {% blocktrans with adjective=bulk_upload.adjective %}Download your current {{ adjective }} Excel file.{% endblocktrans %}
             </p>
+            {% block extra_option %}
+            {% endblock %}
             <p>
-                <a href="{{ bulk_upload.download_url }}">
+                <a id="download_link" href="{{ bulk_upload.download_url }}" data-bind="attr: {href: url}">
                     <button class="btn btn-success">
                         <i class="icon-download-alt"></i> {% blocktrans with plural_noun=bulk_upload.plural_noun|title %}Download {{ plural_noun }}{% endblocktrans %}
                     </button>

--- a/corehq/apps/locations/templates/locations/manage/import.html
+++ b/corehq/apps/locations/templates/locations/manage/import.html
@@ -2,7 +2,7 @@
 {% load hq_shared_tags %}
 
 {% block js %} {{ block.super }}
-    <script src="{% static 'hqwebapp/ko/bulk_upload_file.js' %}"></script>
+    <script src="{% static 'commtrack/ko/location_bulk_upload_file.js' %}"></script>
 {% endblock %}
 
 {% block main_column %}

--- a/corehq/apps/locations/templates/locations/manage/import.html
+++ b/corehq/apps/locations/templates/locations/manage/import.html
@@ -6,5 +6,5 @@
 {% endblock %}
 
 {% block main_column %}
-    {% include "hqwebapp/partials/bulk_upload.html" %}
+    {% include "locations/manage/partials/bulk_upload.html" %}
 {% endblock %}

--- a/corehq/apps/locations/templates/locations/manage/partials/bulk_upload.html
+++ b/corehq/apps/locations/templates/locations/manage/partials/bulk_upload.html
@@ -1,0 +1,16 @@
+{% extends "hqwebapp/partials/bulk_upload.html" %}
+{% load i18n %}
+
+{% block extra_option %}
+    {% if manage_consumption %}
+    <div class="controls">
+        <label for="include_consumption" class="checkbox">
+            <input class="checkboxinput"
+                   id="include_consumption"
+                   type="checkbox"
+                   data-bind="checked: include_consumption">
+            {% trans "Include consumption data (this can cause the download to take several minutes)." %}
+        </label>
+    </div>
+    {% endif %}
+{% endblock %}

--- a/corehq/apps/locations/util.py
+++ b/corehq/apps/locations/util.py
@@ -197,13 +197,19 @@ def get_default_column_data(domain, location_types):
     return data
 
 
-def dump_locations(response, domain):
+def dump_locations(response, domain, include_consumption=False):
     file = StringIO()
     writer = Excel2007ExportWriter()
 
     location_types = defined_location_types(domain)
 
-    defaults = get_default_column_data(domain, location_types)
+    if include_consumption:
+        defaults = get_default_column_data(domain, location_types)
+    else:
+        defaults = {
+            'headers': {},
+            'values': {}
+        }
 
     common_types = ['site_code', 'name', 'parent_site_code', 'latitude', 'longitude']
     writer.open(

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -289,6 +289,7 @@ class LocationImportView(BaseLocationView):
                 "adjective": _("location"),
                 "plural_noun": _("locations"),
             },
+            "manage_consumption": self.domain_object.commtrack_settings.individual_consumption_defaults,
         }
         context.update({
             'bulk_upload_form': get_bulk_upload_form(context),
@@ -334,9 +335,10 @@ def location_importer_job_poll(request, domain, download_id, template="hqwebapp/
 
 @login_and_domain_required
 def location_export(request, domain):
+    include_consumption = request.GET.get('include_consumption') == 'true'
     response = HttpResponse(mimetype=Format.from_format('xlsx').mimetype)
     response['Content-Disposition'] = 'attachment; filename="locations.xlsx"'
-    dump_locations(response, domain)
+    dump_locations(response, domain, include_consumption)
     return response
 
 


### PR DESCRIPTION
This is still super slow to build consumption data for domains with large product/location lists (P*L+P requests to cloudant), so adding a (temporary) fix of making it not the default option.

![screenshot 2014-08-29 14 37 44](https://cloud.githubusercontent.com/assets/152134/4094751/9abb02fa-2fab-11e4-843c-204b2207fc93.png)
