### PR TITLE
speed up TestGatewayFee

### DIFF
--- a/corehq/apps/smsbillables/tests/test_gateway_fees.py
+++ b/corehq/apps/smsbillables/tests/test_gateway_fees.py
@@ -210,7 +210,11 @@ class TestGatewayFee(TestCase):
         SmsUsageFeeCriteria.objects.all().delete()
         cls.currency_usd.delete()
         cls.other_currency.delete()
-        for log in SMSLog.by_domain_asc(generator.TEST_DOMAIN):
-            log.delete()
-        for backend_instance in cls.backend_ids.values():
-            SMSBackend.get(backend_instance).delete()
+        SMSLog.get_db().delete_docs(
+            SMSLog.by_domain_asc(generator.TEST_DOMAIN).all()
+        )
+
+        SMSBackend.get_db().delete_docs(
+            SMSBackend.get_db().all_docs(
+                keys=cls.backend_ids.values(), include_docs=True).all()
+        )

--- a/corehq/apps/smsbillables/tests/test_gateway_fees.py
+++ b/corehq/apps/smsbillables/tests/test_gateway_fees.py
@@ -8,26 +8,27 @@ from corehq.apps.smsbillables import generator
 
 
 class TestGatewayFee(TestCase):
-    def setUp(self):
-        self.currency_usd, _ = Currency.objects.get_or_create(
+    @classmethod
+    def setUpClass(cls):
+        cls.currency_usd, _ = Currency.objects.get_or_create(
             code=settings.DEFAULT_CURRENCY,
             name="Default Currency",
             symbol="$",
             rate_to_default=Decimal('1.0')
         )
-        self.available_backends = get_available_backends().values()
+        cls.available_backends = get_available_backends().values()
 
-        self.backend_ids = generator.arbitrary_backend_ids()
-        self.message_logs = generator.arbitrary_messages_by_backend_and_direction(self.backend_ids)
+        cls.backend_ids = generator.arbitrary_backend_ids()
+        cls.message_logs = generator.arbitrary_messages_by_backend_and_direction(cls.backend_ids)
 
-        self.least_specific_fees = generator.arbitrary_fees_by_direction_and_backend()
-        self.country_code_fees = generator.arbitrary_fees_by_country()
-        self.instance_fees = generator.arbitrary_fees_by_backend_instance(self.backend_ids)
-        self.most_specific_fees = generator.arbitrary_fees_by_all(self.backend_ids)
-        self.country_code_and_prefixes = generator.arbitrary_country_code_and_prefixes()
-        self.prefix_fees = generator.arbitrary_fees_by_prefix(self.backend_ids, self.country_code_and_prefixes)
+        cls.least_specific_fees = generator.arbitrary_fees_by_direction_and_backend()
+        cls.country_code_fees = generator.arbitrary_fees_by_country()
+        cls.instance_fees = generator.arbitrary_fees_by_backend_instance(cls.backend_ids)
+        cls.most_specific_fees = generator.arbitrary_fees_by_all(cls.backend_ids)
+        cls.country_code_and_prefixes = generator.arbitrary_country_code_and_prefixes()
+        cls.prefix_fees = generator.arbitrary_fees_by_prefix(cls.backend_ids, cls.country_code_and_prefixes)
 
-        self.other_currency = generator.arbitrary_currency()
+        cls.other_currency = generator.arbitrary_currency()
 
     def create_least_specific_gateway_fees(self):
         for direction, fees in self.least_specific_fees.items():
@@ -200,15 +201,16 @@ class TestGatewayFee(TestCase):
                 self.assertIsNotNone(billable)
                 self.assertIsNone(billable.gateway_fee)
 
-    def tearDown(self):
+    @classmethod
+    def tearDownClass(cls):
         SmsBillable.objects.all().delete()
         SmsGatewayFee.objects.all().delete()
         SmsGatewayFeeCriteria.objects.all().delete()
         SmsUsageFee.objects.all().delete()
         SmsUsageFeeCriteria.objects.all().delete()
-        self.currency_usd.delete()
-        self.other_currency.delete()
+        cls.currency_usd.delete()
+        cls.other_currency.delete()
         for log in SMSLog.by_domain_asc(generator.TEST_DOMAIN):
             log.delete()
-        for backend_instance in self.backend_ids.values():
+        for backend_instance in cls.backend_ids.values():
             SMSBackend.get(backend_instance).delete()

--- a/settings.py
+++ b/settings.py
@@ -1384,6 +1384,7 @@ TRAVIS_TEST_GROUPS = (
         'facilities', 'fixtures', 'fluff_filter', 'formplayer',
         'formtranslate', 'fri', 'grapevine', 'groups', 'gsid', 'hope',
         'hqadmin', 'hqcase', 'hqcouchlog', 'hqmedia',
+        'smsbillables',
     ),
 )
 


### PR DESCRIPTION
just using setUpClass takes 30 seconds off tests, the quickcache optimization should take a lot more off, though I could never reproduce the 6 minute runtime locally; travis couch is probably slower than mine due to memory constraints or something.
