### PR TITLE
Allow modules with case list menu item but no forms

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1568,11 +1568,6 @@ class ModuleBase(IndexedSchema, NavMenuItemMediaMixin):
 
     def validate_for_build(self):
         errors = []
-        if not self.forms:
-            errors.append({
-                'type': 'no forms',
-                'module': self.get_module_info(),
-            })
         if self.requires_case_details():
             errors.extend(self.get_case_errors(
                 needs_case_type=True,
@@ -1732,6 +1727,11 @@ class Module(ModuleBase):
 
     def validate_for_build(self):
         errors = super(Module, self).validate_for_build()
+        if not self.forms and not self.case_list.show:
+            errors.append({
+                'type': 'no forms or case list',
+                'module': self.get_module_info(),
+            })
         for sort_element in self.detail_sort_elements:
             try:
                 validate_detail_screen_field(sort_element.field)
@@ -2255,7 +2255,11 @@ class AdvancedModule(ModuleBase):
 
     def validate_for_build(self):
         errors = super(AdvancedModule, self).validate_for_build()
-
+        if not self.forms and not self.case_list.show:
+            errors.append({
+                'type': 'no forms or case list',
+                'module': self.get_module_info(),
+            })
         if self.case_list_form.form_id:
             forms = self.forms
 
@@ -2608,6 +2612,15 @@ class CareplanModule(ModuleBase):
             errors = self.validate_detail_columns(columns)
             for error in errors:
                 yield error
+
+    def validate_for_build(self):
+        errors = super(CareplanModule, self).validate_for_build()
+        if not self.forms:
+            errors.append({
+                'type': 'no forms',
+                'module': self.get_module_info(),
+            })
+        return errors
 
 
 class VersionedDoc(LazyAttachmentDoc):

--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -56,6 +56,10 @@
                             Module
                             <a href="{% url "view_module" domain app.id error.module.id %}">{{ error.module.name|trans:langs }}</a>
                             has no forms.
+                        {% case "no forms or case list" %}
+                            Module
+                            <a href="{% url "view_module" domain app.id error.module.id %}">{{ error.module.name|trans:langs }}</a>
+                            has no forms or case list.
                         {% case "no case type" %}
                             Module
                             <a href="{% url "view_module" domain app.id error.module.id %}">{{ error.module.name|trans:langs }}</a>


### PR DESCRIPTION
Allows user to build apps that contain modules with a case list menu item set to show but no forms.
Addresses http://manage.dimagi.com/default.asp?157080

@dannyroberts 
