### PR TITLE
don't fail on strings that match re_loose_datetime but aren't iso8601

### DIFF
--- a/corehq/ex-submodules/couchforms/tests/test_adjust_datetimes.py
+++ b/corehq/ex-submodules/couchforms/tests/test_adjust_datetimes.py
@@ -28,3 +28,10 @@ class AdjustDatetimesTest(SimpleTestCase):
                 adjust_datetimes({'datetime': '2013-03-09T06:30:09.007+03'}),
                 {'datetime': '2013-03-09T06:30:09.007000Z'}
             )
+
+    def test_match_no_parse(self):
+        fake_datetime = '2015-07-14 2015-06-07 '
+        self.assertEqual(
+            adjust_datetimes({'fake_datetime': fake_datetime}),
+            {'fake_datetime': fake_datetime}
+        )

--- a/corehq/ex-submodules/couchforms/util.py
+++ b/corehq/ex-submodules/couchforms/util.py
@@ -121,16 +121,19 @@ def adjust_datetimes(data, parent=None, key=None):
     """
     # this strips the timezone like we've always done
     # todo: in the future this will convert to UTC
-    if isinstance(data, basestring):
-        if re_loose_datetime.match(data):
+    if isinstance(data, basestring) and re_loose_datetime.match(data):
+        try:
+            matching_datetime = iso8601.parse_date(data)
+        except iso8601.ParseError:
+            pass
+        else:
             if phone_timezones_should_be_processed():
                 parent[key] = json_format_datetime(
-                    iso8601.parse_date(data).astimezone(pytz.utc)
-                    .replace(tzinfo=None)
+                    matching_datetime.astimezone(pytz.utc).replace(tzinfo=None)
                 )
             else:
                 parent[key] = json_format_datetime(
-                    iso8601.parse_date(data).replace(tzinfo=None))
+                    matching_datetime.replace(tzinfo=None))
 
     elif isinstance(data, dict):
         for key, value in data.items():


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?176505
