### PR TITLE
add ability to override restore mode via url param

### DIFF
--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -43,13 +43,15 @@ def get_restore_params(request):
         'since': request.GET.get('since'),
         'version': request.GET.get('version', "1.0"),
         'state': request.GET.get('state'),
-        'items': request.GET.get('items') == 'true'
+        'items': request.GET.get('items') == 'true',
+        'force_restore_mode': request.GET.get('mode', None)
     }
 
 
 def get_restore_response(domain, couch_user, since=None, version='1.0',
                          state=None, items=False, force_cache=False,
-                         cache_timeout=None, overwrite_cache=False):
+                         cache_timeout=None, overwrite_cache=False,
+                         force_restore_mode=None):
     # not a view just a view util
     if not couch_user.is_commcare_user():
         return HttpResponse("No linked chw found for %s" % couch_user.username,
@@ -67,6 +69,7 @@ def get_restore_response(domain, couch_user, since=None, version='1.0',
             version=version,
             state_hash=state,
             include_item_count=items,
+            force_restore_mode=force_restore_mode,
         ),
         cache_settings=RestoreCacheSettings(
             force_cache=force_cache,

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -224,13 +224,16 @@ class RestoreParams(object):
     :param version:             The version of the restore format
     :param state_hash:          The case state hash string to use to verify the state of the phone
     :param include_item_count:  Set to `True` to include the item count in the response
+    :param force_restore_mode:  Set to `clean` or `legacy` to force a particular restore type.
     """
 
-    def __init__(self, sync_log_id='', version=V1, state_hash='', include_item_count=False):
+    def __init__(self, sync_log_id='', version=V1, state_hash='', include_item_count=False,
+                 force_restore_mode=None):
         self.sync_log_id = sync_log_id
         self.version = version
         self.state_hash = state_hash
         self.include_item_count = include_item_count
+        self.force_restore_mode = force_restore_mode
 
 
 class RestoreCacheSettings(object):
@@ -326,6 +329,12 @@ class RestoreState(object):
                 if override is not None:
                     return override
             return OWNERSHIP_CLEANLINESS_RESTORE.enabled(domain)
+
+        # this can be overridden explicitly in the params but will default to the domain setting
+        if self.params.force_restore_mode == 'clean':
+            return True
+        elif self.params.force_restore_mode == 'legacy':
+            return False
 
         return should_use_clean_restore(self.domain)
 

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_cleanliness.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_cleanliness.py
@@ -6,7 +6,10 @@ from casexml.apps.phone.cleanliness import set_cleanliness_flags, hint_still_val
     get_cleanliness_flag_from_scratch
 from casexml.apps.phone.data_providers.case.clean_owners import pop_ids
 from casexml.apps.phone.models import OwnershipCleanlinessFlag
+from casexml.apps.phone.restore import RestoreState, RestoreParams
 from casexml.apps.phone.tests.test_sync_mode import SyncBaseTest
+from corehq.apps.domain.models import Domain
+from corehq.apps.users.models import CommCareUser
 from corehq.toggles import OWNERSHIP_CLEANLINESS
 
 
@@ -246,3 +249,26 @@ class CleanlinessUtilitiesTest(SimpleTestCase):
         self.assertEqual(5, len(back))
         self.assertEqual(0, len(five))
         self.assertEqual(set(back), set(range(5)))
+
+
+class OverrideSyncModeTest(SimpleTestCase):
+
+    @override_settings(TESTS_SHOULD_USE_CLEAN_RESTORE=True)
+    def test_override_settings_clean(self):
+        self.assertEqual(True, _dummy_restore_state(force_restore_mode=None).use_clean_restore)
+        self.assertEqual(True, _dummy_restore_state(force_restore_mode='clean').use_clean_restore)
+        self.assertEqual(False, _dummy_restore_state(force_restore_mode='legacy').use_clean_restore)
+
+    @override_settings(TESTS_SHOULD_USE_CLEAN_RESTORE=False)
+    def test_override_settings_legacy(self):
+        self.assertEqual(False, _dummy_restore_state(force_restore_mode=None).use_clean_restore)
+        self.assertEqual(True, _dummy_restore_state(force_restore_mode='clean').use_clean_restore)
+        self.assertEqual(False, _dummy_restore_state(force_restore_mode='legacy').use_clean_restore)
+
+
+def _dummy_restore_state(force_restore_mode=None):
+    return RestoreState(
+        project=Domain(name='clean'),
+        user=CommCareUser(username='testing'),
+        params=RestoreParams(force_restore_mode=force_restore_mode)
+    )


### PR DESCRIPTION
@snopoke this will let you pass `mode=clean` or `mode=legacy` to a restore URL to force the code to use one version or the other.

note that if you want to test on a project you should also run `set_cleanliness_flags` for that project and change the feature flag that updates flags during submission. 
