### PR TITLE
Increase LateFlag.template_width to 11%

### DIFF
--- a/corehq/apps/app_manager/detail_screen.py
+++ b/corehq/apps/app_manager/detail_screen.py
@@ -327,7 +327,7 @@ class EnumImage(Enum):
 @register_format_type('late-flag')
 class LateFlag(HideShortHeaderColumn):
 
-    template_width = "10%"
+    template_width = "11%"
 
     XPATH_FUNCTION = u"if({xpath} = '', '*', if(today() - date({xpath}) > {column.late_flag}, '*', ''))"
 


### PR DESCRIPTION
11% seems to be the goldilocks width; just wide enough to show the whole asterisk, but not so wide that it pushes other columns out of alignment with their headings.

cc @millerdev 
