### PR TITLE
memoize domain_has_privilege

### DIFF
--- a/corehq/apps/accounting/utils.py
+++ b/corehq/apps/accounting/utils.py
@@ -3,6 +3,7 @@ import datetime
 from decimal import Decimal
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
+from dimagi.utils.decorators.memoized import memoized
 
 from corehq import Domain, privileges
 from corehq.apps.accounting.exceptions import (
@@ -98,6 +99,7 @@ def get_change_status(from_plan_version, to_plan_version):
     return adjustment_reason, downgraded_privs, upgraded_privs
 
 
+@memoized
 def domain_has_privilege(domain, privilege_slug, **assignment):
     from corehq.apps.accounting.models import Subscription
     try:

--- a/corehq/apps/accounting/utils.py
+++ b/corehq/apps/accounting/utils.py
@@ -3,7 +3,6 @@ import datetime
 from decimal import Decimal
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
-from dimagi.utils.decorators.memoized import memoized
 
 from corehq import Domain, privileges
 from corehq.apps.accounting.exceptions import (
@@ -11,6 +10,7 @@ from corehq.apps.accounting.exceptions import (
     ProductPlanNotFoundError,
 )
 from dimagi.utils.couch.database import iter_docs
+from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.dates import add_months
 from django_prbac.models import Role, UserRole
 

--- a/corehq/apps/accounting/utils.py
+++ b/corehq/apps/accounting/utils.py
@@ -5,12 +5,12 @@ from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 
 from corehq import Domain, privileges
+from corehq.util.quickcache import quickcache
 from corehq.apps.accounting.exceptions import (
     AccountingError,
     ProductPlanNotFoundError,
 )
 from dimagi.utils.couch.database import iter_docs
-from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.dates import add_months
 from django_prbac.models import Role, UserRole
 
@@ -99,7 +99,7 @@ def get_change_status(from_plan_version, to_plan_version):
     return adjustment_reason, downgraded_privs, upgraded_privs
 
 
-@memoized
+@quickcache(timeout=10)
 def domain_has_privilege(domain, privilege_slug, **assignment):
     from corehq.apps.accounting.models import Subscription
     try:


### PR DESCRIPTION
`domain_has_privilege` gets called quite a bit with repeat parameters. not complicated queries, but good to reduce total query count

:leopard: 
