### PR TITLE
fix exception check to check the right property

### DIFF
--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -65,8 +65,8 @@ class ReportColumn(JsonObject):
         return None
 
     def get_sql_column(self):
-        if self.type == "expand":
-            raise RuntimeError("Don't use this method if self.type is 'expand'")
+        if self.aggregation == "expand":
+            raise RuntimeError("Don't use this method if the aggregation is 'expand'")
         return DatabaseColumn(
             self.display,
             SQLAGG_COLUMN_MAP[self.aggregation](self.field, alias=self.alias),


### PR DESCRIPTION
as per tests, e.g. https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/userreports/tests/test_columns.py#L172 `type` is still set to `"field"` but `aggregation` is set to `"expand"`
