### PR TITLE
avoid invalidaing the cache unless necessary

### DIFF
--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -514,16 +514,18 @@ class Domain(Document, SnapshotMixin):
                 else:
                     notify_exception(None, '%r is not a valid domain name' % name)
                     return None
+
         cache_key = _domain_cache_key(name)
-        MISSING = object()
-        res = cache.get(cache_key, MISSING)
-        if res != MISSING:
-            return res
-        else:
-            domain = cls._get_by_name(name, strict)
-            # 30 mins, so any unforeseen invalidation bugs aren't too bad.
-            cache.set(cache_key, domain, 30*60)
-            return domain
+        if not strict:
+            MISSING = object()
+            res = cache.get(cache_key, MISSING)
+            if res != MISSING:
+                return res
+
+        domain = cls._get_by_name(name, strict)
+        # 30 mins, so any unforeseen invalidation bugs aren't too bad.
+        cache.set(cache_key, domain, 30*60)
+        return domain
 
     @classmethod
     def _get_by_name(cls, name, strict=False):

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -116,7 +116,10 @@ class DomainViewMixin(object):
     """
         Paving the way for a world of entirely class-based views.
         Let's do this, guys. :-)
+
+        Set strict_domain_fetching to True in subclasses to bypass the cache.
     """
+    strict_domain_fetching = False
 
     @property
     @memoized
@@ -127,7 +130,7 @@ class DomainViewMixin(object):
     @property
     @memoized
     def domain_object(self):
-        domain = Domain.get_by_name(self.domain, strict=True)
+        domain = Domain.get_by_name(self.domain, strict=self.strict_domain_fetching)
         if not domain:
             raise Http404()
         return domain
@@ -261,6 +264,7 @@ class BaseEditProjectInfoView(BaseAdminProjectSettingsView):
     """
         The base class for all the edit project information views.
     """
+    strict_domain_fetching = True
 
     @property
     def autocomplete_fields(self):
@@ -1442,6 +1446,7 @@ class CreateNewExchangeSnapshotView(BaseAdminProjectSettingsView):
     template_name = 'domain/create_snapshot.html'
     urlname = 'domain_create_snapshot'
     page_title = ugettext_noop("Publish New Version")
+    strict_domain_fetching = True
 
     @property
     def parent_pages(self):
@@ -1861,6 +1866,7 @@ class OrgSettingsView(BaseAdminProjectSettingsView):
 
 
 class BaseInternalDomainSettingsView(BaseProjectSettingsView):
+    strict_domain_fetching = True
 
     @method_decorator(login_and_domain_required)
     @method_decorator(require_superuser)
@@ -1884,6 +1890,7 @@ class EditInternalDomainInfoView(BaseInternalDomainSettingsView):
     urlname = 'domain_internal_settings'
     page_title = ugettext_noop("Project Information")
     template_name = 'domain/internal_settings.html'
+    strict_domain_fetching = True
 
     @property
     @memoized

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -886,6 +886,7 @@ class DomainSmsGatewayListView(CRUDPaginatedViewMixin, BaseMessagingSectionView)
     template_name = "sms/gateway_list.html"
     urlname = 'list_domain_backends_new'
     page_title = ugettext_noop("SMS Connectivity")
+    strict_domain_fetching = True
 
     @property
     def page_url(self):


### PR DESCRIPTION
Most classes that extend `DomainViewMixin` are fine with a cached copy of the domain object. I think I've got all the places where `strict` is needed by hard to be 100% sure.

Originally this was made strict for publishing to the exchange: https://github.com/dimagi/commcare-hq/commit/5bbe915a0b71735463a0775b16a0941f565006de#diff-21bd1c0e52720275d9cf19e3dd556434R72
