### PR TITLE
deactivate subscriptions when its date is set to end in the past as well as today

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -816,7 +816,7 @@ class Subscription(models.Model):
         today = datetime.date.today()
         if self.date_end is None or self.date_end > today:
             self.date_end = date_end
-        if self.is_active and self.date_end == today:
+        if self.is_active and self.date_end <= today:
             self.is_active = False
 
         if (self.date_start > today and date_start is not None


### PR DESCRIPTION
turns out you can set a subscription's end date to the past, so `<=` is needed

fixes http://manage.dimagi.com/default.asp?151149
