### PR TITLE
Add full name and phone numbers to the restore

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1527,7 +1527,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
             loadtest_factor=self.loadtest_factor,
             first_name=self.first_name,
             last_name=self.last_name,
-            phone_numbers=self.phone_numbers,
+            phone_number=self.phone_number,
         )
 
         def get_owner_ids():

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1525,6 +1525,8 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
             user_data=self.user_data,
             domain=self.domain,
             loadtest_factor=self.loadtest_factor,
+            full_name=self.full_name,
+            phone_number=self.phone_number,
         )
 
         def get_owner_ids():

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1526,7 +1526,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
             domain=self.domain,
             loadtest_factor=self.loadtest_factor,
             full_name=self.full_name,
-            phone_number=self.phone_number,
+            phone_numbers=self.phone_numbers,
         )
 
         def get_owner_ids():

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1525,7 +1525,8 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
             user_data=self.user_data,
             domain=self.domain,
             loadtest_factor=self.loadtest_factor,
-            full_name=self.full_name,
+            first_name=self.first_name,
+            last_name=self.last_name,
             phone_numbers=self.phone_numbers,
         )
 

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -23,11 +23,13 @@ class User(object):
     find cases and generate the user XML.
     """
     
-    def __init__(self, user_id, username, password, date_joined,
-                 user_data=None, additional_owner_ids=None, domain=None,
-                 loadtest_factor=1):
+    def __init__(self, user_id, username, password, date_joined, full_name=None,
+                 phone_number=None, user_data=None, additional_owner_ids=None,
+                 domain=None, loadtest_factor=1):
         self.user_id = user_id
         self.username = username
+        self.full_name = full_name
+        self.phone_number = phone_number
         self.password = password
         self.date_joined = date_joined
         self.user_data = user_data or {}

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -18,18 +18,18 @@ logger = logging.getLogger('phone.models')
 
 
 class User(object):
-    """ 
+    """
     This is a basic user model that's used for OTA restore to properly
     find cases and generate the user XML.
     """
-    
+
     def __init__(self, user_id, username, password, date_joined, full_name=None,
-                 phone_number=None, user_data=None, additional_owner_ids=None,
+                 phone_numbers=None, user_data=None, additional_owner_ids=None,
                  domain=None, loadtest_factor=1):
         self.user_id = user_id
         self.username = username
         self.full_name = full_name
-        self.phone_number = phone_number
+        self.phone_numbers = phone_numbers or []
         self.password = password
         self.date_joined = date_joined
         self.user_data = user_data or {}
@@ -47,7 +47,7 @@ class User(object):
         return cls(user_id=str(django_user.pk), username=django_user.username,
                    password=django_user.password, date_joined=django_user.date_joined,
                    user_data={})
-    
+
 
 class CaseState(LooselyEqualDocumentSchema, IndexHoldingMixIn):
     """

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -24,13 +24,13 @@ class User(object):
     """
 
     def __init__(self, user_id, username, password, date_joined, first_name=None,
-                 last_name=None, phone_numbers=None, user_data=None,
+                 last_name=None, phone_number=None, user_data=None,
                  additional_owner_ids=None, domain=None, loadtest_factor=1):
         self.user_id = user_id
         self.username = username
         self.first_name = first_name
         self.last_name = last_name
