### PR TITLE
fix format of datetime strings sent down during OTA restore

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/models.py
+++ b/corehq/ex-submodules/casexml/apps/case/models.py
@@ -973,7 +973,9 @@ class CommCareCase(SafeSaveDocument, IndexHoldingMixIn, ComputedDocumentMixin,
 
     def dynamic_case_properties(self):
         """(key, value) tuples sorted by key"""
-        return sorted([(key, value) for key, value in self.dynamic_properties().items() if re.search(r'^[a-zA-Z]', key)])
+        json = self.to_json()
+        return sorted([(key, json[key]) for key in self.dynamic_properties()
+                       if re.search(r'^[a-zA-Z]', key)])
 
     def save(self, **params):
         self.server_modified_on = datetime.utcnow()

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_restore.py
@@ -197,7 +197,7 @@ class OtaRestoreTest(TestCase):
        <request_name>ME</request_name>
        <request_rank>staff_nurse</request_rank>
        <request_reason></request_reason>
-       <request_timestamp>2011-02-19 16:46:28</request_timestamp>
+       <request_timestamp>2011-02-19T16:46:28Z</request_timestamp>
        <ringing></ringing>
        <seizures></seizures>
        <short_name>SIEGEL, ROBERT</short_name>
@@ -275,7 +275,7 @@ class OtaRestoreTest(TestCase):
        <request_name>ME</request_name>
        <request_rank>staff_nurse</request_rank>
        <request_reason></request_reason>
-       <request_timestamp>2011-02-19 16:46:28</request_timestamp>
+       <request_timestamp>2011-02-19T16:46:28Z</request_timestamp>
        <ringing></ringing>
        <seizures></seizures>
        <short_name>SIEGEL, ROBERT</short_name>


### PR DESCRIPTION
not sure if this causes other problems,
but the date format here was just from calling unicode on a datetime
which seems unintenional

Wait for build; @czue any thoughts?
