### PR TITLE
Make terms facet accurate.

### DIFF
--- a/corehq/apps/es/facets.py
+++ b/corehq/apps/es/facets.py
@@ -1,5 +1,7 @@
 import re
 
+from corehq.elastic import SIZE_LIMIT
+
 
 class FacetResult(object):
     def __init__(self, raw, facet):
@@ -36,9 +38,8 @@ class TermsFacet(Facet):
         self.name = name
         self.params = {
             "field": term,
+            "size": size if size is not None else SIZE_LIMIT,
         }
-        if size is not None:
-            self.params["size"] = size
 
 
 class DateHistogram(Facet):

--- a/corehq/apps/es/facets.py
+++ b/corehq/apps/es/facets.py
@@ -39,6 +39,7 @@ class TermsFacet(Facet):
         self.params = {
             "field": term,
             "size": size if size is not None else SIZE_LIMIT,
+            "shard_size": SIZE_LIMIT,
         }
 
 


### PR DESCRIPTION
In light of this horrid default behavior: 
http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-facets-terms-facet.html#_accuracy_control

Looks like elasticsearch 1.0 handles this [a bit better](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html#_size_amp_shard_size) anyways, with size defaulting to Integer.MAX_VALUE
As Nick discovered here https://github.com/dimagi/commcare-hq/pull/4663
@nickpell @emord
