### PR TITLE
[Operation Cheetah] - Enable silk for profiling locally

### DIFF
--- a/localsettings.example.py
+++ b/localsettings.example.py
@@ -157,6 +157,9 @@ MAPS_LAYERS = {
 }
 
 FORMTRANSLATE_TIMEOUT = 5
+LOCAL_MIDDLEWARE_CLASSES = [
+#    'silk.middleware.SilkyMiddleware',
+]
 LOCAL_APPS = (
 #    'django_coverage', # Adds `python manage.py test_coverage` (settings below)
 #    'debug_toolbar',   # Adds a retractable panel to every page giving profiling & debugging info
@@ -164,6 +167,7 @@ LOCAL_APPS = (
 #    'devserver',       # Adds improved dev server that also prints SQL on the console (for AJAX, etc, when you cannot use debug_toolbar)
 #    'django_cpserver', # Another choice for a replacement server
 #    'dimagi.utils'     
+#    'silk'             # Adds profiling to every request
 )
 
 # list of domains to enable ADM reporting on

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -1,5 +1,6 @@
 django-debug-toolbar
 django-devserver>=0.7.0
+django-silk
 coverage
 guppy
 werkzeug

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -37,7 +37,7 @@ pytz==2013d
 PyYAML==3.10
 raven==3.1.10
 requests==2.0.0
-south==0.7.3
+south==1.0
 tropo-webapi-python==0.1.3
 tornado==3.1.1
 xlutils==1.4.1

--- a/urls.py
+++ b/urls.py
@@ -139,5 +139,6 @@ if 'rosetta' in settings.INSTALLED_APPS:
 if settings.DEBUG:
     urlpatterns += patterns('django.contrib.staticfiles.views',
         url(r'^static/(?P<path>.*)$', 'serve'),
+        (r'^silk/', include('silk.urls', namespace='silk')),
     )
 


### PR DESCRIPTION
Did some research into tools we can use to debug django. Not that many great ones out there, but this one seems really promising. Relies on South 1.0, but doesn't look like there are much issues with [upgrading](http://south.readthedocs.org/en/latest/releasenotes/1.0.html#release-notes). Some next steps would be to enable this for certain users so we can take a look at our app on prod.

More info here: http://mtford.co.uk/blog/2/

Anyways I was playing around with it and looks like there are a ton of low hanging fruit.

We're making a TON of permission requests. I added a `memoized` statement to one function: `domain_has_privilege` and it cut the queries in about half:

Before:
![before](https://cloud.githubusercontent.com/assets/918514/6643881/35431082-c986-11e4-8f84-5ffb666ab87e.png)
After:
![after](https://cloud.githubusercontent.com/assets/918514/6643899/57900118-c986-11e4-8d5c-5c8890166a1b.png)

While probably not a huge time save cause role lookups arent that expensive, it saves a lot on simple overheard of calling postgres needlessly. Also that optimization is not included in this PR.

@czue @snopoke 

~ Operation :leopard: 
