### PR TITLE
Add refresh text & button to 500 page

### DIFF
--- a/corehq/apps/hqwebapp/templates/500.html
+++ b/corehq/apps/hqwebapp/templates/500.html
@@ -30,11 +30,15 @@
         </div>
         <div class="span8">
             <div class="well">
-                <legend>
-                    First time here?
-                </legend>
-                <p>Try refreshing: often the problem is temporary and the page will succeed if you try again.</p>
-                <button id="refresh" class="btn btn-primary">{% trans "Refresh Page" %}</button>
+                <form>
+                    <fieldset>
+                        <legend>
+                            First time here?
+                        </legend>
+                        Try refreshing. Often the problem is temporary and the page will succeed if you try again.<br><br>
+                        <button id="refresh" class="btn btn-primary">{% trans "Refresh Page" %}</button>
+                    </fieldset>
+                </form>
             </div>
             <form class="well form form-horizontal" style="padding-bottom: 0;" action="{% url "bug_report" %}" method="post">
                 <input type="hidden" id="bug-report-500-url" name="url" value="{{ request.build_absolute_uri }}"/>
@@ -53,20 +57,17 @@
                             Been here before? <small>Report an issue to help us get this problem fixed faster.</small>
                         {% endblocktrans %}
                     </legend>
-                    <p>{% trans "We would appreciate it a lot if you could provide us with any additional info about what happened before you encountered this problem." %}</p>
+                    {% trans "We would appreciate it a lot if you could provide us with any additional info about what happened before you encountered this problem." %}<br><br>
                     <div class="control-group">
                         <label class="control-label" for="bug-report-500-subject">{% trans "Short Description" %}</label>
                         <div class="controls">
                             <input type="text" class="input-xlarge" name="subject" id="bug-report-500-subject">
-                            <p class="help-block">{% trans "Please summarize the issue in one sentence&mdash;the message field below should contain more detail." %}</p>
                         </div>
                     </div>
                     <div class="control-group">
                         <label class="control-label" for="bug-report-500-message">{% trans "Full Description" %}</label>
                         <div class="controls">
-                            <textarea class="input-xlarge" name="message" id="bug-report-500-message" rows="10"></textarea>
-                            <p class="help-block">{% trans "Please try to include as much information as possible." %}
-                            </p>
+                            <textarea class="input-xlarge" name="message" id="bug-report-500-message" rows="5"></textarea>
                         </div>
                     </div>
                 </fieldset>

--- a/corehq/apps/hqwebapp/templates/500.html
+++ b/corehq/apps/hqwebapp/templates/500.html
@@ -11,6 +11,9 @@
                 title: "{% trans "This is Danny, one of our best developers." %}",
                 content: "{% trans "Danny is pretty sad that you had to encounter this issue. He's making sure it gets fixed as soon as possible." %}"
             });
+            $('#refresh').click(function() {
+                window.location.reload(true);
+            });
         });
     </script>
 {% endblock %}
@@ -26,6 +29,13 @@
             <blockquote><p>{% trans "This problem has been logged and we're already hard at work figuring out the issue." %}</p></blockquote>
         </div>
         <div class="span8">
+            <div class="well">
+                <legend>
+                    First time here?
+                </legend>
+                <p>Try refreshing: often the problem is temporary and the page will succeed if you try again.</p>
+                <button id="refresh" class="btn btn-primary">{% trans "Refresh Page" %}</button>
+            </div>
             <form class="well form form-horizontal" style="padding-bottom: 0;" action="{% url "bug_report" %}" method="post">
                 <input type="hidden" id="bug-report-500-url" name="url" value="{{ request.build_absolute_uri }}"/>
                 <input type="hidden" id="bug-report-500-username" name="username" value="{{ user.username }}"/>
@@ -40,7 +50,7 @@
                 <fieldset>
                     <legend>
                         {% blocktrans %}
-                            Report an Issue <small>Help us get this problem fixed faster.</small>
+                            Been here before? <small>Report an issue to help us get this problem fixed faster.</small>
                         {% endblocktrans %}
                     </legend>
                     <p>{% trans "We would appreciate it a lot if you could provide us with any additional info about what happened before you encountered this problem." %}</p>


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?169121

Also dropped the help text and narrowed some spacing to shorten the page - the field descriptions seem pretty self-explanatory, and having a 500 page that doesn't fit on one screen feels excessive.

![screen shot 2015-05-26 at 6 02 54 pm](https://cloud.githubusercontent.com/assets/1486591/7824520/7e78c0f0-03d1-11e5-846e-cf528b1a65c4.png)
