### PR TITLE
Don't email for disallowed host

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -805,6 +805,9 @@ LOGGING = {
             'level': 'ERROR',
             'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler',
         },
+        'null': {
+            'class': 'django.utils.log.NullHandler',
+        },
     },
     'loggers': {
         '': {
@@ -816,6 +819,10 @@ LOGGING = {
             'handlers': ['mail_admins'],
             'level': 'ERROR',
             'propagate': True,
+        },
+        'django.security.DisallowedHost': {
+            'handlers': ['null'],
+            'propogate': False,
         },
         'notify': {
             'handlers': ['mail_admins'],

--- a/settings.py
+++ b/settings.py
@@ -822,7 +822,7 @@ LOGGING = {
         },
         'django.security.DisallowedHost': {
             'handlers': ['null'],
-            'propogate': False,
+            'propagate': False,
         },
         'notify': {
             'handlers': ['mail_admins'],


### PR DESCRIPTION
From skype (no ticket):
[2:20:41 PM] cory.zue: is anyone on interrupt looking at the ALLOWED_HOSTS errors?
[2:20:43 PM] cory.zue: those are getting annoying
[2:22:41 PM] Jonathan Emord: not right now as far as i know. I can look at them
[2:22:59 PM] cory.zue: i wonder if we can turn them off

Here's the django suggestion https://github.com/django/django/commit/d228c1192ed59ab0114d9eba82ac99df611652d2#diff-8011fc099a35825013324622cda73f6bR460

@czue @snopoke 
