### PR TITLE
allow disabling editing a form in vellum

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -547,6 +547,7 @@ class FormBase(DocumentSchema):
         choices=[WORKFLOW_DEFAULT, WORKFLOW_MODULE, WORKFLOW_PREVIOUS]
     )
     auto_gps_capture = BooleanProperty(default=False)
+    no_vellum = BooleanProperty(default=False)
 
     @classmethod
     def wrap(cls, data):

--- a/corehq/apps/app_manager/templates/app_manager/form_view_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view_base.html
@@ -197,8 +197,12 @@
                 {% endif %}
 
                 ko.applyBindings({
-                    auto_gps_capture: ko.observable({{ form.auto_gps_capture|JSON }}),
+                    auto_gps_capture: ko.observable({{ form.auto_gps_capture|JSON }})
                 }, $('#auto-gps-capture').get(0));
+                ko.applyBindings({
+                    no_vellum: ko.observable({{ form.no_vellum|JSON }})
+                }, $('#no-vellum').get(0));
+
             {% endif %}
 
             {% if allow_cloudcare %}
@@ -247,15 +251,24 @@
 
     {% if edit %}
     <div class="btn-group">
+        {% if not form.no_vellum %}
         <a id="edit_label" href="{% if is_user_registration %}
                                     {% url "user_registration_source" domain app.id %}
                                  {% else %}
                                     {% url "form_source" domain app.id module.id form.id %}
                                  {% endif %}
-                                 " class="btn btn-primary">
+                                 "
+                                 class="btn btn-primary">
             <i class="icon-pencil"></i>
             {% trans "Edit" %}
         </a>
+        {% else %}
+        <button class="btn btn-primary disabled" disabled="disabled"
+                title="{% trans "Your administrator has locked this form from edits through the form builder"|force_escape %}">
+            <i class="icon-pencil"></i>
+            {% trans "Edit" %}
+        </button>
+        {% endif %}
         {% if allow_cloudcare %}
             {% if form.source and not is_user_registration %}
             <a id="cloudcare-preview-url" href="#" target="_blank" class="btn">

--- a/corehq/apps/app_manager/templates/app_manager/managed_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/managed_app.html
@@ -259,7 +259,7 @@
                                             {{ form.name|html_trans:langs }}
                                             </span>
                                         </a>
-                                        {% if edit %}
+                                        {% if edit and not form.no_vellum %}
                                             <div class="edit-form-pencil pull-right">
                                                 <a id="edit_pen_{{ module.id }}_{{ form.id }}" href="{% url "form_source" domain app.id module.id form.id %}">
                                                     <i class="icon-pencil" {% ifequal form selected_form %}style="color: white"{% endifequal %}"></i>

--- a/corehq/apps/app_manager/templates/app_manager/partials/form_tab_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/form_tab_settings.html
@@ -66,6 +66,28 @@
                 {% include "app_manager/partials/form_gps_capture.html" %}
 
             </div>
+            {% if request|toggle_enabled:'NO_VELLUM' %}
+            <div class="control-group">
+                <label class="control-label">
+                    {% trans "Disallow editing form in Form Builder" %}
+                    <span class="hq-help-template"
+                          data-title="{% trans "Disallow editing form in Form Builder" %}"
+                          data-content="{% blocktrans %}For custom forms that the Form Builder breaks,
+                                        use this option to disallow editing in the Form Builder.{% endblocktrans %}"
+                    ></span>
+                </label>
+                <div class="controls" id="no-vellum">
+                    {% if edit %}
+                         <input type="checkbox" value="true"
+                                data-bind="checked: no_vellum"/>
+                    {% else %}
+                        <input type="checkbox" value="true" disabled="disabled"
+                               data-bind="checked: no_vellum"/>
+                    {% endif %}
+                    <input type="hidden" name="no_vellum" data-bind="value: no_vellum"/>
+                </div>
+            </div>
+            {% endif %}
         </div>
     </form>
 </div>

--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -1028,6 +1028,15 @@ def form_designer(req, domain, app_id, module_id=None, form_id=None,
         except IndexError:
             return bail(req, domain, app_id, not_found="form")
 
+    if form.no_vellum:
+        messages.warning(req, _(
+            "You tried to edit this form in the Form Builder. "
+            "However, your administrator has locked this form against editing "
+            "in the form builder, so we have redirected you to "
+            "the form's front page instead."
+        ))
+        return back_to_main(req, domain, app_id=app_id,
+                            unique_form_id=form.unique_id)
     context = get_apps_base_context(req, domain, app)
     context.update(locals())
     context.update({
@@ -1568,6 +1577,8 @@ def edit_form_attr(req, domain, app_id, unique_form_id, attr):
         form.post_form_workflow = req.POST['post_form_workflow']
     if should_edit('auto_gps_capture'):
         form.auto_gps_capture = req.POST['auto_gps_capture'] == 'true'
+    if should_edit('no_vellum'):
+        form.no_vellum = req.POST['no_vellum'] == 'true'
 
     _handle_media_edits(req, form, should_edit, resp)
 

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -209,3 +209,10 @@ MULTIMEDIA_EXPORT = StaticToggle(
     'multimedia_export',
     'Export multimedia from forms'
 )
+
+NO_VELLUM = StaticToggle(
+    'no_vellum',
+    'Allow disabling Form Builder per form '
+    '(for custom forms that Vellum breaks)',
+    [NAMESPACE_DOMAIN, NAMESPACE_USER]
+)


### PR DESCRIPTION
This is for forms that vellum breaks, so that we can block users from
mistakenly editing them in vellum.

This feature under is a toggle (/hq/flags/edit/no_vellum/),
and is basically intended to stay there indefinitely,
so that a Dimagi power-user can disable editing certain
forms and hide that option from others
(and their future selves if they wish).

The form can still be edited by choosing Advanced > Download,
editing by hand, and reuploading with Advanced > Upload.

The following modifications are made on form pages for which vellum is disallowed (whether or not the domain/viewing user has the toggle enabled):

![screen shot 2014-11-25 at 12 49 58 pm](https://cloud.githubusercontent.com/assets/137212/5183013/b93a8fc6-74a1-11e4-8161-e64769b92307.png)

Configurable in Advanced form settings, only if you have the toggle enabled for the domain or user:

![screen shot 2014-11-25 at 12 51 55 pm](https://cloud.githubusercontent.com/assets/137212/5183059/0c856fa2-74a2-11e4-9c2c-abc152296bae.png)
