### PR TITLE
split out index reference tests into their atomic units

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -219,84 +219,133 @@ class SyncTokenUpdateTest(SyncBaseTest):
         assert_user_doesnt_have_case(self, self.user, case_id, restore_id=self.sync_log.get_id)
 
     @run_with_all_restore_configs
-    def testIndexReferences(self):
+    def test_change_index_type(self):
         """
-        Tests that indices properly get set in the sync log when created. 
+        Test that changing an index type updates the sync log
         """
-        # first create the parent case
-        parent_id = "mommy"
-        updated_id = "updated_mommy_id"
-        new_parent_id = "daddy"
-        self._createCaseStubs([parent_id, updated_id, new_parent_id])
-        self._testUpdate(self.sync_log.get_id, {parent_id: [], updated_id: [], new_parent_id: []})
-        
-        # create the child        
-        child_id = "baby"
-        index_id = 'my_mom_is'
-        self.factory.create_or_update_case(CaseStructure(
-            case_id=child_id,
-            attrs={'create': True},
-            relationships=[CaseRelationship(
-                CaseStructure(case_id=parent_id),
-                relationship=index_id,
-                related_type=PARENT_TYPE,
-            )],
-            walk_related=False,
-        ))
-        index_ref = CommCareCaseIndex(identifier=index_id,
-                                      referenced_type=PARENT_TYPE,
-                                      referenced_id=parent_id)
-    
-        self._testUpdate(self.sync_log.get_id, {parent_id: [], updated_id: [], new_parent_id: [],
-                                                child_id: [index_ref]})
-        
+        child_id, parent_id, index_id, parent_ref = self._initialize_parent_child()
         # update the child's index (parent type)
-        updated_type = "updated_mother_type"
+        updated_type = "updated_type"
         child = CaseBlock(create=False, case_id=child_id, user_id=USER_ID, version=V2,
                           index={index_id: (updated_type, parent_id)},
         ).as_xml()
         self._postFakeWithSyncToken(child, self.sync_log.get_id)
-        index_ref = CommCareCaseIndex(identifier=index_id,
-                                      referenced_type=updated_type,
-                                      referenced_id=parent_id)
-    
-        self._testUpdate(self.sync_log.get_id, {parent_id: [], updated_id: [], new_parent_id: [],
-                                                child_id: [index_ref]})
-        
+        parent_ref.referenced_type = updated_type
+        self._testUpdate(self.sync_log.get_id, {parent_id: [],
+                                                child_id: [parent_ref]})
+
+    @run_with_all_restore_configs
+    def test_change_index_id(self):
+        """
+        Test that changing an index ID updates the sync log
+        """
+        child_id, parent_id, index_id, parent_ref = self._initialize_parent_child()
+
         # update the child's index (parent id)
-        child = CaseBlock(create=False, case_id=child_id, user_id=USER_ID, version=V2,
-                          index={index_id: (updated_type, updated_id)},
-        ).as_xml()
-        self._postFakeWithSyncToken(child, self.sync_log.get_id)
-        index_ref = CommCareCaseIndex(identifier=index_id,
-                                      referenced_type=updated_type,
-                                      referenced_id=updated_id)
-    
-        self._testUpdate(self.sync_log.get_id, {parent_id: [], updated_id: [], new_parent_id: [],
-                                                child_id: [index_ref]})
-        
+        updated_id = 'changed_index_id'
+        self.factory.create_or_update_case(CaseStructure(
+            case_id=child_id,
+            relationships=[CaseRelationship(
+                CaseStructure(case_id=updated_id, attrs={'create': True}),
+                relationship=index_id,
+                related_type=PARENT_TYPE,
+            )],
+        ))
+        parent_ref.referenced_id = updated_id
+        self._testUpdate(self.sync_log.get_id, {parent_id: [], updated_id: [],
+                                                child_id: [parent_ref]})
+
+    @run_with_all_restore_configs
+    def test_add_multiple_indices(self):
+        """
+        Test that adding multiple indices works as expected
+        """
+        child_id, parent_id, index_id, parent_ref = self._initialize_parent_child()
         # add new index
-        new_index_id = "my_daddy"
-        new_index_type = "dad"
+        new_case_id = 'new_case_id'
+        new_index_id = 'new_index_id'
+        new_index_type = 'new_index_type'
+
+        self.factory.create_or_update_case(CaseStructure(
+            case_id=child_id,
+            relationships=[CaseRelationship(
+                CaseStructure(case_id=new_case_id, attrs={'create': True}),
+                relationship=new_index_id,
+                related_type=PARENT_TYPE,
+            )],
+        ))
+        new_index_ref = CommCareCaseIndex(identifier=new_index_id, referenced_type=PARENT_TYPE,
+                                          referenced_id=new_case_id)
+
+        self._testUpdate(self.sync_log.get_id, {parent_id: [], new_case_id: [],
+                                                child_id: [parent_ref, new_index_ref]})
+
+    @run_with_all_restore_configs
+    def test_delete_only_index(self):
+        child_id, parent_id, index_id, parent_ref = self._initialize_parent_child()
+        # delete the first index
         child = CaseBlock(create=False, case_id=child_id, user_id=USER_ID, version=V2,
-                          index={new_index_id: (new_index_type, new_parent_id)},
+                          index={index_id: (PARENT_TYPE, "")},
         ).as_xml()
         self._postFakeWithSyncToken(child, self.sync_log.get_id)
