### PR TITLE
Coerce group names to unicode

### DIFF
--- a/corehq/apps/users/bulkupload.py
+++ b/corehq/apps/users/bulkupload.py
@@ -277,7 +277,7 @@ def create_or_update_groups(domain, group_specs, log):
     group_names = set()
     for row in group_specs:
         group_id = row.get('id')
-        group_name = row.get('name')
+        group_name = unicode(row.get('name') or '')
         case_sharing = row.get('case-sharing')
         reporting = row.get('reporting')
         data = row.get('data')
@@ -337,7 +337,7 @@ def create_or_update_users_and_groups(domain, user_specs, group_specs, location_
 
             data = row.get('data')
             email = row.get('email')
-            group_names = row.get('group')
+            group_names = map(unicode, row.get('group') or [])
             language = row.get('language')
             name = row.get('name')
             password = row.get('password')
@@ -349,7 +349,6 @@ def create_or_update_users_and_groups(domain, user_specs, group_specs, location_
 
             if password:
                 password = unicode(password)
-            group_names = group_names or []
             try:
                 username = normalize_username(str(username), domain)
             except TypeError:

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -712,8 +712,8 @@ class UploadCommCareUsers(BaseManageCommCareUserView):
         return context
 
     def post(self, request, *args, **kwargs):
-        upload = request.FILES.get('bulk_upload_file')
         """View's dispatch method automatically calls this"""
+        upload = request.FILES.get('bulk_upload_file')
         try:
             self.workbook = WorkbookJSONReader(upload)
         except InvalidFileException:


### PR DESCRIPTION
@sravfeyn
http://manage.dimagi.com/default.asp?176465
The xlsx library returns the same value as is stored in the spreadsheet, so
10101 could be a string OR an int, and it's kinda opaque to the user. Really,
this parsing should be schema'd (passed to a JsonObject or something) to
validate properly, but this should do for now.

Also, `row.get` is super weird.  `row.get('name', []) == []`, but
`row.get('name', '') == None`.  Go figure.  That's why I decided not to use
that syntax.
