### PR TITLE
Set COMPRESS_CSS_HASHING_METHOD to content rather than default to mtime

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -1375,3 +1375,5 @@ COMPRESS_OFFLINE_CONTEXT = {
     'less_debug': LESS_DEBUG,
     'less_watch': LESS_WATCH,
 }
+
+COMPRESS_CSS_HASHING_METHOD = 'content'


### PR DESCRIPTION
We think this is causing static files to have different hashes appended to the urls on different proxy machines and should change those hashes to be calculated based on file content rather than modified time.  The None method described in the documentation below is in the development branch, not on any tag yet.

@biyeun 

http://django-compressor.readthedocs.org/en/latest/settings/#django.conf.settings.COMPRESS_CSS_HASHING_METHOD
