### PR TITLE
Prevent repeated data source table ids in user configurable reports

### DIFF
--- a/corehq/apps/userreports/ui/forms.py
+++ b/corehq/apps/userreports/ui/forms.py
@@ -90,6 +90,12 @@ class ConfigurableDataSourceEditForm(DocumentFormBase):
             raise ValidationError(
                 _('Table id is too long. Your table id and domain name must add up to fewer than 40 characters')
             )
+        for src in self.instance.by_domain(self.domain):
+            if src.table_id == table_id and src.get_id != self.instance.get_id:
+                raise ValidationError(
+                    _('A data source with this table id already exists. Table'
+                      ' ids must be unique')
+                )
         return table_id
 
     def clean(self):


### PR DESCRIPTION
During form validation, get all the data source configurations associated with the current domain and raise an error if the new data source's `table_id` is already in use.
