### PR TITLE
Show unchecked option labels in custom Abt report

### DIFF
--- a/custom/abt/reports/progress_report.json
+++ b/custom/abt/reports/progress_report.json
@@ -25,16 +25,17 @@
             "required":false,
             "datatype":"string",
             "show_all":true,
-            "display":"Niveau 1",
-            "field":"level_1",
+            "display":"Niveau 2",
+            "field":"level_2",
             "type":"dynamic_choice_list",
-            "slug":"level_1"
+            "slug":"level_2"
         }
     ],
     "visible":true,
     "aggregation_columns":[
         "country",
-        "level_1"
+        "level_2",
+        "target_number"
     ],
     "configured_charts":[
 
@@ -61,15 +62,15 @@
         },
         {
             "description":null,
-            "field":"level_1",
+            "field":"level_2",
             "format":"default",
             "transform":{
 
             },
-            "column_id":"level_1",
+            "column_id":"level_2",
             "alias":null,
             "type":"field",
-            "display":"Niveau 1",
+            "display":"Niveau 2",
             "aggregation":"simple"
         },
         {
@@ -106,7 +107,7 @@
             "field":"cum_spray_progress",
             "alias":null,
             "type":"percent",
-            "display":"Taux de couverture: District",
+            "display":"Taux de couverture: Niveau 2",
             "aggregation":"simple"
         },
         {
@@ -118,11 +119,11 @@
                 "transform":{
 
                 },
-                "column_id":"cum_spray_progress_denominator",
+                "column_id":"target_number",
                 "field":"target_number",
                 "type":"field",
                 "display":null,
-                "aggregation":"sum"
+                "aggregation":"simple"
             },
             "numerator":{
                 "description":null,
@@ -143,7 +144,7 @@
             "field":"cum_spray_progress",
             "alias":null,
             "type":"percent",
-            "display":"Progr\u00e8s de pulv\u00e9risation quotidien: District",
+            "display":"Progr\u00e8s de pulv\u00e9risation quotidien: Niveau 2",
             "aggregation":"simple"
         }
     ]

--- a/custom/abt/reports/sms_datasource_indicators.json
+++ b/custom/abt/reports/sms_datasource_indicators.json
@@ -1,6 +1,7 @@
 [
   {
     "display_name": "country", 
+    "transform": {}, 
     "datatype": "string", 
     "expression": {
       "value_expression": {
@@ -20,14 +21,14 @@
         ]
       }
     }, 
-    "transform": {}, 
-    "is_nullable": true, 
     "is_primary_key": false, 
+    "is_nullable": true, 
     "column_id": "country", 
     "type": "expression"
   }, 
   {
     "display_name": "level_1", 
+    "transform": {}, 
     "datatype": "string", 
     "expression": {
       "value_expression": {
@@ -47,14 +48,14 @@
         ]
       }
     }, 
-    "transform": {}, 
-    "is_nullable": true, 
     "is_primary_key": false, 
+    "is_nullable": true, 
     "column_id": "level_1", 
     "type": "expression"
   }, 
   {
     "display_name": "level_2", 
+    "transform": {}, 
     "datatype": "string", 
     "expression": {
       "value_expression": {
@@ -74,14 +75,14 @@
         ]
       }
     }, 
-    "transform": {}, 
-    "is_nullable": true, 
     "is_primary_key": false, 
+    "is_nullable": true, 
     "column_id": "level_2", 
     "type": "expression"
   }, 
   {
     "display_name": "level_3", 
+    "transform": {}, 
     "datatype": "string", 
     "expression": {
       "value_expression": {
@@ -101,14 +102,14 @@
         ]
       }
     }, 
-    "transform": {}, 
-    "is_nullable": true, 
     "is_primary_key": false, 
+    "is_nullable": true, 
     "column_id": "level_3", 
     "type": "expression"
   }, 
   {
     "display_name": "level_4", 
+    "transform": {}, 
     "datatype": "string", 
     "expression": {
       "value_expression": {
@@ -128,14 +129,14 @@
         ]
       }
     }, 
-    "transform": {}, 
-    "is_nullable": true, 
     "is_primary_key": false, 
+    "is_nullable": true, 
     "column_id": "level_4", 
     "type": "expression"
   }, 
   {
     "display_name": "worker_code", 
+    "transform": {}, 
     "datatype": "string", 
     "expression": {
       "value_expression": {
@@ -155,9 +156,8 @@
         ]
       }
     }, 
-    "transform": {}, 
-    "is_nullable": true, 
     "is_primary_key": false, 
+    "is_nullable": true, 
     "column_id": "worker_code", 
     "type": "expression"
   }, 
