### PR TITLE
Ownership cleanliness

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/util.py
@@ -53,7 +53,7 @@ def reprocess_form_cases(form, config=None, case_db=None):
     from casexml.apps.case.xform import process_cases, process_cases_with_casedb
 
     if case_db:
-        process_cases_with_casedb(form, case_db, config=config)
+        process_cases_with_casedb([form], case_db, config=config)
     else:
         process_cases(form, config)
     # mark cleaned up now that we've reprocessed it

--- a/corehq/ex-submodules/casexml/apps/case/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/util.py
@@ -117,6 +117,21 @@ def reverse_indices(db, case, wrap=True):
     ).all()
 
 
+def get_reverse_indexed_cases(cases):
+    """
+    Given a base list of cases, gets all wrapped cases that directly
+    reference them (child cases).
+    """
+    from casexml.apps.case.models import CommCareCase
+    keys = [[c['domain'], c['_id'], 'reverse_index'] for c in cases]
+    return CommCareCase.view(
+        'case/related',
+        keys=keys,
+        reduce=False,
+        include_docs=True,
+    )
+
+
 def primary_actions(case):
     return filter(lambda a: a.action_type != const.CASE_ACTION_REBUILD,
                   case.actions)

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -78,7 +78,7 @@ def process_cases(xform, config=None):
 
 def process_cases_with_casedb(xforms, case_db, config=None):
     config = config or CaseProcessingConfig()
-    case_processing_result = _get_or_update_cases(xforms, case_db).values()
+    case_processing_result = _get_or_update_cases(xforms, case_db)
     cases = case_processing_result.cases
     xform = xforms[0]
 

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -331,6 +331,7 @@ def _get_or_update_cases(xforms, case_db):
     touched_cases = copy.copy(case_db.cache)
 
     # once we've gotten through everything, validate all indices
+    # and check for new dirtiness flags
     def _validate_indices(case):
         dirtiness_flags = []
         if case.indices:

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -1,5 +1,6 @@
 import copy
 import logging
+import warnings
 
 from couchdbkit import ResourceNotFound
 import datetime
@@ -44,6 +45,7 @@ class CaseProcessingResult(object):
     def set_cases(self, cases):
         self.cases = cases
 
+
 def process_cases(xform, config=None):
     """
     Creates or updates case objects which live outside of the form.
@@ -51,6 +53,10 @@ def process_cases(xform, config=None):
     If reconcile is true it will perform an additional step of
     reconciling the case update history after the case is processed.
     """
+    warnings.warn(
+        'This function is deprecated. You should be using SubmissionPost.',
+        DeprecationWarning,
+    )
 
     assert getattr(settings, 'UNIT_TESTING', False)
     domain = get_and_check_xform_domain(xform)

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -47,12 +47,7 @@ def process_cases(xform, config=None):
     return cases
 
 
-def process_cases_with_casedb(xform, case_db, config=None):
-    # this is a convenience/legacy API. all the work happens in bulk now
-    return process_cases_with_casedb_bulk([xform], case_db, config)
-
-
-def process_cases_with_casedb_bulk(xforms, case_db, config=None):
+def process_cases_with_casedb(xforms, case_db, config=None):
     config = config or CaseProcessingConfig()
     cases = _get_or_update_cases(xforms, case_db).values()
     xform = xforms[0]

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -334,6 +334,7 @@ def _get_or_update_cases(xforms, case_db):
     # and check for new dirtiness flags
     def _validate_indices(case):
         dirtiness_flags = []
+        is_dirty = False
         if case.indices:
             for index in case.indices:
                 # call get and not doc_exists to force domain checking
@@ -348,7 +349,9 @@ def _get_or_update_cases(xforms, case_db):
                     )
                 else:
                     if referenced_case.owner_id != case.owner_id:
-                        dirtiness_flags.append(DirtinessFlag(index.referenced_id, case.owner_id))
+                        is_dirty = True
+        if is_dirty:
+            dirtiness_flags.append(DirtinessFlag(case._id, case.owner_id))
         return dirtiness_flags
 
     dirtiness_flags = [flag for case in case_db.cache.values() for flag in _validate_indices(case)]

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 import copy
 import logging
 import warnings
@@ -26,13 +27,8 @@ from casexml.apps.case.xml.parser import case_update_from_block
 from dimagi.utils.logging import notify_exception
 
 
