### PR TITLE
Fix bug in UCR dynamic choice list filter

### DIFF
--- a/corehq/apps/userreports/reports/filters.py
+++ b/corehq/apps/userreports/reports/filters.py
@@ -1,4 +1,5 @@
 from django.core.urlresolvers import reverse
+from sqlagg.filters import EQFilter
 from dimagi.utils.dates import DateSpan
 
 
@@ -74,7 +75,7 @@ class ChoiceListFilterValue(FilterValue):
     def to_sql_filter(self):
         if self.show_all:
             return ''
-        return '{0} = :{0}'.format(self.filter.field)
+        return EQFilter(self.filter.field, self.filter.field)
 
     def to_sql_values(self):
         if self.show_all:


### PR DESCRIPTION
Postgres column labels in sql `WHERE` clauses were not being quoted. This caused errors to occur with filters that referenced data source columns that were also reserved postgres words, like `user` for example. The filter would fail silently because the query produced was syntactically valid but did not select the expected rows.
Resolves this ticket: http://manage.dimagi.com/default.asp?158629
