### PR TITLE
Reword help text of "Avg # Forms Submitted" column in Worker Activity Report

### DIFF
--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -1000,7 +1000,7 @@ class WorkerActivityReport(WorkerMonitoringReportTableBase, DatespanMixin):
             DataTablesColumn(_("# Forms Submitted"), sort_type=DTSortType.NUMERIC,
                 help_text=_("Number of forms submitted in chosen date range. %s" % CASE_TYPE_MSG)),
             DataTablesColumn(_("Avg # Forms Submitted"), sort_type=DTSortType.NUMERIC,
-                help_text=_("Average number of forms submitted in the last three date ranges of the same length. %s" % CASE_TYPE_MSG)),
+                help_text=_("Average number of forms submitted in the three preceding date ranges of the same length. %s" % CASE_TYPE_MSG)),
             DataTablesColumn(_("Last Form Submission"),
                 help_text=_("Date of last form submission in time period.  Total row displays proportion of users submitting forms in date range")) \
             if not by_group else DataTablesColumn(_("# Active Users"), sort_type=DTSortType.NUMERIC,


### PR DESCRIPTION
The new wording should hopefully make it more clear that the average does not include the forms submitted in the currently selected date range.
This came to my attention in this ticket: http://manage.dimagi.com/default.asp?159696
