### PR TITLE
Unicel fixes

### DIFF
--- a/corehq/apps/unicel/api.py
+++ b/corehq/apps/unicel/api.py
@@ -20,7 +20,7 @@ class InboundParams(object):
     SENDER = "send"
     MESSAGE = "msg"
     TIMESTAMP = "stime"
-    UDHI = "udhi"
+    UDHI = "UDHI"
     DCS = "dcs"
 
 class OutboundParams(object):
@@ -125,7 +125,7 @@ def create_from_request(request, delay=True):
     else:
         actual_timestamp = None
 
-    # not sure yet if this check is valid
+    # if the message is a unicode hex string, then the UDHI parameter is set to 1, otherwise it's 0
     is_unicode = request.REQUEST.get(InboundParams.UDHI, "") == "1"
     if is_unicode:
         message = message.decode("hex").decode("utf_16_be")

--- a/corehq/apps/unicel/api.py
+++ b/corehq/apps/unicel/api.py
@@ -21,6 +21,7 @@ class InboundParams(object):
     MESSAGE = "msg"
     TIMESTAMP = "stime"
     UDHI = "UDHI"
+    MID = "MID"
 
 
 class OutboundParams(object):
@@ -130,7 +131,9 @@ def create_from_request(request, delay=True):
     if is_unicode:
         message = message.decode("hex").decode("utf_16_be")
 
-    log = incoming(sender, message, UnicelBackend.get_api_id(), timestamp=actual_timestamp, delay=delay)
+    backend_message_id = request.REQUEST.get(InboundParams.MID, None)
+
+    log = incoming(sender, message, UnicelBackend.get_api_id(), timestamp=actual_timestamp, delay=delay, backend_message_id=backend_message_id)
 
     return log
 

--- a/corehq/apps/unicel/api.py
+++ b/corehq/apps/unicel/api.py
@@ -21,7 +21,7 @@ class InboundParams(object):
     MESSAGE = "msg"
     TIMESTAMP = "stime"
     UDHI = "UDHI"
-    DCS = "dcs"
+
 
 class OutboundParams(object):
     """

--- a/corehq/apps/unicel/api.py
+++ b/corehq/apps/unicel/api.py
@@ -103,7 +103,7 @@ def convert_timestamp(timestamp):
     raise ValueError('could not parse unicel inbound timestamp [%s]' % timestamp)
 
 
-def create_from_request(request, delay=True):
+def create_from_request(request):
     """
     From an inbound request (representing an incoming message),
     create a message (log) object with the right fields populated.
@@ -133,7 +133,7 @@ def create_from_request(request, delay=True):
 
     backend_message_id = request.REQUEST.get(InboundParams.MID, None)
 
-    log = incoming(sender, message, UnicelBackend.get_api_id(), timestamp=actual_timestamp, delay=delay, backend_message_id=backend_message_id)
+    log = incoming(sender, message, UnicelBackend.get_api_id(), timestamp=actual_timestamp, backend_message_id=backend_message_id)
 
     return log
 

--- a/corehq/apps/unicel/tests/test_create_from_request.py
+++ b/corehq/apps/unicel/tests/test_create_from_request.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 from django.test.client import Client
 from corehq.apps.sms.models import SMSLog, INCOMING
 from corehq.apps.users.models import CouchUser, WebUser
-from corehq.apps.unicel.api import InboundParams, DATE_FORMAT, convert_timestamp
+from corehq.apps.unicel.api import InboundParams
 import json
 
 class IncomingPostTest(TestCase):
@@ -28,22 +28,9 @@ class IncomingPostTest(TestCase):
         self.message_ascii = 'It Works'
         self.message_utf_hex = '0939093F0928094D092609400020091509300924093E00200939094800200907093800200938092E092F00200915093E092E002009390948003F'
 
-    def testDateFormats(self):
-        """
-        add other date formats to this list to verify that they work
-        """
-        for date_format in ["2013-07-16 08:29:01", "2013-07-03%2015:34:21"]:
-            actual_timestamp = convert_timestamp(date_format)
-            self.assertIsNotNone(actual_timestamp)
-        # assure that bad format still gets logged
-        with self.assertRaises(ValueError):
-            convert_timestamp("This string isn't formatted properly")
-
-
     def testPostToIncomingAscii(self):
         fake_post = {InboundParams.SENDER: str(self.number),
                      InboundParams.MESSAGE: self.message_ascii,
-                     InboundParams.TIMESTAMP: datetime.utcnow().strftime(DATE_FORMAT),
                      InboundParams.MID: '00001',
                      InboundParams.UDHI: '0'}
         response, log = post(fake_post)
@@ -51,14 +38,10 @@ class IncomingPostTest(TestCase):
         self.assertEqual(self.message_ascii, log.text)
         self.assertEqual(INCOMING, log.direction)
         self.assertEqual(log.backend_message_id, fake_post[InboundParams.MID])
