### PR TITLE
rebuild re-assigned cases when users are deleted

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1641,8 +1641,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
                 deleted_cases.add(case['_id'])
 
         for formlist in chunked(self.get_forms(wrap=False, include_docs=True), 50):
-            tag_forms_as_deleted_rebuild_associated_cases.delay(XFormInstance, formlist, deletion_id,
-                                                                deleted_cases=deleted_cases)
+            tag_forms_as_deleted_rebuild_associated_cases.delay(formlist, deletion_id, deleted_cases=deleted_cases)
 
         for phone_number in self.get_verified_numbers(True).values():
             phone_number.retire(deletion_id)

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1641,7 +1641,8 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
                 deleted_cases.add(case['_id'])
 
         for formlist in chunked(self.get_forms(wrap=False, include_docs=True), 50):
-            tag_forms_as_deleted_rebuild_associated_cases.delay(XFormInstance, formlist, deletion_id, deleted_cases=deleted_cases)
+            tag_forms_as_deleted_rebuild_associated_cases.delay(XFormInstance, formlist, deletion_id,
+                                                                deleted_cases=deleted_cases)
 
         for phone_number in self.get_verified_numbers(True).values():
             phone_number.retire(deletion_id)

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -46,11 +46,10 @@ def tag_forms_as_deleted_rebuild_associated_cases(formlist, deletion_id, deleted
     for form in formlist:
         form['doc_type'] += DELETED_SUFFIX
         form['-deletion_id'] = deletion_id
-        for case in get_case_ids_from_form(form) - deleted_cases:
-            cases_to_rebuild.add(case)
+        cases_to_rebuild.update(get_case_ids_from_form(form))
     XFormInstance.get_db().bulk_save(formlist)
 
-    for case in cases_to_rebuild:
+    for case in cases_to_rebuild - deleted_cases:
         rebuild_case(case)
 
 @periodic_task(

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -10,6 +10,9 @@ from django.core.cache import cache
 import uuid
 from soil import CachedDownload, DownloadBase
 
+from dimagi.utils.couch.database import iter_docs
+from casexml.apps.case.xform import get_case_ids_from_form
+from casexml.apps.case.models import CommCareCase
 
 @task(ErrorMail=SensitiveErrorMail)
 def bulk_upload_async(domain, user_specs, group_specs, location_specs):
@@ -35,6 +38,24 @@ def tag_docs_as_deleted(cls, docs, deletion_id):
         doc['-deletion_id'] = deletion_id
     cls.get_db().bulk_save(docs)
 
+@task(rate_limit=2, queue='background_queue', ignore_result=True)  # limit this to two bulk saves a second so cloudant has time to reindex
+def tag_forms_as_deleted_rebuild_associated_cases(cls, formlist, deletion_id, deleted_cases=set()):
+    from casexml.apps.case.cleanup import rebuild_case
+
+    for doc in formlist:
+        doc['doc_type'] += DELETED_SUFFIX
+        doc['-deletion_id'] = deletion_id
+    cls.get_db().bulk_save(formlist)
+
+    cases_to_rebuild = set()
+    for form in formlist:
+        cases = get_case_ids_from_form(form) - deleted_cases
+        for case in iter_docs(CommCareCase.get_db(), cases):
+            if case['owner_id'] != form['form']['meta']['userID']:
+                cases_to_rebuild.add(case['_id'])
+
+    for case_id in cases_to_rebuild:
+        rebuild_case(case_id)
 
 @periodic_task(
     run_every=crontab(hour=23, minute=55),

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -10,9 +10,7 @@ from django.core.cache import cache
 import uuid
 from soil import CachedDownload, DownloadBase
 
-from dimagi.utils.couch.database import iter_docs
 from casexml.apps.case.xform import get_case_ids_from_form
-from casexml.apps.case.models import CommCareCase
 from couchforms.models import XFormInstance
 
 @task(ErrorMail=SensitiveErrorMail)

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -39,8 +39,10 @@ def tag_docs_as_deleted(cls, docs, deletion_id):
 
 
 @task(rate_limit=2, queue='background_queue', ignore_result=True)  # 2 saves/sec for cloudant slowness
-def tag_forms_as_deleted_rebuild_associated_cases(formlist, deletion_id, deleted_cases=set()):
+def tag_forms_as_deleted_rebuild_associated_cases(formlist, deletion_id, deleted_cases=None):
     from casexml.apps.case.cleanup import rebuild_case
+    if deleted_cases is None:
+        deleted_cases = set()
 
     cases_to_rebuild = set()
     for form in formlist:

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -38,7 +38,8 @@ def tag_docs_as_deleted(cls, docs, deletion_id):
         doc['-deletion_id'] = deletion_id
     cls.get_db().bulk_save(docs)
 
-@task(rate_limit=2, queue='background_queue', ignore_result=True)  # limit this to two bulk saves a second so cloudant has time to reindex
+
+@task(rate_limit=2, queue='background_queue', ignore_result=True)  # 2 saves/sec for cloudant slowness
 def tag_forms_as_deleted_rebuild_associated_cases(cls, formlist, deletion_id, deleted_cases=set()):
     from casexml.apps.case.cleanup import rebuild_case
 

--- a/corehq/apps/users/tests/__init__.py
+++ b/corehq/apps/users/tests/__init__.py
@@ -5,3 +5,4 @@ from .phone_users import *
 from .sync import *
 from .permissions import *
 from .bulk_upload import *
+from .retire import *

--- a/corehq/apps/users/tests/retire.py
+++ b/corehq/apps/users/tests/retire.py
@@ -8,7 +8,6 @@ from corehq.apps.hqcase.utils import submit_case_blocks
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.tests.util import delete_all_cases, delete_all_xforms
-from couchforms.models import XFormInstance
 
 
 class RetireUserTestCase(TestCase):

--- a/corehq/apps/users/tests/retire.py
+++ b/corehq/apps/users/tests/retire.py
@@ -46,12 +46,7 @@ class RetireUserTestCase(TestCase):
             user_id=self.commcare_user._id,
         )
         casexml = ElementTree.tostring(caseblock.as_xml())
-        form_id = submit_case_blocks(casexml, self.domain)
-        form = XFormInstance.get(form_id)
-
-        form.form['meta']['userID'] = self.other_user._id
-        # Case is now assigned to commcare_user, form was submitted by other_user
-        form.save()
+        submit_case_blocks(casexml, self.domain, user_id=self.other_user._id)
 
         self.other_user.retire()
 
@@ -69,10 +64,7 @@ class RetireUserTestCase(TestCase):
             user_id=self.commcare_user._id,
         )
         casexml = ElementTree.tostring(caseblock.as_xml())
-        form_id = submit_case_blocks(casexml, self.domain)
-        form = XFormInstance.get(form_id)
-        form.form['meta']['userID'] = self.commcare_user._id
-        form.save()
+        submit_case_blocks(casexml, self.domain, user_id=self.commcare_user._id)
 
         self.other_user.retire()
 
@@ -91,11 +83,8 @@ class RetireUserTestCase(TestCase):
             user_id=self.commcare_user._id,
         ) for case_id in case_ids]
         casexmls = [ElementTree.tostring(caseblock.as_xml()) for caseblock in caseblocks]
