### PR TITLE
Itemsets not avaiable for community plan

### DIFF
--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -1232,7 +1232,8 @@ def form_designer(request, domain, app_id, module_id=None, form_id=None,
                             unique_form_id=form.unique_id)
 
     vellum_plugins = ["modeliteration"]
-    if toggles.VELLUM_ITEMSETS.enabled(domain):
+    if (toggles.VELLUM_ITEMSETS.enabled(domain) and request.subscription):
+        # request.subscription checks it's not a community subscription
         vellum_plugins.append("itemset")
     if toggles.VELLUM_TRANSACTION_QUESTION_TYPES.enabled(domain):
         vellum_plugins.append("commtrack")


### PR DESCRIPTION
Going to be pretty tough to use itemsets in vellum if you can't create lookup tables

cc @czue
