### PR TITLE
Fixed drag-and-drop in Case Detail page in Firefox

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list_properties.html
@@ -17,7 +17,10 @@
             data: columns,
             afterAdd: function (elem) { $(elem).hide().fadeIn() },
             beforeRemove: function (elem) { $(elem).fadeOut() }
-        }"><tr data-bind="css: {info: isTab}, attr: {'data-order': _sortableOrder, 'tabindex': 1000 + $index()},
+        }"
+        {# there must be no whitespace between <tbody> and <tr> #}
+        {# the .hide().fadeIn() will fail badly on FireFox #}
+        ><tr data-bind="css: {info: isTab}, attr: {'data-order': _sortableOrder, 'tabindex': 1000 + $index()},
                            copy: function () { return copyCallback(); },
                            paste: function (data) { $parent.pasteCallback(data, $index() + 1); }">
                 <td class="detail-screen-icon" data-bind="jqueryElement: $grip, visible: $root.edit"></td>

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list_properties.html
@@ -17,8 +17,7 @@
             data: columns,
             afterAdd: function (elem) { $(elem).hide().fadeIn() },
             beforeRemove: function (elem) { $(elem).fadeOut() }
-        }">
-            <tr data-bind="css: {info: isTab}, attr: {'data-order': _sortableOrder, 'tabindex': 1000 + $index()},
+        }"><tr data-bind="css: {info: isTab}, attr: {'data-order': _sortableOrder, 'tabindex': 1000 + $index()},
                            copy: function () { return copyCallback(); },
                            paste: function (data) { $parent.pasteCallback(data, $index() + 1); }">
                 <td class="detail-screen-icon" data-bind="jqueryElement: $grip, visible: $root.edit"></td>
@@ -45,8 +44,7 @@
                         attr: {title: DetailScreenConfig.message.DELETE_COLUMN}
                     "></i>
                 </td>
-            </tr>
-        </tbody>
+            </tr></tbody>
         <tbody>
             <tr>
                 <td></td>


### PR DESCRIPTION
Read [JQuery ticket](http://bugs.jquery.com/ticket/12462), removed text nodes around `<tr>` node. Whaddayaknow!

cf. [FogBugz 154557](http://manage.dimagi.com/default.asp?154557)
