### PR TITLE
display_lang() to return user's language, if set.

### DIFF
--- a/corehq/apps/reports/filters/forms.py
+++ b/corehq/apps/reports/filters/forms.py
@@ -45,7 +45,7 @@ class FormsByApplicationFilter(BaseDrilldownOptionFilter):
         """
             This should return the lang code of the language being used to view this form.
         """
-        return self.request.couch_user.language or 'en'
+        return hasattr(self.request, 'couch_user') and self.request.couch_user.language or 'en'
 
     @property
     def rendered_labels(self):

--- a/corehq/apps/reports/filters/forms.py
+++ b/corehq/apps/reports/filters/forms.py
@@ -45,8 +45,7 @@ class FormsByApplicationFilter(BaseDrilldownOptionFilter):
         """
             This should return the lang code of the language being used to view this form.
         """
-        # todo make this functional
-        return 'en'
+        return self.request.couch_user.language or 'en'
 
     @property
     def rendered_labels(self):


### PR DESCRIPTION
This addresses [FB 170191](http://manage.dimagi.com/default.asp?170191) where the names of modules and forms in report filter dropdowns are always given in English, instead of the language the HQ user has chosen.

Elven @dannyroberts, ping @snopoke 
