### PR TITLE
post-merge git hook to notify if a requirements changed

### DIFF
--- a/git-hooks/post-merge.sh
+++ b/git-hooks/post-merge.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Notify if requirements files are changed
+CHANGED=`git diff HEAD@{1} --stat -- $GIT_DIR/../requirements/ | wc -l`
+if [ $CHANGED -gt 0 ];
+then
+    echo "Requirements files changed"
+    git diff HEAD@{1} -- ./requirements/
+    echo "You might want to update your environment as per above requirements changes"
+fi


### PR DESCRIPTION
I lazy-install new requirements. This hook notifies if the files in `corehq/requirements/` directory changes, so you can lazy `pip install`
