### PR TITLE
[Feature Flagged] Experiment with App Logo Uploader

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/app_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/app_view.html
@@ -339,3 +339,9 @@
         </div>
     </div>
 {% endblock %}
+
+{% block modals %}{{ block.super }}
+{% for uploader in uploaders %}
+{% include 'hqmedia/partials/multimedia_uploader.html' %}
+{% endfor %}
+{% endblock %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/app-settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/app-settings.html
@@ -49,11 +49,6 @@
             mediaUploadComplete: uploadComplete
         }
     ">{% trans "Upload" %}</a>
-    {% for uploader in uploaders %}
-        <div data-bind="if: is_uploader('{{ uploader.slug }}')">
-            {% include 'hqmedia/partials/multimedia_uploader.html' %}
-        </div>
-    {% endfor %}
 </script>
 
 {% include 'hqmedia/partials/multimedia_js.html' %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/app-settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/app-settings.html
@@ -39,7 +39,9 @@
 </script>
 
 <script type="text/html" id="CommcareSettings.widgets.image_uploader">
-    <a data-toggle="modal" data-bind="
+    <a data-toggle="modal"
+       class="btn btn-default"
+       data-bind="
         attr: {
             'data-hqmediapath': path,
             href: href
@@ -48,7 +50,7 @@
         event: {
             mediaUploadComplete: uploadComplete
         }
-    ">{% trans "Upload" %}</a>
+    "><i class="icon-plus"></i> {% trans "Add Logo" %}</a>
 </script>
 
 {% include 'hqmedia/partials/multimedia_js.html' %}


### PR DESCRIPTION
So the https setup on production likes to wreak havoc on YUI's uploader if not configured in a very specific manner. Unfortunately, solutions are difficult to test unless you actually test on prod.

What I did here was move the YUI Uploader Select File button (which later turns into the select file SWF) out of the template and into the modals section so that it is rendered on the initial DOM processing of the file. I vaguely remember from long, long ago that if you remove the SWF from the DOM and then add it back in, YUI will no longer load the local files and instead try to grab stuff from yahoo's api directly. This works good and fine on a local instance, but as soon as you add https into the mix---watch out!

Anyway, who knows if this will actually solve the issue, but this is my best guess.

@nickpell 
