### PR TITLE
Support bulk exports in revamped UX

### DIFF
--- a/corehq/apps/reports/standard/export.py
+++ b/corehq/apps/reports/standard/export.py
@@ -448,6 +448,7 @@ class FormExportReport(FormExportReportBase):
                 } for export_id in self.export_ids)
             ),
             'selected_exports_data': self.selected_exports_data,
+            'bulk_download_notice_text': ugettext_noop('Form Exports'),
         })
         return context
 

--- a/corehq/apps/reports/standard/export.py
+++ b/corehq/apps/reports/standard/export.py
@@ -439,6 +439,7 @@ class FormExportReport(FormExportReportBase):
     @property
     def template_context(self):
         context = super(FormExportReport, self).template_context
+        # TODO - seems redundant, cleanup at some point
         context.update({
             'export': self.exports[0],
             'exports': self.exports,

--- a/corehq/apps/reports/standard/export.py
+++ b/corehq/apps/reports/standard/export.py
@@ -4,6 +4,7 @@ import logging
 from datetime import timedelta, datetime
 from django.conf import settings
 
+from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_noop, ugettext_lazy
 from django.http import Http404
 from casexml.apps.case.models import CommCareCase
@@ -441,9 +442,11 @@ class FormExportReport(FormExportReportBase):
             'export': self.exports[0],
             'exports': self.exports,
             "use_bulk": len(self.export_ids) > 1,
-            'additional_params': '&'.join('export_id=%(export_id)s' % {
-                'export_id': export_id,
-            } for export_id in self.export_ids),
+            'additional_params': mark_safe(
+                '&'.join('export_id=%(export_id)s' % {
+                    'export_id': export_id,
+                } for export_id in self.export_ids)
+            ),
             'selected_exports_data': self.selected_exports_data,
         })
         return context

--- a/corehq/apps/reports/standard/export.py
+++ b/corehq/apps/reports/standard/export.py
@@ -399,9 +399,14 @@ class DataExportInterface(GenericReportView):
     def template_context(self):
         context = super(DataExportInterface, self).template_context
         context.update({
+            'bulk_export_format': self.bulk_export_format,
             'saved_exports': self.saved_exports,
         })
         return context
+
+    @property
+    def bulk_export_format(self):
+        return Format.XLS_2007
 
     @property
     @memoized

--- a/corehq/apps/reports/standard/export.py
+++ b/corehq/apps/reports/standard/export.py
@@ -403,6 +403,7 @@ class DataExportInterface(GenericReportView):
             'bulk_download_notice_text': ugettext_noop('Form Export'),
             'bulk_export_format': self.bulk_export_format,
             'saved_exports': self.saved_exports,
+            'download_page_url_root': FormExportReport.get_url(domain=self.domain),
         })
         return context
 

--- a/corehq/apps/reports/standard/export.py
+++ b/corehq/apps/reports/standard/export.py
@@ -399,6 +399,7 @@ class DataExportInterface(GenericReportView):
     def template_context(self):
         context = super(DataExportInterface, self).template_context
         context.update({
+            'bulk_download_notice_text': ugettext_noop('Form Export'),
             'bulk_export_format': self.bulk_export_format,
             'saved_exports': self.saved_exports,
         })

