### PR TITLE
fix a js error intoduced by the no-vellum feature

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/form_view_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view_base.html
@@ -203,9 +203,11 @@
                 ko.applyBindings({
                     auto_gps_capture: ko.observable({{ form.auto_gps_capture|JSON }})
                 }, $('#auto-gps-capture').get(0));
+                {% if request|toggle_enabled:'NO_VELLUM' %}
                 ko.applyBindings({
                     no_vellum: ko.observable({{ form.no_vellum|JSON }})
                 }, $('#no-vellum').get(0));
+                {% endif %}
 
             {% endif %}
 


### PR DESCRIPTION
if it wasn't enabled, you'd see

```
Uncaught ReferenceError: Unable to parse bindings.
Bindings value: attr: {href: '#' + id}, css: {collapsed: reallyCollapse}
Message: id is not defined
```

in the console every time you load a form settings page.

To my knowledge this didn't cause any user-facing errors.
