### PR TITLE
Add data type to UCR expressions

### DIFF
--- a/corehq/apps/userreports/README.md
+++ b/corehq/apps/userreports/README.md
@@ -102,6 +102,7 @@ This expression returns `doc["age"]`:
     "property_name": "age"
 }
 ```
+An optional `"datatype"` attribute may be specified, which will attempt to cast the property to the given data type. The options are "date", "datetime", "string", "integer", and "decimal". If no datatype is specified, "string" will be used.
 ##### Property Path Expression
 
 This expression returns `doc["child"]["age"]`:
@@ -111,6 +112,7 @@ This expression returns `doc["child"]["age"]`:
     "property_path": ["child", "age"]
 }
 ```
+An optional `"datatype"` attribute may be specified, which will attempt to cast the property to the given data type. The options are "date", "datetime", "string", "integer", and "decimal". If no datatype is specified, "string" will be used.
 ##### Conditional Expression
 
 This expression returns `"legal" if doc["age"] > 21 else "underage"`:
@@ -122,6 +124,7 @@ This expression returns `"legal" if doc["age"] > 21 else "underage"`:
         "expression": {
             "type": "property_name",
             "property_name": "age"
+            "datatype": "integer"
         },
         "type": "boolean_expression",
         "property_value": 21
@@ -137,6 +140,8 @@ This expression returns `"legal" if doc["age"] > 21 else "underage"`:
 }
 ```
 Note that this expression contains other expressions inside it! This is why expressions are powerful. (It also contains a filter, but we haven't covered those yet - if you find the `"test"` section confusing, keep reading...)
+
+Note also that it's important to make sure that you comparing values of the same type. The expression that retrieves the age property from the document also casts the value to an integer. If this datatype is not specified, the expression will compare a string to the `21` value, which will not produce the expected results! 
 
 #### Related document expressions
 
@@ -168,6 +173,7 @@ Here is a sample JSON format for simple `boolean_expression` filter:
     "expression": {
         "type": "property_name",
         "property_name": "age",
+        "datatype": "integer"
     },
     "operator": "gt",
     "property_value": 21
@@ -206,6 +212,7 @@ The following filter represents the statement: `doc["age"] < 21 and doc["nationa
             "expression": {
                 "type": "property_name",
                 "property_name": "age",
+                "datatype": "integer"
             },
             "operator": "lt",
             "property_value": 21
@@ -234,6 +241,7 @@ The following filter represents the statement: `doc["age"] > 21 or doc["national
             "expression": {
                 "type": "property_name",
                 "property_name": "age",
+                "datatype": "integer",
             },
             "operator": "gt",
             "property_value": 21

--- a/corehq/apps/userreports/README.md
+++ b/corehq/apps/userreports/README.md
@@ -141,7 +141,7 @@ This expression returns `"legal" if doc["age"] > 21 else "underage"`:
 ```
 Note that this expression contains other expressions inside it! This is why expressions are powerful. (It also contains a filter, but we haven't covered those yet - if you find the `"test"` section confusing, keep reading...)
 
-Note also that it's important to make sure that you comparing values of the same type. The expression that retrieves the age property from the document also casts the value to an integer. If this datatype is not specified, the expression will compare a string to the `21` value, which will not produce the expected results! 
+Note also that it's important to make sure that you are comparing values of the same type. In this example, the expression that retrieves the age property from the document also casts the value to an integer. If this datatype is not specified, the expression will compare a string to the `21` value, which will not produce the expected results! 
 
 #### Related document expressions
 

--- a/corehq/apps/userreports/expressions/getters.py
+++ b/corehq/apps/userreports/expressions/getters.py
@@ -108,6 +108,8 @@ def transform_from_datatype(datatype):
     identity = lambda x: x
     return {
         'date': transform_date,
+        'datetime': transform_datetime,
+        'decimal': transform_decimal,
         'integer': transform_int,
         'string': unicode,
     }.get(datatype) or identity

--- a/corehq/apps/userreports/expressions/getters.py
+++ b/corehq/apps/userreports/expressions/getters.py
@@ -77,8 +77,6 @@ def transform_date(item):
 
 
 def transform_datetime(item):
-    # Following the example of transform_date here, but it seems like this
-    # should do some transforming?
     return item or None
 
 
@@ -91,7 +89,6 @@ def transform_int(item):
 
 def transform_decimal(item):
     try:
-        # Set precision?
         return Decimal(item)
     except (ValueError, TypeError):
         return None

--- a/corehq/apps/userreports/expressions/getters.py
+++ b/corehq/apps/userreports/expressions/getters.py
@@ -95,6 +95,8 @@ def transform_decimal(item):
 
 
 def transform_unicode(item):
+    if item is None:
+        return None
     try:
         return unicode(item)
     except (ValueError, TypeError):
@@ -111,7 +113,7 @@ def transform_from_datatype(datatype):
         'datetime': transform_datetime,
         'decimal': transform_decimal,
         'integer': transform_int,
-        'string': unicode,
+        'string': transform_unicode,
     }.get(datatype) or identity
 
 

--- a/corehq/apps/userreports/expressions/getters.py
+++ b/corehq/apps/userreports/expressions/getters.py
@@ -101,6 +101,18 @@ def transform_unicode(item):
         return None
 
 
+def transform_from_datatype(datatype):
+    """
+    Given a datatype, return a transform for that type.
+    """
+    identity = lambda x: x
+    return {
+        'date': transform_date,
+        'integer': transform_int,
+        'string': unicode,
+    }.get(datatype) or identity
+
+
 def getter_from_property_reference(spec):
     if spec.property_name:
         assert not spec.property_path, \

--- a/corehq/apps/userreports/expressions/getters.py
+++ b/corehq/apps/userreports/expressions/getters.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 
 
 class TransformedGetter(object):
@@ -75,9 +76,30 @@ def transform_date(item):
     return item or None
 
 
+def transform_datetime(item):
+    # Following the example of transform_date here, but it seems like this
+    # should do some transforming?
+    return item or None
+
+
 def transform_int(item):
     try:
         return int(item)
+    except (ValueError, TypeError):
+        return None
+
+
+def transform_decimal(item):
+    try:
+        # Set precision?
+        return Decimal(item)
+    except (ValueError, TypeError):
+        return None
+
+
+def transform_unicode(item):
+    try:
+        return unicode(item)
     except (ValueError, TypeError):
         return None
 

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -16,13 +16,9 @@ from corehq.util.quickcache import quickcache
 from dimagi.utils.couch.database import get_db
 
 
-# Should PropertyName and PropertyPath cast automagically based on the question type?
-
-
 class ConstantGetterSpec(JsonObject):
     type = TypeProperty('constant')
     constant = DefaultProperty(required=True)
-    # Would datatype here be useful? (maybe for dates)
 
     def __call__(self, item, context=None):
         return self.constant

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -24,7 +24,7 @@ class ConstantGetterSpec(JsonObject):
 class PropertyNameGetterSpec(JsonObject):
     type = TypeProperty('property_name')
     property_name = StringProperty(required=True)
-    datatype = DataTypeProperty(required=False, default="string")
+    datatype = DataTypeProperty(required=False)
 
     @property
     def expression(self):
@@ -39,7 +39,7 @@ class PropertyNameGetterSpec(JsonObject):
 class PropertyPathGetterSpec(JsonObject):
     type = TypeProperty('property_path')
     property_path = ListProperty(unicode, required=True)
-    datatype = DataTypeProperty(required=False, default="string")
+    datatype = DataTypeProperty(required=False)
 
     @property
     def expression(self):

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -6,11 +6,8 @@ from corehq.apps.userreports.expressions.getters import (
     DictGetter,
     NestedDictGetter,
     TransformedGetter,
-)
-from corehq.apps.userreports.indicators.specs import (
-    DataTypeProperty,
-    _transform_from_datatype,
-)
+    transform_from_datatype)
+from corehq.apps.userreports.indicators.specs import DataTypeProperty
 from corehq.apps.userreports.specs import TypeProperty, EvaluationContext
 from corehq.util.quickcache import quickcache
 from dimagi.utils.couch.database import get_db
