### PR TITLE
don't error if no app found

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/backbone/apps.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/backbone/apps.js
@@ -883,7 +883,10 @@ cloudCare.AppMainView = Backbone.View.extend({
 
         // utilities
         var selectApp = function (appId) {
-            self.appListView.getAppView(appId).select();
+            var appView = self.appListView.getAppView(appId);
+            if (appView) {
+                appView.select();
+            }
         };
 
         var selectModule = function (moduleIndex) {


### PR DESCRIPTION
Usually only happens if you follow a link to an app that doesn't exist anymore.
