### PR TITLE
Only publish specified apps to the exchange.

### DIFF
--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -675,7 +675,8 @@ class Domain(Document, SnapshotMixin):
 
         for res in db.view('domain/related_to_domain', key=[self.name, True]):
             if (copy_by_id and res['value']['_id'] not in copy_by_id and
-                res['value']['doc_type'] == 'FixtureDataType'):
+                res['value']['doc_type'] in ('Application', 'RemoteApp',
+                                             'FixtureDataType')):
                 continue
             if not self.is_snapshot and res['value']['doc_type'] in ('Application', 'RemoteApp'):
                 app = get_app(self.name, res['value']['_id']).get_latest_saved()

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1625,10 +1625,16 @@ class CreateNewExchangeSnapshotView(BaseAdminProjectSettingsView):
             if not request.POST.get('share_reminders', False):
                 ignore.append('CaseReminderHandler')
 
+            latest_apps = [app.get_latest_saved() or app for app in self.domain_object.applications()]
+            latest_apps = {app.id: app for app in latest_apps}
             copy_by_id = set()
             for k in request.POST.keys():
                 if k.endswith("-publish"):
-                    copy_by_id.add(k[:-len("-publish")])
+                    doc_id = k[:-len("-publish")]
+                    if doc_id in latest_apps:
+                        doc_id = latest_apps[doc_id].get("copy_of", doc_id)
+                    copy_by_id.add(doc_id)
+
 
             old = self.domain_object.published_snapshot()
             new_domain = self.domain_object.save_snapshot(ignore=ignore,

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1632,7 +1632,7 @@ class CreateNewExchangeSnapshotView(BaseAdminProjectSettingsView):
                 if k.endswith("-publish"):
                     doc_id = k[:-len("-publish")]
                     if doc_id in latest_apps:
-                        doc_id = latest_apps[doc_id].get("copy_of", doc_id)
+                        doc_id = latest_apps[doc_id].copy_of or doc_id
                     copy_by_id.add(doc_id)
 
 


### PR DESCRIPTION
[Ticket](http://manage.dimagi.com/default.asp?151638)
There was a bug where all apps in a domain would be published to the exchange, even when their "publish" checkbox was unchecked. This bug was introduced by a fix (https://github.com/dimagi/commcare-hq/pull/5159) for a related bug that was causing no apps to be published. This original bug was introduced in #4640.

The root cause of both of these issues was this:
The app docs that were being published were being filtered by a list of doc ids (that happens [here](https://github.com/dimagi/commcare-hq/blob/31ee4beb59bcca875393f0c2ff03a5e667a81cf5/corehq/apps/domain/models.py#L677-L680)). This list of app docs was coming from the `domain/related_to_domain` couch view, and only contained the original versions of each app, not copies. However, the list of doc ids (called `copy_by_id`) contained the doc ids of the latest saved copies of the original apps, not the original app documents themselves (that happens [here](https://github.com/dimagi/commcare-hq/blob/31ee4beb59bcca875393f0c2ff03a5e667a81cf5/corehq/apps/domain/views.py#L1512), among other places).

This resulted in the apps specified by the user (that is, the latest saved versions) never matching the apps retrieved by the view (the "original" docs). This is what caused the original bug where no apps were being copied. The attempted fix ignored the filtering altogether, which resulted in all the apps being published.

It's possible that a cleaner fix to this problem would be to just use the original apps instead of their latest saved versions in the first place, but I haven't couldn't quite figured out why it was implemented this way in the first place.

FYI @emord @esoergel 
