### PR TITLE
Add minimal option for custom export

### DIFF
--- a/corehq/apps/export/custom_export_helpers.py
+++ b/corehq/apps/export/custom_export_helpers.py
@@ -63,7 +63,8 @@ class CustomExportHelper(object):
     @classmethod
     def make(cls, request, export_type, domain=None, export_id=None):
         export_type = export_type or request.GET.get('request_type', 'form')
-        return cls.subclasses_map[export_type](request, domain, export_id=export_id)
+        minimal = bool(request.GET.get('minimal', False))
+        return cls.subclasses_map[export_type](request, domain, export_id=export_id, minimal=minimal)
 
     def update_custom_params(self):
         if len(self.custom_export.tables) > 0:
@@ -81,12 +82,13 @@ class CustomExportHelper(object):
             for col in self.custom_export.tables[0].columns
         ) if self.custom_export.tables else False
 
-    def __init__(self, request, domain, export_id=None):
+    def __init__(self, request, domain, export_id=None, minimal=False):
         self.request = request
         self.domain = domain
         self.presave = False
         self.transform_dates = False
         self.creating_new_export = not bool(export_id)
+        self.minimal = minimal
 
         if export_id:
             self.custom_export = self.ExportSchemaClass.get(export_id)
@@ -164,6 +166,8 @@ class CustomExportHelper(object):
 
     def get_context(self):
         table_configuration = self.format_config_for_javascript(self.custom_export.table_configuration)
+        if self.minimal:
+            table_configuration = filter(lambda t: t['selected'], table_configuration)
         return {
             'custom_export': self.custom_export,
             'default_order': self.default_order,
@@ -175,6 +179,7 @@ class CustomExportHelper(object):
             'table_configuration': table_configuration,
             'domain': self.domain,
             'commtrack_domain': Domain.get_by_name(self.domain).commtrack_enabled,
+            'minimal': self.minimal,
             'helper': {
                 'back_url': self.ExportReport.get_url(domain=self.domain),
                 'export_title': self.export_title,

--- a/corehq/apps/export/templates/export/customize_export.html
+++ b/corehq/apps/export/templates/export/customize_export.html
@@ -226,8 +226,9 @@
                     // assumes unselected
                     var unselected;
                     var columns = table.column_configuration();
+                    var spliceIdx = 0;
 
-                    _(columns).each(function (column) {
+                    _(columns).each(function (column, idx) {
                         var niceField = self.utils.parseField(column.index, table.index, column.tag());
                         var special = ko.utils.unwrapObservable(column.special);
                         if (special) {
@@ -246,19 +247,20 @@
                             }
                             return false;
                         }.bind(column);
+                        if (!self.minimal() && !column.selected() && !spliceIdx) {
+                            spliceIdx = idx;
+                        }
                     });
 
-                    for (var i = 0; i < columns.length; i++) {
-                        if (!columns[i].selected()) {
-                            break;
-                        }
+                    // Splice out unselected and put them at the end and reorder
+                    if (!self.minimal()) {
+                        unselected = table.column_configuration.splice(spliceIdx, columns.length);
+                        unselected = self.utils.putInDefaultOrder(table.index(), unselected);
+                        table.column_configuration.push.apply(
+                            table.column_configuration,
+                            unselected
+                        );
                     }
-                    unselected = table.column_configuration.splice(i, columns.length);
-                    unselected = self.utils.putInDefaultOrder(table.index(), unselected);
-                    table.column_configuration.push.apply(
-                        table.column_configuration,
-                        unselected
-                    );
                 });
 
                 self.showDeidColumn = ko.observable(function () {
@@ -430,7 +432,8 @@
                     save: {{ request.get_full_path|safe|JSON }}
                 },
                 allow_repeats: {{ helper.allow_repeats|JSON }},
-                default_order: {{ default_order|JSON }}
+                default_order: {{ default_order|JSON }},
+                minimal: {{ minimal|JSON }}
             });
 
             ko.applyBindings(customExportView, $('#customize-export').get(0));
@@ -560,10 +563,14 @@
                                     {% endif %}
                                 </tr>
                                 </thead>
+                                {% if minimal %}
+                                <tbody data-bind="foreach: column_configuration">
+                                {% else %}
                                 <tbody data-bind="sortable: column_configuration">
+                                {% endif %}
                                     <tr data-bind="
-                                        visible:  $parent.show_deleted() || ($data.show() || selected),
-                                        attr: {'data-order': _sortableOrder}
+                                        visible:  $parent.show_deleted() || ($data.show || selected)
+                                        {% if not minimal %}, attr: {'data-order': _sortableOrder}{% endif %}
                                         ">
                                         <td class="sortable-handle">
                                             <i class="icon-resize-vertical"></i>

--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -118,6 +118,10 @@ class BaseCreateCustomExportView(BaseExportView):
         if not schema and self.export_helper.export_type == "form":
             schema = create_basic_form_checkpoint(export_tag)
 
+        if request.GET.get('minimal', False):
+            messages.warning(request,
+                _("Warning you are using minimal mode, some things may not be functional"))
+
         if schema:
             app_id = request.GET.get('app_id')
             self.export_helper.custom_export = self.export_helper.ExportSchemaClass.default(


### PR DESCRIPTION
@czue 
code buddy: @millerdev you're probably not going to like this hack, but it's a quick fix for a client.

This enables a user to put `minimal=true` in the url and that makes the page only render the default selected tables and no longer makes the rows sortable. There are still other things to fix, but these were the two easiest and biggest impact things. Note, this page is still horribly slow to render, but it should no longer kill the browser
