### PR TITLE
Don't auto-populate products or location types

### DIFF
--- a/corehq/apps/commtrack/tests/test_settings.py
+++ b/corehq/apps/commtrack/tests/test_settings.py
@@ -1,14 +1,16 @@
 from django.test import TestCase
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.commtrack.models import CommtrackConfig, ConsumptionConfig, StockRestoreConfig
-from corehq.apps.commtrack.tests.util import bootstrap_domain
 from corehq.apps.commtrack.const import DAYS_IN_MONTH
 from corehq.apps.consumption.shortcuts import set_default_monthly_consumption_for_domain
+
+from .util import bootstrap_domain, bootstrap_products
 
 
 class CommTrackSettingsTest(TestCase):
     def testOTASettings(self):
         self.domain = bootstrap_domain()
+        bootstrap_products(self.domain.name)
         ct_settings = CommtrackConfig.for_domain(self.domain.name)
         ct_settings.consumption_config = ConsumptionConfig(
             min_transactions=10,

--- a/corehq/apps/commtrack/tests/util.py
+++ b/corehq/apps/commtrack/tests/util.py
@@ -11,8 +11,7 @@ from corehq.apps.locations.models import Location, LocationType
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.domain.models import Domain
 from corehq.apps.commtrack.sms import StockReportParser, process
-from corehq.apps.commtrack.util import get_default_requisition_config, \
-    bootstrap_location_types
+from corehq.apps.commtrack.util import get_default_requisition_config
 from corehq.apps.commtrack.models import SupplyPointCase, CommtrackConfig, ConsumptionConfig
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.sms.backend import test
@@ -105,6 +104,26 @@ def bootstrap_user(setup, username=TEST_USER, domain=TEST_DOMAIN,
 
     user.save_verified_number(domain, phone_number, verified=True, backend_id=backend)
     return CommCareUser.wrap(user.to_json())
+
+
+def bootstrap_location_types(domain):
+    previous = None
+    for name, administrative in [
+        ('state', True),
+        ('district', True),
+        ('block', True),
+        ('village', True),
+        ('outlet', False),
+    ]:
+        location_type, _ = LocationType.objects.get_or_create(
+            domain=domain,
+            name=name,
+            defaults={
+                'parent_type': previous,
+                'administrative': administrative,
+            },
+        )
+        previous = location_type
 
 
 def make_loc(code, name=None, domain=TEST_DOMAIN, type=TEST_LOCATION_TYPE, parent=None):

--- a/corehq/apps/commtrack/tests/util.py
+++ b/corehq/apps/commtrack/tests/util.py
@@ -1,25 +1,28 @@
 from django.test import TestCase
+from lxml import etree
+
 from casexml.apps.case.tests import delete_all_cases, delete_all_xforms
 from casexml.apps.case.tests.util import delete_all_sync_logs
 from casexml.apps.case.xml import V2
 from casexml.apps.phone.tests.utils import generate_restore_payload
-from casexml.apps.stock.models import StockReport, StockTransaction
 from casexml.apps.stock.const import COMMTRACK_REPORT_XMLNS
-from corehq.apps.commtrack import const
-from corehq.apps.groups.models import Group
-from corehq.apps.locations.models import Location, LocationType
-from corehq.apps.domain.shortcuts import create_domain
-from corehq.apps.domain.models import Domain
-from corehq.apps.commtrack.sms import StockReportParser, process
-from corehq.apps.commtrack.util import get_default_requisition_config, get_or_create_default_program
-from corehq.apps.commtrack.models import SupplyPointCase, CommtrackConfig, ConsumptionConfig
-from corehq.apps.users.models import CommCareUser
-from corehq.apps.sms.backend import test
-from corehq.apps.commtrack.helpers import make_supply_point
-from corehq.apps.products.models import Product
+from casexml.apps.stock.models import StockReport, StockTransaction
 from couchforms.models import XFormInstance
 from dimagi.utils.couch.database import get_safe_write_kwargs
-from lxml import etree
+
+from corehq.apps.domain.models import Domain
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.groups.models import Group
+from corehq.apps.locations.models import Location, LocationType
+from corehq.apps.products.models import Product
+from corehq.apps.sms.backend import test
+from corehq.apps.users.models import CommCareUser
+
+from .. import const
+from ..helpers import make_supply_point
+from ..models import SupplyPointCase, CommtrackConfig, ConsumptionConfig
+from ..sms import StockReportParser, process
+from ..util import get_default_requisition_config, get_or_create_default_program
 
 
 TEST_DOMAIN = 'commtrack-test'

--- a/corehq/apps/commtrack/util.py
+++ b/corehq/apps/commtrack/util.py
@@ -54,16 +54,6 @@ def get_supply_point(domain, site_code=None, loc=None):
     }
 
 
-def make_product(domain, name, code, program_id):
-    p = Product()
-    p.domain = domain
-    p.name = name
-    p.code = code.lower()
-    p.program_id = program_id
-    p.save()
-    return p
-
-
 def make_program(domain, name, code, default=False):
     p = Program()
     p.domain = domain
@@ -86,27 +76,6 @@ def get_or_create_default_program(domain):
             _('uncategorized'),
             default=True
         )
