### PR TITLE
don't swallow stock-only xform_ids during case rebuilds

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/cleanup.py
+++ b/corehq/ex-submodules/casexml/apps/case/cleanup.py
@@ -89,6 +89,7 @@ def rebuild_case(case_id):
     # call "rebuild" on the case, which should populate xform_ids
     # and re-sort actions if necessary
     case.rebuild(strict=False, xforms={f._id: f for f in sorted_forms})
+    case.xform_ids = case.xform_ids + [f._id for f in sorted_forms if f._id not in case.xform_ids]
 
     if not case.xform_ids:
         if not found:

--- a/corehq/ex-submodules/casexml/apps/case/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/util.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from casexml.apps.case import const
 from casexml.apps.case.sharedmodels import CommCareCaseIndex
 from casexml.apps.phone.models import SyncLogAssertionError, SyncLog
+from casexml.apps.stock.models import StockReport
 from couchforms.models import XFormInstance
 
 
@@ -77,7 +78,11 @@ def get_case_xform_ids(case_id):
                                           reduce=False,
                                           startkey=[case_id],
                                           endkey=[case_id, {}])
-    return list(set([row['key'][1] for row in results]))
+
+    # also have to add commtrack forms, which may not appear in the form --> case index
+    commtrack_reports = StockReport.objects.filter(stocktransaction__case_id=case_id)
+    commtrack_forms = commtrack_reports.values_list('form_id', flat=True).distinct()
+    return list(set([row['key'][1] for row in results] + list(commtrack_forms)))
 
 
 def update_sync_log_with_checks(sync_log, xform, cases, case_db,


### PR DESCRIPTION
fix of #4880

http://manage.dimagi.com/default.asp?147961

this was introduced by me in dee0551. intrahealth forms don't actually update cases, they just update ledgers, so these were getting cleared from the case.xform_ids property which was messing up the case history view. this shouldn't have any effect on data integrity since that property is only really used for reports.
