### PR TITLE
Check that module has parent_select attribute

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -3349,7 +3349,7 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
                     return False
                 return True
             visited.add(m.id)
-            if m.parent_select.active:
+            if hasattr(m, 'parent_select') and m.parent_select.active:
                 parent = modules.get(m.parent_select.module_id, None)
                 if parent != None and cycle_helper(parent):
                     return True


### PR DESCRIPTION
@NoahCarnahan
Apps with advanced modules aren't building.  It looks like that's because they have no parent_select attribute, so I just checked for existence.  This might require more work to support cycle detection for advanced modules, but in the meantime this fix should allow them to build.