-        self.form_id = submit_case_blocks(casexmls, self.domain)
+        submit_case_blocks(casexmls, self.domain, user_id=self.other_user._id)
 
-        form = XFormInstance.get(self.form_id)
-        form.form['meta']['userID'] = self.other_user._id
-        form.save()
         self.other_user.retire()
 
         expected_call_args = [mock.call(case_id) for case_id in case_ids]
@@ -116,11 +105,7 @@ class RetireUserTestCase(TestCase):
             user_id=self.commcare_user._id,
         ) for case_id in case_ids]
         casexmls = [ElementTree.tostring(caseblock.as_xml()) for caseblock in caseblocks]
-        self.form_id = submit_case_blocks(casexmls, self.domain)
-
-        form = XFormInstance.get(self.form_id)
-        form.form['meta']['userID'] = self.other_user._id
-        form.save()
+        submit_case_blocks(casexmls, self.domain, user_id=self.other_user._id)
 
         # This case will get deleted when the user is retired
         case = CommCareCase.get(case_ids[0])

--- a/corehq/apps/users/tests/retire.py
+++ b/corehq/apps/users/tests/retire.py
@@ -12,6 +12,7 @@ from couchforms.models import XFormInstance
 
 
 class RetireUserTestCase(TestCase):
+
     def setUp(self):
         self.domain = 'test'
         self.username = "fake-person@test.commcarehq.org"
