### PR TITLE
Conditionally separate SITE_NAME and title with " - "

### DIFF
--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -332,3 +332,32 @@ class CaseNode(template.Node):
         if nodelist is None:
             return ""
         return nodelist.render(context)
+
+
+# https://djangosnippets.org/snippets/545/
+@register.tag(name='captureas')
+def do_captureas(parser, token):
+    """
+    Assign to a context variable from within a template
+        {% capturas my_context_var %}<!-- anything -->{% endcaptureas %}
+        <h1>Nice job capturing {{ my_context_var }}</h1>
+    """
+    try:
+        tag_name, args = token.contents.split(None, 1)
+    except ValueError:
+        raise template.TemplateSyntaxError("'captureas' node requires a "
+                                           "variable name.")
+    nodelist = parser.parse(('endcaptureas',))
+    parser.delete_first_token()
+    return CaptureasNode(nodelist, args)
+
+
+class CaptureasNode(template.Node):
+    def __init__(self, nodelist, varname):
+        self.nodelist = nodelist
+        self.varname = varname
+
+    def render(self, context):
+        output = self.nodelist.render(context)
+        context[self.varname] = output
+        return ''

--- a/corehq/apps/style/templates/style/bootstrap2/base.html
+++ b/corehq/apps/style/templates/style/bootstrap2/base.html
@@ -3,7 +3,10 @@
 <html lang="{{ LANGUAGE_CODE }}">
     <head>
         <meta charset="utf-8"/>
-        <title>{% block title %}{% endblock title %} - {{ SITE_NAME }}</title>
+        {% captureas title_block %}{% block title %}{% endblock title %}{% endcaptureas %}
+        <title>
+            {% if title_block %}{{ title_block }} - {% endif %}{{ SITE_NAME }}
+        </title>
         <meta name="application-name" content="{{ SITE_NAME }}">
         <meta http-equiv="content-language" content="{{ LANGUAGE_CODE }}">
         <link type="application/opensearchdescription+xml" rel="search" href="{% url 'osdd' %}" title="CommCare HQ"/>

--- a/corehq/apps/style/templates/style/bootstrap2/base.html
+++ b/corehq/apps/style/templates/style/bootstrap2/base.html
@@ -3,7 +3,7 @@
 <html lang="{{ LANGUAGE_CODE }}">
     <head>
         <meta charset="utf-8"/>
-        <title>{% block title %}{% endblock title %}{{ SITE_NAME }}</title>
+        <title>{% block title %}{% endblock title %} - {{ SITE_NAME }}</title>
         <meta name="application-name" content="{{ SITE_NAME }}">
         <meta http-equiv="content-language" content="{{ LANGUAGE_CODE }}">
         <link type="application/opensearchdescription+xml" rel="search" href="{% url 'osdd' %}" title="CommCare HQ"/>

--- a/corehq/apps/style/templates/style/bootstrap3/base.html
+++ b/corehq/apps/style/templates/style/bootstrap3/base.html
@@ -2,7 +2,10 @@
 {% get_current_language as LANGUAGE_CODE %}
 <html lang="{{ LANGUAGE_CODE }}">
     <head>
-        <title>{% block title %}{% endblock title %} - {{ SITE_NAME }}</title>
+        {% captureas title_block %}{% block title %}{% endblock title %}{% endcaptureas %}
+        <title>
+            {% if title_block %}{{ title_block }} - {% endif %}{{ SITE_NAME }}
+        </title>
 
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/corehq/apps/style/templates/style/bootstrap3/base.html
+++ b/corehq/apps/style/templates/style/bootstrap3/base.html
@@ -2,7 +2,7 @@
 {% get_current_language as LANGUAGE_CODE %}
 <html lang="{{ LANGUAGE_CODE }}">
     <head>
-        <title>{% block title %}{% endblock title %}{{ SITE_NAME }}</title>
+        <title>{% block title %}{% endblock title %} - {{ SITE_NAME }}</title>
 
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?176390
The problem is that title blocks aren't always set.
`<title>{% block title %}{% endblock title %}{{ SITE_NAME }}</title>`
looks good if it hasn't been overriden, but if it has, you get a title of `Edit Mobile WorkerCommCare HQ`
`<title>{% block title %}{% endblock title %} - {{ SITE_NAME }}</title>`
looks good if there IS a title, but looks like `- CommCare HQ` otherwise.

The easy answer is to set a default title, so we get `CommCare HQ - CommCare HQ`, but that's kinda ugly, and I found this solution pretty quickly with some googling.

I pulled in a djangosnippet template tag which allows you to grab bits of the template and assign them to a context variable.  This lets you see whether or not that block is overridden so you can conditionally insert the `-`
@biyeun 
