### PR TITLE
deactivate a subscription if its end date is changed to today

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -816,6 +816,8 @@ class Subscription(models.Model):
         today = datetime.date.today()
         if self.date_end is None or self.date_end > today:
             self.date_end = date_end
+        if self.is_active and self.date_end == today:
+            self.is_active = False
 
         if (self.date_start > today and date_start is not None
             and date_start > today and not date_start > self.date_end


### PR DESCRIPTION
Fixes a problem where an active subscription will never be deactivated if its end date is changed to today.

@biyeun 
