### PR TITLE
fix location type references in ils/ews reports

### DIFF
--- a/custom/ilsgateway/tanzania/__init__.py
+++ b/custom/ilsgateway/tanzania/__init__.py
@@ -340,7 +340,7 @@ class DetailsReport(MultiReport):
 
     @property
     def with_tabs(self):
-        return self.location and self.location.location_type == 'FACILITY'
+        return self.location and self.location.location_type.name.upper() == 'FACILITY'
 
     @property
     def report_context(self):

--- a/custom/ilsgateway/tanzania/reports/dashboard_report.py
+++ b/custom/ilsgateway/tanzania/reports/dashboard_report.py
@@ -20,14 +20,14 @@ class DashboardReport(MultiReport):
     @property
     def title(self):
         title = _("Dashboard report")
-        if self.location and self.location.location_type == 'FACILITY':
+        if self.location and self.location.location_type.name.upper() == 'FACILITY':
             title = _('Facility Details')
         return title
 
     @property
     def fields(self):
         fields = [AsyncLocationFilter, MonthFilter, YearFilter, ProductByProgramFilter]
-        if self.location and self.location.location_type == 'FACILITY':
+        if self.location and self.location.location_type.name.upper() == 'FACILITY':
             fields = [AsyncLocationFilter, ProductByProgramFilter]
         return fields
 
@@ -36,7 +36,7 @@ class DashboardReport(MultiReport):
     def data_providers(self):
         config = self.report_config
         if self.location:
