### PR TITLE
Switch BillingAccountContactForm to model form

### DIFF
--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -252,35 +252,25 @@ class BillingAccountContactForm(forms.ModelForm):
 
     class Meta:
         model = BillingContactInfo
-
-    first_name = forms.CharField(label='First Name', required=False)
-    last_name = forms.CharField(label='Last Name', required=False)
-    company_name = forms.CharField(label='Company Name', required=False)
-    phone_number = forms.CharField(label='Phone Number', required=False)
-    address_line_1 = forms.CharField(label='Address Line 1')
-    address_line_2 = forms.CharField(label='Address Line 2', required=False)
-    city = forms.CharField()
-    region = forms.CharField(label="State/Province/Region")
-    postal_code = forms.CharField(label="Postal Code")
-    country = forms.CharField()
+        fields = [
+            'first_name',
+            'last_name',
+            'company_name',
+            'phone_number',
+            'first_line',
+            'second_line',
+            'city',
+            'state_province_region',
+            'postal_code',
+            'country',
+        ]
 
     def __init__(self, account, *args, **kwargs):
         contact_info, _ = BillingContactInfo.objects.get_or_create(
             account=account,
         )
-        kwargs['initial'] = {
-            'first_name': contact_info.first_name,
-            'last_name': contact_info.last_name,
-            'company_name': contact_info.company_name,
-            'phone_number': contact_info.phone_number,
-            'address_line_1': contact_info.first_line,
-            'address_line_2': contact_info.second_line,
-            'city': contact_info.city,
-            'region': contact_info.state_province_region,
-            'postal_code': contact_info.postal_code,
-            'country': contact_info.country,
-        }
-        super(BillingAccountContactForm, self).__init__(*args, **kwargs)
+        super(BillingAccountContactForm, self).__init__(instance=contact_info,
+                                                        *args, **kwargs)
         self.helper = FormHelper()
         self.helper.form_class = "form-horizontal"
         self.helper.layout = crispy.Layout(
@@ -290,10 +280,10 @@ class BillingAccountContactForm(forms.ModelForm):
                 'last_name',
                 'company_name',
                 'phone_number',
-                'address_line_1',
-                'address_line_2',
+                'first_line',
+                'second_line',
                 'city',
-                'region',
+                'state_province_region',
                 'postal_code',
                 crispy.Field(
                     'country',
@@ -314,22 +304,6 @@ class BillingAccountContactForm(forms.ModelForm):
                 )
             ),
         )
-
-    def update_contact_info(self, account):
-        contact_info, _ = BillingContactInfo.objects.get_or_create(
-            account=account,
-        )
-        contact_info.first_name = self.cleaned_data['first_name']
-        contact_info.last_name = self.cleaned_data['last_name']
-        contact_info.company_name = self.cleaned_data['company_name']
-        contact_info.phone_number = self.cleaned_data['phone_number']
-        contact_info.first_line = self.cleaned_data['address_line_1']
-        contact_info.second_line = self.cleaned_data['address_line_2']
-        contact_info.city = self.cleaned_data['city']
-        contact_info.state_province_region = self.cleaned_data['region']
-        contact_info.postal_code = self.cleaned_data['postal_code']
-        contact_info.country = self.cleaned_data['country']
-        contact_info.save()
 
 
 class SubscriptionForm(forms.Form):

--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -248,7 +248,11 @@ class BillingAccountBasicForm(forms.Form):
         contact_info.save()
 
 
-class BillingAccountContactForm(forms.Form):
+class BillingAccountContactForm(forms.ModelForm):
+
+    class Meta:
+        model = BillingContactInfo
+
     first_name = forms.CharField(label='First Name', required=False)
     last_name = forms.CharField(label='Last Name', required=False)
     company_name = forms.CharField(label='Company Name', required=False)
@@ -1353,7 +1357,7 @@ class FeatureRateForm(forms.ModelForm):
     """
     A form for creating a new FeatureRate.
     """
-    # feature id will point to a  select2 field, hence the CharField here.
+    # feature id will point to a select2 field, hence the CharField here.
     feature_id = forms.CharField(
         required=False,
         widget=forms.HiddenInput,

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -196,7 +196,7 @@ class ManageBillingAccountView(BillingAccountsSectionView, AsyncHandlerMixin):
             return HttpResponseRedirect(self.page_url)
         elif ('account_contact' in self.request.POST
               and self.contact_form.is_valid()):
-            self.contact_form.update_contact_info(self.account)
+            self.contact_form.save()
             messages.success(request, "Account Contact Info successfully updated.")
             return HttpResponseRedirect(self.page_url)
         elif ('adjust_credit' in self.request.POST


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?169608
Using a model form gives all kinds of awesome validation.  Now if you try to type more than 50 characters in the text box, it'll block you (or show an error message if you circumvent that), instead of 500ing when you try to save the model.  This also strips some boilerplate.
@emord @nickpell
