### PR TITLE
Add "numeric" type report filter to UCR

### DIFF
--- a/corehq/apps/reports_core/filters.py
+++ b/corehq/apps/reports_core/filters.py
@@ -161,21 +161,15 @@ class NumericFilter(BaseFilter):
     def value(self, **kwargs):
         operator = kwargs[self.operator_param_name]
         operand = kwargs[self.operand_param_name]
-
         if operand == "":
             return None
-        
         try:
             assert operator in ["=", "!=", "<", "<=", ">", ">="]
-            try:
-                operand = int(operand)
-            except ValueError:
-                operand = float(operand)
-        except (AssertionError, ValueError) as e:
+            assert isinstance(operand, float) or isinstance(operand, int)
+        except AssertionError as e:
             raise FilterValueException('Error parsing numeric filter parameters: {}'.format(e.message))
 
-        if operator is not None and operand is not None:
-            return {"operator": operator, "operand": operand}
+        return {"operator": operator, "operand": operand}
 
     def default_value(self):
         return None

--- a/corehq/apps/reports_core/filters.py
+++ b/corehq/apps/reports_core/filters.py
@@ -137,6 +137,46 @@ class DatespanFilter(BaseFilter):
         }
 
 
+class NumericFilter(BaseFilter):
+
+    def __init__(self, name, required=True, label='Numeric Filter', css_id=None):
+        self.label = label
+        self.css_id = css_id or name
+        params = [
+            FilterParam(self.operator_param_name, True),
+            FilterParam(self.operand_param_name, True),
+        ]
+        super(NumericFilter, self).__init__(required=required, name=name, params=params)
+
+    @property
+    def operator_param_name(self):
+        return "{}-operator".format(self.css_id)
+
+    @property
+    def operand_param_name(self):
+        return "{}-operand".format(self.css_id)
+
+    @memoized
+    def value(self, **kwargs):
+        operator = kwargs[self.operator_param_name]
+        operand = kwargs[self.operand_param_name]
+
+        try:
+            assert operator in ["eq", "neq", "lt", "lte", "gt", "gte"]
+            try:
+                operand = int(operand)
+            except ValueError:
+                operand = float(operand)
+        except (AssertionError, ValueError) as e:
+            raise FilterValueException('Error parsing numeric filter parameters: {}'.format(e.message))
+
+        if operator is not None and operand is not None:
+            return {"operator": operator, "operand": operand}
+
+    def default_value(self):
+        return None
+
+
 Choice = namedtuple('Choice', ['value', 'display'])
 
 

--- a/corehq/apps/reports_core/filters.py
+++ b/corehq/apps/reports_core/filters.py
@@ -4,6 +4,7 @@ from corehq.apps.userreports.reports.filters import SHOW_ALL_CHOICE
 
 from dimagi.utils.dates import DateSpan
 from dimagi.utils.decorators.memoized import memoized
+from django.utils.translation import ugettext as _
 
 
 class FilterException(Exception):
@@ -140,7 +141,7 @@ class DatespanFilter(BaseFilter):
 class NumericFilter(BaseFilter):
     template = "reports_core/filters/numeric_filter.html"
 
