### PR TITLE
Cache case id list

### DIFF
--- a/corehq/apps/cloudcare/api.py
+++ b/corehq/apps/cloudcare/api.py
@@ -351,7 +351,7 @@ def get_filters_from_request(request, limit_top_level=None):
         filters = dict([(key, val) for key, val in filters.items() if '/' in key or key in limit_top_level])
 
     for system_property in ['user_id', 'closed', 'format', 'footprint',
-                            'ids_only', 'include_children', 'cache_bust']:
+                            'ids_only', 'include_children', 'use_cache']:
         if system_property in filters:
             del filters[system_property]
     return filters

--- a/corehq/apps/cloudcare/api.py
+++ b/corehq/apps/cloudcare/api.py
@@ -351,7 +351,7 @@ def get_filters_from_request(request, limit_top_level=None):
         filters = dict([(key, val) for key, val in filters.items() if '/' in key or key in limit_top_level])
 
     for system_property in ['user_id', 'closed', 'format', 'footprint',
-                            'ids_only', 'include_children']:
+                            'ids_only', 'include_children', 'cache_bust']:
         if system_property in filters:
             del filters[system_property]
     return filters

--- a/corehq/apps/cloudcare/tests/test_api.py
+++ b/corehq/apps/cloudcare/tests/test_api.py
@@ -9,6 +9,8 @@ from casexml.apps.case.tests import delete_all_cases
 from casexml.apps.case.util import post_case_blocks
 from casexml.apps.case.xml import V2
 from casexml.apps.phone.xml import date_to_xml_string
+from toggle.shortcuts import update_toggle_cache, clear_toggle_cache
+from corehq import toggles
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.util import format_username
@@ -53,6 +55,7 @@ class CaseAPITest(TestCase):
 
         self.test_type = self.case_types[0]
         self.test_user_id = self.users[0]._id
+        update_toggle_cache(toggles.CLOUDCARE_CACHE.slug, TEST_DOMAIN, True, toggles.NAMESPACE_DOMAIN)
 
     def tearDown(self):
         for user in self.users:
@@ -60,6 +63,7 @@ class CaseAPITest(TestCase):
             django_user.delete()
             user.delete()
         delete_all_cases()
+        clear_toggle_cache(toggles.CLOUDCARE_CACHE.slug, TEST_DOMAIN, toggles.NAMESPACE_DOMAIN)
 
     def assertListMatches(self, list, function):
         for item in list:

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -236,7 +236,13 @@ def get_cases_vary_on(request, domain):
 
 
 def get_cases_skip_arg(request, domain):
-    return string_to_boolean(request.REQUEST.get('cache_bust', 'true'))
+    """
+    When this function returns True, skippable_quickcache will not go to the cache for the result. By default,
+    if neither of these params are passed into the function, nothing will be cached. Cache will always be
+    skipped if ids_only is false.
+    """
+    return (not string_to_boolean(request.REQUEST.get('use_cache', 'false')) or
+        not string_to_boolean(request.REQUEST.get('ids_only', 'false')))
 
 
 @cloudcare_api

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -240,7 +240,7 @@ def get_cases_skip_arg(request, domain):
     When this function returns True, skippable_quickcache will not go to the cache for the result. By default,
     if neither of these params are passed into the function, nothing will be cached. Cache will always be
     skipped if ids_only is false.
