### PR TITLE
Sphinx docs

### DIFF
--- a/docs/documenting.rst
+++ b/docs/documenting.rst
@@ -1,5 +1,5 @@
 Documenting
-=============
+===========
 
 .. This is a comment
 
@@ -17,17 +17,18 @@ For a more complete working set of documentation, check out `Django's docs direc
 .. _dj_docs: https://docs.djangoproject.com
 
 Index
-------
+-----
 
 #. :ref:`sphinx` is used to build the documentation.
 #. :ref:`doc-style` - Some general tips for writing documentation
 #. :ref:`rst` is used for markup.
+#. :ref:`editors` with RestructuredText support
 
 
 .. _sphinx:
 
 Sphinx
---------
+------
 
 Sphinx builds the documentation and extends the functionality of rst a bit
 for stuff like pointing to other files and modules.
@@ -42,27 +43,46 @@ Open ``<path_to_commcare-hq>/docs/_build/html/index.html`` in your browser and y
 .. _doc-style:
 
 Writing Documentation
-----------------------
+---------------------
 
-For some great references, check out Jacob Kaplan-Moss's series `Writing Great Documentation <jkm_>`_ and this `blog post`_ by Steve Losh.  Here are some takeaways:
+For some great references, check out Jacob Kaplan-Moss's series `Writing Great Documentation <jkm_>`_ and this
+`blog post`_ by Steve Losh.  Here are some takeaways:
 
 * Use short sentences and paragraphs
 * Break your documentation into sections to avoid text walls
 * Avoid making assumptions about your reader's background knowledge
-* Consider `three levels of documentation <jkm_>`_:
+* Consider `three types of documentation <jkm_wtw_>`_:
 
    #. Tutorials - quick introduction to the basics
    #. Topical Guides - comprehensive overview of the project; everything but the dirty details
    #. Reference Material - complete reference for the API
 
-.. _jkm: http://jacobian.org/writing/great-documentation/what-to-write/
+One aspect that Kaplan-Moss doesn't mention explicitly (other than advising us to "Omit fluff" in his
+`Technical style <jkm_ts_>`_ piece) but is clear from both his documentation series and the Django documentation,
+is *what not to write*.
+It's an important aspect of the readability of any written work, but has other implications when it comes to
+technical writing.
+
+Antoine de Saint Exupéry wrote, "... perfection is attained not when there is nothing more to add, but when there
+is nothing more to remove."
+
+Keep things short and take stuff out where possible.
+It can help to get your point across, but, maybe more importantly with documentation, means there is less that
+needs to change when the codebase changes.
+
+Think of it as an extension of the DRY principle.
+
+
+.. _jkm: http://jacobian.org/writing/great-documentation/
 .. _blog post: http://stevelosh.com/blog/2013/09/teach-dont-tell/
+.. _jkm_wtw: http://jacobian.org/writing/what-to-write/
+.. _jkm_ts: http://jacobian.org/writing/technical-style/
 
 
 .. _rst:
 
 reStructuredText
------------------
+----------------
 
 reStructuredText is a markup language that is commonly used for Python documentation.  You can view the source of this document or any other to get an idea of how to do stuff (this document has hidden comments).  Here are some useful links for more detail:
 
@@ -99,16 +119,37 @@ reStructuredText is a markup language that is commonly used for Python documenta
     Of course, none of this will show up in the html, because it's all part of the comment block (by indentation)
 
 
+.. _editors:
+
+Editors
+-------
+
+While you can use any text editor for editing RestructuredText
+documents, I find two particularly useful:
+
+* PyCharm (or other JetBrains IDE, like IntelliJ), which has great
+  syntax highlighting and linting.
+* Sublime Text, which has a useful plugin for hard-wrapping lines called
+  `Sublime Wrap Plus`_. Hard-wrapped lines make documentation easy to
+  read in a console, or editor that doesn't soft-wrap lines (i.e. most
+  code editors).
+* Vim has a command ``gq`` to reflow a block of text (``:help gq``). It
+  uses the value of ``textwidth`` to wrap (``:setl tw=75``).  Also check
+  out ``:help autoformat``.  Syntastic has a rst linter.  To make a line a
+  header, just ``yypVr=`` (or whatever symbol you want).
+
+
+.. _Sublime Wrap Plus: https://github.com/ehuss/Sublime-Wrap-Plus
 
 -----------------------
 
 Examples
-~~~~~~~~~
+~~~~~~~~
 
 Some basic examples adapted from 2 Scoops of Django:
 
 Section Header
-^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^
 
 Sections are explained well `here <http://docutils.sourceforge.net/docs/user/rst/quickstart.html#sections>`_ 
 

