### PR TITLE
Return default translation from `Xform.localize` if lang arg is None

### DIFF
--- a/corehq/apps/app_manager/tests/test_xform_parsing.py
+++ b/corehq/apps/app_manager/tests/test_xform_parsing.py
@@ -33,6 +33,8 @@ class XFormParsingTest(TestCase, TestFileMixin):
             self.assertEqual(str(e), "Can't find <itext>")
         self.assertEqual(self.xforms["itext_form"].localize(id="pork", lang="kosher"), None)
         self.assertEqual(self.xforms["itext_form"].localize(id="question1", lang="pt"), "P1")
+        self.assertEqual(self.xforms["itext_form"].localize(id="question1", lang="en"), "Q1")
+        self.assertEqual(self.xforms["itext_form"].localize(id="question1"), "Q1")
 
     def test_normalize_itext(self):
         original = self.xforms['itext_form']

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -1,4 +1,4 @@
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 from functools import wraps
 import logging
 from casexml.apps.case.xml import V2_NAMESPACE
@@ -568,7 +568,7 @@ class XForm(WrappedNode):
     @memoized
     @requires_itext(dict)
     def translations(self):
-        translations = {}
+        translations = OrderedDict()
         for translation in self.itext_node.findall('{f}translation'):
             lang = translation.attrib['lang']
             translations[lang] = translation
@@ -699,6 +699,7 @@ class XForm(WrappedNode):
         if not node_group:
             return None
 
+        lang = lang or self.translations().keys()[0]
         text_node = node_group.nodes.get(lang)
         if not text_node:
             return None


### PR DESCRIPTION
I believe this function was recently inadvertently changed in https://github.com/dimagi/commcare-hq/pull/5821 to return `None` if the `lang` provided to `Xform.localize()` is `None`. It had previously returned the label from the first translation node, and this restores that behavior. @snopoke let me know if that change was intentional.
