### PR TITLE
add loose sync token toggle and test to not fail hard on missing sync logs

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -53,18 +53,17 @@ def process_cases_with_casedb(xform, case_db, config=None):
         for c in cases:
             c.reconcile_actions(rebuild=True)
 
-    # attach domain and export tag if domain is there
-    if hasattr(xform, "domain"):
-        domain = xform.domain
+    # attach domain and export tag
+    domain = xform.domain
 
-        def attach_extras(case):
-            case.domain = domain
-            if domain:
-                assert hasattr(case, 'type')
-                case['#export_tag'] = ["domain", "type"]
-            return case
+    def attach_extras(case):
+        case.domain = domain
+        if domain:
+            assert hasattr(case, 'type')
+            case['#export_tag'] = ["domain", "type"]
+        return case
 
-        cases = [attach_extras(case) for case in cases]
+    cases = [attach_extras(case) for case in cases]
 
     # handle updating the sync records for apps that use sync mode
 

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -1,11 +1,11 @@
 from StringIO import StringIO
 from collections import defaultdict
 import hashlib
-from couchdbkit import ResourceConflict
+from couchdbkit import ResourceConflict, ResourceNotFound
 from casexml.apps.phone.caselogic import BatchedCaseSyncOperation
 from casexml.apps.stock.consumption import compute_consumption_or_default
 from casexml.apps.stock.utils import get_current_ledger_transactions_multi
-from corehq.toggles import BATCHED_RESTORE
+from corehq.toggles import BATCHED_RESTORE, LOOSE_SYNC_TOKEN_VALIDATION
 from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.parsing import json_format_datetime
 from casexml.apps.case.exceptions import BadStateException, RestoreException
@@ -139,7 +139,16 @@ class RestoreConfig(object):
     @memoized
     def sync_log(self):
         if self.restore_id:
-            sync_log = SyncLog.get(self.restore_id)
+            try:
+                sync_log = SyncLog.get(self.restore_id)
+            except ResourceNotFound:
+                # if we are in loose mode, return an HTTP 412 so that the phone will
+                # just force a fresh sync
+                if LOOSE_SYNC_TOKEN_VALIDATION.enabled(self.domain):
+                    raise HttpException(412)
+                else:
+                    raise
+
             if sync_log.user_id == self.user.user_id \
                     and sync_log.doc_type == 'SyncLog':
                 return sync_log

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -262,3 +262,9 @@ COMMCARE_LOGO_UPLOADER = StaticToggle(
     'commcare_logo_uploader',
     'CommCare logo uploader',
 )
+
+LOOSE_SYNC_TOKEN_VALIDATION = StaticToggle(
+    'loose_sync_token_validation',
+    "Don't fail hard on missing or deleted sync tokens.",
+    [NAMESPACE_DOMAIN]
+)


### PR DESCRIPTION
necessary to enable submissions in scenarios where a sync log was deleted or is no longer in the database