--- a/docs/profiling.rst
+++ b/docs/profiling.rst
@@ -177,7 +177,7 @@ to aggregate the data.
 This will produce a '.agg.prof' file which can be analysed with the `prof.py <https://gist.github.com/czue/4947238>`_ script.
 
 Line profiling
-^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^
 
 In addition to the above methods of profiling it is possible to do line profiling of code which attached profile
 data to individual lines of code as opposed to function names.

--- a/docs/reporting.rst
+++ b/docs/reporting.rst
@@ -56,7 +56,8 @@ Example Custom Report Scaffolding
             ]
 
 Hooking up reports to CommCare HQ
-----------------------------------
+---------------------------------
+
 Custom reports can be configured in code or in the database. To configure custom reports in code
 follow the following instructions.
 
@@ -84,11 +85,13 @@ Finally, add a mapping to your custom reports to `__init__.py` in your custom re
 
 Reporting on data stored in SQL
 -------------------------------
+
 As described above there are various ways of getting reporting data into
 and SQL database. From there we can query the data in a number of ways.
 
 Extending the ``SqlData`` class
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 The ``SqlData`` class allows you to define how to query the data
 in a declarative manner by breaking down a query into a number of components.
 
@@ -246,7 +249,7 @@ at the `drew` or `aaharsneha` domains on prod for examples.
 .. _Fluff:
 
 How pillow/fluff work
-----------------------
+---------------------
 
 `GitHub <https://github.com/dimagi/fluff>`_
 

--- a/docs/translations.rst
+++ b/docs/translations.rst
@@ -193,7 +193,7 @@ It will be quicker for testing during development to only build one language::
 After this command has run, your .po files will be up to date. To have content
 in this file show up on the website you still need to compile the strings.
 
-.. code-block:: python
+.. code-block:: bash
 
         $ django-admin.py compilemessages
 
@@ -209,3 +209,4 @@ Example::
         #, fuzzy
         msgid "Export Data"
         msgstr "Exporter des cas"
+


### PR DESCRIPTION
This PR might be for Jenny.

This branch is my exploration into what's involved with including some of the Confluence documentation into the Sphinx documentation. I also took the opportunity to eyeball the Sphinx docs we've got, and wrap the longer lines so that they're easier to read in an editor (which is how I usually read docs in the codebase I'm working with -- a browser is nice, but your IDE is right there -- and reStructuredText is really cool for that, because it's such a readable markup).

So, some feedback on importing docs from Confluence. Here's how I did it:
1. Open Confluence page you want to import.
2. Click Tools, and choose View Source.
3. Right-click, choose "Save Page As...", and save the page as an HTML document locally.
4. In a terminal, convert to reStructuredText with pandoc:
   
   ```
   $ pandoc -f html -t rst my_doc.html > my_doc.rst
   ```

That's it. I found that pandoc gets most things right, but it's rubbish at tables. It just puts each cell in a new paragraph. So tables are time consuming.

Also code literals seem to be converted to single-cell tables. So you need to put in the "::", and remove the block, but that's not too bad.

In conclusion, importing the public documentation from Confluence is going to take more than half an hour, but it should be doable in four to eight (depending on those tables).

Personally, I like the idea of having the documentation with the code -- it's a little easier to keep them up-to-date together -- and code changes that affect docs can be tracked the same way with GitHub. But I'm new, and I'll defer to your opinions. :-)