@@ -31,7 +28,7 @@ class PropertyNameGetterSpec(JsonObject):
 
     @property
     def expression(self):
-        transform = _transform_from_datatype(self.datatype)
+        transform = transform_from_datatype(self.datatype)
         getter = DictGetter(self.property_name)
         return TransformedGetter(getter, transform)
 
@@ -46,7 +43,7 @@ class PropertyPathGetterSpec(JsonObject):
 
     @property
     def expression(self):
-        transform = _transform_from_datatype(self.datatype)
+        transform = transform_from_datatype(self.datatype)
         getter = NestedDictGetter(self.property_path)
         return TransformedGetter(getter, transform)
 

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -2,15 +2,27 @@ import json
 from couchdbkit.exceptions import ResourceNotFound
 from jsonobject import JsonObject, StringProperty, ListProperty, DictProperty
 from jsonobject.base_properties import DefaultProperty
-from corehq.apps.userreports.expressions.getters import DictGetter, NestedDictGetter
+from corehq.apps.userreports.expressions.getters import (
+    DictGetter,
+    NestedDictGetter,
+    TransformedGetter,
+)
+from corehq.apps.userreports.indicators.specs import (
+    DataTypeProperty,
+    _transform_from_datatype,
+)
 from corehq.apps.userreports.specs import TypeProperty, EvaluationContext
 from corehq.util.quickcache import quickcache
 from dimagi.utils.couch.database import get_db
 
 
