### PR TITLE
check tile visibility before rendering

### DIFF
--- a/corehq/apps/dashboard/views.py
+++ b/corehq/apps/dashboard/views.py
@@ -69,7 +69,10 @@ class DomainDashboardView(JSONResponseMixin, BaseDashboardView):
 
     @property
     def tile_configs(self):
-        return _get_default_tile_configurations()
+        return [
+            tile for tile in _get_default_tile_configurations()
+            if tile.visibility_check(self.request)
+        ]
 
     @property
     def slug_to_tile(self):


### PR DESCRIPTION
`upate_tile` is being called before `check_permissions` resulting in an permission denied response and a JS error here: `TypeError: Cannot read property 'icon' of undefined` at https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/dashboard/static/dashboard/js/hq_dashboard.ng.js#L124-124
