### PR TITLE
Added build error message for modules missing parent_select.module_id

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1271,6 +1271,11 @@ class ModuleBase(IndexedSchema, NavMenuItemMediaMixin):
                 needs_case_type=True,
                 needs_case_detail=True
             ))
+        if self.parent_select.active and not self.parent_select.module_id:
+            errors.append({
+                'type': 'no parent select id',
+                'module': self.get_module_info()
+            })
         return errors
 
 

--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -81,6 +81,12 @@
                             {% endif %}
                             <a href="{% url "view_module" domain app.id error.module.id %}">{{ error.module.name|trans:langs }}</a>
                         {% endif %}
+                        {% if error.type == "no parent select id" %}
+                            Module
+                            <a href="{% url "view_module" domain app.id error.module.id %}">{{ error.module.name|trans:langs }}</a>
+                            uses parent case selection but doesn't have a parent
+                            module specified.
+                        {% endif %}
                         {% if error.type == "invalid location xpath" %}
                             Case List has invalid location reference <code>{{ error.column.field_property}}</code>.
                             Details: {{ error.details }}


### PR DESCRIPTION
Addresses: http://manage.dimagi.com/default.asp?133172#752523

A user managed to get a module into a state where `module.parent_select.active` was `True` but `module.parent_select.module_id` was `None`. This adds build validation that checks for that condition.