@@ -295,6 +295,7 @@
   }, 
   {
     "display_name": "target_number", 
+    "transform": {}, 
     "datatype": "integer", 
     "expression": {
       "test": {
@@ -304,7 +305,7 @@
           "value_expression": {
             "datatype": null, 
             "type": "property_name", 
-            "property_name": "country"
+            "property_name": "level_2_data"
           }, 
           "type": "related_doc", 
           "related_doc_type": "CommCareCase", 
@@ -318,10 +319,10 @@
             ]
           }
         }, 
-        "property_value": "senegal"
+        "property_value": "koumpentoum"
       }, 
       "expression_if_true": {
-        "constant": 120553, 
+        "constant": 45118, 
         "type": "constant"
       }, 
       "type": "conditional", 
@@ -333,7 +334,7 @@
             "value_expression": {
               "datatype": null, 
               "type": "property_name", 
-              "property_name": "country"
+              "property_name": "level_2_data"
             }, 
             "type": "related_doc", 
             "related_doc_type": "CommCareCase", 
@@ -347,10 +348,10 @@
               ]
             }
           }, 
-          "property_value": "benin"
+          "property_value": "malem_hodar"
         }, 
         "expression_if_true": {
-          "constant": 265907, 
+          "constant": 5304, 
           "type": "constant"
         }, 
         "type": "conditional", 
@@ -362,7 +363,7 @@
               "value_expression": {
                 "datatype": null, 
                 "type": "property_name", 
-                "property_name": "country"
+                "property_name": "level_2_data"
               }, 
               "type": "related_doc", 
               "related_doc_type": "CommCareCase", 
@@ -376,23 +377,52 @@
                 ]
               }
             }, 
-            "property_value": "ethiopia"
+            "property_value": "koungheul"
           }, 
           "expression_if_true": {
-            "constant": 120553, 
+            "constant": 45733, 
             "type": "constant"
           }, 
           "type": "conditional", 
           "expression_if_false": {
-            "constant": 0, 
-            "type": "constant"
+            "test": {
+              "operator": "eq", 
+              "type": "boolean_expression", 
+              "expression": {
+                "value_expression": {
+                  "datatype": null, 
+                  "type": "property_name", 
+                  "property_name": "level_2_data"
+                }, 
+                "type": "related_doc", 
+                "related_doc_type": "CommCareCase", 
+                "doc_id_expression": {
+                  "datatype": null, 
+                  "type": "property_path", 
+                  "property_path": [
+                    "form", 
+                    "case", 
+                    "@case_id"
+                  ]
+                }
+              }, 
+              "property_value": "nioro"
+            }, 
+            "expression_if_true": {
+              "constant": 85891, 
+              "type": "constant"
+            }, 
+            "type": "conditional", 
+            "expression_if_false": {
+              "constant": 0, 
+              "type": "constant"
+            }
           }
         }
       }
     }, 
-    "transform": {}, 
-    "is_nullable": true, 
     "is_primary_key": false, 
+    "is_nullable": true, 
     "column_id": "target_number", 
     "type": "expression"
   }

