### PR TITLE
Fixed bug where CloudCare erroneously expected a parent case in some instances

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/backbone/apps.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/backbone/apps.js
@@ -1034,7 +1034,7 @@ cloudCare.AppMainView = Backbone.View.extend({
                 // Why make a new instance of this object?
                 var caseModel = new cloudCare.Case(self.initialCase);
 
-                if (module.get("parent_select").module_id) {
+                if (module.get("parent_select").active) {
                     if (self.initialParent){
 
                         var parentModuleId = module.get("parent_select").module_id;


### PR DESCRIPTION
I should have been checking the `active` property of the module's `parent_select`, not the `module_id`. If a module is set up for parent select, then parent select is disabled, then it's `parent_select` will have a module id, but `active` will be set to `False`. Thus, CloudCare was preforming incorrectly on these modules.

Addresses this ticket: http://manage.dimagi.com/default.asp?135974
