### PR TITLE
Raise 404 if user attempts to access remote app with cloudcare api

### DIFF
--- a/corehq/apps/cloudcare/api.py
+++ b/corehq/apps/cloudcare/api.py
@@ -2,6 +2,7 @@ import json
 from django.utils import html
 from couchdbkit.exceptions import ResourceNotFound
 from django.contrib.humanize.templatetags.humanize import naturaltime
+from corehq.apps.cloudcare.exceptions import RemoteAppError
 from corehq.apps.users.models import CouchUser
 from casexml.apps.case.models import CommCareCase, CASE_STATUS_ALL, CASE_STATUS_CLOSED, CASE_STATUS_OPEN
 from corehq.apps.locations.models import Location
@@ -358,12 +359,14 @@ def get_app_json(app):
     app_json['post_url'] = app.post_url
     return app_json
 
+
 def look_up_app_json(domain, app_id):
-    print "WE GOT IT YEAH!!"
-    assert(False)
     app = get_app(domain, app_id)
+    if app.is_remote_app():
+        raise RemoteAppError()
     assert(app.domain == domain)
     return get_app_json(app)
+
 
 def get_cloudcare_app(domain, app_name):
     apps = get_cloudcare_apps(domain)

--- a/corehq/apps/cloudcare/api.py
+++ b/corehq/apps/cloudcare/api.py
@@ -5,7 +5,11 @@ from django.contrib.humanize.templatetags.humanize import naturaltime
 from corehq.apps.users.models import CouchUser
 from casexml.apps.case.models import CommCareCase, CASE_STATUS_ALL, CASE_STATUS_CLOSED, CASE_STATUS_OPEN
 from corehq.apps.locations.models import Location
-from corehq.apps.app_manager.models import ApplicationBase, Application
+from corehq.apps.app_manager.models import (
+    Application,
+    ApplicationBase,
+    get_app,
+)
 from dimagi.utils.couch.safe_index import safe_index
 from dimagi.utils.decorators import inline
 from casexml.apps.phone.caselogic import get_footprint, get_related_cases
@@ -355,7 +359,9 @@ def get_app_json(app):
     return app_json
 
 def look_up_app_json(domain, app_id):
-    app = Application.get(app_id)
+    print "WE GOT IT YEAH!!"
+    assert(False)
+    app = get_app(domain, app_id)
     assert(app.domain == domain)
     return get_app_json(app)
 

--- a/corehq/apps/cloudcare/exceptions.py
+++ b/corehq/apps/cloudcare/exceptions.py
@@ -1,0 +1,2 @@
+class RemoteAppError(Exception):
+    """Exception raised when cloudcare attempts to display a remote app"""

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -325,6 +325,7 @@ def get_apps_api(request, domain):
 @cloudcare_api
 def get_app_api(request, domain, app_id):
     return json_response(look_up_app_json(domain, app_id))
+    #Uhh... raise 404?
 
 @cloudcare_api
 @cache_page(60 * 30)

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -8,6 +8,7 @@ from django.views.decorators.cache import cache_page
 from casexml.apps.case.models import CommCareCase
 from corehq import toggles, privileges
 from corehq.apps.app_manager.suite_xml import SuiteGenerator
+from corehq.apps.cloudcare.exceptions import RemoteAppError
 from corehq.apps.cloudcare.models import CaseSpec, ApplicationAccess
 from corehq.apps.cloudcare.touchforms_api import DELEGATION_STUB_CASE_TYPE, SessionDataHelper
 from corehq.apps.domain.decorators import login_and_domain_required, login_or_digest_ex, domain_admin_required
@@ -324,8 +325,11 @@ def get_apps_api(request, domain):
 
 @cloudcare_api
 def get_app_api(request, domain, app_id):
-    return json_response(look_up_app_json(domain, app_id))
-    #Uhh... raise 404?
+    try:
+        return json_response(look_up_app_json(domain, app_id))
+    except RemoteAppError:
+        raise Http404()
+
 
 @cloudcare_api
 @cache_page(60 * 30)


### PR DESCRIPTION
Addresses http://manage.dimagi.com/default.asp?137874

If a user accessed this cloudcare endpoint with a remote app id, then `Application.get(app_id)` was raising an exception. Now we raise a 404 (instead of a 500) because remote apps are not supported by cloudcare.

I'm not adding any sort of message or redirect anywhere because I don't know how it came to be that the user hit this url (cloudcare doesn't display remote apps in it's navigation).
