### PR TITLE
default to 'show all dates'

### DIFF
--- a/corehq/apps/reports_core/templates/reports_core/filters/datespan_filter/datespan_filter.js
+++ b/corehq/apps/reports_core/templates/reports_core/filters/datespan_filter/datespan_filter.js
@@ -6,3 +6,4 @@ $(filter_id).on('apply', function(ev, picker) {
     $('#{{ filter.css_id }}-start').val(dates[0]);
     $('#{{ filter.css_id }}-end').val(dates[1]);
 });
+$(filter_id).val("Show All Dates");

--- a/corehq/apps/userreports/reports/filters.py
+++ b/corehq/apps/userreports/reports/filters.py
@@ -22,17 +22,17 @@ class DateFilterValue(FilterValue):
 
     def __init__(self, filter, value):
         assert filter.type == 'date'
-        # todo: might want some better way to set defaults
-        if value is None:
-            # default to one week
-            value = DateSpan.since(7)
-        assert isinstance(value, DateSpan)
+        assert isinstance(value, DateSpan) or value is None
         super(DateFilterValue, self).__init__(filter, value)
 
     def to_sql_filter(self):
+        if self.value is None:
+            return ""
         return "{} between :startdate and :enddate".format(self.filter.field)
 
     def to_sql_values(self):
+        if self.value is None:
+            return {}
         return {
             'startdate': self.value.startdate,
             'enddate': self.value.enddate,


### PR DESCRIPTION
![screen shot 2014-12-09 at 4 15 57 pm](https://cloud.githubusercontent.com/assets/1757035/5366040/b3f4d8c8-7fbe-11e4-8532-6275f63227b9.png)

Downside is that the select date widget is from bootstrap, so it's complicated to go back to "show all dates" without refreshing once a daterange has been chosen.  Alternative would be to choose whether or not to apply the filter, much like "Date Created" in https://www.commcarehq.org/hq/accounting/accounts/

![screen shot 2014-12-09 at 4 17 59 pm](https://cloud.githubusercontent.com/assets/1757035/5366078/f867e86a-7fbe-11e4-9fa9-a4a53738ffa8.png)

I'm suggesting going with the simple approach for now.
