### PR TITLE
Check for global event object

### DIFF
--- a/corehq/apps/export/templates/export/customize_export.html
+++ b/corehq/apps/export/templates/export/customize_export.html
@@ -363,9 +363,7 @@
                             if (event_category) {
                                 // Record an event
                                 ga_track_event(event_category, 'Custom export creation', "", {
-                                    'hitCallback': function () {
-                                        redirect();
-                                    }
+                                    'hitCallback': redirect
                                 });
                                 return;
                             }

--- a/corehq/apps/style/templates/style/includes/analytics_google.html
+++ b/corehq/apps/style/templates/style/includes/analytics_google.html
@@ -75,8 +75,8 @@
         // rather than the 3rd or 4th from the left, because it's variable
         // https://developers.google.com/analytics/devguides/collection/analyticsjs/events#overview
         var lastArg = arguments[arguments.length - 1];
-        if (lastArg && lastArg.hitCallback) {
-            event.preventDefault();
+        if (lastArg && lastArg.hitCallback && window.event) {
+            window.event.preventDefault();
         }
         ga.apply(null, args);
     }


### PR DESCRIPTION
Firefox does not have the global event object like other browsers do. So when it tries to call `event.preventDefault` it fails. A refactor is probably needed at some point to pass in the event object, but I held off because I wasn't sure how important calling `preventDefault`. The call to `preventDefault` might best be done outside of this function.

http://manage.dimagi.com/default.asp?157932#877714
