### PR TITLE
Convert EMWF to use paginate_options

### DIFF
--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -63,7 +63,7 @@ class EmwfOptionsView(LoginAndDomainMixin, JSONResponseMixin, View):
     def get_locations(self, query, start, size):
         for loc in self.get_locations_query(query)[start:size]:
             group = loc.reporting_group_object()
-            yield (group._id, group.name + ' [group]')
+            yield self.utils.location_group_tuple(group)
 
     def get_locations_size(self, query):
         return self.get_locations_query(query).count()

--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -2,7 +2,6 @@
 API endpoints for filter options
 """
 import logging
-from itertools import islice
 
 from django.views.generic import View
 
@@ -31,29 +30,11 @@ class EmwfOptionsView(LoginAndDomainMixin, JSONResponseMixin, View):
     def get(self, request, domain):
         self.domain = domain
         self.q = self.request.GET.get('q', None)
-        if self.q and self.q.strip():
-            tokens = self.q.split()
-            queries = ['%s*' % tokens.pop()] + tokens
-            self.user_query = {"bool": {"must": [
-                {"query_string": {
-                    "query": q,
-                    "fields": ["first_name", "last_name", "username"],
-                }} for q in queries
-            ]}}
-            self.group_query = {"bool": {"must": [
-                {"query_string": {
-                    "query": q,
-                    "default_field": "name",
-                }} for q in queries
-            ]}}
-        else:
-            self.user_query = None
-            self.group_query = None
         try:
-            self._init_counts()
+            count, options = self.get_options()
             return self.render_json_response({
-                'results': self.get_options(),
-                'total': self.total_results,
+                'results': options,
+                'total': count,
             })
         except ESError as e:
             if self.q:
@@ -64,7 +45,7 @@ class EmwfOptionsView(LoginAndDomainMixin, JSONResponseMixin, View):
                 # introduced by the addition of the query_string query, which
                 # contains the user's input.
                 logger.info('ElasticSearch error caused by query "%s": %s',
-                    self.q, e)
+                            self.q, e)
             else:
                 # The error was our fault
                 notify_exception(request, e)
@@ -73,81 +54,88 @@ class EmwfOptionsView(LoginAndDomainMixin, JSONResponseMixin, View):
             'total': 0,
         })
 
-    @property
-    def locations_query(self):
+    def get_locations_query(self, query):
         return SQLLocation.objects.filter(
-            name__icontains=self.q.lower(),
+            name__icontains=query.lower(),
             domain=self.domain,
         )
 
-    def get_location_groups(self):
-        for loc in self.locations_query:
+    def get_locations(self, query, start, size):
+        for loc in self.get_locations_query(query)[start:size]:
             group = loc.reporting_group_object()
             yield (group._id, group.name + ' [group]')
 
-    def get_locations_size(self):
-        return self.locations_query.count()
+    def get_locations_size(self, query):
+        return self.get_locations_query(query).count()
 
-    def _init_counts(self):
-        users, _ = self.user_es_call(size=0, return_count=True)
-        self.group_start = len(self.static_options)
-        self.location_start = self.group_start + self.get_group_size()
-        self.user_start = self.location_start + self.get_locations_size()
-        self.total_results = self.user_start + users
+    @property
+    def data_sources(self):
+        return [
+            (self.get_static_options_size, self.get_static_options),
+            (self.get_groups_size, self.get_groups),
+            (self.get_locations_size, self.get_locations),
+            (self.get_users_size, self.get_users),
+        ]
 
     def get_options(self):
         page = int(self.request.GET.get('page', 1))
-        limit = int(self.request.GET.get('page_limit', 10))
-        start = limit * (page - 1)
-        stop = start + limit
+        size = int(self.request.GET.get('page_limit', 10))
+        start = size * (page - 1)
+        count, options = paginate_options(self.data_sources, self.q, start, size)
+        return count, [{'id': id_, 'text': text} for id_, text in options]
 
-        options = self.static_options[start:stop]
+    def get_static_options_size(self, query):
+        return len(self.get_all_static_options(query))
 
-        g_start = max(0, start - self.group_start)
-        g_size = limit - len(options) if start < self.location_start else 0
-        options += self.get_groups(g_start, g_size) if g_size else []
+    def get_all_static_options(self, query):
+        return [user_type for user_type in self.utils.static_options
+                if query.lower() in user_type[1].lower()]
 
-        l_start = max(0, start - self.location_start)
-        l_size = limit - len(options) if start < self.user_start else 0
-        l_end = l_start + l_size
-        location_groups = islice(self.get_location_groups(), l_start, l_end)
-        options += location_groups
+    def get_static_options(self, query, start, size):
+        return self.get_all_static_options(query)[start:start+size]
 
-        u_start = max(0, start - self.user_start)
-        u_size = limit - len(options)
-        options += self.get_users(u_start, u_size) if u_size else []
+    def get_es_query_strings(self, query):
+        if query and query.strip():
+            tokens = query.split()
+            return ['%s*' % tokens.pop()] + tokens
 
-        return [{'id': id, 'text': text} for id, text in options]
+    def user_es_call(self, query, **kwargs):
+        query = {"bool": {"must": [
+            {"query_string": {
+                "query": q,
+                "fields": ["first_name", "last_name", "username"],
+            }} for q in self.get_es_query_strings(query)
+        ]}} if query and query.strip() else None
+        return es_wrapper('users', domain=self.domain, q=query, **kwargs)
 
-    @property
-    @memoized
-    def static_options(self):
-        return filter(
-            lambda user_type: self.q.lower() in user_type[1].lower(),
-            self.utils.static_options
-        )
+    def get_users_size(self, query):
+        return self.user_es_call(query, size=0, return_count=True)[0]
 
-    def user_es_call(self, **kwargs):
-        return es_wrapper('users', domain=self.domain, q=self.user_query, **kwargs)
-
-    def get_users(self, start, size):
+    def get_users(self, query, start, size):
         fields = ['_id', 'username', 'first_name', 'last_name', 'doc_type']
-        users = self.user_es_call(fields=fields, start_at=start, size=size,
+        users = self.user_es_call(query, fields=fields, start_at=start, size=size,
                                   sort_by='username.exact', order='asc')
         return [self.utils.user_tuple(u) for u in users]
 
-    def get_group_size(self):
-        return self.group_es_call(size=0, return_count=True)[0]
+    def get_groups_size(self, query):
+        return self.group_es_call(query, size=0, return_count=True)[0]
 
-    def group_es_call(self, **kwargs):
-        reporting_filter = {"term": {'reporting': "true"}}
-        return es_wrapper('groups', domain=self.domain, q=self.group_query,
-                          filters=[reporting_filter], doc_type='Group',
+    def group_es_call(self, query, group_type="reporting", **kwargs):
+        query = {"bool": {"must": [
+            {"query_string": {
+                "query": q,
+                "default_field": "name",
+            }} for q in self.get_es_query_strings(query)
+        ]}} if query and query.strip() else None
+        type_filter = {"term": {group_type: "true"}}
+        return es_wrapper('groups', domain=self.domain, q=query,
+                          filters=[type_filter], doc_type='Group',
                           **kwargs)
 
-    def get_groups(self, start, size):
+    def get_groups(self, query, start, size):
         fields = ['_id', 'name']
         groups = self.group_es_call(
+            query,
             fields=fields,
             sort_by="name.exact",
             order="asc",
@@ -166,17 +154,18 @@ def paginate_options(data_sources, query, start, size):
     """
     # Note this is pretty confusing, check TestEmwfPagination for reference
     options = []
