### PR TITLE
Fix the product page pagination problems

### DIFF
--- a/corehq/apps/commtrack/static/commtrack/ko/products_and_programs.async.js
+++ b/corehq/apps/commtrack/static/commtrack/ko/products_and_programs.async.js
@@ -1,6 +1,8 @@
 var CommtrackProductsProgramsViewModel = function (o) {
     var view_model = BaseListViewModel(o);
 
+    view_model.currently_searching = ko.observable(false);
+
     view_model.colspan = ko.computed(function () {
         return 7;
     });
@@ -15,6 +17,7 @@ var CommtrackProductsProgramsViewModel = function (o) {
         page = ko.utils.unwrapObservable(page);
 
         if (page) {
+            view_model.currently_searching(true);
             $.ajax({
                 url: format_url(page),
                 dataType: 'json',
@@ -23,6 +26,7 @@ var CommtrackProductsProgramsViewModel = function (o) {
                     $('.hide-until-load').fadeIn();
                     $('#user-list-notification').text('Sorry, there was an problem contacting the server ' +
                         'to fetch the data. Please, try again in a little bit.');
+                    view_model.currently_searching(false);
                 },
                 success: reloadList
             });
@@ -32,6 +36,7 @@ var CommtrackProductsProgramsViewModel = function (o) {
     };
 
     var reloadList = function(data) {
+        view_model.currently_searching(false);
         if (data.success) {
             if (!view_model.initial_load()) {
                 view_model.initial_load(true);

--- a/corehq/apps/products/templates/products/manage/products.html
+++ b/corehq/apps/products/templates/products/manage/products.html
@@ -80,7 +80,7 @@
         </div>
     </div>
 
-    <div class="row-fluid" data-bind="visible: !initial_load()">
+    <div class="row-fluid" data-bind="visible: !initial_load() || currently_searching()">
         <div class="span12">
             <img src="{% static 'hqwebapp/img/ajax-loader.gif' %}" alt="loading indicator" />
             {% trans 'Loading products...' %}
@@ -106,14 +106,14 @@
 
         <div class="row-fluid">
             <div class="span12">
-                <div id="user-list-notification" data-bind="visible: !data_list().length" class="alert alert-info">
+                <div id="user-list-notification" data-bind="visible: !currently_searching() && !data_list().length" class="alert alert-info">
                     {% if show_inactive %}
                         {% blocktrans %}There are no inactive products for this project.{% endblocktrans %}
                     {% else %}
                         {% blocktrans %}There are no products for this project yet.{% endblocktrans %}
                     {% endif %}
                 </div>
-                <table data-bind="visible: data_list().length + archive_action_items().length > 0" class="table table-striped table-bordered" style="margin-bottom:0">
+                <table data-bind="visible: !currently_searching() && (data_list().length + archive_action_items().length > 0)" class="table table-striped table-bordered" style="margin-bottom:0">
                     <thead data-bind="visible: data_list().length > 0">
                         <tr>
                             <th></th>

--- a/corehq/apps/products/views.py
+++ b/corehq/apps/products/views.py
@@ -160,7 +160,7 @@ class FetchProductListView(ProductListView):
     def get(self, request, *args, **kwargs):
         return HttpResponse(json.dumps({
             'success': True,
-            'current_page': self.page,
+            'current_page': int(self.page),
             'data_list': self.product_data,
         }), 'text/json')
 


### PR DESCRIPTION
Two things here..

1) It used to not show a loading screen even if your connection was bad
and the async call took forever. I just copied over the "searching"
concept from the users page that this is similar to. We'll want product
searching soon anyway, so no reason to come up with new names for
things.

2) Pagination used to just be wonky. Turns out that the view was sending
a string for the current page number, so javascript did '11'+3 == '113'
and weird stuff happened.
