### PR TITLE
Change property list to export_id

### DIFF
--- a/corehq/apps/reports/standard/export.py
+++ b/corehq/apps/reports/standard/export.py
@@ -119,14 +119,12 @@ class ExcelExportReport(FormExportReportBase):
     def properties(self, size_hash):
         properties = dict()
         exports = self.get_saved_exports()
-        prop_url_query = '&properties='
 
         for export in exports:
             for table in export.tables:
-                prop = [c.display for c in table.columns]
                 properties[export.name] = {
                     'xmlns': export.index[1],
-                    'query_url': prop_url_query + prop_url_query.join(prop),
+                    'export_id': export._id,
                     'size': size_hash.get((export.app_id, export.index[1]), None),
                 }
 

--- a/corehq/apps/reports/templates/reports/partials/saved_custom_exports.html
+++ b/corehq/apps/reports/templates/reports/partials/saved_custom_exports.html
@@ -70,7 +70,7 @@
             <td class="cell-vertical-centered">
                 {% with property_hash|dict_lookup:export.name as properties %}
                   {% if properties.size %}
-                      <a href="{% url "form_multimedia_export" domain export.app_id %}?xmlns={{export.xmlns}}{{properties.query_url}}&{{ get_filter_params.urlencode|safe }}&name={{export.name}}"
+                      <a href="{% url "form_multimedia_export" domain export.app_id %}?xmlns={{export.xmlns}}&export_id={{properties.export_id}}&{{ get_filter_params.urlencode|safe }}&name={{export.name}}"
                          class="btn btn-primary dl-export" ><i
                          class="icon-download-alt icon-white"></i> {% trans "Download " %} <br> ({{properties.size}})</a>
                   {% else %}


### PR DESCRIPTION
Putting properties in the url make urls too long for django (>4096 characters) on some exports, so using the export id and looking up properties on download.
