### PR TITLE
change typo iso_string_to_datetime to iso_string_to_date

### DIFF
--- a/custom/m4change/fields.py
+++ b/custom/m4change/fields.py
@@ -1,5 +1,5 @@
 import datetime
-from corehq.util.dates import iso_string_to_datetime
+from corehq.util.dates import iso_string_to_date
 from dimagi.utils.dates import DateSpan
 import json
 from django.utils.translation import ugettext as _, ugettext_noop
@@ -20,9 +20,9 @@ class DateRangeField(ReportField):
         if range is not None:
             dates = str(range).split(_(' to '))
             self.request.datespan.startdate = datetime.datetime.combine(
-                iso_string_to_datetime(dates[0]), datetime.time())
+                iso_string_to_date(dates[0]), datetime.time())
             self.request.datespan.enddate = datetime.datetime.combine(
-                iso_string_to_datetime(dates[1]), datetime.time())
+                iso_string_to_date(dates[1]), datetime.time())
 
         self.datespan = DateSpan.since(self.default_days, timezone=self.timezone, inclusive=self.inclusive)
         if self.request.datespan.is_valid():


### PR DESCRIPTION
I found this because of a soft assert within `iso_string_to_datetime`. When I did a cleanup last week, I used the wrong function here.
