### PR TITLE
Multi export final changes

### DIFF
--- a/corehq/apps/export/custom_export_helpers.py
+++ b/corehq/apps/export/custom_export_helpers.py
@@ -216,6 +216,7 @@ class FormCustomExportHelper(CustomExportHelper):
         p = self.post_data['custom_export']
         e = self.custom_export
         e.include_errors = p['include_errors']
+        e.split_multiselects = p['split_multiselects']
         e.app_id = p['app_id']
 
         super(FormCustomExportHelper, self).update_custom_params()

--- a/corehq/apps/export/templates/export/customize_export.html
+++ b/corehq/apps/export/templates/export/customize_export.html
@@ -441,27 +441,22 @@
 {% block main_column %}
 <div id="customize-export" style="display: none;" data-bind="visible: true">
     {# content for multi-select help popover #}
+    {% if custom_export.type == 'case' %}
     <div id="popover_content_wrapper" style="display: none">
         {% blocktrans %}
             These options allow you to configure how CommCare exports data from multi-select questions.
             If you do not want to split the options into multiple columns select the 'plain' option.
         {% endblocktrans %}
         <br/>
-        {% if custom_export.type == 'form' %}
         {% blocktrans %}
-            When the export is run a new column will be added to the export file
-            for each item in the multi-select field.
-        {% endblocktrans %}
-        {% else %}
-            {% blocktrans %}
             Each item that is selected in the select list will appear as a column in the exported data.
             Any options not selected will be in an "extra" column.
         {% endblocktrans %}
-        {% endif %}
         <a href='https://help.commcarehq.org/display/commcarepublic/Splitting+multi-select+data+in+exports' target="_blank" class="allow-click">
             {% trans "More info" %}
         </a>
     </div>
+    {% endif %}
     <form class="form-horizontal" method="post">
         <fieldset>
             <legend>{% trans "Export Settings" %}</legend>
@@ -556,7 +551,7 @@
                                         {% trans "Question" %}
                                     </th>
                                     <th>{% trans "Display" %}</th>
-                                    {% if request|toggle_enabled:'SPLIT_MULTISELECT_EXPORT' %}
+                                    {% if custom_export.type == 'case' and request|toggle_enabled:'SPLIT_MULTISELECT_EXPORT' %}
                                     <th>{% trans "Type" %}</th>
                                     {% endif %}
                                     {% if helper.allow_deid %}
@@ -581,7 +576,7 @@
 
                                         </td>
                                         <td><input class="input-xlarge" type="text" data-bind="value: display" /></td>
-                                        {% if request|toggle_enabled:'SPLIT_MULTISELECT_EXPORT' %}
+                                        {% if custom_export.type == 'case' and request|toggle_enabled:'SPLIT_MULTISELECT_EXPORT' %}
                                         <td class="input">
                                             <div data-bind="if: !allOptions()">
                                                 <select disabled>
@@ -596,7 +591,6 @@
                                                     <option data-bind="value: value, text: label"></option>
                                                 </select>
                                                 <span data-bind="makeHqHelp: {name: '{% trans "Split multi-select data" %}', placement: 'left', trigger: 'click'}"></span>
-                                                {% if custom_export.type == 'case' %}
                                                 <div data-bind="if: doc_type() === 'SplitColumn'">
                                                     <a href="#" data-bind="visible: !showOptions(), click: function() {showOptions(true);}">{% trans "Show Options" %}</a>
                                                     <div data-bind="visible: showOptions">
@@ -607,7 +601,6 @@
                                                         <button class="btn" data-bind="click: addOption">{% trans "Add" %}</button>
                                                     </div>
                                                 </div>
-                                                {% endif %}
                                             </div>
                                         </td>
                                         {% endif %}

--- a/corehq/apps/export/templates/export/customize_export.html
+++ b/corehq/apps/export/templates/export/customize_export.html
@@ -517,10 +517,12 @@
                         <input type="checkbox" id="include-errors-checkbox" data-bind="checked: custom_export.include_errors" />
                         {% trans "Include duplicates and other unprocessed forms" %}
                     </label>
+                    {% if request|toggle_enabled:'SPLIT_MULTISELECT_EXPORT' %}
                     <label class="checkbox">
                         <input type="checkbox" id="split-multiselects-checkbox" data-bind="checked: custom_export.split_multiselects" />
                         {% trans "Expand Multiple Answer Questions" %}
                     </label>
+                    {% endif %}
                 {% endif %}
                 </div>
             </div>

--- a/corehq/apps/export/templates/export/customize_export.html
+++ b/corehq/apps/export/templates/export/customize_export.html
@@ -464,9 +464,21 @@
         </a>
     </div>
     {% endif %}
+    <header>
+        <div class="row-fluid">
+            <div class="span12">
+                <h3>{% trans "Export Settings" %}</h3>
+                <p>
+                    {% blocktrans %}
+                    Learn more about exports on our <a href="https://help.commcarehq.org/display/commcarepublic/Data+Export+Overview" target="_blank">Help Site</a>.
+                    {% endblocktrans %}
+                </p>
+                <hr/>
+            </div>
+        </div>
+    </header>
     <form class="form-horizontal" method="post">
         <fieldset>
-            <legend>{% trans "Export Settings" %}</legend>
             <div class="control-group">
                 <label for="export-name" class="control-label">{% trans "Export Name" %}</label>
                 <div class="controls">
@@ -507,7 +519,7 @@
                     </label>
                     <label class="checkbox">
                         <input type="checkbox" id="split-multiselects-checkbox" data-bind="checked: custom_export.split_multiselects" />
-                        {% trans "Split multi-selects" %}
+                        {% trans "Expand Multiple Answer Questions" %}
                     </label>
                 {% endif %}
                 </div>

--- a/corehq/apps/export/templates/export/customize_export.html
+++ b/corehq/apps/export/templates/export/customize_export.html
@@ -309,7 +309,13 @@
                                         transform: column.transform() || null, // it doesn't save '' well
                                         is_sensitive: Boolean(is_sensitive)
                                 };
