### PR TITLE
improve performance of 'Active Mobile Users (last 30 days)'

### DIFF
--- a/corehq/apps/hqadmin/reporting/reports.py
+++ b/corehq/apps/hqadmin/reporting/reports.py
@@ -278,6 +278,13 @@ def get_active_users_data(domains, datespan, interval, datefield='date',
     30 days before each timestamp
     """
     histo_data = []
+    mobile_users = set(
+        UserES()
+        .show_inactive()
+        .mobile_users()
+        .domain(domains)
+        .run().doc_ids
+    )
     for timestamp in daterange(interval, datespan.startdate, datespan.enddate):
         t = timestamp
         f = timestamp - relativedelta(days=30)
@@ -294,13 +301,7 @@ def get_active_users_data(domains, datespan, interval, datefield='date',
                 .size(0)
                 .run()
                 .facets.user.result
-                if u['term'] in (
-                    UserES()
-                    .show_inactive()
-                    .mobile_users()
-                    .domain(domains)
-                    .run().doc_ids
-                )
+                if u['term'] in mobile_users
             }
         c = len(users)
         if c > 0:


### PR DESCRIPTION
Improves performance of this report by:
- Running the query for all mobile workers once, instead of in the `for` loop.
- Perform the lookup into a `set` (O(1)) instead of a `list` (O(n)).

@emord 
