### PR TITLE
Use Hubspot API to update contacts

### DIFF
--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -14,7 +14,7 @@ def _track_on_hubspot(webuser, properties):
     properties is a dictionary mapping property names to values.
     Note that property names must exist on hubspot prior to use.
     """
-    # TODO: Use OAuth
+    # Note: Hubspot recommends OAuth instead of api key
     # TODO: Use batch requests / be mindful of rate limit
     api_key = ANALYTICS_IDS.get('HUBSPOT_API_KEY', None)
     if api_key and not webuser.is_dimagi:
@@ -30,7 +30,7 @@ def _track_on_hubspot(webuser, properties):
         req.raise_for_status()
 
 
-@task(queue='background_queue')
+@task(queue='background_queue', acks_late=True)
 def track_created_hq_account_on_hubspot(webuser):
     _track_on_hubspot(webuser, {
         'created_account_in_hq': True,
@@ -38,7 +38,7 @@ def track_created_hq_account_on_hubspot(webuser):
     })
 
 
-@task(queue='background_queue')
+@task(queue='background_queue', acks_late=True)
 def track_built_app_on_hubspot(webuser):
     # TODO: Confirm that previously untracked users should be tracked
     _track_on_hubspot(webuser, {'built_app': True})

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -6,7 +6,7 @@ import urllib
 from settings import ANALYTICS_IDS
 
 
-def _track_on_hubspot(email, properties):
+def _track_on_hubspot(webuser, properties):
     """
     Update or create a new "contact" on hubspot. Record that the user has
     created an account on HQ.
@@ -15,11 +15,11 @@ def _track_on_hubspot(email, properties):
     Note that property names must exist on hubspot prior to use.
     """
     # TODO: Use OAuth
-    # TODO: Use batch requests / don't violate rate limit
+    # TODO: Use batch requests / be mindful of rate limit
     api_key = ANALYTICS_IDS.get('HUBSPOT_API_KEY', None)
-    if api_key:
+    if api_key and not webuser.is_dimagi:
         req = requests.post(
-            "https://api.hubapi.com/contacts/v1/contact/createOrUpdate/email/{}".format(urllib.quote(email)),
+            "https://api.hubapi.com/contacts/v1/contact/createOrUpdate/email/{}".format(urllib.quote(webuser.username)),
             params={'hapikey': api_key},
             data=json.dumps(
                 {'properties': [
@@ -31,10 +31,11 @@ def _track_on_hubspot(email, properties):
 
 
 @task(queue='background_queue')
-def track_created_hq_account_on_hubspot(email):
-    _track_on_hubspot(email, {'created_account_in_hq': True})
+def track_created_hq_account_on_hubspot(webuser):
+    _track_on_hubspot(webuser, {'created_account_in_hq': True})
 
 
 @task(queue='background_queue')
-def track_built_app_on_hubspot(email):
-    _track_on_hubspot(email, {'built_app': True})
+def track_built_app_on_hubspot(webuser):
+    # TODO: Confirm that previously untracked users should be tracked
+    _track_on_hubspot(webuser, {'built_app': True})

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -20,7 +20,9 @@ def _track_on_hubspot(webuser, properties):
     api_key = ANALYTICS_IDS.get('HUBSPOT_API_KEY', None)
     if api_key and not webuser.is_dimagi:
         req = requests.post(
-            u"https://api.hubapi.com/contacts/v1/contact/createOrUpdate/email/{}".format(urllib.quote(webuser.username)),
+            u"https://api.hubapi.com/contacts/v1/contact/createOrUpdate/email/{}".format(
+                urllib.quote(webuser.username)
+            ),
             params={'hapikey': api_key},
             data=json.dumps(
                 {'properties': [

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -35,7 +35,9 @@ def _get_user_hubspot_id(webuser):
     api_key = ANALYTICS_IDS.get('HUBSPOT_API_KEY', None)
     if api_key:
         req = requests.get(
-            u"https://api.hubapi.com/contacts/v1/contact/email/{}/profile".format(urllib.quote(webuser.username)),
+            u"https://api.hubapi.com/contacts/v1/contact/email/{}/profile".format(
+                urllib.quote(webuser.username)
+            ),
             params={'hapikey': api_key},
         )
         if req.status_code == 404:

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -16,16 +16,18 @@ def _track_on_hubspot(email, properties):
     """
     # TODO: Use OAuth
     # TODO: Use batch requests / don't violate rate limit
