### PR TITLE
remove module level import of functions

### DIFF
--- a/corehq/apps/receiverwrapper/views.py
+++ b/corehq/apps/receiverwrapper/views.py
@@ -5,9 +5,8 @@ from django.http import (
     HttpResponseBadRequest,
     HttpResponseForbidden,
 )
-from casexml.apps.case import get_case_updates
 from casexml.apps.case.models import CommCareCase
-from casexml.apps.case.xform import is_device_report
+from casexml.apps.case.xform import get_case_updates, is_device_report
 from corehq.apps.domain.decorators import login_or_digest_ex, login_or_basic_ex
 from corehq.apps.receiverwrapper.auth import (
     AuthContext,

--- a/corehq/ex-submodules/casexml/apps/case/__init__.py
+++ b/corehq/ex-submodules/casexml/apps/case/__init__.py
@@ -1,1 +1,0 @@
-from .xform import process_cases, process_cases_with_casedb, get_case_updates

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
@@ -11,7 +11,7 @@ from casexml.apps.case.tests.util import delete_all_cases
 from casexml.apps.case.util import post_case_blocks
 from casexml.apps.case.xml import V2
 from couchforms.tests.testutils import post_xform_to_couch
-from casexml.apps.case import process_cases
+from casexml.apps.case.xform import process_cases
 
 
 @override_settings(CASEXML_FORCE_DOMAIN_CHECK=False)

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_domains.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_domains.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from casexml.apps.case.exceptions import IllegalCaseId
 from casexml.apps.case.models import CommCareCase
-from casexml.apps.case import process_cases
+from casexml.apps.case.xform import process_cases
 from couchforms.tests.testutils import post_xform_to_couch
 
 ALICE_XML = """<?xml version='1.0' ?>

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_exclusion.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_exclusion.py
@@ -4,7 +4,7 @@ from django.test.utils import override_settings
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.tests.util import delete_all_cases
 from couchforms.tests.testutils import post_xform_to_couch
-from casexml.apps.case import process_cases
+from casexml.apps.case.xform import process_cases
 
 
 @override_settings(CASEXML_FORCE_DOMAIN_CHECK=False)

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_multi_case_submits.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_multi_case_submits.py
@@ -3,9 +3,8 @@ import os
 from django.test.utils import override_settings
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.tests import delete_all_xforms, delete_all_cases
-from couchforms.models import XFormInstance
 from couchforms.tests.testutils import post_xform_to_couch
-from casexml.apps.case import process_cases
+from casexml.apps.case.xform import process_cases
 
 
 @override_settings(CASEXML_FORCE_DOMAIN_CHECK=False)

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_multimedia.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_multimedia.py
@@ -9,13 +9,12 @@ import lxml
 from django.core.files.uploadedfile import UploadedFile
 
 from casexml.apps.case.models import CommCareCase
-from casexml.apps.case import process_cases
 from casexml.apps.case.tests.util import delete_all_cases, delete_all_xforms
 from casexml.apps.case.xml import V2
 from casexml.apps.phone.models import SyncLog
 import couchforms
 from couchforms.models import XFormInstance, XFormDeprecated
-from couchforms.tests.testutils import post_xform_to_couch
+
 
 TEST_CASE_ID = "EOL9FIAKIQWOFXFOH0QAMWU64"
 CREATE_XFORM_ID = "6RGAZTETE3Z2QC0PE2DKM88MO"

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_ota_restore.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_ota_restore.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 import os
 from django.test.utils import override_settings
 from casexml.apps.case.models import CommCareCase
-from casexml.apps.case import process_cases
+from casexml.apps.case.xform import process_cases
 from casexml.apps.case.tests import delete_all_cases
 from couchforms.tests.testutils import post_xform_to_couch
 

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_out_of_order_processing.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_out_of_order_processing.py
@@ -2,7 +2,7 @@ import os
 from django.test.utils import override_settings
 from django.test import TestCase
 from casexml.apps.case.models import CommCareCase
-from casexml.apps.case import process_cases
+from casexml.apps.case.xform import process_cases
 from casexml.apps.case.tests.util import post_util as real_post_util, delete_all_cases
 from couchforms.tests.testutils import post_xform_to_couch
 

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_v2_parsing.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_v2_parsing.py
@@ -4,7 +4,7 @@ from django.test.utils import override_settings
 from casexml.apps.case.models import CommCareCase
 from couchforms.tests.testutils import post_xform_to_couch
 from casexml.apps.case.tests.util import check_xml_line_by_line, CaseBlock, delete_all_cases
-from casexml.apps.case import process_cases
+from casexml.apps.case.xform import process_cases
 from datetime import datetime
 from casexml.apps.phone import views as phone_views
 from django.http import HttpRequest

--- a/corehq/ex-submodules/casexml/apps/case/tests/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/util.py
@@ -14,7 +14,7 @@ from casexml.apps.phone.models import SyncLog
 from couchforms.tests.testutils import post_xform_to_couch
 from couchforms.models import XFormInstance
 from casexml.apps.case.models import CommCareCase
-from casexml.apps.case import process_cases
+from casexml.apps.case.xform import process_cases
 from casexml.apps.phone.restore import RestoreConfig
 from casexml.apps.case.util import post_case_blocks
 

--- a/corehq/ex-submodules/casexml/apps/case/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/util.py
@@ -61,7 +61,7 @@ def reprocess_form_cases(form, config=None, case_db=None):
     correctly inject the update into the case history if the form was NOT
     successfully processed.
     """
-    from casexml.apps.case import process_cases, process_cases_with_casedb
+    from casexml.apps.case.xform import process_cases, process_cases_with_casedb
 
     if case_db:
         process_cases_with_casedb(form, case_db, config=config)

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_restore.py
@@ -5,7 +5,7 @@ from django.test.utils import override_settings
 from couchforms.tests.testutils import post_xform_to_couch
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.tests.util import check_xml_line_by_line, delete_all_cases, delete_all_sync_logs
-from casexml.apps.case import process_cases
+from casexml.apps.case.xform import process_cases
 from datetime import datetime, date
 from casexml.apps.phone.models import User, SyncLog
 from casexml.apps.phone import xml, views

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_restore_v3.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_restore_v3.py
@@ -5,7 +5,7 @@ from django.test.utils import override_settings
 from casexml.apps.case.xml import V3
 from couchforms.tests.testutils import post_xform_to_couch
 from casexml.apps.case.tests.util import check_xml_line_by_line, delete_all_cases, delete_all_sync_logs
-from casexml.apps.case import process_cases
+from casexml.apps.case.xform import process_cases
 from casexml.apps.phone.models import SyncLog
 from casexml.apps.phone.restore import generate_restore_payload, StringRestoreResponse
 from casexml.apps.phone.tests.dummy import dummy_restore_xml, dummy_user

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -11,7 +11,7 @@ from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.tests.util import (check_user_has_case, delete_all_sync_logs,
     delete_all_xforms, delete_all_cases, assert_user_doesnt_have_case,
     assert_user_has_case)
-from casexml.apps.case import process_cases
+from casexml.apps.case.xform import process_cases
 from casexml.apps.phone.models import SyncLog, User
 from casexml.apps.phone.restore import generate_restore_payload, RestoreConfig
 from dimagi.utils.parsing import json_format_datetime

--- a/corehq/ex-submodules/couchforms/util.py
+++ b/corehq/ex-submodules/couchforms/util.py
@@ -413,9 +413,8 @@ class SubmissionPost(object):
             )
             return self.get_exception_response(e.error_log), None, []
         else:
-            from casexml.apps.case import process_cases_with_casedb
             from casexml.apps.case.models import CommCareCase
-            from casexml.apps.case.xform import get_and_check_xform_domain, CaseDbCache
+            from casexml.apps.case.xform import get_and_check_xform_domain, CaseDbCache, process_cases_with_casedb
             from casexml.apps.case.signals import case_post_save
             from casexml.apps.case.exceptions import IllegalCaseId
             from corehq.apps.commtrack.processing import process_stock

--- a/custom/uth/utils.py
+++ b/custom/uth/utils.py
@@ -1,4 +1,4 @@
-from casexml.apps.case import get_case_updates
+from casexml.apps.case.xform import get_case_updates
 from corehq.apps.receiverwrapper import submit_form_locally
 from couchforms import convert_xform_to_json
 from dimagi.utils.couch.database import get_db


### PR DESCRIPTION
@dannyroberts I know you like these but they seem to be causing more import issues than it might be worth. in particular doing something like:

`from casexml.apps.case import const`

causes the `.xform` module to be imported which then goes and tries to import a whole bunch of stuff. it's nice to be able to import the `const` from anywhere without having to worry about that.

feel free to push back on this if you want though, or propose a better solution.

either way wait for build.
