### PR TITLE
display human readable messages in cloudcare

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/backbone/apps.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/backbone/apps.js
@@ -673,7 +673,7 @@ cloudCare.AppView = Backbone.View.extend({
             });
         };
         data.onerror = function (resp) {
-            showError(resp.message, $("#cloudcare-notifications"));
+            showError(resp.human_readable_message, $("#cloudcare-notifications"));
             cloudCare.dispatch.trigger("form:error", form, caseModel);
         };
         data.onload = function (adapter, resp) {


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?132358#787365

relies on https://github.com/dimagi/touchforms/pull/65

I'm not sure if this has any other ramifications. I don't think it should since the message attribute remains the same.
