### PR TITLE
If the toggle doesn't exist, don't iterate its domains

### DIFF
--- a/custom/dhis2/models.py
+++ b/custom/dhis2/models.py
@@ -4,6 +4,7 @@ import json
 import logging
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.fixtures.models import FixtureDataItem, FixtureDataType, FieldList, FixtureItemField
+from couchdbkit import ResourceNotFound
 from couchdbkit.ext.django.schema import *
 from dimagi.utils.couch.cache import cache_core
 import requests
@@ -33,7 +34,10 @@ class Dhis2Settings(Document):
         """
         Yields settings of all domains for which "enabled" is true
         """
-        toggle = Toggle.get('dhis2_domain')
+        try:
+            toggle = Toggle.get('dhis2_domain')
+        except ResourceNotFound:
+            raise StopIteration
         for domain in toggle.enabled_users:
             if domain.startswith('domain:'):
                 # If the "domain" namespace is given, strip it off

--- a/custom/dhis2/models.py
+++ b/custom/dhis2/models.py
@@ -37,7 +37,7 @@ class Dhis2Settings(Document):
         try:
             toggle = Toggle.get('dhis2_domain')
         except ResourceNotFound:
-            raise StopIteration
+            return
         for domain in toggle.enabled_users:
             if domain.startswith('domain:'):
                 # If the "domain" namespace is given, strip it off


### PR DESCRIPTION
Catch ResourceNotFound exception and raise StopIteration.

This is regarding [FB 159819](http://manage.dimagi.com/default.asp?159819)
