### PR TITLE
Subscription change email alerts

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -985,7 +985,9 @@ class Subscription(models.Model):
     def change_plan(self, new_plan_version, date_end=None,
                     note=None, web_user=None, adjustment_method=None,
                     service_type=None, pro_bono_status=None,
-                    transfer_credits=True, internal_change=False):
+                    transfer_credits=True, internal_change=False, account=None,
+                    do_not_invoice=None, **kwargs
+    ):
         """
         Changing a plan TERMINATES the current subscription and
         creates a NEW SUBSCRIPTION where the old plan left off.
@@ -999,7 +1001,7 @@ class Subscription(models.Model):
         new_start_date = today if self.date_start < today else self.date_start
 
         new_subscription = Subscription(
-            account=self.account,
+            account=account if account else self.account,
             plan_version=new_plan_version,
             subscriber=self.subscriber,
             salesforce_contract_id=self.salesforce_contract_id,
@@ -1007,9 +1009,10 @@ class Subscription(models.Model):
             date_end=date_end,
             date_delay_invoicing=self.date_delay_invoicing,
             is_active=self.is_active,
-            do_not_invoice=self.do_not_invoice,
+            do_not_invoice=do_not_invoice if do_not_invoice else self.do_not_invoice,
             service_type=(service_type or SubscriptionType.NOT_SET),
             pro_bono_status=(pro_bono_status or ProBonoStatus.NOT_SET),
+            **kwargs
         )
         new_subscription.save()
 

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -986,8 +986,7 @@ class Subscription(models.Model):
                     note=None, web_user=None, adjustment_method=None,
                     service_type=None, pro_bono_status=None,
                     transfer_credits=True, internal_change=False, account=None,
-                    do_not_invoice=None, **kwargs
-    ):
+                    do_not_invoice=None, **kwargs):
         """
         Changing a plan TERMINATES the current subscription and
         creates a NEW SUBSCRIPTION where the old plan left off.

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1569,7 +1569,8 @@ class ContractedPartnerForm(InternalSubscriptionManagementForm):
                     auto_generate_credits=True,
                     service_type=SubscriptionType.CONTRACTED
                 )
-                if new_subscription.date_start <= datetime.date.today() and datetime.date.today() < new_subscription.date_end:
+                if (new_subscription.date_start <= datetime.date.today()
+                   and datetime.date.today() < new_subscription.date_end):
                     new_subscription.is_active = True
                     new_subscription.save()
         except:

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -45,6 +45,7 @@ from corehq.apps.accounting.models import (
     Subscription,
     SubscriptionAdjustmentMethod,
     SubscriptionType,
+    EntryPoint,
 )
 from corehq.apps.app_manager.models import (Application, RemoteApp,
                                             FormBase, get_apps_in_domain)
@@ -1240,6 +1241,7 @@ class InternalSubscriptionManagementForm(forms.Form):
                 currency=Currency.get_default(),
                 dimagi_contact=self.web_user,
                 account_type=BillingAccountType.GLOBAL_SERVICES,
+                entry_point=EntryPoint.CONTRACTED,
             )
             account.save()
         contact_info, _ = BillingContactInfo.objects.get_or_create(account=account)

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1553,6 +1553,10 @@ class ContractedPartnerForm(InternalSubscriptionManagementForm):
                     date_start=self.cleaned_data['start_date'],
                     date_end=self.cleaned_data['end_date'],
                     web_user=self.web_user,
+                    do_not_invoice=False,
+                    auto_generate_credits=True,
+                    service_type=SubscriptionType.CONTRACTED,
+                    internal_change=True,
                 )
             else:
                 new_subscription = self.current_subscription.change_plan(
@@ -1560,14 +1564,14 @@ class ContractedPartnerForm(InternalSubscriptionManagementForm):
                     date_end=self.cleaned_data['end_date'],
                     web_user=self.web_user,
                     transfer_credits=self.current_subscription.account == self.next_account,
+                    account=self.next_account,
+                    do_not_invoice=False,
+                    auto_generate_credits=True,
+                    service_type=SubscriptionType.CONTRACTED
                 )
-                new_subscription.account = self.next_account
-            if new_subscription.date_start <= datetime.date.today() and datetime.date.today() < new_subscription.date_end:
-                new_subscription.is_active = True
-            new_subscription.do_not_invoice = False
-            new_subscription.auto_generate_credits = True
-            new_subscription.service_type = SubscriptionType.CONTRACTED
-            new_subscription.save()
+                if new_subscription.date_start <= datetime.date.today() and datetime.date.today() < new_subscription.date_end:
+                    new_subscription.is_active = True
+                    new_subscription.save()
         except:
             # If the entire transaction did not go through, rollback saved changes
             if revert_current_subscription_end_date:


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?174032#969804
http://manage.dimagi.com/default.asp?174037#969805

This was a hairy one... The email gets sent in `apply_upgrades_and_downgrades`, which gets called from both `new_domain_subscription` _and_ `change_plan`. The properties were getting set _after_ the email had been set, which is why it was good in the admin interface but wrong in the email. 

Probably a good candidate for some refactoring at a later point.

@nickpell 
code buddy: @biyeun 
