### PR TITLE
Domain transfer

### DIFF
--- a/corehq/apps/domain/exceptions.py
+++ b/corehq/apps/domain/exceptions.py
@@ -1,0 +1,2 @@
+class InactiveTransferDomainException(Exception):
+    pass

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -275,6 +275,7 @@ class SnapshotSettingsForm(SnapshotSettingsMixin):
 
 ########################################################################################################
 
+
 class TransferDomainFormErrors(object):
     USER_DNE = _(u'The user being transferred to does not exist')
     DOMAIN_MISMATCH = _(u'Mismatch in domains when confirming')
@@ -285,7 +286,6 @@ class TransferDomainForm(forms.ModelForm):
     class Meta:
         model = TransferDomainRequest
         fields = ['domain', 'to_username']
-
 
     def __init__(self, domain, from_username, *args, **kwargs):
         super(TransferDomainForm, self).__init__(*args, **kwargs)

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -276,8 +276,9 @@ class SnapshotSettingsForm(SnapshotSettingsMixin):
 ########################################################################################################
 
 class TransferDomainFormErrors(object):
-    USER_DNE = 'The user being transferred to does not exist'
-    DOMAIN_MISMATCH = 'Mismatch in domains when confirming'
+    USER_DNE = _(u'The user being transferred to does not exist')
+    DOMAIN_MISMATCH = _(u'Mismatch in domains when confirming')
+
 
 class TransferDomainForm(forms.ModelForm):
 
@@ -285,16 +286,21 @@ class TransferDomainForm(forms.ModelForm):
         model = TransferDomainRequest
         fields = ['domain', 'to_username']
 
+
     def __init__(self, domain, from_username, *args, **kwargs):
         super(TransferDomainForm, self).__init__(*args, **kwargs)
         self.current_domain = domain
         self.from_username = from_username
