### PR TITLE
truncate column ids when they are too long going into tables

### DIFF
--- a/corehq/apps/userreports/sql.py
+++ b/corehq/apps/userreports/sql.py
@@ -87,8 +87,10 @@ def get_indicator_table(indicator_config, custom_metadata=None):
 
 
 def column_to_sql(column):
+    # we have to explicitly truncate the column IDs otherwise postgres will do it
+    # and will choke on them if there are duplicates: http://manage.dimagi.com/default.asp?175495
     return sqlalchemy.Column(
-        column.id,
+        truncate_value(column.id),
         _get_column_type(column.datatype),
         nullable=column.is_nullable,
         primary_key=column.is_primary_key,
@@ -104,6 +106,17 @@ def rebuild_table(engine, table):
         table.drop(connection, checkfirst=True)
         table.create(connection)
     engine.dispose()
+
+
+def truncate_value(value, max_length=63):
+    """
+    Truncate a value (typically a column name) to a certain number of characters,
+    using a hash to ensure uniqueness.
+    """
+    if len(value) > max_length:
+        short_hash = hashlib.sha1(value).hexdigest()[:8]
+        return '{}_{}'.format(value[-54:], short_hash)
+    return value
 
 
 def get_column_name(path):

--- a/corehq/apps/userreports/tests/test_columns.py
+++ b/corehq/apps/userreports/tests/test_columns.py
@@ -3,6 +3,7 @@ import uuid
 from jsonobject.exceptions import BadValueError
 from sqlagg import SumWhen
 from django.test import SimpleTestCase, TestCase
+from corehq.db import Session
 
 from corehq.apps.userreports import tasks
 from corehq.apps.userreports.app_manager import _clean_table_name
@@ -12,7 +13,7 @@ from corehq.apps.userreports.models import (
 )
 from corehq.apps.userreports.reports.factory import ReportFactory, ReportColumnFactory
 from corehq.apps.userreports.reports.specs import FieldColumn, PercentageColumn, AggregateDateColumn
-from corehq.apps.userreports.sql import _expand_column, _get_distinct_values
+from corehq.apps.userreports.sql import _expand_column, _get_distinct_values, IndicatorSqlAdapter, get_engine
 
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.models import CommCareCase
@@ -71,6 +72,39 @@ class TestFieldColumn(SimpleTestCase):
                 "format": "default_",
                 "type": "field",
             })
+
+
+class ChoiceListColumnDbTest(TestCase):
+
+    def test_column_uniqueness_when_truncated(self):
+        problem_spec = {
+            "display_name": "practicing_lessons",
+            "property_path": [
+                "form",
+                "previous_lesson_review",
+                "practicing_lessons"
+            ],
+            "choices": [
+                "duplicate_choice_1",
+                "duplicate_choice_2",
+            ],
+            "select_style": "multiple",
+            "column_id": "a_very_long_base_selection_column_name_with_limted_room",
+            "type": "choice_list",
+        }
+        data_source_config = DataSourceConfiguration(
+            domain='test',
+            display_name='foo',
+            referenced_doc_type='CommCareCase',
+            table_id=uuid.uuid4().hex,
+            configured_filter={},
+            configured_indicators=[problem_spec],
+        )
+        adapter = IndicatorSqlAdapter(get_engine(), data_source_config)
+        adapter.rebuild_table()
+        # ensure we can query the table
+        q = Session.query(adapter.get_table())
+        self.assertEqual(0, q.count())
 
 
 class TestExpandedColumn(TestCase):


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?175495

@NoahCarnahan what do you think about this? One problem is that any existing UCR tables that had columns which were already being truncated automatically by postgres are now going to have bad configurations. Do you think we need to write a migration to deal with that? It's tempting to just fix them as they come up.
