### PR TITLE
EWS: Added domain filtering

### DIFF
--- a/custom/ewsghana/reports/__init__.py
+++ b/custom/ewsghana/reports/__init__.py
@@ -242,7 +242,8 @@ class MultiReport(MonthWeekMixin, CustomProjectReport, CommtrackReportMixin, Pro
                 self.report_location.get_descendants().exclude(
                     supply_point_id__isnull=True
                 ).values_list('supply_point_id', flat=True)),
-            report__date__range=[self.report_config['startdate'], self.report_config['enddate']]
+            report__date__range=[self.report_config['startdate'], self.report_config['enddate']],
+            report__domain=self.domain
         ).order_by('report__date', 'pk')
 
     @classmethod


### PR DESCRIPTION
@czue @esoergel I noticed that planner decide to first fetch all reports in date range. On my local machine it doesn't make a difference because my stock report table mostly contains record from ews domain but on prod situation is different. I'm not sure that this improve performance on production but I think it's worth to try.
