### PR TITLE
Allow Location to be hashable

### DIFF
--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -12,7 +12,7 @@ class LocationSet(object):
 
     def __init__(self, locations=None):
         self.by_id = {}
-        self.by_parent = defaultdict(lambda: set())
+        self.by_parent = defaultdict(set)
         if locations is not None:
             for loc in locations:
                 self.add_location(loc)

--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -223,6 +223,15 @@ class Location(CachedCouchDocumentMixin, Document):
     def __repr__(self):
         return "%s (%s)" % (self.name, self.location_type)
 
+    def __eq__(self, other):
+        if isinstance(other, Location):
+            return self._id == other._id
+        else:
+            return False
+
+    def __hash__(self):
+        return hash(self._id)
+
     def _sync_location(self):
         properties_to_sync = [
             ('location_id', '_id'),

--- a/corehq/apps/locations/tests/test_locations.py
+++ b/corehq/apps/locations/tests/test_locations.py
@@ -390,6 +390,10 @@ class LocationGroupTest(LocationTestBase):
         )
 
     def test_location_fixture_generator(self):
+        """
+        This tests the location XML fixture generator. It specifically ensures that no duplicate XML
+        nodes are generated when all locations have a parent and multiple locations are enabled.
+        """
         self.domain.commtrack_enabled = True
         self.domain.save()
         self.loc.delete()
@@ -423,5 +427,5 @@ class LocationGroupTest(LocationTestBase):
         self.user.add_location(loc4)
         self.user.save()
         fixture = location_fixture_generator(self.user, '2.0')
+        self.assertEquals(len(fixture[0].findall('.//state')), 1)
         self.assertEquals(len(fixture[0].findall('.//outlet')), 3)
-        pass

--- a/corehq/apps/locations/tests/test_locations.py
+++ b/corehq/apps/locations/tests/test_locations.py
@@ -1,10 +1,12 @@
 from corehq.apps.locations.models import Location, SQLLocation, LOCATION_SHARING_PREFIX, LOCATION_REPORTING_PREFIX
 from corehq.apps.locations.schema import LocationType
 from corehq.apps.locations.tests.util import make_loc
+from corehq.apps.locations.fixtures import location_fixture_generator
 from corehq.apps.commtrack.helpers import make_supply_point, make_product
 from corehq.apps.users.models import CommCareUser
 from django.test import TestCase
 from couchdbkit import ResourceNotFound
+from corehq import toggles
 from corehq.apps.groups.models import Group
 from corehq.apps.groups.exceptions import CantSaveException
 from corehq.apps.products.models import SQLProduct
@@ -279,6 +281,8 @@ class LocationGroupTest(LocationTestBase):
             domain=self.domain.name
         )
 
+        toggles.MULTIPLE_LOCATIONS_PER_USER.set("domain:{}".format(self.domain.name), True)
+
     def test_group_name(self):
         # just location name for top level
         self.assertEqual(
@@ -384,3 +388,40 @@ class LocationGroupTest(LocationTestBase):
             },
             self.loc.sql_location.reporting_group_object().metadata
         )
+
+    def test_location_fixture_generator(self):
+        self.domain.commtrack_enabled = True
+        self.domain.save()
+        self.loc.delete()
+        loc = make_loc(
+            'testregion1',
+            type='state',
+            domain=self.domain.name
+        )
+        loc2 = make_loc(
+            'testoutlet1',
+            type='outlet',
+            domain=self.domain.name,
+            parent=loc
+        )
+        loc3 = make_loc(
+            'testoutlet2',
+            type='outlet',
+            domain=self.domain.name,
+            parent=loc
+        )
+        loc4 = make_loc(
+            'testoutlet3',
+            type='outlet',
+            domain=self.domain.name,
+            parent=loc
+        )
+        self.user.set_location(loc2)
+        self.user.add_location(loc)
+        self.user.add_location(loc2)
+        self.user.add_location(loc3)
+        self.user.add_location(loc4)
+        self.user.save()
+        fixture = location_fixture_generator(self.user, '2.0')
+        self.assertEquals(len(fixture[0].findall('.//outlet')), 3)
+        pass


### PR DESCRIPTION
@emord @czue 

Duplicate locations were being added to the `by_parent` set because `Location`s aren't hashable. Only happens when all locations have a parent for some reason. Instead of digging into the logic for why this was happening, I made `Location`s hashable so it just works. Not sure if this is unpythonic/dangerous solution, my brain was a bit too fried to dive deeper.

https://github.com/dimagi/commcare-hq/pull/5686/files#diff-29ea9598cea171ab08caff56a3506a63R22

Fixes http://manage.dimagi.com/default.asp?158655