-class DirtinessFlag(object):
-    """
-    Lightweight class used to store the dirtyness of a case/owner pair.
-    """
-    def __init__(self, case_id, owner_id):
-        self.case_id = case_id
-        self.owner_id = owner_id
+# Lightweight class used to store the dirtyness of a case/owner pair.
+DirtinessFlag = namedtuple('DirtinessFlag', ['case_id', 'owner_id'])
 
 
 class CaseProcessingResult(object):

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -365,8 +365,8 @@ class OwnershipCleanliness(models.Model):
 
     We use this field to optimize restores.
     """
-    owner_id = models.CharField(max_length=100, db_index=True, primary_key=True)
     domain = models.CharField(max_length=100, db_index=True)
+    owner_id = models.CharField(max_length=100, db_index=True, primary_key=True)
     is_clean = models.BooleanField(default=False)
     last_checked = models.DateTimeField()
     hint = models.CharField(max_length=100, null=True, blank=True)
@@ -375,3 +375,7 @@ class OwnershipCleanliness(models.Model):
              update_fields=None):
         self.last_checked = datetime.utcnow()
         super(OwnershipCleanliness, self).save(force_insert, force_update, using, update_fields)
+
+    @classmethod
+    def get_for_owner(cls, domain, owner_id):
+        return cls.objects.get_or_create(domain=domain, owner_id=owner_id)[0]

--- a/corehq/ex-submodules/casexml/apps/phone/tests/__init__.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/__init__.py
@@ -1,5 +1,6 @@
 import logging
 try:
+    from .test_cleanliness import *
     from .test_ota_restore import *
     from .test_ota_restore_v3 import *
     from .test_state_hash import *

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_cleanliness.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_cleanliness.py
@@ -84,7 +84,7 @@ class OwnerCleanlinessTest(SyncBaseTest):
             )
         )
         self.assert_owner_dirty()
-        self.assertEqual(parent._id, self.owner_cleanliness.hint)
+        self.assertEqual(child._id, self.owner_cleanliness.hint)
 
     def test_add_dirty_parent_makes_dirty(self):
         # add parent with a different owner and make sure the owner becomes dirty
@@ -98,11 +98,11 @@ class OwnerCleanlinessTest(SyncBaseTest):
             )
         )
         self.assert_owner_dirty()
-        self.assertEqual(parent._id, self.owner_cleanliness.hint)
+        self.assertEqual(child._id, self.owner_cleanliness.hint)
 
     def test_change_parent_owner_makes_dirty(self):
         # change the owner id of a parent case and make sure the owner becomes dirty
         new_owner = uuid.uuid4().hex
         self._set_owner(self.parent._id, new_owner)
         self.assert_owner_dirty()
-        self.assertEqual(self.parent._id, self.owner_cleanliness.hint)
+        self.assertEqual(self.child._id, self.owner_cleanliness.hint)

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_cleanliness.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_cleanliness.py
@@ -1,0 +1,105 @@
+import uuid
+from casexml.apps.case.mock import CaseFactory, CaseStructure, CaseRelationship
+from casexml.apps.phone.models import OwnershipCleanliness
+from casexml.apps.phone.tests.test_sync_mode import SyncBaseTest
+
+
+class OwnerCleanlinessTest(SyncBaseTest):
+
+    def setUp(self):
+        super(OwnerCleanlinessTest, self).setUp()
+        self.owner_id = uuid.uuid4().hex
+        self.synclog_id = uuid.uuid4().hex
+        self.domain = uuid.uuid4().hex
+        self.factory = CaseFactory(
+            domain=self.domain,
+            case_defaults={
+                'create': True,
+                'owner_id': self.owner_id,
+                'user_id': self.owner_id,
+            }
+        )
+        self.assert_owner_clean()  # this first call creates the OwnershipCleanliness doc
+        self.sample_case = self.factory.create_case()
+        self.child, self.parent = self.factory.create_or_update_case(
+            CaseStructure(
+                relationships=[
+                    CaseRelationship(),
+                ]
+            )
+        )
+        self.assert_owner_clean()  # this is an actual assertion
+
+    @property
+    def owner_cleanliness(self):
+        return OwnershipCleanliness.objects.get_or_create(
+            owner_id=self.owner_id,
+            domain=self.domain,
+            defaults={'is_clean': True}
+        )[0]
+
+    def assert_owner_clean(self):
+        return self.assertTrue(self.owner_cleanliness.is_clean)
+
+    def assert_owner_dirty(self):
+        return self.assertFalse(self.owner_cleanliness.is_clean)
+
+    def _set_owner(self, case_id, owner_id):
+        case = self.factory.create_or_update_case(
+            CaseStructure(case_id=case_id, attrs={'create': False, 'owner_id': owner_id})
+        )[0]
+        self.assertEqual(owner_id, case.owner_id)
+
+    def test_add_normal_case_stays_clean(self):
+        # change the owner ID of a normal case, should remain clean
+        self.factory.create_case()
+        self.assert_owner_clean()
+
+    def test_change_owner_stays_clean(self):
+        # change the owner ID of a normal case, should remain clean
+        new_owner = uuid.uuid4().hex
+        self._set_owner(self.sample_case._id, new_owner)
+        self.assert_owner_clean()
+
+    def test_change_owner_child_case_stays_clean(self):
+        # change the owner ID of a child case, should remain clean
+        new_owner = uuid.uuid4().hex
+        self._set_owner(self.child._id, new_owner)
+        self.assert_owner_clean()
+
+    def test_add_clean_parent_stays_clean(self):
+        # add a parent with the same owner, should remain clean
+        self.factory.create_or_update_case(CaseStructure(relationships=[CaseRelationship()]))
+        self.assert_owner_clean()
+
+    def test_create_dirty_makes_dirty(self):
+        # create a case and a parent case with a different owner at the same time
+        # make sure the owner becomes dirty.
+        new_owner = uuid.uuid4().hex
+        self.factory.create_or_update_case(
+            CaseStructure(
+                relationships=[
+                    CaseRelationship(CaseStructure(attrs={'owner_id': new_owner}))
+                ]
+            )
+        )
+        self.assert_owner_dirty()
+
+    def test_add_dirty_parent_makes_dirty(self):
+        # add parent with a different owner and make sure the owner becomes dirty
+        new_owner = uuid.uuid4().hex
+        self.factory.create_or_update_case(
+            CaseStructure(
+                case_id=self.sample_case._id,
+                relationships=[
+                    CaseRelationship(CaseStructure(attrs={'owner_id': new_owner}))
+                ]
+            )
+        )
+        self.assert_owner_dirty()
+
+    def test_change_parent_owner_makes_dirty(self):
+        # change the owner id of a parent case and make sure the owner becomes dirty
+        new_owner = uuid.uuid4().hex
+        self._set_owner(self.parent._id, new_owner)
+        self.assert_owner_dirty()

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_cleanliness.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_cleanliness.py
@@ -76,7 +76,7 @@ class OwnerCleanlinessTest(SyncBaseTest):
         # create a case and a parent case with a different owner at the same time
         # make sure the owner becomes dirty.
         new_owner = uuid.uuid4().hex
-        self.factory.create_or_update_case(
+        [child, parent] = self.factory.create_or_update_case(
             CaseStructure(
                 relationships=[
                     CaseRelationship(CaseStructure(attrs={'owner_id': new_owner}))
@@ -84,11 +84,12 @@ class OwnerCleanlinessTest(SyncBaseTest):
             )
         )
         self.assert_owner_dirty()
+        self.assertEqual(parent._id, self.owner_cleanliness.hint)
 
     def test_add_dirty_parent_makes_dirty(self):
         # add parent with a different owner and make sure the owner becomes dirty
         new_owner = uuid.uuid4().hex
-        self.factory.create_or_update_case(
+        [child, parent] = self.factory.create_or_update_case(
             CaseStructure(
                 case_id=self.sample_case._id,
                 relationships=[
@@ -97,9 +98,11 @@ class OwnerCleanlinessTest(SyncBaseTest):
             )
         )
         self.assert_owner_dirty()
+        self.assertEqual(parent._id, self.owner_cleanliness.hint)
 
     def test_change_parent_owner_makes_dirty(self):
         # change the owner id of a parent case and make sure the owner becomes dirty
         new_owner = uuid.uuid4().hex
         self._set_owner(self.parent._id, new_owner)
         self.assert_owner_dirty()
+        self.assertEqual(self.parent._id, self.owner_cleanliness.hint)

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_cleanliness.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_cleanliness.py
@@ -2,12 +2,15 @@ import uuid
 from casexml.apps.case.mock import CaseFactory, CaseStructure, CaseRelationship
 from casexml.apps.phone.models import OwnershipCleanliness
 from casexml.apps.phone.tests.test_sync_mode import SyncBaseTest
+from corehq.toggles import OWNERSHIP_CLEANLINESS
 
 
 class OwnerCleanlinessTest(SyncBaseTest):
 
     def setUp(self):
         super(OwnerCleanlinessTest, self).setUp()
+        # ensure that randomization is on
+        OWNERSHIP_CLEANLINESS.randomness = 1
         self.owner_id = uuid.uuid4().hex
         self.synclog_id = uuid.uuid4().hex
         self.domain = uuid.uuid4().hex
@@ -106,3 +109,10 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self._set_owner(self.parent._id, new_owner)
         self.assert_owner_dirty()
         self.assertEqual(self.child._id, self.owner_cleanliness.hint)
+
+    def test_toggle(self):
+        # make sure the flag gets removed
+        OWNERSHIP_CLEANLINESS.randomness = 0
+        # and any test that normally expects a flag to be set to fail
+        with self.assertRaises(AssertionError):
+            self.test_create_dirty_makes_dirty()

--- a/corehq/ex-submodules/couchforms/util.py
+++ b/corehq/ex-submodules/couchforms/util.py
@@ -452,7 +452,7 @@ class SubmissionPost(object):
                     domain = get_and_check_xform_domain(instance)
                     with CaseDbCache(domain=domain, lock=True, deleted_ok=True, xforms=xforms) as case_db:
                         try:
-                            process_cases_with_casedb(xforms, case_db)
+                            case_result = process_cases_with_casedb(xforms, case_db)
                             process_stock(instance, case_db)
                         except IllegalCaseId as e:
                             # errors we know about related to the content of the form
@@ -506,6 +506,8 @@ class SubmissionPost(object):
                         unfinished_submission_stub.save()
                         for case in cases:
                             case_post_save.send(CommCareCase, case=case)
+
+                        case_result.commit_dirtiness_flags()
                         responses, errors = self.process_signals(instance)
                         if errors:
                             # .problems was added to instance

--- a/corehq/ex-submodules/couchforms/util.py
+++ b/corehq/ex-submodules/couchforms/util.py
@@ -434,7 +434,7 @@ class SubmissionPost(object):
         else:
             from casexml.apps.case.models import CommCareCase
             from casexml.apps.case.xform import (
-                get_and_check_xform_domain, CaseDbCache, process_cases_with_casedb_bulk
+                get_and_check_xform_domain, CaseDbCache, process_cases_with_casedb
             )
             from casexml.apps.case.signals import case_post_save
             from casexml.apps.case.exceptions import IllegalCaseId
@@ -452,7 +452,7 @@ class SubmissionPost(object):
                     domain = get_and_check_xform_domain(instance)
                     with CaseDbCache(domain=domain, lock=True, deleted_ok=True, xforms=xforms) as case_db:
                         try:
-                            process_cases_with_casedb_bulk(xforms, case_db)
+                            process_cases_with_casedb(xforms, case_db)
                             process_stock(instance, case_db)
                         except IllegalCaseId as e:
                             # errors we know about related to the content of the form

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -465,3 +465,12 @@ ENABLE_LOADTEST_USERS = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN],
     help_link='https://confluence.dimagi.com/display/ccinternal/Loadtest+Users',
 )
+
+OWNERSHIP_CLEANLINESS = PredicatablyRandomToggle(
+    'enable_owner_cleanliness_flags',
+    'Enable tracking ownership cleanliness on submission',
+    TAG_EXPERIMENTAL,
+    randomness=.05,
+    namespace=NAMESPACE_DOMAIN,
+    help_link='https://docs.google.com/a/dimagi.com/document/d/12WfZLerFL832LZbMwqRAvXt82scdjDL51WZVNa31f28/edit#heading=h.gu9sjekp0u2p',
+)

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -68,8 +68,9 @@ class PredicatablyRandomToggle(StaticToggle):
     It extends StaticToggle, so individual domains/users can also be explicitly added.
     """
 
-    def __init__(self, slug, label, tag, namespace, randomness):
-        super(PredicatablyRandomToggle, self).__init__(slug, label, tag, list(namespace))
+    def __init__(self, slug, label, tag, namespace, randomness, help_link=None, description=None):
+        super(PredicatablyRandomToggle, self).__init__(slug, label, tag, list(namespace),
+                                                       help_link=help_link, description=description)
         assert namespace, 'namespace must be defined!'
         self.namespace = namespace
         assert 0 <= randomness <= 1, 'randomness must be between 0 and 1!'


### PR DESCRIPTION
 Starting to implement ownership cleanliness based on https://docs.google.com/a/dimagi.com/document/d/12WfZLerFL832LZbMwqRAvXt82scdjDL51WZVNa31f28/edit#. 

This currently _only_ saves dirtiness to the database. It assume some other cron-like thing is responsible for marking things as clean.

There's also one legitimately failing test I need to figure out how to address.

Can be reviewed commit-by-commit though there are a couple bugs in some of the interim commits that were later fixed.
