### PR TITLE
Fast case query

### DIFF
--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -263,6 +263,7 @@ def get_cases(request, domain):
 
     ids_only = string_to_boolean(request.REQUEST.get("ids_only", "false"))
     case_id = request.REQUEST.get("case_id", "")
+    case_ids = request.REQUEST.get("case_ids", None)
     footprint = string_to_boolean(request.REQUEST.get("footprint", "false"))
     include_children = string_to_boolean(request.REQUEST.get("include_children", "false"))
     if case_id and not footprint and not include_children:
@@ -275,6 +276,8 @@ def get_cases(request, domain):
         case = CommCareCase.get(case_id)
         assert case.domain == domain
         cases = [CaseAPIResult(id=case_id, couch_doc=case, id_only=ids_only)]
+    elif case_ids is not None:
+        cases = [CaseAPIResult(couch_doc=doc) for doc in iter_docs(CommCareCase.get_db(), case_ids)]
     else:
         filters = get_filters_from_request(request)
         status = api_closed_to_status(request.REQUEST.get('closed', 'false'))


### PR DESCRIPTION
Ok, so after doing a bit of digging into the TF logs and seeing what is actually slowing us down big time, I found that `touchcare-filter-cases` is killing us. This happens when a user loads a case list and there is a case filter. We first send a request to TF to filter the cases, TF then sends a request to HQ to load all the cases, then TF filters the cases, and finally HQ returns the result.

We already have an optimization that caches the case universe ids. The idea is, that we can leverage that cache to speed up this call. When we load all objects we should first query `ids_only`. Then once we have the ids or the cached ids, we query HQ to do a `iter_docs` over those ids and return the cases
