### PR TITLE
correctly display date in Payment Record report

### DIFF
--- a/corehq/apps/accounting/interface.py
+++ b/corehq/apps/accounting/interface.py
@@ -790,7 +790,7 @@ class PaymentRecordInterface(GenericTabularReport):
         for record in self.payment_records:
             rows.append([
                 format_datatables_data(
-                    text=record.date_created.strftime("%B %m %Y"),
+                    text=record.date_created.strftime("%B %d %Y"),
                     sort_key=record.date_created.isoformat(),
                 ),
                 record.payment_method.account.name,


### PR DESCRIPTION
display date of the month instead of the month's number: https://docs.python.org/2/library/datetime.html

@benrudolph @biyeun 