+
+        self.fields['domain'].label = _(u'Type the name of the project to confirm')
+        self.fields['to_username'].label = _(u'New owner\'s CommCare username')
+
         self.helper = FormHelper()
         self.helper.layout = crispy.Layout(
             'domain',
             'to_username',
             StrictButton(
-                _("Transfer Domain"),
+                _("Transfer Project"),
                 type="submit",
                 css_class='btn-danger',
             )

--- a/corehq/apps/domain/migrations/0001_initial.py
+++ b/corehq/apps/domain/migrations/0001_initial.py
@@ -1,0 +1,49 @@
+# encoding: utf-8
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        
+        # Adding model 'TransferDomainRequest'
+        db.create_table(u'domain_transferdomainrequest', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('active', self.gf('django.db.models.fields.BooleanField')(default=True)),
+            ('request_time', self.gf('django.db.models.fields.DateTimeField')(null=True, blank=True)),
+            ('request_ip', self.gf('django.db.models.fields.CharField')(max_length=80, null=True, blank=True)),
+            ('confirm_time', self.gf('django.db.models.fields.DateTimeField')(null=True, blank=True)),
+            ('confirm_ip', self.gf('django.db.models.fields.CharField')(max_length=80, null=True, blank=True)),
+            ('transfer_guid', self.gf('django.db.models.fields.CharField')(max_length=32, null=True, blank=True)),
+            ('domain', self.gf('django.db.models.fields.CharField')(max_length=256)),
+            ('from_username', self.gf('django.db.models.fields.CharField')(max_length=80)),
+            ('to_username', self.gf('django.db.models.fields.CharField')(max_length=80)),
+        ))
+        db.send_create_signal(u'domain', ['TransferDomainRequest'])
+
+
+    def backwards(self, orm):
+        
+        # Deleting model 'TransferDomainRequest'
+        db.delete_table(u'domain_transferdomainrequest')
+
+
+    models = {
+        u'domain.transferdomainrequest': {
+            'Meta': {'object_name': 'TransferDomainRequest'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'confirm_ip': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'confirm_time': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'from_username': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'request_ip': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'request_time': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'to_username': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'transfer_guid': ('django.db.models.fields.CharField', [], {'max_length': '32', 'null': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['domain']

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -1084,7 +1084,7 @@ class TransferDomainRequest(models.Model):
     to_username = models.CharField(max_length=80)
 
     TRANSFER_TO_EMAIL = 'domain/email/domain_transfer_to_request'
-    TRANSFER_FROM_EMAIL = 'domain/email/domain_transfer_to_request'
+    TRANSFER_FROM_EMAIL = 'domain/email/domain_transfer_from_request'
     DIMAGI_CONFIRM_EMAIL = 'domain/email/domain_transfer_confirm'
     DIMAGI_CONFIRM_ADDRESS = 'commcarehq-support@dimagi.com'
 
@@ -1155,24 +1155,27 @@ class TransferDomainRequest(models.Model):
 
     def email_to_request(self):
         context = self.as_dict()
-        context.update({ 'url': self.deactivate_url() })
 
-        html_content = render_to_string(
-            "{template}.html".format(template=self.TRANSFER_TO_EMAIL),
-            context)
-        #text_content = render_to_string("{template}.html".format(template=TRANSFER_TO_EMAIL))
-        send_HTML_email(_('CommcareHQ Domain transfer request'), self.to_user.email, html_content)
+        html_content = render_to_string("{template}.html".format(template=self.TRANSFER_TO_EMAIL), context)
+        text_content = render_to_string("{template}.txt".format(template=self.TRANSFER_TO_EMAIL), context)
+
+        send_HTML_email(
+            _('Transfer of ownership for CommCare project space.'),
+            self.to_user.email,
+            html_content,
+            text_content=text_content)
 
     def email_from_request(self):
         context = self.as_dict()
-        context.update({ 'url': self.activate_url() })
 
-        html_content = render_to_string(
-            "{template}.html".format(template=self.TRANSFER_FROM_EMAIL),
-            context)
-        #text_content = render_to_string('domain/domain_transfer_from_request.txt')
+        html_content = render_to_string("{template}.html".format(template=self.TRANSFER_FROM_EMAIL), context)
+        text_content = render_to_string("{template}.txt".format(template=self.TRANSFER_FROM_EMAIL), context)
 
-        send_HTML_email(_('CommcareHQ Domain transfer request'), self.from_user.email, html_content)
+        send_HTML_email(
+            _('Transfer of ownership for CommCare project space.'),
+            self.from_user.email,
+            html_content,
+            text_content=text_content)
 
     @requires_active_transfer
     def transfer_domain(self, *args, **kwargs):

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -14,6 +14,7 @@ from couchdbkit.ext.django.schema import (
     StringListProperty, SchemaListProperty, TimeProperty, DecimalProperty
 )
 from django.core.cache import cache
+from django.core.urlresolvers import reverse
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from corehq.apps.appstore.models import SnapshotMixin
@@ -1166,6 +1167,9 @@ class TransferDomainRequest(models.Model):
 
     def email_from_request(self):
         context = self.as_dict()
+        context['settings_url'] = u"{url_base}{path}".format(
+            url_base=get_url_base(),
+            path=reverse('transfer_domain_view', args=[self.domain]))
 
         html_content = render_to_string("{template}.html".format(template=self.TRANSFER_FROM_EMAIL), context)
         text_content = render_to_string("{template}.txt".format(template=self.TRANSFER_FROM_EMAIL), context)

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -33,7 +33,6 @@ from corehq.apps.locations.schema import LocationType
 
 from .exceptions import InactiveTransferDomainException
 
-
 lang_lookup = defaultdict(str)
 
 DATA_DICT = settings.INTERNAL_DATA

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -1116,7 +1116,7 @@ class TransferDomainRequest(models.Model):
         except TransferDomainRequest.MultipleObjectsReturned:
             # Deactivate all active transfer except for most recent
             latest = cls.objects \
-                        .filter(domain=domain, from_username=from_username, active=True) \
+                        .filter(domain=domain, from_username=from_username, active=True, request_time__isnull=False) \
                         .latest('request_time')
             cls.objects \
                 .filter(domain=domain, from_username=from_username) \

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -3,15 +3,19 @@ from itertools import imap
 import hashlib
 import json
 import logging
+import uuid
 from couchdbkit.exceptions import ResourceConflict
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
+from django.template.loader import render_to_string
 from couchdbkit.ext.django.schema import (
     Document, StringProperty, BooleanProperty, DateTimeProperty, IntegerProperty,
     DocumentSchema, SchemaProperty, DictProperty,
     StringListProperty, SchemaListProperty, TimeProperty, DecimalProperty
 )
 from django.core.cache import cache
+from django.db import models
+from django.utils.translation import ugettext_lazy as _
 from corehq.apps.appstore.models import SnapshotMixin
 from dimagi.utils.couch.cache import cache_core
 from dimagi.utils.couch.database import iter_docs
@@ -19,11 +23,15 @@ from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.html import format_html
 from dimagi.utils.logging import notify_exception
 from dimagi.utils.couch.database import get_db, get_safe_write_kwargs, apply_update, iter_bulk_delete
+from dimagi.utils.django.email import send_HTML_email
+from dimagi.utils.web import get_url_base
 from itertools import chain
 from langcodes import langs as all_langs
 from collections import defaultdict
 from django.utils.importlib import import_module
 from corehq.apps.locations.schema import LocationType
+
+from .exceptions import InactiveTransferDomainException
 
 
 lang_lookup = defaultdict(str)
@@ -1061,6 +1069,116 @@ class DomainCounter(Document):
                 if num_tries >= 500:
                     raise
         return (range_start, range_end)
+
+
+class TransferDomainRequest(models.Model):
+    active = models.BooleanField(default=True, blank=True)
+    request_time = models.DateTimeField(null=True, blank=True)
+    request_ip = models.CharField(max_length=80, null=True, blank=True)
+    confirm_time = models.DateTimeField(null=True, blank=True)
+    confirm_ip = models.CharField(max_length=80, null=True, blank=True)
+    transfer_guid = models.CharField(max_length=32, null=True, blank=True)
+
+    domain = models.CharField(max_length=256)
+    from_username = models.CharField(max_length=80)
+    to_username = models.CharField(max_length=80)
+
+    TRANSFER_TO_EMAIL = 'domain/email/domain_transfer_to_request'
+    TRANSFER_FROM_EMAIL = 'domain/email/domain_transfer_to_request'
+
+    @property
+    @memoized
+    def to_user(self):
+        from corehq.apps.users.models import WebUser
+        return WebUser.get_by_username(self.to_username)
+
+    @property
+    @memoized
+    def from_user(self):
+        from corehq.apps.users.models import WebUser
+        return WebUser.get_by_username(self.from_username)
+
+    @classmethod
+    def get_by_guid(cls, guid):
+        return cls.objects.get(transfer_guid=guid)
+
+    @classmethod
+    def get_active_transfer(cls, domain, username):
+        try:
+            return cls.objects.get(domain=domain, from_username=username, active=True)
+        except TransferDomainRequest.DoesNotExist:
+            return None
+
+    def requires_active_transfer(fn):
+        def decorate(self, *args, **kwargs):
+            if not self.active:
+                raise InactiveTransferDomainException("Transfer domain request is no longer active")
+            return fn(self, *args, **kwargs)
+        return decorate
+
+    @requires_active_transfer
+    def send_transfer_request(self):
+        self.transfer_guid = uuid.uuid4().hex
+        self.request_time = datetime.now()
+        self.save()
+
+        self.email_to_request()
+        self.email_from_request()
+
+    def activate_url(self):
+        return "{url_base}/domain/transfer/{guid}/activate".format(
+            url_base=get_url_base(),
+            guid=self.transfer_guid
+        )
+
+    def deactivate_url(self):
+        return "{url_base}/domain/transfer/{guid}/deactivate".format(
+            url_base=get_url_base(),
+            guid=self.transfer_guid
+        )
+
+    def email_to_request(self):
+        context = self.as_dict()
+        context.update({ 'url': self.deactivate_url() })
+
+        html_content = render_to_string(
+            "{template}.html".format(template=self.TRANSFER_TO_EMAIL),
+            context)
+        #text_content = render_to_string("{template}.html".format(template=TRANSFER_TO_EMAIL))
+        send_HTML_email(_('CommcareHQ Domain transfer request'), self.to_user.email, html_content)
+
+    def email_from_request(self):
+        context = self.as_dict()
+        context.update({ 'url': self.activate_url() })
+
+        html_content = render_to_string(
+            "{template}.html".format(template=self.TRANSFER_FROM_EMAIL),
+            context)
+        #text_content = render_to_string('domain/domain_transfer_from_request.txt')
+
+        send_HTML_email(_('CommcareHQ Domain transfer request'), self.from_user.email, html_content)
+
+    @requires_active_transfer
+    def transfer_domain(self, *args, **kwargs):
+
+        self.confirm_time = datetime.now()
+        if 'ip' in kwargs:
+            self.confirm_ip = kwargs['ip']
+
+        self.from_user.transfer_domain_membership(self.domain, self.to_user)
+        self.active = False
+        self.save()
+
+    def as_dict(self):
+        return {
+            'domain': self.domain,
+            'from_username': self.from_username,
+            'to_username': self.to_username,
+            'guid': self.transfer_guid,
+            'request_time': self.request_time,
+            'deactivate_url': self.deactivate_url(),
+            'activate_url': self.deactivate_url(),
+        }
 
 
 def _domain_cache_key(name):

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -1116,8 +1116,8 @@ class TransferDomainRequest(models.Model):
         except TransferDomainRequest.MultipleObjectsReturned:
             # Deactivate all active transfer except for most recent
             latest = cls.objects \
-                        .filter(domain=domain, from_username=from_username, active=True, request_time__isnull=False) \
-                        .latest('request_time')
+                .filter(domain=domain, from_username=from_username, active=True, request_time__isnull=False) \
+                .latest('request_time')
             cls.objects \
                 .filter(domain=domain, from_username=from_username) \
                 .exclude(pk=latest.pk) \
@@ -1128,7 +1128,7 @@ class TransferDomainRequest(models.Model):
     def requires_active_transfer(fn):
         def decorate(self, *args, **kwargs):
             if not self.active:
-                raise InactiveTransferDomainException("Transfer domain request is no longer active")
+                raise InactiveTransferDomainException(_("Transfer domain request is no longer active"))
             return fn(self, *args, **kwargs)
         return decorate
 
@@ -1142,13 +1142,13 @@ class TransferDomainRequest(models.Model):
         self.email_from_request()
 
     def activate_url(self):
-        return "{url_base}/domain/transfer/{guid}/activate".format(
+        return u"{url_base}/domain/transfer/{guid}/activate".format(
             url_base=get_url_base(),
             guid=self.transfer_guid
         )
 
     def deactivate_url(self):
-        return "{url_base}/domain/transfer/{guid}/deactivate".format(
+        return u"{url_base}/domain/transfer/{guid}/deactivate".format(
             url_base=get_url_base(),
             guid=self.transfer_guid
         )
@@ -1160,7 +1160,7 @@ class TransferDomainRequest(models.Model):
         text_content = render_to_string("{template}.txt".format(template=self.TRANSFER_TO_EMAIL), context)
 
         send_HTML_email(
-            _('Transfer of ownership for CommCare project space.'),
+            _(u'Transfer of ownership for CommCare project space.'),
             self.to_user.email,
             html_content,
             text_content=text_content)
@@ -1172,7 +1172,7 @@ class TransferDomainRequest(models.Model):
         text_content = render_to_string("{template}.txt".format(template=self.TRANSFER_FROM_EMAIL), context)
 
         send_HTML_email(
-            _('Transfer of ownership for CommCare project space.'),
+            _(u'Transfer of ownership for CommCare project space.'),
             self.from_user.email,
             html_content,
             text_content=text_content)
@@ -1194,7 +1194,7 @@ class TransferDomainRequest(models.Model):
             "{template}.html".format(template=self.DIMAGI_CONFIRM_EMAIL),
             self.as_dict())
 
-        send_HTML_email(_('There has been a transfer of ownership of {domain}').format(domain=self.domain),
+        send_HTML_email(_(u'There has been a transfer of ownership of {domain}').format(domain=self.domain),
                         self.DIMAGI_CONFIRM_ADDRESS,
                         html_content)
 

--- a/corehq/apps/domain/templates/domain/activate_transfer_domain.html
+++ b/corehq/apps/domain/templates/domain/activate_transfer_domain.html
@@ -11,15 +11,27 @@
     <div class="col-md-8 col-xs-12">
       {% if transfer %}
         <p class="lead">
-          By clicking "accept" below You acknowledge that You accept full ownership of this project space
-          ("{{ transfer.domain }}").  You agree to be bound by the terms of Dimagi's <a href="https://www.commcarehq.org/eula/">End User License Agreement</a>.  By accepting this agreement, your are acknowledging you have permission and authority to accept Dimagi's End User License Agreement.
+          {% blocktrans with domain=transfer.domain%}
+          By clicking "accept" below you acknowledge that you accept full ownership of this project space ("{{ domain }}").  You agree to be bound by the terms of Dimagi's <a href="https://www.commcarehq.org/eula/">End User License Agreement</a>.  By accepting this agreement, your are acknowledging you have permission and authority to accept Dimagi's End User License Agreement.
+          {% endblocktrans %}
         </p>
-        <form action="{{ transfer.activate_url }}" method="POST">{% csrf_token %}
-          <input type="submit" value="Accept" class="btn btn-primary"/>
-        </form>
+        <div class="row">
+          <div class="col-md-2">
+            <form action="{{ transfer.activate_url }}" method="POST">{% csrf_token %}
+              <input type="submit" value="{% trans "Accept" %}" class="btn btn-primary"/>
+            </form>
+          </div>
+          <div class="col-md-2">
+            <form action="{{ transfer.deactivate_url }}" method="POST">{% csrf_token %}
+              <input type="submit" value="{% trans "Decline" %}" class="btn btn-danger"/>
+            </form>
+          </div>
+        </div>
       {% else %}
         <p class="lead">
+          {% blocktrans %}
           Sorry this transfer request has expired.
+          {% endblocktrans %}
         </p>
       {% endif %}
     </div>

--- a/corehq/apps/domain/templates/domain/activate_transfer_domain.html
+++ b/corehq/apps/domain/templates/domain/activate_transfer_domain.html
@@ -1,0 +1,28 @@
+{% extends 'style/base.html' %}
+{% load hq_shared_tags %}
+{% load i18n %}
+
+{% block content %}
+<div class="container" id="hq-content">
+  <div class="row">
+    <div class="page-header">
+        <h1>{% trans "Transfer project ownership" %}</h1>
+    </div>
+    <div class="col-md-8 col-xs-12">
+      {% if transfer %}
+        <p class="lead">
+          By clicking "accept" below You acknowledge that You accept full ownership of this project space
+          ("{{ transfer.domain }}").  You agree to be bound by the terms of Dimagi's <a href="https://www.commcarehq.org/eula/">End User License Agreement</a>.  By accepting this agreement, your are acknowledging you have permission and authority to accept Dimagi's End User License Agreement.
+        </p>
+        <form action="{{ transfer.activate_url }}" method="POST">{% csrf_token %}
+          <input type="submit" value="Accept" class="btn btn-primary"/>
+        </form>
+      {% else %}
+        <p class="lead">
+          Sorry this transfer request has expired.
+        </p>
+      {% endif %}
+    </div>
+  </div>
+</div>
+{% endblock content %}

--- a/corehq/apps/domain/templates/domain/admin/transfer_domain.html
+++ b/corehq/apps/domain/templates/domain/admin/transfer_domain.html
@@ -1,0 +1,19 @@
+{% extends "settings/base_template.html" %}
+{% load hqstyle_tags %}
+{% load hq_shared_tags %}
+{% load crispy_forms_tags %}
+{% load i18n %}
+
+
+{% block main_column %}
+    <div class="well">
+        <p class="lead">
+            {% blocktrans %}
+                Use this form to transfer domains between users.
+            {% endblocktrans %}
+        </p>
+    </div>
+    <hr />
+    {% crispy form %}
+{% endblock %}
+

--- a/corehq/apps/domain/templates/domain/admin/transfer_domain.html
+++ b/corehq/apps/domain/templates/domain/admin/transfer_domain.html
@@ -6,14 +6,13 @@
 
 
 {% block main_column %}
-    <div class="well">
-        <p class="lead">
-            {% blocktrans %}
-                Use this form to transfer domains between users.
-            {% endblocktrans %}
-        </p>
+    <div class="page-header">
+        <h3>
+        {% blocktrans %}
+            Use this to transfer your project to another user.
+        {% endblocktrans %}
+        </h3>
     </div>
-    <hr />
     {% crispy form %}
 {% endblock %}
 

--- a/corehq/apps/domain/templates/domain/admin/transfer_domain_pending.html
+++ b/corehq/apps/domain/templates/domain/admin/transfer_domain_pending.html
@@ -1,0 +1,20 @@
+{% extends "settings/base_template.html" %}
+{% load hqstyle_tags %}
+{% load hq_shared_tags %}
+{% load crispy_forms_tags %}
+{% load i18n %}
+
+
+{% block main_column %}
+    <h4>
+        You have a pending transfer with {{ transfer.to_username }}
+    </h4>
+    <a href="{% url 'transfer_domain_view' domain %}?resend=true" class="btn btn-primary">
+        Resend Transfer Request
+    </a>
+    <a href="{{ transfer.deactivate_url }}" class="btn btn-danger">
+        Cancel Transfer
+    </a>
+{% endblock %}
+
+

--- a/corehq/apps/domain/templates/domain/admin/transfer_domain_pending.html
+++ b/corehq/apps/domain/templates/domain/admin/transfer_domain_pending.html
@@ -9,19 +9,23 @@
     <div class="row-fluid">
         <div class="span12">
             <h4>
-                You have a pending transfer with {{ transfer.to_username }}
+                {% blocktrans with username=transfer.to_username %}
+                You have a pending transfer with {{ username }}
+                {% endblocktrans %}
             </h4>
         </div>
     </div>
     <div class="row-fluid">
         <div class="span2">
             <a href="{% url 'transfer_domain_view' domain %}?resend=true" class="btn btn-primary">
+                {% blocktrans %}
                 Resend Transfer Request
+                {% endblocktrans %}
             </a>
         </div>
         <div class="span2">
             <form action="{{ transfer.deactivate_url }}" method="POST">
-                <input class="btn btn-danger" type="submit" value="Cancel Transfer" />
+                <input class="btn btn-danger" type="submit" value="{% trans "Cancel Transfer" %}" />
             </form>
         </div>
     </div>

--- a/corehq/apps/domain/templates/domain/admin/transfer_domain_pending.html
+++ b/corehq/apps/domain/templates/domain/admin/transfer_domain_pending.html
@@ -6,15 +6,25 @@
 
 
 {% block main_column %}
-    <h4>
-        You have a pending transfer with {{ transfer.to_username }}
-    </h4>
-    <a href="{% url 'transfer_domain_view' domain %}?resend=true" class="btn btn-primary">
-        Resend Transfer Request
-    </a>
-    <a href="{{ transfer.deactivate_url }}" class="btn btn-danger">
-        Cancel Transfer
-    </a>
+    <div class="row-fluid">
+        <div class="span12">
+            <h4>
+                You have a pending transfer with {{ transfer.to_username }}
+            </h4>
+        </div>
+    </div>
+    <div class="row-fluid">
+        <div class="span2">
+            <a href="{% url 'transfer_domain_view' domain %}?resend=true" class="btn btn-primary">
+                Resend Transfer Request
+            </a>
+        </div>
+        <div class="span2">
+            <form action="{{ transfer.deactivate_url }}" method="POST">
+                <input class="btn btn-danger" type="submit" value="Cancel Transfer" />
+            </form>
+        </div>
+    </div>
 {% endblock %}
 
 

--- a/corehq/apps/domain/templates/domain/email/domain_transfer_confirm.html
+++ b/corehq/apps/domain/templates/domain/email/domain_transfer_confirm.html
@@ -1,6 +1,6 @@
-Initiator: {{ transfer.from_username }}
-Project Space: {{ transfer.domain }}
-Acceptor: {{ transfer.to_username }}
+Initiator: {{ from_username }}
+Project Space: {{ domain }}
+Acceptor: {{ to_username }}
 
 Please validate that the transfer is valid and email both parties notifying them that the transfer is complete.
 

--- a/corehq/apps/domain/templates/domain/email/domain_transfer_confirm.html
+++ b/corehq/apps/domain/templates/domain/email/domain_transfer_confirm.html
@@ -1,0 +1,8 @@
+Initiator: {{ transfer.from_username }}
+Project Space: {{ transfer.domain }}
+Acceptor: {{ transfer.to_username }}
+
+Please validate that the transfer is valid and email both parties notifying them that the transfer is complete.
+
+Cheers!
+

--- a/corehq/apps/domain/templates/domain/email/domain_transfer_confirm.html
+++ b/corehq/apps/domain/templates/domain/email/domain_transfer_confirm.html
@@ -2,7 +2,7 @@ Initiator: {{ from_username }}
 Project Space: {{ domain }}
 Acceptor: {{ to_username }}
 
-Please validate that the transfer is valid and email both parties notifying them that the transfer is complete.
+Please verify that the transfer is valid and email both parties notifying them that the transfer is complete.
 
 Cheers!
 

--- a/corehq/apps/domain/templates/domain/email/domain_transfer_from_request.html
+++ b/corehq/apps/domain/templates/domain/email/domain_transfer_from_request.html
@@ -1,0 +1,8 @@
+<p>Hi {{ from_username }},</p>
+<p>You have invited {{ to_username }} to own the {{ domain }} project space at CommCareHQ.</p>
+<p>If you think this was a mistake, click <a href="{{ url }}">this link</a> and contact [[email]] as soon as
+possible. If you are unable to click the link, copy and paste the following url into your browser. {{url}}</p>
+<p>Thanks for using our site!</p>
+<p>-The CommCareHQ team</p>
+
+

--- a/corehq/apps/domain/templates/domain/email/domain_transfer_from_request.html
+++ b/corehq/apps/domain/templates/domain/email/domain_transfer_from_request.html
@@ -8,7 +8,7 @@
 
 <p>
     {% blocktrans %}
-    A transfer of project space has been initiated by {{ from_username }} to {{ to_username }}.  If you believe this is an error, please contact Dimagi immediately at support@dimagi.com and click  <a href="{{ deactivate_url }}">this link</a> to deactivate the transfer: {{ deactivate_url }}
+    A transfer of project space has been initiated by {{ from_username }} to {{ to_username }}.  If you believe this is an error, please contact Dimagi immediately at support@dimagi.com and follow <a href="{{ settings_url }}">this link</a> to deactivate the transfer: {{ settings_url }}
     {% endblocktrans %}
 </p>
 

--- a/corehq/apps/domain/templates/domain/email/domain_transfer_from_request.html
+++ b/corehq/apps/domain/templates/domain/email/domain_transfer_from_request.html
@@ -1,8 +1,20 @@
-<p>Hi {{ from_username }},</p>
-<p>You have invited {{ to_username }} to own the {{ domain }} project space at CommCareHQ.</p>
-<p>If you think this was a mistake, click <a href="{{ url }}">this link</a> and contact [[email]] as soon as
-possible. If you are unable to click the link, copy and paste the following url into your browser. {{url}}</p>
-<p>Thanks for using our site!</p>
+{% load i18n %}
+
+<p>
+    {% blocktrans %}
+    Hello,
+    {% endblocktrans %}
+</p>
+
+<p>
+    {% blocktrans %}
+    A transfer of project space has been initiated by {{ from_username }} to {{ to_username }}.  If you believe this is an error, please contact Dimagi immediately at support@dimagi.com and click  <a href="{{ deactivate_url }}">this link</a> to deactivate the transfer: {{ deactivate_url }}
+    {% endblocktrans %}
+</p>
+
+<p>
+    {% blocktrans %}
+    Thanks for using our site!
+    {% endblocktrans %}
+</p>
 <p>-The CommCareHQ team</p>
-
-

--- a/corehq/apps/domain/templates/domain/email/domain_transfer_from_request.txt
+++ b/corehq/apps/domain/templates/domain/email/domain_transfer_from_request.txt
@@ -1,0 +1,15 @@
+{% load i18n %}
+
+{% blocktrans %}
+Hello,
+{% endblocktrans %}
+
+{% blocktrans %}
+A transfer of project space has been initiated by {{ from_username }} to {{ to_username }}.  If you believe this is an error, please contact Dimagi immediately at support@dimagi.com and click  this link to deactivate the transfer: {{ deactivate_url }}
+{% endblocktrans %}
+
+{% blocktrans %}
+Thanks for using our site!
+{% endblocktrans %}
+-The CommCareHQ team
+

--- a/corehq/apps/domain/templates/domain/email/domain_transfer_from_request.txt
+++ b/corehq/apps/domain/templates/domain/email/domain_transfer_from_request.txt
@@ -5,7 +5,7 @@ Hello,
 {% endblocktrans %}
 
 {% blocktrans %}
-A transfer of project space has been initiated by {{ from_username }} to {{ to_username }}.  If you believe this is an error, please contact Dimagi immediately at support@dimagi.com and click  this link to deactivate the transfer: {{ deactivate_url }}
+A transfer of project space has been initiated by {{ from_username }} to {{ to_username }}.  If you believe this is an error, please contact Dimagi immediately at support@dimagi.com and follow this link to deactivate the transfer: {{ settings_url }}
 {% endblocktrans %}
 
 {% blocktrans %}

--- a/corehq/apps/domain/templates/domain/email/domain_transfer_to_request.html
+++ b/corehq/apps/domain/templates/domain/email/domain_transfer_to_request.html
@@ -1,7 +1,39 @@
-<p>Hi!</p>
-<p>{{ from_username }} has invited you to own the {{ domain }} project space at CommCareHQ. This invitation expires in  day(s)</p>
-<p>To accept this invitation click <a href="{{ url }}">this link</a>. If you are unable to click the link, copy and paste the following url into your browser. {{url}}</p>
-<p>If you think you have received this by mistake, you can go ahead and ignore this email. To find out more about CommCareHQ visit http://www.commcarehq.org/.</p>
-<p>Thanks for using our site!</p>
-<p>-The CommCareHQ team</p>
+{% load i18n %}
 
+<p>
+    {% blocktrans %}
+    Hello,
+    {% endblocktrans %}
+</p>
+
+<p>
+    {% blocktrans %}
+    {{ from_username }} has initiatied a transfer of ownership for a CommCareHQ project space. To accept
+    ownership of this project space, please follow <a href="{{ activate_url }}">this link</a>: {{ activate_url }}.  If you do not already have a CommCare user account, you will be required to create one in order to accept ownership of this project space.
+    {% endblocktrans %}
+</p>
+
+<p>
+    {% blocktrans %}
+After you accept the transfer, someone from Dimagi will contact you to verify that the transfer of ownership is complete.
+    {% endblocktrans %}
+</p>
+
+<p>
+    {% blocktrans %}
+    All project settings, user accounts, and permissions will remain in their current settings after transfer of ownership.  If you wish to alter any of this settings, please do so after accepting ownership of the project space form the Project space settings menu.
+    {% endblocktrans %}
+</p>
+
+<p>
+    {% blocktrans %}
+    If you think you have received this by mistake, you can go ahead and ignore this email. To find out more about CommCareHQ visit <a href="http://www.commcarehq.org/">http://www.commcarehq.org/</a>.
+    {% endblocktrans %}
+</p>
+
+<p>
+    {% blocktrans %}
+    Thanks for using our site!
+    {% endblocktrans %}
+</p>
+<p>-The CommCareHQ team</p>

--- a/corehq/apps/domain/templates/domain/email/domain_transfer_to_request.html
+++ b/corehq/apps/domain/templates/domain/email/domain_transfer_to_request.html
@@ -1,0 +1,7 @@
+<p>Hi!</p>
+<p>{{ from_username }} has invited you to own the {{ domain }} project space at CommCareHQ. This invitation expires in  day(s)</p>
+<p>To accept this invitation click <a href="{{ url }}">this link</a>. If you are unable to click the link, copy and paste the following url into your browser. {{url}}</p>
+<p>If you think you have received this by mistake, you can go ahead and ignore this email. To find out more about CommCareHQ visit http://www.commcarehq.org/.</p>
+<p>Thanks for using our site!</p>
+<p>-The CommCareHQ team</p>
+

--- a/corehq/apps/domain/templates/domain/email/domain_transfer_to_request.txt
+++ b/corehq/apps/domain/templates/domain/email/domain_transfer_to_request.txt
@@ -1,0 +1,27 @@
+{% load i18n %}
+
+{% blocktrans %}
+Hello,
+{% endblocktrans %}
+
+{% blocktrans %}
+{{ from_username }} has initiatied a transfer of ownership for a CommCareHQ project space. To accept ownership of this project space, please follow this link: {{ activate_url }}.  If you do not already have a CommCare user account, you will be required to create one in order to accept ownership of this project space.
+{% endblocktrans %}
+
+{% blocktrans %}
+After you accept the transfer, someone from Dimagi will contact you to verify that the transfer of ownership is complete.
+{% endblocktrans %}
+
+{% blocktrans %}
+All project settings, user accounts, and permissions will remain in their current settings after transfer of ownership.  If you wish to alter any of this settings, please do so after accepting ownership of the project space form the Project space settings menu.
+{% endblocktrans %}
+
+{% blocktrans %}
+If you think you have received this by mistake, you can go ahead and ignore this email. To find out more about CommCareHQ visit http://www.commcarehq.org/.
+{% endblocktrans %}
+
+{% blocktrans %}
+Thanks for using our site!
+{% endblocktrans %}
+-The CommCareHQ team
+

--- a/corehq/apps/domain/tests/__init__.py
+++ b/corehq/apps/domain/tests/__init__.py
@@ -2,3 +2,4 @@ from __future__ import absolute_import
 
 from .test_views import *
 from .test_utils import *
+from .test_domain_transfer import *

--- a/corehq/apps/domain/tests/test_domain_transfer.py
+++ b/corehq/apps/domain/tests/test_domain_transfer.py
@@ -33,6 +33,37 @@ class BaseDomainTest(TestCase):
         self.user.delete()
         self.domain.delete()
         self.muggle.delete()
+
+class TestTransferDomainForm(BaseDomainTest):
+
+    def test_valid_data(self):
+        data = {
+            'to_username': self.mugglename,
+            'domain': self.domain.name,
+        }
+
+        form = TransferDomainForm(self.domain.name, self.user.username, data)
+
+        self.assertTrue(form.is_valid(), form.errors)
+
+        transfer = form.save()
+        self.assertEqual(transfer.to_username, self.mugglename)
+        self.assertEqual(transfer.domain, self.domain.name)
+        self.assertEqual(transfer.from_username, self.username)
+
+    def test_invalid_user_data(self):
+        data = {
+            'to_username': 'non-existant',
+            'domain': 'mismatch',
+        }
+
+        form = TransferDomainForm(self.domain.name, self.user.username, data)
+        self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors, {
+            'to_username': [TransferDomainFormErrors.USER_DNE],
+            'domain': [TransferDomainFormErrors.DOMAIN_MISMATCH],
+        })
+
 class TestTransferDomainModel(BaseDomainTest):
 
     def setUp(self):

--- a/corehq/apps/domain/tests/test_domain_transfer.py
+++ b/corehq/apps/domain/tests/test_domain_transfer.py
@@ -6,6 +6,7 @@ from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.client import Client
 
+from corehq import toggles
 from corehq.apps.dashboard.views import DomainDashboardView
 from corehq.apps.users.models import WebUser
 from corehq.apps.domain.models import Domain, TransferDomainRequest
@@ -19,6 +20,7 @@ class BaseDomainTest(TestCase):
 
         self.domain = Domain(name="fandago", is_active=True)
         self.domain.save()
+        toggles.TRANSFER_DOMAIN.set("domain:{domain}".format(domain=self.domain.name), True)
 
         self.username = 'bananafana'
         self.password = '*******'

--- a/corehq/apps/domain/tests/test_domain_transfer.py
+++ b/corehq/apps/domain/tests/test_domain_transfer.py
@@ -1,4 +1,5 @@
 from __future__ import print_function, unicode_literals
+from datetime import datetime
 
 from django.core import mail
 from django.core.urlresolvers import reverse
@@ -103,6 +104,21 @@ class TestTransferDomainModel(BaseDomainTest):
         self.assertIsNotNone(self.transfer.transfer_guid)
         self.assertEqual(len(mail.outbox), 2,
                          "Should send an email to both requester and requestee")
+
+    def test_get_active_transfer(self):
+        res = TransferDomainRequest.get_active_transfer(self.domain, self.user.username)
+        self.assertIsNotNone(res)
+
+        newer = TransferDomainRequest(
+            to_username=self.mugglename,
+            from_username=self.username,
+            request_time=datetime.now(),
+            domain=self.domain.name)
+        newer.save()
+
+        res = TransferDomainRequest.get_active_transfer(self.domain, self.user.username)
+        self.assertEqual(res.pk, newer.pk)
+        self.assertFalse(TransferDomainRequest.objects.get(pk=self.transfer.pk).active)
 
 
 class TestTransferDomainIntegration(BaseDomainTest):

--- a/corehq/apps/domain/tests/test_domain_transfer.py
+++ b/corehq/apps/domain/tests/test_domain_transfer.py
@@ -1,0 +1,76 @@
+from __future__ import print_function, unicode_literals
+
+from django.core import mail
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+from django.test.client import Client
+
+from corehq.apps.dashboard.views import NewUserDashboardView
+from corehq.apps.users.models import WebUser
+from corehq.apps.domain.models import Domain, TransferDomainRequest
+from corehq.apps.domain.forms import TransferDomainForm, TransferDomainFormErrors
+from corehq.apps.domain.views import TransferDomainView
+from corehq.apps.domain.exceptions import InactiveTransferDomainException
+
+class BaseDomainTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+
+        self.domain = Domain(name="fandago", is_active=True)
+        self.domain.save()
+
+        self.username = 'bananafana'
+        self.password = '*******'
+        self.user = WebUser.create(self.domain.name, self.username, self.password)
+        self.user.set_role(self.domain.name, 'admin')
+        self.user.save()
+
+        self.mugglename = 'muggle'
+        self.muggle = WebUser.create('anotherdomain', self.mugglename, self.password)
+        self.muggle.save()
+
+    def tearDown(self):
+        self.user.delete()
+        self.domain.delete()
+        self.muggle.delete()
+class TestTransferDomainModel(BaseDomainTest):
+
+    def setUp(self):
+        super(TestTransferDomainModel, self).setUp()
+
+        self.transfer = TransferDomainRequest(
+            to_username=self.mugglename,
+            from_username=self.username,
+            domain=self.domain.name)
+        self.transfer.save()
+
+    def tearDown(self):
+        super(TestTransferDomainModel, self).tearDown()
+
+        self.transfer.delete()
+
+    def test_domain_transfer_inactive(self):
+        self.transfer.active = False
+        self.transfer.save()
+
+        with self.assertRaises(InactiveTransferDomainException):
+            self.transfer.transfer_domain()
+
+        with self.assertRaises(InactiveTransferDomainException):
+            self.transfer.send_transfer_request()
+
+    def test_domain_transfer(self):
+        self.transfer.transfer_domain()
+
+        self.assertFalse(self.transfer.active)
+        self.assertFalse(self.transfer.from_user.is_member_of(self.domain))
+        self.assertTrue(self.transfer.to_user.is_member_of(self.domain))
+
+    def test_send_transfer_request(self):
+        self.transfer.send_transfer_request()
+
+        self.assertIsNotNone(self.transfer.transfer_guid)
+        self.assertEqual(len(mail.outbox), 2,
+                         "Should send an email to both requester and requestee")
+
+

--- a/corehq/apps/domain/tests/test_domain_transfer.py
+++ b/corehq/apps/domain/tests/test_domain_transfer.py
@@ -7,7 +7,6 @@ from django.test import TestCase
 from django.test.client import Client
 
 from corehq import toggles
-from corehq.apps.dashboard.views import DomainDashboardView
 from corehq.apps.users.models import WebUser
 from corehq.apps.domain.models import Domain, TransferDomainRequest
 from corehq.apps.domain.forms import TransferDomainForm, TransferDomainFormErrors
@@ -184,19 +183,19 @@ class TestTransferDomainViews(BaseDomainTest):
     def test_permissions_for_transfer_domain_view(self):
         # No one logged in
         resp = self.client.get(reverse('transfer_domain_view',
-                                        args=[self.domain.name]), follow=True)
+                                       args=[self.domain.name]), follow=True)
         self.assertEqual(resp.status_code, 404)
 
         # Random user who belongs to the domain but not an admin
         self.client.login(username=self.rando.username, password=self.password)
         resp = self.client.get(reverse('transfer_domain_view',
-                                        args=[self.domain.name]))
+                                       args=[self.domain.name]))
         self.assertEqual(resp.status_code, 302, 'Should redirect to dashboard')
 
         # Domain admin logged in
         self.client.login(username=self.user.username, password=self.password)
         resp = self.client.get(reverse('transfer_domain_view',
-                                        args=[self.domain.name]))
+                                       args=[self.domain.name]))
         self.assertEqual(resp.status_code, 200)
 
 
