### PR TITLE
Fix import app page by scoping applyBindings

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/import_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/import_app.html
@@ -27,7 +27,7 @@
         }
         var source = {{ app.export_json|JSON }};
         var post_url = "{% url "corehq.apps.app_manager.views.import_app" domain %}";
-        ko.applyBindings(new CompressionViewModel(source, post_url));
+        ko.applyBindings(new CompressionViewModel(source, post_url), $('#app-import-form').get(0));
     </script>
 {% endblock %}
 
@@ -36,7 +36,7 @@
 {% endblock %}
 
 {% block main_column %}
-    <form action="{% url "corehq.apps.app_manager.views.import_app" domain %}" method="post" data-bind="submit: save">
+    <form action="{% url "corehq.apps.app_manager.views.import_app" domain %}" id="app-import-form" method="post" data-bind="submit: save">
 {% if app %}
         <p>Import application <strong>{{ app.name }}</strong> from domain <strong>{{ app.domain }}</strong>?</p>
         <table {% if not is_superuser %}class="hide"{% endif %}>


### PR DESCRIPTION
This is another `applyBindings` call that stopped working as a result of the recent knockout addition to the base template.
