### PR TITLE
Mock model when testing get_document_or_404

### DIFF
--- a/corehq/util/tests/test_couch.py
+++ b/corehq/util/tests/test_couch.py
@@ -1,7 +1,12 @@
+from contextlib import contextmanager
+from couchdbkit import ResourceNotFound
+from django.http import Http404
 from django.test import TestCase
 from corehq.util.couch import get_document_or_404
 from corehq.apps.users.models import WebUser
 from corehq.apps.users.models import CommCareUser
+from jsonobject.exceptions import WrappingAttributeError
+from mock import Mock
 
 
 class GetDocTestCase(TestCase):
@@ -20,3 +25,76 @@ class GetDocTestCase(TestCase):
 
     def test_get_commcare_user(self):
         get_document_or_404(CommCareUser, 'test', self.commcare_user._id)
+
+
+class MockDb(object):
+    def get(self, doc_id):
+        return {'_id': doc_id, 'domain': 'ham', 'doc_type': 'MockModel'}
+
+
+class MockModel(object):
+    @staticmethod
+    def get_db():
+        return MockDb()
+
+    @staticmethod
+    def wrap(model):
+        return {'wrapped': model}
+
+
+@contextmanager
+def mock_get_context():
+    func = MockDb.get
+    MockDb.get = Mock(side_effect=ResourceNotFound)
+    try:
+        yield
+    finally:
+        MockDb.get = func
+
+
+@contextmanager
+def mock_wrap_context():
+    func = MockModel.wrap
+    MockModel.wrap = Mock(side_effect=WrappingAttributeError)
+    try:
+        yield
+    finally:
+        MockModel.wrap = func
+
+
+class GetDocMockTestCase(TestCase):
+    """
+    Tests get_document_or_404 with mocking
+    """
+
+    def test_get_document_or_404_not_found(self):
+        """
+        get_document_or_404 should raise 404 on ResourceNotFound
+        """
+        with mock_get_context():
+            with self.assertRaises(Http404):
+                get_document_or_404(MockModel, 'ham', '123')
+
+    def test_get_document_or_404_bad_domain(self):
+        """
+        get_document_or_404 should raise 404 on incorrect domain
+        """
+        with self.assertRaises(Http404):
+            get_document_or_404(MockModel, 'spam', '123')
+
+    def test_get_document_or_404_wrapping_error(self):
+        """
+        get_document_or_404 should raise 404 on WrappingAttributeError
+        """
+        import ipdb; ipdb.set_trace()
+        with mock_wrap_context():
+            with self.assertRaises(Http404):
+                get_document_or_404(MockModel, 'ham', '123')
+
+    def test_get_document_or_404_success(self):
+        """
+        get_document_or_404 should return a wrapped model on success
+        """
+        import ipdb; ipdb.set_trace()
+        doc = get_document_or_404(MockModel, 'ham', '123')
+        self.assertEqual(doc, {'wrapped': {'_id': '123', 'domain': 'ham', 'doc_type': 'MockModel'}})

--- a/corehq/util/tests/test_couch.py
+++ b/corehq/util/tests/test_couch.py
@@ -66,7 +66,6 @@ class GetDocMockTestCase(TestCase):
         """
         get_document_or_404 should raise 404 on WrappingAttributeError
         """
-        import ipdb; ipdb.set_trace()
         with mock_wrap_context():
             with self.assertRaises(Http404):
                 get_document_or_404(MockModel, 'ham', '123')
@@ -75,6 +74,5 @@ class GetDocMockTestCase(TestCase):
         """
         get_document_or_404 should return a wrapped model on success
         """
-        import ipdb; ipdb.set_trace()
         doc = get_document_or_404(MockModel, 'ham', '123')
         self.assertEqual(doc, {'wrapped': {'_id': '123', 'domain': 'ham', 'doc_type': 'MockModel'}})

--- a/corehq/util/tests/test_couch.py
+++ b/corehq/util/tests/test_couch.py
@@ -3,28 +3,8 @@ from couchdbkit import ResourceNotFound
 from django.http import Http404
 from django.test import TestCase
 from corehq.util.couch import get_document_or_404
-from corehq.apps.users.models import WebUser
-from corehq.apps.users.models import CommCareUser
 from jsonobject.exceptions import WrappingAttributeError
 from mock import Mock
-
-
-class GetDocTestCase(TestCase):
-    def setUp(self):
-        self.web_user = WebUser.create('test', 'test', 'test')
-        self.commcare_user = CommCareUser.create('test',
-                                                 'commcaretest',
-                                                 'test')
-
-    def tearDown(self):
-        self.web_user.delete()
-        self.commcare_user.delete()
-
-    def test_get_web_user(self):
-        get_document_or_404(WebUser, 'test', self.web_user._id)
-
-    def test_get_commcare_user(self):
-        get_document_or_404(CommCareUser, 'test', self.commcare_user._id)
 
 
 class MockDb(object):


### PR DESCRIPTION
Avoids hitting CouchDB, and checks specific functionality of code under test.

(FB 146661, from [Test get document](https://github.com/dimagi/commcare-hq/pull/4763#issuecomment-62683742) PR)
