### PR TITLE
Fix build importing ui for new build server

### DIFF
--- a/corehq/apps/builds/models.py
+++ b/corehq/apps/builds/models.py
@@ -78,8 +78,8 @@ class CommCareBuild(Document):
             try:
                 for name in z.namelist():
                     path = name.split('/')
-                    if path[0] == "dist" and path[-1] != "":
-                        path = '/'.join(path[1:])
+                    if path[0:3] == ["archive", "application", "dist"] and path[-1] != "":
+                        path = '/'.join(path[3:])
                         self.put_file(z.read(name), path)
             except:
                 self.delete()


### PR DESCRIPTION
The new build server seems to produce an artifacts zip file with a different structure than before. This causes build imports to fail. This PR updates the way in which we check the paths of the files in the zip. It is worth noting that this produces a different set of attachments for the build doc in couch than before! See the following list. I do not know if this is correct or not, but I was able to build an app with `2.19`.
@wspride might be able to answer this question.
FYI @dannyroberts 

(items with a "-" were not attached to the `2.19` build doc, but were attached to the `2.18` doc)

```
 Generic/CustomKeys/CommCare.jad
 Generic/CustomKeys/CommCare.jar
-Generic/CustomKeys/buildlist.txt
 Generic/Default/CommCare.jad
 Generic/Default/CommCare.jar
-Generic/Default/buildlist.txt
 Generic/International/CommCare.jad
 Generic/International/CommCare.jar
-Generic/International/buildlist.txt
-Generic/WebDemo/CommCare.jar
-Generic/WebDemo/cldcapi10.jar
-Generic/WebDemo/cldcapi11.jar
-Generic/WebDemo/demo.html
-Generic/WebDemo/microemu-javase-applet.jar
-Generic/WebDemo/microemu-jsr-120.jar
-Generic/WebDemo/microemu-jsr-135.jar
-Generic/WebDemo/microemu-jsr-75.jar
-Generic/WebDemo/microemu-jsr-82.jar
-Generic/WebDemo/microemu-nokiaui.jar
-Generic/WebDemo/microemu-siemensapi.jar
-Generic/WebDemo/microemulator.jar
-Generic/WebDemo/midpapi20.jar
 Native/WinMo/CommCare.jad
 Native/WinMo/CommCare.jar
-Native/WinMo/buildlist.txt
 Nokia/Minimal/CommCare.jad
 Nokia/Minimal/CommCare.jar
-Nokia/Minimal/buildlist.txt
 Nokia/S40-custom-keys/CommCare.jad
 Nokia/S40-custom-keys/CommCare.jar
-Nokia/S40-custom-keys/buildlist.txt
 Nokia/S40-generic/CommCare.jad
 Nokia/S40-generic/CommCare.jad
 Nokia/S40-generic/CommCare.jar
-Nokia/S40-generic/buildlist.txt
 Nokia/S40-gps-native-input/CommCare.jad
 Nokia/S40-gps-native-input/CommCare.jar
-Nokia/S40-gps-native-input/buildlist.txt
 Nokia/S40-gps/CommCare.jad
 Nokia/S40-gps/CommCare.jar
-Nokia/S40-gps/buildlist.txt
 Nokia/S40-native-input/CommCare.jad
 Nokia/S40-native-input/CommCare.jar
-Nokia/S40-native-input/buildlist.txt
 Nokia/S40-qwerty/CommCare.jad
 Nokia/S40-qwerty/CommCare.jar
-Nokia/S40-qwerty/buildlist.txt
 Nokia/S60-generic/CommCare.jad
 Nokia/S60-generic/CommCare.jar
-Nokia/S60-generic/buildlist.txt
 Nokia/S60-native-input/CommCare.jad
 Nokia/S60-native-input/CommCare.jar
-Nokia/S60-native-input/buildlist.txt
 Nokia/S60-qwerty/CommCare.jad
 Nokia/S60-qwerty/CommCare.jar
-Nokia/S60-qwerty/buildlist.txt
-custom-devices.xml
```
