### PR TITLE
Update sorl to get rid of deprecation warning

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -39,7 +39,7 @@ PyYAML==3.10
 raven==3.1.10
 requests==2.0.0
 south==0.7.3
-sorl-thumbnail==11.12
+sorl-thumbnail==11.12.1b
 tropo-webapi-python==0.1.3
 tornado==3.1.1
 xlutils==1.4.1


### PR DESCRIPTION
sorl 11.12 uses django.util.simplejson, which is deprecated.  That dependency has been removed in sorl 11.12.1b.  It's a minor version bump, so I don't expect any issues.  We only use sorl for image thumbnails on multimedia upload.

@dannyroberts can you give your thoughts on this?  It looks like a "hutch"-specific thing, which seems to be dmyung only.  Any idea how I can test this, exactly?
