### PR TITLE
Better 404 messages from get_document_or_404() in debug mode

### DIFF
--- a/corehq/util/couch.py
+++ b/corehq/util/couch.py
@@ -19,17 +19,24 @@ def get_document_or_404(cls, domain, doc_id, additional_doc_types=None):
     try:
         unwrapped = cls.get_db().get(doc_id)
     except ResourceNotFound:
-        raise Http404()
+        raise Http404("Document {} of class {} not found!".format(doc_id, cls.__name__))
 
     if ((unwrapped.get('domain', None) != domain and
          domain not in unwrapped.get('domains', [])) or
         unwrapped['doc_type'] not in allowed_doc_types):
-        raise Http404()
+        raise Http404("Document {} of class {} not in domain {}!".format(
+            doc_id,
+            cls.__name__,
+            domain
+        ))
 
     try:
         return cls.wrap(unwrapped)
     except WrappingAttributeError:
-        raise Http404()
+        raise Http404("Issue wrapping document {} of class {}!".format(
+            doc_id,
+            cls.__name__
+        ))
 
 
 def categorize_bulk_save_errors(error):

--- a/corehq/util/couch.py
+++ b/corehq/util/couch.py
@@ -1,3 +1,4 @@
+import traceback
 import requests
 import json
 from copy import deepcopy
@@ -18,24 +19,34 @@ def get_document_or_404(cls, domain, doc_id, additional_doc_types=None):
     allowed_doc_types = (additional_doc_types or []) + [cls.__name__]
     try:
         unwrapped = cls.get_db().get(doc_id)
-    except ResourceNotFound:
-        raise Http404("Document {} of class {} not found!".format(doc_id, cls.__name__))
+    except ResourceNotFound as e:
+        tb = traceback.format_exc()
+        raise Http404("Document {} of class {} not found!\n\n{}".format(
+            doc_id,
+            cls.__name__,
+            tb
+        ))
 
     if ((unwrapped.get('domain', None) != domain and
          domain not in unwrapped.get('domains', [])) or
         unwrapped['doc_type'] not in allowed_doc_types):
-        raise Http404("Document {} of class {} not in domain {}!".format(
+
+        tb = traceback.format_exc()
+        raise Http404("Document {} of class {} not in domain {}!\n\n{}!".format(
             doc_id,
             cls.__name__,
-            domain
+            domain,
+            tb
         ))
 
     try:
         return cls.wrap(unwrapped)
     except WrappingAttributeError:
-        raise Http404("Issue wrapping document {} of class {}!".format(
+        tb = traceback.format_exc()
+        raise Http404("Issue wrapping document {} of class {}!\n\n{}".format(
             doc_id,
-            cls.__name__
+            cls.__name__,
+            tb
         ))
 
 

--- a/corehq/util/couch.py
+++ b/corehq/util/couch.py
@@ -31,12 +31,10 @@ def get_document_or_404(cls, domain, doc_id, additional_doc_types=None):
          domain not in unwrapped.get('domains', [])) or
         unwrapped['doc_type'] not in allowed_doc_types):
 
-        tb = traceback.format_exc()
-        raise Http404("Document {} of class {} not in domain {}!\n\n{}!".format(
+        raise Http404("Document {} of class {} not in domain {}!".format(
             doc_id,
             cls.__name__,
             domain,
-            tb
         ))
 
     try:


### PR DESCRIPTION
404 pages triggered by `get_document_or_404()` will now display a short message about the reason for the exception when in debug mode. Can be useful if you don't know where the exception was raised.

<img width="927" alt="screen shot 2015-07-09 at 10 46 09 am" src="https://cloud.githubusercontent.com/assets/2117127/8598312/ff226684-2627-11e5-9fd3-2250def1ec35.png">

FYI @esoergel.
cc @snopoke 
