### PR TITLE
Quickcache

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -464,7 +464,7 @@ class FormSource(object):
 
         try:
             source = app.lazy_fetch_attachment(filename)
-        except (ResourceNotFound, KeyError):
+        except ResourceNotFound:
             source = ''
 
         return source

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -59,7 +59,8 @@ from corehq.apps.users.util import cc_user_domain
 from corehq.apps.domain.models import cached_property
 from corehq.apps.app_manager import current_builds, app_strings, remote_app
 from corehq.apps.app_manager import fixtures, suite_xml, commcare_settings
-from corehq.apps.app_manager.util import split_path, save_xform, get_correct_app_class
+from corehq.apps.app_manager.util import split_path, save_xform, get_correct_app_class, \
+    get_questions_from_xform
 from corehq.apps.app_manager.xform import XForm, parse_xml as _parse_xml, \
     validate_xform
 from corehq.apps.app_manager.templatetags.xforms_extras import trans
@@ -705,7 +706,7 @@ class FormBase(DocumentSchema):
         return xform.render()
 
     def get_questions(self, langs, **kwargs):
-        return XForm(self.source).get_questions(langs, **kwargs)
+        return get_questions_from_xform(self.source, langs, **kwargs)
 
     @memoized
     def get_case_property_name_formatter(self):

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -1,4 +1,5 @@
 import functools
+import hashlib
 import json
 import itertools
 from couchdbkit.exceptions import DocTypeError
@@ -305,3 +306,19 @@ def commtrack_ledger_sections(mode):
         sections += [CT_LEDGER_REQUESTED, CT_LEDGER_APPROVED]
 
     return ['{}{}'.format(CT_LEDGER_PREFIX, s) for s in sections]
+
+
+def get_questions_from_xform(xform_xml, langs, include_triggers=False,
+                             include_groups=False):
+    cache_key = 'get_questions_from_xform' + ','.join(
+        [hashlib.md5(xform_xml.encode('utf-8')).hexdigest(), json.dumps(langs),
+         str(int(include_triggers)), str(int(include_groups))])
+    value = cache.get(cache_key)
+    if value is None:
+        value = XForm(xform_xml).get_questions(
+            langs=langs,
+            include_triggers=include_triggers,
+            include_groups=include_groups,
+        )
+        cache.set(cache_key, value, timeout=60*60*24)
+    return value

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -1,5 +1,4 @@
 import functools
-import hashlib
 import json
 import itertools
 from couchdbkit.exceptions import DocTypeError
@@ -306,19 +305,3 @@ def commtrack_ledger_sections(mode):
         sections += [CT_LEDGER_REQUESTED, CT_LEDGER_APPROVED]
 
     return ['{}{}'.format(CT_LEDGER_PREFIX, s) for s in sections]
-
-
-def get_questions_from_xform(xform_xml, langs, include_triggers=False,
-                             include_groups=False):
-    cache_key = 'get_questions_from_xform' + ','.join(
-        [hashlib.md5(xform_xml.encode('utf-8')).hexdigest(), json.dumps(langs),
-         str(int(include_triggers)), str(int(include_groups))])
-    value = cache.get(cache_key)
-    if value is None:
-        value = XForm(xform_xml).get_questions(
-            langs=langs,
-            include_triggers=include_triggers,
-            include_groups=include_groups,
-        )
-        cache.set(cache_key, value, timeout=60*60*24)
-    return value

--- a/corehq/apps/builds/models.py
+++ b/corehq/apps/builds/models.py
@@ -5,6 +5,7 @@ from couchdbkit.exceptions import ResourceNotFound, BadValueError
 from couchdbkit.ext.django.schema import *
 from corehq.apps.builds.fixtures import commcare_build_config
 from corehq.apps.builds.jadjar import JadJar
+from corehq.util.quickcache import quickcache
 
 
 class SemanticVersionProperty(StringProperty):
@@ -205,6 +206,11 @@ class CommCareBuildConfig(Document):
         return config
 
     @classmethod
