### PR TITLE
add middlewares that can log rudimentary memory/timing info

### DIFF
--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -1,4 +1,13 @@
+import logging
+import os
+import datetime
 from django.conf import settings
+
+try:
+    import psutil
+except ImportError:
+    psutil = None
+
 
 # this isn't OR specific, but we like it to be included
 OPENROSA_ACCEPT_LANGUAGE = "HTTP_ACCEPT_LANGUAGE"
@@ -27,4 +36,48 @@ class OpenRosaMiddleware(object):
 
     def process_response(self, request, response):
         response[OPENROSA_VERSION_HEADER] = settings.OPENROSA_VERSION
+        return response
+
+
+profile_logger = logging.getLogger('profile_middleware')
+
+
+class MemoryUsageMiddleware(object):
+    """
+    Stolen and modified from http://stackoverflow.com/a/12254394/8207
+
+    This is a pretty poor, blunt tool and is not recommended to be treated as definitive truth.
+    """
+    _psutil_installed = None
+
+    def _check_psutil(self):
+        if self._psutil_installed is None:
+            if psutil is None:
+                profile_logger.warning('Install dev-requirements (psutil) in order to use MemoryUsageMiddleware')
+                self._psutil_installed = False
+            else:
+                self._psutil_installed = True
+        return self._psutil_installed
+
+    def process_request(self, request):
+        if self._check_psutil():
+            request._profile_memory = psutil.Process(os.getpid()).get_memory_info()
+
+    def process_response(self, request, response):
+        if self._check_psutil() and hasattr(request, '_profile_memory'):
+            mem = psutil.Process(os.getpid()).get_memory_info()
+            diff = (mem.rss - request._profile_memory.rss) / 1024
+            profile_logger.info('{} memory usage {} KB'.format(request.path, diff))
+        return response
+
+
+class TimingMiddleware(object):
+
+    def process_request(self, request):
+        request._profile_starttime = datetime.datetime.utcnow()
+
+    def process_response(self, request, response):
+        if hasattr(request, '_profile_starttime'):
+            end = datetime.datetime.utcnow() - request._profile_starttime
+            profile_logger.info('{} time {}'.format(request.path, end))
         return response

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -13,3 +13,4 @@ docutils==0.11
 -e git+git://github.com/dimagi/luna.git@1.0.0#egg=luna
 fixture
 sniffer
+psutil  # for memory profiling


### PR DESCRIPTION
You can add these lines to your `localsettings.py`:

``` python
LOCAL_MIDDLEWARE_CLASSES = (
    'corehq.middleware.MemoryUsageMiddleware',
    'corehq.middleware.TimingMiddleware',
)
```

and configure your logging as well

``` python
LOGGING = {
    # some parts shortened
    'handlers': {
        'console': {
            'level': 'INFO',
            'class': 'logging.StreamHandler',
            'formatter': 'simple'
        },
   },
    'loggers': {
        'profile_middleware': {
            'handlers': ['console'],
            'level': 'DEBUG',
            'propagate': False,
        },
    }
}
```

And then (almost) every request you make will print out something like:

```
INFO /hq/admin/phone/restore/ time 0:00:03.979062
INFO /hq/admin/phone/restore/ memory usage 45488 KB
```

@TylerSheffels cc @dimagi/team-commcare-hq  
