### PR TITLE
Update translations on a hotfix deploy in case any line numbers change

### DIFF
--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -640,6 +640,7 @@ def hotfix_deploy():
 
     try:
         execute(update_code)
+        _execute_with_timing(do_update_translations)
     except Exception:
         execute(mail_admins, "Deploy failed", "You had better check the logs.")
         # hopefully bring the server back to life


### PR DESCRIPTION
Not sure if this is the right thing to do.  This ticket has a bit more context http://manage.dimagi.com/default.asp?169833, but I think that a hotfix deploy that results in line numbers changing can break some translations (doesn't feel like it should be nearly as many as were affected in that ticket, but a full deploy fixed the issue).

compilemessages also doesn't take very long to run, so shouldn't slow down hotfix_deploy.

@orangejenny
@czue 