+    total = 0
     for get_size, get_objects in data_sources:
-        if size <= 0:
-            break
-
         count = get_size(query)
+        total += count
+
         if start > count:  # skip over this whole data source
             start -= count
             continue
 
-        objects = get_objects(query, start, size)  # return a page of objects
+        # return a page of objects
+        objects = list(get_objects(query, start, size))
         start = 0
         size -= len(objects)  # how many more do we need for this page?
         options.extend(objects)
-    return options
+    return total, options

--- a/corehq/apps/reports/filters/case_list.py
+++ b/corehq/apps/reports/filters/case_list.py
@@ -72,7 +72,7 @@ class CaseListFilter(ExpandedMobileWorkerFilter):
             )
             for loc in locs:
                 loc_group = loc.case_sharing_group_object()
-                selected.append(self.sharing_location_tuple(loc_group))
+                selected.append(self.utils.sharing_location_tuple(loc_group))
         return selected
 
     def selected_group_entries(self, request):
@@ -130,7 +130,7 @@ class CaseListFilterOptions(EmwfOptionsView):
     def get_sharing_locations(self, query, start, size):
         for loc in self.get_sharing_locations_query(query)[start:size]:
             group = loc.case_sharing_group_object()
-            yield (group._id, group.name + ' [case sharing]')
+            yield self.utils.sharing_location_tuple(group)
 
     def get_sharing_locations_size(self, query):
         return self.get_sharing_locations_query(query).count()

