### PR TITLE
Check for value before passing to strptime

### DIFF
--- a/custom/succeed/reports/patient_task_list.py
+++ b/custom/succeed/reports/patient_task_list.py
@@ -125,7 +125,7 @@ class PatientTaskListReportDisplay(CaseDisplay):
     @property
     def task_due(self):
         rand_date = self.get_property("task_due")
-        if rand_date != EMPTY_FIELD:
+        if rand_date and rand_date != EMPTY_FIELD:
             date = datetime.strptime(rand_date, INPUT_DATE_FORMAT)
             return date.strftime(OUTPUT_DATE_FORMAT)
         else:
@@ -134,7 +134,7 @@ class PatientTaskListReportDisplay(CaseDisplay):
     @property
     def last_modified(self):
         rand_date = self.get_property("last_updated")
-        if rand_date != EMPTY_FIELD:
+        if rand_date and rand_date != EMPTY_FIELD:
             date = datetime.strptime(rand_date, INPUT_DATE_FORMAT)
             return date.strftime(OUTPUT_DATE_FORMAT)
         else:


### PR DESCRIPTION
From the traceback in [FB 173240](http://manage.dimagi.com/default.asp?173240) I can see that rand_date == '', but I'm not able to reproduce this locally because I haven't successfully copied a domain since IP whitelisting, and my own Cloudant setup has some outstanding, unresolved issues (which will probably take more than a few minutes to resolve).

I'm not happy to test on production, so hold off on merge. Any suggestions on the best way to reproduce the bug and verify whether this resolves it? (Feel free just to pull this branch, if that's going to be easiest.)

fyi @snopoke, buddy @dannyroberts
