### PR TITLE
Double enter groups that are both reporting and sharing groups    

### DIFF
--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -124,4 +124,13 @@ class EmwfOptionsView(LoginAndDomainMixin, EmwfMixin, JSONResponseMixin, View):
         groups = self.group_es_call(fields=fields,
             sort_by=[('reporting', 'desc'), ('name.exact', 'asc')],
             start_at=start, size=size)
+        # Idea: If `groups` contains a group that is both case sharing and reporting,
+        #       modify the first version (in the list we return) to just be a
+        #       reporting group and add a second version of that group that is
+        #       just a reporting group to our return list.
+        #       But there is a problem... Due to pagination, this second version
+        #       of the group will be out of order. We can't just sort `groups`
+        #       again because it will only contain the beginning of the list.
+        #       Possible solution:
+        #       Do two queries here instead of one...
         return [self.group_tuple(g) for g in groups]

--- a/corehq/apps/reports/filters/urls.py
+++ b/corehq/apps/reports/filters/urls.py
@@ -5,4 +5,5 @@ from . import api
 urlpatterns = patterns('',
     url(r'^emwf_options/$', api.EmwfOptionsView.as_view(), name='emwf_options'),
     url(r'^emwf_options/all-data/$', api.EmwfOptionsView.as_view(), {'all_data':True}, name='emwf_options_with_all_data'),
+    url(r'^emwf_options/share-groups/$', api.EmwfOptionsView.as_view(), {'share_groups':True}, name='emwf_options_with_share_groups'),
 )

--- a/corehq/apps/reports/filters/urls.py
+++ b/corehq/apps/reports/filters/urls.py
@@ -4,6 +4,8 @@ from . import api
 
 urlpatterns = patterns('',
     url(r'^emwf_options/$', api.EmwfOptionsView.as_view(), name='emwf_options'),
-    url(r'^emwf_options/all-data/$', api.EmwfOptionsView.as_view(), {'all_data':True}, name='emwf_options_with_all_data'),
-    url(r'^emwf_options/share-groups/$', api.EmwfOptionsView.as_view(), {'share_groups':True}, name='emwf_options_with_share_groups'),
+    url(r'^emwf_options/all-data/$', api.EmwfOptionsView.as_view(),
+        {'all_data':True, "share_groups":True},
+        name='emwf_options_with_all_data'
+    ),
 )

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -462,6 +462,14 @@ class ExpandedMobileWorkerFilter(EmwfMixin, BaseMultipleOptionFilter):
         }
 
 
+class CaseListReportMobileWorkerFilter(ExpandedMobileWorkerFilter):
+    @property
+    def filter_context(self):
+        context = super(CaseListReportMobileWorkerFilter, self).filter_context
+        url = reverse('emwf_options_with_share_groups', args=[self.domain])
+        context.update({'endpoint': url})
+        return context
+
 class ExpandedMobileWorkerFilterWithAllData(ExpandedMobileWorkerFilter):
     show_all_filter = True
 

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -462,14 +462,6 @@ class ExpandedMobileWorkerFilter(EmwfMixin, BaseMultipleOptionFilter):
         }
 
 
-class CaseListReportMobileWorkerFilter(ExpandedMobileWorkerFilter):
-    @property
-    def filter_context(self):
-        context = super(CaseListReportMobileWorkerFilter, self).filter_context
-        url = reverse('emwf_options_with_share_groups', args=[self.domain])
-        context.update({'endpoint': url})
-        return context
-
 class ExpandedMobileWorkerFilterWithAllData(ExpandedMobileWorkerFilter):
     show_all_filter = True
 

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -452,11 +452,7 @@ class ExpandedMobileWorkerFilter(EmwfMixin, BaseMultipleOptionFilter):
         }
 
     @classmethod
-    def for_group(cls, group_id):
-        # TODO: Break this into two methods: for_reporting_group and for_sharing_group
-        # NOTE NOTE NOTE!: It looks like its possible for this group_id to come from a url:
-        #                  see corehq.apps.reports.standard.ProjectReportParametersMixin#group_ids
-        #                  So it could be a reporting group and it could be a sharing group I think
+    def for_reporting_group(cls, group_id):
         return {
             cls.slug: 'g__%s' % group_id
         }

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -283,8 +283,8 @@ class ExpandedMobileWorkerFilter(EmwfMixin, BaseMultipleOptionFilter):
 
     @classmethod
     def selected_group_ids(cls, request):
