### PR TITLE
Usercase in Advanced Modules

### DIFF
--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -140,21 +140,22 @@ class AppStringsBase(object):
                 (u'The lookup table settings for your user are incorrect. '
                     u'This user must have access to exactly one lookup table row for the table: ${0}')
 
-        from corehq.apps.app_manager.models import AUTO_SELECT_CASE, AUTO_SELECT_FIXTURE, AUTO_SELECT_USER
+        from corehq.apps.app_manager.models import (
+            AUTO_SELECT_CASE, AUTO_SELECT_FIXTURE, AUTO_SELECT_USER, AUTO_SELECT_USERCASE
+        )
 
         mode_text = {
             AUTO_SELECT_FIXTURE: u'lookup table field',
             AUTO_SELECT_USER: u'user data key',
-            AUTO_SELECT_CASE: u'case index'
+            AUTO_SELECT_CASE: u'case index',
+            AUTO_SELECT_USERCASE: u'user case',
         }
 
-        for mode in [AUTO_SELECT_FIXTURE, AUTO_SELECT_CASE, AUTO_SELECT_USER]:
+        for mode, text in mode_text.items():
             key = 'case_autoload.{0}.property_missing'.format(mode)
             if key not in messages:
                 messages[key] = (u'The {} specified for case auto-selecting '
-                                 u'could not be found: ${{0}}').format(mode_text[mode])
-
-        for mode in [AUTO_SELECT_FIXTURE, AUTO_SELECT_CASE, AUTO_SELECT_USER]:
+                                 u'could not be found: ${{0}}').format(text)
             key = 'case_autoload.{0}.case_missing'.format(mode)
             if key not in messages:
                 messages[key] = u'Unable to find case referenced by auto-select case ID.'

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -100,6 +100,7 @@ AUTO_SELECT_USER = 'user'
 AUTO_SELECT_FIXTURE = 'fixture'
 AUTO_SELECT_CASE = 'case'
 AUTO_SELECT_RAW = 'raw'
+AUTO_SELECT_USERCASE = 'usercase'
 
 DETAIL_TYPES = ['case_short', 'case_long', 'ref_short', 'ref_long']
 
