### PR TITLE
fix get_fixture_by_id for multiple item-lists

### DIFF
--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -375,12 +375,9 @@ def get_fixtures(request, domain, user_id, fixture_id=None):
             ret.append(fixture)
         return HttpResponse(ElementTree.tostring(ret), content_type="text/xml")
     else:
-        fixtures = generator.get_fixture_by_id(fixture_id, casexml_user, version=V2)
-        try:
-            fixture = next(fixtures)
-        except StopIteration:
+        fixture = generator.get_fixture_by_id(fixture_id, casexml_user, version=V2)
+        if not fixture:
             raise Http404
-
         assert len(fixture.getchildren()) == 1, 'fixture {} expected 1 child but found {}'.format(
             fixture_id, len(fixture.getchildren())
         )

--- a/corehq/ex-submodules/casexml/apps/phone/fixtures.py
+++ b/corehq/ex-submodules/casexml/apps/phone/fixtures.py
@@ -80,7 +80,10 @@ class FixtureGenerator(object):
         """
         Only get fixtures with the specified ID.
         """
-        return self._get_fixtures(None, fixture_id, user, version, last_sync)
+        fixtures = self._get_fixtures(None, fixture_id, user, version, last_sync)
+        for fixture in fixtures:
+            if fixture.attrib.get("id") == fixture_id:
+                return fixture
 
     def get_fixtures(self, user, version, last_sync=None, group=None):
         """

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_fixtures.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_fixtures.py
@@ -12,6 +12,8 @@ from corehq.apps.users.models import CommCareUser
 from casexml.apps.case.tests.util import check_xml_line_by_line
 
 DOMAIN = 'fixture-test'
+SA_PROVINCES = 'sa_provinces'
+FR_PROVINCES = 'fr_provinces'
 
 
 class OtaFixtureTest(TestCase):
@@ -25,27 +27,10 @@ class OtaFixtureTest(TestCase):
         cls.group2 = Group(domain=DOMAIN, name='group2', case_sharing=True, users=[cls.user._id])
         cls.group2.save()
 
-        cls.data_type = FixtureDataType(
-            domain=DOMAIN,
-            tag="district",
-            name="Districts",
-            fields=[FixtureTypeField(field_name="state_name", properties=[])],
-            item_attributes=[],
-            is_global=True
-        )
-        cls.data_type.save()
-
-        cls.data_item = FixtureDataItem(
-            domain=DOMAIN,
-            data_type_id=cls.data_type.get_id,
-            fields={
-                "state_name": FieldList(
-                    field_list=[FixtureItemField(field_value="Delhi_state", properties={})]
-                )
-            },
-            item_attributes={},
-        )
-        cls.data_item.save()
+        cls.item_lists = {
+            SA_PROVINCES: make_item_lists(SA_PROVINCES, 'western cape'),
+            FR_PROVINCES: make_item_lists(FR_PROVINCES, 'burgundy'),
+        }
 
         cls.casexml_user = cls.user.to_casexml_user()
 
@@ -56,22 +41,33 @@ class OtaFixtureTest(TestCase):
         for user in CommCareUser.all():
             user.delete()
 
-        cls.data_type.delete()
-        cls.data_item.delete()
+        for _, item_list in cls.item_lists.items():
+            item_list[0].delete()
+            item_list[1].delete()
+
         cls.domain.delete()
 
-    def _check_fixture(self, fixture_xml, has_groups=True, has_item_lists=True):
-        fixtures = [ElementTree.tostring(xml) for xml in fixture_xml]
-        expected_len = sum([has_groups, has_item_lists])
-        self.assertEqual(len(fixtures), expected_len)
+    def _check_fixture(self, fixture_xml, has_groups=True, item_lists=None):
+        fixture_xml = list(fixture_xml)
+        item_lists = item_lists or []
+        expected_len = sum([has_groups, len(item_lists)])
+        self.assertEqual(len(fixture_xml), expected_len)
 
         if has_groups:
             expected = _get_group_fixture(self.user.get_id, [self.group1, self.group2])
-            check_xml_line_by_line(self, expected, fixtures[0])
+            check_xml_line_by_line(self, expected, ElementTree.tostring(fixture_xml[0]))
 
-        if has_item_lists:
-            expected = _get_item_list_fixture(self.user.get_id, self.data_type.tag, self.data_item)
-            check_xml_line_by_line(self, expected, fixtures[-1])
+        if item_lists:
+            for i, item_list_tag in enumerate(item_lists):
+                data_type, data_item = self.item_lists[item_list_tag]
+                item_list_xml = [
+                    ElementTree.tostring(fixture)
+                    for fixture in fixture_xml if item_list_tag in fixture.attrib.get("id")
+                ]
+                self.assertEqual(len(item_list_xml), 1)
+
+                expected = _get_item_list_fixture(self.user.get_id, data_type.tag, data_item)
+                check_xml_line_by_line(self, expected, item_list_xml[0])
 
     def test_fixture_gen_v1(self):
         fixture_xml = generator.get_fixtures(self.casexml_user, version=V1)
@@ -79,27 +75,30 @@ class OtaFixtureTest(TestCase):
 
     def test_basic_fixture_generation(self):
         fixture_xml = generator.get_fixtures(self.casexml_user, version=V2)
-        self._check_fixture(fixture_xml)
+        self._check_fixture(fixture_xml, item_lists=[SA_PROVINCES, FR_PROVINCES])
 
     def test_fixtures_by_group(self):
         fixture_xml = generator.get_fixtures(self.casexml_user, version=V2, group='case')
         self.assertEqual(list(fixture_xml), [])
 
         fixture_xml = generator.get_fixtures(self.casexml_user, version=V2, group='standalone')
-        self._check_fixture(fixture_xml)
+        self._check_fixture(fixture_xml, item_lists=[SA_PROVINCES, FR_PROVINCES])
 
     def test_fixtures_by_id(self):
         fixture_xml = generator.get_fixture_by_id('user-groups', self.casexml_user, version=V2)
-        self._check_fixture(fixture_xml, has_item_lists=False)
+        self._check_fixture(fixture_xml)
 
-        fixture_xml = generator.get_fixture_by_id('item-list:district', self.casexml_user, version=V2)
-        self._check_fixture(fixture_xml, has_groups=False)
+        fixture_xml = generator.get_fixture_by_id('item-list:sa_provinces', self.casexml_user, version=V2)
+        self._check_fixture(fixture_xml, has_groups=False, item_lists=[SA_PROVINCES])
+
+        fixture_xml = generator.get_fixture_by_id('item-list:fr_provinces', self.casexml_user, version=V2)
+        self._check_fixture(fixture_xml, has_groups=False, item_lists=[FR_PROVINCES])
 
         fixture_xml = generator.get_fixture_by_id('user-locations', self.casexml_user, version=V2)
-        self.assertEqual(list(fixture_xml), [])
+        self.assertIsNone(fixture_xml)
 
         fixture_xml = generator.get_fixture_by_id('bad ID', self.casexml_user, version=V2)
-        self.assertEqual(list(fixture_xml), [])
+        self.assertIsNone(fixture_xml)
 
 
 def _get_group_fixture(user_id, groups):
@@ -126,9 +125,9 @@ def _get_group_fixture(user_id, groups):
 def _get_item_list_fixture(user_id, tag, fixture_item):
     template = """
     <fixture id="item-list:{tag}" user_id="{user_id}">
