### PR TITLE
Include nav-header class as stopgap for css issues

### DIFF
--- a/corehq/apps/style/templates/style/includes/menu_submenu.html
+++ b/corehq/apps/style/templates/style/includes/menu_submenu.html
@@ -5,7 +5,7 @@
     {% if submenu.is_divider %}
         <li class="divider"></li>
     {% else %}
-        <li {% if submenu.is_header %}class="dropdown-header"{% endif %}>
+        <li {% if submenu.is_header %}class="dropdown-header nav-header"{% endif %}>
             {% if submenu.url %}<a href="{{ submenu.url }}" {% if submenu.data_id %}data-id="{{ submenu.data_id }}"{% endif %}>{% endif %}
             {% trans submenu.title %}
             {% if submenu.url %}</a>{% endif %}


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?149874

This is a strange one. Locally and on prod I've seen the header for the Applications tab ("My Applications") appear unstyled, but it works most of the time.  It doesn't appear to be connected to a particular page, rather it's a transient issue that comes up eventually after clicking around to a few pages.  Anyways, other places use the `nav-header` class, which seems to provide the same styling, so I figured I'd just tack that on the end there.

This is entirely a stopgap solution that doesn't address whatever the real issue is, so I'm happy to revert if we can find a better fix.

@biyeun fyi