-        self.phone_numbers = phone_numbers or []
+        self.phone_number = phone_number
         self.password = password
         self.date_joined = date_joined
         self.user_data = user_data or {}

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -23,12 +23,13 @@ class User(object):
     find cases and generate the user XML.
     """
 
-    def __init__(self, user_id, username, password, date_joined, full_name=None,
-                 phone_numbers=None, user_data=None, additional_owner_ids=None,
-                 domain=None, loadtest_factor=1):
+    def __init__(self, user_id, username, password, date_joined, first_name=None,
+                 last_name=None, phone_numbers=None, user_data=None,
+                 additional_owner_ids=None, domain=None, loadtest_factor=1):
         self.user_id = user_id
         self.username = username
-        self.full_name = full_name
+        self.first_name = first_name
+        self.last_name = last_name
         self.phone_numbers = phone_numbers or []
         self.password = password
         self.date_joined = date_joined

--- a/corehq/ex-submodules/casexml/apps/phone/tests/dummy.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/dummy.py
@@ -22,7 +22,10 @@ def dummy_user_xml():
         <uuid>foo</uuid>
         <date>2011-06-09</date>
         <user_data>
+            <data key="commcare_first_name"/>
+            <data key="commcare_last_name"/>
             <data key="something">arbitrary</data>
+            <data key="commcare_phone_number"/>
         </user_data>
     </Registration>"""
 

--- a/corehq/ex-submodules/casexml/apps/phone/xml.py
+++ b/corehq/ex-submodules/casexml/apps/phone/xml.py
@@ -87,8 +87,10 @@ def get_case_xml(case, updates, version=V1):
 
 def get_registration_element(user):
     root = safe_element("Registration")
-    root.attrib = { "xmlns": USER_REGISTRATION_XMLNS }
+    root.attrib = {"xmlns": USER_REGISTRATION_XMLNS}
     root.append(safe_element("username", user.username))
+    root.append(safe_element("full_name", user.full_name))
+    root.append(safe_element("phone_number", user.phone_number))
     root.append(safe_element("password", user.password))
     root.append(safe_element("uuid", user.user_id))
     root.append(safe_element("date", date_to_xml_string(user.date_joined)))

--- a/corehq/ex-submodules/casexml/apps/phone/xml.py
+++ b/corehq/ex-submodules/casexml/apps/phone/xml.py
@@ -95,7 +95,9 @@ def get_registration_element(user):
     root.append(safe_element("date", date_to_xml_string(user.date_joined)))
     user_data = user.user_data
     user_data["{}_full_name".format(SYSTEM_PREFIX)] = user.full_name
-    user_data["{}_phone_number".format(SYSTEM_PREFIX)] = user.phone_number
+    for i, phone_number in enumerate(user.phone_numbers):
+        data_key = "{}_phone_number_{}".format(SYSTEM_PREFIX, i+1)
+        user_data[data_key] = phone_number
     root.append(get_data_element('user_data', user.user_data))
     return root
 

--- a/corehq/ex-submodules/casexml/apps/phone/xml.py
+++ b/corehq/ex-submodules/casexml/apps/phone/xml.py
@@ -86,16 +86,17 @@ def get_case_xml(case, updates, version=V1):
     
 
 def get_registration_element(user):
+    from corehq.apps.custom_data_fields.models import SYSTEM_PREFIX
     root = safe_element("Registration")
     root.attrib = {"xmlns": USER_REGISTRATION_XMLNS}
     root.append(safe_element("username", user.username))
-    root.append(safe_element("full_name", user.full_name))
-    root.append(safe_element("phone_number", user.phone_number))
     root.append(safe_element("password", user.password))
     root.append(safe_element("uuid", user.user_id))
     root.append(safe_element("date", date_to_xml_string(user.date_joined)))
-    if user.user_data:
-        root.append(get_data_element('user_data', user.user_data))
+    user_data = user.user_data
+    user_data["{}_full_name".format(SYSTEM_PREFIX)] = user.full_name
+    user_data["{}_phone_number".format(SYSTEM_PREFIX)] = user.phone_number
+    root.append(get_data_element('user_data', user.user_data))
     return root
 
 

--- a/corehq/ex-submodules/casexml/apps/phone/xml.py
+++ b/corehq/ex-submodules/casexml/apps/phone/xml.py
@@ -32,16 +32,16 @@ def get_sync_element(restore_id):
 
 
 def get_case_element(case, updates, version=V1):
-    
+
     check_version(version)
