### PR TITLE
Enable user-as-a-case for a domain when it is used in an advanced form

### DIFF
--- a/corehq/apps/app_manager/const.py
+++ b/corehq/apps/app_manager/const.py
@@ -32,4 +32,11 @@ USERCASE_TYPE = 'commcare-user'
 USERCASE_ID = 'usercase_id'
 USERCASE_PREFIX = 'user/'
 
+AUTO_SELECT_USER = 'user'
+AUTO_SELECT_FIXTURE = 'fixture'
+AUTO_SELECT_CASE = 'case'
+AUTO_SELECT_LOCATION = 'location'
+AUTO_SELECT_RAW = 'raw'
+AUTO_SELECT_USERCASE = 'usercase'
+
 RETURN_TO = 'return_to'

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -96,13 +96,6 @@ WORKFLOW_MODULE = 'module'
 WORKFLOW_PREVIOUS = 'previous_screen'
 WORKFLOW_FORM = 'form'
 
-AUTO_SELECT_USER = 'user'
-AUTO_SELECT_FIXTURE = 'fixture'
-AUTO_SELECT_CASE = 'case'
-AUTO_SELECT_LOCATION = 'location'
-AUTO_SELECT_RAW = 'raw'
-AUTO_SELECT_USERCASE = 'usercase'
-
 DETAIL_TYPES = ['case_short', 'case_long', 'ref_short', 'ref_long']
 
 FIELD_SEPARATOR = ':'

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -17,6 +17,7 @@ from corehq.apps.app_manager.const import (
     CT_REQUISITION_MODE_4,
     CT_LEDGER_APPROVED,
     CT_LEDGER_PREFIX,
+    AUTO_SELECT_USERCASE,
     USERCASE_TYPE,
     USERCASE_ID,
     USERCASE_PREFIX)
@@ -411,6 +412,10 @@ def get_commcare_versions(request_user):
 def actions_use_usercase(actions):
     return (('usercase_update' in actions and actions['usercase_update'].update) or
             ('usercase_preload' in actions and actions['usercase_preload'].preload))
+
+
+def advanced_actions_use_usercase(actions):
+    return any(c.auto_select and c.auto_select.mode == AUTO_SELECT_USERCASE for c in actions.load_update_cases)
 
 
 def enable_usercase(domain_name):

--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -99,7 +99,8 @@ from corehq.apps.app_manager.util import (
     is_usercase_in_use,
     enable_usercase,
     actions_use_usercase,
-    get_usercase_properties, 
+    advanced_actions_use_usercase,
+    get_usercase_properties,
     prefix_usercase_properties,
     get_per_type_defaults
 )
@@ -2049,6 +2050,8 @@ def edit_advanced_form_actions(request, domain, app_id, module_id, form_id):
     json_loads = json.loads(request.POST.get('actions'))
     actions = AdvancedFormActions.wrap(json_loads)
     form.actions = actions
+    if advanced_actions_use_usercase(form.actions) and not is_usercase_in_use(domain):
+        enable_usercase(domain)
     response_json = {}
     app.save(response_json)
     response_json['propertiesMap'] = get_all_case_properties(app)


### PR DESCRIPTION
Previously it was only enabled when it was used in a normal form.

@snopoke, buddy @dannyroberts 
