### PR TITLE
fix intermittent test failure

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
@@ -67,9 +67,10 @@ class CaseRebuildTest(TestCase):
         self.assertTrue(copy != orig)
 
     def testBasicRebuild(self):
-        case_id = post_util(create=True)
-        post_util(case_id=case_id, p1='p1-1', p2='p2-1')
-        post_util(case_id=case_id, p2='p2-2', p3='p3-2')
+        user_id = 'test-basic-rebuild-user'
+        case_id = post_util(create=True, user_id=user_id)
+        post_util(case_id=case_id, p1='p1-1', p2='p2-1', user_id=user_id)
+        post_util(case_id=case_id, p2='p2-2', p3='p3-2', user_id=user_id)
 
         # check initial state
         case = CommCareCase.get(case_id)
@@ -143,8 +144,6 @@ class CaseRebuildTest(TestCase):
         case.actions = [a1, create, a2, a3]
         case.rebuild()
         _confirm_action_order(case, [a1, a2, a3])
-
-
 
     def testRebuildEmpty(self):
         self.assertEqual(None, rebuild_case('notarealid'))


### PR DESCRIPTION
should fix the intermittent errors of this form

```
======================================================================
FAIL: testBasicRebuild (casexml.apps.case.tests.test_rebuild.CaseRebuildTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py", line 92, in testBasicRebuild
    self.assertEqual(case.p2, 'p2-1') # updated (back!)
AssertionError: u'p2-2' != 'p2-1'
```
