### PR TITLE
sort locations by name in OTA restore

### DIFF
--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -105,6 +105,7 @@ def _location_footprint(locations):
 def _append_children(node, location_db, locations, type_lookup_function):
     by_type = _group_by_type(locations)
     for type, locs in by_type.items():
+        locs = sorted(locs, key=lambda loc: loc.name)
         node.append(_types_to_fixture(location_db, type, locs, type_lookup_function))
 
 


### PR DESCRIPTION
like they are in the Setup > Locations UI.
Previously they came down in an arbitrary order

@twymer @czue
