### PR TITLE
Fix encoding issue with deleted custom user data on user page

### DIFF
--- a/corehq/apps/custom_data_fields/edit_entity.py
+++ b/corehq/apps/custom_data_fields/edit_entity.py
@@ -102,7 +102,7 @@ class CustomDataEditor(object):
     def get_uncategorized_form(self):
 
         def FakeInput(val):
-            return HTML('<span class="input-xlarge uneditable-input">{}</span>'
+            return HTML(u'<span class="input-xlarge uneditable-input">{}</span>'
                         .format(val))
 
         def Label(val):


### PR DESCRIPTION
[Ticket](http://manage.dimagi.com/default.asp?151004)

The user page would 500 if there was custom user data with non-ascii characters in fields that had been deleted since the last save of this user. Changing this string literal to a unicode string literal solved the issue.
