### PR TITLE
Address inconsistent type vs location_type usage

### DIFF
--- a/custom/ilsgateway/api.py
+++ b/custom/ilsgateway/api.py
@@ -96,10 +96,10 @@ class SMSUser(object):
 
 
 class Location(object):
-    def __init__(self, id, name, type, parent, latitude, longitude, code, groups):
+    def __init__(self, id, name, location_type, parent, latitude, longitude, code, groups):
         self.id = id
         self.name = name
-        self.type = type
+        self.location_type = location_type
         self.parent = parent
         self.latitude = latitude
         self.longitude = longitude
@@ -111,7 +111,7 @@ class Location(object):
         return cls(
             id=json_rep['id'],
             name=json_rep['name'],
-            type=json_rep['type'],
+            location_type=json_rep['location_type'],
             parent=json_rep['parent_id'],
             latitude=json_rep['latitude'],
             longitude=json_rep['longitude'],

--- a/custom/ilsgateway/commtrack.py
+++ b/custom/ilsgateway/commtrack.py
@@ -214,7 +214,7 @@ def sync_ilsgateway_location(domain, endpoint, ilsgateway_location):
             location.latitude = float(ilsgateway_location.latitude)
         if ilsgateway_location.longitude:
             location.longitude = float(ilsgateway_location.longitude)
-        location.location_type = ilsgateway_location.type
+        location.location_type = ilsgateway_location.location_type
         location.site_code = ilsgateway_location.code
         location.external_id = str(ilsgateway_location.id)
         location.save()
@@ -225,7 +225,7 @@ def sync_ilsgateway_location(domain, endpoint, ilsgateway_location):
             'name': ilsgateway_location.name,
             'latitude': float(ilsgateway_location.latitude) if ilsgateway_location.latitude else None,
             'longitude': float(ilsgateway_location.longitude) if ilsgateway_location.longitude else None,
-            'type': ilsgateway_location.type,
+            'location_type': ilsgateway_location.location_type,
             'site_code': ilsgateway_location.code.lower(),
             'external_id': str(ilsgateway_location.id),
         }
@@ -339,11 +339,11 @@ def bootstrap_domain(ilsgateway_config):
     apis = [
         ('product', partial(products_sync, domain, endpoint, checkpoint)),
         ('location_facility', partial(locations_sync, domain, endpoint, checkpoint, date=date,
-                                      filters=dict(date_updated__gte=date, type='facility'))),
+                                      filters=dict(date_updated__gte=date, location_type='facility'))),
         ('location_district', partial(locations_sync, domain, endpoint, checkpoint, date=date,
-                                      filters=dict(date_updated__gte=date, type='district'))),
+                                      filters=dict(date_updated__gte=date, location_type='district'))),
         ('location_region', partial(locations_sync, domain, endpoint, checkpoint, date=date,
-                                    filters=dict(date_updated__gte=date, type='region'))),
+                                    filters=dict(date_updated__gte=date, location_type='region'))),
         ('webuser', partial(webusers_sync, domain, endpoint, checkpoint, date=date,
                             filters=dict(user__date_joined__gte=date))),
         ('smsuser', partial(smsusers_sync, domain, endpoint, checkpoint, date=date,

--- a/custom/ilsgateway/tests/data/sample_location.json
+++ b/custom/ilsgateway/tests/data/sample_location.json
@@ -1,7 +1,7 @@
 {
     "id" : 1,
     "name": "MOHSW",
-    "type": "MOHSW",
+    "location_type": "MOHSW",
     "parent_id": null,
     "latitude": -10.6676087700,
     "longitude": 39.1621900200,

--- a/custom/ilsgateway/tests/test_apis.py
+++ b/custom/ilsgateway/tests/test_apis.py
@@ -52,7 +52,7 @@ class ProductApiTest(TestCase):
             location = Location.from_json(json.loads(f.read()))
         self.assertEqual(location.id, 1)
         self.assertEqual(location.name, "MOHSW")
-        self.assertEqual(location.type, "MOHSW")
+        self.assertEqual(location.location_type, "MOHSW")
         self.assertEqual(location.parent, None)
         self.assertEqual(location.latitude, -10.6676087700)
         self.assertEqual(location.longitude, 39.1621900200)

--- a/custom/ilsgateway/tests/test_locations_sync.py
+++ b/custom/ilsgateway/tests/test_locations_sync.py
@@ -22,7 +22,7 @@ class LocationSyncTest(TestCase):
 
         ilsgateway_location = sync_ilsgateway_location(TEST_DOMAIN, None, location)
         self.assertEqual(ilsgateway_location.name, location.name)
-        self.assertEqual(ilsgateway_location.location_type, location.type)
+        self.assertEqual(ilsgateway_location.location_type, location.location_type)
         self.assertEqual(ilsgateway_location.longitude, location.longitude)
         self.assertEqual(ilsgateway_location.latitude, location.latitude)
         self.assertEqual(ilsgateway_location.parent, location.parent)

--- a/custom/openlmis/tests/test_apis.py
+++ b/custom/openlmis/tests/test_apis.py
@@ -155,7 +155,7 @@ class PostApiTest(TestCase):
 
     def testCreateVirtualFacility(self):
         loc = Location(site_code='1234', name='beavis', domain=self.domain,
-                       type='chw')
+                       location_type='chw')
         loc.save()
         sp = make_supply_point(self.domain, loc)
         self.assertTrue(sync_supply_point_to_openlmis(sp, self.api))


### PR DESCRIPTION
There was inconsistent usage of location type in openlmis and ilsgateway api's. This was not previously a problem, as setting `.type` on a `Location` object doesn't actually cause any problems until `SQLLocation` expects the proper `.location_type` to be a required field.
