### PR TITLE
Improve warning message on pillow reset button

### DIFF
--- a/corehq/apps/hqadmin/templates/hqadmin/partials/reset-pillow-checkpoint-modal.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/partials/reset-pillow-checkpoint-modal.html
@@ -8,7 +8,8 @@
         <div class="modal-body">
             <p>{% trans "Are you sure you want to reset checkpoint for this pillow?" %}</p>
             <div class="alert">
-            <p><i class="icon-warning-sign"></i><strong>{% trans "You still have to RESTART the pillow manually!" %}</strong></p>
+            <p><i class="icon-warning-sign"></i> {% trans "You still have to RESTART the pillow manually!" %}</p>
+            <p><i class="icon-warning-sign"></i> {% trans "NOTE: this may invoke a huge indexing task that could slow down many parts of the site!" %}</p>
             </div>
             <input type="hidden" id="pillow_name" name="pillow_name" />
         </div>


### PR DESCRIPTION
I removed the boldness because it reduced legibility. If two warnings doesn't get their attention then I don't know what will.

@czue @snopoke 
