### PR TITLE
Add 'starter app' facet to exchange

### DIFF
--- a/corehq/apps/appstore/templates/appstore/appstore_base.html
+++ b/corehq/apps/appstore/templates/appstore/appstore_base.html
@@ -242,8 +242,9 @@
     {% block view-tabs %}
     <div class="tabbable" style="padding-top: 15px;">
         <ul class="nav nav-pills">
-            <li{% if not sort_by %} class="active"{% endif %}><a href="{% urlencode request.path request.GET without "sort_by" %}">{% trans "Most Downloaded" %}</a></li>
-            <li{% if sort_by == 'newest' %} class="active"{% endif %}><a href="{% urlencode request.path request.GET with "sort_by" as "newest" %}">{% trans "Newest" %}</a></li>
+            <li{% if not sort_by and not show_starter_apps %} class="active"{% endif %}><a href="{% urlencode request.path request.GET without "sort_by" without 'is_starter_app' %}">{% trans "Most Downloaded" %}</a></li>
+            <li{% if sort_by == 'newest' %} class="active"{% endif %}><a href="{% urlencode request.path request.GET with "sort_by" as "newest" without 'is_starter_app' %}">{% trans "Newest" %}</a></li>
+            <li {% if show_starter_apps %} class="active"{% endif %}><a href="{% urlencode request.path request.GET with 'is_starter_app' as 'T' without 'sort_by' %}">{% trans "Starter Apps" %}</a></li>
         </ul>
     </div>
     {% endblock %}

--- a/corehq/apps/appstore/templates/appstore/appstore_base.html
+++ b/corehq/apps/appstore/templates/appstore/appstore_base.html
@@ -305,6 +305,7 @@
                     {% if app.short_description %}
                         <p>{{ app.short_description }}</p>
                     {% endif %}
+                    {% if app.is_starter_app %}<span class="label label-success">{% trans "Starter App" %}</span>{% endif %}
                 </div>
             </div>
         </div>

--- a/corehq/apps/appstore/views.py
+++ b/corehq/apps/appstore/views.py
@@ -117,6 +117,7 @@ def appstore(request, template="appstore/appstore_base.html"):
     hits = deduplicate(hits)
     d_results = [Domain.wrap(res['_source']) for res in hits]
 
+    starter_apps = request.GET.get('is_starter_app', None)
     sort_by = request.GET.get('sort_by', None)
     if sort_by == 'newest':
         pass
@@ -140,6 +141,7 @@ def appstore(request, template="appstore/appstore_base.html"):
         next_page=(page + 1),
         more_pages=more_pages,
         sort_by=sort_by,
+        show_starter_apps=starter_apps,
         include_unapproved=include_unapproved,
         facet_map=facet_map,
         facets=results.get("facets", []),

--- a/corehq/apps/appstore/views.py
+++ b/corehq/apps/appstore/views.py
@@ -19,7 +19,7 @@ from dimagi.utils.couch.database import apply_update
 from corehq.apps.fixtures.models import FixtureDataType
 
 
-SNAPSHOT_FACETS = ['project_type', 'license', 'author.exact']
+SNAPSHOT_FACETS = ['project_type', 'license', 'author.exact', 'is_starter_app']
 DEPLOYMENT_FACETS = ['deployment.region']
 SNAPSHOT_MAPPING = [
     ("", True, [
@@ -38,6 +38,15 @@ SNAPSHOT_MAPPING = [
             }
         },
         {"facet": "author.exact", "name": ugettext_lazy("Author"), "expanded": True},
+        # {
+        #     "facet": "is_starter_app",
+        #     "name": ugettext_lazy("Starter Application"),
+        #     "expanded": True,
+        #     "mapping": {
+        #         'T': 'Starter Application',
+        #         'F': 'Regular Application',
+        #     }
+        # },
     ]),
 ]
 DEPLOYMENT_MAPPING = [

--- a/corehq/apps/appstore/views.py
+++ b/corehq/apps/appstore/views.py
@@ -38,15 +38,6 @@ SNAPSHOT_MAPPING = [
             }
         },
         {"facet": "author.exact", "name": ugettext_lazy("Author"), "expanded": True},
-        # {
-        #     "facet": "is_starter_app",
-        #     "name": ugettext_lazy("Starter Application"),
-        #     "expanded": True,
-        #     "mapping": {
-        #         'T': 'Starter Application',
-        #         'F': 'Regular Application',
-        #     }
-        # },
     ]),
 ]
 DEPLOYMENT_MAPPING = [

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -192,7 +192,7 @@ class SnapshotSettingsForm(forms.Form):
         help_text=ugettext_noop("An optional file to tell users more about your app."))
     old_documentation_file = forms.BooleanField(required=False)
     cda_confirmed = BooleanField(required=False, label=ugettext_noop("Content Distribution Agreement"))
-    starter_app = BooleanField(required=False, label=ugettext_noop("This is a starter application"))
+    is_starter_app = BooleanField(required=False, label=ugettext_noop("This is a starter application"))
 
     def __init__(self, *args, **kw):
         self.dom = kw.pop("domain", None)
@@ -236,7 +236,7 @@ class SnapshotSettingsForm(forms.Form):
         )
 
         if self.is_superuser:
