### PR TITLE
add phone endpoint for form submissions by user

### DIFF
--- a/corehq/apps/ota/urls.py
+++ b/corehq/apps/ota/urls.py
@@ -1,5 +1,7 @@
 from django.conf.urls import url, patterns
 
-urlpatterns = patterns('',
-    url(r'^restore/$', 'corehq.apps.ota.views.restore'),
+
+urlpatterns = patterns('corehq.apps.ota.views',
+    url(r'^restore/$', 'restore'),
+    url(r'^historical_forms/$', 'historical_forms'),
 )

--- a/corehq/ex-submodules/couchforms/models.py
+++ b/corehq/ex-submodules/couchforms/models.py
@@ -266,7 +266,10 @@ class XFormInstance(SafeSaveDocument, UnicodeMixIn, ComputedDocumentMixin,
                 return None
 
     def get_xml_element(self):
-        return self._xml_string_to_element(self.get_xml())
+        xml_string = self.get_xml()
+        if not xml_string:
+            return None
+        return self._xml_string_to_element(xml_string)
 
     def _xml_string_to_element(self, xml_string):
 


### PR DESCRIPTION
Nothing's hitting this yet—next step is going to be to add an invisible option to the app builder, but putting this up will let @ctsims test it. URL is /a/<domain>/phone/historical_forms/ with digest auth (or a logged-in user).
