### PR TITLE
Sri Lanka DHIS2 server supports importing below given org unit.

### DIFF
--- a/custom/dhis2/models.py
+++ b/custom/dhis2/models.py
@@ -289,7 +289,10 @@ class Dhis2Api(object):
             'orgUnit': ou_id,
             'attributes': self._data_to_attributes(instance_data)
         }
-        return self._request.put('trackedEntityInstances/' + te_inst_id, request_data)
+        response = self._request.put('trackedEntityInstances/' + te_inst_id, request_data)
+        if response['status'] != 'SUCCESS':
+            logger.error('Failed to update instance of tracked entity "%s". DHIS2 API error: %s',
+                         te_inst_id, response)
 
     def get_top_org_unit(self):
         """

--- a/custom/dhis2/models.py
+++ b/custom/dhis2/models.py
@@ -388,7 +388,7 @@ class Dhis2Api(object):
                     'links': 'false',
                     'trackedEntity': te_id,
                     'ou': top_ou['id'],
-                    # 'ouMode': 'DESCENDANTS',  # Causes SQL error in DHIS2 2.16. Fixed in 2.18
+                    'ouMode': 'DESCENDANTS',
                     'attribute': attr_id
                 })
             instances = self.entities_to_dicts(response)
@@ -421,7 +421,7 @@ class Dhis2Api(object):
                     'links': 'false',
                     'trackedEntity': te_id,
                     'ou': top_ou['id'],
-                    # 'ouMode': 'DESCENDANTS',  # Causes SQL error in DHIS2 2.16. Fixed in 2.18
+                    'ouMode': 'DESCENDANTS',
                     'attribute': attr_id + ':EQ:' + attr_value
                 })
             instances = self.entities_to_dicts(response)
@@ -447,7 +447,7 @@ class Dhis2Api(object):
                     'page': page,
                     'links': 'false',
                     'ou': top_ou['id'],
-                    # 'ouMode': 'DESCENDANTS',  # Causes SQL error in DHIS2 2.16. Fixed in 2.18
+                    'ouMode': 'DESCENDANTS',
                     'program': program_id
                 })
             instances = self.entities_to_dicts(response)


### PR DESCRIPTION
The internal DHIS2 test server 500ed with a SQL error when searching descendants of org units for tracked entity instances. The bug doesn't appear on the Sri Lanka production server, fortunately, which allows us to import tracked entity instances below a given organisation unit.

This is important for syncing cases from DHIS2.

This relates to [FB 161599](http://manage.dimagi.com/default.asp?161599).
