### PR TITLE
move domain/related_to_domain calls to dbaccessors

### DIFF
--- a/corehq/apps/cachehq/cachemodels.py
+++ b/corehq/apps/cachehq/cachemodels.py
@@ -31,7 +31,6 @@ class UserGenerationCache(GenerationCache):
         "users/by_org_and_team",
         "users/by_username",
         "users/mailing_list_emails",
-        "domain/related_to_domain",
         "domain/old_users",
         "domain/docs",
         "sms/phones_to_domains",
@@ -57,7 +56,6 @@ class UserRoleGenerationCache(GenerationCache):
     generation_key = '#gen#user_role#'
     doc_types = ['UserRole']
     views = [
-        'domain/related_to_domain',
         'users/roles_by_domain'
     ]
 

--- a/corehq/apps/domain/dbaccessors.py
+++ b/corehq/apps/domain/dbaccessors.py
@@ -1,0 +1,59 @@
+from dimagi.utils.decorators.memoized import memoized
+
+
+@memoized
+def get_dbs_for_public_docs():
+    return _get_dbs(public__in=(True,))
+
+
+@memoized
+def get_dbs_for_all_docs():
+    return _get_dbs(public__in=(True, False))
+
+
+def _get_dbs(public__in):
+    from casexml.apps.case.models import CommCareCase
+    from corehq.apps.app_manager.models import Application, RemoteApp
+    from corehq.apps.fixtures.models import FixtureDataType
+    from corehq.apps.registration.models import RegistrationRequest
+    from corehq.apps.reminders.models import CaseReminderHandler
+    from corehq.apps.sms.models import MessageLog, SMSLog
+    from corehq.apps.users.models import CommCareUser, UserRole
+    from couchforms.models import XFormInstance
+    from couchlog.models import ExceptionRecord
+
+    doc_types_to_public = {
+        ExceptionRecord: False,
+        MessageLog: False,
+        RegistrationRequest: False,
+        SMSLog: False,
+        XFormInstance: False,
+        CommCareUser: False,
+        CommCareCase: False,
+        UserRole: True,
+        Application: True,
+        RemoteApp: True,
+        CaseReminderHandler: True,
+        FixtureDataType: True
+    }
+
+    dbs = {}
+    for doc_type, public in doc_types_to_public.items():
+        if public in public__in:
+            db = doc_type.get_db()
+            dbs[db.server_uri, db.dbname] = db
+    return dbs.values()
+
+
+def get_public_documents_related_to_domain(domain):
+    for db in get_dbs_for_public_docs():
+        for res in db.view('domain/related_to_domain', key=[domain, True]):
+            yield res['value']['_id'], res['value']['doc_type']
+
+
+def get_all_documents_related_to_domain(domain):
+    for db in get_dbs_for_all_docs():
+        for res in db.view('domain/related_to_domain',
+                           startkey=[domain],
+                           endkey=[domain, {}]):
+            yield res['value']['_id'], res['value']['doc_type']

--- a/settings.py
+++ b/settings.py
@@ -1011,7 +1011,9 @@ COUCHDB_APPS = [
     'appstore',
     'orgs',
     'builds',
-    'case',
+    'case'
+    # uncomment this to switch to separated db for cases
+    # ('case', 'case'),
     'callcenter',
     'cleanup',
     'cloudcare',


### PR DESCRIPTION
and make them check all relevant dbs

@benrudolph I was thinking something like this.

The point of this is that domain/related_to_domain is the only view that references both CommCareCase and _any other doc type_. By rewriting the very few (2) calls to it into dbaccessors functions, and making those functions iterate over all relevant dbs, we can make the code work for cases in a separate db by just changing the settings. (This would be in a situation where you've been replicating case docs to a separate db in the background and you're ready to make the switch.) This code acts as a sort of bridge between those two scenarios.

I'm pretty sure this isn't quite done, as we'd also need a way to make sure to sync the related_to_domain view to the case db as well. I think the only other doc type affected by changing the db for the 'case' app_label is CommCareCaseGroup.
