### PR TITLE
155338 build errors

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load hq_shared_tags %}
 {% load xforms_extras %}{% if build_errors %}
     <div class="alert alert-warning alert-block">
         {% if not_actual_build %}
@@ -11,170 +12,140 @@
                 <li>
                     <i class="icon icon-exclamation-sign"></i>
                     <span>
-                        {% if error.type == "blank form" %}
+                        {% case error.type "blank form" %}
                             {% if not error.message %}
                                 Blank form
                             {% endif %}
                             {% include "app_manager/partials/form_error_message.html" %}
-                        {% endif %}
-                         {% if error.type == "invalid xml" %}
+                        {% case "invalid xml" %}
                             {% if not error.message %}
                                 If you don't know why this happened, please report an issue.
                             {% endif %}
                             {% include "app_manager/partials/form_error_message.html" %}
-                        {% endif %}
-                        {% if error.type == "validation error" %}
+                        {% case "validation error" %}
                             {{ error.validation_message|linebreaksbr }} in form
                             {% include "app_manager/partials/form_error_message.html" %}
-                        {% endif %}
-                        {% if error.type == "no ref detail" %}
+                        {% case "no ref detail" %}
                             Module
                             <a href="{% url "view_module" domain app.id error.module.id %}">{{ error.module.name|trans:langs }}</a>
                             uses referrals but doesn't have
                             detail screens configured for referrals.
-                        {% endif %}
-                        {% if error.type == "no case detail" %}
+                        {% case "no case detail" %}
                             Module
                             <a href="{% url "view_module" domain app.id error.module.id %}">{{ error.module.name|trans:langs }}</a>
                             uses cases but doesn't have
                             detail screens configured for cases.
-                        {% endif %}
-                        {% if error.type == "no product detail" %}
+                        {% case "no product detail" %}
                             Module
                             <a href="{% url "view_module" domain app.id error.module.id %}">{{ error.module.name|trans:langs }}</a>
                             uses CommTrack products but doesn't have
                             detail screens configured for products.
-                        {% endif %}
-                        {% if error.type == "invalid id key" %}
+                        {% case "invalid id key" %}
                             Module
                             <a href="{% url "view_module" domain app.id error.module.id %}">{{ error.module.name|trans:langs }}</a>
                             has an incorrectly formatted ID key ({{ error.key }}).
                             Make sure your key has only letters and numbers and no spaces.
-                        {% endif %}
-                        {% if error.type == "no modules" %}
+                        {% case "no modules" %}
                             This application has no modules.
-                        {% endif %}
-                        {% if error.type == "no forms" %}
+                        {% case "no forms" %}
                             Module
                             <a href="{% url "view_module" domain app.id error.module.id %}">{{ error.module.name|trans:langs }}</a>
                             has no forms.
-                        {% endif %}
-                        {% if error.type == "no case type" %}
+                        {% case "no case type" %}
                             Module
                             <a href="{% url "view_module" domain app.id error.module.id %}">{{ error.module.name|trans:langs }}</a>
                             uses cases but doesn't have a
                             case type defined.
-                        {% endif %}
-                        {% if error.type == "invalid filter xpath" %}
+                        {% case "invalid filter xpath" %}
                             {% if error.filter %}
                                 Case List has invalid filter xpath <code>{{ error.filter }}</code> in module
                             {% else %}
                                 Case List has blank filter in module
                             {% endif %}
                             <a href="{% url "view_module" domain app.id error.module.id %}">{{ error.module.name|trans:langs }}</a>
-                        {% endif %}
-                        {% if error.type == "invalid sort field" %}
+                        {% case "invalid sort field" %}
                             {% if error.field %}
                                 Case List has invalid sort field <code>{{ error.field }}</code> in module
                             {% else %}
                                 Case List has blank sort field in module
                             {% endif %}
                             <a href="{% url "view_module" domain app.id error.module.id %}">{{ error.module.name|trans:langs }}</a>
-                        {% endif %}
-                        {% if error.type == "no parent select id" %}
+                        {% case "no parent select id" %}
                             Module
                             <a href="{% url "view_module" domain app.id error.module.id %}">{{ error.module.name|trans:langs }}</a>
                             uses parent case selection but doesn't have a parent
                             module specified.
-                        {% endif %}
-                        {% if error.type ==  "parent cycle" %}
+                        {% case "parent cycle" %}
                             The app's parent child case selection graph contains a cycle.
-                        {% endif %}
-                        {% if error.type == "invalid location xpath" %}
+                        {% case "invalid location xpath" %}
                             Case List has invalid location reference <code>{{ error.column.field_property}}</code>.
                             Details: {{ error.details }}
                             <a href="{% url "view_module" domain app.id error.module.id %}">{{ error.module.name|trans:langs }}</a>
