### PR TITLE
Fix UCR repeat data bug

### DIFF
--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -112,6 +112,6 @@ class RelatedDocExpressionSpec(JsonObject):
             if context.root_doc['domain'] != doc.get('domain'):
                 return None
             # explicitly use a new evaluation context since this is a new document
-            return self._value_expression(doc, EvaluationContext(doc))
+            return self._value_expression(doc, EvaluationContext(doc, 0))
         except ResourceNotFound:
             return None

--- a/corehq/apps/userreports/indicators/factory.py
+++ b/corehq/apps/userreports/indicators/factory.py
@@ -10,7 +10,6 @@ from corehq.apps.userreports.indicators.specs import (
     BooleanIndicatorSpec,
     IndicatorSpecBase,
     ExpressionIndicatorSpec,
-    RepeatIterationIndicatorSpec
 )
 
 
@@ -87,17 +86,15 @@ def _build_choice_list_indicator(spec, context):
 
 
 def _build_repeat_iteration_indicator(spec, context):
-    wrapped = RepeatIterationIndicatorSpec.wrap(spec)
-    column = Column(
-        id=wrapped.column_id,
-        datatype=wrapped.datatype,
-        is_nullable=wrapped.is_nullable,
-        is_primary_key=wrapped.is_primary_key,
-    )
     return RawIndicator(
-        wrapped.display_name,
-        column,
-        getter=wrapped.getter
+        "base document iteration",
+        Column(
+            id="repeat_iteration",
+            datatype="integer",
+            is_nullable=False,
+            is_primary_key=True,
+        ),
+        getter=lambda doc, ctx: ctx.iteration
     )
 
 

--- a/corehq/apps/userreports/indicators/factory.py
+++ b/corehq/apps/userreports/indicators/factory.py
@@ -87,7 +87,6 @@ def _build_choice_list_indicator(spec, context):
 
 
 def _build_repeat_iteration_indicator(spec, context):
-    # NOTE: This is exactly the same as _build_raw_indicator but with a different spec class...
     wrapped = RepeatIterationIndicatorSpec.wrap(spec)
     column = Column(
         id=wrapped.column_id,
@@ -100,7 +99,6 @@ def _build_repeat_iteration_indicator(spec, context):
         column,
         getter=wrapped.getter
     )
-    # NOTE: I define the getter function in the RepeatIterationIndicatorSpec, but I could also just define it here. Which is better?
 
 
 class IndicatorFactory(object):

--- a/corehq/apps/userreports/indicators/specs.py
+++ b/corehq/apps/userreports/indicators/specs.py
@@ -74,7 +74,7 @@ class RepeatIterationIndicatorSpec(RawIndicatorSpec):
 
     @property
     def getter(self):
-        return lambda doc, context:  context.iteration
+        return lambda doc, context: context.iteration
 
 
 class ExpressionIndicatorSpec(IndicatorSpecBase):

--- a/corehq/apps/userreports/indicators/specs.py
+++ b/corehq/apps/userreports/indicators/specs.py
@@ -69,6 +69,14 @@ class RawIndicatorSpec(PropertyReferenceIndicatorSpecBase):
         return TransformedGetter(getter, transform)
 
 
+class RepeatIterationIndicatorSpec(RawIndicatorSpec):
+    type = TypeProperty('repeat_iteration')
+
+    @property
+    def getter(self):
+        return lambda doc, context:  context.iteration
+
+
 class ExpressionIndicatorSpec(IndicatorSpecBase):
     type = TypeProperty('expression')
     datatype = DataTypeProperty(required=True)

--- a/corehq/apps/userreports/indicators/specs.py
+++ b/corehq/apps/userreports/indicators/specs.py
@@ -69,19 +69,6 @@ class RawIndicatorSpec(PropertyReferenceIndicatorSpecBase):
         return TransformedGetter(getter, transform)
 
 
