### PR TITLE
Properly check index value

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1508,7 +1508,7 @@ class Module(ModuleBase):
         else:
             raise IncompatibleFormTypeException()
 
-        if index:
+        if index is not None:
             self.forms.insert(index, new_form)
         else:
             self.forms.append(new_form)


### PR DESCRIPTION
When index was 0, this would be incorrectly evaluated as false