-        return cls.selected_reporting_group_ids(cls, request) +\
-               cls.selected_sharing_group_ids(cls, request)
+        return cls.selected_reporting_group_ids(request) +\
+               cls.selected_sharing_group_ids(request)
 
     @classmethod
     def selected_reporting_group_ids(cls, request):

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -331,7 +331,7 @@ class ExpandedMobileWorkerFilter(EmwfMixin, BaseMultipleOptionFilter):
             for group in res['hits']['hits']:
                 if group['fields']["reporting"]:
                     selected.append(self.reporting_group_tuple(group['fields']))
-                elif group['fields']["case_sharing"]:
+                if group['fields']["case_sharing"]:
                     selected.append(self.sharing_group_tuple(group['fields']))
         if user_ids:
             q = {"query": {"filtered": {"filter": {

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -215,6 +215,9 @@ class EmwfMixin(object):
         return (uid, name)
 
     def group_tuple(self, g):
+        # Idea:
+        #   Change the first value of these tuples to ge either "g__<id>" or
+        #   "sg__<id>" if the group is a case sharing group.
         return ("g__%s" % g['_id'], "%s [%s]" % (g['name'], 'group' if g['reporting'] else 'case sharing'))
 
     def user_type_tuple(self, t):
@@ -282,6 +285,9 @@ class ExpandedMobileWorkerFilter(EmwfMixin, BaseMultipleOptionFilter):
     def selected_group_ids(cls, request):
         emws = request.GET.getlist(cls.slug)
         return [g[3:] for g in emws if g.startswith("g__")]
+
+    # Idea: Add an additional method here called selected_case_sharing_group_ids
+    #       that looks for items starting with "sg__" in emws
 
     @property
     @memoized

--- a/corehq/apps/reports/management/commands/migrate_saved_reports.py
+++ b/corehq/apps/reports/management/commands/migrate_saved_reports.py
@@ -30,9 +30,6 @@ def migrate(config, db):
         users += indy_users
         groups += indy_groups
         users = ["u__%s" % u_id for u_id in users]
-        #TODO: I believe that it was impossible to specify case sharing groups
-        #      before, therefore I think these groups must be reporting groups
-        #      Ethan, can you confirm that groups here are always reporting groups?
         groups = ["g__%s" % g_id for g_id in groups]
         ufilters = ["t__%s" % t_id for t_id in ufilters]
         config["filters"]["emw"] = config["filters"].get("emw", []) +  users + groups + ufilters

--- a/corehq/apps/reports/management/commands/migrate_saved_reports.py
+++ b/corehq/apps/reports/management/commands/migrate_saved_reports.py
@@ -30,6 +30,9 @@ def migrate(config, db):
         users += indy_users
         groups += indy_groups
         users = ["u__%s" % u_id for u_id in users]
+        #TODO: I believe that it was impossible to specify case sharing groups
+        #      before, therefore I think these groups must be reporting groups
+        #      Ethan, can you confirm that groups here are always reporting groups?
         groups = ["g__%s" % g_id for g_id in groups]
         ufilters = ["t__%s" % t_id for t_id in ufilters]
         config["filters"]["emw"] = config["filters"].get("emw", []) +  users + groups + ufilters

--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -140,17 +140,14 @@ class CaseListMixin(ElasticProjectInspectionReport, ProjectReportParametersMixin
         selected_user_ids = EMWF.selected_user_ids(self.request)
 
         # Get group ids for each group that was specified
-        selected_group_ids = EMWF.selected_group_ids(self.request)
-
-        # Idea: Use a new method in EMWF to get selected_case_sharing_groups
-        #       (This is necessary because we need to know if a both group was
-        #        selected as a case_sharing group or as a reporting groups)
+        selected_reporting_group_ids = EMWF.selected_reporting_group_ids(self.request)
+        selected_sharing_group_ids = EMWF.selected_sharing_group_ids(self.request)
+        #TODO: It is impossible to get this to show cases owned by a reporting (only) group. Is this desired?
 
         # Get user ids for each user in specified reporting groups
         report_group_q = HQESQuery(index="groups").domain(self.domain)\
                                            .doc_type("Group")\
-                                           .filter(filters.term("_id", selected_group_ids))\
-                                           .filter(filters.term("reporting", True))\
+                                           .filter(filters.term("_id", selected_reporting_group_ids))\
                                            .fields(["users"])
         user_lists = [group["users"] for group in report_group_q.run().hits]
         selected_reporting_group_users = list(set().union(*user_lists))
@@ -165,7 +162,7 @@ class CaseListMixin(ElasticProjectInspectionReport, ProjectReportParametersMixin
 
         owner_ids = list(set().union(special_user_ids,
                                 selected_user_ids,
-                                selected_group_ids,
+                                selected_sharing_group_ids,
                                 selected_reporting_group_users,
                                 sharing_group_ids))
         if HQUserType.COMMTRACK in EMWF.selected_user_types(self.request):

--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -192,11 +192,11 @@ class CaseListMixin(ElasticProjectInspectionReport, ProjectReportParametersMixin
 
 
 class CaseListReport(CaseListMixin, ProjectInspectionReport, ReportDataSource):
-
     # note that this class is not true to the spirit of ReportDataSource; the whole
     # point is the decouple generating the raw report data from the report view/django
     # request. but currently these are too tightly bound to decouple
 
+    fields = ['corehq.apps.reports.filters.users.CaseListReportMobileWorkerFilter'] + CaseListMixin.fields[1:]
     name = ugettext_noop('Case List')
     slug = 'case_list'
 

--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -142,7 +142,6 @@ class CaseListMixin(ElasticProjectInspectionReport, ProjectReportParametersMixin
         # Get group ids for each group that was specified
         selected_reporting_group_ids = EMWF.selected_reporting_group_ids(self.request)
         selected_sharing_group_ids = EMWF.selected_sharing_group_ids(self.request)
-        #TODO: It is impossible to get this to show cases owned by a reporting (only) group. Is this desired?
 
         # Get user ids for each user in specified reporting groups
         report_group_q = HQESQuery(index="groups").domain(self.domain)\

--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -142,6 +142,10 @@ class CaseListMixin(ElasticProjectInspectionReport, ProjectReportParametersMixin
         # Get group ids for each group that was specified
         selected_group_ids = EMWF.selected_group_ids(self.request)
 
+        # Idea: Use a new method in EMWF to get selected_case_sharing_groups
+        #       (This is necessary because we need to know if a both group was
+        #        selected as a case_sharing group or as a reporting groups)
+
         # Get user ids for each user in specified reporting groups
         report_group_q = HQESQuery(index="groups").domain(self.domain)\
                                            .doc_type("Group")\

--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -192,11 +192,11 @@ class CaseListMixin(ElasticProjectInspectionReport, ProjectReportParametersMixin
 
 
 class CaseListReport(CaseListMixin, ProjectInspectionReport, ReportDataSource):
+
     # note that this class is not true to the spirit of ReportDataSource; the whole
     # point is the decouple generating the raw report data from the report view/django
     # request. but currently these are too tightly bound to decouple
 
-    fields = ['corehq.apps.reports.filters.users.CaseListReportMobileWorkerFilter'] + CaseListMixin.fields[1:]
     name = ugettext_noop('Case List')
     slug = 'case_list'
 

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -1145,7 +1145,7 @@ class WorkerActivityReport(WorkerMonitoringReportTableBase, DatespanMixin):
                 url_args = EMWF.for_user(owner_id)
             else:
                 assert type == 'group'
-                url_args = EMWF.for_group(owner_id)
+                url_args = EMWF.for_reporting_group(owner_id)
 
             start_date, end_date = dates_for_linked_reports()
             url_args.update({


### PR DESCRIPTION
Addresses this comment: http://manage.dimagi.com/default.asp?132165#BugEvent.743280

We want groups that are both reporting and sharing groups to appear twice in the list of groups and also for the filter to behave differently depending on which entry in the list you choose. Therefore, adding `g__<group_id>` to the url no longer conveys enough information. Therefore, I've added another type of string, `sg__<group_id>` for sharing groups.

This also required reworking the `EmwfOptionsView.get_groups(start, size)` function. Because the group query is paginated, and a group that is both a reporting and sharing group might show up on different pages (once for being a reporting group, once for being a sharing group), I was forced to turn this into two separate queries. There might be a way to do this in one query, but I wasn't able to figure out how.

What do you think of these changes @esoergel ?

Note: This PR requests a pull into caselistmixin-refactor, not master.
