### PR TITLE
(FB: 151548) - Fix MM when read-only user

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/app-settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/app-settings.html
@@ -24,7 +24,7 @@
             </span>
         </span>
         <span data-bind="if: !$root.edit()">
-            <span data-bind="text: selectedOption().label"></span>
+            <span data-bind="text: (selectedOption() ? selectedOption().label : '')"></span>
         </span>
     </span>
 </script>

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/main.js
@@ -139,7 +139,8 @@ var SaveButton = {
         });
 
         var beforeunload = function () {
-            var stillAttached = button.ui.parents()[button.ui.parents().length - 1].tagName.toLowerCase() == 'html';
+            var parentEl = button.ui.parents()[button.ui.parents().length - 1];
+            var stillAttached = parentEl ? parentEl.tagName.toLowerCase() == 'html' : false;
             if (button.state !== 'saved' && stillAttached) {
                 return options.unsavedMessage || "";
             }


### PR DESCRIPTION
When user is read-only a few errors were occurring. The first in
`app-settings.html`. `selectionOption()` would return null and then an
error would be thrown when accessing `.label`. The next error was in
`main.js` when changing tabs. The unattached button had no parent element
so when accessing `tagName`, an error was thrown.

Not sure what the source of truth is, but here is what I'm currently viewing for read-only user:

![screen shot 2015-01-28 at 3 25 46 pm](https://cloud.githubusercontent.com/assets/918514/5946204/f838043c-a701-11e4-85f1-17e00df5ca4e.png)
![screen shot 2015-01-28 at 3 25 41 pm](https://cloud.githubusercontent.com/assets/918514/5946209/fc7e3890-a701-11e4-96f9-f0176d14863e.png)

http://manage.dimagi.com/default.asp?151548#861201
