### PR TITLE
Fix encoding issue when saving case close condition

### DIFF
--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -1107,9 +1107,9 @@ class XForm(WrappedNode):
             return 'true()'
         elif condition.type == 'if':
             if condition.operator == 'selected':
-                template = "selected({path}, '{answer}')"
+                template = u"selected({path}, '{answer}')"
             else:
-                template = "{path} = '{answer}'"
+                template = u"{path} = '{answer}'"
             return template.format(
                 path=self.resolve_path(condition.question),
                 answer=condition.answer


### PR DESCRIPTION
[Ticket](http://manage.dimagi.com/default.asp?150013)
If a form has a case close condition that involves a question that contains unicode, then making builds will fail. This fixes that encoding issue.
