### PR TITLE
Fixture domain endpoint

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/form_designer.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_designer.html
@@ -19,6 +19,13 @@
             plugins: {{ plugins|JSON }},
             features: {{ features|JSON }},
             core: {
+                dataSources: [
+                    {
+                        key: 'fixture',
+                        name: 'Fixtures',
+                        endpoint: '{% url 'fixture_metadata' domain=domain %}'
+                    }
+                ],
                 form: {{ form.source|to_javascript_string }},
                 formId: '{{ form.get_unique_id }}',
                 formName: "{{ form.name|trans:app.langs|escapejs }}",

--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -6,6 +6,22 @@ from corehq.apps.users.models import CommCareUser
 from dimagi.utils.modules import to_function
 
 
+def item_lists_by_domain(domain):
+    ret = list()
+    for data_type in FixtureDataType.by_domain(domain):
+        ret.append({
+            'sourceUri': 'jr://fixture/item-list:%s' % data_type.tag,
+            'defaultId': data_type.tag,
+            'initialQuery': "instance('{tag}')/item-list:{tag}/{tag}".format(tag=data_type.tag),
+            'name': data_type.tag,
+            'structure': {
+                f.field_name: {
+                    'name': f.field_name,
+                    'no_option': True
+                } for f in data_type.fields},
+        })
+    return ret
+
 def item_lists(user, version, last_sync=None):
     assert isinstance(user, CommCareUser)
 

--- a/corehq/apps/fixtures/urls.py
+++ b/corehq/apps/fixtures/urls.py
@@ -6,6 +6,7 @@ from django.views.generic import RedirectView
 
 urlpatterns = patterns('corehq.apps.fixtures.views',
     url(r'^fixapi/', 'upload_fixture_api'),
+    url(r'^metadata/$', 'fixture_metadata', name='fixture_metadata'),
     url(r'^$', RedirectView.as_view(url='edit_lookup_tables')), FixtureInterfaceDispatcher.url_pattern(),
     url(r'^edit_lookup_tables/data-types/$', 'tables', name='fixture_data_types'),
     url(r'^edit_lookup_tables/download/$', 'download_item_lists', name="download_fixtures"),

--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -430,4 +430,4 @@ def fixture_metadata(request, domain):
     """
     Returns list of fixtures and metadata needed for itemsets in vellum
     """
-    return HttpResponse(json.dumps(item_lists_by_domain(domain)))
+    return json_response(item_lists_by_domain(domain))

--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -12,7 +12,7 @@ from django.utils.translation import ugettext as _, ugettext_noop
 from django.views.decorators.http import require_POST
 from django.views.generic.base import TemplateView
 
-from corehq.apps.domain.decorators import login_or_digest
+from corehq.apps.domain.decorators import login_or_digest, login_and_domain_required
 from corehq.apps.domain.views import BaseDomainView
 from corehq.apps.fixtures.tasks import fixture_upload_async, fixture_download_async
 from corehq.apps.fixtures.dispatcher import require_can_edit_fixtures
@@ -26,6 +26,7 @@ from corehq.apps.fixtures.exceptions import (
 )
 from corehq.apps.fixtures.models import FixtureDataType, FixtureDataItem, FieldList, FixtureTypeField
 from corehq.apps.fixtures.upload import run_upload, validate_file_format, get_workbook
+from corehq.apps.fixtures.fixturegenerators import item_lists_by_domain
 from corehq.apps.reports.datatables import DataTablesHeader, DataTablesColumn
 from corehq.apps.reports.util import format_datatables_data
 from corehq.apps.users.models import Permissions
@@ -422,3 +423,11 @@ def upload_fixture_api(request, domain, **kwargs):
         resp_json["message"] += "%s%s%s" % (("and following " if num_unknown_groups else ""), warn_users, upload_resp.unknown_users)
 
     return HttpResponse(json.dumps(resp_json), mimetype="application/json")
+
+
+@login_and_domain_required
+def fixture_metadata(request, domain):
+    """
+    Returns list of fixtures and metadata needed for itemsets in vellum
+    """
+    return HttpResponse(json.dumps(item_lists_by_domain(domain)))


### PR DESCRIPTION
@millerdev 

HQ endpoint for fixtures for itemsets.

The form I decided on was:

``` js
[
  {
    sourceUri: "jr://fixture/item-list:fixture1",
    defaultId: "fixture1",
    initialQuery: "instance('fixture1')/item-list:fixture1/fixture1",
    name: "fixture1",
    structure: {
      prop1: {
        name: "prop1",
        no_option: true,
        structure: {
           innerprop1: {}
        }
      },
      prop2: {}
    }
  }
]
```

no_option indicates to not have that show up in the dropdown
name gives a prettified name for the dropdown.
