### PR TITLE
Hide OpenLMIS settings behind a toggle

### DIFF
--- a/corehq/apps/hqwebapp/models.py
+++ b/corehq/apps/hqwebapp/models.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 from urllib import urlencode
+from corehq.toggles import OPENLMIS
 
 from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe, mark_for_escaping
@@ -494,7 +495,7 @@ class SetupTab(UITab):
         from corehq.apps.locations.views import FacilitySyncView
 
         if self.project.commtrack_enabled:
-            return [[_('CommCare Supply Setup'), [
+            commcare_supply_setup = [
                 # products
                 {
                     'title': ProductListView.page_title,
@@ -544,17 +545,21 @@ class SetupTab(UITab):
                     'title': CommTrackSettingsView.page_title,
                     'url': reverse(CommTrackSettingsView.urlname, args=[self.domain]),
                 },
-                # external sync
-                {
-                    'title': FacilitySyncView.page_title,
-                    'url': reverse(FacilitySyncView.urlname, args=[self.domain]),
-                },
+                # (external sync goes here, if OpenLMIS toggle is enabled)
                 # stock levels
                 {
                     'title': StockLevelsView.page_title,
                     'url': reverse(StockLevelsView.urlname, args=[self.domain]),
                 },
-            ]]]
+            ]
+            if OPENLMIS.enabled(self.domain, namespace='domain'):
+                commcare_supply_setup.insert(-1,
+                    # insert external sync just above stock levels
+                    {
+                        'title': FacilitySyncView.page_title,
+                        'url': reverse(FacilitySyncView.urlname, args=[self.domain]),
+                    })
+            return [[_('CommCare Supply Setup'), commcare_supply_setup]]
 
 
 class ProjectDataTab(UITab):

--- a/corehq/apps/hqwebapp/models.py
+++ b/corehq/apps/hqwebapp/models.py
@@ -545,16 +545,15 @@ class SetupTab(UITab):
                     'title': CommTrackSettingsView.page_title,
                     'url': reverse(CommTrackSettingsView.urlname, args=[self.domain]),
                 },
-                # (external sync goes here, if OpenLMIS toggle is enabled)
                 # stock levels
                 {
                     'title': StockLevelsView.page_title,
                     'url': reverse(StockLevelsView.urlname, args=[self.domain]),
                 },
             ]
-            if OPENLMIS.enabled(self.domain, namespace='domain'):
-                commcare_supply_setup.insert(-1,
-                    # insert external sync just above stock levels
+            if OPENLMIS.enabled(self.domain):
+                commcare_supply_setup.append(
+                    # external sync
                     {
                         'title': FacilitySyncView.page_title,
                         'url': reverse(FacilitySyncView.urlname, args=[self.domain]),

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -463,3 +463,10 @@ INSTANCE_VIEWER = StaticToggle(
     TAG_EXPERIMENTAL,
     namespaces=[NAMESPACE_USER],
 )
+
+OPENLMIS = StaticToggle(
+    'openlmis',
+    'Offer OpenLMIS settings',
+    TAG_UNKNOWN,
+    namespaces=[NAMESPACE_DOMAIN],
+)


### PR DESCRIPTION
For context see [FB 170111](http://manage.dimagi.com/default.asp?170111).

Labelling "hold off on merge" because in local dev environment I can't seem to get the CommTrack / CommCare Supply settings sidebar to appear, so I can't confirm that this change addresses the issue. I must be missing something small. (Yes, CommTrack is enabled for the domain.) Will remove label once I can see it working, but pushing in case whatever I'm missing is obvious to you.

@czue, is this what you had in mind re the toggle? Anything else you think I should put behind it (maybe [the OpenLMIS task](https://github.com/dimagi/commcare-hq/blob/master/custom/openlmis/tasks.py#L15))? I checked Confluence, and it has a whole section on OpenLMIS, but not how to enabled it, so it seems there's nothing that needs to be changed there -- unless I missed something.

Buddy @snopoke
