### PR TITLE
Move shared test methods to a mixin

### DIFF
--- a/corehq/apps/groups/tests/test_groups.py
+++ b/corehq/apps/groups/tests/test_groups.py
@@ -44,9 +44,9 @@ class GroupTest(TestCase):
         _check_all_users(group.get_static_user_ids(is_active=False))
 
 
-class WrapGroupTest(SimpleTestCase):
-
-    document_class = Group
+# This is a mixin so importing it doesn't re-run the tests
+class WrapGroupTestMixin(object):
+    document_class = None
 
     def test_yes_Z(self):
         date_string = '2014-08-26T15:20:20.062732Z'
@@ -73,3 +73,7 @@ class WrapGroupTest(SimpleTestCase):
         bad_date_string = '2014-08-26T15:20'
         with self.assertRaises(BadValueError):
             self.document_class.wrap({'last_modified': bad_date_string})
+
+
+class WrapGroupTest(WrapGroupTestMixin, SimpleTestCase):
+    document_class = Group

--- a/corehq/apps/locations/tests/test_locations.py
+++ b/corehq/apps/locations/tests/test_locations.py
@@ -1,4 +1,4 @@
-from corehq.apps.groups.tests import WrapGroupTest
+from corehq.apps.groups.tests import WrapGroupTestMixin
 from corehq.apps.locations.models import Location, LocationType, SQLLocation, \
     LOCATION_REPORTING_PREFIX
 from corehq.apps.locations.tests.util import make_loc
@@ -6,10 +6,8 @@ from corehq.apps.locations.fixtures import location_fixture_generator
 from corehq.apps.commtrack.helpers import make_supply_point, make_product
 from corehq.apps.commtrack.tests.util import bootstrap_location_types
 from corehq.apps.users.models import CommCareUser
-from django.test import TestCase
-from couchdbkit import ResourceNotFound
+from django.test import TestCase, SimpleTestCase
 from corehq import toggles
-from corehq.apps.groups.models import Group
 from corehq.apps.groups.exceptions import CantSaveException
 from corehq.apps.products.models import SQLProduct
 from corehq.apps.domain.shortcuts import create_domain
@@ -433,5 +431,5 @@ class LocationGroupTest(LocationTestBase):
         self.assertEquals(len(fixture[0].findall('.//outlet')), 3)
 
 
-class WrapLocationTest(WrapGroupTest):
+class WrapLocationTest(WrapGroupTestMixin, SimpleTestCase):
     document_class = Location

--- a/corehq/apps/products/tests/test_products.py
+++ b/corehq/apps/products/tests/test_products.py
@@ -1,6 +1,7 @@
-from corehq.apps.groups.tests import WrapGroupTest
+from django.test import SimpleTestCase
+from corehq.apps.groups.tests import WrapGroupTestMixin
 from corehq.apps.products.models import Product
 
 
-class WrapProductTest(WrapGroupTest):
+class WrapProductTest(WrapGroupTestMixin, SimpleTestCase):
     document_class = Product

--- a/corehq/apps/programs/tests/test_programs.py
+++ b/corehq/apps/programs/tests/test_programs.py
@@ -1,6 +1,7 @@
-from corehq.apps.groups.tests import WrapGroupTest
+from django.test import SimpleTestCase
+from corehq.apps.groups.tests import WrapGroupTestMixin
 from corehq.apps.programs.models import Program
 
 
-class WrapProgramTest(WrapGroupTest):
+class WrapProgramTest(WrapGroupTestMixin, SimpleTestCase):
     document_class = Program


### PR DESCRIPTION
So tests don't run just from importing the util class.
@kaapstorm what do you think of this as a way of resolving the issue you brought up [here](https://github.com/dimagi/commcare-hq/commit/ff92488a0ac81db1f5234c79db0e598a6a8316d2#commitcomment-11480545)?
