### PR TITLE
Add assertion for HTML equality

### DIFF
--- a/corehq/apps/app_manager/tests/util.py
+++ b/corehq/apps/app_manager/tests/util.py
@@ -78,7 +78,7 @@ def parse_normalize(xml, to_string=True, is_html=False):
 
 
 def _check_shared(expected, actual, checker, extension):
-     # snippet from http://stackoverflow.com/questions/321795/comparing-xml-in-a-unit-test-in-python/7060342#7060342
+    # snippet from http://stackoverflow.com/questions/321795/comparing-xml-in-a-unit-test-in-python/7060342#7060342
     if not checker.check_output(expected, actual, 0):
         message = "{} mismatch\n\n".format(extension.upper())
         diff = difflib.unified_diff(

--- a/corehq/apps/app_manager/tests/util.py
+++ b/corehq/apps/app_manager/tests/util.py
@@ -91,6 +91,7 @@ def _check_shared(expected, actual, checker, extension):
             message += line
         raise AssertionError(message)
 
+
 def extract_xml_partial(xml, xpath):
     actual = parse_normalize(xml, to_string=False)
     nodes = actual.findall(xpath)

--- a/corehq/apps/app_manager/tests/util.py
+++ b/corehq/apps/app_manager/tests/util.py
@@ -71,9 +71,7 @@ def parse_normalize(xml, to_string=True, is_html=False):
         parser_class = lxml.etree.HTMLParser
         markup_class = lxml.etree.HTML
         meth = "html"
-
     parser = parser_class(remove_blank_text=True)
-
     parse = lambda *args: normalize_attributes(markup_class(*args))
     parsed = parse(xml, parser)
     return lxml.etree.tostring(parsed, pretty_print=True, method=meth) if to_string else parsed

--- a/corehq/apps/app_manager/tests/util.py
+++ b/corehq/apps/app_manager/tests/util.py
@@ -1,7 +1,7 @@
 import json
 import os
 import lxml
-from lxml.doctestcompare import LXMLOutputChecker
+from lxml.doctestcompare import LXMLOutputChecker, LHTMLOutputChecker
 import mock
 from corehq.apps.builds.models import CommCareBuild, CommCareBuildConfig, \
     BuildSpec
@@ -44,20 +44,13 @@ class TestFileMixin(object):
         if normalize:
             expected = parse_normalize(expected)
             actual = parse_normalize(actual)
+        _check_shared(expected, actual, LXMLOutputChecker(), "html")
 
-        # snippet from http://stackoverflow.com/questions/321795/comparing-xml-in-a-unit-test-in-python/7060342#7060342
-        checker = LXMLOutputChecker()
-        if not checker.check_output(expected, actual, 0):
-            message = "XML mismatch\n\n"
-            diff = difflib.unified_diff(
-                expected.splitlines(1),
-                actual.splitlines(1),
-                fromfile='want.xml',
-                tofile='got.xml'
-            )
-            for line in diff:
-                message += line
-            raise AssertionError(message)
+    def assertHtmlEqual(self, expected, actual, normalize=True):
+        if normalize:
+            expected = parse_normalize(expected, is_html=True)
+            actual = parse_normalize(actual, is_html=True)
+        _check_shared(expected, actual, LHTMLOutputChecker(), "html")
 
 
 def normalize_attributes(xml):
@@ -70,12 +63,35 @@ def normalize_attributes(xml):
     return xml
 
 
-def parse_normalize(xml, to_string=True):
-    parser = lxml.etree.XMLParser(remove_blank_text=True)
-    parse = lambda *args: normalize_attributes(lxml.etree.XML(*args))
-    parsed = parse(xml, parser)
-    return lxml.etree.tostring(parsed, pretty_print=True) if to_string else parsed
+def parse_normalize(xml, to_string=True, is_html=False):
+    parser_class = lxml.etree.XMLParser
+    markup_class = lxml.etree.XML
+    meth = "xml"
+    if is_html:
+        parser_class = lxml.etree.HTMLParser
+        markup_class = lxml.etree.HTML
+        meth = "html"
 
+    parser = parser_class(remove_blank_text=True)
+
+    parse = lambda *args: normalize_attributes(markup_class(*args))
+    parsed = parse(xml, parser)
+    return lxml.etree.tostring(parsed, pretty_print=True, method=meth) if to_string else parsed
+
+
+def _check_shared(expected, actual, checker, extension):
+     # snippet from http://stackoverflow.com/questions/321795/comparing-xml-in-a-unit-test-in-python/7060342#7060342
+    if not checker.check_output(expected, actual, 0):
+        message = "{} mismatch\n\n".format(extension.upper())
+        diff = difflib.unified_diff(
+            expected.splitlines(1),
+            actual.splitlines(1),
+            fromfile='want.{}'.format(extension),
+            tofile='got.{}'.format(extension)
+        )
+        for line in diff:
+            message += line
+        raise AssertionError(message)
 
 def extract_xml_partial(xml, xpath):
     actual = parse_normalize(xml, to_string=False)


### PR DESCRIPTION
Add a method, `assertHtmlEqual`, that mirrors `assertXmlEqual` but parses the markup as HTML.
