### PR TITLE
Append missing Z to datetime

### DIFF
--- a/corehq/apps/products/models.py
+++ b/corehq/apps/products/models.py
@@ -8,6 +8,7 @@ from dimagi.ext.couchdbkit import (
 )
 from datetime import datetime
 from decimal import Decimal
+from corehq.apps.groups.models import dt_no_Z_re
 from django.db import models
 from django.utils.translation import ugettext as _
 import json_field
@@ -31,6 +32,15 @@ class Product(Document):
     product_data = DictProperty()
     is_archived = BooleanProperty(default=False)
     last_modified = DateTimeProperty()
+
+    @classmethod
+    def wrap(cls, data):
+        # If "Z" is missing because of the Aug 2014 migration, then add it.
+        # cf. Group class
+        last_modified = data.get('last_modified')
+        if last_modified and dt_no_Z_re.match(last_modified):
+            data['last_modified'] += 'Z'
+        return super(Product, cls).wrap(data)
 
     def sync_to_sql(self):
         properties_to_sync = [

--- a/corehq/apps/products/models.py
+++ b/corehq/apps/products/models.py
@@ -8,7 +8,6 @@ from dimagi.ext.couchdbkit import (
 )
 from datetime import datetime
 from decimal import Decimal
-from corehq.apps.groups.models import dt_no_Z_re
 from django.db import models
 from django.utils.translation import ugettext as _
 import json_field
@@ -35,6 +34,7 @@ class Product(Document):
 
     @classmethod
     def wrap(cls, data):
+        from corehq.apps.groups.models import dt_no_Z_re
         # If "Z" is missing because of the Aug 2014 migration, then add it.
         # cf. Group class
         last_modified = data.get('last_modified')


### PR DESCRIPTION
Thanks, @snopoke  

BTW, are we going to have the same problem with other models?

```
    $ git grep 'DateTimeProperty()' | wc -l
    74
```

Is the problem only with models related to locations? e.g. FacilityRegistry, SQLProduct, SQLLocation also have datetime fields. 

Buddy @millerdev 
