### PR TITLE
Use new send_to_elasticsearch method

### DIFF
--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -981,7 +981,7 @@ class CommConnectProjectSpacesReport(GlobalAdminReports):
     name = ugettext_noop('Project Spaces Using Messaging')
     default_params = {
         'es_is_test': 'false',
-        'es_cp_sms_ever': 'true',
+        'es_cp_sms_ever': 'T',
     }
     indicators = [
         'commconnect_domain_count',


### PR DESCRIPTION
Calculated properties were only getting updated on some domains and there didn't seem to be a pattern. I think it may have to do with es timing out after 30 seconds (default for get_es), so no longer using the stream.

cc @czue 
