### PR TITLE
remove couchforms/edits view

### DIFF
--- a/corehq/ex-submodules/couchforms/_design/views/edits/map.js
+++ b/corehq/ex-submodules/couchforms/_design/views/edits/map.js
@@ -1,6 +1,0 @@
-function (doc) {
-    //function to reveal prior edits of xforms.
-    if(doc['doc_type'] == "XFormDeprecated") {
-        emit(doc.orig_id, null);
-    }
-}


### PR DESCRIPTION
this is only used in a single test, where a temp view can be used instead

@czue is there any reason you can think of this isn't a good idea? Is this view secretly used elsewhere, even though 'couchforms/edits' doesn't appear in code?
