### PR TITLE
Properly strip suffix

### DIFF
--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -489,7 +489,7 @@ def process_url_params(params, columns):
 
         for suffix, fn in sql_directives:
             if key.endswith(suffix):
-                field = key.rstrip(suffix)
+                field = key[:-len(suffix)]
                 if field not in columns:
                     raise UserQueryError(_('No field named {}').format(field))
                 sql_filters.append(fn(columns[field], value))


### PR DESCRIPTION
`strip` and `rstrip` use the argument string as a collection for some reason...

``` python
>>> 'ethan-range'.rstrip('-range')
'eth'
```

@benrudolph
