### PR TITLE
A better solution for stripping tags from Excel exports

### DIFF
--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -832,6 +832,21 @@ class GenericTabularReport(GenericReportView):
         """
         return dict(num=1, width=200)
 
+    @staticmethod
+    def _strip_tags(value):
+        """
+        Strip HTML tags from a value
+        """
+        # Uses regex. Regex is much faster than using an HTML parser, but will
+        # strip "<2 && 3>" from a value like "1<2 && 3>2". A parser will treat
+        # each cell like an HTML document, which might be overkill, but if
+        # using regex breaks values then we should use a parser instead, and
+        # take the knock. Assuming we won't have values with angle brackets,
+        # using regex for now.
+        if isinstance(value, basestring):
+            return re.sub('<[^>]*?>', '', value)
+        return value
+
     @property
     def override_export_sheet_name(self):
         """
@@ -858,21 +873,12 @@ class GenericTabularReport(GenericReportView):
         3. str(cell)
         """
         headers = self.headers
-        # Strip HTML tags using regex. Regex is much faster than using an HTML
-        # parser, but will strip "<2 && 3>" from a value like "1<2 && 3>2". A
-        # parser will treat each cell like an HTML document, which might be
-        # overkill, but if using regex breaks values then we should use a
-        # parser instead, and take the knock. Assuming we won't have values
-        # with angle brackets, using regex for now.
-        tag_pattern = re.compile('<[^>]*?>')
 
         def _unformat_row(row):
             def _unformat_val(val):
                 if isinstance(val, dict):
                     return val.get('raw', val.get('sort_key', val))
-                elif isinstance(val, basestring):
-                    return tag_pattern.sub('', val)
-                return val
+                return self._strip_tags(val)
 
             return [_unformat_val(val) for val in row]
 

--- a/corehq/apps/reports/tests/__init__.py
+++ b/corehq/apps/reports/tests/__init__.py
@@ -8,6 +8,7 @@ try:
     from corehq.apps.reports.tests.test_data_sources import *
     from corehq.apps.reports.tests.test_readable_formdata import *
     from corehq.apps.reports.tests.test_time_and_date_manipulations import *
+    from corehq.apps.reports.tests.test_generic import *
     from .test_pillows_xforms import *
     from .test_pillows_cases import *
     from .test_scheduled_reports import *

--- a/corehq/apps/reports/tests/test_generic.py
+++ b/corehq/apps/reports/tests/test_generic.py
@@ -1,0 +1,39 @@
+from unittest2 import expectedFailure
+from corehq.apps.reports.generic import GenericTabularReport
+from django.test import SimpleTestCase
+
+
+class GenericTabularReportTests(SimpleTestCase):
+
+    def test_strip_tags_html_bytestring(self):
+        """
+        _strip_tags should strip HTML tags
+        """
+        value = '<blink>182</blink>'
+        value = GenericTabularReport._strip_tags(value)
+        self.assertEqual(value, '182')
+
+    def test_strip_tags_html_unicode(self):
+        """
+        _strip_tags should strip HTML tags from Unicode
+        """
+        value = u'<blink>182</blink>'
+        value = GenericTabularReport._strip_tags(value)
+        self.assertEqual(value, u'182')
+
+    def test_strip_tags_passthru(self):
+        """
+        _strip_tags should allow non-basestring values to pass through
+        """
+        value = {'blink': 182}
+        value = GenericTabularReport._strip_tags(value)
+        self.assertEqual(value, {'blink': 182})
+
+    @expectedFailure
+    def test_strip_tags_expected_fail(self):
+        """
+        _strip_tags should not strip strings inside angle brackets, but does
+        """
+        value = '1 < 8 > 2'
+        value = GenericTabularReport._strip_tags(value)
+        self.assertEqual(value, '1 < 8 > 2')


### PR DESCRIPTION
After discussing with Cory and Daniel, this commit is a second take at
[FB 115140](http://manage.dimagi.com/default.asp?155140).

It still uses regex, which we would need to review if valid report values
include "<" and ">" (in that order). I've used regex because I've assumed we
don't have values like that, and regex is faster than using a full HTML parser
to strip tags.

Ultimately it would be better if cells in reports had content-type, but that
is going to be a lot more work.

This solution strips tags specifically for Excel exports, which is better than
the [previous attempt](https://github.com/dimagi/couchexport/pull/112) which affects all exports.

Once this PR is merged, [couchexport PR 112](https://github.com/dimagi/couchexport/pull/112) can be reverted.
