### PR TITLE
Move case list widths to 2.22

### DIFF
--- a/corehq/apps/app_manager/feature_support.py
+++ b/corehq/apps/app_manager/feature_support.py
@@ -86,6 +86,6 @@ class CommCareFeatureSupportMixin(object):
     @property
     def enable_case_list_icon_dynamic_width(self):
         """
-        In 2.23 and higher, case list icon column is sized based on actual image width.
+        In 2.22 and higher, case list icon column is sized based on actual image width.
         """
-        return self._require_minimum_version('2.23')
+        return self._require_minimum_version('2.22')


### PR DESCRIPTION
Mobile support for dynamic case list widths (https://github.com/dimagi/commcare-hq/pull/6931) got squeezed into 2.22 after all.

@nickpell 
