### PR TITLE
revet change to stock transaction query

### DIFF
--- a/corehq/ex-submodules/casexml/apps/stock/utils.py
+++ b/corehq/ex-submodules/casexml/apps/stock/utils.py
@@ -69,30 +69,13 @@ def get_current_ledger_transactions_multi(case_ids):
     if not case_ids:
         return {}
 
-    relevant_transactions = StockTransaction.objects.raw(
-        """
-        SELECT MAX(stx.id) AS id FROM
-        (
-            SELECT case_id, product_id, section_id, MAX(sr.date) AS date
-            FROM stock_stocktransaction st JOIN stock_stockreport sr ON st.report_id = sr.id
-            WHERE case_id IN %s
-            GROUP BY case_id, section_id, product_id
-        ) AS x INNER JOIN stock_stocktransaction AS stx ON
-            stx.case_id = x.case_id
-            AND stx.product_id = x.product_id
-            AND stx.section_id = x.section_id
-        JOIN stock_stockreport str ON
-            str.date = x.date
-            AND stx.report_id = str.id
-        GROUP BY stx.case_id, stx.product_id, stx.section_id, str.date;
-        """,
-        [tuple(case_ids)]
-    )
+    results = StockTransaction.objects.filter(
+        case_id__in=case_ids
+    ).values_list('case_id', 'section_id', 'product_id').distinct()
 
-    transaction_ids = [tx.id for tx in relevant_transactions]
-    results = StockTransaction.objects.filter(id__in=transaction_ids).select_related()
     ret = {case_id: {} for case_id in case_ids}
-    for txn in results:
-        sections = ret[txn.case_id].setdefault(txn.section_id, {})
-        sections[txn.product_id] = txn
+    for case_id, section_id, product_id in results:
+        sections = ret[case_id].setdefault(section_id, {})
+        sections[product_id] = StockTransaction.latest(case_id, section_id, product_id)
+
     return ret


### PR DESCRIPTION
This reverts the change made here: https://github.com/dimagi/commcare-hq/commit/5ac6e5f223dad372dbf0f974a153e6436e88d024#diff-73cd95f5a70423050142eb4f58338510

This method results in significantly more queries (~3000 in the comparison I did) but they run much more quickly. The previous optimisation was good for small tables only.

@czue @proteusvacuum 
hobbit @benrudolph 
