### PR TITLE
Add a javascript hook to our message framework

### DIFF
--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -104,17 +104,12 @@
                         <a href="https://www.google.com/chrome">Chrome</a> or <a href="http://www.mozilla.org/">Firefox</a>.
                     </p>
                 </div>
-                {% block messages %}
-                {% if messages %}
-                    {% for message in messages %}
-                        <div class="alert fade in alert-block alert-full page-level-alert{% if message.tags %} {{ message.tags }}{% endif %}">
-                            <a class="close" data-dismiss="alert" href="#">&times;</a>
-                            {% if 'html' in message.tags %}{{ message|safe }}{% else %}{{ message }}{% endif %}
-                        </div>
-                    {% endfor %}
-                {% endif %}
-
-                {% endblock %}
+                <div id="message-alerts" data-bind="foreach: alerts">
+                    <div data-bind="attr: {'class': alert_class}">
+                        <a class="close" data-dismiss="alert" href="#">&times;</a>
+                        <span data-bind="text: message"></span>
+                    </div>
+                </div>
                 <h1 class="page-header">
                     {% block page-title %}
                     {% endblock %}
@@ -568,6 +563,49 @@
                     $('#unsupported-browser').show();
                 }
             });
+        </script>
+
+        <script>
+            {% comment %}
+            This is the javascript analog of messages in Django
+
+            Use the function `alert_user` to make a message appear on the page.
+            this accepts two args, message, and emphasis.  Emphasis corresponds to bootstrap
+            styling, and can be "success", "error", "info", or "warning"
+
+                alert_user("Awesome job!", "success");
+            {% endcomment %}
+            function MessageAlert (message, tags) {
+                var self = this;
+                self.message = message;
+                self.alert_class = "alert fade in alert-block alert-full page-level-alert";
+                if (tags) {
+                    self.alert_class += " " + tags;
+                };
+            }
+            var message_alerts = ko.observableArray();
+
+            function alert_user (message, emphasis) {
+                message_alerts.push(MessageAlert(message, "alert-" + emphasis));
+            }
+
+            ko.applyBindings(
+                {alerts: message_alerts},
+                $("#message-alerts").get(0)
+            );
+
+            // Add in the Django messages
+            {% if messages %}
+                {% for message in messages %}
+                    console.log("{% if 'html' in message.tags %}{{ message|safe }}{% else %}{{ message }}{% endif %}");
+                    console.log("{{ message.tags }}");
+                    message_alerts.push(MessageAlert(
+                        "{% if 'html' in message.tags %}{{ message|safe }}{% else %}{{ message }}{% endif %}",
+                        "{{ message.tags }}"
+                    ));
+                {% endfor %}
+            {% endif %}
+
         </script>
     </body>
 </html>

--- a/corehq/apps/hqwebapp/templates/hqwebapp/base.html
+++ b/corehq/apps/hqwebapp/templates/hqwebapp/base.html
@@ -570,23 +570,25 @@
             This is the javascript analog of messages in Django
 
             Use the function `alert_user` to make a message appear on the page.
-            this accepts two args, message, and emphasis.  Emphasis corresponds to bootstrap
+            This accepts two args, message, and emphasis.  Emphasis corresponds to bootstrap
             styling, and can be "success", "error", "info", or "warning"
 
                 alert_user("Awesome job!", "success");
             {% endcomment %}
-            function MessageAlert (message, tags) {
-                var self = this;
-                self.message = message;
-                self.alert_class = "alert fade in alert-block alert-full page-level-alert";
+            function message_alert (message, tags) {
+                var alert_obj = {
+                    "message": message,
+                    "alert_class": "alert fade in alert-block alert-full page-level-alert"
+                }
                 if (tags) {
-                    self.alert_class += " " + tags;
+                    alert_obj.alert_class += " " + tags;
                 };
+                return alert_obj;
             }
             var message_alerts = ko.observableArray();
 
             function alert_user (message, emphasis) {
-                message_alerts.push(MessageAlert(message, "alert-" + emphasis));
+                message_alerts.push(message_alert(message, "alert-" + emphasis));
             }
 
             ko.applyBindings(
@@ -597,9 +599,7 @@
             // Add in the Django messages
             {% if messages %}
                 {% for message in messages %}
-                    console.log("{% if 'html' in message.tags %}{{ message|safe }}{% else %}{{ message }}{% endif %}");
-                    console.log("{{ message.tags }}");
-                    message_alerts.push(MessageAlert(
+                    message_alerts.push(message_alert(
                         "{% if 'html' in message.tags %}{{ message|safe }}{% else %}{{ message }}{% endif %}",
                         "{{ message.tags }}"
                     ));

--- a/corehq/apps/locations/templates/locations/manage/locations.html
+++ b/corehq/apps/locations/templates/locations/manage/locations.html
@@ -35,8 +35,9 @@ function loc_unarchive_url(loc_id) {
     return template.replace('-locid-', loc_id);
 }
 
-archive_loc = function(button, loc_id) {
+archive_loc = function(button, name, loc_id) {
     $(button).button('loading');
+    alert_user("You have successfully archived the location " + name, "success");
     $.ajax({
         type: 'POST',
         url: loc_archive_url(loc_id),
@@ -124,7 +125,7 @@ $(function() {
                 </a>
                 {% else %}
                 <a class="loc_edit btn btn-primary"
-                    data-bind="click: function(data, event) { archive_loc(event.currentTarget, uuid()) }">
+                    data-bind="click: function(data, event) { archive_loc(event.currentTarget, name(), uuid()) }">
                     Archive
                 </a>
                 {% endif %}


### PR DESCRIPTION
@dimagi/team-commcare-hq 
This is the javascript analog of messages in Django.

Use the function `alert_user` to make a message appear on the page. This accepts two args, message, and emphasis.  Emphasis corresponds to bootstrap styling, and can be "success", "error", "info", or "warning"

`alert_user("Awesome job!", "success");`

I'd like a little feedback before merging, if possible.  In particular, where should this _actually_ live?  The bit where I add in the Django messages has to live in this file, but the rest could go elsewhere (although it IS small).  Should I be sticking some of this in a `$(...)`?

http://manage.dimagi.com/default.asp?149536
