### PR TITLE
Fix for assertion error in /apps/reports/views.py

### DIFF
--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -548,7 +548,7 @@ def normalize_hour(hour):
     if hour < 0:
         day_change = -1
         hour += 24
-    elif hour > 24:
+    elif hour >= 24:
         day_change = 1
         hour -= 24
 


### PR DESCRIPTION
I believe that this error occurs when hour after calculations is 24. Inequality was strict so when hour was equal 24 wasn't normalize to range <0, 23> and then assertion error occurred.
http://manage.dimagi.com/default.asp?136589
