### PR TITLE
Compare language codes

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/supported-languages.js
+++ b/corehq/apps/app_manager/static/app_manager/js/supported-languages.js
@@ -170,9 +170,9 @@ var SupportedLanguages = (function () {
                 self.languages()[i].originalLangcode();
                 if (message || language == self.languages()[i]) {
                     continue;
-                } else if (language === self.languages()[i].langcode()) {
+                } else if (language.langcode() === self.languages()[i].langcode()) {
                     message = "Language appears twice";
-                } else if (language === self.languages()[i].originalLangcode()) {
+                } else if (language.originalLangcode() === self.languages()[i].originalLangcode()) {
                     message = "This conflicts with a current language";
                 }
             }


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?115321#841042

There are two bugs in that ticket. You can save a duplicate language if it is next to the original language and you get a non descriptive error if you have the duplicate language not next to the original.

![selection_001](https://cloud.githubusercontent.com/assets/1471773/5706860/3b3aead6-9a52-11e4-9711-108a8b9cb8cf.png)
