### PR TITLE
World Vision reports layout changes

### DIFF
--- a/custom/world_vision/reports/mixed_report.py
+++ b/custom/world_vision/reports/mixed_report.py
@@ -20,6 +20,7 @@ class MixedTTCReport(TTCReport):
     fields = [WVDatespanFilter, LocationFilter]
     default_rows = 10
     exportable = True
+    is_mixed_report = True
 
     @property
     @memoized
@@ -31,16 +32,15 @@ class MixedTTCReport(TTCReport):
             PregnantMotherBreakdownByTrimester(config=config),
             AnteNatalCareServiceOverview(config=config),
             DeliveryPlaceDetails(config=config),
-            DeliveryLiveBirthDetails(config=config),
             DeliveryStillBirthDetails(config=config),
+            DeliveryLiveBirthDetails(config=config),
             PostnatalCareOverview(config=config),
-            CauseOfMaternalDeaths(config=config),
             AnteNatalCareServiceOverviewExtended(config=config),
+            CauseOfMaternalDeaths(config=config),
             ChildRegistrationDetails(config=config),
             ClosedChildCasesBreakdown(config=config),
             ImmunizationOverview(config=config),
             ChildrenDeaths(config=config),
-            ChildrenDeathDetails(config=config),
             NutritionMeanMedianBirthWeightDetails(config=config),
             NutritionBirthWeightDetails(config=config),
             NutritionFeedingDetails(config=config),

--- a/custom/world_vision/sqldata/__init__.py
+++ b/custom/world_vision/sqldata/__init__.py
@@ -35,6 +35,8 @@ class BaseSqlData(SqlData):
     custom_total_calculate = False
     accordion_start = True
     accordion_end = True
+    chart_only = False
+    table_only = False
 
     def percent_fn(self, x, y):
         return "%.0f%%" % (100 * float(y or 0) / (x or 1))

--- a/custom/world_vision/sqldata/child_sqldata.py
+++ b/custom/world_vision/sqldata/child_sqldata.py
@@ -89,6 +89,7 @@ class ClosedChildCasesBreakdown(BaseSqlData):
     show_charts = True
     chart_x_label = ''
     chart_y_label = ''
+    chart_only = True
 
     @property
     def group_by(self):
@@ -133,6 +134,7 @@ class ChildrenDeaths(BaseSqlData):
     custom_total_calculate = True
     accordion_start = True
     accordion_end = False
+    table_only = True
 
     def calculate_total_row(self, rows):
         total_row = []
@@ -345,6 +347,7 @@ class NutritionBirthWeightDetails(BaseSqlData):
     chart_y_label = ''
     accordion_start = False
     accordion_end = False
+    chart_only = True
 
     @property
     def headers(self):

--- a/custom/world_vision/sqldata/main_sqldata.py
+++ b/custom/world_vision/sqldata/main_sqldata.py
@@ -122,6 +122,7 @@ class ImmunizationOverview(BaseSqlData):
     show_charts = True
     chart_x_label = ''
     chart_y_label = ''
+    chart_only = True
 
     @property
     def headers(self):

--- a/custom/world_vision/sqldata/mother_sqldata.py
+++ b/custom/world_vision/sqldata/mother_sqldata.py
@@ -95,6 +95,7 @@ class ClosedMotherCasesBreakdown(BaseSqlData):
     show_charts = True
     chart_x_label = ''
     chart_y_label = ''
+    chart_only = True
 
     @property
     def group_by(self):
@@ -135,6 +136,7 @@ class PregnantMotherBreakdownByTrimester(BaseSqlData):
     show_charts = True
     chart_x_label = ''
     chart_y_label = ''
+    chart_only = True
 
 
     def percent_fn(self, y):
@@ -189,6 +191,7 @@ class AnteNatalCareServiceOverviewExtended(AnteNatalCareServiceOverview):
     show_charts = True
     chart_x_label = ''
     chart_y_label = ''
+    chart_only = True
 
     @property
     def rows(self):
@@ -323,6 +326,7 @@ class DeliveryLiveBirthDetails(BaseSqlData):
     total_row_name = "Total live births"
     accordion_start = False
     accordion_end = False
+    chart_only = True
 
     @property
     def headers(self):
@@ -377,7 +381,7 @@ class DeliveryStillBirthDetails(BaseSqlData):
 
     @property
     def headers(self):
-        return DataTablesHeader(*[DataTablesColumn('Entity'), DataTablesColumn('Number')])
+        return DataTablesHeader(*[DataTablesColumn(''), DataTablesColumn('Number')])
 
     @property
     def columns(self):
@@ -411,6 +415,7 @@ class PostnatalCareOverview(BaseSqlData):
     chart_x_label = ''
     chart_y_label = ''
     accordion_end = False
+    chart_only = True
 
     @property
     def filters(self):
