### PR TITLE
Autoselect location if available

### DIFF
--- a/corehq/apps/app_manager/suite_xml.py
+++ b/corehq/apps/app_manager/suite_xml.py
@@ -1464,9 +1464,21 @@ class SuiteGenerator(SuiteGeneratorBase):
         entry.require_instance(*instances)
 
     def get_userdata_autoselect(self, key, session_id, mode):
+        base_xpath = session_var('data', path='user')
         xpath = session_var(key, path='user/data')
         datum = SessionDatum(id=session_id, function=xpath)
-        assertions = self.get_auto_select_assertions(xpath, mode, [key])
+        assertions = [
+            self.get_assertion(
+                XPath.and_(base_xpath.count().eq(1),
+                           xpath.count().eq(1)),
+                'case_autoload.{0}.property_missing'.format(mode),
+                [key],
+            ),
+            self.get_assertion(
+                CaseIDXPath(xpath).case().count().eq(1),
+                'case_autoload.{0}.case_missing'.format(mode),
+            )
+        ]
         return datum, assertions
 
     @property
@@ -1491,7 +1503,10 @@ class SuiteGenerator(SuiteGeneratorBase):
                 }[form.form_type]
                 config_entry(module, e, form)
 
-                if self.app.commtrack_enabled:
+                if (
+                    self.app.commtrack_enabled and
+                    session_var('supply_point_id') in getattr(form, 'source', "")
+                ):
                     from .models import AUTO_SELECT_LOCATION
                     datum, assertions = self.get_userdata_autoselect(
                         'commtrack-supply-point',

--- a/corehq/apps/app_manager/suite_xml.py
+++ b/corehq/apps/app_manager/suite_xml.py
@@ -1491,6 +1491,16 @@ class SuiteGenerator(SuiteGeneratorBase):
                 }[form.form_type]
                 config_entry(module, e, form)
 
+                if self.app.commtrack_enabled:
+                    from .models import AUTO_SELECT_LOCATION
+                    datum, assertions = self.get_userdata_autoselect(
+                        'commtrack-supply-point',
+                        'supply_point_id',
+                        AUTO_SELECT_LOCATION,
+                    )
+                    e.datums.append(datum)
+                    e.assertions.extend(assertions)
+
                 results.append(e)
 
             if hasattr(module, 'case_list') and module.case_list.show:

--- a/corehq/apps/app_manager/suite_xml.py
+++ b/corehq/apps/app_manager/suite_xml.py
@@ -1466,7 +1466,12 @@ class SuiteGenerator(SuiteGeneratorBase):
     def get_userdata_autoselect(self, key, session_id, mode):
         base_xpath = session_var('data', path='user')
         xpath = session_var(key, path='user/data')
