### PR TITLE
Fix bug in UCReport `DynamicChoiceListFilter`

### DIFF
--- a/corehq/apps/reports_core/filters.py
+++ b/corehq/apps/reports_core/filters.py
@@ -213,7 +213,7 @@ class DynamicChoiceListFilter(BaseFilter):
     template = 'reports_core/filters/dynamic_choice_list_filter/dynamic_choice_list.html'
     javascript_template = 'reports_core/filters/dynamic_choice_list_filter/dynamic_choice_list.js'
 
-    def __init__(self, name, required, label, show_all, url_generator, css_id=None):
+    def __init__(self, name, field, required, label, show_all, url_generator, css_id=None):
         """
         url_generator should be a callable that takes a domain, report, and filter and returns a url.
         see userreports.reports.filters.dynamic_choice_list_url for an example.
@@ -222,6 +222,7 @@ class DynamicChoiceListFilter(BaseFilter):
             FilterParam(name, True),
         ]
         super(DynamicChoiceListFilter, self).__init__(required=required, name=name, params=params)
+        self.field = field
         self.label = label
         self.show_all = show_all
         self.css_id = css_id or self.name

--- a/corehq/apps/userreports/reports/factory.py
+++ b/corehq/apps/userreports/reports/factory.py
@@ -45,6 +45,7 @@ def _build_dynamic_choice_list_filter(spec):
     wrapped = DynamicChoiceListFilterSpec.wrap(spec)
     return DynamicChoiceListFilter(
         name=wrapped.slug,
+        field=wrapped.field,
         label=wrapped.display,
         required=wrapped.required,
         show_all=wrapped.show_all,

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -234,7 +234,7 @@ def choice_list_api(request, domain, report_id, filter_id):
 
     def get_choices(data_source, filter, search_term=None, limit=20):
         table = get_indicator_table(data_source)
-        sql_column = table.c[filter.name]
+        sql_column = table.c[filter.field]
         query = Session.query(sql_column)
         if search_term:
             query = query.filter(sql_column.contains(search_term))


### PR DESCRIPTION
The select2 of the user configurable report `DynamicChoiceListFilter` filter causes an error if the filter's `slug` property does not equal its `field` property. @czue am I right in saying this wasn't intended? Otherwise, it seems like there wouldn't be a point in having a `slug` property separate from the `field` property.
