### PR TITLE
Stop using elasticsearch to generate the case history

### DIFF
--- a/corehq/apps/api/es.py
+++ b/corehq/apps/api/es.py
@@ -248,7 +248,7 @@ class XFormES(ESView):
 
     def run_query(self, es_query, **kwargs):
         es_results = super(XFormES, self).run_query(es_query)
-        #hack, walk the results again, and if we have xmlns, populate human readable names
+        # hack, walk the results again, and if we have xmlns, populate human readable names
         # Note that `get_unknown_form_name` does not require the request, which is also
         # not necessarily available here. So `None` is passed here.
         form_filter = FormsByApplicationFilter(None, domain=self.domain)

--- a/corehq/apps/reports/urls.py
+++ b/corehq/apps/reports/urls.py
@@ -35,6 +35,7 @@ urlpatterns = patterns('corehq.apps.reports.views',
     url(r'^saved_reports', 'old_saved_reports'),
 
     url(r'^case_data/(?P<case_id>[\w\-]+)/$', 'case_details', name="case_details"),
+    url(r'^case_data/(?P<case_id>[\w\-]+)/forms/$', 'case_forms', name="single_case_forms"),
     url(r'^case_data/(?P<case_id>[\w\-]+)/attachments/$', 'case_attachments', name="single_case_attachments"),
     url(r'^case_data/(?P<case_id>[\w\-]+)/view/xml/$', 'case_xml', name="single_case_xml"),
     url(r'^case_data/(?P<case_id>[\w\-]+)/rebuild/$', 'rebuild_case_view', name="rebuild_case"),

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -929,6 +929,11 @@ def case_details(request, domain, case_id):
 @require_GET
 def case_forms(request, domain, case_id):
     case = get_document_or_404(CommCareCase, domain, case_id)
+    try:
+        start_range = int(request.GET['start_range'])
+        end_range = int(request.GET['end_range'])
+    except (KeyError, ValueError):
+        raise HttpResponseBadRequest()
 
     def form_to_json(form):
         return {
@@ -940,8 +945,10 @@ def case_forms(request, domain, case_id):
             },
             'readable_name': form.form.get('@name') or _('unknown'),
         }
+
+    slice = list(reversed(case.xform_ids))[start_range:end_range]
     return json_response([
-        form_to_json(XFormInstance.get(form_id)) for form_id in reversed(case.xform_ids)
+        form_to_json(XFormInstance.get(form_id)) for form_id in slice
     ])
 
 

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -924,6 +924,27 @@ def case_details(request, domain, case_id):
     })
 
 
+@require_case_view_permission
+@login_and_domain_required
+@require_GET
+def case_forms(request, domain, case_id):
+    case = get_document_or_404(CommCareCase, domain, case_id)
+
+    def form_to_json(form):
+        return {
+            'id': form._id,
+            'received_on': json_format_datetime(form.received_on),
+            'user': {
+                "id": form.metadata.userID,
+                "username": form.metadata.username,
+            },
+            'readable_name': form.form.get('@name') or _('unknown'),
+        }
+    return json_response([
+        form_to_json(XFormInstance.get(form_id)) for form_id in reversed(case.xform_ids)
+    ])
+
+
 @login_and_domain_required
 @require_GET
 def case_attachments(request, domain, case_id):