-        new_index_ref = CommCareCaseIndex(identifier=new_index_id,
-                                          referenced_type=new_index_type,
-                                          referenced_id=new_parent_id)
-    
-        self._testUpdate(self.sync_log.get_id, {parent_id: [], updated_id: [], new_parent_id: [],
-                                                child_id: [index_ref, new_index_ref]})
-        
-        # delete index
+        self._testUpdate(self.sync_log.get_id, {parent_id: [], child_id: []})
+
+    @run_with_all_restore_configs
+    def test_delete_one_of_multiple_indices(self):
+        child_id = "child_id"
+        parent_id_1 = "parent_id"
+        index_id_1 = 'parent_index_id'
+        parent_id_2 = "parent_id_2"
+        index_id_2 = 'parent_index_id_2'
+
+        self.factory.create_or_update_case(CaseStructure(
+            case_id=child_id,
+            attrs={'create': True},
+            relationships=[
+                CaseRelationship(
+                    CaseStructure(case_id=parent_id_1, attrs={'create': True}),
+                    relationship=index_id_1,
+                    related_type=PARENT_TYPE,
+                ),
+                CaseRelationship(
+                    CaseStructure(case_id=parent_id_2, attrs={'create': True}),
+                    relationship=index_id_2,
+                    related_type=PARENT_TYPE,
+                ),
+            ],
+        ))
+        parent_ref_1 = CommCareCaseIndex(
+            identifier=index_id_1, referenced_type=PARENT_TYPE, referenced_id=parent_id_1)
+        parent_ref_2 = CommCareCaseIndex(
+            identifier=index_id_2, referenced_type=PARENT_TYPE, referenced_id=parent_id_2)
+        self._testUpdate(self.sync_log.get_id, {parent_id_1: [], parent_id_2: [],
+                                                child_id: [parent_ref_1, parent_ref_2]})
+
+        # delete the first index
         child = CaseBlock(create=False, case_id=child_id, user_id=USER_ID, version=V2,
-                          index={index_id: (updated_type, "")},
+                          index={index_id_1: (PARENT_TYPE, "")},
         ).as_xml()
         self._postFakeWithSyncToken(child, self.sync_log.get_id)
-        self._testUpdate(self.sync_log.get_id, {parent_id: [], updated_id: [], new_parent_id: [],
-                                                child_id: [new_index_ref]})
-        
+        self._testUpdate(self.sync_log.get_id, {parent_id_1: [], parent_id_2: [],
+                                                child_id: [parent_ref_2]})
+
+    def _initialize_parent_child(self):
+        child_id = "child_id"
+        parent_id = "parent_id"
+        index_id = 'parent_index_id'
+        self.factory.create_or_update_case(CaseStructure(
+            case_id=child_id,
+            attrs={'create': True},
+            relationships=[CaseRelationship(
+                CaseStructure(case_id=parent_id, attrs={'create': True}),
+                relationship=index_id,
+                related_type=PARENT_TYPE,
+            )],
+        ))
+        parent_ref = CommCareCaseIndex(identifier=index_id, referenced_type=PARENT_TYPE, referenced_id=parent_id)
+        self._testUpdate(self.sync_log.get_id, {parent_id: [], child_id: [parent_ref]})
+        return (child_id, parent_id, index_id, parent_ref)
+
     @run_with_all_restore_configs
     def testClosedParentIndex(self):
         """

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -264,7 +264,6 @@ class SyncTokenUpdateTest(SyncBaseTest):
         # add new index
         new_case_id = 'new_case_id'
         new_index_id = 'new_index_id'
-        new_index_type = 'new_index_type'
 
         self.factory.create_or_update_case(CaseStructure(
             case_id=child_id,

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -226,8 +226,9 @@ class SyncTokenUpdateTest(SyncBaseTest):
         child_id, parent_id, index_id, parent_ref = self._initialize_parent_child()
         # update the child's index (parent type)
         updated_type = "updated_type"
-        child = CaseBlock(create=False, case_id=child_id, user_id=USER_ID, version=V2,
-                          index={index_id: (updated_type, parent_id)},
+        child = CaseBlock(
+            create=False, case_id=child_id, user_id=USER_ID, version=V2,
+            index={index_id: (updated_type, parent_id)},
         ).as_xml()
         self._postFakeWithSyncToken(child, self.sync_log.get_id)
         parent_ref.referenced_type = updated_type


### PR DESCRIPTION
I can't figure out what's causing the below build fails to happen intermittently, but that test was horrible anyways, so maybe splitting it up will either make it more clear or fix it.

@NoahCarnahan or whoever. tests only

```
======================================================================
FAIL: testIndexReferences (casexml.apps.phone.tests.test_sync_mode.FileRestoreSyncTokenUpdateTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "corehq/ex-submodules/casexml/apps/phone/tests/restore_test_utils.py", line 45, in inner
    return helper(*args, **kwargs)
  File "corehq/ex-submodules/casexml/apps/phone/tests/restore_test_utils.py", line 32, in __call__
    call_with_settings(fn_with_pre_and_post, run_config.settings, args, kwargs)
  File "/home/travis/build/dimagi/commcare-hq/corehq/apps/tzmigration/test_utils.py", line 28, in call_with_settings
    fn(*args, **kwargs)
  File "corehq/ex-submodules/casexml/apps/phone/tests/restore_test_utils.py", line 28, in fn_with_pre_and_post
    self.fn(*args, **kwargs)
  File "corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py", line 298, in testIndexReferences
    child_id: [new_index_ref]})
  File "corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py", line 108, in _testUpdate
    self._checkLists(index_ids, sync_log.index_tree.indices[case_id].values())
  File "corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py", line 93, in _checkLists
    self.assertEqual(set(l1), set(l2))
AssertionError: Items in the second set but not the first:
u'updated_mommy_id'
----------------------------------------------------------------------
```
