### PR TITLE
Credit card prepay

### DIFF
--- a/corehq/apps/accounting/static/accounting/ko/accounting.credits.js
+++ b/corehq/apps/accounting/static/accounting/ko/accounting.credits.js
@@ -4,6 +4,7 @@ var CreditsManager = function (products, features, paymentHandler, can_purchase_
 
     self.products = ko.observableArray();
     self.features = ko.observableArray();
+    self.prepayments = ko.observable()
 
     can_purchase_credits = can_purchase_credits && !is_plan_trial;
 
@@ -14,13 +15,30 @@ var CreditsManager = function (products, features, paymentHandler, can_purchase_
         _.each(features, function (feature) {
             self.features.push(new CreditItem('feature', feature, paymentHandler, can_purchase_credits));
         });
+        self.prepayments(new Prepayments(self.products, self.features, paymentHandler, can_purchase_credits));
     }
+};
+
+var Prepayments = function(products, features, paymentHandler, can_purchase_credits) {
+    'use strict';
+    var self = this;
+    self.products = products;
+    self.features = features;
+
+    self.paymentHandler = paymentHandler;
+
+    self.triggerPayment = function () {
+        self.paymentHandler.reset();
+        self.paymentHandler.costItem(new PrepaymentItems({
+            products: self.products,
+            features: self.features,
+        }));
+    };
 };
 
 var CreditItem = function (category, data, paymentHandler, can_purchase_credits) {
     'use strict';
     var self = this;
-
     self.category = ko.observable(category);
     self.name = ko.observable(data.name);
     self.creditType = ko.observable(data.type);
@@ -31,6 +49,7 @@ var CreditItem = function (category, data, paymentHandler, can_purchase_credits)
     self.hasAmount = ko.observable(data.credit && data.credit.is_visible);
     self.canPurchaseCredits = ko.observable(can_purchase_credits);
     self.paymentHandler = paymentHandler;
+    self.addAmount = ko.observable(0.5);
 
     self.isVisible = ko.computed(function () {
         return self.hasAmount() && self.canPurchaseCredits();

--- a/corehq/apps/accounting/static/accounting/ko/accounting.credits.js
+++ b/corehq/apps/accounting/static/accounting/ko/accounting.credits.js
@@ -4,7 +4,7 @@ var CreditsManager = function (products, features, paymentHandler, can_purchase_
 
     self.products = ko.observableArray();
     self.features = ko.observableArray();
-    self.prepayments = ko.observable()
+    self.prepayments = ko.observable();
 
     can_purchase_credits = can_purchase_credits && !is_plan_trial;
 

--- a/corehq/apps/accounting/static/accounting/ko/accounting.credits.js
+++ b/corehq/apps/accounting/static/accounting/ko/accounting.credits.js
@@ -51,6 +51,13 @@ var CreditItem = function (category, data, paymentHandler, can_purchase_credits)
     self.paymentHandler = paymentHandler;
     self.addAmount = ko.observable(0.5);
 
+    self.addAmountValid = ko.computed(function(){
+        var is_number = !isNaN(self.addAmount());
+        var valid_amount = parseFloat(self.addAmount()) === 0 || (parseFloat(self.addAmount()) >= 0.5);
+        console.log(self.addAmount(), is_number, valid_amount);
+        return is_number && valid_amount;
+    });
+
     self.isVisible = ko.computed(function () {
         return self.hasAmount() && self.canPurchaseCredits();
     });

--- a/corehq/apps/accounting/static/accounting/ko/accounting.credits.js
+++ b/corehq/apps/accounting/static/accounting/ko/accounting.credits.js
@@ -52,10 +52,7 @@ var CreditItem = function (category, data, paymentHandler, can_purchase_credits)
     self.addAmount = ko.observable(0.5);
 
     self.addAmountValid = ko.computed(function(){
-        var is_number = !isNaN(self.addAmount());
-        var valid_amount = parseFloat(self.addAmount()) === 0 || (parseFloat(self.addAmount()) >= 0.5);
-        console.log(self.addAmount(), is_number, valid_amount);
-        return is_number && valid_amount;
+        return  parseFloat(self.addAmount()) === 0 || (parseFloat(self.addAmount()) >= 0.5);
     });
 
     self.isVisible = ko.computed(function () {

--- a/corehq/apps/accounting/static/accounting/ko/accounting.payment_method_handler.js
+++ b/corehq/apps/accounting/static/accounting/ko/accounting.payment_method_handler.js
@@ -332,7 +332,7 @@ TotalCostItem.protoptye = Object.create( ChargedCostItem.prototype );
 TotalCostItem.prototype.constructor = TotalCostItem;
 
 var PrepaymentItems = function(data){
-    'use strict'
+    'use strict';
     BaseCostItem.call(this, data);
     var self = this;
     self.products = data.products;
@@ -340,14 +340,14 @@ var PrepaymentItems = function(data){
 
     self.amount = ko.computed(function(){
         var product_sum = _.reduce(self.products(), function(memo, product){
-            return memo + product.addAmount();
+            return memo + parseFloat(product.addAmount());
         }, 0);
 
         var feature_sum =_.reduce(self.features(), function(memo, feature){
-            return memo + feature.addAmount();
+            return memo + parseFloat(feature.addAmount());
         }, 0);
-
-        return product_sum + feature_sum;
+        var sum = product_sum + feature_sum;
+        return isNaN(sum) ? 0.0 : sum;
     });
 
     self.reset = function (response) {
@@ -359,13 +359,13 @@ var PrepaymentItems = function(data){
             if (update_balance){
                 update_balance.amount(balance.balance);
             }
-        })
+        });
     };
 
     self.isValid = function () {
         return self.amount() >= 0.5;
     };
-}
+};
 
 var CreditCostItem = function (initData) {
    'use strict';

--- a/corehq/apps/accounting/static/accounting/ko/accounting.payment_method_handler.js
+++ b/corehq/apps/accounting/static/accounting/ko/accounting.payment_method_handler.js
@@ -351,8 +351,15 @@ var PrepaymentItems = function(data){
     });
 
     self.reset = function (response) {
-        console.log("TODO: handle response");
-        // self.creditItem.amount(response.balance);
+        var items = self.products().concat(self.features());
+        _.each(response.balances, function(balance){
+            var update_balance = _.find(items, function(item){
+                return item.creditType() === balance.type;
+            });
+            if (update_balance){
+                update_balance.amount(balance.balance);
+            }
+        })
     };
 
     self.isValid = function () {

--- a/corehq/apps/accounting/static/accounting/ko/accounting.payment_method_handler.js
+++ b/corehq/apps/accounting/static/accounting/ko/accounting.payment_method_handler.js
@@ -331,6 +331,35 @@ var TotalCostItem = function (initData) {
 TotalCostItem.protoptye = Object.create( ChargedCostItem.prototype );
 TotalCostItem.prototype.constructor = TotalCostItem;
 
+var PrepaymentItems = function(data){
+    'use strict'
+    BaseCostItem.call(this, data);
+    var self = this;
+    self.products = data.products;
+    self.features = data.features;
+
+    self.amount = ko.computed(function(){
+        var product_sum = _.reduce(self.products(), function(memo, product){
+            return memo + product.addAmount();
+        }, 0);
+
+        var feature_sum =_.reduce(self.features(), function(memo, feature){
+            return memo + feature.addAmount();
+        }, 0);
+
+        return product_sum + feature_sum;
+    });
+
+    self.reset = function (response) {
+        console.log("TODO: handle response");
+        // self.creditItem.amount(response.balance);
+    };
+
+    self.isValid = function () {
+        return self.amount() >= 0.5;
+    };
+}
+
 var CreditCostItem = function (initData) {
    'use strict';
     BaseCostItem.call(this, initData);

--- a/corehq/apps/accounting/templates/accounting/credit_receipt_email.html
+++ b/corehq/apps/accounting/templates/accounting/credit_receipt_email.html
@@ -8,18 +8,35 @@
 
 <p>
     {% blocktrans %}
-    This email is a receipt for your payment of {{ amount }} for {{ credit_name }}
-    credits to your project {{ project }}.
+    This email is a receipt for your prepayment of {{ amount }} for credits to your project {{ project }}.
     {% endblocktrans %}
 </p>
 
-<ul>
-    <li><strong>{% trans 'Amount' %}:</strong> {{ amount }}</li>
-    <li><strong>{% trans 'Item' %}:</strong> {{ credit_name }} Credits</li>
-    <li><strong>{% trans 'Payment Date' %}:</strong> {{ date_paid }}</li>
-    <li><strong>{% trans 'Transaction No.' %}:</strong> {{ transaction_id }}</li>
-</ul>
+<table border='1' style="border-collapse:collapse;">
+    <thead>
+        <tr>
+            <td><strong>{% trans 'Item' %}</strong></td>
+            <td><strong>{% trans 'Amount' %}</strong></td>
+        </tr>
 
+    </thead>
+    <tbody>
+        {% for item in items %}
+            <tr>
+                <td>{{ item.type }}</td>
+                <td>{{ item.amount }}</td>
+            </tr>
+        {% endfor %}
+            <tr>
+                <td><strong>{% trans 'Total' %}</strong></td>
+                <td><strong>{{ amount }}</strong></td>
+            </tr>
+    </tbody>
+</table>
+<p>
+    <strong>{% trans 'Payment Date' %}:</strong> {{ date_paid }} <br />
+    <strong>{% trans 'Transaction No.' %}:</strong> {{ transaction_id }}
+</p>
 <p>
     {% blocktrans %}
     Thank you for using {{ product }}. If you have any questions, please don't

--- a/corehq/apps/accounting/templates/accounting/credit_receipt_email_plaintext.txt
+++ b/corehq/apps/accounting/templates/accounting/credit_receipt_email_plaintext.txt
@@ -1,20 +1,29 @@
-{% load i18n %}{% blocktrans %}Dear {{ name }},
+{% load i18n %}{% blocktrans %}Dear {{ name }},{% endblocktrans %}
 
-This email is a receipt for your payment of {{ amount }} for {{ credit_name }}
-credits to your project {{ project }}.
+{% blocktrans %}
+This email is a receipt for your prepayment of {{ amount }} for credits to your project {{ project }}.
+{% endblocktrans %}
 
-Amount: {{ amount }}
-Item: {{ credit_name }} Credits
-Payment Date: {{ date_paid }}
-Transaction No.: {{ transaction_id }}
+{% for item in items %}
+    {{item.type}}: {{item.amount}}
+{% endfor %}
+    {% trans 'Total' %}: {{ amount }}
 
+{% trans 'Payment Date' %}: {{ date_paid }}
+{% trans 'Transaction No.' %}: {{ transaction_id }}
+
+{% blocktrans %}
 Thank you for using {{ product }}. If you have any questions, please don't
 hesitate to contact {{ invoicing_contact_email }}.
+{% endblocktrans %}
 
+{% blocktrans %}
 Best Regards,
 The {{ product }} HQ Team
 www.commcarehq.org
+{% endblocktrans %}
 
+{% blocktrans %}
 Email From:
 CommCare HQ and the corporation Dimagi, Inc.
 585 Massachusetts Ave, Ste 4, Cambridge, MA 02139 USA

--- a/corehq/apps/domain/templates/domain/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/current_subscription.html
@@ -245,7 +245,16 @@
                                    name="product_credits"
                                    data-bind="
                                    attr:{name: creditType},
-                                   numericValue: addAmount" />
+                                   value: addAmount" />
+                        </div>
+                        <div class="alert alert-error"
+                        data-bind="visible: !addAmountValid()">
+                           <i class="icon-warning-sign"></i>
+                           <span>
+                               {% blocktrans %}
+                               Please enter an amount that's either $0 or  greater than $0.5
+                              {% endblocktrans %}
+                          </span>
                         </div>
                     </div>
                 </div>
@@ -263,7 +272,16 @@
                                    class="input-small"
                                    data-bind="
                                    attr:{name: creditType},
-                                   numericValue: addAmount" />
+                                   value: addAmount" />
+                        </div>
+                        <div class="alert alert-error"
+                        data-bind="visible: !addAmountValid()">
+                           <i class="icon-warning-sign"></i>
+                           <span>
+                               {% blocktrans %}
+                               Please enter an amount that's either $0 or  greater than $0.5
+                              {% endblocktrans %}
+                          </span>
                         </div>
                     </div>
                 </div>

--- a/corehq/apps/domain/templates/domain/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/current_subscription.html
@@ -4,7 +4,6 @@
 {% load i18n %}
 
 {% block js %}{{ block.super }}
-    <script type="text/javascript" src="{% static 'style/ko/knockout_bindings.ko.js' %}"></script>
     <script type="text/javascript" src="{% static 'accounting/ko/accounting.payment_method_handler.js' %}"></script>
     <script type="text/javascript" src="{% static 'accounting/ko/accounting.credits.js' %}"></script>
     <script type="text/javascript" src="https://js.stripe.com/v2/"></script>

--- a/corehq/apps/domain/templates/domain/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/current_subscription.html
@@ -118,21 +118,6 @@
                                 <span class="help-inline"
                                       style="margin-right: 10px;"
                                       data-bind="text: amount"></span>
-                                {% if not is_ops_user_but_not_admin %}
-                                <button type="button"
-                                        class="btn add-credit-button"
-                                        data-toggle="modal"
-                                        data-target="#paymentModal"
-                                        data-bind="click: triggerPayment, visible: canPurchaseCredits">
-                                    <i class="icon-plus"></i>
-                                    {% trans 'Add Credit' %}
-                                </button>
-                                {% else %}
-                                    <span class="label">
-                                        <i class="icon-info-sign"></i>
-                                        {% trans "Not Billing Admin, Can't Add Credit" %}
-                                    </span>
-                                {% endif %}
                             </div>
                         </div>
                     </div>
@@ -196,9 +181,6 @@
                         {% if not plan.is_trial %}
                         <th>{% trans "Credits Available" %}</th>
                         {% endif %}
-                        {% if can_purchase_credits and not plan.is_trial %}
-                        <th>{% trans "Add Credit" %}</th>
-                        {% endif %}
                     </tr>
                 </thead>
                 <tbody data-bind="foreach: features">
@@ -208,25 +190,6 @@
                         <td data-bind="text: remaining"></td>
                         {% if not plan.is_trial %}
                         <td data-bind="text: amount"></td>
-                        {% endif %}
-                        {% if can_purchase_credits and not plan.is_trial %}
-                        <td data-bind="visible: canPurchaseCredits">
-                            {% if not is_ops_user_but_not_admin %}
-                                <button type="button"
-                                        class="btn"
-                                        data-toggle="modal"
-                                        data-target="#paymentModal"
-                                        data-bind="click: triggerPayment">
-                                    <i class="icon-plus"></i>
-                                    {% trans 'Add Credit' %}
-                                </button>
-                            {% else %}
-                                <span class="label">
-                                    <i class="icon-info-sign"></i>
-                                    {% trans "Not Billing Admin, Can't Add Credit" %}
-                                </span>
-                            {% endif %}
-                        </td>
                         {% endif %}
                     </tr>
                 </tbody>

--- a/corehq/apps/domain/templates/domain/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/current_subscription.html
@@ -4,6 +4,7 @@
 {% load i18n %}
 
 {% block js %}{{ block.super }}
+    <script type="text/javascript" src="{% static 'style/ko/knockout_bindings.ko.js' %}"></script>
     <script type="text/javascript" src="{% static 'accounting/ko/accounting.payment_method_handler.js' %}"></script>
     <script type="text/javascript" src="{% static 'accounting/ko/accounting.credits.js' %}"></script>
     <script type="text/javascript" src="https://js.stripe.com/v2/"></script>
@@ -120,25 +121,6 @@
                                       data-bind="text: amount"></span>
                             </div>
                         </div>
-                        <div class="control-group">
-                            <div class="controls">
-                                {% if can_purchase_credits and not plan.is_trial %}
-                                <button type="button"
-                                        class="btn btn-success"
-                                        data-toggle="modal"
-                                        data-target="#paymentModal"
-                                        data-bind="click: triggerPayment"
-                                >
-                                    {% trans 'Prepay by Credit Card' %}
-                                </button>
-                                {% else %}
-                                <span class="label">
-                                    <i class="icon-info-sign"></i>
-                                    {% trans "Not Billing Admin, Can't Add Credit" %}
-                                </span>
-                                {% endif %}
-                            </div>
-                        </div>
                     </div>
                     {% if plan.general_credit and plan.general_credit.is_visible %}
                         <div class="control-group">
@@ -188,6 +170,27 @@
                             </div>
                         </div>
                     {% endif %}
+                    <div data-bind="with: prepayments">
+                        <div class="control-group">
+                            <div class="controls">
+                                {% if can_purchase_credits and not plan.is_trial %}
+                                <button type="button"
+                                class="btn btn-success"
+                                data-toggle="modal"
+                                data-target="#paymentModal"
+                                data-bind="click: triggerPayment"
+                                >
+                                {% trans 'Prepay by Credit Card' %}
+                                </button>
+                                {% else %}
+                                <span class="label">
+                                    <i class="icon-info-sign"></i>
+                                    {% trans "Not Billing Admin, Can't Add Credit" %}
+                                </span>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
                 {% endif %}
             </div>
             <h2>{% trans 'Usage Summary' %}</h2>
@@ -228,48 +231,39 @@
             <div class="control-group">
                 One credit is equivalent to one USD.
             </div>
-
-            <div class="control-group">
-                <label class="control-label">
-                    {% trans 'Plan Credits' %}
-                </label>
-                <div class="controls">
-                    <div class="input-prepend">
-                        <span class="add-on">$</span>
-                        <input type="text"
-                               class="input-small"
-                               name="plan_credit"
-                               data-bind="value: plan_credit" />
+            <div data-bind="foreach: products">
+                <div class="control-group">
+                    <label class="control-label">
+                        {% trans 'Plan Credits for ' %}
+                        <strong><span data-bind="text: name"></span></strong>
+                    </label>
+                    <div class="controls">
+                        <div class="input-prepend">
+                            <span class="add-on">$</span>
+                            <input type="text"
+                                   class="input-small"
+                                   data-bind="
+                                   attr:{name: creditType},
+                                   numericValue: addAmount" />
+                        </div>
                     </div>
                 </div>
             </div>
 
-            <div class="control-group">
-                <label class="control-label">
-                    {% trans 'SMS Credits' %}
-                </label>
-                <div class="controls">
-                    <div class="input-prepend">
-                        <span class="add-on">$</span>
-                        <input type="text"
-                               class="input-small"
-                               name="sms_credit"
-                               data-bind="value: sms_credit" />
-                    </div>
-                </div>
-            </div>
-
-            <div class="control-group">
-                <label class="control-label">
-                    {% trans 'Mobile Worker Credits' %}
-                </label>
-                <div class="controls">
-                    <div class="input-prepend">
-                        <span class="add-on">$</span>
-                        <input type="text"
-                               class="input-small"
-                               name="user_credit"
-                               data-bind="value: user_credit" />
+            <div data-bind="foreach: features">
+                <div class="control-group">
+                    <label class="control-label">
+                        <span data-bind="text: name"></span>
+                    </label>
+                    <div class="controls">
+                        <div class="input-prepend">
+                            <span class="add-on">$</span>
+                            <input type="text"
+                                   class="input-small"
+                                   data-bind="
+                                   attr:{name: creditType},
+                                   numericValue: addAmount" />
+                        </div>
                     </div>
                 </div>
             </div>
@@ -281,17 +275,9 @@
                 <div class="controls">
                     <div>
                         <span class="add-on">$</span>
-                        <span>9</span>
+                        <span data-bind="text: amount()"></span>
                     </div>
                 </div>
-{#                <div class="controls">#}
-{#                    <div class="input-prepend">#}
-{#                        <span class="add-on">$</span>#}
-{#                        <input type="text"#}
-{#                               class="input-small"#}
-{#                               data-bind="value: total_credit" />#}
-{#                    </div>#}
-{#                </div>#}
             </div>
         </fieldset>
     </script>

--- a/corehq/apps/domain/templates/domain/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/current_subscription.html
@@ -290,8 +290,12 @@
             </span>
         </h3>
     </script>
+
+    <script type="text/html" id="payment-complete-template">
+        {% trans "Thank you for your payment!" %}
+    </script>
 {% endblock %}
 
 {% block modals %}{{ block.super }}
-    {% include 'domain/partials/payment_modal.html' with payment_modal_id="paymentModal" title_template="payment-method-modal-title" cost_item_template="cost-item-template" %}
+    {% include 'domain/partials/payment_modal.html' with payment_modal_id="paymentModal" title_template="payment-method-modal-title" cost_item_template="cost-item-template" payment_complete_template="payment-complete-template" %}
 {% endblock %}

--- a/corehq/apps/domain/templates/domain/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/current_subscription.html
@@ -120,6 +120,25 @@
                                       data-bind="text: amount"></span>
                             </div>
                         </div>
+                        <div class="control-group">
+                            <div class="controls">
+                                {% if can_purchase_credits and not plan.is_trial %}
+                                <button type="button"
+                                        class="btn btn-success"
+                                        data-toggle="modal"
+                                        data-target="#paymentModal"
+                                        data-bind="click: triggerPayment"
+                                >
+                                    {% trans 'Prepay by Credit Card' %}
+                                </button>
+                                {% else %}
+                                <span class="label">
+                                    <i class="icon-info-sign"></i>
+                                    {% trans "Not Billing Admin, Can't Add Credit" %}
+                                </span>
+                                {% endif %}
+                            </div>
+                        </div>
                     </div>
                     {% if plan.general_credit and plan.general_credit.is_visible %}
                         <div class="control-group">
@@ -201,58 +220,86 @@
     {% include 'accounting/partials/stripe_card_ko_template.html' %}
 
     <script type="text/html" id="cost-item-template">
-        <p data-bind="visible: isPlanCredit">
-            {% blocktrans %}
-            <strong>Plan Credits</strong> are only applied toward the monthly
-            fee of your plan, and are not used toward charges related to SMS or
-            User usage fees. One credit is equivalent to one USD.
-            {% endblocktrans %}
-        </p>
-        <p data-bind="visible: isSMSCredit">
-            {% blocktrans %}
-            <strong>SMS Credits</strong> are applied to SMS fees for messages
-            that exceed your plan's monthly limit. One credit is equivalent
-            to one USD. SMS fees vary depending on country,
-            cellular network, and whether you are using a Dimagi gateway.
-            <a href="{{ sms_rate_calc_url }}" target="_blank">Learn more about our SMS charges.</a>
-            {% endblocktrans %}
-        </p>
-        <p data-bind="visible: isUserCredit">
-            {% blocktrans %}
-            One <strong>Mobile Worker Credit</strong> is equivalent to one USD,
-            which is the monthly cost of a CommCare Mobile Worker. For example,
-            if you purchase 50 Mobile Worker Credits, you will cover an additional
-            50 users for one month, or 25 users for two months, etc.
-            {% endblocktrans %}
-        </p>
-        <div class="control-group">
-            <input type="hidden"
-                   data-bind="attr: {name: category}, value: creditType" />
-            <label class="control-label">
-                {% trans 'Credit Amount' %}
-            </label>
-            <div class="controls">
-                <div class="input-prepend">
-                    <span class="add-on">$</span>
-                    <input type="text"
-                           class="input-small"
-                           name="amount"
-                           data-bind="value: amount" />
+        <fieldset>
+            <legend>
+                {% trans 'Prepayment Amount' %}
+            </legend>
+
+            <div class="control-group">
+                One credit is equivalent to one USD.
+            </div>
+
+            <div class="control-group">
+                <label class="control-label">
+                    {% trans 'Plan Credits' %}
+                </label>
+                <div class="controls">
+                    <div class="input-prepend">
+                        <span class="add-on">$</span>
+                        <input type="text"
+                               class="input-small"
+                               name="plan_credit"
+                               data-bind="value: plan_credit" />
+                    </div>
                 </div>
             </div>
-        </div>
+
+            <div class="control-group">
+                <label class="control-label">
+                    {% trans 'SMS Credits' %}
+                </label>
+                <div class="controls">
+                    <div class="input-prepend">
+                        <span class="add-on">$</span>
+                        <input type="text"
+                               class="input-small"
+                               name="sms_credit"
+                               data-bind="value: sms_credit" />
+                    </div>
+                </div>
+            </div>
+
+            <div class="control-group">
+                <label class="control-label">
+                    {% trans 'Mobile Worker Credits' %}
+                </label>
+                <div class="controls">
+                    <div class="input-prepend">
+                        <span class="add-on">$</span>
+                        <input type="text"
+                               class="input-small"
+                               name="user_credit"
+                               data-bind="value: user_credit" />
+                    </div>
+                </div>
+            </div>
+
+            <div class="control-group">
+                <label class="control-label">
+                    {% trans 'Total Credits' %}
+                </label>
+                <div class="controls">
+                    <div>
+                        <span class="add-on">$</span>
+                        <span>9</span>
+                    </div>
+                </div>
+{#                <div class="controls">#}
+{#                    <div class="input-prepend">#}
+{#                        <span class="add-on">$</span>#}
+{#                        <input type="text"#}
+{#                               class="input-small"#}
+{#                               data-bind="value: total_credit" />#}
+{#                    </div>#}
+{#                </div>#}
+            </div>
+        </fieldset>
     </script>
 
     <script type="text/html" id="payment-method-modal-title">
         <h3>
-            <span data-bind="visible: isPlanCredit">
-                {% trans 'Add Plan Credit' %}
-            </span>
-            <span data-bind="visible: isSMSCredit">
-                {% trans 'Add SMS Credit' %}
-            </span>
-            <span data-bind="visible: isUserCredit">
-                {% trans 'Add Mobile Worker Credit' %}
+            <span>
+                {% trans 'Prepay by Credit Card' %}
             </span>
         </h3>
     </script>

--- a/corehq/apps/domain/templates/domain/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/current_subscription.html
@@ -243,8 +243,9 @@
                             <input type="text"
                                    class="input-small"
                                    name="product_credits"
-                                   data-bind="numericValue: addAmount" />
-                            <input type="hidden" name="product_type" data-bind="value: creditType" />
+                                   data-bind="
+                                   attr:{name: creditType},
+                                   numericValue: addAmount" />
                         </div>
                     </div>
                 </div>

--- a/corehq/apps/domain/templates/domain/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/current_subscription.html
@@ -242,9 +242,9 @@
                             <span class="add-on">$</span>
                             <input type="text"
                                    class="input-small"
-                                   data-bind="
-                                   attr:{name: creditType},
-                                   numericValue: addAmount" />
+                                   name="product_credits"
+                                   data-bind="numericValue: addAmount" />
+                            <input type="hidden" name="product_type" data-bind="value: creditType" />
                         </div>
                     </div>
                 </div>
@@ -279,6 +279,7 @@
                     </div>
                 </div>
             </div>
+            <input type="hidden" name="amount" data-bind="value: amount" />
         </fieldset>
     </script>
 

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1066,8 +1066,7 @@ class CreditsStripePaymentView(BaseStripePaymentView):
             self.get_or_create_payment_method(),
             self.account,
             subscription=Subscription.get_subscribed_plan_by_domain(self.domain_object)[1],
-            product_type=self.request.POST.get('product'),
-            feature_type=self.request.POST.get('feature'),
+            post_data=self.request.POST.copy(),
         )
 
 


### PR DESCRIPTION
Part one of prepayements: 
https://trello.com/c/tdPln28v/427-billing-wire-prepayments
https://docs.google.com/document/d/1sV5fxBSGIuODBU232TB18YDOQa4w7Z8wENiffKyLkZM/edit
https://confluence.dimagi.com/display/internal/Prepayments+Mockup

This implements the new prepayment UI for credit cards. 
Wire prepayments coming in a later PR. 

![cc_prepay](https://cloud.githubusercontent.com/assets/146896/8315177/a8ca1f60-19bc-11e5-80a1-bebf3c7b7106.gif)

code buddy: @millerdev 
cc: @nickpell 
