### PR TITLE
commit dirtiness flags prior to raising signals

### DIFF
--- a/corehq/ex-submodules/couchforms/util.py
+++ b/corehq/ex-submodules/couchforms/util.py
@@ -551,10 +551,10 @@ class SubmissionPost(object):
                             raise
                         unfinished_submission_stub.saved = True
                         unfinished_submission_stub.save()
+                        case_result.commit_dirtiness_flags()
+
                         for case in cases:
                             case_post_save.send(CommCareCase, case=case)
-
-                        case_result.commit_dirtiness_flags()
 
                     responses, errors = self.process_signals(instance)
                     if errors:


### PR DESCRIPTION
in case anything goes wrong we still want them to save

@dannyroberts cc @TylerSheffels 

(this wasn't triggered by anything just saw it and thought it should be different)
