### PR TITLE
fix variable typo

### DIFF
--- a/corehq/apps/commtrack/sms.py
+++ b/corehq/apps/commtrack/sms.py
@@ -204,7 +204,7 @@ class StockReportParser(object):
                 keyword = next()
             except StopIteration:
                 if not found_product_for_action:
-                    raise SMSError('product expected for action "%s"' % action_code)
+                    raise SMSError('product expected for action "%s"' % action)
                 break
 
             old_action = action


### PR DESCRIPTION
I'm guessing this line has never executed?  Otherwise a syntax error would have appeared at some point