--- a/custom/abt/reports/sms_report.json
+++ b/custom/abt/reports/sms_report.json
@@ -6,6 +6,14 @@
     "title":"SMS Indicator Report",
     "filters":[
         {
+            "datatype":"date",
+            "required":false,
+            "display":"Date soumis",
+            "field":"timeEnd",
+            "type":"date",
+            "slug":"timeEnd"
+        },
+        {
             "required":false,
             "datatype":"string",
             "show_all":true,

--- a/custom/abt/reports/supervisory_datasource_filter.json
+++ b/custom/abt/reports/supervisory_datasource_filter.json
@@ -3,72 +3,72 @@
   "filters": [
     {
       "operator": "eq", 
+      "type": "boolean_expression", 
       "expression": {
         "datatype": null, 
         "type": "property_name", 
         "property_name": "xmlns"
       }, 
-      "type": "boolean_expression", 
       "property_value": "http://openrosa.org/formdesigner/BB2BF979-BD8F-4B8D-BCF8-A46451228BA9"
     }, 
     {
       "operator": "eq", 
+      "type": "boolean_expression", 
       "expression": {
         "datatype": null, 
         "type": "property_name", 
         "property_name": "xmlns"
       }, 
-      "type": "boolean_expression", 
       "property_value": "http://openrosa.org/formdesigner/BBBA67FC-4E25-46B4-AB64-56F820D48A9E"
     }, 
     {
       "operator": "eq", 
+      "type": "boolean_expression", 
       "expression": {
         "datatype": null, 
         "type": "property_name", 
         "property_name": "xmlns"
       }, 
-      "type": "boolean_expression", 
       "property_value": "http://openrosa.org/formdesigner/54338047-CFB6-4D5B-861B-2256A10BBBC8"
     }, 
     {
       "operator": "eq", 
+      "type": "boolean_expression", 
       "expression": {
         "datatype": null, 
         "type": "property_name", 
         "property_name": "xmlns"
       }, 
-      "type": "boolean_expression", 
       "property_value": "http://openrosa.org/formdesigner/2BAC5FDC-72F3-4AF4-8381-9160E8AE13CF"
     }, 
     {
       "operator": "eq", 
+      "type": "boolean_expression", 
       "expression": {
         "datatype": null, 
         "type": "property_name", 
         "property_name": "xmlns"
       }, 
-      "type": "boolean_expression", 
       "property_value": "http://openrosa.org/formdesigner/7B543EA4-A416-4E46-A121-C4F57412B5AA"
     }, 
     {
       "operator": "eq", 
+      "type": "boolean_expression", 
       "expression": {
         "datatype": null, 
         "type": "property_name", 
         "property_name": "xmlns"
       }, 
-      "type": "boolean_expression", 
       "property_value": "http://openrosa.org/formdesigner/89F60CF0-C6A7-4AD8-A48E-AA0F7A7A9B4D"
     }, 
     {
       "operator": "eq", 
+      "type": "boolean_expression", 
       "expression": {
         "datatype": null, 
         "type": "property_name", 
         "property_name": "xmlns"
       }, 
-      "type": "boolean_expression", 
       "property_value": "http://openrosa.org/formdesigner/1BE9CFE7-8EE6-4DFA-B9ED-D37993729843"
     }
   ]

--- a/custom/abt/reports/supervisory_datasource_indicators.json
+++ b/custom/abt/reports/supervisory_datasource_indicators.json
@@ -1,13 +1,9 @@
 [
   {
     "display_name": "timeEnd", 
-    "datatype": "datetime", 
-    "type": "expression", 
-    "is_primary_key": false, 
     "transform": {}, 
-    "is_nullable": true, 
+    "datatype": "datetime", 
     "expression": {
-      "type": "root_doc", 
       "expression": {
         "datatype": null, 
         "type": "property_path", 
@@ -16,19 +12,19 @@
           "meta", 
           "timeEnd"
         ]
-      }
+      }, 
+      "type": "root_doc"
     }, 
-    "column_id": "timeEnd"
+    "is_primary_key": false, 
+    "is_nullable": true, 
+    "column_id": "timeEnd", 
+    "type": "expression"
   }, 
   {
     "display_name": "country", 
-    "datatype": "string", 
-    "type": "expression", 
-    "is_primary_key": false, 
     "transform": {}, 
-    "is_nullable": true, 
+    "datatype": "string", 
     "expression": {
-      "type": "root_doc", 
       "expression": {
         "datatype": null, 
         "type": "property_path", 
@@ -37,19 +33,19 @@
           "location_data", 
           "country"
         ]
-      }
+      }, 
+      "type": "root_doc"
     }, 
-    "column_id": "country"
+    "is_primary_key": false, 
+    "is_nullable": true, 
+    "column_id": "country", 
+    "type": "expression"
   }, 
   {
     "display_name": "level_1", 
-    "datatype": "string", 
-    "type": "expression", 
-    "is_primary_key": false, 
     "transform": {}, 
-    "is_nullable": true, 
+    "datatype": "string", 
     "expression": {
-      "type": "root_doc", 
       "expression": {
         "datatype": null, 
         "type": "property_path", 
@@ -58,19 +54,19 @@
           "location_data", 
           "level_1_name"
         ]
-      }
+      }, 
+      "type": "root_doc"
     }, 
-    "column_id": "level_1"
+    "is_primary_key": false, 
+    "is_nullable": true, 
+    "column_id": "level_1", 
+    "type": "expression"
   }, 
   {
     "display_name": "level_2", 
-    "datatype": "string", 
-    "type": "expression", 
-    "is_primary_key": false, 
     "transform": {}, 
-    "is_nullable": true, 
+    "datatype": "string", 
     "expression": {
-      "type": "root_doc", 
       "expression": {
         "datatype": null, 
         "type": "property_path", 
@@ -79,19 +75,19 @@
           "location_data", 
           "level_2_name"
         ]
-      }
+      }, 
+      "type": "root_doc"
     }, 
-    "column_id": "level_2"
+    "is_primary_key": false, 
+    "is_nullable": true, 
+    "column_id": "level_2", 
+    "type": "expression"
   }, 
   {
     "display_name": "level_3", 
-    "datatype": "string", 
-    "type": "expression", 
-    "is_primary_key": false, 
     "transform": {}, 
-    "is_nullable": true, 
+    "datatype": "string", 
     "expression": {
-      "type": "root_doc", 
       "expression": {
         "datatype": null, 
         "type": "property_path", 
@@ -100,19 +96,19 @@
           "location_data", 
           "level_3_name"
         ]
-      }
+      }, 
+      "type": "root_doc"
     }, 