--- a/corehq/apps/reports/static/reports/ko/export.manager.js
+++ b/corehq/apps/reports/static/reports/ko/export.manager.js
@@ -64,6 +64,8 @@ var ExportManager = function (o) {
 
     self.sheet_names = ko.observable(new Object());
 
+    self.selectedExportsData = o.selectedExportsData || {};
+
     var resetModal = function (modal_title, newLine) {
             self.$modal.find(self.exportModalLoading).removeClass('hide');
             self.$modal.find(self.exportModalLoadedData).empty();
@@ -244,22 +246,29 @@ var ExportManager = function (o) {
         if (self.is_custom)
             prepareExport = new Array();
 
-        for (var i in self.selected_exports()) {
-            var curExpButton = self.selected_exports()[i];
+        for (var export_id in self.selectedExportsData) {
+//            var curExpButton = self.selected_exports()[i];
+//
+//            var _id = curExpButton.data('appid') || curExpButton.data('exportid'),
+//                xmlns = curExpButton.data('xmlns'),
+//                module = curExpButton.data('modulename'),
+//                export_type = curExpButton.data('exporttype'),
+//                form = curExpButton.data('formname');
 
-            var _id = curExpButton.data('appid') || curExpButton.data('exportid'),
-                xmlns = curExpButton.data('xmlns'),
-                module = curExpButton.data('modulename'),
-                export_type = curExpButton.data('exporttype'),
-                form = curExpButton.data('formname');
+            var export_data = self.selectedExportsData[export_id];
+            var xmlns = export_data['xmlns'],
+                module = export_data['modulename'],
+                export_type = export_data['exporttype'],
+                form = export_data['formname'],
+                _id = export_id;
 
             var sheetName = "sheet";
-            if (self.is_custom) {
-                var $sheetNameElem = curExpButton.parent().parent().find('.sheetname');
-                if($sheetNameElem.data('duplicate'))
-                    break;
-                sheetName = curExpButton.parent().parent().find('.sheetname').val();
-            } else
+//            if (self.is_custom) {
+//                var $sheetNameElem = curExpButton.parent().parent().find('.sheetname');
+//                if($sheetNameElem.data('duplicate'))
+//                    break;
+//                sheetName = curExpButton.parent().parent().find('.sheetname').val();
+//            } else
                 sheetName = getSheetName(module, form, xmlns);
 
             var export_tag;

--- a/corehq/apps/reports/static/reports/ko/export.manager.js
+++ b/corehq/apps/reports/static/reports/ko/export.manager.js
@@ -29,6 +29,15 @@ var ExportManager = function (o) {
 
     self.selectedExportsData = o.selectedExportsData || {};
 
+    if(self.isNewExporter) {
+        self.bulkDownloadPageUrlRoot = o.bulkDownloadPageUrlRoot;
+        self.bulkDownloadPageUrl = ko.computed(function() {
+            return self.bulkDownloadPageUrlRoot + '?' + self.selected_exports().map(
+                function(export_id) { return "export_id=" + export_id; }
+            ).join('&');
+        });
+    }
+
     var resetModal = function (modal_title, newLine) {
             self.$modal.find(self.exportModalLoading).removeClass('hide');
             self.$modal.find(self.exportModalLoadedData).empty();

--- a/corehq/apps/reports/static/reports/ko/export.manager.js
+++ b/corehq/apps/reports/static/reports/ko/export.manager.js
@@ -143,7 +143,7 @@ var ExportManager = function (o) {
         }
     };
 
-    if(self.isNewExporter) {
+    if(!self.isNewExporter) {
         self.updateSelectedExports = function (data, event) {
             var $checkbox = $(event.srcElement || event.currentTarget);
             var add_to_list = ($checkbox.attr('checked') === 'checked'),
@@ -319,7 +319,6 @@ var ExportManager = function (o) {
                 params[filter] = self.jsonExportFilters[filter];
             }
         }
-
         self.downloadBulkExport(self.bulkDownloadUrl, params);
     };
 
@@ -418,7 +417,7 @@ var ExportManager = function (o) {
         return true;
     };
 
-    if(self.isNewExporter) {
+    if(!self.isNewExporter) {
         self.toggleSelectAllExports = function (data, event) {
             var $toggleBtn = $(event.srcElement || event.currentTarget),
                 check_class = (self.is_custom) ? '.select-custom' : '.select-bulk';

--- a/corehq/apps/reports/static/reports/ko/export.manager.js
+++ b/corehq/apps/reports/static/reports/ko/export.manager.js
@@ -1,3 +1,42 @@
+var NewExportManager = function (o) {
+    var self = this;
+    self.selected_exports = ko.observableArray();
+    self.bulk_download_notice_text = o.bulk_download_notice_text || '';
+
+    self.requestBulkDownload = function() {
+        console.log('self.requestBulkDownload');
+    };
+
+    self.toggleSelectAllExports = function (data, event) {
+        var $toggleBtn = $(event.srcElement || event.currentTarget),
+            check_class = '.select-export';
+        if ($toggleBtn.data('all')) {
+            $.each($(check_class), function () {
+                $(this).attr('checked', true);
+                self.updateSelectedExports({}, {srcElement: this})
+            });
+        } else {
+            $.each($(check_class), function () {
+                $(this).attr('checked', false);
+                self.updateSelectedExports({}, {srcElement: this})
+            });
+        }
+    };
+
+    self.updateSelectedExports = function (data, event) {
+        var $checkbox = $(event.srcElement || event.currentTarget);
+        var add_to_list = ($checkbox.attr('checked') === 'checked'),
+            export_id = $checkbox.attr('value');
+        if (add_to_list) {
+            $checkbox.parent().find('.label').removeClass('label-info').addClass('label-success');
+            self.selected_exports.push(export_id);
+        } else {
+            $checkbox.parent().find('.label').removeClass('label-success').addClass('label-info');
+            self.selected_exports.splice(self.selected_exports().indexOf(export_id), 1);
+        }
+    };
+};
+
 var ExportManager = function (o) {
     var self = this;
     self.selected_exports = ko.observableArray();

--- a/corehq/apps/reports/static/reports/ko/export.manager.js
+++ b/corehq/apps/reports/static/reports/ko/export.manager.js
@@ -224,54 +224,84 @@ var ExportManager = function (o) {
         if (self.is_custom)
             prepareExport = new Array();
 
-        for (var export_id in self.selectedExportsData) {
-//            var curExpButton = self.selected_exports()[i];
-//
-//            var _id = curExpButton.data('appid') || curExpButton.data('exportid'),
-//                xmlns = curExpButton.data('xmlns'),
-//                module = curExpButton.data('modulename'),
-//                export_type = curExpButton.data('exporttype'),
-//                form = curExpButton.data('formname');
+        if(self.isNewExporter) {
+            for (var export_id in self.selectedExportsData) {
+                var export_data = self.selectedExportsData[export_id];
+                var xmlns = export_data['xmlns'],
+                    module = export_data['modulename'],
+                    export_type = export_data['exporttype'],
+                    form = export_data['formname'],
+                    _id = export_id;
 
-            var export_data = self.selectedExportsData[export_id];
-            var xmlns = export_data['xmlns'],
-                module = export_data['modulename'],
-                export_type = export_data['exporttype'],
-                form = export_data['formname'],
-                _id = export_id;
+                var sheetName = getSheetName(module, form, xmlns);
 
-            var sheetName = "sheet";
-//            if (self.is_custom) {
-//                var $sheetNameElem = curExpButton.parent().parent().find('.sheetname');
-//                if($sheetNameElem.data('duplicate'))
-//                    break;
-//                sheetName = curExpButton.parent().parent().find('.sheetname').val();
-//            } else
-                sheetName = getSheetName(module, form, xmlns);
+                var export_tag;
+                if (self.is_custom)
+                    export_tag = {
+                        domain: self.domain,
+                        xmlns: xmlns,
+                        sheet_name: sheetName,
+                        export_id: _id,
+                        export_type: export_type
+                    };
+                else
+                    export_tag = [self.domain, xmlns, sheetName];
 
-            var export_tag;
-            if (self.is_custom)
-                export_tag = {
-                    domain: self.domain,
-                    xmlns: xmlns,
-                    sheet_name: sheetName,
-                    export_id: _id,
-                    export_type: export_type
-                };
-            else
-                export_tag = [self.domain, xmlns, sheetName];
+                if (!_id)
+                    _id = "unknown_application";
 
-            if (!_id)
-                _id = "unknown_application";
+                if (self.is_custom)
+                    prepareExport.push(export_tag);
+                else {
+                    if (!prepareExport.hasOwnProperty(_id))
+                        prepareExport[_id] = new Array();
+                    prepareExport[_id].push(export_tag);
+                }
+            }
+        } else {
+            for (var i in self.selected_exports()) {
+                var curExpButton = self.selected_exports()[i];
 
-            if (self.is_custom)
-                prepareExport.push(export_tag);
-            else {
-                if (!prepareExport.hasOwnProperty(_id))
-                    prepareExport[_id] = new Array();
-                prepareExport[_id].push(export_tag);
+                var _id = curExpButton.data('appid') || curExpButton.data('exportid'),
+                    xmlns = curExpButton.data('xmlns'),
+                    module = curExpButton.data('modulename'),
+                    export_type = curExpButton.data('exporttype'),
+                    form = curExpButton.data('formname');
+
+                var sheetName = "sheet";
+                if (self.is_custom) {
+                    var $sheetNameElem = curExpButton.parent().parent().find('.sheetname');
+                    if($sheetNameElem.data('duplicate'))
+                        break;
+                    sheetName = curExpButton.parent().parent().find('.sheetname').val();
+                } else
+                    sheetName = getSheetName(module, form, xmlns);
+
+                var export_tag;
+                if (self.is_custom)
+                    export_tag = {
+                        domain: self.domain,
+                        xmlns: xmlns,
+                        sheet_name: sheetName,
+                        export_id: _id,
+                        export_type: export_type
+                    };
+                else
+                    export_tag = [self.domain, xmlns, sheetName];
+
+                if (!_id)
+                    _id = "unknown_application";
+
+                if (self.is_custom)
+                    prepareExport.push(export_tag);
+                else {
+                    if (!prepareExport.hasOwnProperty(_id))
+                        prepareExport[_id] = new Array();
+                    prepareExport[_id].push(export_tag);
+                }
             }
         }
+
 
         if (self.is_custom && prepareExport.length == 0) {
             displayModalError('No valid sheets were available for Custom Bulk Export. Please check for duplicate sheet names.');

--- a/corehq/apps/reports/static/reports/ko/export.manager.js
+++ b/corehq/apps/reports/static/reports/ko/export.manager.js
@@ -236,10 +236,10 @@ var ExportManager = function (o) {
         if(self.isNewExporter) {
             for (var export_id in self.selectedExportsData) {
                 var export_data = self.selectedExportsData[export_id];
-                var xmlns = export_data['xmlns'],
-                    module = export_data['modulename'],
-                    export_type = export_data['exporttype'],
-                    form = export_data['formname'],
+                var xmlns = export_data.xmlns,
+                    module = export_data.modulename,
+                    export_type = export_data.exporttype,
+                    form = export_data.formname,
                     _id = export_id;
 
                 var sheetName = getSheetName(module, form, xmlns);
@@ -263,7 +263,7 @@ var ExportManager = function (o) {
                     prepareExport.push(export_tag);
                 else {
                     if (!prepareExport.hasOwnProperty(_id))
-                        prepareExport[_id] = new Array();
+                        prepareExport[_id] = [];
                     prepareExport[_id].push(export_tag);
                 }
             }
@@ -433,12 +433,12 @@ var ExportManager = function (o) {
             if ($toggleBtn.data('all'))
                 $.each($(check_class), function () {
                     $(this).attr('checked', true);
-                    self.updateSelectedExports({}, {srcElement: this})
+                    self.updateSelectedExports({}, {srcElement: this});
                 });
             else
                 $.each($(check_class), function () {
                     $(this).attr('checked', false);
-                    self.updateSelectedExports({}, {srcElement: this})
+                    self.updateSelectedExports({}, {srcElement: this});
                 });
         };
     } else {
@@ -448,12 +448,12 @@ var ExportManager = function (o) {
             if ($toggleBtn.data('all')) {
                 $.each($(check_class), function () {
                     $(this).attr('checked', true);
-                    self.updateSelectedExports({}, {srcElement: this})
+                    self.updateSelectedExports({}, {srcElement: this});
                 });
             } else {
                 $.each($(check_class), function () {
                     $(this).attr('checked', false);
-                    self.updateSelectedExports({}, {srcElement: this})
+                    self.updateSelectedExports({}, {srcElement: this});
                 });
             }
         };

--- a/corehq/apps/reports/static/reports/ko/export.manager.js
+++ b/corehq/apps/reports/static/reports/ko/export.manager.js
@@ -1,44 +1,6 @@
-var NewExportManager = function (o) {
-    var self = this;
-    self.selected_exports = ko.observableArray();
-    self.bulk_download_notice_text = o.bulk_download_notice_text || '';
-
-    self.requestBulkDownload = function() {
-        console.log('self.requestBulkDownload');
-    };
-
-    self.toggleSelectAllExports = function (data, event) {
-        var $toggleBtn = $(event.srcElement || event.currentTarget),
-            check_class = '.select-export';
-        if ($toggleBtn.data('all')) {
-            $.each($(check_class), function () {
-                $(this).attr('checked', true);
-                self.updateSelectedExports({}, {srcElement: this})
-            });
-        } else {
-            $.each($(check_class), function () {
-                $(this).attr('checked', false);
-                self.updateSelectedExports({}, {srcElement: this})
-            });
-        }
-    };
-
-    self.updateSelectedExports = function (data, event) {
-        var $checkbox = $(event.srcElement || event.currentTarget);
-        var add_to_list = ($checkbox.attr('checked') === 'checked'),
-            export_id = $checkbox.attr('value');
-        if (add_to_list) {
-            $checkbox.parent().find('.label').removeClass('label-info').addClass('label-success');
-            self.selected_exports.push(export_id);
-        } else {
-            $checkbox.parent().find('.label').removeClass('label-success').addClass('label-info');
-            self.selected_exports.splice(self.selected_exports().indexOf(export_id), 1);
-        }
-    };
-};
-
 var ExportManager = function (o) {
     var self = this;
+    self.isNewExporter = o.is_new_exporter || false;
     self.selected_exports = ko.observableArray();
     self.export_type = o.export_type || "form";
     self.is_custom = o.is_custom || false;
@@ -56,9 +18,10 @@ var ExportManager = function (o) {
     self.exportModalLoading = o.loadingIndicator || '.loading-indicator';
     self.exportModalLoadedData = o.loadedData || '.loaded-data';
 
-    self.bulk_download_notice_text = (self.is_custom) ?
-        "Custom Form Exports" :
-        "Full Form Exports";
+    self.bulk_download_notice_text = self.isNewExporter ? (
+        o.bulk_download_notice_text || ''): (self.is_custom ?
+        "Custom Form Exports" : "Full Form Exports"
+    );
 
     self.xmlns_formdesigner = o.xmlns_formdesigner || 'formdesigner';
 
@@ -180,18 +143,33 @@ var ExportManager = function (o) {
         }
     };
 
-    self.updateSelectedExports = function (data, event) {
-        var $checkbox = $(event.srcElement || event.currentTarget);
-        var add_to_list = ($checkbox.attr('checked') === 'checked'),
-            downloadButton = $checkbox.parent().parent().parent().find('.dl-export');
-        if (add_to_list) {
-            $checkbox.parent().find('.label').removeClass('label-info').addClass('label-success');
-            self.selected_exports.push(downloadButton);
-        } else {
-            $checkbox.parent().find('.label').removeClass('label-success').addClass('label-info');
-            self.selected_exports.splice(self.selected_exports().indexOf(downloadButton), 1);
-        }
-    };
+    if(self.isNewExporter) {
+        self.updateSelectedExports = function (data, event) {
+            var $checkbox = $(event.srcElement || event.currentTarget);
+            var add_to_list = ($checkbox.attr('checked') === 'checked'),
+                downloadButton = $checkbox.parent().parent().parent().find('.dl-export');
+            if (add_to_list) {
+                $checkbox.parent().find('.label').removeClass('label-info').addClass('label-success');
+                self.selected_exports.push(downloadButton);
+            } else {
+                $checkbox.parent().find('.label').removeClass('label-success').addClass('label-info');
+                self.selected_exports.splice(self.selected_exports().indexOf(downloadButton), 1);
+            }
+        };
+    } else {
+        self.updateSelectedExports = function (data, event) {
+            var $checkbox = $(event.srcElement || event.currentTarget);
+            var add_to_list = ($checkbox.attr('checked') === 'checked'),
+                export_id = $checkbox.attr('value');
+            if (add_to_list) {
+                $checkbox.parent().find('.label').removeClass('label-info').addClass('label-success');
+                self.selected_exports.push(export_id);
+            } else {
+                $checkbox.parent().find('.label').removeClass('label-success').addClass('label-info');
+                self.selected_exports.splice(self.selected_exports().indexOf(export_id), 1);
+            }
+        };
+    }
 
     self.downloadExport = function(params) {
         var displayDownloadError = function (response) {
@@ -410,20 +388,39 @@ var ExportManager = function (o) {
         return true;
     };
 
-    self.toggleSelectAllExports = function (data, event) {
-        var $toggleBtn = $(event.srcElement || event.currentTarget),
-            check_class = (self.is_custom) ? '.select-custom' : '.select-bulk';
-        if ($toggleBtn.data('all'))
-            $.each($(check_class), function () {
-                $(this).attr('checked', true);
-                self.updateSelectedExports({}, {srcElement: this})
-            });
-        else
-            $.each($(check_class), function () {
-                $(this).attr('checked', false);
-                self.updateSelectedExports({}, {srcElement: this})
-            });
-    };
+    if(self.isNewExporter) {
+        self.toggleSelectAllExports = function (data, event) {
+            var $toggleBtn = $(event.srcElement || event.currentTarget),
+                check_class = (self.is_custom) ? '.select-custom' : '.select-bulk';
+            if ($toggleBtn.data('all'))
+                $.each($(check_class), function () {
+                    $(this).attr('checked', true);
+                    self.updateSelectedExports({}, {srcElement: this})
+                });
+            else
+                $.each($(check_class), function () {
+                    $(this).attr('checked', false);
+                    self.updateSelectedExports({}, {srcElement: this})
+                });
+        };
+    } else {
+        self.toggleSelectAllExports = function (data, event) {
+            var $toggleBtn = $(event.srcElement || event.currentTarget),
+                check_class = '.select-export';
+            if ($toggleBtn.data('all')) {
+                $.each($(check_class), function () {
+                    $(this).attr('checked', true);
+                    self.updateSelectedExports({}, {srcElement: this})
+                });
+            } else {
+                $.each($(check_class), function () {
+                    $(this).attr('checked', false);
+                    self.updateSelectedExports({}, {srcElement: this})
+                });
+            }
+        };
+    }
+
 
 },
     getFormattedSheetName = function (a, b) {

--- a/corehq/apps/reports/templates/reports/partials/bulk_export_notice.html
+++ b/corehq/apps/reports/templates/reports/partials/bulk_export_notice.html
@@ -2,6 +2,18 @@
 <div class="well" data-bind="showBulkExportNotice: selected_exports" style="display: none;">
         <span class="lead">
             {% trans "Download" %} <span data-bind="text: bulk_download_notice_text"></span>:
-            <a data-toggle="modal" data-backdrop="static" href="#export-download-status" class="btn btn-success pull-right" data-bind="click: requestBulkDownload"><i class="icon-download-alt icon-white"></i> {% trans "Bulk Download of" %} <span data-bind="text: bulk_download_notice_text"></span></a>
+            <a class="btn btn-success pull-right"
+               {% if not is_revamped %}
+               data-toggle="modal"
+               data-backdrop="static"
+               href="#export-download-status"
+               data-bind="click: requestBulkDownload"
+               {% else %}
+               data-bind="attr: { href: bulkDownloadPageUrl }"
+               {% endif %}
+            >
+                <i class="icon-download-alt icon-white"></i>
+                {% trans "Bulk Download of" %} <span data-bind="text: bulk_download_notice_text"></span>
+            </a>
         </span>
 </div>

--- a/corehq/apps/reports/templates/reports/partials/download_export.html
+++ b/corehq/apps/reports/templates/reports/partials/download_export.html
@@ -15,17 +15,18 @@
 
         var filterParams = '{{ get_filter_params.urlencode|safe }}';
         var jsonFilterParams = {{ get_filter_params|JSON }};
-        var customExportManager = new ExportManager( {
+        var singleOrBulkExportManager = new ExportManager( {
             domain: '{{ domain }}',
             exportFilters: filterParams,
             jsonExportFilters: jsonFilterParams,
             bulkDownloadUrl: '{% url "export_bulk_download" domain %}',
             selectedExportsData: {{ selected_exports_data|JSON }},
             is_custom: true,
-            is_deid_form_report: {{ is_deid_form_report|JSON }}
+            is_deid_form_report: {{ is_deid_form_report|JSON }},
+            is_new_exporter: true
         } );
 
-        ko.applyBindings(customExportManager, $('#downloads')[0]);
+        ko.applyBindings(singleOrBulkExportManager, $('#downloads')[0]);
     </script>
 {% endblock %}
 

--- a/corehq/apps/reports/templates/reports/partials/download_export.html
+++ b/corehq/apps/reports/templates/reports/partials/download_export.html
@@ -20,6 +20,7 @@
             exportFilters: filterParams,
             jsonExportFilters: jsonFilterParams,
             bulkDownloadUrl: '{% url "export_bulk_download" domain %}',
+            selectedExportsData: {{ selected_exports_data|JSON }},
             is_custom: true,
             is_deid_form_report: {{ is_deid_form_report|JSON }}
         } );
@@ -38,7 +39,7 @@
                    data-exporttype="form"
                    data-dlocation='{% url "export_custom_data" domain export.get_id %}'
                    data-format="{{ export.default_format }}"
-                   data-bind="click: requestDownload"
+                   data-bind="click: {% if use_bulk %}requestBulkDownload{% else %}requestDownload{% endif %}"
                    class="dl-export btn btn-primary"><i class="icon-download-alt icon-white"></i> {% trans "Download" %}</a>
 </section>
 {% endblock reportcontent %}

--- a/corehq/apps/reports/templates/reports/partials/download_export.html
+++ b/corehq/apps/reports/templates/reports/partials/download_export.html
@@ -23,7 +23,8 @@
             selectedExportsData: {{ selected_exports_data|JSON }},
             is_custom: true,
             is_deid_form_report: {{ is_deid_form_report|JSON }},
-            is_new_exporter: true
+            is_new_exporter: true,
+            bulk_download_notice_text: '{{ bulk_download_notice_text }}'
         } );
 
         ko.applyBindings(singleOrBulkExportManager, $('#downloads')[0]);

--- a/corehq/apps/reports/templates/reports/partials/saved_exports.html
+++ b/corehq/apps/reports/templates/reports/partials/saved_exports.html
@@ -7,7 +7,7 @@
         <th>{% trans "Export" %}</th>
         <th>{% trans "Edit" %}</th>
         <th>
-            {% trans "Add to Custom Bulk Export" %} <i class="icon-white icon-info-sign custom-bulk-export-info"></i>
+            {% trans "Add to Bulk Export" %} <i class="icon-white icon-info-sign bulk-export-info"></i>
             <small style="display: block;">
                 {% trans "Select" %}:
                 <a href="#" class="btn btn-mini" data-all="true" data-bind="click: toggleSelectAllExports">{% trans "all" %}</a>
@@ -22,15 +22,6 @@
             <td class="control-group form-inline">
                 {{ export.name|default:"[blank]" }}
                 {% if not deid and export.is_safe %}<span class="label">{% trans "de-identified" %}</span>{% endif %}
-                <p style="display:none; margin-top:1em;" class="controls">
-                    <label>{% trans "Sheet Name" %} <i class="icon icon-info-sign sheet-name-info"></i>:</label>
-                    <input data-bind="updateCustomSheetName: selected_exports, checkForUniqueSheetName: sheet_names, event: {keydown: checkCustomSheetNameLength, keyup: updateCustomSheetNameCharacterCount}"
-                           class="sheetname"
-                           data-exportid="{{ export.get_id }}"
-                           value="{{ export.name|default:"[blank]" }}" />
-                    <span class="label label-info sheetname-count">31</span>
-                    <span class="label label-important sheetname-duplicate hide">{% trans "duplicate" %} <i class="icon-white icon-info-sign"></i></span>
-                </p>
                 <div><p class="help-inline">{{ export.formname }}</p></div>
             </td>
             <td class="cell-vertical-centered">
@@ -46,7 +37,7 @@
             <td class="form-inline">
                 {% ifequal export.default_format bulk_export_format %}
                     <label>
-                        <input type="checkbox" class="select-custom" data-bind="event: {change: updateSelectedExports}" />
+                        <input type="checkbox" class="select-export" data-bind="event: {change: updateSelectedExports}" value="{{ export.get_id }}"/>
                         <span class="label label-info">+ {% trans "Bulk Export" %}</span>
                     </label>
                 {% else %}

--- a/corehq/apps/reports/templates/reports/partials/saved_exports.html
+++ b/corehq/apps/reports/templates/reports/partials/saved_exports.html
@@ -44,7 +44,7 @@
                 </a>
             </td>
             <td class="form-inline">
-                {% ifequal export.default_format custom_bulk_export_format %}
+                {% ifequal export.default_format bulk_export_format %}
                     <label>
                         <input type="checkbox" class="select-custom" data-bind="event: {change: updateSelectedExports}" />
                         <span class="label label-info">+ {% trans "Bulk Export" %}</span>

--- a/corehq/apps/reports/templates/reports/reportdata/data_export.html
+++ b/corehq/apps/reports/templates/reports/reportdata/data_export.html
@@ -10,7 +10,8 @@
 {% block js-inline %} {{ block.super }}
     <script type="text/javascript">
         var exportManager = new ExportManager({
-            bulk_download_notice_text: '{{ bulk_download_notice_text }}'
+            bulk_download_notice_text: '{{ bulk_download_notice_text }}',
+            is_new_exporter: true
         });
         ko.applyBindings(exportManager, $('#export-ui').get(0));
 

--- a/corehq/apps/reports/templates/reports/reportdata/data_export.html
+++ b/corehq/apps/reports/templates/reports/reportdata/data_export.html
@@ -11,7 +11,8 @@
     <script type="text/javascript">
         var exportManager = new ExportManager({
             bulk_download_notice_text: '{{ bulk_download_notice_text }}',
-            is_new_exporter: true
+            is_new_exporter: true,
+            bulkDownloadPageUrlRoot: '{{ download_page_url_root }}'
         });
         ko.applyBindings(exportManager, $('#export-ui').get(0));
 
@@ -40,7 +41,7 @@
     <div id="export-ui">
         {% if saved_exports %}
             <p>
-                {% include 'reports/partials/bulk_export_notice.html' %}
+                {% include 'reports/partials/bulk_export_notice.html' with is_revamped=True%}
                 {% include 'reports/partials/saved_exports.html' %}
             </p>
         {% endif %}

--- a/corehq/apps/reports/templates/reports/reportdata/data_export.html
+++ b/corehq/apps/reports/templates/reports/reportdata/data_export.html
@@ -2,6 +2,33 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
+{% block js %} {{ block.super }}
+    <script type="text/javascript" src="{% static 'reports/javascripts/reports.download_export.js' %}"></script>
+    <script type="text/javascript" src="{% static 'reports/ko/export.manager.js' %}"></script>
+{% endblock %}
+
+{% block js-inline %} {{ block.super }}
+    <script type="text/javascript">
+        var exportManager = new NewExportManager({
+            bulk_download_notice_text: '{{ bulk_download_notice_text }}'
+        });
+        ko.applyBindings(exportManager, $('#export-ui').get(0));
+
+        var bulkExportTitle = "{% trans "What is Bulk Export?" %}";
+        var bulkExportContent = (
+            "{% trans "Bulk Export creates a single Excel file with each export as a separate sheet inside that file." %}"
+            + "<br /><br />{% trans "NOTE: Excel 2007+ is currently the only bulk export format supported." %}"
+        );
+        $('.bulk-export-info').popover({
+            title: bulkExportTitle,
+            content: bulkExportContent,
+            placement: 'left',
+            trigger: 'hover',
+            html: 'true'
+        });
+    </script>
+{% endblock %}
+
 {% block main_column %}
     <h2>{{ report.title }}</h2>
     <a href="{% url 'create_export_form' domain %}" class="btn btn-success">
@@ -9,5 +36,12 @@
             {% trans 'Create New Export' %}
         </i>
     </a>
-    {% include 'reports/partials/saved_exports.html' %}
+    <div id="export-ui">
+        {% if saved_exports %}
+            <p>
+                {% include 'reports/partials/bulk_export_notice.html' %}
+                {% include 'reports/partials/saved_exports.html' %}
+            </p>
+        {% endif %}
+    </div>
 {% endblock %}

--- a/corehq/apps/reports/templates/reports/reportdata/data_export.html
+++ b/corehq/apps/reports/templates/reports/reportdata/data_export.html
@@ -9,7 +9,7 @@
 
 {% block js-inline %} {{ block.super }}
     <script type="text/javascript">
-        var exportManager = new NewExportManager({
+        var exportManager = new ExportManager({
             bulk_download_notice_text: '{{ bulk_download_notice_text }}'
         });
         ko.applyBindings(exportManager, $('#export-ui').get(0));


### PR DESCRIPTION
Adds link from "Bulk Download of Form Export" button...
<img width="1392" alt="screen shot 2015-07-07 at 5 27 00 pm" src="https://cloud.githubusercontent.com/assets/1757035/8557772/80bd89d2-24cd-11e5-863d-16d44fb279fa.png">
... to download page with filters ...
<img width="1392" alt="screen shot 2015-07-07 at 5 27 08 pm" src="https://cloud.githubusercontent.com/assets/1757035/8557785/8e7a260c-24cd-11e5-82d1-42fadd15e23d.png">
... where you can download the export ...
<img width="1392" alt="screen shot 2015-07-07 at 5 27 13 pm" src="https://cloud.githubusercontent.com/assets/1757035/8557792/99e3b940-24cd-11e5-914a-067915b459f2.png">
(can ignore error message in screenshot)

Much of the existing code will become dead code once the feature flag is lifted.  I'll delete that code then.

Sorry for the messy commit history.

@NoahCarnahan cc: @orangejenny 
