### PR TITLE
Revert "Exclude archived forms from daily exports"

### DIFF
--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -425,8 +425,7 @@ def hq_update_saved_export(req, domain):
     index = int(req.POST['index'])
     group_config = get_document_or_404(HQGroupExportConfiguration, domain, group_id)
     config, schema = group_config.all_exports[index]
-    filter = SerializableFunction(instances)
-    rebuild_export_task.delay(group_id, index, filter=filter)
+    rebuild_export_task.delay(group_id, index)
     messages.success(
         req,
         _('Data update for {} has started and the saved export will be automatically updated soon. '


### PR DESCRIPTION
Reverts dimagi/commcare-hq#6804

This causes daily saved case exports to be blank. Will revisit this addition with better tests and case export handling.

http://manage.dimagi.com/default.asp?169925

@esoergel @orangejenny 
