### PR TITLE
Use primary key to refer to location types

### DIFF
--- a/corehq/apps/commtrack/static/commtrack/ko/locations.js
+++ b/corehq/apps/commtrack/static/commtrack/ko/locations.js
@@ -70,7 +70,7 @@ function LocationSettingsViewModel() {
     this.has_cycles = function() {
         var loc_type_parents = {};
         $.each(this.loc_types(), function(i, loc_type) {
-            loc_type_parents[loc_type.name()] = loc_type.parent_type();
+            loc_type_parents[loc_type.pk] = loc_type.parent_type();
         });
 
         var already_visited = function(lt, visited) {
@@ -85,7 +85,7 @@ function LocationSettingsViewModel() {
         };
         for (var i = 0; i < this.loc_types().length; i++) {
             var visited = [];
-                loc_type = this.loc_types()[i].name();
+                loc_type = this.loc_types()[i].pk;
             if (already_visited(loc_type, visited)) {
                 return true;
             }
@@ -108,10 +108,19 @@ function LocationSettingsViewModel() {
     };
 }
 
+// Make a fake pk to refer to this location type even if the name changes
+var get_fake_pk = function () {
+    var counter = 0;
+    return function() {
+        counter ++;
+        return "fake-pk-" + counter;
+    };
+}();
+
 function LocationTypeModel(data, root) {
     var name = data.name || '';
     var self = this;
-    this.pk = data.pk || null;
+    this.pk = data.pk || get_fake_pk();
     this.name = ko.observable(name);
 
     this.parent_type = ko.observable(data.parent_type);

--- a/corehq/apps/locations/templates/locations/settings.html
+++ b/corehq/apps/locations/templates/locations/settings.html
@@ -117,7 +117,7 @@
                         <td class="control-group">
                             <select data-bind="options: $root.loc_types,
                                                optionsText: 'name',
-                                               optionsValue: 'name',
+                                               optionsValue: 'pk',
                                                value: parent_type,
                                                optionsCaption: '\u2013top level\u2013'">
                             </select>

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -129,7 +129,7 @@ class LocationTypesView(BaseLocationView):
         return {
             'pk': loctype.pk,
             'name': loctype.name,
-            'parent_type': (loctype.parent_type.name
+            'parent_type': (loctype.parent_type.pk
                             if loctype.parent_type else None),
             'administrative': loctype.administrative,
             'shares_cases': loctype.shares_cases,
@@ -140,13 +140,20 @@ class LocationTypesView(BaseLocationView):
         payload = json.loads(request.POST.get('json'))
         sql_loc_types = {}
 
+        def _is_fake_pk(pk):
+            return isinstance(pk, basestring) and pk.startswith("fake-pk-")
+
         def mk_loctype(name, parent_type, administrative,
                        shares_cases, view_descendants, pk):
             parent = sql_loc_types[parent_type] if parent_type else None
 
-            try:
-                loc_type = LocationType.objects.get(domain=self.domain, pk=pk)
-            except LocationType.DoesNotExist:
+            loc_type = None
+            if not _is_fake_pk(pk):
+                try:
+                    loc_type = LocationType.objects.get(domain=self.domain, pk=pk)
+                except LocationType.DoesNotExist:
+                    pass
+            if loc_type is None:
                 loc_type = LocationType(domain=self.domain)
             loc_type.name = name
             loc_type.administrative = administrative
@@ -154,7 +161,7 @@ class LocationTypesView(BaseLocationView):
             loc_type.shares_cases = shares_cases
             loc_type.view_descendants = view_descendants
             loc_type.save()
-            sql_loc_types[name] = loc_type
+            sql_loc_types[pk] = loc_type
 
         loc_types = payload['loc_types']
         pks = []
@@ -162,7 +169,9 @@ class LocationTypesView(BaseLocationView):
             for prop in ['name', 'parent_type', 'administrative',
                          'shares_cases', 'view_descendants', 'pk']:
                 assert prop in loc_type, "Missing a location type property!"
-            pks.append(loc_type['pk'])
+            pk = loc_type['pk']
+            if not _is_fake_pk(pk):
+                pks.append(loc_type['pk'])
 
         hierarchy = self.get_hierarchy(loc_types)
 
@@ -196,7 +205,7 @@ class LocationTypesView(BaseLocationView):
         """
         Return loc types in order from parents to children
         """
-        lt_dict = {lt['name']: lt for lt in loc_types}
+        lt_dict = {lt['pk']: lt for lt in loc_types}
 
         # Make sure there are no cycles
         for loc_type in loc_types:


### PR DESCRIPTION
Resolves http://manage.dimagi.com/default.asp?167892
Been meaning to do this for a while - glad for an excuse.  This uses an unchanging unique ID (pk for existing location types, autogenerated "fake pk" for new location types) to refer to a location type, rather than the name, which can be changed.

@benrudolph
@snopoke FYI
