### PR TITLE
Allow dev environments to function without segment api key

### DIFF
--- a/corehq/apps/style/templates/style/includes/analytics_segment.html
+++ b/corehq/apps/style/templates/style/includes/analytics_segment.html
@@ -16,4 +16,14 @@
       email: '{{ user.email }}'
     });
 </script>
+{% else %}
+<script>
+    var analytics = {
+        track: function(){},
+        identify: function(){},
+        page: function(){},
+        alias: function(){}
+    };
+</script>
 {% endif %}
+

--- a/corehq/apps/style/templates/style/includes/analytics_segment.html
+++ b/corehq/apps/style/templates/style/includes/analytics_segment.html
@@ -1,4 +1,3 @@
-{% if SEGMENT_ANALYTICS_KEY %}
 <script>
 	// Segment analytics tracker.
 	// This snippet automatically takes care of Segment library load failure
@@ -16,14 +15,3 @@
       email: '{{ user.email }}'
     });
 </script>
-{% else %}
-<script>
-    var analytics = {
-        track: function(){},
-        identify: function(){},
-        page: function(){},
-        alias: function(){}
-    };
-</script>
-{% endif %}
-


### PR DESCRIPTION
Not sure why I'm just getting this now (as the segment code has been here for about a month I think), but I can't use the application deploy page because the js throws a `ReferenceError: analytics is not defined` error. I would think that other people would be having this problem to? @sravfeyn assigning to you as I think you added segment in #6067. Feel free to close without merging if there is a better solution that I missed, or if I should be changing something in my config files instead.

FYI review buddy @biyeun 