-class RepeatIterationIndicatorSpec(RawIndicatorSpec):
-    type = TypeProperty('repeat_iteration')
-    datatype = DataTypeProperty(default='integer')
-    is_nullable = BooleanProperty(default=False)
-    is_primary_key = BooleanProperty(default=True)
-    column_id = StringProperty(default="repeat_iteration")
-    display_name = StringProperty(default="base document iteration")
-
-    @property
-    def getter(self):
-        return lambda doc, context: context.iteration
-
-
 class ExpressionIndicatorSpec(IndicatorSpecBase):
     type = TypeProperty('expression')
     datatype = DataTypeProperty(required=True)

--- a/corehq/apps/userreports/indicators/specs.py
+++ b/corehq/apps/userreports/indicators/specs.py
@@ -71,6 +71,11 @@ class RawIndicatorSpec(PropertyReferenceIndicatorSpecBase):
 
 class RepeatIterationIndicatorSpec(RawIndicatorSpec):
     type = TypeProperty('repeat_iteration')
+    datatype = DataTypeProperty(default='integer')
+    is_nullable = BooleanProperty(default=False)
+    is_primary_key = BooleanProperty(default=True)
+    column_id = StringProperty(default="repeat_iteration")
+    display_name = StringProperty(default="base document iteration")
 
     @property
     def getter(self):

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -153,12 +153,7 @@ class DataSourceConfiguration(UnicodeMixIn, CachedCouchDocumentMixin, Document):
         }, self.named_filter_objects)]
         if self.base_item_expression:
             default_indicators.append(IndicatorFactory.from_spec({
-                "column_id": "repeat_iteration",
                 "type": "repeat_iteration",
-                "display_name": "base document iteration",
-                "datatype": "integer",
-                "is_nullable": False,
-                "is_primary_key": True,
             }, self.named_filter_objects))
         return CompoundIndicator(
             self.display_name,

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -136,7 +136,7 @@ class DataSourceConfiguration(UnicodeMixIn, CachedCouchDocumentMixin, Document):
 
     @property
     def indicators(self):
-        doc_id_indicator = IndicatorFactory.from_spec({
+        default_indicators = [IndicatorFactory.from_spec({
             "column_id": "doc_id",
             "type": "expression",
             "display_name": "document id",
@@ -150,18 +150,19 @@ class DataSourceConfiguration(UnicodeMixIn, CachedCouchDocumentMixin, Document):
                     "property_name": "_id"
                 }
             }
-        }, self.named_filter_objects)
-        repeat_iteration_indicator = IndicatorFactory.from_spec({
-            "column_id": "repeat_iteration",
-            "type": "repeat_iteration",
-            "display_name": "base document iteration",
-            "datatype": "integer",
-            "is_nullable": False,
-            "is_primary_key": True,
-        }, self.named_filter_objects)
+        }, self.named_filter_objects)]
+        if self.base_item_expression:
+            default_indicators.append(IndicatorFactory.from_spec({
+                "column_id": "repeat_iteration",
+                "type": "repeat_iteration",
+                "display_name": "base document iteration",
+                "datatype": "integer",
+                "is_nullable": False,
+                "is_primary_key": True,
+            }, self.named_filter_objects))
         return CompoundIndicator(
             self.display_name,
-            [doc_id_indicator, repeat_iteration_indicator] + [
+            default_indicators + [
                 IndicatorFactory.from_spec(indicator, self.named_filter_objects)
                 for indicator in self.configured_indicators
             ]

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -142,7 +142,6 @@ class DataSourceConfiguration(UnicodeMixIn, CachedCouchDocumentMixin, Document):
             "display_name": "document id",
             "datatype": "string",
             "is_nullable": False,
-            "is_primary_key": True,
             "expression": {
                 "type": "root_doc",
                 "expression": {

--- a/corehq/apps/userreports/specs.py
+++ b/corehq/apps/userreports/specs.py
@@ -15,6 +15,6 @@ class EvaluationContext(object):
     An evaluation context. Necessary for repeats to pass both the row of the repeat as well
     as the root document and the iteration number.
     """
-    def __init__(self, root_doc, iteration):
+    def __init__(self, root_doc, iteration=0):
         self.root_doc = root_doc
         self.iteration = iteration

--- a/corehq/apps/userreports/specs.py
+++ b/corehq/apps/userreports/specs.py
@@ -13,7 +13,8 @@ def TypeProperty(value):
 class EvaluationContext(object):
     """
     An evaluation context. Necessary for repeats to pass both the row of the repeat as well
-    as the root document.
+    as the root document and the iteration number.
     """
-    def __init__(self, root_doc):
+    def __init__(self, root_doc, iteration):
         self.root_doc = root_doc
+        self.iteration = iteration

--- a/corehq/apps/userreports/sql.py
+++ b/corehq/apps/userreports/sql.py
@@ -32,11 +32,11 @@ class IndicatorSqlAdapter(object):
         indicator_rows = self.config.get_all_values(doc)
         if indicator_rows:
             table = self.get_table()
-            for indicator_row in indicator_rows:
-                with self.engine.begin() as connection:
-                    # delete all existing rows for this doc to ensure we aren't left with stale data
-                    delete = table.delete(table.c.doc_id == doc['_id'])
-                    connection.execute(delete)
+            with self.engine.begin() as connection:
+                # delete all existing rows for this doc to ensure we aren't left with stale data
+                delete = table.delete(table.c.doc_id == doc['_id'])
+                connection.execute(delete)
+                for indicator_row in indicator_rows:
                     all_values = {i.column.id: i.value for i in indicator_row}
                     insert = table.insert().values(**all_values)
                     try:

--- a/corehq/apps/userreports/tests/test_app_manager_integration.py
+++ b/corehq/apps/userreports/tests/test_app_manager_integration.py
@@ -35,8 +35,8 @@ class AppManagerDataSourceConfigTest(SimpleTestCase):
 
         # check the indicators
         expected_columns = set(
-            ["doc_id", "modified_on", "user_id", "opened_on", "owner_id",
-             "name", "category", "priority", "starred", "estimate"]
+            ["doc_id", "repeat_iteration", "modified_on", "user_id", "opened_on",
+             "owner_id", "name", "category", "priority", "starred", "estimate"]
         )
         self.assertEqual(expected_columns, set(col_back.id for col_back in data_source.get_columns()))
 
@@ -62,12 +62,13 @@ class AppManagerDataSourceConfigTest(SimpleTestCase):
         default_case_property_datatypes = DEFAULT_CASE_PROPERTY_DATATYPES
         [row] = data_source.get_all_values(sample_doc)
         for result in row:
-            self.assertEqual(sample_doc[_get_column_property(result.column)], result.value)
-            if result.column.id in default_case_property_datatypes:
-                self.assertEqual(
-                    result.column.datatype,
-                    default_case_property_datatypes[result.column.id]
-                )
+            if result.column.id != "repeat_iteration":
+                self.assertEqual(sample_doc[_get_column_property(result.column)], result.value)
+                if result.column.id in default_case_property_datatypes:
+                    self.assertEqual(
+                        result.column.datatype,
+                        default_case_property_datatypes[result.column.id]
+                    )
 
     def test_simple_form_management(self):
         app = Application.wrap(self.get_json('simple_app.json'))

--- a/corehq/apps/userreports/tests/test_app_manager_integration.py
+++ b/corehq/apps/userreports/tests/test_app_manager_integration.py
@@ -35,7 +35,7 @@ class AppManagerDataSourceConfigTest(SimpleTestCase):
 
         # check the indicators
         expected_columns = set(
-            ["doc_id", "repeat_iteration", "modified_on", "user_id", "opened_on",
+            ["doc_id", "modified_on", "user_id", "opened_on",
              "owner_id", "name", "category", "priority", "starred", "estimate"]
         )
         self.assertEqual(expected_columns, set(col_back.id for col_back in data_source.get_columns()))

--- a/corehq/apps/userreports/tests/test_data_source_config.py
+++ b/corehq/apps/userreports/tests/test_data_source_config.py
@@ -37,7 +37,6 @@ class DataSourceConfigurationTest(SimpleTestCase):
         # columns
         expected_columns = [
             'doc_id',
-            'repeat_iteration',
             'date',
             'owner',
             'count',
@@ -234,8 +233,8 @@ class IndicatorNamedFilterTest(SimpleTestCase):
             'mother_state': 'pregnant',
             'evil': 'yes'
         })
-        # Confirm that 2 is the right values index:
-        i = 2
+        # Confirm that 1 is the right values index:
+        i = 1
         self.assertEqual('is_evil', values[i].column.id)
         self.assertEqual(1, values[i].value)
 
@@ -247,8 +246,8 @@ class IndicatorNamedFilterTest(SimpleTestCase):
             'mother_state': 'pregnant',
             'evil': 'no'
         })
-        # Confirm that 2 is the right values index:
-        i = 2
+        # Confirm that 1 is the right values index:
+        i = 1
         self.assertEqual('is_evil', values[i].column.id)
         self.assertEqual(0, values[i].value)
 
@@ -260,8 +259,8 @@ class IndicatorNamedFilterTest(SimpleTestCase):
             'mother_state': 'pregnant',
             'evil': 'yes'
         })
-        # Confirm that 3 is the right values index:
-        i = 3
+        # Confirm that 2 is the right values index:
+        i = 2
         self.assertEqual('laugh_sound', values[i].column.id)
         self.assertEqual('mwa-ha-ha', values[i].value)
 
@@ -273,7 +272,7 @@ class IndicatorNamedFilterTest(SimpleTestCase):
             'mother_state': 'pregnant',
             'evil': 'no'
         })
-        # Confirm that 3 is the right values index:
-        i = 3
+        # Confirm that 2 is the right values index:
+        i = 2
         self.assertEqual('laugh_sound', values[i].column.id)
         self.assertEqual('hehe', values[i].value)

--- a/corehq/apps/userreports/tests/test_data_source_config.py
+++ b/corehq/apps/userreports/tests/test_data_source_config.py
@@ -277,4 +277,3 @@ class IndicatorNamedFilterTest(SimpleTestCase):
         i = 3
         self.assertEqual('laugh_sound', values[i].column.id)
         self.assertEqual('hehe', values[i].value)
-

--- a/corehq/apps/userreports/tests/test_data_source_config.py
+++ b/corehq/apps/userreports/tests/test_data_source_config.py
@@ -37,6 +37,7 @@ class DataSourceConfigurationTest(SimpleTestCase):
         # columns
         expected_columns = [
             'doc_id',
+            'repeat_iteration',
             'date',
             'owner',
             'count',
@@ -90,6 +91,7 @@ def get_sample_doc_and_indicators():
     )
     expected_indicators = {
         'doc_id': 'some-doc-id',
+        'repeat_iteration': 0,
         'date': datetime.datetime.strptime(date_opened, '%Y-%m-%d').date(),
         'owner': 'some-user-id',
         'count': 1,
@@ -232,7 +234,10 @@ class IndicatorNamedFilterTest(SimpleTestCase):
             'mother_state': 'pregnant',
             'evil': 'yes'
         })
-        self.assertEqual(1, values[1].value)
+        # Confirm that 2 is the right values index:
+        i = 2
+        self.assertEqual('is_evil', values[i].column.id)
+        self.assertEqual(1, values[i].value)
 
     def test_simple_indicator_nomatch(self):
         [values] = self.indicator_configuration.get_all_values({
@@ -242,7 +247,10 @@ class IndicatorNamedFilterTest(SimpleTestCase):
             'mother_state': 'pregnant',
             'evil': 'no'
         })
-        self.assertEqual(0, values[1].value)
+        # Confirm that 2 is the right values index:
+        i = 2
+        self.assertEqual('is_evil', values[i].column.id)
+        self.assertEqual(0, values[i].value)
 
     def test_expression_match(self):
         [values] = self.indicator_configuration.get_all_values({
@@ -252,7 +260,10 @@ class IndicatorNamedFilterTest(SimpleTestCase):
             'mother_state': 'pregnant',
             'evil': 'yes'
         })
-        self.assertEqual('mwa-ha-ha', values[2].value)
+        # Confirm that 3 is the right values index:
+        i = 3
+        self.assertEqual('laugh_sound', values[i].column.id)
+        self.assertEqual('mwa-ha-ha', values[i].value)
 
     def test_expression_nomatch(self):
         [values] = self.indicator_configuration.get_all_values({
@@ -262,4 +273,8 @@ class IndicatorNamedFilterTest(SimpleTestCase):
             'mother_state': 'pregnant',
             'evil': 'no'
         })
-        self.assertEqual('hehe', values[2].value)
+        # Confirm that 3 is the right values index:
+        i = 3
+        self.assertEqual('laugh_sound', values[i].column.id)
+        self.assertEqual('hehe', values[i].value)
+

--- a/corehq/apps/userreports/tests/test_data_source_repeats.py
+++ b/corehq/apps/userreports/tests/test_data_source_repeats.py
@@ -43,8 +43,9 @@ class RepeatDataSourceConfigurationTest(RepeatDataSourceTestMixin, SimpleTestCas
             "start_time": start, "end_time": end, "person": "al"
         }}))
         self.assertEqual(1, len(rows))
-        doc_id_ind, start_ind, end_ind, person_ind, created_base_ind = rows[0]
+        doc_id_ind, repeat_iteration, start_ind, end_ind, person_ind, created_base_ind = rows[0]
         self.assertEqual(DOC_ID, doc_id_ind.value)
+        self.assertEqual(0, repeat_iteration.value)
         self.assertEqual(start, start_ind.value)
         self.assertEqual(end, end_ind.value)
         self.assertEqual('al', person_ind.value)
@@ -61,9 +62,10 @@ class RepeatDataSourceConfigurationTest(RepeatDataSourceTestMixin, SimpleTestCas
         rows = self.config.get_all_values(_test_doc(form={"time_logs": logs}))
         self.assertEqual(len(logs), len(rows))
         for i, row in enumerate(rows):
-            doc_id_ind, start_ind, end_ind, person_ind, created_base_ind = row
+            doc_id_ind, repeat_iteration, start_ind, end_ind, person_ind, created_base_ind = row
             self.assertEqual(DOC_ID, doc_id_ind.value)
             self.assertEqual(logs[i]['start_time'], start_ind.value)
+            self.assertEqual(i, repeat_iteration.value)
             self.assertEqual(logs[i]['end_time'], end_ind.value)
             self.assertEqual(logs[i]['person'], person_ind.value)
             self.assertEqual(DAY_OF_WEEK, created_base_ind.value)
@@ -96,9 +98,10 @@ class RepeatDataSourceBuildTest(RepeatDataSourceTestMixin, TestCase):
             rows = connection.execute(adapter.get_table().select())
         retrieved_logs = [
             {
-                'start_time': r[1],
-                'end_time': r[2],
-                'person': r[3],
+                'start_time': r[2],
+                'end_time': r[3],
+                'person': r[4],
+
             } for r in rows
         ]
         # Clean up

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -3,8 +3,11 @@ from django.test import SimpleTestCase
 from fakecouch import FakeCouchDb
 from corehq.apps.userreports.exceptions import BadSpecError
 from corehq.apps.userreports.expressions.factory import ExpressionFactory
-from corehq.apps.userreports.expressions.specs import PropertyNameGetterSpec, PropertyPathGetterSpec, \
-    RelatedDocExpressionSpec
+from corehq.apps.userreports.expressions.specs import (
+    PropertyNameGetterSpec,
+    PropertyPathGetterSpec,
+    RelatedDocExpressionSpec,
+)
 from corehq.apps.userreports.specs import EvaluationContext
 
 
@@ -175,7 +178,7 @@ class RootDocExpressionTest(SimpleTestCase):
             None,
             self.expression(
                 {"base_property": "item_value"},
-                context=EvaluationContext({})
+                context=EvaluationContext({}, 0)
             )
         )
 
@@ -184,7 +187,7 @@ class RootDocExpressionTest(SimpleTestCase):
             "base_value",
             self.expression(
                 {"base_property": "item_value"},
-                context=EvaluationContext({"base_property": "base_value"})
+                context=EvaluationContext({"base_property": "base_value"}, 0)
             )
         )
 
@@ -243,7 +246,7 @@ class DocJoinExpressionTest(SimpleTestCase):
             'my-id': my_doc,
             related_id: related_doc
         }
-        self.assertEqual('foo', self.expression(my_doc, EvaluationContext(my_doc)))
+        self.assertEqual('foo', self.expression(my_doc, EvaluationContext(my_doc, 0)))
 
     def test_related_doc_not_found(self):
         self.assertEqual(None, self.expression({'parent_id': 'some-missing-id'}))
@@ -262,7 +265,7 @@ class DocJoinExpressionTest(SimpleTestCase):
             'my-id': my_doc,
             related_id: related_doc
         }
-        self.assertEqual(None, self.expression(my_doc, EvaluationContext(my_doc)))
+        self.assertEqual(None, self.expression(my_doc, EvaluationContext(my_doc, 0)))
 
     def test_nested_lookup(self):
         related_id = 'nested-id-1'
@@ -285,7 +288,7 @@ class DocJoinExpressionTest(SimpleTestCase):
             related_id: related_doc,
             related_id_2: related_doc_2
         }
-        self.assertEqual('bar', self.nested_expression(my_doc, EvaluationContext(my_doc)))
+        self.assertEqual('bar', self.nested_expression(my_doc, EvaluationContext(my_doc, 0)))
 
     def test_nested_lookup_cross_domains(self):
         related_id = 'cross-nested-id-1'
@@ -308,7 +311,7 @@ class DocJoinExpressionTest(SimpleTestCase):
             related_id: related_doc,
             related_id_2: related_doc_2
         }
-        self.assertEqual(None, self.nested_expression(my_doc, EvaluationContext(my_doc)))
+        self.assertEqual(None, self.nested_expression(my_doc, EvaluationContext(my_doc, 0)))
 
     def test_caching(self):
         self.test_simple_lookup()
@@ -317,7 +320,7 @@ class DocJoinExpressionTest(SimpleTestCase):
         self.database.mock_docs.clear()
 
         self.assertEqual({}, self.database.mock_docs)
-        self.assertEqual('foo', self.expression(my_doc, EvaluationContext(my_doc)))
+        self.assertEqual('foo', self.expression(my_doc, EvaluationContext(my_doc, 0)))
 
         same_expression = ExpressionFactory.from_spec(self.spec)
-        self.assertEqual('foo', same_expression(my_doc, EvaluationContext(my_doc)))
+        self.assertEqual('foo', same_expression(my_doc, EvaluationContext(my_doc, 0)))


### PR DESCRIPTION
When referencing repeated data in a `base_item_expression`, only one row (for the last item of the repeat) would exist in the database. This is demonstrated in the added test.

This was happening because, for each document in the repeat, we deleted all existing rows with the given doc id. Since repeat questions all have the same doc id, all previous entries for the repeat in the table were being deleted before saving each subsequent item. This PR fixes that by only deleting existing rows once per document, instead of once per repeat item.

This PR also removes the primary key constraint on the `doc_id` column of data source tables. Otherwise, rows for repeat questions can't be inserted, because they all have the same doc id. @czue @snopoke, will removing the primary key have any adverse effects that you know of? I know it's generally considered bad practice to not have a pk on every table. Should we give data source tables a separate id column? Maybe making a compound key out of doc id and repeat iteration, or something like that, is a better approach. Thoughts?
