### PR TITLE
memoize filters in data sources

### DIFF
--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -77,9 +77,11 @@ class DataSourceConfiguration(UnicodeMixIn, CachedCouchDocumentMixin, Document):
         filter_fn = self._get_deleted_filter()
         return filter_fn and filter_fn(document, EvaluationContext(document, 0))
 
+    @memoized
     def _get_main_filter(self):
         return self._get_filter([self.referenced_doc_type])
 
+    @memoized
     def _get_deleted_filter(self):
         return self._get_filter(get_deleted_doc_types(self.referenced_doc_type))
 


### PR DESCRIPTION
these get called on every data source for every doc.

locally seemed to improve pillow speed by about 10x in the case when
there are no matches.

am hoping this is a stopgap against http://manage.dimagi.com/default.asp?170117

we may also want to consider dropping support for deleted (from the database) documents since
we don't ever do that for forms or cases, and we have to call it on every table. seems reasonable to make
people rebuild tables if they delete stuff from the database.

longer term this seems like a problematic architecture we'll need to figure out how to scale it on an X or Z axis.

@TylerSheffels cc @snopoke 
