### PR TITLE
fixes for UCRs

### DIFF
--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -59,7 +59,6 @@ from couchexport.tasks import rebuild_schemas
 from couchexport.util import SerializableFunction
 from dimagi.utils.chunked import chunked
 from dimagi.utils.couch.bulk import wrapped_docs
-from dimagi.utils.couch.database import iter_docs
 from dimagi.utils.couch.loosechange import parse_date
 from dimagi.utils.decorators.datespan import datespan_in_request
 from dimagi.utils.export import WorkBook

--- a/corehq/apps/reports_core/filters.py
+++ b/corehq/apps/reports_core/filters.py
@@ -178,20 +178,21 @@ class ChoiceListFilter(BaseFilter):
     Filter for a list of choices. Each choice should be a Choice object as per above.
     """
 
-    def __init__(self, name, required=True, label='Choice List Filter',
+    def __init__(self, name, datatype, required=True, label='Choice List Filter',
                  template='reports_core/filters/choice_list_filter.html',
                  css_id=None, choices=None):
         params = [
             FilterParam(name, True),
         ]
         super(ChoiceListFilter, self).__init__(required=required, name=name, params=params)
+        self.datatype = datatype
         self.label = label
         self.template = template
         self.css_id = css_id or self.name
         self.choices = choices or []
 
     def value(self, **kwargs):
-        choice = unicode(kwargs[self.name])
+        choice = transform_from_datatype(self.datatype)(kwargs[self.name]) or kwargs[self.name]
         choice_values = map(lambda c: c.value, self.choices)
         if choice not in choice_values:
             raise FilterValueException(_(u'Choice "{choice}" not found in choices: {choices}')

--- a/corehq/apps/reports_core/filters.py
+++ b/corehq/apps/reports_core/filters.py
@@ -230,7 +230,7 @@ class DynamicChoiceListFilter(BaseFilter):
         self.url_generator = url_generator
 
     def value(self, **kwargs):
-        selection = kwargs.get(self.name, "")
+        selection = unicode(kwargs.get(self.name, ""))
         if selection:
             choices = selection.split(CHOICE_DELIMITER)
             typed_choices = [transform_from_datatype(self.datatype)(c) for c in choices]

--- a/corehq/apps/userreports/reports/factory.py
+++ b/corehq/apps/userreports/reports/factory.py
@@ -43,6 +43,7 @@ def _build_choice_list_filter(spec):
         choices.insert(0, Choice(SHOW_ALL_CHOICE, _('Show all')))
     return ChoiceListFilter(
         name=wrapped.slug,
+        datatype=wrapped.datatype,
         label=wrapped.display,
         required=wrapped.required,
         choices=choices,

--- a/corehq/apps/userreports/reports/filters.py
+++ b/corehq/apps/userreports/reports/filters.py
@@ -81,7 +81,9 @@ class ChoiceListFilterValue(FilterValue):
 
     def __init__(self, filter, value):
         assert filter.type in ('choice_list', 'dynamic_choice_list')
-        assert(type(value) == list)
+        if not isinstance(value, list):
+            # if in single selection mode just force it to a list
+            value = [value]
         super(ChoiceListFilterValue, self).__init__(filter, value)
 
     @property

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -239,6 +239,7 @@ class FilterSpec(JsonObject):
     field = StringProperty(required=True)  # this is the actual column that is queried
     display = DefaultProperty()
     required = BooleanProperty(default=False)
+    datatype = DataTypeProperty(default='string')
 
     def get_display(self):
         return self.display or self.slug
@@ -251,6 +252,7 @@ class DateFilterSpec(FilterSpec):
 class ChoiceListFilterSpec(FilterSpec):
     type = TypeProperty('choice_list')
     show_all = BooleanProperty(default=True)
+    datatype = DataTypeProperty(default='string')
     choices = ListProperty(FilterChoice)
 
 

--- a/corehq/apps/userreports/tests/test_report_filters.py
+++ b/corehq/apps/userreports/tests/test_report_filters.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from django.test import SimpleTestCase
+from corehq.apps.reports_core.exceptions import FilterValueException
 from corehq.apps.reports_core.filters import DatespanFilter, ChoiceListFilter, \
     NumericFilter, DynamicChoiceListFilter, Choice
 from corehq.apps.userreports.exceptions import BadSpecError
@@ -151,6 +152,9 @@ class ChoiceListFilterTestCase(SimpleTestCase):
             self.assertEqual(filter.choices[i].value, choice['value'])
             self.assertEqual(filter.choices[i].display, choice['display'])
 
+        # check values
+        self.assertEqual('positive', filter.value(diagnosis_slug='POSITIVE').display)
+
     def test_choice_list_filter_show_all(self):
         filter = ReportFilterFactory.from_spec({
             "type": "choice_list",
@@ -167,6 +171,9 @@ class ChoiceListFilterTestCase(SimpleTestCase):
             self.assertEqual(filter.choices[i + 1].value, choice['value'])
             self.assertEqual(filter.choices[i + 1].display, choice['display'])
 
+        # check all value
+        self.assertEqual('Show all', filter.value(diagnosis_slug=SHOW_ALL_CHOICE).display)
+
     def test_choice_list_filter_with_integers(self):
         choices = [
             {
@@ -182,17 +189,35 @@ class ChoiceListFilterTestCase(SimpleTestCase):
             "type": "choice_list",
             "slug": "diagnosis_slug",
             "field": "diagnosis_field",
+            "datatype": "integer",
             "display": "Diagnosis",
             "choices": choices,
-            "show_all": False,
+            "show_all": True,
         })
         self.assertEqual(ChoiceListFilter, type(filter))
         self.assertEqual('diagnosis_slug', filter.name)
         self.assertEqual('Diagnosis', filter.label)
-        self.assertEqual(2, len(filter.choices))
+        self.assertEqual(3, len(filter.choices))
+        non_all_choices = filter.choices[1:]
         for i, choice in enumerate(choices):
-            self.assertEqual(filter.choices[i].value, choice['value'])
-            self.assertEqual(filter.choices[i].display, choice['display'])
+            self.assertEqual(non_all_choices[i].value, choice['value'])
+            self.assertEqual(non_all_choices[i].display, choice['display'])
+
+        # ensure integer values work
+        self.assertEqual('positive', filter.value(diagnosis_slug=1).display)
+        # check string to int coercion
+        self.assertEqual('positive', filter.value(diagnosis_slug='1').display)
+
+        # check missing values raise errors
+        with self.assertRaises(FilterValueException):
+            filter.value(diagnosis_slug='4')
+
+        # check non-integers raise errors
+        with self.assertRaises(FilterValueException):
+            filter.value(diagnosis_slug='foo')
+
+        # check that all still works
+        self.assertEqual('Show all', filter.value(diagnosis_slug=SHOW_ALL_CHOICE).display)
 
 
 class DynamicChoiceListFilterTestCase(SimpleTestCase):


### PR DESCRIPTION
several fixes for issues introduced in https://github.com/dimagi/commcare-hq/pull/7222/

can be read commit-by-commit. the big issue is is that `ChoiceList` filters were broken (http://manage.dimagi.com/default.asp?174374 and fixed in https://github.com/dimagi/commcare-hq/commit/33dc29935c543c299cfb66561f6e82ecaa628608). This also addresses some type conversion issues revealed by debugging locally with some reports that have integer choice lists and improves tests a bit.

@NoahCarnahan cc @nickpell 
