### PR TITLE
Fix unstyled errors

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -1150,8 +1150,8 @@ MESSAGE_TAGS = {
     messages.INFO: 'alert-info',
     messages.DEBUG: '',
     messages.SUCCESS: 'alert-success',
-    messages.WARNING: 'alert-error',
-    messages.ERROR: 'alert-error',
+    messages.WARNING: 'alert-error alert-danger',
+    messages.ERROR: 'alert-error alert-danger',
 }
 
 COMMCARE_USER_TERM = "Mobile Worker"


### PR DESCRIPTION
Bootstrap 3 changes `alert-error` to `alert-danger`, so sometimes this happens:
![screen shot 2015-07-06 at 11 59 21 am](https://cloud.githubusercontent.com/assets/1486591/8526829/ffd740d4-23d6-11e5-899b-7cb2ac40fdd6.png)

Fixed:
![screen shot 2015-07-06 at 12 01 37 pm](https://cloud.githubusercontent.com/assets/1486591/8526833/0505d1ba-23d7-11e5-9aea-f0ed806a7342.png)

@nickpell 