-    "column_id": "level_3"
+    "is_primary_key": false, 
+    "is_nullable": true, 
+    "column_id": "level_3", 
+    "type": "expression"
   }, 
   {
     "display_name": "level_4", 
-    "datatype": "string", 
-    "type": "expression", 
-    "is_primary_key": false, 
     "transform": {}, 
-    "is_nullable": true, 
+    "datatype": "string", 
     "expression": {
-      "type": "root_doc", 
       "expression": {
         "datatype": null, 
         "type": "property_path", 
@@ -121,20 +117,18 @@
           "location_data", 
           "level_4_name"
         ]
-      }
+      }, 
+      "type": "root_doc"
     }, 
-    "column_id": "level_4"
+    "is_primary_key": false, 
+    "is_nullable": true, 
+    "column_id": "level_4", 
+    "type": "expression"
   }, 
   {
     "display_name": "username", 
     "datatype": "string", 
-    "type": "expression", 
-    "transform": {}, 
-    "is_nullable": true, 
-    "is_primary_key": false, 
-    "column_id": "username", 
     "expression": {
-      "type": "root_doc", 
       "expression": {
         "datatype": null, 
         "type": "property_path", 
@@ -143,18 +137,20 @@
           "meta", 
           "username"
         ]
-      }
-    }
-  }, 
-  {
-    "display_name": "form_name", 
-    "datatype": "string", 
-    "type": "expression", 
+      }, 
+      "type": "root_doc"
+    }, 
     "is_primary_key": false, 
     "transform": {}, 
     "is_nullable": true, 
+    "type": "expression", 
+    "column_id": "username"
+  }, 
+  {
+    "display_name": "form_name", 
+    "transform": {}, 
+    "datatype": "string", 
     "expression": {
-      "type": "root_doc", 
       "expression": {
         "datatype": null, 
         "type": "property_path", 
@@ -162,64 +158,68 @@
           "form", 
           "@name"
         ]
-      }
+      }, 
+      "type": "root_doc"
     }, 
-    "column_id": "form_name"
+    "is_primary_key": false, 
+    "is_nullable": true, 
+    "column_id": "form_name", 
+    "type": "expression"
   }, 
   {
     "display_name": "inspector_names", 
-    "datatype": "string", 
-    "type": "expression", 
-    "is_primary_key": false, 
     "transform": {}, 
-    "is_nullable": true, 
+    "datatype": "string", 
     "expression": {
       "datatype": null, 
       "type": "property_name", 
       "property_name": "names"
     }, 
-    "column_id": "inspector_names"
+    "is_primary_key": false, 
+    "is_nullable": true, 
+    "column_id": "inspector_names", 
+    "type": "expression"
   }, 
   {
     "display_name": "flag", 
-    "datatype": "string", 
-    "type": "expression", 
-    "is_primary_key": false, 
     "transform": {}, 
-    "is_nullable": true, 
+    "datatype": "string", 
     "expression": {
       "datatype": null, 
       "type": "property_name", 
       "property_name": "flag"
     }, 
-    "column_id": "flag"
+    "is_primary_key": false, 
+    "is_nullable": true, 
+    "column_id": "flag", 
+    "type": "expression"
   }, 
   {
     "display_name": "warning", 
-    "datatype": "string", 
-    "type": "expression", 
-    "is_primary_key": false, 
     "transform": {}, 
-    "is_nullable": true, 
+    "datatype": "string", 
     "expression": {
       "datatype": null, 
       "type": "property_name", 
       "property_name": "warning"
     }, 
-    "column_id": "warning"
+    "is_primary_key": false, 
+    "is_nullable": true, 
+    "column_id": "warning", 
+    "type": "expression"
   }, 
   {
     "display_name": "comments", 
-    "datatype": "string", 
-    "type": "expression", 
-    "is_primary_key": false, 
     "transform": {}, 
-    "is_nullable": true, 
+    "datatype": "string", 
     "expression": {
       "datatype": null, 
       "type": "property_name", 
       "property_name": "comments"
     }, 
-    "column_id": "comments"
+    "is_primary_key": false, 
+    "is_nullable": true, 
+    "column_id": "comments", 
+    "type": "expression"
   }
 ]

--- a/custom/abt/reports/supervisory_report.json
+++ b/custom/abt/reports/supervisory_report.json
@@ -6,6 +6,13 @@
     "title":"Supervisory Report",
     "filters":[
         {
+            "field":"timeEnd",
+            "required":false,
+            "type":"date",
+            "slug":"timeEnd",
+            "display":"Date soumis"
+        },
+        {
             "required":false,
             "datatype":"string",
             "show_all":true,


### PR DESCRIPTION
Insert the option labels, instead of the ids, in the report warning column. The last commit is the only one that needs to be reviewed. The other three are just updates to the report configurations that I am tracking in the repo, but which aren't executed or loaded or anything.

FYI review buddy @czue 
