### PR TITLE
add segment-key to localsettings example

### DIFF
--- a/localsettings.example.py
+++ b/localsettings.example.py
@@ -133,6 +133,7 @@ ANALYTICS_IDS = {
     'GOOGLE_ANALYTICS_ID': '*******',
     'PINGDOM_ID': '*****',
     'ANALYTICS_ID_PUBLIC_COMMCARE': '*****',
+    'SEGMENT_ANALYTICS_KEY': '*****',
 }
 
 AXES_LOCK_OUT_AT_FAILURE = False


### PR DESCRIPTION
@dimagi/team-commcare-hq Should add this key to your localsettings to get rid of console errors related to analytics.
