### PR TITLE
Use count instead of len in reindex

### DIFF
--- a/corehq/apps/hqcase/management/commands/ptop_fast_reindexer.py
+++ b/corehq/apps/hqcase/management/commands/ptop_fast_reindexer.py
@@ -117,7 +117,7 @@ class PtopReindexer(NoArgsCommand):
             **view_kwargs
         )
 
-        while len(view_chunk) > 0:
+        while view_chunk.count() > 0:
             for item in view_chunk:
                 yield item
             start_seq += self.chunk_size * self.chunk_size


### PR DESCRIPTION
@snopoke @czue 

I don't have enough data in my local setup, but I think using len may cause us to still load the entire view in memory
