### PR TITLE
allow user to provide report column alias

### DIFF
--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -26,6 +26,7 @@ class ReportColumn(JsonObject):
     display = StringProperty()
     field = StringProperty(required=True)
     aggregation = StringProperty(required=True)
+    alias = StringProperty()
 
     def get_sql_column(self):
         # todo: find a better home for this
@@ -33,8 +34,12 @@ class ReportColumn(JsonObject):
             'sum': SumColumn,
             'simple': SimpleColumn,
         }
-        return DatabaseColumn(self.display, sqlagg_column_map[self.aggregation](self.field),
-                              sortable=False, data_slug=self.field)
+        return DatabaseColumn(
+            self.display,
+            sqlagg_column_map[self.aggregation](self.field, alias=self.alias),
+            sortable=False,
+            data_slug=self.field,
+        )
 
 
 class FilterChoice(JsonObject):


### PR DESCRIPTION
A report errors if report columns reference the same field.  Allowing the user to specify a column alias provides a workaround.

Would be nice if report columns were aliased automatically in the future.
