### PR TITLE
Add persist and pull-down options to custom case lists

### DIFF
--- a/corehq/apps/app_manager/suite_xml.py
+++ b/corehq/apps/app_manager/suite_xml.py
@@ -1451,10 +1451,13 @@ class SuiteGenerator(SuiteGeneratorBase):
             detail_persistent = None
             detail_inline = False
             for detail_type, detail, enabled in datum['module'].get_details():
-                if detail.persist_tile_on_forms and detail.use_case_tiles and enabled:
+                if (
+                    detail.persist_tile_on_forms
+                    and (detail.use_case_tiles or detail.custom_xml)
+                    and enabled
+                ):
                     detail_persistent = self.id_strings.detail(datum['module'], detail_type)
-                    if detail.pull_down_tile:
-                        detail_inline = True
+                    detail_inline = bool(detail.pull_down_tile)
                     break
 
             e.datums.append(SessionDatum(

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list.html
@@ -31,18 +31,16 @@
         <option value="yes">Use Case Tiles</option>
     </select>
     {% endif %}
-    {% if request|toggle_enabled:'CASE_LIST_TILE' or request|toggle_enabled:'CASE_LIST_CUSTOM_XML'%}
     <div data-bind="visible: useCaseTiles() == 'yes' || window.toggles.CASE_LIST_CUSTOM_XML">
-    <label class="checkbox">
-        <input type="checkbox" data-bind="checked: persistTileOnForms">
-        Use this case list tile persistently in forms
-    </label>
-    <label class="checkbox" data-bind="visible: persistTileOnForms()">
-        <input type="checkbox" data-bind="checked: enableTilePullDown">
-        Embed case details in case tile pull-down
-    </label>
+        <label class="checkbox">
+            <input type="checkbox" data-bind="checked: persistTileOnForms">
+            Use this case list tile persistently in forms
+        </label>
+        <label class="checkbox" data-bind="visible: persistTileOnForms()">
+            <input type="checkbox" data-bind="checked: enableTilePullDown">
+            Embed case details in case tile pull-down
+        </label>
     </div>
-    {% endif %}
     {% include 'app_manager/partials/case_list_properties.html' %}
 </div>
 

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list.html
@@ -30,14 +30,18 @@
         <option value="no">Don't Use Case Tiles</option>
         <option value="yes">Use Case Tiles</option>
     </select>
-    <label class="checkbox" data-bind="visible: useCaseTiles() == 'yes'">
+    {% endif %}
+    {% if request|toggle_enabled:'CASE_LIST_TILE' or request|toggle_enabled:'CASE_LIST_CUSTOM_XML'%}
+    <div data-bind="visible: useCaseTiles() == 'yes' || window.toggles.CASE_LIST_CUSTOM_XML">
+    <label class="checkbox">
         <input type="checkbox" data-bind="checked: persistTileOnForms">
         Use this case list tile persistently in forms
     </label>
-    <label class="checkbox" data-bind="visible: useCaseTiles() == 'yes' && persistTileOnForms()">
+    <label class="checkbox" data-bind="visible: persistTileOnForms()">
         <input type="checkbox" data-bind="checked: enableTilePullDown">
         Embed case details in case tile pull-down
     </label>
+    </div>
     {% endif %}
     {% include 'app_manager/partials/case_list_properties.html' %}
 </div>


### PR DESCRIPTION
Make the "persist case tile" and "enable tile pull-down" options available when the custom case list xml box is in use.
