### PR TITLE
sleep longer after reloading supervisor

### DIFF
--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -868,7 +868,7 @@ def services_restart():
 
     _supervisor_command('update')
     _supervisor_command('reload')
-    time.sleep(1)
+    time.sleep(5)
     _supervisor_command('start  all')
 
 


### PR DESCRIPTION
hoping this reduces the frequency of `error: <class 'xmlrpclib.Fault'>, <Fault 6: 'SHUTDOWN_STATE'>: file: /usr/lib/python2.7/xmlrpclib.py line: 793` errors
