### PR TITLE
Prevent deleting last case list property

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -472,10 +472,6 @@ var DetailScreenConfig = (function () {
             this.format.$edit_view.on("change", function(event){
                 ga_track_event('Case List Config', 'Display Format', event.target.value);
             });
-
-            this.$delete = $('<i></i>').addClass(COMMCAREHQ.icons.DELETE).click(function () {
-                that.screen.columns.remove(that);
-            }).css({cursor: 'pointer'}).attr('title', DetailScreenConfig.message.DELETE_COLUMN);
         }
 
         Column.init = function (col, screen) {

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list_properties.html
@@ -35,7 +35,16 @@
                 <!--ko if: isTab -->
                     <td colspan="3" data-bind="jqueryElement: header.ui"></td>
                 <!--/ko-->
-                <td class="detail-screen-icon" data-bind="jqueryElement: $delete, visible: $root.edit"></td>
+
+                <td class="detail-screen-icon">
+                    <i style="cursor: pointer;"
+                       data-bind="
+                        visible: $root.edit && ($parent.columns().length > 1),
+                        click: function(){screen.columns.remove($data);},
+                        css: COMMCAREHQ.icons.DELETE,
+                        attr: {title: DetailScreenConfig.message.DELETE_COLUMN}
+                    "></i>
+                </td>
             </tr>
         </tbody>
         <tbody>


### PR DESCRIPTION
Don't show the "x" icon on a case list property row if it's the only row.
Also moves the markup for that icon out of javascript and into the html template.
