### PR TITLE
change all references from now to utcnow

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1662,7 +1662,7 @@ class InvoicePdf(SafeSaveDocument):
         pdf_data.close()
 
         self.invoice_id = str(invoice.id)
-        self.date_created = datetime.datetime.now()
+        self.date_created = datetime.datetime.utcnow()
         self.save()
 
     def get_filename(self, invoice):

--- a/corehq/apps/app_manager/management/commands/upload_app_forms.py
+++ b/corehq/apps/app_manager/management/commands/upload_app_forms.py
@@ -58,7 +58,7 @@ class Command(BaseCommand):
         print 'successfully updated {}'.format(app.name)
         if options['deploy']:
             # make build and star it
-            comment = options.get('comment', 'form changes from {0}'.format(datetime.now().strftime("%Y-%m-%d %H:%M")))
+            comment = options.get('comment', 'form changes from {0}'.format(datetime.utcnow().strftime("%Y-%m-%d %H:%M")))
             copy = app.make_build(
                 comment=comment,
                 user_id=user._id,

--- a/corehq/apps/callcenter/tests/sql_fixture.py
+++ b/corehq/apps/callcenter/tests/sql_fixture.py
@@ -15,7 +15,7 @@ def get_table(mapping):
 
 
 def get_formdata(days_ago, domain, user_id, xmlns=None, duration=1):
-    now = datetime.now()
+    now = datetime.utcnow()
     return FormData(
         doc_type='XFormInstance',
         domain=domain,
@@ -33,7 +33,7 @@ CaseInfo = namedtuple('CaseInfo', 'id, days_ago, case_type, is_closed')
 
 
 def get_casedata(case_info, domain, user_id, owner_id, opened_by, closed_by):
-    now = datetime.now()
+    now = datetime.utcnow()
     date_ago = now - timedelta(days=case_info.days_ago)
     return CaseData(
         case_id=case_info.id,

--- a/corehq/apps/cleanup/management/commands/fire_repeaters.py
+++ b/corehq/apps/cleanup/management/commands/fire_repeaters.py
@@ -14,7 +14,7 @@ class Command(BaseCommand):
         else:
             raise CommandError('Usage: %s\n%s' % (self.args, self.help))
 
-        next_year = datetime.datetime.now() + datetime.timedelta(days=365)
+        next_year = datetime.datetime.utcnow() + datetime.timedelta(days=365)
         records = RepeatRecord.all(domain=domain, due_before=next_year)
         for record in records:
             record.fire(post_fn=simple_post)

--- a/corehq/apps/commtrack/management/commands/product_program_last_modified.py
+++ b/corehq/apps/commtrack/management/commands/product_program_last_modified.py
@@ -19,7 +19,7 @@ class Command(BaseCommand):
 
         for product in iter_docs(Product.get_db(), relevant_ids):
             if 'last_modified' not in product or not product['last_modified']:
-                product['last_modified'] = datetime.now().isoformat()
+                product['last_modified'] = datetime.utcnow().isoformat()
                 to_save.append(product)
 
                 if len(to_save) > 500:
@@ -40,7 +40,7 @@ class Command(BaseCommand):
 
         for program in iter_docs(Program.get_db(), relevant_ids):
             if 'last_modified' not in program or not program['last_modified']:
-                program['last_modified'] = datetime.now().isoformat()
+                program['last_modified'] = datetime.utcnow().isoformat()
                 to_save.append(program)
 
                 if len(to_save) > 500:

--- a/corehq/apps/commtrack/sms.py
+++ b/corehq/apps/commtrack/sms.py
@@ -536,7 +536,7 @@ def requisition_case_xml(data, stock_blocks):
         update={'requisition_status': status},
     ).as_xml())
 
-    timestamp = data['transactions'][0].timestamp or datetime.now()
+    timestamp = data['transactions'][0].timestamp or datetime.utcnow()
     device_id = get_device_id(data)
 
     return """

--- a/corehq/apps/commtrack/tests/test_stock_report.py
+++ b/corehq/apps/commtrack/tests/test_stock_report.py
@@ -28,7 +28,7 @@ class StockReportDomainTest(TestCase):
         form.save()
         report = NewStockReport(
             form,
-            date or datetime.now(),
+            date or datetime.utcnow(),
             tag or REPORT_TYPE_BALANCE,
             transactions or [],
         )
@@ -94,7 +94,7 @@ class StockReportDomainTest(TestCase):
     def _test_get_current_ledger_transactions(self, tester_fn):
         tester_fn(self.transactions)
 
-        date = datetime.now()
+        date = datetime.utcnow()
         report, _ = self.create_report([
             STrans(
                 case_id='c1',

--- a/corehq/apps/commtrack/tests/test_stock_state.py
+++ b/corehq/apps/commtrack/tests/test_stock_state.py
@@ -102,7 +102,7 @@ class StockStateBehaviorTest(StockStateTest):
             section_id='stock',
             case_id=self.sp._id,
             product_id=self.products[0]._id,
-            last_modified_date=datetime.now(),
+            last_modified_date=datetime.utcnow(),
             sql_product=SQLProduct.objects.get(product_id=self.products[0]._id),
         ).save()
 

--- a/corehq/apps/commtrack/tests/test_xml.py
+++ b/corehq/apps/commtrack/tests/test_xml.py
@@ -514,7 +514,7 @@ class CommTrackArchiveSubmissionTest(CommTrackSubmissionTest):
         initial_amounts = [(p._id, float(100)) for p in self.products]
         self.submit_xml_form(
             balance_submission(initial_amounts),
-            timestamp=datetime.now() + timedelta(-30)
+            timestamp=datetime.utcnow() + timedelta(-30)
         )
 
         final_amounts = [(p._id, float(50)) for i, p in enumerate(self.products)]

--- a/corehq/apps/domain/calculations.py
+++ b/corehq/apps/domain/calculations.py
@@ -41,7 +41,7 @@ def active_mobile_users(domain, *args):
     Returns the number of mobile users who have submitted a form or SMS in the
     last 30 days
     """
-    now = datetime.now()
+    now = datetime.utcnow()
     then = (now - timedelta(days=30))
 
     user_ids = get_mobile_users(domain)
@@ -80,7 +80,7 @@ def cases_in_last(domain, days):
     """
     Returns the number of open cases that have been modified in the last <days> days
     """
-    now = datetime.now()
+    now = datetime.utcnow()
     then = (now - timedelta(days=int(days))).strftime(DATE_FORMAT)
     now = now.strftime(DATE_FORMAT)
 
@@ -96,7 +96,7 @@ def inactive_cases_in_last(domain, days):
     """
     Returns the number of open cases that have been modified in the last <days> days
     """
-    now = datetime.now()
+    now = datetime.utcnow()
     then = (now - timedelta(days=int(days))).strftime(DATE_FORMAT)
     now = now.strftime(DATE_FORMAT)
 
@@ -137,7 +137,7 @@ def sms_in_last_bool(domain, days=None):
 
 
 def active(domain, *args):
-    now = datetime.now()
+    now = datetime.utcnow()
     then = (now - timedelta(days=30)).strftime(DATE_FORMAT)
     now = now.strftime(DATE_FORMAT)
 

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -499,7 +499,7 @@ class Domain(Document, SnapshotMixin):
             include_docs=False,
             limit=1).all()
         if len(res) > 0: # if there have been any submissions in the past 30 days
