### PR TITLE
simplify sms languages' use of app langs template

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/supported-languages.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/supported-languages.html
@@ -5,7 +5,7 @@
         <tr class="row control-group" data-bind="css: {error: validateGeneral()}">
             <th></th>
             <th></th>
-            <th>{% if not always_deploy %}{% trans "Deploy" %}{% endif %}</th>
+            <th>{% if not hide_deploy_column %}{% trans "Deploy" %}{% endif %}</th>
             <th></th>
             <th></th>
             <th></th>
@@ -30,7 +30,7 @@
                 <span class="label label-info" data-bind="visible: isDefaultLang()">1. default</span>
             </td>
             <td>
-                {% if always_deploy %}
+                {% if hide_deploy_column %}
                 <input type="checkbox" checked="checked" data-bind="value: deploy, visible: false" />
                 {% else %}
                 <span data-bind="editableBool: deploy, editing: $root.editing"></span>

--- a/corehq/apps/sms/templates/sms/languages.html
+++ b/corehq/apps/sms/templates/sms/languages.html
@@ -65,7 +65,7 @@
         </div>
         <div class="tab-content">
             <div id="supported-languages" class="tab-pane active">
-                {% include "app_manager/partials/supported-languages.html" %}
+                {% include "app_manager/partials/supported-languages.html" with hide_deploy_column=True %}
             </div>
             <div id="translations-tab" class="tab-pane">
                 <div>

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -1222,7 +1222,6 @@ def sms_languages(request, domain):
             tdoc.save()
     context = {
         "domain": domain,
-        "always_deploy": True,
         "sms_langs": tdoc.langs,
         "bulk_upload": {
             "action": reverse("upload_sms_translations",


### PR DESCRIPTION
(tiny/cleanup) use `{% include ... with ... %}` rather than passing in all the way from
the view context
