### PR TITLE
use dimagi fork of select2 and rewind to latest stable 3.5 release

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -81,7 +81,7 @@
 	url = https://github.com/angular-ui/ui-select.git
 [submodule "corehq/apps/style/static/style/lib/select2"]
 	path = corehq/apps/style/static/style/lib/select2
-	url = https://github.com/ivaynberg/select2.git
+	url = https://github.com/dimagi/select2.git
 [submodule "corehq/apps/style/static/style/lib/jquery-cookie"]
 	path = corehq/apps/style/static/style/lib/jquery-cookie
 	url = https://github.com/carhartl/jquery-cookie.git


### PR DESCRIPTION
should address http://manage.dimagi.com/default.asp?165223

wait for the build.

everyone should run:

`git submodule sync corehq/apps/style/static/style/lib/select2`

locally after this change to avoid accidentally bumping the submodule again