-      <district_list>
+      <{tag}_list>
         {item_xml}
-      </district_list>
+      </{tag}_list>
     </fixture>
     """
     return template.format(
@@ -136,3 +135,28 @@ def _get_item_list_fixture(user_id, tag, fixture_item):
         tag=tag,
         item_xml=ElementTree.tostring(fixture_item.to_xml())
     )
+
+
+def make_item_lists(tag, item_name):
+    data_type = FixtureDataType(
+        domain=DOMAIN,
+        tag=tag,
+        name="Provinces",
+        fields=[FixtureTypeField(field_name="name", properties=[])],
+        item_attributes=[],
+        is_global=True
+    )
+    data_type.save()
+
+    data_item = FixtureDataItem(
+        domain=DOMAIN,
+        data_type_id=data_type.get_id,
+        fields={
+            "name": FieldList(
+                field_list=[FixtureItemField(field_value=item_name, properties={})]
+            )
+        },
+        item_attributes={},
+    )
+    data_item.save()
+    return data_type, data_item

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_fixtures.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_fixtures.py
@@ -86,13 +86,13 @@ class OtaFixtureTest(TestCase):
 
     def test_fixtures_by_id(self):
         fixture_xml = generator.get_fixture_by_id('user-groups', self.casexml_user, version=V2)
-        self._check_fixture(fixture_xml)
+        self._check_fixture([fixture_xml])
 
         fixture_xml = generator.get_fixture_by_id('item-list:sa_provinces', self.casexml_user, version=V2)
-        self._check_fixture(fixture_xml, has_groups=False, item_lists=[SA_PROVINCES])
+        self._check_fixture([fixture_xml], has_groups=False, item_lists=[SA_PROVINCES])
 
         fixture_xml = generator.get_fixture_by_id('item-list:fr_provinces', self.casexml_user, version=V2)
-        self._check_fixture(fixture_xml, has_groups=False, item_lists=[FR_PROVINCES])
+        self._check_fixture([fixture_xml], has_groups=False, item_lists=[FR_PROVINCES])
 
         fixture_xml = generator.get_fixture_by_id('user-locations', self.casexml_user, version=V2)
         self.assertIsNone(fixture_xml)


### PR DESCRIPTION
Fixture providers can return multiple fixtures so make sure we return the correct one. I realized this was a bug while :walking: the :dog2: this morning.

@benrudolph @czue 

buddy @TylerSheffels 

cc @kaapstorm 
