### PR TITLE
Fix timezones in ledger xml parsing

### DIFF
--- a/corehq/apps/commtrack/exceptions.py
+++ b/corehq/apps/commtrack/exceptions.py
@@ -25,3 +25,10 @@ class MultipleSupplyPointException(Exception):
 class MissingProductId(Exception):
     pass
 
+
+class LedgerParseError(ValueError):
+    pass
+
+
+class InvalidDate(LedgerParseError):
+    pass

--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -4,16 +4,17 @@ import logging
 from xml.etree import ElementTree
 
 from couchdbkit.exceptions import ResourceNotFound
+
 from django.utils.translation import ugettext as _
 from django.dispatch import receiver
 from django.db import models
 from django.db.models.signals import post_save, post_delete
 
 from corehq.apps.commtrack.dbaccessors import get_supply_point_case_by_location
+
 from dimagi.ext.couchdbkit import *
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.models import CommCareCase
-from casexml.apps.stock import const as stockconst
 from casexml.apps.stock.consumption import (ConsumptionConfiguration, compute_default_monthly_consumption,
     compute_daily_consumption)
 from casexml.apps.stock.models import StockReport, StockTransaction, DocDomainMapping
@@ -32,7 +33,6 @@ from corehq.apps.products.models import Product, SQLProduct
 from corehq.apps.commtrack.const import StockActions, RequisitionActions, DAYS_IN_MONTH
 from corehq.apps.commtrack.xmlutil import XML
 from couchexport.models import register_column_type, ComplexExportColumn
-from dimagi.utils.dates import force_to_datetime
 from dimagi.utils.decorators.memoized import memoized
 
 
@@ -309,97 +309,6 @@ def force_empty_string_to_null(value):
         return None
     else:
         return value
-
-
-def xml_to_stock_report_helper(form, elem):
-    tag = elem.tag
-    tag = tag[tag.find('}') + 1:]  # strip out ns
-    timestamp = force_to_datetime(
-        elem.attrib.get('date') or form.received_on).replace(tzinfo=None)
-    products = elem.findall('./{%s}entry' % stockconst.COMMTRACK_REPORT_XMLNS)
-    transactions = [
-        t for prod_entry in products for t in
-        _xml_to_stock_transaction_helper(form.domain, timestamp, tag, elem,
-                                         prod_entry)
-    ]
-
-    return StockReportHelper(form, timestamp, tag, transactions)
-
-
-def _xml_to_stock_transaction_helper(domain, timestamp, action_tag,
-                                     action_node, product_node):
-    action_type = action_node.attrib.get('type')
-    subaction = action_type
-    product_id = product_node.attrib.get('id')
-
-    def _txn(action, case_id, section_id, quantity):
-        # warning: here be closures
-        return StockTransactionHelper(
-            domain=domain,
-            timestamp=timestamp,
-            product_id=product_id,
-            quantity=Decimal(str(quantity)) if quantity is not None else None,
-            action=action,
-            case_id=case_id,
-            section_id=section_id,
-            subaction=subaction if subaction and subaction != action else None
-            # note: no location id
-        )
-
-    def _yield_txns(section_id, quantity):
-        # warning: here be closures
-        if action_tag == 'balance':
-            case_id = action_node.attrib['entity-id']
-            yield _txn(
-                action=(const.StockActions.STOCKONHAND if quantity > 0
-                        else const.StockActions.STOCKOUT),
-                case_id=case_id,
-                section_id=section_id,
-                quantity=quantity,
-            )
-        elif action_tag == 'transfer':
-            src, dst = [action_node.attrib.get(k) for k in ('src', 'dest')]
-            assert src or dst
-            if src is not None:
-                yield _txn(action=const.StockActions.CONSUMPTION, case_id=src,
-                           section_id=section_id, quantity=quantity)
-            if dst is not None:
-                yield _txn(action=const.StockActions.RECEIPTS, case_id=dst,
-                           section_id=section_id, quantity=quantity)
-
-    def _quantity_or_none(value, section_id):
-        try:
-            return float(value)
-        except (ValueError, TypeError):
-            logging.error((
-                "Non-numeric quantity submitted on domain %s for "
-                "a %s ledger" % (domain, section_id)
-            ))
-            return None
-
-    section_id = action_node.attrib.get('section-id', None)
-    grouped_entries = section_id is not None
-    if grouped_entries:
-        quantity = _quantity_or_none(
-            product_node.attrib.get('quantity'),
-            section_id
-        )
-        # make sure quantity is not an empty, unset node value
-        if quantity is not None:
-            for txn in _yield_txns(section_id, quantity):
-                yield txn
-    else:
-        values = [child for child in product_node]
-        for value in values:
-            section_id = value.attrib.get('section-id')
-            quantity = _quantity_or_none(
-                value.attrib.get('quantity'),
-                section_id
-            )
-            # make sure quantity is not an empty, unset node value
-            if quantity is not None:
-                for txn in _yield_txns(section_id, quantity):
-                    yield txn
 
 
 class StockReportHelper(object):

