### PR TITLE
Remove thousands separator so full number visible

### DIFF
--- a/corehq/apps/hqadmin/static/hqadmin/js/nvd3_charts_helper.js
+++ b/corehq/apps/hqadmin/static/hqadmin/js/nvd3_charts_helper.js
@@ -252,7 +252,7 @@ function formatChart(chart, selector, xname, data, margin_left) {
         .tickFormat(function(d){return d3.time.format.utc('%b %d' + linebreak_txt + '%Y')(new Date(d));});
 
     chart.yAxis
-        .tickFormat(d3.format(',.1d'))
+        .tickFormat(d3.format('.1d'))
         .axisLabel(xname);
 
     d3.select(selector)


### PR DESCRIPTION
One can't make the y-axis margin wider in NVD3 graphs, because of [NVD3 issue 17](https://github.com/novus/nvd3/issues/17). (Setting left margin width to 100 [as suggested](https://github.com/novus/nvd3/issues/17#issuecomment-17506855) did not make a visible difference.) To see numbers >= 1000000 one has to remove the thousands separator. This is a poor compromise because it sacrifices readablility.

Leaving this with Review label to see whether we are happy with the compromise.

Context: [FB 169822](http://manage.dimagi.com/default.asp?169822)

Before:
![chart_before](https://cloud.githubusercontent.com/assets/708421/7989851/c1775200-0aec-11e5-9b20-f4016b5dab0b.png)

After:
![chart_after](https://cloud.githubusercontent.com/assets/708421/7989853/c4e6272c-0aec-11e5-8731-4e52f100b3d1.png)

@snopoke, @czue 
