### PR TITLE
Make show_all an actual option and remove default

### DIFF
--- a/custom/opm/filters.py
+++ b/custom/opm/filters.py
@@ -1,10 +1,11 @@
+from django.utils.translation import ugettext_noop, ugettext as _
 from sqlagg.columns import SimpleColumn
-from corehq.apps.reports.filters.base import (
-    BaseSingleOptionFilter, CheckboxFilter, BaseDrilldownOptionFilter)
 
-from django.utils.translation import ugettext_noop, ugettext_lazy
-from corehq.apps.reports.filters.select import SelectOpenCloseFilter
 from dimagi.utils.decorators.memoized import memoized
+
+from corehq.apps.reports.filters.select import SelectOpenCloseFilter
+from corehq.apps.reports.filters.base import (BaseSingleOptionFilter,
+                                              BaseDrilldownOptionFilter)
 from corehq.apps.reports.sqlreport import SqlData, DatabaseColumn
 
 
@@ -26,6 +27,7 @@ class HierarchySqlData(SqlData):
             DatabaseColumn('Gram Panchayat', SimpleColumn('gp')),
             DatabaseColumn('AWC', SimpleColumn('awc'))
         ]
+
 
 class OpmBaseDrilldownOptionFilter(BaseDrilldownOptionFilter):
     single_option_select = -1
@@ -123,7 +125,8 @@ class MetHierarchyFilter(OpmBaseDrilldownOptionFilter):
     @property
     def drilldown_map(self):
         hierarchy = super(MetHierarchyFilter, self).drilldown_map
-        met_hierarchy = [x for x in hierarchy if x['val'].lower() in ['atri', 'wazirganj']]
+        met_hierarchy = [x for x in hierarchy
+                         if x['val'].lower() in ['atri', 'wazirganj']]
         return met_hierarchy
 
 
@@ -138,8 +141,24 @@ class SelectBlockFilter(BaseSingleOptionFilter):
 
 
 class OPMSelectOpenCloseFilter(SelectOpenCloseFilter):
+    default_text = None
+
+    @property
+    def options(self):
+        return [
+            ('all', _("Show All")),
+            ('open', _("Only Open")),
+            ('closed', _("Only Closed")),
+        ]
 
     @property
     @memoized
     def selected(self):
         return self.get_value(self.request, self.domain) or "open"
+
+    @classmethod
+    def case_status(cls, request_params):
+        """
+        returns either "all", "open", or "closed"
+        """
+        return request_params.get(cls.slug) or 'open'

--- a/custom/opm/reports.py
+++ b/custom/opm/reports.py
@@ -45,7 +45,8 @@ from .utils import BaseMixin, normal_format, format_percent
 from .beneficiary import Beneficiary, ConditionsMet
 from .health_status import HealthStatus
 from .incentive import Worker
-from .filters import HierarchyFilter, MetHierarchyFilter, OPMSelectOpenCloseFilter
+from .filters import (HierarchyFilter, MetHierarchyFilter,
+                      OPMSelectOpenCloseFilter as OpenCloseFilter)
 from .constants import *
 
 
@@ -637,12 +638,8 @@ class CaseReportMixin(object):
     is_rendered_as_email = False
 
     @property
-    def display_open_cases_only(self):
-        return self.request_params.get('is_open') == 'open'
-
-    @property
-    def display_closed_cases_only(self):
-        return self.request_params.get('is_open') == 'closed'
+    def case_status(self):
+        return OpenCloseFilter.case_status(self.request_params)
 
     def get_rows(self, datespan):
         def get_awc_filter(awcs):
@@ -662,12 +659,12 @@ class CaseReportMixin(object):
                 .term("type.exact", self.default_case_type)
         query.index = 'report_cases'
 
-        if self.display_open_cases_only:
+        if self.case_status == 'open':
             query = query.filter(es_filters.OR(
                 case_es.is_closed(False),
                 case_es.closed_range(gte=self.datespan.enddate_utc)
             ))
-        elif self.display_closed_cases_only:
+        elif self.case_status == 'closed':
             query = query.filter(case_es.closed_range(lte=self.datespan.enddate_utc))
 
         if self.awcs:
@@ -685,7 +682,7 @@ class CaseReportMixin(object):
             MetHierarchyFilter,
             MonthFilter,
             YearFilter,
-            OPMSelectOpenCloseFilter,
+            OpenCloseFilter,
         ]
 
     @property
@@ -966,11 +963,11 @@ class HealthStatusReport(DatespanMixin, BaseReport):
 
     @property
     def fields(self):
-        return [HierarchyFilter, OPMSelectOpenCloseFilter, DatespanFilter]
+        return [HierarchyFilter, OpenCloseFilter, DatespanFilter]
 
     @property
     def case_status(self):
-        return self.request.GET['is_open']
+        return OpenCloseFilter.case_status(self.request_params)
 
     @property
     @memoized
@@ -1177,7 +1174,7 @@ class HealthMapReport(BaseMixin, ElasticSearchMapReport, GetParamsMixin, CustomP
     name = "Health Status (Map)"
     slug = "health_status_map"
 
-    fields = [HierarchyFilter, OPMSelectOpenCloseFilter, DatespanFilter]
+    fields = [HierarchyFilter, OpenCloseFilter, DatespanFilter]
 
     data_source = {
         'adapter': 'legacyreport',


### PR DESCRIPTION
The filter was set to default to "Only Open", so even if you explicitly set "Show All", it wouldn't appear that way in the UI (although it DID still work correctly in the report itself).
@czue @sravfeyn 
