### PR TITLE
Have linter ignore migration files

### DIFF
--- a/.lintrc
+++ b/.lintrc
@@ -1,7 +1,7 @@
 # See https://github.com/markstory/lint-review
 [files]
 ignore = */migrations/*
-ignore = *.min.js
+         *.min.js
 
 [tools]
 linters = flake8, jshint


### PR DESCRIPTION
I think this hasn't been working correctly because the `[files]` `ignore` is multiply defined.  Hopefully this should fix it  (the [docs](https://github.com/markstory/lint-review#lintrc-files) suggest that multiple patterns should be newline separated)
