### PR TITLE
support for named filters in expressions

### DIFF
--- a/corehq/apps/userreports/filters/factory.py
+++ b/corehq/apps/userreports/filters/factory.py
@@ -49,7 +49,7 @@ def _build_property_match_filter(spec, context):
 def _build_boolean_expression_filter(spec, context):
     wrapped = BooleanExpressionFilterSpec.wrap(spec)
     return SinglePropertyValueFilter(
-        expression=ExpressionFactory.from_spec(wrapped.expression),
+        expression=ExpressionFactory.from_spec(wrapped.expression, context),
         operator=get_operator(wrapped.operator),
         reference_value=wrapped.property_value,
     )

--- a/corehq/apps/userreports/indicators/factory.py
+++ b/corehq/apps/userreports/indicators/factory.py
@@ -44,7 +44,7 @@ def _build_expression_indicator(spec, context):
     return RawIndicator(
         wrapped.display_name,
         column,
-        getter=wrapped.parsed_expression,
+        getter=wrapped.parsed_expression(context),
     )
 
 

--- a/corehq/apps/userreports/indicators/specs.py
+++ b/corehq/apps/userreports/indicators/specs.py
@@ -74,10 +74,9 @@ class ExpressionIndicatorSpec(IndicatorSpecBase):
     is_primary_key = BooleanProperty(default=False)
     expression = DictProperty(required=True)
 
-    @property
-    def parsed_expression(self):
+    def parsed_expression(self, context):
         transform = _transform_from_datatype(self.datatype)
-        expression = ExpressionFactory.from_spec(self.expression)
+        expression = ExpressionFactory.from_spec(self.expression, context)
         return TransformedGetter(expression, transform)
 
 

--- a/corehq/apps/userreports/tests/test_indicator_config.py
+++ b/corehq/apps/userreports/tests/test_indicator_config.py
@@ -143,6 +143,11 @@ class IndicatorNamedFilterTest(SimpleTestCase):
                     'type': 'property_match',
                     'property_name': 'mother_state',
                     'property_value': 'pregnant',
+                },
+                'evil': {
+                    'type': 'property_match',
+                    'property_name': 'evil',
+                    'property_value': 'yes',
                 }
             },
             'configured_filter': {
@@ -158,7 +163,37 @@ class IndicatorNamedFilterTest(SimpleTestCase):
                         'name': 'pregnant',
                     }
                 ]
-            }
+            },
+            'configured_indicators': [
+                {
+                    "type": "boolean",
+                    "column_id": "is_evil",
+                    "filter": {
+                        "type": "named",
+                        "name": "evil"
+                    }
+                },
+                {
+                    "type": "expression",
+                    "column_id": "laugh_sound",
+                    "datatype": "string",
+                    "expression": {
+                        'type': 'conditional',
+                        'test': {
+                            "type": "named",
+                            "name": "evil"
+                        },
+                        'expression_if_true': {
+                            'type': 'constant',
+                            'constant': 'mwa-ha-ha',
+                        },
+                        'expression_if_false': {
+                            'type': 'constant',
+                            'constant': 'hehe',
+                        },
+                    }
+                }
+            ]
         })
 
     def test_match(self):
@@ -176,3 +211,43 @@ class IndicatorNamedFilterTest(SimpleTestCase):
             'type': 'ttc_mother',
             'mother_state': 'not pregnant'
         }))
+
+    def test_simple_indicator_match(self):
+        values = self.indicator_configuration.indicators.get_values({
+            'doc_type': 'CommCareCase',
+            'domain': 'test',
+            'type': 'ttc_mother',
+            'mother_state': 'pregnant',
+            'evil': 'yes'
+        })
+        self.assertEqual(1, values[1].value)
+
+    def test_simple_indicator_nomatch(self):
+        values = self.indicator_configuration.indicators.get_values({
+            'doc_type': 'CommCareCase',
+            'domain': 'test',
+            'type': 'ttc_mother',
+            'mother_state': 'pregnant',
+            'evil': 'no'
+        })
+        self.assertEqual(0, values[1].value)
+
+    def test_expression_match(self):
+        values = self.indicator_configuration.indicators.get_values({
+            'doc_type': 'CommCareCase',
+            'domain': 'test',
+            'type': 'ttc_mother',
+            'mother_state': 'pregnant',
+            'evil': 'yes'
+        })
+        self.assertEqual('mwa-ha-ha', values[2].value)
+
+    def test_expression_nomatch(self):
+        values = self.indicator_configuration.indicators.get_values({
+            'doc_type': 'CommCareCase',
+            'domain': 'test',
+            'type': 'ttc_mother',
+            'mother_state': 'pregnant',
+            'evil': 'no'
+        })
+        self.assertEqual('hehe', values[2].value)


### PR DESCRIPTION
addresses http://manage.dimagi.com/default.asp?152731

just passes the context all the way through the chain to make sure nested filters have access to it
