### PR TITLE
Translate UCR Report Columns

### DIFF
--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -72,7 +72,7 @@ def _create_custom_app_strings(app, lang):
                 yield id_strings.report_name_header(), 'Report Name'
                 yield id_strings.report_description_header(), 'Report Description'
                 for column in config.report.report_columns:
-                    yield id_strings.report_column_header(config.report_id, column.column_id), column.display
+                    yield id_strings.report_column_header(config.report_id, column.column_id), column.get_header(lang)
 
         if hasattr(module, 'case_list'):
             if module.case_list.show:

--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -72,7 +72,10 @@ def _create_custom_app_strings(app, lang):
                 yield id_strings.report_name_header(), 'Report Name'
                 yield id_strings.report_description_header(), 'Report Description'
                 for column in config.report.report_columns:
-                    yield id_strings.report_column_header(config.report_id, column.column_id), column.get_header(lang)
+                    yield (
+                        id_strings.report_column_header(config.report_id, column.column_id),
+                        column.get_header(lang)
+                    )
 
         if hasattr(module, 'case_list'):
             if module.case_list.show:

--- a/corehq/apps/userreports/README.md
+++ b/corehq/apps/userreports/README.md
@@ -701,7 +701,7 @@ The value displayed to the user is determined as follows:
 - If `"en"` is not present, show an arbitrary translation from the `display` object.
 - If `display` is a string, and not an object, the report shows the string.
 
-Valid `display` languages are any of the two letter language codes specified by [ISO 639-1](http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes).
+Valid `display` languages are any of the two or three letter language codes available on the user settings page.
 
 
 ## Aggregation

