### PR TITLE
make callcenter task work with domains in all timezones

### DIFF
--- a/corehq/apps/callcenter/tasks.py
+++ b/corehq/apps/callcenter/tasks.py
@@ -14,7 +14,8 @@ def calculate_indicators():
     domains = [
         domain
         for domain in get_call_center_domains()
-        if is_midnight_for_domain(domain.midnight, error_margin=15)
+        for midnight in domain.midnights
+        if is_midnight_for_domain(midnight, error_margin=20)
     ]
     for domain in domains:
         all_cases = get_call_center_cases(domain.name, domain.cc_case_type)

--- a/corehq/apps/callcenter/tasks.py
+++ b/corehq/apps/callcenter/tasks.py
@@ -2,6 +2,9 @@ from celery.schedules import crontab
 from celery.task.base import periodic_task
 from corehq.apps.callcenter.indicator_sets import CallCenterIndicators
 from corehq.apps.callcenter.utils import get_call_center_domains, is_midnight_for_domain, get_call_center_cases
+from celery.utils.log import get_task_logger
+
+logger = get_task_logger(__name__)
 
 
 @periodic_task(run_every=crontab(minute='*/15'), queue='background_queue')
@@ -17,6 +20,7 @@ def calculate_indicators():
         for midnight in domain.midnights
         if is_midnight_for_domain(midnight, error_margin=20)
     ]
+    logger.info("Calculating callcenter indicators for domains:\n{}".format(domains))
     for domain in domains:
         all_cases = get_call_center_cases(domain.name, domain.cc_case_type)
         indicator_set = CallCenterIndicators(

--- a/corehq/apps/callcenter/tests/test_utils.py
+++ b/corehq/apps/callcenter/tests/test_utils.py
@@ -138,7 +138,8 @@ class CallCenterUtilsTests(TestCase):
 
 class DomainTimezoneTests(SimpleTestCase):
     def test_midnight_for_domain(self):
-        midnight = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+        midnight_past = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+        midnight_future = midnight_past + timedelta(days=1)
         timezones = [
             ('Asia/Kolkata', 5.5),
             ('UTC', 0),
@@ -152,9 +153,12 @@ class DomainTimezoneTests(SimpleTestCase):
             ('Africa/Nairobi', 3),
         ]
         for tz, offset in timezones:
+            # account for DST
             offset += datetime.now(pytz.timezone(tz)).dst().total_seconds() / 3600
+
             dom = DomainLite(name='', default_timezone=tz, cc_case_type='')
-            self.assertEqual(dom.midnight, midnight - timedelta(hours=offset), tz)
+            self.assertEqual(dom.midnights[0], midnight_past - timedelta(hours=offset), tz)
+            self.assertEqual(dom.midnights[1], midnight_future - timedelta(hours=offset), tz)
 
     def test_is_midnight_for_domain(self):
         midnight = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)

--- a/corehq/apps/callcenter/utils.py
+++ b/corehq/apps/callcenter/utils.py
@@ -22,10 +22,16 @@ from dimagi.utils.couch import CriticalSection
 
 class DomainLite(namedtuple('DomainLite', 'name default_timezone cc_case_type')):
     @property
-    def midnight(self):
+    def midnights(self):
+        """Returns a list containing a datetime for midnight in the domains timezone
+        on either side of the current date.
+        """
         tz = pytz.timezone(self.default_timezone)
-        midnight = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
-        return UserTime(midnight, tz).server_time().done()
+        now = datetime.utcnow()
+        midnight_utc = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        midnight_tz1 = UserTime(midnight_utc, tz).server_time().done()
+        midnight_tz2 = midnight_tz1 + timedelta(days=(1 if midnight_tz1 < now else -1))
+        return sorted([midnight_tz1, midnight_tz2])
 
 
 CallCenterCase = namedtuple('CallCenterCase', 'case_id hq_user_id')


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?174956 and http://manage.dimagi.com/default.asp?171653
Domains with timezones ahead of UTC were never getting run.

@TylerSheffels 
cc @czue 
