### PR TITLE
Revert "Downgrade missing table to Http404"

### DIFF
--- a/corehq/apps/fixtures/download.py
+++ b/corehq/apps/fixtures/download.py
@@ -6,8 +6,8 @@ from datetime import datetime, timedelta
 from django.contrib import messages
 from django.template.defaultfilters import yesno
 from django.utils.translation import ugettext as _
-from django.http import Http404
 
+from corehq.apps.fixtures.exceptions import FixtureDownloadError
 from corehq.apps.fixtures.models import FixtureDataType, FixtureDataItem, _id_from_doc
 from corehq.apps.fixtures.upload import DELETE_HEADER
 from couchexport.export import export_raw
@@ -53,7 +53,7 @@ def _prepare_fixture(table_ids, domain, html_response=False, task=None):
             data_types_view = [FixtureDataType.get(id) for id in table_ids]
         except ResourceNotFound:
             if html_response:
-                raise Http404(
+                raise FixtureDownloadError(
                     _("Sorry, we couldn't find that table. If you think this "
                       "is a mistake please report an issue."))
             data_types_view = FixtureDataType.by_domain(domain)

--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -198,7 +198,7 @@ def data_table(request, domain):
         sheets = prepare_fixture_html(table_ids, domain)
     except FixtureDownloadError as e:
         messages.info(request, unicode(e))
-        raise
+        raise Http404()
     sheets.pop("types")
     if not sheets:
         return {


### PR DESCRIPTION
Reverts dimagi/commcare-hq#6510

@proteusvacuum I think that replacing https://github.com/dimagi/commcare-hq/blob/ebd5fcbec207cd572409b5d553fb869242329afa/corehq/apps/fixtures/views.py#L201-201 with a 404 is a much better way to deal with this problem, going along the following rule of thumb:
- internal functions/helpers raise semantically meaningful exceptions (that are agnostic to what course of action is taken with that information)
- views, handlers, and callers catch exceptions and determine what course of action to take

If you like that then you can make a commit on top of this PR and I'll merge
