### PR TITLE
Billing self service

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -997,6 +997,8 @@ class Subscription(models.Model):
         )
         new_subscription.save()
 
+        new_subscription.set_billing_account_entry_point()
+
         if self.date_start > today:
             self.date_start = today
         if self.date_end is None or self.date_end > today:
@@ -1230,6 +1232,13 @@ class Subscription(models.Model):
                     'email': email,
                 })
 
+    def set_billing_account_entry_point(self):
+        no_current_entry_point = self.account.entry_point == EntryPoint.NOT_SET
+        self_serve = self.service_type == SubscriptionType.SELF_SERVICE
+        if (no_current_entry_point and self_serve and not self.is_trial):
+            self.account.entry_point = EntryPoint.SELF_STARTED
+            self.account.save()
+
     @classmethod
     def _get_plan_by_subscriber(cls, subscriber):
         active_subscriptions = cls.objects\
@@ -1354,6 +1363,8 @@ class Subscription(models.Model):
             web_user=web_user
         )
         subscription.save()
+
+        subscription.set_billing_account_entry_point()
 
         return subscription
 

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1017,7 +1017,8 @@ class ConfirmNewSubscriptionForm(EditBillingAccountInfoForm):
                 subscription = Subscription.new_domain_subscription(
                     self.account, self.domain, self.plan_version,
                     web_user=self.creating_user,
-                    adjustment_method=SubscriptionAdjustmentMethod.USER)
+                    adjustment_method=SubscriptionAdjustmentMethod.USER,
+                    service_type=SubscriptionType.SELF_SERVICE)
                 subscription.is_active = True
                 if subscription.plan_version.plan.edition == SoftwarePlanEdition.ENTERPRISE:
                     # this point can only be reached if the initiating user was a superuser


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?171124#958659
- Set subscription to self_service when creating a new subscription (i.e. choosing a subscription when currently on the "community plan")
- Set billing account entry_point to self_start if this is not already set

code buddy: @orangejenny 
cc: @nickpell 
