### PR TITLE
Mark DeviceLogDetailsReport non-inclusive

### DIFF
--- a/corehq/ex-submodules/phonelog/reports.py
+++ b/corehq/ex-submodules/phonelog/reports.py
@@ -183,6 +183,7 @@ class DeviceLogDetailsReport(PhonelogReport):
     }
     default_rows = 100
     default_sort = {'date': 'asc'}
+    inclusive = False
 
     @property
     def headers(self):


### PR DESCRIPTION
This sets the date range for the device log details report to end at midnight tonight instead of midnight last night.

This is to resolve [FB 161623](http://manage.dimagi.com/default.asp?161623).
