### PR TITLE
support making loadtest users

### DIFF
--- a/corehq/apps/hqcase/tests/__init__.py
+++ b/corehq/apps/hqcase/tests/__init__.py
@@ -3,8 +3,9 @@ try:
     from .test_bugs import *
     from .test_case_assigment import *
     from .test_case_sharing import *
-    from .test_object_cache import *
     from .test_explode_cases import *
+    from .test_loadtest_users import *
+    from .test_object_cache import *
 except ImportError, e:
     # for some reason the test harness squashes these so log them here for clarity
     # otherwise debugging is a pain

--- a/corehq/apps/hqcase/tests/test_loadtest_users.py
+++ b/corehq/apps/hqcase/tests/test_loadtest_users.py
@@ -1,0 +1,51 @@
+from django.test import TestCase
+from casexml.apps.case.mock import CaseFactory
+from casexml.apps.case.tests import delete_all_cases
+from casexml.apps.case.tests.util import extract_caseblocks_from_xml
+from casexml.apps.case.xml import V2
+from casexml.apps.phone.restore import RestoreConfig
+from corehq import Domain
+from corehq.apps.users.models import CommCareUser
+
+
+class LoadtestUserTest(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.domain = Domain(name='foo')
+        cls.domain.save()
+        cls.user = CommCareUser.create(cls.domain.name, 'somebody', 'password')
+        cls.user_id = cls.user._id
+        cls.factory = CaseFactory(domain='foo', case_defaults={'owner_id': cls.user_id})
+
+    def setUp(self):
+        delete_all_cases()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.user.delete()
+        cls.domain.delete()
+
+    def test_no_factor_set(self):
+        self.user.loadtest_factor = None
+        self.user.save()
+        case = self.factory.create_case()
+        restore_config = RestoreConfig(self.user, version=V2)
+        payload_string = restore_config.get_payload().as_string()
+        caseblocks = extract_caseblocks_from_xml(payload_string)
+        self.assertEqual(1, len(caseblocks))
+        self.assertEqual(caseblocks[0].get_case_id(), case._id)
+
+    def test_simple_factor(self):
+        self.user.loadtest_factor = 3
+        self.user.save()
+        case1 = self.factory.create_case(case_name='case1')
+        case2 = self.factory.create_case(case_name='case2')
+        restore_config = RestoreConfig(self.user, version=V2)
+        payload_string = restore_config.get_payload().as_string()
+        caseblocks = extract_caseblocks_from_xml(payload_string)
+        self.assertEqual(6, len(caseblocks))
+        self.assertEqual(1, len(filter(lambda cb: cb.get_case_id() == case1._id, caseblocks)))
+        self.assertEqual(1, len(filter(lambda cb: cb.get_case_id() == case2._id, caseblocks)))
+        self.assertEqual(3, len(filter(lambda cb: cb.get_case_name() == case1.name, caseblocks)))
+        self.assertEqual(3, len(filter(lambda cb: cb.get_case_name() == case2.name, caseblocks)))

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -115,7 +115,7 @@ class MyAccountSettingsView(BaseMyAccountView):
             form = UpdateMyAccountInfoForm(
                 username=self.request.couch_user.username
             )
-        form.initialize_form(existing_user=self.request.couch_user)
+        form.initialize_form(self.request.domain, existing_user=self.request.couch_user)
         form.load_language(language_choices)
         return form
 

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -12,6 +12,7 @@ from django.utils.translation import ugettext as _, ugettext_noop, ugettext_lazy
 from django.template.loader import get_template
 from django.template import Context
 from django_countries.countries import COUNTRIES
+from corehq import toggles
 from corehq.apps.domain.forms import EditBillingAccountInfoForm
 from corehq.apps.domain.models import Domain
 from corehq.apps.locations.models import Location
@@ -103,7 +104,7 @@ class BaseUpdateUserForm(forms.Form):
             existing_user.save()
         return is_update_successful
 
-    def initialize_form(self, existing_user=None, **kwargs):
+    def initialize_form(self, domain, existing_user=None):
         if existing_user is None:
             return
 
@@ -230,6 +231,11 @@ class UpdateMyAccountInfoForm(BaseUpdateUserForm, BaseUserInfoForm):
 
 
 class UpdateCommCareUserInfoForm(BaseUserInfoForm, UpdateUserRoleForm):
+    loadtest_factor = forms.IntegerField(
+        required=False, min_value=1, max_value=50000,
+        help_text=_(u"Multiply this user's case load by a number for load testing on phones. "
+                    u"Leave blank for normal users."),
+        widget=forms.HiddenInput())
 
     def __init__(self, *args, **kwargs):
         super(UpdateCommCareUserInfoForm, self).__init__(*args, **kwargs)
@@ -244,6 +250,11 @@ class UpdateCommCareUserInfoForm(BaseUserInfoForm, UpdateUserRoleForm):
     def direct_properties(self):
         indirect_props = ['role']
         return [k for k in self.fields.keys() if k not in indirect_props]
+
+    def initialize_form(self, domain, existing_user=None):
+        if toggles.ENABLE_LOADTEST_USERS.enabled(domain):
+            self.fields['loadtest_factor'].widget = forms.TextInput()
+        super(UpdateCommCareUserInfoForm, self).initialize_form(domain, existing_user)
 
 
 class RoleForm(forms.Form):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1522,6 +1522,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
             date_joined=self.date_joined,
             user_data=self.user_data,
             domain=self.domain,
+            loadtest_factor=self.loadtest_factor,
         )
 
         def get_owner_ids():

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1324,6 +1324,8 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
 
     domain = StringProperty()
     registering_device_id = StringProperty()
