### PR TITLE
don't process indicators due to deleted docs

### DIFF
--- a/custom/_legacy/mvp_docs/pillows.py
+++ b/custom/_legacy/mvp_docs/pillows.py
@@ -52,11 +52,12 @@ class MVPIndicatorPillowBase(BasicPillow):
         if doc_type in self._deleted_doc_types:
             self._delete_doc(doc_dict)
 
-        domain = doc_dict.get('domain')
-        if not domain:
-            return
-        namespaces = get_namespaces(domain)
-        self.process_indicators(namespaces, domain, doc_dict)
+        else:
+            domain = doc_dict.get('domain')
+            if not domain:
+                return
+            namespaces = get_namespaces(domain)
+            self.process_indicators(namespaces, domain, doc_dict)
 
     def process_indicators(self, namespaces, domain, doc_dict):
         raise NotImplementedError("Your pillow must implement this method.")


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?165579

introduced by https://github.com/dimagi/commcare-hq/pull/6333

this isn't actually causing any report problems since the error prevents the documents from being saved, but this should silence sentry.

@biyeun @kaapstorm 
