### PR TITLE
improve performance of invoice report page when no filters are specified

### DIFF
--- a/corehq/apps/accounting/interface.py
+++ b/corehq/apps/accounting/interface.py
@@ -658,9 +658,10 @@ class InvoiceInterface(GenericTabularReport):
     @property
     def report_context(self):
         context = super(InvoiceInterface, self).report_context
-        context.update(
-            adjust_balance_forms=self.adjust_balance_forms,
-        )
+        if self.request.GET.items():  # A performance improvement
+            context.update(
+                adjust_balance_forms=self.adjust_balance_forms,
+            )
         return context
 
     @property


### PR DESCRIPTION
Shouldn't load adjust balance forms for all invoices if none are currently showing in the report.  Improves loadtime of https://staging.commcarehq.org/hq/accounting/invoices/ from 15s to 2.5s.  When filters are applied, in a typical workflow the number of rows shown are small enough for the adjust balance forms not to cause a performance issue.  If that workflow changes, additional optimizations (have one form and dynamically populate it depending on which row is chosen) might be needed to keep the report usable.

@biyeun 