--- a/corehq/ex-submodules/casexml/apps/case/static/case/js/case_details.js
+++ b/corehq/ex-submodules/casexml/apps/case/static/case/js/case_details.js
@@ -111,15 +111,6 @@ function XFormListViewModel() {
 
     var api_url = CASE_DETAILS.xform_api_url;
 
-    self.xform_query = function () {
-        //elastic query based upon case id
-        var id_query = self.xform_id_query();
-        return id_query;
-        //todo once the xform index is updated with embedded case properties
-        //real query to be filled out here below once index is modified
-
-    };
-
     self.xform_id_query = function () {
         //hacky query based upon xform_ids due to nested case properties not being indexed in pillowtop at the moment
 
@@ -150,7 +141,7 @@ function XFormListViewModel() {
 
 
     self.stats_query = function () {
-        var q = self.xform_query();
+        var q = self.xform_id_query();
         q["facets"] = {
             "received_facets": {
                 "date_histogram": {
@@ -292,16 +283,16 @@ function XFormListViewModel() {
 
     //main function data collection - entry point if you will
     //self.run_es_query(self.stats_query(), self.stats_data_cb);
-    self.run_es_query(self.xform_query(), self.xform_history_cb);
+    self.run_es_query(self.xform_id_query(), self.xform_history_cb);
 
     self.nextPage = function() {
         self.disp_page_index(self.disp_page_index() + 1);
-        self.run_es_query(self.xform_query(), self.xform_history_cb);
+        self.run_es_query(self.xform_id_query(), self.xform_history_cb);
     };
 
     self.prevPage = function() {
         self.disp_page_index(self.disp_page_index() - 1);
-        self.run_es_query(self.xform_query(), self.xform_history_cb);
+        self.run_es_query(self.xform_id_query(), self.xform_history_cb);
     };
 
     self.clickRow = function(item) {
@@ -341,12 +332,12 @@ function XFormListViewModel() {
         if (disp_index > self.page_count()) {
             self.disp_page_index(self.page_count());
         } else {
-            self.run_es_query(self.xform_query(), self.xform_history_cb);
+            self.run_es_query(self.xform_id_query(), self.xform_history_cb);
         }
     });
 
     self.disp_page_index_changed = self.disp_page_index.subscribe(function () {
-        self.run_es_query(self.xform_query(), self.xform_history_cb);
+        self.run_es_query(self.xform_id_query(), self.xform_history_cb);
     });
 
 

--- a/corehq/ex-submodules/casexml/apps/case/static/case/js/case_details.js
+++ b/corehq/ex-submodules/casexml/apps/case/static/case/js/case_details.js
@@ -92,35 +92,6 @@ function XFormListViewModel() {
 
     var api_url = CASE_DETAILS.xform_api_url;
 
-    self.xform_id_query = function () {
-        //hacky query based upon xform_ids due to nested case properties not being indexed in pillowtop at the moment
-
-        var start_num = self.disp_page_index() || 1;
-        var start_range = (start_num - 1) * self.page_size();
-        var end_range = start_range + self.page_size();
-        var xform_ids = CASE_DETAILS.xform_ids;
-
-        if (end_range > xform_ids.length) {
-            end_range = xform_ids.length;
-        }
-        xform_ids.reverse();
-
-        return {
-            "filter": {
-                "ids": {
-                    "values": _.map(_.range(start_range, end_range),
-                                    function(idx) {
-                                        return xform_ids[idx];
-                                    })
-                }
-            },
-            "from": 0,
-            "size": self.page_size(),
-            "sort": [{"received_on": "desc"}]
-        };
-    };
-
-
     self.get_xform_data = function(xform_id) {
         //method for getting individual xform via GET
         $.cachedAjax({
@@ -137,27 +108,6 @@ function XFormListViewModel() {
             "complete": function(data) {
             }
         })
-    };
-
-    self.run_es_query = function(query, success_cb) {
-        //generic caller for ES query
-        self.data_loading(true);
-        $.ajax({
-            "type": "POST",
-            "url":  api_url,
-            "data": ko.toJSON(query),
-            "success": function(data) {
-                success_cb(data);
-            }, //end success
-            "error": function(data) {
-                console.log("Error");
-                console.log(data);
-            },
-            "complete": function(data){
-                //{#                        self.is_loading(false);#}
-                self.data_loading(false);
-            }
-        });
     };
 
     self.xform_history_cb = function(data) {

--- a/corehq/ex-submodules/casexml/apps/case/static/case/js/case_details.js
+++ b/corehq/ex-submodules/casexml/apps/case/static/case/js/case_details.js
@@ -179,7 +179,6 @@ function XFormListViewModel() {
         });
     };
 
-
     self.xform_history_cb = function(data) {
         //callback for rendering the xforms list
         //todo until indexing is fixed for nested case blocks
@@ -193,22 +192,25 @@ function XFormListViewModel() {
         self.selected_xform_idx(-1);
     };
 
+    self.refresh_forms = function () {
+        self.run_es_query(self.xform_id_query(), self.xform_history_cb);
+    };
 
     self.calc_page_count = function() {
         self.page_count(Math.ceil(self.total_rows()/self.page_size()));
     };
 
     //main function data collection - entry point if you will
-    self.run_es_query(self.xform_id_query(), self.xform_history_cb);
+    self.refresh_forms();
 
     self.nextPage = function() {
         self.disp_page_index(self.disp_page_index() + 1);
-        self.run_es_query(self.xform_id_query(), self.xform_history_cb);
+        self.refresh_forms();
     };
 
     self.prevPage = function() {
         self.disp_page_index(self.disp_page_index() - 1);
-        self.run_es_query(self.xform_id_query(), self.xform_history_cb);
+        self.refresh_forms();
     };
 
     self.clickRow = function(item) {
@@ -248,14 +250,13 @@ function XFormListViewModel() {
         if (disp_index > self.page_count()) {
             self.disp_page_index(self.page_count());
         } else {
-            self.run_es_query(self.xform_id_query(), self.xform_history_cb);
+            self.refresh_forms();
         }
     });
 
     self.disp_page_index_changed = self.disp_page_index.subscribe(function () {
-        self.run_es_query(self.xform_id_query(), self.xform_history_cb);
+        self.refresh_forms();
     });
-
 
     self.all_pages = function() {
         return _.range(1, self.page_count()+1);

--- a/corehq/ex-submodules/casexml/apps/case/static/case/js/case_details.js
+++ b/corehq/ex-submodules/casexml/apps/case/static/case/js/case_details.js
@@ -122,9 +122,16 @@ function XFormListViewModel() {
 
     self.refresh_forms = function () {
         self.data_loading(true);
+        var start_num = self.disp_page_index() || 1;
+        var start_range = (start_num - 1) * self.page_size();
+        var end_range = start_range + self.page_size();
         $.ajax({
             "type": "GET",
             "url":  api_url,
+            "data": {
+                'start_range': start_range,
+                'end_range': end_range
+            },
             "success": function(data) {
                 self.xform_history_cb(data);
             },

--- a/corehq/ex-submodules/casexml/apps/case/templates/case/partials/single_case.html
+++ b/corehq/ex-submodules/casexml/apps/case/templates/case/partials/single_case.html
@@ -7,7 +7,7 @@
 {# standalone template, js files included at bottom #}
 <script>
     var CASE_DETAILS = {};
-    CASE_DETAILS.xform_api_url = "/a/{{ case.domain }}/api/v0.1/xform_es/";
+    CASE_DETAILS.xform_api_url = "{{ xform_api_url }}";
     CASE_DETAILS.xform_ids = {{ case.xform_ids|JSON }};
     CASE_DETAILS.xform_ajax_url = "{% url 'case_form_data' case.domain case.get_id 'placeholder-form-id' %}".replace('placeholder-form-id/', '');
     CASE_DETAILS.timezone_offset = {{ timezone_offset }};

--- a/corehq/ex-submodules/casexml/apps/case/templates/case/partials/single_case.html
+++ b/corehq/ex-submodules/casexml/apps/case/templates/case/partials/single_case.html
@@ -87,8 +87,6 @@
                 <span data-bind="text: form_count"></span>
             </li>
         </ul>
-
-
         <div class="hq-loading" data-bind="visible: $root.data_loading">Loading <img src="/static/hqwebapp/img/ajax-loader.gif" alt="loading indicator"></div>
         <table class="table table-bordered table-striped table-hover datatable dataTable">
             <thead>

--- a/corehq/ex-submodules/casexml/apps/case/templatetags/case_tags.py
+++ b/corehq/ex-submodules/casexml/apps/case/templatetags/case_tags.py
@@ -120,6 +120,7 @@ def render_case(case, options):
         "ledgers": ledgers,
         "timezone_offset": tz_offset_ms,
         "show_transaction_export": show_transaction_export,
+        "xform_api_url": reverse('single_case_forms', args=[case.domain, case._id]),
     })
 
 


### PR DESCRIPTION
some context in http://manage.dimagi.com/default.asp?165324 and http://manage.dimagi.com/default.asp?164917

probably easiest read commit-by-commit.

there was a ton of cruft in `case_details.js` that I got rid of. another hopefully nice side effect is that we now only send the minimal set of results back to the browser.

@kaapstorm 
