### PR TITLE
Save user to properly remove outdated property

### DIFF
--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -1269,6 +1269,7 @@ class CommTrackUser(CommCareUser):
             del data['commtrack_location']
 
             instance = super(CommTrackUser, cls).wrap(data)
+            instance.save()
 
             try:
                 original_location_object = Location.get(original_location)


### PR DESCRIPTION
This lazy migration (that will probably go away soon anyway) wasn't quite working. It didn't save the doc so it didn't actually remove the `commtrack_user` property. That means the next time the user gets wrapped, it would regenerate the case mapping location style association based on the old data. Fixes a bug that screwed with @emord today.
