### PR TITLE
Extended trial billing

### DIFF
--- a/corehq/apps/accounting/decorators.py
+++ b/corehq/apps/accounting/decorators.py
@@ -5,7 +5,8 @@ from django.utils.encoding import force_unicode
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext
 from corehq import privileges
-from corehq.apps.accounting.models import DefaultProductPlan
+from corehq.apps.accounting.models import DefaultProductPlan, \
+    SoftwarePlanVisibility
 from django.http import Http404, HttpResponse
 from corehq.const import USER_DATE_FORMAT
 from django_prbac.decorators import requires_privilege
@@ -24,7 +25,7 @@ def requires_privilege_with_fallback(slug, **assignment):
             try:
                 if (hasattr(request, 'subscription')
                     and request.subscription is not None
-                    and request.subscription.is_trial
+                    and (request.subscription.is_trial or request.subscription.plan_version.plan.visibility == SoftwarePlanVisibility.TRIAL_INTERNAL)
                     and request.subscription.date_end is not None
                 ):
                     edition_req = DefaultProductPlan.get_lowest_edition_by_domain(

--- a/corehq/apps/accounting/filters.py
+++ b/corehq/apps/accounting/filters.py
@@ -173,6 +173,8 @@ class CreatedSubAdjMethodFilter(BaseSingleOptionFilter):
         (SubscriptionAdjustmentMethod.INTERNAL, "Operations Created"),
         (SubscriptionAdjustmentMethod.USER, "User Created"),
         (SubscriptionAdjustmentMethod.TASK, "Created During Invoicing"),
+        (SubscriptionAdjustmentMethod.TRIAL_INTERNAL, "Custom Trial"),
+        (SubscriptionAdjustmentMethod.TRIAL, "30 Day Trial (default signup)"),
     )
 
 

--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -545,7 +545,11 @@ class SubscriptionForm(forms.Form):
                     'account': account.name,
                 }))
 
-        start_date = self.cleaned_data.get('start_date') or self.subscription.date_start
+        start_date = self.cleaned_data.get('start_date')
+        if start_date is None and self.subscription is not None:
+            start_date = self.subscription.date_start
+        elif start_date is None:
+            raise ValidationError(_("You must specify a start date"))
         if (self.cleaned_data['end_date'] is not None
             and start_date > self.cleaned_data['end_date']):
             raise ValidationError(_("End date must be after start date."))

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -120,10 +120,12 @@ class SoftwarePlanVisibility(object):
     PUBLIC = "PUBLIC"
     INTERNAL = "INTERNAL"
     TRIAL = "TRIAL"
+    TRIAL_INTERNAL = "TRIAL_INT"
     CHOICES = (
         (PUBLIC, "Anyone can subscribe"),
         (INTERNAL, "Dimagi must create subscription"),
         (TRIAL, "This is a Trial Plan"),
+        (TRIAL_INTERNAL, "This is special Trial plan that Dimagi manages."),
     )
 
 
@@ -171,11 +173,13 @@ class SubscriptionAdjustmentMethod(object):
     INTERNAL = "INTERNAL"
     TASK = "TASK"
     TRIAL = "TRIAL"
+    TRIAL_INTERNAL = "TRIAL_INT"
     CHOICES = (
         (USER, "User"),
         (INTERNAL, "Ops"),
         (TASK, "Task (Invoicing)"),
-        (TRIAL, "30 Day Trial")
+        (TRIAL, "30 Day Trial"),
+        (TRIAL_INTERNAL, "Custom Trial Period"),
     )
 
 

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1223,7 +1223,8 @@ class InternalSubscriptionManagementView(BaseAdminProjectSettingsView):
                 subscription_type = "contracted_partner"
             elif plan.edition == SoftwarePlanEdition.ENTERPRISE:
                 subscription_type = "dimagi_only_enterprise"
-            elif plan.edition == SoftwarePlanEdition.ADVANCED and plan.visibility == SoftwarePlanVisibility.TRIAL:
+            elif (plan.edition == SoftwarePlanEdition.ADVANCED
+                  and plan.visibility == SoftwarePlanVisibility.TRIAL_INTERNAL):
                 subscription_type = "advanced_extended_trial"
 
         return SelectSubscriptionTypeForm({'subscription_type': subscription_type})

--- a/corehq/apps/style/templates/style/bootstrap2/base.html
+++ b/corehq/apps/style/templates/style/bootstrap2/base.html
@@ -332,8 +332,8 @@
                         {% blocktrans %}
                             We want you to have a chance to use and evaluate our
                             pay-only features before deciding which plan to subscribe to.
-                            You will have access to <strong>{{ feat_name }}</strong> for a
-                            30 day trial period. <strong>This period is ending on {{ date_end }}.</strong>
+                            You will have access to <strong>{{ feat_name }}</strong> during
+                            this trial period, ending on {{ date_end }}.
                             After {{ date_end }}, you will no longer have access to {{ feat_name }}.
                         {% endblocktrans %}
                         </p>

--- a/corehq/apps/style/templates/style/includes/modal_30_day_trial.html
+++ b/corehq/apps/style/templates/style/includes/modal_30_day_trial.html
@@ -15,16 +15,16 @@
                         <p class="lead">
                         {% blocktrans %}
                             <strong>{{ feat_name }}</strong> is only available for the {{ req_plan }}
-                            Plan and higher. You are currently on a trial version
-                            of the {{ current_plan }} Plan.
+                            Plan and higher. Your subscription to {{ current_plan }} Plan is under a
+                            trial period.
                         {% endblocktrans %}
                         </p>
                         <p>
                         {% blocktrans %}
                             We want you to have a chance to use and evaluate our
                             pay-only features before deciding which plan to subscribe to.
-                            You will have access to <strong>{{ feat_name }}</strong> for a
-                            30 day trial period. <strong>This period is ending on {{ date_end }}.</strong>
+                            You will have access to <strong>{{ feat_name }}</strong> during
+                            this trial period, ending on {{ date_end }}.
                             After {{ date_end }}, you will no longer have access to {{ feat_name }}.
                         {% endblocktrans %}
                         </p>


### PR DESCRIPTION
Addresses
http://manage.dimagi.com/default.asp?176175#978845
- creates a new visibility option that is `TRIAL_INTERNAL`
- the extended plan discussed in the ticket must have this visibility option set once this PR is merged and deployed
- updates trial modal language to be general for 30 day or extended trials.

@esoergel @TylerSheffels 
