### PR TITLE
Add vellum help text feature flag

### DIFF
--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -287,3 +287,8 @@ PRIME_RESTORE = StaticToggle(
     'Prime restore cache',
     [NAMESPACE_DOMAIN, NAMESPACE_USER]
 )
+
+VELLUM_HELP_TEXT = StaticToggle(
+    'add_help_text',
+    "Adds a help text in the form builder"
+)


### PR DESCRIPTION
@snopoke 

Looks like this feature flag was erroneously deleted here: https://github.com/dimagi/commcare-hq/pull/5496/

Still used by Vellum as it's in QA
