### PR TITLE
compare with 1 not '1' in vhnd-service-availability

### DIFF
--- a/custom/opm/reports.py
+++ b/custom/opm/reports.py
@@ -434,7 +434,7 @@ class SharedDataProvider(object):
         for (owner_id, date), row in data.iteritems():
             if row['vhnd_available'] > 0:
                 for prop in VHND_PROPERTIES:
-                    if row[prop] == '1' or prop == 'vhnd_available':
+                    if row[prop] == 1 or prop == 'vhnd_available':
                         results[owner_id][prop].add(date)
         return results
 


### PR DESCRIPTION
This fixes the bug - "all the rows for 'service_availability' columns in HSR are zero (or 'no')"

It should be noted that this function is invoked from [other reports](https://github.com/dimagi/commcare-hq/blob/master/custom/opm/beneficiary.py#L196) as well, but the `prop` argument is always `vhnd_available` from those reports, for which this function evaluates correctly ([lucky accident](https://github.com/dimagi/commcare-hq/blob/master/custom/opm/beneficiary.py#L196))

@esoergel or @czue 
