### PR TITLE
Localize emailed reports to recipients

### DIFF
--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -13,9 +13,7 @@ from celery.schedules import crontab
 from celery.task import periodic_task
 from corehq.apps.indicators.utils import get_mvp_domains
 from corehq.apps.reports.scheduled import get_scheduled_reports
-from corehq.apps.users.models import WebUser
 from corehq.util.view_utils import absolute_reverse
-from corehq.util.translation import localize
 from couchexport.files import Temp
 from couchexport.groupexports import export_for_group, rebuild_export
 from dimagi.utils.couch.database import get_db
@@ -124,11 +122,8 @@ def get_report_queue(report):
 @task(ignore_result=True)
 def send_report(notification_id):
     notification = ReportNotification.get(notification_id)
-    owner = WebUser.get(notification.owner_id)
-    language = owner.get_language_code()
     try:
-        with localize(language):
-            notification.send()
+        notification.send()
     except UnsupportedScheduledReportError:
         pass
 

--- a/corehq/apps/users/dbaccessors/__init__.py
+++ b/corehq/apps/users/dbaccessors/__init__.py
@@ -1,0 +1,2 @@
+from .all_commcare_users import (get_all_commcare_users_by_domain,
+                                 get_user_docs_by_username)

--- a/corehq/apps/users/dbaccessors/all_commcare_users.py
+++ b/corehq/apps/users/dbaccessors/all_commcare_users.py
@@ -13,3 +13,13 @@ def get_all_commcare_users_by_domain(domain):
         include_docs=False)]
 
     return [CommCareUser.wrap(user) for user in iter_docs(CommCareUser.get_db(), ids)]
+
+
+def get_user_docs_by_username(usernames):
+    from corehq.apps.users.models import CouchUser
+    return [res['doc'] for res in CouchUser.get_db().view(
+        'users/by_username',
+        keys=usernames,
+        reduce=False,
+        include_docs=True,
+    ).all()]

--- a/corehq/apps/users/tests/test_db_accessors.py
+++ b/corehq/apps/users/tests/test_db_accessors.py
@@ -1,6 +1,9 @@
 from django.test import TestCase
 from corehq.apps.users.models import WebUser, CommCareUser
-from corehq.apps.users.dbaccessors.all_commcare_users import get_all_commcare_users_by_domain
+from corehq.apps.users.dbaccessors.all_commcare_users import (
+    get_all_commcare_users_by_domain,
+    get_user_docs_by_username
+)
 from corehq.apps.domain.models import Domain
 
 
@@ -46,3 +49,11 @@ class AllCommCareUsersTest(TestCase):
         expected_usernames = [user.username for user in expected_users]
         actual_usernames = [user.username for user in get_all_commcare_users_by_domain(self.ccdomain.name)]
         self.assertItemsEqual(actual_usernames, expected_usernames)
+
+    def test_get_user_docs_by_username(self):
+        users = [self.ccuser_1, self.web_user, self.ccuser_other_domain]
+        usernames = [u.username for u in users] + ['nonexistant@username.com']
+        self.assertItemsEqual(
+            get_user_docs_by_username(usernames),
+            [u.to_json() for u in users]
+        )

--- a/corehq/apps/users/tests/test_db_accessors.py
+++ b/corehq/apps/users/tests/test_db_accessors.py
@@ -8,6 +8,7 @@ from corehq.apps.domain.models import Domain
 
 
 class AllCommCareUsersTest(TestCase):
+    @classmethod
     def setUpClass(cls):
         cls.ccdomain = Domain(name='cc_user_domain')
         cls.ccdomain.save()
@@ -39,6 +40,7 @@ class AllCommCareUsersTest(TestCase):
             email='email_other_domain@example.com',
         )
 
+    @classmethod
     def tearDownClass(cls):
         cls.ccdomain.delete()
         cls.other_domain.delete()

--- a/corehq/apps/users/tests/test_db_accessors.py
+++ b/corehq/apps/users/tests/test_db_accessors.py
@@ -5,40 +5,41 @@ from corehq.apps.domain.models import Domain
 
 
 class AllCommCareUsersTest(TestCase):
-    def setUp(self):
-        self.ccdomain = Domain(name='cc_user_domain')
-        self.ccdomain.save()
-        self.other_domain = Domain(name='other_domain')
-        self.other_domain.save()
+    def setUpClass(cls):
+        cls.ccdomain = Domain(name='cc_user_domain')
+        cls.ccdomain.save()
+        cls.other_domain = Domain(name='other_domain')
+        cls.other_domain.save()
 
-        self.ccuser_1 = CommCareUser.create(
-            domain=self.ccdomain.name,
+        cls.ccuser_1 = CommCareUser.create(
+            domain=cls.ccdomain.name,
             username='ccuser_1',
             password='secret',
             email='email@example.com',
         )
-        self.ccuser_2 = CommCareUser.create(
-            domain=self.ccdomain.name,
+        cls.ccuser_2 = CommCareUser.create(
+            domain=cls.ccdomain.name,
             username='ccuser_2',
             password='secret',
             email='email1@example.com',
         )
-        self.web_user = WebUser.create(
-            domain=self.ccdomain.name,
+        cls.web_user = WebUser.create(
+            domain=cls.ccdomain.name,
             username='webuser',
             password='secret',
             email='webuser@example.com',
         )
-        self.ccuser_other_domain = CommCareUser.create(
-            domain=self.other_domain.name,
+        cls.ccuser_other_domain = CommCareUser.create(
+            domain=cls.other_domain.name,
             username='cc_user_other_domain',
             password='secret',
             email='email_other_domain@example.com',
         )
 
-    def tearDown(self):
-        self.ccdomain.delete()
-        self.other_domain.delete()
+    def tearDownClass(cls):
+        cls.ccdomain.delete()
+        cls.other_domain.delete()
+        cls.web_user.delete()
 
     def test_get_all_commcare_users_by_domain(self):
         expected_users = [self.ccuser_2, self.ccuser_1]


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?176146
The last commit is the direct functional change.

This figures out what email addresses correspond to users on HQ and checks if they have a language specified.  It then splits the recipients up by language, and for each language, runs the report and sends to the appropriate users.