--- a/corehq/apps/commtrack/parsing.py
+++ b/corehq/apps/commtrack/parsing.py
@@ -1,0 +1,98 @@
+from decimal import Decimal
+import logging
+from casexml.apps.stock import const as stockconst
+from corehq.apps.commtrack import const
+from corehq.apps.commtrack.models import StockReportHelper, \
+    StockTransactionHelper
+from dimagi.utils.dates import force_to_datetime
+
+
+def xml_to_stock_report_helper(form, elem):
+    tag = elem.tag
+    tag = tag[tag.find('}') + 1:]  # strip out ns
+    timestamp = force_to_datetime(
+        elem.attrib.get('date') or form.received_on).replace(tzinfo=None)
+    products = elem.findall('./{%s}entry' % stockconst.COMMTRACK_REPORT_XMLNS)
+    transactions = [
+        t for prod_entry in products for t in
+        _xml_to_stock_transaction_helper(form.domain, timestamp, tag, elem,
+                                         prod_entry)
+    ]
+
+    return StockReportHelper(form, timestamp, tag, transactions)
+
+
+def _xml_to_stock_transaction_helper(domain, timestamp, action_tag,
+                                     action_node, product_node):
+    action_type = action_node.attrib.get('type')
+    subaction = action_type
+    product_id = product_node.attrib.get('id')
+
+    def _txn(action, case_id, section_id, quantity):
+        # warning: here be closures
+        return StockTransactionHelper(
+            domain=domain,
+            timestamp=timestamp,
+            product_id=product_id,
+            quantity=Decimal(str(quantity)) if quantity is not None else None,
+            action=action,
+            case_id=case_id,
+            section_id=section_id,
+            subaction=subaction if subaction and subaction != action else None
+            # note: no location id
+        )
+
+    def _yield_txns(section_id, quantity):
+        # warning: here be closures
+        if action_tag == 'balance':
+            case_id = action_node.attrib['entity-id']
+            yield _txn(
+                action=(const.StockActions.STOCKONHAND if quantity > 0
+                        else const.StockActions.STOCKOUT),
+                case_id=case_id,
+                section_id=section_id,
+                quantity=quantity,
+            )
+        elif action_tag == 'transfer':
+            src, dst = [action_node.attrib.get(k) for k in ('src', 'dest')]
+            assert src or dst
+            if src is not None:
+                yield _txn(action=const.StockActions.CONSUMPTION, case_id=src,
+                           section_id=section_id, quantity=quantity)
+            if dst is not None:
+                yield _txn(action=const.StockActions.RECEIPTS, case_id=dst,
+                           section_id=section_id, quantity=quantity)
+
+    def _quantity_or_none(value, section_id):
+        try:
+            return float(value)
+        except (ValueError, TypeError):
+            logging.error((
+                "Non-numeric quantity submitted on domain %s for "
+                "a %s ledger" % (domain, section_id)
+            ))
+            return None
+
+    section_id = action_node.attrib.get('section-id', None)
+    grouped_entries = section_id is not None
+    if grouped_entries:
+        quantity = _quantity_or_none(
+            product_node.attrib.get('quantity'),
+            section_id
+        )
+        # make sure quantity is not an empty, unset node value
+        if quantity is not None:
+            for txn in _yield_txns(section_id, quantity):
+                yield txn
+    else:
+        values = [child for child in product_node]
+        for value in values:
+            section_id = value.attrib.get('section-id')
+            quantity = _quantity_or_none(
+                value.attrib.get('quantity'),
+                section_id
+            )
+            # make sure quantity is not an empty, unset node value
+            if quantity is not None:
+                for txn in _yield_txns(section_id, quantity):
+                    yield txn

