### PR TITLE
Add shell_plus imports to localsettings

### DIFF
--- a/localsettings.example.py
+++ b/localsettings.example.py
@@ -156,6 +156,22 @@ MAPS_LAYERS = {
     },
 }
 
+####### Django Extensions #######
+# These things will be imported when you run ./manage.py shell_plus
+SHELL_PLUS_POST_IMPORTS = (
+    # Models
+    ('corehq.apps.domain.models', 'Domain'),
+    ('corehq.apps.groups.models', 'Group'),
+    ('corehq.apps.locations', 'Location'),
+    ('corehq.apps.users.models', ('CommCareUser', 'CommCareCase')),
+    ('couchforms.models', 'XFormInstance'),
+
+    # Data querying utils
+    ('dimagi.utils.couch.database', 'get_db'),
+    ('corehq.apps.sofabed.models', ('FormData', 'CaseData')),
+    ('corehq.apps.es', '*'),
+)
+
 FORMTRANSLATE_TIMEOUT = 5
 LOCAL_APPS = (
 #    'django_coverage', # Adds `python manage.py test_coverage` (settings below)


### PR DESCRIPTION
@dimagi/team-commcare-hq If you use django-extensions' `shell_plus`, this setting will allow you to add additional imports.  This way you run `$ ./manage.py shell_plus`, and you get dropped in to a shell that has our core couch models imported too.

On a related note, this doesn't feel like it belongs in `settings.py`, but it'd be nice to have this some place where I'll actually receive updates and similar settings without needing to manually copy stuff over from localsettings.example.py.  What do you all think of a shared `dev_settings.py` or something?  In my opinion, `localsettings.py`, especially because it's out of version control, should really be the home to only two types of things - passwords and things that need to stay hidden, and stuff that you personally want to override from the other settings file(s).  Eg: if someone adds a new flag that will break your dev environment if it's not set properly, there should be a sensible default in place.
