### PR TITLE
Use SI prefixes when number is >= 10k

### DIFF
--- a/corehq/apps/hqadmin/static/hqadmin/js/nvd3_charts_helper.js
+++ b/corehq/apps/hqadmin/static/hqadmin/js/nvd3_charts_helper.js
@@ -247,12 +247,20 @@ function addStackedAreaGraph(selector, xname, data) {
 
 var linebreak_txt = " -- ";
 function formatChart(chart, selector, xname, data, margin_left) {
+    var si_prefix_formatter = d3.format('.3s'),
+        integer_formatter = d3.format(',.1d');
+
     chart.xAxis
         .axisLabel('Date')
         .tickFormat(function(d){return d3.time.format.utc('%b %d' + linebreak_txt + '%Y')(new Date(d));});
 
     chart.yAxis
-        .tickFormat(d3.format(',.1d'))
+        .tickFormat(function(d){
+            if(d >= Math.pow(10,4)){
+                return si_prefix_formatter(d);
+            }
+            return integer_formatter(d);
+        })
         .axisLabel(xname);
 
     d3.select(selector)


### PR DESCRIPTION
Keeps the number the same when it is less than 10k, when above, uses SI prefixes.
That x-axis looks like it could do with some work, but out of scope for this. 

discussion here: https://github.com/dimagi/commcare-hq/pull/6980
http://manage.dimagi.com/default.asp?169822

![screen shot 2015-07-02 at 1 32 46 pm](https://cloud.githubusercontent.com/assets/146896/8483495/f71e60b4-20be-11e5-89e5-3c8f87a9f421.png)
![screen shot 2015-07-02 at 1 33 14 pm](https://cloud.githubusercontent.com/assets/146896/8483504/02016e4a-20bf-11e5-95d1-fae14296cc22.png)

@kaapstorm @orangejenny 
code buddy: @biyeun 
