### PR TITLE
make vary_on a required argument of quickcache

### DIFF
--- a/corehq/apps/builds/models.py
+++ b/corehq/apps/builds/models.py
@@ -210,7 +210,7 @@ class CommCareBuildConfig(Document):
         cls.fetch.clear(cls)
 
     @classmethod
-    @quickcache(timeout=30)
+    @quickcache([], timeout=30)
     def fetch(cls):
         try:
             return cls.get(cls._ID)

--- a/corehq/apps/domain/utils.py
+++ b/corehq/apps/domain/utils.py
@@ -35,7 +35,7 @@ def get_domain_from_url(path):
     return domain
 
 
-@quickcache(timeout=60)
+@quickcache([], timeout=60)
 def get_domain_module_map():
     hardcoded = getattr(settings, 'DOMAIN_MODULE_MAP', {})
     try:
@@ -47,7 +47,7 @@ def get_domain_module_map():
     return hardcoded
 
 
-@quickcache(timeout=60)
+@quickcache([], timeout=60)
 def get_adm_enabled_domains():
     try:
         domains = get_db().open_doc('ADM_ENABLED_DOMAINS').get('domains', {})

--- a/corehq/apps/indicators/utils.py
+++ b/corehq/apps/indicators/utils.py
@@ -3,7 +3,7 @@ from corehq.util.quickcache import quickcache
 from dimagi.utils.couch.database import get_db
 
 
-@quickcache(timeout=60)
+@quickcache([], timeout=60)
 def get_indicator_config():
     try:
         doc = get_db().open_doc('INDICATOR_CONFIGURATION')

--- a/corehq/util/quickcache.py
+++ b/corehq/util/quickcache.py
@@ -126,14 +126,14 @@ class QuickCache(object):
         return 'quickcache.{}/{}'.format(self.prefix, args_string)
 
 
-def quickcache(vary_on='', timeout=None, memoize_timeout=None, cache=None):
+def quickcache(vary_on, timeout=None, memoize_timeout=None, cache=None):
     """
     An easy "all-purpose" cache decorator
 
     Examples:
         - caching a singleton function, refresh every 5 minutes
 
-            @quickcache(timeout=5 * 60)
+            @quickcache([], timeout=5 * 60)
             def get_config_from_db():
                 # ...
 

--- a/corehq/util/tests/test_quickcache.py
+++ b/corehq/util/tests/test_quickcache.py
@@ -41,7 +41,7 @@ class QuickcacheTest(SimpleTestCase):
         return result
 
     def test_tiered_cache(self):
-        @quickcache(cache=_cache)
+        @quickcache([], cache=_cache)
         def simple():
             BUFFER.append('called')
             return 'VALUE'
@@ -158,7 +158,7 @@ class QuickcacheTest(SimpleTestCase):
             len(key), len('quickcache.lots_of_args.xxxxxxxx/H') + 32, key)
 
     def test_really_long_function_name(self):
-        @quickcache()
+        @quickcache([])
         def aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa():
             """60 a's in a row"""
             pass


### PR DESCRIPTION
this prevents someone from by mistake creating a singleton cache when
they meant to vary on the arguments of a function

http://manage.dimagi.com/default.asp?161813
