### PR TITLE
have UCR's use their own celery queue

### DIFF
--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -10,7 +10,7 @@ from couchforms.models import XFormInstance
 from dimagi.utils.couch.database import iter_docs
 
 
-@task(queue='background_queue', ignore_result=True, acks_late=True)
+@task(queue='ucr_queue', ignore_result=True, acks_late=True)
 def rebuild_indicators(indicator_config_id):
     is_static = indicator_config_id.startswith(CustomDataSourceConfiguration._datasource_id_prefix)
     if is_static:

--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -39,6 +39,8 @@ development:
         concurrency: 1
       sms_queue:
         concurrency: 1
+      ucr_queue:
+        concurrency: 1
       flower: {}
 
 india:
@@ -65,6 +67,8 @@ india:
         concurrency: 3
       sms_queue:
         concurrency: 8
+      ucr_queue:
+        concurrency: 4
       flower: {}
 
 preview:
@@ -101,6 +105,8 @@ production:
         concurrency: 3
       sms_queue:
         concurrency: 8
+      ucr_queue:
+        concurrency: 4
       flower: {}
 
 staging:
@@ -122,6 +128,8 @@ staging:
         concurrency: 1
       saved_exports_queue:
         concurrency: 3
+      ucr_queue:
+        concurrency: 1
       flower: {}
 
 zambia:
@@ -133,7 +141,7 @@ zambia:
       main:
         concurrency: 4
       background_queue:
-        concurrency: 4
+        concurrency: 2
       periodic:
         concurrency: 4
       pillow_retry_queue:
@@ -148,4 +156,6 @@ zambia:
         concurrency: 3
       sms_queue:
         concurrency: 4
+      ucr_queue:
+        concurrency: 2
       flower: {}

--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -1129,6 +1129,7 @@ def set_celery_supervisorconf():
         'pillow_retry_queue':           ['supervisor_celery_pillow_retry_queue.conf'],
         'background_queue':             ['supervisor_celery_background_queue.conf'],
         'saved_exports_queue':          ['supervisor_celery_saved_exports_queue.conf'],
+        'ucr_queue':                    ['supervisor_celery_ucr_queue.conf'],
         'flower':                       ['supervisor_celery_flower.conf'],
         }
 

--- a/fab/services/templates/supervisor_celery_ucr_queue.conf
+++ b/fab/services/templates/supervisor_celery_ucr_queue.conf
@@ -1,0 +1,20 @@
+[program:{{ project }}-{{ environment }}-celery_ucr_queue]
+environment={{ supervisor_env_vars }}
+command={{ new_relic_command }}{{ virtualenv_root }}/bin/python {{ code_root }}/manage.py celery worker --queues=ucr_queue --events --loglevel=INFO --hostname={{ host_string }}_ucr_queue --maxtasksperchild=5 --concurrency={{ celery_params.concurrency }} -Ofair
+directory={{ code_root }}
+user={{ sudo_user }}
+numprocs=1
+autostart=true
+autorestart=true
+stopasgroup=true
+killasgroup=true
+stdout_logfile={{ log_dir }}/celery_ucr_queue.log
+redirect_stderr=true
+stderr_logfile={{ log_dir }}/celery_ucr_queue.error.log
+startsecs=10
+; Need to wait for currently executing tasks to finish at shutdown.
+; Increase this if you have very long running tasks.
+stopwaitsecs = 60
+; if rabbitmq is supervised, set its priority higher
+; so it starts first
+priority=998


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?176104

@dannyroberts @TylerSheffels 

I looked and both celery0 and celery1 seem to be maxing out at about 50% memory and way less than that CPU, so I think introducing 4 more jobs is ok. cc @gcapalbo @snopoke in case any concerns. here's the new relic chart of memory and cpu from the last 7 days for celery1 (where this puts it)

![image](https://cloud.githubusercontent.com/assets/66555/8670739/a8fbd2c6-2a1f-11e5-8de0-08672127ceca.png)
