### PR TITLE
don't 500 if billing contact info does not exist

### DIFF
--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -553,7 +553,7 @@ class SubscriptionForm(forms.Form):
             if (
                 not self.cleaned_data['do_not_invoice']
                 and (
-                    not account.billingcontactinfo
+                    not BillingContactInfo.objects.filter(account=account).exists()
                     or not account.billingcontactinfo.emails
                 )
             ):


### PR DESCRIPTION
fixes the following error:

```
  File "/home/cchq/www/production/code_root/corehq/apps/accounting/forms.py", line 556, in clean
    not account.billingcontactinfo

  File "/home/cchq/www/production/python_env/local/lib/python2.7/site-packages/django/db/models/fields/related.py", line 206, in __get__
    self.related.get_accessor_name()))

DoesNotExist: BillingAccount has no billingcontactinfo.
```

@benrudolph 
