### PR TITLE
Upping pip timeout to 60 seconds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   # set env variables for couch username/password, used by install.sh, to blank
   - "time (bash -e .travis/quietly-run-install.sh | ts)"
   - "curl -X PUT http://localhost:5984/commcarehq_test"  # this is an auth test
-  - "time (pip install --exists-action w -r requirements/requirements.txt --use-mirrors)"
+  - "time (pip install --exists-action w -r requirements/requirements.txt --use-mirrors --timeout 60)"
   - "time (bash -e .travis/misc-setup.sh | ts)"
   - "cp .travis/localsettings.py localsettings.py"
   - "pip install coverage unittest2 mock --use-mirrors"

--- a/fabfile.py
+++ b/fabfile.py
@@ -893,7 +893,7 @@ def update_virtualenv(preindex=False):
         # but only the ones that are actually installed (checks pip freeze)
         sudo("%s bash scripts/uninstall-requirements.sh" % cmd_prefix,
              user=env.sudo_user)
-        sudo('%s pip install --requirement %s --requirement %s' % (
+        sudo('%s pip install --timeout 60 --requirement %s --requirement %s' % (
             cmd_prefix,
             posixpath.join(requirements, 'prod-requirements.txt'),
             posixpath.join(requirements, 'requirements.txt'),


### PR DESCRIPTION
Refer to: http://manage.dimagi.com/default.asp?152957#851069

@czue I think this will fix the issue we were seeing last night, it worked for me on Jenkins.  Worst case it should just add 45 seconds to builds failing and we can revert it.
