### PR TITLE
Always sync users' locations and their parents

### DIFF
--- a/corehq/apps/commtrack/forms.py
+++ b/corehq/apps/commtrack/forms.py
@@ -34,9 +34,6 @@ class CommTrackSettingsForm(forms.Form):
         required=False
     )
 
-    sync_location_fixtures = forms.BooleanField(
-        label=ugettext_lazy("Sync location fixtures"), required=False)
-
     sync_consumption_fixtures = forms.BooleanField(
         label=ugettext_lazy("Sync consumption fixtures"), required=False)
 
@@ -87,7 +84,6 @@ class CommTrackSettingsForm(forms.Form):
             ),
             Fieldset(
                 _('Phone Settings'),
-                'sync_location_fixtures',
                 'sync_consumption_fixtures',
             ),
             ButtonHolder(

--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -205,7 +205,6 @@ class CommtrackConfig(CachedCouchDocumentMixin, Document):
     # configured on Advanced Settings page
     use_auto_emergency_levels = BooleanProperty(default=False)
 
-    sync_location_fixtures = BooleanProperty(default=True)
     sync_consumption_fixtures = BooleanProperty(default=True)
     use_auto_consumption = BooleanProperty(default=False)
     consumption_config = SchemaProperty(ConsumptionConfig)

--- a/corehq/apps/commtrack/views.py
+++ b/corehq/apps/commtrack/views.py
@@ -101,7 +101,6 @@ class CommTrackSettingsView(BaseCommTrackManageView):
             data = self.commtrack_settings_form.cleaned_data
             previous_config = copy.copy(self.commtrack_settings)
             self.commtrack_settings.use_auto_consumption = bool(data.get('use_auto_consumption'))
-            self.commtrack_settings.sync_location_fixtures = bool(data.get('sync_location_fixtures'))
             self.commtrack_settings.sync_consumption_fixtures = bool(data.get('sync_consumption_fixtures'))
             self.commtrack_settings.individual_consumption_defaults = bool(data.get('individual_consumption_defaults'))
 

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -1040,6 +1040,14 @@ class Domain(Document, SnapshotMixin):
         return LocationType.objects.filter(domain=self.name).all()
 
     @property
+    @memoized
+    def uses_locations(self):
+        if self.commtrack_enabled:
+            return True
+        from corehq.apps.locations.models import LocationType
+        return LocationType.objects.filter(domain=self.name).exists()
+
+    @property
     def supports_multiple_locations_per_user(self):
         """
         This method is a wrapper around the toggle that

--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -49,11 +49,8 @@ def location_fixture_generator(user, version, last_sync=None):
     There is an admin feature flag that will make this generate
     a fixture with ALL locations for the domain.
     """
-    project = user.project
-    if (not project or not project.commtrack_enabled
-        or not project.commtrack_settings
-        or not project.commtrack_settings.sync_location_fixtures):
-            return []
+    if not user.project.uses_locations:
+        return []
 
     if toggles.SYNC_ALL_LOCATIONS.enabled(user.domain):
         location_db = _location_footprint(Location.by_domain(user.domain))
@@ -79,7 +76,7 @@ def location_fixture_generator(user, version, last_sync=None):
                    {'id': 'commtrack:locations',
                     'user_id': user.user_id})
 
-    loc_types = project.location_types
+    loc_types = user.project.location_types
     type_to_slug_mapping = dict((ltype.name, ltype.code) for ltype in loc_types)
 
     def location_type_lookup(location_type):


### PR DESCRIPTION
This still doesn't sync the full set of locations, just the direct parents. If
the location type has "Views Child Locations" checked, it'll sync those too.
@sravfeyn
@twymer @czue FYI
probably a good idea to wait on build
