### PR TITLE
Use unique ids for custom data source configurations

### DIFF
--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -334,8 +334,8 @@ class CustomDataSourceConfiguration(JsonObject):
     config = DictProperty()
 
     @classmethod
-    def get_doc_id(cls, table_id):
-        return '{}{}'.format(cls._datasource_id_prefix, table_id)
+    def get_doc_id(cls, domain, table_id):
+        return '{}{}-{}'.format(cls._datasource_id_prefix, domain, table_id)
 
     @classmethod
     def all(cls):
@@ -345,7 +345,7 @@ class CustomDataSourceConfiguration(JsonObject):
                 for domain in wrapped.domains:
                     doc = copy(wrapped.config)
                     doc['domain'] = domain
-                    doc['_id'] = cls.get_doc_id(doc['table_id'])
+                    doc['_id'] = cls.get_doc_id(domain, doc['table_id'])
                     yield DataSourceConfiguration.wrap(doc)
 
     @classmethod

--- a/custom/up_nrhm/sql_data.py
+++ b/custom/up_nrhm/sql_data.py
@@ -7,6 +7,7 @@ from corehq.apps.userreports.models import CustomDataSourceConfiguration
 from corehq.apps.userreports.sql import get_table_name, get_indicator_table
 
 TABLE_ID = 'asha_facilitators'
+DOMAIN = 'up-nrhm'
 
 
 class FunctionalityChecklistMeta(QueryMeta):
@@ -46,7 +47,9 @@ class FunctionalityChecklistMeta(QueryMeta):
         self.columns.append(column.sql_column)
 
     def get_asha_table(self, metadata):
-        config = CustomDataSourceConfiguration.by_id(CustomDataSourceConfiguration.get_doc_id(TABLE_ID))
+        config = CustomDataSourceConfiguration.by_id(
+            CustomDataSourceConfiguration.get_doc_id(DOMAIN, TABLE_ID)
+        )
         return get_indicator_table(config, custom_metadata=metadata)
 
     def execute(self, metadata, connection, filter_values):


### PR DESCRIPTION
[`CustomDataSourceConfiguration.by_id()`](https://github.com/dimagi/commcare-hq/blob/1697579bd17d48f67a245b9728d64527a392047f/corehq/apps/userreports/models.py#L367) sometimes had unexpected results. An alternative to this PR would be to remove this check that confirms the domain of a custom data source: [userreports/views.py:L67](https://github.com/dimagi/commcare-hq/blob/1697579bd17d48f67a245b9728d64527a392047f/corehq/apps/userreports/views.py#L67)

cc: @nickpell 
