### PR TITLE
fix timezone in form and case data pages

### DIFF
--- a/corehq/apps/hqwebapp/templatetags/proptable_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/proptable_tags.py
@@ -236,13 +236,21 @@ def render_tables(tables, options=None):
         })
 
 
-def get_definition(keys, num_columns=1, name=None):
+def get_default_definition(keys, num_columns=1, name=None):
     """
     Get a default single table layout definition for `keys` split across
     `num_columns` columns.
-    
+
+    All datetimes will be treated as "phone times".
+    (See corehq.util.timezones.conversions.PhoneTime for more context.)
+
     """
-    layout = chunked([{"expr": prop} for prop in keys], num_columns)
+
+    # is_phone_time isn't necessary on non-datetime columns,
+    # but doesn't hurt either, and is easier than trying to detect.
+    # I believe no caller uses this on non-phone-time datetimes
+    # but if something does, we'll have to do this in a more targetted way
+    layout = chunked([{"expr": prop, "is_phone_time": True} for prop in keys], num_columns)
 
     return [
         {

--- a/corehq/apps/hqwebapp/templatetags/proptable_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/proptable_tags.py
@@ -236,7 +236,7 @@ def render_tables(tables, options=None):
         })
 
 
-def get_default_definition(keys, num_columns=1, name=None):
+def get_default_definition(keys, num_columns=1, name=None, assume_phonetimes=True):
     """
     Get a default single table layout definition for `keys` split across
     `num_columns` columns.
@@ -250,7 +250,8 @@ def get_default_definition(keys, num_columns=1, name=None):
     # but doesn't hurt either, and is easier than trying to detect.
     # I believe no caller uses this on non-phone-time datetimes
     # but if something does, we'll have to do this in a more targetted way
-    layout = chunked([{"expr": prop, "is_phone_time": True} for prop in keys], num_columns)
+    layout = chunked([{"expr": prop, "is_phone_time": assume_phonetimes}
+                      for prop in keys], num_columns)
 
     return [
         {

--- a/corehq/apps/reports/templatetags/xform_tags.py
+++ b/corehq/apps/reports/templatetags/xform_tags.py
@@ -8,6 +8,7 @@ from django.utils.html import escape
 from django.utils.translation import ugettext as _
 from couchdbkit.exceptions import ResourceNotFound
 from corehq import privileges
+from corehq.apps.cloudcare import CLOUDCARE_DEVICE_ID
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_enabled
 
 from corehq.apps.receiverwrapper.auth import AuthContext
@@ -119,7 +120,10 @@ def render_form(form, domain, options):
         else:
             url = "#"
 
-        definition = get_default_definition(sorted_case_update_keys(b.keys()))
+        definition = get_default_definition(
+            sorted_case_update_keys(b.keys()),
+            assume_phonetimes=(form.metadata.deviceID != CLOUDCARE_DEVICE_ID)
+        )
         cases.append({
             "is_current_case": case_id and this_case_id == case_id,
             "name": case_inline_display(this_case),

--- a/corehq/ex-submodules/casexml/apps/case/templatetags/case_tags.py
+++ b/corehq/ex-submodules/casexml/apps/case/templatetags/case_tags.py
@@ -44,7 +44,7 @@ def render_case(case, options):
     Uses options since Django 1.3 doesn't seem to support templatetag kwargs.
     Change to kwargs when we're on a version of Django that does.
     """
-    from corehq.apps.hqwebapp.templatetags.proptable_tags import get_tables_as_rows, get_definition
+    from corehq.apps.hqwebapp.templatetags.proptable_tags import get_tables_as_rows, get_default_definition
     case = wrapped_case(case)
     timezone = options.get('timezone', pytz.utc)
     timezone = timezone.localize(datetime.datetime.utcnow()).tzinfo
@@ -71,8 +71,8 @@ def render_case(case, options):
 
     if dynamic_data:
         dynamic_keys = sorted(dynamic_data.keys())
-        definition = get_definition(
-                dynamic_keys, num_columns=DYNAMIC_CASE_PROPERTIES_COLUMNS)
+        definition = get_default_definition(
+            dynamic_keys, num_columns=DYNAMIC_CASE_PROPERTIES_COLUMNS)
 
         dynamic_properties = _get_tables_as_rows(dynamic_data, definition)
     else:

--- a/corehq/util/timezones/utils.py
+++ b/corehq/util/timezones/utils.py
@@ -3,6 +3,7 @@ import pytz
 import datetime
 from corehq.apps.domain.models import Domain
 from corehq.apps.users.models import CouchUser, WebUser
+from corehq.util.global_request import get_request
 
 
 def coerce_timezone_value(value):
@@ -17,6 +18,19 @@ def validate_timezone_max_length(max_length, zones):
         return x and (len(y) <= max_length)
     if not reduce(reducer, zones, True):
         raise Exception("corehq.apps.timezones.fields.TimeZoneField MAX_TIMEZONE_LENGTH is too small")
+
+
+def get_timezone_for_request(request=None):
+    if request is None:
+        request = get_request()
+
+    user = getattr(request, 'couch_user', None)
+    domain = getattr(request, 'domain', None)
+
+    if user or domain:
+        return get_timezone_for_user(request.couch_user, request.domain)
+    else:
+        return None
 
 
 def get_timezone_for_user(couch_user_or_id, domain):

--- a/corehq/util/timezones/utils.py
+++ b/corehq/util/timezones/utils.py
@@ -28,7 +28,7 @@ def get_timezone_for_request(request=None):
     domain = getattr(request, 'domain', None)
 
     if user or domain:
-        return get_timezone_for_user(request.couch_user, request.domain)
+        return get_timezone_for_user(user, domain)
     else:
         return None
 


### PR DESCRIPTION
Before:
![screen shot 2015-05-26 at 6 26 34 pm](https://cloud.githubusercontent.com/assets/137212/7824887/e8f1d02c-03d4-11e5-8acc-f7c3bdded912.png)
After:
![screen shot 2015-05-26 at 6 27 10 pm](https://cloud.githubusercontent.com/assets/137212/7824889/ed2ebdd0-03d4-11e5-8849-c2744ab76247.png)

Actual string in XML: `2014-08-06T17:08:03.399-04`. Note, that for pre-migrated domains, i.e. all domains currently, this doesn't actually _use_ the `-04`, it just guesses it from the domain's timezone. That's all about to change :)

~~**Note** This change is unfortunately not strictly an improvement, because a form that was actually submitted with datetimes in UTC will now have those datetimes converted into the domain timezone; and again unfortunately, CloudCare makes all submissions with UTC timestamps. For CloudCare-heavy domains, this will actually make this time incorrect—where it says "EDT" or whatever timezone, it should actually say UTC—but there's no super easy way to detect that.~~
