### PR TITLE
go back to accepting ~anything as a date

### DIFF
--- a/corehq/apps/reports/standard/cases/data_sources.py
+++ b/corehq/apps/reports/standard/cases/data_sources.py
@@ -1,4 +1,6 @@
 from couchdbkit import ResourceNotFound
+import datetime
+import dateutil
 from dimagi.utils.parsing import string_to_utc_datetime
 from django.core import cache
 from django.core.urlresolvers import reverse, NoReverseMatch
@@ -176,7 +178,17 @@ class CaseInfo(object):
         return username
 
     def parse_date(self, date_string):
-        return string_to_utc_datetime(date_string)
+        try:
+            return string_to_utc_datetime(date_string)
+        except:
+            try:
+                date_obj = dateutil.parser.parse(date_string)
+                if isinstance(date_obj, datetime.datetime):
+                    return date_obj.replace(tzinfo=None)
+                else:
+                    return date_obj
+            except:
+                return date_string
 
 
 class CaseDisplay(CaseInfo):


### PR DESCRIPTION
but to continue working the datetime returned has to be timezone naive

I guess what I'm learning today is that it's really hard to recover from a function that used to accept anything. I'm going to try and devise a reasonable way to do this in the future that doesn't involve lots of 500 or spamming
