### PR TITLE
disallow inactive users from viewing project reports even if they are a member

### DIFF
--- a/corehq/apps/reports/dispatcher.py
+++ b/corehq/apps/reports/dispatcher.py
@@ -224,6 +224,8 @@ class ProjectReportDispatcher(ReportDispatcher):
     def permissions_check(self, report, request, domain=None, is_navigation_check=False):
         if domain is None:
             return False
+        if not request.couch_user.is_active:
+            return False
         return request.couch_user.can_view_report(domain, report)
 
 

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1303,6 +1303,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, EulaMi
     def is_current_web_user(self, request):
         return self.user_id == request.couch_user.user_id
 
+    # gets hit for can_view_reports, etc.
     def __getattr__(self, item):
         if item.startswith('can_'):
             perm = item[len('can_'):]


### PR DESCRIPTION
fixes http://manage.dimagi.com/default.asp?162563#902168

There were two possible approaches to this bug: either catch the 302 response and show an error message, or modify `permissions_check` to return `False` for inactive users.  I chose the later, since it abides by the existing use of the `dispatch` function, and seems more consistent with the notion of an inactive user.

@dannyroberts @czue 
