### PR TITLE
Rename stuff in legacy commtrack migrations

### DIFF
--- a/corehq/apps/commtrack/util.py
+++ b/corehq/apps/commtrack/util.py
@@ -93,7 +93,6 @@ def bootstrap_commtrack_settings_if_necessary(domain, requisitions_enabled=False
     Create a new CommtrackConfig object for a domain
     if it does not already exist.
 
-
     This adds some collection of default products, programs,
     SMS keywords, etc.
     """

--- a/custom/ewsghana/tasks.py
+++ b/custom/ewsghana/tasks.py
@@ -9,7 +9,7 @@ from custom.ewsghana.api import GhanaEndpoint
 from custom.ewsghana.extensions import ews_location_extension, ews_smsuser_extension, ews_webuser_extension, \
     ews_product_extension
 from custom.ewsghana.models import EWSGhanaConfig
-from custom.ilsgateway.tasks import get_stock_transaction, get_product_stock
+from custom.ilsgateway.tasks import sync_stock_transactions, sync_product_stocks
 from custom.logistics.commtrack import bootstrap_domain as ews_bootstrap_domain, \
     bootstrap_domain
 from custom.logistics.tasks import stock_data_task
@@ -45,8 +45,8 @@ def migration_task():
             endpoint = GhanaEndpoint.from_config(config)
             ews_bootstrap_domain(EWSApi(config.domain, endpoint))
             apis = (
-                ('product_stock', get_product_stock),
-                ('stock_transaction', get_stock_transaction),
+                ('product_stock', sync_product_stocks),
+                ('stock_transaction', sync_stock_transactions),
             )
             stock_data_task.delay(config.domain, endpoint, apis, EWS_FACILITIES)
 

--- a/custom/ewsghana/views.py
+++ b/custom/ewsghana/views.py
@@ -16,7 +16,7 @@ from custom.ewsghana.reminders.reminders import first_soh_process_user, second_s
 from custom.ewsghana.reports.stock_levels_report import InventoryManagementData
 from custom.ewsghana.tasks import ews_bootstrap_domain_task, ews_clear_stock_data_task, \
     EWS_FACILITIES
-from custom.ilsgateway.tasks import get_product_stock, get_stock_transaction
+from custom.ilsgateway.tasks import sync_product_stocks, sync_stock_transactions
 from custom.ilsgateway.views import GlobalStats
 from custom.logistics.tasks import sms_users_fix, add_products_to_loc, locations_fix
 from custom.logistics.tasks import stock_data_task
@@ -92,8 +92,8 @@ def sync_ewsghana(request, domain):
 @require_POST
 def ews_sync_stock_data(request, domain):
     apis = (
-        ('product_stock', get_product_stock),
-        ('stock_transaction', get_stock_transaction)
+        ('product_stock', sync_product_stocks),
+        ('stock_transaction', sync_stock_transactions)
     )
     config = EWSGhanaConfig.for_domain(domain)
     domain = config.domain

--- a/custom/ilsgateway/tasks.py
+++ b/custom/ilsgateway/tasks.py
@@ -30,8 +30,8 @@ def migration_task():
             endpoint = ILSGatewayEndpoint.from_config(config)
             ils_bootstrap_domain(ILSGatewayAPI(config.domain, endpoint))
             apis = (
-                ('product_stock', get_product_stock),
-                ('stock_transaction', get_stock_transaction),
+                ('product_stock', sync_product_stocks),
+                ('stock_transaction', sync_stock_transactions),
                 ('supply_point_status', get_supply_point_statuses),
                 ('delivery_group', get_delivery_group_reports)
             )
@@ -195,13 +195,13 @@ def sync_stock_transaction(domain, endpoint, facility, xform, checkpoint,
                 next_url = meta['next'].split('?')[1]
 
 
-def get_product_stock(domain, endpoint, facilities, checkpoint, date, limit=100, offset=0):
+def sync_product_stocks(domain, endpoint, facilities, checkpoint, date, limit=100, offset=0):
     for facility in facilities:
         sync_product_stock(domain, endpoint, facility, checkpoint, date, limit, offset)
         offset = 0  # reset offset for each facility, is only set in the context of a checkpoint resume
 
 
-def get_stock_transaction(domain, endpoint, facilities, checkpoint, date, limit=100, offset=0):
+def sync_stock_transactions(domain, endpoint, facilities, checkpoint, date, limit=100, offset=0):
     # todo: should figure out whether there's a better thing to be doing than faking this global form
     try:
         xform = XFormInstance.get(docid='ilsgateway-xform')

--- a/custom/ilsgateway/tasks.py
+++ b/custom/ilsgateway/tasks.py
@@ -73,7 +73,7 @@ def get_locations(api_object, facilities):
         api_object.location_sync(api_object.endpoint.models_map['location'](location))
 
 
-def sync_product_stock(domain, endpoint, facility, checkpoint, date, limit=100, offset=0):
+def sync_product_stock_for_facility(domain, endpoint, facility, checkpoint, date, limit=100, offset=0):
     """
     Syncs ProductStock objects in ILSGateway to StockState objects in CommTrack
     """
@@ -133,7 +133,7 @@ def sync_product_stock(domain, endpoint, facility, checkpoint, date, limit=100, 
                 next_url = meta['next'].split('?')[1]
 
 
-def sync_stock_transaction(domain, endpoint, facility, xform, checkpoint,
+def sync_stock_transactions_for_facility(domain, endpoint, facility, xform, checkpoint,
                            date, limit=100, offset=0):
     """
     Syncs stock data from StockTransaction objects in ILSGateway to StockTransaction objects in HQ
@@ -197,7 +197,7 @@ def sync_stock_transaction(domain, endpoint, facility, xform, checkpoint,
 
 def sync_product_stocks(domain, endpoint, facilities, checkpoint, date, limit=100, offset=0):
     for facility in facilities:
-        sync_product_stock(domain, endpoint, facility, checkpoint, date, limit, offset)
+        sync_product_stock_for_facility(domain, endpoint, facility, checkpoint, date, limit, offset)
         offset = 0  # reset offset for each facility, is only set in the context of a checkpoint resume
 
 
@@ -209,7 +209,7 @@ def sync_stock_transactions(domain, endpoint, facilities, checkpoint, date, limi
         xform = XFormInstance(_id='ilsgateway-xform')
         xform.save()
     for facility in facilities:
-        sync_stock_transaction(domain, endpoint, facility, xform, checkpoint, date, limit, offset)
+        sync_stock_transactions_for_facility(domain, endpoint, facility, xform, checkpoint, date, limit, offset)
         offset = 0  # reset offset for each facility, is only set in the context of a checkpoint resume
 
 

--- a/custom/ilsgateway/views.py
+++ b/custom/ilsgateway/views.py
@@ -27,7 +27,7 @@ from custom.ilsgateway.tanzania.reminders.randr import send_ror_reminder
 from custom.ilsgateway.tanzania.reminders.stockonhand import send_soh_reminder
 from custom.ilsgateway.tanzania.reminders.supervision import send_supervision_reminder
 
-from custom.ilsgateway.tasks import get_product_stock, get_stock_transaction, get_supply_point_statuses, \
+from custom.ilsgateway.tasks import sync_product_stocks, sync_stock_transactions, get_supply_point_statuses, \
     get_delivery_group_reports, ILS_FACILITIES
 from casexml.apps.stock.models import StockTransaction
 from custom.logistics.tasks import sms_users_fix
@@ -240,8 +240,8 @@ def ils_sync_stock_data(request, domain):
     domain = config.domain
     endpoint = ILSGatewayEndpoint.from_config(config)
     apis = (
-        ('product_stock', get_product_stock),
-        ('stock_transaction', get_stock_transaction),
+        ('product_stock', sync_product_stocks),
+        ('stock_transaction', sync_stock_transactions),
         ('supply_point_status', get_supply_point_statuses),
         ('delivery_group', get_delivery_group_reports)
     )


### PR DESCRIPTION
just using function names that are more representative of what they're actually doing
