### PR TITLE
Retry `rebuild_indicators()` if it fails

### DIFF
--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -10,7 +10,7 @@ from couchforms.models import XFormInstance
 from dimagi.utils.couch.database import iter_docs
 
 
-@task(queue='background_queue', ignore_result=True)
+@task(queue='background_queue', ignore_result=True, acks_late=True)
 def rebuild_indicators(indicator_config_id):
     is_static = indicator_config_id.startswith(CustomDataSourceConfiguration._datasource_id_prefix)
     if is_static:


### PR DESCRIPTION
As we discussed @czue , it's ok to retry `rebuild_indicators()` if the worker crashes mid execution.
cc @gcapalbo 
