### PR TITLE
only allow subscription end dates in the future

### DIFF
--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -566,6 +566,9 @@ class SubscriptionForm(forms.Form):
             and start_date > self.cleaned_data['end_date']):
             raise ValidationError("End date must be after start date.")
 
+        if self.cleaned_data['end_date'] <= datetime.date.today():
+            raise ValidationError("End date must be in the future.")
+
         return self.cleaned_data
 
     def create_subscription(self):


### PR DESCRIPTION
Addresses the problems listed in http://manage.dimagi.com/default.asp?163885, where a subscription is not properly deactivated due to its end date being set to a past date.  Since the workflow for Ops to guarantee that the subscription isn't just canceled is complicated (the next subscription has to be already set up or else reminders will get canceled) it's easier just to prevent the Ops user from canceling the subscription in this manner.

@benrudolph @biyeun 
