### PR TITLE
Simplify propertyArrayToDict

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/case-config-ui-2.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case-config-ui-2.js
@@ -549,7 +549,7 @@ var CaseConfig = (function () {
             var o = CaseTransaction.unwrap(case_transaction);
             var x = CC_UTILS.propertyArrayToDict(['name'], o.case_properties);
             var case_properties = x[0], case_name = x[1].name;
-            var case_preload = CC_UTILS.propertyArrayToDict([], o.case_preload, true)[0];
+            var case_preload = CC_UTILS.preloadArrayToDict(o.case_preload);
             var open_condition = o.condition;
             var close_condition = o.close_condition;
             var update_condition = DEFAULT_CONDITION_ALWAYS;

--- a/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
@@ -752,7 +752,7 @@ var AdvancedCase = (function () {
             self.show_product_stock(self.disable_tag());
             var action = ko.mapping.toJS(self, LoadUpdateAction.mapping(self));
 
-            action.preload = CC_UTILS.propertyArrayToDict([], action.preload, true)[0];
+            action.preload = CC_UTILS.preloadArrayToDict(action.preload);
             action.case_properties = CC_UTILS.propertyArrayToDict([], action.case_properties)[0];
             return action;
         }

--- a/corehq/apps/app_manager/static/app_manager/js/case-config-utils.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case-config-utils.js
@@ -61,12 +61,12 @@ var CC_UTILS = {
         });
         return required.concat(property_array);
     },
-    propertyArrayToDict: function (required, property_array, keyIsPath) {
+    propertyArrayToDict: function (required, property_array) {
         var property_dict = {},
             extra_dict = {};
         _(property_array).each(function (case_property) {
-            var key = case_property[!keyIsPath ? 'key' : 'path'];
-            var path = case_property[!keyIsPath ? 'path' : 'key'];
+            var key = case_property.key;
+            var path = case_property.path;
             if (key || path) {
                 if (_(required).contains(key) && case_property.required) {
                     extra_dict[key] = path;
@@ -76,5 +76,14 @@ var CC_UTILS = {
             }
         });
         return [property_dict, extra_dict];
+    },
+    preloadArrayToDict: function (preloadArray) {
+        // i.e. {i.path: i.key for i in preloadArray if i.key or i.path}
+        return _.object(
+            _.map(
+                _.filter(preloadArray, function (i) { return (i.key || i.path); }),
+                function (i) { return [i.path, i.key]; }
+            )
+        );
     }
 };


### PR DESCRIPTION
Instead of passing a boolean to the function, split into two functions; the function for preloads is just a dict comprehension (which is a little messier in JavaScript than in Python, but still quite short) and only needs one parameter.

What do you think, @snopoke? Buddy ping @czue 
