### PR TITLE
Use wide question select dropdowns in report builder

### DIFF
--- a/corehq/apps/userreports/templates/userreports/base_report_builder.html
+++ b/corehq/apps/userreports/templates/userreports/base_report_builder.html
@@ -2,6 +2,14 @@
 {% load i18n %}
 {% load crispy_forms_tags %}
 
+{% block head %}{{ block.super }}
+    <style>
+        .bigdrop {
+            width: 600px !important;
+        }
+    </style>
+{% endblock %}
+
 {% block main_column %}
     {% crispy form %}
 {% endblock %}

--- a/corehq/apps/userreports/templates/userreports/base_report_builder.html
+++ b/corehq/apps/userreports/templates/userreports/base_report_builder.html
@@ -4,6 +4,10 @@
 
 {% block head %}{{ block.super }}
     <style>
+        {% comment %}
+        TODO: Use select2's dropdownAutoWidth option instead.
+              (Couldn't get it to work properly at this time.)
+        {% endcomment %}
         .bigdrop {
             width: 600px !important;
         }

--- a/corehq/apps/userreports/templates/userreports/base_report_builder.html
+++ b/corehq/apps/userreports/templates/userreports/base_report_builder.html
@@ -6,7 +6,7 @@
     <style>
         {% comment %}
         TODO: Use select2's dropdownAutoWidth option instead.
-              (Couldn't get it to work properly at this time.)
+              (Couldn't get it to work properly at this time; messes up dropdown scrolling)
         {% endcomment %}
         .bigdrop {
             width: 600px !important;


### PR DESCRIPTION
Uses the same technique that the "form > case management" page [uses](https://github.com/dimagi/commcare-hq/blob/9ea4c8c70ca5962714b83be05ec28e4b75f86146/corehq/apps/app_manager/templates/app_manager/form_view_base.html#L57) to create wide drop downs. Ideally the todo would be resolved, but trying to get this feature to UAT sooner rather than later.
@gcapalbo 
