### PR TITLE
Do not do lookup if id is None

### DIFF
--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -602,6 +602,8 @@ class SupplyPointCase(CommCareCase):
     @property
     @memoized
     def location(self):
+        if self.location_id is None:
+            return None
         try:
             return Location.get(self.location_id)
         except ResourceNotFound:


### PR DESCRIPTION
@esoergel 

Found out that couchdbkit itself chokes when you call `get` with `None` as an argument. Decided that the best way to resolve this is to ensure we don't pass `None` into `get`.

http://manage.dimagi.com/default.asp?159684#888067
