### PR TITLE
prevent tests from failing between 11pm and 11:59pm

### DIFF
--- a/corehq/apps/sofabed/tests/test_casedata.py
+++ b/corehq/apps/sofabed/tests/test_casedata.py
@@ -67,7 +67,7 @@ class CaseDataTests(TestCase):
             if action.index == 1:
                 self.assertEqual('update', action.action_type)
                 self.assertEqual('update', action.action_type)
-            self.assertEqual(date.today(), action.date.date())
+            self.assertEqual(self.date_modified.date(), action.date.date())
             self.assertEqual(date.today(), action.server_date.date())
             self.assertEqual('user', action.user_id)
             if action.index == 2:


### PR DESCRIPTION
should prevent the common failures of this format:

```
======================================================================
FAIL: test_create (corehq.apps.sofabed.tests.test_casedata.CaseDataTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/czue/src/commcare-hq/corehq/apps/sofabed/tests/test_casedata.py", line 72, in test_create
    self.assertEqual(date.today(), action.date.date())
AssertionError: datetime.date(2014, 12, 3) != datetime.date(2014, 12, 2)
```
