### PR TITLE
Remove unused couch app

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -1046,7 +1046,6 @@ COUCHDB_APPS = [
     ('cvsu', 'fluff-cvsu'),
     ('mc', 'fluff-mc'),
     ('m4change', 'm4change'),
-    ('wvindia2', 'wvindia2'),
     ('export', 'meta'),
     'tdhtesting'
 ]


### PR DESCRIPTION
This app isn't being used and there is no couch database for it