-            self.helper.layout.append(crispy.Fieldset('Starter App', 'starter_app',),)
+            self.helper.layout.append(crispy.Fieldset('Starter App', 'is_starter_app',),)
 
 
         self.fields['license'].help_text = \

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -192,9 +192,11 @@ class SnapshotSettingsForm(forms.Form):
         help_text=ugettext_noop("An optional file to tell users more about your app."))
     old_documentation_file = forms.BooleanField(required=False)
     cda_confirmed = BooleanField(required=False, label=ugettext_noop("Content Distribution Agreement"))
+    starter_app = BooleanField(required=False, label=ugettext_noop("This is a starter application"))
 
     def __init__(self, *args, **kw):
         self.dom = kw.pop("domain", None)
+        self.is_superuser = kw.pop("is_superuser", None)
         super(SnapshotSettingsForm, self).__init__(*args, **kw)
 
         self.helper = FormHelper()
@@ -232,6 +234,9 @@ class SnapshotSettingsForm(forms.Form):
                 'cda_confirmed',
             ),
         )
+
+        if self.is_superuser:
+            self.helper.layout.append(crispy.Fieldset('Starter App', 'starter_app',),)
 
 
         self.fields['license'].help_text = \

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1744,7 +1744,9 @@ class CreateNewExchangeSnapshotView(BaseAdminProjectSettingsView):
         for attr in init_attribs:
             initial[attr] = getattr(proj, attr)
 
-        return SnapshotSettingsForm(initial=initial, domain=self.domain_object)
+        return SnapshotSettingsForm(initial=initial,
+                                    domain=self.domain_object,
+                                    is_superuser=self.request.user.is_superuser)
 
     @property
     @memoized

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1727,7 +1727,10 @@ class CreateNewExchangeSnapshotView(BaseAdminProjectSettingsView):
     @memoized
     def snapshot_settings_form(self):
         if self.request.method == 'POST':
-            form = SnapshotSettingsForm(self.request.POST, self.request.FILES, domain=self.domain_object)
+            form = SnapshotSettingsForm(self.request.POST,
+                                        self.request.FILES,
+                                        domain=self.domain_object,
+                                        is_superuser=self.request.user.is_superuser)
             return form
 
         proj = self.published_snapshot if self.published_snapshot else self.domain_object

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1816,7 +1816,7 @@ class CreateNewExchangeSnapshotView(BaseAdminProjectSettingsView):
             new_domain.author = request.POST.get('author', None)
 
             new_domain.is_approved = False
-            new_domain.starter_app = request.POST.get('starter_app', '') == 'on'
+            new_domain.is_starter_app = request.POST.get('is_starter_app', '') == 'on'
             publish_on_submit = request.POST.get('publish_on_submit', "no") == "yes"
 
             image = self.snapshot_settings_form.cleaned_data['image']

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1816,6 +1816,7 @@ class CreateNewExchangeSnapshotView(BaseAdminProjectSettingsView):
             new_domain.author = request.POST.get('author', None)
 
             new_domain.is_approved = False
+            new_domain.starter_app = request.POST.get('starter_app', '') == 'on'
             publish_on_submit = request.POST.get('publish_on_submit', "no") == "yes"
 
             image = self.snapshot_settings_form.cleaned_data['image']

--- a/corehq/pillows/mappings/domain_mapping.py
+++ b/corehq/pillows/mappings/domain_mapping.py
@@ -1,5 +1,5 @@
-DOMAIN_INDEX = "hqdomains_20150403_1448"
-DOMAIN_MAPPING={'_meta': {'comment': 'Yedi modified on 3/20/2014',
+DOMAIN_INDEX = "hqdomains_201505012_1117"
+DOMAIN_MAPPING={'_meta': {'comment': 'Farid modified on 5/12/2015',
            'created': None},
  'date_detection': False,
  'date_formats': ['yyyy-MM-dd',
@@ -189,6 +189,7 @@ DOMAIN_MAPPING={'_meta': {'comment': 'Yedi modified on 3/20/2014',
                 'is_sms_billable': {'type': 'boolean'},
                 'is_snapshot': {'type': 'boolean'},
                 'is_test': {'type': 'string'},
+                'is_starter_app': {'type': 'boolean'},
                 'license': {'type': 'string'},
                 'migrations': {'dynamic': False,
                                'properties': {'doc_type': {'index': 'not_analyzed',


### PR DESCRIPTION
@amsagoff what do you think of this? Not too sure about the language, but I think this makes sense.
http://manage.dimagi.com/default.asp?167132#938749
# Admin-only option on publish page

![screen shot 2015-05-12 at 12 39 32 pm](https://cloud.githubusercontent.com/assets/146896/7585421/18d24bf0-f8a4-11e4-8a81-3b43536b6d09.png)

There are 2 options on the exchange listing:
# option 1 filter button at the top

![screen shot 2015-05-12 at 12 37 44 pm](https://cloud.githubusercontent.com/assets/146896/7585468/5317420c-f8a4-11e4-9f1c-4ea70e740781.png)
# option 2 new facet on the side

I thought this was a bit weird, as there would only be one option here.
![screen shot 2015-05-12 at 12 38 07 pm](https://cloud.githubusercontent.com/assets/146896/7585482/6277d8a6-f8a4-11e4-8b34-980918977a54.png)

This PR is for option 1, but wouldn't be hard to have option 2 instead.

I also added the "Starter Application" badge to each application tile if they are starter apps. 

Enchantress @gcapalbo 
FYI @czue 
