### PR TITLE
(FB: 130819) - When copying form, modify name

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -21,7 +21,7 @@ from lxml import etree
 from django.core.cache import cache
 from django.utils.encoding import force_unicode
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext as _, ugettext
+from django.utils.translation import override, ugettext as _, ugettext
 from couchdbkit.exceptions import BadValueError, DocTypeError
 from couchdbkit.ext.django.schema import *
 from django.conf import settings
@@ -3454,6 +3454,9 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
         if 'unique_id' in copy_source:
             del copy_source['unique_id']
 
+        for lang, name in copy_source['name'].iteritems():
+            with override(lang):
+                copy_source['name'][lang] = _('Copy of %(name)s') % { 'name': name }
 
         copy_form = to_module.add_insert_form(from_module, FormBase.wrap(copy_source))
         save_xform(self, copy_form, form.source)

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -3445,18 +3445,19 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
         from_module = self.get_module(module_id)
         form = from_module.get_form(form_id)
         to_module = self.get_module(to_module_id)
-        self._copy_form(from_module, form, to_module)
+        self._copy_form(from_module, form, to_module, rename=True)
 
-    def _copy_form(self, from_module, form, to_module):
+    def _copy_form(self, from_module, form, to_module, *args, **kwargs):
         if not form.source:
             raise BlankXFormError()
         copy_source = deepcopy(form.to_json())
         if 'unique_id' in copy_source:
             del copy_source['unique_id']
 
-        for lang, name in copy_source['name'].iteritems():
-            with override(lang):
-                copy_source['name'][lang] = _('Copy of %(name)s') % { 'name': name }
+        if 'rename' in kwargs and kwargs['rename']:
+            for lang, name in copy_source['name'].iteritems():
+                with override(lang):
+                    copy_source['name'][lang] = _('Copy of {name}').format(name=name)
 
         copy_form = to_module.add_insert_form(from_module, FormBase.wrap(copy_source))
         save_xform(self, copy_form, form.source)

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -251,6 +251,21 @@ class SuiteTest(SimpleTestCase, TestFileMixin):
 
         self.assertXmlEqual(self.get_xml('suite-workflow-root'), app.create_suite())
 
+    def test_copy_form(self):
+        app = Application.new_app('domain', "Untitled Application", application_version=APP_V2)
+        module = app.add_module(AdvancedModule.new_module('module', None))
+        original_form = app.new_form(module.id, "Untitled Form", None)
+        original_form.source = '<source>'
+
+        app._copy_form(module, original_form, module, rename=True)
+
+        form_count = 0
+        for f in app.get_forms():
+            form_count += 1
+            if f.unique_id != original_form.unique_id:
+                self.assertEqual(f.name['en'], 'Copy of {}'.format(original_form.name['en']))
+        self.assertEqual(form_count, 2, 'Copy form has copied multiple times!')
+
     def test_owner_name(self):
         self._test_generic_suite('owner-name')
 


### PR DESCRIPTION
When copying a form, this will add ‘Copy of’ around name. This is a simple implementation and does not look at other forms in the app to determine whether the form has been copied before.

http://manage.dimagi.com/default.asp?130819#858895
