### PR TITLE
Moved `parent_select` build validation to appropriate function

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1271,11 +1271,6 @@ class ModuleBase(IndexedSchema, NavMenuItemMediaMixin):
                 needs_case_type=True,
                 needs_case_detail=True
             ))
-        if self.parent_select.active and not self.parent_select.module_id:
-            errors.append({
-                'type': 'no parent select id',
-                'module': self.get_module_info()
-            })
         return errors
 
 
@@ -1403,6 +1398,11 @@ class Module(ModuleBase):
                     'field': sort_element.field,
                     'module': self.get_module_info(),
                 })
+        if self.parent_select.active and not self.parent_select.module_id:
+            errors.append({
+                'type': 'no parent select id',
+                'module': self.get_module_info()
+            })
         return errors
 
     def export_json(self, dump_json=True, keep_unique_id=False):


### PR DESCRIPTION
Was in `ModuleBase`, should be in `Module`. See #4337.
