### PR TITLE
Show real number of deidentified exports on subscription change page

### DIFF
--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -366,7 +366,8 @@ class DomainDowngradeStatusHandler(BaseModifySubscriptionHandler):
         """
         startkey = json.dumps([self.domain.name, ""])[:-3]
         endkey = "%s{" % startkey
-        reports = SavedExportSchema.view("couchexport/saved_export_schemas",
+        reports = SavedExportSchema.view(
+            "couchexport/saved_export_schemas",
             startkey=startkey,
             endkey=endkey,
             include_docs=True,

--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -366,11 +366,12 @@ class DomainDowngradeStatusHandler(BaseModifySubscriptionHandler):
         """
         startkey = json.dumps([self.domain.name, ""])[:-3]
         endkey = "%s{" % startkey
-        num_deid_reports = SavedExportSchema.view("couchexport/saved_export_schemas",
+        reports = SavedExportSchema.view("couchexport/saved_export_schemas",
             startkey=startkey,
             endkey=endkey,
-            include_docs=False,
-        ).count()
+            include_docs=True,
+        )
+        num_deid_reports = len(filter(lambda r: r.is_safe, reports))
         if num_deid_reports > 0:
             return self._fmt_alert(
                 ungettext(


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?174445#971036

Previously the subscription downgrade page was warning people when they had _any_ custom exports. This now only warns them when they have de-identified custom exports.

code buddy @biyeun 
