### PR TITLE
use old-style format for .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,4 @@ docs/_build
 celerybeat-schedule
 
 # compiled translations
-/locale/**/*.mo
+/locale/*/*/*.mo


### PR DESCRIPTION
the prod boxes have 1.7 installed which doesn't support the *\* wildcards

this is a cleaner answer to https://github.com/dimagi/commcare-hq/pull/6930

@TylerSheffels 
