### PR TITLE
Properly wrap couch_user

### DIFF
--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -194,7 +194,7 @@ class GenericReportView(CacheableRequestMixIn):
         request.datespan = request_data.get('datespan')
 
         try:
-            couch_user = CouchUser.get(request_data.get('couch_user'))
+            couch_user = CouchUser.get_by_user_id(request_data.get('couch_user'))
             request.couch_user = couch_user
         except Exception as e:
             logging.error("Could not unpickle couch_user from request for report %s. Error: %s" %

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -202,21 +202,14 @@ def apps_update_calculated_properties():
 @task
 def export_all_rows_task(ReportClass, report_state):
     report = object.__new__(ReportClass)
-
-    # Somehow calling generic _init function or __setstate__ is raising AttributeError
-    # on '_update_initial_context' function call...
-    try:
-        report.__setstate__(report_state)
-    except AttributeError:
-        pass
+    report.__setstate__(report_state)
 
     # need to set request
     setattr(report.request, 'REQUEST', {})
 
     file = report.excel_response
     hash_id = _store_excel_in_redis(file)
-    user = WebUser.get(report_state["request"]["couch_user"])
-    _send_email(user, report, hash_id)
+    _send_email(report.request.couch_user, report, hash_id)
 
 
 def _send_email(user, report, hash_id):


### PR DESCRIPTION
Found this when debugging this ticket: http://manage.dimagi.com/default.asp?159628#887637

Seemed like a bad idea to pass over an attribute error
