### PR TITLE
Fix small bug in EMWF related to missing `case_sharing` field on ES group docs

### DIFF
--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -329,9 +329,9 @@ class ExpandedMobileWorkerFilter(EmwfMixin, BaseMultipleOptionFilter):
                 fields=['_id', 'name', "case_sharing", "reporting"],
             )
             for group in res['hits']['hits']:
-                if group['fields']["reporting"]:
+                if group['fields'].get("reporting", False):
                     selected.append(self.reporting_group_tuple(group['fields']))
-                if group['fields']["case_sharing"]:
+                if group['fields'].get("case_sharing", False):
                     selected.append(self.sharing_group_tuple(group['fields']))
         if user_ids:
             q = {"query": {"filtered": {"filter": {


### PR DESCRIPTION
Use `get('case_sharing', False)` instead of directly indexing the fields dictionary.

Addresses: http://manage.dimagi.com/default.asp?135317
