### PR TITLE
Fix typo in casedb data source root path

### DIFF
--- a/corehq/apps/app_manager/tests/test_util.py
+++ b/corehq/apps/app_manager/tests/test_util.py
@@ -14,7 +14,7 @@ class SchemaTest(SimpleTestCase):
             "id": "casedb",
             "uri": "jr://instance/casedb",
             "name": "case",
-            "path": "/cases/case",
+            "path": "/casedb/case",
             "structure": {},
             "subsets": [],
         })

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -265,7 +265,7 @@ def get_casedb_schema(app):
         "id": "casedb",
         "uri": "jr://instance/casedb",
         "name": "case",
-        "path": "/cases/case",
+        "path": "/casedb/case",
         "structure": {},
         "subsets": [{
             "id": ctype,


### PR DESCRIPTION
@amsagoff found this while testing case management in vellum

cc @kaapstorm 
