### PR TITLE
Make DeprecationWarnings show up

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -965,6 +965,7 @@ if DEBUG:
 
     import warnings
     warnings.simplefilter('default')
+    os.environ['PYTHONWARNINGS'] = 'd'  # Show DeprecationWarning
 else:
     TEMPLATE_LOADERS = [
         ('django.template.loaders.cached.Loader', TEMPLATE_LOADERS),


### PR DESCRIPTION
@dimagi/team-commcare-hq we haven't been seeing deprecation warnings for a while, apparently.
[DeprecationWarning no longer loud by default in Python 2.7+](https://code.djangoproject.com/ticket/18985)

I tried the suggestions in that ticket and mimicked the line from the new [`./manage.py` template](https://github.com/django/django/pull/385/files), but the only things that worked for me were to start the dev server with `$ python -Wd manage.py runserver` and to set the environment variable `PYTHONWARNINGS="d"`.  If anyone can make the suggested methods work, I'd prefer that.

Note that we have a LOT of deprecation warnings (mostly commit_on_success), so this is pretty spammy.
