### PR TITLE
Adds "Owned by Group" case export filter

### DIFF
--- a/corehq/apps/reports/models.py
+++ b/corehq/apps/reports/models.py
@@ -50,10 +50,13 @@ class HQUserType(object):
                       ugettext_noop("demo_user"),
                       ugettext_noop("admin"),
                       ugettext_noop("Unknown Users"),
-                      ugettext_noop("CommCare Supply")]
-    toggle_defaults = (True, False, False, False, False)
+                      ugettext_noop("CommCare Supply"),
+                      # "Owned by Group" uses the "Unknown Users" filter, but is less misleading because the users
+                      # aren't necessarily unknown. cf. FB 166197 for more details.
+                      ugettext_noop("Owned by Group")]
+    toggle_defaults = (True, False, False, False, False, False)
     count = len(human_readable)
-    included_defaults = (True, True, True, True, False)
+    included_defaults = (True, True, True, True, False, True)
 
     @classmethod
     def use_defaults(cls):


### PR DESCRIPTION
The new filter behaves the same as the "Unknown Users" filter, but is less misleading because the users aren't necessarily unknown.

[FB 166197](http://manage.dimagi.com/default.asp?166197) for context.

I chose to add a new filter name rather than changing the behaviour of the "Mobile Worker" filter because I was concerned that users will be familiar with the current behaviour of the "Mobile Worker" filter, and so it would be safer to go for the option of least surprise.

@amsagoff, let me know if you think this is the best approach, or whether changing existing behaviour would be better (maybe because the interface has fewer options, or some other reason I haven't considered), or whether there are totally different options that I've also missed.

Ping @dannyroberts 