-                                if (column.doc_type() === 'SplitColumn'){
+                                if (self.export_type() === 'form') {
+                                    if (self.custom_export.split_multiselects() && column.allOptions()) {
+                                        col.doc_type = 'SplitColumn';
+                                    } else {
+                                        col.doc_type = 'ExportColumn';
+                                    }
+                                } else if (column.doc_type() === 'SplitColumn'){
                                     col.doc_type = column.doc_type();
                                     col.options = column.options();
                                 }
@@ -420,6 +426,7 @@
 
         $(function () {
             var customExportView = CustomExportView.wrap({
+                export_type: {{ custom_export.type|JSON }},
                 custom_export: {{ custom_export|JSON }},
                 table_configuration: {{ table_configuration|JSON }},
                 presave: {{ presave|JSON }},

--- a/corehq/apps/export/templates/export/customize_export.html
+++ b/corehq/apps/export/templates/export/customize_export.html
@@ -503,6 +503,10 @@
                         <input type="checkbox" id="include-errors-checkbox" data-bind="checked: custom_export.include_errors" />
                         {% trans "Include duplicates and other unprocessed forms" %}
                     </label>
+                    <label class="checkbox">
+                        <input type="checkbox" id="split-multiselects-checkbox" data-bind="checked: custom_export.split_multiselects" />
+                        {% trans "Split multi-selects" %}
+                    </label>
                 {% endif %}
                 </div>
             </div>

--- a/corehq/apps/export/templates/export/customize_export.html
+++ b/corehq/apps/export/templates/export/customize_export.html
@@ -340,7 +340,7 @@
                     return tables;
                 };
 
-                self.output = ko.computed(function () {
+                self.output = function () {
                     var output = ko.mapping.toJS({
                         custom_export: self.custom_export,
                         presave: self.presave,
@@ -348,7 +348,7 @@
                     });
                     output.custom_export.tables = self.make_tables();
                     return JSON.stringify(output);
-                });
+                };
 
                 self.save = function () {
                     self.save.state('saving');

--- a/corehq/apps/reports/models.py
+++ b/corehq/apps/reports/models.py
@@ -655,16 +655,17 @@ class FormExportSchema(HQExportSchema):
     doc_type = 'SavedExportSchema'
     app_id = StringProperty()
     include_errors = BooleanProperty(default=False)
+    split_multiselects = BooleanProperty(default=False)
 
     def update_schema(self):
         super(FormExportSchema, self).update_schema()
-        self.update_question_schema()
-        # update SplitColumn options
-        for column in [column for table in self.tables for column in table.columns]:
-            if isinstance(column, SplitColumn):
-                question = self.question_schema.question_schema.get(column.index)
-                column.options = question.options
-                column.ignore_extras = True
+        if self.split_multiselects:
+            self.update_question_schema()
+            for column in [column for table in self.tables for column in table.columns]:
+                if isinstance(column, SplitColumn):
+                    question = self.question_schema.question_schema.get(column.index)
+                    column.options = question.options
+                    column.ignore_extras = True
 
     def update_question_schema(self):
         schema = self.question_schema


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?153368#907604

![image](https://cloud.githubusercontent.com/assets/249606/7062855/9f7693a4-dea1-11e4-8668-f4dd3dfe6eaa.png)

form export
- make it a global option to split multi-selects
- add help text with link to wiki (https://help.commcarehq.org/display/commcarepublic/Form+Data+Export). See https://www.commcarehq.org/a/ademo/settings/users/commcare/ as example

case export:
- leave as is and under feature flag for now
