### PR TITLE
Add description to user configurable report headers

### DIFF
--- a/corehq/apps/reports_core/templates/reports_core/base_template_new.html
+++ b/corehq/apps/reports_core/templates/reports_core/base_template_new.html
@@ -81,6 +81,14 @@
             event.preventDefault();
             reportTables.render();
         });
+
+        $(function() {
+            $('.header-popover').popout({
+                trigger: 'hover',
+                placement: 'bottom'
+            });
+        });
+
     });
 
     $(function () {

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -32,6 +32,7 @@ class ReportFilter(JsonObject):
 class ReportColumn(JsonObject):
     type = StringProperty(required=True)
     display = StringProperty()
+    description = StringProperty()
     field = StringProperty(required=True)
     aggregation = StringProperty(
         choices=SQLAGG_COLUMN_MAP.keys(),
@@ -55,7 +56,8 @@ class ReportColumn(JsonObject):
             SQLAGG_COLUMN_MAP[self.aggregation](self.field, alias=self.alias),
             sortable=False,
             data_slug=self.field,
-            format_fn=self.get_format_fn()
+            format_fn=self.get_format_fn(),
+            help_text=self.description
         )
 
 

--- a/corehq/apps/userreports/tests/data/configs/sample_report_config.json
+++ b/corehq/apps/userreports/tests/data/configs/sample_report_config.json
@@ -24,6 +24,7 @@
         {
             "type": "field",
             "display": "Tickets",
+            "description": "Number of tickets",
             "field": "count",
             "aggregation": "sum"
         },


### PR DESCRIPTION
This adds a `"description"` property to report columns and then sets the `DatabaseColumn`s `help_text` properties to the given description.
Also adds the javascript necessary for the hover effect and updates a test slightly.
