### PR TITLE
denormalize sofabed data for query performance

### DIFF
--- a/corehq/apps/sofabed/migrations/0009_auto__add_field_caseactiondata_domain__add_field_caseactiondata_case_o.py
+++ b/corehq/apps/sofabed/migrations/0009_auto__add_field_caseactiondata_domain__add_field_caseactiondata_case_o.py
@@ -1,0 +1,102 @@
+# encoding: utf-8
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        
+        # Adding field 'CaseActionData.domain'
+        db.add_column(u'sofabed_caseactiondata', 'domain', self.gf('django.db.models.fields.CharField')(max_length=128, null=True), keep_default=False)
+
+        # Adding field 'CaseActionData.case_owner'
+        db.add_column(u'sofabed_caseactiondata', 'case_owner', self.gf('django.db.models.fields.CharField')(max_length=128, null=True), keep_default=False)
+
+        # Adding field 'CaseActionData.case_type'
+        db.add_column(u'sofabed_caseactiondata', 'case_type', self.gf('django.db.models.fields.CharField')(max_length=128, null=True), keep_default=False)
+
+        # Adding field 'CaseData.case_owner'
+        db.add_column(u'sofabed_casedata', 'case_owner', self.gf('django.db.models.fields.CharField')(max_length=128, null=True), keep_default=False)
+
+
+    def backwards(self, orm):
+        
+        # Deleting field 'CaseActionData.domain'
+        db.delete_column(u'sofabed_caseactiondata', 'domain')
+
+        # Deleting field 'CaseActionData.case_owner'
+        db.delete_column(u'sofabed_caseactiondata', 'case_owner')
+
+        # Deleting field 'CaseActionData.case_type'
+        db.delete_column(u'sofabed_caseactiondata', 'case_type')
+
+        # Deleting field 'CaseData.case_owner'
+        db.delete_column(u'sofabed_casedata', 'case_owner')
+
+
+    models = {
+        u'sofabed.caseactiondata': {
+            'Meta': {'unique_together': "(('case', 'index'),)", 'object_name': 'CaseActionData'},
+            'action_type': ('django.db.models.fields.CharField', [], {'max_length': '64', 'db_index': 'True'}),
+            'case': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'actions'", 'to': u"orm['sofabed.CaseData']"}),
+            'case_owner': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True'}),
+            'case_type': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True'}),
+            'date': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'}),
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'index': ('django.db.models.fields.IntegerField', [], {}),
+            'server_date': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'sync_log_id': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True'}),
+            'user_id': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'db_index': 'True'}),
+            'xform_id': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True'}),
+            'xform_xmlns': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True'})
+        },
+        u'sofabed.casedata': {
+            'Meta': {'object_name': 'CaseData'},
+            'case_id': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '128', 'primary_key': 'True'}),
+            'case_owner': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True'}),
+            'closed': ('django.db.models.fields.BooleanField', [], {'db_index': 'True'}),
+            'closed_by': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'db_index': 'True'}),
+            'closed_on': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'db_index': 'True'}),
+            'doc_type': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'}),
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'}),
+            'external_id': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True'}),
+            'modified_by': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'db_index': 'True'}),
+            'modified_on': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '512', 'null': 'True'}),
+            'opened_by': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'db_index': 'True'}),
+            'opened_on': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'db_index': 'True'}),
+            'owner_id': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'db_index': 'True'}),
+            'server_modified_on': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'db_index': 'True'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'db_index': 'True'}),
+            'user_id': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'db_index': 'True'}),
+            'version': ('django.db.models.fields.CharField', [], {'max_length': '10', 'null': 'True', 'db_index': 'True'})
+        },
+        u'sofabed.caseindexdata': {
+            'Meta': {'object_name': 'CaseIndexData'},
+            'case': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'indices'", 'to': u"orm['sofabed.CaseData']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'identifier': ('django.db.models.fields.CharField', [], {'max_length': '64', 'db_index': 'True'}),
+            'referenced_id': ('django.db.models.fields.CharField', [], {'max_length': '128', 'db_index': 'True'}),
+            'referenced_type': ('django.db.models.fields.CharField', [], {'max_length': '64', 'db_index': 'True'})
+        },
+        u'sofabed.formdata': {
+            'Meta': {'object_name': 'FormData'},
+            'app_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'db_index': 'True'}),
+            'device_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            'doc_type': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'duration': ('django.db.models.fields.BigIntegerField', [], {}),
+            'instance_id': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255', 'primary_key': 'True'}),
+            'received_on': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'}),
+            'time_end': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'}),
+            'time_start': ('django.db.models.fields.DateTimeField', [], {}),
+            'user_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'db_index': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            'xmlns': ('django.db.models.fields.CharField', [], {'max_length': '1000', 'null': 'True', 'db_index': 'True'})
+        }
+    }
+
+    complete_apps = ['sofabed']

