### PR TITLE
Send MVP reports in the background queue

### DIFF
--- a/corehq/apps/indicators/utils.py
+++ b/corehq/apps/indicators/utils.py
@@ -1,4 +1,5 @@
 from couchdbkit import ResourceNotFound
+from django.conf import settings
 from corehq.util.quickcache import quickcache
 from dimagi.utils.couch.database import get_db
 
@@ -29,3 +30,10 @@ def get_namespace_name(domain, namespace):
 
 def get_indicator_domains():
     return get_indicator_config().keys()
+
+
+def get_mvp_domains():
+    from mvp.models import MVP
+    if settings.UNIT_TESTING:
+        return MVP.DOMAINS
+    return get_indicator_domains() or MVP.DOMAINS

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -4,6 +4,7 @@ import uuid
 
 from celery.schedules import crontab
 from celery.task import periodic_task
+from corehq.apps.indicators.utils import get_mvp_domains
 from corehq.apps.reports.scheduled import get_scheduled_reports
 from corehq.util.view_utils import absolute_reverse
 from couchexport.files import Temp
@@ -92,8 +93,7 @@ def get_report_queue(report):
     # This is a super-duper hacky, hard coded way to deal with the fact that MVP reports
     # consistently crush the celery queue for everyone else.
     # Just send them to their own longrunning background queue
-    from mvp.models import MVP
-    if report.domain in MVP.DOMAINS:
+    if report.domain in get_mvp_domains():
         return 'background_queue'
     else:
         return 'celery'

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -88,7 +88,7 @@ def send_delayed_report(report):
     send_report.delay(report._id)
 
 
-@task
+@task(ignore_result=True)
 def send_report(notification_id):
     notification = ReportNotification.get(notification_id)
     try:

--- a/corehq/apps/reports/tests/test_scheduled_reports.py
+++ b/corehq/apps/reports/tests/test_scheduled_reports.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from django.test import SimpleTestCase, TestCase
 from corehq.apps.reports.models import ReportNotification
 from corehq.apps.reports.scheduled import guess_reporting_minute, get_scheduled_reports
+from corehq.apps.reports.tasks import get_report_queue
 
 
 class GuessReportingMinuteTest(SimpleTestCase):
@@ -142,3 +143,12 @@ class ScheduledReportTest(TestCase):
         ReportNotification(hour=12, minute=None, day=31, interval='monthly').save()
         ReportNotification(hour=12, minute=None, day=32, interval='monthly').save()
         self._check('monthly', datetime(2014, 10, 31, 12, 0), 1)
+
+
+class TestMVPCeleryQueueHack(SimpleTestCase):
+
+    def test_queue_selection_mvp(self):
+        self.assertEqual('background_queue', get_report_queue(ReportNotification(domain='mvp-tiby')))
+
+    def test_queue_selection_normal(self):
+        self.assertEqual('celery', get_report_queue(ReportNotification(domain='not-mvp')))

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -787,7 +787,6 @@ def delete_scheduled_report(request, domain, scheduled_report_id):
 
 @login_and_domain_required
 def send_test_scheduled_report(request, domain, scheduled_report_id):
-    from corehq.apps.reports.tasks import send_report
     from corehq.apps.users.models import CouchUser, CommCareUser, WebUser
 
     user_id = request.couch_user._id

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -92,7 +92,7 @@ from corehq.apps.reports.models import (
     HQGroupExportConfiguration
 )
 from corehq.apps.reports.standard.cases.basic import CaseListReport
-from corehq.apps.reports.tasks import create_metadata_export, rebuild_export_async
+from corehq.apps.reports.tasks import create_metadata_export, rebuild_export_async, send_delayed_report
 from corehq.apps.reports import util
 from corehq.apps.reports.util import (
     get_all_users_by_domain,
@@ -799,7 +799,7 @@ def send_test_scheduled_report(request, domain, scheduled_report_id):
         user = CommCareUser.get_by_user_id(user_id, domain)
 
     try:
-        send_report.delay(notification._id)
+        send_delayed_report(notification)
     except Exception, e:
         import logging
         logging.exception(e)

--- a/custom/_legacy/mvp/management/commands/mvp_force_update.py
+++ b/custom/_legacy/mvp/management/commands/mvp_force_update.py
@@ -14,10 +14,10 @@ from casexml.apps.case.models import CommCareCase
 from corehq.apps.indicators.models import CaseIndicatorDefinition, FormIndicatorDefinition, DocumentMismatchError, DocumentNotInDomainError
 from couchforms.models import XFormInstance
 from dimagi.utils.couch.database import get_db
-from dimagi.utils.management.commands import prime_views
 from mvp.models import MVP
 
 POOL_SIZE = 10
+
 
 class Command(LabelCommand):
     help = "Update MVP indicators in existing cases and forms."


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?152343

hoping this will fix the mvp issue as well as the monday morning celery woes.

is broken up by commit but is also pretty small.

I talked with @dannyroberts and I think we decided this was the best way to go. cc @kaapstorm 
