### PR TITLE
Add [Project Data] option to case list report

### DIFF
--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -122,6 +122,7 @@ class ESQuery(object):
             filters.term,
             filters.OR,
             filters.AND,
+            filters.NOT,
             filters.range_filter,
             filters.date_range,
             filters.exists,

--- a/corehq/apps/es/filters.py
+++ b/corehq/apps/es/filters.py
@@ -27,6 +27,13 @@ def AND(*filters):
     return {"and": filters}
 
 
+def NOT(filter):
+    """
+    Exclude docs matching the filter passed in
+    """
+    return {"not": filter}
+
+
 def range_filter(field, gt=None, gte=None, lt=None, lte=None):
     """
     You must specify either gt (greater than) or gte (greater than or

--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -4,7 +4,6 @@ API endpoints for filter options
 import logging
 from itertools import islice
 
-from django.utils.translation import ugettext as _
 from django.views.generic import View
 
 from braces.views import JSONResponseMixin

--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -88,7 +88,7 @@ class EmwfOptionsView(LoginAndDomainMixin, EmwfMixin, JSONResponseMixin, View):
     def _init_counts(self):
         groups, _ = self.group_es_call(size=0, return_count=True)
         users, _ = self.user_es_call(size=0, return_count=True)
-        self.group_start = len(self.user_types)
+        self.group_start = len(self.static_options)
         self.location_start = self.group_start + groups
         self.user_start = self.location_start + self.get_locations_size()
         self.total_results = self.user_start + users
@@ -99,7 +99,7 @@ class EmwfOptionsView(LoginAndDomainMixin, EmwfMixin, JSONResponseMixin, View):
         start = limit * (page - 1)
         stop = start + limit
 
-        options = self.user_types[start:stop]
+        options = self.static_options[start:stop]
 
         g_start = max(0, start - self.group_start)
         g_size = limit - len(options) if start < self.location_start else 0
@@ -119,10 +119,10 @@ class EmwfOptionsView(LoginAndDomainMixin, EmwfMixin, JSONResponseMixin, View):
 
     @property
     @memoized
-    def user_types(self):
+    def static_options(self):
         return filter(
             lambda user_type: self.q.lower() in user_type[1].lower(),
-            super(EmwfOptionsView, self).user_types
+            super(EmwfOptionsView, self).static_options
         )
 
     def user_es_call(self, **kwargs):

--- a/corehq/apps/reports/filters/case_list.py
+++ b/corehq/apps/reports/filters/case_list.py
@@ -47,8 +47,8 @@ class CaseListFilter(CaseListFilterMixin, ExpandedMobileWorkerFilter):
 
     @classmethod
     def selected_group_ids(cls, request):
-        return super(CaseListFilter, cls).selected_group_ids(request) + \
-               cls.selected_sharing_group_ids(request)
+        return (super(CaseListFilter, cls).selected_group_ids(request) +
+                cls.selected_sharing_group_ids(request))
 
     @classmethod
     def selected_sharing_location_ids(cls, request):

--- a/corehq/apps/reports/filters/case_list.py
+++ b/corehq/apps/reports/filters/case_list.py
@@ -9,16 +9,22 @@ from .api import EmwfOptionsView
 
 
 class CaseListFilterMixin(object):
-    @property
-    def additional_options(self):
-        return [("all_data", _("[All Data]")),
-                ('project_data', _("[Project Data]"))]
-
     def sharing_group_tuple(self, g):
         return ("sg__%s" % g['_id'], '%s [case sharing]' % g['name'])
 
     def sharing_location_tuple(self, loc_group):
         return (loc_group._id, loc_group.name + ' [case sharing]')
+
+    @property
+    @memoized
+    def static_options(self):
+        options = super(CaseListFilterMixin, self).static_options
+        # replace [All mobile workers] with case-list-specific options
+        assert options[0][0] == "t__0"
+        return [
+            ("all_data", _("[All Data]")),
+            ('project_data', _("[Project Data]"))
+        ] + options[1:]
 
 
 class CaseListFilter(CaseListFilterMixin, ExpandedMobileWorkerFilter):

--- a/corehq/apps/reports/filters/case_list.py
+++ b/corehq/apps/reports/filters/case_list.py
@@ -1,0 +1,78 @@
+from dimagi.utils.decorators.memoized import memoized
+from corehq.elastic import es_wrapper
+
+from .users import ExpandedMobileWorkerFilter
+from .api import EmwfOptionsView
+
+
+class CaseListFilterMixin(object):
+    additional_options = [("all_data", "[All Data]")]
+
+    def sharing_group_tuple(self, g):
+        return ("sg__%s" % g['_id'], '%s [case sharing]' % g['name'])
+
+
+class CaseListFilter(CaseListFilterMixin, ExpandedMobileWorkerFilter):
+    options_url = 'case_list_options'
+
+    @classmethod
+    def show_all_data(cls, request):
+        emws = request.GET.getlist(cls.slug)
+        return 'all_data' in emws
+
+    @property
+    @memoized
+    def selected(self):
+        selected = super(CaseListFilter, self).selected
+        if self.show_all_data(self.request):
+            selected = [{'id': 'all_data', 'text': "[All Data]"}] + selected
+        return selected
+
+
+class CaseListFilterOptions(CaseListFilterMixin, EmwfOptionsView):
+    def group_es_call(self, group_type=None, **kwargs):
+        # Valid group_types are "reporting" and "case_sharing"
+        if group_type is None:
+            type_filter = {"or": [
+                {"term": {"reporting": "true"}},
+                {"term": {"case_sharing": "true"}}
+            ]}
+        else:
+            type_filter = {"term": {group_type: "true"}}
+        return es_wrapper('groups', domain=self.domain, q=self.group_query,
+                          filters=[type_filter], doc_type='Group', **kwargs)
+
+    def get_groups(self, start, size):
+        def wrap_group(group):
+            print 'wrap_group', group
+            print group.get('case_sharing', None), group.get('reporting', None)
+            if group.get('case_sharing', None):
+                return self.sharing_group_tuple(group)
+            return self.reporting_group_tuple(group)
+
+        fields = ['_id', 'name']
+        groups = self.group_es_call(
+            fields=fields,
+            sort_by="name.exact",
+            order="asc",
+            start_at=start,
+            size=size,
+        )
+        return map(wrap_group, groups)
+
+    @property
+    def case_sharing_locations_query(self):
+        return self.locations_query.filter(location_type__shares_cases=True)
+
+    def get_location_groups(self):
+        for location in super(CaseListFilterOptions, self).get_location_groups():
+            yield location
+
+        # filter out any non case share type locations for this part
+        for loc in self.case_sharing_locations_query:
+            group = loc.case_sharing_group_object()
+            yield (group._id, group.name + ' [case sharing]')
+
+    def get_locations_size(self):
+        return (self.locations_query.count() +
+                self.case_sharing_locations_query.count())

--- a/corehq/apps/reports/filters/case_list.py
+++ b/corehq/apps/reports/filters/case_list.py
@@ -1,4 +1,5 @@
 from dimagi.utils.decorators.memoized import memoized
+from corehq.apps.locations.models import SQLLocation
 from corehq.elastic import es_wrapper
 
 from .users import ExpandedMobileWorkerFilter
@@ -11,6 +12,9 @@ class CaseListFilterMixin(object):
     def sharing_group_tuple(self, g):
         return ("sg__%s" % g['_id'], '%s [case sharing]' % g['name'])
 
+    def sharing_location_tuple(self, loc_group):
+        return (loc_group._id, loc_group.name + ' [case sharing]')
+
 
 class CaseListFilter(CaseListFilterMixin, ExpandedMobileWorkerFilter):
     options_url = 'case_list_options'
@@ -20,13 +24,51 @@ class CaseListFilter(CaseListFilterMixin, ExpandedMobileWorkerFilter):
         emws = request.GET.getlist(cls.slug)
         return 'all_data' in emws
 
-    @property
-    @memoized
-    def selected(self):
-        selected = super(CaseListFilter, self).selected
-        if self.show_all_data(self.request):
-            selected = [{'id': 'all_data', 'text': "[All Data]"}] + selected
+    @classmethod
+    def selected_sharing_group_ids(cls, request):
+        emws = request.GET.getlist(cls.slug)
+        return [g[4:] for g in emws if g.startswith("sg__")]
+
+    @classmethod
+    def selected_group_ids(cls, request):
+        return super(CaseListFilter, cls).selected_group_ids(request) + \
+               cls.selected_sharing_group_ids(request)
+
+    @classmethod
+    def selected_sharing_location_ids(cls, request):
+        emws = request.GET.getlist(cls.slug)
+        return SQLLocation.objects.filter(
+            location_id__in=emws,
+            is_archived=False
+        ).values_list('location_id', flat=True)
+
+    def selected_location_entries(self, request):
+        selected = super(CaseListFilter, self).selected_location_entries(request)
+        location_sharing_ids = self.selected_sharing_location_ids(self.request)
+        if location_sharing_ids:
+            locs = SQLLocation.objects.filter(
+                location_id__in=location_sharing_ids
+            )
+            for loc in locs:
+                loc_group = loc.case_sharing_group_object()
+                selected.append(self.sharing_location_tuple(loc_group))
         return selected
+
+    def selected_user_type_entries(self, request):
+        selected = super(CaseListFilter, self).selected_user_type_entries(request)
+        if self.show_all_data(self.request):
+            selected = [('all_data', "[All Data]")] + selected
+        return selected
+
+    def selected_group_entries(self, request):
+        query_results = self.selected_groups_query(request)
+        reporting = [self.reporting_group_tuple(group['fields'])
+                     for group in query_results
+                     if group['fields'].get("reporting", False)]
+        sharing = [self.sharing_group_tuple(group['fields'])
+                   for group in query_results
+                   if group['fields'].get("case_sharing", False)]
+        return reporting + sharing
 
 
 class CaseListFilterOptions(CaseListFilterMixin, EmwfOptionsView):
@@ -44,8 +86,6 @@ class CaseListFilterOptions(CaseListFilterMixin, EmwfOptionsView):
 
     def get_groups(self, start, size):
         def wrap_group(group):
-            print 'wrap_group', group
-            print group.get('case_sharing', None), group.get('reporting', None)
             if group.get('case_sharing', None):
                 return self.sharing_group_tuple(group)
             return self.reporting_group_tuple(group)

--- a/corehq/apps/reports/filters/urls.py
+++ b/corehq/apps/reports/filters/urls.py
@@ -1,11 +1,11 @@
 from django.conf.urls import *
 
-from . import api
+from .api import EmwfOptionsView
+from .case_list import CaseListFilterOptions
 
 urlpatterns = patterns('',
-    url(r'^emwf_options/$', api.EmwfOptionsView.as_view(), name='emwf_options'),
-    url(r'^emwf_options/all-data/$', api.EmwfOptionsView.as_view(),
-        {'all_data':True, "share_groups":True},
-        name='emwf_options_with_all_data'
+    url(r'^emwf_options/$', EmwfOptionsView.as_view(), name='emwf_options'),
+    url(r'^case_list_options/$', CaseListFilterOptions.as_view(),
+        name='case_list_options'
     ),
 )

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -213,8 +213,6 @@ class BaseGroupedMobileWorkerFilter(BaseSingleOptionFilter):
 
 
 class EmwfMixin(object):
-    additional_options = None
-
     def user_tuple(self, u):
         user = util._report_user_dict(u)
         uid = "u__%s" % user['user_id']
@@ -237,9 +235,6 @@ class EmwfMixin(object):
     @memoized
     def static_options(self):
         static_options = [("t__0", _("[All mobile workers]"))]
-
-        if self.additional_options:
-            static_options.extend(self.additional_options)
 
         types = ['DEMO_USER', 'ADMIN', 'UNKNOWN']
         if Domain.get_by_name(self.domain).commtrack_enabled:

--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -17,7 +17,7 @@ from corehq.apps.reports.api import ReportDataSource
 from corehq.apps.reports.datatables import DataTablesHeader, DataTablesColumn
 from corehq.apps.reports.filters.search import SearchFilter
 from corehq.apps.reports.filters.select import SelectOpenCloseFilter
-from corehq.apps.reports.filters.users import ExpandedMobileWorkerFilterWithAllData as EMWF
+from corehq.apps.reports.filters.case_list import CaseListFilter as EMWF
 from corehq.apps.reports.generic import ElasticProjectInspectionReport
 from corehq.apps.reports.models import HQUserType
 from corehq.apps.reports.standard import ProjectReportParametersMixin
@@ -28,7 +28,7 @@ from .data_sources import CaseInfo, CaseDisplay
 
 class CaseListMixin(ElasticProjectInspectionReport, ProjectReportParametersMixin):
     fields = [
-        'corehq.apps.reports.filters.users.ExpandedMobileWorkerFilterWithAllData',
+        'corehq.apps.reports.filters.case_list.CaseListFilter',
         'corehq.apps.reports.filters.select.CaseTypeFilter',
         'corehq.apps.reports.filters.select.SelectOpenCloseFilter',
         'corehq.apps.reports.standard.cases.filters.CaseSearchFilter',

--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -182,7 +182,7 @@ class CaseListMixin(ElasticProjectInspectionReport, ProjectReportParametersMixin
         id that is important for case sharing group selection
         is that actual group id.
         """
