### PR TITLE
Fix threaded issue on syncing locations

### DIFF
--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -128,7 +128,11 @@ class Location(CachedCouchDocumentMixin, Document):
         ]
 
         sql_location, _ = SQLLocation.objects.get_or_create(
-            location_id=self._id
+            location_id=self._id,
+            defaults={
+                'domain': self.domain,
+                'site_code': self.site_code
+            }
         )
 
         for prop in properties_to_sync:


### PR DESCRIPTION
This issue only really comes up in big migrations, but domain/site_code
are unique-together so creating two objects with empty domain and site
code values breaks the unique constraint.
