### PR TITLE
Add location.metadata to location fixture restore

### DIFF
--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -139,7 +139,7 @@ def _types_to_fixture(location_db, type, locs, type_lookup_function):
 def _get_metadata_node(location):
     node = Element('location_data')
     for key, value in location.metadata.items():
-        element = Element('data', attrib={'key': unicode(key)})
+        element = Element(key)
         element.text = value
         node.append(element)
     return node

--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from xml.etree import ElementTree
+from xml.etree.ElementTree import Element
 from corehq.apps.commtrack.util import unicode_slug
 from corehq.apps.locations.models import Location
 from corehq import toggles
@@ -75,9 +75,9 @@ def location_fixture_generator(user, version, last_sync=None):
     if not should_sync_locations(last_sync, location_db):
         return []
 
-    root = ElementTree.Element('fixture',
-                               {'id': 'commtrack:locations',
-                                'user_id': user.user_id})
+    root = Element('fixture',
+                   {'id': 'commtrack:locations',
+                    'user_id': user.user_id})
 
     loc_types = project.location_types
     type_to_slug_mapping = dict((ltype.name, ltype.code) for ltype in loc_types)
@@ -130,14 +130,23 @@ def _group_by_type(locations):
 
 
 def _types_to_fixture(location_db, type, locs, type_lookup_function):
-    type_node = ElementTree.Element('%ss' % type_lookup_function(type))  # ghetto pluralization
+    type_node = Element('%ss' % type_lookup_function(type))  # ghetto pluralization
     for loc in locs:
         type_node.append(_location_to_fixture(location_db, loc, type_lookup_function))
     return type_node
 
 
+def _get_metadata_node(location):
+    node = Element('location_data')
+    for key, value in location.metadata.items():
+        element = Element('data', attrib={'key': unicode(key)})
+        element.text = value
+        node.append(element)
+    return node
+
+
 def _location_to_fixture(location_db, location, type_lookup_function):
-    root = ElementTree.Element(type_lookup_function(location.location_type), {'id': location._id})
+    root = Element(type_lookup_function(location.location_type), {'id': location._id})
     fixture_fields = [
         'name',
         'site_code',
@@ -147,10 +156,11 @@ def _location_to_fixture(location_db, location, type_lookup_function):
         'location_type',
     ]
     for field in fixture_fields:
-        field_node = ElementTree.Element(field)
+        field_node = Element(field)
         val = getattr(location, field)
         field_node.text = unicode(val if val is not None else '')
         root.append(field_node)
 
+    root.append(_get_metadata_node(location))
     _append_children(root, location_db, location_db.by_parent[location._id], type_lookup_function)
     return root

--- a/corehq/apps/locations/tests/__init__.py
+++ b/corehq/apps/locations/tests/__init__.py
@@ -4,3 +4,4 @@ from .test_locations import *
 from .test_products_at_location import *
 from .test_site_code import *
 from .test_location_set import *
+from .test_location_fixtures import *

--- a/corehq/apps/locations/tests/test_location_fixtures.py
+++ b/corehq/apps/locations/tests/test_location_fixtures.py
@@ -1,0 +1,22 @@
+from django.test import SimpleTestCase
+from corehq.apps.locations.models import Location
+from ..fixtures import _location_to_fixture, _location_footprint
+
+
+class LocationFixturesTest(SimpleTestCase):
+
+    def test_metadata(self):
+        location = Location(
+            _id="unique-id",
+            domain="test-domain",
+            name="Braavos",
+            location_type="state",
+            metadata={'best_swordsman': "Sylvio Forel",
+                      'in_westeros': "false"},
+        )
+        location_db = _location_footprint([location])
+        fixture = _location_to_fixture(location_db, location, id)
+        location_data = {
+            e.attrib['key']: e.text for e in fixture.find('location_data')
+        }
+        self.assertEquals(location_data, location.metadata)

--- a/corehq/apps/locations/tests/test_location_fixtures.py
+++ b/corehq/apps/locations/tests/test_location_fixtures.py
@@ -17,6 +17,6 @@ class LocationFixturesTest(SimpleTestCase):
         location_db = _location_footprint([location])
         fixture = _location_to_fixture(location_db, location, id)
         location_data = {
-            e.attrib['key']: e.text for e in fixture.find('location_data')
+            e.tag: e.text for e in fixture.find('location_data')
         }
         self.assertEquals(location_data, location.metadata)


### PR DESCRIPTION
this adds a block to each location like:

``` xml
<location_data>
    <best_swordsman>Sylvio Forel</best_swordsman>
    <in_westeros>false</in_westeros>
</location_data>
```

for a dict of the form:

``` json
{"best_swordsman": "Sylvio Forel",
 "in_westeros": false}
```
