### PR TITLE
Rename function

### DIFF
--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -67,7 +67,7 @@ def track_built_app_on_hubspot(webuser):
 
 
 @task(queue='background_queue', acks_late=True, ignore_result=True)
-def track_usage(email, event, properties=None):
+def track_workflow(email, event, properties=None):
     """
     Record an event in KISSmetrics.
     :param email: The email address by which to identify the user.

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -11,7 +11,7 @@ from django.utils.translation import ugettext as _
 import sys
 
 from corehq.apps.analytics.tasks import track_created_hq_account_on_hubspot, \
-    track_usage
+    track_workflow
 from corehq.apps.domain.decorators import login_required
 from corehq.apps.domain.models import Domain
 from corehq.apps.orgs.views import orgs_landing
@@ -67,7 +67,7 @@ def register_user(request, domain_type=None):
                 new_user = authenticate(username=form.cleaned_data['email'],
                                         password=form.cleaned_data['password'])
                 login(request, new_user)
-                track_usage.delay(new_user.email, "Requested new account")
+                track_workflow.delay(new_user.email, "Requested new account")
                 return redirect(
                     'registration_domain', domain_type=domain_type)
         else:


### PR DESCRIPTION
Meant to call this function `track_workflow()` to correspond with [`analytics.workflow()`](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/style/templates/style/includes/analytics_all.html#L69).
