### PR TITLE
Create fallback for missing `deployment` on domain

### DIFF
--- a/corehq/pillows/domain.py
+++ b/corehq/pillows/domain.py
@@ -54,6 +54,7 @@ class DomainPillow(HQPillow):
         sub =  Subscription.objects.filter(
                 subscriber__domain=doc_dict['name'],
                 is_active=True)
+        doc_dict['deployment'] = doc_dict.get('deployment', None) or {}
         countries = doc_dict['deployment'].get('countries', [])
         doc_ret['deployment']['countries'] = []
         if sub:


### PR DESCRIPTION
Came across this when debugging something else.  It appears some domain docs
don't have a `deployment` field - snapshots, I think.  This should prevent
pillow errors like this: 
https://www.commcarehq.org/hq/pillow_errors/edit_errors/?error=53475
