### PR TITLE
Enable Spanish and Portuguese for Transifex

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -6,4 +6,6 @@ file_filter = po/<lang><lang>.po
 source_file = locale/en/LC_MESSAGES/django.po
 source_lang = en
 trans.fr = locale/fra/LC_MESSAGES/django.po
+trans.es = locale/es/LC_MESSAGES/django.po
+trans.pt = locale/por/LC_MESSAGES/django.po
 type = PO


### PR DESCRIPTION
All the languages!

This just causes the `tx pull` and `tx push` commands to grab these languages as well, if there are new translations on those.
