### PR TITLE
Don't return retired users

### DIFF
--- a/corehq/apps/users/dbaccessors/all_commcare_users.py
+++ b/corehq/apps/users/dbaccessors/all_commcare_users.py
@@ -1,18 +1,24 @@
+from itertools import imap
 from dimagi.utils.couch.database import iter_docs
 
 
 def get_all_commcare_users_by_domain(domain):
     """Returns all CommCareUsers by domain regardless of their active status"""
     from corehq.apps.users.models import CommCareUser
-    key = [domain, CommCareUser.__name__]
-    ids = [user['id'] for user in CommCareUser.get_db().view(
-        'domain/docs',
-        startkey=key,
-        endkey=key + [{}],
-        reduce=False,
-        include_docs=False)]
 
-    return [CommCareUser.wrap(user) for user in iter_docs(CommCareUser.get_db(), ids)]
+    def get_ids():
+        for flag in ['active', 'inactive']:
+            key = [flag, domain, CommCareUser.__name__]
+            for user in CommCareUser.get_db().view(
+                'users/by_domain',
+                startkey=key,
+                endkey=key + [{}],
+                reduce=False,
+                include_docs=False
+            ):
+                yield user['id']
+
+    return imap(CommCareUser.wrap, iter_docs(CommCareUser.get_db(), get_ids()))
 
 
 def get_user_docs_by_username(usernames):

--- a/corehq/apps/users/tests/test_db_accessors.py
+++ b/corehq/apps/users/tests/test_db_accessors.py
@@ -52,6 +52,21 @@ class AllCommCareUsersTest(TestCase):
         actual_usernames = [user.username for user in get_all_commcare_users_by_domain(self.ccdomain.name)]
         self.assertItemsEqual(actual_usernames, expected_usernames)
 
+    def test_exclude_retired_users(self):
+        deleted_user = CommCareUser.create(
+            domain=self.ccdomain.name,
+            username='deleted_user',
+            password='secret',
+            email='deleted_email@example.com',
+        )
+        deleted_user.retire()
+        self.assertNotIn(
+            deleted_user.username,
+            [user.username for user in
+             get_all_commcare_users_by_domain(self.ccdomain.name)]
+        )
+        deleted_user.delete()
+
     def test_get_user_docs_by_username(self):
         users = [self.ccuser_1, self.web_user, self.ccuser_other_domain]
         usernames = [u.username for u in users] + ['nonexistant@username.com']


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?176588
Retiring a user gives a base doc of `CouchUser-Deleted`.  These should be
excluded.
@sravfeyn @proteusvacuum
