### PR TITLE
Make format clearer with multiple merge conflicts

### DIFF
--- a/scripts/rebuildstaging.py
+++ b/scripts/rebuildstaging.py
@@ -227,7 +227,7 @@ def rebuild_staging(config, print_details=True, push=True):
     if merge_conflicts:
         print "You must fix the following merge conflicts before rebuilding:"
         for cwd, branch, config in merge_conflicts:
-            print "  [{cwd}] {branch} => {name}".format(
+            print "\n[{cwd}] {branch} => {name}".format(
                 cwd=format_cwd(cwd),
                 branch=branch,
                 name=config.name,


### PR DESCRIPTION
Really small.  Previously the output for merge conflicts mashed together:

``` sh
    2014-11-17 [Sravan Reddy] 9c3f8be  
    pep8 

    This commit also appears on these branches:
    * hq-dropdown
    * /4741
  [.] edit-build-messages => autostaging
  * First conflicting commit on autostaging:
```

The line `[.] edit-build-messages => autostaging` indicates another merge conflict.
