### PR TITLE
Default single select questions to 1 column in data sources

### DIFF
--- a/corehq/apps/userreports/app_manager.py
+++ b/corehq/apps/userreports/app_manager.py
@@ -78,7 +78,7 @@ def get_form_data_source(app, form):
     def _get_indicator_data_type(data_type, options):
         if data_type == "date":
             return {"datatype": "date"}
-        if data_type in ("Select", "MSelect"):
+        if data_type == "MSelect":
             return {
                 "type": "choice_list",
                 "select_style": DATATYPE_MAP[data_type],


### PR DESCRIPTION
Treating single selects as string fields inputs the text of the result into 1 column, rather than creating a binary column for each option in the select.
