### PR TITLE
Removed limit on number of load-able cases in advanced app builder

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
@@ -276,20 +276,18 @@ var AdvancedCase = (function () {
 
         self.actionOptions = ko.computed(function () {
             var options = [];
-            if (self.load_update_cases().length <= 2) {
-                options.push({
-                    display: 'Load / Update / Close a case',
-                    value: 'load'
-                });
-                options.push({
-                    display: 'Automatic Case Selection',
-                    value: 'auto_select'
-                });
-                options.push({
-                    display: '---',
-                    value: 'separator'
-                });
-            }
+            options.push({
+                display: 'Load / Update / Close a case',
+                value: 'load'
+            });
+            options.push({
+                display: 'Automatic Case Selection',
+                value: 'auto_select'
+            });
+            options.push({
+                display: '---',
+                value: 'separator'
+            });
             options.push({
                 display: 'Open a Case',
                 value: 'open'


### PR DESCRIPTION
Addresses: http://manage.dimagi.com/default.asp?137058

The limit wasn't there for any reason. Now it's gone.
@snopoke 
