### PR TITLE
Don't error if domain_membership not found

### DIFF
--- a/corehq/apps/domainsync/management/commands/copy_group_data.py
+++ b/corehq/apps/domainsync/management/commands/copy_group_data.py
@@ -151,7 +151,8 @@ class Command(LabelCommand):
         role_ids = set([])
         for user in filter(lambda u: u is not None, users):
             # if we use bulk save, django user doesn't get sync'd
-            if user.get_domain_membership(domain.name).role_id:
+            domain_membership = user.get_domain_membership(domain.name)
+            if domain_membership and domain_membership.role_id:
                 role_ids.add(user.domain_membership.role_id)
             user.save(force_update=True)
 


### PR DESCRIPTION
I was getting `AttributeError: 'NoneType' object has no attribute 'role_id'` when running copy_group_data.
