### PR TITLE
Iso string to datetime

### DIFF
--- a/corehq/apps/reports/standard/cases/data_sources.py
+++ b/corehq/apps/reports/standard/cases/data_sources.py
@@ -1,7 +1,6 @@
 from couchdbkit import ResourceNotFound
 import datetime
 import dateutil
-from dimagi.utils.parsing import string_to_utc_datetime
 from django.core import cache
 from django.core.urlresolvers import reverse, NoReverseMatch
 from django.template.defaultfilters import yesno
@@ -11,6 +10,7 @@ import json
 from casexml.apps.case.models import CommCareCaseAction
 from corehq.apps.groups.models import Group
 from corehq.apps.users.models import CommCareUser, CouchUser
+from corehq.util.dates import iso_string_to_datetime
 from corehq.util.view_utils import absolute_reverse
 from dimagi.utils.couch.database import get_db
 from dimagi.utils.decorators.memoized import memoized
@@ -179,7 +179,7 @@ class CaseInfo(object):
 
     def parse_date(self, date_string):
         try:
-            return string_to_utc_datetime(date_string)
+            return iso_string_to_datetime(date_string)
         except:
             try:
                 date_obj = dateutil.parser.parse(date_string)

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -19,12 +19,13 @@ from corehq.apps.sofabed.models import FormData, CaseData
 from corehq.apps.users.models import CommCareUser
 from corehq.elastic import es_query
 from corehq.pillows.mappings.case_mapping import CASE_INDEX
+from corehq.util.dates import iso_string_to_datetime
 from corehq.util.timezones.conversions import ServerTime, PhoneTime
 from corehq.util.view_utils import absolute_reverse
 from dimagi.utils.couch.database import get_db
 from dimagi.utils.dates import DateSpan, today_or_tomorrow
 from dimagi.utils.decorators.memoized import memoized
-from dimagi.utils.parsing import string_to_datetime, string_to_utc_datetime
+from dimagi.utils.parsing import string_to_datetime
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_noop
 
@@ -910,7 +911,7 @@ class WorkerActivityTimes(WorkerMonitoringChartBase,
                     startkey=key+[self.datespan.startdate_param_utc],
                     endkey=key+[self.datespan.enddate_param_utc],
                 ).all()
-                all_times.extend([string_to_utc_datetime(d['key'][-1])
+                all_times.extend([iso_string_to_datetime(d['key'][-1])
                                   for d in data])
         if self.by_submission_time:
             all_times = [ServerTime(t).user_time(self.timezone).done()

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -16,6 +16,7 @@ from corehq.apps.groups.models import Group
 from corehq.apps.reports.models import HQUserType, TempCommCareUser
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.util import user_id_to_username
+from corehq.util.dates import iso_string_to_datetime
 from corehq.util.timezones.utils import get_timezone_for_user
 from couchexport.util import SerializableFunction
 from dimagi.utils.couch.cache import cache_core
@@ -23,7 +24,7 @@ from dimagi.utils.couch.database import get_db
 from dimagi.utils.dates import DateSpan
 from corehq.apps.domain.models import Domain
 from dimagi.utils.decorators.memoized import memoized
-from dimagi.utils.parsing import string_to_datetime, string_to_utc_datetime
+from dimagi.utils.parsing import string_to_datetime
 from dimagi.utils.web import json_request
 
 
@@ -272,7 +273,7 @@ def datespan_export_filter(doc, datespan):
     if isinstance(datespan, dict):
         datespan = DateSpan(**datespan)
     try:
-        received_on = string_to_utc_datetime(doc['received_on']).replace(tzinfo=pytz.utc)
+        received_on = iso_string_to_datetime(doc['received_on']).replace(tzinfo=pytz.utc)
     except Exception:
         if settings.DEBUG:
             raise

--- a/corehq/util/dates.py
+++ b/corehq/util/dates.py
@@ -1,5 +1,6 @@
 import datetime
 import time
+from corehq.util.soft_assert import soft_assert
 
 
 def unix_time(dt):
@@ -52,3 +53,31 @@ def safe_strftime(val, fmt):
     return safe_val.strftime(fmt
                              .replace("%Y", str(val.year))
                              .replace("%y", str(val.year)[-2:]))
+
+
+_assert = soft_assert('droberts' + '@' + 'dimagi.com')
+
+
+def iso_string_to_datetime(iso_string):
+    """
+    parse datetime string in iso format with or without microseconds,
+    always with both date and time
+    and always with the 'Z' UTC timezone suffix
+
+    return an offset-naive datetime representing UTC
+
+
+    >>> iso_string_to_datetime('2015-04-07T19:07:55Z')
+    datetime.datetime(2015, 4, 7, 19, 7, 55)
+    >>> iso_string_to_datetime('2015-04-07T19:07:55.437086Z')
+    datetime.datetime(2015, 4, 7, 19, 7, 55, 437086)
+
+    """
+    for fmt in ['%Y-%m-%dT%H:%M:%SZ', '%Y-%m-%dT%H:%M:%S.%fZ']:
+        try:
+            return datetime.datetime.strptime(iso_string, fmt)
+        except ValueError:
+            pass
+    _assert(False, 'input not in expected format: {!r}'.format(iso_string))
+    from dimagi.utils.parsing import string_to_utc_datetime
+    return string_to_utc_datetime(iso_string)

--- a/corehq/util/tests/__init__.py
+++ b/corehq/util/tests/__init__.py
@@ -3,3 +3,9 @@ from test_toggle import *
 from test_quickcache import *
 from test_timezone_conversions import *
 from test_soft_assert import *
+
+from corehq.util.dates import iso_string_to_datetime
+
+__test__ = {
+    'iso_string_to_datetime': iso_string_to_datetime
+}

--- a/custom/bihar/reports/display.py
+++ b/custom/bihar/reports/display.py
@@ -4,10 +4,10 @@ from corehq.apps.reports.standard.cases.data_sources import CaseDisplay
 from casexml.apps.case.models import CommCareCase
 from django.utils.translation import ugettext as _
 import logging
+from corehq.util.dates import iso_string_to_datetime
 from custom.bihar.calculations.utils.xmlns import BP, NEW, MTB_ABORT, DELIVERY, REGISTRATION, PNC
 from couchdbkit.exceptions import ResourceNotFound
 from corehq.apps.users.models import CommCareUser, CouchUser
-from dimagi.utils.parsing import string_to_utc_datetime
 
 EMPTY_FIELD = "---"
 
@@ -96,7 +96,7 @@ class MCHDisplay(CaseDisplay):
                 # assuming it's a date string or datetime string,
                 # DefaultProperty will wrap it as the correct type
                 # todo: there has to be a better way
-                return str(self.report.date_to_json(string_to_utc_datetime(date_string)))
+                return str(self.report.date_to_json(iso_string_to_datetime(date_string)))
             except AttributeError:
                 return _("Bad date format!")
             except TypeError:


### PR DESCRIPTION
Add stricter replacement for `string_to_utc_datetime` and `string_to_datetime`. It falls back on `string_to_utc_datetime` if it gets a format it doesn't expect, and notifies me via a `soft_assert`

Also change a bunch of random places to use `iso_string_to_datetime`. I did this somewhat conservatively with `string_to_datetime` because that function's behavior is a little more unpredictable.
