### PR TITLE
New Login Duration Android setting

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/json/commcare-profile-settings.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-profile-settings.yaml
@@ -285,3 +285,11 @@
   values_txt: "Whether searches can match similar strings"
   since: "2.15"
 
+- name: "Login Duration"
+  description: "Amount of time after which you will be logged out automatically"
+  id: "cc-login-duration-seconds"
+  values:      [   "86400",    "43200",   "28800",    "7200",   "3600",       "1800",        "900"]
+  value_names: ["24 hours", "12 hours", "8 hours", "2 hours", "1 hour", "30 minutes", "15 minutes"]
+  default: "28800"
+  values_txt: "This will set the amount of time you will remain logged in before automatically being logged out."
+  since: "2.21"

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-settings-layout.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-settings-layout.yaml
@@ -63,6 +63,7 @@
     - properties.logo_android_home
     - properties.logo_android_login
     - hq.auto_gps_capture
+    - properties.cc-login-duration-seconds
 
 - title: 'Advanced'
   id: app-settings-advanced


### PR DESCRIPTION
Named "cc-login-duration-seconds", and default set to 8 hours, to match current [commcare-odk master](https://github.com/dimagi/commcare-odk/blob/master/app/src/org/commcare/dalvik/preferences/CommCarePreferences.java#L89).

This is being tracked in [FogBugz 162838](http://manage.dimagi.com/default.asp?162838).

![login_duration_setting](https://cloud.githubusercontent.com/assets/708421/7470916/5aa7c70e-f321-11e4-857a-8b40f8c961a7.png)
