### PR TITLE
Handle unicode names in profile.xml

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -3258,7 +3258,7 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
             'uniqueid': self.copy_of or self.id,
             'name': self.name,
             'descriptor': u"Profile File"
-        }).decode('utf-8')
+        }).encode('utf-8')
 
     @property
     def custom_suite(self):

--- a/corehq/apps/app_manager/tests/test_profile.py
+++ b/corehq/apps/app_manager/tests/test_profile.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 from django.test import SimpleTestCase
 from corehq.apps.app_manager.commcare_settings import SETTINGS_LOOKUP, SETTINGS
 from corehq.apps.app_manager.models import Application
@@ -13,7 +14,9 @@ class ProfileTest(SimpleTestCase, TestFileMixin):
     def setUp(self):
         self.app = Application(build_spec=BuildSpec(
             version='2.7.0'
-        ))
+            ),
+            name=u"TÉST ÁPP"
+        )
 
     def _test_profile(self, app):
         profile_xml = ET.fromstring(app.create_profile())

--- a/corehq/apps/app_manager/tests/test_profile.py
+++ b/corehq/apps/app_manager/tests/test_profile.py
@@ -19,7 +19,10 @@ class ProfileTest(SimpleTestCase, TestFileMixin):
         )
 
     def _test_profile(self, app):
-        profile_xml = ET.fromstring(app.create_profile())
+        profile = app.create_profile()
+        assert isinstance(profile, bytes), type(profile)
+        assert u"TÉST ÁPP" in profile.decode('utf-8')
+        profile_xml = ET.fromstring(profile)
         types = {
             'features': self._test_feature,
             'properties': self._test_property,


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?157944#877660

Introduced here: https://github.com/dimagi/commcare-hq/commit/4370405c28e5ecdf19a79c96e81938f3096f76f0

I think this just happened to be all ascii before.
