### PR TITLE
don't duplicate function names for different celery tasks

### DIFF
--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -192,26 +192,12 @@ def send_bookkeeper_email(month=None, year=None, emails=None):
 
 
 @periodic_task(run_every=crontab(minute=0, hour=0))
-def remind_subscription_ending_30_days():
+def remind_subscription_ending():
     """
-    Sends reminder emails for subscriptions ending 30 days from now.
+    Sends reminder emails for subscriptions ending N days from now.
     """
     send_subscription_reminder_emails(30)
-
-
-@periodic_task(run_every=crontab(minute=0, hour=0))
-def remind_subscription_ending_30_days(based_on_date=None):
-    """
-    Sends reminder emails for subscriptions ending 10 days from now.
-    """
     send_subscription_reminder_emails(10, exclude_trials=False)
-
-
-@periodic_task(run_every=crontab(minute=0, hour=0))
-def remind_subscription_ending_30_days(based_on_date=None):
-    """
-    Sends reminder emails for subscriptions ending tomorrow.
-    """
     send_subscription_reminder_emails(1, exclude_trials=False)
 
 


### PR DESCRIPTION
removes misleading code where `remind_subscription_ending_30_days` is reused for different tasks

@proteusvacuum cc: @esoergel 
