### PR TITLE
Project dashboard tweak

### DIFF
--- a/corehq/apps/dashboard/templates/dashboard/dashboard_new_user.html
+++ b/corehq/apps/dashboard/templates/dashboard/dashboard_new_user.html
@@ -29,7 +29,7 @@
          <small>{% trans 'What would you like to do?' %}</small></h1>
 </div>
 <div class="row">
-    <div class="col-md-4">
+    <div class="col-md-3">
         <div class="panel panel-dashboard">
             <div class="panel-heading">
                 {% trans 'Exchange' %}
@@ -44,7 +44,7 @@
             </div>
         </div>
     </div>
-    <div class="col-md-4">
+    <div class="col-md-6">
         <div class="panel panel-dashboard">
             <div class="panel-heading">
                 {% if project.commtrack_enabled %}
@@ -60,14 +60,14 @@
                        id="new-app-link">
                         <i class="fcc dashboard-icon dashboard-icon-large fcc-applications"></i>
                         <span class="lead">
-                            Build a new application
+                            Build a new application<br><br>
                         </span>
                    </a>
                 </p>
             </div>
         </div>
     </div>
-    <div class="col-md-4">
+    <div class="col-md-3">
         <div class="panel panel-dashboard">
             <div class="panel-heading">{% trans 'Help Site' %}</div>
             <div class="panel-body">

--- a/corehq/apps/dashboard/templates/dashboard/dashboard_new_user.html
+++ b/corehq/apps/dashboard/templates/dashboard/dashboard_new_user.html
@@ -38,7 +38,7 @@
                 <p class="text-center"><a href="{% url 'appstore' %}" class="dashboard-link" id="appstore-link">
                     <i class="fcc fcc-exchange dashboard-icon dashboard-icon-large"></i>
                     <span class="lead">{% blocktrans %}
-                        Start with an existing application
+                        Start with an<br>existing application
                     {% endblocktrans %}</span>
                 </a></p>
             </div>
@@ -77,7 +77,7 @@
                       target="_blank">
                     <i class="fcc fcc-help dashboard-icon dashboard-icon-large"></i>
                     <span class="lead">{% blocktrans %}
-                        Learn how to build an application
+                        Learn how to build<br>an application
                     {% endblocktrans %}</span>
                 </a></p>
             </div>

--- a/corehq/apps/style/static/dashboard/less/dashboard.less
+++ b/corehq/apps/style/static/dashboard/less/dashboard.less
@@ -52,6 +52,7 @@
   .panel-heading {
     font-weight: bold;
     font-size: @font-size-large;
+    text-align: center;
   }
 }
 


### PR DESCRIPTION
cc @amsagoff 

On project dashboard, visually emphasize the most common action, which is to build a new application. This is a perhaps temporary change, looking to see how it affects KISSmetrics.
![screen shot 2015-05-06 at 2 07 29 pm](https://cloud.githubusercontent.com/assets/1486591/7500043/48b51230-f3f9-11e4-8efa-7dbdcae9c75d.png)

For fun, some other possibilities...

Can't tell which is the primary action (old version):
![screen shot 2015-05-06 at 12 50 30 pm](https://cloud.githubusercontent.com/assets/1486591/7499914/6151ddce-f3f8-11e4-8618-fd58ae428940.png)

Often the primary action should be on the left, but this looks weirdly unbalanced:
![screen shot 2015-05-06 at 1 00 10 pm](https://cloud.githubusercontent.com/assets/1486591/7499929/8635adfa-f3f8-11e4-9073-23a0ac5bb8fc.png)

Now it's starting to look like a pyramid:
![screen shot 2015-05-06 at 1 10 54 pm](https://cloud.githubusercontent.com/assets/1486591/7499941/9cebaa0e-f3f8-11e4-8992-be90f88223c9.png)

Now the secondary actions are so de-emphasized that this looks like a one-action page:
![screen shot 2015-05-06 at 1 31 47 pm](https://cloud.githubusercontent.com/assets/1486591/7499971/cd63c1da-f3f8-11e4-8e6a-ac001e760100.png)
