### PR TITLE
a bit of refactoring in xform.py

### DIFF
--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from functools import wraps
 import logging
 from casexml.apps.case.xml import V2_NAMESPACE
 from corehq.apps.app_manager.const import APP_V1, SCHEDULE_PHASE, SCHEDULE_LAST_VISIT, SCHEDULE_LAST_VISIT_DATE, \
@@ -68,6 +69,19 @@ def relative_path(from_path, to_path):
                     break
 
             return '%s/%s' % ('/'.join(['..' for n in from_nodes]), '/'.join(to_nodes))
+
+
+def requires_itext(on_fail_return=None):
+    def _wrapper(func):
+        @wraps(func)
+        def _inner(self, *args, **kwargs):
+            try:
+                self.itext_node
+            except XFormException:
+                return on_fail_return() if on_fail_return else None
+            return func(self, *args, **kwargs)
+        return _inner
+    return _wrapper
 
 
 SESSION_CASE_ID = CaseIDXPath(session_var(CASE_ID))
@@ -189,13 +203,13 @@ class ItextNodeGroup(object):
     def __eq__(self, other):
         for lang, node in self.nodes.items():
             other_node = other.nodes.get(lang)
-            if node.values != other_node.values:
+            if node.rendered_values != other_node.rendered_values:
                 return False
 
         return True
 
     def __hash__(self):
-        return ''.join(["{0}{1}".format(n.lang, n.values) for n in self.nodes.values()]).__hash__()
+        return ''.join(["{0}{1}".format(n.lang, n.rendered_values) for n in self.nodes.values()]).__hash__()
 
     def __repr__(self):
         return "{0}, {1}".format(self.id, self.nodes)
@@ -206,7 +220,12 @@ class ItextNode(object):
         self.lang = lang
         self.id = itext_node.attrib['id']
         values = itext_node.findall('{f}value')
-        self.values = sorted([str.strip(ET.tostring(v.xml)) for v in values])
+        self.values_by_form = {value.attrib.get('form'): value for value in values}
+
+    @property
+    @memoized
+    def rendered_values(self):
+        return sorted([str.strip(ET.tostring(v.xml)) for v in self.values_by_form.values()])
 
     def __repr__(self):
         return self.id
@@ -520,12 +539,10 @@ class XForm(WrappedNode):
         else:
             return self.data_node.find('{x}case')
 
+    @requires_itext(list)
     def media_references(self, form):
-        try:
-            nodes = self.itext_node.findall('{f}translation/{f}text/{f}value[@form="%s"]' % form)
-            return list(set([n.text for n in nodes]))
-        except XFormException:
-            return []
+        nodes = self.itext_node.findall('{f}translation/{f}text/{f}value[@form="%s"]' % form)
+        return list(set([n.text for n in nodes]))
 
     @property
     def image_references(self):
@@ -548,6 +565,36 @@ class XForm(WrappedNode):
         except XFormException:
             pass
 
+    @memoized
+    @requires_itext(dict)
+    def translations(self):
+        translations = {}
+        for translation in self.itext_node.findall('{f}translation'):
+            lang = translation.attrib['lang']
+            translations[lang] = translation
+
+        return translations
+
+    @memoized
+    def itext_node_groups(self):
+        """
+        :return: dict mapping 'lang' to ItextNodeGroup objects.
+        """
+        node_groups = {}
+        for lang, translation in self.translations().items():
+            text_nodes = translation.findall('{f}text')
+            for text in text_nodes:
+                node = ItextNode(lang, text)
+                group = node_groups.get(node.id)
+                if not group:
+                    group = ItextNodeGroup([node])
+                else:
+                    group.add_node(node)
+                node_groups[node.id] = group
+
+        return node_groups
+
+    @requires_itext()
     def normalize_itext(self):
         """
         Convert this:
@@ -561,24 +608,8 @@ class XForm(WrappedNode):
 
         and rename the appropriate label references.
         """
-        try:
-            itext = self.itext_node
-        except XFormException:
-            return
-        node_groups = {}
-        translations = {}
-        for translation in itext.findall('{f}translation'):
-            lang = translation.attrib['lang']
-            translations[lang] = translation
-            text_nodes = translation.findall('{f}text')
-            for text in text_nodes:
-                node = ItextNode(lang, text)
-                group = node_groups.get(node.id)
-                if not group:
-                    group = ItextNodeGroup([node])
-                else:
-                    group.add_node(node)
-                node_groups[node.id] = group
+        translations = self.translations()
+        node_groups = self.itext_node_groups()
 
         duplicate_dict = defaultdict(list)
         for g in node_groups.values():
@@ -610,6 +641,9 @@ class XForm(WrappedNode):
 
         self.xml = parse_xml(xf_string)
 
