### PR TITLE
Pull out hqcase/by_owner

### DIFF
--- a/corehq/apps/hqadmin/views.py
+++ b/corehq/apps/hqadmin/views.py
@@ -32,6 +32,7 @@ from django.http import (
 )
 from restkit import Resource
 from restkit.errors import Unauthorized
+from casexml.apps.case.dbaccessors import get_total_case_count
 
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.callcenter.indicator_sets import CallCenterIndicators
@@ -467,7 +468,7 @@ def db_comparisons(request):
         },
         {
             'description': 'Cases (doc_type is "CommCareCase")',
-            'couch_docs': _simple_view_couch_query(CommCareCase.get_db(), 'case/by_owner'),
+            'couch_docs': get_total_case_count(),
             'es_query': CaseES().size(0),
             'sql_rows': CaseData.objects.count(),
         }

--- a/corehq/apps/hqcase/dbaccessors.py
+++ b/corehq/apps/hqcase/dbaccessors.py
@@ -61,6 +61,19 @@ def get_case_types_for_domain(domain):
 
 def get_case_ids_in_domain_by_owner(domain, owner_id=None, owner_id__in=None,
                                     closed=None):
+    """
+    get case_ids for open, closed, or all cases in a domain
+    that belong to an owner_id or list of owner_ids
+
+    domain: required
+    owner_id: a single owner_id to filter on
+    owner_id__in: a list of owner ids to filter on.
+        A case matches if it belongs to any of them.
+        You cannot specify both this and owner_id
+    closed: True (only closed cases), False (only open cases), or None (all)
+    returns a list of case_ids
+
+    """
     assert not (owner_id__in and owner_id)
     assert closed in (True, False, None)
     if closed is None:

--- a/corehq/apps/hqcase/dbaccessors.py
+++ b/corehq/apps/hqcase/dbaccessors.py
@@ -57,3 +57,23 @@ def get_case_types_for_domain(domain):
         if case_type:
             case_types.append(case_type)
     return case_types
+
+
+def get_case_ids_in_domain_by_owner(domain, owner_id=None, owner_id__in=None,
+                                    closed=None):
+    assert not (owner_id__in and owner_id)
+    assert closed in (True, False, None)
+    if closed is None:
+        closed_flags = [True, False]
+    else:
+        closed_flags = [closed]
+    if owner_id:
+        owner_id__in = [owner_id]
+    return [res["id"] for res in CommCareCase.view(
+        'hqcase/by_owner',
+        keys=[[domain, owner_id, closed_flag]
+              for owner_id in owner_id__in
+              for closed_flag in closed_flags],
+        include_docs=False,
+        reduce=False,
+    )]

--- a/corehq/apps/hqcase/tests/test_dbaccessors.py
+++ b/corehq/apps/hqcase/tests/test_dbaccessors.py
@@ -3,7 +3,8 @@ from casexml.apps.case.dbaccessors import get_open_case_docs_in_domain, \
     get_open_case_ids_in_domain, get_number_of_cases_by_filters
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.hqcase.dbaccessors import get_number_of_cases_in_domain, \
-    get_case_ids_in_domain, get_case_types_for_domain, get_cases_in_domain
+    get_case_ids_in_domain, get_case_types_for_domain, get_cases_in_domain, \
+    get_case_ids_in_domain_by_owner
 
 
 class DBAccessorsTest(TestCase):
@@ -124,4 +125,31 @@ class DBAccessorsTest(TestCase):
             result,
             len([case for case in self.cases
                  if case.domain == self.domain and case.user_id == 'XXX'])
+        )
+
+    def test_get_case_ids_in_domain_by_owner(self):
+        self.assertEqual(
+            set(get_case_ids_in_domain_by_owner(self.domain, owner_id='XXX')),
+            {case.get_id for case in self.cases
+             if case.domain == self.domain and case.user_id == 'XXX'}
+        )
+        self.assertEqual(
+            set(get_case_ids_in_domain_by_owner(
+                self.domain, owner_id__in=['XXX'])),
+            {case.get_id for case in self.cases
+             if case.domain == self.domain and case.user_id == 'XXX'}
+        )
+        self.assertEqual(
+            set(get_case_ids_in_domain_by_owner(self.domain, owner_id='XXX',
+                                                closed=False)),
+            {case.get_id for case in self.cases
+             if case.domain == self.domain and case.user_id == 'XXX'
+                and case.closed is False}
+        )
+        self.assertEqual(
+            set(get_case_ids_in_domain_by_owner(self.domain, owner_id='XXX',
+                                                closed=True)),
+            {case.get_id for case in self.cases
+             if case.domain == self.domain and case.user_id == 'XXX'
+                and case.closed is True}
         )

--- a/corehq/util/tests/__init__.py
+++ b/corehq/util/tests/__init__.py
@@ -4,6 +4,7 @@ from test_quickcache import *
 from test_timezone_conversions import *
 from test_soft_assert import *
 from test_cache_util import *
+from test_override_db import *
 
 from corehq.util.dates import iso_string_to_datetime, iso_string_to_date
 

