### PR TITLE
fix direct references to "%Y-%m-%d"

### DIFF
--- a/corehq/apps/accounting/filters.py
+++ b/corehq/apps/accounting/filters.py
@@ -12,6 +12,7 @@ from corehq.apps.reports.filters.base import (
     BaseReportFilter, BaseSingleOptionFilter
 )
 from corehq.apps.reports.filters.search import SearchFilter
+from corehq.util.dates import iso_string_to_date
 from dimagi.utils.dates import DateSpan
 from django.utils.translation import ugettext_noop as _
 
@@ -197,7 +198,8 @@ class DateRangeFilter(BaseReportFilter):
         date_str = cls.get_date_str(request, date_type)
         if date_str is not None:
             try:
-                return datetime.datetime.strptime(date_str, "%Y-%m-%d")
+                return datetime.datetime.combine(
+                    iso_string_to_date(date_str), datetime.time())
             except ValueError:
                 if date_type == cls.START_DATE:
                     return datetime.datetime.today() - datetime.timedelta(days=cls.default_days)
@@ -220,7 +222,6 @@ class DateRangeFilter(BaseReportFilter):
     def datespan(self):
         datespan = DateSpan.since(self.default_days,
                                   enddate=datetime.date.today(),
-                                  format="%Y-%m-%d",
                                   timezone=self.timezone)
         if self.get_start_date(self.request) is not None:
             datespan.startdate = self.get_start_date(self.request)

--- a/corehq/apps/api/es.py
+++ b/corehq/apps/api/es.py
@@ -12,6 +12,7 @@ from corehq.pillows.mappings.reportcase_mapping import REPORT_CASE_INDEX
 from corehq.pillows.mappings.reportxform_mapping import REPORT_XFORM_INDEX
 from corehq.pillows.mappings.user_mapping import USER_INDEX
 from corehq.pillows.mappings.xform_mapping import XFORM_INDEX
+from dimagi.utils.parsing import ISO_DATE_FORMAT
 
 from no_exceptions.exceptions import Http400
 from dimagi.utils.logging import notify_exception
