### PR TITLE
don't archive/restore already archived/restored forms

### DIFF
--- a/corehq/ex-submodules/couchforms/exceptions.py
+++ b/corehq/ex-submodules/couchforms/exceptions.py
@@ -11,7 +11,3 @@ class XMLSyntaxError(CouchFormException):
 
 class DuplicateError(CouchFormException):
     pass
-
-
-class BadOperationException(CouchFormException):
-    pass

--- a/corehq/ex-submodules/couchforms/exceptions.py
+++ b/corehq/ex-submodules/couchforms/exceptions.py
@@ -11,3 +11,7 @@ class XMLSyntaxError(CouchFormException):
 
 class DuplicateError(CouchFormException):
     pass
+
+
+class BadOperationException(CouchFormException):
+    pass

--- a/corehq/ex-submodules/couchforms/models.py
+++ b/corehq/ex-submodules/couchforms/models.py
@@ -29,7 +29,6 @@ from dimagi.utils.mixins import UnicodeMixIn
 from couchforms.signals import xform_archived, xform_unarchived
 from couchforms.const import ATTACHMENT_NAME
 from couchforms import const
-from .exceptions import BadOperationException
 
 
 def doc_types():
@@ -340,7 +339,7 @@ class XFormInstance(SafeSaveDocument, UnicodeMixIn, ComputedDocumentMixin,
 
     def archive(self, user=None):
         if self.is_archived:
-            raise BadOperationException("This form is already archived")
+            return
         self.doc_type = "XFormArchived"
         self.history.append(XFormOperation(
             user=user,
@@ -351,7 +350,7 @@ class XFormInstance(SafeSaveDocument, UnicodeMixIn, ComputedDocumentMixin,
 
     def unarchive(self, user=None):
         if not self.is_archived:
-            raise BadOperationException("This form is already restored or never archived")
+            return
         self.doc_type = "XFormInstance"
         self.history.append(XFormOperation(
             user=user,


### PR DESCRIPTION
If you make repeated POST to archive form URL, currently, it will repeatedly archive, which I think shouldn't be the case

I have quickly checked uses of `.archive` method to make sure that nowhere a form needs to be archived twice. 

@esoergel 
