### PR TITLE
Fix report builder metadata filter bug

### DIFF
--- a/corehq/apps/userreports/app_manager.py
+++ b/corehq/apps/userreports/app_manager.py
@@ -67,7 +67,7 @@ def get_form_data_source(app, form):
             make_form_question_indicator(q, column_id=get_column_name(q['value']))
             for q in questions
         ] + [
-            make_form_meta_block_indicator(field[0], field[1])
+            make_form_meta_block_indicator(field)
             for field in FORM_METADATA_PROPERTIES
         ],
     )

--- a/corehq/apps/userreports/reports/builder/__init__.py
+++ b/corehq/apps/userreports/reports/builder/__init__.py
@@ -76,14 +76,17 @@ def make_form_question_indicator(question, column_id=None):
     return ret
 
 
-def make_form_meta_block_indicator(field_name, data_type):
+def make_form_meta_block_indicator(spec, column_id=None):
     """
     Return a data source indicator configuration (a dict) for the given
     form meta field and data type.
     """
+    field_name = spec[0]
+    data_type = spec[1]
+    column_id = column_id or field_name
     ret = {
         "type": "raw",
-        "column_id": field_name,
+        "column_id": column_id,
         "property_path": ['form', 'meta'] + [field_name],
         "display_name": field_name,
     }
@@ -92,8 +95,8 @@ def make_form_meta_block_indicator(field_name, data_type):
 
 
 def _get_form_indicator_data_type(data_type, options):
-    if data_type == "date":
-        return {"datatype": "date"}
+    if data_type in ["date", "datetime"]:
+        return {"datatype": data_type}
     if data_type == "MSelect":
         return {
             "type": "choice_list",

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -106,7 +106,7 @@ class DataSourceBuilder(object):
         for prop in self.data_source_properties.values():
             if prop['type'] == 'meta':
                 ret.append(make_form_meta_block_indicator(
-                    prop['source'][0], prop['source'][1]
+                    prop['source'], prop['column_id']
                 ))
             elif prop['type'] == "question":
                 ret.append(make_form_question_indicator(


### PR DESCRIPTION
The report builder was creating metadata filters with column ids that didn't match the columns in the data source. This fixes that.
