### PR TITLE
properly update code on db machine prior to syncdb/migrate

### DIFF
--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -33,7 +33,7 @@ from fabric.contrib import files, console
 from fabric.operations import require, local, prompt
 
 
-ROLES_ALL_SRC = ['django_monolith', 'django_app', 'django_celery', 'django_pillowtop', 'formsplayer', 'staticfiles']
+ROLES_ALL_SRC = ['pg', 'django_monolith', 'django_app', 'django_celery', 'django_pillowtop', 'formsplayer', 'staticfiles']
 ROLES_ALL_SERVICES = ['django_monolith', 'django_app', 'django_celery', 'django_pillowtop', 'formsplayer']
 ROLES_CELERY = ['django_monolith', 'django_celery']
 ROLES_PILLOWTOP = ['django_monolith', 'django_pillowtop']


### PR DESCRIPTION
this wasn't updating `code_root` and as a result when `syncdb` and `migrate` ran on hqdb they were running on a stale version of the code.

@dannyroberts @snopoke - this seemed like the simplest change, though another option would be to move running this stuff on something like pillowtop. Looking at prod it looks like pillowtop would need to be reconfigured to update its preindex directory.
