### PR TITLE
Fix bug in Case Activity report

### DIFF
--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -270,6 +270,8 @@ class CaseActivityReport(WorkerMonitoringReportTableBase):
             kwargs['modified_on__gte'] = modified_after
         if modified_before:
             kwargs['modified_on__lt'] = modified_before
+        if self.case_type:
+            kwargs['type'] = self.case_type
 
         qs = CaseData.objects.filter(
             domain=self.domain,


### PR DESCRIPTION
The case type filter in the case activity report wasn't doing anything. I think the filtering capability was lost here: https://github.com/dimagi/commcare-hq/pull/4881.
Addresses http://manage.dimagi.com/default.asp?159279.
