### PR TITLE
rebuild indicators for static datasources during bootstrap

### DIFF
--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -2,6 +2,7 @@ from alembic.autogenerate.api import compare_metadata
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.userreports.models import DataSourceConfiguration, CustomDataSourceConfiguration
 from corehq.apps.userreports.sql import get_engine, IndicatorSqlAdapter, metadata
+from corehq.apps.userreports.tasks import rebuild_indicators
 from fluff.signals import get_migration_context, get_tables_to_rebuild
 from pillowtop.couchdb import CachedCouchDB
 from pillowtop.listener import PythonPillow
@@ -48,10 +49,12 @@ class ConfigurableIndicatorPillow(PythonPillow):
             diffs = compare_metadata(migration_context, metadata)
 
         tables_to_rebuild = get_tables_to_rebuild(diffs, table_map.keys())
-
         for table_name in tables_to_rebuild:
             table = table_map[table_name]
-            table.rebuild_table()
+            self.rebuild_table(table)
+
+    def rebuild_table(self, table):
+        table.rebuild_table()
 
     def python_filter(self, doc):
         # filtering is done manually per indicator set change_transport
@@ -78,3 +81,7 @@ class CustomDataSourcePillow(ConfigurableIndicatorPillow):
 
     def get_all_configs(self):
         return CustomDataSourceConfiguration.all()
+
+    def rebuild_table(self, table):
+        super(CustomDataSourcePillow, self).rebuild_table(table)
+        rebuild_indicators.delay(table.config.get_id)

--- a/corehq/apps/userreports/sql.py
+++ b/corehq/apps/userreports/sql.py
@@ -1,6 +1,7 @@
 import hashlib
 import sqlalchemy
 from django.conf import settings
+from sqlalchemy.exc import IntegrityError
 from dimagi.utils.decorators.memoized import memoized
 from fluff.util import get_column_type
 
@@ -30,12 +31,18 @@ class IndicatorSqlAdapter(object):
             table = self.get_table()
             for indicator_row in indicator_rows:
                 with self.engine.begin() as connection:
-                    # delete all existing rows for this doc to ensure we aren't left with stale data
-                    delete = table.delete(table.c.doc_id == doc['_id'])
-                    connection.execute(delete)
-                    all_values = {i.column.id: i.value for i in indicator_row}
-                    insert = table.insert().values(**all_values)
-                    connection.execute(insert)
+                    try:
+                        # delete all existing rows for this doc to ensure we aren't left with stale data
+                        delete = table.delete(table.c.doc_id == doc['_id'])
+                        connection.execute(delete)
+                        all_values = {i.column.id: i.value for i in indicator_row}
+                        insert = table.insert().values(**all_values)
+                        connection.execute(insert)
+                    except IntegrityError:
+                        # Someone beat us to it. Concurrent inserts can happen
+                        # when a doc is processed by the celery rebuild task
+                        # at the same time as the pillow.
+                        pass
 
     def delete(self, doc):
         table = self.get_table()

--- a/corehq/apps/userreports/sql.py
+++ b/corehq/apps/userreports/sql.py
@@ -31,12 +31,12 @@ class IndicatorSqlAdapter(object):
             table = self.get_table()
             for indicator_row in indicator_rows:
                 with self.engine.begin() as connection:
+                    # delete all existing rows for this doc to ensure we aren't left with stale data
+                    delete = table.delete(table.c.doc_id == doc['_id'])
+                    connection.execute(delete)
+                    all_values = {i.column.id: i.value for i in indicator_row}
+                    insert = table.insert().values(**all_values)
                     try:
-                        # delete all existing rows for this doc to ensure we aren't left with stale data
-                        delete = table.delete(table.c.doc_id == doc['_id'])
-                        connection.execute(delete)
-                        all_values = {i.column.id: i.value for i in indicator_row}
-                        insert = table.insert().values(**all_values)
                         connection.execute(insert)
                     except IntegrityError:
                         # Someone beat us to it. Concurrent inserts can happen


### PR DESCRIPTION
Prevents one having to manually rebuild the indicators after a deploy.
