### PR TITLE
Use the dashboard template if no apps defined

### DIFF
--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -1046,10 +1046,11 @@ def view_generic(request, domain, app_id=None, module_id=None, form_id=None, is_
     elif module:
         template, module_context = get_module_view_context_and_template(app, module)
         context.update(module_context)
-    else:
+    elif app:
         template = "app_manager/app_view.html"
-        if app:
-            context.update(get_app_view_context(request, app))
+        context.update(get_app_view_context(request, app))
+    else:
+        template = "dashboard/dashboard_new_user.html"
 
     # update multimedia context for forms and modules.
     menu_host = form or module

--- a/corehq/apps/style/templates/style/base.html
+++ b/corehq/apps/style/templates/style/base.html
@@ -97,6 +97,16 @@
                 </nav>
             </div>
         </div>
+        <div class="container-fluid">
+            {% if messages %}
+                {% for message in messages %}
+                    <div class="alert fade in alert-block alert-full page-level-alert{% if message.tags %} {{ message.tags }}{% endif %}">
+                        <a class="close" data-dismiss="alert" href="#">&times;</a>
+                        {% if 'html' in message.tags %}{{ message|safe }}{% else %}{{ message }}{% endif %}
+                    </div>
+                {% endfor %}
+            {% endif %}
+        </div>
         {% block content %}{% endblock content %}
         <footer>
             <nav id="hq-footer"


### PR DESCRIPTION
I think this is a cleaner solution than [PR 6977](https://github.com/dimagi/commcare-hq/pull/6977) for [FB 168663](http://manage.dimagi.com/default.asp?168663).

Instead of adding a chunk of CSS and duplicated HTML to the Applications page, just use the dashboard. In order to support Django messages when a user has just deleted a their last app, I've added a messages div. The result looks like so:
![dashboard_with_message](https://cloud.githubusercontent.com/assets/708421/8088021/b5b48e2c-0f9e-11e5-81c5-67456829ab7d.png)

No need for the modal box that's missing in the dashboard; the normal apps page will be used if the user tries to get to a deleted app.

What do you reckon, @biyeun?

cc @snopoke 
