### PR TITLE
Improve performance on reminder definition lookups

### DIFF
--- a/corehq/apps/domain/calculations.py
+++ b/corehq/apps/domain/calculations.py
@@ -194,7 +194,7 @@ def app_list(domain, *args):
     return render_to_string("domain/partials/app_list.html", {"apps": apps, "domain": domain.name})
 
 def uses_reminders(domain, *args):
-    handlers = CaseReminderHandler.get_handlers(domain=domain).all()
+    handlers = CaseReminderHandler.get_handlers(domain)
     return len(handlers) > 0
 
 def not_implemented(domain, *args):

--- a/corehq/apps/reminders/models.py
+++ b/corehq/apps/reminders/models.py
@@ -22,7 +22,7 @@ from dimagi.utils.multithreading import process_fast
 from dimagi.utils.logging import notify_exception
 from random import randint
 from django.conf import settings
-
+from dimagi.utils.couch.database import iter_docs
 
 class IllegalModelStateException(Exception):
     pass
@@ -1204,23 +1204,40 @@ class CaseReminderHandler(Document):
                 print_stack_interval=60)
 
     @classmethod
-    def get_handlers(cls, domain, case_type=None, ids_only=False):
-        key = [domain]
-        if case_type:
-            key.append(case_type)
-        result = cls.view('reminders/handlers_by_domain_case_type',
-            startkey=key,
-            endkey=key + [{}],
-            include_docs=(not ids_only),
+    def get_handlers(cls, domain, reminder_type_filter=None):
+        ids = cls.get_handler_ids(domain,
+            reminder_type_filter=reminder_type_filter)
+        return cls.get_handlers_from_ids(ids)
+
+    @classmethod
+    def get_handlers_from_ids(cls, ids):
+        return [
+            CaseReminderHandler.wrap(doc)
+            for doc in iter_docs(cls.get_db(), ids)
+        ]
+
+    @classmethod
+    def get_handler_ids(cls, domain, reminder_type_filter=None):
+        result = cls.view('reminders/handlers_by_reminder_type',
+            startkey=[domain],
+            endkey=[domain, {}],
+            include_docs=False,
+            reduce=False,
         )
-        if ids_only:
-            return [row["id"] for row in result]
-        else:
-            return result
+        def filter_fcn(reminder_type):
+            if reminder_type_filter is None:
+                return True
+            else:
+                return ((reminder_type or REMINDER_TYPE_DEFAULT) ==
+                    reminder_type_filter)
+        return [
+            row['id'] for row in result
+            if filter_fcn(row['key'][1])
+        ]
 
     @classmethod
     def get_referenced_forms(cls, domain):
-        handlers = cls.get_handlers(domain=domain).all()
+        handlers = cls.get_handlers(domain)
         referenced_forms = [e.form_unique_id for events in [h.events for h in handlers] for e in events]
         return filter(None, referenced_forms)
 

--- a/corehq/apps/reminders/models.py
+++ b/corehq/apps/reminders/models.py
@@ -1224,6 +1224,7 @@ class CaseReminderHandler(Document):
             include_docs=False,
             reduce=False,
         )
+
         def filter_fcn(reminder_type):
             if reminder_type_filter is None:
                 return True

--- a/corehq/apps/reminders/signals.py
+++ b/corehq/apps/reminders/signals.py
@@ -1,13 +1,15 @@
 import logging
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.signals import case_post_save
-from corehq.apps.reminders.models import CaseReminderHandler
+from corehq.apps.reminders.models import (CaseReminderHandler,
+    REMINDER_TYPE_DEFAULT)
 from corehq.apps.reminders.tasks import case_changed
 from dimagi.utils.logging import notify_exception
 
 def case_changed_receiver(sender, case, **kwargs):
     try:
-        handler_ids = CaseReminderHandler.get_handler_ids(case.domain)
+        handler_ids = CaseReminderHandler.get_handler_ids(case.domain,
+            reminder_type_filter=REMINDER_TYPE_DEFAULT)
         if len(handler_ids) > 0:
             case_changed.delay(case._id, handler_ids)
     except Exception:

--- a/corehq/apps/reminders/signals.py
+++ b/corehq/apps/reminders/signals.py
@@ -7,8 +7,7 @@ from dimagi.utils.logging import notify_exception
 
 def case_changed_receiver(sender, case, **kwargs):
     try:
-        handler_ids = CaseReminderHandler.get_handlers(case.domain,
-            ids_only=True)
+        handler_ids = CaseReminderHandler.get_handler_ids(case.domain)
         if len(handler_ids) > 0:
             case_changed.delay(case._id, handler_ids)
     except Exception:

--- a/corehq/apps/reminders/tasks.py
+++ b/corehq/apps/reminders/tasks.py
@@ -49,8 +49,7 @@ def case_changed(case_id, handler_ids, retry_num=0):
 def _case_changed(case_id, handler_ids):
     subcases = None
     case = CommCareCase.get(case_id)
-    for handler_id in handler_ids:
-        handler = CaseReminderHandler.get(handler_id)
+    for handler in CaseReminderHandler.get_handlers_from_ids(handler_ids):
         if handler.start_condition_type == CASE_CRITERIA:
             handler.case_changed(case)
             if handler.uses_parent_case_property:

--- a/corehq/apps/reminders/views.py
+++ b/corehq/apps/reminders/views.py
@@ -109,7 +109,7 @@ def default(request, domain):
 
 @reminders_framework_permission
 def list_reminders(request, domain, reminder_type=REMINDER_TYPE_DEFAULT):
-    all_handlers = CaseReminderHandler.get_handlers(domain=domain).all()
+    all_handlers = CaseReminderHandler.get_handlers(domain)
     all_handlers = filter(lambda x : x.reminder_type == reminder_type, all_handlers)
     if reminder_type == REMINDER_TYPE_ONE_TIME:
         all_handlers.sort(key=lambda handler : handler.start_datetime)
@@ -1659,7 +1659,7 @@ class RemindersListView(BaseMessagingSectionView):
 
     @property
     def reminders(self):
-        all_handlers = CaseReminderHandler.get_handlers(domain=self.domain).all()
+        all_handlers = CaseReminderHandler.get_handlers(self.domain)
         all_handlers = filter(lambda x : x.reminder_type == REMINDER_TYPE_DEFAULT, all_handlers)
         if not self.can_use_survey:
             all_handlers = filter(

--- a/corehq/apps/reminders/views.py
+++ b/corehq/apps/reminders/views.py
@@ -1659,8 +1659,8 @@ class RemindersListView(BaseMessagingSectionView):
 
     @property
     def reminders(self):
-        all_handlers = CaseReminderHandler.get_handlers(self.domain)
-        all_handlers = filter(lambda x : x.reminder_type == REMINDER_TYPE_DEFAULT, all_handlers)
+        all_handlers = CaseReminderHandler.get_handlers(self.domain,
+            reminder_type_filter=REMINDER_TYPE_DEFAULT)
         if not self.can_use_survey:
             all_handlers = filter(
                 lambda x: x.method not in [METHOD_IVR_SURVEY, METHOD_SMS_SURVEY],


### PR DESCRIPTION
The first commit is a refactor, which allows for the performance enhancements in the second commit.  Basically adds the ability to filter on doc ids first instead of retrieving all docs and filtering later. Also improves performance when looking up just by ids.
