### PR TITLE
Update XForm title when form name is changed

### DIFF
--- a/corehq/apps/app_manager/tests/data/xform_test/MySuperSpecialForm.xml
+++ b/corehq/apps/app_manager/tests/data/xform_test/MySuperSpecialForm.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa">
+    <h:head>
+        <h:title>MySuperSpecialForm</h:title>
+        <model>
+            <instance>
+                <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/A22A5D53-037A-48DE-979B-BAA54734194E" uiVersion="1" version="1" name="MySuperSpecialForm">
+                    <question1 />
+                </data>
+            </instance>
+            <bind nodeset="/data/question1" type="xsd:string" />
+            <itext>
+                <translation lang="en" default="">
+                    <text id="question1-label">
+                        <value>question1</value>
+                    </text>
+                </translation>
+            </itext>
+        </model>
+    </h:head>
+    <h:body>
+        <input ref="/data/question1">
+            <label ref="jr:itext('question1-label')" />
+        </input>
+    </h:body>
+</h:html>

--- a/corehq/apps/app_manager/tests/test_form_preparation_v2.py
+++ b/corehq/apps/app_manager/tests/test_form_preparation_v2.py
@@ -451,7 +451,7 @@ class TestXForm(TestCase, TestFileMixin):
     def test_set_name(self):
 
         app = Application.new_app('domain', 'New App', APP_V2)
-        module = app.add_module(Module.new_module('New Module', lang='en'))
+        app.add_module(Module.new_module('New Module', lang='en'))
         form = app.new_form(0, 'MySuperSpecialForm', lang='en')
         form.source = self.get_file("MySuperSpecialForm", "xml")
 

--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -1474,7 +1474,7 @@ def edit_form_attr(req, domain, app_id, unique_form_id, attr):
         form.name[lang] = name
         xform = form.wrapped_xform()
         xform.set_name(name)
-        save_xform(app, form, etree.tostring(xform.xml, encoding="unicode"))
+        save_xform(app, form, xform.render())
         resp['update'] = {'.variable-form_name': form.name[lang]}
     if should_edit("xform"):
         try:

--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -1472,6 +1472,9 @@ def edit_form_attr(req, domain, app_id, unique_form_id, attr):
     if should_edit("name"):
         name = req.POST['name']
         form.name[lang] = name
+        xform = form.wrapped_xform()
+        xform.set_name(name)
+        save_xform(app, form, etree.tostring(xform.xml, encoding="unicode"))
         resp['update'] = {'.variable-form_name': form.name[lang]}
     if should_edit("xform"):
         try:

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -524,6 +524,10 @@ class XForm(WrappedNode):
     def video_references(self):
         return self.media_references(form="video")
 
+    def set_name(self, new_name):
+        self.find('{h}head/{h}title').xml.text = new_name
+        self.data_node.set('name', "%s" % new_name)
+
     def normalize_itext(self):
         """
         Convert this:


### PR DESCRIPTION
Addresses this [ticket](http://manage.dimagi.com/default.asp?141586).
Only the form builder was updating the name of a form in the XForm. Therefore, if a user changed the name of a form and deployed without first saving in the form builder again, the XForm would not be updated. this resulted in the "You are at the start of `<form name>` ..." and "You are at the end of `<form name>` ..." messages on the mobile device to display the wrong form name.

I've changed the method that alters the form name to also alter the name on the XForm, thereby resolving the issue.