@@ -217,7 +216,7 @@ class TestTransferDomainIntegration(BaseDomainTest):
         # Get the transfer request page
         resp = self.client.get(reverse(TransferDomainView.urlname, args=[self.domain.name]))
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(type(resp.context['form']), TransferDomainForm, 
+        self.assertEqual(type(resp.context['form']), TransferDomainForm,
                          "Should get TransferRequestForm")
 
         form = resp.context['form']
@@ -225,7 +224,8 @@ class TestTransferDomainIntegration(BaseDomainTest):
         form.data['to_username'] = self.muggle.username
 
         # Post the form data
-        resp = self.client.post(reverse(TransferDomainView.urlname, args=[self.domain.name]), form.data, follow=True)
+        resp = self.client.post(reverse(TransferDomainView.urlname, args=[self.domain.name]),
+                                form.data, follow=True)
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(len(mail.outbox), 2,
                          "Should send an email to both requester and requestee")
@@ -244,7 +244,7 @@ class TestTransferDomainIntegration(BaseDomainTest):
         self.assertIsNotNone(resp.context['transfer'])
 
         # Finally accept the transfer
-        mail.outbox = [] # Clear outbox
+        mail.outbox = []  # Clear outbox
         resp = self.client.post(reverse('activate_transfer_domain', args=[transfer.transfer_guid]), follow=True)
         self.assertEqual(len(mail.outbox), 1, "Send an email to Dimagi to confirm")
 

--- a/corehq/apps/domain/urls.py
+++ b/corehq/apps/domain/urls.py
@@ -67,9 +67,9 @@ urlpatterns =\
         url(r'^domain/select/$', 'select', name='domain_select'),
         url(r'^domain/autocomplete/(?P<field>\w+)/$', 'autocomplete_fields', name='domain_autocomplete_fields'),
         url(r'^domain/incomplete_email/$', 'incomplete_email'),
-        url(r'^domain/transfer/(?P<guid>\w+)/activate$', 
+        url(r'^domain/transfer/(?P<guid>\w+)/activate$',
             ActivateTransferDomainView.as_view(), name='activate_transfer_domain'),
-        url(r'^domain/transfer/(?P<guid>\w+)/deactivate$', 
+        url(r'^domain/transfer/(?P<guid>\w+)/deactivate$',
             DeactivateTransferDomainView.as_view(), name='deactivate_transfer_domain'),
     ) +\
     patterns('django.contrib.auth.views',

--- a/corehq/apps/domain/urls.py
+++ b/corehq/apps/domain/urls.py
@@ -20,7 +20,8 @@ from corehq.apps.domain.views import (
     FeaturePreviewsView, ConfirmSubscriptionRenewalView,
     InvoiceStripePaymentView, CreditsStripePaymentView, SMSRatesView,
     AddFormRepeaterView, AddOpsUserAsDomainAdminView,
-    FeatureFlagsView, EditDhis2SettingsView)
+    FeatureFlagsView, EditDhis2SettingsView, TransferDomainView,
+    ActivateTransferDomainView, DeactivateTransferDomainView)
 
 #
 # After much reading, I discovered that Django matches URLs derived from the environment
@@ -66,6 +67,8 @@ urlpatterns =\
         url(r'^domain/select/$', 'select', name='domain_select'),
         url(r'^domain/autocomplete/(?P<field>\w+)/$', 'autocomplete_fields', name='domain_autocomplete_fields'),
         url(r'^domain/incomplete_email/$', 'incomplete_email'),
+        url(r'^domain/transfer/(?P<guid>\w+)/activate$', ActivateTransferDomainView.as_view(), name='activate_transfer_domain'),
+        url(r'^domain/transfer/(?P<guid>\w+)/deactivate$', DeactivateTransferDomainView.as_view(), name='deactivate_transfer_domain'),
     ) +\
     patterns('django.contrib.auth.views',
         url(r'^accounts/password_change/$', 'password_change', auth_pages_path('password_change_form.html'), name='password_change'),
@@ -125,6 +128,7 @@ domain_settings = patterns(
     url(r'^snapshots/set_published/(?P<snapshot_name>[\w-]+)/$', 'set_published_snapshot', name='domain_set_published'),
     url(r'^snapshots/set_published/$', 'set_published_snapshot', name='domain_clear_published'),
     url(r'^snapshots/$', ExchangeSnapshotsView.as_view(), name=ExchangeSnapshotsView.urlname),
+    url(r'^transfer/$', TransferDomainView.as_view(), name=TransferDomainView.urlname),
     url(r'^snapshots/new/$', CreateNewExchangeSnapshotView.as_view(), name=CreateNewExchangeSnapshotView.urlname),
     url(r'^multimedia/$', ManageProjectMediaView.as_view(), name=ManageProjectMediaView.urlname),
     url(r'^commtrack/settings/$', RedirectView.as_view(url='commtrack_settings')),

--- a/corehq/apps/domain/urls.py
+++ b/corehq/apps/domain/urls.py
@@ -67,8 +67,10 @@ urlpatterns =\
         url(r'^domain/select/$', 'select', name='domain_select'),
         url(r'^domain/autocomplete/(?P<field>\w+)/$', 'autocomplete_fields', name='domain_autocomplete_fields'),
         url(r'^domain/incomplete_email/$', 'incomplete_email'),
-        url(r'^domain/transfer/(?P<guid>\w+)/activate$', ActivateTransferDomainView.as_view(), name='activate_transfer_domain'),
-        url(r'^domain/transfer/(?P<guid>\w+)/deactivate$', DeactivateTransferDomainView.as_view(), name='deactivate_transfer_domain'),
+        url(r'^domain/transfer/(?P<guid>\w+)/activate$', 
+            ActivateTransferDomainView.as_view(), name='activate_transfer_domain'),
+        url(r'^domain/transfer/(?P<guid>\w+)/deactivate$', 
+            DeactivateTransferDomainView.as_view(), name='deactivate_transfer_domain'),
     ) +\
     patterns('django.contrib.auth.views',
         url(r'^accounts/password_change/$', 'password_change', auth_pages_path('password_change_form.html'), name='password_change'),

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -2306,8 +2306,8 @@ class TransferDomainView(BaseAdminProjectSettingsView):
 
             if request.GET.get('resend', None):
                 self.active_transfer.send_transfer_request()
-                messages.info(request, _(u"Resent transfer request for project '{domain}'")
-                                         .format(domain=self.domain))
+                messages.info(request,
+                              _(u"Resent transfer request for project '{domain}'").format(domain=self.domain))
 
         return super(TransferDomainView, self).get(request, *args, **kwargs)
 
@@ -2323,9 +2323,9 @@ class TransferDomainView(BaseAdminProjectSettingsView):
     @property
     def page_context(self):
         if self.active_transfer:
-            return { 'transfer': self.active_transfer.as_dict() }
+            return {'transfer': self.active_transfer.as_dict()}
         else:
-            return { 'form': TransferDomainForm(self.domain, self.request.user.username) }
+            return {'form': TransferDomainForm(self.domain, self.request.user.username)}
 
     @method_decorator(domain_admin_required)
     @method_decorator(login_required)
@@ -2348,7 +2348,7 @@ class ActivateTransferDomainView(BasePageView):
     @property
     def page_context(self):
         if self.active_transfer:
-            return { 'transfer': self.active_transfer.as_dict() }
+            return {'transfer': self.active_transfer.as_dict()}
         else:
             return {}
 
@@ -2377,7 +2377,7 @@ class ActivateTransferDomainView(BasePageView):
 
         self.active_transfer.transfer_domain(ip=get_ip(request))
         messages.success(request, _(u"Successfully transferred ownership of project '{domain}'")
-                                    .format(domain=self.active_transfer.domain))
+                         .format(domain=self.active_transfer.domain))
 
         return HttpResponseRedirect(reverse('dashboard_default', args=[self.active_transfer.domain]))
 
@@ -2407,8 +2407,8 @@ class DeactivateTransferDomainView(View):
 
         # Do not want to send them back to the activate page
         if referer.endswith(reverse('activate_transfer_domain', args=[guid])):
-            messages.info(request, _(u"Declined ownership of project '{domain}'")
-                                   .format(domain=transfer.domain))
+            messages.info(request,
+                          _(u"Declined ownership of project '{domain}'").format(domain=transfer.domain))
             return HttpResponseRedirect('/')
         else:
             return HttpResponseRedirect(referer)

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -2298,6 +2298,7 @@ class TransferDomainView(BaseAdminProjectSettingsView):
     def active_transfer(self):
         return TransferDomainRequest.get_active_transfer(self.domain,
                                                          self.request.user.username)
+
     @property
     @memoized
     def transfer_domain_form(self):

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -2329,7 +2329,6 @@ class TransferDomainView(BaseAdminProjectSettingsView):
         context = self.get_context_data(**kwargs)
         return self.render_to_response(context)
 
-
     @property
     def page_context(self):
         if self.active_transfer:

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -32,7 +32,7 @@ from corehq.apps.smsbillables.async_handlers import SMSRatesAsyncHandler, SMSRat
 from corehq.apps.smsbillables.forms import SMSRateCalculatorForm
 from corehq.apps.users.models import DomainInvitation
 from corehq.apps.fixtures.models import FixtureDataType
-from corehq.toggles import NAMESPACE_DOMAIN, all_toggles, CAN_EDIT_EULA
+from corehq.toggles import NAMESPACE_DOMAIN, all_toggles, CAN_EDIT_EULA, TRANSFER_DOMAIN
 from corehq.util.context_processors import get_domain_type
 from dimagi.utils.couch.resource_conflict import retry_resource
 from django.conf import settings
@@ -2329,8 +2329,10 @@ class TransferDomainView(BaseAdminProjectSettingsView):
 
     @method_decorator(domain_admin_required)
     @method_decorator(login_required)
-    def dispatch(self, *args, **kwargs):
-        return super(TransferDomainView, self).dispatch(*args, **kwargs)
+    def dispatch(self, request, *args, **kwargs):
+        if not TRANSFER_DOMAIN.enabled(request.domain):
+            raise Http404()
+        return super(TransferDomainView, self).dispatch(request, *args, **kwargs)
 
 
 class ActivateTransferDomainView(BasePageView):

--- a/corehq/apps/hqwebapp/models.py
+++ b/corehq/apps/hqwebapp/models.py
@@ -1119,7 +1119,9 @@ class ProjectSettingsTab(UITab):
 
     @property
     def sidebar_items(self):
-        from corehq.apps.domain.views import FeatureFlagsView, FeaturePreviewsView
+        from corehq.apps.domain.views import (FeatureFlagsView,
+                                              FeaturePreviewsView,
+                                              TransferDomainView)
 
         items = []
         user_is_admin = self.couch_user.is_domain_admin(self.domain)
@@ -1207,6 +1209,11 @@ class ProjectSettingsTab(UITab):
             administration.append({
                 'title': _(FeaturePreviewsView.page_title),
                 'url': reverse(FeaturePreviewsView.urlname, args=[self.domain])
+            })
+
+            administration.append({
+                'title': _(TransferDomainView.page_title),
+                'url': reverse(TransferDomainView.urlname, args=[self.domain])
             })
             items.append((_('Project Administration'), administration))
 

--- a/corehq/apps/hqwebapp/models.py
+++ b/corehq/apps/hqwebapp/models.py
@@ -1211,10 +1211,11 @@ class ProjectSettingsTab(UITab):
                 'url': reverse(FeaturePreviewsView.urlname, args=[self.domain])
             })
 
