### PR TITLE
figure out what's inside the ES results of failing query on india

### DIFF
--- a/corehq/apps/hqadmin/escheck.py
+++ b/corehq/apps/hqadmin/escheck.py
@@ -233,6 +233,7 @@ def _check_es_rev(index, doc_id, couch_revs):
         else:
             status = False
             message = "Not in sync - query failed"
+            logging.error("%s: %s" % message, str(res))
     except Exception, ex:
         message = "ES Error: %s" % ex
         status = False


### PR DESCRIPTION
A hacky way of seeing what's inside of the results to the ES query that's failing.  It works fine in the shell on the india server, so I want to know what's being returned in real time.

@czue 
