### PR TITLE
Reduce max tasks per child on main queue

### DIFF
--- a/fab/services/templates/supervisor_celery_main.conf
+++ b/fab/services/templates/supervisor_celery_main.conf
@@ -1,6 +1,6 @@
 [program:{{ project }}-{{ environment }}-celery_main]
 environment={{ supervisor_env_vars }}
-command={{ new_relic_command }}{{ virtualenv_root }}/bin/python {{ code_root }}/manage.py celery worker --queues=celery --events --loglevel=INFO --hostname={{ host_string }}_main --maxtasksperchild=20 --concurrency={{ celery_params.main.concurrency }}
+command={{ new_relic_command }}{{ virtualenv_root }}/bin/python {{ code_root }}/manage.py celery worker --queues=celery --events --loglevel=INFO --hostname={{ host_string }}_main --maxtasksperchild=5 --concurrency={{ celery_params.main.concurrency }}
 directory={{ code_root }}
 user={{ sudo_user }}
 numprocs=1

--- a/fab/services/templates/supervisor_celery_saved_exports_queue.conf
+++ b/fab/services/templates/supervisor_celery_saved_exports_queue.conf
@@ -1,6 +1,6 @@
 [program:{{ project }}-{{ environment }}-celery_saved_exports_queue]
 environment={{ supervisor_env_vars }}
-command={{ new_relic_command }}{{ virtualenv_root }}/bin/python {{ code_root }}/manage.py celery worker --queues=saved_exports_queue --events --loglevel=INFO --hostname={{ host_string }}_saved_exports_queue --maxtasksperchild=10 --concurrency={{ celery_params.saved_exports_queue.concurrency }}
+command={{ new_relic_command }}{{ virtualenv_root }}/bin/python {{ code_root }}/manage.py celery worker --queues=saved_exports_queue --events --loglevel=INFO --hostname={{ host_string }}_saved_exports_queue --maxtasksperchild=5 --concurrency={{ celery_params.saved_exports_queue.concurrency }}
 directory={{ code_root }}
 user={{ sudo_user }}
 numprocs=1


### PR DESCRIPTION
Trying to free up some memory on the celery machine since high memory usage tends to cause issues. The main problem I saw was that there were 2 processes (out of the total 8) in the main queue that were taking up 18.4% memory usage. Below is a list of tasks that had completed in the main queue up to that point:

soil.tasks.prepare_download: 2
couchexport.tasks.export_async: 10
corehq.apps.fixtures.tasks.fixture_download_async: 8
corehq.apps.hqpillow_retry.tasks.pillow_retry_notifier: 2
corehq.apps.sms.tasks.store_billable: 48
corehq.apps.fixtures.tasks.fixture_upload_async: 5
corehq.apps.reports.tasks.send_report: 3
ctable.tasks.process_extract: 3

It would be good to try and find out which one(s) of these tasks is taking up so much memory, but in the meantime reducing max tasks per child to 5 will make the processes get replaced more often and hopefully reduce the memory load (at the expense of potentially making things a tad bit slower).
