### PR TITLE
Trigger popover on hover

### DIFF
--- a/corehq/apps/groups/templates/groups/all_groups.html
+++ b/corehq/apps/groups/templates/groups/all_groups.html
@@ -6,12 +6,14 @@
     $(function () {
         $('.reporting-group-icon').popover({
             placement: 'right',
+            trigger: 'hover',
             title: 'This is a Reporting Group',
             content: "Reporting groups are used in reports to filter and view data. You can remove this group from " +
                     "reports by editing this group's settings."
         });
         $('.case-sharing-group-icon').popover({
             placement: 'right',
+            trigger: 'hover',
             title: 'This is a Case Sharing Group',
             content: "Case sharing groups allow their members to share a case list in a case-sharing app. You can change this " +
                     "by editing this group's settings."


### PR DESCRIPTION
It seems that most help popovers are triggered by hover. Bring the popovers in Group Management in line.

The group name and its icons are linked to the page to manage that group. Triggering the popover on click (properly) would require unlinking the icons. But anchor tags inside list items are styled as block-level elements, not spans. So unlinking the icons makes them appear on the next line, and look really dumb. Changing the styling affects many other places. ... Another reason to use hover instead of click.

Context: [FB 168672](http://manage.dimagi.com/default.asp?168672)

Elven consultant: @dannyroberts 
