### PR TITLE
rewrite trivial views

### DIFF
--- a/corehq/apps/cloudcare/dbaccessors.py
+++ b/corehq/apps/cloudcare/dbaccessors.py
@@ -1,0 +1,15 @@
+from corehq.apps.cloudcare.models import ApplicationAccess
+
+
+def get_application_access_for_domain(domain):
+    """
+    there should only be one ApplicationAccess per domain,
+    return it if found, otherwise None.
+
+    if more than one is found, one is arbitrarily returned.
+    """
+    return ApplicationAccess.view(
+        'cloudcare/application_access',
+        key=domain,
+        include_docs=True
+    ).first()

--- a/corehq/apps/cloudcare/dbaccessors.py
+++ b/corehq/apps/cloudcare/dbaccessors.py
@@ -9,7 +9,9 @@ def get_application_access_for_domain(domain):
     if more than one is found, one is arbitrarily returned.
     """
     return ApplicationAccess.view(
-        'cloudcare/application_access',
-        key=domain,
-        include_docs=True
+        'domain/docs',
+        startkey=[domain, 'ApplicationAccess'],
+        endkey=[domain, 'ApplicationAccess', {}],
+        include_docs=True,
+        reduce=False,
     ).first()

--- a/corehq/apps/cloudcare/models.py
+++ b/corehq/apps/cloudcare/models.py
@@ -1,10 +1,8 @@
 from couchdbkit import ResourceNotFound
 from dimagi.ext.couchdbkit import (
     BooleanProperty,
-    DictProperty,
     Document,
     DocumentSchema,
-    Property,
     SchemaListProperty,
     StringProperty,
 )
@@ -78,10 +76,9 @@ class ApplicationAccess(Document):
 
     @classmethod
     def get_by_domain(cls, domain):
-        self = cls.view('cloudcare/application_access',
-            key=domain,
-            include_docs=True
-        ).first()
+        from corehq.apps.cloudcare.dbaccessors import \
+            get_application_access_for_domain
+        self = get_application_access_for_domain(domain)
         return self or cls(domain=domain)
 
     def user_can_access_app(self, user, app):

--- a/corehq/apps/cloudcare/tests/__init__.py
+++ b/corehq/apps/cloudcare/tests/__init__.py
@@ -1,1 +1,2 @@
 from .test_api import *
+from .test_dbaccessors import *

--- a/corehq/apps/cloudcare/tests/test_dbaccessors.py
+++ b/corehq/apps/cloudcare/tests/test_dbaccessors.py
@@ -1,0 +1,27 @@
+from django.test import TestCase
+from corehq.apps.cloudcare.dbaccessors import get_application_access_for_domain
+from corehq.apps.cloudcare.models import ApplicationAccess
+
+
+class DBAccessorsTest(TestCase):
+    def test_get_application_access_for_domain(self):
+        application_access_objects = []
+        domain = 'application-access-dbaccessors'
+        try:
+            self.assertIsNone(get_application_access_for_domain(domain))
+            o = ApplicationAccess(domain=domain)
+            o.save()
+            application_access_objects.append(o)
+            self.assertEqual(
+                o.to_json(),
+                get_application_access_for_domain(domain).to_json()
+            )
+            o = ApplicationAccess(domain=domain)
+            o.save()
+            application_access_objects.append(o)
+            self.assertIn(
+                get_application_access_for_domain(domain).to_json(),
+                [o.to_json() for o in application_access_objects]
+            )
+        finally:
+            ApplicationAccess.get_db().bulk_delete(application_access_objects)

--- a/corehq/apps/facilities/dbaccessors.py
+++ b/corehq/apps/facilities/dbaccessors.py
@@ -3,8 +3,9 @@ from corehq.apps.facilities.models import FacilityRegistry
 
 def get_facility_registries_in_domain(domain):
     return FacilityRegistry.view(
-        'facilities/registries_by_domain',
+        'domain/docs',
         reduce=False,
-        key=domain,
+        startkey=[domain, 'FacilityRegistry'],
+        endkey=[domain, 'FacilityRegistry', {}],
         include_docs=True,
     ).all()

--- a/corehq/apps/facilities/dbaccessors.py
+++ b/corehq/apps/facilities/dbaccessors.py
@@ -1,0 +1,10 @@
+from corehq.apps.facilities.models import FacilityRegistry
+
+
+def get_facility_registries_in_domain(domain):
+    return FacilityRegistry.view(
+        'facilities/registries_by_domain',
+        reduce=False,
+        key=domain,
+        include_docs=True,
+    ).all()

--- a/corehq/apps/facilities/tests.py
+++ b/corehq/apps/facilities/tests.py
@@ -1,0 +1,28 @@
+from django.test import TestCase
+from corehq.apps.facilities.dbaccessors import \
+    get_facility_registries_in_domain
+from corehq.apps.facilities.models import FacilityRegistry
+
+
+class DBAccessorsTest(TestCase):
+    def test_get_facility_registries_in_domain(self):
+        objects = []
+        domain = 'facility-registry-dbaccessors'
+        try:
+            self.assertEqual(get_facility_registries_in_domain(domain), [])
+            o = FacilityRegistry(domain=domain)
+            o.save()
+            objects.append(o)
+            self.assertItemsEqual(
+                [o.to_json() for o in get_facility_registries_in_domain(domain)],
+                [o.to_json() for o in objects],
+            )
+            o = FacilityRegistry(domain=domain)
+            o.save()
+            objects.append(o)
+            self.assertItemsEqual(
+                [o.to_json() for o in get_facility_registries_in_domain(domain)],
+                [o.to_json() for o in objects],
+            )
+        finally:
+            FacilityRegistry.get_db().bulk_delete(objects)

--- a/corehq/apps/fixtures/dbaccessors.py
+++ b/corehq/apps/fixtures/dbaccessors.py
@@ -1,0 +1,20 @@
+from corehq.apps.fixtures.models import FixtureDataType
+
+
+def get_number_of_fixture_data_types_in_domain(domain):
+    num_fixtures = FixtureDataType.get_db().view(
+        'fixtures/data_types_by_domain',
+        reduce=True,
+        key=domain,
+    ).first()
+    return num_fixtures['value'] if num_fixtures is not None else 0
+
+
+def get_fixture_data_types_in_domain(domain):
+    return FixtureDataType.view(
+        'fixtures/data_types_by_domain',
+        key=domain,
+        reduce=False,
+        include_docs=True,
+        descending=True,
+    )

--- a/corehq/apps/fixtures/dbaccessors.py
+++ b/corehq/apps/fixtures/dbaccessors.py
@@ -3,17 +3,20 @@ from corehq.apps.fixtures.models import FixtureDataType
 
 def get_number_of_fixture_data_types_in_domain(domain):
     num_fixtures = FixtureDataType.get_db().view(
-        'fixtures/data_types_by_domain',
+        'domain/docs',
+        startkey=[domain, 'FixtureDataType'],
+        endkey=[domain, 'FixtureDataType', {}],
         reduce=True,
-        key=domain,
+        group_level=2,
     ).first()
     return num_fixtures['value'] if num_fixtures is not None else 0
 
 
 def get_fixture_data_types_in_domain(domain):
     return FixtureDataType.view(
-        'fixtures/data_types_by_domain',
-        key=domain,
+        'domain/docs',
+        endkey=[domain, 'FixtureDataType'],
+        startkey=[domain, 'FixtureDataType', {}],
         reduce=False,
         include_docs=True,
         descending=True,

--- a/corehq/apps/fixtures/models.py
+++ b/corehq/apps/fixtures/models.py
@@ -49,16 +49,15 @@ class FixtureDataType(Document):
 
     @classmethod
     def total_by_domain(cls, domain):
-        num_fixtures = FixtureDataType.get_db().view(
-            'fixtures/data_types_by_domain',
-            reduce=True,
-            key=domain,
-        ).first()
-        return num_fixtures['value'] if num_fixtures is not None else 0
+        from corehq.apps.fixtures.dbaccessors import \
+            get_number_of_fixture_data_types_in_domain
+        return get_number_of_fixture_data_types_in_domain(domain)
 
     @classmethod
     def by_domain(cls, domain):
-        return cls.view('fixtures/data_types_by_domain', key=domain, reduce=False, include_docs=True, descending=True)
+        from corehq.apps.fixtures.dbaccessors import \
+            get_fixture_data_types_in_domain
+        return get_fixture_data_types_in_domain(domain)
 
     @classmethod
     def by_domain_tag(cls, domain, tag):

--- a/corehq/apps/reminders/dbaccessors.py
+++ b/corehq/apps/reminders/dbaccessors.py
@@ -1,0 +1,8 @@
+def get_surveys_in_domain(domain):
+    from corehq.apps.reminders.models import Survey
+    return Survey.view(
+        'reminders/survey_by_domain',
+        startkey=[domain],
+        endkey=[domain, {}],
+        include_docs=True
+    ).all()

--- a/corehq/apps/reminders/dbaccessors.py
+++ b/corehq/apps/reminders/dbaccessors.py
@@ -1,8 +1,9 @@
 def get_surveys_in_domain(domain):
     from corehq.apps.reminders.models import Survey
-    return Survey.view(
-        'reminders/survey_by_domain',
-        startkey=[domain],
-        endkey=[domain, {}],
-        include_docs=True
-    ).all()
+    return sorted(Survey.view(
+        'domain/docs',
+        startkey=[domain, 'Survey'],
+        endkey=[domain, 'Survey', {}],
+        include_docs=True,
+        reduce=False,
+    ), key=lambda survey: survey.name)

--- a/corehq/apps/reminders/models.py
+++ b/corehq/apps/reminders/models.py
@@ -4,6 +4,7 @@ from datetime import timedelta, datetime, date, time
 import re
 from corehq.apps.casegroups.models import CommCareCaseGroup
 from corehq.apps.hqcase.dbaccessors import get_case_ids_in_domain
+from corehq.apps.reminders.dbaccessors import get_surveys_in_domain
 from dimagi.ext.couchdbkit import *
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.sms.models import CommConnectCase
@@ -1506,6 +1507,7 @@ class SurveyWave(DocumentSchema):
                 return True
         return False
 
+
 class Survey(Document):
     domain = StringProperty()
     name = StringProperty()
@@ -1514,24 +1516,20 @@ class Survey(Document):
     samples = ListProperty(DictProperty)
     send_automatically = BooleanProperty()
     send_followup = BooleanProperty()
-    
+
     @classmethod
     def get_all(cls, domain):
-        return cls.view('reminders/survey_by_domain',
-            startkey=[domain],
-            endkey=[domain, {}],
-            include_docs=True
-        ).all()
-    
+        return get_surveys_in_domain(domain)
+
     def has_started(self):
         for wave in self.waves:
             if wave.has_started(self):
                 return True
         return False
-    
+
     def update_delegation_tasks(self, submitting_user_id):
         utcnow = datetime.utcnow()
-        
+
         # Get info about each CATI sample and the instance of that sample used for this survey
         cati_sample_data = {}
         for sample_json in self.samples:

--- a/corehq/apps/reminders/tests/__init__.py
+++ b/corehq/apps/reminders/tests/__init__.py
@@ -1,4 +1,4 @@
-from casexml.apps.case.models import CommCareCase
+from django.test import TestCase
 from casexml.apps.case.sharedmodels import CommCareCaseIndex
 from corehq.apps.accounting.models import (
     BillingAccount,
@@ -8,6 +8,7 @@ from corehq.apps.accounting.models import (
     SubscriptionAdjustment,
 )
 from corehq.apps.accounting.tests import BaseAccountingTest
+from corehq.apps.reminders.dbaccessors import get_surveys_in_domain
 from corehq.apps.reminders.models import *
 from corehq.apps.reminders.event_handlers import get_message_template_params
 from corehq.apps.users.models import CommCareUser
@@ -1155,3 +1156,31 @@ class MessageTestCase(BaseReminderTestCase):
         parent_result["case"]["parent"] = {}
         self.assertEqual(
             get_message_template_params(self.parent_case), parent_result)
+
+
+class DBAccessorsTest(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.domain = 'reminders-dbaccessor'
+        cls.surveys = [
+            Survey(domain=cls.domain, name='B'),
+            Survey(domain=cls.domain, name='D'),
+            Survey(domain=cls.domain, name='E'),
+            Survey(domain=cls.domain, name='C'),
+            Survey(domain=cls.domain, name='A'),
+            Survey(domain='other', name='FOO'),
+        ]
+        Survey.get_db().bulk_save(cls.surveys)
+
+    @classmethod
+    def tearDownClass(cls):
+        Survey.get_db().bulk_delete(cls.surveys)
+
+    def test_get_surveys_in_domain(self):
+        self.assertEqual(
+            [survey.to_json()
+             for survey in get_surveys_in_domain(self.domain)],
+            [survey.to_json()
+             for survey in sorted(self.surveys, key=lambda s: s.name)
+             if survey.domain == self.domain],
+        )

--- a/corehq/apps/sms/dbaccessors.py
+++ b/corehq/apps/sms/dbaccessors.py
@@ -1,0 +1,9 @@
+from corehq.apps.sms.models import ForwardingRule
+
+
+def get_forwarding_rules_for_domain(domain):
+    return ForwardingRule.view(
+        "sms/forwarding_rule",
+        key=[domain],
+        include_docs=True,
+    ).all()

--- a/corehq/apps/sms/dbaccessors.py
+++ b/corehq/apps/sms/dbaccessors.py
@@ -3,7 +3,9 @@ from corehq.apps.sms.models import ForwardingRule
 
 def get_forwarding_rules_for_domain(domain):
     return ForwardingRule.view(
-        "sms/forwarding_rule",
-        key=[domain],
+        "domain/docs",
+        startkey=[domain, 'ForwardingRule'],
+        endkey=[domain, 'ForwardingRule', {}],
         include_docs=True,
+        reduce=False,
     ).all()

--- a/corehq/apps/sms/handlers/forwarding.py
+++ b/corehq/apps/sms/handlers/forwarding.py
@@ -1,11 +1,10 @@
-from corehq.apps.sms.models import (
-    ForwardingRule, FORWARD_ALL, FORWARD_BY_KEYWORD,
-)
+from corehq.apps.sms.dbaccessors import get_forwarding_rules_for_domain
+from corehq.apps.sms.models import FORWARD_ALL, FORWARD_BY_KEYWORD
 from corehq.apps.sms.api import send_sms_with_backend
 
+
 def forwarding_handler(v, text, msg):
-    rules = ForwardingRule.view("sms/forwarding_rule",
-        key=[v.domain], include_docs=True).all()
+    rules = get_forwarding_rules_for_domain(v.domain)
     text_words = text.upper().split()
     keyword_to_match = text_words[0] if len(text_words) > 0 else ""
     for rule in rules:
@@ -20,4 +19,3 @@ def forwarding_handler(v, text, msg):
                 rule.backend_id)
             return True
     return False
-

--- a/corehq/apps/sms/tests/__init__.py
+++ b/corehq/apps/sms/tests/__init__.py
@@ -1,3 +1,19 @@
+#from .inbound_handlers import *
+from .opt_tests import *
+from .migration import *
+from .test_dbaccessors import *
+
+from corehq.apps.domain.calculations import num_mobile_users
+from corehq.apps.sms.api import send_sms_to_verified_number, send_sms_with_backend, send_sms_with_backend_name
+from corehq.apps.sms.mixin import SMSBackend, BadSMSConfigException, MobileBackend
+from corehq.apps.sms.models import CommConnectCase
+from dimagi.ext.couchdbkit import *
+from couchdbkit.exceptions import ResourceNotFound
+from casexml.apps.case.models import CommCareCase
+from corehq.apps.users.models import CommCareUser
+from django.contrib.sites.models import Site
+from corehq.apps.users.util import format_username
+from django.conf import settings
 from corehq.apps.accounting import generator
 from corehq.apps.accounting.models import (
     BillingAccount,
@@ -7,24 +23,11 @@ from corehq.apps.accounting.models import (
     SubscriptionAdjustment,
 )
 from corehq.apps.accounting.tests import BaseAccountingTest
-from corehq.apps.domain.calculations import num_mobile_users
-from corehq.apps.sms.api import send_sms_to_verified_number, send_sms_with_backend, send_sms_with_backend_name
-from corehq.apps.sms.mixin import SMSBackend, BadSMSConfigException, MobileBackend
-from corehq.apps.sms.models import CommConnectCase
-from django.conf import settings
-from dimagi.ext.couchdbkit import *
-from couchdbkit.exceptions import ResourceNotFound
-from casexml.apps.case.models import CommCareCase
-#from .inbound_handlers import *
-from .opt_tests import *
-from .migration import *
-from corehq.apps.users.models import CommCareUser
-from django.contrib.sites.models import Site
-from corehq.apps.users.util import format_username
 
 
 class BackendInvocationDoc(Document):
     pass
+
 
 class TestCaseBackend(SMSBackend):
 

--- a/corehq/apps/sms/tests/test_dbaccessors.py
+++ b/corehq/apps/sms/tests/test_dbaccessors.py
@@ -1,0 +1,27 @@
+from django.test import TestCase
+from corehq.apps.sms.dbaccessors import get_forwarding_rules_for_domain
+from corehq.apps.sms.models import ForwardingRule
+
+
+class DBAccessorsTest(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.domain = 'forwarding-rules-dbaccessors'
+        cls.forwarding_rules = [
+            ForwardingRule(domain=cls.domain),
+            ForwardingRule(domain=cls.domain),
+            ForwardingRule(domain='other'),
+        ]
+        ForwardingRule.get_db().bulk_save(cls.forwarding_rules)
+
+    @classmethod
+    def tearDownClass(cls):
+        ForwardingRule.get_db().bulk_delete(cls.forwarding_rules)
+
+    def test_get_forwarding_rules_for_domain(self):
+        self.assertItemsEqual(
+            [rule.to_json()
+             for rule in get_forwarding_rules_for_domain(self.domain)],
+            [rule.to_json() for rule in self.forwarding_rules
+             if rule.domain == self.domain]
+        )

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -29,6 +29,7 @@ from corehq.apps.sms.api import (
 )
 from corehq.apps.domain.views import BaseDomainView
 from corehq.apps.hqwebapp.views import CRUDPaginatedViewMixin
+from corehq.apps.sms.dbaccessors import get_forwarding_rules_for_domain
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import CouchUser, Permissions, CommCareUser
 from corehq.apps.users import models as user_models
@@ -405,10 +406,11 @@ def api_send_sms(request, domain):
     else:
         return HttpResponseBadRequest("POST Expected.")
 
+
 @login_and_domain_required
 @require_superuser
 def list_forwarding_rules(request, domain):
-    forwarding_rules = ForwardingRule.view("sms/forwarding_rule", key=[domain], include_docs=True).all()
+    forwarding_rules = get_forwarding_rules_for_domain(domain)
 
     context = {
         "domain" : domain,

--- a/corehq/apps/userreports/dbaccessors.py
+++ b/corehq/apps/userreports/dbaccessors.py
@@ -1,10 +1,37 @@
-def get_report_configs_by_data_source(domain, data_source_id):
+from dimagi.utils.couch.database import iter_docs
+
+
+def get_number_of_report_configs_by_data_source(domain, data_source_id):
     """
     Return the number of report configurations that use the given data source.
     """
-    from corehq.apps.userreports.models import DataSourceConfiguration
-    return DataSourceConfiguration.view(
+    from corehq.apps.userreports.models import ReportConfiguration
+    return ReportConfiguration.view(
         'userreports/report_configs_by_data_source',
         reduce=True,
         key=[domain, data_source_id]
     ).one()['value']
+
+
+def get_all_report_configs():
+    from corehq.apps.userreports.models import ReportConfiguration
+    ids = [res['id'] for res in ReportConfiguration.view(
+        'userreports/report_configs_by_domain',
+        reduce=False,
+        include_docs=False,
+    )]
+    for result in iter_docs(ReportConfiguration.get_db(), ids):
+        yield ReportConfiguration.wrap(result)
+
+
+def get_report_configs_for_domain(domain):
+    from corehq.apps.userreports.models import ReportConfiguration
+    return sorted(
+        ReportConfiguration.view(
+            'userreports/report_configs_by_domain',
+            key=domain,
+            reduce=False,
+            include_docs=True,
+        ),
+        key=lambda report: report.title,
+    )

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -12,7 +12,8 @@ from dimagi.ext.couchdbkit import (
 from dimagi.ext.couchdbkit import StringProperty, DictProperty, ListProperty, IntegerProperty
 from dimagi.ext.jsonobject import JsonObject
 from corehq.apps.cachehq.mixins import CachedCouchDocumentMixin
-from corehq.apps.userreports.dbaccessors import get_report_configs_by_data_source
+from corehq.apps.userreports.dbaccessors import get_number_of_report_configs_by_data_source, \
+    get_report_configs_for_domain, get_all_report_configs
 from corehq.apps.userreports.exceptions import BadSpecError
 from corehq.apps.userreports.expressions.factory import ExpressionFactory
 from corehq.apps.userreports.filters.factory import FilterFactory
@@ -203,7 +204,7 @@ class DataSourceConfiguration(UnicodeMixIn, CachedCouchDocumentMixin, Document):
         """
         Return the number of ReportConfigurations that reference this data source.
         """
-        return get_report_configs_by_data_source(self.domain, self._id)
+        return get_number_of_report_configs_by_data_source(self.domain, self._id)
 
     def validate(self, required=True):
         super(DataSourceConfiguration, self).validate(required)
@@ -341,17 +342,11 @@ class ReportConfiguration(UnicodeMixIn, CachedCouchDocumentMixin, Document):
 
     @classmethod
     def by_domain(cls, domain):
-        return sorted(
-            cls.view('userreports/report_configs_by_domain', key=domain, reduce=False, include_docs=True),
-            key=lambda report: report.title,
-        )
+        return get_report_configs_for_domain(domain)
 
     @classmethod
     def all(cls):
-        ids = [res['id'] for res in cls.view('userreports/report_configs_by_domain',
-                                             reduce=False, include_docs=False)]
-        for result in iter_docs(cls.get_db(), ids):
-            yield cls.wrap(result)
+        return get_all_report_configs()
 
 
 class CustomDataSourceConfiguration(JsonObject):

--- a/corehq/apps/userreports/tests/__init__.py
+++ b/corehq/apps/userreports/tests/__init__.py
@@ -16,6 +16,7 @@ from .test_report_filters import *
 from .test_transforms import *
 from .test_utils import *
 from .test_view import *
+from .test_dbaccessors import *
 
 from corehq.apps.userreports.expressions.getters import recursive_lookup
 

--- a/corehq/apps/userreports/tests/test_dbaccessors.py
+++ b/corehq/apps/userreports/tests/test_dbaccessors.py
@@ -1,0 +1,49 @@
+from django.test import TestCase
+from corehq import ReportConfiguration
+from corehq.apps.userreports.dbaccessors import get_report_configs_for_domain, \
+    get_all_report_configs, get_number_of_report_configs_by_data_source
+
+
+class DBAccessorsTest(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.data_source_id = 'd36c7c934cb84725899cca9a0ef96e3a'
+        cls.domain = 'userreport-dbaccessors'
+        cls.report_configs = [
+            ReportConfiguration(domain=cls.domain,
+                                config_id=cls.data_source_id, title='A'),
+            ReportConfiguration(domain=cls.domain,
+                                config_id=cls.data_source_id, title='B'),
+            ReportConfiguration(domain=cls.domain,
+                                config_id='asabsdjf', title='C'),
+            ReportConfiguration(domain='mallory',
+                                config_id=cls.data_source_id, title='X'),
+        ]
+        ReportConfiguration.get_db().bulk_save(cls.report_configs)
+
+    @classmethod
+    def tearDownClass(cls):
+        ReportConfiguration.get_db().bulk_delete(cls.report_configs)
+
+    def test_get_number_of_report_configs_by_data_source(self):
+        self.assertEqual(
+            get_number_of_report_configs_by_data_source(
+                self.domain, self.data_source_id),
+            len([report_config for report_config in self.report_configs
+                 if report_config.domain == self.domain
+                 and report_config.config_id == self.data_source_id])
+        )
+
+    def test_get_all_report_configs(self):
+        self.assertItemsEqual(
+            [o.to_json() for o in get_all_report_configs()],
+            [o.to_json() for o in self.report_configs]
+        )
+
+    def test_get_report_configs_for_domain(self):
+        self.assertEqual(
+            [o.to_json() for o in get_report_configs_for_domain(self.domain)],
+            [report_config.to_json() for report_config
+             in sorted(self.report_configs, key=lambda report: report.title)
+             if report_config.domain == self.domain]
+        )


### PR DESCRIPTION
The following views just emit docs of a certain type by domain, which can be trivally replaced by a call to `domain/docs`. I'm going to rewrite them one by one, and then we can delete them in a future PR.
- [x] `cloudcare/application_access`
- [x] `facilities/registries_by_domain`
- [x] `fixtures/data_types_by_domain`
- [x] ~~`userreports/report_configs_by_domain`~~ this is in a different db, so domain/docs doesn't exist, and having an extra view here is way cheaper than in the main db
- [x] ~~`groupexport/by_domain`~~ there's a call that doesn't group by domain (just gets all of them in any domain), which you can't do with domain/docs, so this isn't worth doing
- [x] ~~`commtrack/domain_config`~~ there's a call that doesn't group by domain
- [x] `sms/forwarding_rule`
- [x] ~~`groups/by_domain`~~ this one uses cachehq; I'm don't feel like the way it's done right now is very good to begin with, but I'm going to just leave it be.
- [x] `reminders/survey_by_domain`
