### PR TITLE
Show user case details if user-case-only module

### DIFF
--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -179,7 +179,8 @@ def form_context(request, domain, app_id, module_id, form_id):
     case_id = request.GET.get('case_id')
     instance_id = request.GET.get('instance_id')
     try:
-        form = app.get_module(module_id).get_form(form_id)
+        module = app.get_module(module_id)
+        form = module.get_form(form_id)
     except (FormNotFoundException, ModuleNotFoundException):
         raise Http404()
 
@@ -207,7 +208,7 @@ def form_context(request, domain, app_id, module_id, form_id):
 
     session_extras = {'session_name': session_name, 'app_id': app._id}
     suite_gen = SuiteGenerator(app, is_usercase_in_use(domain))
-    session_extras.update(get_cloudcare_session_data(suite_gen, domain, form, request.couch_user))
+    session_extras.update(get_cloudcare_session_data(suite_gen, domain, module, form, request.couch_user))
 
     delegation = request.GET.get('task-list') == 'true'
     offline = request.GET.get('offline') == 'true'

--- a/corehq/apps/smsforms/app.py
+++ b/corehq/apps/smsforms/app.py
@@ -58,7 +58,7 @@ def start_session(domain, contact, app, module, form, case_id=None, yield_respon
     
     if app and form:
         suite_gen = SuiteGenerator(app, is_usercase_in_use(domain))
-        session_data.update(get_cloudcare_session_data(suite_gen, domain, form, contact))
+        session_data.update(get_cloudcare_session_data(suite_gen, domain, module, form, contact))
 
     language = contact.get_language_code()
     config = XFormsConfig(form_content=form.render_xform(),


### PR DESCRIPTION
Hold off on merge -- needs a test.

This adds a "detail-confirm" attribute to the user case datum if a module only uses the user case and not its case type. This is to indicate to the app when to show the details of the user case when opening a module.

@snopoke, ping @ctsims, cc @millerdev 
