### PR TITLE
doc_ret needs a value for 'deployment'

### DIFF
--- a/corehq/pillows/domain.py
+++ b/corehq/pillows/domain.py
@@ -49,11 +49,11 @@ class DomainPillow(HQPillow):
                                        "mapping": self.default_mapping})
 
     def change_transform(self, doc_dict):
-        doc_ret = copy.deepcopy(doc_dict)
         sub =  Subscription.objects.filter(
                 subscriber__domain=doc_dict['name'],
                 is_active=True)
         doc_dict['deployment'] = doc_dict.get('deployment', None) or {}
+        doc_ret = copy.deepcopy(doc_dict)
         countries = doc_dict['deployment'].get('countries', [])
         doc_ret['deployment']['countries'] = []
         if sub:

--- a/corehq/pillows/domain.py
+++ b/corehq/pillows/domain.py
@@ -49,11 +49,11 @@ class DomainPillow(HQPillow):
                                        "mapping": self.default_mapping})
 
     def change_transform(self, doc_dict):
+        doc_ret = copy.deepcopy(doc_dict)
         sub =  Subscription.objects.filter(
                 subscriber__domain=doc_dict['name'],
                 is_active=True)
-        doc_dict['deployment'] = doc_dict.get('deployment', None) or {}
-        doc_ret = copy.deepcopy(doc_dict)
+        doc_ret['deployment'] = doc_dict.get('deployment', None) or {}
         countries = doc_dict['deployment'].get('countries', [])
         doc_ret['deployment']['countries'] = []
         if sub:


### PR DESCRIPTION
Deepcopy doc_dict after doc_dict['deployment'] has been assigned an empty dict if necessary, not before.

[FB 168313](http://manage.dimagi.com/default.asp?168313)
