### PR TITLE
Request cache refactor

### DIFF
--- a/corehq/apps/accounting/interface.py
+++ b/corehq/apps/accounting/interface.py
@@ -703,7 +703,7 @@ class InvoiceInterface(GenericTabularReport):
         )
 
     @property
-    @request_cache("default")
+    @request_cache()
     def view_response(self):
         if self.request.method == 'POST':
             if self.adjust_balance_form.is_valid():

--- a/corehq/apps/reports/dont_use/fields.py
+++ b/corehq/apps/reports/dont_use/fields.py
@@ -13,14 +13,14 @@ from corehq.apps.reports.filters.users import get_user_toggle
 from corehq.apps.reports.models import HQUserType
 from django.utils.translation import ugettext_noop
 from django.utils.translation import ugettext as _
-from corehq.apps.reports.cache import CacheableRequestMixIn
 import uuid
 from corehq.apps.users.models import WebUser
 
 
-class ReportField(CacheableRequestMixIn):
+class ReportField(object):
     slug = ""
     template = ""
+    is_cacheable = False
 
     def __init__(self, request, domain=None, timezone=pytz.utc, parent_report=None):
         warnings.warn(

--- a/corehq/apps/reports/filters/base.py
+++ b/corehq/apps/reports/filters/base.py
@@ -1,14 +1,12 @@
 import pytz
 from django.template.loader import render_to_string
-#from corehq.apps.reports.cache import CacheableRequestMixIn, request_cache
-from corehq.apps.reports.cache import CacheableRequestMixIn
 from dimagi.utils.decorators.memoized import memoized
 # For translations
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_noop
 
 
-class BaseReportFilter(CacheableRequestMixIn):   # (CacheableRequestMixIn):
+class BaseReportFilter(object):
     """
         For filtering the results of CommCare HQ Reports.
 
@@ -21,6 +19,7 @@ class BaseReportFilter(CacheableRequestMixIn):   # (CacheableRequestMixIn):
     label = None
     css_class = "span4"
     help_text = None
+    is_cacheable = False
 
     def __init__(self, request, domain=None, timezone=pytz.utc, parent_report=None):
         if self.slug is None:
@@ -244,7 +243,6 @@ class BaseDrilldownOptionFilter(BaseReportFilter):
         return self.get_labels()
 
     @property
-#    @request_cache('drilldownfiltercontext')
     def filter_context(self):
         controls = []
         for level, label in enumerate(self.rendered_labels):

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -517,12 +517,11 @@ class GenericReportView(object):
         self.set_announcements()
         return render(self.request, template, self.context)
 
-    
     @property
     @request_cache()
     def mobile_response(self):
         """
-        This tries to render a mobile version of the report, by just calling 
+        This tries to render a mobile version of the report, by just calling
         out to a very simple default template. Likely won't work out of the box
         with most reports.
         """
@@ -533,7 +532,7 @@ class GenericReportView(object):
         async_context = self._async_context()
         self.context.update(async_context)
         return render(self.request, self.mobile_template_base, self.context)
-    
+
     @property
     def email_response(self):
         """
@@ -551,7 +550,7 @@ class GenericReportView(object):
             Renders the asynchronous view of the report template, returned as json.
         """
         return HttpResponse(json.dumps(self._async_context()), content_type='application/json')
-    
+
     def _async_context(self):
         self.update_template_context()
         self.update_report_context()
@@ -723,7 +722,7 @@ class GenericTabularReport(GenericReportView):
     use_datatables = True
     charts_per_row = 1
     bad_request_error_text = None
-    
+
     # override old class properties
     report_template_path = "reports/async/tabular.html"
     flush_layout = True

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -25,13 +25,13 @@ from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.modules import to_function
 from dimagi.utils.web import json_request, json_response
 from dimagi.utils.parsing import string_to_boolean
-from corehq.apps.reports.cache import CacheableRequestMixIn, request_cache
+from corehq.apps.reports.cache import request_cache
 from django.utils.translation import ugettext
 
 CHART_SPAN_MAP = {1: '10', 2: '6', 3: '4', 4: '3', 5: '2', 6: '2'}
 
 
-class GenericReportView(CacheableRequestMixIn):
+class GenericReportView(object):
     """
         A generic report structure for viewing a report
         (or pages that follow the reporting structure closely---though that seems a bit hacky)
@@ -73,6 +73,8 @@ class GenericReportView(CacheableRequestMixIn):
     slug = None  # Name to be used in the URL (with lowercase and underscores)
     section_name = None  # string. ex: "Reports"
     dispatcher = None  # ReportDispatcher subclass
+
+    is_cacheable = False  # whether to use caching on @request_cache methods
 
     # Code can expect `fields` to be an iterable even when empty (never None)
     fields = ()
@@ -517,7 +519,7 @@ class GenericReportView(CacheableRequestMixIn):
 
     
     @property
-    @request_cache("mobile")
+    @request_cache()
     def mobile_response(self):
         """
         This tries to render a mobile version of the report, by just calling 
@@ -542,7 +544,7 @@ class GenericReportView(CacheableRequestMixIn):
         return self.async_response
 
     @property
-    @request_cache("async")
+    @request_cache()
     def async_response(self):
         """
             Intention: Not to be overridden in general.
@@ -579,7 +581,7 @@ class GenericReportView(CacheableRequestMixIn):
         return file
 
     @property
-    @request_cache("filters", expiry=60 * 10)
+    @request_cache(expiry=60 * 10)
     def filters_response(self):
         """
             Intention: Not to be overridden in general.
@@ -596,7 +598,7 @@ class GenericReportView(CacheableRequestMixIn):
         )))
 
     @property
-    @request_cache("json")
+    @request_cache()
     def json_response(self):
         """
             Intention: Not to be overridden in general.
@@ -605,7 +607,7 @@ class GenericReportView(CacheableRequestMixIn):
         return json_response(self.json_dict)
 
     @property
-    @request_cache("export")
+    @request_cache()
     def export_response(self):
         """
         Intention: Not to be overridden in general.
@@ -620,7 +622,7 @@ class GenericReportView(CacheableRequestMixIn):
             return export_response(temp, self.export_format, self.export_name)
 
     @property
-    @request_cache("raw")
+    @request_cache()
     def print_response(self):
         """
         Returns the report for printing.
@@ -910,7 +912,7 @@ class GenericTabularReport(GenericReportView):
             return self.rows
 
     @property
-    @request_cache("report_context")
+    @request_cache()
     def report_context(self):
         """
             Don't override.

--- a/corehq/apps/reports/tests/test_cache.py
+++ b/corehq/apps/reports/tests/test_cache.py
@@ -2,21 +2,22 @@ import uuid
 from django.http import HttpRequest
 from django.test import TestCase
 from corehq.apps.domain.shortcuts import create_domain
-from corehq.apps.reports.cache import CacheableRequestMixIn, request_cache
+from corehq.apps.reports.cache import request_cache
 from corehq.apps.users.models import WebUser
 
 
-class MockReport(CacheableRequestMixIn):
+class MockReport(object):
+    is_cacheable = False
 
     def __init__(self, request, is_cacheable=True):
         self.request = request
         self.is_cacheable = is_cacheable
 
-    @request_cache('v1')
+    @request_cache()
     def v1(self):
         return uuid.uuid4().hex
 
-    @request_cache('v2')
+    @request_cache()
     def v2(self):
         return uuid.uuid4().hex
 

--- a/corehq/util/quickcache.py
+++ b/corehq/util/quickcache.py
@@ -126,7 +126,8 @@ class QuickCache(object):
         return 'quickcache.{}/{}'.format(self.prefix, args_string)
 
 
-def quickcache(vary_on, timeout=None, memoize_timeout=None, cache=None):
+def quickcache(vary_on, timeout=None, memoize_timeout=None, cache=None,
+               helper_class=QuickCache):
     """
     An easy "all-purpose" cache decorator
 
@@ -181,7 +182,7 @@ def quickcache(vary_on, timeout=None, memoize_timeout=None, cache=None):
                              get_cache('default', timeout=timeout)])
 
     def decorator(fn):
