### PR TITLE
use new case processing in 5% of the domains

### DIFF
--- a/corehq/apps/domain/templates/domain/admin/feature_flags.html
+++ b/corehq/apps/domain/templates/domain/admin/feature_flags.html
@@ -1,0 +1,42 @@
+{% extends "settings/base_template.html" %}
+{% load i18n %}
+{% block main_column %}
+    <div class="row-fluid">
+        <div class="span6">
+            <p>
+                {% url 'toggle_list' as toggle_url %}
+                {% blocktrans %}
+                    Feature Flags are superuser-only things that can be turn on features for individual users or projects.
+                    They can be edited manually at the <a href="{{ toggle_url }}">Feature Flag edit UI</a> (also super-only).
+                    In addition, some feature flags are randomly enabled by a domain.
+                {% endblocktrans %}
+            </p>
+            <p>
+                {% blocktrans %}
+                    You can see a list of all enabled flags for this domain here.
+                    This does not include any flags set for users within the domain.
+                {% endblocktrans %}
+            </p>
+        </div>
+    </div>
+    <div class="row-fluid">
+        <div class="span6">
+            <table class="table table-striped">
+                <thead>
+                    <th>{% trans "Feature" %}</th>
+                    <th>{% trans "Enabled?" %}</th>
+                    <th>{% trans "Edit" %}</th>
+                </thead>
+                <tbody>
+                    {% for feature, enabled in flags %}
+                    <tr {% if enabled %}class="info"{% endif %}>
+                        <td>{{ feature.label }}</td>
+                        <td>{{ enabled }}</td>
+                        <td><a href="{% url 'edit_toggle' feature.slug %}">{% trans "change" %}</a></td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+{% endblock %}

--- a/corehq/apps/domain/urls.py
+++ b/corehq/apps/domain/urls.py
@@ -20,7 +20,7 @@ from corehq.apps.domain.views import (
     FeaturePreviewsView, ConfirmSubscriptionRenewalView,
     InvoiceStripePaymentView, CreditsStripePaymentView, SMSRatesView,
     AddFormRepeaterView, AddOpsUserAsDomainAdminView,
-)
+    FeatureFlagsView)
 
 #
 # After much reading, I discovered that Django matches URLs derived from the environment
@@ -128,5 +128,6 @@ domain_settings = patterns(
     url(r'^internal/calculations/$', EditInternalCalculationsView.as_view(), name=EditInternalCalculationsView.urlname),
     url(r'^internal/calculated_properties/$', 'calculated_properties', name='calculated_properties'),
     url(r'^previews/$', FeaturePreviewsView.as_view(), name=FeaturePreviewsView.urlname),
+    url(r'^flags/$', FeatureFlagsView.as_view(), name=FeatureFlagsView.urlname),
     url(r'^sms_rates/$', SMSRatesView.as_view(), name=SMSRatesView.urlname),
 )

--- a/corehq/apps/hqwebapp/models.py
+++ b/corehq/apps/hqwebapp/models.py
@@ -1057,6 +1057,8 @@ class ProjectSettingsTab(UITab):
 
     @property
     def sidebar_items(self):
+        from corehq.apps.domain.views import FeatureFlagsView, FeaturePreviewsView
+
         items = []
         user_is_admin = self.couch_user.is_domain_admin(self.domain)
 
@@ -1135,8 +1137,8 @@ class ProjectSettingsTab(UITab):
             ])
 
             administration.append({
-                    'title': _('Feature Previews'),
-                    'url': reverse('feature_previews', args=[self.domain])
+                    'title': _(FeaturePreviewsView.page_title),
+                    'url': reverse(FeaturePreviewsView.urlname, args=[self.domain])
             })
             items.append((_('Project Administration'), administration))
 
