### PR TITLE
use nav-hq-sidebar for app summary page

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/ng_partials/base_summary_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/ng_partials/base_summary_view.html
@@ -4,7 +4,7 @@
 {% angularjs %}
 <div id="hq-sidebar" class="col-xs-4 col-sm-3 col-lg-2 col-hq-sidebar" role="navigation">
     <nav class="app-manager-content">
-        <ul class="nav nav-pills nav-stacked">
+        <ul class="nav nav-hq-sidebar">
             <li role="presentation" ng-class="{active: isActive('/forms')}">
                 <a href="#/forms">
                     <i class="fa fa-file-text-o"></i>

--- a/corehq/apps/app_manager/templates/app_manager/ng_partials/case_summary_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/ng_partials/case_summary_view.html
@@ -145,7 +145,7 @@
 <!-- template for rendering case type hierarchy in navigation -->
 <script type="text/ng-template" id="/hierarchy.html">
 <div class="well">
-    <ul class="nav nav-pills nav-stacked">
+    <ul class="nav nav-hq-sidebar">
         <member ng-repeat='(casetype, subhierarchy) in hierarchy' casetype='casetype' hierarchy="subhierarchy"
                 type-search="typeSearch" filter-case-types="filterCaseTypes({casetype: casetype})"
                 has-errors="hasErrors({casetype: casetype})"></member>

--- a/corehq/apps/app_manager/templates/app_manager/ng_partials/form_summary_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/ng_partials/form_summary_view.html
@@ -8,13 +8,13 @@
     <li role="presentation" ng-class="{ 'active' : allSelected()}">
         <a ng-click="filterList()">{% trans "All Forms" %}</a>
         <div class="well">
-            <ul class="nav nav-pills nav-stacked">
+            <ul class="nav nav-hq-sidebar">
                 <li ng-repeat="module in modules" role="presentation" ng-class="{ 'active' : moduleSelected(module)}">
                     <a ng-click="filterList(module)"><i class="hq-icon fa fa-folder-open"></i>
                         {% verbatim %}{{ getFormModuleLabel(module) }}{% endverbatim %}
                     </a>
                     <div class="well">
-                        <ul class="nav nav-pills nav-stacked">
+                        <ul class="nav nav-hq-sidebar">
                             <li ng-repeat="form in module.forms" ng-class="{ 'active' : formSearch.id === form.id }">
                                 <a ng-click="filterList(module, form)">
                                     {% verbatim %}{{ getFormModuleLabel(form) }}{% endverbatim %}

--- a/corehq/apps/style/static/style/less/components-3/navs.less
+++ b/corehq/apps/style/static/style/less/components-3/navs.less
@@ -12,13 +12,10 @@
       background-color: #dbdbdb;
     }
     &.active {
-      a, a:link, a:visited, a:hover {
+      > a, > a:link, > a:visited, > a:hover {
         background-color: @brand-primary;
         color: #ffffff;
       }
     }
   }
 }
-
-
-


### PR DESCRIPTION
@biyeun fixed up some bootstrap sidebar action on the app summary page
enchantress: @millerdev 
before:
![screen shot 2015-04-28 at 8 26 23 pm](https://cloud.githubusercontent.com/assets/918514/7382957/fbde8280-ede4-11e4-925a-247ec6ce31da.png)
after:
![screen shot 2015-04-28 at 8 26 07 pm](https://cloud.githubusercontent.com/assets/918514/7382963/0e16f676-ede5-11e4-8d44-157176c9a879.png)
