### PR TITLE
Warn web users that user-as-a-case will not work in CloudCare

### DIFF
--- a/corehq/apps/cloudcare/templates/cloudcare/cloudcare_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/cloudcare_home.html
@@ -155,7 +155,8 @@
                 {% blocktrans %}
                     You are using CloudCare as a Web User!
                     Any data you submit will show up in reports as submitted by "Unknown User".
-                    Features that rely on mobile workers, like case sharing and lookup tables, will not work properly.
+                    Features that rely on mobile workers, like case sharing, lookup tables and user-as-a-case,
+                    will not work properly.
                     For the best experience please logout and login as a Mobile Worker.
                     More information on CloudCare can be found at the <a href="https://help.commcarehq.org/display/commcarepublic/CloudCare+-+Web+Data+Entry">CommCare Help Site</a>.
                 {% endblocktrans %}


### PR DESCRIPTION
I thought of adding an

```
elif couch_user.doc_type == 'WebUser':
```

to [app_manager/util.py](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/app_manager/util.py#L443), but the clause turns out to be quite long for an edge case, and it felt stupid. So I opted just to include "user-as-a-case" in the warning for web users.

@snopoke, do you reckon this is a reasonable compromise?

cc @dannyroberts 
