### PR TITLE
Update clear_locations reference and fix spelling

### DIFF
--- a/corehq/apps/commtrack/tests/test_locations.py
+++ b/corehq/apps/commtrack/tests/test_locations.py
@@ -167,7 +167,7 @@ class MultiLocationsTest(CommTrackTest):
 
     def test_can_clear_locations(self):
         user = self.user
-        user.clear_location_delgates()
+        user.clear_location_delegates()
 
         self.assertEqual(len(user.locations), 0)
 
@@ -206,7 +206,7 @@ class MultiLocationsTest(CommTrackTest):
     def test_setting_existing_list_does_not_submit(self):
         user = self.user
 
-        user.clear_location_delgates()
+        user.clear_location_delegates()
 
         loc1 = make_loc('secondloc')
         make_supply_point(self.domain.name, loc1)

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1376,7 +1376,7 @@ class LocationUserMixin(DocumentSchema):
         self.user_data.pop('commtrack-supply-point', None)
         self.user_data.pop('commcare_primary_case_sharing_id', None)
         self.location_id = None
-        self.clear_locations()
+        self.clear_location_delegates()
         self.save()
 
     @property
@@ -1491,7 +1491,7 @@ class LocationUserMixin(DocumentSchema):
 
                 self.submit_location_block(caseblock)
 
-    def clear_location_delgates(self):
+    def clear_location_delegates(self):
         """
         Wipe all case delagate access.
         """
@@ -1517,7 +1517,7 @@ class LocationUserMixin(DocumentSchema):
                 # as we can't compare the location objects themself
                 return
 
-        self.clear_location_delgates()
+        self.clear_location_delegates()
 
         if not locations:
             return

--- a/custom/logistics/commtrack.py
+++ b/custom/logistics/commtrack.py
@@ -1,13 +1,10 @@
 import itertools
-from functools import partial
 import logging
 import traceback
 from corehq.apps.commtrack.models import SupplyPointCase
 
 from corehq.apps.locations.models import Location
-from corehq.apps.users.models import WebUser
 from custom.logistics.models import MigrationCheckpoint
-from dimagi.utils.dates import force_to_datetime
 from requests.exceptions import ConnectionError
 from datetime import datetime
 from custom.ilsgateway.utils import get_next_meta_url
@@ -85,7 +82,7 @@ def save_stock_data_checkpoint(checkpoint, api, limit, offset, date, external_id
 def add_location(user, location_id):
     if location_id:
         loc = Location.get(location_id)
-        user.clear_location_delgates()
+        user.clear_location_delegates()
         user.add_location_delegate(loc)
 
 


### PR DESCRIPTION
Small bug I just noticed.  I added a reference to clear_locations and Cory renamed it clear_location_delegates at the same time.
@sravfeyn @anyone
