### PR TITLE
Revert "new user es index hash"

### DIFF
--- a/corehq/pillows/mappings/user_mapping.py
+++ b/corehq/pillows/mappings/user_mapping.py
@@ -1,4 +1,4 @@
-USER_INDEX = "hqusers_946fb82f0e2f4946a6d73a89e558d000"
+USER_INDEX="hqusers_06f9a5af623c08f48baea0bc1f5185c8"
 USER_MAPPING={'_all': {'analyzer': 'standard'},
  '_meta': {'comment': 'Ethan modified on 2015-01-29',
            'created': None},


### PR DESCRIPTION
Reverts dimagi/commcare-hq#6170

looks like we won't be needing this