-
-
-def bootstrap_location_types(domain):
-    previous = None
-    for name, administrative in [
-        ('state', True),
-        ('district', True),
-        ('block', True),
-        ('village', True),
-        ('outlet', False),
-    ]:
-        location_type, _ = LocationType.objects.get_or_create(
-            domain=domain,
-            name=name,
-            defaults={
-                'parent_type': previous,
-                'administrative': administrative,
-            },
-        )
-        previous = location_type
-
 
 
 def bootstrap_commtrack_settings_if_necessary(domain, requisitions_enabled=False):
@@ -165,11 +134,6 @@ def bootstrap_commtrack_settings_if_necessary(domain, requisitions_enabled=False
     config.save()
 
     program = get_or_create_default_program(domain.name)
-    make_product(domain.name, 'Sample Product 1', 'pp', program.get_id)
-    make_product(domain.name, 'Sample Product 2', 'pq', program.get_id)
-    make_product(domain.name, 'Sample Product 3', 'pr', program.get_id)
-
-    bootstrap_location_types(domain.name)
 
     # Enable feature flags if necessary - this is required by exchange
     # and should have no effect on changing the project settings directly

--- a/corehq/apps/locations/tests/test_locations.py
+++ b/corehq/apps/locations/tests/test_locations.py
@@ -4,7 +4,7 @@ from corehq.apps.locations.models import Location, LocationType, SQLLocation, \
 from corehq.apps.locations.tests.util import make_loc
 from corehq.apps.locations.fixtures import location_fixture_generator
 from corehq.apps.commtrack.helpers import make_supply_point, make_product
-from corehq.apps.commtrack.util import bootstrap_location_types
+from corehq.apps.commtrack.tests.util import bootstrap_location_types
 from corehq.apps.users.models import CommCareUser
 from django.test import TestCase
 from couchdbkit import ResourceNotFound

--- a/custom/ewsghana/tests/test_locations_sync.py
+++ b/custom/ewsghana/tests/test_locations_sync.py
@@ -2,7 +2,8 @@ import json
 import os
 from django.test import TestCase
 from corehq.apps.commtrack.models import SupplyPointCase
-from corehq.apps.commtrack.tests.util import bootstrap_domain as initial_bootstrap
+from corehq.apps.commtrack.tests.util import (bootstrap_products,
+                                              bootstrap_domain as initial_bootstrap)
 from corehq.apps.locations.models import Location as CouchLocation, SQLLocation
 from corehq.apps.products.models import SQLProduct
 from custom.ewsghana.api import Location, EWSApi, Product
@@ -19,6 +20,7 @@ class LocationSyncTest(TestCase):
         cls.api_object = EWSApi(TEST_DOMAIN, cls.endpoint)
         cls.datapath = os.path.join(os.path.dirname(__file__), 'data')
         initial_bootstrap(TEST_DOMAIN)
+        bootstrap_products(TEST_DOMAIN)
         cls.api_object.prepare_commtrack_config()
         with open(os.path.join(cls.datapath, 'sample_products.json')) as f:
             for p in json.loads(f.read()):


### PR DESCRIPTION
We decided to get rid of these.  Good idea to wait on build (although I ran it locally)
@benrudolph 
