### PR TITLE
Project space metadata

### DIFF
--- a/corehq/apps/api/domain_metadata.py
+++ b/corehq/apps/api/domain_metadata.py
@@ -1,0 +1,44 @@
+from django.http import Http404
+from django.utils.decorators import method_decorator
+from django.views.generic import View
+
+from corehq import Domain
+from corehq.apps.domain.decorators import login_or_digest_ex
+from corehq.apps.es.domains import DomainES
+
+from dimagi.utils.web import json_response
+
+
+def _get_metadata(domain):
+    return {
+        "calculated_properties": _get_calculated_properties(domain),
+        "domain_properties": _get_domain_properties(domain),
+    }
+
+
+def _get_calculated_properties(domain):
+    es_data = (DomainES()
+               .in_domains([domain.name])
+               .run()
+               .raw_hits[0]['_source'])
+    return {
+        raw_hit: es_data[raw_hit]
+        for raw_hit in es_data if raw_hit[:3] == 'cp_'
+    }
+
+
+def _get_domain_properties(domain):
+    return {term: domain[term] for term in domain}
+
+
+class DomainMetadataAPI(View):
+    @method_decorator(login_or_digest_ex())
+    def get(self, request, *args, **kwargs):
+        domain_name = args[0]
+        try:
+            domain = Domain.get_by_name(domain_name)
+        except ValueError:
+            domain = None
+        if not domain:
+            raise Http404
+        return json_response(_get_metadata(domain))

--- a/corehq/apps/api/domain_metadata.py
+++ b/corehq/apps/api/domain_metadata.py
@@ -3,6 +3,7 @@ from django.utils.decorators import method_decorator
 from django.views.generic import View
 
 from corehq import Domain
+from corehq.apps.accounting.models import Subscription
 from corehq.apps.domain.decorators import login_or_digest_ex
 from corehq.apps.es.domains import DomainES
 
@@ -11,8 +12,20 @@ from dimagi.utils.web import json_response
 
 def _get_metadata(domain):
     return {
+        "billing_data": _get_billing_data(domain),
         "calculated_properties": _get_calculated_properties(domain),
         "domain_properties": _get_domain_properties(domain),
+    }
+
+
+def _get_billing_data(domain):
+    return {
+        "plan_version": [
+            str(subscription) for subscription in Subscription.objects.filter(
+                subscriber__domain=domain.name,
+                is_active=True,
+            )
+        ]
     }
 
 

--- a/corehq/apps/api/urls.py
+++ b/corehq/apps/api/urls.py
@@ -1,3 +1,4 @@
+from corehq.apps.api.domain_metadata import DomainMetadataAPI
 from corehq.apps.api.object_fetch_api import CaseAttachmentAPI
 
 from corehq.apps.api.domainapi import DomainAPI
@@ -94,6 +95,7 @@ def api_url_patterns():
         yield url(r'^custom/%s/v%s/$' % (view_class.api_name(), view_class.api_version()), view_class.as_view(), name="%s_%s" % (view_class.api_name(), view_class.api_version()))
     yield url(r'^case/attachment/(?P<case_id>[\w\-]+)/(?P<attachment_id>.*)$', CaseAttachmentAPI.as_view(), name="api_case_attachment")
     yield url(r'^redis_assets/$', RedisAssetsAPI.as_view())
+    yield url(r'^project_space_metadata/$', DomainMetadataAPI.as_view())
 
 
 urlpatterns = patterns('',


### PR DESCRIPTION
implements
https://docs.google.com/a/dimagi.com/document/d/1ZpdRZLSstmnW_ubertb2jAMphssyOct_kWQ8YhpOhA0/edit#heading=h.i0ohvkukphfh

Restricts permission to domain admins (superusers permitted)

I chose not to use tastypie, since it would have been a mess to integrate with non-django ORM data
