### PR TITLE
Update purge_locations to use unwrapped domain

### DIFF
--- a/corehq/apps/locations/util.py
+++ b/corehq/apps/locations/util.py
@@ -272,6 +272,9 @@ def purge_locations(domain):
             case.delete()
         loc.delete()
 
-    domain_obj = Domain.get_by_name(domain)
-    domain_obj.location_types = []
-    domain_obj.save()
+    db = Domain.get_db()
+    domain_obj = Domain.get_by_name(domain)  # cached lookup is fast but stale
+    domain_json = db.get(domain_obj._id)  # get latest raw, unwrapped doc
+    domain_json.pop('obsolete_location_types', None)
+    domain_json.pop('location_types', None)
+    db.save_doc(domain_json)


### PR DESCRIPTION
@dannyroberts
As part of the recent locations migration I did, I made a cleanup pass to remove inconsistent data.  This means that if you have commtrack data locally that's in a messy state (locations with location types that no longer exist, that sort of thing), the migration will probably fail.  Your options are to either clean it up or blow it away.

TL;DR: blow away all location information on your test domain if you want the quick fix.  either call corehq.apps.locations.util.purge_locations(domain) or use `$ ./manage.py clean_loc_data`.

Run `$ ./manage.py check_loc_types` to find inconsistencies that might exist.  This prints some output and creates a csv cataloging the errors.  Take a look and see which (if any) you want to bother correcting.  I run `$ column -txs, check_loc_types-2015-03-23.csv` to cleanly view the csv in the terminal.  If it's a problem with the location types (anything involving parentage or codes), you can probably just go to http://localhost:8000/a/<domain>/settings/locations/location_settings/ and click save to fix it.  If you have locations with types which don't exist, you can either change the types of those locations (hard) or just add in a new location type with the missing location type name/code as a temporary fix.

To just purge all the location data from any domains you don't care about, you can pass that csv file to `$ manage.py clean_loc_data check_loc_types-2015-03-23.csv`.  This will purge location data from any domains remaining in the csv.  You can also just use the function this calls directly if you prefer:

``` python
from corehq.apps.locations.util import purge_locations
purge_locations("tyler-commtrack")
```

Feel free to ping me if you have any problems while running this.
