### PR TITLE
Add Google Analytics event tracking for Group page

### DIFF
--- a/corehq/apps/groups/templates/groups/all_groups.html
+++ b/corehq/apps/groups/templates/groups/all_groups.html
@@ -16,7 +16,19 @@
             content: "Case sharing groups allow their members to share a case list in a case-sharing app. You can change this " +
                     "by editing this group's settings."
         });
-    })
+
+        var $createGroupForm = $("#create_group_form");
+        $("button:submit", $createGroupForm).click(function(){
+            ga_track_event("Groups", "Create Group", {
+               'hitCallback': function () {
+                   $createGroupForm.submit();
+               }
+            });
+            return false;
+        });
+    });
+
+
 </script>
 {% endblock %}
 
@@ -53,7 +65,7 @@
         </div>
         {% endif %}
     </div>
-    <form class="well form-inline" method="post" action="{% url "add_group" domain %}">
+    <form class="well form-inline" method="post" action="{% url "add_group" domain %}" id="create_group_form">
         <input type="text" placeholder="{% trans "Group Name" %}" id="id_group_name" name="group_name" />
         <button class="btn btn-success" type="submit">{% trans "Create Group" %}</button>
     </form>

--- a/corehq/apps/groups/templates/groups/group_members.html
+++ b/corehq/apps/groups/templates/groups/group_members.html
@@ -47,6 +47,17 @@
                 unsavedChanges["Group data"] = true;
             });
 
+            // Delete group event
+            var $deleteGroupModalForm = $("#delete_group_modal form");
+            $("button:submit", $deleteGroupModalForm).click(function(){
+                ga_track_event("Editing Group", "Deleted Group", "{{group.get_id|escapejs}}", {
+                    'hitCallback': function() {
+                        $deleteGroupModalForm.submit();
+                    }
+                });
+                return false;
+            });
+
             $(window).bind('beforeunload', function () {
                 var someUnsavedChanges = false;
                 var ret = "{% trans "The following changes will not be saved: " %}";

--- a/corehq/apps/groups/templates/groups/group_members.html
+++ b/corehq/apps/groups/templates/groups/group_members.html
@@ -76,20 +76,23 @@
                 return;
             });
 
-            function success(name, id) {
+            function success(name, id, gaEventLabel) {
                 return function() {
                     unsavedChanges[name] = false;
                     $('.alert').removeClass('alert-error alert-info').addClass('alert-success');
                     $('.alert')[0].innerHTML = name + " was successfully saved";
                     $('.alert').show();
                     $(id).find(':button').enableButton();
-                    $('#editGroupSettings').modal('hide')
+                    $('#editGroupSettings').modal('hide');
+                    if (gaEventLabel){
+                        ga_track_event("Editing Group", gaEventLabel, "{{group.get_id|escapejs}}");
+                    }
                 }
             }
 
-            var edit_membership_succ = success("Group membership", "#edit_membership");
-            var edit_settings_succ = success("Group settings", "#edit-group-settings");
-            var edit_data_succ = success("Group data", "#group-data-form");
+            var edit_membership_succ = success("Group membership", "#edit_membership", "Edit Group Membership");
+            var edit_settings_succ = success("Group settings", "#edit-group-settings", "Edit Settings");
+            var edit_data_succ = success("Group data", "#group-data-form", "Edit Group Data");
 
             function failure(name, id) {
                 return function() {
@@ -128,7 +131,7 @@
                     } else {
                         $('#group-case-sharing-warning').attr('hidden', 'hidden')
                     }
-                })
+                });
                 $('#group-data-form').submit(function() {
                     $(this).find(':button').attr('disabled', 'disabled');
                     $(this).ajaxSubmit({


### PR DESCRIPTION
Track the following events:
- Clicking on "Create Group" 
- Clicking on "X Delete Group <group name>"
- Clicking on "Update"
- Clicking on "Edit Group Data"
- Clicking on "<Pencil> Edit Settings"
