### PR TITLE
Add case_id as a standard column for any form user configurable report.

### DIFF
--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -71,9 +71,22 @@ class DataSourceConfiguration(UnicodeMixIn, ConfigurableIndicatorMixIn, CachedCo
             "is_nullable": False,
             "is_primary_key": True,
         }, self.named_filter_objects)
+        case_id_indicator = IndicatorFactory.from_spec({
+            "column_id": "case_id",
+            "type": "raw",
+            "display_name": "case id",
+            "datatype": "string",
+            "property_path": [
+                "form",
+                "case",
+                "@case_id",
+            ],
+            "is_nullable": True,
+            "is_primary_key": False,
+        }, self.named_filter_objects)
         return CompoundIndicator(
             self.display_name,
-            [doc_id_indicator] + [
+            [doc_id_indicator] + ([case_id_indicator] if self.referenced_doc_type == "XFormInstance" else []) + [
                 IndicatorFactory.from_spec(indicator, self.named_filter_objects)
                 for indicator in self.configured_indicators
             ]

--- a/corehq/apps/userreports/tests/test_app_manager_integration.py
+++ b/corehq/apps/userreports/tests/test_app_manager_integration.py
@@ -70,3 +70,19 @@ class AppManagerDataSourceConfigTest(SimpleTestCase):
         data_source = data_sources['http://openrosa.org/formdesigner/AF6F83BA-09A9-4773-9177-AB51EA6CF802']
         for indicator in data_source.configured_indicators:
             self.assertIsNotNone(indicator)
+
+        expected_columns = [
+            "doc_id",
+            "case_id",
+            "name",
+            "category_bug",
+            "category_feature",
+            "category_support",
+            "category_schedule",
+            "priority",
+            "starred",
+            "estimate",
+            "date_question",
+        ]
+        for col in data_source.get_columns():
+            self.assertIn(col.id, expected_columns)


### PR DESCRIPTION
@czue @nickpell 

I took a stab at this, wanted it for a discussion with Tableau people tomorrow evening.  This doesn't address apps that don't have case sharing enabled, because I think if a field doesn't exist, it will just be blank in the postgres table.  Would definitely be cleaner to avoid adding the indicator if case sharing isn't enabled.
