### PR TITLE
Check for WrappedNode existence before accessing its xml attribute

### DIFF
--- a/corehq/apps/app_manager/tests/test_form_preparation_v2.py
+++ b/corehq/apps/app_manager/tests/test_form_preparation_v2.py
@@ -448,11 +448,16 @@ class TestXForm(TestCase, TestFileMixin):
             actual = xform.action_relevance(case[0])
             self.assertEqual(actual, case[1])
 
-    def test_set_name(self):
-
+    @classmethod
+    def construct_form(cls):
         app = Application.new_app('domain', 'New App', APP_V2)
         app.add_module(Module.new_module('New Module', lang='en'))
         form = app.new_form(0, 'MySuperSpecialForm', lang='en')
+        return form
+
+    def test_set_name(self):
+
+        form = self.construct_form()
         form.source = self.get_file("MySuperSpecialForm", "xml")
 
         xform = form.wrapped_xform()
@@ -468,3 +473,7 @@ class TestXForm(TestCase, TestFileMixin):
             ),
             new_rendered_form
         )
+
+    def test_set_name_on_empty_form(self):
+        form = self.construct_form()
+        form.wrapped_xform().set_name("Passes if there is no exception")

--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -1473,8 +1473,9 @@ def edit_form_attr(req, domain, app_id, unique_form_id, attr):
         name = req.POST['name']
         form.name[lang] = name
         xform = form.wrapped_xform()
-        xform.set_name(name)
-        save_xform(app, form, xform.render())
+        if xform.exists():
+            xform.set_name(name)
+            save_xform(app, form, xform.render())
         resp['update'] = {'.variable-form_name': form.name[lang]}
     if should_edit("xform"):
         try:

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -245,7 +245,7 @@ def raise_if_none(message):
     """
     raise_if_none("message") is a decorator that turns a function that returns a WrappedNode
     whose xml can possibly be None to a function that always returns a valid WrappedNode or raises
-    an XFormException with the message given
+    an XFormError with the message given
 
     """
     def decorator(fn):
@@ -525,8 +525,13 @@ class XForm(WrappedNode):
         return self.media_references(form="video")
 
     def set_name(self, new_name):
-        self.find('{h}head/{h}title').xml.text = new_name
-        self.data_node.set('name', "%s" % new_name)
+        title = self.find('{h}head/{h}title')
+        if title.exists():
+            title.xml.text = new_name
+        try:
+            self.data_node.set('name', "%s" % new_name)
+        except XFormError:
+            pass
 
     def normalize_itext(self):
         """


### PR DESCRIPTION
This fixes a bug that prevents users from changing a form name before the first time they save the form in form builder.
