### PR TITLE
Case list callout

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1428,9 +1428,11 @@ class Detail(IndexedSchema):
     use_case_tiles = BooleanProperty()
     persist_tile_on_forms = BooleanProperty()
     pull_down_tile = BooleanProperty()
-    search_callout_enabled = BooleanProperty(default=False)
-    search_callout_action = StringProperty()
-    search_callout_image = StringProperty()
+    lookup_enabled = BooleanProperty(default=False)
+    lookup_action = StringProperty()
+    lookup_image = JRResourceProperty(required=False)
+    lookup_extras = SchemaListProperty()
+    lookup_responses = SchemaListProperty()
 
     def get_tab_spans(self):
         '''

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1409,7 +1409,24 @@ class SortOnlyDetailColumn(DetailColumn):
         raise NotImplementedError()
 
 
-class Detail(IndexedSchema):
+class CaseListLookupMixin(DocumentSchema):
+    """
+        Allows for the addition of Android Callouts to do lookups from the CaseList
+        <lookup action="" image="" name="">
+            <extra key="" value = "" />
+            <response key ="" />
+        </lookup>
+    """
+    lookup_enabled = BooleanProperty(default=False)
+    lookup_action = StringProperty()
+    lookup_name = StringProperty()
+    lookup_image = JRResourceProperty(required=False)
+
+    lookup_extras = SchemaListProperty()
+    lookup_responses = SchemaListProperty()
+
+
+class Detail(IndexedSchema, CaseListLookupMixin):
     """
     Full configuration for a case selection screen
 
@@ -1428,11 +1445,6 @@ class Detail(IndexedSchema):
     use_case_tiles = BooleanProperty()
     persist_tile_on_forms = BooleanProperty()
     pull_down_tile = BooleanProperty()
-    lookup_enabled = BooleanProperty(default=False)
-    lookup_action = StringProperty()
-    lookup_image = JRResourceProperty(required=False)
-    lookup_extras = SchemaListProperty()
-    lookup_responses = SchemaListProperty()
 
     def get_tab_spans(self):
         '''

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1428,6 +1428,9 @@ class Detail(IndexedSchema):
     use_case_tiles = BooleanProperty()
     persist_tile_on_forms = BooleanProperty()
     pull_down_tile = BooleanProperty()