-        helper = QuickCache(fn, vary_on=vary_on, cache=cache)
+        helper = helper_class(fn, vary_on=vary_on, cache=cache)
 
         @functools.wraps(fn)
         def inner(*args, **kwargs):

--- a/custom/bihar/reports/mch_reports.py
+++ b/custom/bihar/reports/mch_reports.py
@@ -2,7 +2,6 @@ import copy
 from django.http.response import HttpResponse
 from django.utils.translation import ugettext as _
 from corehq.apps.groups.models import Group
-from corehq.apps.reports.cache import request_cache
 from corehq.apps.reports.standard.cases.basic import CaseListReport
 from corehq.apps.api.es import CaseES
 

--- a/custom/m4change/reports/mcct_project_review.py
+++ b/custom/m4change/reports/mcct_project_review.py
@@ -6,7 +6,6 @@ from django.utils.translation import ugettext as _
 from jsonobject import DateTimeProperty
 
 from corehq.apps.locations.models import Location
-from corehq.apps.reports.cache import request_cache
 from corehq.apps.reports.filters.fixtures import AsyncLocationFilter
 from corehq.elastic import ES_URLS
 from corehq.apps.reports.standard import CustomProjectReport

--- a/custom/opm/reports.py
+++ b/custom/opm/reports.py
@@ -660,7 +660,7 @@ class BaseReport(BaseMixin, GetParamsMixin, MonthYearMixin, CustomProjectReport,
         return {}
 
     @property
-    @request_cache("raw")
+    @request_cache()
     def print_response(self):
         """
         Returns the report for printing.
@@ -926,7 +926,7 @@ class MetReport(CaseReportMixin, BaseReport):
                 ])
 
     @property
-    @request_cache("raw")
+    @request_cache()
     def print_response(self):
         """
         Returns the report for printing.
@@ -1266,7 +1266,7 @@ class HealthStatusReport(DatespanMixin, BaseReport):
         return dict(num=2, width=300)
 
     @property
-    @request_cache("raw")
+    @request_cache()
     def print_response(self):
         """
         Returns the report for printing.


### PR DESCRIPTION
This was a little weekend project from something I'd found that seemed like it could be cleaned up.

I'm torn between this being a great improvement and it being just an excuse to stuff something into quickcache just because it's my baby, but I think it's a good change.

Benefits of this change:
- you don't have to pass in the name of the function as an argument (if someone was using that for some clever purpose like making two different functions share a cache, then (1) wow! and (2) let me know
- if the function you're caching changes, it invalidates the cache (quickcache feature)
- investing in one simple broadly usable caching pattern, not having coffee for basically the same thing twice
- no longer need the request cache mixin

Potential drawbacks:
- maybe it's harder to read/understand the implementation than when it was directly implementing a recognizable caching pattern, and it's now dependent on the internals of the quickcache lib
- changing anything that's used in a number of places always has an associated risk of breaking something
