### PR TITLE
fix locmem

### DIFF
--- a/corehq/util/quickcache.py
+++ b/corehq/util/quickcache.py
@@ -272,7 +272,7 @@ def quickcache(vary_on, timeout=None, memoize_timeout=None, cache=None,
     memoize_timeout = memoize_timeout or 10
 
     if cache is None:
-        cache = TieredCache([get_cache('locmem://', timeout=memoize_timeout),
+        cache = TieredCache([get_cache('django.core.cache.backends.locmem.LocMemCache', timeout=memoize_timeout),
                              get_cache('default', timeout=timeout)])
 
     def decorator(fn):


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.8/releases/1.7/#miscellaneous

> The old cache URI syntax (e.g. "locmem://") is no longer supported. It still worked, even though it was not documented or officially supported. If you’re still using it, please update to the current CACHES syntax.

code buddy @gcapalbo 