@@ -434,7 +435,8 @@ class ReportXFormES(XFormES):
 
     @classmethod
     def by_case_id_query(cls, domain, case_id, terms=None, doc_type='xforminstance',
-                         date_field=None, startdate=None, enddate=None, date_format='%Y-%m-%d'):
+                         date_field=None, startdate=None, enddate=None,
+                         date_format=ISO_DATE_FORMAT):
         """
         Run a case_id query on both case properties (supporting old and new) for xforms.
 
@@ -609,7 +611,7 @@ class ESQuerySet(object):
 
 def validate_date(date):
     try:
-        datetime.datetime.strptime(date, '%Y-%m-%d')
+        datetime.datetime.strptime(date, ISO_DATE_FORMAT)
     except ValueError:
         try:
             datetime.datetime.strptime(date, '%Y-%m-%dT%H:%M:%S')

--- a/corehq/apps/callcenter/tests/test_indicator_fixture.py
+++ b/corehq/apps/callcenter/tests/test_indicator_fixture.py
@@ -20,7 +20,7 @@ class MockIndicatorSet(object):
 
     @property
     def reference_date(self):
-        return datetime.strptime("2014-01-01T00:00:00", "%Y-%m-%dT%H:%M:%S")
+        return datetime(2014, 1, 1, 0, 0)
 
 
 class CallcenterFixtureTests(SimpleTestCase):

--- a/corehq/apps/cleanup/management/commands/check_case_integrity.py
+++ b/corehq/apps/cleanup/management/commands/check_case_integrity.py
@@ -8,6 +8,7 @@ import dateutil.parser as dparser
 import csv
 import logging
 from dimagi.utils.chunked import chunked
+from dimagi.utils.parsing import json_format_date
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +24,7 @@ def forms_with_cases(domain=None, since=None, chunksize=500):
     if since:
         q["filter"]["and"][0]["bool"]["must"] = {
             "range": {
-                "received_on": {"from": since.strftime("%Y-%m-%d")}}}
+                "received_on": {"from": json_format_date(since)}}}
     q["filter"]["and"].extend(ADD_TO_ES_FILTER["forms"][:])
     return stream_es_query(params=params, q=q, es_url=ES_URLS["forms"],
                            fields=["__retrieved_case_ids", "domain", "received_on"], chunksize=chunksize)

--- a/corehq/apps/cloudcare/api.py
+++ b/corehq/apps/cloudcare/api.py
@@ -18,6 +18,7 @@ import urllib
 from dimagi.utils.couch.database import iter_docs
 from dimagi.utils.chunked import chunked
 from django.utils.translation import ugettext as _
+from dimagi.utils.parsing import json_format_date
 from touchforms.formplayer.models import EntrySession
 from django.core.urlresolvers import reverse
 
@@ -236,19 +237,19 @@ class ElasticCaseQuery(object):
         
     @property
     def date_modified_start(self):
-        return self._date_modified_start or datetime(1970,1,1).strftime("%Y-%m-%d")
+        return self._date_modified_start or json_format_date(datetime(1970, 1, 1))
         
     @property
     def date_modified_end(self):
-        return self._date_modified_end or datetime.max.strftime("%Y-%m-%d")
+        return self._date_modified_end or json_format_date(datetime.max)
         
     @property
     def server_date_modified_start(self):
-        return self._server_date_modified_start or datetime(1970,1,1).strftime("%Y-%m-%d")
+        return self._server_date_modified_start or json_format_date(datetime(1970, 1, 1))
         
     @property
     def server_date_modified_end(self):
-        return self._server_date_modified_end or datetime.max.strftime("%Y-%m-%d")
+        return self._server_date_modified_end or json_format_date(datetime.max)
         
     @property
     def scrubbed_filters(self):

--- a/corehq/apps/commtrack/util.py
+++ b/corehq/apps/commtrack/util.py
@@ -19,6 +19,7 @@ from casexml.apps.case.xml import V2
 from django.utils.text import slugify
 from unidecode import unidecode
 from corehq.feature_previews import enable_commtrack_previews
+from corehq.util.dates import iso_string_to_date
 from dimagi.utils.parsing import json_format_datetime
 from django.utils.translation import ugettext as _
 import re
@@ -239,7 +240,7 @@ def due_date_monthly(day, from_end=False, past_period=0):
 
 
 def num_periods_late(product_case, schedule, *schedule_args):
-    last_reported = datetime.strptime(getattr(product_case, 'last_reported', '2000-01-01')[:10], '%Y-%m-%d').date()
+    last_reported = iso_string_to_date(getattr(product_case, 'last_reported', '2000-01-01')[:10])
 
     class DueDateStream(object):
         """mimic an array of due dates to perform a binary search"""

--- a/corehq/apps/domainsync/management/commands/copy_domain.py
+++ b/corehq/apps/domainsync/management/commands/copy_domain.py
@@ -7,6 +7,7 @@ from django.core.management.base import BaseCommand, CommandError
 from casexml.apps.stock.models import StockTransaction, StockReport, DocDomainMapping
 from corehq.apps.domain.models import Domain
 from corehq.apps.domainsync.management.commands.copy_utils import copy_postgres_data_for_docs
+from corehq.util.dates import iso_string_to_date
 from dimagi.utils.couch.database import get_db, iter_docs
 from corehq.apps.domainsync.config import DocumentTransform, save
 from couchdbkit.client import Database
@@ -15,6 +16,7 @@ from datetime import datetime
 
 # doctypes we want to be careful not to copy, which must be explicitly
 # specified with --include
+from dimagi.utils.parsing import json_format_date
 
 DEFAULT_EXCLUDE_TYPES = [
     'ReportNotification',
@@ -88,7 +90,7 @@ class Command(BaseCommand):
         simulate = options['simulate']
         exclude_attachments = options['exclude_attachments']
 
-        since = datetime.strptime(options['since'], '%Y-%m-%d').isoformat() if options['since'] else None
+        since = json_format_date(iso_string_to_date(options['since'])) if options['since'] else None
 
         if options['list_types']:
             self.list_types(sourcedb, domain, since)

--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -18,6 +18,7 @@ from couchexport.schema import build_latest_schema
 from dimagi.utils.decorators.memoized import memoized
 from django.utils.translation import ugettext as _, ugettext_noop, ugettext_lazy
 from dimagi.utils.logging import notify_exception
+from dimagi.utils.parsing import json_format_date
 from dimagi.utils.web import json_response
 
 require_form_export_permission = require_permission(
@@ -125,7 +126,7 @@ class BaseCreateCustomExportView(BaseExportView):
                 name="%s: %s" % (
                     xmlns_to_name(self.domain, export_tag[1], app_id=app_id)
                         if self.export_helper.export_type == "form" else export_tag[1],
-                    datetime.utcnow().strftime("%Y-%m-%d")
+                    json_format_date(datetime.utcnow())
                 ),
                 type=self.export_helper.export_type
             )

--- a/corehq/apps/hqadmin/reporting/reports.py
+++ b/corehq/apps/hqadmin/reporting/reports.py
@@ -57,7 +57,7 @@ from corehq.elastic import (
 )
 
 from casexml.apps.stock.models import StockReport, StockTransaction
-from corehq.util.dates import get_timestamp_millis
+from corehq.util.dates import get_timestamp_millis, iso_string_to_date
 
 CASE_COUNT_UPPER_BOUND = 1000 * 1000 * 10
 COUNTRY_COUNT_UPPER_BOUND = 1000 * 1000 * 10
@@ -848,11 +848,8 @@ def _histo_data_non_cumulative(domain_list, histogram_type, start_date,
         # TODO - add to configs
         return 90 if histogram_type == 'active_cases' else 30
 
-    timestamps = daterange(
-        interval,
-        datetime.strptime(start_date, "%Y-%m-%d").date(),
-        datetime.strptime(end_date, "%Y-%m-%d").date(),
-    )
+    timestamps = daterange(interval, iso_string_to_date(start_date),
+                           iso_string_to_date(end_date))
     histo_data = {}
     for domain_name_data in domain_list:
         display_name = domain_name_data['display_name']

--- a/corehq/apps/hqadmin/views.py
+++ b/corehq/apps/hqadmin/views.py
@@ -76,7 +76,7 @@ from corehq.db import Session
 from corehq.elastic import parse_args_for_es, ES_URLS, run_query
 from dimagi.utils.couch.database import get_db, is_bigcouch
 from dimagi.utils.decorators.datespan import datespan_in_request
-from dimagi.utils.parsing import json_format_datetime
+from dimagi.utils.parsing import json_format_datetime, json_format_date
 from dimagi.utils.web import json_response, get_url_base
 from dimagi.utils.django.email import send_HTML_email
 
@@ -790,7 +790,7 @@ def callcenter_test(request):
     context = {
         "error": error,
         "mobile_user": user,
-        "date": query_date.strftime("%Y-%m-%d"),
+        "date": json_format_date(query_date),
         "enable_caching": enable_caching,
         "data": data,
         "doc_id": doc_id

--- a/corehq/apps/hqpillow_retry/views.py
+++ b/corehq/apps/hqpillow_retry/views.py
@@ -18,6 +18,7 @@ from corehq.apps.reports.dispatcher import AdminReportDispatcher
 from corehq.apps.reports.generic import GenericTabularReport, GetParamsMixin
 from corehq.apps.reports.standard import DatespanMixin
 from dimagi.utils.decorators.memoized import memoized
+from dimagi.utils.parsing import json_format_date
 from dimagi.utils.web import get_url_base
 from pillow_retry.models import PillowError
 from django.conf import settings
@@ -31,7 +32,7 @@ ACTIONS = [ACTION_RESET, ACTION_DELETE, ACTION_SEND]
 
 
 def safe_format_date(date):
-    return date.strftime("%Y-%m-%d") if date else date
+    return json_format_date(date) if date else date
 
 
 class PillowErrorsReport(GenericTabularReport, DatespanMixin, GetParamsMixin):

--- a/corehq/apps/reminders/views.py
+++ b/corehq/apps/reminders/views.py
@@ -1312,7 +1312,7 @@ def reminders_in_error(request, domain):
             "handler_name" : handler.nickname,
             "case_id" : case.get_id if case is not None else None,
             "case_name" : case.name if case is not None else None,
-            "next_fire" : ServerTime(reminder.next_fire).user_time(timezone).done().strftime("%Y-%m-%d %H:%M:%S"),
+            "next_fire" : ServerTime(reminder.next_fire).user_time(timezone).ui_string("%Y-%m-%d %H:%M:%S"),
             "error_msg" : reminder.error_msg or "-",
             "recipient_name" : get_recipient_name(recipient),
         })

--- a/corehq/apps/reports/filters/dates.py
+++ b/corehq/apps/reports/filters/dates.py
@@ -1,5 +1,6 @@
 import json
 from django.utils.translation import ugettext_lazy, ugettext as _
+from corehq.util.dates import iso_string_to_date
 from dimagi.utils.dates import DateSpan
 from corehq.apps.reports.filters.base import BaseReportFilter
 import datetime
@@ -19,7 +20,7 @@ class DatespanFilter(BaseReportFilter):
 
     @property
     def datespan(self):
-        datespan = DateSpan.since(self.default_days, format="%Y-%m-%d", timezone=self.timezone, inclusive=self.inclusive)
+        datespan = DateSpan.since(self.default_days, timezone=self.timezone, inclusive=self.inclusive)
         if self.request.datespan.is_valid() and self.slug == 'datespan':
             datespan.startdate = self.request.datespan.startdate
             datespan.enddate = self.request.datespan.enddate
@@ -56,7 +57,7 @@ class SingleDateFilter(BaseReportFilter):
         from_req = self.request.GET.get('date')
         if from_req:
             try:
-                return datetime.datetime.strptime(from_req, '%Y-%m-%d').date()
+                return iso_string_to_date(from_req)
             except ValueError:
                 pass
 

--- a/corehq/apps/reports/standard/__init__.py
+++ b/corehq/apps/reports/standard/__init__.py
@@ -1,9 +1,8 @@
-from datetime import timedelta, datetime
+from datetime import datetime
 import dateutil
 from django.core.cache import cache
 from django.core.urlresolvers import reverse
 import operator
-import pytz
 from casexml.apps.case.models import CommCareCaseGroup
 from corehq.apps.groups.models import Group
 from corehq.apps.reports import util
@@ -18,7 +17,6 @@ from dimagi.utils.dates import DateSpan
 from django.utils.translation import ugettext_noop
 from dimagi.utils.decorators.memoized import memoized
 
-DATE_FORMAT = "%Y-%m-%d"
 
 class ProjectReport(GenericReportView):
     # overriding properties from GenericReportView

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -10,7 +10,7 @@ from corehq.apps.es.forms import FormES
 from corehq.apps.reports import util
 from corehq.apps.reports.filters.users import ExpandedMobileWorkerFilter as EMWF
 from corehq.apps.reports.standard import ProjectReportParametersMixin, \
-    DatespanMixin, ProjectReport, DATE_FORMAT
+    DatespanMixin, ProjectReport
 from corehq.apps.reports.filters.forms import CompletionOrSubmissionTimeFilter, FormsByApplicationFilter, SingleFormByApplicationFilter, MISSING_APP_ID
 from corehq.apps.reports.datatables import DataTablesHeader, DataTablesColumn, DTSortType, DataTablesColumnGroup
 from corehq.apps.reports.generic import GenericTabularReport
@@ -25,7 +25,7 @@ from corehq.util.view_utils import absolute_reverse
 from dimagi.utils.couch.database import get_db
 from dimagi.utils.dates import DateSpan, today_or_tomorrow
 from dimagi.utils.decorators.memoized import memoized
-from dimagi.utils.parsing import string_to_datetime
+from dimagi.utils.parsing import string_to_datetime, json_format_date
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_noop
 
@@ -440,7 +440,7 @@ class DailyFormStatsReport(WorkerMonitoringReportTableBase, CompletionOrSubmissi
     def headers(self):
         headers = DataTablesHeader(DataTablesColumn(_("Username"), span=3))
         for d in self.dates:
-            headers.add_column(DataTablesColumn(d.strftime(DATE_FORMAT), sort_type=DTSortType.NUMERIC))
+            headers.add_column(DataTablesColumn(json_format_date(d), sort_type=DTSortType.NUMERIC))
         headers.add_column(DataTablesColumn(_("Total"), sort_type=DTSortType.NUMERIC))
         return headers
 
@@ -584,7 +584,7 @@ class DailyFormStatsReport(WorkerMonitoringReportTableBase, CompletionOrSubmissi
         count_field = '%s__count' % self.date_field
         counts_by_date = dict((result['date'].isoformat(), result[count_field]) for result in results)
         date_cols = [
-            counts_by_date.get(date.strftime(DATE_FORMAT), 0)
+            counts_by_date.get(json_format_date(date), 0)
             for date in self.dates
         ]
         styled_date_cols = ['<span class="muted">0</span>' if c == 0 else c for c in date_cols]

--- a/corehq/apps/reports/tests/test_data_sources.py
+++ b/corehq/apps/reports/tests/test_data_sources.py
@@ -14,8 +14,8 @@ PRODUCT_ID = StockStatusDataSource.SLUG_PRODUCT_ID
 LOCATION_ID = StockStatusDataSource.SLUG_LOCATION_ID
 
 
-format_string = "%Y-%m-%d"
 TEST_DOMAIN = 'commtrack-test1'
+
 
 class DataSourceTest(object):
     # fixme: need to make a test again

--- a/corehq/apps/reports/tests/test_report_api.py
+++ b/corehq/apps/reports/tests/test_report_api.py
@@ -8,7 +8,6 @@ from .sql_fixture import load_data
 from .sql_reports import combine_indicator
 
 DOMAIN = "test"
-format_string = "%Y-%m-%d"''
 
 unity = lambda x: x
 

--- a/corehq/apps/reports/tests/test_sql_reports.py
+++ b/corehq/apps/reports/tests/test_sql_reports.py
@@ -1,16 +1,17 @@
-from datetime import datetime
+from datetime import datetime, time
 from django import test as unittest
 from django.test.client import RequestFactory
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import WebUser
 from corehq.db import Session
+from corehq.util.dates import iso_string_to_date
 from dimagi.utils.dates import DateSpan
+from dimagi.utils.parsing import json_format_date
 
 from .sql_fixture import load_data
 from .sql_reports import test_report, UserTestReport, RegionTestReport
 
 DOMAIN = "test"
-format_string = "%Y-%m-%d"
 
 
 class BaseReportTest(unittest.TestCase):
@@ -51,11 +52,11 @@ class BaseReportTest(unittest.TestCase):
     def _get_request(self, startdate, enddate):
         request = self.factory.get('/')
         request.couch_user = self.couch_user
-        request.datespan = DateSpan(self.date(startdate), self.date(enddate), format_string)
+        request.datespan = DateSpan(self.date(startdate), self.date(enddate))
         return request
 
     def date(self, d):
-        return datetime.strptime(d, format_string)
+        return datetime.combine(iso_string_to_date(d), time())
 
 
 class SimpleReportTest(BaseReportTest):

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -109,8 +109,6 @@ from corehq.apps.domain.decorators import login_and_domain_required
 
 from casexml.apps.case.xform import extract_case_blocks
 
-DATE_FORMAT = "%Y-%m-%d"
-
 datespan_default = datespan_in_request(
     from_param="startdate",
     to_param="enddate",

--- a/corehq/apps/reports_core/filters.py
+++ b/corehq/apps/reports_core/filters.py
@@ -1,7 +1,8 @@
 from collections import namedtuple
-from datetime import datetime
+from datetime import datetime, time
 from corehq.apps.userreports.expressions.getters import transform_from_datatype
 from corehq.apps.userreports.reports.filters import SHOW_ALL_CHOICE
+from corehq.util.dates import iso_string_to_date
 
 from dimagi.utils.dates import DateSpan
 from dimagi.utils.decorators.memoized import memoized
@@ -118,8 +119,10 @@ class DatespanFilter(BaseFilter):
         date_range_inclusive = kwargs.get('date_range_inclusive', True)
 
         def date_or_nothing(param):
-            return datetime.strptime(param, "%Y-%m-%d") \
-                if param else None
+            if param:
+                return datetime.combine(iso_string_to_date(param), time())
+            else:
+                return None
         try:
             startdate = date_or_nothing(startdate)
             enddate = date_or_nothing(enddate)

--- a/corehq/apps/userreports/tests/test_data_source_config.py
+++ b/corehq/apps/userreports/tests/test_data_source_config.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from django.test import SimpleTestCase, TestCase
 from jsonobject.exceptions import BadValueError
 from corehq.apps.userreports.models import DataSourceConfiguration
+from corehq.util.dates import iso_string_to_date
 
 
 class DataSourceConfigurationTest(SimpleTestCase):
@@ -91,7 +92,7 @@ def get_sample_doc_and_indicators():
     expected_indicators = {
         'doc_id': 'some-doc-id',
         'repeat_iteration': 0,
-        'date': datetime.datetime.strptime(date_opened, '%Y-%m-%d').date(),
+        'date': iso_string_to_date(date_opened),
         'owner': 'some-user-id',
         'count': 1,
         'category_bug': 1, 'category_feature': 0, 'category_app': 0, 'category_schedule': 0,

--- a/corehq/apps/users/tests/create.py
+++ b/corehq/apps/users/tests/create.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from django.test import TestCase
 from corehq.apps.users.util import format_username
+from corehq.util.dates import iso_string_to_date
 from couchforms.models import XFormInstance
 from corehq.apps.users.models import CouchUser, WebUser, CommCareUser
 from dimagi.utils.dates import force_to_datetime
@@ -132,7 +133,7 @@ class CreateTestCase(TestCase):
         self.assertEqual(couch_user.username, format_username(self.username, self.domain))
         self.assertEqual(couch_user.domain, self.domain)
         self.assertEqual(couch_user.user_id, self.uuid)
-        date = datetime.date(datetime.strptime(self.date_string,'%Y-%m-%d'))
+        date = iso_string_to_date(self.date_string)
         self.assertEqual(couch_user.created_on, force_to_datetime(date))
         self.assertEqual(couch_user.device_ids[0], self.registering_device_id)
 

--- a/corehq/ex-submodules/casexml/apps/case/xml/generator.py
+++ b/corehq/ex-submodules/casexml/apps/case/xml/generator.py
@@ -1,7 +1,8 @@
 from casexml.apps.case.xml import V1, V2, V3, check_version, V2_NAMESPACE
 from xml.etree import ElementTree
 import logging
-from dimagi.utils.parsing import json_format_datetime
+from dimagi.utils.parsing import json_format_datetime, json_format_date
+
 
 def safe_element(tag, text=None):
     # shortcut for commonly used functionality
@@ -13,9 +14,9 @@ def safe_element(tag, text=None):
     else:
         return ElementTree.Element(tag)
 
+
 def date_to_xml_string(date):
-    if date: return date.strftime("%Y-%m-%d")
-    return ""
+    return json_format_date(date) if date else ''
 
 
 def get_dynamic_element(key, val):

--- a/corehq/util/dates.py
+++ b/corehq/util/dates.py
@@ -1,6 +1,7 @@
 import datetime
 import time
 from corehq.util.soft_assert import soft_assert
+from dimagi.utils.parsing import ISO_DATE_FORMAT
 
 
 def unix_time(dt):
@@ -81,3 +82,15 @@ def iso_string_to_datetime(iso_string):
     _assert(False, 'input not in expected format: {!r}'.format(iso_string))
     from dimagi.utils.parsing import string_to_utc_datetime
     return string_to_utc_datetime(iso_string)
+
+
+def iso_string_to_date(iso_string):
+    """
+    parse a date string in iso format
+
+    return a datetime.date
+    >>> iso_string_to_date('2015-04-07')
+    datetime.date(2015, 4, 7)
+
+    """
+    return datetime.datetime.strptime(iso_string, ISO_DATE_FORMAT).date()

--- a/corehq/util/tests/__init__.py
+++ b/corehq/util/tests/__init__.py
@@ -4,8 +4,9 @@ from test_quickcache import *
 from test_timezone_conversions import *
 from test_soft_assert import *
 
-from corehq.util.dates import iso_string_to_datetime
+from corehq.util.dates import iso_string_to_datetime, iso_string_to_date
 
 __test__ = {
-    'iso_string_to_datetime': iso_string_to_datetime
+    'iso_string_to_datetime': iso_string_to_datetime,
+    'iso_string_to_date': iso_string_to_date,
 }

--- a/custom/_legacy/a5288/reports.py
+++ b/custom/_legacy/a5288/reports.py
@@ -8,7 +8,7 @@ from casexml.apps.case.models import CommCareCase
 from corehq.apps.sms.models import ExpectedCallbackEventLog, CALLBACK_PENDING, CALLBACK_RECEIVED, CALLBACK_MISSED
 from datetime import datetime, timedelta
 from corehq.util.timezones.conversions import ServerTime
-from dimagi.utils.parsing import json_format_datetime
+from dimagi.utils.parsing import json_format_datetime, json_format_date
 
 
 class MissedCallbackReport(CustomProjectReport, GenericTabularReport):
@@ -62,7 +62,7 @@ class MissedCallbackReport(CustomProjectReport, GenericTabularReport):
                 }
 
         dates = self.get_past_two_weeks()
-        date_strings = [date.strftime("%Y-%m-%d") for date in dates]
+        date_strings = [json_format_date(date) for date in dates]
 
         start_date = dates[0] - timedelta(days=1)
         end_date = dates[-1] + timedelta(days=2)

--- a/custom/_legacy/hsph/reports/call_center.py
+++ b/custom/_legacy/hsph/reports/call_center.py
@@ -4,6 +4,7 @@ import numbers
 import time
 
 from django.utils.datastructures import SortedDict
+from corehq.util.dates import iso_string_to_date
 
 from dimagi.utils.couch.database import get_db
 
@@ -17,9 +18,16 @@ from corehq.apps.groups.models import Group
 
 import hsph.const as const
 
+
 def datestring_minus_days(datestring, days):
-    date = datetime.datetime.strptime(datestring[:10], '%Y-%m-%d')
+    """
+    returns e.g. '2015-04-08T00:00:00' (date + zeroed out time)
+    """
+    # todo: should this return '2015-04-08' instead?
+    date = datetime.datetime.combine(
+        iso_string_to_date(datestring[:10]), datetime.time())
     return (date - datetime.timedelta(days=days)).isoformat()
+
 
 def numeric_cell(val):
     if isinstance(val, numbers.Number):

--- a/custom/_legacy/pact/api.py
+++ b/custom/_legacy/pact/api.py
@@ -8,6 +8,7 @@ from lxml import etree
 from django.core.servers.basehttp import FileWrapper
 from django.utils.decorators import method_decorator
 from casexml.apps.phone.middleware import LAST_SYNCTOKEN_HEADER
+from dimagi.utils.parsing import json_format_date
 from django_digest.decorators import httpdigest
 import json
 from django.http import Http404, HttpResponse
@@ -251,7 +252,8 @@ def submit_case_update_form(casedoc, update_dict, couch_user, submit_date=None, 
 
     update_block = prepare_case_update_xml_block(casedoc, couch_user, update_dict, submit_date)
     form.append(update_block)
-    encounter_date = etree.XML('<encounter_date>%s</encounter_date>' % datetime.utcnow().strftime('%Y-%m-%d'))
+    # todo: this date is based off midnight UTC not local time...
+    encounter_date = etree.XML('<encounter_date>%s</encounter_date>' % json_format_date(datetime.utcnow()))
     form.append(encounter_date)
 
     submission_xml_string = etree.tostring(form)

--- a/custom/_legacy/pact/forms/patient_form.py
+++ b/custom/_legacy/pact/forms/patient_form.py
@@ -4,6 +4,7 @@ from django import forms
 #flipping to tuple
 from django.forms import Form
 from corehq.apps.api.es import ReportCaseES
+from dimagi.utils.parsing import json_format_date
 from pact.enums import PACT_HP_CHOICES, PACT_DOT_CHOICES, PACT_REGIMEN_CHOICES, GENDER_CHOICES, PACT_RACE_CHOICES, PACT_HIV_CLINIC_CHOICES, PACT_LANGUAGE_CHOICES, CASE_NONART_REGIMEN_PROP, CASE_ART_REGIMEN_PROP, DOT_ART, DOT_NONART
 from django.forms import widgets
 from pact.regimen import regimen_dict_from_choice
@@ -101,13 +102,12 @@ class PactPatientForm(Form):
 
     def clean_dob(self):
         if self.cleaned_data['dob'] is not None:
-            return self.cleaned_data['dob'].strftime('%Y-%m-%d')
+            return json_format_date(self.cleaned_data['dob'])
         else:
             return None
 
     def clean_mass_health_expiration(self):
         if self.cleaned_data['mass_health_expiration'] is not None:
-            return self.cleaned_data['mass_health_expiration'].strftime('%Y-%m-%d')
+            return json_format_date(self.cleaned_data['mass_health_expiration'])
         else:
             return None
-

--- a/custom/_legacy/pact/models.py
+++ b/custom/_legacy/pact/models.py
@@ -6,6 +6,7 @@ from casexml.apps.case.models import CommCareCase
 from corehq.apps.users.models import CommCareUser
 from couchforms.models import XFormInstance
 from dimagi.utils.decorators.memoized import memoized
+from dimagi.utils.parsing import json_format_date
 from pact import enums
 
 from pact.enums import (
@@ -512,10 +513,10 @@ class CObservation(Document):
         app_label = 'pact'
 
     def __unicode__(self):
-        return "Obs %s [%s] %d/%d" % (self.observed_date.strftime("%Y-%m-%d"), "ART" if self.is_art else "NonART", self.dose_number+1, self.total_doses)
+        return "Obs %s [%s] %d/%d" % (json_format_date(self.observed_date), "ART" if self.is_art else "NonART", self.dose_number+1, self.total_doses)
 
     def __str__(self):
-        return "Obs %s [%s] %d/%d" % (self.observed_date.strftime("%Y-%m-%d"), "ART" if self.is_art else "NonART", self.dose_number+1, self.total_doses)
+        return "Obs %s [%s] %d/%d" % (json_format_date(self.observed_date), "ART" if self.is_art else "NonART", self.dose_number+1, self.total_doses)
 
     def __repr__(self):
         return json.dumps(self.to_json(), indent=4)

--- a/custom/_legacy/pact/reports/__init__.py
+++ b/custom/_legacy/pact/reports/__init__.py
@@ -2,6 +2,7 @@ import dateutil
 from corehq.apps.reports.dispatcher import CustomProjectReportDispatcher
 from corehq.apps.reports.generic import ElasticProjectInspectionReport
 from corehq.apps.reports.standard import CustomProjectReport, ProjectReportParametersMixin
+from dimagi.utils.parsing import ISO_DATE_FORMAT
 
 
 class PactPatientDispatcher(CustomProjectReportDispatcher):
@@ -16,7 +17,7 @@ class PactPatientDispatcher(CustomProjectReportDispatcher):
 
 
 class PactElasticTabularReportMixin(CustomProjectReport, ElasticProjectInspectionReport, ProjectReportParametersMixin):
-    def format_date(self, date_string, format="%Y-%m-%d"):
+    def format_date(self, date_string, format=ISO_DATE_FORMAT):
         try:
             date_obj = dateutil.parser.parse(date_string)
             return date_obj.strftime(format)

--- a/custom/_legacy/pact/reports/admin_chw_reports.py
+++ b/custom/_legacy/pact/reports/admin_chw_reports.py
@@ -2,6 +2,7 @@ from corehq.apps.reports.datatables import DataTablesHeader, DataTablesColumn
 from corehq.apps.reports.generic import GenericTabularReport
 from corehq.apps.reports.standard import CustomProjectReport
 from corehq.apps.users.models import CommCareUser
+from dimagi.utils.parsing import json_format_date
 from pact.enums import PACT_DOMAIN
 from pact.reports import chw_schedule
 
@@ -53,9 +54,8 @@ class PactCHWAdminReport(GenericTabularReport, CustomProjectReport):
             rowdata = []
             if len(patient_visits) > 0:
                 for patient_case, visit in patient_visits:
-                    rowdata = [visit_date.strftime('%Y-%m-%d')]
-                    rowdata.append(username)
-                    rowdata.append(patient_case['pactid'])
+                    rowdata = [json_format_date(visit_date), username,
+                               patient_case['pactid']]
                     if visit is not None:
                         ####is scheduled
                         if visit.get('scheduled', '---') == 'yes':
@@ -87,7 +87,7 @@ class PactCHWAdminReport(GenericTabularReport, CustomProjectReport):
                     yield finish_row_blanks(rowdata)
             # else:
             #     no patients scheduled, skipping day altogether - matches chw schedule view
-                # nopatient_row = [visit_date.strftime('%Y-%m-%d'), username, 'nopatient']
+                # nopatient_row = [json_format_date(visit_date), username, 'nopatient']
                 # yield finish_row_blanks(nopatient_row)
 
 

--- a/custom/_legacy/pact/reports/dot.py
+++ b/custom/_legacy/pact/reports/dot.py
@@ -1,11 +1,13 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, time
 import uuid
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.api.es import ReportCaseES, ReportXFormES
 from corehq.apps.reports.filters.base import BaseSingleOptionFilter
 from corehq.apps.reports.generic import GenericTabularReport
 from corehq.apps.reports.standard import CustomProjectReport, ProjectReportParametersMixin, DatespanMixin
+from corehq.util.dates import iso_string_to_date
 from dimagi.utils.decorators.memoized import memoized
+from dimagi.utils.parsing import json_format_date
 
 from pact.enums import PACT_DOMAIN, PACT_CASE_TYPE, XMLNS_DOTS_FORM
 from pact.models import PactPatientCase, DOTSubmission, CObservation
@@ -68,12 +70,11 @@ class PactDOTReport(GenericTabularReport, CustomProjectReport, ProjectReportPara
         casedoc = PactPatientCase.get(ret['dot_case_id'])
         ret['patient_case'] = casedoc
         start_date_str = self.request.GET.get('startdate',
-                                              (datetime.utcnow() - timedelta(days=7)).strftime(
-                                                  '%Y-%m-%d'))
-        end_date_str = self.request.GET.get('enddate', datetime.utcnow().strftime("%Y-%m-%d"))
+                                              json_format_date(datetime.utcnow() - timedelta(days=7)))
+        end_date_str = self.request.GET.get('enddate', json_format_date(datetime.utcnow()))
 
-        start_date = datetime.strptime(start_date_str, "%Y-%m-%d")
-        end_date = datetime.strptime(end_date_str, "%Y-%m-%d")
+        start_date = datetime.combine(iso_string_to_date(start_date_str), time())
+        end_date = datetime.combine(iso_string_to_date(end_date_str), time())
 
         ret['startdate'] = start_date_str
         ret['enddate'] = end_date_str

--- a/custom/apps/crs_reports/reports.py
+++ b/custom/apps/crs_reports/reports.py
@@ -14,6 +14,7 @@ from corehq.apps.reports.standard.cases.data_sources import CaseDisplay
 from corehq.pillows.base import restore_property_dict
 from corehq.util.timezones.conversions import PhoneTime
 from dimagi.utils.decorators.memoized import memoized
+from dimagi.utils.parsing import json_format_date
 
 
 def visit_completion_counter(case):
@@ -208,7 +209,7 @@ class HBNCMotherReport(BaseHNBCReport):
         fromdate = now - timedelta(days=42)
         filters = BaseHNBCReport.base_filters(self)
         filters.append({'term': {'pp_case_filter.#value': "1"}})
-        filters.append({'range': {'date_birth.#value': {"gte": fromdate.strftime("%Y-%m-%d")}}})
+        filters.append({'range': {'date_birth.#value': {"gte": json_format_date(fromdate)}}})
         status = self.request_params.get('PNC_status', '')
 
         or_stmt = []

--- a/custom/apps/gsid/ctable_mappings.py
+++ b/custom/apps/gsid/ctable_mappings.py
@@ -1,5 +1,6 @@
 from ctable.fixtures import CtableMappingFixture
 from ctable.models import ColumnDef, KeyMatcher
+from dimagi.utils.parsing import ISO_DATE_FORMAT
 
 
 class PatientSummaryMapping(CtableMappingFixture):
@@ -19,7 +20,7 @@ class PatientSummaryMapping(CtableMappingFixture):
             ColumnDef(name="district", data_type="string", value_source="key", value_index=5),
             ColumnDef(name="clinic", data_type="string", value_source="key", value_index=6),
             ColumnDef(name="gender", data_type="string", value_source="key", value_index=7),
-            ColumnDef(name="date", data_type="date", value_source="key", value_index=8, date_format="%Y-%m-%d"),
+            ColumnDef(name="date", data_type="date", value_source="key", value_index=8, date_format=ISO_DATE_FORMAT),
             ColumnDef(name="diagnosis", data_type="string", value_source="key", value_index=9),
             ColumnDef(name="lot_number", data_type="string", value_source="key", value_index=10),
             ColumnDef(name="gps", data_type="string", value_source="key", value_index=11),

--- a/custom/apps/gsid/reports/sql_reports.py
+++ b/custom/apps/gsid/reports/sql_reports.py
@@ -9,7 +9,9 @@ from corehq.apps.reports.sqlreport import DatabaseColumn, SummingSqlTabularRepor
 from corehq.apps.reports.standard import CustomProjectReport, DatespanMixin
 from corehq.apps.reports.standard.maps import GenericMapReport
 from corehq.apps.reports.util import format_datatables_data, make_ctable_table_name
+from corehq.util.dates import iso_string_to_date
 from dimagi.utils.decorators.memoized import memoized
+from dimagi.utils.parsing import json_format_date
 from util import get_unique_combinations,  capitalize_fn
 from django.conf import settings
 
@@ -372,7 +374,7 @@ class GSIDSQLByDayReport(GSIDSQLReport):
 
     def daterange(self, start_date, end_date):
         for n in range(int((end_date - start_date).days) + 1):
-            yield (start_date + timedelta(n)).strftime("%Y-%m-%d")
+            yield json_format_date(start_date + timedelta(n))
 
     @property
     def headers(self):
@@ -388,7 +390,7 @@ class GSIDSQLByDayReport(GSIDSQLReport):
         prev_month = startdate.month
         month_columns = [startdate.strftime("%B %Y")]
         for n, day in enumerate(self.daterange(startdate, enddate)):
-            day_obj = datetime.strptime(day, "%Y-%m-%d")
+            day_obj = iso_string_to_date(day)
             month = day_obj.month
             day_column = DataTablesColumn("Day%(n)s (%(day)s)" % {'n':n+1, 'day': day})
 
@@ -397,8 +399,7 @@ class GSIDSQLByDayReport(GSIDSQLReport):
             else:
                 month_group = DataTablesColumnGroup(*month_columns)
                 column_headers.append(month_group)
-                month_columns = [day_obj.strftime("%B %Y")]
-                month_columns.append(day_column)
+                month_columns = [day_obj.strftime("%B %Y"), day_column]
                 prev_month = month
         
         month_group = DataTablesColumnGroup(*month_columns)
@@ -424,7 +425,7 @@ class GSIDSQLByDayReport(GSIDSQLReport):
                 row.append(disease_names[index])
                 for n, day in enumerate(self.daterange(startdate, enddate)):
                     temp_key = [loc for loc in loc_key]
-                    temp_key.append(datetime.strptime(day, "%Y-%m-%d").date())
+                    temp_key.append(iso_string_to_date(day))
                     temp_key.append(disease)
                     keymap = old_data.get(tuple(temp_key), None)
                     day_count = (keymap["day_count"] if keymap else None)

--- a/custom/bihar/reports/supervisor.py
+++ b/custom/bihar/reports/supervisor.py
@@ -21,6 +21,7 @@ from dimagi.utils.decorators.memoized import memoized
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.adm.reports.supervisor import SupervisorReportsADMSection
 from custom.bihar.reports.indicators.mixins import IndicatorConfigMixIn
+from dimagi.utils.parsing import json_format_date
 
 
 def shared_bihar_context(report):
@@ -301,8 +302,8 @@ class WorkerRankSelectionReport(SubCenterSelectionReport):
         start = end - timedelta(days=30)
         params = {
             "ufilter": 0,
-            "startdate": start.strftime("%Y-%m-%d"),
-            "enddate": end.strftime("%Y-%m-%d")
+            "startdate": json_format_date(start),
+            "enddate": json_format_date(end)
         }
         def _awcc_link(g):
             params["group"] = g.get_id

--- a/custom/dhis2/payload_generators.py
+++ b/custom/dhis2/payload_generators.py
@@ -30,6 +30,7 @@ from custom.dhis2.const import NUTRITION_ASSESSMENT_EVENT_FIELDS, RISK_ASSESSMEN
     RISK_ASSESSMENT_PROGRAM_FIELDS, REGISTER_CHILD_XMLNS, GROWTH_MONITORING_XMLNS, RISK_ASSESSMENT_XMLNS, \
     NUTRITION_ASSESSMENT_PROGRAM_FIELDS, CASE_TYPE
 from custom.dhis2.tasks import push_case
+from dimagi.utils.parsing import json_format_date
 
 
 logger = logging.getLogger(__name__)
@@ -98,7 +99,7 @@ class FormRepeaterDhis2EventPayloadGenerator(BasePayloadGenerator):
             # Check whether the case needs to be enrolled in the Risk Assessment Program
             program_id = dhis2_api.get_program_id('Underlying Risk Assessment')
             if not dhis2_api.enrolled_in(case['external_id'], 'Underlying Risk Assessment'):
-                today = date.today().strftime('%Y-%m-%d')
+                today = json_format_date(date.today())
                 program_data = {dhis2_attr: case[cchq_attr]
                                 for cchq_attr, dhis2_attr in RISK_ASSESSMENT_PROGRAM_FIELDS.iteritems()}
                 dhis2_api.enroll_in_id(case['external_id'], program_id, today, program_data)

--- a/custom/ewsghana/reports/specific_reports/reporting_rates.py
+++ b/custom/ewsghana/reports/specific_reports/reporting_rates.py
@@ -18,6 +18,7 @@ from custom.ilsgateway.tanzania import make_url
 from custom.ilsgateway.tanzania.reports.utils import link_format
 from django.utils.translation import ugettext as _
 from dimagi.utils.dates import DateSpan
+from dimagi.utils.parsing import json_format_date
 
 
 class ReportingRates(ReportingRatesData):
@@ -324,8 +325,8 @@ class AlertsData(ReportingRatesData):
             for sp in supply_points:
                 url = make_url(
                     StockLevelsReport, self.config['domain'], '?location_id=%s&startdate=%s&enddate=%s',
-                    (sp.location_id, self.config['startdate'].strftime("%Y-%m-%d"),
-                     self.config['enddate'].strftime("%Y-%m-%d"))
+                    (sp.location_id, json_format_date(self.config['startdate']),
+                     json_format_date(self.config['enddate']))
                 )
                 if sp.supply_point_id not in reported:
                     rows.append(['<div style="background-color: rgba(255, 0, 0, 0.2)">%s has not reported last '

--- a/custom/ewsghana/reports/stock_levels_report.py
+++ b/custom/ewsghana/reports/stock_levels_report.py
@@ -17,6 +17,7 @@ from custom.ewsghana.reports import EWSData, MultiReport, get_url_with_location,
 from dimagi.utils.decorators.memoized import memoized
 from django.utils.translation import ugettext as _
 from corehq.apps.locations.models import Location, SQLLocation
+from dimagi.utils.parsing import json_format_date
 
 
 class StockLevelsLegend(EWSData):
@@ -100,7 +101,7 @@ class FacilityReportData(EWSData):
                     'monthly_consumption': monthly_consumption,
                     'reorder_level': int(monthly_consumption * loc.location_type.overstock_threshold) / 2,
                     'maximum_level': int(monthly_consumption * loc.location_type.overstock_threshold),
-                    'date_of_last_report': state.last_modified_date.strftime("%Y-%m-%d")
+                    'date_of_last_report': json_format_date(state.last_modified_date)
                 }
 
         for state in st:

--- a/custom/fri/reports/filters.py
+++ b/custom/fri/reports/filters.py
@@ -4,6 +4,8 @@ from corehq.apps.reports.filters.base import BaseSingleOptionFilter
 from custom.fri.models import PROFILE_A, PROFILE_B, PROFILE_C, PROFILE_D, PROFILE_E, PROFILE_F, PROFILE_G, PROFILE_H, PROFILE_DESC
 from custom.fri.api import get_interactive_participants
 from datetime import datetime, date, timedelta
+from dimagi.utils.parsing import json_format_date
+
 
 class InteractiveParticipantFilter(BaseSingleOptionFilter):
     slug = "participant"
@@ -43,7 +45,7 @@ class SurveyDateSelector(BaseSingleOptionFilter):
 
     @classmethod
     def get_value(cls, *args, **kwargs):
-        default = cls.get_date_choices()[-1].strftime("%Y-%m-%d")
+        default = json_format_date(cls.get_date_choices()[-1])
         return super(SurveyDateSelector, cls).get_value(*args, **kwargs) or default
 
     @classmethod
@@ -66,6 +68,6 @@ class SurveyDateSelector(BaseSingleOptionFilter):
     def options(self):
         result = []
         for date in sorted(self._date_choices, reverse=True):
-            result.append((date.strftime("%Y-%m-%d"), date.strftime("%m/%d/%y")))
+            result.append((json_format_date(date), date.strftime("%m/%d/%y")))
         return result
 

--- a/custom/ilsgateway/tanzania/__init__.py
+++ b/custom/ilsgateway/tanzania/__init__.py
@@ -13,10 +13,11 @@ from custom.common import ALL_OPTION
 from custom.ilsgateway.filters import MonthAndQuarterFilter
 from custom.ilsgateway.models import SupplyPointStatusTypes, OrganizationSummary
 from corehq.apps.reports.graph_models import PieChart
-from dimagi.utils.dates import DateSpan, DEFAULT_DATE_FORMAT
+from dimagi.utils.dates import DateSpan
 from dimagi.utils.decorators.memoized import memoized
 from custom.ilsgateway.tanzania.reports.utils import make_url
 from django.utils import html
+from dimagi.utils.parsing import ISO_DATE_FORMAT
 
 
 class ILSData(object):
@@ -119,7 +120,7 @@ class ILSMixin(object):
 class ILSDateSpan(DateSpan):
 
     @classmethod
-    def from_month_or_quarter(cls, month_or_quarter=None, year=None, format=DEFAULT_DATE_FORMAT,
+    def from_month_or_quarter(cls, month_or_quarter=None, year=None, format=ISO_DATE_FORMAT,
                               inclusive=True, timezone=pytz.utc):
         """
         Generate a DateSpan object given a numerical month and year.