+    def clear_local_cache(cls):
+        cls.fetch.clear(cls)
+
+    @classmethod
+    @quickcache(timeout=30)
     def fetch(cls):
         try:
             return cls.get(cls._ID)

--- a/corehq/apps/builds/views.py
+++ b/corehq/apps/builds/views.py
@@ -64,12 +64,12 @@ class EditMenuView(TemplateView):
 
     @method_decorator(require_superuser)
     def dispatch(self, *args, **kwargs):
+        # different local caches on different workers
+        # but this at least makes it so your changes take effect immediately
+        # while you're editing the config
+        CommCareBuildConfig.clear_local_cache()
         self.doc = CommCareBuildConfig.fetch()
         return super(EditMenuView, self).dispatch(*args, **kwargs)
-
-    def get_doc(self):
-        db = get_db()
-        return db.get(self.doc_id)
 
     def save_doc(self):
         db = get_db()

--- a/corehq/apps/indicators/utils.py
+++ b/corehq/apps/indicators/utils.py
@@ -1,11 +1,12 @@
 from couchdbkit import ResourceNotFound
-from dimagi.utils.couch.cache import cache_core
+from corehq.util.quickcache import quickcache
 from dimagi.utils.couch.database import get_db
 
 
+@quickcache(timeout=60)
 def get_indicator_config():
     try:
-        doc = cache_core.cached_open_doc(get_db(), 'INDICATOR_CONFIGURATION')
+        doc = get_db().open_doc('INDICATOR_CONFIGURATION')
     except ResourceNotFound:
         return {}
     else:

