### PR TITLE
Add feature flag for Vellum itemset plugin

### DIFF
--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -1150,7 +1150,7 @@ def form_designer(req, domain, app_id, module_id=None, form_id=None,
                             unique_form_id=form.unique_id)
 
     vellum_plugins = ["modeliteration"]
-    if settings.VELLUM_PRERELEASE:
+    if toggles.VELLUM_ITEMSETS.enabled(domain):
         vellum_plugins.append("itemset")
     if toggles.VELLUM_TRANSACTION_QUESTION_TYPES.enabled(domain):
         vellum_plugins.append("commtrack")

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -323,3 +323,10 @@ VELLUM_TRANSACTION_QUESTION_TYPES = StaticToggle(
     "Adds transaction-related question types in the form builder",
     [NAMESPACE_DOMAIN]
 )
+
+VELLUM_ITEMSETS = StaticToggle(
+    'itemsets',
+    "Adds dynamic (itemset) select and multi-select question types to the "
+    "form builder",
+    [NAMESPACE_DOMAIN]
+)

--- a/settings.py
+++ b/settings.py
@@ -28,10 +28,6 @@ LESS_WATCH = False
 # "dev-min" - use built/minified vellum (submodules/formdesigner/_build/src)
 VELLUM_DEBUG = None
 
-# enables all plugins, including ones that haven't been released on production
-# yet
-VELLUM_PRERELEASE = False
-
 try:
     UNIT_TESTING = 'test' == sys.argv[1]
 except IndexError:


### PR DESCRIPTION
Related to https://github.com/dimagi/Vellum/pull/337

If enabled before https://github.com/dimagi/Vellum/pull/337 is deployed, this will enable an older version of the itemset plugin, which has been around but disabled for a long time.
