### PR TITLE
Itemset products

### DIFF
--- a/corehq/apps/custom_data_fields/models.py
+++ b/corehq/apps/custom_data_fields/models.py
@@ -54,10 +54,8 @@ class CustomDataFieldsDefinition(Document):
         return filter(_is_match, self.fields)
 
     @classmethod
-    def get_or_create(cls, domain, field_type):
-        # todo: this overrides get_or_create from DocumentBase but with a completely different signature.
-        # This method should probably be renamed.
-        existing = cls.view(
+    def get_by_domain_and_type(cls, domain, field_type):
+        return cls.view(
             'custom_data_fields/by_field_type',
             key=[domain, field_type],
             include_docs=True,
@@ -68,6 +66,12 @@ class CustomDataFieldsDefinition(Document):
             # todo: a better solution might be to use locking in this code
             limit=1,
         ).one()
+
+    @classmethod
+    def get_or_create(cls, domain, field_type):
+        # todo: this overrides get_or_create from DocumentBase but with a completely different signature.
+        # This method should probably be renamed.
+        existing = cls.get_by_domain_and_type(domain, field_type)
 
         if existing:
             return existing

--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -2,6 +2,8 @@ from collections import defaultdict
 from xml.etree import ElementTree
 from corehq.apps.fixtures.models import FixtureDataItem, FixtureDataType
 from corehq.apps.users.models import CommCareUser
+from corehq.apps.products.models import SQLProduct
+from corehq.apps.products.fixtures import PRODUCT_FIELDS
 
 
 def item_lists_by_domain(domain):
@@ -18,7 +20,21 @@ def item_lists_by_domain(domain):
                     'no_option': True
                 } for f in data_type.fields},
         })
+
+    if SQLProduct.objects.filter(domain=domain).count() > 1:
+        ret.append({
+            'sourceUri': 'jr://fixture/commtrack:products',
+            'defaultId': 'products',
+            'initialQuery': "instance('products')/products/product",
+            'name': 'Products',
+            'structure': {
+                f: {
+                    'name': f,
+                    'no_option': True
+                } for f in PRODUCT_FIELDS},
+        })
     return ret
+
 
 def item_lists(user, version, last_sync=None):
     assert isinstance(user, CommCareUser)

--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -2,8 +2,7 @@ from collections import defaultdict
 from xml.etree import ElementTree
 from corehq.apps.fixtures.models import FixtureDataItem, FixtureDataType
 from corehq.apps.users.models import CommCareUser
-from corehq.apps.products.models import SQLProduct
-from corehq.apps.products.fixtures import PRODUCT_FIELDS
+from corehq.apps.products.fixtures import product_fixture_generator_json
 
 
 def item_lists_by_domain(domain):
@@ -21,18 +20,9 @@ def item_lists_by_domain(domain):
                 } for f in data_type.fields},
         })
 
-    if SQLProduct.objects.filter(domain=domain).count() > 1:
-        ret.append({
-            'sourceUri': 'jr://fixture/commtrack:products',
-            'defaultId': 'products',
-            'initialQuery': "instance('products')/products/product",
-            'name': 'Products',
-            'structure': {
-                f: {
-                    'name': f,
-                    'no_option': True
-                } for f in PRODUCT_FIELDS},
-        })
+    products = product_fixture_generator_json(domain)
+    if products:
+        ret.append(products)
     return ret
 
 

--- a/corehq/apps/products/fixtures.py
+++ b/corehq/apps/products/fixtures.py
@@ -22,6 +22,7 @@ def product_fixture_generator_json(domain):
         return None
 
     fields = filter(lambda x: x != CUSTOM_DATA_SLUG, PRODUCT_FIELDS)
+    fields.append('@id')
 
     custom_fields = CustomDataFieldsDefinition.get_by_domain_and_type(domain, 'ProductFields')
     if custom_fields:

--- a/corehq/apps/products/fixtures.py
+++ b/corehq/apps/products/fixtures.py
@@ -1,5 +1,7 @@
 from corehq.apps.products.models import Product
 from corehq.apps.commtrack.fixtures import _simple_fixture_generator
+from corehq.apps.products.models import SQLProduct
+from corehq.apps.custom_data_fields.models import CustomDataFieldsDefinition
 
 PRODUCT_FIELDS = [
     'name',
@@ -11,6 +13,32 @@ PRODUCT_FIELDS = [
     'cost',
     'product_data'
 ]
+
+CUSTOM_DATA_SLUG = 'product_data'
+
+
+def product_fixture_generator_json(domain):
+    if SQLProduct.objects.filter(domain=domain).count() == 0:
+        return None
+
+    fields = filter(lambda x: x != CUSTOM_DATA_SLUG, PRODUCT_FIELDS)
+
+    custom_fields = CustomDataFieldsDefinition.get_by_domain_and_type(domain, 'ProductFields')
+    if custom_fields:
+        for f in custom_fields.fields:
+            fields.append(CUSTOM_DATA_SLUG + '/' + f.slug)
+
+    return {
+        'sourceUri': 'jr://fixture/commtrack:products',
+        'defaultId': 'products',
+        'initialQuery': "instance('products')/products/product",
+        'name': 'Products',
+        'structure': {
+            f: {
+                'name': f,
+                'no_option': True
+            } for f in fields},
+    }
 
 
 def product_fixture_generator(user, version, last_sync=None):

--- a/corehq/apps/products/fixtures.py
+++ b/corehq/apps/products/fixtures.py
@@ -1,17 +1,18 @@
 from corehq.apps.products.models import Product
 from corehq.apps.commtrack.fixtures import _simple_fixture_generator
 
+PRODUCT_FIELDS = [
+    'name',
+    'unit',
+    'code',
+    'description',
+    'category',
+    'program_id',
+    'cost',
+    'product_data'
+]
+
 
 def product_fixture_generator(user, version, last_sync=None):
-    fields = [
-        'name',
-        'unit',
-        'code',
-        'description',
-        'category',
-        'program_id',
-        'cost',
-        'product_data'
-    ]
     data_fn = lambda: Product.by_domain(user.domain, include_archived=True)
-    return _simple_fixture_generator(user, "product", fields, data_fn, last_sync)
+    return _simple_fixture_generator(user, "product", PRODUCT_FIELDS, data_fn, last_sync)


### PR DESCRIPTION
@czue 

Support for products in itemsets. I threw it in with fixtures since they are both represented as fixtures in the phone restore. Could possibly break it out into it's own endpoint once vellum's data source module is more generic, but probably not a need to.

@esoergel I went ahead and supported custom data, although it does look like the phone restore XML is not homogenous when using that.