-    req = requests.post(
-        "https://api.hubapi.com/contacts/v1/contact/createOrUpdate/email/{}".format(urllib.quote(email)),
-        params={'hapikey': ANALYTICS_IDS.get('HUBSPOT_API_KEY', None)},
-        data=json.dumps(
-            {'properties': [
-                {'property': k, 'value': v} for k, v in properties.items()
-            ]}
-        ),
-    )
-    req.raise_for_status()
+    api_key = ANALYTICS_IDS.get('HUBSPOT_API_KEY', None)
+    if api_key:
+        req = requests.post(
+            "https://api.hubapi.com/contacts/v1/contact/createOrUpdate/email/{}".format(urllib.quote(email)),
+            params={'hapikey': api_key},
+            data=json.dumps(
+                {'properties': [
+                    {'property': k, 'value': v} for k, v in properties.items()
+                ]}
+            ),
+        )
+        req.raise_for_status()
 
 
 @task(queue='background_queue')

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -1,0 +1,37 @@
+from celery.task import task
+import json
+import requests
+import urllib
+
+from settings import ANALYTICS_IDS
+
+
+def _track_on_hubspot(email, properties):
+    """
+    Update or create a new "contact" on hubspot. Record that the user has
+    created an account on HQ.
+
+    properties is a dictionary mapping property names to values.
+    Note that property names must exist on hubspot prior to use.
+    """
+    # TODO: Use OAuth
+    req = requests.post(
+        "https://api.hubapi.com/contacts/v1/contact/createOrUpdate/email/{}".format(urllib.quote(email)),
+        params={'hapikey': ANALYTICS_IDS.get('HUBSPOT_KEY', None)},
+        data=json.dumps(
+            {'properties': [
+                {'property': k, 'value': v} for k, v in properties.items()
+            ]}
+        ),
+    )
+    # TODO: Raise errors for bad requests etc.
+
+
+@task(queue='background_queue')
+def track_created_hq_account_on_hubspot(email):
+    _track_on_hubspot(email, {'created_account_in_hq': True})
+
+
+@task(queue='background_queue')
+def track_built_app_on_hubspot(email):
+    _track_on_hubspot(email, {'built_app': True})

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -32,7 +32,10 @@ def _track_on_hubspot(webuser, properties):
 
 @task(queue='background_queue')
 def track_created_hq_account_on_hubspot(webuser):
