### PR TITLE
Removed "Code" column from CommTrack program list

### DIFF
--- a/corehq/apps/commtrack/templates/commtrack/manage/programs.html
+++ b/corehq/apps/commtrack/templates/commtrack/manage/programs.html
@@ -60,14 +60,12 @@
                 <thead>
                     <tr>
                         <th>{% trans "Program" %}</th>
-                        <th>{% trans "Code" %}</th>
                         <th>{% trans "Delete" %}</th>
                     </tr>
                 </thead>
                 <tbody data-bind="foreach: data_list">
                     <tr>
                         <td><a data-bind="attr: {href: edit_url}, text: name"></a></td>
-                        <td data-bind="text: code"></td>
                         <td>
                             <div data-bind="visible: is_default">
                                 {% trans "This program is the default and cannot be deleted." %}


### PR DESCRIPTION
I removed the "Code" column from the programs.html template.

See [case 145210](http://manage.dimagi.com/default.asp?145210) for details of the case.

Knockout will not be affected by the removed column.

If the "code" attribute of program instances is never used -- I haven't checked -- we may want to remove the attribute from the model/document. I'm leaving it for now.