-            administration.append({
-                'title': _(TransferDomainView.page_title),
-                'url': reverse(TransferDomainView.urlname, args=[self.domain])
-            })
+            if toggles.TRANSFER_DOMAIN.enabled(self.domain):
+                administration.append({
+                    'title': _(TransferDomainView.page_title),
+                    'url': reverse(TransferDomainView.urlname, args=[self.domain])
+                })
             items.append((_('Project Administration'), administration))
 
         from corehq.apps.users.models import WebUser

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -549,6 +549,10 @@ class _AuthorizableMixin(IsMemberOfMixin):
             record.save()
             return record
 
+    def transfer_domain_membership(self, domain, to_user, create_record=False):
+        to_user.add_domain_membership(domain)
+        self.delete_domain_membership(domain, create_record=create_record)
+
     def is_domain_admin(self, domain=None):
         if not domain:
             # hack for template
@@ -657,6 +661,9 @@ class SingleMembershipMixin(_AuthorizableMixin):
         raise NotImplementedError
 
     def delete_domain_membership(self, domain, create_record=False):
+        raise NotImplementedError
+
+    def transfer_domain_membership(self, domain, user, create_record=False):
         raise NotImplementedError
 
 class MultiMembershipMixin(_AuthorizableMixin):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -549,8 +549,8 @@ class _AuthorizableMixin(IsMemberOfMixin):
             record.save()
             return record
 
