### PR TITLE
Fix 5 minute delay on new locations showing up

### DIFF
--- a/corehq/apps/locations/resources/v0_1.py
+++ b/corehq/apps/locations/resources/v0_1.py
@@ -10,7 +10,7 @@ from corehq.util.quickcache import quickcache
 from ..models import Location, SQLLocation
 
 
-@quickcache(['user._id', 'project.name', 'only_editable'])
+@quickcache(['user._id', 'project.name', 'only_editable'], timeout=10)
 def _user_locations_ids(user, project, only_editable):
     # admins and users not assigned to a location can see and edit everything
     def all_ids():


### PR DESCRIPTION
Previously there was a bug that due to the default quickcache time, if you
created a new location it wouldn't show up in the location list for
5 minutes.
