### PR TITLE
Sanitize case_json

### DIFF
--- a/corehq/apps/cloudcare/api.py
+++ b/corehq/apps/cloudcare/api.py
@@ -48,11 +48,12 @@ class CaseAPIResult(object):
     The result of a case API query. Useful for abstracting out the difference
     between an id-only representation and a full_blown one.
     """
-    def __init__(self, id=None, couch_doc=None, id_only=False, lite=True):
+    def __init__(self, id=None, couch_doc=None, id_only=False, lite=True, sanitize=True):
         self._id = id
         self._couch_doc = couch_doc
         self.id_only = id_only
         self.lite = lite
+        self.sanitize = sanitize
 
     def __getitem__(self, key):
         if key == 'case_id':
@@ -74,7 +75,7 @@ class CaseAPIResult(object):
 
     @property
     def case_json(self):
-        return self.couch_doc.get_json(lite=self.lite)
+        return self.couch_doc.get_json(lite=self.lite, sanitize=self.sanitize)
 
     def to_json(self):
         return self.id if self.id_only else self.case_json

--- a/corehq/apps/cloudcare/tests/test_api.py
+++ b/corehq/apps/cloudcare/tests/test_api.py
@@ -7,7 +7,7 @@ from casexml.apps.phone.xml import date_to_xml_string
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.util import format_username
-from corehq.apps.cloudcare.api import get_filtered_cases, CASE_STATUS_OPEN, CASE_STATUS_ALL,\
+from corehq.apps.cloudcare.api import get_filtered_cases, CaseAPIResult, CASE_STATUS_OPEN, CASE_STATUS_ALL,\
     CASE_STATUS_CLOSED
 import uuid
 
@@ -215,6 +215,17 @@ class CaseAPITest(TestCase):
         # when filtering with footprint, the filters get intentionally ignored
         # so just ensure the whole footprint including open and closed is available
         self.assertEqual(self.expectedOpenByUserWithFootprint + self.expectedClosedByUserWithFootprint, len(list))
+
+    def testCaseAPIResultJSON(self):
+        case = _create_case(self.users[0], None, close=False)
+        res_sanitized = CaseAPIResult(id=case._id, couch_doc=case, sanitize=True)
+        res_unsanitized = CaseAPIResult(id=case._id, couch_doc=case, sanitize=False)
+
+        json = res_sanitized.case_json
+        self.assertEqual(json['properties']['case_type'], '')
+
+        json = res_unsanitized.case_json
+        self.assertEqual(json['properties']['case_type'], None)
 
 
 def _child_case_type(type):

--- a/corehq/apps/cloudcare/tests/test_api.py
+++ b/corehq/apps/cloudcare/tests/test_api.py
@@ -226,6 +226,7 @@ class CaseAPITest(TestCase):
 
         json = res_unsanitized.case_json
         self.assertEqual(json['properties']['case_type'], None)
+        case.delete()
 
 
 def _child_case_type(type):

--- a/corehq/ex-submodules/casexml/apps/case/models.py
+++ b/corehq/ex-submodules/casexml/apps/case/models.py
@@ -349,14 +349,7 @@ class CommCareCase(SafeSaveDocument, IndexHoldingMixIn, ComputedDocumentMixin,
 
         return json
 
-    def get_json(self, lite=False, sanitize=False):
-        """
-        Returns a JSON representation of a case
-
-        Keyword arguments:
-        lite - include reverse indices (default False)
-        sanitize - replace None with "", useful for passing json to mobile (default False)
-        """
+    def get_json(self, lite=False):
         ret = {
             # referrals and actions excluded here
             "domain": self.domain,
@@ -391,15 +384,6 @@ class CommCareCase(SafeSaveDocument, IndexHoldingMixIn, ComputedDocumentMixin,
             ret.update({
                 "reverse_indices": self.get_index_map(True),
             })
-        if sanitize:
-            def _sanitize(props):
-                for key, val in props.items():
-                    if val is None:
-                        props[key] = ''
-                    elif isinstance(val, dict):
-                        props[key] = _sanitize(val)
-                return props
-            ret = _sanitize(ret)
         return ret
 
     @memoized

--- a/corehq/ex-submodules/casexml/apps/case/models.py
+++ b/corehq/ex-submodules/casexml/apps/case/models.py
@@ -349,7 +349,14 @@ class CommCareCase(SafeSaveDocument, IndexHoldingMixIn, ComputedDocumentMixin,
 
         return json
 
-    def get_json(self, lite=False):
+    def get_json(self, lite=False, sanitize=False):
+        """
+        Returns a JSON representation of a case
+
+        Keyword arguments:
+        lite - include reverse indices (default False)
+        sanitize - replace None with "", useful for passing json to mobile (default False)
+        """
         ret = {
             # referrals and actions excluded here
             "domain": self.domain,
@@ -384,6 +391,15 @@ class CommCareCase(SafeSaveDocument, IndexHoldingMixIn, ComputedDocumentMixin,
             ret.update({
                 "reverse_indices": self.get_index_map(True),
             })
+        if sanitize:
+            def _sanitize(props):
+                for key, val in props.items():
+                    if val is None:
+                        props[key] = ''
+                    elif isinstance(val, dict):
+                        props[key] = _sanitize(val)
+                return props
+            ret = _sanitize(ret)
         return ret
 
     @memoized


### PR DESCRIPTION
@czue this ensures that all properties that are None are now "" when sending JSON back to mobile. @ctsims do you think it's fine to always encode `null` as `""`? Or do some values have a distinction between `null` and `""`. If so I'll just put a quick line in to just make `case_type` an empty string.

http://manage.dimagi.com/default.asp?158655#890304
