### PR TITLE
don't redirect if download project from exchange is clicked after being disabled

### DIFF
--- a/corehq/apps/appstore/templates/appstore/project_info.html
+++ b/corehq/apps/appstore/templates/appstore/project_info.html
@@ -51,7 +51,9 @@
             });
             $('#agree-button').click(function() {
                 $('#download-new-project').removeAttr('data-toggle');
+                $('#download-new-project').removeAttr('href');
                 $('#import-into-button').removeAttr('data-toggle');
+                $('#import-into-button').removeAttr('href');
                 var form = $("#" + $(this).attr('data-form'));
                 form.submit();
             });


### PR DESCRIPTION
usability fix related to https://github.com/dimagi/commcare-hq/pull/5773.  people like to re-click this button when it takes a long time to download a project. Allowing redirects prevents form validation errors from being shown to the user

@czue 
