### PR TITLE
add hq_user_id to CaseState

### DIFF
--- a/corehq/apps/callcenter/indicator_sets.py
+++ b/corehq/apps/callcenter/indicator_sets.py
@@ -144,8 +144,8 @@ class CallCenterIndicators(object):
             all_owned_cases = CaseSyncOperation(self.user, None).actual_owned_cases
 
         relevant_cases = filter(lambda case: case.type == self.cc_case_type, all_owned_cases)
-
         ids = {getattr(case, 'hq_user_id', None) for case in relevant_cases}
+
         try:
             ids.remove(None)
         except KeyError:

--- a/corehq/apps/callcenter/tests/test_indicators.py
+++ b/corehq/apps/callcenter/tests/test_indicators.py
@@ -1,6 +1,8 @@
 from collections import namedtuple
+from datetime import datetime
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.xml import V2
+from casexml.apps.phone.models import SyncLog, CaseState
 from corehq.apps.callcenter.indicator_sets import AAROHI_MOTHER_FORM, CallCenterIndicators, \
     cache_key, CachedIndicators
 from corehq.apps.callcenter.utils import sync_user_cases
@@ -137,9 +139,9 @@ class CallCenterTests(BaseCCTests):
         clear_data()
 
     def check_cc_indicators(self, data_set, expected):
-        super(CallCenterTests, self)._test_indicators(self.cc_user, data_set, expected)
+        self._test_indicators(self.cc_user, data_set, expected)
         expected_no_data = expected_standard_indicators(no_data=True)
-        super(CallCenterTests, self)._test_indicators(self.cc_user_no_data, data_set, expected_no_data)
+        self._test_indicators(self.cc_user_no_data, data_set, expected_no_data)
 
     def test_standard_indicators(self):
         indicator_set = CallCenterIndicators(self.cc_domain, self.cc_user, custom_cache=locmem_cache)
@@ -147,6 +149,24 @@ class CallCenterTests(BaseCCTests):
         self.assertEqual(indicator_set.users_needing_data, set([self.cc_user.get_id, self.cc_user_no_data.get_id]))
         self.assertEqual(indicator_set.owners_needing_data, set([self.cc_user.get_id, self.cc_user_no_data.get_id]))
         self.check_cc_indicators(indicator_set.get_data(), expected_standard_indicators())
+
+    def test_sync_log(self):
+        user_case = get_case_by_domain_hq_user_id(
+            self.cc_domain.name,
+            self.cc_user.get_id,
+            include_docs=True
+        )
+        synclog = SyncLog(
+            user_id=self.cc_user.get_id,
+            date=datetime.utcnow(),
+            cases_on_phone=[CaseState.from_case(user_case)]
+        )
+
+        indicator_set = CallCenterIndicators(self.cc_domain, self.cc_user, synclog=synclog, custom_cache=locmem_cache)
+        self.assertEqual(indicator_set.all_user_ids, set([self.cc_user.get_id]))
+        self.assertEqual(indicator_set.users_needing_data, set([self.cc_user.get_id]))
+        self.assertEqual(indicator_set.owners_needing_data, set([self.cc_user.get_id]))
+        self._test_indicators(self.cc_user, indicator_set.get_data(), expected_standard_indicators())
 
     def test_custom_indicators(self):
         expected = {'totalCases': 0L}

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -55,6 +55,9 @@ class CaseState(LooselyEqualDocumentSchema, IndexHoldingMixIn):
 
     case_id = StringProperty()
     type = StringProperty()
+
+    # this property is here as a hack to enable the call center fixtures to work.
+    # https://github.com/dimagi/commcare-hq/pull/4799 has some context.
     hq_user_id = StringProperty()
     indices = SchemaListProperty(CommCareCaseIndex)
 

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -52,15 +52,20 @@ class CaseState(LooselyEqualDocumentSchema, IndexHoldingMixIn):
     """
     Represents the state of a case on a phone.
     """
-    
+
     case_id = StringProperty()
     type = StringProperty()
+    hq_user_id = StringProperty()
     indices = SchemaListProperty(CommCareCaseIndex)
-    
+
     @classmethod
     def from_case(cls, case):
-        return cls(case_id=case.get_id, type=case.type,
-                   indices=case.indices)
+        return cls(
+            case_id=case.get_id,
+            type=case.type,
+            indices=case.indices,
+            hq_user_id=getattr(case, 'hq_user_id', None)
+        )
 
     def __repr__(self):
         return "case state: %s (%s)" % (self.case_id, self.indices)


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?146765

@czue how embarrassing 

This seemed like the least invasive option. Other options require an extra query to get the user_ids:
- update the `hqcase/by_domain_hq_user_id` so that you can get user_id's from case_id's
- update the SQL case index to include `hq_user_id` column