--- a/custom/intrahealth/reports/__init__.py
+++ b/custom/intrahealth/reports/__init__.py
@@ -8,6 +8,7 @@ from corehq.util.translation import localize
 from custom.intrahealth.sqldata import NombreData, TauxConsommationData
 from django.utils.translation import ugettext as _
 from dimagi.utils.decorators.memoized import memoized
+from dimagi.utils.parsing import json_format_date
 
 
 def get_localized_months():
@@ -41,8 +42,8 @@ class IntraHealthReportConfigMixin(object):
             startdate=self.datespan.startdate,
             enddate=self.datespan.enddate,
             visit="''",
-            strsd=self.datespan.startdate.strftime("%Y-%m-%d"),
-            stred=self.datespan.enddate.strftime("%Y-%m-%d")
+            strsd=json_format_date(self.datespan.startdate),
+            stred=json_format_date(self.datespan.enddate)
         )
         self.config_update(config)
         return config

--- a/custom/intrahealth/sqldata.py
+++ b/custom/intrahealth/sqldata.py
@@ -12,6 +12,7 @@ from sqlagg.filters import EQ, BETWEEN, AND, GTE, LTE
 from corehq.apps.reports.sqlreport import DatabaseColumn, SqlData, AggregateColumn
 from django.utils.translation import ugettext as _
 from sqlalchemy import select
