### PR TITLE
Fix case list/detail property validation

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -331,6 +331,13 @@ var DetailScreenConfig = (function () {
                 {label: "Case", value: "case"}
             ]).val(this.original.model);
             this.field = uiElement.input().val(this.original.field).setIcon(icon);
+
+            // Make it possible to observe changes to this.field :
+            this.field.observableVal = ko.observable("");
+            this.field.on("change", function(){
+                that.field.observableVal(that.field.val());
+            });
+
             this.format_warning = DetailScreenConfig.field_format_warning.clone().hide();
 
             (function () {

--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -332,13 +332,19 @@ var DetailScreenConfig = (function () {
             ]).val(this.original.model);
             this.field = uiElement.input().val(this.original.field).setIcon(icon);
 
-            // Make it possible to observe changes to this.field :
+            // Make it possible to observe changes to this.field
+            // note that observableVal is read only!
+            // Writing to it will not update the value of the this.field text input
             this.field.observableVal = ko.observable(this.field.val());
             this.field.on("change", function(){
                 that.field.observableVal(that.field.val());
             });
 
             this.format_warning = DetailScreenConfig.field_format_warning.clone().hide();
+            this.showWarning = ko.computed(function() {
+                // True if an invalid property name warning should be displayed.
+                return this.field.observableVal() && !DetailScreenConfig.field_val_re.test(this.field.observableVal());
+            }, this);
 
             (function () {
                 var i, lang, visibleVal = "", invisibleVal = "";

--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -333,7 +333,7 @@ var DetailScreenConfig = (function () {
             this.field = uiElement.input().val(this.original.field).setIcon(icon);
 
             // Make it possible to observe changes to this.field :
-            this.field.observableVal = ko.observable("");
+            this.field.observableVal = ko.observable(this.field.val());
             this.field.on("change", function(){
                 that.field.observableVal(that.field.val());
             });

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list_properties.html
@@ -18,11 +18,13 @@
                 <td class="detail-screen-icon" data-bind="jqueryElement: $grip, visible: $root.edit"></td>
                 <!--ko if: !isTab -->
                     <td class="detail-screen-field control-group"
-                        data-bind="css: {error: field.value && !DetailScreenConfig.field_val_re.test(field.value)}">
+                        data-bind="css: {
+                            error: field.observableVal() && !DetailScreenConfig.field_val_re.test(field.observableVal())
+                        }">
                         <div data-bind="html: CC_DETAIL_SCREEN.getFieldHtml(field.val()), visible: !field.edit"></div>
                         <div data-bind="jqueryElement: field.ui, visible: field.edit"></div>
                         <div data-bind="jqueryElement: format_warning,
-                                        visible: field.value && !DetailScreenConfig.field_val_re.test(field.value)"></div>
+                                        visible: field.observableVal && !DetailScreenConfig.field_val_re.test(field.observableVal)"></div>
                     </td>
                     <td class="detail-screen-header" data-bind="jqueryElement: header.ui"></td>
                     <td class="detail-screen-format" data-bind="jqueryElement: $format"></td>

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list_properties.html
@@ -18,13 +18,10 @@
                 <td class="detail-screen-icon" data-bind="jqueryElement: $grip, visible: $root.edit"></td>
                 <!--ko if: !isTab -->
                     <td class="detail-screen-field control-group"
-                        data-bind="css: {
-                            error: field.observableVal() && !DetailScreenConfig.field_val_re.test(field.observableVal())
-                        }">
+                        data-bind="css: {error: showWarning}">
                         <div data-bind="html: CC_DETAIL_SCREEN.getFieldHtml(field.val()), visible: !field.edit"></div>
                         <div data-bind="jqueryElement: field.ui, visible: field.edit"></div>
-                        <div data-bind="jqueryElement: format_warning,
-                                        visible: field.observableVal && !DetailScreenConfig.field_val_re.test(field.observableVal)"></div>
+                        <div data-bind="jqueryElement: format_warning, visible: showWarning"></div>
                     </td>
                     <td class="detail-screen-header" data-bind="jqueryElement: header.ui"></td>
                     <td class="detail-screen-format" data-bind="jqueryElement: $format"></td>


### PR DESCRIPTION
Some bindings were being bound to objects that were not knockout observables. As a result, these bindings weren't being updated. This PR creates an observable on the `Column.field` object that mirrors the objects non-observable value.
Bug was introduced in #4951.
[Ticket](http://manage.dimagi.com/default.asp?152283).
@dannyroberts Let me know if you think of or know a better way to interface between the jQuery.ui object and knockout.
