### PR TITLE
add request object to soft_assert when possible

### DIFF
--- a/corehq/util/dates.py
+++ b/corehq/util/dates.py
@@ -46,7 +46,8 @@ def iso_string_to_datetime(iso_string):
             return datetime.datetime.strptime(iso_string, fmt)
         except ValueError:
             pass
-    _assert(False, 'input not in expected format: {!r}'.format(iso_string))
+    _assert(False, 'iso_string_to_datetime input not in expected format',
+            iso_string)
     from dimagi.utils.parsing import string_to_utc_datetime
     return string_to_utc_datetime(iso_string)
 

--- a/corehq/util/soft_assert/api.py
+++ b/corehq/util/soft_assert/api.py
@@ -1,5 +1,5 @@
 from django.core.mail import mail_admins, send_mail
-from django.core.cache import cache
+from corehq.util.global_request import get_request
 from corehq.util.soft_assert.core import SoftAssert
 import settings
 
@@ -9,7 +9,9 @@ def _send_message(info, backend):
         subject='Soft Assert: [{}] {}'.format(info.key[:8], info.msg),
         message=('Message: {info.msg}\n'
                  'Traceback:\n{info.traceback}\n'
-                 'Occurrences to date: {info.count}\n').format(info=info)
+                 'Request:\n{request}\n'
+                 'Occurrences to date: {info.count}\n').format(
+                info=info, request=get_request())
     )
 
 

--- a/corehq/util/soft_assert/api.py
+++ b/corehq/util/soft_assert/api.py
@@ -8,6 +8,7 @@ def _send_message(info, backend):
     backend(
         subject='Soft Assert: [{}] {}'.format(info.key[:8], info.msg),
         message=('Message: {info.msg}\n'
+                 'Value: {info.obj!r}\n'
                  'Traceback:\n{info.traceback}\n'
                  'Request:\n{request}\n'
                  'Occurrences to date: {info.count}\n').format(

--- a/corehq/util/soft_assert/core.py
+++ b/corehq/util/soft_assert/core.py
@@ -7,7 +7,7 @@ from corehq.util.cache_utils import ExponentialBackoff
 
 SoftAssertInfo = namedtuple('SoftAssertInfo',
                             ['traceback', 'count', 'msg', 'key', 'line',
-                             'short_traceback'])
+                             'short_traceback', 'obj'])
 
 
 class SoftAssert(object):
@@ -20,12 +20,19 @@ class SoftAssert(object):
         self.tb_skip = skip_frames + 3
         self.key_limit = key_limit
 
-    def __call__(self, assertion, msg=None):
-        return self._call(assertion, msg)
+    def __call__(self, assertion, msg=None, obj=None):
+        return self._call(assertion, msg, obj)
 
     call = __call__
 
-    def _call(self, assertion, msg=None):
+    def _call(self, assertion, msg=None, obj=None):
+        """
+        assertion: what we're asserting
+        msg: a static message describing the error
+        obj: the specific piece of data, if any, that tripped the assertion
+
+        returns the assertion itself
+        """
         if not assertion:
             if self.debug:
                 raise AssertionError(msg)
@@ -39,7 +46,7 @@ class SoftAssert(object):
                                          short_traceback=short_tb,
                                          count=count,
                                          msg=msg,
-                                         key=tb_id, line=line))
+                                         key=tb_id, line=line, obj=obj))
         return assertion
 
 

--- a/corehq/util/tests/test_soft_assert.py
+++ b/corehq/util/tests/test_soft_assert.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 import math
 from django.test import SimpleTestCase
 from corehq.util.soft_assert.core import SoftAssert


### PR DESCRIPTION
This will make these emails a lot more useful by adding two features:
- Adds the request (if available) to the email; helps to know how something got triggered, where some piece of weird data comes from, etc.
- Adds ability to log the offending value (or a few values as a tuple or dict) in the email, without changing the email subject. This makes them thread correctly!