--- a/corehq/util/tests/test_override_db.py
+++ b/corehq/util/tests/test_override_db.py
@@ -1,0 +1,82 @@
+from Queue import Queue
+import threading
+from couchdbkit import Server
+from django.test import TestCase
+from casexml.apps.case.models import CommCareCase
+from corehq.util.couch_helpers import OverrideDB, _override_db
+from django.conf import settings
+
+
+class OverrideDBTest(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.server = Server(settings.COUCH_SERVER)
+        cls.other_db_1 = cls.server.create_db('foo-boo-test')
+        cls.other_db_2 = cls.server.create_db('foo-boo-boo-test')
+        cls.normal_db = CommCareCase.get_db()
+        cls.normal_get_db = CommCareCase.get_db
+
+    def setUp(self):
+        self.assertEqual(self.normal_db.dbname, 'commcarehq_test')
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.delete_db(cls.other_db_1.dbname)
+        cls.server.delete_db(cls.other_db_2.dbname)
+
+    def test_nested(self):
+        self.assertEqual(CommCareCase.get_db(), self.normal_db)
+        self.assertEqual(CommCareCase.get_db, self.normal_get_db)
+
+        with OverrideDB(CommCareCase, self.other_db_1):
+            self.assertEqual(CommCareCase.get_db(), self.other_db_1)
+            self.assertNotEqual(CommCareCase.get_db(), self.normal_db)
+            self.assertNotEqual(CommCareCase.get_db(), self.normal_get_db)
+
+            with OverrideDB(CommCareCase, self.other_db_2):
+                self.assertEqual(CommCareCase.get_db(), self.other_db_2)
+                self.assertNotEqual(CommCareCase.get_db(), self.normal_db)
+                self.assertNotEqual(CommCareCase.get_db(), self.normal_get_db)
+
+            self.assertEqual(CommCareCase.get_db(), self.other_db_1)
+            self.assertNotEqual(CommCareCase.get_db(), self.normal_db)
+            self.assertNotEqual(CommCareCase.get_db(), self.normal_get_db)
+
+        self.assertEqual(CommCareCase.get_db(), self.normal_db)
+        self.assertEqual(CommCareCase.get_db, self.normal_get_db)
+
+    def test_series(self):
+        self.assertEqual(CommCareCase.get_db(), self.normal_db)
+        self.assertEqual(CommCareCase.get_db, self.normal_get_db)
+
+        with OverrideDB(CommCareCase, self.other_db_1):
+            self.assertEqual(CommCareCase.get_db(), self.other_db_1)
+            self.assertNotEqual(CommCareCase.get_db(), self.normal_db)
+            self.assertNotEqual(CommCareCase.get_db(), self.normal_get_db)
+
+        self.assertEqual(CommCareCase.get_db(), self.normal_db)
+        self.assertEqual(CommCareCase.get_db, self.normal_get_db)
+
+        with OverrideDB(CommCareCase, self.other_db_2):
+            self.assertEqual(CommCareCase.get_db(), self.other_db_2)
+            self.assertNotEqual(CommCareCase.get_db(), self.normal_db)
+            self.assertNotEqual(CommCareCase.get_db(), self.normal_get_db)
+
+        self.assertEqual(CommCareCase.get_db(), self.normal_db)
+        self.assertEqual(CommCareCase.get_db, self.normal_get_db)
+
+    def test_threading(self):
+        result_queue = Queue()
+
+        with OverrideDB(CommCareCase, self.other_db_1):
+            obj = _override_db.class_to_db
+
+        def run():
+            with OverrideDB(CommCareCase, self.other_db_2):
+                result_queue.put(_override_db.class_to_db)
+
+        t = threading.Thread(target=run)
+        t.start()
+        t.join()
+        result = result_queue.get_nowait()
+        self.assertNotEqual(id(obj), id(result))

--- a/custom/bihar/management/commands/bihar_run_calcs.py
+++ b/custom/bihar/management/commands/bihar_run_calcs.py
@@ -1,4 +1,5 @@
 import gevent
+from corehq.apps.hqcase.dbaccessors import get_case_ids_in_domain_by_owner
 from custom.bihar.models import CareBiharFluffPillow
 from dimagi.utils.couch.database import iter_docs
 from django.core.management import BaseCommand
@@ -21,21 +22,12 @@ class Command(BaseCommand):
         def process_case(case):
             pillow.change_transport(pillow.change_transform(case))
 
-
         for i, owner_id in enumerate(owner_ids):
             print '{0}/{1} owner_ids'.format(i, len(owner_ids))
-            rows = CommCareCase.view(
-                'hqcase/by_owner',
-                startkey=[domain, owner_id],
-                endkey=[domain, owner_id, {}],
-                reduce=False,
-            ).all()
-            case_ids = [row['id'] for row in rows]
+            case_ids = get_case_ids_in_domain_by_owner(
+                domain, owner_id=owner_id)
             print '{0} case_ids'.format(len(case_ids))
             for case in iter_docs(db, case_ids):
                 g = gevent.Greenlet.spawn(process_case, case)
                 greenlets.append(g)
         gevent.joinall(greenlets)
-
-
-


### PR DESCRIPTION
A continuation on the theme of https://github.com/dimagi/commcare-hq/pull/7014. Move all calls to `'hqcase/by_owner'` to `hqcase.dbaccessors`.
