### PR TITLE
Fix missing logo

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -3338,7 +3338,6 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
     commtrack_enabled = BooleanProperty(default=False)
     commtrack_requisition_mode = StringProperty(choices=CT_REQUISITION_MODES)
     auto_gps_capture = BooleanProperty(default=False)
-    logo_refs = DictProperty()
 
     @classmethod
     def wrap(cls, data):

--- a/corehq/apps/app_manager/suite_xml.py
+++ b/corehq/apps/app_manager/suite_xml.py
@@ -2058,11 +2058,7 @@ class MediaSuiteGenerator(SuiteGeneratorBase):
         PREFIX = 'jr://file/'
         # you have to call remove_unused_mappings
         # before iterating through multimedia_map
-        self.app.remove_unused_mappings(
-            additional_permitted_paths=[
-                value['path'] for value in self.app.logo_refs.values()
-            ]
-        )
+        self.app.remove_unused_mappings()
         if self.app.multimedia_map is None:
             self.app.multimedia_map = {}
         for path, m in self.app.multimedia_map.items():

--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -635,14 +635,14 @@ class HQMediaMixin(Document):
     def logo_paths(self):
         return set(value['path'] for value in self.logo_refs.values())
 
-    def remove_unused_mappings(self, additional_permitted_paths=()):
+    def remove_unused_mappings(self):
         """
             This checks to see if the paths specified in the multimedia map still exist in the Application.
             If not, then that item is removed from the multimedia map.
         """
         map_changed = False
         paths = self.multimedia_map.keys() if self.multimedia_map else []
-        permitted_paths = self.all_media_paths | set(additional_permitted_paths)
+        permitted_paths = self.all_media_paths | self.logo_paths
         for path in paths:
             if path not in permitted_paths:
                 map_changed = True

--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -507,6 +507,9 @@ class HQMediaMixin(Document):
     # keys are the paths to each file in the final application media zip
     multimedia_map = SchemaDictProperty(HQMediaMapItem)
 
+    # paths to custom logos
+    logo_refs = DictProperty()
+
     @property
     @memoized
     def all_media(self):

--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -630,6 +630,11 @@ class HQMediaMixin(Document):
             'is_menu_media': is_menu_media,
         }
 
+    @property
+    @memoized
+    def logo_paths(self):
+        return set(value['path'] for value in self.logo_refs.values())
+
     def remove_unused_mappings(self, additional_permitted_paths=()):
         """
             This checks to see if the paths specified in the multimedia map still exist in the Application.


### PR DESCRIPTION
fixes http://manage.dimagi.com/default.asp?163595

Confirmed backwards compatibility with apps that have working logos.  If the logo does not appear in an existing app, it simply can be re-uploaded to fix it.