--- a/corehq/apps/userreports/README.md
+++ b/corehq/apps/userreports/README.md
@@ -674,6 +674,36 @@ Then you will get a report like this:
 +----------+----------------------+----------------------+
 ```
 
+### Internationalization
+Report columns can be translated into multiple languages. To specify translations
+for a column header, use an object as the `display` value in the configuration
+instead of a string. For example:
+```
+{
+    "type": "field",
+    "field": "owner_id",
+    "column_id": "owner_id",
+    "display": {
+        "en": "Owner Name",
+        "he": "שם"
+    },
+    "format": "default",
+    "transform": {
+        "type": "custom",
+        "custom_type": "owner_display"
+    },
+    "aggregation": "simple"
+}
+```
+The value displayed to the user is determined as follows:
+- If a display value is specified for the users language, that value will appear in the report.
+- If the users language is not present, display the `"en"` value.
+- If `"en"` is not present, show an arbitrary translation from the `display` object.
+- If `display` is a string, and not an object, the report shows the string.
+
+Valid `display` languages are any of the two letter language codes specified by [ISO 639-1](http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes).
+
+
 ## Aggregation
 
 TODO: finish aggregation docs

--- a/corehq/apps/userreports/reports/data_source.py
+++ b/corehq/apps/userreports/reports/data_source.py
@@ -16,6 +16,7 @@ from dimagi.utils.decorators.memoized import memoized
 class ConfigurableReportDataSource(SqlData):
 
     def __init__(self, domain, config_or_config_id, filters, aggregation_columns, columns):
+        self.lang = None
         self.domain = domain
         if isinstance(config_or_config_id, DataSourceConfiguration):
             self._config = config_or_config_id
@@ -87,9 +88,8 @@ class ConfigurableReportDataSource(SqlData):
         return [c for sql_conf in self.sql_column_configs for c in sql_conf.columns]
 
     @property
-    @memoized
     def sql_column_configs(self):
-        return [col.get_sql_column_config(self.config) for col in self.column_configs]
+        return [col.get_sql_column_config(self.config, self.lang) for col in self.column_configs]
 
     @property
     def column_warnings(self):

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -45,7 +45,7 @@ class ReportFilter(JsonObject):
 class ReportColumn(JsonObject):
     type = StringProperty(required=True)
     column_id = StringProperty(required=True)
-    display = StringProperty()
+    display = DefaultProperty()
     description = StringProperty()
     transform = DictProperty()
 
@@ -55,7 +55,7 @@ class ReportColumn(JsonObject):
         """
         pass
 
-    def get_sql_column_config(self, data_source_config):
+    def get_sql_column_config(self, data_source_config, lang):
         raise NotImplementedError('subclasses must override this')
 
     def get_format_fn(self):
@@ -68,6 +68,13 @@ class ReportColumn(JsonObject):
 
     def get_group_by_columns(self):
         raise NotImplementedError(_("You can't group by columns of type {}".format(self.type)))
+
+    def get_header(self, lang):
+        if isinstance(self.display, basestring) or self.display is None:
+            return self.display
+        return self.display.get(
+            lang, self.display.get("en", self.display.values()[0])
+        )
 
 
 class FieldColumn(ReportColumn):
@@ -105,10 +112,10 @@ class FieldColumn(ReportColumn):
                     float(row[column_name]) / total
                 )
 
-    def get_sql_column_config(self, data_source_config):
+    def get_sql_column_config(self, data_source_config, lang):
         return SqlColumnConfig(columns=[
             DatabaseColumn(
-                header=self.display,
+                header=self.get_header(lang),
                 agg_column=SQLAGG_COLUMN_MAP[self.aggregation](self.field, alias=self.column_id),
                 sortable=False,
                 data_slug=self.column_id,
@@ -132,8 +139,8 @@ class ExpandedColumn(ReportColumn):
         _add_column_id_if_missing(obj)
         return super(ExpandedColumn, cls).wrap(obj)
 
-    def get_sql_column_config(self, data_source_config):
-        return get_expanded_column_config(data_source_config, self)
+    def get_sql_column_config(self, data_source_config, lang):
+        return get_expanded_column_config(data_source_config, self, lang)
 
 
 class AggregateDateColumn(ReportColumn):
@@ -143,10 +150,10 @@ class AggregateDateColumn(ReportColumn):
     type = TypeProperty('aggregate_date')
     field = StringProperty(required=True)
 
-    def get_sql_column_config(self, data_source_config):
+    def get_sql_column_config(self, data_source_config, lang):
         return SqlColumnConfig(columns=[
             AggregateColumn(
-                header=self.display,
+                header=self.get_header(lang),
                 aggregate_fn=lambda year, month: {'year': year, 'month': month},
                 format_fn=self.get_format_fn(),
                 columns=[
@@ -178,13 +185,13 @@ class PercentageColumn(ReportColumn):
     denominator = ObjectProperty(FieldColumn, required=True)
     format = StringProperty(choices=['percent', 'fraction', 'both'], default='percent')
 
-    def get_sql_column_config(self, data_source_config):
+    def get_sql_column_config(self, data_source_config, lang):
         # todo: better checks that fields are not expand
-        num_config = self.numerator.get_sql_column_config(data_source_config)
-        denom_config = self.denominator.get_sql_column_config(data_source_config)
+        num_config = self.numerator.get_sql_column_config(data_source_config, lang)
+        denom_config = self.denominator.get_sql_column_config(data_source_config, lang)
         return SqlColumnConfig(columns=[
             AggregateColumn(
-                header=self.display,
+                header=self.get_header(lang),
                 aggregate_fn=lambda n, d: {'num': n, 'denom': d},
                 format_fn=self.get_format_fn(),
                 columns=[c.view for c in num_config.columns + denom_config.columns],

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -228,7 +228,7 @@ class ConfigurableReport(JSONResponseMixin, TemplateView):
 
         report_config = ReportConfiguration.get(self.report_config_id)
         raw_rows = list(data.get_data())
-        headers = [column['display'] for column in report_config.columns]
+        headers = [column.header for column in self.data_source.columns]
         columns = [column['field'] for column in report_config.columns]
         rows = [[raw_row[column] for column in columns] for raw_row in raw_rows]
         return [

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -45,7 +45,7 @@ class ConfigurableReport(JSONResponseMixin, TemplateView):
     @memoized
     def data_source(self):
         report = ReportFactory.from_spec(self.spec)
-        report.lang = self.request.LANGUAGE_CODE
+        report.lang = self.request.couch_user.language
         return report
 
     @property

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -44,7 +44,9 @@ class ConfigurableReport(JSONResponseMixin, TemplateView):
     @property
     @memoized
     def data_source(self):
-        return ReportFactory.from_spec(self.spec)
+        report = ReportFactory.from_spec(self.spec)
+        report.lang = self.request.LANGUAGE_CODE
+        return report
 
     @property
     @memoized

--- a/corehq/apps/userreports/sql.py
+++ b/corehq/apps/userreports/sql.py
@@ -156,7 +156,7 @@ def get_expanded_column_config(data_source_configuration, column_config, lang):
         column_warnings.append(
             'The "{}" column had too many values to expand! '
             'Expansion limited to {} distinct values.'.format(
-                column_config.display, MAXIMUM_EXPANSION
+                column_config.get_header(lang), MAXIMUM_EXPANSION
             )
         )
     return SqlColumnConfig(_expand_column(column_config, vals, lang), warnings=column_warnings)

--- a/corehq/apps/userreports/sql.py
+++ b/corehq/apps/userreports/sql.py
@@ -134,7 +134,7 @@ def get_table_name(domain, table_id):
     return 'config_report_{0}_{1}_{2}'.format(domain, table_id, _hash(domain, table_id))
 
 
-def get_expanded_column_config(data_source_configuration, column_config):
+def get_expanded_column_config(data_source_configuration, column_config, lang):
     """
     Given a ReportColumn, return a list of DatabaseColumn objects. Each DatabaseColumn
     is configured to show the number of occurrences of one of the values present for
@@ -159,7 +159,7 @@ def get_expanded_column_config(data_source_configuration, column_config):
                 column_config.display, MAXIMUM_EXPANSION
             )
         )
-    return SqlColumnConfig(_expand_column(column_config, vals), warnings=column_warnings)
+    return SqlColumnConfig(_expand_column(column_config, vals, lang), warnings=column_warnings)
 
 
 def _get_distinct_values(data_source_configuration, column_config, expansion_limit=10):
@@ -199,7 +199,7 @@ def _get_distinct_values(data_source_configuration, column_config, expansion_lim
     return distinct_values, too_many_values
 
 
-def _expand_column(report_column, distinct_values):
+def _expand_column(report_column, distinct_values, lang):
     """
     Given a ReportColumn, return a list of DatabaseColumn objects. Each column
     is configured to show the number of occurrences of one of the given distinct_values.
@@ -211,7 +211,7 @@ def _expand_column(report_column, distinct_values):
     columns = []
     for val in distinct_values:
         columns.append(DatabaseColumn(
-            u"{}-{}".format(report_column.display, val),
+            u"{}-{}".format(report_column.get_header(lang), val),
             SumWhen(
                 report_column.field,
                 whens={val: 1},

--- a/corehq/apps/userreports/tests/data/configs/sample_report_config.json
+++ b/corehq/apps/userreports/tests/data/configs/sample_report_config.json
@@ -23,7 +23,10 @@
         },
         {
             "type": "field",
-            "display": "Tickets",
+            "display": {
+                "en": "Tickets",
+                "fr": "Billets"
+            },
             "description": "Number of tickets",
             "field": "count",
             "aggregation": "sum"

--- a/corehq/apps/userreports/tests/test_columns.py
+++ b/corehq/apps/userreports/tests/test_columns.py
@@ -194,7 +194,7 @@ class TestExpandedColumn(TestCase):
             format="default",
             description="foo"
         ))
-        cols = _expand_column(column, ["positive", "negative"])
+        cols = _expand_column(column, ["positive", "negative"], "en")
 
         self.assertEqual(len(cols), 2)
         self.assertEqual(type(cols[0].view), SumWhen)

--- a/corehq/apps/userreports/tests/test_report_config.py
+++ b/corehq/apps/userreports/tests/test_report_config.py
@@ -3,7 +3,6 @@ from jsonobject.exceptions import BadValueError
 from corehq.apps.userreports.exceptions import BadSpecError
 from corehq.apps.userreports.models import ReportConfiguration, DataSourceConfiguration
 from corehq.apps.userreports.reports.factory import ReportFactory
-from corehq.apps.userreports.reports.specs import FieldColumn
 from corehq.apps.userreports.tests.utils import get_sample_report_config
 
 


### PR DESCRIPTION
This PR Allows users to specify multiple languages for report column headings. Django's `request.LANGUAGE_CODE` is used to determine which language is displayed to the user viewing the reports. Example column spec:

``` json
{
    "type": "field",
    "field": "owner_id",
    "display": {
        "en": "Name",
        "he": "שם"
    },
    ...
}
```

Strings can still be used in the spec if the report builder doesn't want to specify any translations:

``` json
{
    "type": "field",
    "field": "owner_id",
    "display": "Name",
    ...
}
```

Related features that we will probably want eventually:
- Translations of filter display values
- Set language for emailed reports (currently will send in the language of the user who scheduled the report)
