### PR TITLE
Add UCR transform for date format

### DIFF
--- a/corehq/apps/userreports/README.md
+++ b/corehq/apps/userreports/README.md
@@ -774,6 +774,16 @@ Rounds decimal and floating point numbers to two decimal places.
 }
 ```
 
+### Date formatting
+Formats dates with the given format string. See [here](https://docs.python.org/2/library/datetime.html#strftime-strptime-behavior) for an explanation of format string behavior.
+If there is an error formatting the date, the transform is not applied to that value.
+```
+{
+   "type": "date_format", 
+   "format": "%Y-%m-%d %H:%M"
+}
+```
+
 ## Charts
 
 There are currently three types of charts supported. Pie charts, and two types of bar charts.

--- a/corehq/apps/userreports/transforms/factory.py
+++ b/corehq/apps/userreports/transforms/factory.py
@@ -2,12 +2,13 @@ import json
 from django.utils.translation import ugettext as _
 from jsonobject.exceptions import BadValueError
 from corehq.apps.userreports.exceptions import BadSpecError
-from corehq.apps.userreports.transforms.specs import CustomTransform
+from corehq.apps.userreports.transforms.specs import CustomTransform, DateFormatTransform
 
 
 class TransformFactory(object):
     spec_map = {
         'custom': CustomTransform,
+        'date_format': DateFormatTransform,
     }
 
     @classmethod

--- a/corehq/apps/userreports/transforms/specs.py
+++ b/corehq/apps/userreports/transforms/specs.py
@@ -47,7 +47,6 @@ class DateFormatTransform(Transform):
     type = TypeProperty('date_format')
     format = StringProperty(required=True)
 
-
     def get_transform_function(self):
 
         def transform_function(value):

--- a/corehq/apps/userreports/transforms/specs.py
+++ b/corehq/apps/userreports/transforms/specs.py
@@ -41,3 +41,19 @@ class CustomTransform(JsonObject):
 
     def transform(self, value):
         return self.get_transform_function()(value)
+
+
+class DateFormatTransform(Transform):
+    type = TypeProperty('date_format')
+    format = StringProperty(required=True)
+
+
+    def get_transform_function(self):
+
+        def transform_function(value):
+            try:
+                return value.strftime(self.format)
+            except:
+                return value
+
+        return transform_function


### PR DESCRIPTION
Allows users to specify a formatting string to control how dates are displayed in the report.
e.g.

``` json
{
    "field": "timeEnd", 
    "transform": {
      "type": "date_format", 
      "format": "%Y-%m-%d %H:%M"
    }, 
    "column_id": "timeEnd", 
    "type": "field", 
    "display": "Date and time submitted", 
    "aggregation": "simple"
  }
```

Will display time stamps like "2015-06-28 12:34" instead of "2015-06-28T12:34:21.042088"

Note that this adds a new transform type instead of using "custom" as the type, which all transforms up to this point do. This way seems cleaner to me, but did you have something else in mind @czue when it came to transform types/names?

cc @gcapalbo 