+    # used by loadtesting framework - should typically be empty
+    loadtest_factor = IntegerProperty()
 
     @classmethod
     def wrap(cls, data):

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -169,7 +169,7 @@ class BaseEditUserView(BaseUserSettingsView):
             return self.user_update_form_class(data=self.request.POST)
 
         form = self.user_update_form_class()
-        form.initialize_form(existing_user=self.editable_user)
+        form.initialize_form(domain=self.request.domain, existing_user=self.editable_user)
         return form
 
     @property

--- a/corehq/ex-submodules/casexml/apps/case/tests/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/util.py
@@ -28,6 +28,9 @@ class RestoreCaseBlock(object):
         self.xml_element = xml_element
         self.version = version
 
+    def to_string(self):
+        return ElementTree.tostring(self.xml_element)
+
     def get_case_id(self):
         if self.version == V1:
             return self.xml_element.findtext('{{{0}}}case_id'.format(get_case_xmlns(self.version)))
@@ -158,8 +161,8 @@ def check_user_has_case(testcase, user, case_blocks, should_have=True,
                     if line_by_line:
                         check_xml_line_by_line(
                             testcase,
-                            ElementTree.tostring(case_block),
-                            ElementTree.tostring(block)
+                            case_block.to_string(),
+                            block.to_string(),
                         )
                     match = block
                     n += 1

--- a/corehq/ex-submodules/casexml/apps/case/tests/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/util.py
@@ -37,6 +37,11 @@ class RestoreCaseBlock(object):
         else:
             return self.xml_element.get('case_id')
 
+    def get_case_name(self):
+        assert self.version == V2, 'get_case_name not yet supported for legacy V1 casexml'
+        # note: there has to be a better way to work with namespaced xpath.... right?!?!
+        return self.xml_element.findtext('{{{0}}}create/{{{0}}}case_name'.format(get_case_xmlns(self.version)))
+
 
 def bootstrap_case_from_xml(test_class, filename, case_id_override=None, domain=None):
     starttime = utcnow_sans_milliseconds()

--- a/corehq/ex-submodules/casexml/apps/case/tests/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/util.py
@@ -19,6 +19,22 @@ from casexml.apps.phone.restore import RestoreConfig
 from casexml.apps.case.util import post_case_blocks
 
 
+class RestoreCaseBlock(object):
+    """
+    Little shim class for working with XML case blocks in a restore payload
+    """
+
+    def __init__(self, xml_element, version=V2):
+        self.xml_element = xml_element
+        self.version = version
+
+    def get_case_id(self):
+        if self.version == V1:
+            return self.xml_element.findtext('{{{0}}}case_id'.format(get_case_xmlns(self.version)))
+        else:
+            return self.xml_element.get('case_id')
+
+
 def bootstrap_case_from_xml(test_class, filename, case_id_override=None, domain=None):
     starttime = utcnow_sans_milliseconds()
     
@@ -101,6 +117,16 @@ def assert_user_doesnt_have_cases(testcase, user, case_ids, **kwargs):
                                should_have=False, version=V2, **kwargs)
 
 
+def get_case_xmlns(version):
+    return NS_VERSION_MAP.get(version, 'http://openrosa.org/http/response')
+
+
+def extract_caseblocks_from_xml(payload_string, version=V2):
+    parsed_payload = ElementTree.fromstring(payload_string)
+    xml_blocks = parsed_payload.findall('{{{0}}}case'.format(get_case_xmlns(version)))
+    return [RestoreCaseBlock(b, version) for b in xml_blocks]
+
+
 def check_user_has_case(testcase, user, case_blocks, should_have=True,
                         line_by_line=True, restore_id="", version=V1,
                         purge_restore_cache=False, return_single=False):
