### PR TITLE
Fix bug in bulk app translation with mismatched form/app languages

### DIFF
--- a/corehq/apps/app_manager/translations.py
+++ b/corehq/apps/app_manager/translations.py
@@ -314,7 +314,7 @@ def update_form_translations(sheet, rows, missing_cols, app):
             new_trans_el.set('lang', lang)
             if lang != app.langs[0]:
                 # If the language isn't the default language
-                new_trans_el.attrib.pop('default')
+                new_trans_el.attrib.pop('default', None)
             else:
                 new_trans_el.set('default', '')
             itext.xml.append(new_trans_el)


### PR DESCRIPTION
There was a bug that manifested itself when the `<translation>` elements of a form had different `lang` attributes than the app, and when the `<translation>` element indicated as the default was not the first `<translation>` element. If these conditions existed, then bulk app translation threw a 500. Fixed by removing an implicit assumption about which `<translation>` in the form is indicated as the default.

[Ticket](http://manage.dimagi.com/default.asp?151635)
