### PR TITLE
Remove a couple noisy errors from linter

### DIFF
--- a/.lintrc
+++ b/.lintrc
@@ -6,3 +6,5 @@ linters = flake8, jshint
 
 [tool_flake8]
 max-line-length = 115
+# http://pep8.readthedocs.org/en/latest/intro.html#error-codes
+ignore = 'E128,F403'


### PR DESCRIPTION
Removing:
E128 continuation line under-indented for visual indent
F403 'from test_filters import *' used; unable to detect undefined names

Feel free to object and/or add more.
