### PR TITLE
Add soft_assert utility

### DIFF
--- a/corehq/util/soft_assert/__init__.py
+++ b/corehq/util/soft_assert/__init__.py
@@ -1,0 +1,1 @@
+from .api import soft_assert

--- a/corehq/util/soft_assert/api.py
+++ b/corehq/util/soft_assert/api.py
@@ -34,20 +34,30 @@ def soft_assert(to, notify_admins=False,
     send an email with stack trace if assertion is not True
 
     Parameters:
-    - msg: A message to include in the email body
-    - recipient_list: List of email addresses that should receive the email
+    - to: List of email addresses that should receive the email
     - notify_admins: Send to all admins (using mail_admins) as well
-    - fail_hard_if_debug: if True, will fail hard (like a normal assert)
+    - fail_if_debug: if True, will fail hard (like a normal assert)
       if called in a developer environment (settings.DEBUG = True).
       If False, behavior will not depend on DEBUG setting.
     - exponential_backoff: if True, will only email every time an assert has
       failed 2**n times (1, 2, 4, 8, 16 times, etc.). If False, it will email
       every time.
+    - skip_frames: number of frames of the traceback (from the bottom)
+      to ignore. Useful if you're calling this from within a helper function.
+      In that case if you want the call _to_ the helper function to be the
+      last frame in the stack trace, then pass in skip_frames=1.
+      This affects both the traceback in the email as the "key" by which
+      errors are grouped.
+
+    For the purposes of grouping errors into email threads,
+    counting occurrences (sent in the email), and implementing exponential
+    backoff, errors are always grouped by a key that varies on the
+    last two frames (that aren't skipped by skip_frames) of the stack.
 
     Returns assertion. This makes it easy to do something like the following:
 
-        if not soft_assert(isinstance(n, float),
-                           recipient_list=['me@mycompany.com']):
+        if not soft_assert(to=['me@mycompany.com']).call(
+                isinstance(n, float), 'myfunction should be passed a float'):
             n = float(n)
 
     etc.

--- a/corehq/util/soft_assert/api.py
+++ b/corehq/util/soft_assert/api.py
@@ -66,7 +66,9 @@ def soft_assert(to, notify_admins=False,
 
     def send_to_recipients(subject, message):
         send_mail(
-            subject=subject,
+            # this prefix is automatically added in mail_admins
+            # but not send mail
+            subject=settings.EMAIL_SUBJECT_PREFIX + subject,
             message=message,
             from_email=settings.DEFAULT_FROM_EMAIL,
             recipient_list=to,

--- a/corehq/util/soft_assert/api.py
+++ b/corehq/util/soft_assert/api.py
@@ -21,15 +21,15 @@ def _django_caching_counter(key):
 
 def _send_message(info, backend):
     backend(
-        subject='Soft Assert: [{}] {}'.format(info.key[:8], info.line),
+        subject='Soft Assert: [{}] {}'.format(info.key[:8], info.msg),
         message=('Message: {info.msg}\n'
                  'Traceback:\n{info.traceback}\n'
                  'Occurrences to date: {info.count}\n').format(info=info)
     )
 
 
-def soft_assert(assertion, msg=None, to=None, notify_admins=False,
-                fail_if_debug=False, exponential_backoff=True):
+def soft_assert(to, notify_admins=False,
+                fail_if_debug=False, exponential_backoff=True, skip_frames=0):
     """
     send an email with stack trace if assertion is not True
 
@@ -91,5 +91,5 @@ def soft_assert(assertion, msg=None, to=None, notify_admins=False,
         send=send,
         incrementing_counter=_django_caching_counter,
         should_send=should_send,
-        tb_skip=3,
-    )(assertion, msg)
+        skip_frames=skip_frames,
+    )

--- a/corehq/util/soft_assert/api.py
+++ b/corehq/util/soft_assert/api.py
@@ -1,0 +1,95 @@
+from django.core.mail import mail_admins, send_mail
+from django.core.cache import cache
+from corehq.util.soft_assert.core import SoftAssert
+import settings
+
+
+def _number_is_power_of_two(x):
+    # it turns out that x & (x - 1) == 0 if and only if x is a power of two
+    # http://stackoverflow.com/a/600306/240553
+    return x > 0 and (x & (x - 1) == 0)
+
+
+def _django_caching_counter(key):
+    cache_key = 'django-soft-assert.{}'.format(key)
+    try:
+        return cache.incr(cache_key)
+    except ValueError:
+        cache.set(cache_key, 1)
+        return 1
+
+
+def _send_message(info, backend):
+    backend(
+        subject='Soft Assert: [{}] {}'.format(info.key[:8], info.line),
+        message=('Message: {info.msg}\n'
+                 'Traceback:\n{info.traceback}\n'
+                 'Occurrences to date: {info.count}\n').format(info=info)
+    )
+
+
+def soft_assert(assertion, msg=None, to=None, notify_admins=False,
+                fail_if_debug=False, exponential_backoff=True):
+    """
+    send an email with stack trace if assertion is not True
+
+    Parameters:
+    - msg: A message to include in the email body
+    - recipient_list: List of email addresses that should receive the email
+    - notify_admins: Send to all admins (using mail_admins) as well
+    - fail_hard_if_debug: if True, will fail hard (like a normal assert)
+      if called in a developer environment (settings.DEBUG = True).
+      If False, behavior will not depend on DEBUG setting.
+    - exponential_backoff: if True, will only email every time an assert has
+      failed 2**n times (1, 2, 4, 8, 16 times, etc.). If False, it will email
+      every time.
+
+    Returns assertion. This makes it easy to do something like the following:
+
+        if not soft_assert(isinstance(n, float),
+                           recipient_list=['me@mycompany.com']):
+            n = float(n)
+
+    etc.
+
+    """
+
+    def send_to_recipients(subject, message):
+        send_mail(
+            subject=subject,
+            message=message,
+            from_email=settings.DEFAULT_FROM_EMAIL,
+            recipient_list=to,
+        )
+
+    if to and notify_admins:
+        def send(info):
+            _send_message(info, backend=mail_admins)
+            _send_message(info, backend=send_to_recipients)
+    elif to:
+        def send(info):
+            _send_message(info, backend=send_to_recipients)
+    elif notify_admins:
+        def send(info):
+            _send_message(info, backend=mail_admins)
+    else:
+        raise ValueError('You must call soft assert with either a '
+                         'list of recipients or notify_admins=True')
+
+    if fail_if_debug:
+        debug = settings.DEBUG
+    else:
+        debug = False
+
+    if exponential_backoff:
+        should_send = _number_is_power_of_two
+    else:
+        should_send = lambda count: True
+
+    return SoftAssert(
+        debug=debug,
+        send=send,
+        incrementing_counter=_django_caching_counter,
+        should_send=should_send,
+        tb_skip=3,
+    )(assertion, msg)

--- a/corehq/util/soft_assert/core.py
+++ b/corehq/util/soft_assert/core.py
@@ -1,0 +1,52 @@
+from collections import namedtuple
+import hashlib
+import traceback
+
+
+SoftAssertInfo = namedtuple('SoftAssertInfo',
+                            ['traceback', 'count', 'msg', 'key', 'line',
+                             'short_traceback'])
+
+
+class SoftAssert(object):
+    def __init__(self, debug=False, send=None, incrementing_counter=None,
+                 should_send=None, tb_skip=2, key_limit=2):
+        assert send
+        assert incrementing_counter
+        assert should_send
+        self.debug = debug
+        self.send = send
+        self.incrementing_counter = incrementing_counter
+        self.should_send = should_send
+        self.tb_skip = tb_skip
+        self.key_limit = key_limit
+
+    def __call__(self, assertion, msg=None):
+        if not assertion:
+            if self.debug:
+                raise AssertionError(msg)
+            short_tb = get_traceback(skip=self.tb_skip, limit=self.key_limit)
+            full_tb = get_traceback(skip=self.tb_skip)
+            line = short_tb.strip().split('\n')[-1].strip()
+            tb_id = hashlib.md5(short_tb).hexdigest()
+            count = self.incrementing_counter(tb_id)
+            if self.should_send(count):
+                self.send(SoftAssertInfo(traceback=full_tb,
+                                         short_traceback=short_tb,
+                                         count=count,
+                                         msg=msg,
+                                         key=tb_id, line=line))
+        return assertion
+
+
+def get_traceback(skip=0, limit=None):
+    if limit:
+        total_limit = skip + limit
+    else:
+        total_limit = None
+    stack = traceback.extract_stack(limit=total_limit)
+    if skip:
+        stack = stack[:-skip]
+    if limit:
+        stack = stack[-limit:]
+    return ''.join(traceback.format_list(stack))

--- a/corehq/util/soft_assert/core.py
+++ b/corehq/util/soft_assert/core.py
@@ -10,7 +10,7 @@ SoftAssertInfo = namedtuple('SoftAssertInfo',
 
 class SoftAssert(object):
     def __init__(self, debug=False, send=None, incrementing_counter=None,
-                 should_send=None, tb_skip=2, key_limit=2):
+                 should_send=None, skip_frames=0, key_limit=2):
         assert send
         assert incrementing_counter
         assert should_send
@@ -18,10 +18,15 @@ class SoftAssert(object):
         self.send = send
         self.incrementing_counter = incrementing_counter
         self.should_send = should_send
-        self.tb_skip = tb_skip
+        self.tb_skip = skip_frames + 3
         self.key_limit = key_limit
 
     def __call__(self, assertion, msg=None):
+        return self._call(assertion, msg)
+
+    call = __call__
+
+    def _call(self, assertion, msg=None):
         if not assertion:
             if self.debug:
                 raise AssertionError(msg)

--- a/corehq/util/tests/__init__.py
+++ b/corehq/util/tests/__init__.py
@@ -2,3 +2,4 @@ from test_couch import *
 from test_toggle import *
 from test_quickcache import *
 from test_timezone_conversions import *
+from test_soft_assert import *

--- a/corehq/util/tests/test_soft_assert.py
+++ b/corehq/util/tests/test_soft_assert.py
@@ -1,0 +1,128 @@
+from collections import defaultdict
+import math
+from django.test import SimpleTestCase
+from corehq.util.soft_assert.core import SoftAssert
+from corehq.util.soft_assert.api import _number_is_power_of_two, _send_message
+
+
+class SoftAssertTest(SimpleTestCase):
+
+    def setUp(self):
+        self.infos = []
+        self.counter = defaultdict(int)
+        self.soft_assert = SoftAssert(
+            send=self.send,
+            incrementing_counter=self.incrementing_counter,
+            should_send=self.should_send,
+        )
+
+    def send(self, info):
+        self.infos.append(info)
+
+    def should_send(self, count):
+        return True
+
+    def incrementing_counter(self, key):
+        self.counter[key] += 1
+        return self.counter[key]
+
+    def hypotenuse(self, a, b):
+        return self.square_root(self.squared(a) + self.squared(b))
+
+    def square_root(self, x):
+        if not self.soft_assert(isinstance(x, float)):
+            x = float(x)
+        return math.sqrt(x)
+
+    def squared(self, x):
+        if not self.soft_assert(isinstance(x, float)):
+            x = float(x)
+        return x * x
+
+    def test_soft_assert(self):
+        self.assertEqual(self.hypotenuse('3.0', 4), 5.0)
+        self.assertEqual(len(self.infos), 2)
+        key0 = self.infos[0].key
+        key1 = self.infos[1].key
+        self.assertEqual(self.hypotenuse('3.0', 4), 5.0)
+        self.assertEqual(len(self.infos), 4)
+        self.assertEqual(self.infos[2].key, key0, '\n{}\n{}'.format(
+            self.infos[0].traceback,
+            self.infos[2].traceback,
+        ))
+        self.assertEqual(self.infos[3].key, key1, '\n{}\n{}'.format(
+            self.infos[1].traceback,
+            self.infos[3].traceback,
+        ))
+        self.assertEqual(self.infos[0].line,
+                         'if not self.soft_assert(isinstance(x, float)):')
+        self.assertEqual(self.infos[1].line,
+                         'if not self.soft_assert(isinstance(x, float)):')
+        self.assertEqual(self.infos[2].line,
+                         'if not self.soft_assert(isinstance(x, float)):')
+        self.assertEqual(self.infos[3].line,
+                         'if not self.soft_assert(isinstance(x, float)):')
+
+
+class SoftAssertHelpersTest(SimpleTestCase):
+    def test_number_is_power_of_two(self):
+        powers_of_two = [2**i for i in range(10)]
+        for n in range(100):
+            actual = _number_is_power_of_two(n)
+            expected = n in powers_of_two
+            self.assertEqual(actual, expected,
+                             '_number_is_power_of_two: {}'.format(actual))
+
+    def test_send_message(self):
+
+        def test1(subject, message):
+            self.assertRegexpMatches(subject,
+                                     r"Soft Assert: \[\w+\] self.soft_assert\(False, 'This should fail'\)")
+            things_that_should_show_up_in_message = [
+                r"Message: This should fail",
+                r"Traceback:",
+                r'File ".*corehq/util/tests/test_soft_assert.py", line \d+, in test_send_message',
+                r"self\.soft_assert\(False, 'This should fail'\)",
+                r"Occurrences to date: 1",
+            ]
+            for thing in things_that_should_show_up_in_message:
+                self.assertRegexpMatches(
+                    message,
+                    thing,
+                    '{!r}\ndoes not match\n---\n{}---\n'.format(thing, message)
+                )
+
+        def test2(subject, message):
+            self.assertRegexpMatches(
+                subject,
+                r'Soft Assert: \[\w+\] self.soft_assert\(False\)',
+            )
+            things_that_should_show_up_in_message = [
+                r"Message: None",
+                r"Traceback:",
+                r'File ".*corehq/util/tests/test_soft_assert.py", line \d+, in test_send_message',
+                r"self\.soft_assert\(False\)",
+                r"Occurrences to date: 1",
+            ]
+            for thing in things_that_should_show_up_in_message:
+                self.assertRegexpMatches(
+                    message,
+                    thing,
+                    '{!r}\ndoes not match\n---\n{}---\n'.format(thing, message)
+                )
+
+        tests = iter([test1, test2])
+
+        def backend(subject, message):
+            test_ = tests.next()
+            test_(subject, message)
+
+        self.soft_assert = SoftAssert(
+            send=lambda info: _send_message(info, backend=backend),
+            incrementing_counter=lambda key: 1,
+            should_send=lambda count: True,
+        )
+        # sent to test1
+        self.soft_assert(False, 'This should fail')
+        # sent to test2
+        self.soft_assert(False)

--- a/corehq/util/tests/test_soft_assert.py
+++ b/corehq/util/tests/test_soft_assert.py
@@ -77,7 +77,7 @@ class SoftAssertHelpersTest(SimpleTestCase):
 
         def test1(subject, message):
             self.assertRegexpMatches(subject,
-                                     r"Soft Assert: \[\w+\] self.soft_assert\(False, 'This should fail'\)")
+                                     r"Soft Assert: \[\w+\] This should fail")
             things_that_should_show_up_in_message = [
                 r"Message: This should fail",
                 r"Traceback:",
@@ -95,7 +95,7 @@ class SoftAssertHelpersTest(SimpleTestCase):
         def test2(subject, message):
             self.assertRegexpMatches(
                 subject,
-                r'Soft Assert: \[\w+\] self.soft_assert\(False\)',
+                r'Soft Assert: \[\w+\] None',
             )
             things_that_should_show_up_in_message = [
                 r"Message: None",

--- a/corehq/util/timezones/conversions.py
+++ b/corehq/util/timezones/conversions.py
@@ -73,9 +73,10 @@ class PhoneTime(_HQTZTime):
 
 
 def _soft_assert_tz_not_string(tz):
-    if not soft_assert(hasattr(tz, "localize"),
-                       to=['droberts@dimagi.com'],
-                       msg='Timezone should be a tzinfo object, not a string'):
+    _assert = soft_assert(to=['droberts@dimagi.com'], skip_frames=1)
+
+    if not _assert(hasattr(tz, "localize"),
+                   'Timezone should be a tzinfo object, not a string'):
         # tz is a string, or at least string-like
         return pytz.timezone(smart_str(tz))
     else:


### PR DESCRIPTION
And use it to (soft) assert timezones are not strings.

The use case for soft assert is when you think something shouldn't be happening and you want to see where in production, if at all, it's happening. When you add a `soft_assert` to your code, you pass in your own email as a parameter, and every time your assumption is violated, you'll get an email with the traceback, and the number of times it's happened so far, with an exponential back-off so you only get emailed the 1st, 2nd, 4th, 8th, 16th, etc. time that the same error happens. Two errors are considered the same if the last two frames of the stack output (the one where you called soft_assert and then previous one) are identical. This means that if two functions call the same function, and that function uses `soft_assert` there will be one "thread" for each of those two functions. This helps you see all of the separate places from which your function is called "incorrectly".

Looks something like this in your inbox. (Except that now there's going to be "[production] " (or whatever) prefixed to the subject.)

![screen shot 2015-03-31 at 4 40 16 pm](https://cloud.githubusercontent.com/assets/137212/6928842/cde389d8-d7c4-11e4-8894-805cbe956f4e.png)
