### PR TITLE
Fix short code url generation

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/releases.html
@@ -210,7 +210,11 @@
                             <a class="btn" data-bind="
                                 openModal: 'deploy-build-modal-template',
                                 css: {'btn-primary': !build_broken(), 'btn-danger': build_broken},
-                                click: function() { ga_track_event('App Manager', 'Deploy Button', '{{ app.id }}'); analytics.track('Clicked Deploy-Button');}
+                                click: function() {
+                                    generate_short_url('short_odk_url');
+                                    ga_track_event('App Manager', 'Deploy Button', '{{ app.id }}');
+                                    analytics.track('Clicked Deploy-Button');
+                                }
                             ">
                                 <span class="icon icon-exclamation-sign" data-bind="visible: build_broken"></span>
                                 {% trans "Deploy" %}
@@ -318,8 +322,8 @@
                     <div class="accordion-group">
                         <div class="accordion-heading">
                             <a class="accordion-toggle" data-bind="
+                                {# TODO: This tracking code is probably rarely fired anymore because now this accordion is open by default #}
                                 click: function() { track_deploy_type('Download to Android'); },
-                                click: function() { generate_short_url('short_odk_url'); }
                             ">
                                 {% trans "Download to Android" %}
                             </a>


### PR DESCRIPTION
Addresses http://manage.dimagi.com/default.asp?166891

"No Shortcode Available" was being displayed in the deploy modal.

A change was recently introduced so that the android pane of the deploy modal is open initially. However, the code to generate the short code url was being triggered when the user toggled the accordion state. Because it used to start closed, the user had to toggle the state to get to the point where the url would be displayed. This PR fixes the bug by triggering the short code generation when the user opens the modal (by clicking the deploy button).

It's also worth noting that the Google Analytics event that gets fired upon opening the android pane is probably not useful anymore (I will follow up with Amelia about how she wants this to change).

FYI @orangejenny @biyeun 
