### PR TITLE
Generate consumption and receipts during migration

### DIFF
--- a/custom/logistics/tasks.py
+++ b/custom/logistics/tasks.py
@@ -174,7 +174,17 @@ def sync_stock_transactions_for_facility(domain, endpoint, facility, xform, chec
                     except SQLProduct.DoesNotExist:
                         # todo: kkrampa what's the deal with this logic? this should never be true
                         continue
-
+                    if stocktransaction.quantity != 0:
+                        transactions_to_add.append(StockTransaction(
+                            case_id=case._id,
+                            product_id=sql_product.product_id,
+                            sql_product=sql_product,
+                            section_id=section_id,
+                            type='receipts' if stocktransaction.quantity > 0 else 'consumption',
+                            stock_on_hand=Decimal(stocktransaction.ending_balance),
+                            quantity=Decimal(stocktransaction.quantity),
+                            report=report
+                        ))
                     transactions_to_add.append(StockTransaction(
                         case_id=case._id,
                         product_id=sql_product.product_id,

--- a/custom/logistics/utils.py
+++ b/custom/logistics/utils.py
@@ -1,3 +1,4 @@
+from corehq import Domain
 from corehq.apps.commtrack.models import SupplyPointCase
 
 
@@ -8,3 +9,10 @@ def get_supply_point_by_external_id(domain, external_id):
         include_docs=True,
         limit=1
     ).first()
+
+
+def get_reporting_types(domain):
+    return [
+        location_type for location_type in Domain.get_by_name(domain).location_types
+        if not location_type.administrative
+    ]


### PR DESCRIPTION
@czue I think we need this to compute daily_consumption (https://github.com/dimagi/commcare-hq/blob/master/corehq/ex-submodules/casexml/apps/stock/consumption.py#L220). Normally It's generated on create signal but we don't send it.
