### PR TITLE
Clean up timezone treatment in callcenter fixturegenerator and tests

### DIFF
--- a/corehq/apps/callcenter/fixturegenerators.py
+++ b/corehq/apps/callcenter/fixturegenerators.py
@@ -3,6 +3,8 @@ from datetime import datetime
 import pytz
 from corehq.apps.callcenter.indicator_sets import CallCenterIndicators
 from corehq.apps.users.models import CommCareUser
+from corehq.util.soft_assert import soft_assert
+from corehq.util.timezones.conversions import UserTime, ServerTime
 from dimagi.utils.logging import notify_exception
 
 utc = pytz.utc
@@ -13,17 +15,26 @@ def should_sync(domain, last_sync, utcnow=None):
     if not last_sync or not last_sync.date:
         return True
 
+    # utcnow only used in tests to mock other times
+    utcnow = utcnow or datetime.utcnow()
+
     try:
         timezone = domain.get_default_timezone()
     except pytz.UnknownTimeZoneError:
         timezone = utc
 
-    # check if user has already synced today (in local timezone). Indicators only change daily.
-    last_sync_utc = last_sync.date if last_sync.date.tzinfo else utc.localize(last_sync.date)
-    last_sync_local = timezone.normalize(last_sync_utc.astimezone(timezone))
+    _assert = soft_assert(to=['droberts' + '@' + 'dimagi.com'])
 
-    utcnow = utcnow if utcnow else utc.localize(datetime.utcnow())
-    current_date_local = timezone.normalize(utcnow.astimezone(timezone))
+    last_sync_utc = last_sync.date
+
+    if not _assert(last_sync_utc.tzinfo is None,
+                   'last_sync.date should be an offset-naive dt'):
+        last_sync_utc = UserTime(last_sync_utc).server_time().done()
+
+    # check if user has already synced today (in local timezone).
+    # Indicators only change daily.
+    last_sync_local = ServerTime(last_sync_utc).user_time(timezone).done()
+    current_date_local = ServerTime(utcnow).user_time(timezone).done()
 
     if current_date_local.date() != last_sync_local.date():
         return True

--- a/corehq/apps/callcenter/tests/test_indicator_fixture.py
+++ b/corehq/apps/callcenter/tests/test_indicator_fixture.py
@@ -66,9 +66,9 @@ class CallcenterFixtureTests(SimpleTestCase):
     def test_should_sync_timezone(self):
         domain = Domain(name='test', default_timezone='Africa/Johannesburg')
         # yesterday at 21:59:59 = yesterday at 23:59:59 locally
-        last_sync = datetime.combine(date.today() - timedelta(days=1), time(21, 59, 59)).replace(tzinfo=pytz.utc)
+        last_sync = datetime.combine(date.today() - timedelta(days=1), time(21, 59, 59))
         # yesterday at 21:59:59 = today at 00:00:00 locally
-        utcnow = datetime.combine(date.today() - timedelta(days=1), time(22, 00, 00)).replace(tzinfo=pytz.utc)
+        utcnow = datetime.combine(date.today() - timedelta(days=1), time(22, 00, 00))
         self.assertTrue(should_sync(domain, SyncLog(date=last_sync), utcnow=utcnow))
 
         domain = Domain(name='test', default_timezone='UTC')


### PR DESCRIPTION
There should be no functional changes here, cleanup only.

The `soft_assert` is because I'm making an educated guess that `last_sync` comes in without a timezone, but if I'm wrong, I want to know (and it'll maintain previous behavior).

Cherry-picked from https://github.com/dimagi/commcare-hq/pull/6299, because an assert I was making in there made this test fail—because it's passing in an offset-aware datetime in `SyncLog(date=last_sync)`, whereas jsonobject (implicitly) expects offset-naive—but this change stands on its own and doesn't need to be part of that PR.
