### PR TITLE
change Applications dashboard link to default app

### DIFF
--- a/corehq/apps/app_manager/urls.py
+++ b/corehq/apps/app_manager/urls.py
@@ -37,7 +37,7 @@ app_urls = patterns('corehq.apps.app_manager.views',
 )
 
 urlpatterns = patterns('corehq.apps.app_manager.views',
-    url(r'^$', 'default'),
+    url(r'^$', 'default', name='default_app'),
     url(r'^xform/(?P<form_unique_id>[\w-]+)/$', 'xform_display'),
     url(r'^browse/(?P<app_id>[\w-]+)/modules-(?P<module_id>[\w-]+)/forms-(?P<form_id>[\w-]+)/source/$',
         'get_xform_source', name='get_xform_source'),

--- a/corehq/apps/dashboard/views.py
+++ b/corehq/apps/dashboard/views.py
@@ -142,7 +142,7 @@ def _get_default_tile_configurations():
             icon='fcc fcc-applications',
             context_processor_class=AppsPaginatedContext,
             visibility_check=can_edit_apps,
-            urlname='default_new_app',
+            urlname='default_app',
             help_text=_('Build, update, and deploy applications'),
         ),
         TileConfiguration(


### PR DESCRIPTION
Currently it is unclear that the dashboard header `Applications` links to a new app.
Now, clicking that link will go to the first application on the list.

enchantress / elf: @gcapalbo 

http://manage.dimagi.com/default.asp?166205#924791
