### PR TITLE
add document show function for doc_type, date and domain

### DIFF
--- a/corehq/apps/domain/_design/shows/domain_date.js
+++ b/corehq/apps/domain/_design/shows/domain_date.js
@@ -1,0 +1,13 @@
+function (doc, req) {
+    // !code util/doc_utils.js
+
+    if (doc !== null) {
+        return {
+            'json': {
+                'domains': get_domains(doc),
+                'date': get_date(doc),
+                'doc_type': doc.doc_type
+            }
+        }
+    }
+}

--- a/corehq/apps/domain/_design/util/doc_utils.js
+++ b/corehq/apps/domain/_design/util/doc_utils.js
@@ -1,0 +1,45 @@
+function get_date(doc){
+    // TODO: list is incomplete
+    switch (doc.doc_type){
+        case "CommCareCase":
+        case "CommCareCase-Deleted":
+            return doc.opened_on;
+        case "XFormInstance":
+        case "XFormInstance-Deleted":
+        case "XFormError":
+        case "XFormDuplicate":
+        case "XFormDeprecated":
+        case "XFormArchived":
+        case "SubmissionErrorLog":
+            return doc.received_on
+        case "CommCareUser":
+        case "WebUser":
+            return doc.created_on;
+        case "MessageLog":
+        case "CallLog":
+        case "SMSLog":
+            return doc.date;
+        case "EventLog":
+            return doc.date;
+        case "Application":
+        case "Application-Deleted":
+        case "RemoteApp":
+        case "RemoteApp-Deleted":
+            return doc.copy_of ? doc.built_on : null;
+        default:
+            return null;
+    }
+}
+
+function get_domains(doc) {
+    var domains = [];
+    if (doc.domain) {
+        domains.push(doc.domain)
+    }
+    if (doc.domains && doc.domains.length) {
+        for (i = 0; i < doc.domains.length; i += 1) {
+            domains.push(doc.domains[i]);
+        }
+    }
+    return domains;
+}

--- a/corehq/apps/domain/_design/views/docs/map.js
+++ b/corehq/apps/domain/_design/views/docs/map.js
@@ -1,46 +1,14 @@
 function (doc) {
-    var i;
-    if (doc.doc_type) {
-        if (doc.domain) {
-            emit([doc.domain, doc.doc_type, get_date(doc)], null);
-        }
-        if (doc.domains && doc.domains.length) {
-            for (i = 0; i < doc.domains.length; i += 1) {
-                emit([doc.domains[i], doc.doc_type, get_date(doc)], null);
-            }
-        }
-    }
+    // !code util/doc_utils.js
 
-    function get_date(doc){
-        // TODO: list is incomplete
-        switch (doc.doc_type){
-            case "CommCareCase":
-            case "CommCareCase-Deleted":
-                return doc.opened_on;
-            case "XFormInstance":
-            case "XFormInstance-Deleted":
-            case "XFormError":
-            case "XFormDuplicate":
-            case "XFormDeprecated":
-            case "XFormArchived":
-            case "SubmissionErrorLog":
-                return doc.received_on
-            case "CommCareUser":
-            case "WebUser":
-                return doc.created_on;
-            case "MessageLog":
-            case "CallLog":
-            case "SMSLog":
-                return doc.date;
-            case "EventLog":
-                return doc.date;
-            case "Application":
-            case "Application-Deleted":
-            case "RemoteApp":
-            case "RemoteApp-Deleted":
-                return doc.copy_of ? doc.built_on : null;
-            default:
-                return null;
+    var i,
+        date,
+        domains;
+    if (doc.doc_type) {
+        date = get_date(doc);
+        domains = get_domains(doc);
+        for (i = 0; i < domains.length; i += 1) {
+            emit([domains[i], doc.doc_type, date], null);
         }
     }
 }


### PR DESCRIPTION
Useful if all you want is a doc's domain / doc_type / date. See [pillowtop retry](https://github.com/dimagi/pillowtop/pull/89/files#diff-6dac4be25b780fb79c406285662331fcR300) for an example use.

REQUIRES REINDEX
