### PR TITLE
Add column for aggregation field to UCR reports by default

### DIFF
--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -722,6 +722,22 @@ class ConfigureTableReportForm(ConfigureListReportForm, ConfigureBarChartReportF
         agg_field_id = self.data_source_properties[self.aggregation_field]['column_id']
 
         columns = super(ConfigureTableReportForm, self)._report_columns
+
+        # Add the aggregation indicator to the columns if it's not already present.
+        displaying_agg_column = False
+        for c in columns:
+            if c['field'] == agg_field_id:
+                displaying_agg_column = True
+                break
+        if not displaying_agg_column:
+            columns = [{
+                'format': 'default',
+                'aggregation': 'simple',
+                "type": "field",
+                'field': agg_field_id,
+                'display': self.aggregation_field
+            }] + columns
+
         # Expand all columns except for the column being used for aggregation.
         for c in columns:
             if c['field'] != agg_field_id:

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -724,11 +724,7 @@ class ConfigureTableReportForm(ConfigureListReportForm, ConfigureBarChartReportF
         columns = super(ConfigureTableReportForm, self)._report_columns
 
         # Add the aggregation indicator to the columns if it's not already present.
-        displaying_agg_column = False
-        for c in columns:
-            if c['field'] == agg_field_id:
-                displaying_agg_column = True
-                break
+        displaying_agg_column = bool([c for c in columns if c['field'] == agg_field_id])
         if not displaying_agg_column:
             columns = [{
                 'format': 'default',

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -719,12 +719,12 @@ class ConfigureTableReportForm(ConfigureListReportForm, ConfigureBarChartReportF
 
     @property
     def _report_columns(self):
-        agg_col_id = self.data_source_properties[self.aggregation_field]['column_id']
+        agg_field_id = self.data_source_properties[self.aggregation_field]['column_id']
 
         columns = super(ConfigureTableReportForm, self)._report_columns
         # Expand all columns except for the column being used for aggregation.
         for c in columns:
-            if c['field'] != agg_col_id:
+            if c['field'] != agg_field_id:
                 c['aggregation'] = "expand"
         return columns
 


### PR DESCRIPTION
In the report builder, if you build a report that uses aggregation ("Data Table" and "Worker" reports), a column will now be added to the report for the aggregation field if the user did not add it his or her self.
Part of report builder UAT.
@nickpell 

Ticket: http://manage.dimagi.com/default.asp?171132