@@ -39,11 +40,11 @@ class RetireUserTestCase(TestCase):
 
         case_id = uuid.uuid4().hex
         caseblock = CaseBlock(
-                create=True,
-                case_id=case_id,
-                owner_id=self.commcare_user._id,
-                user_id=self.commcare_user._id,
-            )
+            create=True,
+            case_id=case_id,
+            owner_id=self.commcare_user._id,
+            user_id=self.commcare_user._id,
+        )
         casexml = ElementTree.tostring(caseblock.as_xml())
         form_id = submit_case_blocks(casexml, self.domain)
         form = XFormInstance.get(form_id)
@@ -62,11 +63,11 @@ class RetireUserTestCase(TestCase):
 
         case_id = uuid.uuid4().hex
         caseblock = CaseBlock(
-                create=True,
-                case_id=case_id,
-                owner_id=self.commcare_user._id,
-                user_id=self.commcare_user._id,
-            )
+            create=True,
+            case_id=case_id,
+            owner_id=self.commcare_user._id,
+            user_id=self.commcare_user._id,
+        )
         casexml = ElementTree.tostring(caseblock.as_xml())
         form_id = submit_case_blocks(casexml, self.domain)
         form = XFormInstance.get(form_id)
@@ -84,11 +85,11 @@ class RetireUserTestCase(TestCase):
         case_ids = [uuid.uuid4().hex, uuid.uuid4().hex, uuid.uuid4().hex]
 
         caseblocks = [CaseBlock(
-                create=True,
-                case_id=case_id,
-                owner_id=self.commcare_user._id,
-                user_id=self.commcare_user._id,
-            ) for case_id in case_ids]
+            create=True,
+            case_id=case_id,
+            owner_id=self.commcare_user._id,
+            user_id=self.commcare_user._id,
+        ) for case_id in case_ids]
         casexmls = [ElementTree.tostring(caseblock.as_xml()) for caseblock in caseblocks]
         self.form_id = submit_case_blocks(casexmls, self.domain)
 
@@ -109,11 +110,11 @@ class RetireUserTestCase(TestCase):
         case_ids = [uuid.uuid4().hex, uuid.uuid4().hex, uuid.uuid4().hex]
 
         caseblocks = [CaseBlock(
-                create=True,
-                case_id=case_id,
-                owner_id=self.commcare_user._id,
-                user_id=self.commcare_user._id,
-            ) for case_id in case_ids]
+            create=True,
+            case_id=case_id,
+            owner_id=self.commcare_user._id,
+            user_id=self.commcare_user._id,
+        ) for case_id in case_ids]
         casexmls = [ElementTree.tostring(caseblock.as_xml()) for caseblock in caseblocks]
         self.form_id = submit_case_blocks(casexmls, self.domain)
 