-    def __init__(self, name, required=True, label='Numeric Filter', css_id=None):
+    def __init__(self, name, required=True, label=_('Numeric Filter'), css_id=None):
         self.label = label
         self.css_id = css_id or name
         params = [

--- a/corehq/apps/reports_core/filters.py
+++ b/corehq/apps/reports_core/filters.py
@@ -138,6 +138,7 @@ class DatespanFilter(BaseFilter):
 
 
 class NumericFilter(BaseFilter):
+    template = "reports_core/filters/numeric_filter.html"
 
     def __init__(self, name, required=True, label='Numeric Filter', css_id=None):
         self.label = label
@@ -162,7 +163,7 @@ class NumericFilter(BaseFilter):
         operand = kwargs[self.operand_param_name]
 
         try:
-            assert operator in ["eq", "neq", "lt", "lte", "gt", "gte"]
+            assert operator in ["=", "!=", "<", "<=", ">", ">="]
             try:
                 operand = int(operand)
             except ValueError:

--- a/corehq/apps/reports_core/filters.py
+++ b/corehq/apps/reports_core/filters.py
@@ -162,6 +162,9 @@ class NumericFilter(BaseFilter):
         operator = kwargs[self.operator_param_name]
         operand = kwargs[self.operand_param_name]
 
+        if operand == "":
+            return None
+        
         try:
             assert operator in ["=", "!=", "<", "<=", ">", ">="]
             try:

--- a/corehq/apps/reports_core/templates/reports_core/filters/numeric_filter.html
+++ b/corehq/apps/reports_core/templates/reports_core/filters/numeric_filter.html
@@ -1,0 +1,12 @@
+{% extends "reports_core/filters/filter_base.html" %}
+{% block filter-controls %}
+    <select id="{{ filter.css_id }}-operator" name="{{ filter.css_id }}-operator">
+        <option value="=">=</option>
+        <option value="!=">&ne;</option>
+        <option value="&lt;">&lt;</option>
+        <option value="&lt;=">&le;</option>
+        <option value="&gt;">&gt;</option>
+        <option value="&gt;=">&ge;</option>
+    </select>
+    <input type="text" id="{{ filter.css_id }}-operand" name="{{ filter.css_id }}-operand"/>
+{% endblock %}

--- a/corehq/apps/userreports/README.md
+++ b/corehq/apps/userreports/README.md
@@ -459,7 +459,7 @@ Report filters are _completely_ different from data source filters. Data source 
 
 #### "numeric" Filters
 Numeric filters allow users to filter the rows in the report by comparing a column to some constant that the user specifies when viewing the report.
-Numeric filters are only intended to be used with numeric (integer or decimal type) columns. Supported operators are &eq;, &ne;, &lt;, &le;, &gt;, and &ge;.
+Numeric filters are only intended to be used with numeric (integer or decimal type) columns. Supported operators are =, &ne;, &lt;, &le;, &gt;, and &ge;.
 
 ex:
 ```

--- a/corehq/apps/userreports/README.md
+++ b/corehq/apps/userreports/README.md
@@ -457,6 +457,20 @@ TODO: Report filters docs will go here.
 
 Report filters are _completely_ different from data source filters. Data source filters limit the global set of data that ends up in the table, whereas report filters allow you to select values to limit the data returned by a query.
 
+#### "numeric" Filters
+Numeric filters allow users to filter the rows in the report by comparing a column to some constant that the user specifies when viewing the report.
+Numeric filters are only intended to be used with numeric (integer or decimal type) columns. Supported operators are &eq;, &ne;, &lt;, &le;, &gt;, and &ge;.
+
+ex:
+```
+{
+  "type": "numeric",
+  "slug": "number_of_children_slug",
+  "field": "number_of_children",
+  "display": "Number of Children"
+}
+```
+
 Here are a few examples of report filters:
 
 ```

--- a/corehq/apps/userreports/reports/factory.py
+++ b/corehq/apps/userreports/reports/factory.py
@@ -1,16 +1,27 @@
 import json
 from jsonobject.exceptions import BadValueError
-from corehq.apps.reports_core.filters import DatespanFilter, ChoiceListFilter, Choice, DynamicChoiceListFilter
+from corehq.apps.reports_core.filters import DatespanFilter, ChoiceListFilter, Choice, DynamicChoiceListFilter, \
+    NumericFilter
 from corehq.apps.userreports.exceptions import BadSpecError
 from django.utils.translation import ugettext as _
 from corehq.apps.userreports.reports.filters import SHOW_ALL_CHOICE, dynamic_choice_list_url
 from corehq.apps.userreports.reports.specs import FilterSpec, ChoiceListFilterSpec, PieChartSpec, \
-    MultibarAggregateChartSpec, MultibarChartSpec, ReportFilter, ReportColumn, DynamicChoiceListFilterSpec
+    MultibarAggregateChartSpec, MultibarChartSpec, ReportFilter, ReportColumn, DynamicChoiceListFilterSpec, \
+    NumericFilterSpec
 
 
 def _build_date_filter(spec):
     wrapped = FilterSpec.wrap(spec)
     return DatespanFilter(
+        name=wrapped.slug,
+        label=wrapped.get_display(),
+        required=wrapped.required,
+    )
+
+
+def _build_numeric_filter(spec):
+    wrapped = NumericFilterSpec.wrap(spec)
+    return NumericFilter(
         name=wrapped.slug,
         label=wrapped.get_display(),
         required=wrapped.required,
@@ -46,6 +57,7 @@ class ReportFilterFactory(object):
         'date': _build_date_filter,
         'choice_list': _build_choice_list_filter,
         'dynamic_choice_list': _build_dynamic_choice_list_filter,
+        'numeric': _build_numeric_filter
     }
 
     @classmethod

--- a/corehq/apps/userreports/reports/filters.py
+++ b/corehq/apps/userreports/reports/filters.py
@@ -43,16 +43,20 @@ class NumericFilterValue(FilterValue):
 
     def __init__(self, filter, value):
         assert filter.type == "numeric"
-        assert ("operator" in value and "operand" in value) or value is None
+        assert (isinstance(value, dict) and "operator" in value and "operand" in value) or value is None
         super(NumericFilterValue, self).__init__(filter, value)
 
     def to_sql_filter(self):
-        pass
-        # TODO: write me!
+        if self.value is None:
+            return ""
+        return "{0} {1} :operand".format(self.filter.field, self.value['operator'])
 
     def to_sql_values(self):
-        pass
-        # TODO: write me!
+        if self.value is None:
+            return {}
+        return {
+            "operand": self.value["operand"]
+        }
 
 
 class ChoiceListFilterValue(FilterValue):

--- a/corehq/apps/userreports/reports/filters.py
+++ b/corehq/apps/userreports/reports/filters.py
@@ -44,6 +44,8 @@ class NumericFilterValue(FilterValue):
     def __init__(self, filter, value):
         assert filter.type == "numeric"
         assert (isinstance(value, dict) and "operator" in value and "operand" in value) or value is None
+        assert value['operator'] in ["=", "!=", "<", "<=", ">", ">="]
+        assert isinstance(value['operand'], int) or isinstance(value['operand'], float)
         super(NumericFilterValue, self).__init__(filter, value)
 
     def to_sql_filter(self):

--- a/corehq/apps/userreports/reports/filters.py
+++ b/corehq/apps/userreports/reports/filters.py
@@ -39,6 +39,22 @@ class DateFilterValue(FilterValue):
         }
 
 
