### PR TITLE
Refactor SMS Settings UI

### DIFF
--- a/corehq/apps/hqwebapp/models.py
+++ b/corehq/apps/hqwebapp/models.py
@@ -852,12 +852,20 @@ class MessagingTab(UITab):
                 ],
             })
         if self.couch_user.is_superuser or self.couch_user.is_domain_admin(self.domain):
-            settings_pages.extend([
-                {'title': ugettext_lazy("General Settings"),
-                 'url': reverse('sms_settings', args=[self.domain])},
+            if toggles.REMINDERS_UI_PREVIEW.enabled(self.couch_user.username):
+                settings_pages.append(
+                    {'title': ugettext_lazy("General Settings"),
+                     'url': reverse('sms_settings_new', args=[self.domain])},
+                )
+            else:
+                settings_pages.append(
+                    {'title': ugettext_lazy("General Settings"),
+                     'url': reverse('sms_settings', args=[self.domain])},
+                )
+            settings_pages.append(
                 {'title': ugettext_lazy("Languages"),
-                 'url': reverse('sms_languages', args=[self.domain])},
-            ])
+                 'url': reverse('sms_languages', args=[self.domain])}
+            )
         if settings_pages:
             items.append((_("Settings"), settings_pages))
 

--- a/corehq/apps/sms/forms.py
+++ b/corehq/apps/sms/forms.py
@@ -527,28 +527,33 @@ class SettingsForm(Form):
                     "is read by anyone, or if it counts as being read only "
                     "to the user who reads it."),
             ),
-            BootstrapMultiField(
-                _("Chat Template"),
-                InlineField(
-                    "use_custom_chat_template",
-                    data_bind="value: use_custom_chat_template",
-                ),
-                InlineField(
-                    "custom_chat_template",
-                    data_bind="visible: showCustomChatTemplate",
-                ),
-                help_bubble_text=_("To use a custom template to render the "
-                    "chat window, enter it here."),
-                css_id="custom-chat-template-group",
-            ),
         ]
+        if self._cchq_is_previewer:
+            fields.append(
+                BootstrapMultiField(
+                    _("Chat Template"),
+                    InlineField(
+                        "use_custom_chat_template",
+                        data_bind="value: use_custom_chat_template",
+                    ),
+                    InlineField(
+                        "custom_chat_template",
+                        data_bind="visible: showCustomChatTemplate",
+                    ),
+                    help_bubble_text=_("To use a custom template to render the "
+                        "chat window, enter it here."),
+                    css_id="custom-chat-template-group",
+                )
+            )
         return crispy.Fieldset(
             _("Chat Settings"),
             *fields
         )
 
-    def __init__(self, data=None, cchq_domain=None, *args, **kwargs):
+    def __init__(self, data=None, cchq_domain=None, cchq_is_previewer=False,
+        *args, **kwargs):
         self._cchq_domain = cchq_domain
+        self._cchq_is_previewer = cchq_is_previewer
         super(SettingsForm, self).__init__(data, *args, **kwargs)
         self.populate_dynamic_choices()
 
@@ -647,9 +652,13 @@ class SettingsForm(Form):
         return value
 
     def clean_use_custom_chat_template(self):
+        if not self._cchq_is_previewer:
+            return None
         return self.cleaned_data.get("use_custom_chat_template") == CUSTOM
 
     def clean_custom_chat_template(self):
+        if not self._cchq_is_previewer:
+            return None
         value = self._clean_dependent_field("use_custom_chat_template",
             "custom_chat_template")
         if value is not None and value not in settings.CUSTOM_CHAT_TEMPLATES:

--- a/corehq/apps/sms/forms.py
+++ b/corehq/apps/sms/forms.py
@@ -354,6 +354,199 @@ class SettingsForm(Form):
         label=ugettext_noop("Registration Submitter"),
     )
 
