### PR TITLE
Fixed a small bug in the UCLA task creation script

### DIFF
--- a/custom/ucla/views.py
+++ b/custom/ucla/views.py
@@ -74,7 +74,7 @@ def _ucla_form_modifier(form, question_ids):
 
             # Create new hidden values for each question option if they don't already exist:
 
-            if hidden_value_path not in question_dict:
+            if hidden_value_tag not in question_dict:
 
                 # Add data element
                 tag = "{x}%s" % hidden_value_tag

--- a/custom/ucla/views.py
+++ b/custom/ucla/views.py
@@ -65,6 +65,8 @@ def _ucla_form_modifier(form, question_ids):
     # Get the existing subcases
     existing_subcases = {c.case_name:c for c in form.actions.subcases}
 
+    message += "Found %s questions.\n" % len(questions)
+
     for question in questions:
         for option in question.options:
 

--- a/custom/ucla/views.py
+++ b/custom/ucla/views.py
@@ -58,8 +58,8 @@ def _ucla_form_modifier(form, question_ids):
     xform = form.wrapped_xform()
 
     # Get the questions specified in question_ids
-    question_dict = {q["value"]:FormQuestion.wrap(q) for q in form.get_questions(["en"])}
-    question_ids = {"/data/" + q for q in question_ids}.intersection(question_dict.keys())
+    question_dict = {q["value"].split("/")[-1]: FormQuestion.wrap(q) for q in form.get_questions(["en"])}
+    question_ids = {q for q in question_ids}.intersection(question_dict.keys())
     questions = [question_dict[k] for k in question_ids]
 
     # Get the existing subcases
@@ -68,7 +68,8 @@ def _ucla_form_modifier(form, question_ids):
     for question in questions:
         for option in question.options:
 
-            hidden_value_path = question.value + "-" + option.value
+            hidden_value_tag = question.value.split("/")[-1] + "-" + option.value
+            hidden_value_path = "/data/" + hidden_value_tag
             hidden_value_text = option.label
 
             # Create new hidden values for each question option if they don't already exist:
@@ -76,7 +77,7 @@ def _ucla_form_modifier(form, question_ids):
             if hidden_value_path not in question_dict:
 
                 # Add data element
-                tag = "{x}%s" % hidden_value_path.replace("/data/", "")
+                tag = "{x}%s" % hidden_value_tag
                 element = etree.Element(tag.format(**namespaces))
                 xform.data_node.append(element)
 


### PR DESCRIPTION
I had erroneously assumed that all questions had paths in the form "/data/<question_id>". This of course meant that questions within question groups were not handled properly. These changes remove that assumption and fix the issue.

@dannyroberts or anyone
