### PR TITLE
Suppress invoice UI

### DIFF
--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -1876,6 +1876,38 @@ class ResendEmailForm(forms.Form):
         record.send_email(contact_emails=contact_emails)
 
 
+class SuppressInvoiceForm(forms.Form):
+    submit_kwarg = 'suppress_invoice'
+
+    def __init__(self, invoice, *args, **kwargs):
+        self.invoice = invoice
+        super(SuppressInvoiceForm, self).__init__(*args, **kwargs)
+
+        self.helper = FormHelper()
+        self.helper.form_class = 'form-horizontal'
+        self.helper.layout = crispy.Layout(
+            crispy.Fieldset(
+                'Suppress invoice from all reports and user-facing statements',
+                crispy.Div(
+                    crispy.HTML('Warning: this can only be undone by a developer.'),
+                    css_class='alert alert-error',
+                )
+            ),
+            FormActions(
+                StrictButton(
+                    'Suppress Invoice',
+                    css_class='btn-danger',
+                    name=self.submit_kwarg,
+                    type='submit',
+                ),
+            ),
+        )
+
+    def suppress_invoice(self):
+        self.invoice.is_hidden_to_ops = True
+        self.invoice.save()
+
+
 class CreateAdminForm(forms.Form):
     username = forms.CharField(
         required=False,

--- a/corehq/apps/accounting/templates/accounting/invoice.html
+++ b/corehq/apps/accounting/templates/accounting/invoice.html
@@ -39,6 +39,7 @@
         {% if adjustment_list %}
         <li><a href="#adjustments" data-toggle="tab">{% trans "Adjustments" %}</a></li>
         {% endif %}
+        <li><a href="#suppress" data-toggle="tab">{% trans "Suppress" %}</a></li>
     </ul>
 
     <div class="tab-content">
@@ -109,5 +110,8 @@
             </table>
         </div>
         {% endif %}
+        <div class="tab-pane" id="suppress">
+            {% crispy suppress_invoice_form %}
+        </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
Add an admin UI tab to hide invoices from ops to make support's job easier.

@benrudolph @proteusvacuum cc: @orangejenny 

<img width="1280" alt="screen shot 2015-07-06 at 11 37 10 am" src="https://cloud.githubusercontent.com/assets/1757035/8526233/63fc8aaa-23d3-11e5-920d-1951656e3d3c.png">
