### PR TITLE
Stale OK

### DIFF
--- a/corehq/apps/cloudcare/api.py
+++ b/corehq/apps/cloudcare/api.py
@@ -184,7 +184,8 @@ class CaseAPIHelper(object):
                 for bool in status_to_closed_flags(self.status):
                     yield [self.domain, owner_id, bool]
 
-        view_results = CommCareCase.view('hqcase/by_owner',
+        view_results = CommCareCase.view(
+            'hqcase/by_owner',
             keys=keys,
             include_docs=False,
             reduce=False,

--- a/corehq/apps/cloudcare/api.py
+++ b/corehq/apps/cloudcare/api.py
@@ -1,6 +1,7 @@
 import json
 from couchdbkit.exceptions import ResourceNotFound
 from django.contrib.humanize.templatetags.humanize import naturaltime
+from django.conf import settings
 from casexml.apps.case.util import iter_cases
 from corehq.apps.cloudcare.exceptions import RemoteAppError
 from corehq.apps.users.models import CouchUser
@@ -183,8 +184,12 @@ class CaseAPIHelper(object):
                 for bool in status_to_closed_flags(self.status):
                     yield [self.domain, owner_id, bool]
 
-        view_results = CommCareCase.view('hqcase/by_owner', keys=keys,
-                                         include_docs=False, reduce=False)
+        view_results = CommCareCase.view('hqcase/by_owner',
+            keys=keys,
+            include_docs=False,
+            reduce=False,
+            stale=settings.COUCH_STALE_QUERY
+        )
         ids = [res["id"] for res in view_results]
         return self._case_results(ids)
 


### PR DESCRIPTION
@dannyroberts do you think the implications of this would be OK? I've been doing some profiling of cloudcare and sometimes this just gets massively stuck:

```
   Ordered by: cumulative time, call count
   List reduced from 459 to 200 due to restriction <200>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000   23.003   23.003 /Users/benrudolph/Dimagi/commcare-hq/corehq/apps/cloudcare/views.py:245(get_cases)
        1    0.000    0.000   23.001   23.001 /Users/benrudolph/Dimagi/commcare-hq/corehq/apps/cloudcare/api.py:201(get_filtered_cases)
        1    0.000    0.000   23.001   23.001 /Users/benrudolph/Dimagi/commcare-hq/corehq/apps/cloudcare/api.py:170(get_owned)
       53    0.000    0.000   22.918    0.432 /Users/benrudolph/.virtualenvs/commcare-hq/lib/python2.7/site-packages/couchdbkit/client.py:972(iterator)
        4    0.000    0.000   22.918    5.729 /Users/benrudolph/.virtualenvs/commcare-hq/lib/python2.7/site-packages/couchdbkit/client.py:1050(_fetch_if_needed)
        4    0.000    0.000   22.918    5.729 /Users/benrudolph/.virtualenvs/commcare-hq/lib/python2.7/site-packages/couchdbkit/client.py:1021(fetch)
       45    0.000    0.000   22.793    0.507 /Users/benrudolph/.virtualenvs/commcare-hq/lib/python2.7/site-packages/http_parser/_socketio.py:56(readinto)
       45    0.000    0.000   22.793    0.507 /Users/benrudolph/.virtualenvs/commcare-hq/lib/python2.7/site-packages/http_parser/_socketio.py:24(<lambda>)
       45    0.001    0.000   22.793    0.507 /System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/ssl.py:245(recv_into)
       45   22.792    0.506   22.792    0.506 /System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/ssl.py:154(read)
        6    0.000    0.000   22.677    3.780 /Users/benrudolph/.virtualenvs/commcare-hq/lib/python2.7/site-packages/couchdbkit/resource.py:69(request)
        6    0.000    0.000   22.677    3.779 /Users/benrudolph/.virtualenvs/commcare-hq/lib/python2.7/site-packages/restkit/resource.py:164(request)
        6    0.000    0.000   22.676    3.779 /Users/benrudolph/.virtualenvs/commcare-hq/lib/python2.7/site-packages/restkit/client.py:415(request)
        6    0.000    0.000   22.676    3.779 /Users/benrudolph/.virtualenvs/commcare-hq/lib/python2.7/site-packages/restkit/client.py:293(perform)
        4    0.000    0.000   22.602    5.651 /Users/benrudolph/.virtualenvs/commcare-hq/lib/python2.7/site-packages/couchdbkit/client.py:1046(fetch_raw)
        4    0.000    0.000   22.602    5.651 /Users/benrudolph/.virtualenvs/commcare-hq/lib/python2.7/site-packages/couchdbkit/client.py:718(raw_view)
        6    0.000    0.000   22.488    3.748 /Users/benrudolph/.virtualenvs/commcare-hq/lib/python2.7/site-packages/restkit/client.py:456(get_response)
       12    0.000    0.000   22.486    1.874 /Users/benrudolph/.virtualenvs/commcare-hq/lib/python2.7/site-packages/http_parser/http.py:135(headers)
       22    0.000    0.000   22.484    1.022 /Users/benrudolph/.virtualenvs/commcare-hq/lib/python2.7/site-packages/http_parser/http.py:50(_check_headers_complete)
        6    0.000    0.000   22.484    3.747 /Users/benrudolph/.virtualenvs/commcare-hq/lib/python2.7/site-packages/http_parser/http.py:191(__next__)
        3    0.000    0.000   20.191    6.730 /Users/benrudolph/.virtualenvs/commcare-hq/lib/python2.7/site-packages/restkit/resource.py:132(post)
        1    0.000    0.000   10.253   10.253 /Users/benrudolph/Dimagi/commcare-hq/corehq/apps/cloudcare/api.py:118(_case_results)
```

Other times it's fine and returns in a second. Which is pretty in sync with the complaints we're getting. My logic is that most of the time some other domain is taking a dump on the database and that slows everyone else down (to like minutes on a page load). 

elf: @esoergel 
