### PR TITLE
do not abort mvp indicator pillow on cases with no indicators

### DIFF
--- a/custom/_legacy/mvp_docs/pillows.py
+++ b/custom/_legacy/mvp_docs/pillows.py
@@ -102,8 +102,6 @@ class MVPCaseIndicatorPillow(MVPIndicatorPillowBase):
                 domain,
                 case_type=case_type
             ))
-        if not case_indicator_defs:
-            return
 
         try:
             indicator_case = IndicatorCase.wrap_for_indicator_db(doc_dict)


### PR DESCRIPTION
This is the first step to fixing http://manage.dimagi.com/default.asp?158402.

The next step is to run a migration to copy all of the skipped cases from the main db to the MVP indicator case (rough estimate of 150,000 cases).