--- a/corehq/apps/sofabed/models.py
+++ b/corehq/apps/sofabed/models.py
@@ -165,6 +165,9 @@ class CaseData(BaseDataIndex):
     name = models.CharField(max_length=CASE_NAME_LEN, null=True)
     external_id = models.CharField(max_length=128, null=True)
 
+    # owner_id || user_id
+    case_owner = models.CharField(max_length=128, null=True)
+
     @classmethod
     def get_instance_id(cls, instance):
         return instance.case_id
@@ -204,12 +207,13 @@ class CaseData(BaseDataIndex):
         self.server_modified_on = case.server_modified_on
         self.name = name
         self.external_id = case.external_id
+        self.case_owner = case.owner_id or case.user_id
 
         if not is_new:
             CaseActionData.objects.filter(case_id=case_id).delete()
             CaseIndexData.objects.filter(case_id=case_id).delete()
 
-        self.actions = [CaseActionData.from_instance(action, i) for i, action in enumerate(case.actions)]
+        self.actions = [CaseActionData.from_instance(case, action, i) for i, action in enumerate(case.actions)]
         self.indices = [CaseIndexData.from_instance(index) for index in case.indices]
 
     def matches_exact(self, case):
@@ -262,6 +266,11 @@ class CaseActionData(models.Model):
     xform_xmlns = models.CharField(max_length=128, null=True)
     sync_log_id = models.CharField(max_length=128, null=True)
 
+    # de-normalized fields
+    domain = models.CharField(max_length=128, null=True)
+    case_owner = models.CharField(max_length=128, null=True)
+    case_type = models.CharField(max_length=128, null=True)
+
     def __unicode__(self):
         return "CaseAction: {xform}: {type} - {date} ({server_date})".format(
             xform=self.xform_id, type=self.action_type,
@@ -269,8 +278,13 @@ class CaseActionData(models.Model):
         )
 
     @classmethod
-    def from_instance(cls, action, index):
+    def from_instance(cls, case, action, index):
         ret = cls()
+
+        ret.domain = case.domain
+        ret.case_type = case.type
+        ret.case_owner = case.owner_id or case.user_id
+
         ret.index = index
         ret.action_type = action.action_type
         ret.user_id = action.user_id


### PR DESCRIPTION
The only really slow callcenter query is the one for 'active cases' which is made slow by two things:
- COALESCE(owner_id, user_id) which skips the user / owner indexes 
- join CaseActionData and CaseData for the case type and case owner
# Before

``` sql
SELECT 
    COALESCE(owner_id, sofabed_casedata.user_id) AS "case_owner", 
    "sofabed_casedata"."type", 
    COUNT(DISTINCT "sofabed_casedata"."case_id") AS "count" 
FROM "sofabed_casedata" 
    INNER JOIN "sofabed_caseactiondata" ON ( "sofabed_casedata"."case_id" = "sofabed_caseactiondata"."case_id" ) 
WHERE 
    COALESCE(owner_id, sofabed_casedata.user_id) in (case_ids ...) 
    AND NOT ("sofabed_casedata"."type" = 'FLW' AND "sofabed_casedata"."type" IS NOT NULL) 
    AND "sofabed_casedata"."doc_type" = 'CommCareCase'  
    AND "sofabed_casedata"."domain" = 'domain'  
    AND "sofabed_caseactiondata"."date" < '2015-05-27 00:00:00'  
    AND "sofabed_caseactiondata"."date" >= '2015-05-20 00:00:00' 
GROUP BY "sofabed_casedata"."type", (COALESCE(owner_id, sofabed_casedata.user_id))
```
# After

``` sql
SELECT 
    case_owner, 
    case_type, 
    COUNT(DISTINCT case_id) AS "count" 
FROM "sofabed_caseactiondata" 
WHERE 
    case_owner in (case_ids ...) 
    AND NOT (case_type = 'FLW' AND case_type IS NOT NULL) 
    AND domain = 'domain'  
    AND "date" < '2015-05-27 00:00:00'  
    AND "date" >= '2015-05-20 00:00:00' 
GROUP BY case_type, case_owner
```
