### PR TITLE
search couch views

### DIFF
--- a/scripts/searchcouchviews
+++ b/scripts/searchcouchviews
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# usage
+#   scripts/searchcouchviews <pattern>
+# example
+#   scripts/searchcouchviews CommCareCase
+
+ag -G 'map.js' $1 | grep -o '[^/]*/_design/views/.*/map.js' | sed 's|\(.*\)/_design/views/\(.*\)/map.js|\1/\2|g' | sort


### PR DESCRIPTION
requires ag installed

Example:

``` bash
$ scripts/searchcouchviews CommCareCase
case/all_cases
case/by_date_modified_owner
case/by_owner
case/by_owner_lite
case/get_lite
case/groups_by_domain
case/related
commtrack/requisitions
commtrack/supply_point_by_loc
crs_reports/field_block
domain/related_to_domain
hqadmin/cases_over_time
hqcase/all_case_properties
hqcase/by_domain_external_id
hqcase/by_domain_hq_user_id
hqcase/by_owner
hqcase/types_by_domain
pact/chw_dot_schedules
phone/case_modification_status
phone/cases_to_sync_logs
reports/case_activity
users/deleted_cases_by_user
wisepill/device
```
