### PR TITLE
Docker (PR #5502 follow up)

### DIFF
--- a/.lintrc
+++ b/.lintrc
@@ -2,6 +2,7 @@
 [files]
 ignore = */migrations/*
          *.min.js
+         localsettings.py
 
 [tools]
 linters = flake8, jshint

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,38 @@
+CommCare HQ docker
+==================
+
+The purpose of this docker initiative is to allow non-tech users to install and run offline demo instances of CommCareHQ for training / remote app building. The possibility to mount a source tree into a well-defined container may also help development.
+
+This project is made of :
+
+* a Dockerfile in the root directory that build a docker image containing the latest version of CommCareHQ
+* scripts in the docker folder to build / instanciate / start / stop a CommCareHQ stack
+
+
+Try it
+------
+
+* [install docker](http://docs.docker.com/installation)
+* run {commcare-hq}/docker/docker-run.sh
+* connect to http://[hostip]:8000
+* login: example@example.com / password: example
+* [install commcare-mobile builds](https://github.com/dimagi/commcare-hq/tree/master/corehq/apps/builds)
+
+
+Notes
+-----
+
+* It is possible to mount a git clone into a commcare-hq container with the -v option : `docker run --link postgres:postgres --link couchdb:couchdb --link redis:redis --link elasticsearch:elasticsearch -p 8000:8000 -v /path/to/clone:/usr/src/commcare-hq -i -t charlesfleche/commcare-hq /bin/bash`. /usr/src/commcare-hq is the default source location within the image.
+* BASE_ADDRESS can be set with the environment variable BASE_HOST, with a fall back to localhost. In the docker-run.sh BASE_HOST is set by taking the first address returned by `hostname -I`. This is not ideal…
+* Each commit to [my docker branch](https://github.com/charlesfleche/commcare-hq/tree/docker) triggers a [charlesfleche/commcare-hq](https://registry.hub.docker.com/u/charlesfleche/commcare-hq/) image build.
+* I am not using [fig](http://www.fig.sh/) for the time being as the current goal is to target deployments on OSX / Windows laptops.
+* Wheezy has been choosen as a base image because the official redis, postgres and couchdb are based on the same image, potentialy reducing the amount of data to download.
+* Databases initializations (users, db, django) is done by instanciating temporary couchdb / postgres / commcarehq images that already contain the necessary binaries (like psql).
+* Celery, rabbitmq and other components not strictly necessary for a laptop install are not part of this setup.
+
+
+Caveats
+-------
+
+* CloudCare is not currently part of this set up. It should probably be another docker image, different from CommCareHQ.
+* Some CommCareHQ pages trigger errors, probably because of missing components / misconfigurations.

--- a/docker/docker-run.sh
+++ b/docker/docker-run.sh
@@ -29,4 +29,4 @@ docker run --rm --link postgres:postgres --link couchdb:couchdb --link redis:red
 docker run --rm --link postgres:postgres --link couchdb:couchdb --link redis:redis --link elasticsearch:elasticsearch charlesfleche/commcare-hq python manage.py bootstrap example example@example.com example
 
 
-docker run --name commcare-hq --link postgres:postgres --link couchdb:couchdb --link redis:redis --link elasticsearch:elasticsearch -p 8000:8000 -d charlesfleche/commcare-hq
+docker run --name commcare-hq --link postgres:postgres --link couchdb:couchdb --link redis:redis --link elasticsearch:elasticsearch -p 8000:8000 -e BASE_HOST=`hostname -I | awk '{print $1}'` -d charlesfleche/commcare-hq

--- a/docker/localsettings.py
+++ b/docker/localsettings.py
@@ -77,14 +77,14 @@ BITLY_APIKEY = '*******'
 
 ####### Jar signing config ########
 
-_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
-JAR_SIGN = {
-    'jad_tool': os.path.join(_ROOT_DIR, "corehq", "apps", "app_manager", "JadTool.jar"),
-    'key_store': os.path.join(os.path.dirname(os.path.dirname(_ROOT_DIR)), "DimagiKeyStore"),
-    'key_alias': "javarosakey",
-    'store_pass': "*******",
-    'key_pass': "*******",
-}
+#_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+#JAR_SIGN = {
+#    'jad_tool': os.path.join(_ROOT_DIR, "corehq", "apps", "app_manager", "JadTool.jar"),
+#    'key_store': os.path.join(os.path.dirname(os.path.dirname(_ROOT_DIR)), "DimagiKeyStore"),
+#    'key_alias': "javarosakey",
+#    'store_pass': "*******",
+#    'key_pass': "*******",
+#}
 
 ####### SMS Config ########
 

--- a/docker/localsettings.py
+++ b/docker/localsettings.py
@@ -125,7 +125,7 @@ OVERRIDE_LOCATION = "https://www.commcarehq.org"
 
 # Set to something like "192.168.1.5:8000" (with your IP address).
 # See corehq/apps/builds/README.md for more information.
-BASE_ADDRESS = 'localhost:8000'
+BASE_ADDRESS = '{}:8000'.format(os.environ.get('BASE_HOST', 'localhost'))
 
 # Set your analytics IDs here for GA and pingdom RUM
 ANALYTICS_IDS = {


### PR DESCRIPTION
Follows up #5502

This PR deactivate JAR signing, add a new commcare-hq environment variable BASE_HOST to set Django's BASE_NAME, add a docker README and exclude localsettings.py from lint checks. 
