### PR TITLE
Remove SubmitHistoryDatespanFilter and fallback to SubmitHistoryReport behavior

### DIFF
--- a/corehq/apps/reports/filters/dates.py
+++ b/corehq/apps/reports/filters/dates.py
@@ -1,15 +1,7 @@
-import datetime
-import logging
 import simplejson
-
 from django.utils.translation import ugettext_lazy, ugettext as _
-
 from dimagi.utils.dates import DateSpan
-from dimagi.utils.parsing import string_to_datetime
-
 from corehq.apps.reports.filters.base import BaseReportFilter
-from corehq.apps.sofabed.models import FormData
-from corehq.elastic import es_query, ES_URLS
 
 
 class DatespanFilter(BaseReportFilter):
@@ -48,22 +40,3 @@ class DatespanFilter(BaseReportFilter):
             'last_month': _('Last Month'),
             'last_30_days': _('Last 30 Days')
         })
-
-
-class SubmitHistoryDatespanFilter(DatespanFilter):
-
-    @property
-    def default_days(self):
-        """
-        Return the earliest date of form submission for the domain
-        falling back to 30 days.
-        """
-        days = 30
-        forms = (FormData.objects
-                 .filter(domain=self.domain)
-                 .order_by('received_on'))
-        if forms.count():
-            start_date = forms[0].received_on.replace(tzinfo=self.timezone)
-            end_date = datetime.datetime.now(self.timezone)
-            days = (end_date - start_date).days
-        return days

--- a/corehq/apps/reports/standard/inspect.py
+++ b/corehq/apps/reports/standard/inspect.py
@@ -48,7 +48,7 @@ class SubmitHistory(ElasticProjectInspectionReport, ProjectReport,
         'corehq.apps.reports.filters.users.ExpandedMobileWorkerFilter',
         'corehq.apps.reports.filters.forms.FormsByApplicationFilter',
         'corehq.apps.reports.filters.forms.CompletionOrSubmissionTimeFilter',
-        'corehq.apps.reports.filters.dates.SubmitHistoryDatespanFilter',
+        'corehq.apps.reports.filters.dates.DatespanFilter',
     ]
     ajax_pagination = True
     filter_users_field_class = StrongFilterUsersField


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?141639
Actually I'm just deleting this separate filter altogether, turns out it's not necessary, as the SubmitHistoryReport already uses oldest form submission as a default daterange, as defined here:
https://github.com/dimagi/commcare-hq/blob/submit-history-filter/corehq/apps/reports/standard/inspect.py#L87-L89, which references
https://github.com/dimagi/commcare-hq/blob/submit-history-filter/corehq/apps/reports/util.py#L477-L498
