### PR TITLE
Make commtrack tests pass in parallel

### DIFF
--- a/corehq/apps/commtrack/tests/test_sms_reporting.py
+++ b/corehq/apps/commtrack/tests/test_sms_reporting.py
@@ -3,8 +3,7 @@ from decimal import Decimal
 from casexml.apps.stock.models import StockReport, StockTransaction
 from corehq.apps.commtrack import const
 from corehq.apps.commtrack.models import RequisitionCase, StockState
-from casexml.apps.case.models import CommCareCase
-from corehq.apps.commtrack.tests.util import CommTrackTest, bootstrap_user, FIXED_USER, ROAMING_USER
+from corehq.apps.commtrack.tests.util import CommTrackTest, FIXED_USER, ROAMING_USER
 from corehq.apps.commtrack.sms import handle, SMSError
 from corehq.toggles import STOCK_AND_RECEIPT_SMS_HANDLER, NAMESPACE_DOMAIN
 

--- a/corehq/apps/sms/backend/test.py
+++ b/corehq/apps/sms/backend/test.py
@@ -1,3 +1,4 @@
+from couchdbkit import ResourceNotFound
 from corehq.apps.sms.forms import BackendForm
 from corehq.apps.sms.mixin import SMSBackend
 from dimagi.utils.couch.database import get_safe_write_kwargs
@@ -31,6 +32,12 @@ def bootstrap(id=None, to_console=True):
     """
     Create an instance of the test backend in the database
     """
+    if id:
+        try:
+            return TestBackend.get(id)
+        except ResourceNotFound:
+            pass
+
     backend = TestBackend(
         description='test backend',
         is_global=True,


### PR DESCRIPTION
@benrudolph 
Wait on tests.  This function manually sets id, so parallel tests throw doc update conflicts