@@ -489,6 +494,7 @@ class CauseOfMaternalDeaths(BaseSqlData):
     show_charts = True
     chart_x_label = ''
     chart_y_label = ''
+    table_only = True
 
     @property
     def group_by(self):

--- a/custom/world_vision/templates/world_vision/multi_report.html
+++ b/custom/world_vision/templates/world_vision/multi_report.html
@@ -38,13 +38,11 @@
 
     <style>
         .mother_report .table-nonfluid, .child_report .table-nonfluid{
-           width: auto;
+           width: 55%;
         }
 
-        .mother_report .table tr td:nth-child(1) {width:250px;}
-        .child_report .table tr td:nth-child(1) {width:350px;}
-        .mother_report .table tr td:nth-child(n + 2){width:130px;}
-        .child_report .table tr td:nth-child(n + 2) {width:200px;}
+        .mother_report .table tr td:nth-child(1), .child_report .table tr td:nth-child(1) {width:150px;}
+        .mother_report .table tr td:nth-child(n + 2), .child_report .table tr td:nth-child(n + 2) {width:100px;}
 
         .mother_report table, .child_report table {
             display: inline-block;
@@ -60,7 +58,7 @@
             width: 100%;
         }
         .mother_report table + .row, .mother_report .row + .row, .child_report table + .row, .child_report .row + .row {
-            width: 50%;
+            width: 45%;
             float:right;
             display: inline-block;
         }

--- a/custom/world_vision/templates/world_vision/multi_report.html
+++ b/custom/world_vision/templates/world_vision/multi_report.html
@@ -37,37 +37,56 @@
 {% else %}
 
     <style>
