### PR TITLE
add ability to force setting cleanliness flags from scratch

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/cleanliness.py
+++ b/corehq/ex-submodules/casexml/apps/phone/cleanliness.py
@@ -44,16 +44,16 @@ def should_create_flags_on_submission(domain):
     return False
 
 
-def set_cleanliness_flags_for_domain(domain):
+def set_cleanliness_flags_for_domain(domain, force_full=False):
     """
     Sets all cleanliness flags for an entire domain.
     """
     for owner_id in get_all_case_owner_ids(domain):
         if owner_id not in WEIRD_USER_IDS:
-            set_cleanliness_flags(domain, owner_id)
+            set_cleanliness_flags(domain, owner_id, force_full=force_full)
 
 
-def set_cleanliness_flags(domain, owner_id):
+def set_cleanliness_flags(domain, owner_id, force_full=False):
     """
     For a given owner ID, manually sets the cleanliness flag on that ID.
     """
@@ -75,8 +75,8 @@ def set_cleanliness_flags(domain, owner_id):
                 not cleanliness_object.hint or not hint_still_valid(domain, owner_id, cleanliness_object.hint)
             )
         )
-    if needs_full_check(domain, cleanliness_object):
-        # either the hint wasn't set or wasn't valid - rebuild from scratch
+    if force_full or needs_full_check(domain, cleanliness_object):
+        # either the hint wasn't set, wasn't valid or we're forcing a rebuild - rebuild from scratch
         cleanliness_flag = get_cleanliness_flag_from_scratch(domain, owner_id)
         cleanliness_object.is_clean = cleanliness_flag.is_clean
         cleanliness_object.hint = cleanliness_flag.hint

--- a/corehq/ex-submodules/casexml/apps/phone/management/commands/set_cleanliness_flags.py
+++ b/corehq/ex-submodules/casexml/apps/phone/management/commands/set_cleanliness_flags.py
@@ -1,3 +1,4 @@
+from optparse import make_option
 from django.core.management import BaseCommand
 from corehq.apps.domain.models import Domain
 from corehq.toggles import OWNERSHIP_CLEANLINESS
@@ -7,15 +8,23 @@ class Command(BaseCommand):
     """
     Set cleanliness flags for a domain, or for all domains
     """
+    option_list = BaseCommand.option_list + (
+        make_option('--force',
+                    action='store_true',
+                    dest='force',
+                    default=False,
+                    help="Force rebuild on top of existing flags/hints."),
+    )
 
-    def handle(self, *args, **kwargs):
+    def handle(self, *args, **options):
         from casexml.apps.phone.cleanliness import set_cleanliness_flags_for_domain
+        force_full = options['force']
         if len(args) == 1:
             domain = args[0]
-            set_cleanliness_flags_for_domain(domain)
+            set_cleanliness_flags_for_domain(domain, force_full=force_full)
         else:
             assert len(args) == 0
             for domain in Domain.get_all_names():
                 if OWNERSHIP_CLEANLINESS.enabled(domain):
                     print 'updating flags for {}'.format(domain)
-                    set_cleanliness_flags_for_domain(domain)
+                    set_cleanliness_flags_for_domain(domain, force_full=force_full)

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_cleanliness.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_cleanliness.py
@@ -48,7 +48,7 @@ class OwnerCleanlinessTest(SyncBaseTest):
         is_clean = self.owner_cleanliness.is_clean
         hint = self.owner_cleanliness.hint
         self.owner_cleanliness.delete()
-        set_cleanliness_flags(self.domain, self.owner_id)
+        set_cleanliness_flags(self.domain, self.owner_id, force_full=True)
         new_cleanliness = OwnershipCleanlinessFlag.objects.get(owner_id=self.owner_id)
         self.assertEqual(is_clean, new_cleanliness.is_clean)
         self.assertEqual(hint, new_cleanliness.hint)


### PR DESCRIPTION
this is necessary if you set them once but didn't configure the domain to automatically keep them in sync or as a debug check to make sure the setting logic is sound.

@snopoke or whoever