@@ -1189,10 +1191,12 @@ class ProjectSettingsTab(UITab):
             {
                 'title': _(EditInternalCalculationsView.page_title),
                 'url': reverse(EditInternalCalculationsView.urlname, args=[self.domain])
+            },
+            {
+                'title': _(FeatureFlagsView.page_title),
+                'url': reverse(FeatureFlagsView.urlname, args=[self.domain])
             }]
             items.append((_('Internal Data (Dimagi Only)'), internal_admin))
-
-
 
         return items
 

--- a/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
+++ b/corehq/apps/toggle_ui/templates/toggle/edit_flag.html
@@ -113,6 +113,19 @@
                     {% endif %}
                 {% endfor %}
             </ul>
+            {% if toggle_meta.randomness %}
+                <p>
+                    {% blocktrans with percent=toggle_meta.randomness_percent namespace=toggle_meta.namespace %}
+                    And <strong>{{ percent }}%</strong> of all other {{ namespace }}s.
+                    {% endblocktrans %}
+                    <br/>
+                    <ul>
+                        <li>
+                            <span class="muted">{% trans "Go to the project settings page to see if a toggle is randomly enabled for your domain." %}</span>
+                        </li>
+                    </ul>
+                </p>
+            {% endif %}
         </div>
         <hr/>
         <!-- ko foreach: items -->

--- a/corehq/ex-submodules/casexml/apps/case/models.py
+++ b/corehq/ex-submodules/casexml/apps/case/models.py
@@ -15,6 +15,7 @@ from couchdbkit.ext.django.schema import *
 from couchdbkit.exceptions import ResourceNotFound, ResourceConflict
 from PIL import Image
 from casexml.apps.case.exceptions import MissingServerDate, ReconciliationError
+from corehq import toggles
 from corehq.util.couch_helpers import CouchAttachmentsBuilder
 from dimagi.utils.django.cached_object import CachedObject, OBJECT_ORIGINAL, OBJECT_SIZE_MAP, CachedImage, IMAGE_SIZE_ORDERING
 from casexml.apps.phone.xml import get_case_element
