### PR TITLE
Fix assert statement for ESQuery faceting

### DIFF
--- a/corehq/apps/es/facets.py
+++ b/corehq/apps/es/facets.py
@@ -31,8 +31,8 @@ class TermsFacet(Facet):
     result_class = TermsResult
 
     def __init__(self, term, name, size=None):
-        # todo: should fix this. at a minimum periods are also allowed.
-        # assert re.match(r'\w+$', name), "name must be a valid python variable name, was {}".format(name)
+        assert re.match(r'\w+$', name), \
+            "Facet names must be valid python variable names, was {}".format(name)
         self.name = name
         self.params = {
             "field": term,

--- a/corehq/apps/es/tests.py
+++ b/corehq/apps/es/tests.py
@@ -255,3 +255,8 @@ class TestESFacet(ElasticTestMixin, TestCase):
         res = ESQuerySet(example_response, query)
         output = res.facets.user.counts_by_term()
         self.assertEqual(output, expected_output)
+
+    def test_bad_facet_name(self):
+        with self.assertRaises(AssertionError):
+            HQESQuery('forms')\
+                .terms_facet('form.meta.userID', 'form.meta.userID', size=10)

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -1009,17 +1009,17 @@ class WorkerActivityReport(WorkerMonitoringReportTableBase, DatespanMixin):
         else:
             return self.combined_users
 
-    def es_form_submissions(self, datespan=None, dict_only=False):
+    def es_form_submissions(self, datespan=None):
         datespan = datespan or self.datespan
-        form_query = FormES() \
-            .domain(self.domain) \
-            .completed(gte=datespan.startdate.date(), lte=datespan.enddate.date()) \
-            .terms_facet('form.meta.userID', 'form.meta.userID', size=100000) \
-            .size(1)
-
+        form_query = (FormES()
+                      .domain(self.domain)
+                      .completed(gte=datespan.startdate.date(),
+                                 lte=datespan.enddate.date())
+                      .user_facet()
+                      .size(1))
         return form_query.run()
 
-    def es_last_submissions(self, datespan=None, dict_only=False):
+    def es_last_submissions(self, datespan=None):
         """
             Creates a dict of userid => date of last submission
         """
@@ -1102,9 +1102,9 @@ class WorkerActivityReport(WorkerMonitoringReportTableBase, DatespanMixin):
             avg_datespan.startdate = datetime.datetime(1900, 1, 1)
 
         form_data = self.es_form_submissions()
-        submissions_by_user = {t["term"]: t["count"] for t in form_data.facet("form.meta.userID", "terms")}
+        submissions_by_user = form_data.facets.user.counts_by_term()
         avg_form_data = self.es_form_submissions(datespan=avg_datespan)
-        avg_submissions_by_user = {t["term"]: t["count"] for t in avg_form_data.facet("form.meta.userID", "terms")}
+        avg_submissions_by_user = avg_form_data.facets.user.counts_by_term()
 
         if self.view_by == 'groups':
             active_users_by_group = {


### PR DESCRIPTION
@TylerSheffels @czue @snopoke regarding https://github.com/dimagi/commcare-hq/pull/4637 and https://github.com/dimagi/commcare-hq/pull/4635
This code does some dynamic assignment, which is why that name must be a valid python variable name.  I used an assert statement here to raise an exception where the wrong name is used, rather than when the dynamic assignment is made, so it's clearer where the problem is.

Because the assert statement was previously broken, code got in which didn't fit this model, but it never raised an issue because that dynamic assignment was never called on that code.

This whole model might be a bit too clever for its own good.  I'll do a design review soon on this stuff, as that's one thing I've thought about changing.