--- a/corehq/apps/reports/tests/__init__.py
+++ b/corehq/apps/reports/tests/__init__.py
@@ -10,6 +10,7 @@ try:
     from corehq.apps.reports.tests.test_time_and_date_manipulations import *
     from corehq.apps.reports.tests.test_generic import *
     from corehq.apps.reports.tests.test_util import *
+    from .test_filters import *
     from .test_pillows_xforms import *
     from .test_pillows_cases import *
     from .test_scheduled_reports import *

--- a/corehq/apps/reports/tests/test_filters.py
+++ b/corehq/apps/reports/tests/test_filters.py
@@ -1,0 +1,53 @@
+from django.test import SimpleTestCase
+from corehq.apps.reports.filters.api import paginate_options
+
+
+class TestEmwfPagination(SimpleTestCase):
+    def make_data_source(self, options):
+        def matching_objects(query):
+            if not query:
+                return options
+            return [o for o in options if query.lower() in o.lower()]
+
+        def get_size(query):
+            return len(matching_objects(query))
+
+        def get_objects(query, start, size):
+            return matching_objects(query)[start:start+size]
+
+        return (get_size, get_objects)
+
+    @property
+    def data_sources(self):
+        return [
+            self.make_data_source(["Iron Maiden", "Van Halen", "Queen"]),
+            self.make_data_source(["Oslo", "Baldwin", "Perth", "Quito"]),
+            self.make_data_source([]),
+            self.make_data_source(["Jdoe", "Rumpelstiltskin"]),
+        ]
+
+    def test_first_page(self):
+        self.assertEqual(
+            paginate_options(self.data_sources, "", 0, 5),
+            ["Iron Maiden", "Van Halen", "Queen", "Oslo", "Baldwin"],
+        )
+
+    def test_second_page(self):
+        self.assertEqual(
+            paginate_options(self.data_sources, "", 5, 10),
+            ["Perth", "Quito", "Jdoe", "Rumpelstiltskin"],
+        )
+
+    def test_query_first_page(self):
+        query = "o"
+        self.assertEqual(
+            paginate_options(self.data_sources, query, 0, 5),
+            ["Iron Maiden", "Oslo", "Quito", "Jdoe"],
+        )
+
+    def test_query_no_matches(self):
+        query = "Waldo"
+        self.assertEqual(
+            paginate_options(self.data_sources, query, 0, 5),
+            [],
+        )

--- a/corehq/apps/reports/tests/test_filters.py
+++ b/corehq/apps/reports/tests/test_filters.py
@@ -27,27 +27,29 @@ class TestEmwfPagination(SimpleTestCase):
         ]
 
     def test_first_page(self):
+        count, options = paginate_options(self.data_sources, "", 0, 5)
+        self.assertEqual(count, 9)
         self.assertEqual(
-            paginate_options(self.data_sources, "", 0, 5),
+            options,
             ["Iron Maiden", "Van Halen", "Queen", "Oslo", "Baldwin"],
         )
 
     def test_second_page(self):
+        count, options = paginate_options(self.data_sources, "", 5, 10)
+        self.assertEqual(count, 9)
         self.assertEqual(
-            paginate_options(self.data_sources, "", 5, 10),
+            options,
             ["Perth", "Quito", "Jdoe", "Rumpelstiltskin"],
         )
 
     def test_query_first_page(self):
         query = "o"
-        self.assertEqual(
-            paginate_options(self.data_sources, query, 0, 5),
-            ["Iron Maiden", "Oslo", "Quito", "Jdoe"],
-        )
+        count, options = paginate_options(self.data_sources, query, 0, 5)
+        self.assertEqual(count, 4)
+        self.assertEqual(options, ["Iron Maiden", "Oslo", "Quito", "Jdoe"])
 
     def test_query_no_matches(self):
         query = "Waldo"
-        self.assertEqual(
-            paginate_options(self.data_sources, query, 0, 5),
-            [],
-        )
+        count, options = paginate_options(self.data_sources, query, 0, 5)
+        self.assertEqual(count, 0)
+        self.assertEqual(options, [])


### PR DESCRIPTION
There was a bunch of repetitive index manipulation that was happening, and it was pretty difficult to modify or verify that it worked properly, so this PR pulls out the pagination logic and tests that, then moves stuff around a bunch to use that function.  This shouldn't have any user-facing changes.
This came out of http://manage.dimagi.com/default.asp?175315, and it's the cleanup I promised in https://github.com/dimagi/commcare-hq/pull/7337
I spoke with @dannyroberts about how to do this, and @nickpell wrote the `paginate_options` function with me.
@sravfeyn
Happy to walk someone through this if needed
