### PR TITLE
Update breadcrumbs in app manager

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/apps_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/apps_base.html
@@ -10,7 +10,7 @@
 {% block page-title %}
     <ul class="breadcrumb">
         <li>
-            <a href="{% if app %}{% url "view_app" domain app.id %}{% else %}#{% endif %}"><strong>{% trans "Applications" %}</strong></a>
+            <strong>{% trans "Applications" %}</strong>
         </li>
         {% block breadcrumbs %}
         {% endblock %}

--- a/corehq/apps/app_manager/templates/app_manager/form_designer.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_designer.html
@@ -247,11 +247,14 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
+    {% include 'app_manager/partials/module_view_breadcrumbs.html' %}
+    {% if form.id != None %}
     <li>
         <span class="divider">&gt;</span>
         <a href="{% url "view_form" domain app.id module.id form.id %}">
             {{ form.name|trans:app.langs }}
         </a>
     </li>
+    {% endif %}
     <li><span class="divider">&gt;</span> <i class="icon-pencil"></i> Edit</li>
 {% endblock %}

--- a/corehq/apps/app_manager/templates/app_manager/form_designer.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_designer.html
@@ -247,5 +247,11 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
-    <li><span class="divider">&gt;</span> <i class="icon-pencil"></i> {{ form.name|trans:app.langs }}</li>
+    <li>
+        <span class="divider">&gt;</span>
+        <a href="{% url "view_form" domain app.id module.id form.id %}">
+            {{ form.name|trans:app.langs }}
+        </a>
+    </li>
+    <li><span class="divider">&gt;</span> <i class="icon-pencil"></i> Edit</li>
 {% endblock %}

--- a/corehq/apps/app_manager/templates/app_manager/form_view_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view_base.html
@@ -240,15 +240,6 @@
         </div>
     {% endif %}
 
-    <h3>
-        <i class="icon icon-file-alt"></i>
-    {% if is_user_registration %}
-        <span class="app-manager-title">{% trans "User Registration" %}</span>
-    {% else %}
-        <span class="app-manager-title variable-form_name">{{ form.name|html_trans:langs|safe }}</span>
-    {% endif %}
-    </h3>
-
     <div class="btn-group">
         {% if not form.no_vellum %}
         <a id="edit_label" href="{% if is_user_registration %}
@@ -277,7 +268,8 @@
             {% endif %}
         {% endif %}
     </div>
-    <hr/>
+
+    <br/><br/><br/>
 
     {% if is_user_registration %}
     <h4>{% trans "User Registration Properties" %}</h4>
@@ -360,3 +352,17 @@
 {% block modals %}{{ block.super }}
 {% include "app_manager/partials/nav_menu_media_modals.html" %}
 {% endblock modals %}
+
+{% block breadcrumbs %}
+    {{ block.super }}
+    <li>
+        <span class="divider">&gt;</span>
+        <a href="{% url "view_form" domain app.id module.id form.id %}">
+        {% if is_user_registration %}
+            <span class="app-manager-title">{% trans "User Registration" %}</span>
+        {% else %}
+            <span class="app-manager-title variable-form_name">{{ form.name|html_trans:langs|safe }}</span>
+        {% endif %}
+        </a>
+    </li>
+{% endblock %}

--- a/corehq/apps/app_manager/templates/app_manager/form_view_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view_base.html
@@ -204,6 +204,8 @@
                 }, $('#no-vellum').get(0));
                 {% endif %}
 
+                gaTrackLink($('.breadcrumb .view-form'), 'App Builder', 'View Form', 'Breadcrumb');
+
             {% endif %}
 
             {% if allow_cloudcare %}
@@ -357,7 +359,7 @@
     {{ block.super }}
     <li>
         <span class="divider">&gt;</span>
-        <a href="{% url "view_form" domain app.id module.id form.id %}">
+        <a class="view-form" href="{% url "view_form" domain app.id module.id form.id %}">
         {% if is_user_registration %}
             <span class="app-manager-title">{% trans "User Registration" %}</span>
         {% else %}

--- a/corehq/apps/app_manager/templates/app_manager/form_view_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view_base.html
@@ -357,6 +357,7 @@
 
 {% block breadcrumbs %}
     {{ block.super }}
+    {% include 'app_manager/partials/module_view_breadcrumbs.html' %}
     <li>
         <span class="divider">&gt;</span>
         <a class="view-form" href="{% url "view_form" domain app.id module.id form.id %}">

--- a/corehq/apps/app_manager/templates/app_manager/managed_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/managed_app.html
@@ -140,7 +140,7 @@
     {% if app %}
     <li>
         <span class="divider">&gt;</span>