--- a/corehq/util/quickcache.py
+++ b/corehq/util/quickcache.py
@@ -1,0 +1,186 @@
+import functools
+import hashlib
+import inspect
+import logging
+from django.core.cache import get_cache
+
+logger = logging.getLogger('quickcache')
+
+
+class TieredCache(object):
+    """
+    Tries a number of caches in increasing order.
+    Caches should be ordered with faster, more local caches at the beginning
+    and slower, more shared caches towards the end
+
+    Relies on each of the caches' default timeout;
+    TieredCache.set doesn't accept a timeout parameter
+
+    """
+    def __init__(self, caches):
+        self.caches = caches
+
+    def get(self, key, default=None):
+        missed = []
+        for cache in self.caches:
+            content = cache.get(key, default=Ellipsis)
+            if content is not Ellipsis:
+                for missed_cache in missed:
+                    missed_cache.set(key, content)
+                logger.debug('missed caches: {}'.format([c.__class__.__name__
+                                                         for c in missed]))
+                logger.debug('hit cache: {}'.format(cache.__class__.__name__))
+                return content
+            else:
+                missed.append(cache)
+        return default
+
+    def set(self, key, value):
+        for cache in self.caches:
+            cache.set(key, value)
+
+    def delete(self, key):
+        for cache in self.caches:
+            cache.delete(key)
+
+
+class QuickCache(object):
+    def __init__(self, fn, vary_on, cache):
+        self.fn = fn
+        self.cache = cache
+        self.prefix = '{}.{}'.format(fn.__name__,
+                                     self._hash(inspect.getsource(fn), 8))
+
+        arg_names = inspect.getargspec(self.fn).args
+        vary_on = [part.split('.') for part in vary_on]
+        vary_on = [(part[0], tuple(part[1:])) for part in vary_on]
+        for arg, attrs in vary_on:
+            if arg not in arg_names:
+                raise ValueError(
+                    'We cannot vary on "{}" because the function {} has '
+                    'no such argument'.format(arg, self.fn.__name__)
+                )
+
+        self.vary_on = vary_on
+
+    def __call__(self, *args, **kwargs):
+        logger.debug('checking caches for {}'.format(self.fn.__name__))
+        key = self.get_cache_key(*args, **kwargs)
+        logger.debug(key)
+        content = self.cache.get(key, default=Ellipsis)
+        if content is Ellipsis:
+            logger.debug('cache miss, calling {}'.format(self.fn.__name__))
+            content = self.fn(*args, **kwargs)
+            self.cache.set(key, content)
+        return content
+
+    def clear(self, *args, **kwargs):
+        key = self.get_cache_key(*args, **kwargs)
+        self.cache.delete(key)
+
+    @staticmethod
+    def _hash(value, length=32):
+        return hashlib.md5(value).hexdigest()[-length:]
+
+    def _serialize_for_key(self, value):
+        if isinstance(value, unicode):
+            return 'u' + self._hash(value.encode('utf-8'))
+        elif isinstance(value, str):
+            if len(value) <= 32:
+                return 's' + value
+            else:
+                # for long text
+                return 't' + self._hash(value)
+        elif isinstance(value, bool):
+            return 'b' + str(int(value))
+        elif isinstance(value, (int, long, float)):
+            return 'n' + str(value)
+        elif isinstance(value, (list, tuple)):
+            return 'L' + self._hash(
+                ','.join(map(self._serialize_for_key, value)))
+        elif isinstance(value, (list, tuple)):
+            return 'S' + self._hash(
+                ','.join(sorted(map(self._serialize_for_key, value))))
+        else:
+            raise ValueError('Bad type "{}": {}'.format(type(value), value))
+
+    def get_cache_key(self, *args, **kwargs):
+        callargs = inspect.getcallargs(self.fn, *args, **kwargs)
+        values = []
+        for arg_name, attrs in self.vary_on:
+            value = callargs[arg_name]
+            for attr in attrs:
+                value = getattr(value, attr)
+            values.append(value)
+        return 'quickcache.{}/{}'.format(self.prefix, ','.join(
+            self._serialize_for_key(value) for value in values))
+
+
+def quickcache(vary_on='', timeout=None, memoize_timeout=None, cache=None):
+    """
+    An easy "all-purpose" cache decorator
+
+    Examples:
+        - caching a singleton function, refresh every 5 minutes
+
+            @quickcache(timeout=5 * 60)
+            def get_config_from_db():
+                # ...
+
+        - vary on the arguments of a function
+
+            @quickcache(['request.couch_user._rev'], timeout=24 * 60 * 60)
+            def domains_for_user(request):
+                return [Domain.get_by_name(domain)
+                        for domain in request.couch_user.domains]
+
+          now as soon as request.couch_user._rev has changed,
+          the function will be recomputed
+
+    Features:
+        - In addition to caching in the default shared cache,
+          quickcache caches in memory for 10 seconds
+          (conceptually the length of a single request).
+          This can be overridden to a different number with memoize_timeout.
+
+        - In addition to varying on the arguments and the name of the function,
+          quickcache will also make sure to vary
+          on the _source code_ of your function.
+          That way if you change the behavior of the function, there won't be
+          any stale cache when you deploy.
+
+        - Can vary on any number of the function's parameters
+
+        - Does not by default vary on all function parameters.
+          This is because it is not in general obvious what it means
+          to vary on an object, for example.
+
+        - Allows you to vary on an attribute of an object,
+          multiple attrs of the same object, attrs of attrs of an object, etc
+
+    """
+    if cache and timeout:
+        raise ValueError('You can only use timeout '
+                         'when not overriding the cache')
+
+    timeout = timeout or 5 * 60
+    memoize_timeout = memoize_timeout or 10
+
+    if cache is None:
+        cache = TieredCache([get_cache('locmem://', timeout=memoize_timeout),
+                             get_cache('default', timeout=timeout)])
+
+    def decorator(fn):
+        helper = QuickCache(fn, vary_on=vary_on, cache=cache)
+
+        @functools.wraps(fn)
+        def inner(*args, **kwargs):
+            return helper(*args, **kwargs)
+
+        inner.clear = helper.clear
+        inner.get_cache_key = helper.get_cache_key
+        inner.prefix = helper.prefix
+
+        return inner
+
+    return decorator

--- a/corehq/util/quickcache.py
+++ b/corehq/util/quickcache.py
@@ -98,7 +98,7 @@ class QuickCache(object):
         elif isinstance(value, (list, tuple)):
             return 'L' + self._hash(
                 ','.join(map(self._serialize_for_key, value)))
