### PR TITLE
Revert "disable gsid custom code"

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -303,7 +303,7 @@ HQ_APPS = (
     'custom.bihar',
     'custom.penn_state',
     'dca',
-    # 'custom.apps.gsid', no longer in use
+    'custom.apps.gsid',
     'hsph',
     'mvp',
     'mvp_docs',
@@ -1068,7 +1068,7 @@ COUCHDB_APPS = [
     'penn_state',
     'care_benin',
     'dca',
-    # 'gsid', no longer in use
+    'gsid',
     'hsph',
     'mvp',
     ('mvp_docs', MVP_INDICATOR_DB),
@@ -1366,7 +1366,8 @@ DOMAIN_MODULE_MAP = {
     'eagles-fahu': 'dca',
     'fri': 'custom.fri.reports',
     'fri-testing': 'custom.fri.reports',
-    # 'gsid': 'custom.apps.gsid', no longer in use
+    'gsid': 'custom.apps.gsid',
+    'gsid-demo': 'custom.apps.gsid',
     'hsph-dev': 'hsph',
     'hsph-betterbirth-pilot-2': 'hsph',
     'mc-inscale': 'custom.reports.mc',
@@ -1418,7 +1419,7 @@ TRAVIS_TEST_GROUPS = (
         'couchapps', 'couchlog', 'crud', 'cvsu', 'dca', 'django_digest',
         'domain', 'domainsync', 'export',
         'facilities', 'fixtures', 'fluff_filter', 'formplayer',
-        'formtranslate', 'fri', 'grapevine', 'groups', 'hope',
+        'formtranslate', 'fri', 'grapevine', 'groups', 'gsid', 'hope',
         'hqadmin', 'hqcase', 'hqcouchlog', 'hqmedia',
         'care_pathways', 'colalife', 'common', 'compressor',
     ),


### PR DESCRIPTION
Reverts dimagi/commcare-hq#6856

Seems they are still using it (though no new data is coming in)