+    @property
+    def section_general(self):
+        fields = [
+            BootstrapMultiField(
+                _("Default SMS Response"),
+                InlineField(
+                    "use_default_sms_response",
+                    data_bind="value: use_default_sms_response",
+                ),
+                InlineField(
+                    "default_sms_response",
+                    css_class="input-xxlarge",
+                    placeholder=_("Enter Default Response"),
+                    data_bind="visible: showDefaultSMSResponse",
+                ),
+                help_bubble_text=_("Enable this option to provide a "
+                    "default response when a user's incoming SMS does not "
+                    "answer an open survey or match a known keyword."),
+                css_id="default-sms-response-group",
+            ),
+            FieldWithHelpBubble(
+                "use_restricted_sms_times",
+                data_bind="value: use_restricted_sms_times",
+                help_bubble_text=_("Use this option to limit the times "
+                    "that SMS messages can be sent to users. Messages that "
+                    "are sent outside these windows will remained queued "
+                    "and will go out as soon as another window opens up."),
+            ),
+            BootstrapMultiField(
+                "",
+                HiddenFieldWithErrors("restricted_sms_times_json",
+                    data_bind="value: restricted_sms_times_json"),
+                crispy.Div(
+                    data_bind="template: {"
+                              " name: 'ko-template-restricted-sms-times', "
+                              " data: $data"
+                              "}",
+                ),
+                data_bind="visible: showRestrictedSMSTimes",
+            ),
+            FieldWithHelpBubble(
+                "send_to_duplicated_case_numbers",
+                help_bubble_text=_("Enabling this option will send "
+                    "outgoing-only messages to phone numbers registered "
+                    "with more than one mobile worker or case. SMS surveys "
+                    "and keywords will still only work for unique phone "
+                    "numbers in your project."),
+            ),
+        ]
+        return crispy.Fieldset(
+            _("General Settings"),
+            *fields
+        )
+
+    @property
+    def section_registration(self):
+        fields = [
+            FieldWithHelpBubble(
+                "sms_case_registration_enabled",
+                help_bubble_text=_("When this option is enabled, a person "
+                    "can send an SMS into the system saying 'join "
+                    "[project]', where [project] is your project "
+                    "space name, and the system will automatically "
+                    "create a case tied to that person's phone number."),
+                data_bind="value: sms_case_registration_enabled",
+            ),
+            crispy.Div(
+                FieldWithHelpBubble(
+                    "sms_case_registration_type",
+                    placeholder=_("Enter a Case Type"),
+                    help_bubble_text=_("Cases that self-register over SMS "
+                        "will be given this case type."),
+                ),
+                FieldWithHelpBubble(
+                    "sms_case_registration_owner_id",
+                    help_bubble_text=_("Cases that self-register over SMS "
+                        "will be owned by this user or user group."),
+                ),
+                FieldWithHelpBubble(
+                    "sms_case_registration_user_id",
+                    help_bubble_text=_("The form submission for a "
+                        "self-registration will belong to this user."),
+                ),
+                data_bind="visible: showRegistrationOptions",
+            ),
+        ]
+        return crispy.Fieldset(
+            _("Registration Settings"),
+            *fields
+        )
+
+    @property
+    def section_chat(self):
+        fields = [
+            BootstrapMultiField(
+                _("Case Name Display"),
+                InlineField(
+                    "use_custom_case_username",
+                    data_bind="value: use_custom_case_username",
+                ),
+                InlineField(
+                    "custom_case_username",
+                    css_class="input-large",
+                    data_bind="visible: showCustomCaseUsername",
+                ),
+                help_bubble_text=_("By default, when chatting with a case, "
+                    "the chat window will use the case's \"name\" case "
+                    "property when displaying the case's name. To use a "
+                    "different case property, specify it here."),
+                css_id="custom-case-username-group",
+            ),
+            BootstrapMultiField(
+                _("Counter Threshold"),
+                InlineField(
+                    "use_custom_message_count_threshold",
+                    data_bind="value: use_custom_message_count_threshold",
+                ),
+                InlineField(
+                    "custom_message_count_threshold",
+                    css_class="input-large",
+                    data_bind="visible: showCustomMessageCountThreshold",
+                ),
+                help_bubble_text=_("The chat window keeps track of how many "
+                    "messages are being sent and received, and will "
+                    "highlight the counter after it reaches 50. To use a "
+                    "different threshold than 50, enter it here."),
+                css_id="custom-message-count-threshold-group",
+            ),
+            FieldWithHelpBubble(
+                "use_sms_conversation_times",
+                data_bind="value: use_sms_conversation_times",
+                help_bubble_text=_("When this option is enabled, the system "
+                    "will not send automated SMS to chat recipients when "
+                    "those recipients are in the middle of a conversation."),
+            ),
+            BootstrapMultiField(
+                "",
+                HiddenFieldWithErrors("sms_conversation_times_json",
+                    data_bind="value: sms_conversation_times_json"),
+                crispy.Div(
+                    data_bind="template: {"
+                              " name: 'ko-template-sms-conversation-times', "
+                              " data: $data"
+                              "}",
+                ),
+                data_bind="visible: showSMSConversationTimes",
+            ),
+            crispy.Div(
+                FieldWithHelpBubble(
+                    "sms_conversation_length",
+                    help_bubble_text=_("The number of minutes to wait "
+                        "after receiving an incoming SMS from a chat "
+                        "recipient before resuming automated SMS to that "
+                        "recipient."),
+                ),
+                data_bind="visible: showSMSConversationTimes",
+            ),
+            FieldWithHelpBubble(
+                "survey_traffic_option",
+                help_bubble_text=_("This option allows you to hide a chat "
+                    "recipient's survey questions and responses from chat "
+                    "windows. There is also the option to show only invalid "
+                    "responses to questions in the chat window, which could "
+                    "be attempts to converse."),
+            ),
+            FieldWithHelpBubble(
+                "count_messages_as_read_by_anyone",
+                help_bubble_text=_("The chat window will mark unread "
+                    "messages to the user viewing them. Use this option to "
+                    "control whether a message counts as being read if it "
+                    "is read by anyone, or if it counts as being read only "
+                    "to the user who reads it."),
+            ),
+            BootstrapMultiField(
+                _("Chat Template"),
+                InlineField(
+                    "use_custom_chat_template",
+                    data_bind="value: use_custom_chat_template",
+                ),
+                InlineField(
+                    "custom_chat_template",
+                    data_bind="visible: showCustomChatTemplate",
+                ),
+                help_bubble_text=_("To use a custom template to render the "
+                    "chat window, enter it here."),
+                css_id="custom-chat-template-group",
+            ),
+        ]
+        return crispy.Fieldset(
+            _("Chat Settings"),
+            *fields
+        )
+
     def __init__(self, data=None, cchq_domain=None, *args, **kwargs):
         self._cchq_domain = cchq_domain
         super(SettingsForm, self).__init__(data, *args, **kwargs)
