### PR TITLE
show text instead of negative number when remaining usage is unlimited

### DIFF
--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -782,7 +782,11 @@ class DomainSubscriptionView(DomainAccountingSettings):
             feature_info = {
                 'name': get_feature_name(feature_rate.feature.feature_type, self.product),
                 'usage': usage,
-                'remaining': feature_rate.monthly_limit - usage,
+                'remaining': (
+                    feature_rate.monthly_limit - usage
+                    if feature_rate.monthly_limit != -1
+                    else _('Unlimited')
+                ),
                 'credit': self._fmt_credit(),
                 'type': feature_rate.feature.feature_type,
             }


### PR DESCRIPTION
@benrudolph @biyeun 

before:

![screen shot 2015-02-24 at 2 59 55 pm](https://cloud.githubusercontent.com/assets/1757035/6357911/e6f05ac8-bc35-11e4-8059-11a59cde1a52.png)

after:

![screen shot 2015-02-24 at 2 57 16 pm](https://cloud.githubusercontent.com/assets/1757035/6357913/ee3b42c0-bc35-11e4-8eba-228c83946005.png)
