### PR TITLE
Remote staging branches

### DIFF
--- a/scripts/rebuildstaging
+++ b/scripts/rebuildstaging
@@ -58,7 +58,7 @@ args=''
 
 # if staging.yaml isn't up-to-date, warn and quit
 git fetch origin master
-if [[ -n $(git diff origin/master -- scripts/staging.yaml) ]]
+if [[ -n $(git diff origin/master -- scripts/staging.yaml) && $no_push != 'y' ]]
 then
     echo "scripts/staging.yaml on this branch different from the one on master"
     echo "Aborting."


### PR DESCRIPTION
For example, to deploy #4212 (before it was merged), staging.yaml would look like

``` yaml
trunk: master
name: autostaging
branches:
  ...
  - lwyszomi:ilsgateway-integration # <----------- REMOTE BRANCH
submodules:
  ...
```

The branch name `lwyszomi:ilsgateway-integration` can be copied from the top of the github PR page where it says
"@**kkrampa** wants to merge 2 commits into `dimagi:master` from `lwyszomi:ilsgateway-integration`".
