### PR TITLE
Improve generic analytics API

### DIFF
--- a/corehq/apps/style/templates/style/includes/analytics_all.html
+++ b/corehq/apps/style/templates/style/includes/analytics_all.html
@@ -72,12 +72,17 @@
         },
 
         /**
-         * Track an event.
+         * Track a workflow event.
+         *
+         * This is a wrapper for an analytics backend that tracks workflow
+         * events. For example, a backend that links one event to another to
+         * track a user's progress throught the site.
+         *
          * @param {string} event - Event name
          * @param {object} [properties] - Dictionary of properties to set along with the event.
          * @param {function} [callback] - A Callback to be executed after the event has been successfully tracked.
          */
-        track: function(event, properties, callback) {
+        workflow: function(event, properties, callback) {
             if (properties === undefined){
                 properties = {};
             }
@@ -86,6 +91,24 @@
                 args.push(callback);
             }
             _kmq.push(args);
+        },
+
+        /**
+         * Track a usage event.
+         *
+         * This is a wrapper for an analytics backend that tracks site usage
+         * events. For example, a backend that aggregates how many times an
+         * event occurs over some period of time.
+         *
+         * https://developers.google.com/analytics/devguides/collection/analyticsjs/events#overview
+         *
+         * @param {string} category - required
+         * @param {string} action - required
+         * @param {string} label - optional
+         * @param {number} value - optional
+         */
+        usage: function () {
+            ga_track_event.apply(null, arguments);
         },
 
         /**
@@ -105,6 +128,9 @@
             trackLinkHelper(element, function (cb) {self.track(event, properties, cb);});
         }
     };
+
+    // DEPRECATED
+    window.analytics.track = window.analytics.workflow;
 
     {% if request.couch_user %}
         analytics.identify(

--- a/corehq/apps/style/templates/style/includes/analytics_google.html
+++ b/corehq/apps/style/templates/style/includes/analytics_google.html
@@ -85,12 +85,10 @@
     </script>
 
 <script>
-    /*
-    A wrapper function for Google Analytics event tracking.
-
-    Avoids duplicating checks that GA has been loaded.
-
-    Returns true if the event is tracked, and false otherwise.
+    /**
+     * A wrapper function for Google Analytics event tracking.
+     *
+     * Avoids duplicating checks that GA has been loaded.
      */
     function ga_track_event() {
         var args = ['send', 'event'];


### PR DESCRIPTION
- Add semantically named functions for different types of events.
- Add generic API for Google Analytics

I discussed this with Amelia and we decided on two types of analytics events: usage and workflow. See the documentation for the distinction. I tried to make a generic-ish API that does not mention the services behind it (currently Google Analytics and Kissmetrics), but I'm not particularly happy with it because the wrapper around GA is very thin: it exposes the arguments of the underlying engine. I'm open to suggestions if people think this is a bad idea or can think of a better way to implement it.

The motivation for this is that we have switched analytics backends in the past, and I'd prefer to have a stable API to call in Vellum so we don't need to go around to every call site when we switch backends.

@NoahCarnahan 
cc @sravfeyn @dimagi/team-commcare-hq 