+    search_callout_enabled = BooleanProperty(default=False)
+    search_callout_action = StringProperty()
+    search_callout_image = StringProperty()
 
     def get_tab_spans(self):
         '''

--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -245,13 +245,17 @@ var caseListLookupViewModel = function($el, state, saveButton){
             }
         }));
 
+        var image_path = $el.find(".case-list-lookup-icon input[type=hidden]").val() || null;
+
         var data = {
             lookup_enabled: self.lookup_enabled(),
             lookup_action: self.lookup_action(),
             lookup_name: self.lookup_name(),
             lookup_extras: serialized_extras,
             lookup_responses: serialized_responses,
+            lookup_image: image_path,
         };
+
         return data;
     };
 

--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -225,16 +225,29 @@ var caseListLookupViewModel = function($el, state, saveButton){
 
     self.remove_extra = function(extra){
         self.extras.remove(extra);
+        if (self.extras().length === 0){
+            self.add_extra();
+        }
         _fireChange();
     };
 
+    var _remove_empty_responses = function(){
+        self.responses.remove(function(response){
+            var is_blank = response.key() === "";
+            return is_blank;
+        });
+    };
+
     self.add_response = function(){
-        // _remove_empty_extras();
+        _remove_empty_responses();
         self.responses.push(new ObservableKeyValue({key:''}));
     };
 
     self.remove_response = function(response){
         self.responses.remove(response);
+        if (self.responses().length === 0){
+            self.add_response();
+        }
         _fireChange();
     };
 
@@ -283,14 +296,20 @@ var caseListLookupViewModel = function($el, state, saveButton){
     }
 
     self.show_add_extra = ko.computed(function(){
-        var last_key = self.extras()[self.extras().length - 1].key(),
-            last_value = self.extras()[self.extras().length - 1].value();
-        return !(last_key === "" && last_value === "");
+        if (self.extras().length){
+            var last_key = self.extras()[self.extras().length - 1].key(),
+                last_value = self.extras()[self.extras().length - 1].value();
+            return !(last_key === "" && last_value === "");
+        }
+        return true;
     });
 
     self.show_add_response = ko.computed(function(){
-        var last_key = self.responses()[self.responses().length - 1].key();
-        return last_key !== "";
+        if (self.responses().length){
+            var last_key = self.responses()[self.responses().length - 1].key();
+            return last_key !== "";
+        }
+        return true;
     });
 
     self.initSaveButtonListeners(self.$el);

--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -1033,7 +1033,7 @@ var DetailScreenConfig = (function () {
                         containsSortConfiguration: columnType == "short",
                         containsParentConfiguration: columnType == "short",
                         containsFilterConfiguration: columnType == "short",
-                        containsCaseListLookupConfiguration: columnType == "short",
+                        containsCaseListLookupConfiguration: (columnType == "short" && window.toggles.CASE_LIST_LOOKUP),
                         containsCustomXMLConfiguration: columnType == "short",
                         allowsTabs: columnType == 'long',
                         allowsEmptyColumns: columnType == 'long'

--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -194,6 +194,7 @@ var filterViewModel = function(filterText, saveButton){
 };
 
 var caseListLookupViewModel = function($el, state, saveButton){
+    'use strict';
     var self = this;
 
     var ObservableKeyValue = function(obs){
@@ -227,10 +228,26 @@ var caseListLookupViewModel = function($el, state, saveButton){
         _fireChange();
     };
 
+    self.add_response = function(){
+        // _remove_empty_extras();
+        self.responses.push(new ObservableKeyValue({key:''}));
+    };
+
+    self.remove_response = function(response){
+        self.responses.remove(response);
+        _fireChange();
+    };
+
     self.serialize = function(){
         var serialized_extras = _.compact(_.map(self.extras(), function(extra){
             if (!(extra.key() === "" && extra.value() ==="")){
                 return {key: extra.key(), value: extra.value()};
+            }
+        }));
+
+        var serialized_responses = _.compact(_.map(self.responses(), function(response){
+            if (response.key() !== ""){
+                return {key: response.key()};
             }
         }));
 
@@ -239,10 +256,10 @@ var caseListLookupViewModel = function($el, state, saveButton){
             lookup_action: self.lookup_action(),
             lookup_name: self.lookup_name(),
             lookup_extras: serialized_extras,
+            lookup_responses: serialized_responses,
         };
         return data;
     };
-
 
     self.$el = $el;
     self.$form = $el.find('form');
@@ -253,16 +270,27 @@ var caseListLookupViewModel = function($el, state, saveButton){
     self.extras = ko.observableArray(ko.utils.arrayMap(state.lookup_extras, function(extra){
         return new ObservableKeyValue(extra);
     }));
+    self.responses = ko.observableArray(ko.utils.arrayMap(state.lookup_responses, function(response){
+        return new ObservableKeyValue(response);
+    }));
 
     if (self.extras().length === 0){
         //Add empty extra to start if there are none
         self.add_extra();
+    }
+    if (self.responses().length === 0){
+        self.add_response();
     }
 
     self.show_add_extra = ko.computed(function(){
         var last_key = self.extras()[self.extras().length - 1].key(),
             last_value = self.extras()[self.extras().length - 1].value();
         return !(last_key === "" && last_value === "");
+    });
+
+    self.show_add_response = ko.computed(function(){
+        var last_key = self.responses()[self.responses().length - 1].key();
+        return last_key !== "";
     });
 
     self.initSaveButtonListeners(self.$el);

--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -195,7 +195,8 @@ var filterViewModel = function(filterText, saveButton){
 
 var caseListLookupViewModel = function($el, state, saveButton){
     'use strict';
-    var self = this;
+    var self = this,
+        detail_type = $el.data('detail-type');
 
     var ObservableKeyValue = function(obs){
         this.key = ko.observable(obs.key);
@@ -284,7 +285,7 @@ var caseListLookupViewModel = function($el, state, saveButton){
 
     var _validate_extras = function(errors){
         errors = errors || [];
-        var $extra = $el.find("#extras"),
+        var $extra = $el.find("#" + detail_type + "-extras"),
             $extra_help = $extra.find(".help-inline");
 
         if (!_trimmed_extras().length){
@@ -301,7 +302,7 @@ var caseListLookupViewModel = function($el, state, saveButton){
 
     var _validate_responses = function(errors){
         errors = errors || [];
-        var $response = $el.find("#responses"),
+        var $response = $el.find("#" + detail_type + "-responses"),
             $response_help = $response.find(".help-inline");
 
         if (!_trimmed_responses().length){

--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -193,6 +193,36 @@ var filterViewModel = function(filterText, saveButton){
     };
 };
 
+var caseListLookupViewModel = function($el, state, saveButton){
+    var self = this;
+
+    _fireChange = function(){
+        saveButton.fire('change');
+    };
+
+    _initSaveButtonListeners = function($el){
+        $el.find('*').change(_fireChange);
+        $el.find('input, textarea').bind('textchange', _fireChange);
+    };
+
+    self.serialize = function(){
+        var data = {
+            lookup_enabled: self.lookup_enabled(),
+        };
+        return data;
+    };
+
+    self.$el = $el;
+    self.$form = $el.find('form');
+
+    self.lookup_enabled = ko.observable(state.lookup_enabled);
+    self.lookup_action = ko.observable(state.lookup_action);
+    self.lookup_name = ko.observable(state.lookup_name);
+
+
+    _initSaveButtonListeners(self.$el);
+};
+
 // http://www.knockmeout.net/2011/05/dragging-dropping-and-sorting-with.html
 // connect items with observableArrays
 ko.bindingHandlers.sortableList = {
@@ -557,6 +587,7 @@ var DetailScreenConfig = (function () {
             this.containsSortConfiguration = options.containsSortConfiguration;
             this.containsParentConfiguration = options.containsParentConfiguration;
             this.containsFilterConfiguration = options.containsFilterConfiguration;
+            this.containsCaseListLookupConfiguration = options.containsCaseListLookupConfiguration;
             this.containsCustomXMLConfiguration = options.containsCustomXMLConfiguration;
             this.allowsTabs = options.allowsTabs;
             this.useCaseTiles = ko.observable(spec[this.columnKey].use_case_tiles ? "yes" : "no");
@@ -750,6 +781,9 @@ var DetailScreenConfig = (function () {
                 if (this.containsFilterConfiguration) {
                     data.filter = JSON.stringify(this.config.filter.serialize());
                 }
+                if (this.containsCaseListLookupConfiguration){
+                    data.case_list_lookup = JSON.stringify(this.config.caseListLookup.serialize());
+                }
                 if (this.containsCustomXMLConfiguration){
                     data.custom_xml = this.config.customXMLViewModel.xml();
                 }
@@ -831,6 +865,7 @@ var DetailScreenConfig = (function () {
                         containsSortConfiguration: columnType == "short",
                         containsParentConfiguration: columnType == "short",
                         containsFilterConfiguration: columnType == "short",
+                        containsCaseListLookupConfiguration: columnType == "short",
                         containsCustomXMLConfiguration: columnType == "short",
                         allowsTabs: columnType == 'long',
                         allowsEmptyColumns: columnType == 'long'
@@ -864,6 +899,8 @@ var DetailScreenConfig = (function () {
                 this.customXMLViewModel.xml.subscribe(function(v){
                     that.shortScreen.saveButton.fire("change");
                 });
+                var $case_list_lookup_el = $("#" + spec.state.type + "-list-callout-configuration");
+                this.caseListLookup = new caseListLookupViewModel($case_list_lookup_el, spec.state.short, this.shortScreen.saveButton);
             }
             if (spec.state.long !== undefined) {
                 this.longScreen = addScreen(spec.state, "long");

--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -209,6 +209,7 @@ var caseListLookupViewModel = function($el, state, saveButton){
     self.initSaveButtonListeners = function($el){
         $el.find('input[type=text], textarea').bind('textchange', _fireChange);
         $el.find('input[type=checkbox]').bind('change', _fireChange);
+        $el.find(".case-list-lookup-icon button").bind("click", _fireChange); // Trigger save button when icon upload buttons are clicked
     };
 
     var _remove_empty = function(type){

--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -211,42 +211,23 @@ var caseListLookupViewModel = function($el, state, saveButton){
         $el.find('input[type=checkbox]').bind('change', _fireChange);
     };
 
-    var _remove_empty_extras = function(){
-        self.extras.remove(function(extra){
-            var is_blank = extra.key() === "" && extra.value() === "";
+    var _remove_empty = function(type){
+        self[type].remove(function(t){
+            var is_blank = (!t.key() && !t.value());
             return is_blank;
         });
     };
 
-    self.add_extra = function(){
-        _remove_empty_extras();
-        self.extras.push(new ObservableKeyValue({key:'', value:''}));
+    self.add_item = function(type){
+        _remove_empty(type);
+        var data = (type === 'extras') ? {key: '', value: ''} : {key: ''};
+        self[type].push(new ObservableKeyValue(data));
     };
 
-    self.remove_extra = function(extra){
-        self.extras.remove(extra);
-        if (self.extras().length === 0){
-            self.add_extra();
-        }
-        _fireChange();
-    };
-
-    var _remove_empty_responses = function(){
-        self.responses.remove(function(response){
-            var is_blank = response.key() === "";
-            return is_blank;
-        });
-    };
-
-    self.add_response = function(){
-        _remove_empty_responses();
-        self.responses.push(new ObservableKeyValue({key:''}));
-    };
-
-    self.remove_response = function(response){
-        self.responses.remove(response);
-        if (self.responses().length === 0){
-            self.add_response();
+    self.remove_item = function(type, item){
+        self[type].remove(item);
+        if (self[type]().length === 0){
+            self.add_item(type);
         }
         _fireChange();
     };
@@ -288,11 +269,10 @@ var caseListLookupViewModel = function($el, state, saveButton){
     }));
 
     if (self.extras().length === 0){
-        //Add empty extra to start if there are none
-        self.add_extra();
+        self.add_item('extras');
     }
     if (self.responses().length === 0){
-        self.add_response();
+        self.add_item('responses');
     }
 
     self.show_add_extra = ko.computed(function(){

--- a/corehq/apps/app_manager/suite_xml.py
+++ b/corehq/apps/app_manager/suite_xml.py
@@ -408,11 +408,27 @@ class Style(XmlObject):
     grid_y = StringField("grid/@grid-y")
 
 
+class Extra(XmlObject):
+    ROOT_NAME = 'extra'
+
+    key = StringField("@key")
+    value = StringField("@value")
+
+
+class Response(XmlObject):
+    ROOT_NAME = 'response'
+
+    key = StringField("@key")
+    value = StringField("@value")
+
+
 class Lookup(XmlObject):
     ROOT_NAME = 'lookup'
 
     action = StringField("@action", required=True)
     image = StringField("@image")
+    extras = NodeListField('extra', Extra)
+    responses = NodeListField('response', Response)
 
 
 class Field(OrderedXmlObject):
@@ -1057,11 +1073,13 @@ class SuiteGenerator(SuiteGeneratorBase):
         # Base case (has no tabs)
         else:
             # Add lookup
-            if detail.search_callout_enabled and detail.search_callout_action:
+            if detail.lookup_enabled and detail.lookup_action:
                 d.lookup = Lookup(
-                    action=detail.search_callout_action,
-                    image=detail.search_callout_image or None
+                    action=detail.lookup_action,
+                    image=detail.lookup_image or None,
                 )
+                d.lookup.extras = [Extra(key=e['key'], value=e['value']) for e in detail.lookup_extras]
+                d.lookup.responses = [Response(key=r['key'], value=r['value']) for r in detail.lookup_responses]
 
             # Add variables
             variables = list(

--- a/corehq/apps/app_manager/suite_xml.py
+++ b/corehq/apps/app_manager/suite_xml.py
@@ -474,7 +474,9 @@ class Detail(OrderedXmlObject, IdNode):
     """
     <detail id="">
         <title><text/></title>
-        <lookup action="", image="">
+        <lookup action="" image="" name="">
+            <extra key="" value = "" />
+            <response key ="" />
         </lookup>
         <variables>
             <__ function=""/>
@@ -1075,7 +1077,7 @@ class SuiteGenerator(SuiteGeneratorBase):
             # Add lookup
             if detail.lookup_enabled and detail.lookup_action:
                 d.lookup = Lookup(
-                    name = detail.lookup_name or None,
+                    name=detail.lookup_name or None,
                     action=detail.lookup_action,
                     image=detail.lookup_image or None,
                 )

--- a/corehq/apps/app_manager/suite_xml.py
+++ b/corehq/apps/app_manager/suite_xml.py
@@ -408,6 +408,13 @@ class Style(XmlObject):
     grid_y = StringField("grid/@grid-y")
 
 
+class Lookup(XmlObject):
+    ROOT_NAME = 'lookup'
+
+    action = StringField("@action", required=True)
+    image = StringField("@image")
+
+
 class Field(OrderedXmlObject):
     ROOT_NAME = 'field'
     ORDER = ('header', 'template', 'sort_node')
@@ -451,6 +458,8 @@ class Detail(OrderedXmlObject, IdNode):
     """
     <detail id="">
         <title><text/></title>
+        <lookup action="", image="">
+        </lookup>
         <variables>
             <__ function=""/>
         </variables>
@@ -462,9 +471,10 @@ class Detail(OrderedXmlObject, IdNode):
     """
 
     ROOT_NAME = 'detail'
-    ORDER = ('title', 'fields')
+    ORDER = ('title', 'lookup', 'fields')
 
     title = NodeField('title/text', Text)
+    lookup = NodeField('lookup', Lookup)
     fields = NodeListField('field', Field)
     action = NodeField('action', Action)
     details = NodeListField('detail', "self")
@@ -1044,13 +1054,23 @@ class SuiteGenerator(SuiteGeneratorBase):
             else:
                 return None
 
+        # Base case (has no tabs)
         else:
-            # Base case (has no tabs)
+            # Add lookup
+            if detail.search_callout_enabled and detail.search_callout_action:
+                d.lookup = Lookup(
+                    action=detail.search_callout_action,
+                    image=detail.search_callout_image or None
+                )
+
+            # Add variables
             variables = list(
                 self.detail_variables(module, detail, detail_column_infos[start:end])
             )
             if variables:
                 d.variables.extend(variables)
+
+            # Add fields
             for column_info in detail_column_infos[start:end]:
                 fields = get_column_generator(
                     self.app, module, detail,
@@ -1058,6 +1078,7 @@ class SuiteGenerator(SuiteGeneratorBase):
                 ).fields
                 d.fields.extend(fields)
 
+            # Add actions
             if module.case_list_form.form_id and detail_type.endswith('short') and \
                     not (hasattr(module, 'parent_select') and module.parent_select.active):
                 # add form action to detail

--- a/corehq/apps/app_manager/suite_xml.py
+++ b/corehq/apps/app_manager/suite_xml.py
@@ -419,7 +419,6 @@ class Response(XmlObject):
     ROOT_NAME = 'response'
 
     key = StringField("@key")
-    value = StringField("@value")
 
 
 class Lookup(XmlObject):
@@ -1078,8 +1077,8 @@ class SuiteGenerator(SuiteGeneratorBase):
                     action=detail.lookup_action,
                     image=detail.lookup_image or None,
                 )
-                d.lookup.extras = [Extra(key=e['key'], value=e['value']) for e in detail.lookup_extras]
-                d.lookup.responses = [Response(key=r['key'], value=r['value']) for r in detail.lookup_responses]
+                d.lookup.extras = [Extra(**e) for e in detail.lookup_extras]
+                d.lookup.responses = [Response(**r) for r in detail.lookup_responses]
 
             # Add variables
             variables = list(

--- a/corehq/apps/app_manager/suite_xml.py
+++ b/corehq/apps/app_manager/suite_xml.py
@@ -424,6 +424,7 @@ class Response(XmlObject):
 class Lookup(XmlObject):
     ROOT_NAME = 'lookup'
 
+    name = StringField("@name")
     action = StringField("@action", required=True)
     image = StringField("@image")
     extras = NodeListField('extra', Extra)
@@ -1074,6 +1075,7 @@ class SuiteGenerator(SuiteGeneratorBase):
             # Add lookup
             if detail.lookup_enabled and detail.lookup_action:
                 d.lookup = Lookup(
+                    name = detail.lookup_name or None,
                     action=detail.lookup_action,
                     image=detail.lookup_image or None,
                 )

--- a/corehq/apps/app_manager/templates/app_manager/module_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/module_view.html
@@ -32,6 +32,7 @@
     {% include "app_manager/partials/nav_menu_media_js_common.html" %}
     {% include "app_manager/partials/nav_menu_media_js.html" with item=multimedia.menu %}
     {% include "app_manager/partials/nav_menu_media_js.html" with item=multimedia.case_list_menu_item qualifier='case_list-menu_item_' %}
+    {% include "app_manager/partials/nav_menu_media_js.html" with item=multimedia.case_list_lookup qualifier='case-list-lookup-' %}
     {% if case_list_form_options %}
         {% include "app_manager/partials/nav_menu_media_js.html" with item=multimedia.case_list_form qualifier='case_list_form_' %}
     {% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/module_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/module_view.html
@@ -21,6 +21,7 @@
     window.toggles.GRAPH_CREATION = {{ request|toggle_enabled:"GRAPH_CREATION"|BOOL }};
     window.toggles.CASE_LIST_CUSTOM_XML = {{ request|toggle_enabled:"CASE_LIST_CUSTOM_XML"|BOOL }};
     window.toggles.CASE_LIST_TILE = {{ request|toggle_enabled:"CASE_LIST_TILE"|BOOL }};
+    window.toggles.CASE_LIST_LOOKUP = {{ request|toggle_enabled:"CASE_LIST_LOOKUP"|BOOL }}
     </script>
     <script src="{% static 'app_manager/js/detail-screen-config.js' %}"></script>
 {% endblock %}

--- a/corehq/apps/app_manager/templates/app_manager/module_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/module_view.html
@@ -32,7 +32,15 @@
     {% include "app_manager/partials/nav_menu_media_js_common.html" %}
     {% include "app_manager/partials/nav_menu_media_js.html" with item=multimedia.menu %}
     {% include "app_manager/partials/nav_menu_media_js.html" with item=multimedia.case_list_menu_item qualifier='case_list-menu_item_' %}
-    {% include "app_manager/partials/nav_menu_media_js.html" with item=multimedia.case_list_lookup qualifier='case-list-lookup-' %}
+
+    {% for detail in details %}
+        {% if detail.type == 'case' %}
+            {% include "app_manager/partials/nav_menu_media_js.html" with item=multimedia.case_list_lookup qualifier='case-list-lookup'|add:detail.type %}
+        {% else %}
+            {% include "app_manager/partials/nav_menu_media_js.html" with item=multimedia.product_list_lookup qualifier='case-list-lookup'|add:detail.type %}
+        {% endif %}
+    {% endfor %}
+
     {% if case_list_form_options %}
         {% include "app_manager/partials/nav_menu_media_js.html" with item=multimedia.case_list_form qualifier='case_list_form_' %}
     {% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/module_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/module_view.html
@@ -33,13 +33,15 @@
     {% include "app_manager/partials/nav_menu_media_js.html" with item=multimedia.menu %}
     {% include "app_manager/partials/nav_menu_media_js.html" with item=multimedia.case_list_menu_item qualifier='case_list-menu_item_' %}
 
-    {% for detail in details %}
-        {% if detail.type == 'case' %}
-            {% include "app_manager/partials/nav_menu_media_js.html" with item=multimedia.case_list_lookup qualifier='case-list-lookup'|add:detail.type %}
-        {% else %}
-            {% include "app_manager/partials/nav_menu_media_js.html" with item=multimedia.product_list_lookup qualifier='case-list-lookup'|add:detail.type %}
-        {% endif %}
-    {% endfor %}
+    {% if request|toggle_enabled:"CASE_LIST_LOOKUP" %}
+        {% for detail in details %}
+            {% if detail.type == 'case' %}
+                {% include "app_manager/partials/nav_menu_media_js.html" with item=multimedia.case_list_lookup qualifier='case-list-lookup'|add:detail.type %}
+            {% else %}
+                {% include "app_manager/partials/nav_menu_media_js.html" with item=multimedia.product_list_lookup qualifier='case-list-lookup'|add:detail.type %}
+            {% endif %}
+        {% endfor %}
+    {% endif %}
 
     {% if case_list_form_options %}
         {% include "app_manager/partials/nav_menu_media_js.html" with item=multimedia.case_list_form qualifier='case_list_form_' %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list.html
@@ -212,15 +212,4 @@
 </div>
 {% endif %}
 
-<div id="{{ detail.type }}-list-callout-configuration" data-bind="with: caseListLookup">
-    <legend>
-        {% trans "Case List Search Callout" %}
-    </legend>
-    <label class="checkbox">
-        <input type="checkbox" data-bind="checked: lookup_enabled"/>
-        {% trans "Enable case list search callout" %}
-    </label>
-    <div data-bind="visible: lookup_enabled">
-        {% include "app_manager/partials/case_list_lookup.html" %}
-    </div>
-</div>
+{% include "app_manager/partials/case_list_lookup.html" %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list.html
@@ -211,3 +211,16 @@
     </div>
 </div>
 {% endif %}
+
+<div id="{{ detail.type }}-list-callout-configuration" data-bind="with: caseListLookup">
+    <legend>
+        {% trans "Case List Search Callout" %}
+    </legend>
+    <label class="checkbox">
+        <input type="checkbox" data-bind="checked: lookup_enabled"/>
+        {% trans "Enable case list search callout" %}
+    </label>
+    <div data-bind="visible: lookup_enabled">
+        {% include "app_manager/partials/case_list_lookup.html" %}
+    </div>
+</div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list.html
@@ -212,4 +212,6 @@
 </div>
 {% endif %}
 
-{% include "app_manager/partials/case_list_lookup.html" %}
+{% if request|toggle_enabled:"CASE_LIST_LOOKUP" %}
+    {% include "app_manager/partials/case_list_lookup.html" %}
+{% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list_lookup.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list_lookup.html
@@ -43,13 +43,13 @@
                                 <input class="fd-kv-val input-block-level" type="text" data-bind="value: value, addSaveButtonListener: true" placeholder="value" />
                             </div>
                             <div class="span1">
-                                <a href="#" class="btn fd-kv-remove-pair btn-small btn-danger" data-bind="visible: ($parent.extras().length > 1 || !(key() === '' && value() === '')), click: $parent.remove_extra">
+                                <a href="#" class="btn fd-kv-remove-pair btn-small btn-danger" data-bind="visible: ($parent.extras().length > 1 || !(key() === '' && value() === '')), click: function(item){ $parent.remove_item('extras', item) }">
                                     <i class="icon-remove"></i>
                                 </a>
                             </div>
                         </div>
                         <!-- /ko -->
-                        <a href="#" class="btn fd-kv-add-pair" data-bind="visible: show_add_extra(), click: add_extra"><i class="icon-plus"></i> Add Key &rarr; Value Pair</a>
+                        <a href="#" class="btn fd-kv-add-pair" data-bind="visible: show_add_extra(), click: function(){ add_item('extras') }"><i class="icon-plus"></i> Add Key &rarr; Value Pair</a>
                     </div>
                 </div>
             </div>
@@ -65,13 +65,13 @@
                                 <input class="fd-kv-key input-block-level" type="text" data-bind="value: key, addSaveButtonListener: true" placeholder="key" />
                             </div>
                             <div class="span1">
-                                <a href="#" class="btn fd-kv-remove-pair btn-small btn-danger" data-bind="visible: ($parent.responses().length > 1 || key() != ''), click: $parent.remove_response">
+                                <a href="#" class="btn fd-kv-remove-pair btn-small btn-danger" data-bind="visible: ($parent.responses().length > 1 || key() != ''), click: function(item){ $parent.remove_item('responses', item) }">
                                     <i class="icon-remove"></i>
                                 </a>
                             </div>
                         </div>
                         <!-- /ko -->
-                    <a href="#" class="btn fd-kv-add-pair" data-bind="visible: show_add_response(), click: add_response"><i class="icon-plus"></i> Add Key</a>
+                    <a href="#" class="btn fd-kv-add-pair" data-bind="visible: show_add_response(), click: function(){ add_item('responses') }"><i class="icon-plus"></i> Add Key</a>
                     </div>
                 </div>
             </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list_lookup.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list_lookup.html
@@ -16,7 +16,9 @@
                     {% trans "Action" %}
                 </label>
                 <div class="controls">
-                    <input type="text" id="lookup-action" data-bind="value: lookup_action" placeholder="{% trans 'ex: callout.commcarehq.org.dummycallout.LAUNCH' %}"/>
+                    <input type="text" id="lookup-action" data-bind="value: lookup_action" placeholder="{% trans 'ex: callout.commcarehq.org.dummycallout.LAUNCH' %}" required/>
+                    <span class="help-inline" style="display: none;">{% trans "Case list callout requires an action" %}</span>
+        </span>
                 </div>
             </div>
             <div class="control-group">
@@ -24,11 +26,12 @@
                     {% trans "Action Name" %}
                 </label>
                 <div class="controls">
-                    <input type="text" id="lookup-name" data-bind="value: lookup_name" placeholder="{% trans 'ex: Scan fingerprint'%}"/>
+                    <input type="text" id="lookup-name" data-bind="value: lookup_name" placeholder="{% trans 'ex: Scan fingerprint'%}" required/>
+                    <span class="help-inline" style="display: none;">{% trans "Case list callout requires a name" %}</span>
                 </div>
             </div>
-            <div class="control-group">
-                <label class="control-label" for="lookup-action">
+            <div class="control-group" id="extras">
+                <label class="control-label">
                     {% trans "Extra" %}
                 </label>
                 <div class="controls">
@@ -50,11 +53,12 @@
                         </div>
                         <!-- /ko -->
                         <a href="#" class="btn fd-kv-add-pair" data-bind="visible: show_add_extra(), click: function(){ add_item('extras') }"><i class="icon-plus"></i> Add Key &rarr; Value Pair</a>
+                        <span class="help-inline" style="display: none;">{% trans "At least one Extra required" %}</span>
                     </div>
                 </div>
             </div>
-            <div class="control-group">
-                <label class="control-label" for="lookup-action">
+            <div class="control-group" id="responses">
+                <label class="control-label">
                     {% trans "Response" %}
                 </label>
                 <div class="controls">
@@ -71,7 +75,8 @@
                             </div>
                         </div>
                         <!-- /ko -->
-                    <a href="#" class="btn fd-kv-add-pair" data-bind="visible: show_add_response(), click: function(){ add_item('responses') }"><i class="icon-plus"></i> Add Key</a>
+                        <a href="#" class="btn fd-kv-add-pair" data-bind="visible: show_add_response(), click: function(){ add_item('responses') }"><i class="icon-plus"></i> Add Key</a>
+                        <span class="help-inline" style="display: none;">{% trans "At least one Response required" %}</span>
                     </div>
                 </div>
             </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list_lookup.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list_lookup.html
@@ -18,7 +18,6 @@
                 <div class="controls">
                     <input type="text" id="lookup-action" data-bind="value: lookup_action" placeholder="{% trans 'ex: callout.commcarehq.org.dummycallout.LAUNCH' %}" required/>
                     <span class="help-inline" style="display: none;">{% trans "Case list callout requires an action" %}</span>
-        </span>
                 </div>
             </div>
             <div class="control-group">

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list_lookup.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list_lookup.html
@@ -1,5 +1,58 @@
 {% load i18n %}
 {% load hq_shared_tags %}
-Case List Lookup Placeholder
 
-{{detail.short.lookup_enabled}}
+<div id="{{ detail.type }}-list-callout-configuration" data-bind="with: caseListLookup">
+    <legend>
+        {% trans "Case List Search Callout" %}
+    </legend>
+    <label class="checkbox">
+        <input type="checkbox" data-bind="checked: lookup_enabled"/>
+        {% trans "Enable case list search callout" %}
+    </label>
+    <div data-bind="visible: lookup_enabled">
+        <form class="form-horizontal">
+            <div class="control-group">
+                <label class="control-label" for="lookup-action">
+                    {% trans "Action" %}
+                </label>
+                <div class="controls">
+                    <input type="text" id="lookup-action" data-bind="value: lookup_action" placeholder="{% trans 'ex: callout.commcarehq.org.dummycallout.LAUNCH' %}"/>
+                </div>
+            </div>
+            <div class="control-group">
+                <label class="control-label" for="lookup-name">
+                    {% trans "Action Name" %}
+                </label>
+                <div class="controls">
+                    <input type="text" id="lookup-name" data-bind="value: lookup_name" placeholder="{% trans 'ex: Scan fingerprint'%}"/>
+                </div>
+            </div>
+            <div class="control-group">
+                <label class="control-label" for="lookup-action">
+                    {% trans "Extra" %}
+                </label>
+                <div class="controls">
+                    <div class="well well-small form form-inline clearfix span6">
+                        <!-- ko foreach: extras() -->
+                        <div class="fd-kv-pair control-row clearfix" style="margin-bottom: 5px;">
+                            <div class="span3">
+                                <input class="fd-kv-key input-block-level" type="text" data-bind="value: key, addSaveButtonListener: true" placeholder="key" />
+                                </div>
+                            <div class="span1" style="text-align:center;">&rarr;</div>
+                            <div class="span7">
+                                <input class="fd-kv-val input-block-level" type="text" data-bind="value: value, addSaveButtonListener: true" placeholder="value" />
+                            </div>
+                            <div class="span1">
+                                <a href="#" class="btn fd-kv-remove-pair btn-small btn-danger" data-bind="visible: ($parent.extras().length > 1), click: $parent.remove_extra">
+                                    <i class="icon-remove"></i>
+                                </a>
+                            </div>
+                        </div>
+                        <!-- /ko -->
+                        <a href="#" class="btn fd-kv-add-pair" data-bind="visible: show_add_extra(), click: add_extra"><i class="icon-plus"></i> Add Key&rarr;Value Pair</a>
+                    </div>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list_lookup.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list_lookup.html
@@ -43,7 +43,7 @@
                                 <input class="fd-kv-val input-block-level" type="text" data-bind="value: value, addSaveButtonListener: true" placeholder="value" />
                             </div>
                             <div class="span1">
-                                <a href="#" class="btn fd-kv-remove-pair btn-small btn-danger" data-bind="visible: ($parent.extras().length > 1), click: $parent.remove_extra">
+                                <a href="#" class="btn fd-kv-remove-pair btn-small btn-danger" data-bind="visible: ($parent.extras().length > 1 || !(key() === '' && value() === '')), click: $parent.remove_extra">
                                     <i class="icon-remove"></i>
                                 </a>
                             </div>
@@ -65,7 +65,7 @@
                                 <input class="fd-kv-key input-block-level" type="text" data-bind="value: key, addSaveButtonListener: true" placeholder="key" />
                             </div>
                             <div class="span1">
-                                <a href="#" class="btn fd-kv-remove-pair btn-small btn-danger" data-bind="visible: ($parent.responses().length > 1), click: $parent.remove_response">
+                                <a href="#" class="btn fd-kv-remove-pair btn-small btn-danger" data-bind="visible: ($parent.responses().length > 1 || key() != ''), click: $parent.remove_response">
                                     <i class="icon-remove"></i>
                                 </a>
                             </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list_lookup.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list_lookup.html
@@ -1,0 +1,5 @@
+{% load i18n %}
+{% load hq_shared_tags %}
+Case List Lookup Placeholder
+
+{{detail.short.lookup_enabled}}

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list_lookup.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list_lookup.html
@@ -75,6 +75,11 @@
                     </div>
                 </div>
             </div>
+            <div class="case-list-lookup-icon">
+                <!-- ko stopBinding: true -->
+                {% include "app_manager/partials/nav_menu_media.html" with ICON_LABEL="Icon" qualifier='case-list-lookup-' EXCLUDE_AUDIO=True %}
+                <!-- /ko -->
+            </div>
         </form>
     </div>
 </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list_lookup.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list_lookup.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-<div id="{{ detail.type }}-list-callout-configuration" data-bind="with: caseListLookup">
+<div id="{{ detail.type }}-list-callout-configuration" data-bind="with: caseListLookup" data-detail-type="{{ detail.type }}">
     <legend>
         {% trans "Case List Search Callout" %}
     </legend>
@@ -12,24 +12,24 @@
     <div data-bind="visible: lookup_enabled">
         <form class="form-horizontal">
             <div class="control-group">
-                <label class="control-label" for="lookup-action">
+                <label class="control-label" for="{{ detail.type }}-lookup-action">
                     {% trans "Action" %}
                 </label>
                 <div class="controls">
-                    <input type="text" id="lookup-action" data-bind="value: lookup_action" placeholder="{% trans 'ex: callout.commcarehq.org.dummycallout.LAUNCH' %}" required/>
+                    <input type="text" id="{{ detail.type }}-lookup-action" data-bind="value: lookup_action" placeholder="{% trans 'ex: callout.commcarehq.org.dummycallout.LAUNCH' %}" required/>
                     <span class="help-inline" style="display: none;">{% trans "Case list callout requires an action" %}</span>
                 </div>
             </div>
             <div class="control-group">
-                <label class="control-label" for="lookup-name">
+                <label class="control-label" for="{{ detail.type }}-lookup-name">
                     {% trans "Action Name" %}
                 </label>
                 <div class="controls">
-                    <input type="text" id="lookup-name" data-bind="value: lookup_name" placeholder="{% trans 'ex: Scan fingerprint'%}" required/>
+                    <input type="text" id="{{ detail.type }}-lookup-name" data-bind="value: lookup_name" placeholder="{% trans 'ex: Scan fingerprint'%}" required/>
                     <span class="help-inline" style="display: none;">{% trans "Case list callout requires a name" %}</span>
                 </div>
             </div>
-            <div class="control-group" id="extras">
+            <div class="control-group" id="{{ detail.type }}-extras">
                 <label class="control-label">
                     {% trans "Extra" %}
                 </label>
@@ -56,7 +56,7 @@
                     </div>
                 </div>
             </div>
-            <div class="control-group" id="responses">
+            <div class="control-group" id="{{ detail.type }}-responses">
                 <label class="control-label">
                     {% trans "Response" %}
                 </label>

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list_lookup.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list_lookup.html
@@ -77,7 +77,9 @@
             </div>
             <div class="case-list-lookup-icon">
                 <!-- ko stopBinding: true -->
-                {% include "app_manager/partials/nav_menu_media.html" with ICON_LABEL="Icon" qualifier='case-list-lookup-' EXCLUDE_AUDIO=True %}
+                {% with qualifier='case-list-lookup'|add:detail.type %}
+                    {% include "app_manager/partials/nav_menu_media.html" with ICON_LABEL="Icon" qualifier=qualifier EXCLUDE_AUDIO=True %}
+                {% endwith %}
                 <!-- /ko -->
             </div>
         </form>

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list_lookup.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list_lookup.html
@@ -37,7 +37,7 @@
                         <div class="fd-kv-pair control-row clearfix" style="margin-bottom: 5px;">
                             <div class="span3">
                                 <input class="fd-kv-key input-block-level" type="text" data-bind="value: key, addSaveButtonListener: true" placeholder="key" />
-                                </div>
+                            </div>
                             <div class="span1" style="text-align:center;">&rarr;</div>
                             <div class="span7">
                                 <input class="fd-kv-val input-block-level" type="text" data-bind="value: value, addSaveButtonListener: true" placeholder="value" />
@@ -49,7 +49,29 @@
                             </div>
                         </div>
                         <!-- /ko -->
-                        <a href="#" class="btn fd-kv-add-pair" data-bind="visible: show_add_extra(), click: add_extra"><i class="icon-plus"></i> Add Key&rarr;Value Pair</a>
+                        <a href="#" class="btn fd-kv-add-pair" data-bind="visible: show_add_extra(), click: add_extra"><i class="icon-plus"></i> Add Key &rarr; Value Pair</a>
+                    </div>
+                </div>
+            </div>
+            <div class="control-group">
+                <label class="control-label" for="lookup-action">
+                    {% trans "Response" %}
+                </label>
+                <div class="controls">
+                    <div class="well well-small form form-inline clearfix span6">
+                        <!-- ko foreach: responses() -->
+                        <div class="fd-kv-pair control-row clearfix" style="margin-bottom: 5px;">
+                            <div class="span3">
+                                <input class="fd-kv-key input-block-level" type="text" data-bind="value: key, addSaveButtonListener: true" placeholder="key" />
+                            </div>
+                            <div class="span1">
+                                <a href="#" class="btn fd-kv-remove-pair btn-small btn-danger" data-bind="visible: ($parent.responses().length > 1), click: $parent.remove_response">
+                                    <i class="icon-remove"></i>
+                                </a>
+                            </div>
+                        </div>
+                        <!-- /ko -->
+                    <a href="#" class="btn fd-kv-add-pair" data-bind="visible: show_add_response(), click: add_response"><i class="icon-plus"></i> Add Key</a>
                     </div>
                 </div>
             </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/nav_menu_media.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/nav_menu_media.html
@@ -79,6 +79,7 @@
         </div>
     </div>
 </div>
+{% if not EXCLUDE_AUDIO %}
 <div id="{{ qualifier|default_if_none:"" }}media_audio">
     <div class="control-group">
         <label class="control-label" for="menu_audio_path">{% trans AUDIO_LABEL %}</label>
@@ -166,3 +167,4 @@
         </div>
     </div>
 </div>
+{% endif %}

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -748,14 +748,14 @@ class SuiteTest(SimpleTestCase, TestFileMixin):
             app.create_app_strings('default'),
         )
 
-    def test_case_list_search_callout_wo_image(self):
+    def test_case_list_lookup_wo_image(self):
         callout_action = "callout.commcarehq.org.dummycallout.LAUNCH"
 
         app = Application.new_app('domain', 'Untitled Application', application_version=APP_V2)
         module = app.add_module(Module.new_module('Untitled Module', None))
         module.case_type = 'patient'
-        module.case_details.short.search_callout_enabled = True
-        module.case_details.short.search_callout_action = callout_action
+        module.case_details.short.lookup_enabled = True
+        module.case_details.short.lookup_action = callout_action
 
         expected = """
             <partial>
@@ -769,16 +769,16 @@ class SuiteTest(SimpleTestCase, TestFileMixin):
             "./detail/lookup"
         )
 
-    def test_case_list_search_callout_w_image(self):
+    def test_case_list_lookup_w_image(self):
         action = "callout.commcarehq.org.dummycallout.LAUNCH"
         image = "jr://file/commcare/image/callout"
 
         app = Application.new_app('domain', 'Untitled Application', application_version=APP_V2)
         module = app.add_module(Module.new_module('Untitled Module', None))
         module.case_type = 'patient'
-        module.case_details.short.search_callout_enabled = True
-        module.case_details.short.search_callout_action = action
-        module.case_details.short.search_callout_image = image
+        module.case_details.short.lookup_enabled = True
+        module.case_details.short.lookup_action = action
+        module.case_details.short.lookup_image = image
 
         expected = """
             <partial>
@@ -791,6 +791,56 @@ class SuiteTest(SimpleTestCase, TestFileMixin):
             app.create_suite(),
             "./detail/lookup"
         )
+
+    def test_case_list_lookup_w_extras_and_responses(self):
+        app = Application.new_app('domain', 'Untitled Application', application_version=APP_V2)
+        module = app.add_module(Module.new_module('Untitled Module', None))
+        module.case_type = 'patient'
+        module.case_details.short.lookup_enabled = True
+        module.case_details.short.lookup_action = "callout.commcarehq.org.dummycallout.LAUNCH"
+        module.case_details.short.lookup_extras = [
+            {'key': 'action_0', 'value': 'com.biometrac.core.SCAN'},
+            {'key': "action_1", 'value': "com.biometrac.core.IDENTIFY"},
+        ]
+        module.case_details.short.lookup_responses = [
+            {"key": "match_id_0", "value": "left_index"},
+            {"key": "match_id_1", "value": "right_index"},
+        ]
+
+        expected = """
+        <partial>
+            <lookup action="callout.commcarehq.org.dummycallout.LAUNCH">
+                <extra key="action_0" value="com.biometrac.core.SCAN"/>
+                <extra key="action_1" value="com.biometrac.core.IDENTIFY"/>
+                <response key="match_id_0" value="left_index"/>
+                <response key="match_id_1" value="right_index"/>
+            </lookup>
+        </partial>
+        """
+
+        self.assertXmlPartialEqual(
+            expected,
+            app.create_suite(),
+            "./detail/lookup"
+        )
+
+    def test_case_list_lookup_disabled(self):
+        action = "callout.commcarehq.org.dummycallout.LAUNCH"
+        app = Application.new_app('domain', 'Untitled Application', application_version=APP_V2)
+        module = app.add_module(Module.new_module('Untitled Module', None))
+        module.case_type = 'patient'
+        module.case_details.short.lookup_enabled = False
+        module.case_details.short.lookup_action = action
+        module.case_details.short.lookup_responses = ["match_id_0", "left_index"]
+
+        expected = "<partial></partial>"
+
+        self.assertXmlPartialEqual(
+            expected,
+            app.create_suite(),
+            "./detail/lookup"
+        )
+
 
 class AdvancedModuleAsChildTest(SimpleTestCase, TestFileMixin):
     file_path = ('data', 'suite')

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -748,6 +748,49 @@ class SuiteTest(SimpleTestCase, TestFileMixin):
             app.create_app_strings('default'),
         )
 
+    def test_case_list_search_callout_wo_image(self):
+        callout_action = "callout.commcarehq.org.dummycallout.LAUNCH"
+
+        app = Application.new_app('domain', 'Untitled Application', application_version=APP_V2)
+        module = app.add_module(Module.new_module('Untitled Module', None))
+        module.case_type = 'patient'
+        module.case_details.short.search_callout_enabled = True
+        module.case_details.short.search_callout_action = callout_action
+
+        expected = """
+            <partial>
+                <lookup action="{}"/>
+            </partial>
+        """.format(callout_action)
+
+        self.assertXmlPartialEqual(
+            expected,
+            app.create_suite(),
+            "./detail/lookup"
+        )
+
+    def test_case_list_search_callout_w_image(self):
+        action = "callout.commcarehq.org.dummycallout.LAUNCH"
+        image = "jr://file/commcare/image/callout"
+
+        app = Application.new_app('domain', 'Untitled Application', application_version=APP_V2)
+        module = app.add_module(Module.new_module('Untitled Module', None))
+        module.case_type = 'patient'
+        module.case_details.short.search_callout_enabled = True
+        module.case_details.short.search_callout_action = action
+        module.case_details.short.search_callout_image = image
+
+        expected = """
+            <partial>
+                <lookup action="{}" image="{}"/>
+            </partial>
+        """.format(action, image)
+
+        self.assertXmlPartialEqual(
+            expected,
+            app.create_suite(),
+            "./detail/lookup"
+        )
 
 class AdvancedModuleAsChildTest(SimpleTestCase, TestFileMixin):
     file_path = ('data', 'suite')

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -803,8 +803,8 @@ class SuiteTest(SimpleTestCase, TestFileMixin):
             {'key': "action_1", 'value': "com.biometrac.core.IDENTIFY"},
         ]
         module.case_details.short.lookup_responses = [
-            {"key": "match_id_0", "value": "left_index"},
-            {"key": "match_id_1", "value": "right_index"},
+            {"key": "match_id_0"},
+            {"key": "match_id_1"},
         ]
 
         expected = """
@@ -812,8 +812,8 @@ class SuiteTest(SimpleTestCase, TestFileMixin):
             <lookup action="callout.commcarehq.org.dummycallout.LAUNCH">
                 <extra key="action_0" value="com.biometrac.core.SCAN"/>
                 <extra key="action_1" value="com.biometrac.core.IDENTIFY"/>
-                <response key="match_id_0" value="left_index"/>
-                <response key="match_id_1" value="right_index"/>
+                <response key="match_id_0"/>
+                <response key="match_id_1"/>
             </lookup>
         </partial>
         """

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import copy
 from django.test import SimpleTestCase
 from corehq.apps.app_manager.const import APP_V2
@@ -785,6 +786,31 @@ class SuiteTest(SimpleTestCase, TestFileMixin):
                 <lookup action="{}" image="{}"/>
             </partial>
         """.format(action, image)
+
+        self.assertXmlPartialEqual(
+            expected,
+            app.create_suite(),
+            "./detail/lookup"
+        )
+
+    def test_case_list_lookup_w_name(self):
+        action = "callout.commcarehq.org.dummycallout.LAUNCH"
+        image = "jr://file/commcare/image/callout"
+        name = u"ιтѕ α тяαρ ʕ •ᴥ•ʔ"
+
+        app = Application.new_app('domain', 'Untitled Application', application_version=APP_V2)
+        module = app.add_module(Module.new_module('Untitled Module', None))
+        module.case_type = 'patient'
+        module.case_details.short.lookup_enabled = True
+        module.case_details.short.lookup_action = action
+        module.case_details.short.lookup_image = image
+        module.case_details.short.lookup_name = name
+
+        expected = u"""
+            <partial>
+                <lookup name="{}" action="{}" image="{}"/>
+            </partial>
+        """.format(name, action, image)
 
         self.assertXmlPartialEqual(
             expected,

--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -1076,6 +1076,10 @@ def view_generic(request, domain, app_id=None, module_id=None, form_id=None, is_
                 'menu_refs': app.get_case_list_menu_item_media(module, module_id),
                 'default_file_name': '{}_case_list_menu_item'.format(default_file_name),
             }
+            specific_media['case_list_lookup'] = {
+                'menu_refs': app.get_case_list_lookup_image(module, module_id),
+                'default_file_name': '{}_case_list_lookup'.format(default_file_name),
+            }
         context.update({
             'multimedia': {
                 "references": app.get_references(),
@@ -1676,6 +1680,7 @@ def _save_case_list_lookup_params(short, case_list_lookup):
     short.lookup_name = case_list_lookup.get("lookup_name", short.lookup_name)
     short.lookup_extras = case_list_lookup.get("lookup_extras", short.lookup_extras)
     short.lookup_responses = case_list_lookup.get("lookup_responses", short.lookup_responses)
+    short.lookup_image = case_list_lookup.get("lookup_image", short.lookup_image)
 
 @no_conflict_require_POST
 @require_can_edit_apps

--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -1080,6 +1080,13 @@ def view_generic(request, domain, app_id=None, module_id=None, form_id=None, is_
                 'menu_refs': app.get_case_list_lookup_image(module, module_id),
                 'default_file_name': '{}_case_list_lookup'.format(default_file_name),
             }
+
+            if hasattr(module, 'product_details'):
+                specific_media['product_list_lookup'] = {
+                    'menu_refs': app.get_product_list_lookup_image(module, module_id),
+                    'default_file_name': '{}_product_list_lookup'.format(default_file_name),
+                }
+
         context.update({
             'multimedia': {
                 "references": app.get_references(),

--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -1675,6 +1675,7 @@ def _save_case_list_lookup_params(short, case_list_lookup):
     short.lookup_action = case_list_lookup.get("lookup_action", short.lookup_action)
     short.lookup_name = case_list_lookup.get("lookup_name", short.lookup_name)
     short.lookup_extras = case_list_lookup.get("lookup_extras", short.lookup_extras)
+    short.lookup_responses = case_list_lookup.get("lookup_responses", short.lookup_responses)
 
 @no_conflict_require_POST
 @require_can_edit_apps

--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -1689,6 +1689,7 @@ def _save_case_list_lookup_params(short, case_list_lookup):
     short.lookup_responses = case_list_lookup.get("lookup_responses", short.lookup_responses)
     short.lookup_image = case_list_lookup.get("lookup_image", short.lookup_image)
 
+
 @no_conflict_require_POST
 @require_can_edit_apps
 def edit_module_detail_screens(request, domain, app_id, module_id):

--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -1083,7 +1083,7 @@ def view_generic(request, domain, app_id=None, module_id=None, form_id=None, is_
 
             if hasattr(module, 'product_details'):
                 specific_media['product_list_lookup'] = {
-                    'menu_refs': app.get_product_list_lookup_image(module, module_id),
+                    'menu_refs': app.get_case_list_lookup_image(module, module_id, type='product'),
                     'default_file_name': '{}_product_list_lookup'.format(default_file_name),
                 }
 

--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -1671,8 +1671,10 @@ def edit_module_attr(request, domain, app_id, module_id, attr):
 
 
 def _save_case_list_lookup_params(short, case_list_lookup):
-    short.lookup_enabled = case_list_lookup.get("lookup_enabled")
-
+    short.lookup_enabled = case_list_lookup.get("lookup_enabled", short.lookup_enabled)
+    short.lookup_action = case_list_lookup.get("lookup_action", short.lookup_action)
+    short.lookup_name = case_list_lookup.get("lookup_name", short.lookup_name)
+    short.lookup_extras = case_list_lookup.get("lookup_extras", short.lookup_extras)
 
 @no_conflict_require_POST
 @require_can_edit_apps

--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -1669,6 +1669,11 @@ def edit_module_attr(request, domain, app_id, module_id, attr):
     resp['case_list-show'] = module.requires_case_details()
     return HttpResponse(json.dumps(resp))
 
+
+def _save_case_list_lookup_params(short, case_list_lookup):
+    short.lookup_enabled = case_list_lookup.get("lookup_enabled")
+
+
 @no_conflict_require_POST
 @require_can_edit_apps
 def edit_module_detail_screens(request, domain, app_id, module_id):
@@ -1689,6 +1694,7 @@ def edit_module_detail_screens(request, domain, app_id, module_id):
     use_case_tiles = params.get('useCaseTiles', None)
     persist_tile_on_forms = params.get("persistTileOnForms", None)
     pull_down_tile = params.get("enableTilePullDown", None)
+    case_list_lookup = params.get("case_list_lookup", None)
 
     app = get_app(domain, app_id)
     module = app.get_module(module_id)
@@ -1713,6 +1719,9 @@ def edit_module_detail_screens(request, domain, app_id, module_id):
             detail.short.persist_tile_on_forms = persist_tile_on_forms
         if pull_down_tile is not None:
             detail.short.pull_down_tile = pull_down_tile
+        if case_list_lookup is not None:
+            _save_case_list_lookup_params(detail.short, case_list_lookup)
+
     if long is not None:
         detail.long.columns = map(DetailColumn.wrap, long)
         if tabs is not None:

--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -623,9 +623,10 @@ class HQMediaMixin(Document):
             return {}
         media_kwargs = self.get_media_ref_kwargs(module, module_index)
         image = ApplicationMediaReference(
-                module['{}_details'.format(type)].short.lookup_image,
-                media_class=CommCareImage,
-                **media_kwargs).as_dict()
+            module['{}_details'.format(type)].short.lookup_image,
+            media_class=CommCareImage,
+            **media_kwargs
+        ).as_dict()
         return {
             'image': image
         }

--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -537,6 +537,14 @@ class HQMediaMixin(Document):
                 'app_lang': self.default_language,
             }
             _add_menu_media(module, **media_kwargs)
+
+            if (module.case_details.short.lookup_enabled and module.case_details.short.lookup_image):
+                media.append(ApplicationMediaReference(
+                    module.case_details.short.lookup_image,
+                    media_class=CommCareImage,
+                    **media_kwargs)
+                )
+
             if module.case_list_form.form_id:
                 media.append(ApplicationMediaReference(
                     module.case_list_form.media_audio,
@@ -609,6 +617,18 @@ class HQMediaMixin(Document):
             return {}
         media_kwargs = self.get_media_ref_kwargs(module, module_index)
         return self._get_item_media(module.case_list, media_kwargs)
+
+    def get_case_list_lookup_image(self, module, module_index):
+        if not module:
+            return {}
+        media_kwargs = self.get_media_ref_kwargs(module, module_index)
+        image = ApplicationMediaReference(
+                module.case_details.short.lookup_image,
+                media_class=CommCareImage,
+                **media_kwargs).as_dict()
+        return {
+            'image': image
+        }
 
     def _get_item_media(self, item, media_kwargs):
         menu_media = {}

--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -618,24 +618,12 @@ class HQMediaMixin(Document):
         media_kwargs = self.get_media_ref_kwargs(module, module_index)
         return self._get_item_media(module.case_list, media_kwargs)
 
-    def get_case_list_lookup_image(self, module, module_index):
+    def get_case_list_lookup_image(self, module, module_index, type='case'):
         if not module:
             return {}
         media_kwargs = self.get_media_ref_kwargs(module, module_index)
         image = ApplicationMediaReference(
-                module.case_details.short.lookup_image,
-                media_class=CommCareImage,
-                **media_kwargs).as_dict()
-        return {
-            'image': image
-        }
-
-    def get_product_list_lookup_image(self, module, module_index):
-        if not module:
-            return {}
-        media_kwargs = self.get_media_ref_kwargs(module, module_index)
-        image = ApplicationMediaReference(
-                module.product_details.short.lookup_image,
+                module['{}_details'.format(type)].short.lookup_image,
                 media_class=CommCareImage,
                 **media_kwargs).as_dict()
         return {

--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -630,6 +630,18 @@ class HQMediaMixin(Document):
             'image': image
         }
 
+    def get_product_list_lookup_image(self, module, module_index):
+        if not module:
+            return {}
+        media_kwargs = self.get_media_ref_kwargs(module, module_index)
+        image = ApplicationMediaReference(
+                module.product_details.short.lookup_image,
+                media_class=CommCareImage,
+                **media_kwargs).as_dict()
+        return {
+            'image': image
+        }
+
     def _get_item_media(self, item, media_kwargs):
         menu_media = {}
         image_ref = ApplicationMediaReference(

--- a/corehq/apps/style/static/style/ko/knockout_bindings.ko.js
+++ b/corehq/apps/style/static/style/ko/knockout_bindings.ko.js
@@ -775,3 +775,28 @@ ko.bindingHandlers.paste = {
         $(element).data('pasteCallback', valueAccessor());
     }
 };
+
+/**
+ * Normally, bindings can't overlap, this binding allows them to. For example:
+ *
+ * <div id="a">
+ *     <div data-bind="stopBinding: true">
+ *          <div id="b">
+ *              <p>foo</p>
+ *          </div>
+ *     </div>
+ * </div>
+ *
+ * ko.applyBindings({}, $("#a"));
+ * ko.applyBindings({}, $("#b"));
+ *
+ *
+ * Taken straight from:
+ * http://www.knockmeout.net/2012/05/quick-tip-skip-binding.html
+ */
+ko.bindingHandlers.stopBinding = {
+    init: function() {
+        return { controlsDescendantBindings: true };
+    }
+};
+ko.virtualElements.allowedBindings.stopBinding = true;

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -158,6 +158,13 @@ CASE_LIST_TILE = StaticToggle(
     [NAMESPACE_DOMAIN, NAMESPACE_USER]
 )
 
+CASE_LIST_LOOKUP = StaticToggle(
+    'case_list_lookup',
+    'Allow external android callouts to search the caselist',
+    TAG_EXPERIMENTAL,
+    [NAMESPACE_DOMAIN, NAMESPACE_USER]
+)
+
 DETAIL_LIST_TABS = StaticToggle(
     'detail-list-tabs',
     'Tabs in the case detail list',


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?170128#953776

Adds the ability to do android callouts on the case list page. In particular, adds the following to the detail XML block

``` xml
<lookup action="" image="" name="">
   <extra key="" value="" />
   <response key="" />
</lookup>
```

I was having trouble figuring out where to do server-side validation. It seems as though all the other forms on that page only have client-side validation, so I followed suit (but I probably missed something here). 

The UI looks like this:
![screen shot 2015-06-09 at 7 24 48 pm](https://cloud.githubusercontent.com/assets/146896/8071962/419641dc-0edd-11e5-8fb5-b361cd88fd8a.png)

I tried making the Key->Value thing work/look as it does in Vellum. It does, pretty much... 

The specs are here:
https://docs.google.com/document/d/1PPX9WHMBTJKhNyN2DNhbFEEtXfIXxbC0AkzxDdztX2A/edit#
https://confluence.dimagi.com/display/public/Intent+Callout+from+Case+List

props to @NoahCarnahan
code-buddy @orangejenny 
spec-maker @wpride  

I'm wondering whether this is a feature flag? Also, QA worthy? Also also, I should probably add help bubbles to all those inputs... 
