### PR TITLE
Change license display to include link to relevant license

### DIFF
--- a/corehq/apps/appstore/templates/appstore/project_info.html
+++ b/corehq/apps/appstore/templates/appstore/project_info.html
@@ -174,7 +174,7 @@
         {% endif %}
     </dd>
     <dt>{% trans 'License' %}</dt>
-    <dd>{{ project.get_license_display }}</dd>
+    <dd><a href="{{ project.get_license_url }}">{{ project.get_license_display }}</a> </dd>
     <dt>{% trans 'Downloads' %}</dt>
     <dd>
         <!-- This version: -->

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -900,6 +900,9 @@ class Domain(Document, SnapshotMixin):
     def get_license_display(self):
         return LICENSES.get(self.license)
 
+    def get_license_url(self):
+        return LICENSE_LINKS.get(self.license)
+
     def copies(self):
         return Domain.view('domain/copied_from_snapshot', key=self._id, include_docs=True)
 

--- a/corehq/apps/domain/templates/domain/partials/project_version_display.html
+++ b/corehq/apps/domain/templates/domain/partials/project_version_display.html
@@ -31,7 +31,7 @@
     <dt>{% trans 'Published on' %}</dt>
     <dd>{{ version.snapshot_time }}</dd>
     <dt>{% trans 'License' %}</dt>
-    <dd>{{ version.get_license_display }}</dd>
+    <dd><a href="{{ project.get_license_url }}">{{ project.get_license_display }}</a> </dd>
     <dt>{% trans 'Status' %}</dt>
     <dd>{% if version.is_approved %}Approved{% else %}Not yet approved{% endif %}</dd>
     <dd>

--- a/corehq/apps/domain/templates/domain/snapshot_settings.html
+++ b/corehq/apps/domain/templates/domain/snapshot_settings.html
@@ -89,7 +89,7 @@
                 </a>
             </td>
             <td>{{ snapshot.snapshot_time }}</td>
-            <td>{{ snapshot.get_license_display }}</td>
+            <td><a href="{{ project.get_license_url }}">{{ project.get_license_display }}</a> </td>
             {% if snapshot.published %}
             <td>
                 {% if snapshot.is_approved %}


### PR DESCRIPTION
@amsagoff The licenses are displayed with the appropriate abbreviations, but this pr links directly to the appropriate license from project settings and on the exchange.
