### PR TITLE
better call center validation

### DIFF
--- a/corehq/apps/callcenter/fixturegenerators.py
+++ b/corehq/apps/callcenter/fixturegenerators.py
@@ -48,10 +48,7 @@ def indicators_fixture_generator(user, version, last_sync=None):
     domain = user.project
     fixtures = []
 
-    if not domain or not (hasattr(domain, 'call_center_config') and domain.call_center_config.enabled):
-        return fixtures
-
-    if not should_sync(domain, last_sync):
+    if not domain or not domain.call_center_config.is_active_and_valid() or not should_sync(domain, last_sync):
         return fixtures
 
     try:

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -478,6 +478,18 @@ class DomainGlobalSettingsForm(forms.Form):
         timezone_field.run_validators(data)
         return smart_str(data)
 
+    def clean(self):
+        cleaned_data = super(DomainGlobalSettingsForm, self).clean()
+        if (cleaned_data.get('call_center_enabled') and
+                (not cleaned_data.get('call_center_case_type') or
+                 not cleaned_data.get('call_center_case_owner'))):
+            raise forms.ValidationError(_(
+                'You must choose an Owner and Case Type to use the call center application. '
+                'Please uncheck the "Call Center Application" setting or enter values for the other fields.'
+            ))
+
+        return cleaned_data
+
     def save(self, request, domain):
         domain.hr_name = self.cleaned_data['hr_name']
 

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -10,7 +10,7 @@ from PIL import Image
 import uuid
 from dimagi.utils.decorators.memoized import memoized
 from django.contrib.auth import get_user_model
-from corehq import privileges, toggles
+from corehq import privileges
 from corehq.apps.accounting.exceptions import SubscriptionRenewalError
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.sms.phonenumbers_helper import parse_phone_number
@@ -24,7 +24,7 @@ from crispy_forms import layout as crispy
 from django.core.urlresolvers import reverse
 
 from django.forms.fields import (ChoiceField, CharField, BooleanField,
-    ImageField, DecimalField, IntegerField)
+    ImageField)
 from django.forms.widgets import  Select
 from django.utils.encoding import smart_str
 from django.contrib.auth.forms import PasswordResetForm
@@ -404,6 +404,7 @@ class SubAreaMixin():
         if sub_area not in sub_areas:
             raise forms.ValidationError(_('This is not a valid sub-area for the area %s') % area)
         return sub_area
+
 
 class DomainGlobalSettingsForm(forms.Form):
     hr_name = forms.CharField(label=_("Project Name"))

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -121,10 +121,15 @@ class Deployment(DocumentSchema, UpdatableSchema):
     description = StringProperty()
     public = BooleanProperty(default=False)
 
+
 class CallCenterProperties(DocumentSchema):
     enabled = BooleanProperty(default=False)
     case_owner_id = StringProperty()
     case_type = StringProperty()
+
+    def is_active_and_valid(self):
+        return self.enabled and self.case_owner_id and self.case_type
+
 
 class LicenseAgreement(DocumentSchema):
     signed = BooleanProperty(default=False)


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?170937

"If you look at the project settings for this domain you'll see that callcenter is enabled but the case owner and case type fields are empty. We should make those fields compulsory if callcenter is enabled and also not attempt to generate the fixture if either of those fields are None in the domain model: https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/callcenter/fixturegenerators.py#L51-51"

@snopoke cc @TylerSheffels 
