### PR TITLE
speed up tests by 20 seconds

### DIFF
--- a/.travis/localsettings.py
+++ b/.travis/localsettings.py
@@ -98,3 +98,5 @@ LOGGING = {
         }
     }
 }
+
+SOUTH_TESTS_MIGRATE = True

--- a/settings.py
+++ b/settings.py
@@ -889,6 +889,11 @@ SAVED_EXPORT_ACCESS_CUTOFF = 35
 # override for production
 DEFAULT_PROTOCOL = 'http'
 
+####### South Settings #######
+SKIP_SOUTH_TESTS = True
+SOUTH_TESTS_MIGRATE = False
+
+
 try:
     # try to see if there's an environmental variable set for local_settings
     if os.environ.get('CUSTOMSETTINGS', None) == "demo":
@@ -938,10 +943,6 @@ INDICATOR_CONFIG = {
     "mvp-sauri": ['mvp_indicators'],
     "mvp-potou": ['mvp_indicators'],
 }
-
-####### South Settings #######
-SKIP_SOUTH_TESTS = True
-SOUTH_TESTS_MIGRATE = False
 
 ####### Couch Forms & Couch DB Kit Settings #######
 from settingshelper import get_dynamic_db_settings, make_couchdb_tuples, get_extra_couchdbs

--- a/settings.py
+++ b/settings.py
@@ -525,8 +525,6 @@ CELERY_REMINDER_RULE_QUEUE = CELERY_MAIN_QUEUE
 # on its own queue.
 CELERY_REMINDER_CASE_UPDATE_QUEUE = CELERY_MAIN_QUEUE
 
-SKIP_SOUTH_TESTS = True
-#AUTH_PROFILE_MODULE = 'users.HqUserProfile'
 TEST_RUNNER = 'testrunner.TwoStageTestRunner'
 # this is what gets appended to @domain after your accounts
 HQ_ACCOUNT_ROOT = "commcarehq.org"
@@ -942,8 +940,8 @@ INDICATOR_CONFIG = {
 }
 
 ####### South Settings #######
-#SKIP_SOUTH_TESTS=True
-#SOUTH_TESTS_MIGRATE=False
+SKIP_SOUTH_TESTS = True
+SOUTH_TESTS_MIGRATE = False
 
 ####### Couch Forms & Couch DB Kit Settings #######
 from settingshelper import get_dynamic_db_settings, make_couchdb_tuples, get_extra_couchdbs


### PR DESCRIPTION
by settings `SOUTH_TESTS_MIGRATE = False`

@czue do you remember why we didn't have this set?

Before this the overhead of just running a single db test is 30+ seconds of setup; with this it's down to ~11.
