### PR TITLE
Use default data view as link in dashboard

### DIFF
--- a/corehq/apps/dashboard/views.py
+++ b/corehq/apps/dashboard/views.py
@@ -142,8 +142,6 @@ def _get_default_tile_configurations():
     )
 
     is_domain_admin = lambda request: request.couch_user.is_domain_admin(request.domain)
-    data_url_generator = lambda urlname, request: reverse(urlname,
-        args=[request.domain, ExcelExportReport.slug])
 
     return [
         TileConfiguration(
@@ -179,8 +177,7 @@ def _get_default_tile_configurations():
             slug='data',
             icon='fcc fcc-data',
             context_processor_class=IconContext,
-            urlname=DataInterfaceDispatcher.name(),
-            url_generator=data_url_generator,
+            urlname="data_interfaces_default",
             visibility_check=can_edit_data,
             help_text=_('Export and manage data'),
         ),


### PR DESCRIPTION
Instead of linking to /excel_export_data/ by default which leads to issues
when people don't have permission to view export data, the dashboard
tile now links to /data/ which knows how to handle permissions
reasonably.

http://manage.dimagi.com/default.asp?175449#972001

code buddy @biyeun 
