### PR TITLE
Location id fix

### DIFF
--- a/corehq/apps/cloudcare/api.py
+++ b/corehq/apps/cloudcare/api.py
@@ -96,6 +96,7 @@ class CaseAPIHelper(object):
         self.filters = filters
         self.include_children = include_children
 
+
     def iter_cases(self, ids):
         database = CommCareCase.get_db()
         if not self.strip_history:
@@ -103,7 +104,7 @@ class CaseAPIHelper(object):
                 yield CommCareCase.wrap(doc)
         else:
             for doc_ids in chunked(ids, 100):
-                for case in CommCareCase.bulk_get_lite(doc_ids):
+                for case in CommCareCase.bulk_get_lite(doc_ids, wrapper=CommCareCase):
                     yield case
 
     def _case_results(self, case_id_list):

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -231,7 +231,6 @@ def get_groups(request, domain, user_id):
 
 @cloudcare_api
 def get_cases(request, domain):
-
     if request.couch_user.is_commcare_user():
         user_id = request.couch_user.get_id
     else:

--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -588,6 +588,7 @@ class SupplyPointCase(CommCareCase):
     A wrapper around CommCareCases to get more built in functionality
     specific to supply points.
     """
+    location_id = StringProperty()
 
     class Meta:
         # This is necessary otherwise syncdb will confuse this app with casexml
@@ -599,12 +600,10 @@ class SupplyPointCase(CommCareCase):
     @property
     @memoized
     def location(self):
-        if hasattr(self, 'location_id'):
-            try:
-                return Location.get(self.location_id)
-            except ResourceNotFound:
-                pass
-        return None
+        try:
+            return Location.get(self.location_id)
+        except ResourceNotFound:
+            return None
 
     @classmethod
     def _from_caseblock(cls, domain, caseblock):

--- a/corehq/ex-submodules/casexml/apps/case/models.py
+++ b/corehq/ex-submodules/casexml/apps/case/models.py
@@ -273,9 +273,6 @@ class CommCareCase(SafeSaveDocument, IndexHoldingMixIn, ComputedDocumentMixin,
     indices = SchemaListProperty(CommCareCaseIndex)
     case_attachments = SchemaDictProperty(CommCareCaseAttachment)
     
-    # TODO: move to commtrack.models.SupplyPointCases (and full regression test)
-    location_id = StringProperty()
-
     server_modified_on = DateTimeProperty()
 
     def __unicode__(self):

--- a/corehq/ex-submodules/casexml/apps/case/models.py
+++ b/corehq/ex-submodules/casexml/apps/case/models.py
@@ -441,11 +441,12 @@ class CommCareCase(SafeSaveDocument, IndexHoldingMixIn, ComputedDocumentMixin,
         return cls
 
     @classmethod
-    def bulk_get_lite(cls, ids):
+    def bulk_get_lite(cls, ids, wrapper=None):
         for res in cls.get_db().view("case/get_lite", keys=ids,
                                  include_docs=False):
-            # cls.wrap is called in a lot of places; do they all need to be updated?
-            yield cls.get_wrap_class(res['value']).wrap(res['value'])
+            if wrapper is None:
+                wrapper = cls.get_wrap_class(res['value']).wrap(res['value'])
+            yield wrapper.wrap(res['value'])
 
     def get_preloader_dict(self):
         """


### PR DESCRIPTION
should fix http://manage.dimagi.com/default.asp?146818 and http://manage.dimagi.com/default.asp?147063

fixes a subtle but bad bug introduced in https://github.com/dimagi/commcare-hq/commit/ee7cad2d338c72a99906b3ba60734b5cd794e839

once `location_id` was a first class property it was no longer returned in `dynamic_properties` calls which
prevented it from being returned in API results and OTA restores, breaking a lot of application flows that 
depended on this value.

we may need to write a migration for intrahealth to fix their old forms.
