### PR TITLE
make mapping of extra databases available in settings

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -927,7 +927,7 @@ if not SQL_REPORTING_DATABASE_URL or UNIT_TESTING:
 #SOUTH_TESTS_MIGRATE=False
 
 ####### Couch Forms & Couch DB Kit Settings #######
-from settingshelper import get_dynamic_db_settings, make_couchdb_tuples
+from settingshelper import get_dynamic_db_settings, make_couchdb_tuples, get_extra_couchdbs
 
 _dynamic_db_settings = get_dynamic_db_settings(
     COUCH_SERVER_ROOT,
@@ -1037,6 +1037,7 @@ COUCHDB_APPS = [
 COUCHDB_APPS += LOCAL_COUCHDB_APPS
 
 COUCHDB_DATABASES = make_couchdb_tuples(COUCHDB_APPS, COUCH_DATABASE)
+EXTRA_COUCHDB_DATABASES = get_extra_couchdbs(COUCHDB_APPS, COUCH_DATABASE)
 
 INSTALLED_APPS += LOCAL_APPS
 

--- a/settingshelper.py
+++ b/settingshelper.py
@@ -50,3 +50,19 @@ def make_couchdb_tuples(config, couch_database_url):
 
     """
     return [_make_couchdb_tuple(row, couch_database_url) for row in config]
+
+
+def get_extra_couchdbs(config, couch_database_url):
+    """
+    Create a mapping from database prefix to database url
+
+    :param config:              list of database strings or tuples
+    :param couch_database_url:  main database url
+    """
+    extra_dbs = {}
+    for row in config:
+        if isinstance(row, tuple):
+            _, postfix = row
+            extra_dbs[postfix] = '%s__%s' % (couch_database_url, postfix)
+
+    return extra_dbs

--- a/testrunner.py
+++ b/testrunner.py
@@ -47,6 +47,11 @@ class HqTestSuiteRunner(CouchDbKitTestSuiteRunner):
             setattr(settings, setting, value)
             print "set %s settting to %s" % (setting, value)
 
+        settings.EXTRA_COUCHDB_DATABASES = {
+            db_name: self.get_test_db_name(url)
+            for db_name, url in settings.EXTRA_COUCHDB_DATABASES.items()
+        }
+
         return super(HqTestSuiteRunner, self).setup_databases(**kwargs)
 
     def get_all_test_labels(self):


### PR DESCRIPTION
see https://github.com/dimagi/dimagi-utils/pull/238

This is needed to make tests work so that you get `commcarehq__meta_test` instead of `commcarehq_test__meta`