+class NumericFilterValue(FilterValue):
+
+    def __init__(self, filter, value):
+        assert filter.type == "numeric"
+        assert ("operator" in value and "operand" in value) or value is None
+        super(NumericFilterValue, self).__init__(filter, value)
+
+    def to_sql_filter(self):
+        pass
+        # TODO: write me!
+
+    def to_sql_values(self):
+        pass
+        # TODO: write me!
+
+
 class ChoiceListFilterValue(FilterValue):
 
     def __init__(self, filter, value):

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -109,6 +109,10 @@ class DynamicChoiceListFilterSpec(FilterSpec):
         return []
 
 
+class NumericFilterSpec(FilterSpec):
+    type = TypeProperty('numeric')
+
+
 class ChartSpec(JsonObject):
     type = StringProperty(required=True)
     title = StringProperty()

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -7,7 +7,8 @@ from sqlagg.columns import (
     YearColumn,
 )
 from corehq.apps.reports.sqlreport import DatabaseColumn
-from corehq.apps.userreports.reports.filters import DateFilterValue, ChoiceListFilterValue
+from corehq.apps.userreports.reports.filters import DateFilterValue, ChoiceListFilterValue, \
+    NumericFilterValue
 from corehq.apps.userreports.specs import TypeProperty
 from corehq.apps.userreports.transforms.factory import TransformFactory
 
@@ -30,6 +31,7 @@ class ReportFilter(JsonObject):
     def create_filter_value(self, value):
         return {
             'date': DateFilterValue,
+            'numeric': NumericFilterValue,
             'choice_list': ChoiceListFilterValue,
             'dynamic_choice_list': ChoiceListFilterValue,
         }[self.type](self, value)
@@ -84,7 +86,7 @@ class FilterSpec(JsonObject):
     This is the spec for a report filter - a thing that should show up as a UI filter element
     in a report (like a date picker or a select list).
     """
-    type = StringProperty(required=True, choices=['date', 'choice_list', 'dynamic_choice_list'])
+    type = StringProperty(required=True, choices=['date', 'numeric', 'choice_list', 'dynamic_choice_list'])
     slug = StringProperty(required=True)  # this shows up as the ID in the filter HTML
     field = StringProperty(required=True)  # this is the actual column that is queried
     display = StringProperty()

--- a/corehq/apps/userreports/tests/test_report_filters.py
+++ b/corehq/apps/userreports/tests/test_report_filters.py
@@ -1,5 +1,6 @@
 from django.test import SimpleTestCase
-from corehq.apps.reports_core.filters import DatespanFilter, ChoiceListFilter
+from corehq.apps.reports_core.filters import DatespanFilter, ChoiceListFilter, \
+    NumericFilter
 from corehq.apps.userreports.exceptions import BadSpecError
 from corehq.apps.userreports.reports.factory import ReportFilterFactory
 from corehq.apps.userreports.reports.filters import SHOW_ALL_CHOICE
@@ -53,6 +54,20 @@ class DateFilterTestCase(SimpleTestCase):
         self.assertEqual(DatespanFilter, type(filter))
         self.assertEqual('modified_on_slug', filter.name)
         self.assertEqual('Date Modified', filter.label)
+
+
+class NumericFilterTestCase(SimpleTestCase):
+
+    def test_numeric_filter(self):
+        filter = ReportFilterFactory.from_spec({
+            "type": "numeric",
+            "field": "number_of_children_field",
+            "slug": "number_of_children_slug",
+            "display": "Number of Children",
+        })
+        self.assertEqual(NumericFilter, type(filter))
+        self.assertEqual("number_of_children_slug", filter.name)
+        self.assertEqual("Number of Children", filter.label)
 
 
 class ChoiceListFilterTestCase(SimpleTestCase):


### PR DESCRIPTION
If you add this to your reports filters:

```
{
   "type": "numeric",
   "slug": "number_of_children_slug",
   "field": "number_of_children",
   "display": "Number of Children"
 }
```

You get this:
![numeric filter](https://cloud.githubusercontent.com/assets/2117127/6001292/d7303f1e-aaf0-11e4-863a-793f1001f9dd.png)

FYI @nickpell , the L1 report builder calls for this functionality.
