### PR TITLE
get_all_case_owner_ids

### DIFF
--- a/corehq/apps/hqcase/dbaccessors.py
+++ b/corehq/apps/hqcase/dbaccessors.py
@@ -239,3 +239,18 @@ def get_supply_point_case_in_domain_by_id(
         include_docs=True,
         limit=1,
     ).first()
+
+
+def get_all_case_owner_ids(domain):
+    """
+    Get all owner ids that are assigned to cases in a domain.
+    """
+    from casexml.apps.case.models import CommCareCase
+    key = [domain]
+    submitted = CommCareCase.get_db().view(
+        'hqcase/by_owner',
+        group_level=2,
+        startkey=key,
+        endkey=key + [{}],
+    ).all()
+    return set([row['key'][1] for row in submitted])

--- a/corehq/apps/hqcase/tests/test_dbaccessors.py
+++ b/corehq/apps/hqcase/tests/test_dbaccessors.py
@@ -1,11 +1,11 @@
 from django.test import TestCase
 from casexml.apps.case.dbaccessors import get_open_case_docs_in_domain, \
-    get_open_case_ids_in_domain, get_number_of_cases_by_filters, \
-    get_all_case_owner_ids
+    get_open_case_ids_in_domain, get_number_of_cases_by_filters
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.hqcase.dbaccessors import get_number_of_cases_in_domain, \
     get_case_ids_in_domain, get_case_types_for_domain, get_cases_in_domain, \
-    get_case_ids_in_domain_by_owner, get_number_of_cases_in_domain_by_owner
+    get_case_ids_in_domain_by_owner, get_number_of_cases_in_domain_by_owner, \
+    get_all_case_owner_ids
 
 
 class DBAccessorsTest(TestCase):

--- a/corehq/apps/hqcase/tests/test_dbaccessors.py
+++ b/corehq/apps/hqcase/tests/test_dbaccessors.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from casexml.apps.case.dbaccessors import get_open_case_docs_in_domain, \
-    get_open_case_ids_in_domain, get_number_of_cases_by_filters
+    get_open_case_ids_in_domain, get_number_of_cases_by_filters, \
+    get_all_case_owner_ids
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.hqcase.dbaccessors import get_number_of_cases_in_domain, \
     get_case_ids_in_domain, get_case_types_for_domain, get_cases_in_domain, \
@@ -165,4 +166,16 @@ class DBAccessorsTest(TestCase):
             get_number_of_cases_in_domain_by_owner(self.domain, owner_id='XXX'),
             len([case for case in self.cases
                  if case.domain == self.domain and case.user_id == 'XXX'])
+        )
+
+    def test_get_all_case_owner_ids(self):
+        self.assertEqual(
+            get_all_case_owner_ids(self.domain),
+            set(case.user_id for case in self.cases
+                if case.domain == self.domain)
+        )
+        # sanity check!
+        self.assertEqual(
+            get_all_case_owner_ids(self.domain),
+            {'XXX', 'ZZZ'},
         )

--- a/corehq/ex-submodules/casexml/apps/case/dbaccessors/all_cases.py
+++ b/corehq/ex-submodules/casexml/apps/case/dbaccessors/all_cases.py
@@ -1,21 +1,6 @@
 from dimagi.utils.couch.database import iter_docs
 
 
-def get_all_case_owner_ids(domain):
-    """
-    Get all owner ids that are assigned to cases in a domain.
-    """
-    from casexml.apps.case.models import CommCareCase
-    key = ["all owner", domain]
-    submitted = CommCareCase.get_db().view(
-        'case/all_cases',
-        group_level=3,
-        startkey=key,
-        endkey=key + [{}],
-    ).all()
-    return set([row['key'][2] for row in submitted])
-
-
 def get_open_case_ids_in_domain(domain, type=None, owner_id=None):
     from casexml.apps.case.models import CommCareCase
     if owner_id is not None and type is None:

--- a/corehq/ex-submodules/casexml/apps/phone/cleanliness.py
+++ b/corehq/ex-submodules/casexml/apps/phone/cleanliness.py
@@ -1,12 +1,11 @@
 from collections import namedtuple
 from datetime import datetime
-from casexml.apps.case.dbaccessors import get_all_case_owner_ids, \
-    get_reverse_indexed_case_ids, get_indexed_case_ids
+from casexml.apps.case.dbaccessors import get_reverse_indexed_case_ids, get_indexed_case_ids
 from casexml.apps.case.exceptions import IllegalCaseId
 from casexml.apps.case.util import get_indexed_cases
 from casexml.apps.phone.models import OwnershipCleanlinessFlag
 from corehq.apps.hqcase.dbaccessors import get_open_case_ids, \
-    get_closed_case_ids
+    get_closed_case_ids, get_all_case_owner_ids
 from corehq.apps.users.util import WEIRD_USER_IDS
 from corehq.toggles import OWNERSHIP_CLEANLINESS
 from django.conf import settings


### PR DESCRIPTION
Implement get_all_case_owner_ids with a simpler couch view. This will let me simplify the `case/all_cases` view in a later PR.
