### PR TITLE
default to server_date in action sort if not submitted by the same user

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/models.py
+++ b/corehq/ex-submodules/casexml/apps/case/models.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from StringIO import StringIO
 import base64
+from functools import cmp_to_key
 import re
 from datetime import datetime
 import logging
@@ -15,7 +16,6 @@ from couchdbkit.ext.django.schema import *
 from couchdbkit.exceptions import ResourceNotFound, ResourceConflict
 from PIL import Image
 from casexml.apps.case.exceptions import MissingServerDate, ReconciliationError
-from corehq import toggles
 from corehq.util.couch_helpers import CouchAttachmentsBuilder
 from dimagi.utils.django.cached_object import CachedObject, OBJECT_ORIGINAL, OBJECT_SIZE_MAP, CachedImage, IMAGE_SIZE_ORDERING
 from casexml.apps.phone.xml import get_case_element
@@ -1192,23 +1192,31 @@ class CommCareCaseGroup(Document):
 
 
 def _action_sort_key_function(case):
-    form_ids = list(case.xform_ids)
+    def _action_cmp(first_action, second_action):
+        # if the forms aren't submitted by the same user, just default to server dates
+        if first_action.user_id != second_action.user_id:
+            return cmp(first_action.server_date, second_action.server_date)
+        else:
+            form_ids = list(case.xform_ids)
+            def _sortkey(action):
+                if not action.server_date or not action.date:
+                    raise MissingServerDate()
 
-    def _sortkey(action):
-        if not action.server_date or not action.date:
-            raise MissingServerDate()
+                form_cmp = lambda form_id: (form_ids.index(form_id) if form_id in form_ids else sys.maxint, form_id)
+                # if the user is the same you should compare with the special logic below
+                # if the user is not the same you should compare just using received_on
+                return (
+                    # this is sneaky - it's designed to use just the date for the
+                    # server time in case the phone submits two forms quickly out of order
+                    action.server_date.date(),
+                    action.date,
+                    form_cmp(action.xform_id),
+                    _type_sort(action.action_type),
+                )
 
-        form_cmp = lambda form_id: (form_ids.index(form_id) if form_id in form_ids else sys.maxint, form_id)
-        return (
-            # this is sneaky - it's designed to use just the date for the
-            # server time in case the phone submits two forms quickly out of order
-            action.server_date.date(),
-            action.date,
-            form_cmp(action.xform_id),
-            _type_sort(action.action_type),
-        )
+            return cmp(_sortkey(first_action), _sortkey(second_action))
 
-    return _sortkey
+    return cmp_to_key(_action_cmp)
 
 
 def _type_sort(action_type):

--- a/corehq/ex-submodules/casexml/apps/case/models.py
+++ b/corehq/ex-submodules/casexml/apps/case/models.py
@@ -1198,11 +1198,13 @@ def _action_sort_key_function(case):
             return cmp(first_action.server_date, second_action.server_date)
         else:
             form_ids = list(case.xform_ids)
+
             def _sortkey(action):
                 if not action.server_date or not action.date:
                     raise MissingServerDate()
 
