### PR TITLE
Remove internal.commconnect_domain logic

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -610,7 +610,6 @@ class DomainInternalForm(forms.Form, SubAreaMixin):
     goal_time_period = IntegerField(label=ugettext_noop("Goal time period (in days)"), required=False)
     goal_followup_rate = DecimalField(label=ugettext_noop("Goal followup rate (percentage in decimal format. e.g. 70% is .7)"), required=False)
     commtrack_domain = BooleanField(label=ugettext_noop("CommTrack domain?"), required=False)
-    commconnect_domain = BooleanField(label=ugettext_noop("CommConnect domain?"), required=False)
 
     def save(self, domain):
         kw = {"workshop_region": self.cleaned_data["workshop_region"]} if self.cleaned_data["workshop_region"] else {}
@@ -634,7 +633,6 @@ class DomainInternalForm(forms.Form, SubAreaMixin):
             phone_model=self.cleaned_data['phone_model'],
             goal_time_period=self.cleaned_data['goal_time_period'],
             goal_followup_rate=self.cleaned_data['goal_followup_rate'],
-            commconnect_domain=self.cleaned_data['commconnect_domain'],
             commtrack_domain=self.cleaned_data['commtrack_domain'],
             **kw
         )

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -139,9 +139,7 @@ class InternalProperties(DocumentSchema, UpdatableSchema):
     phone_model = StringProperty()
     goal_time_period = IntegerProperty()
     goal_followup_rate = DecimalProperty()
-    # intentionally different from commconnect_enabled and commtrack_enabled so
-    # that FMs can change
-    commconnect_domain = BooleanProperty()
+    # intentionally different from and commtrack_enabled so that FMs can change
     commtrack_domain = BooleanProperty()
 
 

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1954,7 +1954,6 @@ class EditInternalDomainInfoView(BaseInternalDomainSettingsView):
             'phone_model',
             'goal_time_period',
             'goal_followup_rate',
-            'commconnect_domain',
             'commtrack_domain',
         ]
         for attr in internal_attrs:

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -458,7 +458,6 @@ DOMAIN_FACETS = [
     "internal.project_manager",
     "internal.phone_model.exact",
     "internal.commtrack_domain",
-    "internal.commconnect_domain",
 
     "is_approved",
     "is_public",
@@ -778,7 +777,6 @@ class AdminDomainStatsReport(AdminFacetedReport, DomainStatsReport):
                     format_bool(dom.get('internal', {}).get('self_started')),
                     dom.get('is_test') or _('No info'),
                     format_bool(dom.get('cp_is_active') or _('No info')),
-                    format_bool(dom.get('internal', {}).get('commconnect_domain')),
                     format_bool(dom.get('internal', {}).get('commtrack_domain')),
                     dom.get('cp_n_out_sms', _("Not yet calculated")),
                     dom.get('cp_n_in_sms', _("Not yet calculated")),


### PR DESCRIPTION
@czue https://github.com/dimagi/commcare-hq/pull/4911

I think this happened due to doing this in two PRs. (One changed it to "Uses Messaging", then I completely removed it in a later PR/ticket after implementing something else)
