### PR TITLE
Edit submissions UAT feedback

### DIFF
--- a/corehq/apps/reports/templates/reports/form/edit_submission.html
+++ b/corehq/apps/reports/templates/reports/form/edit_submission.html
@@ -1,0 +1,33 @@
+{% extends "reports/base_template.html" %}
+{% load hq_shared_tags %}
+{% load i18n %}
+
+{% block head %}{{ block.super }}
+    {% include 'cloudcare/includes/touchforms-inline.html' %}
+    <script src="{% static 'cloudcare/js/util.js' %}"></script>
+    <script>
+    $(function () {
+        GMAPS_API_KEY = '{{ maps_api_key|safe }}'; // maps api is a global variable depended on by touchforms
+        var edit_context = {{ edit_context|JSON }};
+        $('#edit-container').inlineTouchform({
+            formUrl: edit_context.formUrl,
+            submitUrl: edit_context.submitUrl,
+            sessionData: edit_context.sessionData,
+            onsubmit: function () {
+                window.location.href = edit_context.returnUrl;
+            },
+            onload: function () {
+            }
+        });
+    });
+    </script>
+{% endblock %}
+
+{% block title %}{% trans 'Edit Submission' %}{% endblock %}
+{% block page-title %}
+    {% include 'reports/form/partials/form_breadcrumbs.html' %}
+{% endblock %}
+
+{% block main_column %}
+    <div class="inline-touchforms" id="edit-container"></div>
+{% endblock %}

--- a/corehq/apps/reports/templates/reports/form/partials/form_breadcrumbs.html
+++ b/corehq/apps/reports/templates/reports/form/partials/form_breadcrumbs.html
@@ -1,0 +1,17 @@
+{% load timezone_tags %}
+<ul class="breadcrumb">
+    <li>
+        <a href="{% url "reports_home" domain %}"><strong>Reports</strong></a> <span class="divider">&gt;</span>
+    </li>
+    <li>
+        <a href="{% url "project_report_dispatcher" domain 'submit_history' %}">Submit History</a> <span class="divider">&gt;</span>
+    </li>
+    <li class="active">
+        <a href="#">
+            {{ form_name }}
+            {% if form_received_on %}
+            ({% utc_to_timezone form_received_on timezone %})
+            {% endif %}
+        </a>
+    </li>
+</ul>

--- a/corehq/apps/reports/templates/reports/form/partials/form_breadcrumbs.html
+++ b/corehq/apps/reports/templates/reports/form/partials/form_breadcrumbs.html
@@ -1,10 +1,11 @@
 {% load timezone_tags %}
+{% load i18n %}
 <ul class="breadcrumb">
     <li>
         <a href="{% url "reports_home" domain %}"><strong>Reports</strong></a> <span class="divider">&gt;</span>
     </li>
     <li>
-        <a href="{% url "project_report_dispatcher" domain 'submit_history' %}">Submit History</a> <span class="divider">&gt;</span>
+        <a href="{% url "project_report_dispatcher" domain 'submit_history' %}">{% trans "Submit History" %}</a> <span class="divider">&gt;</span>
     </li>
     <li class="active">
         <a href="#">

--- a/corehq/apps/reports/templates/reports/form/partials/single_form.html
+++ b/corehq/apps/reports/templates/reports/form/partials/single_form.html
@@ -6,7 +6,6 @@
 requires imports/proptable.html to be included in the main template
 {% endcomment %}
 {% include "imports/fancy-code.html" %}
-{% include 'cloudcare/includes/touchforms-inline.html' %}
 <style media="print">
     header {
         display: none !important;
@@ -28,7 +27,6 @@ requires imports/proptable.html to be included in the main template
     width: 800px;
 }
 </style>
-<script src="{% static 'cloudcare/js/util.js' %}"></script>
 <script>
     $(function () {
         var help_text = {
@@ -98,20 +96,6 @@ requires imports/proptable.html to be included in the main template
             }
         });
         showSkipped(false);
