### PR TITLE
Ability to reference parent case properties from reminder messages

### DIFF
--- a/corehq/apps/reminders/event_handlers.py
+++ b/corehq/apps/reminders/event_handlers.py
@@ -101,12 +101,14 @@ def get_recipient_phone_number(reminder, recipient, verified_numbers):
 
 
 def get_message_template_params(case):
-    result = {}
-    parent_case = case.parent if case else None
+    result = {"case": {}}
     if case:
         result["case"] = case.case_properties()
+
+    parent_case = case.parent if case else None
+    result["case"]["parent"] = {}
     if parent_case:
-        result["parent"] = parent_case.case_properties()
+        result["case"]["parent"] = parent_case.case_properties()
     return result
 
 

--- a/corehq/apps/reminders/event_handlers.py
+++ b/corehq/apps/reminders/event_handlers.py
@@ -100,16 +100,24 @@ def get_recipient_phone_number(reminder, recipient, verified_numbers):
     return (verified_number, unverified_number)
 
 
+def get_message_template_params(case):
+    result = {}
+    parent_case = case.parent if case else None
+    if case:
+        result["case"] = case.case_properties()
+    if parent_case:
+        result["parent"] = parent_case.case_properties()
+    return result
+
+
 def fire_sms_event(reminder, handler, recipients, verified_numbers, workflow=None):
     metadata = MessageMetadata(
         workflow=workflow or get_workflow(handler),
         reminder_id=reminder._id,
     )
     current_event = reminder.current_event
-    template_params = {}
     case = reminder.case
-    if case is not None:
-        template_params["case"] = case.case_properties()
+    template_params = get_message_template_params(case)
     for recipient in recipients:
         try:
             lang = recipient.get_language_code()

--- a/corehq/apps/reminders/event_handlers.py
+++ b/corehq/apps/reminders/event_handlers.py
@@ -101,6 +101,26 @@ def get_recipient_phone_number(reminder, recipient, verified_numbers):
 
 
 def get_message_template_params(case):
+    """
+    Data such as case properties can be referenced from reminder messages
+    such as {case.name} which references the case's name. Add to this result
+    all data that can be referenced from a reminder message.
+
+    The result is a dictionary where each key is the object's name and each
+    value is a dictionary of attributes to be referenced. Dictionaries can
+    also be nested, so a result here of {"case": {"parent": {"name": "joe"}}}
+    allows you to reference {case.parent.name} in a reminder message.
+
+    At the moment, the result here is of this structure:
+    {
+        "case": {
+            ...key:value case properties...
+            "parent": {
+                ...key:value parent case properties...
+            }
+        }
+    }
+    """
     result = {"case": {}}
     if case:
         result["case"] = case.case_properties()

--- a/corehq/apps/reminders/tests/__init__.py
+++ b/corehq/apps/reminders/tests/__init__.py
@@ -1,7 +1,9 @@
 from datetime import datetime, timedelta, date, time
 from django.test.testcases import TestCase
 from casexml.apps.case.models import CommCareCase
+from casexml.apps.case.sharedmodels import CommCareCaseIndex
 from corehq.apps.reminders.models import *
+from corehq.apps.reminders.event_handlers import get_message_template_params
 from corehq.apps.users.models import CouchUser, CommCareUser
 from corehq.apps.sms.models import CallLog, ExpectedCallbackEventLog, CALLBACK_RECEIVED, CALLBACK_PENDING, CALLBACK_MISSED
 from corehq.apps.sms.mixin import VerifiedNumber, BackendMapping
@@ -1084,8 +1086,48 @@ class ReminderLockTestCase(BaseReminderTestCase):
 
 
 class MessageTestCase(BaseReminderTestCase):
+
+    def setUp(self):
+        self.domain = "test"
+
+        self.parent_case = CommCareCase(
+            domain=self.domain,
+            type="parent",
+            name="P001",
+        )
+        self.parent_case.set_case_property("parent_prop1", "abc")
+        self.parent_case.save()
+
+        self.child_case = CommCareCase(
+            domain=self.domain,
+            type="child",
+            name="P002",
+            indices=[CommCareCaseIndex(
+                identifier="parent",
+                referenced_type="parent",
+                referenced_id=self.parent_case._id,
+            )],
+        )
+        self.child_case.set_case_property("child_prop1", "def")
+        self.child_case.save()
+
+    def tearDown(self):
+        self.child_case.delete()
+        self.parent_case.delete()
+
     def test_message(self):
         message = 'The EDD for client with ID {case.external_id} is approaching in {case.edd.days_until} days.'
         case = {'external_id': 123, 'edd': datetime.utcnow() + timedelta(days=30)}
         outcome = 'The EDD for client with ID 123 is approaching in 30 days.'
         self.assertEqual(Message.render(message, case=case), outcome)
+
+    def test_template_params(self):
+        child_result = {"case": self.child_case.case_properties()}
+        child_result["case"]["parent"] = self.parent_case.case_properties()
+        self.assertEqual(
+            get_message_template_params(self.child_case), child_result)
+
+        parent_result = {"case": self.parent_case.case_properties()}
+        parent_result["case"]["parent"] = {}
+        self.assertEqual(
+            get_message_template_params(self.parent_case), parent_result)


### PR DESCRIPTION
In addition to specifying {case.property}, now you can specify {case.parent.property} to include a parent case's case property in a message.
