### PR TITLE
Add CREATEDB permissions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,9 @@ To run a particular test or subset of tests
 To run the selenium tests, you first need to install the
 [ChromeDriver](https://code.google.com/p/selenium/wiki/ChromeDriver).
 
+If database tests are failing because of a `permission denied` error, give your postgres user permissions to create a database. 
+In the postgres shell, run the following as a superuser: `ALTER USER commcarehq CREATEDB;`
+
 The tests for CloudCare currently expect the "Basic Tests" app from the
 `corpora` domain on CommCareHQ.org to be installed in the same domain locally.
 


### PR DESCRIPTION
I was running into permission errors when running the test suite for the first time.
See: http://stackoverflow.com/questions/14186055/django-test-app-error-got-an-error-creating-the-test-database-permission-deni/14186439#14186439
