### PR TITLE
propertly use unicode in _fmt_date (deployments reports)

### DIFF
--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -221,10 +221,10 @@ def _fmt_date(date):
         return _bootstrap_class(delta, timedelta(days=7), timedelta(days=3))
 
     if not date:
-        return format_datatables_data('<span class="label">{0}</span>'.format(_("Never")), -1)
+        return format_datatables_data(u'<span class="label">{0}</span>'.format(_("Never")), -1)
     else:
         return format_datatables_data(
-            '<span class="{cls}">{text}</span>'.format(
+            u'<span class="{cls}">{text}</span>'.format(
                 cls=_timedelta_class(datetime.utcnow() - date),
                 text=naturaltime(date),
             ),


### PR DESCRIPTION
Not my error but was scanning staging errors and was easy enough to fix after I ascertained it wasn't related to microseconds change. (Also haven't tested, but this certainly won't it worse and looks correct.)

Error on staging was:

```
  File "/home/cchq/www/staging/code_root/corehq/apps/reports/generic.py", line 931, in report_context
    rows = list(self.rows)

  File "/home/cchq/www/staging/code_root/corehq/apps/reports/standard/deployments.py", line 135, in rows
    [user.username_in_report, _fmt_date(last_seen), _fmt_date(last_sync), app_name or "---"]

  File "/home/cchq/www/staging/code_root/corehq/apps/reports/standard/deployments.py", line 229, in _fmt_date
    text=naturaltime(date),

UnicodeEncodeError: 'ascii' codec can't encode character u'\xa0' in position 1: ordinal not in range(128)
```
