### PR TITLE
Allow users to specify language of scheduled reports

### DIFF
--- a/corehq/apps/reports/forms.py
+++ b/corehq/apps/reports/forms.py
@@ -117,6 +117,10 @@ class ScheduledReportForm(forms.Form):
         label='Other recipients',
         required=False)
 
+    language = forms.CharField(
+        label='Language', required=False
+    )
+
     def __init__(self, display_privacy_disclaimer, *args, **kwargs):
         self.helper = FormHelper()
         self.helper.form_class = 'form-horizontal'
@@ -130,6 +134,7 @@ class ScheduledReportForm(forms.Form):
                 'send_to_owner',
                 'attach_excel',
                 'recipient_emails',
+                'language',
                 crispy.HTML(
                     render_to_string('reports/partials/privacy_disclaimer.html')
                 ) if display_privacy_disclaimer else None

--- a/corehq/apps/reports/forms.py
+++ b/corehq/apps/reports/forms.py
@@ -1,3 +1,5 @@
+import langcodes
+
 from django import forms
 from django.core.validators import MinLengthValidator
 from django.template.loader import render_to_string
@@ -9,6 +11,11 @@ from .models import (
     ReportConfig,
     ReportNotification,
 )
+
+
+class LanguageSelect(forms.Select):
+    class Media:
+        js = ('reports/javascripts/language_field.js',)
 
 
 class SavedReportConfigForm(forms.Form):
@@ -117,8 +124,11 @@ class ScheduledReportForm(forms.Form):
         label='Other recipients',
         required=False)
 
-    language = forms.CharField(
-        label='Language', required=False
+    language = forms.ChoiceField(
+        label='Language',
+        required=False,
+        choices=[('', '')] + langcodes.get_all_langs_for_select(),
+        widget=LanguageSelect()
     )
 
     def __init__(self, display_privacy_disclaimer, *args, **kwargs):

--- a/corehq/apps/reports/forms.py
+++ b/corehq/apps/reports/forms.py
@@ -131,7 +131,7 @@ class ScheduledReportForm(forms.Form):
         widget=LanguageSelect()
     )
 
-    def __init__(self, display_privacy_disclaimer, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         self.helper = FormHelper()
         self.helper.form_class = 'form-horizontal'
         self.helper.form_id = 'id-scheduledReportForm'
@@ -147,7 +147,7 @@ class ScheduledReportForm(forms.Form):
                 'language',
                 crispy.HTML(
                     render_to_string('reports/partials/privacy_disclaimer.html')
-                ) if display_privacy_disclaimer else None
+                )
             )
         )
         self.helper.add_input(crispy.Submit('submit_btn', 'Submit'))

--- a/corehq/apps/reports/models.py
+++ b/corehq/apps/reports/models.py
@@ -505,6 +505,13 @@ class ReportConfig(CachedCouchDocumentMixin, Document):
         return isinstance(self._dispatcher, ConfigurableReport)
 
     @property