+# Should PropertyName and PropertyPath cast automagically based on the question type?
+
+
 class ConstantGetterSpec(JsonObject):
     type = TypeProperty('constant')
     constant = DefaultProperty(required=True)
+    # Would datatype here be useful? (maybe for dates)
 
     def __call__(self, item, context=None):
         return self.constant
@@ -19,10 +31,13 @@ class ConstantGetterSpec(JsonObject):
 class PropertyNameGetterSpec(JsonObject):
     type = TypeProperty('property_name')
     property_name = StringProperty(required=True)
+    datatype = DataTypeProperty(required=False, default="string")
 
     @property
     def expression(self):
-        return DictGetter(self.property_name)
+        transform = _transform_from_datatype(self.datatype)
+        getter = DictGetter(self.property_name)
+        return TransformedGetter(getter, transform)
 
     def __call__(self, item, context=None):
         return self.expression(item, context)
@@ -31,10 +46,13 @@ class PropertyNameGetterSpec(JsonObject):
 class PropertyPathGetterSpec(JsonObject):
     type = TypeProperty('property_path')
     property_path = ListProperty(unicode, required=True)
+    datatype = DataTypeProperty(required=False, default="string")
 
     @property
     def expression(self):
-        return NestedDictGetter(self.property_path)
+        transform = _transform_from_datatype(self.datatype)
+        getter = NestedDictGetter(self.property_path)
+        return TransformedGetter(getter, transform)
 
     def __call__(self, item, context=None):
         return self.expression(item, context)

--- a/corehq/apps/userreports/indicators/specs.py
+++ b/corehq/apps/userreports/indicators/specs.py
@@ -104,6 +104,3 @@ def _transform_from_datatype(datatype):
         'decimal': transform_decimal,
         'integer': transform_int,
     }.get(datatype)
-
-
-

--- a/corehq/apps/userreports/tests/test_app_manager_integration.py
+++ b/corehq/apps/userreports/tests/test_app_manager_integration.py
@@ -53,7 +53,7 @@ class AppManagerDataSourceConfigTest(SimpleTestCase):
             category='bug',
             priority='4',
             starred='yes',
-            estimate=2,
+            estimate='2',
         )
         def _get_column_property(column):
             return column.id if column.id != 'doc_id' else '_id'

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from django.test import SimpleTestCase
 from fakecouch import FakeCouchDb
 from corehq.apps.userreports.exceptions import BadSpecError
@@ -23,6 +24,27 @@ class ConstantExpressionTest(SimpleTestCase):
             ExpressionFactory.from_spec({
                 'type': 'constant',
             })
+
+
+class PropertyExpressionTest(SimpleTestCase):
+
+    def test_datatype(self):
+        # TODO: Test other data types too.
+        for expected, datatype, original in [
+            (5, "integer", "5"),
+            (None, "integer", "5.3"),
+            (Decimal(5), "decimal", "5"),
+            (Decimal("5.3"), "decimal", "5.3"),
+            ("5", "string", "5"),
+            ("5", "string", 5),
+            (u"fo\u00E9", "string", u"fo\u00E9")
+        ]:
+            getter = ExpressionFactory.from_spec({
+                'type': 'property_name',
+                'property_name': 'foo',
+                'datatype': datatype
+            })
+            self.assertEqual(expected, getter({'foo': original}))
 
 
 class ExpressionFromSpecTest(SimpleTestCase):

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -29,7 +29,6 @@ class ConstantExpressionTest(SimpleTestCase):
 class PropertyExpressionTest(SimpleTestCase):
 
     def test_datatype(self):
-        # TODO: Test other data types too.
         for expected, datatype, original in [
             (5, "integer", "5"),
             (None, "integer", "5.3"),

--- a/corehq/apps/userreports/tests/test_indicators.py
+++ b/corehq/apps/userreports/tests/test_indicators.py
@@ -212,8 +212,8 @@ class RawIndicatorTest(SingleIndicatorTestBase):
             "display_name": "raw foos",
         })
         self._check_result(indicator, dict(foo="bar"), 'bar')
-        self._check_result(indicator, dict(foo=1), 1)
-        self._check_result(indicator, dict(foo=1.2), 1.2)
+        self._check_result(indicator, dict(foo=1), '1')
+        self._check_result(indicator, dict(foo=1.2), '1.2')
         self._check_result(indicator, dict(foo=None), None)
         self._check_result(indicator, dict(nofoo='foryou'), None)
 


### PR DESCRIPTION
Allow UCR data source property_name and property_path expressions to specify a data type. Before you were stuck with strings, which meant you couldn't compare them to numbers properly.
Addresses http://manage.dimagi.com/default.asp?158956.

FYI @snopoke @czue @nickpell
