### PR TITLE
remove residual domain creation message

### DIFF
--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -159,12 +159,6 @@ def register_domain(request, domain_type=None):
                 return render(request, 'registration/confirmation_sent.html',
                         context)
             else:
-                messages.success(request, _(
-                    '<strong>The project {project} was successfully created!</strong> '
-                    'An email has been sent to {user} for your records.').format(
-                    project=requested_domain, user=request.user.username),
-                    extra_tags="html")
-
                 if nextpage:
                     return HttpResponseRedirect(nextpage)
                 if referer_url:


### PR DESCRIPTION
When you create a new domain after the first time, you automatically land here:
![screen shot 2015-03-04 at 5 01 21 pm](https://cloud.githubusercontent.com/assets/1757035/6494628/2cefd1dc-c291-11e4-84c7-f6e7c83b0bb1.png)

Then if you click on reports, you awkwardly see this residual welcome message:
![screen shot 2015-03-04 at 5 01 40 pm](https://cloud.githubusercontent.com/assets/1757035/6494636/3b37fa76-c291-11e4-8128-4957d15a7767.png)

So I'm proposing removing that message in its entirety, since the landing page seems to make it obsolete (although I could see a case being made for moving the message to the landing page, but at this point it feels redundant).
