### PR TITLE
only encode if necessary

### DIFF
--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -2392,7 +2392,7 @@ class DownloadCCZ(DownloadMultimediaZip):
                 if name not in skip_files:
                     # TODO: make RemoteApp.create_all_files not return media files
                     extension = os.path.splitext(name)[1]
-                    data = f.encode('utf-8') if extension in text_extensions else f
+                    data = _encode_if_unicode(f) if extension in text_extensions else f
                     yield (get_name(name), data)
 
         if self.app.is_remote_app():


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?159784

It would seem that some of these files are being double encoded and so attempting to encode then a third time produces an error:

```
>>>u'Español'.encode('utf8').encode('utf8')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 4: ordinal not in range(128)
```
