### PR TITLE
fix ES 1.0 incompatibility

### DIFF
--- a/corehq/apps/hqadmin/reporting/reports.py
+++ b/corehq/apps/hqadmin/reporting/reports.py
@@ -97,11 +97,15 @@ def get_real_project_spaces(facets=None):
     """
     Returns a set of names of real domains
     """
-    real_domain_query = DomainES().fields(['name'])
+    real_domain_query = (
+        DomainES()
+        .terms_facet('name', 'name')
+        .size(0)
+    )
     if facets:
         real_domain_query = add_params_to_query(real_domain_query, facets)
-    real_domain_query_results = real_domain_query.run().raw_hits
-    return {x['fields']['name'] for x in real_domain_query_results}
+    real_domain_query_results = real_domain_query.run().facets.name.result
+    return {_['term'] for _ in real_domain_query_results}
 
 
 def get_sms_query(begin, end, facet_name, facet_terms, domains,


### PR DESCRIPTION
Allows any developer running ES 1.0 (like myself) to run the admin reports without having to patch the source code.  Backwards compatible with 0.9

@emord 
