### PR TITLE
don't show "stale data" warning if last_accessed not set

### DIFF
--- a/corehq/apps/reports/templates/reports/partials/hqexport_group_table.html
+++ b/corehq/apps/reports/templates/reports/partials/hqexport_group_table.html
@@ -17,7 +17,7 @@
             <td>{{ component.config.name }} {{ component.config.get_id }}</td>
             <td>{% if component.saved_version.has_file %}
                 {{ component.saved_version.last_updated|naturaltime }}
-                {% if not component.saved_version.last_accessed or component.saved_version.last_accessed < group_export_cutoff %}
+                {% if component.saved_version.last_accessed and component.saved_version.last_accessed < group_export_cutoff %}
                     <p class="muted">
                         <i class="icon-warning-sign"></i>
                         <small>{% trans "This saved export has expired because it has not been used in the last 35 days. To renew daily updates, click the 'Update Data' button and download the file." %}</small>


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?157810

not actually dependent on, but goes with https://github.com/dimagi/couchexport/pull/116
