### PR TITLE
Tag commits on deploy

### DIFF
--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -680,7 +680,6 @@ def deploy():
 
 def _deploy_without_asking():
     try:
-        _tag_commit()
         _execute_with_timing(update_code)
         _execute_with_timing(update_virtualenv)
         _execute_with_timing(install_npm_packages)
@@ -718,6 +717,7 @@ def _deploy_without_asking():
         raise
     else:
         _execute_with_timing(services_restart)
+        _tag_commit()
         _execute_with_timing(record_successful_deploy)
 
 
@@ -735,7 +735,6 @@ def _tag_commit():
     deploy_time = datetime.datetime.utcnow()
     tag_name = "{:%Y-%m-%d_%H.%M}-{}-deploy".format(deploy_time, env.environment)
     branch = "origin/{}".format(env.code_branch)
-    # TODO make it easier than --set message="my message"
     msg = getattr(env, "message", "")
     msg += "\n{} deploy at {}".format(env.environment, deploy_time.isoformat())
     sh.git.tag(tag_name, "-m", msg, branch)

--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -731,14 +731,15 @@ def force_update_static():
 
 
 def _tag_commit():
-    # TODO sh.git.fetch("origin", env.code_branch)
+    sh.git.fetch("origin", env.code_branch)
     deploy_time = datetime.datetime.utcnow()
-    tag_name = "{:%Y-%m-%d_%H.%M}-{}".format(deploy_time, env.environment)
+    tag_name = "{:%Y-%m-%d_%H.%M}-{}-deploy".format(deploy_time, env.environment)
     branch = "origin/{}".format(env.code_branch)
-    msg = getattr(env, "message", "")  # TODO make it easier than --set message
+    # TODO make it easier than --set message="my message"
+    msg = getattr(env, "message", "")
     msg += "\n{} deploy at {}".format(env.environment, deploy_time.isoformat())
     sh.git.tag(tag_name, "-m", msg, branch)
-    # TODO push tag back to origin, eventually deploy tag, not branch
+    sh.git.push("origin", tag_name)
 
 
 @task


### PR DESCRIPTION
@dimagi/team-commcare-hq 
I mentioned this in the meeting yesterday.  

This allows you to answer the questions
- Is my branch on staging/prod?
- When did this commit go live?
- What did master look like on this date?

Here's basic usage:

```
$ git tag -l 2015-06*production-deploy*
// all tags matching the substrings 2015-06 and production-deploy (all prod deploys in June, 2015)
$ git tag -l *prod* --contains 941ffd2
// all tags matching the substring prod which contain commit 941ffd2
```

Note that this output is also `grep`pable, so that might be the easier way of filtering

You can specify a custom message to be added to the tag if you like:
`$ fab production awesome_deploy --set message="emergency bugfix"`

Here's where you can find the tags on github:
![screenshot - 07012015 - 03 36 28 pm](https://cloud.githubusercontent.com/assets/2367539/8463285/1cb2f4d8-2007-11e5-9d39-c4d4ef895195.png)

I've got a couple questions in-line in the PR before merging though.
