### PR TITLE
Custom icon paths

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/app_manager_media.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager_media.js
@@ -125,6 +125,11 @@ var AppMenuMediaManager = function (o) {
             self.ref(new MenuMediaReference(ref));
             self.objectMap(obj_map);
             self.updateResource();
+            if (self.currentPath() !== data.ref.path){
+                //CurrentPath has a different filetype to the
+                //uploaded file
+                self.customPath(data.ref.path);
+            }
         }
     };
 


### PR DESCRIPTION
With https://github.com/dimagi/MediaUploader/pull/8, fixes
http://manage.dimagi.com/default.asp?175417#971109

When setting a custom icon path with a different filetype to the file that is being uploaded, an error would be thrown with an unhelpful error message (e.g. Filetype PNGS is not valid). Additionally, setting a name _without_ a filetype would not throw any errors and not show the uploaded image.

Here, we set the customPath if the filetype is different to the one that the user entered (or which was set by default). If there is no path in the customPath, we add one.

code buddy @biyeun 
