### PR TITLE
Revert "Move shared test methods to a mixin"

### DIFF
--- a/corehq/apps/groups/tests/test_groups.py
+++ b/corehq/apps/groups/tests/test_groups.py
@@ -44,9 +44,9 @@ class GroupTest(TestCase):
         _check_all_users(group.get_static_user_ids(is_active=False))
 
 
-# This is a mixin so importing it doesn't re-run the tests
-class WrapGroupTestMixin(object):
-    document_class = None
+class WrapGroupTest(SimpleTestCase):
+
+    document_class = Group
 
     def test_yes_Z(self):
         date_string = '2014-08-26T15:20:20.062732Z'
@@ -73,7 +73,3 @@ class WrapGroupTestMixin(object):
         bad_date_string = '2014-08-26T15:20'
         with self.assertRaises(BadValueError):
             self.document_class.wrap({'last_modified': bad_date_string})
-
-
-class WrapGroupTest(WrapGroupTestMixin, SimpleTestCase):
-    document_class = Group

--- a/corehq/apps/locations/tests/test_locations.py
+++ b/corehq/apps/locations/tests/test_locations.py
@@ -1,4 +1,4 @@
-from corehq.apps.groups.tests import WrapGroupTestMixin
+from corehq.apps.groups.tests import WrapGroupTest
 from corehq.apps.locations.models import Location, LocationType, SQLLocation, \
     LOCATION_REPORTING_PREFIX
 from corehq.apps.locations.tests.util import make_loc
@@ -6,8 +6,10 @@ from corehq.apps.locations.fixtures import location_fixture_generator
 from corehq.apps.commtrack.helpers import make_supply_point, make_product
 from corehq.apps.commtrack.tests.util import bootstrap_location_types
 from corehq.apps.users.models import CommCareUser
-from django.test import TestCase, SimpleTestCase
+from django.test import TestCase
+from couchdbkit import ResourceNotFound
 from corehq import toggles
+from corehq.apps.groups.models import Group
 from corehq.apps.groups.exceptions import CantSaveException
 from corehq.apps.products.models import SQLProduct
 from corehq.apps.domain.shortcuts import create_domain
@@ -431,5 +433,5 @@ class LocationGroupTest(LocationTestBase):
         self.assertEquals(len(fixture[0].findall('.//outlet')), 3)
 
 
-class WrapLocationTest(WrapGroupTestMixin, SimpleTestCase):
+class WrapLocationTest(WrapGroupTest):
     document_class = Location

--- a/corehq/apps/products/tests/test_products.py
+++ b/corehq/apps/products/tests/test_products.py
@@ -1,7 +1,6 @@
-from django.test import SimpleTestCase
-from corehq.apps.groups.tests import WrapGroupTestMixin
+from corehq.apps.groups.tests import WrapGroupTest
 from corehq.apps.products.models import Product
 
 
-class WrapProductTest(WrapGroupTestMixin, SimpleTestCase):
+class WrapProductTest(WrapGroupTest):
     document_class = Product

--- a/corehq/apps/programs/tests/test_programs.py
+++ b/corehq/apps/programs/tests/test_programs.py
@@ -1,7 +1,6 @@
-from django.test import SimpleTestCase
-from corehq.apps.groups.tests import WrapGroupTestMixin
+from corehq.apps.groups.tests import WrapGroupTest
 from corehq.apps.programs.models import Program
 
 
-class WrapProgramTest(WrapGroupTestMixin, SimpleTestCase):
+class WrapProgramTest(WrapGroupTest):
     document_class = Program


### PR DESCRIPTION
Reverts dimagi/commcare-hq#7065

Letting this build in case we need to revert. Build problems seem to be unrelated though -- requirements  are timing out on install.
