### PR TITLE
Show correct number of members in Group

### DIFF
--- a/corehq/apps/groups/models.py
+++ b/corehq/apps/groups/models.py
@@ -12,8 +12,8 @@ class Group(UndoableDocument):
     """
     The main use case for these 'groups' of users is currently
     so that we can break down reports by arbitrary regions.
-    
-    (Things like who sees what reports are determined by permissions.) 
+
+    (Things like who sees what reports are determined by permissions.)
     """
     domain = StringProperty()
     name = StringProperty()
@@ -38,7 +38,7 @@ class Group(UndoableDocument):
             self.users.append(couch_user_id)
         if save:
             self.save()
-        
+
     def remove_user(self, couch_user_id, save=True):
         if not isinstance(couch_user_id, basestring):
             couch_user_id = couch_user_id.user_id
@@ -49,7 +49,7 @@ class Group(UndoableDocument):
                     if save:
                         self.save()
                     return
-    
+
     def add_group(self, group):
         group.add_to_group(self)
 
@@ -57,7 +57,7 @@ class Group(UndoableDocument):
         """
         food = Food(path=[food_id])
         fruit = Fruit(path=[fruit_id])
-        
+
         If fruit.add_to_group(food._id):
             then update fruit.path to be [food_id, fruit_id]
         """
@@ -71,7 +71,7 @@ class Group(UndoableDocument):
         new_path.extend(self.path)
         self.path = new_path
         self.save()
-    
+
     def remove_group(self, group):
         group.remove_from_group(self)
 
@@ -79,7 +79,7 @@ class Group(UndoableDocument):
         """
         food = Food(path=[food_id])
         fruit = Fruit(path=[food_id, fruit_id])
-        
+
         If fruit.remove_from_group(food._id):
             then update fruit.path to be [fruit_id]
         """
@@ -110,7 +110,7 @@ class Group(UndoableDocument):
             if is_active and not user.is_active:
                 return False
             return True
-        users = imap(CouchUser, iter_docs(self.get_db(), self.users))
+        users = imap(CouchUser.wrap_correctly, iter_docs(self.get_db(), self.users))
         return filter(is_relevant_user, users)
 
     @memoized

--- a/corehq/apps/groups/templates/groups/group_members.html
+++ b/corehq/apps/groups/templates/groups/group_members.html
@@ -136,7 +136,7 @@
 {% else %}
 <div class="row-fluid">
     <div class="span12">
-        <h2>Group "{{ group.name }}"{% if group.case_sharing %} (Case Sharing){% endif %} ({% blocktrans count group.users|length as num_users %}{{ num_users }} member{% plural %}{{ num_users }} members{% endblocktrans %})</h2>
+        <h2>Group "{{ group.name }}"{% if group.case_sharing %} (Case Sharing){% endif %} ({% blocktrans count num_users=num_users %}{{ num_users }} member{% plural %}{{ num_users }} members{% endblocktrans %})</h2>
         <div class="btn-toolbar">
             <a href="#editGroupSettings" class="btn" data-toggle="modal"><i class="icon icon-pencil"></i> {% trans "Edit Settings" %}</a>
             <a class="btn btn-danger pull-right" style="margin-right: 45px;" data-toggle="modal" href="#delete_group_modal">

--- a/corehq/apps/users/views/mobile/groups.py
+++ b/corehq/apps/users/views/mobile/groups.py
@@ -107,5 +107,6 @@ class EditGroupMembersView(BaseGroupsView):
     def page_context(self):
         return {
             'group': self.group,
+            'num_users': len(self.member_ids),
             'user_form': self.user_selection_form
         }


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?134040
The Group Membership page used to use group.users, which is a list of all user ids for that group.  This includes deleted users, which was causing the issue. This PR uses the filtered list of users already retrieved and memoized in the view instead.

Second commit switches the get_users call to Use iter-docs and not keep passing through the list
