### PR TITLE
Require contacts

### DIFF
--- a/corehq/apps/accounting/async_handlers.py
+++ b/corehq/apps/accounting/async_handlers.py
@@ -181,7 +181,7 @@ class Select2BillingInfoHandler(BaseSelect2AsyncHandler):
         accounts = BillingAccount.objects.filter(is_active=True)
         if self.search_string:
             accounts = accounts.filter(name__contains=self.search_string)
-        return [(a.name, a.name) for a in accounts]
+        return [(a.id, a.name) for a in accounts]
 
     @property
     def domain_response(self):

--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -83,7 +83,7 @@ class BillingAccountBasicForm(forms.Form):
         required=False,
         initial=True,
     )
-    active_accounts = forms.CharField(
+    active_accounts = forms.IntegerField(
         label=_("Transfer Subscriptions To"),
         help_text=_("Transfer any existing subscriptions to the "
                     "Billing Account specified here."),
@@ -193,7 +193,7 @@ class BillingAccountBasicForm(forms.Form):
                 _("This account has subscriptions associated with it. "
                   "Please specify a transfer account before deactivating.")
             )
-        if self.account is not None and transfer_subs == self.account.name:
+        if self.account is not None and transfer_subs == self.account.id:
             raise ValidationError(
                 _("The transfer account can't be the same one you're trying "
                   "to deactivate.")
@@ -225,9 +225,9 @@ class BillingAccountBasicForm(forms.Form):
     def update_basic_info(self, account):
         account.name = self.cleaned_data['name']
         account.is_active = self.cleaned_data['is_active']
-        transfer_name = self.cleaned_data['active_accounts']
-        if transfer_name:
-            transfer_account = BillingAccount.objects.get(name=transfer_name)
+        transfer_id = self.cleaned_data['active_accounts']
+        if not transfer_id:
+            transfer_account = BillingAccount.objects.get(id=transfer_id)
             for sub in account.subscription_set.all():
                 sub.account = transfer_account
                 sub.save()
@@ -359,7 +359,7 @@ class SubscriptionForm(forms.Form):
     auto_generate_credits = forms.BooleanField(
         label=_("Auto-generate Plan Credits"), required=False
     )
-    active_accounts = forms.CharField(
+    active_accounts = forms.IntegerField(
         label=_("Transfer Subscription To"),
         required=False,
     )
@@ -583,7 +583,7 @@ class SubscriptionForm(forms.Form):
 
     def clean_active_accounts(self):
         transfer_account = self.cleaned_data.get('active_accounts')
-        if transfer_account and transfer_account == self.subscription.account.name:
+        if transfer_account and transfer_account == self.subscription.account.id:
             raise ValidationError("Please select an account other than the "
                                   "current account to transfer to.")
         return transfer_account
@@ -602,7 +602,7 @@ class SubscriptionForm(forms.Form):
         )
         transfer_account = self.cleaned_data.get('active_accounts')
         if transfer_account:
-            acct = BillingAccount.objects.get(name=transfer_account)
+            acct = BillingAccount.objects.get(id=transfer_account)
             self.subscription.account = acct
             self.subscription.save()
 

--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -74,7 +74,7 @@ class BillingAccountBasicForm(forms.Form):
     currency = forms.ChoiceField(label="Currency")
 
     emails = forms.CharField(
-        label=_('Additional Contact Emails'),
+        label=_('Client Contact Emails'),
         widget=forms.Textarea,
         max_length=BillingContactInfo._meta.get_field('emails').max_length,
     )

--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -328,7 +328,7 @@ class BillingAccountContactForm(forms.Form):
 
 
 class SubscriptionForm(forms.Form):
-    account = forms.CharField(
+    account = forms.IntegerField(
         label=_("Billing Account")
     )
     start_date = forms.DateField(
@@ -348,7 +348,7 @@ class SubscriptionForm(forms.Form):
         label=_("Edition"), initial=SoftwarePlanEdition.ENTERPRISE,
         choices=SoftwarePlanEdition.CHOICES,
     )
-    plan_version = forms.CharField(label=_("Software Plan"))
+    plan_version = forms.IntegerField(label=_("Software Plan"))
     domain = forms.CharField(label=_("Project Space"))
     salesforce_contract_id = forms.CharField(
         label=_("Salesforce Deployment ID"), max_length=80, required=False

--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -545,14 +545,6 @@ class SubscriptionForm(forms.Form):
                 raise forms.ValidationError("A valid project space is required.")
         return domain_name
 
-    def clean_end_date(self):
-        start_date = self.subscription.date_start \
-            if self.is_existing else self.cleaned_data['start_date']
-        if (self.cleaned_data['end_date'] is not None
-            and start_date > self.cleaned_data['end_date']):
-            raise ValidationError("End date must be after start date.")
-        return self.cleaned_data['end_date']
-
     def clean(self):
         account_id = self.cleaned_data['active_accounts'] or self.cleaned_data['account']
         account = BillingAccount.objects.get(id=account_id)
@@ -567,6 +559,12 @@ class SubscriptionForm(forms.Form):
                     account.name,
                 )
             ))
+
+        start_date = self.subscription.date_start \
+            if self.is_existing else self.cleaned_data['start_date']
+        if (self.cleaned_data['end_date'] is not None
+            and start_date > self.cleaned_data['end_date']):
+            raise ValidationError("End date must be after start date.")
 
     def create_subscription(self):
         account = BillingAccount.objects.get(id=self.cleaned_data['account'])


### PR DESCRIPTION
Before creating a new subscription or updating an existing subscription, check that the billing account to be used has client contact emails.  Should reduce the number of times a contracted subscription is missing contact emails for invoicing.
![screen shot 2015-04-07 at 2 07 03 pm](https://cloud.githubusercontent.com/assets/1757035/7031012/a72c8ba6-dd36-11e4-9fa4-b063cb22fad8.png)

Replaces "Additional Contact Emails" with the clearer "Client Contact Emails" (confluence docs to be updated)
![screen shot 2015-04-07 at 2 07 13 pm](https://cloud.githubusercontent.com/assets/1757035/7031016/ab0d1376-dd36-11e4-9e60-94f058739e76.png)

@biyeun @benrudolph @amsagoff 
