### PR TITLE
Surface project names on project settings page

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -394,6 +394,7 @@ class SubAreaMixin():
         return sub_area
 
 class DomainGlobalSettingsForm(forms.Form):
+    hr_name = forms.CharField(required=False, label=_("Project Name"))
     default_timezone = TimeZoneChoiceField(label=ugettext_noop("Default Timezone"), initial="UTC")
 
     logo = ImageField(
@@ -466,6 +467,8 @@ class DomainGlobalSettingsForm(forms.Form):
 
     def save(self, request, domain):
         try:
+            domain.hr_name = self.cleaned_data['hr_name']
+
             if self.can_use_custom_logo:
                 logo = self.cleaned_data['logo']
                 if logo:

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -394,7 +394,7 @@ class SubAreaMixin():
         return sub_area
 
 class DomainGlobalSettingsForm(forms.Form):
-    hr_name = forms.CharField(required=False, label=_("Project Name"))
+    hr_name = forms.CharField(label=_("Project Name"))
     default_timezone = TimeZoneChoiceField(label=ugettext_noop("Default Timezone"), initial="UTC")
 
     logo = ImageField(

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -205,7 +205,7 @@ class Domain(Document, SnapshotMixin):
     secure_submissions = BooleanProperty(default=False)
     cloudcare_releases = StringProperty(choices=['stars', 'nostars', 'default'], default='default')
     organization = StringProperty()
-    hr_name = StringProperty() # the human-readable name for this project within an organization
+    hr_name = StringProperty() # the human-readable name for this project
     creating_user = StringProperty() # username of the user who created this domain
 
     # domain metadata
@@ -870,10 +870,7 @@ class Domain(Document, SnapshotMixin):
     def display_name(self):
         if self.is_snapshot:
             return "Snapshot of %s" % self.copied_from.display_name()
-        if self.hr_name and self.organization:
-            return self.hr_name
-        else:
-            return self.name
+        return self.hr_name or self.name
 
     def long_display_name(self):
         if self.is_snapshot:
@@ -889,7 +886,7 @@ class Domain(Document, SnapshotMixin):
                 self.hr_name or self.name
             )
         else:
-            return self.name
+            return self.hr_name or self.name
 
     __str__ = long_display_name
 

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -919,8 +919,7 @@ class Domain(Document, SnapshotMixin):
         super(Domain, self).delete()
         Domain.get_by_name.clear(Domain, self.name)  # clear the domain cache
 
-    def all_media(self, from_apps=None):
-        #todo add documentation or refactor
+    def all_media(self, from_apps=None):  # todo add documentation or refactor
         from corehq.apps.hqmedia.models import CommCareMultimedia
         dom_with_media = self if not self.is_snapshot else self.copied_from
 

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -43,7 +43,7 @@ DATE_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 
 
 for lang in all_langs:
-    lang_lookup[lang['three']] = lang['names'][0] # arbitrarily using the first name if there are multiple
+    lang_lookup[lang['three']] = lang['names'][0]  # arbitrarily using the first name if there are multiple
     if lang['two'] != '':
         lang_lookup[lang['two']] = lang['names'][0]
 
@@ -104,7 +104,7 @@ class Deployment(DocumentSchema, UpdatableSchema):
     date = DateTimeProperty()
     city = StringProperty()
     countries = StringListProperty()
-    region = StringProperty() # e.g. US, LAC, SA, Sub-saharn Africa, East Africa, West Africa, Southeast Asia)
+    region = StringProperty()  # e.g. US, LAC, SA, Sub-saharn Africa, East Africa, West Africa, Southeast Asia)
     description = StringProperty()
     public = BooleanProperty(default=False)
 
@@ -165,9 +165,9 @@ class CaseDisplaySettings(DocumentSchema):
 
 class DynamicReportConfig(DocumentSchema):
     """configurations of generic/template reports to be set up for this domain"""
-    report = StringProperty() # fully-qualified path to template report class
-    name = StringProperty() # report display name in sidebar
-    kwargs = DictProperty() # arbitrary settings to configure report
+    report = StringProperty()  # fully-qualified path to template report class
+    name = StringProperty()  # report display name in sidebar
+    kwargs = DictProperty()  # arbitrary settings to configure report
     previewers_only = BooleanProperty()
 
 class DynamicReportSet(DocumentSchema):
@@ -205,12 +205,12 @@ class Domain(Document, SnapshotMixin):
     secure_submissions = BooleanProperty(default=False)
     cloudcare_releases = StringProperty(choices=['stars', 'nostars', 'default'], default='default')
     organization = StringProperty()
-    hr_name = StringProperty() # the human-readable name for this project
-    creating_user = StringProperty() # username of the user who created this domain
+    hr_name = StringProperty()  # the human-readable name for this project
+    creating_user = StringProperty()  # username of the user who created this domain
 
     # domain metadata
-    project_type = StringProperty() # e.g. MCH, HIV
-    customer_type = StringProperty() # plus, full, etc.
+    project_type = StringProperty()  # e.g. MCH, HIV
+    customer_type = StringProperty()  # plus, full, etc.
     is_test = StringProperty(choices=["true", "false", "none"], default="none")
     description = StringProperty()
     short_description = StringProperty()
@@ -228,17 +228,17 @@ class Domain(Document, SnapshotMixin):
     # CommConnect settings
     commconnect_enabled = BooleanProperty(default=False)
     survey_management_enabled = BooleanProperty(default=False)
-    sms_case_registration_enabled = BooleanProperty(default=False) # Whether or not a case can register via sms
-    sms_case_registration_type = StringProperty() # Case type to apply to cases registered via sms
-    sms_case_registration_owner_id = StringProperty() # Owner to apply to cases registered via sms
-    sms_case_registration_user_id = StringProperty() # Submitting user to apply to cases registered via sms
-    sms_mobile_worker_registration_enabled = BooleanProperty(default=False) # Whether or not a mobile worker can register via sms
+    sms_case_registration_enabled = BooleanProperty(default=False)  # Whether or not a case can register via sms
+    sms_case_registration_type = StringProperty()  # Case type to apply to cases registered via sms
+    sms_case_registration_owner_id = StringProperty()  # Owner to apply to cases registered via sms
+    sms_case_registration_user_id = StringProperty()  # Submitting user to apply to cases registered via sms
+    sms_mobile_worker_registration_enabled = BooleanProperty(default=False)  # Whether or not a mobile worker can register via sms
     default_sms_backend_id = StringProperty()
     use_default_sms_response = BooleanProperty(default=False)
     default_sms_response = StringProperty()
     chat_message_count_threshold = IntegerProperty()
-    custom_chat_template = StringProperty() # See settings.CUSTOM_CHAT_TEMPLATES
-    custom_case_username = StringProperty() # Case property to use when showing the case's name in a chat window
+    custom_chat_template = StringProperty()  # See settings.CUSTOM_CHAT_TEMPLATES
+    custom_case_username = StringProperty()  # Case property to use when showing the case's name in a chat window
     # If empty, sms can be sent at any time. Otherwise, only send during
     # these windows of time. SMS_QUEUE_ENABLED must be True in localsettings
     # for this be considered.
@@ -278,8 +278,8 @@ class Domain(Document, SnapshotMixin):
     title = StringProperty()
     cda = SchemaProperty(LicenseAgreement)
     multimedia_included = BooleanProperty(default=True)
-    downloads = IntegerProperty(default=0) # number of downloads for this specific snapshot
-    full_downloads = IntegerProperty(default=0) # number of downloads for all snapshots from this domain
+    downloads = IntegerProperty(default=0)  # number of downloads for this specific snapshot
+    full_downloads = IntegerProperty(default=0)  # number of downloads for all snapshots from this domain
     author = StringProperty()
     phone_model = StringProperty()
     attribution_notes = StringProperty()
@@ -500,7 +500,7 @@ class Domain(Document, SnapshotMixin):
             reduce=False,
             include_docs=False,
             limit=1).all()
