### PR TITLE
AdvancedAction should not use IndexedSchema's verison of equality

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -327,6 +327,8 @@ class AdvancedAction(IndexedSchema):
 
     close_condition = SchemaProperty(FormActionCondition)
 
+    __eq__ = DocumentSchema.__eq__
+
     def get_paths(self):
         for path in self.case_properties.values():
             yield path


### PR DESCRIPTION
fixes http://manage.dimagi.com/default.asp?162805

https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/app_manager/models.py#L458 can incorrectly evaluate to `True` when `IndexedSchema.__eq__` is used (since https://github.com/dimagi/commcare-hq/commit/23a153d577a045da89121affe28424bda2100e16)
