### PR TITLE
run tests with ownership cleanliness actually enabled, bugfixes

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -35,7 +35,8 @@ class CaseProcessingResult(object):
     """
     Lightweight class used to collect results of case processing
     """
-    def __init__(self, cases, dirtiness_flags, track_cleanliness):
+    def __init__(self, domain, cases, dirtiness_flags, track_cleanliness):
+        self.domain = domain
         self.cases = cases
         self.dirtiness_flags = dirtiness_flags
         self.track_cleanliness = track_cleanliness
@@ -50,6 +51,7 @@ class CaseProcessingResult(object):
         if self.track_cleanliness:
             flags_to_save = {f.owner_id: f.case_id for f in self.dirtiness_flags}
             flags_to_update = OwnershipCleanlinessFlag.objects.filter(
+                Q(domain=self.domain),
                 Q(owner_id__in=flags_to_save.keys()),
                 Q(is_clean=True) | Q(hint__isnull=True)
             )
@@ -369,7 +371,7 @@ def _get_or_update_cases(xforms, case_db):
         # only do this extra step if the toggle is enabled since we know we aren't going to
         # care about the dirtiness flags otherwise.
         dirtiness_flags += list(_get_dirtiness_flags_for_child_cases(domain, touched_cases.values()))
-    return CaseProcessingResult(touched_cases.values(), dirtiness_flags, track_cleanliness)
+    return CaseProcessingResult(domain, touched_cases.values(), dirtiness_flags, track_cleanliness)
 
 
 def _get_or_update_model(case_update, xform, case_db):

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -43,7 +43,8 @@ class CaseProcessingResult(object):
         self.track_cleanliness = track_cleanliness
 
     def get_clean_owner_ids(self):
-        return set(c.owner_id for c in self.cases if c.owner_id and c.owner_id not in self.get_flags_to_save())
+        dirty_flags = self.get_flags_to_save()
+        return {c.owner_id for c in self.cases if c.owner_id and c.owner_id not in dirty_flags}
 
     def set_cases(self, cases):
         self.cases = cases
@@ -60,10 +61,10 @@ class CaseProcessingResult(object):
             if should_create_flags_on_submission(self.domain):
                 assert settings.UNIT_TESTING  # this is currently only true when unit testing
                 all_touched_ids = set(flags_to_save.keys()) | self.get_clean_owner_ids()
-                to_update = dict((f.owner_id, f) for f in OwnershipCleanlinessFlag.objects.filter(
+                to_update = {f.owner_id: f for f in OwnershipCleanlinessFlag.objects.filter(
                     domain=self.domain,
                     owner_id__in=list(all_touched_ids),
-                ))
+                )}
                 for owner_id in all_touched_ids:
                     if owner_id not in to_update:
                         # making from scratch - default to clean, but set to dirty if needed

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -8,8 +8,9 @@ import datetime
 from django.db.models import Q
 import redis
 from casexml.apps.case.signals import cases_received, case_post_save
+from casexml.apps.phone.cleanliness import should_track_cleanliness
 from casexml.apps.phone.models import OwnershipCleanlinessFlag
