### PR TITLE
Show options in dynamic choice filter before any characters entered

### DIFF
--- a/corehq/apps/reports_core/templates/reports_core/filters/dynamic_choice_list_filter/dynamic_choice_list.js
+++ b/corehq/apps/reports_core/templates/reports_core/filters/dynamic_choice_list_filter/dynamic_choice_list.js
@@ -1,7 +1,8 @@
 {% load reports_core_tags %}
 var filter_id = "#{{ filter.css_id }}-input";
+var pageSize = 20;
 $(filter_id).select2({
-    minimumInputLength: 1,
+    minimumInputLength: 0,
     allowClear: true,
     // allowClear only respected if there is a non empty placeholder
     placeholder: " ",
@@ -11,13 +12,18 @@ $(filter_id).select2({
         quietMillis: 250,
         data: function (term, page) {
             return {
-                q: term // search term
+                q: term, // search term
+                page: page,
+                limit: pageSize
             };
         },
         results: function (data, page) {
             // parse the results into the format expected by Select2.
             var formattedData = _.map(data, function (val) { return {'id': val, 'text': val}});
-            return { results: formattedData };
+            return {
+                results: formattedData,
+                more: data.length === pageSize
+            };
         },
         cache: true
     }

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -562,16 +562,23 @@ def choice_list_api(request, domain, report_id, filter_id):
     report = get_document_or_404(ReportConfiguration, domain, report_id)
     filter = report.get_ui_filter(filter_id)
 
-    def get_choices(data_source, filter, search_term=None, limit=20):
+    def get_choices(data_source, filter, search_term=None, limit=20, page=0):
         table = get_indicator_table(data_source)
         sql_column = table.c[filter.field]
         query = Session.query(sql_column)
         if search_term:
             query = query.filter(sql_column.contains(search_term))
 
-        return [v[0] for v in query.distinct().limit(limit)]
+        offset = page * limit
+        return [v[0] for v in query.distinct().order_by(sql_column).limit(limit).offset(offset)]
 
-    return json_response(get_choices(report.config, filter, request.GET.get('q', None)))
+    return json_response(get_choices(
+        report.config,
+        filter,
+        request.GET.get('q', None),
+        limit=int(request.GET.get('limit', 20)),
+        page=int(request.GET.get('page', 1)) - 1
+    ))
 
 
 def _shared_context(domain):


### PR DESCRIPTION
The UCR dynamic choice list filter required the user to type at least one character before the select2 widget populated with options. This change makes the widget show options right away. The choices api is also paginated now.
@czue 
@gcapalbo 

http://manage.dimagi.com/default.asp?171871