-        return EMWF.selected_location_sharing_group_ids(self.request)
+        return EMWF.selected_sharing_location_ids(self.request)
 
     def location_reporting_owner_ids(self):
         """

--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -62,7 +62,7 @@ class CaseListMixin(ElasticProjectInspectionReport, ProjectReportParametersMixin
                 admin=HQUserType.ADMIN not in user_types,
                 unknown=HQUserType.UNKNOWN not in user_types,
                 demo=HQUserType.DEMO_USER not in user_types,
-                commtrack=HQUserType.COMMTRACK not in user_types,
+                commtrack=False,
             )
             query = query.NOT(case_es.owner(ids_to_exclude))
         else:  # Only show explicit matches

--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -100,6 +100,7 @@ class CaseListMixin(ElasticProjectInspectionReport, ProjectReportParametersMixin
             owner_ids.append("commtrack-system")
         if demo:
             owner_ids.append("demo_user_group_id")
+            owner_ids.append("demo_user")
         return owner_ids
 
 

--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -70,7 +70,6 @@ class CaseListMixin(ElasticProjectInspectionReport, ProjectReportParametersMixin
     @property
     @memoized
     def case_owners(self):
-
         # Get user ids for each user that match the demo_user, admin, Unknown Users, or All Mobile Workers filters
         user_types = EMWF.selected_user_types(self.request)
         user_type_filters = []
@@ -81,8 +80,6 @@ class CaseListMixin(ElasticProjectInspectionReport, ProjectReportParametersMixin
             user_type_filters.append(user_es.web_users())
         if HQUserType.DEMO_USER in user_types:
             user_type_filters.append(user_es.demo_users())
-        if HQUserType.REGISTERED in user_types:
-            user_type_filters.append(user_es.mobile_users())
 
         if len(user_type_filters) > 0:
             special_q = user_es.UserES().domain(self.domain).OR(*user_type_filters).show_inactive()

--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -132,11 +132,13 @@ class CaseListMixin(ElasticProjectInspectionReport, ProjectReportParametersMixin
         selected_reporting_group_users = list(set().union(*user_lists))
 
         # Get ids for each sharing group that contains a user from selected_reporting_group_users OR a user that was specifically selected
-        share_group_q = HQESQuery(index="groups").domain(self.domain)\
-                                                .doc_type("Group")\
-                                                .filter(filters.term("case_sharing", True))\
-                                                .filter(filters.term("users", selected_reporting_group_users+selected_user_ids))\
-                                                .fields([])
+        share_group_q = (HQESQuery(index="groups")
+                         .domain(self.domain)
+                         .doc_type("Group")
+                         .term("case_sharing", True)
+                         .term("users", (selected_reporting_group_users +
+                                         selected_user_ids))
+                         .fields([]))
         sharing_group_ids = share_group_q.run().doc_ids
 
         owner_ids = list(set().union(


### PR DESCRIPTION
@sravfeyn
http://manage.dimagi.com/default.asp?166981
This might be easiest commit-by-commit.  This PR does a few things:

It explicitly makes a CaseListFilter subclass of the ExpandedMobileWorkerFilter, and pulls out the logic specific to that use-case there.  It's significantly different from the original filter, and this is clearer when each behavior is used.

This moves the build_query method of the case list report to use ESQuery, which is easier to read and reason about.

The CaseListFilter now has no [All Mobile Workers] option anymore, instead it has [Project Data] and [All Data] options.  [All Data] doesn't filter on owner id at all.  [Project Data] filters out stuff we know to be most likely not relevant.  If neither is selected, it falls back to the old behavior of getting an exact set of possible owner_ids and only showing matches.

edit: This is currently on staging, and I just went over it with Sheel to make sure it looks good and does what we want.  That's not exactly QA, but it's something.
