### PR TITLE
Add sort order field to UCR report configuration

### DIFF
--- a/corehq/apps/userreports/README.md
+++ b/corehq/apps/userreports/README.md
@@ -674,15 +674,15 @@ Then you will get a report like this:
 +----------+----------------------+----------------------+
 ```
 
-### Aggregation
+## Aggregation
 
 TODO: finish aggregation docs
 
-### Transforms
+## Transforms
 
 Transforms can be used to transform the value returned by a column just before it reaches the user. Currently there are four supported transform types. These are shown below:
 
-#### Displaying username instead of user ID
+### Displaying username instead of user ID
 
 ```
 {
@@ -691,7 +691,7 @@ Transforms can be used to transform the value returned by a column just before i
 }
 ```
 
-#### Displaying username minus @domain.commcarehq.org instead of user ID
+### Displaying username minus @domain.commcarehq.org instead of user ID
 
 ```
 {
@@ -700,7 +700,7 @@ Transforms can be used to transform the value returned by a column just before i
 }
 ```
 
-#### Displaying owner name instead of owner ID
+### Displaying owner name instead of owner ID
 
 ```
 {
@@ -709,7 +709,7 @@ Transforms can be used to transform the value returned by a column just before i
 }
 ```
 
-#### Displaying month name instead of month index
+### Displaying month name instead of month index
 
 ```
 {
@@ -718,11 +718,11 @@ Transforms can be used to transform the value returned by a column just before i
 }
 ```
 
-# Charts
+## Charts
 
 There are currently three types of charts supported. Pie charts, and two types of bar charts.
 
-## Pie charts
+### Pie charts
 
 A pie chart takes two inputs and makes a pie chart. Here are the inputs:
 
@@ -743,7 +743,7 @@ Here's a sample spec:
 }
 ```
 
-## Aggregate multibar charts
+### Aggregate multibar charts
 
 An aggregate multibar chart is used to aggregate across two columns (typically both of which are select questions). It takes three inputs:
 
