### PR TITLE
Set `request.project` in middleware

### DIFF
--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -36,7 +36,6 @@ REDIRECT_FIELD_NAME = 'next'
 def load_domain(req, domain):
     domain_name = normalize_domain_name(domain)
     domain = Domain.get_by_name(domain_name)
-    req.project = domain
     req.can_see_organization = has_privilege(req, privileges.CROSS_PROJECT_REPORTS)
     return domain_name, domain
 

--- a/corehq/apps/domain/middleware.py
+++ b/corehq/apps/domain/middleware.py
@@ -4,6 +4,8 @@ from __future__ import unicode_literals, print_function, absolute_import
 # External imports
 from django.utils.decorators import method_decorator
 from django.views.decorators.debug import sensitive_post_parameters
+from corehq.apps.domain.models import Domain
+from corehq.apps.domain.utils import normalize_domain_name
 from corehq.apps.accounting.exceptions import AccountingError
 from corehq.apps.accounting.models import Subscription
 from django_prbac.models import Role
@@ -57,3 +59,17 @@ class DomainHistoryMiddleware(object):
         last_visited_domain = request.session.get('last_visited_domain')
         if last_visited_domain != request.domain:
             request.session['last_visited_domain'] = request.domain
+
+
+class ProjectMiddleware(object):
+
+    def process_view(self, request, view_func, view_args, view_kwargs):
+        """
+        Add domain, project, and org properties (if applicable) to request object
+        """
+        if 'domain' in view_kwargs:
+            request.domain = view_kwargs['domain']
+            project = Domain.get_by_name(normalize_domain_name(request.domain))
+            request.project = project
+        if 'org' in view_kwargs:
+            request.org = view_kwargs['org']

--- a/corehq/apps/users/middleware.py
+++ b/corehq/apps/users/middleware.py
@@ -26,10 +26,6 @@ class UsersMiddleware(object):
     
     #def process_request(self, request):
     def process_view(self, request, view_func, view_args, view_kwargs):
-        if 'domain' in view_kwargs:
-            request.domain = view_kwargs['domain']
-        if 'org' in view_kwargs:
-            request.org = view_kwargs['org']
         if request.user and hasattr(request.user, 'get_profile'):
             sessionid = request.COOKIES.get('sessionid', None)
             if sessionid:

--- a/settings.py
+++ b/settings.py
@@ -125,6 +125,7 @@ MIDDLEWARE_CLASSES = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'corehq.middleware.OpenRosaMiddleware',
     'corehq.util.global_request.middleware.GlobalRequestMiddleware',
+    'corehq.apps.domain.middleware.ProjectMiddleware',
     'corehq.apps.users.middleware.UsersMiddleware',
     'corehq.apps.domain.middleware.CCHQPRBACMiddleware',
     'corehq.apps.domain.middleware.DomainHistoryMiddleware',


### PR DESCRIPTION
Follow up from https://github.com/dimagi/commcare-hq/pull/6189#issuecomment-90097899.

I'm a little bit scared this could have unintended consequences because this affects most pages and I don't think our tests do much request mocking, but I wouldn't think that setting the `request.project` would have adverse affects. I've loaded a few pages with the change and everything seems fine, but let me know if any of you think I should test this more thoroughly in some way. 

@biyeun @dannyroberts @czue 