+from dimagi.utils.parsing import json_format_date
 
 PRODUCT_NAMES = {
     u'diu': [u"diu"],
@@ -388,11 +389,11 @@ class RecapPassageData(BaseSqlData):
 
     @property
     def slug(self):
-        return 'recap_passage_%s' % self.config['startdate'].strftime("%Y-%m-%d")
+        return 'recap_passage_%s' % json_format_date(self.config['startdate'])
 
     @property
     def title(self):
-        return 'Recap Passage %s' % self.config['startdate'].strftime("%Y-%m-%d")
+        return 'Recap Passage %s' % json_format_date(self.config['startdate'])
 
     @property
     def filters(self):

--- a/custom/m4change/fields.py
+++ b/custom/m4change/fields.py
@@ -1,4 +1,5 @@
 import datetime
+from corehq.util.dates import iso_string_to_datetime
 from dimagi.utils.dates import DateSpan
 import json
 from django.utils.translation import ugettext as _, ugettext_noop
@@ -18,8 +19,10 @@ class DateRangeField(ReportField):
         range = self.request.GET.get('range', None)
         if range is not None:
             dates = str(range).split(_(' to '))
-            self.request.datespan.startdate = datetime.datetime.strptime(dates[0], '%Y-%m-%d')
-            self.request.datespan.enddate = datetime.datetime.strptime(dates[1], '%Y-%m-%d')
+            self.request.datespan.startdate = datetime.datetime.combine(
+                iso_string_to_datetime(dates[0]), datetime.time())
+            self.request.datespan.enddate = datetime.datetime.combine(
+                iso_string_to_datetime(dates[1]), datetime.time())
 
         self.datespan = DateSpan.since(self.default_days, timezone=self.timezone, inclusive=self.inclusive)
         if self.request.datespan.is_valid():

--- a/custom/m4change/fixtures/report_fixtures.py
+++ b/custom/m4change/fixtures/report_fixtures.py
@@ -11,6 +11,7 @@ from corehq.apps.locations.models import Location
 from custom.m4change.constants import M4CHANGE_DOMAINS, NUMBER_OF_MONTHS_FOR_FIXTURES
 from custom.m4change.models import FixtureReportResult
 from custom.m4change.reports.reports import M4ChangeReportDataSource
+from dimagi.utils.parsing import json_format_date
 
 
 def get_last_n_months(months):
@@ -132,9 +133,9 @@ class ReportFixtureProvider(object):
             })
             report_data = {}
             for report_slug in self.report_slugs:
