### PR TITLE
fix case data page timezone

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/models.py
+++ b/corehq/ex-submodules/casexml/apps/case/models.py
@@ -17,7 +17,6 @@ from couchdbkit.exceptions import ResourceNotFound, ResourceConflict
 from PIL import Image
 from casexml.apps.case.exceptions import MissingServerDate, ReconciliationError
 from corehq.util.couch_helpers import CouchAttachmentsBuilder
-from corehq.util.timezones.conversions import TIMEZONE_DATA_MIGRATION_COMPLETE
 from couchforms.util import is_deprecation, is_override
 from dimagi.utils.chunked import chunked
 from dimagi.utils.django.cached_object import CachedObject, OBJECT_ORIGINAL, OBJECT_SIZE_MAP, CachedImage, IMAGE_SIZE_ORDERING
@@ -903,19 +902,19 @@ class CommCareCase(SafeSaveDocument, IndexHoldingMixIn, ComputedDocumentMixin,
                             "expr": "opened_on",
                             "name": _("Opened On"),
                             "parse_date": True,
-                            "is_utc": TIMEZONE_DATA_MIGRATION_COMPLETE,
+                            'is_phone_time': True,
                         },
                         {
                             "expr": "modified_on",
                             "name": _("Modified On"),
                             "parse_date": True,
-                            "is_utc": TIMEZONE_DATA_MIGRATION_COMPLETE,
+                            "is_phone_time": True,
                         },
                         {
                             "expr": "closed_on",
                             "name": _("Closed On"),
                             "parse_date": True,
-                            "is_utc": TIMEZONE_DATA_MIGRATION_COMPLETE,
+                            "is_phone_time": True,
                         },
                     ],
                     [
@@ -954,13 +953,13 @@ class CommCareCase(SafeSaveDocument, IndexHoldingMixIn, ComputedDocumentMixin,
                 'name': _('Date Opened'),
                 'expr': "opened_on",
                 'parse_date': True,
-                "is_utc": TIMEZONE_DATA_MIGRATION_COMPLETE,
+                "is_phone_time": True,
             },
             {
                 'name': _('Date Modified'),
                 'expr': "modified_on",
                 'parse_date': True,
-                "is_utc": TIMEZONE_DATA_MIGRATION_COMPLETE,
+                "is_phone_time": True,
             }
         ]
 


### PR DESCRIPTION
- refactor _to_html and how it's called from get_display_data
- replace is_utc with is_phone_time in case details spec
  - TIMEZONE_DATA_MIGRATION_COMPLETE constant is now entirely contained
    in the timezones util
- fix timezone processing within get_display_data
