### PR TITLE
append Traceback to the ticket created in report-issue of 500 page

### DIFF
--- a/corehq/apps/hqwebapp/templates/500.html
+++ b/corehq/apps/hqwebapp/templates/500.html
@@ -34,6 +34,7 @@
                 <input type="hidden" id="bug-report-500-now" name="now" value="true" />
                 <input type="hidden" id="bug-report-500-when" name="when" value="right now" />
                 <input type="hidden" name="five-hundred-report" value="true" />
+                <input type="hidden" id="bug-report-500t-traceback" name="500traceback" value="{{ 500traceback }}"/>
 
                 {{ now }}
                 <fieldset>

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -3,6 +3,8 @@ from datetime import datetime
 import json
 import os
 import re
+import sys
+import traceback
 import uuid
 
 from django.conf import settings
@@ -152,7 +154,6 @@ def server_error(request, template_name='500.html'):
 
     # hat tip: http://www.arthurkoziel.com/2009/01/15/passing-mediaurl-djangos-500-error-view/
     t = loader.get_template(template_name)
-    import sys, traceback
     type, exc, tb = sys.exc_info()
     return HttpResponseServerError(t.render(RequestContext(request,
         {'MEDIA_URL': settings.MEDIA_URL,
@@ -467,7 +468,8 @@ def bug_report(req):
         reply_to = settings.SERVER_EMAIL
 
     if req.POST.get('five-hundred-report'):
-        extra_message = "This messge was reported from a 500 error page! Please fix this ASAP (as if you wouldn't anyway)..."
+        extra_message = ("This messge was reported from a 500 error page! "
+                         "Please fix this ASAP (as if you wouldn't anyway)...")
         traceback_info = "Traceback of this 500: \n%s" % report['500traceback']
         message = "%s \n\n %s \n\n %s" % (message, extra_message, traceback_info)
 


### PR DESCRIPTION
For http://manage.dimagi.com/default.asp?133441

Implementation was trivial, but turning `DEBUG=False` on local setup was a mess. Following were two issues I spent most time to implement this (FYI for others)
- All HQ pages failed with `SuspiciousOperation: Invalid HTTP_HOST header` found that docs was not upto date and spent good amount of time on the issue before understanding the issue [here](http://getluky.net/2013/02/21/django-debugfalse-and-allowed_hosts/).
- After above fix, the pages are broken with no styling and no images, found that Django doesn't serve `static` when `DEBUG=False`, so I had to run the server with `--insecure` option