-                form_cmp = lambda form_id: (form_ids.index(form_id) if form_id in form_ids else sys.maxint, form_id)
+                form_cmp = lambda form_id: (form_ids.index(form_id)
+                                            if form_id in form_ids else sys.maxint, form_id)
                 # if the user is the same you should compare with the special logic below
                 # if the user is not the same you should compare just using received_on
                 return (

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
@@ -374,34 +374,34 @@ class TestCheckActionOrder(SimpleTestCase):
 
     def test_already_sorted(self):
         case = CommCareCase(actions=[
-            CommCareCaseAction(server_date=datetime(2001, 01, 01, 00, 00, 00)),
-            CommCareCaseAction(server_date=datetime(2001, 01, 02, 00, 00, 00)),
-            CommCareCaseAction(server_date=datetime(2001, 01, 03, 00, 00, 00)),
+            CommCareCaseAction(server_date=datetime(2001, 1, 1, 0, 0, 0)),
+            CommCareCaseAction(server_date=datetime(2001, 1, 2, 0, 0, 0)),
+            CommCareCaseAction(server_date=datetime(2001, 1, 2, 0, 0, 0)),
         ])
         self.assertTrue(case.check_action_order())
 
     def test_out_of_order(self):
         case = CommCareCase(actions=[
-            CommCareCaseAction(server_date=datetime(2001, 01, 01, 00, 00, 00)),
-            CommCareCaseAction(server_date=datetime(2001, 01, 03, 00, 00, 00)),
-            CommCareCaseAction(server_date=datetime(2001, 01, 02, 00, 00, 00)),
+            CommCareCaseAction(server_date=datetime(2001, 1, 1, 0, 0, 0)),
+            CommCareCaseAction(server_date=datetime(2001, 1, 2, 0, 0, 0)),
+            CommCareCaseAction(server_date=datetime(2001, 1, 2, 0, 0, 0)),
         ])
         self.assertFalse(case.check_action_order())
 
     def test_sorted_with_none(self):
         case = CommCareCase(actions=[
-            CommCareCaseAction(server_date=datetime(2001, 01, 01, 00, 00, 00)),
+            CommCareCaseAction(server_date=datetime(2001, 1, 1, 0, 0, 0)),
             CommCareCaseAction(server_date=None),
-            CommCareCaseAction(server_date=datetime(2001, 01, 02, 00, 00, 00)),
-            CommCareCaseAction(server_date=datetime(2001, 01, 03, 00, 00, 00)),
+            CommCareCaseAction(server_date=datetime(2001, 1, 2, 0, 0, 0)),
+            CommCareCaseAction(server_date=datetime(2001, 1, 2, 0, 0, 0)),
         ])
         self.assertTrue(case.check_action_order())
 
     def test_out_of_order_with_none(self):
         case = CommCareCase(actions=[
-            CommCareCaseAction(server_date=datetime(2001, 01, 01, 00, 00, 00)),
-            CommCareCaseAction(server_date=datetime(2001, 01, 03, 00, 00, 00)),
+            CommCareCaseAction(server_date=datetime(2001, 1, 1, 0, 0, 0)),
+            CommCareCaseAction(server_date=datetime(2001, 1, 2, 0, 0, 0)),
             CommCareCaseAction(server_date=None),
-            CommCareCaseAction(server_date=datetime(2001, 01, 02, 00, 00, 00)),
+            CommCareCaseAction(server_date=datetime(2001, 1, 2, 0, 0, 0)),
         ])
         self.assertFalse(case.check_action_order())

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
@@ -377,14 +377,14 @@ class TestCheckActionOrder(SimpleTestCase):
         case = CommCareCase(actions=[
             CommCareCaseAction(server_date=datetime(2001, 1, 1, 0, 0, 0)),
             CommCareCaseAction(server_date=datetime(2001, 1, 2, 0, 0, 0)),
-            CommCareCaseAction(server_date=datetime(2001, 1, 2, 0, 0, 0)),
+            CommCareCaseAction(server_date=datetime(2001, 1, 3, 0, 0, 0)),
         ])
         self.assertTrue(case.check_action_order())
 
     def test_out_of_order(self):
         case = CommCareCase(actions=[
             CommCareCaseAction(server_date=datetime(2001, 1, 1, 0, 0, 0)),
-            CommCareCaseAction(server_date=datetime(2001, 1, 2, 0, 0, 0)),
+            CommCareCaseAction(server_date=datetime(2001, 1, 3, 0, 0, 0)),
             CommCareCaseAction(server_date=datetime(2001, 1, 2, 0, 0, 0)),
         ])
         self.assertFalse(case.check_action_order())
@@ -394,14 +394,14 @@ class TestCheckActionOrder(SimpleTestCase):
             CommCareCaseAction(server_date=datetime(2001, 1, 1, 0, 0, 0)),
             CommCareCaseAction(server_date=None),
             CommCareCaseAction(server_date=datetime(2001, 1, 2, 0, 0, 0)),
-            CommCareCaseAction(server_date=datetime(2001, 1, 2, 0, 0, 0)),
+            CommCareCaseAction(server_date=datetime(2001, 1, 3, 0, 0, 0)),
         ])
         self.assertTrue(case.check_action_order())
 
     def test_out_of_order_with_none(self):
         case = CommCareCase(actions=[
             CommCareCaseAction(server_date=datetime(2001, 1, 1, 0, 0, 0)),
-            CommCareCaseAction(server_date=datetime(2001, 1, 2, 0, 0, 0)),
+            CommCareCaseAction(server_date=datetime(2001, 1, 3, 0, 0, 0)),
             CommCareCaseAction(server_date=None),
             CommCareCaseAction(server_date=datetime(2001, 1, 2, 0, 0, 0)),
         ])

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
@@ -1,5 +1,5 @@
 from couchdbkit.exceptions import ResourceNotFound
-from django.test import TestCase
+from django.test import TestCase, SimpleTestCase
 from casexml.apps.case import const
 from casexml.apps.case.cleanup import rebuild_case
 from casexml.apps.case.models import CommCareCase, CommCareCaseAction
@@ -370,20 +370,25 @@ class CaseRebuildTest(TestCase):
         self.assertEqual(case.doc_type, 'CommCareCase-Deleted')
 
 
-class TestCheckActionOrder(TestCase):
-    def test(self):
+class TestCheckActionOrder(SimpleTestCase):
+
+    def test_already_sorted(self):
         case = CommCareCase(actions=[
             CommCareCaseAction(server_date=datetime(2001, 01, 01, 00, 00, 00)),
             CommCareCaseAction(server_date=datetime(2001, 01, 02, 00, 00, 00)),
             CommCareCaseAction(server_date=datetime(2001, 01, 03, 00, 00, 00)),
         ])
         self.assertTrue(case.check_action_order())
+
+    def test_out_of_order(self):
         case = CommCareCase(actions=[
             CommCareCaseAction(server_date=datetime(2001, 01, 01, 00, 00, 00)),
             CommCareCaseAction(server_date=datetime(2001, 01, 03, 00, 00, 00)),
             CommCareCaseAction(server_date=datetime(2001, 01, 02, 00, 00, 00)),
         ])
         self.assertFalse(case.check_action_order())
+
+    def test_sorted_with_none(self):
         case = CommCareCase(actions=[
             CommCareCaseAction(server_date=datetime(2001, 01, 01, 00, 00, 00)),
             CommCareCaseAction(server_date=None),
@@ -391,6 +396,8 @@ class TestCheckActionOrder(TestCase):
             CommCareCaseAction(server_date=datetime(2001, 01, 03, 00, 00, 00)),
         ])
         self.assertTrue(case.check_action_order())
+
+    def test_out_of_order_with_none(self):
         case = CommCareCase(actions=[
             CommCareCaseAction(server_date=datetime(2001, 01, 01, 00, 00, 00)),
             CommCareCaseAction(server_date=datetime(2001, 01, 03, 00, 00, 00)),


### PR DESCRIPTION
also adds and touches up tests

this is a workaround for http://manage.dimagi.com/default.asp?149884

easiest read commit-by-commit
