### PR TITLE
Contracted invoices

### DIFF
--- a/corehq/apps/accounting/generator.py
+++ b/corehq/apps/accounting/generator.py
@@ -14,7 +14,7 @@ from dimagi.utils.data import generator as data_gen
 from corehq.apps.accounting.models import (
     Currency, BillingAccount, Subscription, Subscriber, SoftwareProductType,
     DefaultProductPlan, BillingAccountAdmin, SubscriptionAdjustment,
-    SoftwarePlanEdition, BillingContactInfo,
+    SoftwarePlanEdition, BillingContactInfo, SubscriptionType,
 )
 from corehq.apps.domain.models import Domain
 from corehq.apps.users.models import WebUser, CommCareUser
@@ -109,7 +109,8 @@ def arbitrary_subscribable_plan():
 
 def generate_domain_subscription_from_date(date_start, billing_account, domain,
                                            min_num_months=None, is_immediately_active=False,
-                                           delay_invoicing_until=None, save=True):
+                                           delay_invoicing_until=None, save=True,
+                                           service_type=SubscriptionType.NOT_SET):
     # make sure the first month is never a full month (for testing)
     date_start = date_start.replace(day=max(2, date_start.day))
 
@@ -130,6 +131,7 @@ def generate_domain_subscription_from_date(date_start, billing_account, domain,
         date_end=date_end,
         is_active=is_immediately_active,
         date_delay_invoicing=delay_invoicing_until,
+        service_type=service_type,
     )
     if save:
         subscription.save()

--- a/corehq/apps/accounting/templates/accounting/invoice_email_contracted.html
+++ b/corehq/apps/accounting/templates/accounting/invoice_email_contracted.html
@@ -1,0 +1,26 @@
+<p>Dear Finance team,</p>
+
+<p>
+The {{ plan_name }} plan subscription for project space {{ domain }} (attached to Billing account {{billing_account_id}} and Salesforce ID {{salesforce_contract_id}}), set as Contracted, has incurred a total of ${{amount_due}} additional charges in the past months. Those charges are linked to additional SMS or user charges that are not included in the Pre-paid software plan nor in any pre-paid additional SMS/Credits that would have been included in the contract and added as credits at the initial set-up of that subscription. You can find attached the detailed invoice.
+</p>
+
+The billing contacts for this Billing Account are:
+<ul>
+{% for billing_contact in billing_contacts %}
+<li><a href="mailto:{{billing_contact}}">{{billing_contact}}</a></li>
+{% endfor %}
+</ul>
+
+<p>
+    The finance team is responsible for deciding when and how to communicate these additional charges/this invoice to the partner.
+</p>
+
+<p>
+If you want to look at the detailed monthly invoices, you can go <a href="{{admin_invoices_url}}">here</a>
+</p>
+
+<p>
+Best Regards,
+The CommCare HQ Team
+<a href="http://www.commcarehq.org">www.commcarehq.org</a>
+</p>

--- a/corehq/apps/accounting/templates/accounting/invoice_email_contracted_plaintext.html
+++ b/corehq/apps/accounting/templates/accounting/invoice_email_contracted_plaintext.html
@@ -1,0 +1,16 @@
+Dear Finance team,
+
+The {{ plan_name }} plan subscription for project space {{ domain }} (attached to Billing account {{billing_account_id}} and Salesforce ID {{salesforce_contract_id}}), set as Contracted, has incurred a total of ${{amount_due}} additional charges in the past months. Those charges are linked to additional SMS or user charges that are not included in the Pre-paid software plan nor in any pre-paid additional SMS/Credits that would have been included in the contract and added as credits at the initial set-up of that subscription. You can find attached the detailed invoice.
+
+The billing contact for this Billing Account are:
+{% for billing_contact in billing_contacts %}
+- {{billing_contact}}
+{% endfor %}
+
+The finance team is responsible for deciding when and how to communicate these additional charges/this invoice to the partner.
+
+If you want to look at the detailed monthly invoices, you can go to {{admin_invoices_url}}
+
+Best Regards,
+The CommCare HQ Team
+www.commcarehq.org

--- a/settings.py
+++ b/settings.py
@@ -460,6 +460,7 @@ DEFAULT_FROM_EMAIL = 'commcarehq-noreply@dimagi.com'
 SUPPORT_EMAIL = "commcarehq-support@dimagi.com"
 CCHQ_BUG_REPORT_EMAIL = 'commcarehq-bug-reports@dimagi.com'
 ACCOUNTS_EMAIL = 'accounts@dimagi.com'
+FINANCE_EMAIL = 'finance@dimagi.com'
 SUBSCRIPTION_CHANGE_EMAIL = 'accounts+subchange@dimagi.com'
 BILLING_EMAIL = 'billing-comm@dimagi.com'
 INVOICING_CONTACT_EMAIL = SUPPORT_EMAIL


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?169520#957349

@nickpell from the spec, it seems that these emails follow the same rules as the regular invoicing emails (doesn't send unless > $100, the attached invoice contains extra charges, etc.). So the only thing I changed was the recipient and the template that is used if the subscription type is `contracted`.

One thing I wasn't sure about was having the template logic in `BillingRecordsBase`, should this conceptually go into `Invoice` since it is now logically linked to some attribute of that?

elf: @orangejenny 

@amsagoff does this need QA'ing do you think?
