### PR TITLE
Try increasing touchforms jvm size to 4 gb

### DIFF
--- a/fab/services/templates/supervisor_formsplayer.conf
+++ b/fab/services/templates/supervisor_formsplayer.conf
@@ -1,5 +1,5 @@
 [program:{{ project }}-{{ environment }}-formsplayer]
-command=java -Xmx2048m -Xss1024k -classpath {{ jython_home }}/jython.jar: -Dpython.home={{ jython_home }} -Dpython.executable={{ jython_home }}/bin/jython org.python.util.jython {{ code_root }}/submodules/touchforms-src/touchforms/backend/xformserver.py
+command=java -Xmx3584m -Xss1024k -classpath {{ jython_home }}/jython.jar: -Dpython.home={{ jython_home }} -Dpython.executable={{ jython_home }}/bin/jython org.python.util.jython {{ code_root }}/submodules/touchforms-src/touchforms/backend/xformserver.py
 user={{ sudo_user }}
 autostart=true
 autorestart=true


### PR DESCRIPTION
This should hopefully unbottleneck touchforms during high load. FYI this is not parametrized per environment, but it appears that touchforms appropriately frees up memory so this shouldn't increase memory usage on other machines.

@dannyroberts @czue 
