### PR TITLE
Fix repeated knockuot bind error

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/static/case/js/case_details.js
+++ b/corehq/ex-submodules/casexml/apps/case/static/case/js/case_details.js
@@ -1,5 +1,5 @@
 $(function () {
-    ko.applyBindings(new XFormListViewModel(), $("#xform-list-block")[0]);
+    ko.applyBindings(new XFormListViewModel(), $("#history")[0]);
 });
 
 function pad_zero(val) {


### PR DESCRIPTION
[Ticket](http://manage.dimagi.com/default.asp?150506)

There was an `Uncaught Error: You cannot apply bindings multiple times to the same element.` on the case history page. The line modified in this PR was throwing the error. `$("#xform-list-block")[0]` was `undefined`, and it seems that binding to `undefined` is equivalent to binding to `window.html` (see this [fiddle](http://jsfiddle.net/bt5n6wg2/)).

Interestingly, the bug didn't show itself until this recent commit: https://github.com/dimagi/commcare-hq/commit/a847ca6cd89873393bf82ad23953adf66aeaff6a. My best guess is that before this commit, the problematic `applyBindings` call was the only one on the page. Therefore, it did not conflict with any other bindings.

I fixed the bug by fixing the jQuery selector, which pointed to a non existent id.
