### PR TITLE
remove unused reconcile code path

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -132,10 +132,6 @@ def process_cases_with_casedb(xforms, case_db, config=None):
     cases = case_processing_result.cases
     xform = xforms[0]
 
-    if config.reconcile:
-        for c in cases:
-            c.reconcile_actions(rebuild=True)
-
     # attach domain and export tag
     domain = xform.domain
 
@@ -163,9 +159,6 @@ def process_cases_with_casedb(xforms, case_db, config=None):
         from casexml.apps.case.util import update_sync_log_with_checks
         update_sync_log_with_checks(relevant_log, xform, cases, case_db,
                                     case_id_blacklist=config.case_id_blacklist)
-
-        if config.reconcile and relevant_log.reconcile_cases():
-            relevant_log.save()
 
     try:
         cases_received.send(sender=None, xform=xform, cases=cases)
@@ -200,14 +193,12 @@ def process_cases_with_casedb(xforms, case_db, config=None):
 
 
 class CaseProcessingConfig(object):
-    def __init__(self, reconcile=False, strict_asserts=True, case_id_blacklist=None):
-        self.reconcile = reconcile
+    def __init__(self, strict_asserts=True, case_id_blacklist=None):
         self.strict_asserts = strict_asserts
         self.case_id_blacklist = case_id_blacklist if case_id_blacklist is not None else []
 
     def __repr__(self):
-        return 'reconcile: {reconcile}, strict: {strict}, ids: {ids}'.format(
-            reconcile=self.reconcile,
+        return 'strict: {strict}, ids: {ids}'.format(
             strict=self.strict_asserts,
             ids=", ".join(self.case_id_blacklist)
         )

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -388,27 +388,6 @@ class SyncLog(AbstractSyncLog):
                 return True
             return False
 
-    def reconcile_cases(self):
-        """
-        Goes through the cases expected to be on the phone and reconciles
-        any duplicate records.
-
-        Return True if any duplicates were found.
-        """
-        num_cases_on_phone_before = len(self.cases_on_phone)
-        num_dependent_cases_before = len(self.dependent_cases_on_phone)
-
-        self.cases_on_phone = list(set(self.cases_on_phone))
-        self.dependent_cases_on_phone = list(set(self.dependent_cases_on_phone))
-
-        if num_cases_on_phone_before != len(self.cases_on_phone) \
-                or num_dependent_cases_before != len(self.dependent_cases_on_phone):
-            self._case_state_map.reset_cache(self)
-            self._dependent_case_state_map.reset_cache(self)
-            return True
-
-        return False
-
     def __unicode__(self):
         return "%s synced on %s (%s)" % (self.user_id, self.date.date(), self.get_id)
 


### PR DESCRIPTION
As far as I can see `CaseProcessingConfig.reconcile` is never set anywhere and therefore defaults to `False`

@dannyroberts @czue 