-                report_data[report_slug] = FixtureReportResult.by_composite_key(self.domain.name, facility_id,
-                                                                                startdate.strftime("%Y-%m-%d"),
-                                                                                enddate.strftime("%Y-%m-%d"), report_slug)
+                report_data[report_slug] = FixtureReportResult.by_composite_key(
+                    self.domain.name, facility_id, json_format_date(startdate),
+                    json_format_date(enddate), report_slug)
                 if report_data[report_slug] is None:
                     name = self.reports[report_slug].name
                     rows = self.reports[report_slug].get_initial_row_data()
@@ -147,8 +148,8 @@ class ReportFixtureProvider(object):
 
         def _month_to_fixture(date_tuple, locations):
             monthly_report_element = ElementTree.Element('monthly-report', attrib={
-                'startdate': date_tuple[0].strftime('%Y-%m-%d'),
-                'enddate': date_tuple[1].strftime('%Y-%m-%d'),
+                'startdate': json_format_date(date_tuple[0]),
+                'enddate': json_format_date(date_tuple[1]),
                 'month_year_label': date_tuple[0].strftime('%b %Y')
             })
 

--- a/custom/m4change/reports/mcct_project_review.py
+++ b/custom/m4change/reports/mcct_project_review.py
@@ -15,12 +15,14 @@ from corehq.apps.reports.dont_use.fields import StrongFilterUsersField
 from corehq.apps.reports.generic import ElasticProjectInspectionReport
 from corehq.apps.reports.standard.monitoring import MultiFormDrilldownMixin
 from corehq.elastic import es_query
