### PR TITLE
(FB: 155998) - Fix for bulk download

### DIFF
--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -8,6 +8,7 @@ from django.template.loader import render_to_string
 from django.utils.datastructures import SortedDict
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
+from django.http import QueryDict
 from corehq.apps.domain.models import Domain
 from dimagi.utils.couch.cache import cache_core
 from dimagi.utils.logging import notify_exception
@@ -21,6 +22,9 @@ register = template.Library()
 
 @register.filter
 def JSON(obj):
+    # json.dumps does not properly convert QueryDict array parameter to json
+    if isinstance(obj, QueryDict):
+        obj = dict(obj)
     return mark_safe(json.dumps(obj, default=json_handler))
 
 

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -483,12 +483,13 @@ class ExpandedMobileWorkerFilterWithAllData(ExpandedMobileWorkerFilter):
 
 
 def get_user_toggle(request):
+    request_obj = request.POST if request.method == 'POST' else request.GET
     ufilter = group = individual = show_commtrack = None
     try:
-        if request.GET.get('ufilter', ''):
-            ufilter = request.GET.getlist('ufilter')
-        group = request.GET.get('group', '')
-        individual = request.GET.get('individual', '')
+        if request_obj.get('ufilter', ''):
+            ufilter = request_obj.getlist('ufilter')
+        group = request_obj.get('group', '')
+        individual = request_obj.get('individual', '')
         show_commtrack = request.project.commtrack_enabled
     except (KeyError, AttributeError):
         pass

--- a/corehq/apps/reports/static/reports/ko/export.manager.js
+++ b/corehq/apps/reports/static/reports/ko/export.manager.js
@@ -176,6 +176,7 @@ var ExportManager = function (o) {
             url: downloadUrl,
             type: 'POST',
             data: data,
+            traditional: true,
             success: function(respData){
                 updateModal({
                     data: respData,

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -348,12 +348,13 @@ def users_matching_filter(domain, user_filters):
 
 
 def create_export_filter(request, domain, export_type='form'):
+    request_obj = request.POST if request.method == 'POST' else request.GET
     from corehq.apps.reports.filters.users import UserTypeFilter
-    app_id = request.GET.get('app_id', None)
+    app_id = request_obj.get('app_id', None)
 
     user_filters, use_user_filters = UserTypeFilter.get_user_filter(request)
     use_user_filters &= bool(user_filters)
-    group = None if use_user_filters else get_group(**json_request(request.GET))
+    group = None if use_user_filters else get_group(**json_request(request_obj))
 
     if export_type == 'case':
         if use_user_filters:

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -305,6 +305,9 @@ def _export_default_or_custom_data(request, domain, export_id=None, bulk_export=
             safe_only=safe_only
         )
 
+        if export_type == 'form':
+            filter &= SerializableFunction(instances)
+
         return export_helper.prepare_export(export_tags, filter)
 
     elif export_id:


### PR DESCRIPTION
Fixes for bulk download so it behaves like the single download. A couple of things going on here.
1. The JSON template filter was not properly transforming array arguments into json. It was only including the last value.
2. The instances function check was never added to the filter for bulk download
3. Many of the util functions depend on `request.GET` yet commcare initiates bulk download with a POST request.

I think in the future these functions should be refactored to not take request as an argument, especially if it's a util function. This made it really hard for me test (hence no tests). I left out the refactor cause I thought it was out of scope for the interrupt bug, but if you think it's something we should do now I could do that.
@czue @emord 

http://manage.dimagi.com/default.asp?155998#873180
