### PR TITLE
Catch AttributeError

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/cleanup.py
+++ b/corehq/ex-submodules/casexml/apps/case/cleanup.py
@@ -61,10 +61,9 @@ def rebuild_case(case_id):
             delattr(case, k)
         except KeyError:
             pass
-        except AttributeError as e:
+        except AttributeError:
             logging.error(
-                'AttributeError: %(error)s, case_id: %(case_id)s, attribute: %(attribute)s' % {
-                    'error': e.message,
+                "Cannot delete attribute '%(attribute)s' from case '%(case_id)s'" % {
                     'case_id': case_id,
                     'attribute': k,
                 }

--- a/corehq/ex-submodules/casexml/apps/case/cleanup.py
+++ b/corehq/ex-submodules/casexml/apps/case/cleanup.py
@@ -69,7 +69,6 @@ def rebuild_case(case_id):
                     'attribute': k,
                 }
             )
-            raise e
 
     # already deleted means it was explicitly set to "deleted",
     # as opposed to getting set to that because it has no actions


### PR DESCRIPTION
the observed `AttributeError`s are from trying to delete a case property that matches the name of a property function defined in the class (http://logs.internal.dimagi.com:9000/commcare-hq-dev-team/hq-production/group/141762/)

Since overwriting a property function is not persistent, seems reasonable to just swallow the error.  However, it does bring up the question as to whether there should be reserved case property keywords that users cannot assign to.