-            if self.location.location_type == 'FACILITY':
+            if self.location.location_type.name.upper() == 'FACILITY':
                 self.use_datatables = True
                 return [
                     InventoryHistoryData(config=config),

--- a/custom/ilsgateway/tanzania/reports/delivery.py
+++ b/custom/ilsgateway/tanzania/reports/delivery.py
@@ -167,14 +167,14 @@ class DeliveryReport(DetailsReport):
     @property
     def title(self):
         title = _('Delivery Report')
-        if self.location and self.location.location_type == 'FACILITY':
+        if self.location and self.location.location_type.name.upper() == 'FACILITY':
             title = _('Facility Details')
         return title
 
     @property
     def fields(self):
         fields = [AsyncLocationFilter, MonthAndQuarterFilter, YearFilter, ProductByProgramFilter, MSDZoneFilter]
-        if self.location and self.location.location_type == 'FACILITY':
+        if self.location and self.location.location_type.name.upper() == 'FACILITY':
             fields = [AsyncLocationFilter, ProductByProgramFilter]
         return fields
 
@@ -187,10 +187,10 @@ class DeliveryReport(DetailsReport):
         config = self.report_config
         if config['location_id']:
             location = SQLLocation.objects.get(location_id=config['location_id'])
-            if location.location_type in ['REGION', 'MOHSW']:
+            if location.location_type.name.upper() in ['REGION', 'MOHSW']:
                 data_providers.append(DeliveryData(config=config, css_class='row_chart_all'))
                 data_providers.append(LeadTimeHistory(config=config, css_class='row_chart_all'))
-            elif location.location_type == 'FACILITY':
+            elif location.location_type.name.upper() == 'FACILITY':
                 return [
                     InventoryHistoryData(config=config),
                     RandRHistory(config=config),

--- a/custom/ilsgateway/tanzania/reports/randr.py
+++ b/custom/ilsgateway/tanzania/reports/randr.py
@@ -177,14 +177,14 @@ class RRreport(DetailsReport):
     @property
     def title(self):
         title = _('R & R')
-        if self.location and self.location.location_type == 'FACILITY':
+        if self.location and self.location.location_type.name.upper() == 'FACILITY':
             title = _('Facility Details')
         return title
 
     @property
     def fields(self):
         fields = [AsyncLocationFilter, MonthAndQuarterFilter, YearFilter, ProductByProgramFilter, MSDZoneFilter]
-        if self.location and self.location.location_type == 'FACILITY':
+        if self.location and self.location.location_type.name.upper() == 'FACILITY':
             fields = [AsyncLocationFilter, ProductByProgramFilter]
         return fields
 

--- a/custom/ilsgateway/tanzania/reports/stock_on_hand.py
+++ b/custom/ilsgateway/tanzania/reports/stock_on_hand.py
@@ -24,11 +24,11 @@ from django.db.models.aggregates import Avg, Max
 
 def get_facilities(location, domain):
 
-    if location.location_type.upper() == 'DISTRICT':
-        locations = SQLLocation.objects.filter(parent=location)
-    elif location.location_type.upper() == 'REGION':
+    if location.location_type.name.upper() == 'DISTRICT':
+        locations = SQLLocation.name.objects.filter(parent=location)
+    elif location.location_type.name.upper() == 'REGION':
         locations = SQLLocation.objects.filter(parent__parent=location)
-    elif location.location_type.upper() == 'FACILITY':
+    elif location.location_type.name.upper() == 'FACILITY':
         locations = SQLLocation.objects.filter(id=location.id)
     else:
         locations = SQLLocation.objects.filter(domain=domain)
@@ -374,14 +374,14 @@ class StockOnHandReport(DetailsReport):
     @property
     def title(self):
         title = _('Stock On Hand')
-        if self.location and self.location.location_type == 'FACILITY':
+        if self.location and self.location.location_type.name.upper() == 'FACILITY':
             title = _('Facility Details')
         return title
 
     @property
     def fields(self):
         fields = [AsyncLocationFilter, MonthAndQuarterFilter, YearFilter, ProgramFilter, MSDZoneFilter]
-        if self.location and self.location.location_type == 'FACILITY':
+        if self.location and self.location.location_type.name.upper() == 'FACILITY':
             fields = [AsyncLocationFilter, ProductByProgramFilter]
         return fields
 
@@ -399,9 +399,9 @@ class StockOnHandReport(DetailsReport):
                 ProductAvailabilitySummary(config=config, css_class='row_chart_all', chart_stacked=False),
             ]
 
-            if location.location_type.upper() == 'DISTRICT':
+            if location.location_type.name.upper() == 'DISTRICT':
                 data_providers.append(DistrictSohPercentageTableData(config=config, css_class='row_chart_all'))
-            elif location.location_type == 'FACILITY':
+            elif location.location_type.name.upper() == 'FACILITY':
                 return [
                     InventoryHistoryData(config=config),
                     RandRHistory(config=config),

--- a/custom/ilsgateway/tanzania/reports/supervision.py
+++ b/custom/ilsgateway/tanzania/reports/supervision.py
@@ -155,14 +155,14 @@ class SupervisionReport(DetailsReport):
     @property
     def title(self):
         title = _('Supervision')
-        if self.location and self.location.location_type == 'FACILITY':
+        if self.location and self.location.location_type.name.upper() == 'FACILITY':
             title = _('Facility Details')
         return title
 
     @property
     def fields(self):
         fields = [AsyncLocationFilter, MonthAndQuarterFilter, YearFilter, ProductByProgramFilter, MSDZoneFilter]
-        if self.location and self.location.location_type == 'FACILITY':
+        if self.location and self.location.location_type.name.upper() == 'FACILITY':
             fields = [AsyncLocationFilter, ProductByProgramFilter]
         return fields
 
@@ -178,9 +178,9 @@ class SupervisionReport(DetailsReport):
                 SupervisionSummaryData(config=config, css_class='row_chart_all'),
             ]
 
-            if location.location_type.upper() == 'DISTRICT':
+            if location.location_type.name.upper() == 'DISTRICT':
                 data_providers.append(DistrictSupervisionData(config=config, css_class='row_chart_all'))
-            elif location.location_type == 'FACILITY':
+            elif location.location_type.name.upper() == 'FACILITY':
                 return [
                     InventoryHistoryData(config=config),
                     RandRHistory(config=config),

--- a/custom/ilsgateway/tanzania/warehouse_updater.py
+++ b/custom/ilsgateway/tanzania/warehouse_updater.py
@@ -299,7 +299,7 @@ def populate_report_data(start_date, end_date, domain, runner):
         non_facilities += list(Location.filter_by_type(domain, 'MOHSW'))
 
     if runner.location:
-        if runner.location.location_type != 'FACILITY':
+        if runner.location.location_type.name.upper() != 'FACILITY':
             facilities = []
             non_facilities = itertools.dropwhile(
                 lambda location: location._id != runner.location.location_id,


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?162573

@esoergel fyi

I tried to be pretty careful about chasing references around and confirming it was in fact a `SQLLocation` and not a couch one.

This whole "sometimes a location is a couch object and sometimes it is sql and they behave totally differently" is a bit of a disaster. I think we should make getting rid of couch locations entirely a pretty high priority.
