### PR TITLE
remove reference to ALLOWED_PROPERTY_TYPES

### DIFF
--- a/custom/_legacy/pact/models.py
+++ b/custom/_legacy/pact/models.py
@@ -1,4 +1,3 @@
-from functools import partial
 from django.utils.translation import ugettext as _
 import uuid
 from dateutil.parser import parser
@@ -9,11 +8,9 @@ from couchforms.models import XFormInstance
 from dimagi.utils.decorators.memoized import memoized
 from pact import enums
 
-from couchdbkit.schema.properties import ALLOWED_PROPERTY_TYPES
 from pact.enums import TIME_LABEL_LOOKUP, PACT_SCHEDULES_NAMESPACE, DOT_ART, DOT_NONART, PACT_REGIMEN_CHOICES_FLAT_DICT, REGIMEN_CHOICES, PACT_DOMAIN
 from pact.regimen import regimen_string_from_doc
 
-ALLOWED_PROPERTY_TYPES.add(partial)
 
 def make_uuid():
     return uuid.uuid4().hex


### PR DESCRIPTION
about to be removed from API

Pretty sure that this was done to get around a particular implementation detail of the old couchdbkit schema; my intuition is that switching to jsonobject probably fixed it. Wait for build.
