### PR TITLE
Fix encoding issue on app exchange search page 

### DIFF
--- a/corehq/apps/app_manager/templatetags/url_extras.py
+++ b/corehq/apps/app_manager/templatetags/url_extras.py
@@ -45,7 +45,8 @@ class URLEncodeNode(template.Node):
         path = self.path_var.resolve(context)
         params = {}
         for key, val in self.params_var.resolve(context).lists():
-            params[key] = [v.encode('utf-8') for v in val]
+            params[key] = [v.encode('utf-8') if isinstance(v, unicode) else v
+                           for v in val]
 
         for key,val in self.extra_params.items():
             key = template.Variable(key).resolve(context)

--- a/corehq/apps/app_manager/templatetags/url_extras.py
+++ b/corehq/apps/app_manager/templatetags/url_extras.py
@@ -44,8 +44,8 @@ class URLEncodeNode(template.Node):
     def render(self, context):
         path = self.path_var.resolve(context)
         params = {}
-        for key,val in self.params_var.resolve(context).lists():
-            params[key] = val
+        for key, val in self.params_var.resolve(context).lists():
+            params[key] = [v.encode('utf-8') for v in val]
 
         for key,val in self.extra_params.items():
             key = template.Variable(key).resolve(context)


### PR DESCRIPTION
`urllib.urlencode` doesn't like unicode. [Ticket](http://manage.dimagi.com/default.asp?151779).
