### PR TITLE
don't step if parent not in dict

### DIFF
--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -186,7 +186,7 @@ class LocationTypesView(BaseCommTrackManageView):
                 assert lt['name'] not in visited, \
                     "There's a loc type cycle, we need to prohibit that"
                 visited.add(lt['name'])
-                if lt['parent_type']:
+                if lt['parent_type'] and lt['parent_type'] in lt_dict:
                     step(lt_dict[lt['parent_type']])
             step(loc_type)
 


### PR DESCRIPTION
@esoergel does the `parent_type` missing from the `lt_dict` constitute a different error?

http://manage.dimagi.com/default.asp?167892