-    _track_on_hubspot(webuser, {'created_account_in_hq': True})
+    _track_on_hubspot(webuser, {
+        'created_account_in_hq': True,
+        'commcare_user': True,
+    })
 
 
 @task(queue='background_queue')

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -18,7 +18,7 @@ def _track_on_hubspot(email, properties):
     # TODO: Use batch requests / don't violate rate limit
     req = requests.post(
         "https://api.hubapi.com/contacts/v1/contact/createOrUpdate/email/{}".format(urllib.quote(email)),
-        params={'hapikey': ANALYTICS_IDS.get('HUBSPOT_KEY', None)},
+        params={'hapikey': ANALYTICS_IDS.get('HUBSPOT_API_KEY', None)},
         data=json.dumps(
             {'properties': [
                 {'property': k, 'value': v} for k, v in properties.items()

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -15,6 +15,7 @@ def _track_on_hubspot(email, properties):
     Note that property names must exist on hubspot prior to use.
     """
     # TODO: Use OAuth
+    # TODO: Use batch requests / don't violate rate limit
     req = requests.post(
         "https://api.hubapi.com/contacts/v1/contact/createOrUpdate/email/{}".format(urllib.quote(email)),
         params={'hapikey': ANALYTICS_IDS.get('HUBSPOT_KEY', None)},
@@ -24,7 +25,7 @@ def _track_on_hubspot(email, properties):
             ]}
         ),
     )
-    # TODO: Raise errors for bad requests etc.
+    req.raise_for_status()
 
 
 @task(queue='background_queue')

--- a/corehq/apps/app_manager/templates/app_manager/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/releases.html
@@ -139,6 +139,7 @@
         <button class="btn btn-primary" data-bind="
             click: function() {
                 analytics.track('Clicked Make New Version');
+                analytics.marketing({'built app': true});
                 return makeNewBuild();
             },
             attr: {disabled: !buildButtonEnabled() ? 'disabled' : undefined},

--- a/corehq/apps/app_manager/templates/app_manager/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/releases.html
@@ -139,7 +139,6 @@
         <button class="btn btn-primary" data-bind="
             click: function() {
                 analytics.track('Clicked Make New Version');
-                analytics.marketing({'built app': true});
                 return makeNewBuild();
             },
             attr: {disabled: !buildButtonEnabled() ? 'disabled' : undefined},

--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -18,6 +18,7 @@ from django.utils.translation import ugettext as _, get_language, ugettext_noop
 from django.views.decorators.cache import cache_control
 from corehq import ApplicationsTab, toggles, privileges, feature_previews, ReportConfiguration
 from corehq.apps.accounting.utils import domain_has_privilege
+from corehq.apps.analytics.tasks import track_built_app_on_hubspot
 from corehq.apps.app_manager import commcare_settings
 from corehq.apps.app_manager.exceptions import (
     AppEditingError,
@@ -2346,6 +2347,8 @@ def save_copy(request, domain, app_id):
     See VersionedDoc.save_copy
 
     """
+    # TODO: Is this only called when making a new build?
+    track_built_app_on_hubspot.delay(request.user.username)
     comment = request.POST.get('comment')
     app = get_app(domain, app_id)
     try:

--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -2347,7 +2347,6 @@ def save_copy(request, domain, app_id):
     See VersionedDoc.save_copy
 
     """
-    # TODO: Is this only called when making a new build?
     track_built_app_on_hubspot.delay(request.user.username)
     comment = request.POST.get('comment')
     app = get_app(domain, app_id)

--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -2347,7 +2347,7 @@ def save_copy(request, domain, app_id):
     See VersionedDoc.save_copy
 
     """
-    track_built_app_on_hubspot.delay(request.user.username)
+    track_built_app_on_hubspot.delay(request.couch_user)
     comment = request.POST.get('comment')
     app = get_app(domain, app_id)
     try:

--- a/corehq/apps/registration/templates/registration/confirmation_complete.html
+++ b/corehq/apps/registration/templates/registration/confirmation_complete.html
@@ -3,9 +3,12 @@
 {% if valid_confirmation %}
 {% block js-inline %}{{ block.super }}
 <script>
+    {% if not is_error %}
     $(function () {
         analytics.track("Confirmed new project");
+        analytics.marketing({'Confirmed new project': true});
     });
+    {% endif %}
 </script>
 {% endblock js-inline %}
 {% endif %}

--- a/corehq/apps/registration/templates/registration/confirmation_complete.html
+++ b/corehq/apps/registration/templates/registration/confirmation_complete.html
@@ -6,7 +6,6 @@
     {% if not is_error %}
     $(function () {
         analytics.track("Confirmed new project");
-        analytics.marketing({'Confirmed new project': true});
     });
     {% endif %}
 </script>

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -10,6 +10,7 @@ from django.template.loader import render_to_string
 from django.utils.translation import ugettext as _
 import sys
 
+from corehq.apps.analytics.tasks import track_created_hq_account_on_hubspot
 from corehq.apps.domain.decorators import login_required
 from corehq.apps.domain.models import Domain
 from corehq.apps.orgs.views import orgs_landing
@@ -284,6 +285,7 @@ def confirm_domain(request, guid=None):
     ) % requesting_user.username
     context['is_error'] = False
     context['valid_confirmation'] = True
+    track_created_hq_account_on_hubspot.delay(requesting_user.username)
     return render(request, 'registration/confirmation_complete.html', context)
 
 

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -285,7 +285,7 @@ def confirm_domain(request, guid=None):
     ) % requesting_user.username
     context['is_error'] = False
     context['valid_confirmation'] = True
-    track_created_hq_account_on_hubspot.delay(requesting_user.username)
+    track_created_hq_account_on_hubspot.delay(requesting_user)
     return render(request, 'registration/confirmation_complete.html', context)
 
 

--- a/corehq/apps/style/templates/style/includes/analytics_all.html
+++ b/corehq/apps/style/templates/style/includes/analytics_all.html
@@ -112,6 +112,35 @@
         },
 
         /**
+         * Update properties for the given user in our marketing tracking system.
+         * Creates a new user in the marketing system if one does not already exist.
+         *
+         * @param {object} properties - A dictionary of properties to set on the user.
+         */
+        marketing: function (properties) {
+            {% if HUBSPOT_KEY and request.couch_user %}
+
+            // TODO: It's rate limited!
+            // TODO: Probably can't straight up do https
+            $.ajax(
+                "https://api.hubapi.com/contacts/v1/contact/createOrUpdate/email/" +
+                    encodeURIComponent('{{ request.couch_user.username }}') +
+                    "?hapikey=" + encodeURIComponent("{{ HUBSPOT_KEY }}"),
+                {
+                    method: "POST",
+                    contentType: "application/json",
+                    data: {
+                        "properties": _.map(properties, function(val, key){
+                            return {"property": key, "value": val};
+                        })
+                    }
+                }
+            );
+            // TODO: Handle errors. Callback.
+            {% endif %}
+        },
+
+        /**
          * Track an event when the given element is clicked.
          * Uses a callback to ensure that the request to the analytics services
          * completes before the default click action happens. This is useful if

--- a/corehq/apps/style/templates/style/includes/analytics_all.html
+++ b/corehq/apps/style/templates/style/includes/analytics_all.html
@@ -112,35 +112,6 @@
         },
 
         /**
-         * Update properties for the given user in our marketing tracking system.
-         * Creates a new user in the marketing system if one does not already exist.
-         *
-         * @param {object} properties - A dictionary of properties to set on the user.
-         */
-        marketing: function (properties) {
-            {% if HUBSPOT_KEY and request.couch_user %}
-
-            // TODO: It's rate limited!
-            // TODO: Probably can't straight up do https
-            $.ajax(
-                "https://api.hubapi.com/contacts/v1/contact/createOrUpdate/email/" +
-                    encodeURIComponent('{{ request.couch_user.username }}') +
-                    "?hapikey=" + encodeURIComponent("{{ HUBSPOT_KEY }}"),
-                {
-                    method: "POST",
-                    contentType: "application/json",
-                    data: {
-                        "properties": _.map(properties, function(val, key){
-                            return {"property": key, "value": val};
-                        })
-                    }
-                }
-            );
-            // TODO: Handle errors. Callback.
-            {% endif %}
-        },
-
-        /**
          * Track an event when the given element is clicked.
          * Uses a callback to ensure that the request to the analytics services
          * completes before the default click action happens. This is useful if

--- a/docker/localsettings.py
+++ b/docker/localsettings.py
@@ -130,7 +130,6 @@ ANALYTICS_IDS = {
     'PINGDOM_ID': '*****',
     'ANALYTICS_ID_PUBLIC_COMMCARE': '*****',
     'KISSMETRICS_KEY': '*****',
-    'HUBSPOT_API_KEY': '*****'
 }
 
 ANALYTICS_CONFIG = {

--- a/docker/localsettings.py
+++ b/docker/localsettings.py
@@ -130,6 +130,7 @@ ANALYTICS_IDS = {
     'PINGDOM_ID': '*****',
     'ANALYTICS_ID_PUBLIC_COMMCARE': '*****',
     'KISSMETRICS_KEY': '*****',
+    'HUBSPOT_API_KEY': '*****'
 }
 
 ANALYTICS_CONFIG = {

--- a/localsettings.example.py
+++ b/localsettings.example.py
@@ -134,7 +134,6 @@ ANALYTICS_IDS = {
     'PINGDOM_ID': '*****',
     'ANALYTICS_ID_PUBLIC_COMMCARE': '*****',
     'KISSMETRICS_KEY': '*****',
-    'HUBSPOT_API_KEY': '*****'
 }
 
 ANALYTICS_CONFIG = {

--- a/localsettings.example.py
+++ b/localsettings.example.py
@@ -134,6 +134,7 @@ ANALYTICS_IDS = {
     'PINGDOM_ID': '*****',
     'ANALYTICS_ID_PUBLIC_COMMCARE': '*****',
     'KISSMETRICS_KEY': '*****',
+    'HUBSPOT_API_KEY': '*****',
 }
 
 ANALYTICS_CONFIG = {

--- a/localsettings.example.py
+++ b/localsettings.example.py
@@ -134,6 +134,7 @@ ANALYTICS_IDS = {
     'PINGDOM_ID': '*****',
     'ANALYTICS_ID_PUBLIC_COMMCARE': '*****',
     'KISSMETRICS_KEY': '*****',
+    'HUBSPOT_API_KEY': '*****'
 }
 
 ANALYTICS_CONFIG = {

--- a/settings.py
+++ b/settings.py
@@ -234,6 +234,7 @@ HQ_APPS = (
     'formtranslate',
     'langcodes',
     'corehq.apps.adm',
+    'corehq.apps.analytics',
     'corehq.apps.announcements',
     'corehq.apps.callcenter',
     'corehq.apps.crud',

--- a/settings.py
+++ b/settings.py
@@ -694,6 +694,7 @@ ANALYTICS_IDS = {
     'PINGDOM_ID': '',
     'ANALYTICS_ID_PUBLIC_COMMCARE': '',
     'KISSMETRICS_KEY': '',
+    'HUBSPOT_API_KEY': '',
     'HUBSPOT_ID': '',
 }
 


### PR DESCRIPTION
This POC was an experiment to see how easy it would be to send event-like information to Hubspot when users do particular things on HQ. The API doesn't support cross-domain requests, which is why it is being consumed server side.

Hold off on merge until I confirm the desired tracking behavior.

FYI review buddy @czue 
