### PR TITLE
Bulk app translations: special chars in simple nodes

### DIFF
--- a/corehq/apps/app_manager/tests/test_bulk_app_translation.py
+++ b/corehq/apps/app_manager/tests/test_bulk_app_translation.py
@@ -149,14 +149,14 @@ class BulkAppTranslationBasicTest(BulkAppTranslationTestBase):
           ("baz (ID Mapping Value)", "detail", "quz", ""),
         )),
         ("module1_form1", (
-          ("question1-label", "in english", "in french", "", "", "", "", "", ""),
+          ("question1-label", "in english", "it's in french", "", "", "", "", "", ""),
           ("question2-label", "one &lt; two", "un &lt; deux", "", "", "", "", "", ""),
-          ("question2-item1-label", "item1's label", "item1's label", "", "", "", "", "", ""),
+          ("question2-item1-label", "item1", "item1", "", "", "", "", "", ""),
           ("question2-item2-label", "item2", "item2", "", "", "", "", "", ""),
           ("question3-label", "question3", "question3&#39;s label", "", "", "", "", "", ""),
           ("question3/question4-label", 'question6: <output value="/data/question6"/>', 'question6: <output value="/data/question6"/>', "", "", "", "", "", ""),
           ("question3/question5-label", "English Label", "English Label", "", "", "", "", "", ""),
-          ("question7-label", "question7", "question7", "", "", "", "", "", "")
+          ("question7-label", 'question1: <output value="/data/question1"/> &lt; 5', "question7", "", "", "", "", "", "")
         ))
     )
 
@@ -201,7 +201,7 @@ class BulkAppTranslationBasicTest(BulkAppTranslationTestBase):
         self.upload_raw_excel_translations(self.upload_headers, self.upload_data)
 
         self.assert_question_label("in english", 0, 0, "en", "/data/question1")
-        self.assert_question_label("in french", 0, 0, "fra", "/data/question1")
+        self.assert_question_label("it's in french", 0, 0, "fra", "/data/question1")
 
         # Test that translations can be deleted.
         self.assert_question_label("English Label", 0, 0, "fra", "/data/question3/question5")
@@ -219,11 +219,11 @@ class BulkAppTranslationBasicTest(BulkAppTranslationTestBase):
         )
 
         # Test special characters and output refs
-        #jls
         self.assert_question_label("one < two", 0, 0, "en", "/data/question2")
         self.assert_question_label("un < deux", 0, 0, "fra", "/data/question2")
         self.assert_question_label("question3's label", 0, 0, "fra", "/data/question3")
         self.assert_question_label("question6: ____", 0, 0, "en", "/data/question3/question4")
+        self.assert_question_label("question1: ____ < 5", 0, 0, "en", "/data/question7")
 
     def test_missing_itext(self):
         self.app = Application.wrap(self.get_json("app_no_itext"))

--- a/corehq/apps/app_manager/tests/test_bulk_app_translation.py
+++ b/corehq/apps/app_manager/tests/test_bulk_app_translation.py
@@ -151,9 +151,9 @@ class BulkAppTranslationBasicTest(BulkAppTranslationTestBase):
         ("module1_form1", (
           ("question1-label", "in english", "in french", "", "", "", "", "", ""),
           ("question2-label", "one &lt; two", "un &lt; deux", "", "", "", "", "", ""),
-          ("question2-item1-label", "item1", "item1", "", "", "", "", "", ""),
+          ("question2-item1-label", "item1's label", "item1's label", "", "", "", "", "", ""),
           ("question2-item2-label", "item2", "item2", "", "", "", "", "", ""),
-          ("question3-label", "question3", "question3", "", "", "", "", "", ""),
+          ("question3-label", "question3", "question3&#39;s label", "", "", "", "", "", ""),
           ("question3/question4-label", 'question6: <output value="/data/question6"/>', 'question6: <output value="/data/question6"/>', "", "", "", "", "", ""),
           ("question3/question5-label", "English Label", "English Label", "", "", "", "", "", ""),
           ("question7-label", "question7", "question7", "", "", "", "", "", "")
@@ -219,8 +219,10 @@ class BulkAppTranslationBasicTest(BulkAppTranslationTestBase):
         )
 
         # Test special characters and output refs
-        self.assert_question_label("one &lt; two", 0, 0, "en", "/data/question2")
-        self.assert_question_label("un &lt; deux", 0, 0, "fra", "/data/question2")
+        #jls
+        self.assert_question_label("one < two", 0, 0, "en", "/data/question2")
+        self.assert_question_label("un < deux", 0, 0, "fra", "/data/question2")
+        self.assert_question_label("question3's label", 0, 0, "fra", "/data/question3")
         self.assert_question_label("question6: ____", 0, 0, "en", "/data/question3/question4")
 
     def test_missing_itext(self):

--- a/corehq/apps/app_manager/translations.py
+++ b/corehq/apps/app_manager/translations.py
@@ -546,8 +546,6 @@ def update_form_translations(sheet, rows, missing_cols, app):
 
                 if new_translation:
                     # Create the node if it does not already exist
-                    complex_node = re.search('<.*>', new_translation)
-
                     if not value_node.exists():
                         e = etree.Element(
                             "{f}value".format(**namespaces), attributes
@@ -558,13 +556,10 @@ def update_form_translations(sheet, rows, missing_cols, app):
                     value_node.xml.tail = ''
                     for node in value_node.findall("./*"):
                         node.xml.getparent().remove(node.xml)
-                    if not complex_node:
-                        value_node.xml.text = new_translation
-                    else:
-                        escaped_trans = _escape_output_value(new_translation)
-                        value_node.xml.text = escaped_trans.text
-                        for n in escaped_trans.getchildren():
-                            value_node.xml.append(n)
+                    escaped_trans = _escape_output_value(new_translation)
+                    value_node.xml.text = escaped_trans.text
+                    for n in escaped_trans.getchildren():
+                        value_node.xml.append(n)
                 else:
                     # Remove the node if it already exists
                     if value_node.exists():


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?174470

Could instead use an HTML parser to unescape simple nodes, but it makes for cleaner code to get rid of the simple/complex distinction.

@emord 

code buddy @sravfeyn 