@@ -362,181 +555,9 @@ class SettingsForm(Form):
         self.helper = FormHelper()
         self.helper.form_class = "form form-horizontal"
         self.helper.layout = crispy.Layout(
-            crispy.Fieldset(
-                _("General Settings"),
-                BootstrapMultiField(
-                    _("Default SMS Response"),
-                    InlineField(
-                        "use_default_sms_response",
-                        data_bind="value: use_default_sms_response",
-                    ),
-                    InlineField(
-                        "default_sms_response",
-                        css_class="input-xxlarge",
-                        placeholder=_("Enter Default Response"),
-                        data_bind="visible: showDefaultSMSResponse",
-                    ),
-                    help_bubble_text=_("Enable this option to provide a "
-                        "default response when a user's incoming SMS does not "
-                        "answer an open survey or match a known keyword."),
-                    css_id="default-sms-response-group",
-                ),
-                FieldWithHelpBubble(
-                    "use_restricted_sms_times",
-                    data_bind="value: use_restricted_sms_times",
-                    help_bubble_text=_("Use this option to limit the times "
-                        "that SMS messages can be sent to users. Messages that "
-                        "are sent outside these windows will remained queued "
-                        "and will go out as soon as another window opens up."),
-                ),
-                BootstrapMultiField(
-                    "",
-                    HiddenFieldWithErrors("restricted_sms_times_json",
-                        data_bind="value: restricted_sms_times_json"),
-                    crispy.Div(
-                        data_bind="template: {"
-                                  " name: 'ko-template-restricted-sms-times', "
-                                  " data: $data"
-                                  "}",
-                    ),
-                    data_bind="visible: showRestrictedSMSTimes",
-                ),
-                FieldWithHelpBubble(
-                    "send_to_duplicated_case_numbers",
-                    help_bubble_text=_("Enabling this option will send "
-                        "outgoing-only messages to phone numbers registered "
-                        "with more than one mobile worker or case. SMS surveys "
-                        "and keywords will still only work for unique phone "
-                        "numbers in your project."),
-                ),
-            ),
-            crispy.Fieldset(
-                _("Registration Settings"),
-                FieldWithHelpBubble(
-                    "sms_case_registration_enabled",
-                    help_bubble_text=_("When this option is enabled, a person "
-                        "can send an SMS into the system saying 'join "
-                        "[project]', where [project] is your project "
-                        "space name, and the system will automatically "
-                        "create a case tied to that person's phone number."),
-                    data_bind="value: sms_case_registration_enabled",
-                ),
-                crispy.Div(
-                    FieldWithHelpBubble(
-                        "sms_case_registration_type",
-                        placeholder=_("Enter a Case Type"),
-                        help_bubble_text=_("Cases that self-register over SMS "
-                            "will be given this case type."),
-                    ),
-                    FieldWithHelpBubble(
-                        "sms_case_registration_owner_id",
-                        help_bubble_text=_("Cases that self-register over SMS "
-                            "will be owned by this user or user group."),
-                    ),
-                    FieldWithHelpBubble(
-                        "sms_case_registration_user_id",
-                        help_bubble_text=_("The form submission for a "
-                            "self-registration will belong to this user."),
-                    ),
-                    data_bind="visible: showRegistrationOptions",
-                ),
-            ),
-            crispy.Fieldset(
-                _("Chat Settings"),
-                BootstrapMultiField(
-                    _("Case Name Display"),
-                    InlineField(
-                        "use_custom_case_username",
-                        data_bind="value: use_custom_case_username",
-                    ),
-                    InlineField(
-                        "custom_case_username",
-                        css_class="input-large",
-                        data_bind="visible: showCustomCaseUsername",
-                    ),
-                    help_bubble_text=_("By default, when chatting with a case, "
-                        "the chat window will use the case's \"name\" case "
-                        "property when displaying the case's name. To use a "
-                        "different case property, specify it here."),
-                    css_id="custom-case-username-group",
-                ),
-                BootstrapMultiField(
-                    _("Counter Threshold"),
-                    InlineField(
-                        "use_custom_message_count_threshold",
-                        data_bind="value: use_custom_message_count_threshold",
-                    ),
-                    InlineField(
-                        "custom_message_count_threshold",
-                        css_class="input-large",
-                        data_bind="visible: showCustomMessageCountThreshold",
-                    ),
-                    help_bubble_text=_("The chat window keeps track of how many "
-                        "messages are being sent and received, and will "
-                        "highlight the counter after it reaches 50. To use a "
-                        "different threshold than 50, enter it here."),
-                    css_id="custom-message-count-threshold-group",
-                ),
-                FieldWithHelpBubble(
-                    "use_sms_conversation_times",
-                    data_bind="value: use_sms_conversation_times",
-                    help_bubble_text=_("When this option is enabled, the system "
-                        "will not send automated SMS to chat recipients when "
-                        "those recipients are in the middle of a conversation."),
-                ),
-                BootstrapMultiField(
-                    "",
-                    HiddenFieldWithErrors("sms_conversation_times_json",
-                        data_bind="value: sms_conversation_times_json"),
-                    crispy.Div(
-                        data_bind="template: {"
-                                  " name: 'ko-template-sms-conversation-times', "
-                                  " data: $data"
-                                  "}",
-                    ),
-                    data_bind="visible: showSMSConversationTimes",
-                ),
-                crispy.Div(
-                    FieldWithHelpBubble(
-                        "sms_conversation_length",
-                        help_bubble_text=_("The number of minutes to wait "
-                            "after receiving an incoming SMS from a chat "
-                            "recipient before resuming automated SMS to that "
-                            "recipient."),
-                    ),
-                    data_bind="visible: showSMSConversationTimes",
-                ),
-                FieldWithHelpBubble(
-                    "survey_traffic_option",
-                    help_bubble_text=_("This option allows you to hide a chat "
-                        "recipient's survey questions and responses from chat "
-                        "windows. There is also the option to show only invalid "
-                        "responses to questions in the chat window, which could "
-                        "be attempts to converse."),
-                ),
-                FieldWithHelpBubble(
-                    "count_messages_as_read_by_anyone",
-                    help_bubble_text=_("The chat window will mark unread "
-                        "messages to the user viewing them. Use this option to "
-                        "control whether a message counts as being read if it "
-                        "is read by anyone, or if it counts as being read only "
-                        "to the user who reads it."),
-                ),
-                BootstrapMultiField(
-                    _("Chat Template"),
-                    InlineField(
-                        "use_custom_chat_template",
-                        data_bind="value: use_custom_chat_template",
-                    ),
-                    InlineField(
-                        "custom_chat_template",
-                        data_bind="visible: showCustomChatTemplate",
-                    ),
-                    help_bubble_text=_("To use a custom template to render the "
-                        "chat window, enter it here."),
-                    css_id="custom-chat-template-group",
-                ),
-            ),
+            self.section_general,
+            self.section_registration,
+            self.section_chat,
             FormActions(
                 StrictButton(
                     _("Save"),

--- a/corehq/apps/sms/static/sms/ko/settings.ko.js
+++ b/corehq/apps/sms/static/sms/ko/settings.ko.js
@@ -37,7 +37,8 @@ function SettingsViewModel(initial) {
     self.use_custom_message_count_threshold = ko.observable();
     self.use_sms_conversation_times = ko.observable();
     self.sms_conversation_times = ko.observableArray();
-    self.use_custom_chat_template = ko.observableArray();
+    self.use_custom_chat_template = ko.observable();
+    self.sms_case_registration_enabled = ko.observable();
 
     self.showDefaultSMSResponse = ko.computed(function() {
         return self.use_default_sms_response() === "ENABLED";
@@ -53,6 +54,10 @@ function SettingsViewModel(initial) {
 
     self.showRestrictedSMSTimes = ko.computed(function() {
         return self.use_restricted_sms_times() === "ENABLED";
+    });
+
+    self.showRegistrationOptions = ko.computed(function() {
+        return self.sms_case_registration_enabled() === "ENABLED";
     });
 
     self.addRestrictedSMSTime = function() {

--- a/corehq/apps/sms/static/sms/ko/settings.ko.js
+++ b/corehq/apps/sms/static/sms/ko/settings.ko.js
@@ -33,13 +33,26 @@ function SettingsViewModel(initial) {
     self.use_default_sms_response = ko.observable();
     self.use_restricted_sms_times = ko.observable();
     self.restricted_sms_times = ko.observableArray();
+    self.use_custom_case_username = ko.observable();
+    self.use_custom_message_count_threshold = ko.observable();
+    self.use_sms_conversation_times = ko.observable();
+    self.sms_conversation_times = ko.observableArray();
+    self.use_custom_chat_template = ko.observableArray();
 
     self.showDefaultSMSResponse = ko.computed(function() {
         return self.use_default_sms_response() === "ENABLED";
     });
 
+    self.showCustomCaseUsername = ko.computed(function() {
+        return self.use_custom_case_username() === "CUSTOM";
+    });
+
+    self.showCustomMessageCountThreshold = ko.computed(function() {
+        return self.use_custom_message_count_threshold() === "CUSTOM";
+    });
+
     self.showRestrictedSMSTimes = ko.computed(function() {
-        return self.use_restricted_sms_times() === "SPECIFIC_TIMES";
+        return self.use_restricted_sms_times() === "ENABLED";
     });
 
     self.addRestrictedSMSTime = function() {
@@ -50,6 +63,23 @@ function SettingsViewModel(initial) {
     self.removeRestrictedSMSTime = function() {
         self.restricted_sms_times.remove(this);
     };
+
+    self.showSMSConversationTimes = ko.computed(function() {
+        return self.use_sms_conversation_times() === "ENABLED";
+    });
+
+    self.addSMSConversationTime = function() {
+        self.sms_conversation_times.push(new DayTimeWindow(-1, null, null));
+        self.refreshTimePickers();
+    };
+
+    self.removeSMSConversationTime = function() {
+        self.sms_conversation_times.remove(this);
+    };
+
+    self.showCustomChatTemplate = ko.computed(function() {
+        return self.use_custom_chat_template() === "CUSTOM";
+    });
 
     self.refreshTimePickers = function() {
         $('[data-timeset="true"]').each(function () {

--- a/corehq/apps/sms/static/sms/ko/settings.ko.js
+++ b/corehq/apps/sms/static/sms/ko/settings.ko.js
@@ -1,4 +1,4 @@
-function DayTimeWindow(day, start_time, end_time) {
+function DayTimeWindow(day, start_time, end_time, time_input_relationship) {
     'use strict';
     var self = this;
     self.day = ko.observable(day);
@@ -15,15 +15,9 @@ function DayTimeWindow(day, start_time, end_time) {
         }
     }
 
-    self.time_input_relationship_change = function() {
-        if(self.time_input_relationship() === "BEFORE") {
-            self.start_time(null);
-        } else if(self.time_input_relationship() === "AFTER") {
-            self.end_time(null);
-        }
-    }
-
-    self.time_input_relationship = ko.observable(self.time_input_relationship_initial());
+    self.time_input_relationship = ko.observable(
+        time_input_relationship || self.time_input_relationship_initial()
+    );
 }
 
 function SettingsViewModel(initial) {
@@ -61,7 +55,7 @@ function SettingsViewModel(initial) {
     });
 
     self.addRestrictedSMSTime = function() {
-        self.restricted_sms_times.push(new DayTimeWindow(-1, null, null));
+        self.restricted_sms_times.push(new DayTimeWindow(-1, null, null, null));
         self.refreshTimePickers();
     };
 
@@ -74,7 +68,7 @@ function SettingsViewModel(initial) {
     });
 
     self.addSMSConversationTime = function() {
-        self.sms_conversation_times.push(new DayTimeWindow(-1, null, null));
+        self.sms_conversation_times.push(new DayTimeWindow(-1, null, null, null));
         self.refreshTimePickers();
     };
 
@@ -84,6 +78,14 @@ function SettingsViewModel(initial) {
 
     self.showCustomChatTemplate = ko.computed(function() {
         return self.use_custom_chat_template() === "CUSTOM";
+    });
+
+    self.restricted_sms_times_json = ko.computed(function() {
+        return ko.toJSON(self.restricted_sms_times());
+    });
+
+    self.sms_conversation_times_json = ko.computed(function() {
+        return ko.toJSON(self.sms_conversation_times());
     });
 
     self.refreshTimePickers = function() {
@@ -97,6 +99,38 @@ function SettingsViewModel(initial) {
     };
 
     self.init = function() {
+        self.use_default_sms_response(initial.use_default_sms_response);
+        self.use_restricted_sms_times(initial.use_restricted_sms_times);
+        self.use_custom_case_username(initial.use_custom_case_username);
+        self.use_custom_message_count_threshold(initial.use_custom_message_count_threshold);
+        self.use_sms_conversation_times(initial.use_sms_conversation_times);
+        self.use_custom_chat_template(initial.use_custom_chat_template);
+        self.sms_case_registration_enabled(initial.sms_case_registration_enabled);
+
+        if(initial.restricted_sms_times_json.length > 0) {
+            for(var i = 0; i < initial.restricted_sms_times_json.length; i++) {
+                var window = initial.restricted_sms_times_json[i];
+                self.restricted_sms_times.push(
+                    new DayTimeWindow(window.day, window.start_time, window.end_time,
+                        window.time_input_relationship)
+                );
+            }
+        } else {
+            self.addRestrictedSMSTime();
+        }
+
+        if(initial.sms_conversation_times_json.length > 0) {
+            for(var i = 0; i < initial.sms_conversation_times_json.length; i++) {
+                var window = initial.sms_conversation_times_json[i];
+                self.sms_conversation_times.push(
+                    new DayTimeWindow(window.day, window.start_time, window.end_time,
+                        window.time_input_relationship)
+                );
+            }
+        } else {
+            self.addSMSConversationTime();
+        }
+
         self.refreshTimePickers();
     };
 

--- a/corehq/apps/sms/static/sms/ko/settings.ko.js
+++ b/corehq/apps/sms/static/sms/ko/settings.ko.js
@@ -1,0 +1,68 @@
+function DayTimeWindow(day, start_time, end_time) {
+    'use strict';
+    var self = this;
+    self.day = ko.observable(day);
+    self.start_time = ko.observable(start_time);
+    self.end_time = ko.observable(end_time);
+
+    self.time_input_relationship_initial = function() {
+        if(self.start_time() === null) {
+            return "BEFORE";
+        } else if(self.end_time() === null) {
+            return "AFTER";
+        } else {
+            return "BETWEEN";
+        }
+    }
+
+    self.time_input_relationship_change = function() {
+        if(self.time_input_relationship() === "BEFORE") {
+            self.start_time(null);
+        } else if(self.time_input_relationship() === "AFTER") {
+            self.end_time(null);
+        }
+    }
+
+    self.time_input_relationship = ko.observable(self.time_input_relationship_initial());
+}
+
+function SettingsViewModel(initial) {
+    'use strict';
+    var self = this;
+
+    self.use_default_sms_response = ko.observable();
+    self.use_restricted_sms_times = ko.observable();
+    self.restricted_sms_times = ko.observableArray();
+
+    self.showDefaultSMSResponse = ko.computed(function() {
+        return self.use_default_sms_response() === "ENABLED";
+    });
+
+    self.showRestrictedSMSTimes = ko.computed(function() {
+        return self.use_restricted_sms_times() === "SPECIFIC_TIMES";
+    });
+
+    self.addRestrictedSMSTime = function() {
+        self.restricted_sms_times.push(new DayTimeWindow(-1, null, null));
+        self.refreshTimePickers();
+    };
+
+    self.removeRestrictedSMSTime = function() {
+        self.restricted_sms_times.remove(this);
+    };
+
+    self.refreshTimePickers = function() {
+        $('[data-timeset="true"]').each(function () {
+            $(this).timepicker({
+                showMeridian: false,
+                showSeconds: false,
+                defaultTime: $(this).val() || false
+            });
+        });
+    };
+
+    self.init = function() {
+        self.refreshTimePickers();
+    };
+
+}

--- a/corehq/apps/sms/templates/sms/partials/day_time_windows.html
+++ b/corehq/apps/sms/templates/sms/partials/day_time_windows.html
@@ -1,0 +1,50 @@
+{% load i18n %}
+
+<script type="text/html" id="{{ context.template_name }}">
+    <p>
+        <i class="icon-info-sign"></i> {{ context.explanation_text }}
+    </p>
+    <table class="table table-bordered table-striped" class="span6">
+        <thead>
+            <tr>
+                <th>{% trans "When the day is..." %}</th>
+                <th>{% trans "And the time is..." %}</th>
+                <th>{% trans "Action" %}</th>
+            </tr>
+        </thead>
+        <tbody data-bind="foreach: {{ context.ko_array_name }}">
+            <tr>
+                <td>
+                    <select class="input-medium" data-bind="value: day">
+                        <option value="-1">{% trans "Any Day" %}</option>
+                        <option value="0">{% trans "Monday" %}</option>
+                        <option value="1">{% trans "Tuesday" %}</option>
+                        <option value="2">{% trans "Wednesday" %}</option>
+                        <option value="3">{% trans "Thursday" %}</option>
+                        <option value="4">{% trans "Friday" %}</option>
+                        <option value="5">{% trans "Saturday" %}</option>
+                        <option value="6">{% trans "Sunday" %}</option>
+                    </select>
+                <td>
+                    <select class="input-medium" data-bind="value: time_input_relationship">
+                        <option value="BEFORE">{% trans "Before" %}</option>
+                        <option value="AFTER">{% trans "After" %}</option>
+                        <option value="BETWEEN">{% trans "Between" %}</option>
+                    </select>
+                    {% include "sms/partials/time_picker.html" with div_data_bind="visible: time_input_relationship() !== 'BEFORE'" input_data_bind="value: start_time" only %}
+                    <span data-bind="visible: time_input_relationship() === 'BETWEEN'">{% trans "and" %}</span>
+                    {% include "sms/partials/time_picker.html" with div_data_bind="visible: time_input_relationship() !== 'AFTER'" input_data_bind="value: end_time" only %}
+                </td>
+                <td><button type="button"
+                            class="btn btn-danger"
+                            data-bind="click: {{ context.remove_window_method }}">
+                    <i class="icon-remove"></i> {% trans "Remove" %}</button></td>
+            </tr>
+        </tbody>
+    </table>
+    <button class="btn btn-success"
+            type="button"
+            data-bind="click: {{ context.add_window_method }}">
+        <i class="icon-plus"></i> {% trans 'Add Day and Time Window' %}
+    </button>
+</script>

--- a/corehq/apps/sms/templates/sms/partials/time_picker.html
+++ b/corehq/apps/sms/templates/sms/partials/time_picker.html
@@ -1,0 +1,4 @@
+<div class="input-append help-inline bootstrap-timepicker" data-bind="{{ div_data_bind|default:'' }}">
+    <input type="text" data-bind="{{ input_data_bind|default:'' }}" data-timeset="true" class="input-small" />
+    <span class="add-on"><i class="icon-time"></i></span>
+</div>

--- a/corehq/apps/sms/templates/sms/settings_new.html
+++ b/corehq/apps/sms/templates/sms/settings_new.html
@@ -1,0 +1,73 @@
+{% extends 'hqwebapp/base_section.html' %}
+{% load i18n %}
+{% load hq_shared_tags %}
+{% load crispy_forms_tags %}
+
+{% block js %}{{ block.super }}
+    <script src="{% static 'sms/ko/settings.ko.js' %}"></script>
+{% endblock %}
+
+{% block js-inline %}{{ block.super }}
+    <script>
+        var settingsViewModel = new SettingsViewModel(
+            {}
+        );
+        ko.applyBindings(settingsViewModel, $('#sms-settings-form').get(0));
+        settingsViewModel.init();
+    </script>
+{% endblock %}
+
+{% block main_column %}
+    <div id="sms-settings-form">
+        {% crispy form %}
+    </div>
+
+    <script type="text/html" id="ko-template-restricted-sms-times">
+        <p>
+            <i class="icon-info-sign"></i> {% trans "SMS will only be sent when any of the following is true:" %}
+        </p>
+        <table class="table table-bordered table-striped" class="span6">
+            <thead>
+                <tr>
+                    <th>{% trans "When the day is..." %}</th>
+                    <th>{% trans "And the time is..." %}</th>
+                    <th>{% trans "Action" %}</th>
+                </tr>
+            </thead>
+            <tbody data-bind="foreach: restricted_sms_times">
+                <tr>
+                    <td>
+                        <select class="input-medium" data-bind="value: day">
+                            <option value="-1">{% trans "Any Day" %}</option>
+                            <option value="0">{% trans "Monday" %}</option>
+                            <option value="1">{% trans "Tuesday" %}</option>
+                            <option value="2">{% trans "Wednesday" %}</option>
+                            <option value="3">{% trans "Thursday" %}</option>
+                            <option value="4">{% trans "Friday" %}</option>
+                            <option value="5">{% trans "Saturday" %}</option>
+                            <option value="6">{% trans "Sunday" %}</option>
+                        </select>
+                    <td>
+                        <select class="input-medium" data-bind="value: time_input_relationship">
+                            <option value="BEFORE">{% trans "Before" %}</option>
+                            <option value="AFTER">{% trans "After" %}</option>
+                            <option value="BETWEEN">{% trans "Between" %}</option>
+                        </select>
+                        {% include "sms/partials/time_picker.html" with div_data_bind="visible: time_input_relationship() !== 'BEFORE'" input_data_bind="value: start_time" only %}
+                        <span data-bind="visible: time_input_relationship() === 'BETWEEN'">{% trans "and" %}</span>
+                        {% include "sms/partials/time_picker.html" with div_data_bind="visible: time_input_relationship() !== 'AFTER'" input_data_bind="value: end_time" only %}
+                    </td>
+                    <td><button type="button"
+                                class="btn btn-danger"
+                                data-bind="click: $parent.removeRestrictedSMSTime">
+                        <i class="icon-remove"></i> {% trans "Remove" %}</button></td>
+                </tr>
+            </tbody>
+        </table>
+        <button class="btn btn-success"
+                type="button"
+                data-bind="click: addRestrictedSMSTime">
+            <i class="icon-plus"></i> {% trans 'Add Allowed Day and Time' %}
+        </button>
+    </script>
+{% endblock %}

--- a/corehq/apps/sms/templates/sms/settings_new.html
+++ b/corehq/apps/sms/templates/sms/settings_new.html
@@ -22,52 +22,6 @@
         {% crispy form %}
     </div>
 
-    <script type="text/html" id="ko-template-restricted-sms-times">
-        <p>
-            <i class="icon-info-sign"></i> {% trans "SMS will only be sent when any of the following is true:" %}
-        </p>
-        <table class="table table-bordered table-striped" class="span6">
-            <thead>
-                <tr>
-                    <th>{% trans "When the day is..." %}</th>
-                    <th>{% trans "And the time is..." %}</th>
-                    <th>{% trans "Action" %}</th>
-                </tr>
-            </thead>
-            <tbody data-bind="foreach: restricted_sms_times">
-                <tr>
-                    <td>
-                        <select class="input-medium" data-bind="value: day">
-                            <option value="-1">{% trans "Any Day" %}</option>
-                            <option value="0">{% trans "Monday" %}</option>
-                            <option value="1">{% trans "Tuesday" %}</option>
-                            <option value="2">{% trans "Wednesday" %}</option>
-                            <option value="3">{% trans "Thursday" %}</option>
-                            <option value="4">{% trans "Friday" %}</option>
-                            <option value="5">{% trans "Saturday" %}</option>
-                            <option value="6">{% trans "Sunday" %}</option>
-                        </select>
-                    <td>
-                        <select class="input-medium" data-bind="value: time_input_relationship">
-                            <option value="BEFORE">{% trans "Before" %}</option>
-                            <option value="AFTER">{% trans "After" %}</option>
-                            <option value="BETWEEN">{% trans "Between" %}</option>
-                        </select>
-                        {% include "sms/partials/time_picker.html" with div_data_bind="visible: time_input_relationship() !== 'BEFORE'" input_data_bind="value: start_time" only %}
-                        <span data-bind="visible: time_input_relationship() === 'BETWEEN'">{% trans "and" %}</span>
-                        {% include "sms/partials/time_picker.html" with div_data_bind="visible: time_input_relationship() !== 'AFTER'" input_data_bind="value: end_time" only %}
-                    </td>
-                    <td><button type="button"
-                                class="btn btn-danger"
-                                data-bind="click: $parent.removeRestrictedSMSTime">
-                        <i class="icon-remove"></i> {% trans "Remove" %}</button></td>
-                </tr>
-            </tbody>
-        </table>
-        <button class="btn btn-success"
-                type="button"
-                data-bind="click: addRestrictedSMSTime">
-            <i class="icon-plus"></i> {% trans 'Add Allowed Day and Time' %}
-        </button>
-    </script>
+    {% include "sms/partials/day_time_windows.html" with context=form.restricted_sms_times_widget_context only %}
+    {% include "sms/partials/day_time_windows.html" with context=form.sms_conversation_times_widget_context only %}
 {% endblock %}

--- a/corehq/apps/sms/templates/sms/settings_new.html
+++ b/corehq/apps/sms/templates/sms/settings_new.html
@@ -10,7 +10,7 @@
 {% block js-inline %}{{ block.super }}
     <script>
         var settingsViewModel = new SettingsViewModel(
-            {}
+            {{ form.current_values|JSON }}
         );
         ko.applyBindings(settingsViewModel, $('#sms-settings-form').get(0));
         settingsViewModel.init();

--- a/corehq/apps/sms/urls.py
+++ b/corehq/apps/sms/urls.py
@@ -5,6 +5,7 @@ from corehq.apps.sms.views import (
     SubscribeSMSView,
     AddDomainGatewayView,
     EditDomainGatewayView,
+    SMSSettingsView,
 )
 
 urlpatterns = patterns('corehq.apps.sms.views',
@@ -37,6 +38,7 @@ urlpatterns = patterns('corehq.apps.sms.views',
     url(r'^api/history/$', 'api_history', name='api_history'),
     url(r'^api/last_read_message/$', 'api_last_read_message', name='api_last_read_message'),
     url(r'^settings/$', 'sms_settings', name='sms_settings'),
+    url(r'^settings_new/$', SMSSettingsView.as_view(), name='sms_settings_new'),
     url(r'^subscribe_sms/$', SubscribeSMSView.as_view(), name=SubscribeSMSView.urlname),
     url(r'^languages/$', 'sms_languages', name='sms_languages'),
     url(r'^languages/edit/$', 'edit_sms_languages', name='edit_sms_languages'),

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -1328,8 +1328,8 @@ def upload_sms_translations(request, domain):
 
 
 class SMSSettingsView(BaseMessagingSectionView):
-    urlname = 'sms_settings_new'
-    template_name = 'sms/settings_new.html'
+    urlname = "sms_settings_new"
+    template_name = "sms/settings_new.html"
     page_title = ugettext_noop("SMS Settings")
 
     @property
@@ -1343,7 +1343,7 @@ class SMSSettingsView(BaseMessagingSectionView):
     @property
     @memoized
     def form(self):
-        if self.request.method == 'POST':
+        if self.request.method == "POST":
             form = SettingsForm(self.request.POST)
         else:
             form = SettingsForm()
@@ -1352,7 +1352,7 @@ class SMSSettingsView(BaseMessagingSectionView):
     @property
     def page_context(self):
         return {
-            'form': self.form,
+            "form": self.form,
         }
 
     def post(self, request, *args, **kwargs):

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -1344,9 +1344,9 @@ class SMSSettingsView(BaseMessagingSectionView):
     @memoized
     def form(self):
         if self.request.method == "POST":
-            form = SettingsForm(self.request.POST)
+            form = SettingsForm(self.request.POST, cchq_domain=self.domain)
         else:
-            form = SettingsForm()
+            form = SettingsForm(cchq_domain=self.domain)
         return form
 
     @property

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -40,7 +40,8 @@ from corehq.apps.sms.mixin import (SMSBackend, BackendMapping, VerifiedNumber,
     SMSLoadBalancingMixin)
 from corehq.apps.sms.forms import (ForwardingRuleForm, BackendMapForm,
     InitiateAddSMSBackendForm, SMSSettingsForm, SubscribeSMSForm,
-    SettingsForm)
+    SettingsForm, SHOW_ALL, SHOW_INVALID, HIDE_ALL, ENABLED, DISABLED,
+    DEFAULT, CUSTOM)
 from corehq.apps.sms.util import get_available_backends, get_contact
 from corehq.apps.sms.messages import _MESSAGES
 from corehq.apps.groups.models import Group
@@ -1346,7 +1347,57 @@ class SMSSettingsView(BaseMessagingSectionView):
         if self.request.method == "POST":
             form = SettingsForm(self.request.POST, cchq_domain=self.domain)
         else:
-            form = SettingsForm(cchq_domain=self.domain)
+            domain_obj = Domain.get_by_name(self.domain, strict=True)
+            enabled_disabled = lambda b: (ENABLED if b else DISABLED)
+            default_custom = lambda b: (CUSTOM if b else DEFAULT)
+            initial = {
+                "use_default_sms_response":
+                    enabled_disabled(domain_obj.use_default_sms_response),
+                "default_sms_response":
+                    domain_obj.default_sms_response,
+                "use_restricted_sms_times":
+                    enabled_disabled(len(domain_obj.restricted_sms_times) > 0),
+                "restricted_sms_times_json":
+                    [w.to_json() for w in domain_obj.restricted_sms_times],
+                "send_to_duplicated_case_numbers":
+                    enabled_disabled(domain_obj.send_to_duplicated_case_numbers),
+                "use_custom_case_username":
+                    default_custom(domain_obj.custom_case_username),
+                "custom_case_username":
+                    domain_obj.custom_case_username,
+                "use_custom_message_count_threshold":
+                    default_custom(
+                        domain_obj.chat_message_count_threshold is not None),
+                "custom_message_count_threshold":
+                    domain_obj.chat_message_count_threshold,
+                "use_sms_conversation_times":
+                    enabled_disabled(len(domain_obj.sms_conversation_times) > 0),
+                "sms_conversation_times_json":
+                    [w.to_json() for w in domain_obj.sms_conversation_times],
+                "sms_conversation_length":
+                    domain_obj.sms_conversation_length,
+                "survey_traffic_option":
+                    (SHOW_ALL
+                     if not domain_obj.filter_surveys_from_chat else
+                     SHOW_INVALID
+                     if domain_obj.show_invalid_survey_responses_in_chat else
+                     HIDE_ALL),
+                "count_messages_as_read_by_anyone":
+                    enabled_disabled(domain_obj.count_messages_as_read_by_anyone),
+                "use_custom_chat_template":
+                    default_custom(domain_obj.custom_chat_template),
+                "custom_chat_template":
+                    domain_obj.custom_chat_template,
+                "sms_case_registration_enabled":
+                    enabled_disabled(domain_obj.sms_case_registration_enabled),
+                "sms_case_registration_type":
+                    domain_obj.sms_case_registration_type,
+                "sms_case_registration_owner_id":
+                    domain_obj.sms_case_registration_owner_id,
+                "sms_case_registration_user_id":
+                    domain_obj.sms_case_registration_user_id,
+            }
+            form = SettingsForm(initial=initial, cchq_domain=self.domain)
         return form
 
     @property
@@ -1356,6 +1407,58 @@ class SMSSettingsView(BaseMessagingSectionView):
         }
 
     def post(self, request, *args, **kwargs):
+        form = self.form
+        if form.is_valid():
+            domain_obj = Domain.get_by_name(self.domain, strict=True)
+            for (model_field_name, form_field_name) in (
+                ("use_default_sms_response",
+                 "use_default_sms_response"),
+                ("default_sms_response",
+                 "default_sms_response"),
+                ("custom_case_username",
+                 "custom_case_username"),
+                ("custom_chat_template",
+                 "custom_chat_template"),
+                ("send_to_duplicated_case_numbers",
+                 "send_to_duplicated_case_numbers"),
+                ("sms_conversation_length",
+                 "sms_conversation_length"),
+                ("count_messages_as_read_by_anyone",
+                 "count_messages_as_read_by_anyone"),
+                ("chat_message_count_threshold",
+                 "custom_message_count_threshold"),
+                ("restricted_sms_times",
+                 "restricted_sms_times_json"),
+                ("sms_conversation_times",
+                 "sms_conversation_times_json"),
+            ):
+                setattr(domain_obj, model_field_name,
+                    form.cleaned_data[form_field_name])
+
+            survey_traffic_option = form.cleaned_data["survey_traffic_option"]
+            if survey_traffic_option == HIDE_ALL:
+                domain_obj.filter_surveys_from_chat = True
+                domain_obj.show_invalid_survey_responses_in_chat = False
+            elif survey_traffic_option == SHOW_INVALID:
+                domain_obj.filter_surveys_from_chat = True
+                domain_obj.show_invalid_survey_responses_in_chat = True
+            else:
+                domain_obj.filter_surveys_from_chat = False
+                domain_obj.show_invalid_survey_responses_in_chat = False
+
+            if form.cleaned_data["sms_case_registration_enabled"]:
+                domain_obj.sms_case_registration_enabled = True
+                domain_obj.sms_case_registration_type = form.cleaned_data[
+                    "sms_case_registration_type"]
+                domain_obj.sms_case_registration_owner_id = form.cleaned_data[
+                    "sms_case_registration_owner_id"]
+                domain_obj.sms_case_registration_user_id = form.cleaned_data[
+                    "sms_case_registration_user_id"]
+            else:
+                domain_obj.sms_case_registration_enabled = False
+
+            domain_obj.save()
+            messages.success(request, _("Changes Saved."))
         return self.get(request, *args, **kwargs)
 
     @method_decorator(domain_admin_required)


### PR DESCRIPTION
- Creates a new view with a refactored version of the SMS Settings UI for a project space, which now uses Crispy forms
- Adds Registration options to the new SMS Settings view
- QA has not happened yet but will happen behind a feature flag along with the rest of the recent CommConnect UI updates

![all_default](https://cloud.githubusercontent.com/assets/1028814/4665076/0a32b562-5548-11e4-9d3c-eafffd683b4a.png)
![all_enabled](https://cloud.githubusercontent.com/assets/1028814/4665077/0fd33cf8-5548-11e4-8ed2-4ab658788208.png)
