### PR TITLE
Hide less error when running Vellum in dev mode

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/form_designer.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_designer.html
@@ -36,6 +36,17 @@
                 onFormSave: function (data) {
                     COMMCAREHQ.app_manager.updateDOM(data.update);
                 },
+                {% if vellum_debug == "dev" %}
+                onReady: function () {
+                    var less_error_id = "#less-error-message\\:static-style-less-hqstyle-core",
+                        less_error = $(less_error_id);
+                    if (less_error) {
+                        console.log("hiding less error:", less_error_id);
+                        console.log(less_error.text());
+                        less_error.hide();
+                    }
+                },
+                {% endif %}
                 sessionid: {{ sessionid|JSON }}
             },
             javaRosa: {


### PR DESCRIPTION
This is a hack, but the error is a nuisance when running Vellum in dev mode (i.e., having HQ load Vellum from un-minified files in the local dev environment). I think the cause is an older version of less in HQ trying to parse newer-version less files used by Vellum. This is not a problem in production because all less files are compiled to minified CSS during the build process.

@emord 
