### PR TITLE
Error email

### DIFF
--- a/corehq/apps/hqadmin/templates/hqadmin/email/error_email.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/email/error_email.html
@@ -26,7 +26,7 @@
 {% else %}
 <div>
     <b>{{ line }}</b>
-    <br />
+    <br>
 </div>
 {% endif %}
 {% endfor %}
@@ -34,6 +34,7 @@
 <h3>Parameters</h3>
 
 <div><b>GET</b></div>
+{% if get %}
 <table>
     <tbody>
         {% for key, value in get.items %}
@@ -44,8 +45,12 @@
         {% endfor %}
     </tbody>
 </table>
+{% else %}
+    Nothing found.
+{% endif %}
 
 <div><b>POST</b></div>
+{% if post %}
 <table>
     <tbody>
         {% for key, value in post.items %}
@@ -56,6 +61,10 @@
         {% endfor %}
     </tbody>
 </table>
+{% else %}
+    Nothing found.
+{% endif %}
+
 <h3>Request</h3>
 {{ request_repr }}
 

--- a/corehq/apps/hqadmin/templates/hqadmin/email/error_email.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/email/error_email.html
@@ -1,15 +1,63 @@
-{{ details }}
+<html>
+<body>
+{% if details %}
+<h3>Details</h3>
+<table>
+    <tbody>
+        {% for key, value in details.items %}
+        <tr>
+            <td>{{ key }}</td>
+            <td>{{ value }}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% endif %}
 
 {% for line in tb_list %}
-{% if 'site-packages' in line %}
+{% if forloop.counter0 == 0 %}
+<div>
+    <h3>{{ line }}</h3>
+</div>
+{% elif 'site-packages' in line %}
 <div>
     <small>{{ line }}</small>
 </div>
 {% else %}
 <div>
     <b>{{ line }}</b>
+    <br />
 </div>
 {% endif %}
 {% endfor %}
 
+<h3>Parameters</h3>
+
+<div><b>GET</b></div>
+<table>
+    <tbody>
+        {% for key, value in get.items %}
+        <tr>
+            <td>{{ key }}</td>
+            <td>{{ value }}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+
+<div><b>POST</b></div>
+<table>
+    <tbody>
+        {% for key, value in post.items %}
+        <tr>
+            <td>{{ key }}</td>
+            <td>{{ value }}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+<h3>Request</h3>
 {{ request_repr }}
+
+</body>
+</html>

--- a/corehq/apps/hqadmin/templates/hqadmin/email/error_email.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/email/error_email.html
@@ -14,6 +14,9 @@
 </table>
 {% endif %}
 
+<p>Method: {{ method }}</p>
+<p>URL: {% if url %}<a href="{{ url }}">{{ url }}</a>{% else %}Unknown{% endif %}</p>
+
 {% for line in tb_list %}
 {% if forloop.counter0 == 0 %}
 <div>

--- a/corehq/apps/hqadmin/templates/hqadmin/email/error_email.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/email/error_email.html
@@ -1,0 +1,15 @@
+{{ details }}
+
+{% for line in tb_list %}
+{% if 'site-packages' in line %}
+<div>
+    <small>{{ line }}</small>
+</div>
+{% else %}
+<div>
+    <b>{{ line }}</b>
+</div>
+{% endif %}
+{% endfor %}
+
+{{ request_repr }}

--- a/corehq/util/log.py
+++ b/corehq/util/log.py
@@ -40,7 +40,7 @@ class HqAdminEmailHandler(AdminEmailHandler):
             request_repr = "Request repr() unavailable."
         subject = self.format_subject(subject)
 
-        tb_list = None
+        tb_list = []
         if record.exc_info:
             exc_info = record.exc_info
             etype, value, tb = exc_info
@@ -49,7 +49,6 @@ class HqAdminEmailHandler(AdminEmailHandler):
             tb_list.extend(traceback.format_list(reversed(traceback.extract_tb(tb))))
             stack_trace = '\n'.join(tb_list)
         else:
-            exc_info = (None, record.getMessage(), None)
             stack_trace = 'No stack trace available'
 
         message = "%s\n\n%s" % (stack_trace, request_repr)
@@ -62,6 +61,8 @@ class HqAdminEmailHandler(AdminEmailHandler):
             'tb_list': tb_list,
             'get': request.GET,
             'post': request.POST,
+            'method': request.method,
+            'url': request.build_absolute_uri(),
             'request_repr': request_repr
         }
         html_message = render_to_string('hqadmin/email/error_email.html', context)

--- a/corehq/util/log.py
+++ b/corehq/util/log.py
@@ -2,7 +2,7 @@ import traceback
 from celery.utils.mail import ErrorMail
 from django.core import mail
 from django.utils.log import AdminEmailHandler
-from django.views.debug import get_exception_reporter_filter, ExceptionReporter
+from django.views.debug import get_exception_reporter_filter
 from django.template.loader import render_to_string
 
 
@@ -57,8 +57,6 @@ class HqAdminEmailHandler(AdminEmailHandler):
         if details:
             message = "%s\n\n%s" % (self.format_details(details), message)
 
-        reporter = ExceptionReporter(request, is_email=True, *exc_info)
-        html_message = reporter.get_traceback_html() or None
         context = {
             'details': details,
             'tb_list': tb_list,

--- a/corehq/util/log.py
+++ b/corehq/util/log.py
@@ -62,6 +62,8 @@ class HqAdminEmailHandler(AdminEmailHandler):
         context = {
             'details': details,
             'tb_list': tb_list,
+            'get': request.GET,
+            'post': request.POST,
             'request_repr': request_repr
         }
         html_message = render_to_string('hqadmin/email/error_email.html', context)

--- a/corehq/util/log.py
+++ b/corehq/util/log.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 import traceback
 from celery.utils.mail import ErrorMail
 from django.core import mail
@@ -31,6 +32,7 @@ class HqAdminEmailHandler(AdminEmailHandler):
             )
             filter = get_exception_reporter_filter(request)
             request_repr = filter.get_request_repr(request)
+            raise Exception('foo')
         except Exception:
             subject = '%s: %s' % (
                 record.levelname,
@@ -56,15 +58,19 @@ class HqAdminEmailHandler(AdminEmailHandler):
         if details:
             message = "%s\n\n%s" % (self.format_details(details), message)
 
-        context = {
+        context = defaultdict(lambda: '')
+        context.update({
             'details': details,
             'tb_list': tb_list,
-            'get': request.GET,
-            'post': request.POST,
-            'method': request.method,
-            'url': request.build_absolute_uri(),
             'request_repr': request_repr
-        }
+        })
+        if request:
+            context.update({
+                'get': request.GET,
+                'post': request.POST,
+                'method': request.method,
+                'url': request.build_absolute_uri(),
+            })
         html_message = render_to_string('hqadmin/email/error_email.html', context)
         mail.mail_admins(subject, message, fail_silently=True, html_message=html_message)
 


### PR DESCRIPTION
@TylerSheffels this adds an email template that looks like this:
![screencapture-mail-google-com-mail-u-0-1435353891646](https://cloud.githubusercontent.com/assets/918514/8387683/9fc4dfb8-1c28-11e5-8408-c144872f0bb8.png)
definitely not all the way there, but it's a start. maybe @orangejenny or @biyeun have some ideas for laying out the email.
elf: @czue 

Some thoughts:
- attempted to get django app from filename. turns out to be pretty hard
- make application code bolded
- separate out important request keys, like GET and POST
- auto fogbugz link?
- store daily stats for an error and then we'll be able to mark an email as common or new
