### PR TITLE
Do copy apps for the exchange

### DIFF
--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -675,8 +675,7 @@ class Domain(Document, SnapshotMixin):
 
         for res in db.view('domain/related_to_domain', key=[self.name, True]):
             if (copy_by_id and res['value']['_id'] not in copy_by_id and
-                res['value']['doc_type'] in ('Application', 'RemoteApp',
-                                             'FixtureDataType')):
+                res['value']['doc_type'] == 'FixtureDataType'):
                 continue
             if not self.is_snapshot and res['value']['doc_type'] in ('Application', 'RemoteApp'):
                 app = get_app(self.name, res['value']['_id']).get_latest_saved()


### PR DESCRIPTION
P2 bugfix
http://manage.dimagi.com/default.asp?151558
Reverts behavior introduced [here](https://github.com/dimagi/commcare-hq/commit/b03a251?w=1) which was causing projects to appear on the exchange without apps.  This only happened sometimes - it appeared to be only when the apps in question were having the latest starred build published.
@emord FYI

This was a bit tricky to track down, and I found a couple [red herrings](https://github.com/dimagi/commcare-hq/pull/5160) on the trail.  I think the intent of the original change is good, but not sure how best to implement it, so I figure this revert should be a simple-enough fix.
