### PR TITLE
show configurable reports error to user instead of 500ing

### DIFF
--- a/corehq/apps/reports_core/templates/reports_core/base_template_new.html
+++ b/corehq/apps/reports_core/templates/reports_core/base_template_new.html
@@ -64,11 +64,17 @@
                 data: postData,
                 headers: {'HTTP_X_REQUESTED_WITH': 'XMLHttpRequest'},
                 success: function(data, textStatus, jqXHR) {
-                    updateCharts(data);
-                    $('#report-error').addClass('hide');
+                    if(data.error) {
+                        $('#error-message').html(data.error);
+                        $('#report-error').removeClass('hide');
+                    } else {
+                        updateCharts(data);
+                        $('#report-error').addClass('hide');
+                    }
                 },
                 error: function(jqXHR, textStatus, errorThrown) {
                     console.log("wah waaaah");
+                    $('#error-message').html(errorThrown);
                     $('#report-error').removeClass('hide');
                 }
             });
@@ -105,6 +111,7 @@
     {% blocktrans %}
     There was an error rendering your report.
     {% endblocktrans %}
+    <div id="error-message"></div>
 </div>
 
 <div class="report-controls">

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -2,6 +2,7 @@ from django.core.urlresolvers import reverse
 from django.views.generic.base import TemplateView
 from braces.views import JSONResponseMixin
 from corehq.apps.reports.dispatcher import cls_to_view_login_and_domain
+from corehq.apps.userreports.exceptions import UserReportsError
 from corehq.apps.userreports.models import ReportConfiguration
 from corehq.apps.userreports.reports.factory import ReportFactory
 from corehq.util.couch import get_document_or_404
@@ -90,11 +91,11 @@ class ConfigurableReport(JSONResponseMixin, TemplateView):
         return DataTablesHeader(*[col.data_tables_column for col in self.data_source.columns])
 
     def get_ajax(self, request, domain=None, **kwargs):
-        data = self.data_source
-        data.set_filter_values(self.filter_values)
         try:
+            data = self.data_source
+            data.set_filter_values(self.filter_values)
             total_records = data.get_total_records()
-        except Exception as e:
+        except UserReportsError as e:
             return self.render_json_response({
                 'error': e.message,
             })

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -92,7 +92,12 @@ class ConfigurableReport(JSONResponseMixin, TemplateView):
     def get_ajax(self, request, domain=None, **kwargs):
         data = self.data_source
         data.set_filter_values(self.filter_values)
-        total_records = data.get_total_records()
+        try:
+            total_records = data.get_total_records()
+        except Exception as e:
+            return self.render_json_response({
+                'error': e.message,
+            })
 
         # todo: this is ghetto pagination - still doing a lot of work in the database
         datatables_params = DatatablesParams.from_request_dict(request.GET)


### PR DESCRIPTION
Known error when rendering report:
![screen shot 2014-12-09 at 8 36 53 pm](https://cloud.githubusercontent.com/assets/1757035/5377738/d42f53b8-8052-11e4-99b6-9dce11dab172.png)

Arbitrary 500 error (appears in logs):
![screen shot 2014-12-09 at 8 36 09 pm](https://cloud.githubusercontent.com/assets/1757035/5377743/da383de2-8052-11e4-8c00-3f9e4835d739.png)
