### PR TITLE
Use form context

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/backbone/apps.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/backbone/apps.js
@@ -640,6 +640,11 @@ cloudCare.AppView = Backbone.View.extend({
             self.caseSelectionView.model.set("childCase", caseModel);
         }
 
+        data.formContext = {
+            // Ensures that caseModel and collection are defined before trying to access allCaseIds
+            all_case_ids: caseModel ? (caseModel.collection ? caseModel.collection.allCaseIds : null) : null,
+            case_model: caseModel ? caseModel.toJSON() : null
+        };
         data.onsubmit = function (xml) {
             window.mainView.router.view.dirty = false;
             // post to receiver

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -339,7 +339,10 @@ def filter_cases(request, domain, app_id, module_id, parent_id=None):
             'parents': parents
         })
     else:
-        return json_response(cases)
+        return json_response({
+            'cases': cases,
+            'all_case_ids': case_ids  # Used to send to touchforms so we do not have to fetch later
+        })
 
 @cloudcare_api
 def get_apps_api(request, domain):


### PR DESCRIPTION
@czue 
elf: @esoergel 

This is one optimization that can be expanded upon. We are loading a lot of the case list data twice. I'm just trying to wrap my head around what the universe of case ids should be for a form. `allCaseIds` seems to cover the status quo, but I'm curious if I can just use the ids loaded in the `casedb` and that'd be sufficient. I also haven't explored too much when a user has a case filter defined