+from corehq.util.dates import iso_string_to_datetime
 from custom.m4change.constants import REJECTION_REASON_DISPLAY_NAMES, MCCT_SERVICE_TYPES
 from custom.m4change.filters import ServiceTypeFilter
 from custom.m4change.models import McctStatus
 from custom.m4change.reports import get_location_hierarchy_by_id
 from custom.m4change.utils import get_case_by_id, get_property, get_form_ids_by_status
 from custom.m4change.constants import EMPTY_FIELD
+from dimagi.utils.parsing import json_format_date
 
 
 def _get_date_range(range):
@@ -246,7 +248,7 @@ class McctProjectReview(BaseReport):
         for form in submissions:
             data = calculate_form_data(self, form)
             row = [
-                DateTimeProperty().wrap(form["form"]["meta"]["timeEnd"]).strftime("%Y-%m-%d"),
+                json_format_date(iso_string_to_datetime(form["form"]["meta"]["timeEnd"])),
                 self._get_case_name_html(data.get('case'), with_checkbox),
                 self._get_service_type_html(form, data.get('service_type'), with_checkbox),
                 data.get('location_name'),
@@ -349,7 +351,7 @@ class McctRejectedClientPage(McctClientApprovalPage):
             except McctStatus.DoesNotExist:
                 reason = None
             row = [
-                DateTimeProperty().wrap(form["form"]["meta"]["timeEnd"]).strftime("%Y-%m-%d %H:%M"),
+                iso_string_to_datetime(form["form"]["meta"]["timeEnd"]).strftime("%Y-%m-%d %H:%M"),
                 self._get_case_name_html(data.get('case'), with_checkbox),
                 self._get_service_type_html(form, data.get('service_type'), with_checkbox),
                 data.get('location_name'),

--- a/custom/m4change/reports/reports.py
+++ b/custom/m4change/reports/reports.py
@@ -50,7 +50,7 @@ class M4ChangeReportDataSource(ReportDataSource):
     def get_data(self, slugs=None):
         startdate = self.config['startdate']
         enddate = self.config['enddate']
-        datespan = DateSpan(startdate, enddate, format='%Y-%m-%d')
+        datespan = DateSpan(startdate, enddate)
         location_id = self.config['location_id']
         domain = self.config['domain']
 

--- a/custom/m4change/tasks.py
+++ b/custom/m4change/tasks.py
@@ -9,6 +9,7 @@ from custom.m4change.constants import NUMBER_OF_MONTHS_FOR_FIXTURES, M4CHANGE_DO
 from custom.m4change.fixtures.report_fixtures import get_last_n_months
 from custom.m4change.models import FixtureReportResult
 from custom.m4change.reports.reports import M4ChangeReportDataSource
+from dimagi.utils.parsing import json_format_date
 import settings
 
 
@@ -42,8 +43,8 @@ def generate_fixtures_for_domain(domain, db, data_source):
 
                 # Remove cached fixture docs
                 db.delete_docs(FixtureReportResult.all_by_composite_key(domain, location_id,
-                                                                        date[0].strftime("%Y-%m-%d"),
-                                                                        date[1].strftime("%Y-%m-%d"), report_slug))
+                                                                        json_format_date(date[0]),
+                                                                        json_format_date(date[1]), report_slug))
 
                 FixtureReportResult.save_result(domain, location_id, date[0].date(), date[1].date(),
                                                 report_slug, rows, name)
