### PR TITLE
Add index to log_id

### DIFF
--- a/corehq/apps/smsbillables/migrations/0010_add_index_to_log_id.py
+++ b/corehq/apps/smsbillables/migrations/0010_add_index_to_log_id.py
@@ -1,51 +1,22 @@
-# -*- coding: utf-8 -*-
+# encoding: utf-8
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
 
-
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
-
-        # Changing field 'SmsBillable.gateway_fee'
-        db.alter_column(u'smsbillables_smsbillable', 'gateway_fee_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['smsbillables.SmsGatewayFee'], null=True, on_delete=models.PROTECT))
+        
         # Adding index on 'SmsBillable', fields ['log_id']
         db.create_index(u'smsbillables_smsbillable', ['log_id'])
 
 
-        # Changing field 'SmsBillable.usage_fee'
-        db.alter_column(u'smsbillables_smsbillable', 'usage_fee_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['smsbillables.SmsUsageFee'], null=True, on_delete=models.PROTECT))
-
-        # Changing field 'SmsGatewayFee.currency'
-        db.alter_column(u'smsbillables_smsgatewayfee', 'currency_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['accounting.Currency'], on_delete=models.PROTECT))
-
-        # Changing field 'SmsGatewayFee.criteria'
-        db.alter_column(u'smsbillables_smsgatewayfee', 'criteria_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['smsbillables.SmsGatewayFeeCriteria'], on_delete=models.PROTECT))
-
-        # Changing field 'SmsUsageFee.criteria'
-        db.alter_column(u'smsbillables_smsusagefee', 'criteria_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['smsbillables.SmsUsageFeeCriteria'], on_delete=models.PROTECT))
-
     def backwards(self, orm):
+        
         # Removing index on 'SmsBillable', fields ['log_id']
         db.delete_index(u'smsbillables_smsbillable', ['log_id'])
 
-
-        # Changing field 'SmsBillable.gateway_fee'
-        db.alter_column(u'smsbillables_smsbillable', 'gateway_fee_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['smsbillables.SmsGatewayFee'], null=True))
-
-        # Changing field 'SmsBillable.usage_fee'
-        db.alter_column(u'smsbillables_smsbillable', 'usage_fee_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['smsbillables.SmsUsageFee'], null=True))
-
-        # Changing field 'SmsGatewayFee.currency'
-        db.alter_column(u'smsbillables_smsgatewayfee', 'currency_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['accounting.Currency']))
-
-        # Changing field 'SmsGatewayFee.criteria'
-        db.alter_column(u'smsbillables_smsgatewayfee', 'criteria_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['smsbillables.SmsGatewayFeeCriteria']))
-
-        # Changing field 'SmsUsageFee.criteria'
-        db.alter_column(u'smsbillables_smsusagefee', 'criteria_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['smsbillables.SmsUsageFeeCriteria']))
 
     models = {
         u'accounting.currency': {
@@ -64,19 +35,19 @@ class Migration(SchemaMigration):
             'date_sent': ('django.db.models.fields.DateField', [], {}),
             'direction': ('django.db.models.fields.CharField', [], {'max_length': '10', 'db_index': 'True'}),
             'domain': ('django.db.models.fields.CharField', [], {'max_length': '25', 'db_index': 'True'}),
-            'gateway_fee': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['smsbillables.SmsGatewayFee']", 'null': 'True', 'on_delete': 'models.PROTECT'}),
+            'gateway_fee': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['smsbillables.SmsGatewayFee']", 'null': 'True'}),
             'gateway_fee_conversion_rate': ('django.db.models.fields.DecimalField', [], {'default': "'1.0'", 'null': 'True', 'max_digits': '20', 'decimal_places': '9'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'is_valid': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'db_index': 'True'}),
             'log_id': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
             'phone_number': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
-            'usage_fee': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['smsbillables.SmsUsageFee']", 'null': 'True', 'on_delete': 'models.PROTECT'})
+            'usage_fee': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['smsbillables.SmsUsageFee']", 'null': 'True'})
         },
         u'smsbillables.smsgatewayfee': {
             'Meta': {'object_name': 'SmsGatewayFee'},
             'amount': ('django.db.models.fields.DecimalField', [], {'default': '0.0', 'max_digits': '10', 'decimal_places': '4'}),
-            'criteria': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['smsbillables.SmsGatewayFeeCriteria']", 'on_delete': 'models.PROTECT'}),
-            'currency': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Currency']", 'on_delete': 'models.PROTECT'}),
+            'criteria': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['smsbillables.SmsGatewayFeeCriteria']"}),
+            'currency': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Currency']"}),
             'date_created': ('django.db.models.fields.DateField', [], {'auto_now_add': 'True', 'blank': 'True'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
         },
@@ -92,7 +63,7 @@ class Migration(SchemaMigration):
         u'smsbillables.smsusagefee': {
             'Meta': {'object_name': 'SmsUsageFee'},
             'amount': ('django.db.models.fields.DecimalField', [], {'default': '0.0', 'max_digits': '10', 'decimal_places': '4'}),
-            'criteria': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['smsbillables.SmsUsageFeeCriteria']", 'on_delete': 'models.PROTECT'}),
+            'criteria': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['smsbillables.SmsUsageFeeCriteria']"}),
             'date_created': ('django.db.models.fields.DateField', [], {'auto_now_add': 'True', 'blank': 'True'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
         },

--- a/corehq/apps/smsbillables/migrations/0010_add_index_to_log_id.py
+++ b/corehq/apps/smsbillables/migrations/0010_add_index_to_log_id.py
@@ -1,22 +1,51 @@
-# encoding: utf-8
+# -*- coding: utf-8 -*-
 import datetime
 from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
 
+
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
-        
+
+        # Changing field 'SmsBillable.gateway_fee'
+        db.alter_column(u'smsbillables_smsbillable', 'gateway_fee_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['smsbillables.SmsGatewayFee'], null=True, on_delete=models.PROTECT))
         # Adding index on 'SmsBillable', fields ['log_id']
         db.create_index(u'smsbillables_smsbillable', ['log_id'])
 
 
+        # Changing field 'SmsBillable.usage_fee'
+        db.alter_column(u'smsbillables_smsbillable', 'usage_fee_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['smsbillables.SmsUsageFee'], null=True, on_delete=models.PROTECT))
+
+        # Changing field 'SmsGatewayFee.currency'
+        db.alter_column(u'smsbillables_smsgatewayfee', 'currency_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['accounting.Currency'], on_delete=models.PROTECT))
+
+        # Changing field 'SmsGatewayFee.criteria'
+        db.alter_column(u'smsbillables_smsgatewayfee', 'criteria_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['smsbillables.SmsGatewayFeeCriteria'], on_delete=models.PROTECT))
+
+        # Changing field 'SmsUsageFee.criteria'
+        db.alter_column(u'smsbillables_smsusagefee', 'criteria_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['smsbillables.SmsUsageFeeCriteria'], on_delete=models.PROTECT))
+
     def backwards(self, orm):
-        
         # Removing index on 'SmsBillable', fields ['log_id']
         db.delete_index(u'smsbillables_smsbillable', ['log_id'])
 
+
+        # Changing field 'SmsBillable.gateway_fee'
+        db.alter_column(u'smsbillables_smsbillable', 'gateway_fee_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['smsbillables.SmsGatewayFee'], null=True))
+
+        # Changing field 'SmsBillable.usage_fee'
+        db.alter_column(u'smsbillables_smsbillable', 'usage_fee_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['smsbillables.SmsUsageFee'], null=True))
+
+        # Changing field 'SmsGatewayFee.currency'
+        db.alter_column(u'smsbillables_smsgatewayfee', 'currency_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['accounting.Currency']))
+
+        # Changing field 'SmsGatewayFee.criteria'
+        db.alter_column(u'smsbillables_smsgatewayfee', 'criteria_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['smsbillables.SmsGatewayFeeCriteria']))
+
+        # Changing field 'SmsUsageFee.criteria'
+        db.alter_column(u'smsbillables_smsusagefee', 'criteria_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['smsbillables.SmsUsageFeeCriteria']))
 
     models = {
         u'accounting.currency': {
@@ -35,19 +64,19 @@ class Migration(SchemaMigration):
             'date_sent': ('django.db.models.fields.DateField', [], {}),
             'direction': ('django.db.models.fields.CharField', [], {'max_length': '10', 'db_index': 'True'}),
             'domain': ('django.db.models.fields.CharField', [], {'max_length': '25', 'db_index': 'True'}),
-            'gateway_fee': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['smsbillables.SmsGatewayFee']", 'null': 'True'}),
+            'gateway_fee': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['smsbillables.SmsGatewayFee']", 'null': 'True', 'on_delete': 'models.PROTECT'}),
             'gateway_fee_conversion_rate': ('django.db.models.fields.DecimalField', [], {'default': "'1.0'", 'null': 'True', 'max_digits': '20', 'decimal_places': '9'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'is_valid': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'db_index': 'True'}),
             'log_id': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
             'phone_number': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
-            'usage_fee': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['smsbillables.SmsUsageFee']", 'null': 'True'})
+            'usage_fee': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['smsbillables.SmsUsageFee']", 'null': 'True', 'on_delete': 'models.PROTECT'})
         },
         u'smsbillables.smsgatewayfee': {
             'Meta': {'object_name': 'SmsGatewayFee'},
             'amount': ('django.db.models.fields.DecimalField', [], {'default': '0.0', 'max_digits': '10', 'decimal_places': '4'}),
-            'criteria': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['smsbillables.SmsGatewayFeeCriteria']"}),
-            'currency': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Currency']"}),
+            'criteria': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['smsbillables.SmsGatewayFeeCriteria']", 'on_delete': 'models.PROTECT'}),
+            'currency': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Currency']", 'on_delete': 'models.PROTECT'}),
             'date_created': ('django.db.models.fields.DateField', [], {'auto_now_add': 'True', 'blank': 'True'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
         },
@@ -63,7 +92,7 @@ class Migration(SchemaMigration):
         u'smsbillables.smsusagefee': {
             'Meta': {'object_name': 'SmsUsageFee'},
             'amount': ('django.db.models.fields.DecimalField', [], {'default': '0.0', 'max_digits': '10', 'decimal_places': '4'}),
-            'criteria': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['smsbillables.SmsUsageFeeCriteria']"}),
+            'criteria': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['smsbillables.SmsUsageFeeCriteria']", 'on_delete': 'models.PROTECT'}),
             'date_created': ('django.db.models.fields.DateField', [], {'auto_now_add': 'True', 'blank': 'True'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
         },

--- a/corehq/apps/smsbillables/migrations/0010_auto.py
+++ b/corehq/apps/smsbillables/migrations/0010_auto.py
@@ -1,0 +1,78 @@
+# encoding: utf-8
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        
+        # Adding index on 'SmsBillable', fields ['log_id']
+        db.create_index(u'smsbillables_smsbillable', ['log_id'])
+
+
+    def backwards(self, orm):
+        
+        # Removing index on 'SmsBillable', fields ['log_id']
+        db.delete_index(u'smsbillables_smsbillable', ['log_id'])
+
+
+    models = {
+        u'accounting.currency': {
+            'Meta': {'object_name': 'Currency'},
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '3'}),
+            'date_updated': ('django.db.models.fields.DateField', [], {'auto_now': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '25', 'db_index': 'True'}),
+            'rate_to_default': ('django.db.models.fields.DecimalField', [], {'default': "'1.0'", 'max_digits': '20', 'decimal_places': '9'}),
+            'symbol': ('django.db.models.fields.CharField', [], {'max_length': '10'})
+        },
+        u'smsbillables.smsbillable': {
+            'Meta': {'object_name': 'SmsBillable'},
+            'api_response': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'date_created': ('django.db.models.fields.DateField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'date_sent': ('django.db.models.fields.DateField', [], {}),
+            'direction': ('django.db.models.fields.CharField', [], {'max_length': '10', 'db_index': 'True'}),
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '25', 'db_index': 'True'}),
+            'gateway_fee': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['smsbillables.SmsGatewayFee']", 'null': 'True'}),
+            'gateway_fee_conversion_rate': ('django.db.models.fields.DecimalField', [], {'default': "'1.0'", 'null': 'True', 'max_digits': '20', 'decimal_places': '9'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_valid': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'db_index': 'True'}),
+            'log_id': ('django.db.models.fields.CharField', [], {'max_length': '50', 'db_index': 'True'}),
+            'phone_number': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'usage_fee': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['smsbillables.SmsUsageFee']", 'null': 'True'})
+        },
+        u'smsbillables.smsgatewayfee': {
+            'Meta': {'object_name': 'SmsGatewayFee'},
+            'amount': ('django.db.models.fields.DecimalField', [], {'default': '0.0', 'max_digits': '10', 'decimal_places': '4'}),
+            'criteria': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['smsbillables.SmsGatewayFeeCriteria']"}),
+            'currency': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['accounting.Currency']"}),
+            'date_created': ('django.db.models.fields.DateField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'smsbillables.smsgatewayfeecriteria': {
+            'Meta': {'object_name': 'SmsGatewayFeeCriteria'},
+            'backend_api_id': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'backend_instance': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'db_index': 'True'}),
+            'country_code': ('django.db.models.fields.IntegerField', [], {'db_index': 'True', 'max_length': '5', 'null': 'True', 'blank': 'True'}),
+            'direction': ('django.db.models.fields.CharField', [], {'max_length': '10', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'prefix': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '10', 'db_index': 'True', 'blank': 'True'})
+        },
+        u'smsbillables.smsusagefee': {
+            'Meta': {'object_name': 'SmsUsageFee'},
+            'amount': ('django.db.models.fields.DecimalField', [], {'default': '0.0', 'max_digits': '10', 'decimal_places': '4'}),
+            'criteria': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['smsbillables.SmsUsageFeeCriteria']"}),
+            'date_created': ('django.db.models.fields.DateField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'smsbillables.smsusagefeecriteria': {
+            'Meta': {'object_name': 'SmsUsageFeeCriteria'},
+            'direction': ('django.db.models.fields.CharField', [], {'max_length': '10', 'db_index': 'True'}),
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '25', 'null': 'True', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        }
+    }
+
+    complete_apps = ['smsbillables']

--- a/corehq/apps/smsbillables/models.py
+++ b/corehq/apps/smsbillables/models.py
@@ -244,7 +244,7 @@ class SmsBillable(models.Model):
     gateway_fee_conversion_rate = models.DecimalField(default=Decimal('1.0'), null=True, max_digits=20,
                                                       decimal_places=EXCHANGE_RATE_DECIMAL_PLACES)
     usage_fee = models.ForeignKey(SmsUsageFee, null=True, on_delete=models.PROTECT)
-    log_id = models.CharField(max_length=50)
+    log_id = models.CharField(max_length=50, db_index=True)
     phone_number = models.CharField(max_length=50)
     api_response = models.TextField(null=True, blank=True)
     is_valid = models.BooleanField(default=True, db_index=True)


### PR DESCRIPTION
@gcapalbo found a few long queries that looked like this:

```
SELECT ( 1 ) AS "a" FROM "smsbillables_smsbillable" WHERE "smsbillables_smsbillable"."log_id" = '11d84b78cc30e39565731a48b94b3d2c' LIMIT 1
```

some of them were taking up to 6 minutes to run. i couldn't find the exact place in the code where the query was being made, so let me know if you don't think this is necessary.

elf @snopoke 