--- a/corehq/apps/commtrack/parsing.py
+++ b/corehq/apps/commtrack/parsing.py
@@ -1,71 +1,179 @@
+"""
+This file is dedicated to parsing ledger xml as documented at
+https://github.com/dimagi/commcare/wiki/ledgerxml
+
+The quirks of ledger xml are outlined as follows.
+
+There are two **Ledger Report Types**, 'balance' and 'transfer':
+
+    <balance entity-id=""/>
+and
+    <transfer src="" dest="" type=""/>
+
+There are also two **Ledger Report Formats**, 'individual' and 'per-entry'.
+
+- Individual Ledger Balance:
+
+    <balance xmlns="http://commcarehq.org/ledger/v1" entity-id="" date="" section-id="">
+        <entry id="" quantity="" /> <!--multiple-->
+    </balance>
+
+  parsed into JSON as
+
+    {"@xmlns": "http://commcarehq.org/ledger/v1", "@entity-id": "",
+     "@date": "", "@section-id": "",
+     "entry": [{"@id": "", "@quantity": ""}]}
+
+- Per-Entry Ledger Balance:
+
+    <balance xmlns="http://commcarehq.org/ledger/v1" entity-id="" date="">
+        <entry id=""> <!--multiple-->
+            <value section-id="" quantity=""/> <!-- multiple -->
+        </entry>
+    </balance>
+
+  parsed into JSON as
+
+    {"@xmlns": "http://commcarehq.org/ledger/v1", "@entity-id": "",
+     "@date": "",
+     "entry": [{"@id": "", "value": [{"@section-id: "", "@quantity": ""},
+               ...]}]}
+
+Conceptually, both formats produce a list of transactions:
+
+    (entity_id="", date="", section_id="", entry_id="", quantity="")
+    ...
+
+but Per-Entry lets you have many different section_ids among the transactions.
+
+"""
+from collections import namedtuple
 from decimal import Decimal
 import logging
+import datetime
 from casexml.apps.stock import const as stockconst
+from casexml.apps.stock.const import COMMTRACK_REPORT_XMLNS
 from corehq.apps.commtrack import const
+from corehq.apps.commtrack.exceptions import InvalidDate
 from corehq.apps.commtrack.models import StockReportHelper, \
     StockTransactionHelper
-from dimagi.utils.dates import force_to_datetime
+from couchforms.models import XFormInstance
+from couchforms.util import adjust_datetimes
+from xml2json.lib import convert_xml_to_json
 
 
-def xml_to_stock_report_helper(form, elem):
-    tag = elem.tag
-    tag = tag[tag.find('}') + 1:]  # strip out ns
-    timestamp = force_to_datetime(
-        elem.attrib.get('date') or form.received_on).replace(tzinfo=None)
-    products = elem.findall('./{%s}entry' % stockconst.COMMTRACK_REPORT_XMLNS)
-    transactions = [
-        t for prod_entry in products for t in
-        _xml_to_stock_transaction_helper(form.domain, timestamp, tag, elem,
-                                         prod_entry)
-    ]
-
-    return StockReportHelper(form, timestamp, tag, transactions)
+LedgerInstruction = namedtuple(
+    'LedgerInstruction',
+    ['date', 'section_id', 'entry_id', 'quantity',
+     # for balance instructions
+     'entity_id',
+     # for transfer instructions
+     'src', 'dest', 'type']
+)
 
 
-def _xml_to_stock_transaction_helper(domain, timestamp, action_tag,
-                                     action_node, product_node):
-    action_type = action_node.attrib.get('type')
-    subaction = action_type
-    product_id = product_node.attrib.get('id')
+class LedgerFormat(object):
+    individual = object()
+    per_entry = object()
 
