### PR TITLE
action_type "subcases" sometimes written singular

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1013,7 +1013,7 @@ class Form(IndexedFormBase, NavMenuItemMediaMixin):
         module_case_type = self.get_module().case_type
         if action_type == 'open_case':
             return 'case_id_new_{}_0'.format(module_case_type)
-        if action_type == 'subcase':
+        if action_type == 'subcases':
             opens_case = 'open_case' in self.active_actions()
             subcase_type = self.actions.subcases[subcase_index].case_type
             if opens_case:

--- a/corehq/apps/app_manager/suite_xml.py
+++ b/corehq/apps/app_manager/suite_xml.py
@@ -1626,7 +1626,9 @@ class SuiteGenerator(SuiteGeneratorBase):
                     # see XForm.create_casexml_2
                     if not subcase.repeat_context:
                         datums.append({
-                            'datum': SessionDatum(id=form.session_var_for_action('subcase', i), function='uuid()'),
+                            'datum': SessionDatum(
+                                id=form.session_var_for_action('subcases', i), function='uuid()'
+                            ),
                             'case_type': subcase.case_type,
                             'requires_selection': False,
                             'action': subcase

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -1327,7 +1327,7 @@ class XForm(WrappedNode):
                     base_path = ''
                     parent_node = self.data_node
                     nest = True
-                    case_id = session_var(form.session_var_for_action('subcase', i))
+                    case_id = session_var(form.session_var_for_action('subcases', i))
 
                 if nest:
                     name = 'subcase_%s' % i


### PR DESCRIPTION
Nitpicky, but might be useful. I'm considering adding a "usercase_subcases" action type. If I want to pass the action type in a variable instead of hardcoded as it is in these two instances, I'll need the name to match.

(The action_type is "subcases" not "subcase", as per models.py:[1044](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/app_manager/models.py#L1044),[1049](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/app_manager/models.py#L1049),[1056](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/app_manager/models.py#L1056))

@snopoke, cc @millerdev 
