### PR TITLE
Don't show case details if case list tile pull-down is enabled

### DIFF
--- a/corehq/apps/app_manager/suite_xml.py
+++ b/corehq/apps/app_manager/suite_xml.py
@@ -1468,7 +1468,7 @@ class SuiteGenerator(SuiteGeneratorBase):
                 detail_select=self.get_detail_id_safe(datum['module'], 'case_short'),
                 detail_confirm=(
                     self.get_detail_id_safe(datum['module'], 'case_long')
-                    if datum['index'] == 0 else None
+                    if datum['index'] == 0 and not detail_inline else None
                 ),
                 detail_persistent=detail_persistent,
                 detail_inline=self.get_detail_id_safe(datum['module'], 'case_long') if detail_inline else None

--- a/corehq/apps/app_manager/tests/data/suite/case_tile_pulldown_session.xml
+++ b/corehq/apps/app_manager/tests/data/suite/case_tile_pulldown_session.xml
@@ -1,5 +1,5 @@
 <partial>
  <session>
-   <datum detail-inline="m0_case_long" id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='patient'][@status='open']" value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long" detail-persistent="m0_case_short"/>
+   <datum detail-inline="m0_case_long" id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='patient'][@status='open']" value="./@case_id" detail-select="m0_case_short" detail-persistent="m0_case_short"/>
  </session>
 </partial>


### PR DESCRIPTION
Adresses this:
https://trello.com/c/FmzEoH3r/35-case-tiles-configured-to-allow-detail-inline-datum-for-case-details