-from corehq.toggles import LOOSE_SYNC_TOKEN_VALIDATION, OWNERSHIP_CLEANLINESS
+from corehq.toggles import LOOSE_SYNC_TOKEN_VALIDATION
 from casexml.apps.case.util import iter_cases, get_reverse_indexed_cases
 from couchforms.models import XFormInstance
 from casexml.apps.case.exceptions import (
@@ -366,7 +367,7 @@ def _get_or_update_cases(xforms, case_db):
 
     dirtiness_flags = [flag for case in case_db.cache.values() for flag in _validate_indices(case)]
     domain = getattr(case_db, 'domain', None)
-    track_cleanliness = domain and OWNERSHIP_CLEANLINESS.enabled(domain)
+    track_cleanliness = should_track_cleanliness(domain)
     if track_cleanliness:
         # only do this extra step if the toggle is enabled since we know we aren't going to
         # care about the dirtiness flags otherwise.

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -8,7 +8,7 @@ import datetime
 from django.db.models import Q
 import redis
 from casexml.apps.case.signals import cases_received, case_post_save
-from casexml.apps.phone.cleanliness import should_track_cleanliness
+from casexml.apps.phone.cleanliness import should_track_cleanliness, should_create_flags_on_submission
 from casexml.apps.phone.models import OwnershipCleanlinessFlag
 from corehq.toggles import LOOSE_SYNC_TOKEN_VALIDATION
 from casexml.apps.case.util import iter_cases, get_reverse_indexed_cases
@@ -42,24 +42,54 @@ class CaseProcessingResult(object):
         self.dirtiness_flags = dirtiness_flags
         self.track_cleanliness = track_cleanliness
 
+    def get_clean_owner_ids(self):
+        return set(c.owner_id for c in self.cases if c.owner_id and c.owner_id not in self.get_flags_to_save())
+
     def set_cases(self, cases):
         self.cases = cases
+
+    def get_flags_to_save(self):
+        return {f.owner_id: f.case_id for f in self.dirtiness_flags}
 
     def commit_dirtiness_flags(self):
         """
         Updates any dirtiness flags in the database.
         """
         if self.track_cleanliness:
-            flags_to_save = {f.owner_id: f.case_id for f in self.dirtiness_flags}
-            flags_to_update = OwnershipCleanlinessFlag.objects.filter(
-                Q(domain=self.domain),
-                Q(owner_id__in=flags_to_save.keys()),
-                Q(is_clean=True) | Q(hint__isnull=True)
-            )
-            for flag in flags_to_update:
-                flag.is_clean = False
-                flag.hint = flags_to_save[flag.owner_id]
-                flag.save()
+            flags_to_save = self.get_flags_to_save()
+            if should_create_flags_on_submission(self.domain):
+                assert settings.UNIT_TESTING  # this is currently only true when unit testing
+                all_touched_ids = set(flags_to_save.keys()) | self.get_clean_owner_ids()
+                to_update = dict((f.owner_id, f) for f in OwnershipCleanlinessFlag.objects.filter(
+                    domain=self.domain,
+                    owner_id__in=list(all_touched_ids),
+                ))
+                for owner_id in all_touched_ids:
+                    if owner_id not in to_update:
+                        # making from scratch - default to clean, but set to dirty if needed
+                        flag = OwnershipCleanlinessFlag(domain=self.domain, owner_id=owner_id, is_clean=True)
+                        if owner_id in flags_to_save:
+                            flag.is_clean = False
+                            flag.hint = flags_to_save[owner_id]
+                        flag.save()
+                    else:
+                        # updating - only save if we are marking dirty or setting a hint
+                        flag = to_update[owner_id]
+                        if owner_id in flags_to_save and (flag.is_clean or not flag.hint):
+                            flag.is_clean = False
+                            flag.hint = flags_to_save[owner_id]
+                            flag.save()
+            else:
+                # only update the flags that are already in the database
+                flags_to_update = OwnershipCleanlinessFlag.objects.filter(
+                    Q(domain=self.domain),
+                    Q(owner_id__in=flags_to_save.keys()),
+                    Q(is_clean=True) | Q(hint__isnull=True)
+                )
+                for flag in flags_to_update:
+                    flag.is_clean = False
+                    flag.hint = flags_to_save[flag.owner_id]
+                    flag.save()
 
 
 def process_cases(xform, config=None):

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -56,7 +56,7 @@ class CaseProcessingResult(object):
         """
         Updates any dirtiness flags in the database.
         """
-        if self.track_cleanliness:
+        if self.track_cleanliness and self.domain:
             flags_to_save = self.get_flags_to_save()
             if should_create_flags_on_submission(self.domain):
                 assert settings.UNIT_TESTING  # this is currently only true when unit testing

--- a/corehq/ex-submodules/casexml/apps/phone/cleanliness.py
+++ b/corehq/ex-submodules/casexml/apps/phone/cleanliness.py
@@ -27,6 +27,22 @@ def should_track_cleanliness(domain):
     return domain and OWNERSHIP_CLEANLINESS.enabled(domain)
 
 
+def should_create_flags_on_submission(domain):
+    """
+    Whether a domain should create default cleanliness flags on submission.
+
+    Right now this is only ever true for tests, though that might change once we more fully
+    switch over to this restore model (requires having a complete set of existing cleanliness
+    flags already in the database).
+    """
+    if settings.UNIT_TESTING:
+        override = getattr(
+            settings, 'TESTS_SHOULD_TRACK_CLEANLINESS', None)
+        if override is not None:
+            return override
+    return False
+
+
 def set_cleanliness_flags_for_domain(domain):
     """
     Sets all cleanliness flags for an entire domain.

--- a/corehq/ex-submodules/casexml/apps/phone/cleanliness.py
+++ b/corehq/ex-submodules/casexml/apps/phone/cleanliness.py
@@ -7,10 +7,24 @@ from casexml.apps.case.util import get_indexed_cases
 from casexml.apps.phone.models import OwnershipCleanlinessFlag
 from corehq.apps.users.util import WEIRD_USER_IDS
 from corehq.toggles import OWNERSHIP_CLEANLINESS
+from django.conf import settings
 
 
 FootprintInfo = namedtuple('FootprintInfo', ['base_ids', 'all_ids'])
 CleanlinessFlag = namedtuple('CleanlinessFlag', ['is_clean', 'hint'])
+
+
+def should_track_cleanliness(domain):
+    """
+    Whether a domain should track cleanliness on submission.
+    """
+    if settings.UNIT_TESTING:
+        override = getattr(
+            settings, 'TESTS_SHOULD_TRACK_CLEANLINESS', None)
+        if override is not None:
+            return override
+
+    return domain and OWNERSHIP_CLEANLINESS.enabled(domain)
 
 
 def set_cleanliness_flags_for_domain(domain):

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/providers.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/providers.py
@@ -28,7 +28,7 @@ def _batched_response(restore_state):
 def should_use_clean_restore(domain):
     if settings.UNIT_TESTING:
         override = getattr(
-            settings, 'SHOULD_USE_CLEAN_RESTORE', None)
+            settings, 'TESTS_SHOULD_USE_CLEAN_RESTORE', None)
         if override is not None:
             return override
     return OWNERSHIP_CLEANLINESS_RESTORE.enabled(domain)


### PR DESCRIPTION
can be read commit-by-commit. mostly just setting up a way to create ownership cleanliness flags on submission for tests.

@snopoke cc @NoahCarnahan (sorry about all the review)

wait for tests
