### PR TITLE
Split one button to two buttons for add reminder and add keyword

### DIFF
--- a/corehq/apps/reminders/templates/reminders/keyword_list.html
+++ b/corehq/apps/reminders/templates/reminders/keyword_list.html
@@ -13,17 +13,12 @@
     <div class="btn-group">
         <a href="{% url 'add_normal_keyword' domain %}" class="btn btn-success">
             <i class="icon-plus"></i>
-            {% trans 'Add Keyword' %}</a>
-        <button type="button" class="btn btn-success dropdown-toggle" data-toggle="dropdown">
-            <span class="caret"></span>
-        </button>
-        <ul class="dropdown-menu">
-            <li><a href="{% url 'add_normal_keyword' domain %}">
-                {% trans 'Add Normal Keyword' %}
-            </a></li>
-            <li><a href="{% url 'add_structured_keyword' domain %}">
-                {% trans 'Add Structured Keyword' %}</a></li>
-        </ul>
+            {% trans 'Add Keyword' %}
+        </a>
+        <a href="{% url 'add_structured_keyword' domain %}" class="btn btn-success">
+            <i class="icon-plus"></i>
+            {% trans 'Add Structured Keyword' %}
+        </a>
     </div>
 {% endblock %}
 

--- a/corehq/apps/reminders/templates/reminders/reminders_list.html
+++ b/corehq/apps/reminders/templates/reminders/reminders_list.html
@@ -33,17 +33,12 @@
     <div class="btn-group">
         <a href="{% url "create_reminder_schedule" domain %}" class="btn btn-success">
             <i class="icon-plus"></i>
-            {% trans 'Add Reminder' %}</a>
-        <button type="button" class="btn btn-success dropdown-toggle" data-toggle="dropdown">
-            <span class="caret"></span>
-        </button>
-        <ul class="dropdown-menu">
-            <li><a href="{% url "create_reminder_schedule" domain %}">
-                {% trans 'Add Reminder' %}
-            </a></li>
-            <li><a href="{% url "create_complex_reminder_schedule" domain %}">
-                {% trans 'Add Multi Event Reminder' %}</a></li>
-        </ul>
+            {% trans 'Add Reminder' %}
+        </a>
+        <a href="{% url "create_complex_reminder_schedule" domain %}" class="btn btn-success">
+            <i class="icon-plus"></i>
+            {% trans 'Add Multi Event Reminder' %}
+        </a>
     </div>
     <div id="reminders-list">
         <div data-bind="template: {

--- a/corehq/apps/reminders/templates/reminders/reminders_list.html
+++ b/corehq/apps/reminders/templates/reminders/reminders_list.html
@@ -30,6 +30,7 @@
 {% endblock %}
 
 {% block main_column %}
+    <h2>{% trans 'Reminders' %}</h2>
     <div class="btn-group">
         <a href="{% url "create_reminder_schedule" domain %}" class="btn btn-success">
             <i class="icon-plus"></i>
@@ -45,7 +46,6 @@
             name: 'reminder-list-template',
             data: {
                 reminders: reminders,
-                title: '{% trans 'Reminders' %}'
             }
         }"></div>
     </div>
@@ -53,7 +53,6 @@
     <script type="text/html" id="reminder-list-template">
         <div class="row-fluid">
             <div class="span12">
-                <h3 data-bind="text: title"></h3>
                 <table id="reminder-list-table" class="table table-striped table-bordered">
                     <thead>
                         <tr>

--- a/corehq/apps/reminders/templates/reminders/reminders_list.html
+++ b/corehq/apps/reminders/templates/reminders/reminders_list.html
@@ -33,7 +33,7 @@
     <div class="btn-group">
         <a href="{% url "create_reminder_schedule" domain %}" class="btn btn-success">
             <i class="icon-plus"></i>
-            {% trans 'Add Reminder' %}
+            {% trans 'Add Single Event Reminder' %}
         </a>
         <a href="{% url "create_complex_reminder_schedule" domain %}" class="btn btn-success">
             <i class="icon-plus"></i>


### PR DESCRIPTION
Removes the dropdown for the Add Keyword and Add Reminder buttons, and splits each into two buttons for the normal keyword / structured keyword, and simple reminder / multi-event reminder.
