### PR TITLE
do not view project on exchange that is unpublished

### DIFF
--- a/corehq/apps/appstore/views.py
+++ b/corehq/apps/appstore/views.py
@@ -56,7 +56,7 @@ def inverse_dict(d):
 
 
 def can_view_app(req, dom):
-    if not dom or not dom.is_snapshot:
+    if not dom or not dom.is_snapshot or not dom.published:
         return False
     if not dom.is_approved and (
         not getattr(req, "couch_user", "") or not req.couch_user.is_domain_admin(dom.copied_from.name)


### PR DESCRIPTION
fixes http://manage.dimagi.com/default.asp?151657#847010 - 404s instead of showing project info for project space that has been unpublished