@@ -368,7 +369,11 @@ class AutoSelectCase(DocumentSchema):
                         xpath expression.
 
     """
-    mode = StringProperty(choices=[AUTO_SELECT_USER, AUTO_SELECT_FIXTURE, AUTO_SELECT_CASE, AUTO_SELECT_RAW])
+    mode = StringProperty(choices=[AUTO_SELECT_USER,
+                                   AUTO_SELECT_FIXTURE,
+                                   AUTO_SELECT_CASE,
+                                   AUTO_SELECT_USERCASE,
+                                   AUTO_SELECT_RAW])
     value_source = StringProperty()
     value_key = StringProperty(required=True)
 
@@ -488,6 +493,7 @@ class AdvancedFormActions(DocumentSchema):
                 AUTO_SELECT_USER: [],
                 AUTO_SELECT_CASE: [],
                 AUTO_SELECT_FIXTURE: [],
+                AUTO_SELECT_USERCASE: [],
                 AUTO_SELECT_RAW: [],
             }
         }
@@ -1971,13 +1977,14 @@ class AdvancedForm(IndexedFormBase, NavMenuItemMediaMixin):
             if isinstance(action, LoadUpdateAction) and action.auto_select:
                 mode = action.auto_select.mode
                 if not action.auto_select.value_key:
-                    key_name = {
+                    key_names = {
                         AUTO_SELECT_CASE: _('Case property'),
                         AUTO_SELECT_FIXTURE: _('Lookup Table field'),
                         AUTO_SELECT_USER: _('custom user property'),
                         AUTO_SELECT_RAW: _('custom XPath expression'),
-                    }[mode]
-                    errors.append({'type': 'auto select key', 'key_name': key_name})
+                    }
+                    if mode in key_names:
+                        errors.append({'type': 'auto select key', 'key_name': key_names[mode]})
 
                 if not action.auto_select.value_source:
                     source_names = {

--- a/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
@@ -26,6 +26,7 @@ var AdvancedCase = (function () {
         self.requires = params.requires;
         self.commtrack = params.commtrack_enabled;
         self.programs = params.commtrack_programs;
+        self.usercaseEnabled = params.usercaseEnabled;
 
         self.setPropertiesMap = function (propertiesMap) {
              self.propertiesMap = ko.mapping.fromJS(propertiesMap);
@@ -83,6 +84,12 @@ var AdvancedCase = (function () {
                 modes.push({
                     label: 'Case Index',
                     value: 'case'
+                });
+            }
+            if (self.usercaseEnabled) {
+                modes.push({
+                    label: 'User Case',
+                    value: 'usercase'
                 });
             }
             return modes;
@@ -358,6 +365,7 @@ var AdvancedCase = (function () {
                         value_source: '',
                         value_key: ''
                     };
+
                 }
                 self.load_update_cases.push(LoadUpdateAction.wrap(action_data, self.config));
                 if (index > 0) {
@@ -587,11 +595,15 @@ var AdvancedCase = (function () {
             if (self.auto_select) {
                 self.auto_select.mode.subscribe(function (value) {
                     // fix for resizing of accordion when content changes
-                    if (!value) {
-                        var index = self.config.caseConfigViewModel.load_update_cases.indexOf(self);
-                        self.config.applyAccordion('load', index);
-                    }
+                    var index = self.config.caseConfigViewModel.load_update_cases.indexOf(self);
+                    self.config.applyAccordion('load', index);
                 }, null, 'beforeChange');
+                self.auto_select.mode.subscribe(function (value) {
+                    // suggestedProperties need to be those of case type "commcare-user"
+                    if (value === 'usercase') {
+                        self.case_type('commcare-user');
+                    }
+                });
             }
 
             self.show_product_stock_var = ko.computed({
@@ -640,7 +652,7 @@ var AdvancedCase = (function () {
                     var value_key = self.auto_select.value_key();
                     if (!mode) {
                         return "Autoselect mode required";
-                    } else if (!value_key) {
+                    } else if (!value_key && mode !== 'usercase') {
                         return 'Property required';
                     } else if (!value_source) {
                         if (mode === 'case') {

--- a/corehq/apps/app_manager/suite_xml.py
+++ b/corehq/apps/app_manager/suite_xml.py
@@ -1679,7 +1679,7 @@ class SuiteGenerator(SuiteGeneratorBase):
 
     def get_auto_select_datums_and_assertions(self, action, auto_select, form):
         from corehq.apps.app_manager.models import AUTO_SELECT_USER, AUTO_SELECT_CASE, \
-            AUTO_SELECT_FIXTURE, AUTO_SELECT_RAW
+            AUTO_SELECT_FIXTURE, AUTO_SELECT_RAW, AUTO_SELECT_USERCASE
         if auto_select.mode == AUTO_SELECT_USER:
             xpath = session_var(auto_select.value_key, path='user/data')
             assertions = self.get_auto_select_assertions(xpath, auto_select.mode, [auto_select.value_key])
@@ -1717,6 +1717,17 @@ class SuiteGenerator(SuiteGeneratorBase):
                 id=action.case_session_var,
                 function=auto_select.value_key
             ), []
+        elif auto_select.mode == AUTO_SELECT_USERCASE:
+            case = UserCaseXPath().case()
+            return SessionDatum(
+                id=USERCASE_ID,
+                function=case.slash('@case_id')
+            ), [
+                self.get_assertion(
+                    "{0} = 1".format(case.count()),
+                    'case_autoload.{0}.case_missing'.format(auto_select.mode)
+                )
+            ]
 
     def configure_entry_advanced_form(self, module, e, form, **kwargs):
         def case_sharing_requires_assertion(form):

--- a/corehq/apps/app_manager/suite_xml.py
+++ b/corehq/apps/app_manager/suite_xml.py
@@ -1720,7 +1720,7 @@ class SuiteGenerator(SuiteGeneratorBase):
         elif auto_select.mode == AUTO_SELECT_USERCASE:
             case = UserCaseXPath().case()
             return SessionDatum(
-                id=USERCASE_ID,
+                id=action.case_session_var,
                 function=case.slash('@case_id')
             ), [
                 self.get_assertion(

--- a/corehq/apps/app_manager/templates/app_manager/form_view_advanced.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view_advanced.html
@@ -22,7 +22,8 @@
         moduleCaseTypes: {{ module_case_types|JSON }},
         propertiesMap: {{ case_properties|JSON }},
         commtrack_enabled: {{ app.commtrack_enabled|JSON }},
-        commtrack_programs: {{ commtrack_programs|JSON }}
+        commtrack_programs: {{ commtrack_programs|JSON }},
+        usercaseEnabled: {{ usercase_toggle_on|JSON }}
     });
     caseConfig.init();
 

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_config_advanced.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_config_advanced.html
@@ -36,6 +36,7 @@
             <div data-bind="template: 'case-config:case-transaction:case-properties'"></div>
         </div>
     </div>
+    <!-- ko if: !auto_select || auto_select.mode() !== 'usercase' -->
     <div class="well well-small">
         <div class="form-inline">
         <!-- ko if:  actionType === 'load' -->
@@ -113,6 +114,7 @@
             </div>
         </div>
     </div>
+    <!-- /ko -->
 </script>
 
 <script type="text/html" id="case-config:case-action">
@@ -188,6 +190,9 @@
     <input type="text" class="input-large" data-bind="value: value_source" />
     {% trans "Table Field:" %}
     <input type="text" class="input-large" data-bind="value: value_key" />
+</script>
+
+<script type="text/html" id="auto-select:usercase">
 </script>
 
 <script type="text/html" id="case-config:case-action-auto-select">

--- a/corehq/apps/app_manager/tests/data/suite/suite-advanced-autoselect-usercase.xml
+++ b/corehq/apps/app_manager/tests/data/suite/suite-advanced-autoselect-usercase.xml
@@ -1,0 +1,22 @@
+<partial>
+    <entry>
+    <form>http://openrosa.org/formdesigner/5FBED77B-E327-495D-97E8-0733B97D8EA5</form>
+    <command id="m1-f0">
+      <text>
+        <locale id="forms.m1f0"/>
+      </text>
+    </command>
+    <instance id="casedb" src="jr://instance/casedb"/>
+    <instance id="commcaresession" src="jr://instance/session"/>
+    <session>
+      <datum function="instance('casedb')/casedb/case[@case_type='commcare-user'][hq_user_id=instance('commcaresession')/session/context/userid][1]/@case_id" id="case_id_case_clinic"/>
+    </session>
+    <assertions>
+      <assert test="count(instance('casedb')/casedb/case[@case_type='commcare-user'][hq_user_id=instance('commcaresession')/session/context/userid][1]) = 1">
+        <text>
+          <locale id="case_autoload.usercase.case_missing"/>
+        </text>
+      </assert>
+    </assertions>
+  </entry>
+</partial>

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -5,7 +5,7 @@ from corehq.apps.app_manager.models import (
     Application, AutoSelectCase, AUTO_SELECT_USER, AUTO_SELECT_CASE, LoadUpdateAction, AUTO_SELECT_FIXTURE,
     AUTO_SELECT_RAW, WORKFLOW_MODULE, DetailColumn, ScheduleVisit, FormSchedule, Module, AdvancedModule,
     WORKFLOW_ROOT, AdvancedOpenCaseAction, SortElement, PreloadAction, MappingItem, OpenCaseAction,
-    OpenSubCaseAction, FormActionCondition, UpdateCaseAction, WORKFLOW_FORM, FormLink,
+    OpenSubCaseAction, FormActionCondition, UpdateCaseAction, WORKFLOW_FORM, FormLink, AUTO_SELECT_USERCASE,
     ReportModule, ReportAppConfig)
 from corehq.apps.app_manager.tests.util import TestFileMixin
 from corehq.apps.app_manager.xpath import dot_interpolate, UserCaseXPath, interpolate_xpath
@@ -181,6 +181,14 @@ class SuiteTest(SimpleTestCase, TestFileMixin):
             )
         ))
         self.assertXmlPartialEqual(self.get_xml('suite-advanced-autoselect-case'), app.create_suite(),
+                                   './entry[2]')
+
+    def test_advanced_suite_auto_select_usercase(self):
+        app = Application.wrap(self.get_json('suite-advanced'))
+        app.get_module(1).get_form(0).actions.load_update_cases[0].auto_select = AutoSelectCase(
+            mode=AUTO_SELECT_USERCASE
+        )
+        self.assertXmlPartialEqual(self.get_xml('suite-advanced-autoselect-usercase'), app.create_suite(),
                                    './entry[2]')
 
     def test_advanced_suite_auto_select_with_filter(self):


### PR DESCRIPTION
These changes are to support user-as-a-case in advanced modules. If the "User-As-A-Case" toggle is enabled, the "Case Management" tab in an advanced form allows you to autoload a user case. 

@snopoke, buddy @dannyroberts 