-        .table-nonfluid {
+        .mother_report .table-nonfluid, .child_report .table-nonfluid{
            width: auto;
         }
-        .table tr td:nth-child(1) {width:230px;}
-        .table tr td:nth-child(n + 2) {width:120px;}
 
-        table {
+        .mother_report .table tr td:nth-child(1) {width:250px;}
+        .child_report .table tr td:nth-child(1) {width:350px;}
+        .mother_report .table tr td:nth-child(n + 2){width:130px;}
+        .child_report .table tr td:nth-child(n + 2) {width:200px;}
+
+        .mother_report table, .child_report table {
             display: inline-block;
             float: left;
         }
-        .row ~ table {
+
+        .mother_report .row ~ table, .child_report .row ~ table {
             margin-top: 200px;
             display: inline-block;
         }
+
         .accordion-inner {
             width: 100%;
         }
-        table + .row, .row + .row {
-            width: 45%;
+        .mother_report table + .row, .mother_report .row + .row, .child_report table + .row, .child_report .row + .row {
+            width: 50%;
             float:right;
             display: inline-block;
         }
+
         svg {
             overflow: visible;
         }
-    </style>
 
-    {% for thisreport in reports %}
-        {% include 'world_vision/partials/report_table.html' with report_table=thisreport.report_table charts=thisreport.charts chart_span=thisreport.chart_span%}
-        <br />
-    {% endfor %}
+        .mother_child_report .table-nonfluid {
+            width: 30%;
+        }
+
+        .mother_child_report table, .mother_child_report .row {
+            width: 30%;
+            margin-left: 10px;
+            margin-bottom: 5px;
+            float:left;
+            display: inline-block;
+        }
+    </style>
+    <div class={{ report.slug }}>
+        {% for thisreport in reports %}
+            {% include 'world_vision/partials/report_table.html' with report_table=thisreport.report_table charts=thisreport.charts chart_span=thisreport.chart_span%}
+            <br />
+        {% endfor %}
+    </div>
 {% endif %}
 {% endblock %}
 {% block posttable %}{% endblock %}

--- a/custom/world_vision/templates/world_vision/partials/report_table.html
+++ b/custom/world_vision/templates/world_vision/partials/report_table.html
@@ -2,7 +2,7 @@
 {% load report_tags %}
 {% load i18n %}
 
-{% if report_table.accordion_start %}
+{% if report_table.accordion_start and not report_table.is_mixed_report %}
     <div class="accordion" id="accordion_{{ report_table.slug }}">
         <div class="accordion-heading">
           <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion_{{ report_table.slug }}" href="#collapse_{{ report_table.slug }}">
@@ -14,68 +14,69 @@
             <div class="accordion-inner">
 {% endif %}
 
-        <table id="report_table_{{ report_table.slug }}" class="table table-nonfluid datatable" {% if pagination.filter %} data-filter="true"{% endif %}
-                >
-            <thead>
-                {%  if report_table.headers.complex %}
-                    {{ report_table.headers.render_html|safe }}
-                {% else %}
+        {% if not report_table.chart_only %}
+            <table id="report_table_{{ report_table.slug }}" class="table table-nonfluid datatable" {% if pagination.filter %} data-filter="true"{% endif %}
+                    >
+                <thead>
+                    {%  if report_table.headers.complex %}
+                        {{ report_table.headers.render_html|safe }}
+                    {% else %}
+                        <tr>
+                            {% for header in report_table.headers %}
+                                <th {% if not report_table.pagination.is_on %}data-sort="{{ header.sort_type }}" data-sortdir="{{ header.sort_direction }}"{% endif %} {% if header.css_class %}class="{{ header.css_class }}"{% endif %}>
+                                    <i class="icon-white"></i>
+                                    {% if header.html %}{{ header.html }}{% else %}{{ header|linebreaksbr }}{% endif %}
+                                    {% if header.help_text %}
+                                        <i class="icon-white icon-question-sign header-tooltip" title="{{ header.help_text }}"></i>
+                                    {% endif %}
+                                </th>
+                            {% endfor %}
+                        </tr>
+                    {% endif %}
+                </thead>
+                <tbody>
+                {% block tabular-body %}
+                {% if report_table.pagination.is_on %}
                     <tr>
-                        {% for header in report_table.headers %}
-                            <th {% if not report_table.pagination.is_on %}data-sort="{{ header.sort_type }}" data-sortdir="{{ header.sort_direction }}"{% endif %} {% if header.css_class %}class="{{ header.css_class }}"{% endif %}>
-                                <i class="icon-white"></i>
-                                {% if header.html %}{{ header.html }}{% else %}{{ header|linebreaksbr }}{% endif %}
-                                {% if header.help_text %}
-                                    <i class="icon-white icon-question-sign header-tooltip" title="{{ header.help_text }}"></i>
-                                {% endif %}
-                            </th>
-                        {% endfor %}
+                        <td colspan="{{ report_table.headers.header|length }}" class="dataTables_empty">
+                            {% trans "Fetching additional data, please wait..." %}
+                        </td>
                     </tr>
                 {% endif %}
-            </thead>
-            <tbody>
-            {% block tabular-body %}
-            {% if report_table.pagination.is_on %}
-                <tr>
-                    <td colspan="{{ report_table.headers.header|length }}" class="dataTables_empty">
-                        {% trans "Fetching additional data, please wait..." %}
-                    </td>
-                </tr>
-            {% endif %}
-            {% for row in report_table.rows %}
-                <tr>
-                    {% for col in row %}
-                        {% include 'world_vision/partials/tabular_cell.html' %}
-                    {% endfor %}
-                </tr>
-            {% endfor %}
-            {% endblock %}
-            </tbody>
-            {% if report_table.total_row and report_table.rows %}
-                <tfoot>
-                <tr>
-                    {% for col in report_table.total_row %}
-                        <td>{% if col.html != None %}{{ col.html|safe }}{% else %}{{ col|safe }}{% endif %}</td>
-                    {% endfor %}
-                </tr>
-                </tfoot>
-            {% endif %}
-        </table>
+                {% for row in report_table.rows %}
+                    <tr>
+                        {% for col in row %}
+                            {% include 'world_vision/partials/tabular_cell.html' %}
+                        {% endfor %}
+                    </tr>
+                {% endfor %}
+                {% endblock %}
+                </tbody>
+                {% if report_table.total_row and report_table.rows %}
+                    <tfoot>
+                    <tr>
+                        {% for col in report_table.total_row %}
+                            <td>{% if col.html != None %}{{ col.html|safe }}{% else %}{{ col|safe }}{% endif %}</td>
+                        {% endfor %}
+                    </tr>
+                    </tfoot>
+                {% endif %}
+            </table>
+        {% endif %}
 
-
-        {% if charts %}
+        {% if charts and not report_table.table_only %}
             {% for chart in charts %}
             <div class="row">
                 {% if chart.title %}<h4 style="text-align: center;">{{ chart.title }}</h4>{% endif %}
-                <div id='chart_{{ report.slug }}_{{ forloop.parentloop.counter }}{{ forloop.counter }}' class="span6 hide">
-                    <svg style='height: {{ chart.height }}px'> </svg>
+                <div id='chart_{{ report.slug }}_{{ forloop.parentloop.counter }}{{ forloop.counter }}' class="span6 hide" style="width: 80%">
+                    <svg style='height: {{ chart.height }}px; width: 100%'> </svg>
                 </div>
             </div>
             {% endfor %}
 
         {% endif %}
 
-    {% if report_table.accordion_end %}
+    {% if report_table.accordion_end and not report_table.is_mixed_report %}
         </div>
     </div>
 </div>


### PR DESCRIPTION
1. Change layout of TTC Overview Report as per the layout given by partner in 'dashboard sample v3.docx'
2. Remove the title 'Entiy' from table Still Birth table in TTC Overview Report. Just leave it blank 
3. Right now when you hover on the pie charts, the percentage shows up. Can we show both number and the percentage there?