--- a/corehq/apps/users/tests/retire.py
+++ b/corehq/apps/users/tests/retire.py
@@ -1,0 +1,134 @@
+from django.test import TestCase
+import mock
+
+import uuid
+from xml.etree import ElementTree
+from corehq.apps.users.models import CommCareUser
+from corehq.apps.hqcase.utils import submit_case_blocks
+from casexml.apps.case.mock import CaseBlock
+from casexml.apps.case.models import CommCareCase
+from casexml.apps.case.tests.util import delete_all_cases, delete_all_xforms
+from couchforms.models import XFormInstance
+
+
+class RetireUserTestCase(TestCase):
+    def setUp(self):
+        self.domain = 'test'
+        self.username = "fake-person@test.commcarehq.org"
+        self.other_username = 'other-user@test.commcarehq.org'
+        self.password = "s3cr3t"
+
+        self.commcare_user = CommCareUser.create(self.domain, self.username, self.password)
+        self.commcare_user.save()
+
+        self.other_user = CommCareUser.create(self.domain, self.other_username, self.password)
+        self.other_user.save()
+
+    def tearDown(self):
+        for user in CommCareUser.all():
+            user.delete()
+        delete_all_cases()
+        delete_all_xforms()
+
+    @mock.patch("casexml.apps.case.cleanup.rebuild_case")
+    def test_rebuild_cases_with_new_owner(self, rebuild_case):
+        """
+            If cases have a different owner to the person who submitted it
+            rebuild it when the submitter is retired.
+        """
+
+        case_id = uuid.uuid4().hex
+        caseblock = CaseBlock(
+                create=True,
+                case_id=case_id,
+                owner_id=self.commcare_user._id,
+                user_id=self.commcare_user._id,
+            )
+        casexml = ElementTree.tostring(caseblock.as_xml())
+        form_id = submit_case_blocks(casexml, self.domain)
+        form = XFormInstance.get(form_id)
+
+        form.form['meta']['userID'] = self.other_user._id
+        # Case is now assigned to commcare_user, form was submitted by other_user
+        form.save()
+
+        self.other_user.retire()
+
+        rebuild_case.assert_called_once_with(case_id)
+
+    @mock.patch("casexml.apps.case.cleanup.rebuild_case")
+    def test_dont_rebuild(self, rebuild_case):
+        """ Don't rebuild cases that are owned by other users """
+
+        case_id = uuid.uuid4().hex
+        caseblock = CaseBlock(
+                create=True,
+                case_id=case_id,
+                owner_id=self.commcare_user._id,
+                user_id=self.commcare_user._id,
+            )
+        casexml = ElementTree.tostring(caseblock.as_xml())
+        form_id = submit_case_blocks(casexml, self.domain)
+        form = XFormInstance.get(form_id)
+        form.form['meta']['userID'] = self.commcare_user._id
+        form.save()
+
+        self.other_user.retire()
+
+        self.assertEqual(rebuild_case.call_count, 0)
+
+    @mock.patch("casexml.apps.case.cleanup.rebuild_case")
+    def test_multiple_case_blocks_all_rebuilt(self, rebuild_case):
+        """ Rebuild all cases in forms with multiple case blocks """
+
+        case_ids = [uuid.uuid4().hex, uuid.uuid4().hex, uuid.uuid4().hex]
+
+        caseblocks = [CaseBlock(
+                create=True,
+                case_id=case_id,
+                owner_id=self.commcare_user._id,
+                user_id=self.commcare_user._id,
+            ) for case_id in case_ids]
+        casexmls = [ElementTree.tostring(caseblock.as_xml()) for caseblock in caseblocks]
+        self.form_id = submit_case_blocks(casexmls, self.domain)
+
+        form = XFormInstance.get(self.form_id)
+        form.form['meta']['userID'] = self.other_user._id
+        form.save()
+        self.other_user.retire()
+
+        expected_call_args = [mock.call(case_id) for case_id in case_ids]
+
+        self.assertEqual(rebuild_case.call_count, len(case_ids))
+        self.assertItemsEqual(rebuild_case.call_args_list, expected_call_args)
+
+    @mock.patch("casexml.apps.case.cleanup.rebuild_case")
+    def test_multiple_case_blocks_some_deleted(self, rebuild_case):
+        """ Don't rebuild deleted cases """
+
+        case_ids = [uuid.uuid4().hex, uuid.uuid4().hex, uuid.uuid4().hex]
+
+        caseblocks = [CaseBlock(
+                create=True,
+                case_id=case_id,
+                owner_id=self.commcare_user._id,
+                user_id=self.commcare_user._id,
+            ) for case_id in case_ids]
+        casexmls = [ElementTree.tostring(caseblock.as_xml()) for caseblock in caseblocks]
+        self.form_id = submit_case_blocks(casexmls, self.domain)
+
+        form = XFormInstance.get(self.form_id)
+        form.form['meta']['userID'] = self.other_user._id
+        form.save()
+
+        # This case will get deleted when the user is retired
+        case = CommCareCase.get(case_ids[0])
+        case.owner_id = self.other_user._id
+        case.save()
+
+        self.other_user.retire()
+
+        expected_call_args = [mock.call(case_id) for case_id in case_ids[1:]]
+
+        self.assertEqual(rebuild_case.call_count, len(case_ids) - 1)
+        self.assertItemsEqual(rebuild_case.call_args_list, expected_call_args)


### PR DESCRIPTION
When cases are reassigned and the original owner was retired, deleted case forms were showing up on the case list page.
Now, when users are retired, reassigned cases that are referenced in the forms the original user created are rebuilt.

http://manage.dimagi.com/default.asp?166198#933261
enchantress : @esoergel 
fyi: @snopoke, @czue 
