### PR TITLE
Show "Reports" nav item when editing UCReports

### DIFF
--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -67,6 +67,7 @@ def configurable_reports_home(request, domain):
 
 
 @toggles.USER_CONFIGURABLE_REPORTS.required_decorator()
+@login_and_domain_required
 def edit_report(request, domain, report_id):
     config = get_document_or_404(ReportConfiguration, domain, report_id)
     return _edit_report_shared(request, domain, config)

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -61,18 +61,20 @@ def get_datasource_config_or_404(config_id, domain):
     return config, is_static
 
 
+@login_and_domain_required
 @toggles.USER_CONFIGURABLE_REPORTS.required_decorator()
 def configurable_reports_home(request, domain):
     return render(request, 'userreports/configurable_reports_home.html', _shared_context(domain))
 
 
-@toggles.USER_CONFIGURABLE_REPORTS.required_decorator()
 @login_and_domain_required
+@toggles.USER_CONFIGURABLE_REPORTS.required_decorator()
 def edit_report(request, domain, report_id):
     config = get_document_or_404(ReportConfiguration, domain, report_id)
     return _edit_report_shared(request, domain, config)
 
 
+@login_and_domain_required
 @toggles.USER_CONFIGURABLE_REPORTS.required_decorator()
 def create_report(request, domain):
     return _edit_report_shared(request, domain, ReportConfiguration(domain=domain))
@@ -227,6 +229,7 @@ def delete_report(request, domain, report_id):
     return HttpResponseRedirect(reverse('configurable_reports_home', args=[domain]))
 
 
+@login_and_domain_required
 @toggles.USER_CONFIGURABLE_REPORTS.required_decorator()
 def import_report(request, domain):
     if request.method == "POST":
@@ -249,6 +252,7 @@ def import_report(request, domain):
     return render(request, "userreports/import_report.html", context)
 
 
+@login_and_domain_required
 @toggles.USER_CONFIGURABLE_REPORTS.required_decorator()
 def report_source_json(request, domain, report_id):
     config = get_document_or_404(ReportConfiguration, domain, report_id)
@@ -256,17 +260,20 @@ def report_source_json(request, domain, report_id):
     return json_response(config)
 
 
+@login_and_domain_required
 @toggles.USER_CONFIGURABLE_REPORTS.required_decorator()
 def edit_data_source(request, domain, config_id):
     config, is_static = get_datasource_config_or_404(config_id, domain)
     return _edit_data_source_shared(request, domain, config, read_only=is_static)
 
 
+@login_and_domain_required
 @toggles.USER_CONFIGURABLE_REPORTS.required_decorator()
 def create_data_source(request, domain):
     return _edit_data_source_shared(request, domain, DataSourceConfiguration(domain=domain))
 
 
+@login_and_domain_required
 @toggles.USER_CONFIGURABLE_REPORTS.required_decorator()
 def create_data_source_from_app(request, domain):
     if request.method == 'POST':
@@ -330,7 +337,6 @@ def _delete_data_source_shared(request, domain, config_id):
                      _(u'Data source "{}" has been deleted.'.format(config.display_name)))
 
 
-
 @toggles.USER_CONFIGURABLE_REPORTS.required_decorator()
 @require_POST
 def rebuild_data_source(request, domain, config_id):
@@ -346,6 +352,7 @@ def rebuild_data_source(request, domain, config_id):
     return HttpResponseRedirect(reverse('edit_configurable_data_source', args=[domain, config._id]))
 
 
+@login_and_domain_required
 @toggles.USER_CONFIGURABLE_REPORTS.required_decorator()
 def preview_data_source(request, domain, config_id):
     config, is_static = get_datasource_config_or_404(config_id, domain)


### PR DESCRIPTION
FYI @czue I took this one from the UCR backlog

This one took a while to track down. The issue was that some of the top navigation bar items did not show when viewing pages like the "edit ucr report" page.

It looks like this tab (and the Dashboard tab) are dependent on the `project` attribute existing on the request object. The request object for this page never had `project` set.

It turns out that the `login_and_domain_required` decorator modifies the request object. `apps.domain.decorators.load_domain()`, which is called by `login_and_domain_required`, adds attributes to the request object, including the `project` attribute.

`UITab` objects store the values of `request.project`, and the `ProjectReportsTab` (which is a `UITab` subclass) checks for the existence of the project in its `is_viewable` method, which in turn determines if the `Reports` nav item will be shown.

It makes sense that the Reports tab wouldn't be visible for pages without a domain/logged in user, but it doesn't seem very intuitive that the `login_and_domain_required` decorator would modify the request or would have an affect on how the page is rendered. It's also confusing because `login_and_domain_required` isn't the only way to check if there is a user logged in and domain associated with the page. In this case the `toggles.USER_CONFIGURABLE_REPORTS.required_decorator()` decorator was performing that check. Anyone have any thoughts on that?

It would nice if `request.project` gets set in a more explicit or universal way, although I'm not sure off the top of my head where that should happen. (In middleware perhaps?)

@dannyroberts 
