### PR TITLE
Show help popovers in accordions

### DIFF
--- a/corehq/apps/style/static/style/less/components/accordion.less
+++ b/corehq/apps/style/static/style/less/components/accordion.less
@@ -65,3 +65,9 @@
     content: "\f101" !important;
   }
 }
+
+//When there are help popovers within small accordions, the popovers are truncated
+.accordion-body.in {
+  overflow:visible;
+}
+

--- a/corehq/apps/style/static/style/lib/bootstrap/less/accordion.less
+++ b/corehq/apps/style/static/style/lib/bootstrap/less/accordion.less
@@ -32,3 +32,8 @@
   padding: 9px 15px;
   border-top: 1px solid #e5e5e5;
 }
+
+//When there are help popovers within small accordions, the popovers are truncated
+.accordion-body.in {
+  overflow:visible;
+}

--- a/corehq/apps/style/static/style/lib/bootstrap/less/accordion.less
+++ b/corehq/apps/style/static/style/lib/bootstrap/less/accordion.less
@@ -32,8 +32,3 @@
   padding: 9px 15px;
   border-top: 1px solid #e5e5e5;
 }
-
-//When there are help popovers within small accordions, the popovers are truncated
-.accordion-body.in {
-  overflow:visible;
-}


### PR DESCRIPTION
When help question marks are in small accordion elements
(e.g. "advanced" sections), the tooltips are truncated.

This seems to be an issue with our version of bootstrap.
See: https://github.com/twbs/bootstrap/issues/7742

@dannyroberts 

http://manage.dimagi.com/default.asp?165735
