### PR TITLE
Allow UCReport dynamic choice filter to be cleared

### DIFF
--- a/corehq/apps/reports_core/templates/reports_core/filters/dynamic_choice_list_filter/dynamic_choice_list.js
+++ b/corehq/apps/reports_core/templates/reports_core/filters/dynamic_choice_list_filter/dynamic_choice_list.js
@@ -2,6 +2,9 @@
 var filter_id = "#{{ filter.css_id }}-input";
 $(filter_id).select2({
     minimumInputLength: 1,
+    allowClear: true,
+    // allowClear only respected if there is a non empty placeholder
+    placeholder: " ",
     ajax: {
         url: "{% ajax_filter_url domain report filter %}",
         dataType: 'json',


### PR DESCRIPTION
Allows users to clear a filter value after they have selected a value when viewing a user configured report.
