### PR TITLE
Fix bug retrieving all xpaths from a tabbed case detail

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/graph-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/graph-config.js
@@ -443,7 +443,7 @@ var GraphSeries = function (original, childCaseTypes, fixtures){
         } else if (source.type == 'case') {
             return "instance('casedb')/casedb/case[@case_type='"+source.name+"'][index/parent=current()/@case_id][@status='open']";
         } else if (source.type == 'fixture') {
-            return "instance('" + self.getFixtureInstanceId(source.name) + "')/tablename_list/" + source.name;
+            return "instance('" + self.getFixtureInstanceId(source.name) + "')/" + source.name + "_list/" + source.name;
         }
     };
 

--- a/corehq/apps/app_manager/suite_xml.py
+++ b/corehq/apps/app_manager/suite_xml.py
@@ -442,6 +442,17 @@ class Detail(IdNode):
     details = NodeListField('detail', "self")
     _variables = NodeField('variables', DetailVariableList)
 
+    def get_all_fields(self):
+        '''
+        Return all fields under this Detail instance and all fields under
+        any details that may be under this instance.
+        :return:
+        '''
+        all_fields = []
+        for detail in [self] + list(self.details):
+            all_fields.extend(list(detail.fields))
+        return all_fields
+
     def _init_variables(self):
         if self._variables is None:
             self._variables = DetailVariableList()
@@ -461,7 +472,7 @@ class Detail(IdNode):
         if self._variables:
             for variable in self.variables:
                 result.add(variable.function)
-        for field in self.fields:
+        for field in self.get_all_fields():
             try:
                 result.add(field.header.text.xpath_function)
                 result.add(field.template.text.xpath_function)

--- a/corehq/apps/app_manager/tests/data/suite/app_fixture_graphing.json
+++ b/corehq/apps/app_manager/tests/data/suite/app_fixture_graphing.json
@@ -498,7 +498,7 @@
                            {
                               "doc_type":"GraphSeries",
                               "y_function":"bar",
-                              "data_path":"instance('item-list:table1')/tablename_list/table1",
+                              "data_path":"instance('item-list:table1')/table1_list/table1",
                               "radius_function":null,
                               "x_function":"foo",
                               "config":{

--- a/corehq/apps/app_manager/tests/data/suite/suite-fixture-graphing.xml
+++ b/corehq/apps/app_manager/tests/data/suite/suite-fixture-graphing.xml
@@ -74,7 +74,7 @@
       </header>
       <template form="graph">
         <graph type="xy">
-          <series nodeset="instance('item-list:table1')/tablename_list/table1">
+          <series nodeset="instance('item-list:table1')/table1_list/table1">
             <configuration/>
             <x function="foo"/>
             <y function="bar"/>


### PR DESCRIPTION
There was a bug where the [`get_all_xpaths()`](https://github.com/dimagi/commcare-hq/compare/fixtures-in-graphs?expand=1#diff-27910c0ed3e4d6d075211ffc4db6cab4L459) method didn't return xpaths in fields that were under tabs. This bug was causing an issue with graph configuration. 
This PR also fixes a graph xpath issue.