+        self.translations.reset_cache(self)
+        self.itext_node_groups.reset_cache(self)
+
     def strip_vellum_ns_attributes(self):
         # vellum_ns is wrapped in braces i.e. '{http...}'
         vellum_ns = self.namespaces['v']
@@ -619,31 +653,30 @@ class XForm(WrappedNode):
                 if key.startswith(vellum_ns):
                     del node.attrib[key]
 
+    @requires_itext()
     def rename_language(self, old_code, new_code):
-        try:
-            trans_node = self.itext_node.find('{f}translation[@lang="%s"]' % old_code)
-            duplicate_node = self.itext_node.find('{f}translation[@lang="%s"]' % new_code)
-        except XFormException:
-            return
+        trans_node = self.translations().get(old_code)
+        duplicate_node = self.translations().get(new_code)
 
-        if not trans_node.exists():
+        if not trans_node or not trans_node.exists():
             raise XFormException("There's no language called '%s'" % old_code)
-        if duplicate_node.exists():
+        if duplicate_node and duplicate_node.exists():
             raise XFormException("There's already a language called '%s'" % new_code)
         trans_node.attrib['lang'] = new_code
 
+        self.translations.reset_cache(self)
+
     def exclude_languages(self, whitelist):
-        try:
-            translations = self.itext_node.findall('{f}translation')
-        except XFormException:
-            # if there's no itext then they must be using labels
-            return
-
-        for trans_node in translations:
-            if trans_node.attrib.get('lang') not in whitelist:
+        changes = False
+        for lang, trans_node in self.translations().items():
+            if lang not in whitelist:
                 self.itext_node.remove(trans_node.xml)
+                changes = True
 
-    def localize(self, id, lang=None, form=None):
+        if changes:
+            self.translations.reset_cache(self)
+
+    def _normalize_itext_id(self, id):
         pre = 'jr:itext('
         post = ')'
 
@@ -652,27 +685,28 @@ class XForm(WrappedNode):
         if id[0] == id[-1] and id[0] in ('"', "'"):
             id = id[1:-1]
 
-        if lang is None:
-            trans_node = self.itext_node.find('{f}translation')
-        else:
-            trans_node = self.itext_node.find('{f}translation[@lang="%s"]' % lang)
-            if not trans_node.exists():
-                return None
+        return id
 
-        text_node = trans_node.find('{f}text[@id="%s"]' % id)
-        if not text_node.exists():
+    def localize(self, id, lang=None, form=None):
+        # fail hard if no itext node present
+        self.itext_node
+
+        id = self._normalize_itext_id(id)
+        node_group = self.itext_node_groups().get(id)
+        if not node_group:
             return None
 
-        search_tag = '{f}value'
-        if form:
-            search_tag += '[@form="%s"]' % form
-        value_node = text_node.find(search_tag)
+        text_node = node_group.nodes.get(lang)
+        if not text_node:
+            return None
+
+        value_node = text_node.values_by_form.get(form)
 
         if value_node:
             text = ItextValue.from_node(value_node)
         else:
             raise XFormException('<translation lang="%s"><text id="%s"> node has no <value>' % (
-                trans_node.attrib.get('lang'), id
+                lang, id
             ))
 
         return text
@@ -707,17 +741,12 @@ class XForm(WrappedNode):
         else:
             return "%s/%s" % (path_context, path)
 
+    @requires_itext(list)
     def get_languages(self):
         if not self.exists():
             return []
-        try:
-            itext = self.itext_node
-        except XFormException:
-            return []
-        langs = []
-        for translation in itext.findall('{f}translation'):
-            langs.append(translation.attrib['lang'])
-        return langs
+
+        return self.translations().keys()
 
     def get_questions(self, langs, include_triggers=False,
                       include_groups=False):
@@ -1048,17 +1077,13 @@ class XForm(WrappedNode):
         # necessary to make casexml work
         transformation()
 
+    @requires_itext()
     def set_default_language(self, lang):
-        try:
-            itext_node = self.itext_node
-        except XFormException:
-            return
-        else:
-            for translation in itext_node.findall('{f}translation'):
-                if translation.attrib.get('lang') == lang:
-                    translation.attrib['default'] = ""
-                else:
-                    translation.attrib.pop('default', None)
+        for this_lang, translation in self.translations().items():
+            if this_lang == lang:
+                translation.attrib['default'] = ""
+            else:
+                translation.attrib.pop('default', None)
 
     def set_version(self, version):
         """set the form's version attribute"""


### PR DESCRIPTION
- `requires_itext` decorator
- memoized versions of `self.itext_node_groups` and `self.translations` to reduce number of similar xpath evaluations