-        if len(res) > 0: # if there have been any submissions in the past 30 days
+        if len(res) > 0:  # if there have been any submissions in the past 30 days
             return (datetime.utcnow() <=
                     datetime.strptime(res[0]['key'][2], "%Y-%m-%dT%H:%M:%SZ")
                     + timedelta(days=30))
@@ -654,7 +654,7 @@ class Domain(Document, SnapshotMixin):
         new_domain.copy_history = self.get_updated_history()
         new_domain.is_snapshot = False
         new_domain.snapshot_time = None
-        new_domain.organization = None # TODO: use current user's organization (?)
+        new_domain.organization = None  # TODO: use current user's organization (?)
 
         # reset stuff
         new_domain.cda.signed = False
@@ -914,7 +914,7 @@ class Domain(Document, SnapshotMixin):
         super(Domain, self).delete()
         Domain.get_by_name.clear(Domain, self.name)  # clear the domain cache
 
-    def all_media(self, from_apps=None): #todo add documentation or refactor
+    def all_media(self, from_apps=None):  #todo add documentation or refactor
         from corehq.apps.hqmedia.models import CommCareMultimedia
         dom_with_media = self if not self.is_snapshot else self.copied_from
 

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -228,11 +228,16 @@ class Domain(Document, SnapshotMixin):
     # CommConnect settings
     commconnect_enabled = BooleanProperty(default=False)
     survey_management_enabled = BooleanProperty(default=False)