@@ -82,8 +83,11 @@ def generate_fixtures_for_locations():
             for report_slug in report_data:
 
                 # Remove cached fixture docs
-                db.delete_docs(FixtureReportResult.all_by_composite_key(domain, location_id, start_date.strftime("%Y-%m-%d"),
-                                                                   end_date.strftime("%Y-%m-%d"), report_slug))
+                db.delete_docs(
+                    FixtureReportResult.all_by_composite_key(
+                        domain, location_id, json_format_date(start_date),
+                        json_format_date(end_date), report_slug)
+                )
                 rows = dict(report_data[report_slug].get("data", []))
                 name = report_data[report_slug].get("name")
                 FixtureReportResult.save_result(domain, location_id, start_date.date(), end_date.date(),

--- a/custom/succeed/reports/__init__.py
+++ b/custom/succeed/reports/__init__.py
@@ -1,5 +1,6 @@
 from django.utils.translation import ugettext as _
 from custom.succeed.utils import CONFIG
+from dimagi.utils.parsing import ISO_DATE_FORMAT
 
 PM1 = 'http://openrosa.org/formdesigner/111B09EB-DFFA-4613-9A16-A19BA6ED7D04'
 PM2 = 'http://openrosa.org/formdesigner/4B52ADB2-AA79-4056-A13E-BB34871876A1'
@@ -56,7 +57,7 @@ EMPTY_FIELD = "---"
 
 OUTPUT_DATE_FORMAT = "%m/%d/%Y"
 INTERACTION_OUTPUT_DATE_FORMAT = "%m/%d/%Y %H:%M"
-INPUT_DATE_FORMAT = "%Y-%m-%d"
+INPUT_DATE_FORMAT = ISO_DATE_FORMAT
 
 CM_APP_CM_MODULE = 0
 CM_APP_HUD_MODULE = 1

--- a/custom/world_vision/reports/__init__.py
+++ b/custom/world_vision/reports/__init__.py
@@ -8,6 +8,7 @@ from custom.world_vision.sqldata.main_sqldata import ImmunizationOverview
 from custom.world_vision.sqldata.mother_sqldata import PostnatalCareOverview, AnteNatalCareServiceOverviewExtended, \
     DeliveryPlaceDetailsExtended
 from dimagi.utils.decorators.memoized import memoized
+from dimagi.utils.parsing import json_format_date
 
 
 class TTCReport(ProjectReportParametersMixin, CustomProjectReport):
@@ -74,18 +75,18 @@ class TTCReport(ProjectReportParametersMixin, CustomProjectReport):
             config['stred'] = self.request.GET['enddate']
 
         today = datetime.date.today()
-        config['today'] = today.strftime("%Y-%m-%d")
+        config['today'] = json_format_date(today)
 
         for d in [35, 56, 84, 85, 112, 196]:
-            config['today_plus_%d' % d] = (today + datetime.timedelta(days=d)).strftime("%Y-%m-%d")
+            config['today_plus_%d' % d] = json_format_date(today + datetime.timedelta(days=d))
 
         for d in [2, 4, 21, 25, 40, 42, 75, 106, 182, 183, 273, 365, 547, 548, 700, 730]:
-            config['today_minus_%d' % d] = (today - datetime.timedelta(days=d)).strftime("%Y-%m-%d")
+            config['today_minus_%d' % d] = json_format_date(today - datetime.timedelta(days=d))
 
         for d in [1, 3, 5, 6]:
             config['%d' % d] = '%d' % d
 
-        config['last_month'] = (today - datetime.timedelta(days=30)).strftime("%Y-%m-%d")
+        config['last_month'] = json_format_date(today - datetime.timedelta(days=30))
 
         for k, v in sorted(LOCATION_HIERARCHY.iteritems(), reverse=True):
             req_prop = 'location_%s' % v['prop']


### PR DESCRIPTION
to use `json_format_date`, `iso_string_to_date`, or `ISO_DATE_FORMAT`

(wait for build)

This was a bit of a tangent, but it's come up a number of times during my work on timezones that it's hard for me to convince myself that I've captured all usages of a particular thing because of all of these hundreds of direct usages of strptime and strftime for parsing and serializing dates. Marking these as what their intention is greatly unclutters code searches and is just all around a good tendency.
