### PR TITLE
Fix popover style

### DIFF
--- a/corehq/apps/style/static/style/lib/bootstrap/less/popovers.less
+++ b/corehq/apps/style/static/style/lib/bootstrap/less/popovers.less
@@ -44,9 +44,9 @@
 
 .popover-content {
   padding: 9px 14px;
-  font-size: 12px;
+  font-size: @baseFontSize;
   font-weight: normal;
-  line-height: normal;
+  line-height: @baseLineHeight;
 }
 
 // Arrows

--- a/corehq/apps/style/static/style/lib/bootstrap/less/popovers.less
+++ b/corehq/apps/style/static/style/lib/bootstrap/less/popovers.less
@@ -44,6 +44,9 @@
 
 .popover-content {
   padding: 9px 14px;
+  font-size: 12px;
+  font-weight: normal;
+  line-height: normal;
 }
 
 // Arrows


### PR DESCRIPTION
@biyeun 

http://manage.dimagi.com/default.asp?157448#875043

This may be the wrong place to fix this. (not sure how you generate the bootstrap less files from the other bootstrap repo)

Right now popovers content will inherit whatever properties its parent element has (like h3) whereas popover titles overwrite these things (https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/style/static/style/lib/bootstrap/less/popovers.less#L37-L39).

Before pic is in ticket
After:
![tooltip_007](https://cloud.githubusercontent.com/assets/1471773/6220193/6b6f9f42-b601-11e4-87fb-5f405ece9be7.png)
