### PR TITLE
Allow null as UCR filter choice value

### DIFF
--- a/corehq/apps/reports_core/templates/reports_core/filters/choice_list_filter.html
+++ b/corehq/apps/reports_core/templates/reports_core/filters/choice_list_filter.html
@@ -2,7 +2,7 @@
 {% block filter-controls %}
     <select name="{{ filter.name }}">
         {% for choice in filter.choices %}
-            <option value="{{ choice.value }}">{{ choice.display }}</option>
+            <option value="{{ choice.value|escapejs }}">{{ choice.display }}</option>
         {% endfor %}
     </select>
 {% endblock %}

--- a/corehq/apps/userreports/reports/factory.py
+++ b/corehq/apps/userreports/reports/factory.py
@@ -4,7 +4,11 @@ from corehq.apps.reports_core.filters import DatespanFilter, ChoiceListFilter, C
     NumericFilter
 from corehq.apps.userreports.exceptions import BadSpecError
 from django.utils.translation import ugettext as _
-from corehq.apps.userreports.reports.filters import SHOW_ALL_CHOICE, dynamic_choice_list_url
+from corehq.apps.userreports.reports.filters import(
+    dynamic_choice_list_url,
+    NONE_CHOICE,
+    SHOW_ALL_CHOICE,
+)
 from corehq.apps.userreports.reports.specs import FilterSpec, ChoiceListFilterSpec, PieChartSpec, \
     MultibarAggregateChartSpec, MultibarChartSpec, ReportFilter, ReportColumn, DynamicChoiceListFilterSpec, \
     NumericFilterSpec
@@ -30,7 +34,10 @@ def _build_numeric_filter(spec):
 
 def _build_choice_list_filter(spec):
     wrapped = ChoiceListFilterSpec.wrap(spec)
-    choices = [Choice(fc.value, fc.get_display()) for fc in wrapped.choices]
+    choices = [Choice(
+        fc.value if fc.value is not None else NONE_CHOICE,
+        fc.get_display()
+    ) for fc in wrapped.choices]
     if wrapped.show_all:
         choices.insert(0, Choice(SHOW_ALL_CHOICE, _('Show all')))
     return ChoiceListFilter(

--- a/corehq/apps/userreports/reports/filters.py
+++ b/corehq/apps/userreports/reports/filters.py
@@ -1,9 +1,10 @@
 from django.core.urlresolvers import reverse
-from sqlagg.filters import BasicFilter, BetweenFilter, EQFilter
+from sqlagg.filters import BasicFilter, BetweenFilter, EQFilter, ISNULLFilter
 from dimagi.utils.dates import DateSpan
 
 
 SHOW_ALL_CHOICE = '_all'  # todo: if someone wants to name an actually choice "_all" this will break
+NONE_CHOICE = u"\u2400"
 
 
 class FilterValue(object):
@@ -74,13 +75,19 @@ class ChoiceListFilterValue(FilterValue):
     def show_all(self):
         return self.value.value == SHOW_ALL_CHOICE
 
+    @property
+    def is_null(self):
+        return self.value.value == NONE_CHOICE
+
     def to_sql_filter(self):
         if self.show_all:
             return ''
+        if self.is_null:
+            return ISNULLFilter(self.filter.field)
         return EQFilter(self.filter.field, self.filter.field)
 
     def to_sql_values(self):
-        if self.show_all:
+        if self.show_all or self.is_null:
             return {}
         return {
             self.filter.field: self.value.value,

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -75,7 +75,7 @@ class ReportColumn(JsonObject):
 
 
 class FilterChoice(JsonObject):
-    value = DefaultProperty(required=True)
+    value = DefaultProperty()
     display = StringProperty()
 
     def get_display(self):


### PR DESCRIPTION
Allow users to specify `null` in UCR report filter specification. Previously, there was no way to create filters that selected rows with `null` in the given column. For example, this is now legal:

```
  {
    "field": "screening_result", 
    "type": "choice_list", 
    "choices": [
      {
        "display": "positive", 
        "value": "positive"
      }, 
      {
        "display": "negative", 
        "value": "negative"
      }, 
      {
        "display": "no result", 
        "value": null
      }
    ], 
    "slug": "screening_result"
  }
```

Related ticket: http://manage.dimagi.com/default.asp?159299
