### PR TITLE
UCR sliding datespan

### DIFF
--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -868,8 +868,8 @@ def _render_report_configs(request, configs, domain, owner_id, couch_user, email
         "owner_name": couch_user.full_name or couch_user.get_email(),
         "email": email,
         "notes": notes,
-        "startdate": date_range["startdate"] if date_range else "",
-        "enddate": date_range["enddate"] if date_range else "",
+        "startdate": date_range.get("startdate") if date_range else "",
+        "enddate": date_range.get("enddate") if date_range else "",
     }), excel_attachments
 
 @login_and_domain_required

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -306,6 +306,11 @@ class ReportConfiguration(UnicodeMixIn, CachedCouchDocumentMixin, Document):
             'Columns cannot contain duplicate column_ids: {}',
         )
 
+        if [f['type'] for f in self.filters].count('sliding_date') > 1:
+            raise BadSpecError(_(
+                'Cannot have more than one filter with type "sliding_date".'
+            ))
+
         # these calls all implicitly do validation
         ReportFactory.from_spec(self)
         self.ui_filters

--- a/corehq/apps/userreports/reports/factory.py
+++ b/corehq/apps/userreports/reports/factory.py
@@ -64,6 +64,7 @@ def _build_dynamic_choice_list_filter(spec):
 class ReportFilterFactory(object):
     constructor_map = {
         'date': _build_date_filter,
+        'sliding_date': _build_date_filter,
         'choice_list': _build_choice_list_filter,
         'dynamic_choice_list': _build_dynamic_choice_list_filter,
         'numeric': _build_numeric_filter

--- a/corehq/apps/userreports/reports/filters.py
+++ b/corehq/apps/userreports/reports/filters.py
@@ -23,7 +23,10 @@ class FilterValue(object):
 class DateFilterValue(FilterValue):
 
     def __init__(self, filter, value):
-        assert filter.type == 'date'
+        assert filter.type in [
+            'date',
+            'sliding_date',
+        ]
         assert isinstance(value, DateSpan) or value is None
         super(DateFilterValue, self).__init__(filter, value)
 

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -34,6 +34,7 @@ class ReportFilter(JsonObject):
     def create_filter_value(self, value):
         return {
             'date': DateFilterValue,
+            'sliding_date': DateFilterValue,
             'numeric': NumericFilterValue,
             'choice_list': ChoiceListFilterValue,
             'dynamic_choice_list': ChoiceListFilterValue,
@@ -227,7 +228,7 @@ class FilterSpec(JsonObject):
     This is the spec for a report filter - a thing that should show up as a UI filter element
     in a report (like a date picker or a select list).
     """
-    type = StringProperty(required=True, choices=['date', 'numeric', 'choice_list', 'dynamic_choice_list'])
+    type = StringProperty(required=True, choices=['date', 'sliding_date', 'numeric', 'choice_list', 'dynamic_choice_list'])
     slug = StringProperty(required=True)  # this shows up as the ID in the filter HTML
     field = StringProperty(required=True)  # this is the actual column that is queried
     display = StringProperty()

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -174,6 +174,14 @@ class ConfigurableReport(JSONResponseMixin, TemplateView):
         """
         return self.report_config_id
 
+    @property
+    def has_datespan(self):
+        filters = self.spec.filters
+        return any(
+            filter['type'] == 'sliding_date'
+            for filter in filters
+        )
+
     @classmethod
     def get_report(cls, domain, slug, report_config_id):
         report = cls()

--- a/corehq/apps/userreports/templates/userreports/configurable_report.html
+++ b/corehq/apps/userreports/templates/userreports/configurable_report.html
@@ -62,7 +62,13 @@
 
         // Bind the ReportConfigsViewModel to the save button.
         var defaultConfig = {{ default_config|JSON }};
-        defaultConfig.date_range = null;
+        {% if report.has_datespan %}
+            if(!defaultConfig.date_range) {
+                defaultConfig.date_range = 'last7';
+            }
+        {% else %}
+            defaultConfig.date_range = null;
+        {% endif %}
         $("#savedReports").reportUserConfigurableConfigEditor({
             filterForm: $("#report-filters"),
             items: {{ report_configs|JSON }},


### PR DESCRIPTION
implements http://manage.dimagi.com/default.asp?162937

Uses the filter type "sliding_date" to represent a date that corresponds to the sliding date range.

Same UI for saving date ranges as in conventional reports.

@czue @NoahCarnahan 

To-do:
- [ ] Use properly formatted datepicker widget in saved reports modal
- [x] Prevent user from adding more than one filter of type "sliding_date"
- [ ] Add tests.
