### PR TITLE
start replacing references to couch session objects with sql equivalents

### DIFF
--- a/corehq/apps/ivr/api.py
+++ b/corehq/apps/ivr/api.py
@@ -3,8 +3,8 @@ from corehq.apps.sms.models import CallLog, INCOMING, OUTGOING
 from corehq.apps.sms.mixin import VerifiedNumber, MobileBackend
 from corehq.apps.sms.util import strip_plus
 from corehq.apps.smsforms.app import start_session, _get_responses
-from corehq.apps.smsforms.models import XFormsSession, XFORMS_SESSION_IVR
-from corehq.apps.app_manager.models import get_app, Form
+from corehq.apps.smsforms.models import XFORMS_SESSION_IVR, get_session_by_session_id
+from corehq.apps.app_manager.models import Form
 from corehq.apps.hqmedia.models import HQMediaMapItem
 from django.http import HttpResponse
 from django.conf import settings
@@ -133,7 +133,7 @@ def incoming(phone_number, backend_module, gateway_session_id, ivr_event, input_
         if hang_up:
             if call_log_entry.xforms_session_id is not None:
                 # Process disconnect
-                session = XFormsSession.by_session_id(call_log_entry.xforms_session_id)
+                session = get_session_by_session_id(call_log_entry.xforms_session_id)
                 if session.end_time is None:
                     if call_log_entry.submit_partial_form:
                         submit_unfinished_form(session.session_id, call_log_entry.include_case_side_effects)

--- a/corehq/apps/sms/handlers/form_session.py
+++ b/corehq/apps/sms/handlers/form_session.py
@@ -22,7 +22,7 @@ def form_session_handler(v, text, msg):
     the handler passes. If multiple sessions are open, they are all closed and an
     error message is displayed to the user.
     """
-    multiple, session = get_single_open_session(v.domain, v.owner_id)
+    multiple, session = get_single_open_session_or_close_multiple(v.domain, v.owner_id)
     if multiple:
         send_sms_to_verified_number(v, get_message(MSG_MULTIPLE_SESSIONS, v))
         return True
@@ -47,7 +47,7 @@ def form_session_handler(v, text, msg):
         return False
 
 
-def get_single_open_session(domain, contact_id):
+def get_single_open_session_or_close_multiple(domain, contact_id):
     """
     Retrieves the current open XFormsSession for the given contact.
     If multiple sessions are open, it closes all of them and returns

--- a/corehq/apps/sms/handlers/form_session.py
+++ b/corehq/apps/sms/handlers/form_session.py
@@ -12,7 +12,7 @@ from corehq.apps.smsforms.app import (
     _responses_to_text,
 )
 from dateutil.parser import parse
-from corehq.apps.smsforms.models import XFormsSession
+from corehq.apps.smsforms.models import SQLXFormsSession
 
 
 def form_session_handler(v, text, msg):
@@ -57,14 +57,15 @@ def get_single_open_session_or_close_multiple(domain, contact_id):
     is True if there were multiple sessions, and session is the session if
     there was a single open session available.
     """
-    sessions = XFormsSession.get_all_open_sms_sessions(domain, contact_id)
-    if len(sessions) > 1:
+    sessions = SQLXFormsSession.get_all_open_sms_sessions(domain, contact_id)
+    count = sessions.count()
+    if count > 1:
         for session in sessions:
             session.end(False)
             session.save()
         return (True, None)
 
-    session = sessions[0] if len(sessions) == 1 else None
+    session = sessions[0] if count == 1 else None
     return (False, session)
 
 

--- a/corehq/apps/sms/handlers/keyword.py
+++ b/corehq/apps/sms/handlers/keyword.py
@@ -324,7 +324,7 @@ def handle_structured_sms(survey_keyword, survey_keyword_action, contact,
         error_msg = get_message(MSG_TOUCHFORMS_ERROR, verified_number)
 
     if session is not None:
-        session = SQLXFormsSession.get(session._id)
+        session = SQLXFormsSession.objects.get(couch_id=session._id)
         if session.is_open:
             session.end(False)
             session.save()

--- a/corehq/apps/sms/handlers/keyword.py
+++ b/corehq/apps/sms/handlers/keyword.py
@@ -1,4 +1,3 @@
-import logging
 from corehq.apps.sms.api import (
     MessageMetadata,
     add_msg_tags,
@@ -9,7 +8,7 @@ from corehq.apps.smsforms.app import _get_responses, start_session
 from corehq.apps.sms.models import WORKFLOW_KEYWORD
 from corehq.apps.sms.messages import *
 from corehq.apps.sms.handlers.form_session import validate_answer
-from corehq.apps.smsforms.models import XFormsSession
+from corehq.apps.smsforms.models import SQLXFormsSession
 from corehq.apps.reminders.models import (
     SurveyKeyword,
     RECIPIENT_SENDER,
@@ -26,7 +25,7 @@ from corehq.apps.groups.models import Group
 from touchforms.formplayer.api import current_question
 from corehq.apps.app_manager.models import Form
 from casexml.apps.case.models import CommCareCase
-from couchdbkit.exceptions import MultipleResultsFound
+
 
 class StructuredSMSException(Exception):
     def __init__(self, *args, **kwargs):
@@ -85,7 +84,7 @@ def global_keyword_start(v, text, msg, text_words, open_sessions):
     return True
 
 def global_keyword_stop(v, text, msg, text_words, open_sessions):
-    XFormsSession.close_all_open_sms_sessions(v.domain, v.owner_id)
+    SQLXFormsSession.close_all_open_sms_sessions(v.domain, v.owner_id)
     return True
 
 def global_keyword_current(v, text, msg, text_words, open_sessions):
@@ -135,7 +134,7 @@ def sms_keyword_handler(v, text, msg):
     if text == "":
         return False
 
-    sessions = XFormsSession.get_all_open_sms_sessions(v.domain, v.owner_id)
+    sessions = SQLXFormsSession.get_all_open_sms_sessions(v.domain, v.owner_id)
     text_words = text.upper().split()
 
     if text.startswith("#"):
@@ -325,7 +324,7 @@ def handle_structured_sms(survey_keyword, survey_keyword_action, contact,
         error_msg = get_message(MSG_TOUCHFORMS_ERROR, verified_number)
 
     if session is not None:
-        session = XFormsSession.get(session._id)
+        session = SQLXFormsSession.get(session._id)
         if session.is_open:
             session.end(False)
             session.save()
@@ -427,7 +426,7 @@ def process_survey_keyword_actions(verified_number, survey_keyword, text, msg):
 
     # Close any open sessions even if it's just an sms that we're
     # responding with.
-    XFormsSession.close_all_open_sms_sessions(verified_number.domain,
+    SQLXFormsSession.close_all_open_sms_sessions(verified_number.domain,
         verified_number.owner_id)
 
     if sender.doc_type == "CommCareCase":

--- a/corehq/apps/sms/tests/util.py
+++ b/corehq/apps/sms/tests/util.py
@@ -14,7 +14,7 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.sms.test_backend import TestSMSBackend
 from corehq.apps.sms.mixin import BackendMapping
 from corehq.apps.sms.models import SMSLog, CallLog
-from corehq.apps.smsforms.models import XFormsSession
+from corehq.apps.smsforms.models import SQLXFormsSession
 from corehq.apps.groups.models import Group
 from corehq.apps.reminders.models import (SurveyKeyword, SurveyKeywordAction,
     RECIPIENT_SENDER, METHOD_SMS_SURVEY, METHOD_STRUCTURED_SMS, METHOD_SMS)
@@ -283,7 +283,7 @@ class TouchformsTestCase(LiveServerTestCase):
         return call
 
     def get_open_session(self, contact):
-        return XFormsSession.get_open_sms_session(self.domain, contact._id)
+        return SQLXFormsSession.get_open_sms_session(self.domain, contact._id)
 
     def assertLastOutboundSMSEquals(self, contact, message):
         sms = self.get_last_outbound_sms(contact)

--- a/corehq/apps/smsforms/app.py
+++ b/corehq/apps/smsforms/app.py
@@ -1,4 +1,4 @@
-from .models import XFormsSession, XFORMS_SESSION_SMS
+from .models import XFormsSession, XFORMS_SESSION_SMS, SQLXFormsSession
 from datetime import datetime
 from corehq.apps.cloudcare.touchforms_api import get_session_data
 from touchforms.formplayer.api import (
@@ -96,10 +96,10 @@ def _get_responses(domain, recipient, text, yield_responses=False, session_id=No
     if session_id is not None:
         if update_timestamp:
             # The IVR workflow passes the session id
-            session = XFormsSession.by_session_id(session_id)
+            session = SQLXFormsSession.by_session_id(session_id)
     else:
         # The SMS workflow grabs the open sms session
-        session = XFormsSession.get_open_sms_session(domain, recipient)
+        session = SQLXFormsSession.get_open_sms_session(domain, recipient)
         if session is not None:
             session_id = session.session_id
 
@@ -130,7 +130,7 @@ def submit_unfinished_form(session_id, include_case_side_effects=False):
 
     The form is only submitted if the smsforms session has not yet completed.
     """
-    session = XFormsSession.by_session_id(session_id)
+    session = SQLXFormsSession.by_session_id(session_id)
     if session is not None and session.end_time is None:
         # Get and clean the raw xml
         try:

--- a/corehq/apps/smsforms/models.py
+++ b/corehq/apps/smsforms/models.py
@@ -234,7 +234,7 @@ def sync_sql_session_from_couch_session(couch_session):
     for attr in SESSION_PROPERTIES_TO_SYNC:
         setattr(sql_session, attr, data.get(attr, None))
 
-    # hack to avoid excess saves. see sync_couch_session_from_couch_session
+    # hack to avoid excess saves. see sync_couch_session_from_sql_session
     sql_session.do_not_sync = True
     sql_session.save()
     sql_session.do_not_sync = False
@@ -242,10 +242,10 @@ def sync_sql_session_from_couch_session(couch_session):
 
 @receiver(post_save, sender=SQLXFormsSession)
 def sync_signal_catcher(sender, instance, *args, **kwargs):
-    sync_couch_session_from_couch_session(instance)
+    sync_couch_session_from_sql_session(instance)
 
 
-def sync_couch_session_from_couch_session(sql_session):
+def sync_couch_session_from_sql_session(sql_session):
     if sql_session.do_not_sync:
         return
 

--- a/corehq/apps/smsforms/models.py
+++ b/corehq/apps/smsforms/models.py
@@ -1,6 +1,5 @@
 from copy import copy
 from datetime import datetime
-import logging
 from couchdbkit import MultipleResultsFound
 from couchdbkit.ext.django.schema import StringProperty, Document,\
     DateTimeProperty, BooleanProperty
@@ -9,6 +8,7 @@ from django.db.models import Q
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from dimagi.utils.couch.database import is_bigcouch, bigcouch_quorum_count
+from dimagi.utils.logging import notify_error
 
 XFORMS_SESSION_SMS = "SMS"
 XFORMS_SESSION_IVR = "IVR"
@@ -199,7 +199,7 @@ def get_session_by_session_id(id):
 
     couch_session = XFormsSession.by_session_id(id)
     if couch_session:
-        logging.error('session {} could not be found in sql.'.format(couch_session._id))
+        notify_error('session {} could not be found in sql.'.format(couch_session._id))
     return couch_session
 
 
@@ -250,7 +250,7 @@ def sync_couch_session_from_couch_session(sql_session):
         return
 
     if not sql_session.couch_id:
-        logging.error('Only existing sessions can be synced for now.')
+        notify_error('Only existing sessions can be synced for now. sql session id is {}'.format(sql_session.pk))
         return
 
     couch_doc = XFormsSession.get(sql_session.couch_id)

--- a/corehq/apps/smsforms/signals.py
+++ b/corehq/apps/smsforms/signals.py
@@ -4,8 +4,8 @@ from corehq.apps.receiverwrapper.util import submit_form_locally
 from couchforms.models import XFormInstance
 
 def handle_sms_form_complete(sender, session_id, form, **kwargs):
-    from corehq.apps.smsforms.models import XFormsSession
-    session = XFormsSession.by_session_id(session_id)
+    from corehq.apps.smsforms.models import SQLXFormsSession
+    session = SQLXFormsSession.by_session_id(session_id)
     if session:
         resp = submit_form_locally(form, session.domain, app_id=session.app_id)
         xform_id = resp['X-CommCareHQ-FormID']

--- a/corehq/apps/smsforms/tests/test_form_api.py
+++ b/corehq/apps/smsforms/tests/test_form_api.py
@@ -4,7 +4,7 @@ import json
 from corehq.apps.app_manager.models import import_app
 from corehq.apps.smsforms.app import start_session
 from corehq.apps.smsforms.tests.util import MockContact, CONTACT_ID, q_and_a
-from corehq.apps.smsforms.models import XFormsSession
+from corehq.apps.smsforms.models import SQLXFormsSession
 from couchforms.models import XFormInstance
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.domain.shortcuts import create_domain
@@ -49,7 +49,7 @@ class FormplayerApiTest(TestCase):
         q_and_a(self, "2", "thanks for submitting!", self.domain)
         
         # check the instance
-        session = XFormsSession.get(session.get_id)
+        session = SQLXFormsSession.objects.get(couch_id=session.get_id)
         self.assertTrue(session.submission_id)
         instance = XFormInstance.get(session.submission_id)
         self.assertEqual("sms contact", instance.xpath("form/name"))
@@ -73,7 +73,7 @@ class FormplayerApiTest(TestCase):
         q_and_a(self, "some case", "thanks, you're done!", self.domain)
         
         def _get_case(session):
-            session = XFormsSession.get(session.get_id)
+            session = SQLXFormsSession.objects.get(couch_id=session.get_id)
             self.assertTrue(session.submission_id)
             instance = XFormInstance.get(session.submission_id)
             case_id = instance.xpath("form/case/@case_id")

--- a/corehq/apps/smsforms/tests/test_sql_session.py
+++ b/corehq/apps/smsforms/tests/test_sql_session.py
@@ -210,8 +210,6 @@ class SQLSessionTestCase(TestCase):
             self.assertEqual(couch_session.session_id, session.session_id)
 
 
-
-
 def _make_session(**kwargs):
     properties = _arbitrary_session_properties(**kwargs)
     couch_session = XFormsSession(**properties)


### PR DESCRIPTION
this is built on top of https://github.com/dimagi/commcare-hq/pull/5456

I'm actually pretty confident in this change just based on test coverage, but hoping @gcapalbo can take a look and see whether he feels comfortable merging versus wanting to do some QA somewhere.

Note that this is only about 30% of the way there in terms of the complete migration to sql
