### PR TITLE
Fix UCR report builder "Edit Report" bug

### DIFF
--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -198,6 +198,16 @@ class DataSourceConfiguration(UnicodeMixIn, CachedCouchDocumentMixin, Document):
             for i, item in enumerate(self.get_items(doc))
         ]
 
+    def get_report_count(self):
+        """
+        Return the number of ReportConfigurations that reference this data source.
+        """
+        return DataSourceConfiguration.view(
+            'userreports/report_configs_by_data_source',
+            reduce=True,
+            key=[self.domain, self._id]
+        ).one()['value']
+
     def validate(self, required=True):
         super(DataSourceConfiguration, self).validate(required)
         # these two properties implicitly call other validation

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -9,14 +9,15 @@ from django.utils.translation import ugettext_noop as _
 from crispy_forms import layout as crispy
 from crispy_forms.bootstrap import FormActions
 from crispy_forms.helper import FormHelper
-from corehq.apps.app_manager.fields import ApplicationDataSourceUIHelper
 
+from corehq.apps.app_manager.fields import ApplicationDataSourceUIHelper
 from corehq.apps.app_manager.models import (
     Application,
     Form,
 )
 from corehq.apps.app_manager.util import get_case_properties
 from corehq.apps.app_manager.xform import XForm
+
 from corehq.apps.userreports import tasks
 from corehq.apps.userreports.app_manager import _clean_table_name
 from corehq.apps.userreports.models import (

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -462,10 +462,7 @@ class ConfigureNewReportBase(forms.Form):
                 # If no one else is using the current data source, delete it.
                 data_source = DataSourceConfiguration.get(self.existing_report.config_id)
                 if data_source.get_report_count() <= 1:
-                    try:
-                        delete_data_source_shared(self.domain, data_source._id)
-                    except Exception as e:
-                        import ipdb; ipdb.set_trace()
+                    delete_data_source_shared(self.domain, data_source._id)
 
                 self.existing_report.config_id = matching_data_source['id']
 

--- a/corehq/apps/userreports/templates/userreports/partials/report_builder_configure_report.html
+++ b/corehq/apps/userreports/templates/userreports/partials/report_builder_configure_report.html
@@ -36,9 +36,11 @@
          */
         var PropertyListItem = function() {
             var that = this;
+            this.existsInCurrentVersion = ko.observable(true);
             this.property = ko.observable("");
             this.displayText = ko.observable("");
             this.format = ko.observable("");
+            this.dataSourceField = ko.observable("");
 
             /**
              * Return a "plain" javascript object representing this view model
@@ -51,13 +53,20 @@
                     format: this.format()
                 };
             };
+
+            this.isNotBlank = ko.computed(function(){
+               return that.property() !== "";
+            });
+
             this.isValid= ko.computed(function(){
-                return that.property() != "";
+                return that.isNotBlank() && that.existsInCurrentVersion();
             });
         };
         PropertyListItem.wrap = function(o){
             var i = new PropertyListItem();
-            i.property(o.property);
+            i.existsInCurrentVersion(o.exists_in_current_version);
+            i.property(o.property !== undefined ? o.property : null);
+            i.dataSourceField(o.data_source_field !== undefined ? o.data_source_field : null);
             i.displayText(o.display_text);
             i.format(o.format);
             return i;
@@ -73,11 +82,28 @@
             this.hasFormatCol = ko.observable(options.hasFormatCol !== undefined ? options.hasFormatCol : true);
             this.formatOptions = ko.observableArray(["Choice", "Date", "Numeric"]);
             this.propertyOptions = ko.observableArray({{ property_options|JSON }});
-            this.optionsContainQuestions = ko.computed(function(){
-                return _.any(that.propertyOptions(),
-                    function (o) {return o.type == 'question';}
-                )
+            var rawOptions = {{ property_options|JSON }};
+            this.optionsContainQuestions = _.any(rawOptions, function (o) {
+                return o.type == 'question';
             });
+            if (!this.optionsContainQuestions){
+                this.propertyOptions = ko.observableArray(rawOptions);
+            } else {
+                // Munge the property_options into the form expected by the questionsSelect binding.
+                this.propertyOptions = ko.observableArray(
+                    _.compact(_.map(that.propertyOptions(), function (o) {
+                        if (o.type === 'question') {
+                            return o.source;
+                        } else if (o.type == 'meta') {
+                            return {
+                                value: o.source[0],
+                                label: ''
+                            }
+                        }
+                    }))
+                )
+            }
+
 
             this.columns = ko.observableArray(options.initialCols !== undefined ? options.initialCols : []);
             this.serializedProperties = ko.computed(function(){

--- a/corehq/apps/userreports/templates/userreports/partials/report_filter_configuration.html
+++ b/corehq/apps/userreports/templates/userreports/partials/report_filter_configuration.html
@@ -41,43 +41,43 @@ TODO:
             "></i>
         </td>
 
-        <td class="control-group" data-bind="css:{'error': $parent.showWarnings() && !isValid()}">
+        <td class="control-group" data-bind="css:{'error': !isValid()}">
 
             <!-- ko ifnot: $parent.optionsContainQuestions -->
             <input type="text" data-bind="select2: $parent.propertyOptions, value: property">
             <!-- /ko -->
             <!-- ko if: $parent.optionsContainQuestions -->
             <input class="input-large" type="hidden" data-bind="
-                questionsSelect: _.compact(_.map($parent.propertyOptions(), function (o) {
-                    if (o.type === 'question'){
-                        return o.source;
-                    } else if (o.type == 'meta'){
-                        return {
-                            value: o.source[0],
-                            label: '',
-                        }
-                    }
-                })),
-                value: property,
-                optionsCaption: ' '
+                questionsSelect: $parent.propertyOptions().concat(
+                    existsInCurrentVersion() ? [] : {value: dataSourceField(), label: ''}
+                ),
+                value: existsInCurrentVersion() ? property : dataSourceField,
+                attr: {disabled: !existsInCurrentVersion()}
             "/>
             <!-- /ko -->
-
-            <label class="help-block" data-bind="if: $parent.showWarnings() && !isValid()">Property may not be blank!</label>
+            <label class="help-block" data-bind="if: $parent.showWarnings() && !isNotBlank()">Property may not be blank!</label>
+            {# This is gross and I hate it #}
+            <label class="help-block" style="white-space: pre-wrap;" data-bind="if: !existsInCurrentVersion()">This property or question no longer exists in your app.
+You must delete this property to update this report.</label>
         </td>
         <td class="control-group">
-            <input type="text" data-bind="value: displayText">
+            <input type="text" data-bind="
+                value: displayText,
+                attr: {disabled: !existsInCurrentVersion()}
+            ">
         </td>
         <!--ko if: $parent.hasFormatCol -->
         <td>
-            <select data-bind="options: $parent.formatOptions, value: format"></select>
+            <select data-bind="
+                options: $parent.formatOptions,
+                value: format,
+                attr: {disabled: !existsInCurrentVersion()}
+            "></select>
         </td>
         <!--/ko-->
 
         <td class="span1">
-            <i style="cursor: pointer;"
-               title="Delete"
-               data-bind="
+            <i style="cursor: pointer;" title="Delete" data-bind="
                 click: function(){$parent.columns.remove($data)},
                 css: COMMCAREHQ.icons.DELETE
             "></i>

--- a/corehq/apps/userreports/tests/__init__.py
+++ b/corehq/apps/userreports/tests/__init__.py
@@ -9,6 +9,7 @@ from .test_data_source_config import *
 from .test_data_source_repeats import *
 from .test_indicators import *
 from .test_pillow import *
+from .test_report_builder import *
 from .test_report_charts import *
 from .test_report_config import *
 from .test_report_filters import *

--- a/corehq/apps/userreports/tests/data/forms/simple.xml
+++ b/corehq/apps/userreports/tests/data/forms/simple.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/8C8E527C-C0DE-470A-A8A9-8348FFB0B904" uiVersion="1" version="1" name="Untitled Form">
+					<first_name />
+					<last_name />
+					<children />
+					<dob />
+				</data>
+			</instance>
+			<bind nodeset="/data/first_name" type="xsd:string" />
+			<bind nodeset="/data/last_name" type="xsd:string" />
+			<bind nodeset="/data/children" type="xsd:int" />
+			<bind nodeset="/data/dob" type="xsd:date" />
+			<itext>
+				<translation lang="en" default="">
+					<text id="first_name-label">
+						<value>First Name</value>
+					</text>
+					<text id="last_name-label">
+						<value>Last Name</value>
+					</text>
+					<text id="children-label">
+						<value>Children</value>
+					</text>
+					<text id="dob-label">
+						<value>Date of Birth</value>
+					</text>
+				</translation>
+			</itext>
+		</model>
+	</h:head>
+	<h:body>
+		<input ref="/data/first_name">
+			<label ref="jr:itext('first_name-label')" />
+		</input>
+		<input ref="/data/last_name">
+			<label ref="jr:itext('last_name-label')" />
+		</input>
+		<input ref="/data/children">
+			<label ref="jr:itext('children-label')" />
+		</input>
+		<input ref="/data/dob">
+			<label ref="jr:itext('dob-label')" />
+		</input>
+	</h:body>
+</h:html>

--- a/corehq/apps/userreports/tests/test_report_builder.py
+++ b/corehq/apps/userreports/tests/test_report_builder.py
@@ -6,7 +6,6 @@ from corehq.apps.userreports.models import DataSourceConfiguration, ReportConfig
 from corehq.apps.userreports.reports.builder.forms import ConfigureListReportForm
 
 
-
 def read(rel_path):
     path = os.path.join(os.path.dirname(__file__), *rel_path)
     with open(path) as f:

--- a/corehq/apps/userreports/tests/test_report_builder.py
+++ b/corehq/apps/userreports/tests/test_report_builder.py
@@ -1,0 +1,74 @@
+import os
+from django.test import TestCase
+from corehq.apps.app_manager.const import APP_V2
+from corehq.apps.app_manager.models import Application, Module
+from corehq.apps.userreports.models import DataSourceConfiguration, ReportConfiguration
+from corehq.apps.userreports.reports.builder.forms import ConfigureListReportForm
+
+
+
+def read(rel_path):
+    path = os.path.join(os.path.dirname(__file__), *rel_path)
+    with open(path) as f:
+        return f.read()
+
+
+class ReportBuilderTest(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.app = Application.new_app('domain', 'Untitled Application', application_version=APP_V2)
+        module = cls.app.add_module(Module.new_module('Untitled Module', None))
+        cls.form = cls.app.new_form(module.id, "Untitled Form", 'en', read(['data', 'forms', 'simple.xml']))
+        cls.app.save()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.app.delete()
+        for config in DataSourceConfiguration.all():
+            config.delete()
+        for config in ReportConfiguration.all():
+            config.delete()
+
+    def test_updating_out_of_date_report(self):
+        """
+        Test that editing a report for an outdated data source creates a new data source.
+        Data sources are tied to app version.
+        """
+
+        # Make report
+        builder_form = ConfigureListReportForm(
+            "Test Report",
+            self.app._id,
+            "form",
+            self.form.unique_id,
+            existing_report=None,
+            data={
+                'filters': '[]',
+                'columns': '[]',
+            }
+        )
+        self.assertTrue(builder_form.is_valid())
+        report = builder_form.create_report()
+        first_data_source_id = report.config_id
+
+        # Bump version of app by saving it
+        self.app.save()
+
+        # Modify the report
+        builder_form = ConfigureListReportForm(
+            "Test Report",
+            self.app._id,
+            "form",
+            self.form.unique_id,
+            existing_report=report,
+            data={
+                'filters': '[]',
+                'columns': '[]'
+            }
+        )
+        self.assertTrue(builder_form.is_valid())
+        report = builder_form.update_report()
+        second_data_source_id = report.config_id
+
+        self.assertNotEqual(first_data_source_id, second_data_source_id)

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -5,6 +5,7 @@ import os
 import tempfile
 
 from django.contrib import messages
+from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect, HttpResponse
 from django.http.response import Http404
@@ -225,7 +226,11 @@ class ConfigureChartReport(ReportBuilderView):
     def post(self, *args, **kwargs):
         if self.report_form.is_valid():
             if self.report_form.existing_report:
-                report_configuration = self.report_form.update_report()
+                try:
+                    report_configuration = self.report_form.update_report()
+                except ValidationError as e:
+                    messages.error(self.request, e.message)
+                    return self.get(*args, **kwargs)
             else:
                 report_configuration = self.report_form.create_report()
             return HttpResponseRedirect(

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -195,7 +195,9 @@ class ConfigureChartReport(ReportBuilderView):
             'form': self.report_form,
             'property_options': self.report_form.data_source_properties.values(),
             'initial_filters': [f._asdict() for f in self.report_form.initial_filters],
-            'initial_columns': getattr(self.report_form, 'initial_columns', []),
+            'initial_columns': [
+                c._asdict() for c in getattr(self.report_form, 'initial_columns', [])
+            ],
         }
         return context
 

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -283,18 +283,11 @@ def delete_report(request, domain, report_id):
     config = get_document_or_404(ReportConfiguration, domain, report_id)
 
     # Delete the data source too if it's not being used by any other reports.
-    data_source_id = config.config_id
-
-    report_count = ReportConfiguration.view(
-        'userreports/report_configs_by_data_source',
-        reduce=True,
-        key=[domain, data_source_id]
-    ).one()['value']
-
-    if report_count <= 1:
+    data_source, __ = get_datasource_config_or_404(config.config_id, domain)
+    if data_source.get_report_count() <= 1:
         # No other reports reference this data source.
         try:
-            _delete_data_source_shared(request, domain, data_source_id)
+            delete_data_source_shared(domain, data_source._id, request)
         except Http404:
             # It's possible the data source has already been deleted, but
             # that's fine with us.
@@ -403,17 +396,20 @@ def _edit_data_source_shared(request, domain, config, read_only=False):
 @toggles.USER_CONFIGURABLE_REPORTS.required_decorator()
 @require_POST
 def delete_data_source(request, domain, config_id):
-    _delete_data_source_shared(request, domain, config_id)
+    delete_data_source_shared(domain, config_id, request)
     return HttpResponseRedirect(reverse('configurable_reports_home', args=[domain]))
 
 
-def _delete_data_source_shared(request, domain, config_id):
+def delete_data_source_shared(domain, config_id, request=None):
     config = get_document_or_404(DataSourceConfiguration, domain, config_id)
     adapter = IndicatorSqlAdapter(get_engine(), config)
     adapter.drop_table()
     config.delete()
-    messages.success(request,
-                     _(u'Data source "{}" has been deleted.'.format(config.display_name)))
+    if request:
+        messages.success(
+            request,
+            _(u'Data source "{}" has been deleted.'.format(config.display_name))
+        )
 
 
 @toggles.USER_CONFIGURABLE_REPORTS.required_decorator()


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?171118
An error could occur when users edited reports that had been built with the builder than were based on a form that had changed. If the report contained columns for questions that no longer exist, the user would get a 500.

In a related bug, updating an existing report to include questions that had been added since the report was originally created would cause errors because the data source backing the report was not updated.

This PR fixes both of those issues. Can be reviewed commit-by-commit.

cc @gcapalbo 