-        self.assertEqual((log.date + self.INDIA_TZ_OFFSET).strftime(DATE_FORMAT),
-                         fake_post[InboundParams.TIMESTAMP])
-
 
     def testPostToIncomingUtf(self):
         fake_post = {InboundParams.SENDER: str(self.number),
                      InboundParams.MESSAGE: self.message_utf_hex,
-                     InboundParams.TIMESTAMP: datetime.utcnow().strftime(DATE_FORMAT),
                      InboundParams.MID: '00002',
                      InboundParams.UDHI: '1'}
         response, log = post(fake_post)
@@ -67,8 +50,7 @@ class IncomingPostTest(TestCase):
                         log.text)
         self.assertEqual(INCOMING, log.direction)
         self.assertEqual(log.backend_message_id, fake_post[InboundParams.MID])
-        self.assertEqual((log.date + self.INDIA_TZ_OFFSET).strftime(DATE_FORMAT),
-                         fake_post[InboundParams.TIMESTAMP])
+
 
 def post(data):
     client = Client()

--- a/corehq/apps/unicel/tests/test_create_from_request.py
+++ b/corehq/apps/unicel/tests/test_create_from_request.py
@@ -25,7 +25,6 @@ class IncomingPostTest(TestCase):
             self.couch_user = WebUser.get_by_username(self.user)
         self.couch_user.add_phone_number(self.number)
         self.couch_user.save()
-        self.dcs = '8'
         self.message_ascii = 'It Works'
         self.message_utf_hex = '0939093F0928094D092609400020091509300924093E00200939094800200907093800200938092E092F00200915093E092E002009390948003F'
 
@@ -45,7 +44,6 @@ class IncomingPostTest(TestCase):
         fake_post = {InboundParams.SENDER: str(self.number),
                      InboundParams.MESSAGE: self.message_ascii,
                      InboundParams.TIMESTAMP: datetime.utcnow().strftime(DATE_FORMAT),
-                     InboundParams.DCS: self.dcs,
                      InboundParams.UDHI: '0'}
         response, log = post(fake_post)
         self.assertEqual(200, response.status_code)
@@ -59,7 +57,6 @@ class IncomingPostTest(TestCase):
         fake_post = {InboundParams.SENDER: str(self.number),
                      InboundParams.MESSAGE: self.message_utf_hex,
                      InboundParams.TIMESTAMP: datetime.utcnow().strftime(DATE_FORMAT),
-                     InboundParams.DCS: self.dcs,
                      InboundParams.UDHI: '1'}
         response, log = post(fake_post)
         self.assertEqual(200, response.status_code)

--- a/corehq/apps/unicel/tests/test_create_from_request.py
+++ b/corehq/apps/unicel/tests/test_create_from_request.py
@@ -44,11 +44,13 @@ class IncomingPostTest(TestCase):
         fake_post = {InboundParams.SENDER: str(self.number),
                      InboundParams.MESSAGE: self.message_ascii,
                      InboundParams.TIMESTAMP: datetime.utcnow().strftime(DATE_FORMAT),
+                     InboundParams.MID: '00001',
                      InboundParams.UDHI: '0'}
         response, log = post(fake_post)
         self.assertEqual(200, response.status_code)
         self.assertEqual(self.message_ascii, log.text)
         self.assertEqual(INCOMING, log.direction)
+        self.assertEqual(log.backend_message_id, fake_post[InboundParams.MID])
         self.assertEqual((log.date + self.INDIA_TZ_OFFSET).strftime(DATE_FORMAT),
                          fake_post[InboundParams.TIMESTAMP])
 
@@ -57,12 +59,14 @@ class IncomingPostTest(TestCase):
         fake_post = {InboundParams.SENDER: str(self.number),
                      InboundParams.MESSAGE: self.message_utf_hex,
                      InboundParams.TIMESTAMP: datetime.utcnow().strftime(DATE_FORMAT),
+                     InboundParams.MID: '00002',
                      InboundParams.UDHI: '1'}
         response, log = post(fake_post)
         self.assertEqual(200, response.status_code)
         self.assertEqual(self.message_utf_hex.decode("hex").decode("utf_16_be"),
                         log.text)
         self.assertEqual(INCOMING, log.direction)
+        self.assertEqual(log.backend_message_id, fake_post[InboundParams.MID])
         self.assertEqual((log.date + self.INDIA_TZ_OFFSET).strftime(DATE_FORMAT),
                          fake_post[InboundParams.TIMESTAMP])
 


### PR DESCRIPTION
Makes a few small fixes to how we handle inbound SMS for Unicel:
- fix udhi parameter to properly handle inbound unicode messages
- removes a couple unused parameters
- adds the message id parameter for better tracking
- removes the use of the gateway timestamp and only uses the server timestamp for more consistency in the logs (small differences in times are making the logs look strange in some circumstances)

@twymer @proteusvacuum 
