### PR TITLE
Fix `analytics.workflow()` callbacks in dev environments

### DIFF
--- a/corehq/apps/style/templates/style/includes/analytics_all.html
+++ b/corehq/apps/style/templates/style/includes/analytics_all.html
@@ -64,7 +64,9 @@
          *
          * @param {string} event - Event name
          * @param {object} [properties] - Dictionary of properties to set along with the event.
-         * @param {function} [callback] - A Callback to be executed after the event has been successfully tracked.
+         * @param {function} [callback] - A Callback to be executed after the
+         *      event has been successfully tracked or after a short timeout
+         *      (whichever happens first) callback will only be called once.
          */
         workflow: function(event, properties, callback) {
             if (properties === undefined){
@@ -72,9 +74,11 @@
             }
             var args = ["record", event, properties];
             if (callback !== undefined){
-                args.push(callback);
+                var oneTimeCallback = _.once(callback);
+                args.push(oneTimeCallback);
             }
             _kmq.push(args);
+            setTimeout(oneTimeCallback, 2000)
         },
 
         /**


### PR DESCRIPTION
I was under the impression that KISSmetric's API called the callback even if tracking the event failed (due to incorrect api key, network issues, etc.). Turns out that isn't the case. This change will invoke the callback after two seconds no matter what. This is the same technique employed by our [trackLink](https://github.com/dimagi/commcare-hq/blob/1b81fed0fcabeba5e825da0001892ccb702c2e1b/corehq/apps/style/templates/style/includes/analytics_google.html#L51-L60) functions.

cc @nickpell 
