### PR TITLE
refactoring restore code a bit

### DIFF
--- a/corehq/apps/commtrack/tests/test_xml.py
+++ b/corehq/apps/commtrack/tests/test_xml.py
@@ -7,7 +7,7 @@ import uuid
 from datetime import datetime, timedelta
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.xml import V2
-from casexml.apps.phone.restore import TemporaryRestoreConfig, RestoreParams
+from casexml.apps.phone.restore import RestoreConfig, RestoreParams
 from casexml.apps.phone.tests.utils import synclog_id_from_restore_payload
 from corehq.apps.commtrack.models import ConsumptionConfig, StockRestoreConfig, RequisitionCase, StockState
 from corehq.apps.domain.models import Domain
@@ -500,7 +500,7 @@ class CommTrackSyncTest(CommTrackSubmissionTest):
         self.ota_settings = self.ct_settings.get_ota_restore_settings()
 
         # get initial restore token
-        restore_config = TemporaryRestoreConfig(
+        restore_config = RestoreConfig(
             domain=self.domain,
             user=self.casexml_user,
             params=RestoreParams(version=V2),
@@ -612,7 +612,7 @@ def _report_soh(amounts, case_id, section_id='stock', report=None):
 
 
 def _get_ota_balance_blocks(domain, user):
-    restore_config = TemporaryRestoreConfig(
+    restore_config = RestoreConfig(
         domain=domain,
         user=user.to_casexml_user(),
         params=RestoreParams(version=V2),

--- a/corehq/apps/commtrack/tests/test_xml.py
+++ b/corehq/apps/commtrack/tests/test_xml.py
@@ -7,9 +7,10 @@ import uuid
 from datetime import datetime, timedelta
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.xml import V2
-from casexml.apps.phone.restore import RestoreConfig
+from casexml.apps.phone.restore import TemporaryRestoreConfig, RestoreParams
 from casexml.apps.phone.tests.utils import synclog_id_from_restore_payload
 from corehq.apps.commtrack.models import ConsumptionConfig, StockRestoreConfig, RequisitionCase, StockState
+from corehq.apps.domain.models import Domain
 from corehq.apps.products.models import Product
 from corehq.apps.consumption.shortcuts import set_default_monthly_consumption_for_domain
 from couchforms.models import XFormInstance
@@ -102,10 +103,11 @@ class CommTrackOTATest(CommTrackTest):
             section_to_consumption_types={'stock': 'consumption'}
         )
         set_default_monthly_consumption_for_domain(self.domain.name, 5 * DAYS_IN_MONTH)
+        self._save_settings_and_clear_cache()
 
         amounts = [(p._id, i*10) for i, p in enumerate(self.products)]
         report = _report_soh(amounts, self.sp._id, 'stock')
-        balance_blocks = _get_ota_balance_blocks(self.ct_settings, self.user)
+        balance_blocks = _get_ota_balance_blocks(self.domain, self.user)
         self.assertEqual(2, len(balance_blocks))
         stock_block, consumption_block = balance_blocks
         check_xml_line_by_line(
@@ -139,22 +141,32 @@ class CommTrackOTATest(CommTrackTest):
             section_to_consumption_types={'stock': 'consumption'},
         )
         set_default_monthly_consumption_for_domain(self.domain.name, 5)
+        self._save_settings_and_clear_cache()
 
-        balance_blocks = _get_ota_balance_blocks(self.ct_settings, self.user)
+        balance_blocks = _get_ota_balance_blocks(self.domain, self.user)
         self.assertEqual(0, len(balance_blocks))
 
-        # self.ct_settings.ota_restore_config.use_dynamic_product_list = True
         self.ct_settings.ota_restore_config.force_consumption_case_types = [const.SUPPLY_POINT_CASE_TYPE]
-        balance_blocks = _get_ota_balance_blocks(self.ct_settings, self.user)
+        self._save_settings_and_clear_cache()
+
+        balance_blocks = _get_ota_balance_blocks(self.domain, self.user)
         # with no data, there should be no consumption block
         self.assertEqual(0, len(balance_blocks))
 
         self.ct_settings.ota_restore_config.use_dynamic_product_list = True
-        balance_blocks = _get_ota_balance_blocks(self.ct_settings, self.user)
+        self._save_settings_and_clear_cache()
+
+        balance_blocks = _get_ota_balance_blocks(self.domain, self.user)
         self.assertEqual(1, len(balance_blocks))
         [balance_block] = balance_blocks
         element = etree.fromstring(balance_block)
         self.assertEqual(3, len([child for child in element]))
+
+    def _save_settings_and_clear_cache(self):
+        # since the commtrack settings object is stored as a memoized property on the domain
+        # we need to refresh that as well
+        self.ct_settings.save()
+        self.domain = Domain.get(self.domain._id)
 
 
 class CommTrackSubmissionTest(CommTrackTest):
@@ -488,10 +500,10 @@ class CommTrackSyncTest(CommTrackSubmissionTest):
         self.ota_settings = self.ct_settings.get_ota_restore_settings()
 
         # get initial restore token
-        restore_config = RestoreConfig(
-            self.casexml_user,
-            version=V2,
-            stock_settings=self.ota_settings,
+        restore_config = TemporaryRestoreConfig(
+            domain=self.domain,
+            user=self.casexml_user,
+            params=RestoreParams(version=V2),
         )
         self.sync_log_id = synclog_id_from_restore_payload(restore_config.get_payload().as_string())
 
@@ -598,11 +610,11 @@ def _report_soh(amounts, case_id, section_id='stock', report=None):
         )
     return report
 
-def _get_ota_balance_blocks(ct_settings, user):
-    ota_settings = ct_settings.get_ota_restore_settings()
-    restore_config = RestoreConfig(
-        user.to_casexml_user(),
-        version=V2,
-        stock_settings=ota_settings,
+
+def _get_ota_balance_blocks(domain, user):
+    restore_config = TemporaryRestoreConfig(
+        domain=domain,
+        user=user.to_casexml_user(),
+        params=RestoreParams(version=V2),
     )
     return extract_balance_xml(restore_config.get_payload().as_string())

--- a/corehq/apps/hqcase/tests/test_bugs.py
+++ b/corehq/apps/hqcase/tests/test_bugs.py
@@ -6,7 +6,7 @@ from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.util import post_case_blocks
 from casexml.apps.case.xml import V2
-from casexml.apps.phone.restore import RestoreConfig
+from casexml.apps.phone.restore import TemporaryRestoreConfig, RestoreParams
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import CommCareUser, CouchUser
 from corehq.apps.users.util import format_username
@@ -52,8 +52,9 @@ class OtaRestoreBugTest(TestCase):
             self.assertEqual(user._id, case.user_id)
             self.assertEqual(user._id, case.owner_id)
 
-        restore_config = RestoreConfig(
-            user.to_casexml_user(), version=V2,
+        restore_config = TemporaryRestoreConfig(
+            user=user.to_casexml_user(),
+            params=RestoreParams(version=V2),
         )
         payload = restore_config.get_payload().as_string()
         self.assertTrue(good_case._id in payload)

--- a/corehq/apps/hqcase/tests/test_bugs.py
+++ b/corehq/apps/hqcase/tests/test_bugs.py
@@ -6,7 +6,7 @@ from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.util import post_case_blocks
 from casexml.apps.case.xml import V2
-from casexml.apps.phone.restore import TemporaryRestoreConfig, RestoreParams
+from casexml.apps.phone.restore import RestoreConfig, RestoreParams
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import CommCareUser, CouchUser
 from corehq.apps.users.util import format_username
@@ -52,7 +52,7 @@ class OtaRestoreBugTest(TestCase):
             self.assertEqual(user._id, case.user_id)
             self.assertEqual(user._id, case.owner_id)
 
-        restore_config = TemporaryRestoreConfig(
+        restore_config = RestoreConfig(
             user=user.to_casexml_user(),
             params=RestoreParams(version=V2),
         )

--- a/corehq/apps/hqcase/tests/test_loadtest_users.py
+++ b/corehq/apps/hqcase/tests/test_loadtest_users.py
@@ -3,7 +3,7 @@ from casexml.apps.case.mock import CaseFactory, CaseStructure, CaseRelationship
 from casexml.apps.case.tests import delete_all_cases
 from casexml.apps.case.tests.util import extract_caseblocks_from_xml
 from casexml.apps.case.xml import V2
-from casexml.apps.phone.restore import TemporaryRestoreConfig, RestoreParams
+from casexml.apps.phone.restore import RestoreConfig, RestoreParams
 from corehq import Domain
 from corehq.apps.users.models import CommCareUser
 from corehq.toggles import ENABLE_LOADTEST_USERS
@@ -33,7 +33,7 @@ class LoadtestUserTest(TestCase):
         self.user.loadtest_factor = None
         self.user.save()
         case = self.factory.create_case()
-        restore_config = TemporaryRestoreConfig(user=self.user, params=RestoreParams(version=V2))
+        restore_config = RestoreConfig(user=self.user, params=RestoreParams(version=V2))
         payload_string = restore_config.get_payload().as_string()
         caseblocks = extract_caseblocks_from_xml(payload_string)
         self.assertEqual(1, len(caseblocks))
@@ -44,7 +44,7 @@ class LoadtestUserTest(TestCase):
         self.user.save()
         case1 = self.factory.create_case(case_name='case1')
         case2 = self.factory.create_case(case_name='case2')
-        restore_config = TemporaryRestoreConfig(
+        restore_config = RestoreConfig(
             domain=self.domain,
             user=self.user,
             params=RestoreParams(version=V2),
@@ -68,7 +68,7 @@ class LoadtestUserTest(TestCase):
                 ]
             )
         )
-        restore_config = TemporaryRestoreConfig(
+        restore_config = RestoreConfig(
             domain=self.domain,
             user=self.user,
             params=RestoreParams(version=V2)

--- a/corehq/apps/hqcase/tests/test_loadtest_users.py
+++ b/corehq/apps/hqcase/tests/test_loadtest_users.py
@@ -3,7 +3,7 @@ from casexml.apps.case.mock import CaseFactory, CaseStructure, CaseRelationship
 from casexml.apps.case.tests import delete_all_cases
 from casexml.apps.case.tests.util import extract_caseblocks_from_xml
 from casexml.apps.case.xml import V2
-from casexml.apps.phone.restore import RestoreConfig
+from casexml.apps.phone.restore import TemporaryRestoreConfig, RestoreParams
 from corehq import Domain
 from corehq.apps.users.models import CommCareUser
 from corehq.toggles import ENABLE_LOADTEST_USERS
@@ -33,7 +33,7 @@ class LoadtestUserTest(TestCase):
         self.user.loadtest_factor = None
         self.user.save()
         case = self.factory.create_case()
-        restore_config = RestoreConfig(self.user, version=V2)
+        restore_config = TemporaryRestoreConfig(user=self.user, params=RestoreParams(version=V2))
         payload_string = restore_config.get_payload().as_string()
         caseblocks = extract_caseblocks_from_xml(payload_string)
         self.assertEqual(1, len(caseblocks))
@@ -44,7 +44,11 @@ class LoadtestUserTest(TestCase):
         self.user.save()
         case1 = self.factory.create_case(case_name='case1')
         case2 = self.factory.create_case(case_name='case2')
-        restore_config = RestoreConfig(self.user, version=V2, domain=self.domain)
+        restore_config = TemporaryRestoreConfig(
+            domain=self.domain,
+            user=self.user,
+            params=RestoreParams(version=V2),
+        )
         payload_string = restore_config.get_payload().as_string()
         caseblocks = extract_caseblocks_from_xml(payload_string)
         self.assertEqual(6, len(caseblocks))
@@ -64,7 +68,11 @@ class LoadtestUserTest(TestCase):
                 ]
             )
         )
-        restore_config = RestoreConfig(self.user, version=V2, domain=self.domain)
+        restore_config = TemporaryRestoreConfig(
+            domain=self.domain,
+            user=self.user,
+            params=RestoreParams(version=V2)
+        )
         payload_string = restore_config.get_payload().as_string()
         caseblocks = extract_caseblocks_from_xml(payload_string)
         self.assertEqual(6, len(caseblocks))

--- a/corehq/apps/ota/tasks.py
+++ b/corehq/apps/ota/tasks.py
@@ -1,7 +1,7 @@
 from celery.task import task
 from couchdbkit.exceptions import ResourceNotFound
 from casexml.apps.case.xml import V1
-from casexml.apps.phone.restore import RestoreConfig
+from casexml.apps.phone.restore import RestoreParams, RestoreCacheSettings, TemporaryRestoreConfig
 from corehq.apps.users.models import CommCareUser
 from soil import DownloadBase
 
@@ -37,13 +37,18 @@ def prime_restore(domain, usernames_or_ids, version=V1, cache_timeout_hours=None
 
         try:
             project = couch_user.project
-            restore_config = RestoreConfig(
-                couch_user.to_casexml_user(), None, version, None,
-                items=True,
+            restore_config = TemporaryRestoreConfig(
                 domain=project,
-                force_cache=True,
-                cache_timeout=cache_timeout_hours * 60 * 60,
-                overwrite_cache=overwrite_cache
+                user=couch_user.to_casexml_user(),
+                params=RestoreParams(
+                    version=version,
+                    include_item_count=True,
+                ),
+                cache_settings=RestoreCacheSettings(
+                    force_cache=True,
+                    cache_timeout=cache_timeout_hours * 60 * 60,
+                    overwrite_cache=overwrite_cache
+                )
             )
 
             if check_cache_only:

--- a/corehq/apps/ota/tasks.py
+++ b/corehq/apps/ota/tasks.py
@@ -1,7 +1,7 @@
 from celery.task import task
 from couchdbkit.exceptions import ResourceNotFound
 from casexml.apps.case.xml import V1
-from casexml.apps.phone.restore import RestoreParams, RestoreCacheSettings, TemporaryRestoreConfig
+from casexml.apps.phone.restore import RestoreParams, RestoreCacheSettings, RestoreConfig
 from corehq.apps.users.models import CommCareUser
 from soil import DownloadBase
 
@@ -37,7 +37,7 @@ def prime_restore(domain, usernames_or_ids, version=V1, cache_timeout_hours=None
 
         try:
             project = couch_user.project
-            restore_config = TemporaryRestoreConfig(
+            restore_config = RestoreConfig(
                 domain=project,
                 user=couch_user.to_casexml_user(),
                 params=RestoreParams(

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -16,7 +16,7 @@ from corehq.util.view_utils import json_error
 from couchforms.models import XFormInstance
 from dimagi.utils.decorators.memoized import memoized
 from django_digest.decorators import *
-from casexml.apps.phone.restore import TemporaryRestoreConfig, RestoreParams, RestoreCacheSettings
+from casexml.apps.phone.restore import RestoreConfig, RestoreParams, RestoreCacheSettings
 from django.http import HttpResponse
 from lxml import etree
 from soil import DownloadBase
@@ -59,7 +59,7 @@ def get_restore_response(domain, couch_user, since=None, version='1.0',
                             status=401)
 
     project = Domain.get_by_name(domain)
-    restore_config = TemporaryRestoreConfig(
+    restore_config = RestoreConfig(
         domain=project,
         user=couch_user.to_casexml_user(),
         params=RestoreParams(

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -16,7 +16,7 @@ from corehq.util.view_utils import json_error
 from couchforms.models import XFormInstance
 from dimagi.utils.decorators.memoized import memoized
 from django_digest.decorators import *
-from casexml.apps.phone.restore import RestoreConfig
+from casexml.apps.phone.restore import TemporaryRestoreConfig, RestoreParams, RestoreCacheSettings
 from django.http import HttpResponse
 from lxml import etree
 from soil import DownloadBase
@@ -59,13 +59,20 @@ def get_restore_response(domain, couch_user, since=None, version='1.0',
                             status=401)
 
     project = Domain.get_by_name(domain)
-    restore_config = RestoreConfig(
-        couch_user.to_casexml_user(), since, version, state,
-        items=items,
+    restore_config = TemporaryRestoreConfig(
         domain=project,
-        force_cache=force_cache,
-        cache_timeout=cache_timeout,
-        overwrite_cache=overwrite_cache
+        user=couch_user.to_casexml_user(),
+        params=RestoreParams(
+            sync_log_id=since,
+            version=version,
+            state_hash=state,
+            include_item_count=items,
+        ),
+        cache_settings=RestoreCacheSettings(
+            force_cache=force_cache,
+            cache_timeout=cache_timeout,
+            overwrite_cache=overwrite_cache
+        ),
     )
     return restore_config.get_response()
 

--- a/corehq/ex-submodules/casexml/apps/case/exceptions.py
+++ b/corehq/ex-submodules/casexml/apps/case/exceptions.py
@@ -38,34 +38,3 @@ class ReconciliationError(CommCareCaseError):
 
 class MissingServerDate(ReconciliationError):
     pass
-
-
-class RestoreException(ValueError, CommCareCaseError):
-    """
-    For stuff that goes wrong during restore
-    """
-    message = "unknown problem during OTA restore"
-
-
-class BadStateException(RestoreException):
-    """
-    Case state hash inconsistencies
-    """
-    message = "Phone case list is inconsistant with server's records."
-
-    def __init__(self, expected, actual, case_ids, **kwargs):
-        super(BadStateException, self).__init__(**kwargs)
-        self.expected = expected
-        self.actual = actual
-        self.case_ids = case_ids
-
-    def __str__(self):
-        return "Phone state has mismatch. Expected %s but was %s. Cases: [%s]" % \
-                (self.expected, self.actual, ", ".join(self.case_ids))
-
-
-class BadVersionException(RestoreException):
-    """
-    Bad ota version
-    """
-    message = "Bad version number submitted during sync."

--- a/corehq/ex-submodules/casexml/apps/case/tests/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/util.py
@@ -15,7 +15,7 @@ from couchforms.tests.testutils import post_xform_to_couch
 from couchforms.models import XFormInstance
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.xform import process_cases
-from casexml.apps.phone.restore import RestoreConfig
+from casexml.apps.phone.restore import TemporaryRestoreConfig, RestoreParams
 from casexml.apps.case.util import post_case_blocks
 from django.conf import settings
 
@@ -148,7 +148,7 @@ def check_user_has_case(testcase, user, case_blocks, should_have=True,
 
     if restore_id and purge_restore_cache:
         SyncLog.get(restore_id).invalidate_cached_payloads()
-    restore_config = RestoreConfig(user, restore_id, version=version)
+    restore_config = TemporaryRestoreConfig(user=user, params=RestoreParams(restore_id, version=version))
     payload_string = restore_config.get_payload().as_string()
     blocks = extract_caseblocks_from_xml(payload_string, version)
 

--- a/corehq/ex-submodules/casexml/apps/case/tests/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/util.py
@@ -15,7 +15,7 @@ from couchforms.tests.testutils import post_xform_to_couch
 from couchforms.models import XFormInstance
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.xform import process_cases
-from casexml.apps.phone.restore import TemporaryRestoreConfig, RestoreParams
+from casexml.apps.phone.restore import RestoreConfig, RestoreParams
 from casexml.apps.case.util import post_case_blocks
 from django.conf import settings
 
@@ -148,7 +148,7 @@ def check_user_has_case(testcase, user, case_blocks, should_have=True,
 
     if restore_id and purge_restore_cache:
         SyncLog.get(restore_id).invalidate_cached_payloads()
-    restore_config = TemporaryRestoreConfig(user=user, params=RestoreParams(restore_id, version=version))
+    restore_config = RestoreConfig(user=user, params=RestoreParams(restore_id, version=version))
     payload_string = restore_config.get_payload().as_string()
     blocks = extract_caseblocks_from_xml(payload_string, version)
 

--- a/corehq/ex-submodules/casexml/apps/case/xml/__init__.py
+++ b/corehq/ex-submodules/casexml/apps/case/xml/__init__.py
@@ -1,4 +1,4 @@
-from casexml.apps.case.exceptions import BadVersionException
+from casexml.apps.phone.exceptions import BadVersionException
 
 V1 = "1.0"
 V2 = "2.0"

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers.py
@@ -10,6 +10,7 @@ class RestoreDataProvider(object):
     def get_elements(self, restore_state):
         raise NotImplementedError('Need to implement this method')
 
+
 class SyncElementProvider(RestoreDataProvider):
     """
     Gets the initial sync element.

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers.py
@@ -1,0 +1,53 @@
+from casexml.apps.phone import xml
+from casexml.apps.phone.fixtures import generator
+
+
+class RestoreDataProvider(object):
+    """
+    Base class for anything that gives data to a restore.
+    """
+
+    def get_elements(self, restore_state):
+        raise NotImplementedError('Need to implement this method')
+
+class SyncElementProvider(RestoreDataProvider):
+    """
+    Gets the initial sync element.
+    """
+    def get_elements(self, restore_state):
+        yield xml.get_sync_element(restore_state.current_sync_log._id)
+
+
+class RegistrationElementProvider(RestoreDataProvider):
+    """
+    Gets the registration XML
+    """
+    def get_elements(self, restore_state):
+        yield xml.get_registration_element(restore_state.user)
+
+
+class FixtureElementProvider(RestoreDataProvider):
+    """
+    Gets any associated fixtures.
+    """
+    def get_elements(self, restore_state):
+        # fixture block
+        for fixture in generator.get_fixtures(
+            restore_state.user,
+            restore_state.params.version,
+            restore_state.last_sync_log
+        ):
+            yield fixture
+
+
+def get_restore_providers():
+    """
+    Get all restore providers. This can be smarter in the future.
+    """
+    # note that ordering matters in this list as this is the order that the items
+    # will appear in the XML, and have access to the RestoreState object
+    return [
+        SyncElementProvider(),
+        RegistrationElementProvider(),
+        FixtureElementProvider(),
+    ]

--- a/corehq/ex-submodules/casexml/apps/phone/exceptions.py
+++ b/corehq/ex-submodules/casexml/apps/phone/exceptions.py
@@ -1,0 +1,12 @@
+
+
+class InvalidSyncLogException(Exception):
+    pass
+
+
+class MissingSyncLog(InvalidSyncLogException):
+    pass
+
+
+class SyncLogUserMismatch(InvalidSyncLogException):
+    pass

--- a/corehq/ex-submodules/casexml/apps/phone/exceptions.py
+++ b/corehq/ex-submodules/casexml/apps/phone/exceptions.py
@@ -1,3 +1,35 @@
+from casexml.apps.case.exceptions import CommCareCaseError
+
+
+class RestoreException(ValueError, CommCareCaseError):
+    """
+    For stuff that goes wrong during restore
+    """
+    message = "unknown problem during OTA restore"
+
+
+class BadStateException(RestoreException):
+    """
+    Case state hash inconsistencies
+    """
+    message = "Phone case list is inconsistant with server's records."
+
+    def __init__(self, expected, actual, case_ids, **kwargs):
+        super(BadStateException, self).__init__(**kwargs)
+        self.expected = expected
+        self.actual = actual
+        self.case_ids = case_ids
+
+    def __str__(self):
+        return "Phone state has mismatch. Expected %s but was %s. Cases: [%s]" % \
+                (self.expected, self.actual, ", ".join(self.case_ids))
+
+
+class BadVersionException(RestoreException):
+    """
+    Bad ota version
+    """
+    message = "Bad version number submitted during sync."
 
 
 class InvalidSyncLogException(Exception):

--- a/corehq/ex-submodules/casexml/apps/phone/exceptions.py
+++ b/corehq/ex-submodules/casexml/apps/phone/exceptions.py
@@ -21,8 +21,8 @@ class BadStateException(RestoreException):
         self.case_ids = case_ids
 
     def __str__(self):
-        return "Phone state has mismatch. Expected %s but was %s. Cases: [%s]" % \
-                (self.expected, self.actual, ", ".join(self.case_ids))
+        return "Phone state hash mismatch. Expected %s but was %s. Cases: [%s]" % \
+            (self.expected, self.actual, ", ".join(self.case_ids))
 
 
 class BadVersionException(RestoreException):

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -194,7 +194,6 @@ class SyncLog(SafeSaveDocument, UnicodeMixIn):
         Get the dependent case state object associated with an id, or None if no such
         object is found
         """
-        # see comment in get_case_state for reasoning
         filtered_list = self._dependent_case_state_map()[case_id]
         if filtered_list:
             self._assert(len(filtered_list) == 1,

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -432,6 +432,7 @@ class RestoreCacheSettings(object):
         self.cache_timeout = cache_timeout if cache_timeout is not None else INITIAL_SYNC_CACHE_TIMEOUT
         self.overwrite_cache = overwrite_cache
 
+
 class RestoreState(object):
 
     def __init__(self, user, params):

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -405,7 +405,7 @@ class RestoreParams(object):
     This is just for user-defined settings that can be configured via the URL.
     """
 
-    def __init__(self, sync_log_id, version, state_hash='', include_item_count=False):
+    def __init__(self, sync_log_id='', version=V1, state_hash='', include_item_count=False):
         self.sync_log_id = sync_log_id
         self.version = version
         self.state_hash = state_hash
@@ -618,3 +618,20 @@ class RestoreConfig(object):
             # on initial sync, only cache if the duration was longer than the threshold
             if self.force_cache or duration > timedelta(seconds=INITIAL_SYNC_CACHE_THRESHOLD):
                 self.cache.set(self._initial_cache_key(), cache_payload, self.cache_timeout)
+
+
+class TemporaryRestoreConfig(RestoreConfig):
+    """
+    Temporary class to change the API of the constructor to ease the refactoring.
+    """
+
+    def __init__(self, domain=None, user=None, params=None):
+        params = params or RestoreParams()
+        super(TemporaryRestoreConfig, self).__init__(
+            user=user,
+            domain=domain,
+            restore_id=params.sync_log_id,
+            version=params.version,
+            state_hash=params.state_hash,
+            items=params.include_item_count,
+        )

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -441,9 +441,11 @@ class RestoreState(object):
     This allows the providers to set values on the state, for either logging or performance
     reasons.
     """
-    def __init__(self, user, params):
+    def __init__(self, domain, user, params):
+        self.domain = domain
         self.user = user
         self.params = params
+        self.provider_log = {}  # individual data providers can log stuff here
         # get set in the start_sync() function
         self.start_time = None
         self.duration = None
@@ -524,7 +526,7 @@ class RestoreConfig(object):
         self.cache_settings = cache_settings or RestoreCacheSettings()
 
         self.version = self.params.version
-        self.restore_state = RestoreState(self.user, self.params)
+        self.restore_state = RestoreState(self.domain, self.user, self.params)
 
         if domain and domain.commtrack_settings:
             self.stock_settings = domain.commtrack_settings.get_ota_restore_settings()

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -489,7 +489,6 @@ class RestoreConfig(object):
         self.cache_settings = cache_settings or RestoreCacheSettings()
 
         self.version = self.params.version
-        self.items = self.params.include_item_count
         self.restore_state = RestoreState(self.user, self.params)
 
         if domain and domain.commtrack_settings:
@@ -553,7 +552,7 @@ class RestoreConfig(object):
         new_synclog.save(**get_safe_write_kwargs())
 
         # start with standard response
-        with get_restore_class(user)(user.username, items=self.items) as response:
+        with get_restore_class(user)(user.username, items=self.params.include_item_count) as response:
             # add sync token info
             response.append(xml.get_sync_element(new_synclog.get_id))
             # registration block

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -36,7 +36,6 @@ from casexml.apps.phone.fixtures import generator
 from django.http import HttpResponse, StreamingHttpResponse
 from django.conf import settings
 from casexml.apps.phone.checksum import CaseStateHash
-from no_exceptions.exceptions import HttpException
 from wsgiref.util import FileWrapper
 
 logger = logging.getLogger(__name__)

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -569,9 +569,7 @@ class RestoreConfig(object):
         if cached_response.exists():
             return cached_response
 
-
         user = self.user
-
         # create a sync log for this
         last_synclog = self.restore_state.last_sync_log
         self.restore_state.start_sync()

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -11,13 +11,15 @@ import tempfile
 from couchdbkit import ResourceConflict, ResourceNotFound
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.phone.caselogic import BatchedCaseSyncOperation, CaseSyncUpdate
-from casexml.apps.phone.exceptions import MissingSyncLog, InvalidSyncLogException, SyncLogUserMismatch
+from casexml.apps.phone.exceptions import (
+    MissingSyncLog, InvalidSyncLogException, SyncLogUserMismatch,
+    BadStateException, RestoreException,
+)
 from casexml.apps.stock.consumption import compute_consumption_or_default
 from casexml.apps.stock.utils import get_current_ledger_transactions_multi
 from corehq.toggles import LOOSE_SYNC_TOKEN_VALIDATION, FILE_RESTORE, STREAM_RESTORE_CACHE, ENABLE_LOADTEST_USERS
 from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.parsing import json_format_datetime
-from casexml.apps.case.exceptions import BadStateException, RestoreException
 from casexml.apps.phone.models import SyncLog
 import logging
 from dimagi.utils.couch.database import get_db, get_safe_write_kwargs

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -412,6 +412,21 @@ class RestoreParams(object):
         self.include_item_count = include_item_count
 
 
+class RestoreCacheSettings(object):
+    """
+    Settings related to restore caching. These only apply if doing an initial restore and
+    are not used if `RestoreParams.sync_log_id` is set.
+
+    :param force_cache:     Set to `True` to force the response to be cached.
+    :param cache_timeout:   Override the default cache timeout of 1 hour.
+    :param overwrite_cache: Ignore any previously cached value and re-generate the restore response.
+    """
+
+    def __init__(self, force_cache=False, cache_timeout=None, overwrite_cache=False):
+        self.force_cache = force_cache
+        self.cache_timeout = cache_timeout
+        self.overwrite_cache = overwrite_cache
+
 class RestoreState(object):
 
     def __init__(self, user, params):
@@ -452,12 +467,6 @@ class RestoreConfig(object):
     :param stock_settings:  CommTrack stock settings for the domain.
                             If None, default settings will be used.
     :param domain:          The domain object. An instance of `Domain`.
-    :param force_cache:     Set to `True` to force the response to be cached.
-                            Only applies if `restore_id` is empty.
-    :param cache_timeout:   Override the default cache timeout of 1 hour.
-                            Only applies if `restore_id` is empty.
-    :param overwrite_cache: Ignore any previously cached value and re-generate the restore response.
-                            Only applies if `restore_id` is empty.
     """
 
     def __init__(self, user, restore_id="", version=V1, state_hash="",
@@ -625,8 +634,9 @@ class TemporaryRestoreConfig(RestoreConfig):
     Temporary class to change the API of the constructor to ease the refactoring.
     """
 
-    def __init__(self, domain=None, user=None, params=None):
+    def __init__(self, domain=None, user=None, params=None, cache_settings=None):
         params = params or RestoreParams()
+        cache_settings = cache_settings or RestoreCacheSettings()
         super(TemporaryRestoreConfig, self).__init__(
             user=user,
             domain=domain,
@@ -634,4 +644,7 @@ class TemporaryRestoreConfig(RestoreConfig):
             version=params.version,
             state_hash=params.state_hash,
             items=params.include_item_count,
+            force_cache=cache_settings.force_cache,
+            cache_timeout=cache_settings.cache_timeout,
+            overwrite_cache=cache_settings.overwrite_cache,
         )

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -572,7 +572,6 @@ class RestoreConfig(object):
 
         user = self.user
         # create a sync log for this
-        last_synclog = self.restore_state.last_sync_log
         self.restore_state.start_sync()
 
         # start with standard response

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -508,6 +508,10 @@ class RestoreState(object):
         new_synclog.save(**get_safe_write_kwargs())
         return new_synclog
 
+    @property
+    def restore_class(self):
+        return get_restore_class(self.user)
+
 
 class RestoreConfig(object):
     """
@@ -577,9 +581,9 @@ class RestoreConfig(object):
         self.restore_state.start_sync()
 
         # start with standard response
-        with get_restore_class(user)(user.username, items=self.params.include_item_count) as response:
-            providers = get_restore_providers()
-            for provider in providers:
+        with self.restore_state.restore_class(user.username, items=self.params.include_item_count) as response:
+            normal_providers = get_restore_providers()
+            for provider in normal_providers:
                 for element in provider.get_elements(self.restore_state):
                     response.append(element)
 

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -470,7 +470,7 @@ class RestoreConfig(object):
     """
 
     def __init__(self, user, restore_id="", version=V1, state_hash="",
-                 items=False, stock_settings=None, domain=None, force_cache=False,
+                 items=False, domain=None, force_cache=False,
                  cache_timeout=None, overwrite_cache=False):
         self.user = user
         self.version = version
@@ -484,9 +484,7 @@ class RestoreConfig(object):
         )
         self.restore_state = RestoreState(self.user, self.params)
 
-        if stock_settings:
-            self.stock_settings = stock_settings
-        elif domain and domain.commtrack_settings:
+        if domain and domain.commtrack_settings:
             self.stock_settings = domain.commtrack_settings.get_ota_restore_settings()
         else:
             self.stock_settings = StockSettings()

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -459,11 +459,11 @@ class RestoreConfig(object):
     :param overwrite_cache: Ignore any previously cached value and re-generate the restore response.
                             Only applies if `restore_id` is empty.
     """
+
     def __init__(self, user, restore_id="", version=V1, state_hash="",
                  items=False, stock_settings=None, domain=None, force_cache=False,
                  cache_timeout=None, overwrite_cache=False):
         self.user = user
-        self.restore_id = restore_id
         self.version = version
         self.state_hash = state_hash
         self.items = items

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_batched_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_batched_mode.py
@@ -11,7 +11,7 @@ class BatchRestoreTests(SyncBaseTest):
         self._createCaseStubs(case_ids, owner_id=USER_ID)
 
         restore_config, _ = assert_user_has_cases(self, self.user, case_ids)
-        self.assertEqual(restore_config.num_batches, 4)
+        self.assertEqual(restore_config.restore_state.provider_log['num_case_batches'], 4)
 
     def test_multiple_batches_sync(self):
         case_ids = ["case_{}".format(i) for i in range(10)]
@@ -20,4 +20,4 @@ class BatchRestoreTests(SyncBaseTest):
         restore_config, _ = assert_user_doesnt_have_cases(self, self.user, case_ids,
                                                           restore_id=self.sync_log.get_id)
         # 4 batches to fetch cases + 1 batch for cases left on phone
-        self.assertEqual(restore_config.num_batches, 5)
+        self.assertEqual(restore_config.restore_state.provider_log['num_case_batches'], 5)

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_restore.py
@@ -7,7 +7,7 @@ from casexml.apps.phone.tests.utils import generate_restore_payload
 from couchforms.tests.testutils import post_xform_to_couch
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.tests.util import check_xml_line_by_line, delete_all_cases, delete_all_sync_logs
-from casexml.apps.phone.restore import RestoreConfig
+from casexml.apps.phone.restore import TemporaryRestoreConfig
 from casexml.apps.case.xform import process_cases
 from datetime import datetime, date
 from casexml.apps.phone.models import User, SyncLog
@@ -33,7 +33,7 @@ class OtaRestoreTest(TestCase):
     def tearDown(self):
         delete_all_cases()
         delete_all_sync_logs()
-        restore_config = RestoreConfig(dummy_user())
+        restore_config = TemporaryRestoreConfig(user=dummy_user())
         restore_config.cache.delete(restore_config._initial_cache_key())
 
     def testFromDjangoUser(self):

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_restore.py
@@ -7,7 +7,7 @@ from casexml.apps.phone.tests.utils import generate_restore_payload
 from couchforms.tests.testutils import post_xform_to_couch
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.tests.util import check_xml_line_by_line, delete_all_cases, delete_all_sync_logs
-from casexml.apps.phone.restore import TemporaryRestoreConfig
+from casexml.apps.phone.restore import RestoreConfig
 from casexml.apps.case.xform import process_cases
 from datetime import datetime, date
 from casexml.apps.phone.models import User, SyncLog
@@ -33,7 +33,7 @@ class OtaRestoreTest(TestCase):
     def tearDown(self):
         delete_all_cases()
         delete_all_sync_logs()
-        restore_config = TemporaryRestoreConfig(user=dummy_user())
+        restore_config = RestoreConfig(user=dummy_user())
         restore_config.cache.delete(restore_config._initial_cache_key())
 
     def testFromDjangoUser(self):

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_state_hash.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_state_hash.py
@@ -1,6 +1,5 @@
 from django.test import TestCase
 from django.test.utils import override_settings
-from casexml.apps.case.exceptions import BadStateException
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.phone.models import SyncLog, User
 from datetime import datetime
@@ -8,6 +7,7 @@ from casexml.apps.phone.checksum import EMPTY_HASH, CaseStateHash
 from casexml.apps.case.xml import V2
 from casexml.apps.case.util import post_case_blocks
 from casexml.apps.case.tests.util import delete_all_sync_logs, delete_all_xforms, delete_all_cases
+from casexml.apps.phone.exceptions import BadStateException
 from casexml.apps.phone.tests.utils import generate_restore_payload, generate_restore_response
 from corehq import toggles
 from toggle.shortcuts import update_toggle_cache, clear_toggle_cache

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -16,7 +16,7 @@ from casexml.apps.case.tests.util import (check_user_has_case, delete_all_sync_l
     assert_user_has_case)
 from casexml.apps.case.xform import process_cases
 from casexml.apps.phone.models import SyncLog, User
-from casexml.apps.phone.restore import RestoreConfig, CachedResponse, TemporaryRestoreConfig, RestoreParams
+from casexml.apps.phone.restore import CachedResponse, TemporaryRestoreConfig, RestoreParams, RestoreCacheSettings
 from dimagi.utils.parsing import json_format_datetime
 from couchforms.models import XFormInstance
 from casexml.apps.case.xml import V2, V1
@@ -448,7 +448,10 @@ class SyncTokenCachingTest(SyncBaseTest):
         self.assertNotEqual(next_sync_log._id, versioned_sync_log._id)
 
     def test_initial_cache(self):
-        restore_config = RestoreConfig(self.user, force_cache=True)
+        restore_config = TemporaryRestoreConfig(
+            user=self.user,
+            cache_settings=RestoreCacheSettings(force_cache=True),
+        )
         original_payload = restore_config.get_payload()
         self.assertNotIsInstance(original_payload, CachedResponse)
 
@@ -537,7 +540,10 @@ class FileRestoreSyncTokenCachingTest(SyncTokenCachingTest):
 
     def testCacheInvalidationAfterFileDelete(self):
         # first request should populate the cache
-        original_payload = RestoreConfig(self.user, force_cache=True).get_payload()
+        original_payload = TemporaryRestoreConfig(
+            user=self.user,
+            cache_settings=RestoreCacheSettings(force_cache=True)
+        ).get_payload()
         self.assertNotIsInstance(original_payload, CachedResponse)
 
         # Delete cached file

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -2,6 +2,7 @@ from couchdbkit import ResourceNotFound
 from django.test.utils import override_settings
 from django.test import TestCase
 import os
+from casexml.apps.phone.exceptions import MissingSyncLog
 from toggle.shortcuts import update_toggle_cache, clear_toggle_cache
 from casexml.apps.phone.tests.utils import generate_restore_payload
 from casexml.apps.case.mock import CaseBlock, CaseFactory, CaseStructure, CaseRelationship
@@ -1113,7 +1114,7 @@ class LooseSyncTokenValidationTest(SyncBaseTest):
         _test()
 
     def test_restore_with_bad_log_default(self):
-        with self.assertRaises(ResourceNotFound):
+        with self.assertRaises(MissingSyncLog):
             RestoreConfig(
                 self.user, version=V2,
                 restore_id='not-a-valid-synclog-id',
@@ -1131,7 +1132,7 @@ class LooseSyncTokenValidationTest(SyncBaseTest):
             ).get_payload()
 
         LOOSE_SYNC_TOKEN_VALIDATION.set(domain, False, namespace='domain')
-        with self.assertRaises(ResourceNotFound):
+        with self.assertRaises(MissingSyncLog):
             _test()
 
         LOOSE_SYNC_TOKEN_VALIDATION.set(domain, True, namespace='domain')

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -2,7 +2,7 @@ from couchdbkit import ResourceNotFound
 from django.test.utils import override_settings
 from django.test import TestCase
 import os
-from casexml.apps.phone.exceptions import MissingSyncLog
+from casexml.apps.phone.exceptions import MissingSyncLog, RestoreException
 from toggle.shortcuts import update_toggle_cache, clear_toggle_cache
 from casexml.apps.phone.tests.utils import generate_restore_payload
 from casexml.apps.case.mock import CaseBlock, CaseFactory, CaseStructure, CaseRelationship
@@ -1169,6 +1169,6 @@ class LooseSyncTokenValidationTest(SyncBaseTest):
             _test()
 
         LOOSE_SYNC_TOKEN_VALIDATION.set(domain, True, namespace='domain')
-        # when the toggle is set the exception should be an HttpException instead
-        with self.assertRaises(HttpException):
+        # when the toggle is set the exception should be a RestoreException instead
+        with self.assertRaises(RestoreException):
             _test()

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -16,7 +16,7 @@ from casexml.apps.case.tests.util import (check_user_has_case, delete_all_sync_l
     assert_user_has_case)
 from casexml.apps.case.xform import process_cases
 from casexml.apps.phone.models import SyncLog, User
-from casexml.apps.phone.restore import CachedResponse, TemporaryRestoreConfig, RestoreParams, RestoreCacheSettings
+from casexml.apps.phone.restore import CachedResponse, RestoreConfig, RestoreParams, RestoreCacheSettings
 from dimagi.utils.parsing import json_format_datetime
 from couchforms.models import XFormInstance
 from casexml.apps.case.xml import V2, V1
@@ -46,7 +46,7 @@ class SyncBaseTest(TestCase):
         self.user = User(user_id=USER_ID, username=USERNAME,
                          password="changeme", date_joined=datetime(2011, 6, 9))
         # this creates the initial blank sync token in the database
-        restore_config = TemporaryRestoreConfig(user=self.user)
+        restore_config = RestoreConfig(user=self.user)
         self.sync_log = synclog_from_restore_payload(restore_config.get_payload().as_string())
         self.factory = CaseFactory(
             case_defaults={
@@ -60,7 +60,7 @@ class SyncBaseTest(TestCase):
         )
 
     def tearDown(self):
-        restore_config = TemporaryRestoreConfig(user=self.user)
+        restore_config = RestoreConfig(user=self.user)
         restore_config.cache.delete(restore_config._initial_cache_key())
 
     def _createCaseStubs(self, id_list, **kwargs):
@@ -413,7 +413,7 @@ class SyncTokenCachingTest(SyncBaseTest):
     def testCaching(self):
         self.assertFalse(self.sync_log.has_cached_payload(V2))
         # first request should populate the cache
-        original_payload = TemporaryRestoreConfig(
+        original_payload = RestoreConfig(
             user=self.user,
             params=RestoreParams(
                 version=V2,
@@ -426,7 +426,7 @@ class SyncTokenCachingTest(SyncBaseTest):
         self.assertTrue(self.sync_log.has_cached_payload(V2))
 
         # a second request with the same config should be exactly the same
-        cached_payload = TemporaryRestoreConfig(
+        cached_payload = RestoreConfig(
             user=self.user,
             params=RestoreParams(
                 version=V2,
@@ -436,7 +436,7 @@ class SyncTokenCachingTest(SyncBaseTest):
         self.assertEqual(original_payload, cached_payload)
 
         # caching a different version should also produce something new
-        versioned_payload = TemporaryRestoreConfig(
+        versioned_payload = RestoreConfig(
             user=self.user,
             params=RestoreParams(
                 version=V1,
@@ -448,21 +448,21 @@ class SyncTokenCachingTest(SyncBaseTest):
         self.assertNotEqual(next_sync_log._id, versioned_sync_log._id)
 
     def test_initial_cache(self):
-        restore_config = TemporaryRestoreConfig(
+        restore_config = RestoreConfig(
             user=self.user,
             cache_settings=RestoreCacheSettings(force_cache=True),
         )
         original_payload = restore_config.get_payload()
         self.assertNotIsInstance(original_payload, CachedResponse)
 
-        restore_config = TemporaryRestoreConfig(user=self.user)
+        restore_config = RestoreConfig(user=self.user)
         cached_payload = restore_config.get_payload()
         self.assertIsInstance(cached_payload, CachedResponse)
 
         self.assertEqual(original_payload.as_string(), cached_payload.as_string())
 
     def testCacheInvalidation(self):
-        original_payload = TemporaryRestoreConfig(
+        original_payload = RestoreConfig(
             user=self.user,
             params=RestoreParams(
                 version=V2,
@@ -479,7 +479,7 @@ class SyncTokenCachingTest(SyncBaseTest):
         self.assertFalse(self.sync_log.has_cached_payload(V2))
 
         # resyncing should recreate the cache
-        next_payload = TemporaryRestoreConfig(
+        next_payload = RestoreConfig(
             user=self.user,
             params=RestoreParams(
                 version=V2,
@@ -496,7 +496,7 @@ class SyncTokenCachingTest(SyncBaseTest):
         self.assertTrue(self.sync_log.phone_has_case(case_id))
 
     def testCacheNonInvalidation(self):
-        original_payload = TemporaryRestoreConfig(
+        original_payload = RestoreConfig(
             user=self.user,
             params=RestoreParams(
                 version=V2,
@@ -517,7 +517,7 @@ class SyncTokenCachingTest(SyncBaseTest):
             case_type=PARENT_TYPE,
             version=V2,
         ).as_xml()])
-        next_payload = TemporaryRestoreConfig(
+        next_payload = RestoreConfig(
             user=self.user,
             params=RestoreParams(
                 version=V2,
@@ -540,7 +540,7 @@ class FileRestoreSyncTokenCachingTest(SyncTokenCachingTest):
 
     def testCacheInvalidationAfterFileDelete(self):
         # first request should populate the cache
-        original_payload = TemporaryRestoreConfig(
+        original_payload = RestoreConfig(
             user=self.user,
             cache_settings=RestoreCacheSettings(force_cache=True)
         ).get_payload()
@@ -550,7 +550,7 @@ class FileRestoreSyncTokenCachingTest(SyncTokenCachingTest):
         os.remove(original_payload.get_filename())
 
         # resyncing should recreate the cache
-        next_file = TemporaryRestoreConfig(user=self.user).get_payload()
+        next_file = RestoreConfig(user=self.user).get_payload()
         self.assertNotIsInstance(next_file, CachedResponse)
         self.assertNotEqual(original_payload.get_filename(), next_file.get_filename())
 
@@ -1142,7 +1142,7 @@ class LooseSyncTokenValidationTest(SyncBaseTest):
 
     def test_restore_with_bad_log_default(self):
         with self.assertRaises(MissingSyncLog):
-            TemporaryRestoreConfig(
+            RestoreConfig(
                 domain=Domain(name="test_restore_with_bad_log_default"),
                 user=self.user,
                 params=RestoreParams(
@@ -1155,7 +1155,7 @@ class LooseSyncTokenValidationTest(SyncBaseTest):
         domain = 'restore-domain-with-toggle'
 
         def _test():
-            TemporaryRestoreConfig(
+            RestoreConfig(
                 domain=Domain(name=domain),
                 user=self.user,
                 params=RestoreParams(

--- a/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
@@ -1,7 +1,7 @@
 from xml.etree import ElementTree
 from casexml.apps.case.xml import V1
 from casexml.apps.phone.models import SyncLog
-from casexml.apps.phone.restore import RestoreConfig, TemporaryRestoreConfig, RestoreParams
+from casexml.apps.phone.restore import TemporaryRestoreConfig, RestoreParams, RestoreCacheSettings
 from casexml.apps.phone.xml import SYNC_XMLNS
 
 
@@ -25,8 +25,19 @@ def generate_restore_payload(user, restore_id="", version=V1, state_hash="",
 
         returns: the xml payload of the sync operation
     """
-    config = RestoreConfig(user, restore_id, version, state_hash, items=items,
-            overwrite_cache=overwrite_cache, force_cache=force_cache)
+    config = TemporaryRestoreConfig(
+        user=user,
+        params=RestoreParams(
+            sync_log_id=restore_id,
+            version=version,
+            state_hash=state_hash,
+            include_item_count=items
+        ),
+        cache_settings=RestoreCacheSettings(
+            overwrite_cache=overwrite_cache,
+            force_cache=force_cache,
+        )
+    )
     return config.get_payload().as_string()
 
 

--- a/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
@@ -1,7 +1,7 @@
 from xml.etree import ElementTree
 from casexml.apps.case.xml import V1
 from casexml.apps.phone.models import SyncLog
-from casexml.apps.phone.restore import RestoreConfig
+from casexml.apps.phone.restore import RestoreConfig, TemporaryRestoreConfig, RestoreParams
 from casexml.apps.phone.xml import SYNC_XMLNS
 
 
@@ -32,7 +32,13 @@ def generate_restore_payload(user, restore_id="", version=V1, state_hash="",
 
 def generate_restore_response(user, restore_id="", version=V1, state_hash="",
                               items=False):
-    config = RestoreConfig(user, restore_id, version, state_hash, items=items)
+    config = TemporaryRestoreConfig(
+        user=user,
+        params=RestoreParams(
+            sync_log_id=restore_id,
+            version=version,
+            state_hash=state_hash,
+            include_item_count=items
+        )
+    )
     return config.get_response()
-
-

--- a/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
@@ -1,7 +1,7 @@
 from xml.etree import ElementTree
 from casexml.apps.case.xml import V1
 from casexml.apps.phone.models import SyncLog
-from casexml.apps.phone.restore import TemporaryRestoreConfig, RestoreParams, RestoreCacheSettings
+from casexml.apps.phone.restore import RestoreConfig, RestoreParams, RestoreCacheSettings
 from casexml.apps.phone.xml import SYNC_XMLNS
 
 
@@ -25,7 +25,7 @@ def generate_restore_payload(user, restore_id="", version=V1, state_hash="",
 
         returns: the xml payload of the sync operation
     """
-    config = TemporaryRestoreConfig(
+    config = RestoreConfig(
         user=user,
         params=RestoreParams(
             sync_log_id=restore_id,
@@ -43,7 +43,7 @@ def generate_restore_payload(user, restore_id="", version=V1, state_hash="",
 
 def generate_restore_response(user, restore_id="", version=V1, state_hash="",
                               items=False):
-    config = TemporaryRestoreConfig(
+    config = RestoreConfig(
         user=user,
         params=RestoreParams(
             sync_log_id=restore_id,

--- a/corehq/ex-submodules/casexml/apps/phone/xml.py
+++ b/corehq/ex-submodules/casexml/apps/phone/xml.py
@@ -30,6 +30,7 @@ def get_sync_element(restore_id):
     elem.append(safe_element("restore_id", restore_id))
     return elem
 
+
 def get_case_element(case, updates, version=V1):
     
     check_version(version)


### PR DESCRIPTION
main changes:
- pushing various bits of config into different objects that can encapsulate them
- separation of restore state logic from code that does the work
- abstracting data providers out so that the restore code itself doesn't know what's in them

i'm going to keep working on this but might be nice to get these changes in incrementally (assuming they are agreed to be good). this is sort of just random cleanup before tackling ownership cleanliness sync as well as service-based restore.

open to feedback, wait for tests

@snopoke @dannyroberts cc @emord 
