### PR TITLE
use new urls module

### DIFF
--- a/corehq/apps/adm/urls.py
+++ b/corehq/apps/adm/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 from corehq.apps.adm.dispatcher import ADMAdminInterfaceDispatcher, ADMSectionDispatcher
 from corehq.apps.adm.views import ADMAdminCRUDFormView
 

--- a/corehq/apps/announcements/urls.py
+++ b/corehq/apps/announcements/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 from .dispatcher import HQAnnouncementAdminInterfaceDispatcher
 from .views import AnnouncementAdminCRUDFormView, TemplatedEmailer
 

--- a/corehq/apps/api/urls.py
+++ b/corehq/apps/api/urls.py
@@ -8,7 +8,7 @@ from corehq.apps.commtrack.resources.v0_1 import ProductResource
 from corehq.apps.fixtures.resources.v0_1 import FixtureResource
 from corehq.apps.locations.resources.v0_1 import LocationResource
 from corehq.apps.reports.resources.v0_1 import ReportResource
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 from django.http import HttpResponseNotFound
 from tastypie.api import Api
 from corehq.apps.api.es import XFormES

--- a/corehq/apps/app_manager/download_urls.py
+++ b/corehq/apps/app_manager/download_urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url, include
+from django.conf.urls import patterns, url, include
 from corehq.apps.hqmedia.urls import download_urls as media_download_urls
 
 urlpatterns = patterns('corehq.apps.app_manager.views',

--- a/corehq/apps/app_manager/urls.py
+++ b/corehq/apps/app_manager/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url, include
+from django.conf.urls import patterns, url, include
 from corehq.apps.app_manager.view_helpers import DynamicTemplateView
 from corehq.apps.app_manager.views import DownloadCCZ, AppSummaryView
 from corehq.apps.hqmedia.urls import application_urls as hqmedia_urls

--- a/corehq/apps/appstore/urls.py
+++ b/corehq/apps/appstore/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import url, include, patterns
+from django.conf.urls import url, include, patterns
 from corehq.apps.appstore.dispatcher import AppstoreDispatcher
 
 store_urls = patterns('corehq.apps.appstore.views',

--- a/corehq/apps/builds/urls.py
+++ b/corehq/apps/builds/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 from .views import EditMenuView
 
 urlpatterns = patterns('corehq.apps.builds.views',

--- a/corehq/apps/cleanup/urls.py
+++ b/corehq/apps/cleanup/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns('corehq.apps.cleanup.views',
 

--- a/corehq/apps/cloudcare/urls.py
+++ b/corehq/apps/cloudcare/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url, include
+from django.conf.urls import patterns, url, include
 from django.views.generic import TemplateView
 from corehq.apps.cloudcare.views import EditCloudcareUserPermissionsView
 

--- a/corehq/apps/commtrack/urls.py
+++ b/corehq/apps/commtrack/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 from corehq.apps.commtrack.views import (
     DefaultConsumptionView, SMSSettingsView, CommTrackSettingsView
 )

--- a/corehq/apps/data_interfaces/urls.py
+++ b/corehq/apps/data_interfaces/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 from corehq.apps.data_interfaces.dispatcher import DataInterfaceDispatcher, EditDataInterfaceDispatcher
 from corehq.apps.data_interfaces.views import CaseGroupListView, CaseGroupCaseManagementView
 

--- a/corehq/apps/domain/urls.py
+++ b/corehq/apps/domain/urls.py
@@ -1,5 +1,5 @@
 import sys
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 from django.contrib.auth.views import password_reset
 from django.shortcuts import render_to_response
 from django.template import RequestContext

--- a/corehq/apps/export/urls.py
+++ b/corehq/apps/export/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 from corehq.apps.export.views import (CreateCustomFormExportView, CreateCustomCaseExportView,
                                       EditCustomFormExportView, EditCustomCaseExportView,
                                       DeleteCustomExportView)

--- a/corehq/apps/facilities/urls.py
+++ b/corehq/apps/facilities/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 settings_urls = patterns('corehq.apps.facilities.views',
     url(r'^$', 'default'),

--- a/corehq/apps/grapevine/urls.py
+++ b/corehq/apps/grapevine/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 from .api import GrapevineResource
 
 gvi_resource = GrapevineResource()

--- a/corehq/apps/groups/urls.py
+++ b/corehq/apps/groups/urls.py
@@ -1,5 +1,4 @@
-#from django.conf.urls.defaults import patterns, url
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns('corehq.apps.groups.views',
     url(r'^add_group/$',

--- a/corehq/apps/hqadmin/urls.py
+++ b/corehq/apps/hqadmin/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 from corehq.apps.hqadmin.views import PrimeRestoreCache
 from corehq.apps.reports.dispatcher import AdminReportDispatcher
 from .views import FlagBrokenBuilds

--- a/corehq/apps/hqcase/urls.py
+++ b/corehq/apps/hqcase/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns('corehq.apps.hqcase.views',
     # stub urls

--- a/corehq/apps/hqcouchlog/urls.py
+++ b/corehq/apps/hqcouchlog/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns('corehq.apps.hqcouchlog.views',
     (r'^fail/$', 'fail'),

--- a/corehq/apps/hqmedia/urls.py
+++ b/corehq/apps/hqmedia/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 from corehq.apps.hqmedia.views import (
     DownloadMultimediaZip,
     BulkUploadMultimediaView,

--- a/corehq/apps/hqwebapp/urls.py
+++ b/corehq/apps/hqwebapp/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns('corehq.apps.hqwebapp.views',
     url(r'^homepage/$', 'redirect_to_default', name='homepage'),

--- a/corehq/apps/importer/urls.py
+++ b/corehq/apps/importer/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns('corehq.apps.importer.views',
     url(r'^excel/config/$', 'excel_config', name='excel_config'),

--- a/corehq/apps/indicators/urls.py
+++ b/corehq/apps/indicators/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 from corehq import IndicatorAdminInterfaceDispatcher
 from corehq.apps.indicators.views import (
     IndicatorAdminCRUDFormView,

--- a/corehq/apps/ivr/urls.py
+++ b/corehq/apps/ivr/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns("corehq.apps.ivr.views",
 )

--- a/corehq/apps/kookoo/urls.py
+++ b/corehq/apps/kookoo/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns('corehq.apps.kookoo.views',
     url(r'^ivr/?$', 'ivr', name='ivr'),

--- a/corehq/apps/locations/urls.py
+++ b/corehq/apps/locations/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 from .views import (
     LocationsListView,

--- a/corehq/apps/megamobile/urls.py
+++ b/corehq/apps/megamobile/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns('corehq.apps.megamobile.views',
     url(r'^sms/?$', 'sms_in', name='sms_in'),

--- a/corehq/apps/mobile_auth/urls.py
+++ b/corehq/apps/mobile_auth/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import url, patterns
+from django.conf.urls import url, patterns
 
 urlpatterns = patterns('corehq.apps.mobile_auth.views',
     url('^keys/$', 'fetch_key_records', name='key_server_url'),

--- a/corehq/apps/orgs/urls.py
+++ b/corehq/apps/orgs/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns('corehq.apps.orgs.views',
     url(r'^(?P<org>[\w\.-]+)/$', 'orgs_landing', name='orgs_landing'),

--- a/corehq/apps/products/urls.py
+++ b/corehq/apps/products/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import url, patterns
+from django.conf.urls import url, patterns
 from corehq.apps.products.views import (
     ProductListView, FetchProductListView, NewProductView, EditProductView,
     UploadProductView, ProductImportStatusView, ProductFieldsView

--- a/corehq/apps/programs/urls.py
+++ b/corehq/apps/programs/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 from corehq.apps.programs.views import (
     ProgramListView, FetchProgramListView, NewProgramView, EditProgramView,
     FetchProductForProgramListView

--- a/corehq/apps/receiverwrapper/urls.py
+++ b/corehq/apps/receiverwrapper/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns('corehq.apps.receiverwrapper.views',
     url(r'^/?$', 'post', name='receiver_post'),

--- a/corehq/apps/registration/urls.py
+++ b/corehq/apps/registration/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns('corehq.apps.registration.views',
     url(r'^$', 'registration_default', name='registration_default'),

--- a/corehq/apps/reminders/urls.py
+++ b/corehq/apps/reminders/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 from corehq.apps.reminders.models import REMINDER_TYPE_ONE_TIME
 from corehq.apps.reminders.views import (
     CreateScheduledReminderView,

--- a/corehq/apps/reports/dispatcher.py
+++ b/corehq/apps/reports/dispatcher.py
@@ -198,7 +198,7 @@ class ReportDispatcher(View):
 
     @classmethod
     def url_pattern(cls):
-        from django.conf.urls.defaults import url
+        from django.conf.urls import url
         return url(cls.pattern(), cls.as_view(), name=cls.name())
 
 cls_to_view_login_and_domain = cls_to_view(additional_decorator=login_and_domain_required)

--- a/corehq/apps/reports/filters/urls.py
+++ b/corehq/apps/reports/filters/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 from . import api
 

--- a/corehq/apps/reports/urls.py
+++ b/corehq/apps/reports/urls.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 from django.core.exceptions import ImproperlyConfigured
 from corehq.apps.reports.util import get_installed_custom_modules
 from corehq.apps.reports.dispatcher import (ProjectReportDispatcher, 

--- a/corehq/apps/settings/urls.py
+++ b/corehq/apps/settings/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 from corehq.apps.domain.urls import domain_settings
 from corehq.apps.cloudcare.urls import settings_urls as cloudcare_settings

--- a/corehq/apps/sislog/urls.py
+++ b/corehq/apps/sislog/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns('corehq.apps.sislog.views',
     url(r'^in/?$', 'sms_in', name='sms_in'),

--- a/corehq/apps/sms/urls.py
+++ b/corehq/apps/sms/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 from corehq import SMSAdminInterfaceDispatcher
 from corehq.apps.sms.views import (
     DomainSmsGatewayListView,

--- a/corehq/apps/telerivet/urls.py
+++ b/corehq/apps/telerivet/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns('corehq.apps.telerivet.views',
     url(r'^in/?$', 'incoming_message', name='incoming_message'),

--- a/corehq/apps/tropo/urls.py
+++ b/corehq/apps/tropo/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns('corehq.apps.tropo.views',
     url(r'^sms/?$', 'sms_in', name='sms_in'),

--- a/corehq/apps/twilio/urls.py
+++ b/corehq/apps/twilio/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns('corehq.apps.twilio.views',
     url(r'^sms/?$', 'sms_in', name='twilio_sms_in'),

--- a/corehq/apps/unicel/urls.py
+++ b/corehq/apps/unicel/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns('',         
     url(r'^in/$', 'corehq.apps.unicel.views.incoming'),

--- a/corehq/apps/users/urls.py
+++ b/corehq/apps/users/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 from corehq.apps.domain.utils import grandfathered_domain_re
 

--- a/corehq/apps/yo/urls.py
+++ b/corehq/apps/yo/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns('corehq.apps.yo.views',
     url(r'^sms/?$', 'sms_in', name='sms_in'),

--- a/corehq/ex-submodules/casexml/apps/case/urls.py
+++ b/corehq/ex-submodules/casexml/apps/case/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 from .views import reference_case_attachment_view
 
 urlpatterns = patterns('',

--- a/corehq/ex-submodules/casexml/apps/phone/urls.py
+++ b/corehq/ex-submodules/casexml/apps/phone/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns('',                       
     url(r'^restore/$', 'casexml.apps.phone.views.restore'),

--- a/corehq/ex-submodules/couchforms/urls.py
+++ b/corehq/ex-submodules/couchforms/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns('',
     url(r'^post/?$', 'couchforms.views.post', name='xform_post'),

--- a/custom/_legacy/mvp/urls.py
+++ b/custom/_legacy/mvp/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 from mvp.views import MVPIndicatorAdminCRUDFormView, MVPBulkCopyIndicatorsView
 
 urlpatterns = patterns('mvp.views',

--- a/custom/_legacy/pathfinder/urls.py
+++ b/custom/_legacy/pathfinder/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns('pathfinder.views',
     url(r'select/$', 'selector'),

--- a/custom/apps/crs_reports/urls.py
+++ b/custom/apps/crs_reports/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns('custom.apps.crs_reports.views',
     url(r'^crs_custom_case_data/(?P<case_id>[\w\-]+)/(?P<report_slug>[\w\-]+)$', "crs_details_report", name="crs_details_report"),

--- a/custom/apps/wisepill/urls.py
+++ b/custom/apps/wisepill/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns('custom.apps.wisepill.views',
     url(r'^device/?$', 'device_data', name='device_data'),

--- a/custom/fri/urls.py
+++ b/custom/fri/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns('custom.fri.views',
     url(r'^upload_message_bank/$', 'upload_message_bank', name='fri_upload_message_bank'),

--- a/custom/m4change/urls.py
+++ b/custom/m4change/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns('custom.m4change.views',
     url(r'^update_service_status/$', 'update_service_status', name='update_service_status'),

--- a/custom/uth/urls.py
+++ b/custom/uth/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 from custom.uth.views import vscan_upload, sonosite_upload, pending_exams
 

--- a/urls.py
+++ b/urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls.defaults import patterns, url, include
+from django.conf.urls import patterns, url, include
 from django.views.generic import TemplateView, RedirectView
 from corehq.apps.domain.utils import legacy_domain_re
 


### PR DESCRIPTION
`django.conf.urls.defaults` is deprecated and removed in Django 1.6
