### PR TITLE
Fix bug in the UI translation download

### DIFF
--- a/corehq/apps/translations/system_text.py
+++ b/corehq/apps/translations/system_text.py
@@ -383,7 +383,6 @@ CCODK_DEFAULT = [
     ('verify.checking', u'Verifying Resources'),
     (   'verify.progress ',
         u' Verifying resources. ${0} resources verified of ${1} total'),
-    ('modules.m0', u'pregenancy'),
     (   'install.barcode',
         u'Welcome to CommCare! Please choose an installation method below '),
     ('install.manual', u'Please enter the URL'),


### PR DESCRIPTION
Addresses this ticket: http://manage.dimagi.com/default.asp?134955

A default translation of "pregnancy" was being provided for `module.m0`. This was causing people using some work flows to mistakenly overwrite the names of their first module. This translation has been removed.