-        datum = SessionDatum(id=session_id, function=xpath)
+        protected_xpath = XPath.if_(
+            XPath.and_(base_xpath.count().eq(1), xpath.count().eq(1)),
+            xpath,
+            XPath.empty_string(),
+        )
+        datum = SessionDatum(id=session_id, function=protected_xpath)
         assertions = [
             self.get_assertion(
                 XPath.and_(base_xpath.count().eq(1),

--- a/corehq/apps/app_manager/tests/data/suite/autoload_supplypoint.xml
+++ b/corehq/apps/app_manager/tests/data/suite/autoload_supplypoint.xml
@@ -14,7 +14,7 @@
              function="instance('commcaresession')/session/user/data/commtrack-supply-point"/>
     </session>
     <assertions>
-      <assert test="count(instance('commcaresession')/session/user/data/commtrack-supply-point) = 1">
+      <assert test="count(instance('commcaresession')/session/user/data) = 1 and count(instance('commcaresession')/session/user/data/commtrack-supply-point) = 1">
         <text>
           <locale id="case_autoload.location.property_missing">
             <argument>commtrack-supply-point</argument>

--- a/corehq/apps/app_manager/tests/data/suite/autoload_supplypoint.xml
+++ b/corehq/apps/app_manager/tests/data/suite/autoload_supplypoint.xml
@@ -11,7 +11,7 @@
     <session>
       <datum id="case_id_new_suite_test_0" function="uuid()"/>
       <datum id="supply_point_id"
-             function="instance('commcaresession')/session/user/data/commtrack-supply-point"/>
+             function="if(count(instance('commcaresession')/session/user/data) = 1 and count(instance('commcaresession')/session/user/data/commtrack-supply-point) = 1, instance('commcaresession')/session/user/data/commtrack-supply-point, '')"/>
     </session>
     <assertions>
       <assert test="count(instance('commcaresession')/session/user/data) = 1 and count(instance('commcaresession')/session/user/data/commtrack-supply-point) = 1">

--- a/corehq/apps/app_manager/tests/data/suite/suite-advanced-autoselect-user.xml
+++ b/corehq/apps/app_manager/tests/data/suite/suite-advanced-autoselect-user.xml
@@ -12,7 +12,7 @@
       <datum id="case_id_case_clinic" function="instance('commcaresession')/session/user/data/case_id"/>
     </session>
     <assertions>
-      <assert test="count(instance('commcaresession')/session/user/data/case_id) = 1">
+      <assert test="count(instance('commcaresession')/session/user/data) = 1 and count(instance('commcaresession')/session/user/data/case_id) = 1">
         <text>
           <locale id="case_autoload.user.property_missing">
             <argument>case_id</argument>

--- a/corehq/apps/app_manager/tests/data/suite/suite-advanced-autoselect-user.xml
+++ b/corehq/apps/app_manager/tests/data/suite/suite-advanced-autoselect-user.xml
@@ -9,7 +9,7 @@
     <instance id="casedb" src="jr://instance/casedb"/>
     <instance id="commcaresession" src="jr://instance/session"/>
     <session>
-      <datum id="case_id_case_clinic" function="instance('commcaresession')/session/user/data/case_id"/>
+      <datum id="case_id_case_clinic" function="if(count(instance('commcaresession')/session/user/data) = 1 and count(instance('commcaresession')/session/user/data/case_id) = 1, instance('commcaresession')/session/user/data/case_id, '')"/>
     </session>
     <assertions>
       <assert test="count(instance('commcaresession')/session/user/data) = 1 and count(instance('commcaresession')/session/user/data/case_id) = 1">

--- a/corehq/apps/app_manager/tests/data/suite/suite-advanced-autoselect-with-filter.xml
+++ b/corehq/apps/app_manager/tests/data/suite/suite-advanced-autoselect-with-filter.xml
@@ -13,7 +13,7 @@
       <datum id="case_id_autoload" function="instance('commcaresession')/session/user/data/case_id"/>
     </session>
     <assertions>
-      <assert test="count(instance('commcaresession')/session/user/data/case_id) = 1">
+      <assert test="count(instance('commcaresession')/session/user/data) = 1 and count(instance('commcaresession')/session/user/data/case_id) = 1">
         <text>
           <locale id="case_autoload.user.property_missing">
             <argument>case_id</argument>

--- a/corehq/apps/app_manager/tests/data/suite/suite-advanced-autoselect-with-filter.xml
+++ b/corehq/apps/app_manager/tests/data/suite/suite-advanced-autoselect-with-filter.xml
@@ -10,7 +10,7 @@
     <instance id="commcaresession" src="jr://instance/session"/>
     <session>
       <datum id="case_id_case_clinic" nodeset="instance('casedb')/casedb/case[@case_type='clinic'][@status='open']" value="./@case_id" detail-select="m1_case_short" detail-confirm="m1_case_long"/>
-      <datum id="case_id_autoload" function="instance('commcaresession')/session/user/data/case_id"/>
+      <datum id="case_id_autoload" function="if(count(instance('commcaresession')/session/user/data) = 1 and count(instance('commcaresession')/session/user/data/case_id) = 1, instance('commcaresession')/session/user/data/case_id, '')"/>
     </session>
     <assertions>
       <assert test="count(instance('commcaresession')/session/user/data) = 1 and count(instance('commcaresession')/session/user/data/case_id) = 1">

--- a/corehq/apps/app_manager/tests/data/suite/suite-advanced-commtrack.xml
+++ b/corehq/apps/app_manager/tests/data/suite/suite-advanced-commtrack.xml
@@ -294,9 +294,26 @@
         <locale id="forms.m0f0"/>
       </text>
     </command>
+    <instance id="casedb" src="jr://instance/casedb"/>
+    <instance id="commcaresession" src="jr://instance/session"/>
     <session>
       <datum id="case_id_new_clinic_0" function="uuid()"/>
+      <datum id="supply_point_id" function="instance('commcaresession')/session/user/data/commtrack-supply-point"/>
     </session>
+    <assertions>
+      <assert test="count(instance('commcaresession')/session/user/data/commtrack-supply-point) = 1">
+        <text>
+          <locale id="case_autoload.location.property_missing">
+            <argument>commtrack-supply-point</argument>
+          </locale>
+        </text>
+      </assert>
+      <assert test="count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/user/data/commtrack-supply-point]) = 1">
+        <text>
+          <locale id="case_autoload.location.case_missing"/>
+        </text>
+      </assert>
+    </assertions>
   </entry>
   <entry>
     <form>http://openrosa.org/formdesigner/5FBED77B-E327-495D-97E8-0733B97D8EA5</form>
@@ -312,7 +329,22 @@
     <session>
       <datum id="case_id_case_clinic" nodeset="instance('casedb')/casedb/case[@case_type='clinic'][@status='open']" value="./@case_id" detail-select="m1_case_short" detail-confirm="m1_case_long"/>
       <datum id="product_id" nodeset="instance('commtrack:products')/products/product" value="./@id" detail-select="m1_product_short"/>
+      <datum id="supply_point_id" function="instance('commcaresession')/session/user/data/commtrack-supply-point"/>
     </session>
+    <assertions>
+      <assert test="count(instance('commcaresession')/session/user/data/commtrack-supply-point) = 1">
+        <text>
+          <locale id="case_autoload.location.property_missing">
+            <argument>commtrack-supply-point</argument>
+          </locale>
+        </text>
+      </assert>
+      <assert test="count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/user/data/commtrack-supply-point]) = 1">
+        <text>
+          <locale id="case_autoload.location.case_missing"/>
+        </text>
+      </assert>
+    </assertions>
   </entry>
   <entry>
     <form>http://openrosa.org/formdesigner/A0B00710-9AD6-4887-98EC-6D3D2F4B1F0D</form>
@@ -322,10 +354,26 @@
       </text>
     </command>
     <instance id="casedb" src="jr://instance/casedb"/>
+    <instance id="commcaresession" src="jr://instance/session"/>
     <session>
       <datum id="case_id_load_clinic0" nodeset="instance('casedb')/casedb/case[@case_type='clinic'][@status='open']" value="./@case_id" detail-select="m1_case_short" detail-confirm="m1_case_long"/>
       <datum id="case_id_new_requisition_0" function="uuid()"/>
+      <datum id="supply_point_id" function="instance('commcaresession')/session/user/data/commtrack-supply-point"/>
     </session>
+    <assertions>
+      <assert test="count(instance('commcaresession')/session/user/data/commtrack-supply-point) = 1">
+        <text>
+          <locale id="case_autoload.location.property_missing">
+            <argument>commtrack-supply-point</argument>
+          </locale>
+        </text>
+      </assert>
+      <assert test="count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/user/data/commtrack-supply-point]) = 1">
+        <text>
+          <locale id="case_autoload.location.case_missing"/>
+        </text>
+      </assert>
+    </assertions>
   </entry>
   <entry>
     <form>http://openrosa.org/formdesigner/E42CCD8F-AD30-48ED-98C8-84451C855AE4</form>
@@ -342,7 +390,22 @@
       <datum id="case_id_load_clinic0" nodeset="instance('casedb')/casedb/case[@case_type='clinic'][@status='open']" value="./@case_id" detail-select="m1_case_short"/>
       <datum id="case_id_case_requisition" nodeset="instance('casedb')/casedb/case[@case_type='requisition'][@status='open'][index/parent=instance('commcaresession')/session/data/case_id_load_clinic0]" value="./@case_id" detail-select="m2_case_short" detail-confirm="m2_case_long"/>
       <datum id="product_id" nodeset="instance('commtrack:products')/products/product" value="./@id" detail-select="m2_product_short"/>
+      <datum id="supply_point_id" function="instance('commcaresession')/session/user/data/commtrack-supply-point"/>
     </session>
+    <assertions>
+      <assert test="count(instance('commcaresession')/session/user/data/commtrack-supply-point) = 1">
+        <text>
+          <locale id="case_autoload.location.property_missing">
+            <argument>commtrack-supply-point</argument>
+          </locale>
+        </text>
+      </assert>
+      <assert test="count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/user/data/commtrack-supply-point]) = 1">
+        <text>
+          <locale id="case_autoload.location.case_missing"/>
+        </text>
+      </assert>
+    </assertions>
   </entry>
   <entry>
     <command id="m1-case-list">
@@ -373,7 +436,22 @@
     <session>
       <datum id="case_id_case_requisition" nodeset="instance('casedb')/casedb/case[@case_type='requisition'][@status='open']" value="./@case_id" detail-select="m2_case_short" detail-confirm="m2_case_long"/>
       <datum id="product_id" nodeset="instance('commtrack:products')/products/product[program_id='abc123def']" value="./@id" detail-select="m2_product_short"/>
+      <datum id="supply_point_id" function="instance('commcaresession')/session/user/data/commtrack-supply-point"/>
     </session>
+    <assertions>
+      <assert test="count(instance('commcaresession')/session/user/data/commtrack-supply-point) = 1">
+        <text>
+          <locale id="case_autoload.location.property_missing">
+            <argument>commtrack-supply-point</argument>
+          </locale>
+        </text>
+      </assert>
+      <assert test="count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/user/data/commtrack-supply-point]) = 1">
+        <text>
+          <locale id="case_autoload.location.case_missing"/>
+        </text>
+      </assert>
+    </assertions>
   </entry>
   <menu id="m0">
     <text>

--- a/corehq/apps/app_manager/tests/data/suite/suite-advanced-commtrack.xml
+++ b/corehq/apps/app_manager/tests/data/suite/suite-advanced-commtrack.xml
@@ -294,26 +294,9 @@
         <locale id="forms.m0f0"/>
       </text>
     </command>
-    <instance id="casedb" src="jr://instance/casedb"/>
-    <instance id="commcaresession" src="jr://instance/session"/>
     <session>
       <datum id="case_id_new_clinic_0" function="uuid()"/>
-      <datum id="supply_point_id" function="instance('commcaresession')/session/user/data/commtrack-supply-point"/>
     </session>
-    <assertions>
-      <assert test="count(instance('commcaresession')/session/user/data/commtrack-supply-point) = 1">
-        <text>
-          <locale id="case_autoload.location.property_missing">
-            <argument>commtrack-supply-point</argument>
-          </locale>
-        </text>
-      </assert>
-      <assert test="count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/user/data/commtrack-supply-point]) = 1">
-        <text>
-          <locale id="case_autoload.location.case_missing"/>
-        </text>
-      </assert>
-    </assertions>
   </entry>
   <entry>
     <form>http://openrosa.org/formdesigner/5FBED77B-E327-495D-97E8-0733B97D8EA5</form>
@@ -329,22 +312,7 @@
     <session>
       <datum id="case_id_case_clinic" nodeset="instance('casedb')/casedb/case[@case_type='clinic'][@status='open']" value="./@case_id" detail-select="m1_case_short" detail-confirm="m1_case_long"/>
       <datum id="product_id" nodeset="instance('commtrack:products')/products/product" value="./@id" detail-select="m1_product_short"/>
-      <datum id="supply_point_id" function="instance('commcaresession')/session/user/data/commtrack-supply-point"/>
     </session>
-    <assertions>
-      <assert test="count(instance('commcaresession')/session/user/data/commtrack-supply-point) = 1">
-        <text>
-          <locale id="case_autoload.location.property_missing">
-            <argument>commtrack-supply-point</argument>
-          </locale>
-        </text>
-      </assert>
-      <assert test="count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/user/data/commtrack-supply-point]) = 1">
-        <text>
-          <locale id="case_autoload.location.case_missing"/>
-        </text>
-      </assert>
-    </assertions>
   </entry>
   <entry>
     <form>http://openrosa.org/formdesigner/A0B00710-9AD6-4887-98EC-6D3D2F4B1F0D</form>
@@ -354,26 +322,10 @@
       </text>
     </command>
     <instance id="casedb" src="jr://instance/casedb"/>
-    <instance id="commcaresession" src="jr://instance/session"/>
     <session>
       <datum id="case_id_load_clinic0" nodeset="instance('casedb')/casedb/case[@case_type='clinic'][@status='open']" value="./@case_id" detail-select="m1_case_short" detail-confirm="m1_case_long"/>
       <datum id="case_id_new_requisition_0" function="uuid()"/>
-      <datum id="supply_point_id" function="instance('commcaresession')/session/user/data/commtrack-supply-point"/>
     </session>
-    <assertions>
-      <assert test="count(instance('commcaresession')/session/user/data/commtrack-supply-point) = 1">
-        <text>
-          <locale id="case_autoload.location.property_missing">
-            <argument>commtrack-supply-point</argument>
-          </locale>
-        </text>
-      </assert>
-      <assert test="count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/user/data/commtrack-supply-point]) = 1">
-        <text>
-          <locale id="case_autoload.location.case_missing"/>
-        </text>
-      </assert>
-    </assertions>
   </entry>
   <entry>
     <form>http://openrosa.org/formdesigner/E42CCD8F-AD30-48ED-98C8-84451C855AE4</form>
@@ -390,22 +342,7 @@
       <datum id="case_id_load_clinic0" nodeset="instance('casedb')/casedb/case[@case_type='clinic'][@status='open']" value="./@case_id" detail-select="m1_case_short"/>
       <datum id="case_id_case_requisition" nodeset="instance('casedb')/casedb/case[@case_type='requisition'][@status='open'][index/parent=instance('commcaresession')/session/data/case_id_load_clinic0]" value="./@case_id" detail-select="m2_case_short" detail-confirm="m2_case_long"/>
       <datum id="product_id" nodeset="instance('commtrack:products')/products/product" value="./@id" detail-select="m2_product_short"/>
-      <datum id="supply_point_id" function="instance('commcaresession')/session/user/data/commtrack-supply-point"/>
     </session>
-    <assertions>
-      <assert test="count(instance('commcaresession')/session/user/data/commtrack-supply-point) = 1">
-        <text>
-          <locale id="case_autoload.location.property_missing">
-            <argument>commtrack-supply-point</argument>
-          </locale>
-        </text>
-      </assert>
-      <assert test="count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/user/data/commtrack-supply-point]) = 1">
-        <text>
-          <locale id="case_autoload.location.case_missing"/>
-        </text>
-      </assert>
-    </assertions>
   </entry>
   <entry>
     <command id="m1-case-list">
@@ -436,22 +373,7 @@
     <session>
       <datum id="case_id_case_requisition" nodeset="instance('casedb')/casedb/case[@case_type='requisition'][@status='open']" value="./@case_id" detail-select="m2_case_short" detail-confirm="m2_case_long"/>
       <datum id="product_id" nodeset="instance('commtrack:products')/products/product[program_id='abc123def']" value="./@id" detail-select="m2_product_short"/>
-      <datum id="supply_point_id" function="instance('commcaresession')/session/user/data/commtrack-supply-point"/>
     </session>
-    <assertions>
-      <assert test="count(instance('commcaresession')/session/user/data/commtrack-supply-point) = 1">
-        <text>
-          <locale id="case_autoload.location.property_missing">
-            <argument>commtrack-supply-point</argument>
-          </locale>
-        </text>
-      </assert>
-      <assert test="count(instance('casedb')/casedb/case[@case_id=instance('commcaresession')/session/user/data/commtrack-supply-point]) = 1">
-        <text>
-          <locale id="case_autoload.location.case_missing"/>
-        </text>
-      </assert>
-    </assertions>
   </entry>
   <menu id="m0">
     <text>

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -140,6 +140,16 @@ class SuiteTest(SimpleTestCase, TestFileMixin):
         app = Application.wrap(self.get_json('suite-advanced'))
         self.assertXmlEqual(self.get_xml('suite-advanced-commtrack'), app.create_suite())
 
+    @commtrack_enabled(True)
+    def test_autoload_supplypoint(self):
+        app = Application.wrap(self.get_json('app'))
+        app_xml = app.create_suite()
+        self.assertXmlPartialEqual(
+            self.get_xml('autoload_supplypoint'),
+            app_xml,
+            './entry[1]'
+        )
+
     def test_advanced_suite_auto_select_user(self):
         app = Application.wrap(self.get_json('suite-advanced'))
         app.get_module(1).get_form(0).actions.load_update_cases[0].auto_select = AutoSelectCase(

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import copy
+import re
 from django.test import SimpleTestCase
 from corehq.apps.app_manager.const import APP_V2
 from corehq.apps.app_manager.models import (
@@ -9,7 +10,8 @@ from corehq.apps.app_manager.models import (
     OpenSubCaseAction, FormActionCondition, UpdateCaseAction, WORKFLOW_FORM, FormLink, AUTO_SELECT_USERCASE,
     ReportModule, ReportAppConfig)
 from corehq.apps.app_manager.tests.util import TestFileMixin, commtrack_enabled
-from corehq.apps.app_manager.xpath import dot_interpolate, UserCaseXPath, interpolate_xpath
+from corehq.apps.app_manager.xpath import (dot_interpolate, UserCaseXPath,
+                                           interpolate_xpath, session_var)
 from corehq.toggles import NAMESPACE_DOMAIN
 from corehq.feature_previews import MODULE_FILTER
 from toggle.shortcuts import update_toggle_cache, clear_toggle_cache
@@ -143,6 +145,9 @@ class SuiteTest(SimpleTestCase, TestFileMixin):
     @commtrack_enabled(True)
     def test_autoload_supplypoint(self):
         app = Application.wrap(self.get_json('app'))
+        app.modules[0].forms[0].source = re.sub('/data/plain',
+                                                session_var('supply_point_id'),
+                                                app.modules[0].forms[0].source)
         app_xml = app.create_suite()
         self.assertXmlPartialEqual(
             self.get_xml('autoload_supplypoint'),

--- a/corehq/apps/app_manager/xpath.py
+++ b/corehq/apps/app_manager/xpath.py
@@ -118,6 +118,10 @@ class XPath(unicode):
     def int(a):
         return XPath(u'int({})'.format(a))
 
+    @staticmethod
+    def empty_string():
+        return XPath(u"''")
+
 
 class CaseSelectionXPath(XPath):
     selector = ''


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?170383
@snopoke
I've verified that with this change, you can access your supply_point_id with `"instance('commcaresession')/session/data/supply_point_id"` if your user has one.  If your user does not have an assigned location, the app fails with the following message:

> Filtering your list failed with a bad filter expression.  Please fix this and re-deploy your app.  Error was XPath evaluation: type mismatch Location instance(commcaresession/session/user/data/commtrack-supply-point was not found.
