### PR TITLE
show only cases open during month

### DIFF
--- a/custom/opm/reports.py
+++ b/custom/opm/reports.py
@@ -109,7 +109,7 @@ class OpmCaseSqlData(SqlData):
         filters = [
             "domain = :domain",
             "user_id = :user_id",
-            "(opened_on <= :enddate AND (closed_on >= :enddate OR closed_on = '')) OR (opened_on <= :enddate AND (closed_on >= :startdate or closed_on <= :enddate))"
+            DATE_FILTER_EXTENDED_OPENED,
         ]
 
         return filters


### PR DESCRIPTION
@czue
The previous logic was the same as used [here](https://github.com/dimagi/commcare-hq/blob/7289fba2a747a6ba9abddfda252dc98fc8d913d3/custom/opm/reports.py#L55-L65):

``` python
DATE_FILTER_EXTENDED = """(
    opened_on <= :enddate AND (
        closed_on >= :enddate OR
        closed_on = ''
    )
) OR (
    opened_on <= :enddate AND (
        closed_on >= :startdate or closed_on <= :enddate
    )
)
"""
```

(indentation slightly modified for readability).  I'm pretty sure this logic is flawed, it's possible there's a typo, but as-is, it's logically the same as just

```
DATE_FILTER_EXTENDED = "opened_on <= :enddate"
```

as any value for closed_on will match one of those clauses (either `<= enddate`, `>= enddate`, or
`== ""`).

@czue do you know the reasoning behind this?  What is it supposed to do?  It looks like one is copypasted from the other - my guess is you just copied this string out and indented for readability.  This is only used in [one place](https://github.com/dimagi/commcare-hq/blob/7289fba2a747a6ba9abddfda252dc98fc8d913d3/custom/opm/reports.py#L258), and it'd be nice to clarify what that should be doing as well.
