### PR TITLE
see if making the IDs unique fixes the build

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -289,13 +289,15 @@ class SyncTokenUpdateTest(SyncBaseTest):
         self._postFakeWithSyncToken(child, self.sync_log.get_id)
         self._testUpdate(self.sync_log.get_id, {parent_id: [], child_id: []})
 
-    # @run_with_all_restore_configs
+    @run_with_all_restore_configs
     def test_delete_one_of_multiple_indices(self):
-        child_id = "child_id"
-        parent_id_1 = "parent_id"
-        index_id_1 = 'parent_index_id'
-        parent_id_2 = "parent_id_2"
-        index_id_2 = 'parent_index_id_2'
+        # make IDs both human readable and globally unique to this test
+        uid = uuid.uuid4().hex
+        child_id = 'child_id-{}'.format(uid)
+        parent_id_1 = 'parent_id={}'.format(uid)
+        index_id_1 = 'parent_index_id-{}'.format(uid)
+        parent_id_2 = 'parent_id_2-{}'.format(uid)
+        index_id_2 = 'parent_index_id_2-{}'.format(uid)
 
         self.factory.create_or_update_case(CaseStructure(
             case_id=child_id,


### PR DESCRIPTION
still unable to reproduce this issue locally: https://github.com/dimagi/commcare-hq/pull/7007#issuecomment-109571035

wondering if maybe it has something to do with global ID uniqueness.

thinking if tests pass and then we merge this and tests continue to pass deterministically then we can assume that was the problem.
