### PR TITLE
404 for an id that is not a web user

### DIFF
--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -38,6 +38,7 @@ from corehq.apps.domain.decorators import (login_and_domain_required, require_su
 from corehq.apps.orgs.models import Team
 from corehq.apps.reports.util import get_possible_reports
 from corehq.apps.sms import verify as smsverify
+from corehq.util.couch import get_document_or_404
 
 from django.utils.translation import ugettext as _, ugettext_noop, ugettext_lazy
 
@@ -135,7 +136,7 @@ class BaseEditUserView(BaseUserSettingsView):
     @memoized
     def editable_user(self):
         try:
-            return WebUser.get(self.editable_user_id)
+            return get_document_or_404(WebUser, self.domain, self.editable_user_id)
         except (ResourceNotFound, CouchUser.AccountTypeError):
             raise Http404()
 


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?145627#812259

Now 404s if there it you give a wrong id for a WebUser (like an id for a group or something)
