### PR TITLE
Add WisePill Device Event Export

### DIFF
--- a/custom/apps/wisepill/models.py
+++ b/custom/apps/wisepill/models.py
@@ -1,4 +1,6 @@
 from couchdbkit.ext.django.schema import *
+from dimagi.utils.decorators.memoized import memoized
+
 
 class WisePillDeviceEvent(Document):
     """
@@ -11,3 +13,43 @@ class WisePillDeviceEvent(Document):
     case_id = StringProperty() # Document _id of the case representing the device that sent this data in
     processed = BooleanProperty()
 
+    @property
+    @memoized
+    def data_as_dict(self):
+        """
+        Convert 'a=b,c=d' to {'a': 'b', 'c': 'd'}
+        """
+        result = {}
+        if isinstance(self.data, basestring):
+            items = self.data.strip().split(',')
+            for item in items:
+                parts = item.partition('=')
+                key = parts[0].strip().upper()
+                value = parts[2].strip()
+                if value:
+                    result[key] = value
+        return result
+
+    @property
+    def serial_number(self):
+        return self.data_as_dict.get('SN', None)
+
+    @property
+    def timestamp(self):
+        raw = self.data_as_dict.get('T', None)
+        if isinstance(raw, basestring) and len(raw) == 12:
+            return "20%s-%s-%s %s:%s:%s" % (
+                raw[4:6],
+                raw[2:4],
+                raw[0:2],
+                raw[6:8],
+                raw[8:10],
+                raw[10:12],
+            )
+        else:
+            return None
+
+    @classmethod
+    def get_all_ids(cls):
+        result = cls.view('wisepill/device_event', include_docs=False)
+        return [row['id'] for row in result]

--- a/custom/apps/wisepill/urls.py
+++ b/custom/apps/wisepill/urls.py
@@ -2,4 +2,5 @@ from django.conf.urls import *
 
 urlpatterns = patterns('custom.apps.wisepill.views',
     url(r'^device/?$', 'device_data', name='device_data'),
+    url(r'^export/events/', 'export_events', name='export_wisepill_events'),
 )

--- a/custom/apps/wisepill/urls.py
+++ b/custom/apps/wisepill/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import *
 
 urlpatterns = patterns('custom.apps.wisepill.views',
-    url(r'^device/?$', 'device_data', name='device_data'),
+    url(r'^device/?$', 'device_data', name='wisepill_device_event'),
     url(r'^export/events/', 'export_events', name='export_wisepill_events'),
 )


### PR DESCRIPTION
Nothing fancy, just a simple csv dump of all the WisePill event data stored for debugging. This can't really be a domain-specific report because we may not be able to tie an event to a domain if the device was not configured properly in CommCareHQ.
