### PR TITLE
change error msg on a bad request for the Daily Form Stats report

### DIFF
--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -700,6 +700,7 @@ class GenericTabularReport(GenericReportView):
     ajax_pagination = False
     use_datatables = True
     charts_per_row = 1
+    bad_request_error_text = None
     
     # override old class properties
     report_template_path = "reports/async/tabular.html"
@@ -924,7 +925,8 @@ class GenericTabularReport(GenericReportView):
                 show_all_rows=self.show_all_rows,
                 pagination=pagination_spec,
                 left_col=left_col,
-                datatables=self.use_datatables
+                datatables=self.use_datatables,
+                bad_request_error_text=self.bad_request_error_text
             ),
             charts=charts,
             chart_span=CHART_SPAN_MAP[self.charts_per_row]

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -384,6 +384,7 @@ class SubmissionsByFormReport(WorkerMonitoringReportTableBase,
 class DailyFormStatsReport(WorkerMonitoringReportTableBase, CompletionOrSubmissionTimeMixin, DatespanMixin):
     slug = "daily_form_stats"
     name = ugettext_noop("Daily Form Activity")
+    bad_request_error_text = ugettext_noop("Your search query was invalid. Please limit the date range to less than 3 months and try again.")
 
     fields = [
         'corehq.apps.reports.filters.users.ExpandedMobileWorkerFilter',

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -384,7 +384,7 @@ class SubmissionsByFormReport(WorkerMonitoringReportTableBase,
 class DailyFormStatsReport(WorkerMonitoringReportTableBase, CompletionOrSubmissionTimeMixin, DatespanMixin):
     slug = "daily_form_stats"
     name = ugettext_noop("Daily Form Activity")
-    bad_request_error_text = ugettext_noop("Your search query was invalid. Please limit the date range to less than 3 months and try again.")
+    bad_request_error_text = ugettext_noop("Your search query was invalid. If you're using a large date range, try using a smaller one.")
 
     fields = [
         'corehq.apps.reports.filters.users.ExpandedMobileWorkerFilter',

--- a/corehq/apps/reports/static/reports/javascripts/config.dataTables.bootstrap.js
+++ b/corehq/apps/reports/static/reports/javascripts/config.dataTables.bootstrap.js
@@ -16,7 +16,7 @@ function HQReportDataTables(options) {
     self.loadingText = options.loadingText || "Loading <img src='/static/hqwebapp/img/ajax-loader.gif' alt='loading indicator' />";
     self.emptyText = options.emptyText || "No data available to display. Please try changing your filters.";
     self.errorText = options.errorText || "<span class='label label-important'>Sorry!</span> There was an error with your query, it has been logged, please try another query.";
-    self.badRequestErrorText = options.errorText || "<span class='label label-important'>Sorry!</span> Your search query is invalid, please adjust the formatting and try again.";
+    self.badRequestErrorText = options.badRequestErrorText || options.errorText || "<span class='label label-important'>Sorry!</span> Your search query is invalid, please adjust the formatting and try again.";
     self.fixColumns = !!(options.fixColumns);
     self.fixColsNumLeft = options.fixColsNumLeft || 1;
     self.fixColsWidth = options.fixColsWidth || 100;

--- a/corehq/apps/reports/templates/reports/async/tabular.html
+++ b/corehq/apps/reports/templates/reports/async/tabular.html
@@ -120,6 +120,10 @@
                     ajaxParams: {{ report_table.pagination.params|JSON }},
                 {% endif %}
 
+                {% if report_table.bad_request_error_text %}
+                    badRequestErrorText: "<span class='label label-important'>Sorry!</span> {{ report_table.bad_request_error_text }}",
+                {% endif %}
+
                 {% if report_table.left_col.is_fixed %}
                     fixColumns: true,
                     fixColsNumLeft: {{ report_table.left_col.fixed.num }},


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?137662

For specifically the Daily Form Stats Report, I modify the error message that shows on a Bad Request so that it informs the user to limit their date span. 

Figured this was the best way to handle this case. Modifying the datetime module / filter to only allow a certain range of dates would take much more effort and custom additions to the filter (possibly a new filter).

Couldn't reproduce locally since my server doesn't have apache running with LimitRequestFieldSize or LimitRequestLine set. I tested locally by making GenericReportView.json_response() always return a 400
