### PR TITLE
Add transforms to UCR data sources

### DIFF
--- a/corehq/apps/userreports/README.md
+++ b/corehq/apps/userreports/README.md
@@ -372,6 +372,7 @@ datatype        | The datatype of the indicator. Current valid choices are: "dat
 is_nullable     | Whether the database column should allow null values.
 is_primary_key  | Whether the database column should be (part of?) the primary key. (TODO: this needs to be confirmed)
 expression      | Any expression.
+transform       | (optional) transform to be applied to the result of the expression. (see "Report Columns > Transforms" section below)
 
 Here is a sample expression indicator that just saves the "age" property to an integer column in the database:
 

--- a/corehq/apps/userreports/tests/test_indicators.py
+++ b/corehq/apps/userreports/tests/test_indicators.py
@@ -340,6 +340,23 @@ class ExpressionIndicatorTest(SingleIndicatorTestBase):
         }, 'incorrect')
         self._check_result(indicator, {}, None)
 
+    def test_datasource_transform(self):
+        indicator = IndicatorFactory.from_spec({
+            "type": "expression",
+            "column_id": "transformed_value",
+            "display_name": "transformed value",
+            "expression": {
+                "type": "property_name",
+                "property_name": "month",
+            },
+            "datatype": "string",
+            "transform": {
+                "type": "custom",
+                "custom_type": "month_display"
+            },
+        })
+        self._check_result(indicator, {'month': "3"}, "March")
+
 
 class ChoiceListIndicatorTest(SimpleTestCase):
     def setUp(self):


### PR DESCRIPTION
@czue another one from the backlog (which will be useful for the report builder I think)

Adds the ability to specify a transform on `expression` data source indicators. Uses the same transforms as report columns. [ticket](http://manage.dimagi.com/default.asp?164112).

When I was writing this, I started to wonder if it makes more sense to instead add a "transform" type expression that can be nested like the boolean expressions. Transforms are also functionally similar to the datatype feature. I wonder if it makes sense to combine those concepts. Thoughts?

FYI @dannyroberts 
