### PR TITLE
Fix exportable_all property

### DIFF
--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -404,6 +404,7 @@ class DailyFormStatsReport(WorkerMonitoringReportTableBase, CompletionOrSubmissi
     emailable = True
     is_cacheable = False
     ajax_pagination = True
+    exportable_all = True
 
     @classmethod
     def display_in_dropdown(cls, domain=None, project=None, user=None):

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -471,7 +471,7 @@ class DailyFormStatsReport(WorkerMonitoringReportTableBase, CompletionOrSubmissi
         return sorted(users, key=lambda u: u['username_in_report'])
 
     def paginate_list(self, data_list):
-        if self.pagination:
+        if self.request_params.get('iDisplayLength'):
             start = self.pagination.start
             end = start + self.pagination.count
             return data_list[start:end]

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -472,7 +472,7 @@ class DailyFormStatsReport(WorkerMonitoringReportTableBase, CompletionOrSubmissi
         return sorted(users, key=lambda u: u['username_in_report'])
 
     def paginate_list(self, data_list):
-        if self.request_params.get('iDisplayLength'):
+        if self.pagination:
             start = self.pagination.start
             end = start + self.pagination.count
             return data_list[start:end]

--- a/custom/bihar/reports/mch_reports.py
+++ b/custom/bihar/reports/mch_reports.py
@@ -13,7 +13,6 @@ from corehq.elastic import stream_es_query, ES_URLS
 from custom.bihar.reports.display import MCHMotherDisplay, MCHChildDisplay
 from dimagi.utils.timezones import utils as tz_utils
 import pytz
-from corehq.apps.reports.tasks import export_all_rows_task
 from custom.bihar.utils import get_all_owner_ids_from_group
 
 
@@ -107,14 +106,6 @@ class MCHBaseReport(CustomProjectReport, CaseListReport):
         query = self.build_query(case_type=self.case_type, afilter=self.case_filter,
                                  status=self.case_status)
         return query
-
-    @property
-    @request_cache("export")
-    def export_response(self):
-        self.request.datespan = None
-        export_all_rows_task.delay(self.__class__, self.__getstate__())
-
-        return HttpResponse()
 
     @property
     def rows(self):

--- a/custom/m4change/reports/mcct_project_review.py
+++ b/custom/m4change/reports/mcct_project_review.py
@@ -22,7 +22,6 @@ from custom.m4change.models import McctStatus
 from custom.m4change.reports import get_location_hierarchy_by_id
 from custom.m4change.utils import get_case_by_id, get_property, get_form_ids_by_status
 from custom.m4change.constants import EMPTY_FIELD
-from corehq.apps.reports.tasks import export_all_rows_task
 
 
 def _get_date_range(range):
@@ -277,14 +276,6 @@ class McctProjectReview(BaseReport):
         export_rows = self.get_all_rows
         table.extend(export_rows)
         return [[self.export_sheet_name, table]]
-
-    @property
-    @request_cache("export")
-    def export_response(self):
-        self.request.datespan = None
-        export_all_rows_task.delay(self.__class__, self.__getstate__())
-
-        return HttpResponse()
 
 
 class McctClientApprovalPage(McctProjectReview):


### PR DESCRIPTION
This should fix exportable_all property. It now sends an email of the full report. Makes use of a function in used to export all in some custom code. One thing to note, I deleted `self.request.datespan = None` assuming that's it's probably wiser to all the report to be filtered by date. If you think this is a bad idea/was there on purpose, I can change it back.

@nickpell 

http://manage.dimagi.com/default.asp?156169#878406
