### PR TITLE
Nudge tooltip

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/managed_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/managed_app.html
@@ -25,6 +25,10 @@
         position: relative;
         width: 110%;
     }
+    /* Push tooltips away from icons that trigger them */
+    .tooltip {
+        margin-right: 12px;
+    }
 </style>
 {% endblock %}
 


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?164741

The French "edit in form builder" tooltip is long enough that it gets in the way of the actual link.

Applying custom styles to bootstrap-specific classes is gross. In the future, Bootstrap 3's viewport option for tooltips might give us a cleaner way to fix this.
