### PR TITLE
Fix cache persisting error which is making heartbeat fail

### DIFF
--- a/settingshelper.py
+++ b/settingshelper.py
@@ -1,5 +1,3 @@
-from redis.exceptions import ConnectionError
-from redis_cache.exceptions import ConnectionInterrumped
 
 
 def get_server_url(http_method, server_root, username, password):
@@ -73,5 +71,7 @@ def get_extra_couchdbs(config, couch_database_url):
 
 
 def celery_failure_handler(task, exc, task_id, args, kwargs, einfo):
+    from redis.exceptions import ConnectionError
+    from redis_cache.exceptions import ConnectionInterrumped
     if isinstance(exc, (ConnectionInterrumped, ConnectionError)):
         task.retry(exc, max_retries=3, countdown=60 * 5)


### PR DESCRIPTION
This is a bit strange, but it looks like there's some weird import-related error that's causing cache persisting to not work properly (and making heartbeat fail).  You can reproduce the error with the current codebase by entering ./manage.py shell and running:

(1)
from soil.tasks import heartbeat
heartbeat()

(2)
from soil import heartbeat
heartbeat.is_alive()

(3)
from django.conf import settings
from django.core.cache import cache
cache.get(settings.SOIL_HEARTBEAT_CACHE_KEY)

When run like this, is_alive() will return True here. Now exit the shell, restart another shell, and run just (2) and (3) above, and  is_alive() will not return True, and the cache value will be empty.

By running the same test on this branch (run 1, 2, 3, exit, new shell, run 2, 3), when you run (2) and (3) the second time from a new shell, is_alive() returns True and you get the right value from the cache.
