### PR TITLE
make travis run with only two parallel processes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ env:
   matrix:
     - TEST_RUNNER=testrunner.GroupTestRunnerCatchall
     - TEST_RUNNER=testrunner.GroupTestRunner0
-    - TEST_RUNNER=testrunner.GroupTestRunner1
 branches:
   only:
     - master

--- a/settings.py
+++ b/settings.py
@@ -1345,15 +1345,13 @@ DOMAIN_MODULE_MAP = {
 
 CASEXML_FORCE_DOMAIN_CHECK = True
 
-# arbitrarily split up tests into three chunks
+# arbitrarily split up tests into two chunks
 # that have approximately equal run times,
-# The two groups shown here, plus a third group consisting of everything else
+# the group shown here, plus a second group consisting of everything else
 TRAVIS_TEST_GROUPS = (
     (
         'accounting', 'adm', 'announcements', 'api', 'app_manager', 'appstore',
         'auditcare', 'bihar', 'builds', 'cachehq', 'callcenter', 'care_benin',
-    ),
-    (
         'care_sa', 'case', 'cleanup', 'cloudcare', 'commtrack', 'consumption',
         'couchapps', 'couchlog', 'crud', 'cvsu', 'dca', 'django_digest',
         'djangocouch', 'djangocouchuser', 'domain', 'domainsync', 'export',


### PR DESCRIPTION
- join `GroupTestRunner0` and `GroupTestRunner1`
- that group together will still run faster than `GroupTestRunnerCatchall`

![screen shot 2015-04-08 at 6 32 25 pm](https://cloud.githubusercontent.com/assets/137212/7056868/a4e17d2e-de1d-11e4-99bb-f1fb7173776a.png)

If the recent delay in even starting travis builds is because we're getting throttled per-process, this will also help. It won't speed up tests at all once they start, but it also won't make them slower. If we eventually want to go back to three processes, that'll be pretty straightforward as well.
