### PR TITLE
Prevent infinite recursion

### DIFF
--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -116,7 +116,8 @@ class ParentCasePropertyBuilder(object):
 
         get_properties_recursive = functools.partial(
             self.get_properties,
-            already_visited=already_visited + (case_type,)
+            already_visited=already_visited + (case_type,),
+            include_shared_properties=include_shared_properties
         )
 
         case_properties = set(self.defaults)


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?146270#816092

Looks like this was introduced in #4677 

Tested this by loading multiple modules/forms on HQ. newmattproject loads really slowly locally, but it looks like it's just an issue with that domain and not with other domains I have.

Don't think any tests hit this either.

@nickpell 
