### PR TITLE
add ability to perform timing on deploys

### DIFF
--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -10,6 +10,7 @@ base:
   home: "/home/cchq"
   project: commcare-hq
   code_repo: 'git://github.com/dimagi/commcare-hq.git'
+  timing_log: None  # make a file path to log deploy timing to it. e.g. '../fabric-timing.txt'
 
   # celery queues all disabled by default
   sms_queue_enabled: False


### PR DESCRIPTION
@dannyroberts what do you think about this? 

output from a staging deploy (during github DoS so `update_code` might be inflated):

```
preindex_views: 32
update_code: 160
update_virtualenv: 14
version_static: 25
_do_collectstatic: 51
_do_compress: 68
update_manifest: 11
clear_services_dir: 8
set_celery_supervisorconf: 30
set_djangoapp_supervisorconf: 14
set_formsplayer_supervisorconf: 6
set_pillowtop_supervisorconf: 5
set_sms_queue_supervisorconf: 0
set_reminder_queue_supervisorconf: 0
set_pillow_retry_queue_supervisorconf: 5
stop_pillows: 19
stop_celery_tasks: 73
_migrate: 60
do_update_django_locales: 8
flip_es_aliases: 5
update_manifest: 7
services_restart: 15
record_successful_deploy: 14
```