@@ -115,27 +141,19 @@ def check_user_has_case(testcase, user, case_blocks, should_have=True,
         SyncLog.get(restore_id).invalidate_cached_payloads()
     restore_config = RestoreConfig(user, restore_id, version=version)
     payload_string = restore_config.get_payload().as_string()
-    payload = ElementTree.fromstring(payload_string)
-
-    blocks = payload.findall('{{{0}}}case'.format(XMLNS))
-
-    def get_case_id(block):
-        if version == V1:
-            return block.findtext('{{{0}}}case_id'.format(XMLNS))
-        else:
-            return block.get('case_id')
+    blocks = extract_caseblocks_from_xml(payload_string, version)
 
     def check_block(case_block):
         case_block.set('xmlns', XMLNS)
-        case_block = ElementTree.fromstring(ElementTree.tostring(case_block))
-        case_id = get_case_id(case_block)
+        case_block = RestoreCaseBlock(ElementTree.fromstring(ElementTree.tostring(case_block)), version=version)
+        case_id = case_block.get_case_id()
         n = 0
 
         def extra_info():
             return "\n%s\n%s" % (ElementTree.tostring(case_block), map(ElementTree.tostring, blocks))
         match = None
         for block in blocks:
-            if get_case_id(block) == case_id:
+            if block.get_case_id() == case_id:
                 if should_have:
                     if line_by_line:
                         check_xml_line_by_line(
@@ -164,7 +182,6 @@ def check_user_has_case(testcase, user, case_blocks, should_have=True,
     matches = [check_block(case_block) for case_block in case_blocks]
     return restore_config, matches[0] if return_single else matches
 
-DEFAULT_TEST_TYPE = 'test'
 
 def post_util(create=False, case_id=None, user_id=None, owner_id=None,
               case_type=None, version=V2, form_extras=None, close=False,
@@ -176,7 +193,7 @@ def post_util(create=False, case_id=None, user_id=None, owner_id=None,
                       case_id=case_id,
                       user_id=user_id or uid(),
                       owner_id=owner_id or uid(),
-                      case_type=case_type or DEFAULT_TEST_TYPE,
+                      case_type=case_type or 'test',
                       version=version,
                       update=kwargs,
                       close=close).as_xml()

--- a/corehq/ex-submodules/casexml/apps/phone/caselogic.py
+++ b/corehq/ex-submodules/casexml/apps/phone/caselogic.py
@@ -81,11 +81,11 @@ class CaseSyncUpdate(object):
     """
     The record of how a case should sync
     """
-    def __init__(self, case, sync_token):
+    def __init__(self, case, sync_token, required_updates=None):
         self.case = case
         self.sync_token = sync_token
         # cache this property since computing it can be expensive
-        self.required_updates = self._get_required_updates()
+        self.required_updates = required_updates if required_updates is not None else self._get_required_updates()
         
     
     def _get_required_updates(self):

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -19,7 +19,8 @@ class User(object):
     """
     
     def __init__(self, user_id, username, password, date_joined,
-                 user_data=None, additional_owner_ids=None, domain=None):
+                 user_data=None, additional_owner_ids=None, domain=None,
+                 loadtest_factor=1):
         self.user_id = user_id
         self.username = username
         self.password = password
@@ -27,6 +28,7 @@ class User(object):
         self.user_data = user_data or {}
         self.additional_owner_ids = additional_owner_ids or []
         self.domain = domain
+        self.loadtest_factor = loadtest_factor
 
     def get_owner_ids(self):
         ret = [self.user_id]

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -8,10 +8,11 @@ import shutil
 import hashlib
 import tempfile
 from couchdbkit import ResourceConflict, ResourceNotFound
-from casexml.apps.phone.caselogic import BatchedCaseSyncOperation
+from casexml.apps.case.models import CommCareCase
+from casexml.apps.phone.caselogic import BatchedCaseSyncOperation, CaseSyncUpdate
 from casexml.apps.stock.consumption import compute_consumption_or_default
 from casexml.apps.stock.utils import get_current_ledger_transactions_multi
-from corehq.toggles import LOOSE_SYNC_TOKEN_VALIDATION, FILE_RESTORE, STREAM_RESTORE_CACHE
+from corehq.toggles import LOOSE_SYNC_TOKEN_VALIDATION, FILE_RESTORE, STREAM_RESTORE_CACHE, ENABLE_LOADTEST_USERS
 from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.parsing import json_format_datetime
 from casexml.apps.case.exceptions import BadStateException, RestoreException
@@ -342,13 +343,45 @@ def get_restore_class(user):
     return restore_class
 
 
+def _get_loadtest_factor(domain, user):
+    """
+    Gets the loadtest factor for a domain and user. Is always 1 unless
+    both the toggle is enabled for the domain, and the user has a non-zero,
+    non-null factor set.
+    """
+    if domain and ENABLE_LOADTEST_USERS.enabled(domain.name):
+        return getattr(user, 'loadtest_factor', 1) or 1
+    return 1
+
+
+def _transform_loadtest_update(update, factor):
+    """
+    Returns a new CaseSyncUpdate object (from an existing one) with all the
+    case IDs and names mapped to have the factor appended.
+    """
+    def _map_id(id, count):
+        return '{}-{}'.format(id, count)
+    case = CommCareCase.wrap(update.case._doc)
+    case._id = _map_id(case._id, factor)
+    for index in case.indices:
+        index.referenced_id = _map_id(index.referenced_id)
+    case.name = '{} ({})'.format(case.name, factor)
+    return CaseSyncUpdate(case, update.sync_token, required_updates=update.required_updates)
+
+
 def get_case_payload_batched(domain, stock_settings, version, user, last_synclog, new_synclog):
     response = get_restore_class(user)()
 
     sync_operation = BatchedCaseSyncOperation(user, last_synclog)
+    factor = _get_loadtest_factor(domain, user)
     for update in sync_operation.get_all_case_updates():
-        element = xml.get_case_element(update.case, update.required_updates, version)
-        response.append(element)
+        current_count = 0
+        while current_count < factor:
+            element = xml.get_case_element(update.case, update.required_updates, version)
+            response.append(element)
+            current_count += 1
+            if current_count < factor:
+                update = _transform_loadtest_update(update, current_count)
 
     sync_state = sync_operation.global_state
     new_synclog.cases_on_phone = sync_state.actual_owned_cases

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -21,7 +21,6 @@ from casexml.apps.case.xml import V2, V1
 from casexml.apps.case.util import post_case_blocks
 from casexml.apps.case.sharedmodels import CommCareCaseIndex
 from datetime import datetime
-from xml.etree import ElementTree
 from no_exceptions.exceptions import HttpException
 
 USER_ID = "main_user"
@@ -585,7 +584,7 @@ class MultiUserSyncTest(SyncBaseTest):
         # original user syncs again
         # make sure updates take
         _, match = assert_user_has_case(self, self.user, case_id, restore_id=self.sync_log.get_id)
-        self.assertTrue("Hello!" in ElementTree.tostring(match))
+        self.assertTrue("Hello!" in match.to_string())
 
     def testOtherUserAddsIndex(self):
         time = datetime.utcnow()
@@ -645,7 +644,7 @@ class MultiUserSyncTest(SyncBaseTest):
                             restore_id=self.sync_log.get_id, version=V2,
                             purge_restore_cache=True)
         _, orig = assert_user_has_case(self, self.user, case_id, restore_id=self.sync_log.get_id)
-        self.assertTrue("index" in ElementTree.tostring(orig))
+        self.assertTrue("index" in orig.to_string())
 
     def testMultiUserEdits(self):
         time = datetime.utcnow()

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -399,3 +399,9 @@ STREAM_RESTORE_CACHE = StaticToggle(
     'Stream cached restore from couchdb',
     [NAMESPACE_DOMAIN]
 )
+
+ENABLE_LOADTEST_USERS = StaticToggle(
+    'enable_loadtest_users',
+    'Enable creating loadtest users on HQ',
+    [NAMESPACE_DOMAIN]
+)


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?165814

![image](https://cloud.githubusercontent.com/assets/66555/7261751/1bd85bb8-e842-11e4-9e18-48b567d74442.png)

probably best reviewed commit by commit.

dependent on https://github.com/dimagi/commcare-hq/pull/6398 for tests (these are the first 3 commits)

this is a rather limited implementation, but i think good enough for mwellcare and can be improved later.

@benrudolph has context on the feature and @snopoke probably is most familiar with the code. cc @kaapstorm 

the meat is in https://github.com/dimagi/commcare-hq/commit/484189da8c1823ef9218d0ba2a9089fd5384ced9 where i've left some comments
