### PR TITLE
Auto redirect to last-visited domain

### DIFF
--- a/corehq/apps/domain/middleware.py
+++ b/corehq/apps/domain/middleware.py
@@ -41,3 +41,16 @@ class CCHQPRBACMiddleware(object):
             request.role = Role.objects.get(slug='community_plan_v0')
         except Role.DoesNotExist:
             request.role = Role()  # A fresh Role() has no privileges
+
+
+class DomainHistoryMiddleware(object):
+
+    def process_response(self, request, response):
+        if hasattr(request, 'domain'):
+            self.remember_domain_visit(request, response)
+        return response
+
+    def remember_domain_visit(self, request, response):
+        last_visited_domain = request.session.get('last_visited_domain')
+        if last_visited_domain != request.domain:
+            request.session['last_visited_domain'] = request.domain

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -124,7 +124,7 @@ def select(request, domain_select_template='domain/select.html', do_not_redirect
         'open_invitations': open_invitations,
     }
 
-    last_visited_domain = request.COOKIES.get('last_visited_domain')
+    last_visited_domain = request.session.get('last_visited_domain')
     if open_invitations \
        or do_not_redirect \
        or not last_visited_domain:
@@ -134,9 +134,8 @@ def select(request, domain_select_template='domain/select.html', do_not_redirect
             from corehq.apps.dashboard.views import dashboard_default
             return dashboard_default(request, last_visited_domain)
         except Http404:
-            response = render(request, domain_select_template, additional_context)
-            response.delete_cookie('last_visited_domain')
-            return response
+            del request.session['last_visited_domain']
+            return render(request, domain_select_template, additional_context)
 
 
 @require_superuser

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -129,14 +129,14 @@ def select(request, domain_select_template='domain/select.html', do_not_redirect
        or do_not_redirect \
        or not last_visited_domain:
         return render(request, domain_select_template, additional_context)
-
-    try:
-        from corehq.apps.dashboard.views import dashboard_default
-        return dashboard_default(request, last_visited_domain)
-    except Http404:
-        response = render(request, domain_select_template, additional_context)
-        response.delete_cookie('last_visited_domain')
-        return response
+    else:
+        try:
+            from corehq.apps.dashboard.views import dashboard_default
+            return dashboard_default(request, last_visited_domain)
+        except Http404:
+            response = render(request, domain_select_template, additional_context)
+            response.delete_cookie('last_visited_domain')
+            return response
 
 
 @require_superuser

--- a/corehq/util/global_request/middleware.py
+++ b/corehq/util/global_request/middleware.py
@@ -7,11 +7,4 @@ class GlobalRequestMiddleware(object):
         set_request(request)
 
     def process_response(self, request, response):
-        if hasattr(request, 'domain'):
-            self.remember_domain_visit(request, response)
         return response
-
-    def remember_domain_visit(self, request, response):
-        last_visited_domain = request.session.get('last_visited_domain')
-        if last_visited_domain != request.domain:
-            request.session['last_visited_domain'] = request.domain

--- a/corehq/util/global_request/middleware.py
+++ b/corehq/util/global_request/middleware.py
@@ -12,6 +12,6 @@ class GlobalRequestMiddleware(object):
         return response
 
     def remember_domain_visit(self, request, response):
-        last_visited_domain = request.COOKIES.get('last_visited_domain')
+        last_visited_domain = request.session.get('last_visited_domain')
         if last_visited_domain != request.domain:
-            response.set_cookie('last_visited_domain', request.domain)
+            request.session['last_visited_domain'] = request.domain

--- a/corehq/util/global_request/middleware.py
+++ b/corehq/util/global_request/middleware.py
@@ -7,4 +7,11 @@ class GlobalRequestMiddleware(object):
         set_request(request)
 
     def process_response(self, request, response):
+        if hasattr(request, 'domain'):
+            self.remember_domain_visit(request, response)
         return response
+
+    def remember_domain_visit(self, request, response):
+        last_visited_domain = request.COOKIES.get('last_visited_domain')
+        if last_visited_domain != request.domain:
+            response.set_cookie('last_visited_domain', request.domain)

--- a/settings.py
+++ b/settings.py
@@ -127,6 +127,7 @@ MIDDLEWARE_CLASSES = [
     'corehq.util.global_request.middleware.GlobalRequestMiddleware',
     'corehq.apps.users.middleware.UsersMiddleware',
     'corehq.apps.domain.middleware.CCHQPRBACMiddleware',
+    'corehq.apps.domain.middleware.DomainHistoryMiddleware',
     'casexml.apps.phone.middleware.SyncTokenMiddleware',
     'auditcare.middleware.AuditMiddleware',
     'no_exceptions.middleware.NoExceptionsMiddleware',


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?164618
- Save last-visited-domain to cookie
- When user visits https://www.commcarehq.org/domain/select/ or https://www.commcarehq.org/, redirect to last-visited-domain dashboard (if available, if not no-redirect).
- Do not auto-redirect if there are pending project invitations

@esoergel 
