### PR TITLE
Get rid of monthly invoice summary

### DIFF
--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -127,9 +127,6 @@ def generate_invoices(based_on_date=None, check_existing=False, is_test=False):
                     "[BILLING] Error occurred while creating invoice for "
                     "domain %s: %s" % (domain.name, e)
                 )
-    # And finally...
-    if not is_test:
-        send_bookkeeper_email()
 
 
 def send_bookkeeper_email(month=None, year=None, emails=None):


### PR DESCRIPTION
This change prevents the invoice summary from being mailed out automatically on the first of every month. It can still be sent from the [Trigger Bookkeeper Email view](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/accounting/views.py#L578).

This is for [FogBugz 167973](http://manage.dimagi.com/default.asp?167973).

@amsagoff, @millerdev 
