### PR TITLE
support commtrack in cloudcare

### DIFF
--- a/corehq/apps/cloudcare/api.py
+++ b/corehq/apps/cloudcare/api.py
@@ -123,8 +123,9 @@ class CaseAPIHelper(object):
         if not self.ids_only or self.filters or self.footprint:
             # optimization hack - we know we'll need the full cases eventually
             # so just grab them now.
-            base_results = [CaseAPIResult(couch_doc=case, id_only=self.ids_only) \
+            base_results = [CaseAPIResult(couch_doc=case, id_only=self.ids_only)
                             for case in self.iter_cases(case_id_list)]
+
         else:
             base_results = [CaseAPIResult(id=id, id_only=True) for id in case_id_list]
 
@@ -205,12 +206,11 @@ def get_filtered_cases(domain, status, user_id=None, case_type=None,
                        filters=None, footprint=False, ids_only=False,
                        strip_history=True, include_children=False):
 
-    # for now, a filter value of None means don't filter
+    # a filter value of None means don't filter
     filters = dict((k, v) for k, v in (filters or {}).items() if v is not None)
     helper = CaseAPIHelper(domain, status, case_type=case_type, ids_only=ids_only,
                            footprint=footprint, strip_history=strip_history,
                            filters=filters, include_children=include_children)
-
     if user_id:
         return helper.get_owned(user_id)
     else:

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -25,7 +25,6 @@ from corehq.apps.cloudcare.api import look_up_app_json, get_cloudcare_apps, get_
     api_closed_to_status, CaseAPIResult, CASE_STATUS_OPEN, get_app_json, get_open_form_sessions
 from dimagi.utils.parsing import string_to_boolean
 from django.conf import settings
-from corehq.apps.cloudcare import touchforms_api
 from touchforms.formplayer.api import DjangoAuth
 from django.core.urlresolvers import reverse
 from casexml.apps.phone.fixtures import generator
@@ -294,7 +293,8 @@ def filter_cases(request, domain, app_id, module_id, parent_id=None):
             status=CASE_STATUS_OPEN,
             case_type=case_type,
             user_id=request.couch_user._id,
-            ids_only=True
+            footprint=True,
+            ids_only=True,
         )]
 
     cases = [CommCareCase.wrap(doc) for doc in iter_docs(CommCareCase.get_db(), case_ids)]


### PR DESCRIPTION
currently any delegation workflow is not supported in cloudcare.
this change fixes that by including the footprint along with the normal
case set. i can't think of any reason this hasn't always been true other
than an oversight.

also includes a tiny amount of cleanup