-    sms_case_registration_enabled = BooleanProperty(default=False)  # Whether or not a case can register via sms
-    sms_case_registration_type = StringProperty()  # Case type to apply to cases registered via sms
-    sms_case_registration_owner_id = StringProperty()  # Owner to apply to cases registered via sms
-    sms_case_registration_user_id = StringProperty()  # Submitting user to apply to cases registered via sms
-    sms_mobile_worker_registration_enabled = BooleanProperty(default=False)  # Whether or not a mobile worker can register via sms
+    # Whether or not a case can register via sms
+    sms_case_registration_enabled = BooleanProperty(default=False)
+    # Case type to apply to cases registered via sms
+    sms_case_registration_type = StringProperty()
+    # Owner to apply to cases registered via sms
+    sms_case_registration_owner_id = StringProperty()
+    # Submitting user to apply to cases registered via sms
+    sms_case_registration_user_id = StringProperty()
+    # Whether or not a mobile worker can register via sms
+    sms_mobile_worker_registration_enabled = BooleanProperty(default=False)
     default_sms_backend_id = StringProperty()
     use_default_sms_response = BooleanProperty(default=False)
     default_sms_response = StringProperty()
@@ -914,7 +919,8 @@ class Domain(Document, SnapshotMixin):
         super(Domain, self).delete()
         Domain.get_by_name.clear(Domain, self.name)  # clear the domain cache
 
-    def all_media(self, from_apps=None):  #todo add documentation or refactor
+    def all_media(self, from_apps=None):
+        #todo add documentation or refactor
         from corehq.apps.hqmedia.models import CommCareMultimedia
         dom_with_media = self if not self.is_snapshot else self.copied_from
 

--- a/corehq/apps/domain/templates/domain/admin/info_basic.html
+++ b/corehq/apps/domain/templates/domain/admin/info_basic.html
@@ -6,6 +6,17 @@
 {% block js-inline %} {{ block.super }}
 <script type="text/javascript">
     $(function() {
+        // Update project dropdown in page header with potentially new project name
+        var hr_name = $('#id_hr_name').val(),
+            $projectsMenu = $('#nav-projects-menu'),
+            currentHref = $projectsMenu.find(".btn-project-active").attr("href");
+        _.each($projectsMenu.find("a"), function(link) {
+            var $link = $(link);
+            if (currentHref.startsWith($link.attr("href"))) {
+                $link.text(hr_name);
+            }
+        });
+
         $('#id_default_timezone').combobox({
             placeholder: 'Select a Timezone...'
         });

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -343,6 +343,7 @@ class EditBasicProjectInfoView(BaseEditProjectInfoView):
     @memoized
     def basic_info_form(self):
         initial = {
+            'hr_name': self.domain_object.hr_name or self.domain_object.name,
             'default_timezone': self.domain_object.default_timezone,
             'case_sharing': json.dumps(self.domain_object.case_sharing),
             'call_center_enabled': self.domain_object.call_center_config.enabled,


### PR DESCRIPTION
Make the existing human-readable name property of domains editable on project settings page.

Human-readable names no longer depend on the domain being linked to an organization.

![screen shot 2015-04-29 at 5 12 16 pm](https://cloud.githubusercontent.com/assets/1486591/7401528/ee9bcfb6-ee92-11e4-8fd2-34dd95fa9fec.png)