-    
-    if case is None: 
+
+    if case is None:
         logging.error("Can't generate case xml for empty case!")
         return ""
 
     generator = get_generator(version, case)
     root = generator.get_root_element()
-    
+
     # if creating, the base data goes there, otherwise it goes in the
     # update block
     do_create = const.CASE_ACTION_CREATE in updates
@@ -55,35 +55,35 @@ def get_case_element(case, updates, version=V1):
         create_block = generator.get_create_element()
         generator.add_base_properties(create_block)
         root.append(create_block)
-    
+
     if do_update:
         update_block = generator.get_update_element()
         # if we don't have a create block, also put the base properties
         # in the update block, in case they changed
         if not do_create:
             generator.add_base_properties(update_block)
-        
+
         # custom properties
         generator.add_custom_properties(update_block)
         if list(update_block):
             root.append(update_block)
-        
+
     if do_index:
         generator.add_indices(root)
     if do_attach:
         generator.add_attachments(root)
-    
+
     if do_purge:
         purge_block = generator.get_close_element()
         root.append(purge_block)
-        
+
     return root
 
 
 def get_case_xml(case, updates, version=V1):
     check_version(version)
     return tostring(get_case_element(case, updates, version))
-    
+
 
 def get_registration_element(user):
     from corehq.apps.custom_data_fields.models import SYSTEM_PREFIX
@@ -102,7 +102,7 @@ def get_registration_element(user):
 
 def get_registration_xml(user):
     return tostring(get_registration_element(user))
-    
+
 
 def get_data_element(name, dict):
     elem = safe_element(name)

--- a/corehq/ex-submodules/casexml/apps/phone/xml.py
+++ b/corehq/ex-submodules/casexml/apps/phone/xml.py
@@ -94,7 +94,8 @@ def get_registration_element(user):
     root.append(safe_element("uuid", user.user_id))
     root.append(safe_element("date", date_to_xml_string(user.date_joined)))
     user_data = user.user_data
-    user_data["{}_full_name".format(SYSTEM_PREFIX)] = user.full_name
+    user_data["{}_first_name".format(SYSTEM_PREFIX)] = user.first_name
+    user_data["{}_last_name".format(SYSTEM_PREFIX)] = user.last_name
     for i, phone_number in enumerate(user.phone_numbers):
         data_key = "{}_phone_number_{}".format(SYSTEM_PREFIX, i+1)
         user_data[data_key] = phone_number

--- a/corehq/ex-submodules/casexml/apps/phone/xml.py
+++ b/corehq/ex-submodules/casexml/apps/phone/xml.py
@@ -96,9 +96,7 @@ def get_registration_element(user):
     user_data = user.user_data
     user_data["{}_first_name".format(SYSTEM_PREFIX)] = user.first_name
     user_data["{}_last_name".format(SYSTEM_PREFIX)] = user.last_name
-    for i, phone_number in enumerate(user.phone_numbers):
-        data_key = "{}_phone_number_{}".format(SYSTEM_PREFIX, i+1)
-        user_data[data_key] = phone_number
+    user_data["{}_phone_number".format(SYSTEM_PREFIX)] = user.phone_number
     root.append(get_data_element('user_data', user.user_data))
     return root
 


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?174025
http://manage.dimagi.com/default.asp?171293
@czue @sshah
This looks like:

``` xml
<user_data>
    <data key="commcare_location_id">f9d54b1d254eadf454caaa0818e8e86e</data>
    <data key="commcare_phone_number_1">0019042411080</data>
    <data key="gender">male</data>
    <data key="commcare_primary_case_sharing_id">f9d54b1d254eadf454caaa0818e8e86e</data>
    <data key="something"/>
    <data key="commcare_full_name">Ethan Soergel</data>
    <data key="commtrack-supply-point">f96ec198a137487bb87763b05a8f8a3c</data>
</user_data>
```

It's on staging now if you want to play with it.  Think we should switch `commcare_full_name` to `commcare_first_name` and `commcare_last_name`?
