### PR TITLE
Return all results if User Sync History report if filter is empty

### DIFF
--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -162,6 +162,7 @@ class SyncHistoryReport(DeploymentsReport):
     @property
     def rows(self):
         base_link_url = '{}?q={{id}}'.format(reverse('global_quick_find'))
+
         user_id = self.request.GET.get('individual')
         if not user_id:
             key_args = {}

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -162,21 +162,22 @@ class SyncHistoryReport(DeploymentsReport):
     @property
     def rows(self):
         base_link_url = '{}?q={{id}}'.format(reverse('global_quick_find'))
-
         user_id = self.request.GET.get('individual')
         if not user_id:
-            return []
-
-        # security check
-        get_document_or_404(CommCareUser, self.domain, user_id)
-
+            key_args = {}
+        else:
+            # security check
+            get_document_or_404(CommCareUser, self.domain, user_id)
+            key_args = {
+                'startkey': [user_id, {}],
+                'endkey': [user_id]
+            }
         sync_log_ids = [row['id'] for row in SyncLog.view(
             "phone/sync_logs_by_user",
-            startkey=[user_id, {}],
-            endkey=[user_id],
             descending=True,
             reduce=False,
-            limit=10
+            limit=10,
+            **key_args
         )]
 
         def _sync_log_to_row(sync_log):


### PR DESCRIPTION
Previously, now results were shown if the "Select Mobile Worker" filter was empty and displaying the help text "All Mobile Workers". Now it shows data for all mobile workers.
http://manage.dimagi.com/default.asp?166564

FYI code review buddy @biyeun 
