### PR TITLE
remove misleading dead code in invoicing

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1518,7 +1518,6 @@ class BillingRecord(models.Model):
         record._pdf = invoice_pdf
         if record.invoice.subscription.do_not_invoice:
             record.skipped_email = True
-            invoice.is_hidden = True
         record.save()
         return record
 

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1516,8 +1516,7 @@ class BillingRecord(models.Model):
         invoice_pdf.generate_pdf(record.invoice)
         record.pdf_data_id = invoice_pdf._id
         record._pdf = invoice_pdf
-        if record.invoice.subscription.do_not_invoice:
-            record.skipped_email = True
+        record.skipped_email = record.invoice.subscription.do_not_invoice
         record.save()
         return record
 

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1516,7 +1516,7 @@ class BillingRecord(models.Model):
         invoice_pdf.generate_pdf(record.invoice)
         record.pdf_data_id = invoice_pdf._id
         record._pdf = invoice_pdf
-        record.skipped_email = record.invoice.subscription.do_not_invoice
+        record.skipped_email = invoice.is_hidden
         record.save()
         return record
 

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1530,7 +1530,7 @@ class BillingRecord(models.Model):
         ).count() > MAX_INVOICE_COMMUNICATIONS
 
     def send_email(self, contact_emails=None):
-        if self.invoice.subscription.do_not_invoice:
+        if self.skipped_email:
             return
         pdf_attachment = {
             'title': self.pdf.get_filename(self.invoice),


### PR DESCRIPTION
save() does not cascade in Django, so removing misleading dead code.  Also enforces that if a subscription has do not invoice removed, the correct workflow is to trigger a new invoice, rather than resend a hidden invoice.

@biyeun @benrudolph 
