### PR TITLE
WIP: Bulk invoices

### DIFF
--- a/corehq/apps/accounting/exceptions.py
+++ b/corehq/apps/accounting/exceptions.py
@@ -30,6 +30,18 @@ class InvoiceEmailThrottledError(Exception):
     pass
 
 
+class BulkInvoiceMultipleAccountsError(Exception):
+    pass
+
+
+class BulkInvoiceMultipleProjectsError(Exception):
+    pass
+
+
+class BulkInvoiceNoInvoicesError(Exception):
+    pass
+
+
 class SubscriptionReminderError(Exception):
     pass
 

--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -1527,7 +1527,7 @@ class TriggerInvoiceForm(forms.Form):
             subscription__subscriber__domain=domain_name
         ).all()
         for invoice in last_generated_invoices:
-            for record in invoice.billingrecord_set.all():
+            for record in invoice.billing_records.all():
                 record.pdf.delete()
                 record.delete()
             invoice.subscriptionadjustment_set.all().delete()
@@ -1735,10 +1735,11 @@ class AdjustBalanceForm(forms.Form):
                                   % adjustment_type)
 
     def adjust_balance(self, web_user=None):
+        account = self.invoice.get_account()
         CreditLine.add_credit(
             -self.amount,
-            account=self.invoice.subscription.account,
-            subscription=self.invoice.subscription,
+            account=account,
+            subscription=self.invoice.subscription if not self.invoice.is_bulk else None,
             note=self.cleaned_data['note'],
             invoice=self.invoice,
             reason=self.cleaned_data['method'],

--- a/corehq/apps/accounting/migrations/0038_auto__add_invoicechild__add_bulkinvoice__add_field_invoice_bulk_invoic.py
+++ b/corehq/apps/accounting/migrations/0038_auto__add_invoicechild__add_bulkinvoice__add_field_invoice_bulk_invoic.py
@@ -1,0 +1,312 @@
+# encoding: utf-8
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        
+        # Adding model 'InvoiceChild'
+        db.create_table(u'accounting_invoicechild', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+        ))
+        db.send_create_signal(u'accounting', ['InvoiceChild'])
+
+        # Adding model 'BulkInvoice'
+        db.create_table(u'accounting_bulkinvoice', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('date_created', self.gf('django.db.models.fields.DateTimeField')(auto_now_add=True, blank=True)),
+            ('date_received', self.gf('django.db.models.fields.DateField')(db_index=True, null=True, blank=True)),
+            ('is_hidden_to_ops', self.gf('django.db.models.fields.BooleanField')(default=False)),
+        ))
+        db.send_create_signal(u'accounting', ['BulkInvoice'])
+
+        # Adding field 'Invoice.bulk_invoice'
+        db.add_column(u'accounting_invoice', 'bulk_invoice', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['accounting.BulkInvoice'], null=True), keep_default=False)
+
+        # Deleting field 'BillingRecord.invoice'
+        db.delete_column(u'accounting_billingrecord', 'invoice_id')
+
+        # Adding field 'BillingRecord.content_type'
+        db.add_column(u'accounting_billingrecord', 'content_type', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['contenttypes.ContentType'], null=True, blank=True), keep_default=False)
+
+        # Adding field 'BillingRecord.object_id'
+        db.add_column(u'accounting_billingrecord', 'object_id', self.gf('django.db.models.fields.PositiveIntegerField')(null=True, blank=True), keep_default=False)
+
+
+    def backwards(self, orm):
+        
+        # Deleting model 'InvoiceChild'
+        db.delete_table(u'accounting_invoicechild')
+
+        # Deleting model 'BulkInvoice'
+        db.delete_table(u'accounting_bulkinvoice')
+
+        # Deleting field 'Invoice.bulk_invoice'
+        db.delete_column(u'accounting_invoice', 'bulk_invoice_id')
+
+        # Adding field 'BillingRecord.invoice'
+        db.add_column(u'accounting_billingrecord', 'invoice', self.gf('django.db.models.fields.related.ForeignKey')(default=3, to=orm['accounting.Invoice']), keep_default=False)
+
+        # Deleting field 'BillingRecord.content_type'
+        db.delete_column(u'accounting_billingrecord', 'content_type_id')
+
+        # Deleting field 'BillingRecord.object_id'
+        db.delete_column(u'accounting_billingrecord', 'object_id')
+
+
+    models = {
+        u'accounting.billingaccount': {
+            'Meta': {'object_name': 'BillingAccount'},
+            'account_type': ('django.db.models.fields.CharField', [], {'default': "'CONTRACT'", 'max_length': '25'}),
+            'billing_admins': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['accounting.BillingAccountAdmin']", 'null': 'True', 'symmetrical': 'False'}),
+            'created_by': ('django.db.models.fields.CharField', [], {'max_length': '80'}),
+            'created_by_domain': ('django.db.models.fields.CharField', [], {'max_length': '256', 'null': 'True', 'blank': 'True'}),
+            'currency': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Currency']"}),
+            'date_confirmed_extra_charges': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'dimagi_contact': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'entry_point': ('django.db.models.fields.CharField', [], {'default': "'NOT_SET'", 'max_length': '25'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_auto_invoiceable': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'db_index': 'True'}),
+            'salesforce_account_id': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '80', 'null': 'True', 'blank': 'True'})
+        },
+        u'accounting.billingaccountadmin': {
+            'Meta': {'object_name': 'BillingAccountAdmin'},
+            'domain': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '256', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'web_user': ('django.db.models.fields.CharField', [], {'max_length': '80', 'db_index': 'True'})
+        },
+        u'accounting.billingcontactinfo': {
+            'Meta': {'object_name': 'BillingContactInfo'},
+            'account': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['accounting.BillingAccount']", 'unique': 'True', 'primary_key': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'company_name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'emails': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True'}),
+            'first_line': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'phone_number': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'postal_code': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'second_line': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'state_province_region': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'accounting.billingrecord': {
+            'Meta': {'object_name': 'BillingRecord'},
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']", 'null': 'True', 'blank': 'True'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'emailed_to': ('django.db.models.fields.CharField', [], {'max_length': '254', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'object_id': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'pdf_data_id': ('django.db.models.fields.CharField', [], {'max_length': '48'}),
+            'skipped_email': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'accounting.bulkinvoice': {
+            'Meta': {'object_name': 'BulkInvoice'},
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'date_received': ('django.db.models.fields.DateField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_hidden_to_ops': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'accounting.creditadjustment': {
+            'Meta': {'object_name': 'CreditAdjustment'},
+            'amount': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'credit_line': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.CreditLine']"}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'invoice': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Invoice']", 'null': 'True'}),
+            'line_item': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.LineItem']", 'null': 'True'}),
+            'note': ('django.db.models.fields.TextField', [], {}),
+            'payment_record': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.PaymentRecord']", 'null': 'True'}),
+            'reason': ('django.db.models.fields.CharField', [], {'default': "'MANUAL'", 'max_length': '25'}),
+            'related_credit': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'creditadjustment_related'", 'null': 'True', 'to': u"orm['accounting.CreditLine']"}),
+            'web_user': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True'})
+        },
+        u'accounting.creditline': {
+            'Meta': {'object_name': 'CreditLine'},
+            'account': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.BillingAccount']"}),
+            'balance': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'feature_type': ('django.db.models.fields.CharField', [], {'max_length': '10', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'product_type': ('django.db.models.fields.CharField', [], {'max_length': '25', 'null': 'True', 'blank': 'True'}),
+            'subscription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Subscription']", 'null': 'True', 'blank': 'True'})
+        },
+        u'accounting.currency': {
+            'Meta': {'object_name': 'Currency'},
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '3'}),
+            'date_updated': ('django.db.models.fields.DateField', [], {'auto_now': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '25', 'db_index': 'True'}),
+            'rate_to_default': ('django.db.models.fields.DecimalField', [], {'default': "'1.0'", 'max_digits': '20', 'decimal_places': '9'}),
+            'symbol': ('django.db.models.fields.CharField', [], {'max_length': '10'})
+        },
+        u'accounting.defaultproductplan': {
+            'Meta': {'object_name': 'DefaultProductPlan'},
+            'edition': ('django.db.models.fields.CharField', [], {'default': "'Community'", 'max_length': '25'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_trial': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'plan': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwarePlan']"}),
+            'product_type': ('django.db.models.fields.CharField', [], {'max_length': '25'})
+        },
+        u'accounting.feature': {
+            'Meta': {'object_name': 'Feature'},
+            'feature_type': ('django.db.models.fields.CharField', [], {'max_length': '10', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '40'})
+        },
+        u'accounting.featurerate': {
+            'Meta': {'object_name': 'FeatureRate'},
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'feature': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Feature']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'monthly_fee': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '10', 'decimal_places': '2'}),
+            'monthly_limit': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'per_excess_fee': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '10', 'decimal_places': '2'})
+        },
+        u'accounting.invoice': {
+            'Meta': {'object_name': 'Invoice'},
+            'balance': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'bulk_invoice': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.BulkInvoice']", 'null': 'True'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'date_due': ('django.db.models.fields.DateField', [], {'db_index': 'True'}),
+            'date_end': ('django.db.models.fields.DateField', [], {}),
+            'date_paid': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_received': ('django.db.models.fields.DateField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'date_start': ('django.db.models.fields.DateField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_hidden': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_hidden_to_ops': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'subscription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Subscription']"}),
+            'tax_rate': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'})
+        },
+        u'accounting.invoicechild': {
+            'Meta': {'object_name': 'InvoiceChild'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'accounting.lineitem': {
+            'Meta': {'object_name': 'LineItem'},
+            'base_cost': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'base_description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'feature_rate': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.FeatureRate']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'invoice': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Invoice']"}),
+            'product_rate': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwareProductRate']", 'null': 'True'}),
+            'quantity': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'unit_cost': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'unit_description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'accounting.paymentmethod': {
+            'Meta': {'object_name': 'PaymentMethod'},
+            'account': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.BillingAccount']"}),
+            'billing_admin': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.BillingAccountAdmin']"}),
+            'customer_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'method_type': ('django.db.models.fields.CharField', [], {'default': "'Stripe'", 'max_length': '50', 'db_index': 'True'})
+        },
+        u'accounting.paymentrecord': {
+            'Meta': {'object_name': 'PaymentRecord'},
+            'amount': ('django.db.models.fields.DecimalField', [], {'default': "'0.0000'", 'max_digits': '10', 'decimal_places': '4'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'payment_method': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.PaymentMethod']"}),
+            'transaction_id': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'accounting.softwareplan': {
+            'Meta': {'object_name': 'SoftwarePlan'},
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'edition': ('django.db.models.fields.CharField', [], {'default': "'Enterprise'", 'max_length': '25'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'visibility': ('django.db.models.fields.CharField', [], {'default': "'INTERNAL'", 'max_length': '10'})
+        },
+        u'accounting.softwareplanversion': {
+            'Meta': {'object_name': 'SoftwarePlanVersion'},
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'feature_rates': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['accounting.FeatureRate']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'plan': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwarePlan']"}),
+            'product_rates': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['accounting.SoftwareProductRate']", 'symmetrical': 'False', 'blank': 'True'}),
+            'role': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['django_prbac.Role']"})
+        },
+        u'accounting.softwareproduct': {
+            'Meta': {'object_name': 'SoftwareProduct'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '40'}),
+            'product_type': ('django.db.models.fields.CharField', [], {'max_length': '25', 'db_index': 'True'})
+        },
+        u'accounting.softwareproductrate': {
+            'Meta': {'object_name': 'SoftwareProductRate'},
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'monthly_fee': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '10', 'decimal_places': '2'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwareProduct']"})
+        },
+        u'accounting.subscriber': {
+            'Meta': {'object_name': 'Subscriber'},
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '256', 'null': 'True', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'organization': ('django.db.models.fields.CharField', [], {'max_length': '256', 'null': 'True', 'db_index': 'True'})
+        },
+        u'accounting.subscription': {
+            'Meta': {'object_name': 'Subscription'},
+            'account': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.BillingAccount']"}),
+            'auto_generate_credits': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'date_delay_invoicing': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_end': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_start': ('django.db.models.fields.DateField', [], {}),
+            'do_not_invoice': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_trial': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'plan_version': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.SoftwarePlanVersion']"}),
+            'pro_bono_status': ('django.db.models.fields.CharField', [], {'default': "'NOT_SET'", 'max_length': '25'}),
+            'salesforce_contract_id': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'service_type': ('django.db.models.fields.CharField', [], {'default': "'NOT_SET'", 'max_length': '25'}),
+            'subscriber': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Subscriber']"})
+        },
+        u'accounting.subscriptionadjustment': {
+            'Meta': {'object_name': 'SubscriptionAdjustment'},
+            'date_created': ('django.db.models.fields.DateField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'invoice': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Invoice']", 'null': 'True'}),
+            'method': ('django.db.models.fields.CharField', [], {'default': "'INTERNAL'", 'max_length': '50'}),
+            'new_date_delay_invoicing': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'new_date_end': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'new_date_start': ('django.db.models.fields.DateField', [], {}),
+            'new_salesforce_contract_id': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True', 'blank': 'True'}),
+            'note': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'reason': ('django.db.models.fields.CharField', [], {'default': "'CREATE'", 'max_length': '50'}),
+            'related_subscription': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'subscriptionadjustment_related'", 'null': 'True', 'to': u"orm['accounting.Subscription']"}),
+            'subscription': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Subscription']"}),
+            'web_user': ('django.db.models.fields.CharField', [], {'max_length': '80', 'null': 'True'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'django_prbac.role': {
+            'Meta': {'object_name': 'Role'},
+            'description': ('django.db.models.fields.TextField', [], {'default': "u''", 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'parameters': ('django_prbac.fields.StringSetField', [], {'default': '[]', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '256'})
+        }
+    }
+
+    complete_apps = ['accounting']

--- a/corehq/apps/accounting/templates/accounting/invoice_email.html
+++ b/corehq/apps/accounting/templates/accounting/invoice_email.html
@@ -3,9 +3,19 @@
 <p>{{ greeting }}</p>
 
 <p>
+    {% if plan_name %}
+
     {% blocktrans %}
     Your {{ plan_name }} Billing Statement is now available for {{ month_name }}.
     {% endblocktrans %}
+
+    {% else %}
+
+    {% blocktrans %}
+    Your Bulk Billing Statement is now available for {{ month_name }}.
+    {% endblocktrans %}
+
+    {% endif %}
 </p>
 
 <table cellpadding="2">
@@ -27,6 +37,7 @@
             </a>
         </td>
     </tr>
+    {% if plan_name %}
     <tr>
         <th align="right">
             {% trans 'Software Plan' %}:
@@ -35,6 +46,7 @@
             {{ plan_name }}
         </td>
     </tr>
+    {% endif %}
     <tr>
         <th align="right">
             {% trans 'Status' %}:
@@ -70,10 +82,19 @@
 </p>
 
 <p>
+    {% if plan_name %}
+
     {% blocktrans %}
-    Thank you for using {{ plan_name }}. If you have any questions, please don't
-    hesitate to contact {{ invoicing_contact_email }}.
+    Thank you for using {{ plan_name }}. If you have any questions, please don't hesitate to contact {{ invoicing_contact_email }}.
     {% endblocktrans %}
+
+    {% else %}
+
+    {% blocktrans %}
+    Thank you. If you have any questions, please don't hesitate to contact {{ invoicing_contact_email }}.
+    {% endblocktrans %}
+
+    {% endif %}
 </p>
 
 <p>

--- a/corehq/apps/accounting/templates/accounting/invoice_email_plaintext.html
+++ b/corehq/apps/accounting/templates/accounting/invoice_email_plaintext.html
@@ -1,12 +1,34 @@
 {% load i18n %}
 {% blocktrans %}
 {{ greeting }}
+{% endblocktrans %}
 
+
+{% if plan_name %}
+
+{% blocktrans %}
 Your {{ plan_name }} Billing Statement is now available for {{ month_name }}.
+{% endblocktrans %}
 
+{% else %}
+
+{% blocktrans %}
+Your Bulk Billing Statement is now available for {{ month_name }}.
+{% endblocktrans %}
+
+{% endif %}
+
+
+{% blocktrans %}
 Statement No.: {{ statement_number }}
 Project Space: {{ domain }}
+{% endblocktrans %}
+{% if plan_name %}
+{% blocktrans %}
 Software Plan: {{ plan_name }}
+{% endblocktrans %}
+{% endif %}
+{% blocktrans %}
 Status: {{ payment_status }}
 Amount Due: {{ amount_due }}
 {% endblocktrans %}
@@ -24,10 +46,17 @@ Billing Statements at {{ statements_url }}
 {% endblocktrans %}
 {% endif %}
 
+{% if plan_name %}
 {% blocktrans %}
-Thank you for using {{ plan_name }}. If you have any questions, please don't
-hesitate to contact {{ invoicing_contact_email }}.
+Thank you for using {{ plan_name }}. If you have any questions, please don't hesitate to contact {{ invoicing_contact_email }}.
+{% endblocktrans %}
+{% else %}
+{% blocktrans %}
+Thank you. If you have any questions, please don't hesitate to contact {{ invoicing_contact_email }}.
+{% endblocktrans %}
+{% endif %}
 
+{% blocktrans %}
 Best Regards,
 The CommCare HQ Team
 www.commcarehq.org

--- a/corehq/apps/accounting/tests/__init__.py
+++ b/corehq/apps/accounting/tests/__init__.py
@@ -4,6 +4,7 @@ from .test_models import *
 from .test_invoicing import *
 from .test_invoice_factory import *
 from .test_credit_lines import *
+from .test_bulk_invoicing import *
 from .test_subscription_changes import *
 from .test_new_domain_subscription import *
 

--- a/corehq/apps/accounting/tests/test_bulk_invoicing.py
+++ b/corehq/apps/accounting/tests/test_bulk_invoicing.py
@@ -1,0 +1,91 @@
+import random
+
+from django.core import mail
+
+from corehq.apps.accounting import generator, tasks, utils
+from corehq.apps.accounting.invoicing import DomainBulkInvoiceFactory
+from corehq.apps.accounting.tests.base_tests import BaseAccountingTest
+from corehq.apps.accounting.tests.test_invoicing import BaseInvoiceTestCase
+from corehq.apps.accounting.models import BulkInvoice, Invoice, CreditLine, BillingRecord
+from corehq.apps.accounting.utils import get_dimagi_from_email
+
+
+class BulkInvoiceTestCase(BaseInvoiceTestCase):
+
+    def setUp(self):
+        super(BulkInvoiceTestCase, self).setUp()
+        invoice_date = utils.months_from_date(self.subscription.date_start, 2)
+        tasks.generate_invoices(invoice_date)
+
+        invoice_date = utils.months_from_date(self.subscription.date_start, 3)
+        tasks.generate_invoices(invoice_date)
+
+        self.bulk_invoice = BulkInvoice.objects.create()
+        self.bulk_invoice.invoice_set = Invoice.objects.all()
+
+        self.invoices = Invoice.objects.all()
+
+    def tearDown(self):
+        super(BulkInvoiceTestCase, self).tearDown()
+        self.invoices.delete()
+        self.bulk_invoice.delete()
+
+    def test_balance(self):
+
+        self.assertEqual(self.bulk_invoice.balance, self.invoices[0].balance + self.invoices[1].balance)
+
+        # Add some credit
+        before_balance = sum(map(lambda i: i.balance, Invoice.objects.all()))
+        credit = 100
+        CreditLine.add_credit(credit, subscription=self.subscription)
+        for i in Invoice.objects.all():
+            i.calculate_credit_adjustments()
+            i.update_balance()
+            i.save()
+
+        self.bulk_invoice = BulkInvoice.objects.get(id=self.bulk_invoice.id)
+        self.assertEqual(self.bulk_invoice.balance, before_balance - credit)
+
+    def test_dates(self):
+        start_dates = sorted(map(lambda i: i.date_start, self.invoices))
+        end_dates = sorted(map(lambda i: i.date_end, self.invoices))
+        due_dates = sorted(map(lambda i: i.date_due, self.invoices))
+
+        self.assertEqual(self.bulk_invoice.date_start, start_dates[0])
+        self.assertEqual(self.bulk_invoice.date_end, end_dates[1])
+        self.assertEqual(self.bulk_invoice.date_due, due_dates[1])
+
+    def test_project_name(self):
+        project_name = self.bulk_invoice.get_project_name()
+        self.assertEqual(project_name, self.invoices[0].subscription.subscriber.domain)
+
+    def test_billing_record(self):
+        mail.outbox = []
+        br = BillingRecord.generate_record(self.bulk_invoice)
+        br.send_email()
+
+        self.assertEqual(len(mail.outbox),
+            sum([len(i.email_recipients) for i in self.invoices]))
+
+        msg = mail.outbox[0]
+        self.assertEqual(len(msg.attachments), 1)
+        self.assertEqual(msg.from_email, get_dimagi_from_email())
+
+    def test_bulk_invoice_factory(self):
+        mail.outbox = []
+        self.bulk_invoice.delete()
+        bi_factory = DomainBulkInvoiceFactory(self.bulk_invoice.get_project_name())
+        bi = bi_factory.create_bulk_invoice()
+
+        self.assertEqual(len(bi.invoice_set.all()), 2)
+        self.assertEqual(len(mail.outbox),
+            sum([len(i.email_recipients) for i in self.invoices]))
+
+        bi_factory = DomainBulkInvoiceFactory(
+            self.bulk_invoice.get_project_name(),
+            contact_emails=emails
+        )
+
+        # Once invoices get assigned to bulk invoice, don't overwrite
+        with self.assertRaises(BulkInvoiceNoInvoicesError):
+            bi = bi_factory.create_bulk_invoice(self.invoices)

--- a/corehq/apps/accounting/utils.py
+++ b/corehq/apps/accounting/utils.py
@@ -151,7 +151,7 @@ def get_address_from_invoice(invoice):
     from corehq.apps.accounting.models import BillingContactInfo
     try:
         contact_info = BillingContactInfo.objects.get(
-            account=invoice.subscription.account,
+            account=invoice.get_account(),
         )
         return Address(
             name=(
@@ -178,6 +178,10 @@ def get_dimagi_from_email_by_product(product):
         'product': product,
         'email': settings.INVOICING_CONTACT_EMAIL,
     })
+
+
+def get_dimagi_from_email():
+    return "Dimagi <{email}>".format(email=settings.INVOICING_CONTACT_EMAIL)
 
 
 def quantize_accounting_decimal(decimal_value):

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -677,7 +677,7 @@ class InvoiceSummaryView(AccountingSectionView):
     @property
     @memoized
     def billing_records(self):
-        return self.invoice.billingrecord_set.all()
+        return self.invoice.billing_records.all()
 
     @property
     @memoized

--- a/corehq/apps/domain/templates/domain/billing_statements.html
+++ b/corehq/apps/domain/templates/domain/billing_statements.html
@@ -13,11 +13,18 @@
 
         var bulkPaymentHandler = new PaymentMethodHandler(
             {{ payment_error_messages|JSON }},
-            "{% trans "Submit Payment" %}"
+            { submitBtnText: "{% trans "Submit Payment" %}" }
+        );
+        var bulkWirePaymentHandler = new PaymentMethodHandler(
+            {{ payment_error_messages|JSON }},
+            {
+                submitBtnText: "{% trans "Submit Invoice Request" %}",
+                isWire: true
+            }
         );
         var paymentHandler = new PaymentMethodHandler(
             {{ payment_error_messages|JSON }},
-            "{% trans "Submit Payment" %}"
+            { submitBtnText: "{% trans "Submit Payment" %}" }
         );
 
         {% if stripe_cards %}
@@ -28,6 +35,7 @@
 
         $(function () {
             ko.applyBindings(bulkPaymentHandler, $('#bulkPaymentModal').get(0));
+            ko.applyBindings(bulkWirePaymentHandler, $('#bulkWirePaymentModal').get(0));
             ko.applyBindings(paymentHandler, $('#paymentModal').get(0));
         });
 
@@ -36,6 +44,12 @@
                 totalBalance: {{ total_balance }}
             }));
             bulkPaymentHandler.reset();
+        });
+        $('#bulkWirePaymentBtn').click(function () {
+            bulkWirePaymentHandler.costItem(new TotalCostItem({
+                totalBalance: {{ total_balance }}
+            }));
+            bulkWirePaymentHandler.reset();
         });
 
         paginatedListModel.showUnpaidBills = ko.observable(true);
@@ -88,6 +102,15 @@
                     data-target="#bulkPaymentModal"
                     id="bulkPaymentBtn">
                 {% trans 'Pay with Credit Card' %}
+            </button>
+        </p>
+        <p>
+            <button type="button"
+                    class="btn btn-success"
+                    data-toggle="modal"
+                    data-target="#bulkWirePaymentModal"
+                    id="bulkWirePaymentBtn">
+                {% trans 'Pay by Wire' %}
             </button>
         </p>
     </div>
@@ -214,14 +237,22 @@
             {% trans 'Bulk Payment' %}
         </h3>
     </script>
+
+    <script type="text/html" id="bulk-wire-payment-method-modal-title">
+        <h3>{% trans 'Bulk Wire Payment' %}</h3>
+    </script>
 {% endblock %}
 
 {% block modals %}{{ block.super }}
     {% with process_invoice_payment_url as process_payment_url %}
         {% include 'domain/partials/payment_modal.html' with payment_modal_id="paymentModal" title_template="payment-method-modal-title" cost_item_template="cost-item-template" %}
     {% endwith %}
+
     {% with process_bulk_payment_url as process_payment_url %}
         {% include 'domain/partials/payment_modal.html' with payment_modal_id="bulkPaymentModal" title_template="bulk-payment-method-modal-title" cost_item_template="cost-item-template" %}
     {% endwith %}
 
+    {% with process_bulk_wire_invoice_url as process_payment_url %}
+        {% include 'domain/partials/payment_modal.html' with payment_modal_id="bulkWirePaymentModal" title_template="bulk-wire-payment-method-modal-title" cost_item_template="cost-item-template" %}
+    {% endwith %}
 {% endblock %}

--- a/corehq/apps/domain/templates/domain/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/current_subscription.html
@@ -15,7 +15,7 @@
 
         var paymentHandler = new PaymentMethodHandler(
             {{ payment_error_messages|JSON }},
-            "{% trans "Buy Credits" %}"
+            { submitBtnText: "{% trans "Buy Credits" %}" }
         );
         {% if plan.cards %}
             paymentHandler.loadCards({{ plan.cards|JSON }});

--- a/corehq/apps/domain/templates/domain/partials/payment_modal.html
+++ b/corehq/apps/domain/templates/domain/partials/payment_modal.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 
-<div class="modal hide fade" id="{{ payment_modal_id }}">
+<div class="payment-modal modal hide fade" id="{{ payment_modal_id }}">
     <div class="modal-header">
         <a class="close" data-dismiss="modal">&times;</a>
         <div data-bind="template: {
@@ -11,8 +11,7 @@
     </div>
     <form action="{{ process_payment_url }}"
           method="POST"
-          class="form form-horizontal"
-          id="payment-form">
+          class="form form-horizontal payment-form">
         <div class="modal-body">
             <div data-bind="template: {
                 data: costItem,
@@ -26,6 +25,31 @@
                 <span data-bind="text: serverErrorMsg"></span>
             </p>
 
+            <!-- ko if: isWire -->
+            <div>
+                <fieldset>
+                    <legend>{% trans 'Wire Payment Information' %}</legend>
+                    <p>
+                    {% blocktrans %}
+                    Dimagi accepts wire payments via ACH and wire transfer. You will receive an invoice via email with instructions for wire payment. Please include the invoice ID in the wire payment details.
+                    {% endblocktrans %}
+                    </p>
+                    <div class="control-group">
+                        <label class="control-label">
+                            {% trans 'Invoice Recipients' %}
+                        </label>
+                        <div class="controls">
+                            <input type="text"
+                                    data-bind="value: wireEmails"
+                                    size="20"
+                                    name="emails"
+                                    placeholder="jane@gmail.com john@gmail.com" />
+                        </div>
+                    </div>
+                </fieldset>
+            </div>
+            <!-- /ko -->
+            <!-- ko ifnot: isWire -->
             <div data-bind="template: {
                 data: newCard,
                 name: 'select-new-stripe-card-template',
@@ -37,6 +61,7 @@
                 name: 'select-stripe-card-template',
                 if: canSelectCard
             }"></div>
+            <!-- /ko -->
 
             <p class="alert alert-success"
                  data-bind="visible: paymentIsComplete">
@@ -57,7 +82,7 @@
                     data-bind="
                         visible: paymentIsNotComplete,
                         disable: isSubmitDisabled,
-                        click: processPayment,
+                        submit: processPayment,
                         text: submitBtnText"
                     class="btn btn-success">
             </button>

--- a/corehq/apps/domain/urls.py
+++ b/corehq/apps/domain/urls.py
@@ -22,7 +22,7 @@ from corehq.apps.domain.views import (
     AddFormRepeaterView, AddOpsUserAsDomainAdminView,
     FeatureFlagsView, EditDhis2SettingsView, TransferDomainView,
     ActivateTransferDomainView, DeactivateTransferDomainView,
-    BulkStripePaymentView)
+    BulkStripePaymentView, BulkWireInvoiceView)
 
 #
 # After much reading, I discovered that Django matches URLs derived from the environment
@@ -118,6 +118,8 @@ domain_settings = patterns(
         name=InvoiceStripePaymentView.urlname),
     url(r'^billing/make_bulk_payment/$', BulkStripePaymentView.as_view(),
         name=BulkStripePaymentView.urlname),
+    url(r'^billing/make_bulk_wire_invoice/$', BulkWireInvoiceView.as_view(),
+        name=BulkWireInvoiceView.urlname),
     url(r'^billing/join_billing_admins/$', AddOpsUserAsDomainAdminView.as_view(),
         name=AddOpsUserAsDomainAdminView.urlname),
     url(r'^subscription/$', DomainSubscriptionView.as_view(), name=DomainSubscriptionView.urlname),


### PR DESCRIPTION
Gonna end up redoing this PR, but thought I'd get some feedback before making any more modifications, since this whole PR feels like a huge hack that deserves a bit more thought if we want it to work well. 

Currently the datamodel is setup such that `BulkInvoice` has many `Invoice`s and both `BulkInvoice` and `Invoice` inherit from `InvoiceBase`. There are a couple of issues with this:
- Because Django's polymorphic support sucks, we can't query both `BulkInvoices` and `Invoices` in the same query. This means all pagination is broken in the sense that we pretty much have to load most models in order to figure out which `BulkInvoices` and which `Invoices` to insert.
- `BulkInvoice` doesn't really have a balance. It's balance is determined by the invoices it has. Thus, when you click `Pay by wire` and submit how much you want to pay, it doesn't really make sense since the balance is predetermined.
- As it stands, BulkInvoice to Invoice is a many to one relationship, so if you try to create multiple BulkInvoices, over the same set of invoices, either the new BulkInvoice has no invoices, or the other one magically has its invoices disappear.
- BulkInvoice technically can span over multiple subscriptions, which breaks a lot of existing functionality that assumes one subscription for an invoice. Not sure what we can do here to fix that besides hack around it.

Some other ideas:
- Don't make BulkInvoice explicitly contain any invoices, rather have it contain a daterange and get its invoices based on the date range.
- Give BulkInvoice a balance and make sure to update any bulk invoice when the invoice gets updated.
- Make InvoiceBase not an abstract class, this should allow for querying both Invoice and BulkInvoice in the same query, but presents its own difficulties regarding data migrations

@nickpell @biyeun let me know if you have any advice/feedback/ideas on what makes most sense, or if you're fine going forward with the caveats listed
