### PR TITLE
Percentage columns

### DIFF
--- a/corehq/apps/userreports/reports/data_source.py
+++ b/corehq/apps/userreports/reports/data_source.py
@@ -62,6 +62,14 @@ class ConfigurableReportDataSource(SqlData):
     def get_data(self, slugs=None):
         try:
             ret = super(ConfigurableReportDataSource, self).get_data(slugs)
+            for report_column in self.column_configs:
+                if report_column.format == 'percent_of_total':
+                    column_name = report_column.get_sql_column().view.name
+                    total = sum(row[column_name] for row in ret)
+                    for row in ret:
+                        row[column_name] = '{:.0%}'.format(
+                            float(row[column_name]) / total
+                        )
         except (
             ColumnNotFoundException,
             TableNotFoundException,

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -37,6 +37,7 @@ class ReportColumn(JsonObject):
         required=True,
     )
     alias = StringProperty()
+    format = StringProperty(default='default')
 
     def get_sql_column(self):
         return DatabaseColumn(

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -37,7 +37,10 @@ class ReportColumn(JsonObject):
         required=True,
     )
     alias = StringProperty()
-    format = StringProperty(default='default')
+    format = StringProperty(default='default', choices=[
+        'default',
+        'percent_of_total'
+    ])
 
     def get_sql_column(self):
         return DatabaseColumn(

--- a/corehq/apps/userreports/tests/data/configs/sample_report_config.json
+++ b/corehq/apps/userreports/tests/data/configs/sample_report_config.json
@@ -31,7 +31,8 @@
             "type": "field",
             "display": "Starred",
             "field": "is_starred",
-            "aggregation": "sum"
+            "aggregation": "sum",
+            "format": "percent_of_total"
         }
     ]
 }

--- a/corehq/apps/userreports/tests/test_columns.py
+++ b/corehq/apps/userreports/tests/test_columns.py
@@ -12,3 +12,26 @@ class TestReportColumn(SimpleTestCase):
                 "field": "doc_id",
                 "type": "field",
             })
+
+    def testGoodFormat(self):
+        for format in [
+            'default',
+            'percent_of_total',
+        ]:
+            self.assertEquals(ReportColumn, type(
+                ReportColumn.wrap({
+                    "aggregation": "simple",
+                    "field": "doc_id",
+                    "format": format,
+                    "type": "field",
+                })
+            ))
+
+    def testBadFormat(self):
+        with self.assertRaises(BadValueError):
+            ReportColumn.wrap({
+                "aggregation": "simple",
+                "field": "doc_id",
+                "format": "default_",
+                "type": "field",
+            })


### PR DESCRIPTION
changes to https://github.com/dimagi/commcare-hq/pull/5132

include option to show numbers in a column as percent of total in its own field, without affecting aggregation

very simple example:
![screen shot 2014-12-19 at 3 37 32 pm](https://cloud.githubusercontent.com/assets/1757035/5510863/009fbf20-8795-11e4-9b12-b0ab4dbf92f8.png)

same example without percentages:
![screen shot 2014-12-19 at 3 38 51 pm](https://cloud.githubusercontent.com/assets/1757035/5510872/27ed1abe-8795-11e4-8dc5-4e8e4deb47c2.png)