+    @memoized
+    def languages(self):
+        if self.is_configurable_report:
+            return self.report.spec.get_languages()
+        return set()
+
+    @property
     def datespan_filters(self):
         from corehq.apps.userreports.reports.view import ConfigurableReport
         return ConfigurableReport.get_report(

--- a/corehq/apps/reports/models.py
+++ b/corehq/apps/reports/models.py
@@ -404,7 +404,7 @@ class ReportConfig(CachedCouchDocumentMixin, Document):
         except CouchUser.AccountTypeError:
             return CommCareUser.get_by_user_id(self.owner_id)
 
-    def get_report_content(self, attach_excel=False):
+    def get_report_content(self, lang, attach_excel=False):
         """
         Get the report's HTML content as rendered by the static view format.
 
@@ -424,6 +424,7 @@ class ReportConfig(CachedCouchDocumentMixin, Document):
         request.user = self.owner.get_django_user()
         request.domain = self.domain
         request.couch_user.current_domain = self.domain
+        request.couch_user.language = lang
 
         request.GET = QueryDict(
             self.query_string
@@ -527,6 +528,8 @@ class ReportNotification(CachedCouchDocumentMixin, Document):
     config_ids = StringListProperty()
     send_to_owner = BooleanProperty()
     attach_excel = BooleanProperty()
+    # language is only used if some of the config_ids refer to UCRs.
+    language = StringProperty()
 
     hour = IntegerProperty(default=8)
     minute = IntegerProperty(default=0)

--- a/corehq/apps/reports/static/reports/javascripts/language_field.js
+++ b/corehq/apps/reports/static/reports/javascripts/language_field.js
@@ -1,0 +1,7 @@
+$(function() {
+    $('.languageselect').combobox({
+        // TODO: Translate this string.
+        // It's hard because this is static.
+        placeholder: "Select a language..."
+    });
+});

--- a/corehq/apps/reports/templates/reports/edit_scheduled_report.html
+++ b/corehq/apps/reports/templates/reports/edit_scheduled_report.html
@@ -17,15 +17,49 @@
 
 {% block reports-js-inline %}
 <script>
+$(function(){
     var isConfigurableMap = {{ is_configurable_map|JSON }};
+    var languagesMap = {{ languages_map|JSON }};
+    var languagesForSelect = {{ languages_for_select|JSON }};
 
     var updateUcrElements = function(selectedConfigs){
-        showUcrElements = _.any(
+        var showUcrElements = _.any(
             selectedConfigs, function(i){return isConfigurableMap[i] === true;}
         );
+        var currentLanguageOptions = [];
+
         if (showUcrElements){
-            $("#div_id_language").show();
             $("#ucr-privacy-warning").show();
+
+            // Figure out which options to show in the combobox
+            var languageLists = _.map(selectedConfigs, function(i){return languagesMap[i];});
+            var languageSet = _.reduce(languageLists, function(memo, list){
+                _.map(list, function(e){
+                    memo[e] = true;
+                });
+                return memo;
+            }, {});
+            var currentLanguageOptions = Object.keys(languageSet).sort();
+            var $id_language = $('#id_language');
+
+            if (currentLanguageOptions.length === 1 && currentLanguageOptions[0] === 'en') {
+                $id_language.val('en');
+                $('#div_id_language').hide();
+            } else {
+                // Update the options of the combobox
+                var current = $id_language.val();
+                $id_language.empty();
+
+                // Populate the select
+                _.map(currentLanguageOptions, function (l) {
+                    $id_language.append(
+                        $("<option></option>").attr("value", l).text(languagesForSelect[l][1])
+                    );
+                });
+                $id_language.val(current);
+                $id_language.data('combobox').refresh();
+                $("#div_id_language").show();
+            }
         } else {
             $("#div_id_language").hide();
             $("#ucr-privacy-warning").hide();
@@ -35,7 +69,8 @@
     $("#id_config_ids").width(600).height(200).multiselect().change(function(){
         updateUcrElements($(this).val());
     });
-
+    updateUcrElements($("#id_config_ids").val());
+});
 </script>
 <script type="text/javascript">
     var scheduled_report_form_helper = new ScheduledReportFormHelper({

--- a/corehq/apps/reports/templates/reports/edit_scheduled_report.html
+++ b/corehq/apps/reports/templates/reports/edit_scheduled_report.html
@@ -2,6 +2,12 @@
 {% load hq_shared_tags %}
 {% load crispy_forms_tags %}
 
+{% block head %}{{ block.super }}
+    {% if form %}
+        {{ form.media }}
+    {% endif %}
+{% endblock %}
+
 {% block reports-js %}
 <script src="{% static 'hqwebapp/js/lib/jquery-ui/jquery-ui-1.9.2.multiselect-deps.custom.min.js' %}"></script>
 <script src="{% static 'hqwebapp/js/lib/jquery-ui/multiselect/ui.multiselect.js' %}"></script>

--- a/corehq/apps/reports/templates/reports/edit_scheduled_report.html
+++ b/corehq/apps/reports/templates/reports/edit_scheduled_report.html
@@ -17,7 +17,25 @@
 
 {% block reports-js-inline %}
 <script>
-    $("#id_config_ids").width(600).height(200).multiselect();
+    var isConfigurableMap = {{ is_configurable_map|JSON }};
+
+    var updateUcrElements = function(selectedConfigs){
+        showUcrElements = _.any(
+            selectedConfigs, function(i){return isConfigurableMap[i] === true;}
+        );
+        if (showUcrElements){
+            $("#div_id_language").show();
+            $("#ucr-privacy-warning").show();
+        } else {
+            $("#div_id_language").hide();
+            $("#ucr-privacy-warning").hide();
+        }
+    };
+
+    $("#id_config_ids").width(600).height(200).multiselect().change(function(){
+        updateUcrElements($(this).val());
+    });
+
 </script>
 <script type="text/javascript">
     var scheduled_report_form_helper = new ScheduledReportFormHelper({

--- a/corehq/apps/reports/templates/reports/partials/privacy_disclaimer.html
+++ b/corehq/apps/reports/templates/reports/partials/privacy_disclaimer.html
@@ -1,12 +1,10 @@
 {% load i18n %}
 
-<p>
-    <div class="alert">
-        <p>
-            <strong>{% trans 'Disclaimer' %}</strong>:  {% blocktrans %}The privacy and protection of personal data is very important to Dimagi.  Dimagi is not responsible for privacy of reports or SMS data you transmit from CommCareHQ to external parties.  However, to protect privacy, we suggest that you include a message like the following in your communications (for instance, by including in the saved report description){% endblocktrans %}:
-        </p>
-        <p>
-            <em>{% blocktrans %}The information contained in this transmission may contain privileged and confidential information, including personal information protected by federal and state privacy laws. It is intended only for the use of the person(s) named above. If you are not the intended recipient, you are hereby notified that any review, dissemination, distribution, or duplication of this communication is strictly prohibited. If you are not the intended recipient, please contact the sender by reply email and destroy all copies of the original message.{% endblocktrans %}</em>
-        </p>
-    </div>
-</p>
+<div class="alert" id="ucr-privacy-warning">
+    <p>
+        <strong>{% trans 'Disclaimer' %}</strong>:  {% blocktrans %}The privacy and protection of personal data is very important to Dimagi.  Dimagi is not responsible for privacy of reports or SMS data you transmit from CommCareHQ to external parties.  However, to protect privacy, we suggest that you include a message like the following in your communications (for instance, by including in the saved report description){% endblocktrans %}:
+    </p>
+    <p>
+        <em>{% blocktrans %}The information contained in this transmission may contain privileged and confidential information, including personal information protected by federal and state privacy laws. It is intended only for the use of the person(s) named above. If you are not the intended recipient, you are hereby notified that any review, dissemination, distribution, or duplication of this communication is strictly prohibited. If you are not the intended recipient, please contact the sender by reply email and destroy all copies of the original message.{% endblocktrans %}</em>
+    </p>
+</div>

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -617,6 +617,7 @@ def email_report(request, domain, report_slug, report_type=ProjectReportDispatch
                                   domain,
                                   user_id, request.couch_user,
                                   True,
+                                  lang=request.couch_user.language,
                                   notes=form.cleaned_data['notes'],
                                   once=once)[0].content
 

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -713,7 +713,7 @@ def edit_scheduled_report(request, domain, scheduled_report_id=None,
     if not configs:
         return render(request, template, context)
 
-    display_privacy_disclaimer = any(c.is_configurable_report for c in configs)
+    is_configurable_map = {c._id: c.is_configurable_report for c in configs}
 
     config_choices = [(c._id, c.full_name) for c in configs]
 
@@ -748,11 +748,7 @@ def edit_scheduled_report(request, domain, scheduled_report_id=None,
     initial['recipient_emails'] = ', '.join(initial['recipient_emails'])
 
     kwargs = {'initial': initial}
-    args = (
-        (display_privacy_disclaimer, request.POST)
-        if request.method == "POST"
-        else (display_privacy_disclaimer,)
-    )
+    args = ((request.POST, ) if request.method == "POST" else ())
     form = ScheduledReportForm(*args, **kwargs)
 
     form.fields['config_ids'].choices = config_choices
@@ -793,6 +789,7 @@ def edit_scheduled_report(request, domain, scheduled_report_id=None,
     else:
         context['form_action'] = _("Edit")
         context['report']['title'] = _("Edit Scheduled Report")
+    context['is_configurable_map'] = is_configurable_map
 
     return render(request, template, context)
 

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -5,6 +5,7 @@ import json
 import tempfile
 import re
 import itertools
+import langcodes
 from datetime import datetime, timedelta, date
 from urllib2 import URLError
 from casexml.apps.case import const
@@ -714,6 +715,8 @@ def edit_scheduled_report(request, domain, scheduled_report_id=None,
         return render(request, template, context)
 
     is_configurable_map = {c._id: c.is_configurable_report for c in configs}
+    languages_map = {c._id: list(c.languages | set(['en'])) for c in configs}
+    languages_for_select = {tup[0]: tup for tup in langcodes.get_all_langs_for_select()}
 
     config_choices = [(c._id, c.full_name) for c in configs]
 
@@ -790,6 +793,8 @@ def edit_scheduled_report(request, domain, scheduled_report_id=None,
         context['form_action'] = _("Edit")
         context['report']['title'] = _("Edit Scheduled Report")
     context['is_configurable_map'] = is_configurable_map
+    context['languages_map'] = languages_map
+    context['languages_for_select'] = languages_for_select
 
     return render(request, template, context)
 

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -301,6 +301,18 @@ class ReportConfiguration(UnicodeMixIn, CachedCouchDocumentMixin, Document):
                 return filter
         return None
 
+    def get_languages(self):
+        """
+        Return the languages used in this report's column and filter display properties.
+        Note that only explicitly identified languages are returned. So, if the
+        display properties are all strings, "en" would not be returned.
+        """
+        langs = set()
+        for item in self.columns + self.filters:
+            if isinstance(item['display'], dict):
+                langs |= set(item['display'].keys())
+        return langs
+
     def validate(self, required=True):
         def _check_for_duplicates(supposedly_unique_list, error_msg):
             # http://stackoverflow.com/questions/9835762/find-and-list-duplicates-in-python-list


### PR DESCRIPTION
UCR reports can have column headings specified in multiple languages. When viewing a UCR on HQ, it displays in the user's language. This PR adds a language setting for scheduled reports that controls the language of column headings in scheduled UCR reports. The language setting has no affect on non-UCR reports, so it is hidden if none are selected. The field uses the widget used for language selection elsewhere.

code buddy @gcapalbo 
fyi @czue 

![screen shot 2015-06-18 at 2 53 09 pm](https://cloud.githubusercontent.com/assets/2117127/8239559/976e043e-15ca-11e5-82eb-74890417867a.png)
