### PR TITLE
Simplify privileges

### DIFF
--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -138,7 +138,7 @@ from corehq.apps.app_manager.decorators import safe_download, no_conflict_requir
     require_can_edit_apps, require_deploy_apps
 from django.contrib import messages
 from django_prbac.exceptions import PermissionDenied
-from django_prbac.utils import ensure_request_has_privilege
+from django_prbac.utils import ensure_request_has_privilege, has_privilege
 # Numbers in paths is prohibited, hence the use of importlib
 import importlib
 FilterMigration = importlib.import_module('corehq.apps.app_manager.migrations.0002_add_filter_to_Detail').Migration
@@ -518,12 +518,7 @@ def get_form_view_context_and_template(request, form, langs, is_user_registratio
 
 def get_app_view_context(request, app):
 
-    is_cloudcare_allowed = False
-    try:
-        ensure_request_has_privilege(request, privileges.CLOUDCARE)
-        is_cloudcare_allowed = True
-    except PermissionDenied:
-        pass
+    is_cloudcare_allowed = has_privilege(request, privileges.CLOUDCARE)
 
     settings_layout = copy.deepcopy(
         commcare_settings.LAYOUT[app.get_doc_type()])

--- a/corehq/apps/dashboard/views.py
+++ b/corehq/apps/dashboard/views.py
@@ -1,6 +1,5 @@
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
-from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext_noop, ugettext as _
 from djangular.views.mixins import JSONResponseMixin, allow_remote_invocation
 
@@ -17,7 +16,7 @@ from corehq.apps.domain.views import DomainViewMixin, LoginAndDomainMixin, \
 from corehq.apps.hqwebapp.views import BasePageView
 from corehq.apps.users.views import DefaultProjectUserSettingsView
 from django_prbac.exceptions import PermissionDenied
-from django_prbac.utils import ensure_request_has_privilege
+from django_prbac.utils import ensure_request_has_privilege, has_privilege
 
 
 @login_and_domain_required
@@ -124,18 +123,10 @@ def _get_default_tile_configurations():
     can_view_commtrack_setup = lambda request: (request.project.commtrack_enabled)
 
     def _can_access_sms(request):
-        try:
-            ensure_request_has_privilege(request, privileges.OUTBOUND_SMS)
-        except PermissionDenied:
-            return False
-        return True
+        return has_privilege(request, privileges.OUTBOUND_SMS)
 
     def _can_access_reminders(request):
-        try:
-            ensure_request_has_privilege(request, privileges.REMINDERS_FRAMEWORK)
-            return True
-        except PermissionDenied:
-            return False
+        return has_privilege(request, privileges.REMINDERS_FRAMEWORK)
 
     can_use_messaging = lambda request: (
         (_can_access_reminders(request) or _can_access_sms(request))

--- a/corehq/apps/dashboard/views.py
+++ b/corehq/apps/dashboard/views.py
@@ -3,7 +3,7 @@ from django.http import HttpResponseRedirect
 from django.utils.translation import ugettext_noop, ugettext as _
 from djangular.views.mixins import JSONResponseMixin, allow_remote_invocation
 
-from corehq import toggles, privileges
+from corehq import privileges
 from corehq.apps.app_manager.models import Application
 from corehq.apps.dashboard.models import (
     TileConfiguration,
@@ -15,8 +15,7 @@ from corehq.apps.domain.views import DomainViewMixin, LoginAndDomainMixin, \
     DefaultProjectSettingsView
 from corehq.apps.hqwebapp.views import BasePageView
 from corehq.apps.users.views import DefaultProjectUserSettingsView
-from django_prbac.exceptions import PermissionDenied
-from django_prbac.utils import ensure_request_has_privilege, has_privilege
+from django_prbac.utils import has_privilege
 
 
 @login_and_domain_required

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -15,8 +15,7 @@ from django.utils.translation import ugettext as _
 
 # External imports
 from django_digest.decorators import httpdigest
-from django_prbac.exceptions import PermissionDenied
-from django_prbac.utils import ensure_request_has_privilege
+from django_prbac.utils import has_privilege
 
 from django.http import HttpResponse
 from django.contrib.auth import authenticate, login
@@ -38,11 +37,7 @@ def load_domain(req, domain):
     domain_name = normalize_domain_name(domain)
     domain = Domain.get_by_name(domain_name)
     req.project = domain
-    req.can_see_organization = True
-    try:
-        ensure_request_has_privilege(req, privileges.CROSS_PROJECT_REPORTS)
-    except PermissionDenied:
-        req.can_see_organization = False
+    req.can_see_organization = has_privilege(req, privileges.CROSS_PROJECT_REPORTS)
     return domain_name, domain
 
 ########################################################################################################

--- a/corehq/apps/hqwebapp/models.py
+++ b/corehq/apps/hqwebapp/models.py
@@ -21,8 +21,7 @@ from corehq.apps.indicators.utils import get_indicator_domains
 from corehq.apps.reminders.util import can_use_survey_reminders
 from corehq.apps.smsbillables.dispatcher import SMSAdminInterfaceDispatcher
 from django_prbac.exceptions import PermissionDenied
-from django_prbac.models import Role, UserRole
-from django_prbac.utils import ensure_request_has_privilege
+from django_prbac.utils import ensure_request_has_privilege, has_privilege
 
 from dimagi.utils.couch.database import get_db
 from dimagi.utils.decorators.memoized import memoized
@@ -662,13 +661,12 @@ class CloudcareTab(UITab):
 
     @property
     def is_viewable(self):
-        try:
-            ensure_request_has_privilege(self._request, privileges.CLOUDCARE)
-        except PermissionDenied:
-            return False
-        return (self.domain
-                and (self.couch_user.can_edit_data() or self.couch_user.is_commcare_user())
-                and not self.project.commconnect_enabled)
+        return (
+            has_privilege(self._request, privileges.CLOUDCARE)
+            and self.domain
+            and (self.couch_user.can_edit_data() or self.couch_user.is_commcare_user())
+            and not self.project.commconnect_enabled
+        )
 
 
 class MessagingTab(UITab):

--- a/corehq/apps/reminders/util.py
+++ b/corehq/apps/reminders/util.py
@@ -1,13 +1,12 @@
 from datetime import datetime, time
-from corehq import toggles, privileges
+from corehq import privileges
 from corehq.apps.app_manager.models import get_app, ApplicationBase, Form
 from couchdbkit.resource import ResourceNotFound
 from django.utils.translation import ugettext as _
 from corehq.apps.groups.models import Group
 from corehq.apps.users.models import CommCareUser
 from casexml.apps.case.models import CommCareCase, CommCareCaseGroup
-from django_prbac.exceptions import PermissionDenied
-from django_prbac.utils import ensure_request_has_privilege
+from django_prbac.utils import has_privilege
 
 
 class DotExpandedDict(dict):
@@ -203,8 +202,4 @@ def create_immediate_reminder(contact, content_type, reminder_type=None, message
 
 
 def can_use_survey_reminders(request):
-    try:
-        ensure_request_has_privilege(request, privileges.INBOUND_SMS)
-    except PermissionDenied:
-        return False
-    return True
+    return has_privilege(request, privileges.INBOUND_SMS)

--- a/corehq/apps/reports/standard/export.py
+++ b/corehq/apps/reports/standard/export.py
@@ -6,9 +6,8 @@ from django.conf import settings
 from django.utils.translation import ugettext_noop, ugettext_lazy
 from django.http import Http404
 from casexml.apps.case.models import CommCareCase
-from django_prbac.exceptions import PermissionDenied
-from django_prbac.utils import ensure_request_has_privilege
-from corehq import privileges, toggles
+from django_prbac.utils import has_privilege
+from corehq import privileges
 
 from corehq.apps.data_interfaces.dispatcher import DataInterfaceDispatcher
 
@@ -48,11 +47,7 @@ class FormExportReportBase(ExportReport, DatespanMixin):
 
     @property
     def can_view_deid(self):
-        try:
-            ensure_request_has_privilege(self.request, privileges.DEIDENTIFIED_DATA)
-        except PermissionDenied:
-            return False
-        return True
+        return has_privilege(self.request, privileges.DEIDENTIFIED_DATA)
 
     def get_saved_exports(self):
         # add saved exports. because of the way in which the key is stored

--- a/corehq/feature_previews.py
+++ b/corehq/feature_previews.py
@@ -4,10 +4,8 @@ a feature preview, you shouldn't need to migrate the data, as long as the
 slug is kept intact.
 """
 from django.utils.translation import ugettext_lazy as _
-from django_prbac.exceptions import PermissionDenied
-from django_prbac.utils import ensure_request_has_privilege
+from django_prbac.utils import has_privilege as prbac_has_privilege
 
-from . import privileges
 from .toggles import StaticToggle, NAMESPACE_DOMAIN
 
 
@@ -38,11 +36,7 @@ class FeaturePreview(StaticToggle):
         if not self.privilege:
             return True
 
-        try:
-            ensure_request_has_privilege(request, self.privilege)
-            return True
-        except PermissionDenied:
-            return False
+        return prbac_has_privilege(request, self.privilege)
 
 
 SUBMIT_HISTORY_FILTERS = FeaturePreview(


### PR DESCRIPTION
uses a central `has_privilege` function instead of similar try/except workflows everywhere.

depends on https://github.com/dimagi/django-prbac/pull/9