-        elif isinstance(value, (list, tuple)):
+        elif isinstance(value, set):
             return 'S' + self._hash(
                 ','.join(sorted(map(self._serialize_for_key, value))))
         else:

--- a/corehq/util/tests/__init__.py
+++ b/corehq/util/tests/__init__.py
@@ -1,0 +1,3 @@
+from test_couch import *
+from test_toggle import *
+from test_quickcache import *

--- a/corehq/util/tests/test_couch.py
+++ b/corehq/util/tests/test_couch.py
@@ -1,0 +1,22 @@
+from django.test import TestCase
+from corehq.util.couch import get_document_or_404
+from corehq.apps.users.models import WebUser
+from corehq.apps.users.models import CommCareUser
+
+
+class GetDocTestCase(TestCase):
+    def setUp(self):
+        self.web_user = WebUser.create('test', 'test', 'test')
+        self.commcare_user = CommCareUser.create('test',
+                                                 'commcaretest',
+                                                 'test')
+
+    def tearDown(self):
+        self.web_user.delete()
+        self.commcare_user.delete()
+
+    def test_get_web_user(self):
+        get_document_or_404(WebUser, 'test', self.web_user._id)
+
+    def test_get_commcare_user(self):
+        get_document_or_404(CommCareUser, 'test', self.commcare_user._id)

--- a/corehq/util/tests/test_quickcache.py
+++ b/corehq/util/tests/test_quickcache.py
@@ -1,0 +1,134 @@
+from django.core.cache.backends.locmem import LocMemCache
+from django.test import SimpleTestCase
+import time
+from corehq.util.quickcache import quickcache, TieredCache
+
+BUFFER = []
+
+
+class CacheMock(LocMemCache):
+    def __init__(self, name, params):
+        self.name = name
+        super(CacheMock, self).__init__(name, params)
+
+    def get(self, key, default=None, version=None):
+        result = super(CacheMock, self).get(key, default, version)
+        if result is default:
+            BUFFER.append('{} miss'.format(self.name))
+        else:
+            BUFFER.append('{} hit'.format(self.name))
+        return result
+
+SHORT_TIME_UNIT = 1
+
+_local_cache = CacheMock('local', {'timeout': SHORT_TIME_UNIT})
+_shared_cache = CacheMock('shared', {'timeout': 2 * SHORT_TIME_UNIT})
+_cache = TieredCache([_local_cache, _shared_cache])
+
+
+class QuickcacheTest(SimpleTestCase):
+
+    def tearDown(self):
+        self.consume_buffer()
+
+    def consume_buffer(self):
+        result = list(BUFFER)
+        while True:
+            try:
+                BUFFER.pop()
+            except IndexError:
+                break
+        return result
+
+    def test_tiered_cache(self):
+        @quickcache(cache=_cache)
+        def simple():
+            BUFFER.append('called')
+            return 'VALUE'
+
+        self.assertEqual(simple(), 'VALUE')
+        self.assertEqual(self.consume_buffer(), ['local miss', 'shared miss', 'called'])
+        self.assertEqual(simple(), 'VALUE')
+        self.assertEqual(self.consume_buffer(), ['local hit'])
+        # let the local cache expire
+        time.sleep(SHORT_TIME_UNIT)
+        self.assertEqual(simple(), 'VALUE')
+        self.assertEqual(self.consume_buffer(), ['local miss', 'shared hit'])
+        # let the shared cache expire
+        time.sleep(SHORT_TIME_UNIT)
+        self.assertEqual(simple(), 'VALUE')
+        self.assertEqual(self.consume_buffer(), ['local miss', 'shared miss', 'called'])
+        # and that this is again cached locally
+        self.assertEqual(simple(), 'VALUE')
+        self.assertEqual(self.consume_buffer(), ['local hit'])
+
+    def test_vary_on(self):
+        @quickcache(['n'], cache=_cache)
+        def fib(n):
+            BUFFER.append(n)
+            if n < 2:
+                return 1
+            else:
+                return fib_r(n - 1) + fib_r(n - 2)
+
+        fib_r = fib
+
+        # [1, 1, 2, 3, 5, 8]
+        self.assertEqual(fib(5), 8)
+        self.assertEqual(self.consume_buffer(),
+                         ['local miss', 'shared miss', 5,
+                          'local miss', 'shared miss', 4,
+                          'local miss', 'shared miss', 3,
+                          'local miss', 'shared miss', 2,
+                          'local miss', 'shared miss', 1,
+                          'local miss', 'shared miss', 0,
+                          # fib(3/4/5) also ask for fib(1/2/3)
+                          # so three cache hits
+                          'local hit', 'local hit', 'local hit'])
+
+    def test_vary_on_attr(self):
+        class Item(object):
+            def __init__(self, id, name):
+                self.id = id
+                self.name = name
+
+            @quickcache(['self.id'], cache=_cache)
+            def get_name(self):
+                BUFFER.append('called method')
+                return self.name
+
+        @quickcache(['item.id'], cache=_cache)
+        def get_name(item):
+            BUFFER.append('called function')
+            return item.name
+
+        james = Item(1, 'james')
+        fred = Item(2, 'fred')
+        self.assertEqual(get_name(james), 'james')
+        self.assertEqual(self.consume_buffer(),
+                         ['local miss', 'shared miss', 'called function'])
+        self.assertEqual(get_name(fred), 'fred')
+        self.assertEqual(self.consume_buffer(),
+                         ['local miss', 'shared miss', 'called function'])
+        self.assertEqual(get_name(james), 'james')
+        self.assertEqual(self.consume_buffer(), ['local hit'])
+        self.assertEqual(get_name(fred), 'fred')
+        self.assertEqual(self.consume_buffer(), ['local hit'])
+
+        # this also works, and uses different keys
+        self.assertEqual(james.get_name(), 'james')
+        self.assertEqual(self.consume_buffer(),
+                         ['local miss', 'shared miss', 'called method'])
+        self.assertEqual(fred.get_name(), 'fred')
+        self.assertEqual(self.consume_buffer(),
+                         ['local miss', 'shared miss', 'called method'])
+        self.assertEqual(james.get_name(), 'james')
+        self.assertEqual(self.consume_buffer(), ['local hit'])
+        self.assertEqual(fred.get_name(), 'fred')
+        self.assertEqual(self.consume_buffer(), ['local hit'])
+
+    def test_bad_vary_on(self):
+        with self.assertRaisesRegexp(ValueError, 'cucumber'):
+            @quickcache(['cucumber'], cache=_cache)
+            def square(number):
+                return number * number