-                        {% endif %}
-                        {% if error.type == "subcase has no case type" %}
+                        {% case "subcase has no case type" %}
                             Child case specifies no module
                             in form {% include "app_manager/partials/form_error_message.html" %}
-                        {% endif %}
-                        {% if error.type == "form error" %}
+                        {% case "form error" %}
                             One or more forms are invalid: check all your forms for error messages.
-                        {% endif %}
-                        {% if error.type == "missing languages" %}
+                        {% case "missing languages" %}
                             {% include "app_manager/partials/form_error_message.html" %} missing languages:
                             {% for lang in error.missing_languages %}
                                 {{ lang }}
                             {% endfor %}
-                        {% endif %}
-                        {% if error.type == "duplicate xmlns" %}
+                        {% case "duplicate xmlns" %}
                             You have two forms with the xmlns "{{ error.xmlns }}"
-                        {% endif %}
-                        {% if error.type == "update_case uses reserved word" %}
+                        {% case "update_case uses reserved word" %}
                             Case Update uses reserved word "{{ error.word }}"
                             {% if error.case_tag %} for action "{{ error.case_tag }}"{% endif %}
                             {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-                        {% endif %}
-                        {% if error.type == "update_case word illegal" %}
+                        {% case "update_case word illegal" %}
                             Case Update "{{ error.word }}" should start with a letter and only contain letters, numbers, '-', and '_'
                             {% if error.case_tag %} for action "{{ error.case_tag }}"{% endif %}
                             {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-                        {% endif %}
-                        {% if error.type == "case_name required" %}
+                        {% case "case_name required" %}
                             Every case must have a name. Please specify a value for the name property under
                             "Save data to the following case properties" {% if error.case_tag %} for action "{{ error.case_tag }}"{% endif %}
                             {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-                        {% endif %}
-                        {% if error.type == "path error" %}
+                        {% case "path error" %}
                             {% if error.path %}
                                 The case management in form {% include "app_manager/partials/form_error_message.html" %}
                                 contains the invalid path "{{ error.path }}".
                             {% else %}
                                 {% trans "You're loading or saving a case property but have not chosen a question from the form. Please choose a question from the dropdown next to the case property." %}
                             {% endif %}
-                        {% endif %}
-                        {% if error.type == "multimedia case property not supported" %}
+                        {% case "multimedia case property not supported" %}
                             Multimedia case property "{{ error.path }}" is not supported on apps on or before v2.5
-                        {% endif %}
-                        {% if error.type == "remote error" %}
+                        {% case "remote error" %}
                             Remote Error:
-                        {% endif %}
-                        {% if error.type == "empty lang" %}
+                        {% case "empty lang" %}
                             One of your languages is empty. Check your <a href="{% url "view_app" domain app.id %}">app settings</a>.
-                        {% endif %}
-                        {% if error.type == "missing parent tag" %}
+                        {% case "missing parent tag" %}
                             A subcase is referencing a parent case tag that does not exist: "{{ error.case_tag }}"
                             {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-                        {% endif %}
-                        {% if error.type == "subcase repeat context" %}
+                        {% case "subcase repeat context" %}
                             The subcase "{{ error.case_tag }}" is in a different repeat context to its parent
                             {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-                        {% endif %}
-                        {% if error.type == "circular ref" %}
+                        {% case "circular ref" %}
                             A circular reference was detected in the hierarchy of subcase "{{ error.case_tag }}"
                             {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-                        {% endif %}
-                        {% if error.type == "auto select key" %}
+                        {% case "auto select key" %}
                             The auto-select case action is missing the "{{ error.key_name }}" value
                             {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-                        {% endif %}
-                        {% if error.type == "auto select source" %}
+                        {% case "auto select source" %}
                             The auto-select case action is missing the "{{ error.source_name }}" value
                             {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-                        {% endif %}
-                        {% if error.type == "auto select case ref" %}
+                        {% case "auto select case ref" %}
                             The case tag referenced in the auto-select expression of "{{ error.case_tag }}" was not found
                             {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-                        {% endif %}
-                        {% if error.type == "no case type in action" %}
+                        {% case "no case type in action" %}
                             The form action "{{ error.case_tag }}" does not have a case type selected
                             {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}
-                        {% endif %}
-                        {% if error.type == "no case type in action" %}
+                        {% case "filtering without case" %}
                             The form has filtering enabled but no cases are being loaded (excluding auto-loaded cases)
                             {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}.
-                        {% endif %}
+                        {% else %}
+                            Unknown error: {{ error.type }}
+                            <p>Details: {{ error }}</p>
+                        {% endcase %}
                         {# And then show the optional `message` regardless #}
                         <span>{{ error.message }}</span>
                     </span>

--- a/corehq/apps/hqwebapp/tests/__init__.py
+++ b/corehq/apps/hqwebapp/tests/__init__.py
@@ -1,0 +1,1 @@
+from .test_hq_shared_tags import TestCaseTag

--- a/corehq/apps/hqwebapp/tests/test_hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/tests/test_hq_shared_tags.py
@@ -1,0 +1,102 @@
+from unittest import TestCase
+from django.template import Context, Template, TemplateSyntaxError
+
+
+class TestCaseTag(TestCase):
+
+    def test_basic_case(self):
+        self.assertEqual(render("""
+            {% case place "first" %}
+                You are first!
+            {% endcase %}
+        """, place="first"), "You are first!")
+
+    def test_second_case(self):
+        self.assertEqual(render("""
+            {% case place "first" %}
+                You won first place!
+            {% case "second" %}
+                Second place!
+            {% endcase %}
+        """, place="second"), "Second place!")
+
+    def test_missing_case_without_else(self):
+        self.assertEqual(render("""
+            {% case place "first" %}one{% endcase %}
+        """, place="nope"), "")
+
+    def test_else(self):
+        self.assertEqual(render("""
+            {% case place "first" %}
+                You won first place!
+            {% case "second" %}
+                Second place!
+            {% else %}
+                Practice is the way to success.
+            {% endcase %}
+        """, place="third"), "Practice is the way to success.")
+
+    def test_multi_value_initial_case(self):
+        temp = Template("""
+            {% load hq_shared_tags %}
+            {% case val 1 2 %}hit{% endcase %}
+        """)
+        self.assertEqual(render(temp, val=1), "hit")
+        self.assertEqual(render(temp, val=2), "hit")
+
+    def test_multi_value_inner_case(self):
+        temp = Template("""
+            {% load hq_shared_tags %}
+            {% case val 1 %}one{% case 2 3 %}two{% endcase %}
+        """)
+        self.assertEqual(render(temp, val=2), "two")
+        self.assertEqual(render(temp, val=3), "two")
+
+    def test_duplicate_case(self):
+        with self.assertRaises(TemplateSyntaxError) as context:
+            render("{% case val 1 %}one{% case 1 %}other one{% endcase %}")
+        self.assertEqual(str(context.exception),
+            "duplicate case not allowed: 1")
+
+    def test_too_few_initial_args(self):
+        with self.assertRaises(TemplateSyntaxError) as context:
+            render("{% load hq_shared_tags %}{% case place %}{% endcase %}")
+        self.assertEqual(str(context.exception),
+            "initial 'case' tag requires at least two arguments: a lookup "
+            "expression and at least one value for the first case")
+
+    def test_too_few_inner_args(self):
+        with self.assertRaises(TemplateSyntaxError) as context:
+            render("{% case place 1 %}{% case %}{% endcase %}")
+        self.assertEqual(str(context.exception),
+            "inner 'case' tag requires at least one argument")
+
+    def test_initial_expression_value(self):
+        with self.assertRaises(TemplateSyntaxError) as context:
+            render("{% case place x %}{% endcase %}")
+        self.assertEqual(str(context.exception),
+            "'case' tag expected literal value, got x")
+
+    def test_inner_expression_value(self):
+        with self.assertRaises(TemplateSyntaxError) as context:
+            render("{% case place 1 %}{% case x %}{% endcase %}")
+        self.assertEqual(str(context.exception),
+            "'case' tag expected literal value, got x")
+
+    def test_else_with_args(self):
+        with self.assertRaises(TemplateSyntaxError) as context:
+            render("{% case place 1 %}{% else x %}{% endcase %}")
+        self.assertEqual(str(context.exception),
+            "'else' tag does not accept arguments")
+
+    def test_endcase_with_args(self):
+        with self.assertRaises(TemplateSyntaxError) as context:
+            render("{% case place 1 %}{% endcase x %}")
+        self.assertEqual(str(context.exception),
+            "'endcase' tag does not accept arguments")
+
+
+def render(template, **context):
+    if not isinstance(template, Template):
+        template = Template("{% load hq_shared_tags %}\n" + template)
+    return template.render(Context(context)).strip()


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?155338

I seem to remember hitting a similar issue before. The new `case` tag should make it much easier to maintain the build errors template because it enforces unique error types and it also outputs error information for unknown error types.
