### PR TITLE
Unsubscribe checkbox

### DIFF
--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -173,7 +173,7 @@ class UpdateMyAccountInfoForm(BaseUpdateUserForm, BaseUserInfoForm):
         required=False,
         label="",
         help_text=ugettext_lazy(
-            "Opt out of emails about new features and other CommCare updates."
+            "Opt out of emails about CommCare updates."
         ),
     )
 

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -169,7 +169,13 @@ class BaseUserInfoForm(forms.Form):
 
 
 class UpdateMyAccountInfoForm(BaseUpdateUserForm, BaseUserInfoForm):
-
+    email_opt_out = forms.BooleanField(
+        required=False,
+        label="",
+        help_text=ugettext_lazy(
+            "Opt out of emails about new features and other CommCare updates."
+        ),
+    )
 
     def __init__(self, *args, **kwargs):
         super(UpdateMyAccountInfoForm, self).__init__(*args, **kwargs)


### PR DESCRIPTION
Add back the mass email subscribe/unsubscribe checkbox to account management.

Also simplify the wording, since new features go out in a separate mailing list now.
![screen shot 2014-10-01 at 4 22 40 pm](https://cloud.githubusercontent.com/assets/1757035/4482452/c3b6da1e-49a8-11e4-9016-704214fbdd84.png)
