### PR TITLE
accept isoformat() for Location.date_modified in wrap

### DIFF
--- a/corehq/apps/groups/tests/test_groups.py
+++ b/corehq/apps/groups/tests/test_groups.py
@@ -46,28 +46,30 @@ class GroupTest(TestCase):
 
 class WrapGroupTest(SimpleTestCase):
 
+    document_class = Group
+
     def test_yes_Z(self):
         date_string = '2014-08-26T15:20:20.062732Z'
-        group = Group.wrap({'last_modified': date_string})
+        group = self.document_class.wrap({'last_modified': date_string})
         self.assertEqual(group.to_json()['last_modified'], date_string)
         date_string_no_usec = '2014-08-26T15:20:20Z'
         date_string_yes_usec = '2014-08-26T15:20:20.000000Z'
-        group = Group.wrap({'last_modified': date_string_no_usec})
+        group = self.document_class.wrap({'last_modified': date_string_no_usec})
         self.assertEqual(group.to_json()['last_modified'], date_string_yes_usec)
 
     def test_no_Z(self):
         date_string_no_Z = '2014-08-26T15:20:20.062732'
         date_string_yes_Z = '2014-08-26T15:20:20.062732Z'
-        group = Group.wrap({'last_modified': date_string_no_Z})
+        group = self.document_class.wrap({'last_modified': date_string_no_Z})
         self.assertEqual(group.to_json()['last_modified'], date_string_yes_Z)
         # iso_format can, technically, produce this if microseconds
         # happens to be exactly 0
         date_string_no_Z = '2014-08-26T15:20:20'
         date_string_yes_Z = '2014-08-26T15:20:20.000000Z'
-        group = Group.wrap({'last_modified': date_string_no_Z})
+        group = self.document_class.wrap({'last_modified': date_string_no_Z})
         self.assertEqual(group.to_json()['last_modified'], date_string_yes_Z)
 
     def test_fail(self):
         bad_date_string = '2014-08-26T15:20'
         with self.assertRaises(BadValueError):
-            Group.wrap({'last_modified': bad_date_string})
+            self.document_class.wrap({'last_modified': bad_date_string})

--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -297,6 +297,17 @@ class Location(CachedCouchDocumentMixin, Document):
     lineage = StringListProperty()
     previous_parents = StringListProperty()
 
+    @classmethod
+    def wrap(cls, data):
+        last_modified = data.get('last_modified')
+        # if it's missing a Z because of the Aug. 2014 migration
+        # that added this in iso_format() without Z, then add a Z
+        # (See also Group class)
+        from corehq.apps.groups.models import dt_no_Z_re
+        if last_modified and dt_no_Z_re.match(last_modified):
+            data['last_modified'] += 'Z'
+        return super(Location, cls).wrap(data)
+
     def __init__(self, *args, **kwargs):
         if 'parent' in kwargs:
             parent = kwargs['parent']

--- a/corehq/apps/locations/tests/test_locations.py
+++ b/corehq/apps/locations/tests/test_locations.py
@@ -1,3 +1,4 @@
+from corehq.apps.groups.tests import WrapGroupTest
 from corehq.apps.locations.models import Location, LocationType, SQLLocation, \
     LOCATION_SHARING_PREFIX, LOCATION_REPORTING_PREFIX
 from corehq.apps.locations.tests.util import make_loc
@@ -414,3 +415,7 @@ class LocationGroupTest(LocationTestBase):
         fixture = location_fixture_generator(self.user, '2.0')
         self.assertEquals(len(fixture[0].findall('.//state')), 1)
         self.assertEquals(len(fixture[0].findall('.//outlet')), 3)
+
+
+class WrapLocationTest(WrapGroupTest):
+    document_class = Location


### PR DESCRIPTION
same thing that happened with Group, also due to a migration
that set date_modified to the output of isoformat(), which lacks Z