-    def _txn(action, case_id, section_id, quantity):
-        # warning: here be closures
+
+def should_be_a_list(obj_or_list):
+    if obj_or_list is None:
+        return []
+    elif isinstance(obj_or_list, list):
+        return obj_or_list
+    else:
+        return [obj_or_list]
+
+
+def unpack_commtrack(xform):
+    form_xml = xform.get_xml_element()
+    commtrack_node_names = ('{%s}balance' % COMMTRACK_REPORT_XMLNS,
+                            '{%s}transfer' % COMMTRACK_REPORT_XMLNS)
+
+    def commtrack_nodes(node):
+        for child in node:
+            if child.tag in commtrack_node_names:
+                yield child
+            else:
+                for e in commtrack_nodes(child):
+                    yield e
+
+    for elem in commtrack_nodes(form_xml):
+        report_type, ledger_json = convert_xml_to_json(
+            elem, last_xmlns=COMMTRACK_REPORT_XMLNS)
+
+        # apply the same datetime & string conversions
+        # that would be applied to XFormInstance.form
+        adjust_datetimes(ledger_json)
+        ledger_json = XFormInstance({'form': ledger_json}).form
+
+        yield ledger_json_to_stock_report_helper(
+            xform, report_type, ledger_json)
+
+
+def ledger_json_to_stock_report_helper(form, report_type, ledger_json):
+    domain = form.domain
+    # figure out what kind of block we're dealing with
+    if ledger_json.get('@section-id'):
+        ledger_format = LedgerFormat.individual
+    else:
+        ledger_format = LedgerFormat.per_entry
+
+    # helper functions
+    def get_date():
+        timestamp = ledger_json.get('@date') or form.received_on
+        if not isinstance(timestamp, datetime.datetime):
+            raise InvalidDate("{} has invalid @date".format(ledger_json))
+        return timestamp
+
+    def make_transaction_helper(ledger_instruction, action, case_id):
+        subaction = ledger_instruction.type
         return StockTransactionHelper(
+            # domain is a closure variable
             domain=domain,
-            timestamp=timestamp,
-            product_id=product_id,
-            quantity=Decimal(str(quantity)) if quantity is not None else None,
+            timestamp=ledger_instruction.date,
+            product_id=ledger_instruction.entry_id,
+            quantity=ledger_instruction.quantity,
             action=action,
             case_id=case_id,
-            section_id=section_id,
-            subaction=subaction if subaction and subaction != action else None
-            # note: no location id
+            section_id=ledger_instruction.section_id,
+            subaction=subaction if subaction and subaction != action else None,
+            location_id=None,
         )
 