-    
+
     The caching is mainly a hack for touchforms to respond more quickly. Touchforms makes repeated requests to
     get the list of case_ids associated with a user.
     """

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -240,6 +240,9 @@ def get_cases_skip_arg(request, domain):
     When this function returns True, skippable_quickcache will not go to the cache for the result. By default,
     if neither of these params are passed into the function, nothing will be cached. Cache will always be
     skipped if ids_only is false.
+    
+    The caching is mainly a hack for touchforms to respond more quickly. Touchforms makes repeated requests to
+    get the list of case_ids associated with a user.
     """
     return (not string_to_boolean(request.REQUEST.get('use_cache', 'false')) or
         not string_to_boolean(request.REQUEST.get('ids_only', 'false')))

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -244,6 +244,8 @@ def get_cases_skip_arg(request, domain):
     The caching is mainly a hack for touchforms to respond more quickly. Touchforms makes repeated requests to
     get the list of case_ids associated with a user.
     """
+    if not toggles.CLOUDCARE_CACHE.enabled(domain):
+        return True
     return (not string_to_boolean(request.REQUEST.get('use_cache', 'false')) or
         not string_to_boolean(request.REQUEST.get('ids_only', 'false')))
 

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -456,6 +456,13 @@ INSTANCE_VIEWER = StaticToggle(
     namespaces=[NAMESPACE_USER],
 )
 
+CLOUDCARE_CACHE = StaticToggle(
+    'cloudcare_cache',
+    'Aggresively cache case list, can result in stale data',
+    TAG_EXPERIMENTAL,
+    namespaces=[NAMESPACE_DOMAIN],
+)
+
 OPENLMIS = StaticToggle(
     'openlmis',
     'Offer OpenLMIS settings',

--- a/corehq/util/quickcache.py
+++ b/corehq/util/quickcache.py
@@ -191,6 +191,15 @@ def skippable_quickcache(vary_on, skip_arg, timeout=None, memoize_timeout=None, 
     @skippable_quickcache(['name'], skip_arg='force')
     def get_by_name(name, force=False):
         ...
+
+    The skip_arg can also be a function and will receive the save arguments as the function:
+    def skip_fn(name, address):
+        return name == 'Ben' and 'Chicago' not in address
+
+    @skippable_quickcache(['name'], skip_arg=skip_fn)
+    def get_by_name_and_address(name, address):
+        ...
+
     """
     skippable_cache = functools.partial(SkippableQuickCache, skip_arg=skip_arg)
 

--- a/corehq/util/tests/test_quickcache.py
+++ b/corehq/util/tests/test_quickcache.py
@@ -230,6 +230,24 @@ class QuickcacheTest(SimpleTestCase):
         self.assertEqual(by_name(name), 'VALUE')
         self.assertEqual(self.consume_buffer(), ['cache hit'])
 
+    def test_skippable_fn(self):
+        @skippable_quickcache(['name'], cache=_cache_with_set, skip_arg=lambda name: name == 'Ben')
+        def by_name(name, force=False):
+            BUFFER.append('called')
+            return 'VALUE'
+
+        name = 'name'
+        self.assertEqual(by_name(name), 'VALUE')
+        self.assertEqual(self.consume_buffer(), ['cache miss', 'called', 'cache set'])
+        self.assertEqual(by_name(name), 'VALUE')
+        self.assertEqual(self.consume_buffer(), ['cache hit'])
+
+        name = 'Ben'
+        self.assertEqual(by_name(name), 'VALUE')
+        self.assertEqual(self.consume_buffer(), ['called', 'cache set'])
+        self.assertEqual(by_name(name), 'VALUE')
+        self.assertEqual(self.consume_buffer(), ['called', 'cache set'])
+
     def test_skippable_non_kwarg(self):
         @skippable_quickcache(['name'], cache=_cache_with_set, skip_arg='skip_cache')
         def by_name(name, skip_cache):


### PR DESCRIPTION
@czue @wpride this will cache case id list when `cache_bust` is set to `false`. By default it will not cache so this won't break any api that doesn't want to cache. I used the skippable_quickcache which is very nice, but makes it hard for me to clear that key on a form submission. Basically I'd have to regenerate the key that's being created when this function is called which I don't think will be trivial and has room for a lot of errors (at least that was my thinking, happy to discuss).

Touchforms will know if it doesn't have an updated list of case ids because it will fail to find the case it's looking for. On failure it will tell HQ to bust the cache and try again.

This is functional, but I wanted to get it reviewed before I wrote a few tests for it

elf: @dannyroberts 