-            return (datetime.now() <=
+            return (datetime.utcnow() <=
                     datetime.strptime(res[0]['key'][2], "%Y-%m-%dT%H:%M:%SZ")
                     + timedelta(days=30))
         else:
@@ -804,7 +804,7 @@ class Domain(Document, SnapshotMixin):
             if copy is None:
                 return None
             copy.is_snapshot = True
-            copy.snapshot_time = datetime.now()
+            copy.snapshot_time = datetime.utcnow()
             del copy.deployment
             copy.save()
             return copy
@@ -1165,7 +1165,7 @@ class TransferDomainRequest(models.Model):
     @requires_active_transfer
     def send_transfer_request(self):
         self.transfer_guid = uuid.uuid4().hex
-        self.request_time = datetime.now()
+        self.request_time = datetime.utcnow()
         self.save()
 
         self.email_to_request()
@@ -1213,7 +1213,7 @@ class TransferDomainRequest(models.Model):
     @requires_active_transfer
     def transfer_domain(self, *args, **kwargs):
 
-        self.confirm_time = datetime.now()
+        self.confirm_time = datetime.utcnow()
         if 'ip' in kwargs:
             self.confirm_ip = kwargs['ip']
 

--- a/corehq/apps/domain/tests/test_domain_transfer.py
+++ b/corehq/apps/domain/tests/test_domain_transfer.py
@@ -116,7 +116,7 @@ class TestTransferDomainModel(BaseDomainTest):
         newer = TransferDomainRequest(
             to_username=self.mugglename,
             from_username=self.username,
-            request_time=datetime.now(),
+            request_time=datetime.utcnow(),
             domain=self.domain.name)
         newer.save()
 

--- a/corehq/apps/fixtures/download.py
+++ b/corehq/apps/fixtures/download.py
@@ -68,7 +68,7 @@ def _prepare_fixture(table_ids, domain, html_response=False, task=None):
     # a small number of tables it renders more accurate progress
     total_events = (total_tables + (0 if total_tables < 4 else 1)) * 10
 
-    now = datetime.now
+    now = datetime.utcnow
     last_update = [now()]
     upate_period = timedelta(seconds=1)  # do not update progress more than once a second
 

--- a/corehq/apps/groups/management/commands/groups_last_modified.py
+++ b/corehq/apps/groups/management/commands/groups_last_modified.py
@@ -19,7 +19,7 @@ class Command(BaseCommand):
         for group in iter_docs(Group.get_db(), relevant_ids):
             if 'last_modified' not in group or not group['last_modified']:
                 print group['_id']
-                group['last_modified'] = datetime.now().isoformat()
+                group['last_modified'] = datetime.utcnow().isoformat()
                 to_save.append(group)
 
                 if len(to_save) > 500:

--- a/corehq/apps/groups/models.py
+++ b/corehq/apps/groups/models.py
@@ -30,7 +30,7 @@ class Group(UndoableDocument):
     metadata = DictProperty()
 
     def save(self, *args, **kwargs):
-        self.last_modified = datetime.now()
+        self.last_modified = datetime.utcnow()
         return super(Group, self).save(*args, **kwargs)
 
     def add_user(self, couch_user_id, save=True):

--- a/corehq/apps/hqadmin/management/commands/list_deploys.py
+++ b/corehq/apps/hqadmin/management/commands/list_deploys.py
@@ -25,7 +25,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         start = parser.parse(options['startdate'])
         enddate = options['enddate']
-        end = parser.parse(enddate) if enddate else datetime.now()
+        end = parser.parse(enddate) if enddate else datetime.utcnow()
 
         ds = HqDeploy.get_list('production', start, end)
         ids = [d['id'] for d in ds]

--- a/corehq/apps/hqadmin/views.py
+++ b/corehq/apps/hqadmin/views.py
@@ -464,7 +464,7 @@ def noneulized_users(request, template="hqadmin/noneulized_users.html"):
 
     days = request.GET.get("days", None)
     days = int(days) if days else 60
-    days_ago = datetime.now() - timedelta(days=days)
+    days_ago = datetime.utcnow() - timedelta(days=days)
 
     users = WebUser.view("eula_report/noneulized_users",
         reduce=False,

--- a/corehq/apps/hqcase/management/commands/ptop_fast_reindexer.py
+++ b/corehq/apps/hqcase/management/commands/ptop_fast_reindexer.py
@@ -108,7 +108,7 @@ class PtopReindexer(NoArgsCommand):
         if hasattr(self, '_seq_prefix'):
             datestring = self._seq_prefix
         else:
-            datestring = datetime.now().strftime("%Y-%m-%d-%H%M")
+            datestring = datetime.utcnow().strftime("%Y-%m-%d-%H%M")
             self._seq_prefix = datestring
         return datestring
 
@@ -324,9 +324,9 @@ class PtopReindexer(NoArgsCommand):
             except Exception as ex:
                 retries += 1
                 retry_time = (datetime.utcnow() - bulk_start).seconds + retries * RETRY_TIME_DELAY_FACTOR
-                self.log("\t%s: Exception sending slice %d:%d, %s, retrying in %s seconds" % (datetime.now().isoformat(), start, end, ex, retry_time))
+                self.log("\t%s: Exception sending slice %d:%d, %s, retrying in %s seconds" % (datetime.utcnow().isoformat(), start, end, ex, retry_time))
                 time.sleep(retry_time)
-                self.log("\t%s: Retrying again %d:%d..." % (datetime.now().isoformat(), start, end))
+                self.log("\t%s: Retrying again %d:%d..." % (datetime.utcnow().isoformat(), start, end))
                 # reset timestamp when looping again
                 bulk_start = datetime.utcnow()
 

--- a/corehq/apps/hqcouchlog/tasks.py
+++ b/corehq/apps/hqcouchlog/tasks.py
@@ -17,7 +17,7 @@ def get_results(key):
 
 @periodic_task(run_every=crontab(minute=0, hour=0), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'))
 def purge_old_logs():
-    key = datetime.now() - timedelta(weeks=52)
+    key = datetime.utcnow() - timedelta(weeks=52)
 
     db = ExceptionRecord.get_db()
 

--- a/corehq/apps/hqwebapp/templatetags/mainreport_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/mainreport_tags.py
@@ -20,7 +20,7 @@ def get_daterange_links_raw(base_link, args={}):
     delta_month = timedelta(days=30)
     delta_3month = timedelta(days=90)
     
-    enddate = datetime.now()
+    enddate = datetime.utcnow()
     yesterday = enddate - delta_day
     #datetime.strptime(startdate_str,'%m/%d/%Y')
     ret = '\n'
@@ -40,7 +40,7 @@ def get_daterange_links_basic(base_link, days=[0,7,30,90], args={}):
        a pretty string to display the time, otherwise it will say
        "last n days"''' 
     #base_link = reverse(view_name,kwargs=args)
-    end_date = datetime.now()
+    end_date = datetime.utcnow()
     ret = ''
     ret += '<div class="daterange_tabs"><ul>\n'
     for num_days in days:

--- a/corehq/apps/hqwebapp/utils.py
+++ b/corehq/apps/hqwebapp/utils.py
@@ -103,7 +103,7 @@ class InvitationView():
 
         self.validate_invitation(invitation)
 
-        if invitation.invited_on.date() + relativedelta(months=1) < datetime.now().date()  and isinstance(invitation, DomainInvitation):
+        if invitation.invited_on.date() + relativedelta(months=1) < datetime.utcnow().date()  and isinstance(invitation, DomainInvitation):
             return HttpResponseRedirect(reverse("no_permissions"))
 
         if request.user.is_authenticated():

--- a/corehq/apps/importer/management/commands/import_cases.py
+++ b/corehq/apps/importer/management/commands/import_cases.py
@@ -16,7 +16,7 @@ class Command(BaseCommand):
         if len(args) != 4:
             raise CommandError('Usage is import_cases %s' % self.args)
 
-        start = datetime.now()
+        start = datetime.utcnow()
         export_file, config_file, domain, user_id = args
         if '@' in user_id:
             user = WebUser.get_by_username(user_id)
@@ -32,4 +32,4 @@ class Command(BaseCommand):
         spreadsheet = ExcelFile(export_file, True)
         print json.dumps(do_import(spreadsheet, config, domain),
                          default=json_handler)
-        print 'finished in %s seconds' % (datetime.now() - start).seconds
+        print 'finished in %s seconds' % (datetime.utcnow() - start).seconds

--- a/corehq/apps/locations/management/commands/location_last_modified.py
+++ b/corehq/apps/locations/management/commands/location_last_modified.py
@@ -23,7 +23,7 @@ class Command(BaseCommand):
                 not location.get('last_modified', False) and
                 'psi' not in location.get('domain', '')
             ):
-                location['last_modified'] = datetime.now().isoformat()
+                location['last_modified'] = datetime.utcnow().isoformat()
                 to_save.append(location)
 
                 if len(to_save) > 500:

--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -194,7 +194,7 @@ class SQLLocation(MPTTModel):
         g = UnsavableGroup()
         g.domain = self.domain
         g.users = [user_id] if user_id else []
-        g.last_modified = datetime.now()
+        g.last_modified = datetime.utcnow()
 
         if case_sharing:
             g.name = group_name() + '-Cases'
@@ -430,7 +430,7 @@ class Location(CachedCouchDocumentMixin, Document):
         one way syncing to the SQLLocation version of this
         location.
         """
-        self.last_modified = datetime.now()
+        self.last_modified = datetime.utcnow()
 
         # lazy migration for site_code
         if not self.site_code:

--- a/corehq/apps/products/models.py
+++ b/corehq/apps/products/models.py
@@ -70,7 +70,7 @@ class Product(Document):
         product.
         """
         # mark modified time stamp for selective syncing
-        self.last_modified = datetime.now()
+        self.last_modified = datetime.utcnow()
 
         # generate code if user didn't specify one
         if not self.code:

--- a/corehq/apps/programs/models.py
+++ b/corehq/apps/programs/models.py
@@ -21,7 +21,7 @@ class Program(Document):
     is_archived = BooleanProperty(default=False)
 
     def save(self, *args, **kwargs):
-        self.last_modified = datetime.now()
+        self.last_modified = datetime.utcnow()
 
         return super(Program, self).save(*args, **kwargs)
 

--- a/corehq/apps/reports/commtrack/data_sources.py
+++ b/corehq/apps/reports/commtrack/data_sources.py
@@ -54,11 +54,11 @@ class CommtrackDataSourceMixin(object):
 
     @property
     def start_date(self):
-        return self.config.get('startdate') or (datetime.now() - timedelta(30)).date()
+        return self.config.get('startdate') or (datetime.utcnow() - timedelta(30)).date()
 
     @property
     def end_date(self):
-        return self.config.get('enddate') or datetime.now().date()
+        return self.config.get('enddate') or datetime.utcnow().date()
 
     @property
     def request(self):
@@ -83,7 +83,7 @@ class SimplifiedInventoryDataSource(ReportDataSource, CommtrackDataSourceMixin):
         try:
             date = parser.parse(date).date()
         except ValueError:
-            date = datetime.now().date()
+            date = datetime.utcnow().date()
 
         return datetime(date.year, date.month, date.day, 23, 59, 59)
 

--- a/corehq/apps/reports/standard/__init__.py
+++ b/corehq/apps/reports/standard/__init__.py
@@ -345,11 +345,11 @@ class MonthYearMixin(object):
         if 'month' in self.request_params:
             return int(self.request_params['month'])
         else:
-            return datetime.now().month
+            return datetime.utcnow().month
 
     @property
     def year(self):
         if 'year' in self.request_params:
             return int(self.request_params['year'])
         else:
-            return datetime.now().year
+            return datetime.utcnow().year

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -171,7 +171,7 @@ def update_calculated_properties():
             "cp_last_form": CALC_FNS["last_form_submission"](dom, False),
             "cp_is_active": CALC_FNS["active"](dom),
             "cp_has_app": CALC_FNS["has_app"](dom),
-            "cp_last_updated": datetime.now().strftime(DATE_FORMAT),
+            "cp_last_updated": datetime.utcnow().strftime(DATE_FORMAT),
             "cp_n_in_sms": int(CALC_FNS["sms"](dom, "I")),
             "cp_n_out_sms": int(CALC_FNS["sms"](dom, "O")),
             "cp_n_sms_ever": int(CALC_FNS["sms_in_last"](dom)),
@@ -186,7 +186,7 @@ def update_calculated_properties():
 
 DATE_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 def is_app_active(app_id, domain):
-    now = datetime.now()
+    now = datetime.utcnow()
     then = (now - timedelta(days=30)).strftime(DATE_FORMAT)
     now = now.strftime(DATE_FORMAT)
 

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -150,7 +150,7 @@ def post(request, domain):
                  #couch_recipient=id, 
                  phone_number=to,
                  direction=INCOMING,
-                 date = datetime.now(),
+                 date = datetime.utcnow(),
                  text = text)
     msg.save()
     return HttpResponse('OK')

--- a/corehq/apps/smsbillables/generator.py
+++ b/corehq/apps/smsbillables/generator.py
@@ -170,7 +170,7 @@ def arbitrary_messages_by_backend_and_direction(backend_ids,
                 backend_api=api_id,
                 backend_id=instance_id,
                 text=arbitrary_message(),
-                date=datetime.datetime.now()
+                date=datetime.datetime.utcnow()
             )
             sms_log.save()
             messages.append(sms_log)

--- a/corehq/apps/sofabed/tests/test_casedata.py
+++ b/corehq/apps/sofabed/tests/test_casedata.py
@@ -27,7 +27,7 @@ class CaseDataTests(TestCase):
         ], {'domain': TEST_DOMAIN})
 
         self.case_id = 'test_case_1'
-        self.date_modified = datetime.now() - timedelta(hours=1)
+        self.date_modified = datetime.utcnow() - timedelta(hours=1)
         self.date_modified = self.date_modified.replace(microsecond=0)
         post_case_blocks([
             CaseBlock(
@@ -89,7 +89,7 @@ class CaseDataTests(TestCase):
             ).as_xml(format_datetime=None)
         ], {'domain': TEST_DOMAIN})
 
-        date_modified = datetime.now().replace(microsecond=0)
+        date_modified = datetime.utcnow().replace(microsecond=0)
         post_case_blocks([
             CaseBlock(
                 close=True,

--- a/corehq/apps/sofabed/tests/test_formdata.py
+++ b/corehq/apps/sofabed/tests/test_formdata.py
@@ -24,7 +24,7 @@ class FormDataTestCase(TestCase):
             instance=xml_data,
             domain='sofabed',
             app_id='12345',
-            received_on=datetime.now()
+            received_on=datetime.utcnow()
         ).get_response()
 
         self.instance = XFormInstance.get('THIS_IS_THE_INSTANCEID')

--- a/corehq/apps/unicel/tests/test_create_from_request.py
+++ b/corehq/apps/unicel/tests/test_create_from_request.py
@@ -44,7 +44,7 @@ class IncomingPostTest(TestCase):
     def testPostToIncomingAscii(self):
         fake_post = {InboundParams.SENDER: str(self.number),
                      InboundParams.MESSAGE: self.message_ascii,
-                     InboundParams.TIMESTAMP: datetime.now().strftime(DATE_FORMAT),
+                     InboundParams.TIMESTAMP: datetime.utcnow().strftime(DATE_FORMAT),
                      InboundParams.DCS: self.dcs,
                      InboundParams.UDHI: '0'}
         response, log = post(fake_post)
@@ -58,7 +58,7 @@ class IncomingPostTest(TestCase):
     def testPostToIncomingUtf(self):
         fake_post = {InboundParams.SENDER: str(self.number),
                      InboundParams.MESSAGE: self.message_utf_hex,
-                     InboundParams.TIMESTAMP: datetime.now().strftime(DATE_FORMAT),
+                     InboundParams.TIMESTAMP: datetime.utcnow().strftime(DATE_FORMAT),
                      InboundParams.DCS: self.dcs,
                      InboundParams.UDHI: '1'}
         response, log = post(fake_post)

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -19,7 +19,7 @@ def rebuild_indicators(indicator_config_id):
         config = DataSourceConfiguration.get(indicator_config_id)
         # Save the start time now in case anything goes wrong. This way we'll be
         # able to see if the rebuild started a long time ago without finishing.
-        config.meta.build.initiated = datetime.datetime.now()
+        config.meta.build.initiated = datetime.datetime.utcnow()
         config.save()
 
     adapter = IndicatorSqlAdapter(get_engine(), config)

--- a/corehq/apps/userreports/tests/test_data_source_repeats.py
+++ b/corehq/apps/userreports/tests/test_data_source_repeats.py
@@ -33,7 +33,7 @@ class RepeatDataSourceConfigurationTest(SimpleTestCase):
         self.assertEqual([], self.config.get_all_values(_test_doc(form={"time_logs": []})))
 
     def test_dict_property(self):
-        start = datetime.datetime.now()
+        start = datetime.datetime.utcnow()
         end = start + datetime.timedelta(minutes=30)
         rows = self.config.get_all_values(_test_doc(form={"time_logs": {
             "start_time": start, "end_time": end, "person": "al"
@@ -47,7 +47,7 @@ class RepeatDataSourceConfigurationTest(SimpleTestCase):
         self.assertEqual(DAY_OF_WEEK, created_base_ind.value)
 
     def test_list_property(self):
-        now = datetime.datetime.now()
+        now = datetime.datetime.utcnow()
         one_hour = datetime.timedelta(hours=1)
         logs = [
             {"start_time": now, "end_time": now + one_hour, "person": "al"},

--- a/corehq/apps/users/old_couch_user_models.py
+++ b/corehq/apps/users/old_couch_user_models.py
@@ -314,7 +314,7 @@ class CouchUser(Document, UnicodeMixIn):
     def unlink_commcare_account(self, domain, commcare_user_index, **kwargs):
         commcare_user_index = int(commcare_user_index)
         c = CouchUser()
-        c.created_on = datetime.now()
+        c.created_on = datetime.utcnow()
         original = self.commcare_accounts[commcare_user_index]
         c.commcare_accounts.append(original)
         c.status = 'unlinked from %s' % self._id

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -48,6 +48,6 @@ def resend_pending_invitations():
     for domain in domains:
         invitations = DomainInvitation.by_domain(domain.name)
         for invitation in invitations:
-            days = (datetime.now() - invitation.invited_on).days
+            days = (datetime.utcnow() - invitation.invited_on).days
             if days in days_to_resend:
                 invitation.send_activation_email(days_to_expire - days)

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -709,7 +709,7 @@ def reinvite_web_user(request, domain):
     invitation_id = request.POST['invite']
     try:
         invitation = DomainInvitation.get(invitation_id)
-        invitation.invited_on = datetime.now()
+        invitation.invited_on = datetime.utcnow()
         invitation.save()
         invitation.send_activation_email()
         return json_response({'response': _("Invitation resent"), 'status': 'ok'})

--- a/corehq/ex-submodules/casexml/apps/case/templatetags/case_tags.py
+++ b/corehq/ex-submodules/casexml/apps/case/templatetags/case_tags.py
@@ -47,7 +47,7 @@ def render_case(case, options):
     from corehq.apps.hqwebapp.templatetags.proptable_tags import get_tables_as_rows, get_definition
     case = wrapped_case(case)
     timezone = options.get('timezone', pytz.utc)
-    timezone = timezone.localize(datetime.datetime.now()).tzinfo
+    timezone = timezone.localize(datetime.datetime.utcnow()).tzinfo
     _get_tables_as_rows = partial(get_tables_as_rows, timezone=timezone)
     display = options.get('display') or case.get_display_config()
     show_transaction_export = options.get('show_transaction_export') or False
@@ -81,7 +81,7 @@ def render_case(case, options):
     actions = case.to_json()['actions']
     actions.reverse()
 
-    the_time_is_now = datetime.datetime.now()
+    the_time_is_now = datetime.datetime.utcnow()
     tz_offset_ms = int(timezone.utcoffset(the_time_is_now).total_seconds()) * 1000
     tz_abbrev = timezone.localize(the_time_is_now).tzname()
 

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_tags.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_tags.py
@@ -7,5 +7,5 @@ class TestCaseTags(SimpleTestCase):
 
     def test_normalize_date(self):
         self.assertIsInstance(normalize_date(date.today()), datetime)
-        self.assertIsInstance(normalize_date(datetime.now()), datetime)
+        self.assertIsInstance(normalize_date(datetime.utcnow()), datetime)
         self.assertEqual(normalize_date('123'), '123')

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -532,7 +532,7 @@ class MultiUserSyncTest(SyncBaseTest):
         self.assertTrue("Hello!" in ElementTree.tostring(match))
 
     def testOtherUserAddsIndex(self):
-        time = datetime.now()
+        time = datetime.utcnow()
 
         # create a case from one user
         case_id = "other_user_adds_index"
@@ -592,7 +592,7 @@ class MultiUserSyncTest(SyncBaseTest):
         self.assertTrue("index" in ElementTree.tostring(orig))
 
     def testMultiUserEdits(self):
-        time = datetime.now()
+        time = datetime.utcnow()
 
         # create a case from one user
         case_id = "multi_user_edits"

--- a/custom/_legacy/hsph/reports/field_management.py
+++ b/custom/_legacy/hsph/reports/field_management.py
@@ -355,7 +355,7 @@ class HSPHCaseDisplay(CaseDisplay):
             else:
                 return UNKNOWN
         else:
-            today = datetime.datetime.now()
+            today = datetime.datetime.utcnow()
             if today <= self._date_admission + datetime.timedelta(days=21):
                 return CALL_CENTER
             else:

--- a/custom/_legacy/pact/reports/chw_schedule.py
+++ b/custom/_legacy/pact/reports/chw_schedule.py
@@ -48,7 +48,7 @@ class CHWPatientSchedule(object):
         cached_schedules = None
 
         if override_date == None:
-            nowdate = datetime.now()
+            nowdate = datetime.utcnow()
         else:
             nowdate = override_date
 
@@ -137,7 +137,7 @@ def get_schedule_tally(username, total_interval, override_date=None):
     where visit = XFormInstance
     """
     if override_date is None:
-        nowdate = datetime.now()
+        nowdate = datetime.utcnow()
         chw_schedule = CHWPatientSchedule.get_schedule(username)
     else:
         nowdate = override_date

--- a/custom/_legacy/pact/reports/dot_calendar.py
+++ b/custom/_legacy/pact/reports/dot_calendar.py
@@ -104,8 +104,8 @@ class DOTCalendarReporter(object):
             endmonth = observations[-1].observed_date.month
             endyear = observations[0].observed_date.year
         else:
-            startmonth = datetime.now().month
-            startyear = datetime.now().year
+            startmonth = datetime.utcnow().month
+            startyear = datetime.utcnow().year
 
         currmonth = startmonth
         curryear = startyear

--- a/custom/apps/crs_reports/reports.py
+++ b/custom/apps/crs_reports/reports.py
@@ -204,7 +204,7 @@ class HBNCMotherReport(BaseHNBCReport):
 
     @property
     def case_filter(self):
-        now = datetime.datetime.now()
+        now = datetime.datetime.utcnow()
         fromdate = now - timedelta(days=42)
         filters = BaseHNBCReport.base_filters(self)
         filters.append({'term': {'pp_case_filter.#value': "1"}})

--- a/custom/ewsghana/alerts/alerts.py
+++ b/custom/ewsghana/alerts/alerts.py
@@ -241,7 +241,7 @@ def reminder_to_visit_website():
     domains = EWSGhanaConfig.get_all_enabled_domains()
     for domain in domains:
         for user in CommCareUser.by_domain(domain):
-            thirteen_days_ago = datetime.datetime.now() - datetime.timedelta(weeks=13)
+            thirteen_days_ago = datetime.datetime.utcnow() - datetime.timedelta(weeks=13)
             if user.location and user.last_login < thirteen_days_ago and user.get_verified_number()\
                     and user.location.location_type.name in ['district', 'region', 'country']:
                     message = WEB_REMINDER % user.name

--- a/custom/ewsghana/reminders/reminders.py
+++ b/custom/ewsghana/reminders/reminders.py
@@ -135,7 +135,7 @@ def third_soh_to_super():
 
 
 def third_soh_process_users_and_facilities(users, facilities, test=False):
-    date = datetime.datetime.now() - datetime.timedelta(days=DAYS_UNTIL_LATE)
+    date = datetime.datetime.utcnow() - datetime.timedelta(days=DAYS_UNTIL_LATE)
     for facility in facilities:
         if not facility.supply_point_id:
             continue
@@ -211,7 +211,7 @@ def stockout_process_user(user, test=False):
                         STOCKOUT_REPORT % {
                             'name': user.name,
                             'facility': supply_point.name,
-                            'date': datetime.datetime.now().strftime('%b %d'),
+                            'date': datetime.datetime.utcnow().strftime('%b %d'),
                             'products': ", ".join(products)
                         }
                     )
@@ -221,7 +221,7 @@ def stockout_process_user(user, test=False):
                         STOCKOUT_REPORT % {
                             'name': user.name,
                             'facility': supply_point.name,
-                            'date': datetime.datetime.now().strftime('%b %d'),
+                            'date': datetime.datetime.utcnow().strftime('%b %d'),
                             'products': ", ".join(products)
                         }
                     )
@@ -255,7 +255,7 @@ def reminder_to_visit_website():
 
 
 def visit_website_process_user(user, test=False):
-    date = datetime.datetime.now() - datetime.timedelta(weeks=13)
+    date = datetime.datetime.utcnow() - datetime.timedelta(weeks=13)
     if user.last_login < date and user.get_verified_number():
         if not test:
             send_sms_to_verified_number(user.get_verified_number(), WEB_REMINDER % {'name': user.name})

--- a/custom/ewsghana/reports/specific_reports/reporting_rates.py
+++ b/custom/ewsghana/reports/specific_reports/reporting_rates.py
@@ -400,7 +400,7 @@ class ReportingRatesReport(MultiReport):
 
     @property
     def default_datespan(self):
-        last_period_st, last_period_end = calculate_last_period(datetime.now())
+        last_period_st, last_period_end = calculate_last_period(datetime.utcnow())
         datespan = DateSpan(startdate=last_period_st, enddate=last_period_end)
         datespan.is_default = True
         return datespan

--- a/custom/ewsghana/tests/handlers/utils.py
+++ b/custom/ewsghana/tests/handlers/utils.py
@@ -25,7 +25,7 @@ class EWSScriptTest(TestScript):
     def _create_stock_state(self, product, consumption):
         xform = XFormInstance.get('test-xform')
         loc = Location.by_site_code(TEST_DOMAIN, 'garms')
-        now = datetime.datetime.now()
+        now = datetime.datetime.utcnow()
         report = StockReport(
             form_id=xform._id,
             date=(now - datetime.timedelta(days=10)).replace(second=0, microsecond=0),

--- a/custom/ewsghana/utils.py
+++ b/custom/ewsghana/utils.py
@@ -211,7 +211,7 @@ class ProductsReportHelper(object):
             domain=self.location.domain,
             is_archived=False
         ).values_list('product_id')
-        date = datetime.now() - timedelta(days=7)
+        date = datetime.utcnow() - timedelta(days=7)
         earlier_reported_products = StockState.objects.filter(
             product_id__in=products_ids,
             case_id=self.location.sql_location.supply_point_id

--- a/custom/ilsgateway/filters.py
+++ b/custom/ilsgateway/filters.py
@@ -104,4 +104,4 @@ class MonthAndQuarterFilter(MonthFilter):
     @property
     @memoized
     def selected(self):
-        return self.get_value(self.request, self.domain) or "%02d" % datetime.now().month
+        return self.get_value(self.request, self.domain) or "%02d" % datetime.utcnow().month

--- a/custom/ilsgateway/models.py
+++ b/custom/ilsgateway/models.py
@@ -160,7 +160,7 @@ class SupplyPointStatus(models.Model):
 class DeliveryGroupReport(models.Model):
     supply_point = models.CharField(max_length=100, db_index=True)
     quantity = models.IntegerField()
-    report_date = models.DateTimeField(default=datetime.now())
+    report_date = models.DateTimeField(default=datetime.utcnow())
     message = models.CharField(max_length=100, db_index=True)
     delivery_group = models.CharField(max_length=1)
     external_id = models.PositiveIntegerField(null=True, db_index=True)

--- a/custom/ilsgateway/tanzania/__init__.py
+++ b/custom/ilsgateway/tanzania/__init__.py
@@ -171,14 +171,14 @@ class MonthQuarterYearMixin(object):
         if 'month' in self.request_params:
             return int(self.request_params['month'])
         else:
-            return datetime.now().month
+            return datetime.utcnow().month
 
     @property
     def year(self):
         if 'year' in self.request_params:
             return int(self.request_params['year'])
         else:
-            return datetime.now().year
+            return datetime.utcnow().year
 
 
 class MultiReport(SqlTabularReport, ILSMixin, CustomProjectReport,

--- a/custom/ilsgateway/tasks.py
+++ b/custom/ilsgateway/tasks.py
@@ -191,4 +191,4 @@ def report_run(domain):
         run.end_run = datetime.utcnow()
         run.complete = True
         run.save()
-        logging.info("ILSGateway report runner end time: %s" % datetime.now())
+        logging.info("ILSGateway report runner end time: %s" % datetime.utcnow())

--- a/custom/ilsgateway/tests/test_locations_sync.py
+++ b/custom/ilsgateway/tests/test_locations_sync.py
@@ -36,8 +36,8 @@ class LocationSyncTest(TestCase):
     def test_locations_migration(self):
         checkpoint = MigrationCheckpoint(
             domain=TEST_DOMAIN,
-            start_date=datetime.now(),
-            date=datetime.now(),
+            start_date=datetime.utcnow(),
+            date=datetime.utcnow(),
             api='product',
             limit=100,
             offset=0

--- a/custom/ilsgateway/tests/test_products_sync.py
+++ b/custom/ilsgateway/tests/test_products_sync.py
@@ -35,8 +35,8 @@ class ProductSyncTest(TestCase):
     def test_locations_migration(self):
         checkpoint = MigrationCheckpoint(
             domain=TEST_DOMAIN,
-            start_date=datetime.now(),
-            date=datetime.now(),
+            start_date=datetime.utcnow(),
+            date=datetime.utcnow(),
             api='product',
             limit=100,
             offset=0

--- a/custom/ilsgateway/tests/test_smsusers_sync.py
+++ b/custom/ilsgateway/tests/test_smsusers_sync.py
@@ -43,8 +43,8 @@ class SMSUsersSyncTest(TestCase):
     def test_smsusers_migration(self):
         checkpoint = MigrationCheckpoint(
             domain=TEST_DOMAIN,
-            start_date=datetime.now(),
-            date=datetime.now(),
+            start_date=datetime.utcnow(),
+            date=datetime.utcnow(),
             api='product',
             limit=100,
             offset=0

--- a/custom/ilsgateway/tests/test_webusers_sync.py
+++ b/custom/ilsgateway/tests/test_webusers_sync.py
@@ -46,8 +46,8 @@ class WebUsersSyncTest(TestCase):
     def test_webusers_migration(self):
         checkpoint = MigrationCheckpoint(
             domain=TEST_DOMAIN,
-            start_date=datetime.now(),
-            date=datetime.now(),
+            start_date=datetime.utcnow(),
+            date=datetime.utcnow(),
             api='product',
             limit=100,
             offset=0

--- a/custom/ilsgateway/views.py
+++ b/custom/ilsgateway/views.py
@@ -220,7 +220,7 @@ class RemindersTester(BaseRemindersTester):
                 if not user:
                     return self.get(request, *args, **kwargs)
                 reminder_function = self.reminders.get(reminder)
-                reminder_function(self.domain, datetime.now(), test_list=[user])
+                reminder_function(self.domain, datetime.utcnow(), test_list=[user])
         messages.success(request, "Reminder was sent successfully")
         return self.get(request, *args, **kwargs)
 
@@ -296,7 +296,7 @@ def save_ils_note(request, domain):
         user_name=user.username,
         user_role=user.user_data['role'] if 'role' in user.user_data else '',
         user_phone=user.default_phone_number,
-        date=datetime.now(),
+        date=datetime.utcnow(),
         text=post_data['text']
     ).save()
     data = []

--- a/custom/opm/reports.py
+++ b/custom/opm/reports.py
@@ -1196,7 +1196,7 @@ def this_month_if_none(month, year):
             "You must pass either nothing or a month AND a year"
         return month, year
     else:
-        this_month = datetime.datetime.now()
+        this_month = datetime.datetime.utcnow()
         return this_month.month, this_month.year
 
 

--- a/custom/succeed/reports/all_patients.py
+++ b/custom/succeed/reports/all_patients.py
@@ -20,7 +20,7 @@ from custom.succeed.utils import is_succeed_admin, SUCCEED_CM_APPNAME, has_any_r
 
 def target_date(visit_name, visit_days, randomization_date):
         if visit_name != 'last':
-            tg_date = ((randomization_date + timedelta(days=int(visit_days))) - datetime.now().date()).days
+            tg_date = ((randomization_date + timedelta(days=int(visit_days))) - datetime.utcnow().date()).days
             if tg_date >= 7:
                 output_html = (randomization_date + timedelta(days=int(visit_days))).strftime("%m/%d/%Y")
             elif 7 > tg_date > 0:

--- a/custom/up_nrhm/reports/block_level_month_report.py
+++ b/custom/up_nrhm/reports/block_level_month_report.py
@@ -28,7 +28,7 @@ class BlockLevelMonthReport(GenericTabularReport, DatespanMixin, CustomProjectRe
 
     @property
     def report_config(self):
-        startdate = datetime.datetime.now()
+        startdate = datetime.datetime.utcnow()
         if not self.needs_filters:
             year = int(self.request.GET.get('year'))
             month = int(self.request.GET.get('month'))

--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -712,7 +712,7 @@ def awesome_deploy(confirm="yes"):
             '{env.environment}?'.format(env=env), default=False):
         utils.abort('Deployment aborted.')
 
-    if datetime.datetime.utcnow().isoweekday() == 5:
+    if datetime.datetime.now().isoweekday() == 5:
         print('')
         print('┓┏┓┏┓┃')
         print('┛┗┛┗┛┃＼○／')

--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -712,7 +712,7 @@ def awesome_deploy(confirm="yes"):
             '{env.environment}?'.format(env=env), default=False):
         utils.abort('Deployment aborted.')
 
-    if datetime.datetime.now().isoweekday() == 5:
+    if datetime.datetime.utcnow().isoweekday() == 5:
         print('')
         print('┓┏┓┏┓┃')
         print('┛┗┛┗┛┃＼○／')


### PR DESCRIPTION
113 usages. Thankfully for us:

``` python
droberts@hqdjango3:~$ sudo -u cchq /home/cchq/www/production/python_env/bin/python /home/cchq/www/production/code_root/manage.py shell
>>> import datetime
>>> datetime.datetime.now()
datetime.datetime(2015, 4, 2, 16, 56, 0, 234312)
>>> datetime.datetime.utcnow()
datetime.datetime(2015, 4, 2, 16, 56, 0, 235776)
```

(I verified this is true on all prod and india servers.) If the servers' default time had not been UTC, we would have been :meat_on_bone:d
