### PR TITLE
Blank out human-readable name when copying domain

### DIFF
--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -659,6 +659,7 @@ class Domain(Document, SnapshotMixin):
             new_domain_name = new_id
         new_domain = Domain.get(new_id)
         new_domain.name = new_domain_name
+        new_domain.hr_name = None
         new_domain.copy_history = self.get_updated_history()
         new_domain.is_snapshot = False
         new_domain.snapshot_time = None


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?169007

@TylerSheffels 
