### PR TITLE
Don't float property-table-container

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/util/proptable/style.css
+++ b/corehq/apps/hqwebapp/static/hqwebapp/util/proptable/style.css
@@ -1,5 +1,4 @@
 .property-table-container {
-    float: left;
     margin-right: 18px;
 }
 


### PR DESCRIPTION
Floating the property-table-container without clearing below it caused the rest of the accordion to appear underneath it instead of below it, and its text to the right of it.

Removing the `float` property fixes the problem.

This style gets used in "property_table.html" and "dl_property_table.html". They are used in "single_case.html" and "single_form.html". In none of those is there any content that should appear to the right of property-table-container. Removing `float` seems to be safe.

`git blame` says Mike White wrote this. Can anyone tell me whether there was content that was supposed to appear to the right of the property-table-container -- I'm curious why he used `float`, and even more curious why he didn't use `clear` afterwards to stop floating? (i.e. Has this always been broken, or was there a reason why this is the way it is? Am I missing something important? )

http://manage.dimagi.com/default.asp?173210

buddy @dannyroberts , ping @snopoke, @czue 
