### PR TITLE
Fixed typo in delete_user management command

### DIFF
--- a/corehq/apps/users/management/commands/delete_user.py
+++ b/corehq/apps/users/management/commands/delete_user.py
@@ -9,5 +9,5 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         user = args[0].strip()
         print "Deleting user %s" % user
-        WebUser.get_by_name(user).delete()
+        WebUser.get_by_username(user).delete()
         print "Operation completed"


### PR DESCRIPTION
In the process of renaming/restructuring the commands I got the name of this method wrong.