--- a/corehq/util/tests/test_toggle.py
+++ b/corehq/util/tests/test_toggle.py
@@ -1,29 +1,7 @@
 from collections import defaultdict
-import random
 import uuid
-from django.test import TestCase, SimpleTestCase
+from django.test import SimpleTestCase
 from corehq.toggles import deterministic_random
-from corehq.util.couch import get_document_or_404
-from corehq.apps.users.models import WebUser
-from corehq.apps.users.models import CommCareUser
-
-
-class GetDocTestCase(TestCase):
-    def setUp(self):
-        self.web_user = WebUser.create('test', 'test', 'test')
-        self.commcare_user = CommCareUser.create('test',
-                                                 'commcaretest',
-                                                 'test')
-
-    def tearDown(self):
-        self.web_user.delete()
-        self.commcare_user.delete()
-
-    def test_get_web_user(self):
-        get_document_or_404(WebUser, 'test', self.web_user._id)
-
-    def test_get_commcare_user(self):
-        get_document_or_404(CommCareUser, 'test', self.commcare_user._id)
 
 
 class DeterministicRandomTestCase(SimpleTestCase):


### PR DESCRIPTION
Wrote an easy "all-purpose" cache decorator and used it in the following places
- to make `get_questions` only do work when the xform source changes
- fetching build config doc
- fetching those one-off config docs (indicators, domain module map, etc.) instead of cache_core

Hoping this will make the activation energy for caching things way lower :)

See `quickcache` docstring for documentation on how to use it and what its features are.