@@ -765,7 +765,7 @@ Here's a sample spec:
 }
 ```
 
-## Multibar charts
+### Multibar charts
 
 A multibar chart takes a single x-axis column (typically a select questions) and any number of y-axis columns (typically indicators or counts) and makes a bar chart from them.
 

--- a/corehq/apps/userreports/README.md
+++ b/corehq/apps/userreports/README.md
@@ -790,7 +790,7 @@ Here's a sample spec:
 
 ## Sort Expression
 
-A sort order for the report rows can be specified. Multiple fields, in either ascending or descending order, may be specified. E.g.:
+A sort order for the report rows can be specified. Multiple fields, in either ascending or descending order, may be specified. Example:
 ```
 [
   {

--- a/corehq/apps/userreports/README.md
+++ b/corehq/apps/userreports/README.md
@@ -788,6 +788,22 @@ Here's a sample spec:
 }
 ```
 
+## Sort Expression
+
+A sort order for the report rows can be specified. Multiple fields, in either ascending or descending order, may be specified. E.g.:
+```
+[
+  {
+    "field": "district", 
+    "order": "DESC"
+  }, 
+  {
+    "field": "date_of_data_collection", 
+    "order": "ASC"
+  }
+]
+```
+
 # Export
 
 A UCR data source can be exported, to back an excel dashboard, for instance.

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -18,7 +18,7 @@ from corehq.apps.userreports.filters.factory import FilterFactory
 from corehq.apps.userreports.indicators.factory import IndicatorFactory
 from corehq.apps.userreports.indicators import CompoundIndicator
 from corehq.apps.userreports.reports.factory import ReportFactory, ChartFactory, ReportFilterFactory, \
-    ReportColumnFactory
+    ReportColumnFactory, ReportOrderByFactory
 from corehq.apps.userreports.reports.specs import FilterSpec
 from django.utils.translation import ugettext as _
 from corehq.apps.userreports.specs import EvaluationContext
@@ -247,6 +247,7 @@ class ReportConfiguration(UnicodeMixIn, CachedCouchDocumentMixin, Document):
     filters = ListProperty()
     columns = ListProperty()
     configured_charts = ListProperty()
+    sort_expression = ListProperty()
     report_meta = SchemaProperty(ReportMeta)
 
     def __unicode__(self):
@@ -274,6 +275,11 @@ class ReportConfiguration(UnicodeMixIn, CachedCouchDocumentMixin, Document):
     @memoized
     def charts(self):
         return [ChartFactory.from_spec(g._obj) for g in self.configured_charts]
+
+    @property
+    @memoized
+    def sort_order(self):
+        return [ReportOrderByFactory.from_spec(e) for e in self.sort_expression]
 
     @property
     def table_id(self):
@@ -312,6 +318,7 @@ class ReportConfiguration(UnicodeMixIn, CachedCouchDocumentMixin, Document):
         ReportFactory.from_spec(self)
         self.ui_filters
         self.charts
+        self.sort_order
 
     @classmethod
     def by_domain(cls, domain):

--- a/corehq/apps/userreports/reports/data_source.py
+++ b/corehq/apps/userreports/reports/data_source.py
@@ -106,9 +106,9 @@ class ConfigurableReportDataSource(SqlData):
             ProgrammingError,
         ) as e:
             raise UserReportsError(e.message)
-        # arbitrarily sort by the first column in memory
-        # todo: should get pushed to the database but not currently supported in sqlagg
+        # TODO: Should sort in the database instead of memory, but not currently supported by sqlagg.
         try:
+            # If a sort order is specified, sort by it.
             if self._order_by:
                 for col in reversed(self._order_by):
                     ret.sort(
@@ -116,6 +116,7 @@ class ConfigurableReportDataSource(SqlData):
                         reverse=col[1] == "DESC"
                     )
                 return ret
+            # Otherwise sort by the first column
             else:
                 return sorted(ret, key=lambda x: x.get(
                     self.column_configs[0].column_id,

--- a/corehq/apps/userreports/reports/data_source.py
+++ b/corehq/apps/userreports/reports/data_source.py
@@ -4,6 +4,7 @@ from sqlagg import (
     TableNotFoundException,
 )
 from sqlalchemy.exc import ProgrammingError
+from apps.userreports.reports.specs import DESCENDING
 from corehq.apps.reports.sqlreport import SqlData
 from corehq.apps.userreports.exceptions import UserReportsError
 from corehq.apps.userreports.models import DataSourceConfiguration
@@ -113,7 +114,7 @@ class ConfigurableReportDataSource(SqlData):
                 for col in reversed(self._order_by):
                     ret.sort(
                         key=lambda x: x.get(col[0], None),
-                        reverse=col[1] == "DESC"
+                        reverse=col[1] == DESCENDING
                     )
                 return ret
             # Otherwise sort by the first column

--- a/corehq/apps/userreports/reports/data_source.py
+++ b/corehq/apps/userreports/reports/data_source.py
@@ -4,10 +4,10 @@ from sqlagg import (
     TableNotFoundException,
 )
 from sqlalchemy.exc import ProgrammingError
-from apps.userreports.reports.specs import DESCENDING
 from corehq.apps.reports.sqlreport import SqlData
 from corehq.apps.userreports.exceptions import UserReportsError
 from corehq.apps.userreports.models import DataSourceConfiguration
+from corehq.apps.userreports.reports.specs import DESCENDING
 from corehq.apps.userreports.sql import get_table_name
 from corehq.apps.userreports.views import get_datasource_config_or_404
 from dimagi.utils.decorators.memoized import memoized

--- a/corehq/apps/userreports/reports/factory.py
+++ b/corehq/apps/userreports/reports/factory.py
@@ -11,7 +11,8 @@ from corehq.apps.userreports.reports.filters import(
 )
 from corehq.apps.userreports.reports.specs import FilterSpec, ChoiceListFilterSpec, PieChartSpec, \
     MultibarAggregateChartSpec, MultibarChartSpec, ReportFilter, DynamicChoiceListFilterSpec, \
-    NumericFilterSpec, FieldColumn, PercentageColumn, ExpandedColumn, AggregateDateColumn
+    NumericFilterSpec, FieldColumn, PercentageColumn, ExpandedColumn, AggregateDateColumn, \
+    OrderBySpec
 
 
 def _build_date_filter(spec):
@@ -147,3 +148,10 @@ class ChartFactory(object):
                 json.dumps(spec, indent=2),
                 str(e),
             ))
+
+
+class ReportOrderByFactory(object):
+
+    @classmethod
+    def from_spec(cls, spec):
+        return OrderBySpec.wrap(spec)

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -23,6 +23,8 @@ SQLAGG_COLUMN_MAP = {
     'simple': SimpleColumn,
     'year': YearColumn,
 }
+ASCENDING = "ASC"
+DESCENDING = "DESC"
 
 
 class ReportFilter(JsonObject):
@@ -285,4 +287,4 @@ class MultibarAggregateChartSpec(ChartSpec):
 
 class OrderBySpec(JsonObject):
     field = StringProperty()
-    order = StringProperty(choices=["ASC", "DESC"], default="ASC")
+    order = StringProperty(choices=[ASCENDING, DESCENDING], default=ASCENDING)

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -281,3 +281,8 @@ class MultibarAggregateChartSpec(ChartSpec):
     primary_aggregation = StringProperty(required=True)
     secondary_aggregation = StringProperty(required=True)
     value_column = StringProperty(required=True)
+
+
+class OrderBySpec(JsonObject):
+    field = StringProperty()
+    order = StringProperty(choices=["ASC", "DESC"], default="ASC")

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -157,6 +157,7 @@ class ConfigurableReport(JSONResponseMixin, TemplateView):
         try:
             data = self.data_source
             data.set_filter_values(self.filter_values)
+            data.set_order_by([(o['field'], o['order']) for o in self.spec.sort_expression])
             total_records = data.get_total_records()
         except UserReportsError as e:
             if settings.DEBUG:
@@ -217,6 +218,7 @@ class ConfigurableReport(JSONResponseMixin, TemplateView):
         try:
             data = self.data_source
             data.set_filter_values(self.filter_values)
+            data.set_order_by([(o['field'], o['order']) for o in self.spec.sort_expression])
         except UserReportsError as e:
             return self.render_json_response({
                 'error': e.message,

--- a/corehq/apps/userreports/ui/forms.py
+++ b/corehq/apps/userreports/ui/forms.py
@@ -53,6 +53,7 @@ class ConfigurableReportEditForm(DocumentFormBase):
     filters = JsonField(expected_type=list)
     columns = JsonField(expected_type=list)
     configured_charts = JsonField(expected_type=list)
+    sort_expression = JsonField(expected_type=list)
 
     def __init__(self, domain, instance=None, read_only=False, *args, **kwargs):
         super(ConfigurableReportEditForm, self).__init__(instance, read_only, *args, **kwargs)


### PR DESCRIPTION
Sort the output of a UCR. Adds a new field to the configuration form:

![screen shot 2015-06-03 at 2 45 32 pm](https://cloud.githubusercontent.com/assets/2117127/7968723/69f03034-0a00-11e5-8b1d-f4d9516676af.png)