-    def transfer_domain_membership(self, domain, to_user, create_record=False):
-        to_user.add_domain_membership(domain)
+    def transfer_domain_membership(self, domain, to_user, create_record=False, is_admin=True):
+        to_user.add_domain_membership(domain, is_admin=is_admin)
         self.delete_domain_membership(domain, create_record=create_record)
 
     def is_domain_admin(self, domain=None):

--- a/corehq/apps/users/tests/create.py
+++ b/corehq/apps/users/tests/create.py
@@ -110,7 +110,6 @@ class CreateTestCase(TestCase):
         self.assertEquals(ccuser.get_domain_membership(domain).domain, domain)
 
         webuser.add_domain_membership(domain)
-        dm = webuser.get_domain_membership(domain)
         webuser.transfer_domain_membership(domain, webuser2)
 
         self.assertEquals(webuser.is_member_of(domain), False)

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -293,6 +293,12 @@ BULK_ARCHIVE_FORMS = StaticToggle(
     'Bulk archive forms with excel',
 )
 
+TRANSFER_DOMAIN = StaticToggle(
+    'transfer_domain',
+    'Transfer domains to different users',
+    [NAMESPACE_DOMAIN]
+)
+
 DHIS2_DOMAIN = StaticToggle(
     'dhis2_domain',
     'Enable DHIS2 integration for this domain',


### PR DESCRIPTION
This essentially provides a way for a user to transfer a domain to another user. e.g. `add_domain_membership` and then `delete_domain_membership` on the requester. It's similar to how Github repo transfer works. Will be adding management command in the future.

Here are some screenshots of the workflow:
![screen shot 2015-02-25 at 11 55 19 am](https://cloud.githubusercontent.com/assets/918514/6375586/fb553e7e-bce5-11e4-9d44-2def8c08b8c8.png)
![screen shot 2015-02-25 at 11 55 29 am](https://cloud.githubusercontent.com/assets/918514/6375588/fdbffe7e-bce5-11e4-9971-b0af6b5baa9d.png)

(Acceptor page)
![screen shot 2015-02-25 at 11 55 59 am](https://cloud.githubusercontent.com/assets/918514/6375590/05dd70c8-bce6-11e4-8bbc-8bfeed0e788d.png)

See [integration tests](https://github.com/benrudolph/commcare-hq/blob/a46ec104b50002146ee48a74094c5bdeab468f9a/corehq/apps/domain/tests/test_domain_transfer.py#L203) to get a better feel for work flow.

spec - https://dimagi.titanpad.com/1437
ticket - http://manage.dimagi.com/default.asp?154937
