### PR TITLE
Add UCR transform for rounding decimals

### DIFF
--- a/corehq/apps/userreports/transforms/custom/numeric.py
+++ b/corehq/apps/userreports/transforms/custom/numeric.py
@@ -1,0 +1,2 @@
+def get_short_decimal_display(num):
+    return round(num, 2)

--- a/corehq/apps/userreports/transforms/specs.py
+++ b/corehq/apps/userreports/transforms/specs.py
@@ -1,6 +1,8 @@
 from dimagi.ext.jsonobject import JsonObject, StringProperty
 from corehq.apps.userreports.specs import TypeProperty
 from corehq.apps.userreports.transforms.custom.date import get_month_display
+from corehq.apps.userreports.transforms.custom.numeric import \
+    get_short_decimal_display
 from corehq.apps.userreports.transforms.custom.users import (
     get_user_display,
     get_owner_display,
@@ -21,6 +23,7 @@ _CUSTOM_TRANSFORM_MAP = {
     'user_display': get_user_display,
     'owner_display': get_owner_display,
     'user_without_domain_display': get_user_without_domain_display,
+    'short_decimal_display': get_short_decimal_display,
 }
 
 


### PR DESCRIPTION
Add a transform type to UCR for rounding decimals. Ideally, the user could specify a precision in the configuration. But, I'm not sure how frequently this will be used, so I'm just hard coding 2 decimal places now for simplicities sake.
cc @nickpell 
