### PR TITLE
change login form to charfield for cloudcare logins

### DIFF
--- a/corehq/apps/hqwebapp/forms.py
+++ b/corehq/apps/hqwebapp/forms.py
@@ -23,7 +23,7 @@ class EmailAuthenticationForm(AuthenticationForm):
 
 
 class CloudCareAuthenticationForm(EmailAuthenticationForm):
-    username = forms.EmailField(label=_("Username"), max_length=75)
+    username = forms.CharField(label=_("Username"), max_length=75)
 
 
 class BulkUploadForm(forms.Form):


### PR DESCRIPTION
in django 1.6 there is client-side validation that prevents you from
entering a non-email, which is not desired for this page
