### PR TITLE
Make case details screen use the right timezone

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/templatetags/case_tags.py
+++ b/corehq/ex-submodules/casexml/apps/case/templatetags/case_tags.py
@@ -47,6 +47,7 @@ def render_case(case, options):
     from corehq.apps.hqwebapp.templatetags.proptable_tags import get_tables_as_rows, get_definition
     case = wrapped_case(case)
     timezone = options.get('timezone', pytz.utc)
+    timezone = timezone.localize(datetime.datetime.now()).tzinfo
     _get_tables_as_rows = partial(get_tables_as_rows, timezone=timezone)
     display = options.get('display') or case.get_display_config()
     show_transaction_export = options.get('show_transaction_export') or False


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?154276
Apparently certain timezones (Asia/Kolkata, I'm looking at you) vary depending
on the date, and pytz thinks it's a good idea to default to the timezone they
used in the 1940s (with a cool 5h53m offset, and a name of HMT, now reserved
for some Antarctic volcanic islands).

``` python
In [1]: import pytz, datetime

In [2]: time = datetime.datetime(2015, 1, 26, tzinfo=pytz.timezone("Asia/Kolkata"))

In [3]: time
Out[3]: datetime.datetime(2015, 1, 26, 0, 0, tzinfo=<DstTzInfo 'Asia/Kolkata' HMT+5:53:00 STD>)

In [4]: time.strftime('%b %d, %Y %H:%M %Z')
Out[4]: 'Jan 26, 2015 00:00 HMT'

In [5]: correct_tz = pytz.timezone("Asia/Kolkata").localize(datetime.datetime.now()).tzinfo

In [6]: datetime.datetime(2015, 1, 26, tzinfo=correct_tz)
Out[6]: datetime.datetime(2015, 1, 26, 0, 0, tzinfo=<DstTzInfo 'Asia/Kolkata' IST+5:30:00 STD>)
```

The other questionable thing about that screen is that the form metadata display uses UTC.  I'm gonna go ahead and leave it though, as per @dannyroberts comment [here](https://github.com/dimagi/commcare-hq/blob/5eef0d18637d8711d85d363c745f06da8f2ee3ac/corehq/apps/reports/templatetags/xform_tags.py#L84-L86)
