### PR TITLE
Form linking UI and backend

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -567,7 +567,7 @@ class FormBase(DocumentSchema):
     )
     post_form_workflow = StringProperty(
         default=WORKFLOW_DEFAULT,
-        choices=[WORKFLOW_DEFAULT, WORKFLOW_ROOT, WORKFLOW_MODULE, WORKFLOW_PREVIOUS]
+        choices=[WORKFLOW_DEFAULT, WORKFLOW_ROOT, WORKFLOW_MODULE, WORKFLOW_PREVIOUS, WORKFLOW_FORM]
     )
     auto_gps_capture = BooleanProperty(default=False)
     no_vellum = BooleanProperty(default=False)

--- a/corehq/apps/app_manager/static/app_manager/js/form_workflow.js
+++ b/corehq/apps/app_manager/static/app_manager/js/form_workflow.js
@@ -1,5 +1,7 @@
-'use strict';
+/* global ko, _, $ */
+
 var FormWorkflow = function(options) {
+    'use strict';
     var self = this;
 
     // Human readable labels for the workflow types
@@ -16,12 +18,12 @@ var FormWorkflow = function(options) {
     /* Form linking */
     self.showFormLinkUI = ko.observable(self.workflow() === FormWorkflow.Values.FORM);
     self.forms = _.map(options.forms, function(f) {
-        return new FormWorkflow.Form(f, { locale: self.locale })
+        return new FormWorkflow.Form(f, { locale: self.locale });
     });
     self.formLinks = ko.observableArray(_.map(options.formLinks, function(link) {
         return new FormWorkflow.FormLink(link.xpath, link.form_id, { forms: self.forms });
     }));
-}
+};
 
 FormWorkflow.Values = {
     DEFAULT: 'default',
@@ -33,7 +35,7 @@ FormWorkflow.Values = {
 
 FormWorkflow.Errors = {
     FORM_NOTFOUND: 'This form either no longer exists or has a different case type',
-}
+};
 
 
 FormWorkflow.prototype.workflowDisplay = function() {
@@ -56,7 +58,7 @@ FormWorkflow.prototype.onWorkflowChange = function(workflow, event) {
 };
 
 FormWorkflow.prototype.onAddFormLink = function(workflow, event) {
-    this.formLinks.push(new FormWorkflow.FormLink())
+    this.formLinks.push(new FormWorkflow.FormLink());
 };
 
 FormWorkflow.prototype.onDestroyFormLink = function(formLink, event) {
@@ -71,15 +73,17 @@ FormWorkflow.prototype.displayUnknownForm = function(formLink) {
         return "Unknown form";
     }
     return;
-}
+};
 
 FormWorkflow.Form = function(form, options) {
+    'use strict';
     this.name = window.localize(form.name, options.locale);
     this.uniqueId = form.unique_id;
     this.locale = options.locale;
 };
 
 FormWorkflow.FormLink = function(xpath, formId, options) {
+    'use strict';
     var self = this;
     self.xpath = ko.observable(xpath);
     self.formId = ko.observable(formId);

--- a/corehq/apps/app_manager/static/app_manager/js/form_workflow.js
+++ b/corehq/apps/app_manager/static/app_manager/js/form_workflow.js
@@ -1,106 +1,107 @@
 /* global ko, _, $ */
 
-var FormWorkflow = function(options) {
+(function() {
     'use strict';
-    var self = this;
 
-    // Human readable labels for the workflow types
-    self.labels = options.labels;
+    window.FormWorkflow = function(options) {
+        var self = this;
 
-    // Workflow type. See FormWorkflow.Values for available types
-    self.workflow = ko.observable(options.workflow);
+        // Human readable labels for the workflow types
+        self.labels = options.labels;
 
-    self.locale = options.locale || 'en';
+        // Workflow type. See FormWorkflow.Values for available types
+        self.workflow = ko.observable(options.workflow);
 
-    // Element used to trigger a change when form link is removed
-    self.$changeEl = options.$changeEl || $('#form-workflow .workflow-change-trigger');
+        self.locale = options.locale || 'en';
 
-    /* Form linking */
-    self.showFormLinkUI = ko.observable(self.workflow() === FormWorkflow.Values.FORM);
-    self.forms = _.map(options.forms, function(f) {
-        return new FormWorkflow.Form(f, { locale: self.locale });
-    });
-    self.formLinks = ko.observableArray(_.map(options.formLinks, function(link) {
-        return new FormWorkflow.FormLink(link.xpath, link.form_id, { forms: self.forms });
-    }));
-};
+        // Element used to trigger a change when form link is removed
+        self.$changeEl = options.$changeEl || $('#form-workflow .workflow-change-trigger');
 
-FormWorkflow.Values = {
-    DEFAULT: 'default',
-    ROOT: 'root',
-    MODULE: 'module',
-    PREVIOUS_SCREEN: 'previous_screen',
-    FORM: 'form',
-};
-
-FormWorkflow.Errors = {
-    FORM_NOTFOUND: 'This form either no longer exists or has a different case type',
-};
-
-
-FormWorkflow.prototype.workflowDisplay = function() {
-    return this.labels[this.workflow()];
-};
-
-FormWorkflow.prototype.workflowOptions = function() {
-    return _.map(this.labels, function(label, value) {
-        return {
-            value: value,
-            label: (value === FormWorkflow.Values.DEFAULT ? '* ' + label : label)
-        };
-    });
-};
-
-FormWorkflow.prototype.onWorkflowChange = function(workflow, event) {
-    var value = $(event.currentTarget).val();
-
-    this.showFormLinkUI(value === FormWorkflow.Values.FORM);
-};
-
-FormWorkflow.prototype.onAddFormLink = function(workflow, event) {
-    this.formLinks.push(new FormWorkflow.FormLink());
-};
-
-FormWorkflow.prototype.onDestroyFormLink = function(formLink, event) {
-    var workflow = this;
-
-    workflow.formLinks.remove(formLink);
-    workflow.$changeEl.trigger('change'); // Manually trigger change so Save button activates
-};
-
-FormWorkflow.prototype.displayUnknownForm = function(formLink) {
-    if (_.contains(formLink.errors(), FormWorkflow.Errors.FORM_NOTFOUND)) {
-        return "Unknown form";
-    }
-    return;
-};
-
-FormWorkflow.Form = function(form, options) {
-    'use strict';
-    this.name = window.localize(form.name, options.locale);
-    this.uniqueId = form.unique_id;
-    this.locale = options.locale;
-};
-
-FormWorkflow.FormLink = function(xpath, formId, options) {
-    'use strict';
-    var self = this;
-    self.xpath = ko.observable(xpath);
-    self.formId = ko.observable(formId);
-    self.forms = options.forms || [];
-
-    self.errors = ko.computed(function() {
-        var found,
-            errors = [];
-
-        found = _.find(self.forms, function(f) {
-            return self.formId() === f.uniqueId;
+        /* Form linking */
+        self.showFormLinkUI = ko.observable(self.workflow() === FormWorkflow.Values.FORM);
+        self.forms = _.map(options.forms, function(f) {
+            return new FormWorkflow.Form(f, { locale: self.locale });
         });
+        self.formLinks = ko.observableArray(_.map(options.formLinks, function(link) {
+            return new FormWorkflow.FormLink(link.xpath, link.form_id, { forms: self.forms });
+        }));
+    };
 
-        if (!found) {
-            errors.push(FormWorkflow.Errors.FORM_NOTFOUND);
+    FormWorkflow.Values = {
+        DEFAULT: 'default',
+        ROOT: 'root',
+        MODULE: 'module',
+        PREVIOUS_SCREEN: 'previous_screen',
+        FORM: 'form',
+    };
+
+    FormWorkflow.Errors = {
+        FORM_NOTFOUND: 'This form either no longer exists or has a different case type',
+    };
+
+
+    FormWorkflow.prototype.workflowDisplay = function() {
+        return this.labels[this.workflow()];
+    };
+
+    FormWorkflow.prototype.workflowOptions = function() {
+        return _.map(this.labels, function(label, value) {
+            return {
+                value: value,
+                label: (value === FormWorkflow.Values.DEFAULT ? '* ' + label : label)
+            };
+        });
+    };
+
+    FormWorkflow.prototype.onWorkflowChange = function(workflow, event) {
+        var value = $(event.currentTarget).val();
+
+        this.showFormLinkUI(value === FormWorkflow.Values.FORM);
+    };
+
+    FormWorkflow.prototype.onAddFormLink = function(workflow, event) {
+        this.formLinks.push(new FormWorkflow.FormLink());
+    };
+
+    FormWorkflow.prototype.onDestroyFormLink = function(formLink, event) {
+        var workflow = this;
+
+        workflow.formLinks.remove(formLink);
+        workflow.$changeEl.trigger('change'); // Manually trigger change so Save button activates
+    };
+
+    FormWorkflow.prototype.displayUnknownForm = function(formLink) {
+        if (_.contains(formLink.errors(), FormWorkflow.Errors.FORM_NOTFOUND)) {
+            return "Unknown form";
         }
+        return;
+    };
 
-        return errors;
-    });
-};
+    FormWorkflow.Form = function(form, options) {
+        this.name = window.localize(form.name, options.locale);
+        this.uniqueId = form.unique_id;
+        this.locale = options.locale;
+    };
+
+    FormWorkflow.FormLink = function(xpath, formId, options) {
+        var self = this;
+        self.xpath = ko.observable(xpath);
+        self.formId = ko.observable(formId);
+        self.forms = options.forms || [];
+
+        self.errors = ko.computed(function() {
+            var found,
+                errors = [];
+
+            found = _.find(self.forms, function(f) {
+                return self.formId() === f.uniqueId;
+            });
+
+            if (!found) {
+                errors.push(FormWorkflow.Errors.FORM_NOTFOUND);
+            }
+
+            return errors;
+        });
+    };
+})();

--- a/corehq/apps/app_manager/static/app_manager/js/form_workflow.js
+++ b/corehq/apps/app_manager/static/app_manager/js/form_workflow.js
@@ -1,0 +1,102 @@
+'use strict';
+var FormWorkflow = function(options) {
+    var self = this;
+
+    // Human readable labels for the workflow types
+    self.labels = options.labels;
+
+    // Workflow type. See FormWorkflow.Values for available types
+    self.workflow = ko.observable(options.workflow);
+
+    self.locale = options.locale || 'en';
+
+    // Element used to trigger a change when form link is removed
+    self.$changeEl = options.$changeEl || $('#form-workflow .workflow-change-trigger');
+
+    /* Form linking */
+    self.showFormLinkUI = ko.observable(self.workflow() === FormWorkflow.Values.FORM);
+    self.forms = _.map(options.forms, function(f) {
+        return new FormWorkflow.Form(f, { locale: self.locale })
+    });
+    self.formLinks = ko.observableArray(_.map(options.formLinks, function(link) {
+        return new FormWorkflow.FormLink(link.xpath, link.form_id, { forms: self.forms });
+    }));
+}
+
+FormWorkflow.Values = {
+    DEFAULT: 'default',
+    ROOT: 'root',
+    MODULE: 'module',
+    PREVIOUS_SCREEN: 'previous_screen',
+    FORM: 'form',
+};
+
+FormWorkflow.Errors = {
+    FORM_NOTFOUND: 'This form either no longer exists or has a different case type',
+}
+
+
+FormWorkflow.prototype.workflowDisplay = function() {
+    return this.labels[this.workflow()];
+};
+
+FormWorkflow.prototype.workflowOptions = function() {
+    return _.map(this.labels, function(label, value) {
+        return {
+            value: value,
+            label: (value === FormWorkflow.Values.DEFAULT ? '* ' + label : label)
+        };
+    });
+};
+
+FormWorkflow.prototype.onWorkflowChange = function(workflow, event) {
+    var value = $(event.currentTarget).val();
+
+    this.showFormLinkUI(value === FormWorkflow.Values.FORM);
+};
+
+FormWorkflow.prototype.onAddFormLink = function(workflow, event) {
+    this.formLinks.push(new FormWorkflow.FormLink())
+};
+
+FormWorkflow.prototype.onDestroyFormLink = function(formLink, event) {
+    var workflow = this;
+
+    workflow.formLinks.remove(formLink);
+    workflow.$changeEl.trigger('change'); // Manually trigger change so Save button activates
+};
+
+FormWorkflow.prototype.displayUnknownForm = function(formLink) {
+    if (_.contains(formLink.errors(), FormWorkflow.Errors.FORM_NOTFOUND)) {
+        return "Unknown form";
+    }
+    return;
+}
+
+FormWorkflow.Form = function(form, options) {
+    this.name = window.localize(form.name, options.locale);
+    this.uniqueId = form.unique_id;
+    this.locale = options.locale;
+};
+
+FormWorkflow.FormLink = function(xpath, formId, options) {
+    var self = this;
+    self.xpath = ko.observable(xpath);
+    self.formId = ko.observable(formId);
+    self.forms = options.forms || [];
+
+    self.errors = ko.computed(function() {
+        var found,
+            errors = [];
+
+        found = _.find(self.forms, function(f) {
+            return self.formId() === f.uniqueId;
+        });
+
+        if (!found) {
+            errors.push(FormWorkflow.Errors.FORM_NOTFOUND);
+        }
+
+        return errors;
+    });
+};

--- a/corehq/apps/app_manager/templates/app_manager/form_view_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view_base.html
@@ -108,6 +108,9 @@
     {% if not is_user_registration %}
         {% include "app_manager/partials/nav_menu_media_js.html" %}
     {% endif %}
+    {% if allow_form_workflow %}
+        <script src="{% static 'app_manager/js/form_workflow.js' %}"></script>
+    {% endif %}
     <script>
         $(function(){
             (function styleSourcePopup() {
@@ -180,22 +183,21 @@
                 {% endif %}
 
                 {% if allow_form_workflow %}
-                    var workflow_labels = {
-                        default: "{% trans "Home Screen" %}",
-                        root: "{% trans "Module Menu" %}",
-                        module: "{% trans "Module:" %} {{ module.name|trans:langs }}",
-                        previous_screen: "{% trans "Previous Screen" %}"
-                    };
-                    var workflow_options = _.map(workflow_labels, function (label, value) {
-                        return {value: value, label: (value === 'default' ? '* ' + label : label)};
-                    });
-                    ko.applyBindings({
-                            workflow: ko.observable('{{ form.post_form_workflow }}'),
-                            form_workflow_options: workflow_options,
-                            workflow_display: workflow_labels["{{ form.post_form_workflow }}"]
-                        },
-                        $('#form-workflow').get(0)
-                    );
+                    var labels = {};
+                    labels[FormWorkflow.Values.DEFAULT] = "{% trans "Home Screen" %}";
+                    labels[FormWorkflow.Values.ROOT] = "{% trans "Module Menu" %}";
+                    labels[FormWorkflow.Values.MODULE] = "{% trans "Module:" %} {{ module.name|trans:langs }}";
+                    labels[FormWorkflow.Values.PREVIOUS_SCREEN] = "{% trans "Previous Screen" %}";
+                    labels[FormWorkflow.Values.FORM] = "{% trans "Link to other form" %}";
+
+                    var options = {
+                        locale: '{{ LANGUAGE_CODE }}',
+                        labels: labels,
+                        workflow: '{{ form.post_form_workflow }}',
+                        forms: {{ linkable_forms|JSON}},
+                        formLinks: {{ form.form_links|JSON }}
+                    }
+                    ko.applyBindings(new FormWorkflow(options), $('#form-workflow').get(0))
                 {% endif %}
 
                 ko.applyBindings({

--- a/corehq/apps/app_manager/templates/app_manager/form_view_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view_base.html
@@ -188,15 +188,21 @@
                     labels[FormWorkflow.Values.ROOT] = "{% trans "Module Menu" %}";
                     labels[FormWorkflow.Values.MODULE] = "{% trans "Module:" %} {{ module.name|trans:langs }}";
                     labels[FormWorkflow.Values.PREVIOUS_SCREEN] = "{% trans "Previous Screen" %}";
-                    labels[FormWorkflow.Values.FORM] = "{% trans "Link to other form" %}";
 
                     var options = {
                         locale: '{{ LANGUAGE_CODE }}',
                         labels: labels,
                         workflow: '{{ form.post_form_workflow }}',
-                        forms: {{ linkable_forms|JSON}},
-                        formLinks: {{ form.form_links|JSON }}
-                    }
+                    };
+                {% endif %}
+
+                {% if allow_form_workflow and request|toggle_enabled:"FORM_LINK_WORKFLOW"%}
+                    labels[FormWorkflow.Values.FORM] = "{% trans "Link to other form" %}";
+                    options.forms = {{ linkable_forms|JSON}}
+                    options.formLinks = {{ form.form_links|JSON }}
+                {% endif %}
+
+                {% if allow_form_workflow %}
                     ko.applyBindings(new FormWorkflow(options), $('#form-workflow').get(0))
                 {% endif %}
 

--- a/corehq/apps/app_manager/templates/app_manager/form_view_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view_base.html
@@ -190,7 +190,6 @@
                     labels[FormWorkflow.Values.PREVIOUS_SCREEN] = "{% trans "Previous Screen" %}";
 
                     var options = {
-                        locale: '{{ LANGUAGE_CODE }}',
                         labels: labels,
                         workflow: '{{ form.post_form_workflow }}',
                     };

--- a/corehq/apps/app_manager/templates/app_manager/partials/form_workflow.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/form_workflow.html
@@ -14,8 +14,7 @@
                 <div class="control-group">
                     <select name="post_form_workflow" data-bind="
                         optstr: workflowOptions(),
-                        value: workflow,
-                        event: { change: onWorkflowChange }
+                        value: workflow
                         "></select>
                 </div>
 
@@ -34,9 +33,7 @@
                         ">
                     </div>
                     <button class="btn btn-primary" data-bind="
-                        event: {
-                            click: onAddFormLink
-                        }
+                        click: onAddFormLink
                         ">
                         {% trans "Add link" %}
                     </button>
@@ -68,7 +65,7 @@
                 value: formLink.formId
                 "></select>
             <button class="btn btn-danger" data-bind="
-                event: { click: $parent.onDestroyFormLink.bind($parent) }
+                click: $parent.onDestroyFormLink.bind($parent)
                 ">
                 <i class="icon-trash"></i>
             </button>
@@ -76,17 +73,12 @@
                 visible: formLink.errors().length
                 ">
                 <ul data-bind="
-                    template: {
-                        name: 'form-link-error-template',
                         foreach: formLink.errors(),
-                        as: 'error'
-                    }
-                "></ul>
+                ">
+                    <li data-bind="text: $data"></li>
+                </ul>
             </div>
 
         </div>
-    </script>
-    <script type="text/html" id="form-link-error-template">
-        <li data-bind="text: error"></li>
     </script>
 {% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/form_workflow.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/form_workflow.html
@@ -1,4 +1,3 @@
-<!-- form tags -->
 {% load i18n %}
 {% if app.application_version == '2.0' %}
     <div class="control-group">

--- a/corehq/apps/app_manager/templates/app_manager/partials/form_workflow.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/form_workflow.html
@@ -42,8 +42,6 @@
                         {% trans "Add link" %}
                     </button>
                     <input type="hidden" class="workflow-change-trigger" />
-
-
                 </div>
             {% else %}
                 <span data-bind="text: workflowDisplay()"></span>
@@ -85,7 +83,6 @@
                         as: 'error'
                     }
                 "></ul>
-                
             </div>
 
         </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/form_workflow.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/form_workflow.html
@@ -1,3 +1,4 @@
+<!-- form tags -->
 {% load i18n %}
 {% if app.application_version == '2.0' %}
     <div class="control-group">
@@ -11,12 +12,85 @@
         </label>
         <div id="form-workflow" class="controls commcare-feature" data-since-version="2.10">
             {% if edit %}
-                 <select name="post_form_workflow" data-bind="
-                    optstr: form_workflow_options,
-                    value: workflow"></select>
+                <div class="control-group">
+                    <select name="post_form_workflow" data-bind="
+                        optstr: workflowOptions(),
+                        value: workflow,
+                        event: { change: onWorkflowChange }
+                        "></select>
+                </div>
+
+                <div class="form-links-container" data-bind="
+                    visible: showFormLinkUI
+                    ">
+
+                    <!-- Container for Form Link UI. Will be populated with existing form links and where new
+                        form links will be added -->
+                    <div class="form-links" data-bind="
+                        template: {
+                            name: 'form-link-template',
+                            foreach: formLinks,
+                            as: 'formLink'
+                        }
+                        ">
+                    </div>
+                    <button class="btn btn-primary" data-bind="
+                        event: {
+                            click: onAddFormLink
+                        }
+                        ">
+                        {% trans "Add link" %}
+                    </button>
+                    <input type="hidden" class="workflow-change-trigger" />
+
+
+                </div>
             {% else %}
-                <span data-bind="text: workflow_display"></span>
+                <span data-bind="text: workflowDisplay()"></span>
             {% endif %}
         </div>
     </div>
+
+    <script type="text/html" id="form-link-template">
+        <div class="control-group">
+            <textarea name="form_links_xpath_expressions"
+                      placeholder="XPath Expression"
+                      rows="1"
+                      data-bind="
+                        text: formLink.xpath,
+                        value: formLink.xpath
+            "></textarea>
+            &nbsp;
+            <i class="icon-arrow-right"></i>
+            &nbsp;
+            <select name="form_links_form_ids" data-bind="
+                options: $parent.forms,
+                optionsText: 'name',
+                optionsValue: 'uniqueId',
+                optionsCaption: $parent.displayUnknownForm.call($parent, formLink),
+                value: formLink.formId
+                "></select>
+            <button class="btn btn-danger" data-bind="
+                event: { click: $parent.onDestroyFormLink.bind($parent) }
+                ">
+                <i class="icon-trash"></i>
+            </button>
+            <div class="alert alert-error" data-bind="
+                visible: formLink.errors().length
+                ">
+                <ul data-bind="
+                    template: {
+                        name: 'form-link-error-template',
+                        foreach: formLink.errors(),
+                        as: 'error'
+                    }
+                "></ul>
+                
+            </div>
+
+        </div>
+    </script>
+    <script type="text/html" id="form-link-error-template">
+        <li data-bind="text: error"></li>
+    </script>
 {% endif %}

--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -1730,7 +1730,7 @@ def edit_form_attr(req, domain, app_id, unique_form_id, attr):
             req.POST.getlist('form_links_xpath_expressions'),
             req.POST.getlist('form_links_form_ids')
         )
-        form.form_links = [FormLink({ 'xpath': link[0], 'form_id': link[1] }) for link in form_links]
+        form.form_links = [FormLink({'xpath': link[0], 'form_id': link[1]}) for link in form_links]
 
     _handle_media_edits(req, form, should_edit, resp)
 

--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -128,6 +128,7 @@ from corehq.apps.app_manager.models import (
     DetailColumn,
     Form,
     FormActions,
+    FormLink,
     FormNotFoundException,
     FormSchedule,
     IncompatibleFormTypeException,
@@ -958,8 +959,10 @@ def view_generic(req, domain, app_id=None, module_id=None, form_id=None, is_user
 
     if form:
         template, form_context = get_form_view_context_and_template(req, form, context['langs'], is_user_registration)
+        modules = filter(lambda m: m.case_type == module.case_type, app.get_modules())
         context.update({
             'case_properties': get_all_case_properties(app),
+            'linkable_forms': sum([list(m.get_forms()) for m in modules], [])
         })
         context.update(form_context)
     elif module:
@@ -1715,6 +1718,12 @@ def edit_form_attr(req, domain, app_id, unique_form_id, attr):
         form.auto_gps_capture = req.POST['auto_gps_capture'] == 'true'
     if should_edit('no_vellum'):
         form.no_vellum = req.POST['no_vellum'] == 'true'
+    if should_edit("form_links_xpath_expressions") and should_edit("form_links_form_ids"):
+        form_links = zip(
+            req.POST.getlist('form_links_xpath_expressions'),
+            req.POST.getlist('form_links_form_ids')
+        )
+        form.form_links = [FormLink({ 'xpath': link[0], 'form_id': link[1] }) for link in form_links]
 
     _handle_media_edits(req, form, should_edit, resp)
 

--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -965,8 +965,12 @@ def view_generic(req, domain, app_id=None, module_id=None, form_id=None, is_user
 
         if toggles.FORM_LINK_WORKFLOW.enabled(req.user.username):
             modules = filter(lambda m: m.case_type == module.case_type, app.get_modules())
+            linkable_forms = list(itertools.chain.from_iterable(list(m.get_forms()) for m in modules))
             context.update({
-                'linkable_forms': sum([list(m.get_forms()) for m in modules], [])
+                'linkable_forms': map(
+                    lambda f: {'unique_id': f.unique_id, 'name': trans(f.name, app.langs)},
+                    linkable_forms
+                )
             })
 
         context.update(form_context)

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -322,6 +322,11 @@ PRIME_RESTORE = StaticToggle(
     [NAMESPACE_DOMAIN, NAMESPACE_USER]
 )
 
+FORM_LINK_WORKFLOW = StaticToggle(
+    'form_link_workflow',
+    'Form linking workflow available on forms',
+)
+
 # not referenced in code directly but passed through to vellum
 # see toggles_dict
 VELLUM_TRANSACTION_QUESTION_TYPES = StaticToggle(


### PR DESCRIPTION
@snopoke here's the UI and saving to the backend. I'd recommend taking a look at the first commit rather than the whole thing since adding the feature flag obfuscates a few parts.

Here are some screenshots of the UI:
![screen shot 2015-03-02 at 2 37 44 pm](https://cloud.githubusercontent.com/assets/918514/6448753/28433096-c0ea-11e4-8c8c-ddefbd13dc4c.png)
With errors:
![screen shot 2015-03-02 at 2 37 37 pm](https://cloud.githubusercontent.com/assets/918514/6448758/2f4e00a0-c0ea-11e4-8736-948453e68d5e.png)

Open questions:
- What's the best way to do the syntax checking for the XPath expression? (I think we said we'd ensure that it's proper syntax, but not ensure that it's a valid XPath expression that will evaluate to something)
- Is there an example you could point me to of how we do JS translation? Or is it mainly ad-hock 
- `linkable_forms` seems like it could be an expensive operation and could potentially add a lot of data to the response object. I couldn't seem to figure out a way to use the existing response in the django template to generate the `linkable_forms`. Let me know if you know of a better way.
- Do we have a way to add JS unit tests? I mainly want to put some in for the ViewModel. `django-qunit` looks like a good candidate, but this is probably a larger discussion