-
-        {% if form_meta %}
-        GMAPS_API_KEY = '{{ maps_api_key|safe }}'; // maps api is a global variable depended on by touchforms
-
-        // unfortunately since cloudcare doesn't have reversible urls, this has to be done in javascript
-        // todo: this probably needs better error handling
-        var cloudCareUrl = getCloudCareUrl(
-            "{% url "cloudcare_main" domain '' %}",
-            "{{ form_meta.app.id }}",
-            "{{ form_meta.module.id }}",
-            "{{ form_meta.form.id }}"
-        ) + "?preview=true&instance={{ instance.get_id }}";
-        $("#edit-form").attr("href", cloudCareUrl);
-        {% endif %}
 
         $("#archive-form").submit(function() {
             document.getElementById('archive-form-btn').disabled=true;
@@ -230,13 +214,6 @@ requires imports/proptable.html to be included in the main template
             {% trans "Raw XML" %}
         </a>
     </li>
-{% if show_edit_submission %}
-    <li>
-        <a href="#edit-submission" data-toggle="tab">
-            {% trans "Edit Submission" %}
-        </a>
-    </li>
-{% endif %}
 </ul>
 
 <div class="tab-content form-details" style="overflow:visible">
@@ -286,6 +263,11 @@ requires imports/proptable.html to be included in the main template
                         <i class="icon-refresh icon-spin" id="resave-spinner" style="display:none"></i>
                     </button>
                 </form>
+                {% endif %}
+                {% if show_edit_submission %}
+                        <a href="{% url 'edit_form_instance' domain instance.get_id %}" target="_blank" class="btn btn-primary">
+                            <i class="icon-edit"></i> {% trans "Edit submission" %}
+                        </a>
                 {% endif %}
             </p>
             {% endif %}
@@ -398,22 +380,4 @@ requires imports/proptable.html to be included in the main template
         <p>{% trans "Double-click code below to select all:" %}</p>
         {% render_form_xml instance %}
     </div>
-{% if show_edit_submission %}
-    <div class="tab-pane" id="edit-submission">
-        <p>
-            <a href="#" class="btn btn-primary touchforms-link"
-                data-target="#form_editor_container"
-                data-app-id="{{ form_meta.app.id }}"
-                data-module-id="{{ form_meta.module.id }}"
-                data-form-id="{{ form_meta.form.id  }}"
-                data-instance-id='{{ instance.get_id }}'
-                data-session-data='{{ edit_session_data|JSON }}'
-                data-submit-url-root='{% url "receiver_post" domain %}'
-                data-form-url-root='{% url "cloudcare_main" domain "" %}'>
-                <i class="icon-edit"></i> {% trans "Edit submission" %}
-            </a>
-        </p>
-        <div class="touchforms-inline" id="form_editor_container"></div>
-    </div>
-{% endif %}
 </div>

--- a/corehq/apps/reports/templates/reports/reportdata/form_data.html
+++ b/corehq/apps/reports/templates/reports/reportdata/form_data.html
@@ -13,22 +13,7 @@
 {% block title %}Form: {{ form_name }}{% if form_received_on %} ({% utc_to_timezone form_received_on timezone %}){% endif %}{% endblock %}
 
 {% block page-title %}
-    <ul class="breadcrumb">
-        <li>
-            <a href="{% url "reports_home" domain %}"><strong>Reports</strong></a> <span class="divider">&gt;</span>
-        </li>
-        <li>
-            <a href="{% url "project_report_dispatcher" domain 'submit_history' %}">Submit History</a> <span class="divider">&gt;</span>
-        </li>
-        <li class="active">
-            <a href="#">
-                {{ form_name }}
-                {% if form_received_on %}
-                ({% utc_to_timezone form_received_on timezone %})
-                {% endif %}
-            </a>
-        </li>
-    </ul>
+    {% include 'reports/form/partials/form_breadcrumbs.html' %}
 {% endblock %}
 
 {% block main_column %}

--- a/corehq/apps/reports/templatetags/xform_tags.py
+++ b/corehq/apps/reports/templatetags/xform_tags.py
@@ -1,5 +1,4 @@
 from functools import partial
-from django.conf import settings
 
 from django.template.loader import render_to_string
 from django.core.urlresolvers import reverse

--- a/corehq/apps/reports/templatetags/xform_tags.py
+++ b/corehq/apps/reports/templatetags/xform_tags.py
@@ -86,7 +86,6 @@ def render_form(form, domain, options):
     case_id = options.get('case_id')
     side_pane = options.get('side_pane', False)
     user = options.get('user', None)
-    case_id_attr = "@%s" % const.CASE_TAG_ID
 
     _get_tables_as_columns = partial(get_tables_as_columns, timezone=timezone)
 
@@ -96,13 +95,13 @@ def render_form(form, domain, options):
     # Case Changes tab
     case_blocks = extract_case_blocks(form)
     for i, block in enumerate(list(case_blocks)):
-        if case_id and block.get(case_id_attr) == case_id:
+        if case_id and block.get(const.CASE_ATTR_ID) == case_id:
             case_blocks.pop(i)
             case_blocks.insert(0, block)
 
     cases = []
     for b in case_blocks:
-        this_case_id = b.get(case_id_attr)
+        this_case_id = b.get(const.CASE_ATTR_ID)
         try:
             this_case = CommCareCase.get(this_case_id) if this_case_id else None
             valid_case = True
@@ -154,10 +153,6 @@ def render_form(form, domain, options):
     else:
         user_info = get_doc_info_by_id(domain, meta_userID)
 
-    edit_session_data = {'user_id': meta_userID}
-    if len(case_blocks) == 1 and case_blocks[0].get(case_id_attr):
-        edit_session_data["case_id"] = case_blocks[0].get(case_id_attr)
-
     request = options.get('request', None)
     user_can_edit = (
         request and user and request.domain
@@ -175,8 +170,6 @@ def render_form(form, domain, options):
     return render_to_string("reports/form/partials/single_form.html", {
         "context_case_id": case_id,
         "instance": form,
-        "form_meta": options.get('form_meta', {}),
-        "maps_api_key": settings.GMAPS_API_KEY,
         "is_archived": form.doc_type == "XFormArchived",
         "domain": domain,
         'question_list_not_found': question_list_not_found,
@@ -192,7 +185,6 @@ def render_form(form, domain, options):
         "user_info": user_info,
         "side_pane": side_pane,
         "user": user,
-        "edit_session_data": edit_session_data,
         "show_edit_submission": show_edit_submission,
         "show_resave": show_resave,
     })

--- a/corehq/apps/reports/urls.py
+++ b/corehq/apps/reports/urls.py
@@ -57,6 +57,7 @@ urlpatterns = patterns('corehq.apps.reports.views',
     # Download and view form data
     url(r'^form_data/(?P<instance_id>[\w\-:]+)/$', 'form_data', name='render_form_data'),
     url(r'^form_data/(?P<instance_id>[\w\-:]+)/download/$', 'download_form', name='download_form'),
+    url(r'^form_data/(?P<instance_id>[\w\-:]+)/edit/$', 'edit_form_instance', name='edit_form_instance'),
     url(r'^form_data/download/media/$',
         'form_multimedia_export', name='form_multimedia_export'),
     url(r'^form_data/(?P<instance_id>[\w\-:]+)/download-attachment/$',

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1283,6 +1283,7 @@ def edit_form_instance(request, domain, instance_id):
     edit_session_data['function_context'] = {
         'static': [
             {'name': 'now', 'value': instance.metadata.timeEnd},
+            {'name': 'today', 'value': instance.metadata.timeEnd.date()},
         ]
     }
 


### PR DESCRIPTION
This basically undoes a lot of what was done in https://github.com/dimagi/commcare-hq/pull/4567
and moves it to a new view/template.
- moves the edit button to the main form properties tab
- opens edit in a new window
- adds stub for properly overriding the now() function once mobile supports it
- small bits of cleanup

@snopoke might be most familiar with this. sorry it's not broken up better, was hard to do in chunks.
