### PR TITLE
Report builder date filter

### DIFF
--- a/corehq/apps/userreports/README.md
+++ b/corehq/apps/userreports/README.md
@@ -680,7 +680,7 @@ TODO: finish aggregation docs
 
 ## Transforms
 
-Transforms can be used to transform the value returned by a column just before it reaches the user. Currently there are four supported transform types. These are shown below:
+Transforms can be used to transform the value returned by a column just before it reaches the user. The currently supported transform types are shown below:
 
 ### Displaying username instead of user ID
 

--- a/corehq/apps/userreports/README.md
+++ b/corehq/apps/userreports/README.md
@@ -535,6 +535,10 @@ Date filters allow you filter on a date. They will show a datepicker in the UI.
   "required": false
 }
 ```
+Date filters have an optional `compare_as_string` option that allows the date
+filter to be compared against an indicator of data type `string`. You shouldn't
+ever need to use this option (make your column a `date` or `datetime` type
+instead), but it exists because the report builder needs it. 
 
 ### Dynamic choice lists
 

--- a/corehq/apps/userreports/reports/factory.py
+++ b/corehq/apps/userreports/reports/factory.py
@@ -12,11 +12,11 @@ from corehq.apps.userreports.reports.filters import(
 from corehq.apps.userreports.reports.specs import FilterSpec, ChoiceListFilterSpec, PieChartSpec, \
     MultibarAggregateChartSpec, MultibarChartSpec, ReportFilter, DynamicChoiceListFilterSpec, \
     NumericFilterSpec, FieldColumn, PercentageColumn, ExpandedColumn, AggregateDateColumn, \
-    OrderBySpec
+    OrderBySpec, DateFilterSpec
 
 
 def _build_date_filter(spec):
-    wrapped = FilterSpec.wrap(spec)
+    wrapped = DateFilterSpec.wrap(spec)
     return DatespanFilter(
         name=wrapped.slug,
         label=wrapped.get_display(),

--- a/corehq/apps/userreports/reports/filters.py
+++ b/corehq/apps/userreports/reports/filters.py
@@ -36,13 +36,19 @@ class DateFilterValue(FilterValue):
     def to_sql_values(self):
         if self.value is None:
             return {}
+
+        startdate = self.value.startdate
+        enddate = self.value.enddate
+        if self.value.inclusive:
+            enddate = self.value.enddate + timedelta(days=1) - timedelta.resolution
+
+        if self.filter.compare_as_string:
+            startdate = str(startdate)
+            enddate = str(enddate)
+
         return {
-            'startdate': self.value.startdate,
-            'enddate': (
-                self.value.enddate
-                if not self.value.inclusive
-                else self.value.enddate + timedelta(days=1) - timedelta.resolution
-            ),
+            'startdate': startdate,
+            'enddate': enddate,
         }
 
 

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -32,6 +32,7 @@ class ReportFilter(JsonObject):
     slug = StringProperty(required=True)
     field = StringProperty(required=True)
     display = StringProperty()
+    compare_as_string = BooleanProperty(default=False)
 
     def create_filter_value(self, value):
         return {
@@ -237,6 +238,10 @@ class FilterSpec(JsonObject):
 
     def get_display(self):
         return self.display or self.slug
+
+
+class DateFilterSpec(FilterSpec):
+    compare_as_string = BooleanProperty(default=False)
 
 
 class ChoiceListFilterSpec(FilterSpec):

--- a/corehq/apps/userreports/tests/test_report_filters.py
+++ b/corehq/apps/userreports/tests/test_report_filters.py
@@ -1,9 +1,11 @@
+from datetime import datetime
 from django.test import SimpleTestCase
 from corehq.apps.reports_core.filters import DatespanFilter, ChoiceListFilter, \
     NumericFilter, DynamicChoiceListFilter
 from corehq.apps.userreports.exceptions import BadSpecError
 from corehq.apps.userreports.reports.factory import ReportFilterFactory
 from corehq.apps.userreports.reports.filters import SHOW_ALL_CHOICE
+from corehq.apps.userreports.reports.specs import ReportFilter
 
 
 class FilterTestCase(SimpleTestCase):
@@ -54,6 +56,32 @@ class DateFilterTestCase(SimpleTestCase):
         self.assertEqual(DatespanFilter, type(filter))
         self.assertEqual('modified_on_slug', filter.name)
         self.assertEqual('Date Modified', filter.label)
+
+    def test_compare_as_string_option(self):
+
+        def get_query_value(compare_as_string):
+
+            spec = {
+                "type": "date",
+                "field": "modified_on_field",
+                "slug": "my_slug",
+                "display": "date Modified",
+                "compare_as_string": compare_as_string,
+            }
+            reports_core_filter = ReportFilterFactory.from_spec(spec)
+            reports_core_value = reports_core_filter.get_value({
+                "my_slug-start": "2015-06-07",
+                "my_slug-end": "2015-06-08",
+            })
+
+            filter = ReportFilter.wrap(spec)
+            return filter.create_filter_value(reports_core_value).to_sql_values()
+
+        val = get_query_value(compare_as_string=False)
+        self.assertEqual(type(val['startdate']), datetime)
+
+        val = get_query_value(compare_as_string=True)
+        self.assertEqual(type(val['startdate']), str)
 
 
 class NumericFilterTestCase(SimpleTestCase):


### PR DESCRIPTION
Add a flag to the UCR date filter spec that allows dates to be compared as strings. This is useful for the L1 report builder, where all case properties are stored in data sources as strings.

example usage:

``` json
 {
    "type": "date",
    "field": "my_case_property",
    "slug": "my_slug",
    "display": "My Date",
    "compare_as_string": true
}
```

@czue, I decided to just go with a simple flag here instead of expanding on the transforms as we had discussed earlier (I'm happy to be convinced otherwise though). This was my reasoning:
- UCR filter parameter transforms would be conceptually different from indicator transforms because indicator transforms operate on python's primitive-like types (`str`, `int`, etc.), but these operate on objects that have already been manipulated by the "core" filters (subclasses of `corehq.apps.reports_core.filters.BaseFilter`) through their `value()` method. Thus, the transforms for UCR filters would be operating on objects like those of type `dimagi.utils.dates.DateSpan`, not builtins. So, it didn't seem like it would make sense to allow a transform intended for indicators to be used with a filter parameter.
- It didn't seem likely to me that one would want to use a transform used with one type of filter with another type of filter.
- This was easier.