-    def _yield_txns(section_id, quantity):
-        # warning: here be closures
-        if action_tag == 'balance':
-            case_id = action_node.attrib['entity-id']
-            yield _txn(
-                action=(const.StockActions.STOCKONHAND if quantity > 0
+    # details of transaction generation
+    # depend on whether it's a balance or a transfer
+    if report_type == stockconst.REPORT_TYPE_BALANCE:
+        def get_transaction_helpers(ledger_instruction):
+
+            case_id = ledger_instruction.entity_id
+            yield make_transaction_helper(
+                ledger_instruction,
+                action=(const.StockActions.STOCKONHAND
+                        if ledger_instruction.quantity > 0
                         else const.StockActions.STOCKOUT),
                 case_id=case_id,
-                section_id=section_id,
-                quantity=quantity,
             )
-        elif action_tag == 'transfer':
-            src, dst = [action_node.attrib.get(k) for k in ('src', 'dest')]
-            assert src or dst
+    elif report_type == stockconst.REPORT_TYPE_TRANSFER:
+        def get_transaction_helpers(ledger_instruction):
+            src = ledger_instruction.src
+            dest = ledger_instruction.dest
+            assert src or dest
             if src is not None:
-                yield _txn(action=const.StockActions.CONSUMPTION, case_id=src,
-                           section_id=section_id, quantity=quantity)
-            if dst is not None:
-                yield _txn(action=const.StockActions.RECEIPTS, case_id=dst,
-                           section_id=section_id, quantity=quantity)
+                yield make_transaction_helper(
+                    ledger_instruction,
+                    action=const.StockActions.CONSUMPTION, case_id=src)
+            if dest is not None:
+                yield make_transaction_helper(
+                    ledger_instruction,
+                    action=const.StockActions.RECEIPTS, case_id=dest)
+    else:
+        raise ValueError()
 
-    def _quantity_or_none(value, section_id):
+    def get_quantity_or_none(value, section_id):
         try:
-            return float(value)
+            return Decimal(str(float(value.get('@quantity'))))
         except (ValueError, TypeError):
             logging.error((
                 "Non-numeric quantity submitted on domain %s for "
@@ -73,26 +181,68 @@ def _xml_to_stock_transaction_helper(domain, timestamp, action_tag,
             ))
             return None
 
-    section_id = action_node.attrib.get('section-id', None)
-    grouped_entries = section_id is not None
-    if grouped_entries:
-        quantity = _quantity_or_none(
-            product_node.attrib.get('quantity'),
-            section_id
-        )
-        # make sure quantity is not an empty, unset node value
-        if quantity is not None:
-            for txn in _yield_txns(section_id, quantity):
-                yield txn
+    timestamp = get_date()
+    ledger_instructions = []
+    if ledger_format == LedgerFormat.individual:
+        # this is @date, @section-id, etc.
+        # but also balance/transfer specific attributes:
+        # @entity-id/@src,@dest
+        section_id = ledger_json.get('@section-id')
+        top_level_attributes = {
+            'date': timestamp,
+            'section_id': section_id,
+            'entity_id': ledger_json.get('@entity-id'),
+            'src': ledger_json.get('@src'),
+            'dest': ledger_json.get('@dest'),
+            'type': ledger_json.get('@type'),
+        }
+
+        product_entries = should_be_a_list(ledger_json.get('entry'))
+        for product_entry in product_entries:
+            # product_entry looks like
+            # {"@id": "", "@quantity": ""}
+            t = {}
+            t.update(top_level_attributes)
+            t.update({'entry_id': product_entry.get('@id'),
+                      'quantity': get_quantity_or_none(product_entry,
+                                                       section_id)})
+            ledger_instructions.append(LedgerInstruction(**t))
     else:
-        values = [child for child in product_node]
-        for value in values:
-            section_id = value.attrib.get('section-id')
-            quantity = _quantity_or_none(
-                value.attrib.get('quantity'),
-                section_id
-            )
-            # make sure quantity is not an empty, unset node value
-            if quantity is not None:
-                for txn in _yield_txns(section_id, quantity):
-                    yield txn
+        top_level_attributes = {
+            'date': timestamp,
+            'entity_id': ledger_json.get('@entity-id'),
+            'src': ledger_json.get('@src'),
+            'dest': ledger_json.get('@dest'),
+            'type': ledger_json.get('@type'),
+        }
+
+        product_entries = should_be_a_list(ledger_json.get('entry'))
+        for product_entry in product_entries:
+            # product_entry looks like
+            # {"@id": "", 'value': [...]}
+            for value in should_be_a_list(product_entry.get('value')):
+                # value looks like
+                # {"@section-id: "", "@quantity": ""}
+                t = {}
+                section_id = value.get('@section-id')
+                t.update(top_level_attributes)
+                t.update({'entry_id': product_entry.get('@id')})
+                t.update({'quantity': get_quantity_or_none(value, section_id),
+                          'section_id': section_id})
+                ledger_instructions.append(LedgerInstruction(**t))
+
+    # filter out ones where quantity is None
+    # todo: is this really the behavior we want when quantity=""?
+    ledger_instructions = [
+        ledger_instruction
+        for ledger_instruction in ledger_instructions
+        if ledger_instruction.quantity is not None
+    ]
+
+    transaction_helpers = [
+        transaction_helper
+        for ledger_instruction in ledger_instructions
+        for transaction_helper in get_transaction_helpers(ledger_instruction)
+    ]
+
+    return StockReportHelper(form, timestamp, report_type, transaction_helpers)

--- a/corehq/apps/commtrack/processing.py
+++ b/corehq/apps/commtrack/processing.py
@@ -4,10 +4,9 @@ from django.utils.translation import ugettext as _
 from casexml.apps.case.const import CASE_ACTION_COMMTRACK
 from casexml.apps.case.exceptions import IllegalCaseId
 from casexml.apps.case.xform import is_device_report, CaseDbCache
-from casexml.apps.stock.const import COMMTRACK_REPORT_XMLNS
 from casexml.apps.stock.models import StockTransaction, StockReport
 from corehq.apps.commtrack.exceptions import MissingProductId
-from corehq.apps.commtrack.parsing import xml_to_stock_report_helper
+from corehq.apps.commtrack.parsing import unpack_commtrack
 from dimagi.utils.decorators.log_exception import log_exception
 from casexml.apps.case.models import CommCareCaseAction
 from casexml.apps.case.xml.parser import AbstractAction
@@ -155,18 +154,3 @@ def process_stock(xform, case_db=None):
         relevant_cases=relevant_cases,
         stock_report_helpers=stock_report_helpers,
     )
-
-
-def unpack_commtrack(xform):
-    xml = xform.get_xml_element()
-
-    def commtrack_nodes(node):
-        for child in node:
-            if child.tag.startswith('{%s}' % COMMTRACK_REPORT_XMLNS):
-                yield child
-            else:
-                for e in commtrack_nodes(child):
-                    yield e
-
-    for elem in commtrack_nodes(xml):
-        yield xml_to_stock_report_helper(xform, elem)

--- a/corehq/apps/commtrack/processing.py
+++ b/corehq/apps/commtrack/processing.py
@@ -7,8 +7,8 @@ from casexml.apps.case.xform import is_device_report, CaseDbCache
 from casexml.apps.stock.const import COMMTRACK_REPORT_XMLNS
 from casexml.apps.stock.models import StockTransaction, StockReport
 from corehq.apps.commtrack.exceptions import MissingProductId
+from corehq.apps.commtrack.parsing import xml_to_stock_report_helper
 from dimagi.utils.decorators.log_exception import log_exception
-from corehq.apps.commtrack.models import xml_to_stock_report_helper
 from casexml.apps.case.models import CommCareCaseAction
 from casexml.apps.case.xml.parser import AbstractAction
 from casexml.apps.stock import const as stockconst


### PR DESCRIPTION
- Pull ledger xml blocks straight from the form XML, so that they come in the right order
- Apply the same transformations to each block that are applied to form JSON
  - xml2json
  - adjust_datetimes
  - default string conversions
- Separate parsing the json into distinct steps for clarity:
  - figure out which format is being used (individual or per-entry) and pull out the ledger instructions in a consistent format (see `LedgerInstruction` namedtuple)
  - figure out which kind of report type (balance vs. transfer) it is and how to generate `StockTransactionHelper`s given a `LedgerInstruction`.
  - loop through the ledger instructions and yield stock transaction helpers based on the previously selected generator function
