### PR TITLE
change denominator for an indicator

### DIFF
--- a/custom/opm/health_status.py
+++ b/custom/opm/health_status.py
@@ -278,7 +278,7 @@ class AWCHealthStatus(object):
         ('nutritional_bonus',
          _("Eligilble for Nutritional status bonus"),
          _("Registered beneficiaries eligible for nutritonal status bonus for the month"),
-         'beneficiaries'),
+         'children'),
         ('closed_pregnants',
          _("Pregnant women cases closed"),
          _("Registered pregnant women cases closed for the month"),


### PR DESCRIPTION
I haven't tested this because of ES being wanky on my computer, but it is a one word change that is very obvious.
For http://manage.dimagi.com/default.asp?171165
1. For the indicator – eligible for nutritional status bonus – the denominator currently uses registered beneficiaries. Please correct this to number of eligible children. The three columns before that show the right denominator while the total column shows a different denominator.

@esoergel 
