### PR TITLE
allow single email in soft_assert

### DIFF
--- a/corehq/util/soft_assert/api.py
+++ b/corehq/util/soft_assert/api.py
@@ -64,6 +64,9 @@ def soft_assert(to, notify_admins=False,
 
     """
 
+    if isinstance(to, basestring):
+        to = [to]
+
     def send_to_recipients(subject, message):
         send_mail(
             # this prefix is automatically added in mail_admins


### PR DESCRIPTION
instead of requiring a list of emails

I've been using it this way in my last couple PRs, so clearly the previous restriction was unintuitive.