-        <a href="{% url "view_module" domain app.id module.id %}">
+        <a href="{% url "view_app" domain app.id %}">
             <span class="app-manager-title variable-app_name">{{ app.name|html_name }}</span>
         </a>
     </li>

--- a/corehq/apps/app_manager/templates/app_manager/managed_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/managed_app.html
@@ -128,6 +128,7 @@
             gaTrackLink($('#edit_label'), 'App Builder', 'Open Form', 'Edit Label');
             {% for module in app.get_modules %}
                 {% for form in module.get_forms %}
+                    gaTrackLink($('#view_form_{{ module.id }}_{{ form.id }}_sidebar'), 'App Builder', 'View Form', 'Sidebar');
                     gaTrackLink($('#edit_pen_{{ module.id }}_{{ form.id }}'), 'App Builder', 'Open Form', 'Edit Pen');
                 {% endfor %}
             {% endfor %}
@@ -243,7 +244,7 @@
                                 {% for form in module.get_forms %}
                                     <li class="edit-form-li{% ifequal form selected_form %} active{% endifequal %}" data-moduleid="{{ module.id }}" data-index="{{ form.id }}">
                                         <!--[F]-->
-                                        <a href="{% url "view_form" domain app.id module.id form.id %}">
+                                        <a id="view_form_{{ module.id }}_{{ form.id }}_sidebar" href="{% url "view_form" domain app.id module.id form.id %}">
                                             <i class="drag_handle"></i>
                                             <span {% if form == selected_form %}class="variable-form_name"{% endif %}>
                                             {{ form.name|html_trans:langs }}

--- a/corehq/apps/app_manager/templates/app_manager/managed_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/managed_app.html
@@ -139,7 +139,9 @@
     {% if app %}
     <li>
         <span class="divider">&gt;</span>
-        <span class="app-manager-title variable-app_name">{{ app.name|html_name }}</span>
+        <a href="{% url "view_module" domain app.id module.id %}">
+            <span class="app-manager-title variable-app_name">{{ app.name|html_name }}</span>
+        </a>
     </li>
     {% endif %}
 {% endblock %}

--- a/corehq/apps/app_manager/templates/app_manager/module_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/module_view.html
@@ -290,3 +290,8 @@
 {% block modals %}{{ block.super }}
 {% include "app_manager/partials/nav_menu_media_modals.html" %}
 {% endblock modals %}
+
+{% block breadcrumbs %}
+    {{ block.super }}
+    {% include 'app_manager/partials/module_view_breadcrumbs.html' %}
+{% endblock %}

--- a/corehq/apps/app_manager/templates/app_manager/module_view_report.html
+++ b/corehq/apps/app_manager/templates/app_manager/module_view_report.html
@@ -79,3 +79,8 @@
         {% include "app_manager/partials/module_filter.html" %}
     </div>
 {% endblock %}
+
+{% block breadcrumbs %}
+    {{ block.super }}
+    {% include 'app_manager/partials/module_view_breadcrumbs.html' %}
+{% endblock %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/module_view_breadcrumbs.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/module_view_breadcrumbs.html
@@ -1,0 +1,9 @@
+{% load xforms_extras %}
+{% if module %}
+<li>
+    <span class="divider">&gt;</span>
+    <a href="{% url "view_module" domain app.id module.id %}">
+        <span class="app-manager-title variable-module_name">{{ module.name|html_trans:langs|safe }}</span>
+    </a>
+</li>
+{% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/module_view_heading.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/module_view_heading.html
@@ -10,7 +10,4 @@
     </form>
 </div>
 
-<h3>
-    <i class="icon-folder-open"></i>
-    <span class="app-manager-title variable-module_name">{{ module.name|html_trans:langs|safe }}</span>
-</h3>
+<div class="clearfix"></div>


### PR DESCRIPTION
Move the module & form names in app builder into breadcrumbs, and link-ify all items in the breadcrumbs. The point is to let user flip back and forth between form view and vellum (as of https://github.com/dimagi/commcare-hq/pull/6770) while still keeping their attention in the main content area, instead of having to go back to the sidebar.

This was quick to do, so happy to revert it if people disagree that it's an improvement. @amsagoff , what do you think?

Module view
![module view new](https://cloud.githubusercontent.com/assets/1486591/7750831/6f67e716-ffa4-11e4-9b68-88d1546f0beb.png)

Form view
![form view new](https://cloud.githubusercontent.com/assets/1486591/7750842/8004c9e0-ffa4-11e4-892b-f7d8243cdbd9.png)

Vellum
![vellum new](https://cloud.githubusercontent.com/assets/1486591/7750848/87eb22b2-ffa4-11e4-92e1-c4e654be4a54.png)