@@ -655,10 +656,15 @@ class CommCareCase(SafeSaveDocument, IndexHoldingMixIn, ComputedDocumentMixin,
     
     def update_from_case_update(self, case_update, xformdoc):
         def _use_new_case_processing():
-            # feature flags ftw
-            return (not case_update.has_referrals()
-                    and (getattr(settings,'UNIT_TESTING', False)
-                         or getattr(xformdoc, 'domain', None) in ('ekjut', 'miralbwsurvey')))
+            domain = getattr(xformdoc, 'domain', None)
+            return (
+                not case_update.has_referrals()
+                and (
+                    getattr(settings,'UNIT_TESTING', False)
+                    or domain in ('ekjut', 'miralbwsurvey')
+                    or toggles.NEW_CASE_PROCESSING.enabled(domain)
+                )
+            )
 
         if _use_new_case_processing():
             return self._new_update_from_case_update(case_update, xformdoc)

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -192,3 +192,10 @@ STOCK_TRANSACTION_EXPORT = StaticToggle(
     'Show "export transactions" link on case details page',
 )
 
+
+NEW_CASE_PROCESSING = PredicatablyRandomToggle(
+    'new_case_processing',
+    'Use new case processing/rebuild logic',
+    namespace=NAMESPACE_DOMAIN,
+    randomness=0.05,
+)

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -55,6 +55,10 @@ class PredicatablyRandomToggle(StaticToggle):
         assert 0 <= randomness <= 1, 'randomness must be between 0 and 1!'
         self.randomness = randomness
 
+    @property
+    def randomness_percent(self):
+        return "{:.0f}".format(self.randomness * 100)
+
     def _get_identifier(self, item):
         return '{}:{}:{}'.format(self.namespace, self.slug, item)
 
@@ -174,3 +178,4 @@ STOCK_TRANSACTION_EXPORT = StaticToggle(
     'ledger_export',
     'Show "export transactions" link on case details page',
 )
+

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -72,6 +72,19 @@ class PredicatablyRandomToggle(StaticToggle):
 NAMESPACE_USER = object()
 NAMESPACE_DOMAIN = 'domain'
 
+
+def all_toggles():
+    """
+    Loads all toggles
+    """
+    # trick for listing the attributes of the current module.
+    # http://stackoverflow.com/a/990450/8207
+    for toggle_name, toggle in globals().items():
+        if not toggle_name.startswith('__'):
+            if isinstance(toggle, StaticToggle):
+                yield toggle
+
+
 APP_BUILDER_CUSTOM_PARENT_REF = StaticToggle(
     'custom-parent-ref',
     'Custom case parent reference'

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -36,6 +36,10 @@ class StaticToggle(object):
 
 
 def deterministic_random(input_string):
+    """
+    Returns a deterministically random number between 0 and 1 based on the
+    value of the string. The same input should always produce the same output.
+    """
     return float.fromhex(hashlib.md5(input_string).hexdigest()) / math.pow(2, 128)
 
 

--- a/corehq/util/tests.py
+++ b/corehq/util/tests.py
@@ -1,4 +1,8 @@
-from django.test import TestCase
+from collections import defaultdict
+import random
+import uuid
+from django.test import TestCase, SimpleTestCase
+from corehq.toggles import deterministic_random
 from corehq.util.couch import get_document_or_404
 from corehq.apps.users.models import WebUser
 from corehq.apps.users.models import CommCareUser
@@ -20,3 +24,45 @@ class GetDocTestCase(TestCase):
 
     def test_get_commcare_user(self):
         get_document_or_404(CommCareUser, 'test', self.commcare_user._id)
+
+
+class DeterministicRandomTestCase(SimpleTestCase):
+
+    def _random_string(self):
+        return uuid.uuid4().hex
+
+    def _random_strings(self, count):
+        return [self._random_string() for i in range(count)]
+
+    def test_random_strings(self):
+        seen = set()
+        for rand in self._random_strings(100):
+            self.assertTrue(rand not in seen)
+            seen.add(rand)
+        self.assertEqual(100, len(seen))
+
+    def test_consistency(self):
+        seen = set()
+        for seed in self._random_strings(100):
+            converted_rand = deterministic_random(seed)
+            self.assertTrue(0 <= converted_rand < 1)
+            self.assertEqual(converted_rand, deterministic_random(seed))
+            self.assertTrue(converted_rand not in seen)
+            seen.add(converted_rand)
+
+    def test_randomness(self):
+        buckets = defaultdict(lambda: 0)
+        for i in range(10000):
+            # use similar looking strings to make sure randomness is in the called function.
+            # note that this also makes this (statistically-determined) test deterministic which is nice
+            seed = 'test-string-{}'.format(i)
+            converted_rand = deterministic_random(seed)
+            self.assertTrue(0 <= converted_rand < 1)
+            first_decimal = int("{:.1f}".format(converted_rand)[-1])
+            buckets[first_decimal] += 1
+
+        self.assertEqual(10, len(buckets))
+        for i in range(10):
+            # we expect about 1000 in each bucket and the sample is big enough that
+            # these constraints are fine.
+            self.assertTrue(900 < buckets[i] < 1100)


### PR DESCRIPTION
@dannyroberts should have context for this.

Also adds a new type of toggle that can do deterministic randomness

http://manage.dimagi.com/default.asp?146788

Also adds an admin-only UI for viewing the enabled toggles for a domain.
![image](https://cloud.githubusercontent.com/assets/66555/5050060/ec6279a6-6bf8-11e4-9a04-85c4ddb1b5f6.png)

And minor tweaks to edit toggle UIs for something that is randomly set.

![image](https://cloud.githubusercontent.com/assets/66555/5050078/05848410-6bf9-11e4-9056-6ac8d38e8f56.png)

The only non-admin-facing change is: https://github.com/dimagi/commcare-hq/commit/d4ce65280c8d56f58bdc24b8be116306cfc6421c
