### PR TITLE
make safe_strftime treat %y correctly

### DIFF
--- a/corehq/const.py
+++ b/corehq/const.py
@@ -1,5 +1,3 @@
-from django.utils.translation import ugettext_lazy
-
-USER_DATETIME_FORMAT = ugettext_lazy("%b %d, %Y %H:%M %Z")
-USER_DATE_FORMAT = ugettext_lazy("%b %d, %Y")
-USER_TIME_FORMAT = ugettext_lazy("%H:%M %Z")
+USER_DATETIME_FORMAT = "%b %d, %Y %H:%M %Z"
+USER_DATE_FORMAT = "%b %d, %Y"
+USER_TIME_FORMAT = "%H:%M %Z"

--- a/corehq/util/dates.py
+++ b/corehq/util/dates.py
@@ -49,4 +49,6 @@ def safe_strftime(val, fmt):
             microsecond=val.microsecond, tzinfo=val.tzinfo)
     else:
         safe_val = datetime.date(a_leap_year, val.month, val.day)
-    return safe_val.strftime(fmt.replace("%Y", str(val.year)))
+    return safe_val.strftime(fmt
+                             .replace("%Y", str(val.year))
+                             .replace("%y", str(val.year)[-2:]))

--- a/corehq/util/tests/test_timezone_conversions.py
+++ b/corehq/util/tests/test_timezone_conversions.py
@@ -1,8 +1,29 @@
+import datetime
 import dateutil.parser
 from django.test import SimpleTestCase
 import pytz
+from corehq.const import USER_DATETIME_FORMAT
+from corehq.util.dates import safe_strftime
 from corehq.util.timezones.conversions import ServerTime, \
     TIMEZONE_DATA_MIGRATION_COMPLETE, PhoneTime, UserTime
+
+
+class UIStringTest(SimpleTestCase):
+    def test_ui_string(self):
+        now = datetime.datetime.utcnow()
+        user_time = ServerTime(now).user_time(pytz.FixedOffset(-4 * 60))
+        self.assertEqual(user_time.ui_string(),
+                         user_time.done().strftime(USER_DATETIME_FORMAT))
+
+    def test_safe_strftime(self):
+        dt = datetime.datetime(2015, 1, 1, 12, 24, 48)
+        self.assertEqual(safe_strftime(dt, '%Y-%m-%dT%H:%M:%SZ'),
+                         '2015-01-01T12:24:48Z')
+
+    def test_safe_strftime_abbr_year(self):
+        dt = datetime.datetime(2015, 1, 1, 12, 24, 48)
+        self.assertEqual(safe_strftime(dt, '%y-%m-%dT%H:%M:%SZ'),
+                         '15-01-01T12:24:48Z')
 
 
 class TimezoneConversionTest(SimpleTestCase):


### PR DESCRIPTION
add tests that fail before code change

```
Running 3 tests without database
.F.
======================================================================
FAIL: test_safe_strftime_abbr_year (corehq.util.tests.test_timezone_conversions.UIStringTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/droberts/dimagi/commcare-hq/corehq/util/tests/test_timezone_conversions.py", line 26, in test_safe_strftime_abbr_year
    15-01-01T12:24:48Z)
AssertionError: 12-01-01T12:24:48Z != 15-01-01T12:24:48Z

----------------------------------------------------------------------
Ran 3 tests in 0.001s

FAILED (failures=1)
```
