### PR TITLE
make UCR date filter inclusive if DateSpan is inclusive

### DIFF
--- a/corehq/apps/userreports/reports/filters.py
+++ b/corehq/apps/userreports/reports/filters.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from django.core.urlresolvers import reverse
 from sqlagg.filters import BasicFilter, BetweenFilter, EQFilter, ISNULLFilter
 from dimagi.utils.dates import DateSpan
@@ -37,7 +38,11 @@ class DateFilterValue(FilterValue):
             return {}
         return {
             'startdate': self.value.startdate,
-            'enddate': self.value.enddate,
+            'enddate': (
+                self.value.enddate
+                if not self.value.inclusive
+                else self.value.enddate + timedelta(days=1)
+            ),
         }
 
 

--- a/corehq/apps/userreports/reports/filters.py
+++ b/corehq/apps/userreports/reports/filters.py
@@ -41,7 +41,7 @@ class DateFilterValue(FilterValue):
             'enddate': (
                 self.value.enddate
                 if not self.value.inclusive
-                else self.value.enddate + timedelta(days=1)
+                else self.value.enddate + timedelta(days=1) - timedelta.resolution
             ),
         }
 


### PR DESCRIPTION
1) Make the "Since Date" option in saved reports useful for UCR.
2) Make UCR date filters consistent with other reports.
