### PR TITLE
allow EMAIL_USE_TLS to be overridden

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -434,11 +434,19 @@ BASE_ASYNC_TEMPLATE = "reports/async/basic.html"
 LOGIN_TEMPLATE = "login_and_password/login.html"
 LOGGEDOUT_TEMPLATE = LOGIN_TEMPLATE
 
-# email settings: these ones are the custom hq ones
+# These are non-standard setting names that are used in localsettings
+# The standard variables are then set to these variables after localsettings
+# Todo: Change to use standard settings variables
+# Todo: Will require changing salt pillar and localsettings template
+# Todo: or more likely in ansible once that's a thing
 EMAIL_LOGIN = "user@domain.com"
 EMAIL_PASSWORD = "changeme"
 EMAIL_SMTP_HOST = "smtp.gmail.com"
 EMAIL_SMTP_PORT = 587
+# These are the normal Django settings
+EMAIL_USE_TLS = True
+SEND_BROKEN_LINK_EMAILS = True
+
 
 # put email addresses here to have them receive bug reports
 BUG_REPORT_RECIPIENTS = ()
@@ -1030,8 +1038,8 @@ EMAIL_HOST = EMAIL_SMTP_HOST
 EMAIL_PORT = EMAIL_SMTP_PORT
 EMAIL_HOST_USER = EMAIL_LOGIN
 EMAIL_HOST_PASSWORD = EMAIL_PASSWORD
-EMAIL_USE_TLS = True
-SEND_BROKEN_LINK_EMAILS = True
+# EMAIL_USE_TLS and SEND_BROKEN_LINK_EMAILS are set above
+# so they can be overridden in localsettings (e.g. in a dev environment)
 
 NO_HTML_EMAIL_MESSAGE = """
 This is an email from CommCare HQ. You're seeing this message because your


### PR DESCRIPTION
and SEND_BROKEN_LINK_EMAILS while we're at it

This is to help me set up a an ansible VM dev environment that's super close to prod (without actually putting in credentials to our real dimagi email)

I'd like to be able to run `python -m smtpd -n -c DebuggingServer 192.168.33.14:1025` on the control VM and have that act as the server, but that requires being able to set `EMAIL_USE_TLS = False`
