### PR TITLE
Copy to json manually

### DIFF
--- a/corehq/apps/userreports/tests/test_data_source_config.py
+++ b/corehq/apps/userreports/tests/test_data_source_config.py
@@ -4,7 +4,8 @@ import datetime
 from decimal import Decimal
 from django.test import SimpleTestCase, TestCase
 from jsonobject.exceptions import BadValueError
-from corehq.apps.userreports.models import DataSourceConfiguration
+from corehq.apps.userreports.models import DataSourceConfiguration, \
+    CustomDataSourceConfiguration
 
 
 class DataSourceConfigurationTest(SimpleTestCase):
@@ -64,20 +65,10 @@ class DataSourceConfigurationTest(SimpleTestCase):
                 # in the database layer. this should eventually be fixed.
                 self.assertEqual(str(expected_indicators[result.column.id]), result.value)
 
-    def test_jsonobject(self):
-        from couchdbkit.ext.django.schema import Document, DictProperty
-        import copy
-
-        class MyDocument(Document):
-            prop = DictProperty()
-
-        doc = MyDocument(prop={})
-        copy.deepcopy(doc)
-        copy.deepcopy(doc.prop)
-
-    def test_save_config(self):
-        config = CustomDataSourceConfiguration.all().next()
-        config.to_json()
+    def test_serializable_custom_configs(self):
+        for config in CustomDataSourceConfiguration.all():
+            # There are some serialization issues with custom configurations.
+            config.to_json()
 
 
 def get_sample_data_source():

--- a/corehq/apps/userreports/tests/test_data_source_config.py
+++ b/corehq/apps/userreports/tests/test_data_source_config.py
@@ -64,6 +64,21 @@ class DataSourceConfigurationTest(SimpleTestCase):
                 # in the database layer. this should eventually be fixed.
                 self.assertEqual(str(expected_indicators[result.column.id]), result.value)
 
+    def test_jsonobject(self):
+        from couchdbkit.ext.django.schema import Document, DictProperty
+        import copy
+
+        class MyDocument(Document):
+            prop = DictProperty()
+
+        doc = MyDocument(prop={})
+        copy.deepcopy(doc)
+        copy.deepcopy(doc.prop)
+
+    def test_save_config(self):
+        config = CustomDataSourceConfiguration.all().next()
+        config.to_json()
+
 
 def get_sample_data_source():
     folder = os.path.join(os.path.dirname(__file__), 'data', 'configs')

--- a/custom/succeed/data_sources/submissions.json
+++ b/custom/succeed/data_sources/submissions.json
@@ -4,7 +4,7 @@
         "referenced_doc_type": "XFormInstance",
         "table_id": "succeed_submissions",
         "display_name": "Patient Submissions",
-         "configured_filter": {
+        "configured_filter": {
             "type": "not",
             "filter": {
                 "type": "boolean_expression",


### PR DESCRIPTION
wait on build
http://manage.dimagi.com/default.asp?162940
@NoahCarnahan @czue @dannyroberts 
It errors on these [two lines](https://github.com/dimagi/commcare-hq/blob/88f70e8c3d813403ab33955331c62e08946a09df/corehq/apps/userreports/tasks.py#L23-L24)

The error we were originally getting was because the corresponding config wasn't found, but I think that was a transient issue.  When I try to run the task manually, I get a `TypeError: cannot deepcopy this pattern object` on a save attempt.  This appears to be a [standing issue](https://github.com/dimagi/jsonobject/issues/115) with jsonobject, as Danny pointed out.  Until a fix for that gets rolled out, this does at least make the config save properly, which lets the task run.
