### PR TITLE
Refactor get_report_render_url

### DIFF
--- a/corehq/apps/reports/static/reports/javascripts/reports.config.js
+++ b/corehq/apps/reports/static/reports/javascripts/reports.config.js
@@ -179,7 +179,7 @@ var HQReport = function (options) {
     }
 
     function getReportBaseUrl(renderType) {
-        return window.location.pathname.replace(self.urlRoot, self.urlRoot+renderType+"/")
+        return window.location.pathname.replace(self.urlRoot, self.urlRoot+renderType+"/");
     }
 
     function getReportRenderUrl(renderType, additionalParams) {

--- a/corehq/apps/reports/static/reports/javascripts/reports.config.js
+++ b/corehq/apps/reports/static/reports/javascripts/reports.config.js
@@ -163,7 +163,7 @@ var HQReport = function (options) {
                     "&enddate="+self.datespan.enddate;
             }
         }
-        params += (additionalParams == undefined ? "" : "&" + additionalParams);
+        params += (additionalParams ? "&" + additionalParams : "");
         if (asObject) {
             // http://stackoverflow.com/a/8649003/835696
             return JSON.parse('{"' +


### PR DESCRIPTION
This passes data as an object for a POST so date filter is correctly
read. The issue for this was that since the arguments were being passed in the URL django was putting them in the GET request object. The datefilter decorator checks the method and then grabs the corresponding request dict therefore the dates weren't being read. See this line of code:

https://github.com/dimagi/dimagi-utils/blob/master/dimagi/utils/decorators/datespan.py#L30

http://manage.dimagi.com/default.asp?159628#887826
