### PR TITLE
add filter to find SMS billables missing a gateway fee

### DIFF
--- a/corehq/apps/smsbillables/filters.py
+++ b/corehq/apps/smsbillables/filters.py
@@ -39,6 +39,18 @@ class DomainFilter(BaseSingleOptionFilter):
         )
 
 
+class HasGatewayFeeFilter(BaseSingleOptionFilter):
+    slug = 'has_gateway_fee'
+    label = _('Has Gateway Fee')
+    default_text = _('All')
+    YES = "yes"
+    NO = "no"
+    options = (
+        (YES, _('Yes')),
+        (NO, _('No')),
+    )
+
+
 class GatewayTypeFilter(BaseSingleOptionFilter):
     slug = 'gateway_type'
     label = _("Gateway Type")

--- a/corehq/apps/smsbillables/interface.py
+++ b/corehq/apps/smsbillables/interface.py
@@ -15,6 +15,7 @@ from corehq.apps.smsbillables.filters import (
     DateSentFilter,
     DirectionFilter,
     DomainFilter,
+    HasGatewayFeeFilter,
     GatewayTypeFilter,
     ShowBillablesFilter,
     SpecificGateway,
@@ -43,6 +44,7 @@ class SMSBillablesInterface(GenericTabularReport):
         'corehq.apps.accounting.interface.DateCreatedFilter',
         'corehq.apps.smsbillables.interface.ShowBillablesFilter',
         'corehq.apps.smsbillables.interface.DomainFilter',
+        'corehq.apps.smsbillables.interface.HasGatewayFeeFilter',
     ]
 
     @property
@@ -154,6 +156,18 @@ class SMSBillablesInterface(GenericTabularReport):
             selected_billables = selected_billables.filter(
                 domain=domain,
             )
+        has_gateway_fee = HasGatewayFeeFilter.get_value(
+            self.request, self.domain
+        )
+        if has_gateway_fee:
+            if has_gateway_fee == HasGatewayFeeFilter.YES:
+                selected_billables = selected_billables.exclude(
+                    gateway_fee=None
+                )
+            else:
+                selected_billables = selected_billables.filter(
+                    gateway_fee=None
+                )
         return selected_billables
 
 

--- a/corehq/apps/smsbillables/interface.py
+++ b/corehq/apps/smsbillables/interface.py
@@ -86,10 +86,15 @@ class SMSBillablesInterface(GenericTabularReport):
                 },
                 {
                     'name': ShowBillablesFilter.slug,
-                    'value': ShowBillablesFilter.get_value(self.request, self.domain)},
+                    'value': ShowBillablesFilter.get_value(self.request, self.domain)
+                },
                 {
                     'name': DomainFilter.slug,
                     'value': DomainFilter.get_value(self.request, self.domain)
+                },
+                {
+                    'name': HasGatewayFeeFilter.slug,
+                    'value': HasGatewayFeeFilter.get_value(self.request, self.domain)
                 },
         ]
 


### PR DESCRIPTION
Speeds up workflows for checking for SMS that have missing gateway fees, so you don't have to ssh into prod to check.
