### PR TITLE
multiple database support for UCRs

### DIFF
--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -21,14 +21,6 @@ class ConfigurableIndicatorPillow(PythonPillow):
         super(ConfigurableIndicatorPillow, self).__init__(couch_db=couch_db)
         self.bootstrapped = False
 
-    @classmethod
-    def get_sql_engine(cls):
-        # todo: switch to connection_manager
-        engine = getattr(cls, '_engine', None)
-        if not engine:
-            cls._engine = connection_manager.get_engine()
-        return cls._engine
-
     def get_all_configs(self):
         return DataSourceConfiguration.all()
 

--- a/corehq/apps/userreports/reports/data_source.py
+++ b/corehq/apps/userreports/reports/data_source.py
@@ -11,6 +11,7 @@ from corehq.apps.userreports.exceptions import (
 from corehq.apps.userreports.models import DataSourceConfiguration
 from corehq.apps.userreports.reports.specs import DESCENDING
 from corehq.apps.userreports.sql import get_table_name
+from corehq.apps.userreports.sql.connection import get_engine_id
 from corehq.apps.userreports.views import get_datasource_config_or_404
 from dimagi.utils.decorators.memoized import memoized
 
@@ -42,14 +43,18 @@ class ConfigurableReportDataSource(SqlData):
             self._column_configs[column.column_id] = column
 
     @property
-    def column_configs(self):
-        return self._column_configs.values()
-
-    @property
     def config(self):
         if self._config is None:
             self._config, _ = get_datasource_config_or_404(self._config_id, self.domain)
         return self._config
+
+    @property
+    def engine_id(self):
+        return get_engine_id(self.config)
+
+    @property
+    def column_configs(self):
+        return self._column_configs.values()
 
     @property
     def table_name(self):

--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -30,6 +30,8 @@ class IndicatorSqlAdapter(object):
             raise TableRebuildError('problem rebuilding UCR table {}: {}'.format(self.config, e))
 
     def drop_table(self):
+        # this will hang if there are any open sessions, so go ahead and close them
+        self.session_helper.Session.remove()
         with self.engine.begin() as connection:
             self.get_table().drop(connection, checkfirst=True)
 

--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -24,6 +24,7 @@ class IndicatorSqlAdapter(object):
         return get_indicator_table(self.config)
 
     def rebuild_table(self):
+        self.session_helper.Session.remove()
         try:
             rebuild_table(self.engine, self.get_table())
         except ProgrammingError, e:

--- a/corehq/apps/userreports/sql/adapter.py
+++ b/corehq/apps/userreports/sql/adapter.py
@@ -15,7 +15,8 @@ class IndicatorSqlAdapter(object):
 
     def __init__(self, config):
         self.config = config
-        self.session_helper = connection_manager.get_session_helper(get_engine_id(config))
+        self.engine_id = get_engine_id(config)
+        self.session_helper = connection_manager.get_session_helper(self.engine_id)
         self.engine = self.session_helper.engine
 
     @memoized

--- a/corehq/apps/userreports/tests/__init__.py
+++ b/corehq/apps/userreports/tests/__init__.py
@@ -7,6 +7,7 @@ from .test_filters import *
 from .test_getters import *
 from .test_data_source_config import *
 from .test_data_source_repeats import *
+from .test_multi_db import *
 from .test_indicators import *
 from .test_pillow import *
 from .test_report_builder import *

--- a/corehq/apps/userreports/tests/test_data_source_repeats.py
+++ b/corehq/apps/userreports/tests/test_data_source_repeats.py
@@ -4,7 +4,6 @@ import datetime
 from django.test import SimpleTestCase, TestCase
 from corehq.apps.userreports.models import DataSourceConfiguration
 from corehq.apps.userreports.sql import IndicatorSqlAdapter
-from corehq.db import connection_manager
 
 
 DOC_ID = 'repeat-id'
@@ -76,7 +75,6 @@ class RepeatDataSourceBuildTest(RepeatDataSourceTestMixin, TestCase):
 
     def test_table_population(self):
 
-        engine = connection_manager.get_engine()
         adapter = IndicatorSqlAdapter(self.config)
         # Delete and create table
         adapter.rebuild_table()
@@ -95,17 +93,15 @@ class RepeatDataSourceBuildTest(RepeatDataSourceTestMixin, TestCase):
         adapter.save(doc)
 
         # Get rows from the table
-        with engine.connect() as connection:
-            rows = connection.execute(adapter.get_table().select())
+        rows = adapter.get_query_object()
         retrieved_logs = [
             {
-                'start_time': r[3],
-                'end_time': r[4],
-                'person': r[5],
+                'start_time': r.start_time,
+                'end_time': r.end_time,
+                'person': r.person,
 
             } for r in rows
         ]
-
         # Check those rows against the expected result
         self.assertItemsEqual(
             retrieved_logs,

--- a/corehq/apps/userreports/tests/test_multi_db.py
+++ b/corehq/apps/userreports/tests/test_multi_db.py
@@ -6,7 +6,6 @@ from sqlalchemy import create_engine
 from sqlalchemy.exc import ProgrammingError
 from corehq.apps.userreports.models import DataSourceConfiguration, ReportConfiguration
 from corehq.apps.userreports.pillow import ConfigurableIndicatorPillow
-from corehq.apps.userreports.reports.data_source import ConfigurableReportDataSource
 from corehq.apps.userreports.reports.factory import ReportFactory
 from corehq.apps.userreports.tests.utils import get_sample_data_source, get_sample_doc_and_indicators, \
     get_sample_report_config
@@ -34,7 +33,6 @@ class UCRMultiDBTest(TestCase):
         for engine_id_patch in cls.engine_id_patches:
             mock_engine_id_method = engine_id_patch.start()
             mock_engine_id_method.side_effect = lambda x: x.engine_id
-
 
         def connection_string_for_engine(engine_id):
             if engine_id == 'engine-1':
@@ -66,7 +64,7 @@ class UCRMultiDBTest(TestCase):
         conn.close()
 
         # initialize the UCR tables
-        cls.ds1_adapter= IndicatorSqlAdapter(cls.ds_1)
+        cls.ds1_adapter = IndicatorSqlAdapter(cls.ds_1)
         cls.ds2_adapter = IndicatorSqlAdapter(cls.ds_2)
 
     def setUp(self):

--- a/corehq/apps/userreports/tests/test_multi_db.py
+++ b/corehq/apps/userreports/tests/test_multi_db.py
@@ -1,0 +1,46 @@
+import uuid
+from django.conf import settings
+from django.test import SimpleTestCase
+from mock import patch
+from corehq.apps.userreports.models import DataSourceConfiguration
+from corehq.apps.userreports.tests import get_sample_data_source
+from corehq.apps.userreports.sql import connection
+from corehq import db
+
+class UCRMultiDBTest(SimpleTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        # setup patches
+        cls.engine_id_patch = patch('corehq.apps.userreports.sql.connection.get_engine_id')
+        cls.connection_manager_patch = patch('corehq.db.connection_manager')
+        mock_engine_id_method = cls.engine_id_patch.start()
+        mock_engine_id_method.side_effect = lambda x: x.engine_id
+
+        mock_manager = cls.connection_manager_patch.start()
+        def connection_string_for_engine(engine_id):
+            if engine_id == 'engine-1':
+                return settings.SQL_REPORTING_DATABASE_URL
+            else:
+                return '{}_2'.format(settings.SQL_REPORTING_DATABASE_URL)
+        mock_manager._get_connection_string.side_effect = connection_string_for_engine
+
+        data_source_template = get_sample_data_source()
+        cls.ds_1 = DataSourceConfiguration.wrap(data_source_template.to_json())
+        cls.ds_1.engine_id = 'engine-1'
+        cls.ds_2 = DataSourceConfiguration.wrap(data_source_template.to_json())
+        cls.ds_2.engine_id = 'engine-2'
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.engine_id_patch.stop()
+        cls.connection_manager_patch.stop()
+
+    def test_patches(self):
+        self.assertEqual('engine-1', connection.get_engine_id(self.ds_1))
+        self.assertEqual('engine-2', connection.get_engine_id(self.ds_2))
+
+        self.assertEqual(settings.SQL_REPORTING_DATABASE_URL,
+                         db.connection_manager._get_connection_string('engine-1'))
+        self.assertEqual('{}_2'.format(settings.SQL_REPORTING_DATABASE_URL),
+                         db.connection_manager._get_connection_string('engine-2'))

--- a/corehq/apps/userreports/tests/test_multi_db.py
+++ b/corehq/apps/userreports/tests/test_multi_db.py
@@ -1,46 +1,139 @@
 import uuid
 from django.conf import settings
-from django.test import SimpleTestCase
+from django.test import TestCase
 from mock import patch
+from sqlalchemy import create_engine
+from sqlalchemy.exc import ProgrammingError
 from corehq.apps.userreports.models import DataSourceConfiguration
-from corehq.apps.userreports.tests import get_sample_data_source
-from corehq.apps.userreports.sql import connection
+from corehq.apps.userreports.pillow import ConfigurableIndicatorPillow
+from corehq.apps.userreports.tests import get_sample_data_source, get_sample_doc_and_indicators
+from corehq.apps.userreports.sql import connection, IndicatorSqlAdapter
 from corehq import db
 
-class UCRMultiDBTest(SimpleTestCase):
+
+class UCRMultiDBTest(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        # setup patches
-        cls.engine_id_patch = patch('corehq.apps.userreports.sql.connection.get_engine_id')
-        cls.connection_manager_patch = patch('corehq.db.connection_manager')
-        mock_engine_id_method = cls.engine_id_patch.start()
-        mock_engine_id_method.side_effect = lambda x: x.engine_id
+        cls.db2_name = 'cchq_ucr_tests'
+        db_conn_parts = settings.SQL_REPORTING_DATABASE_URL.split('/')
+        db_conn_parts[-1] = cls.db2_name
+        cls.db2_url = '/'.join(db_conn_parts)
 
-        mock_manager = cls.connection_manager_patch.start()
+        # setup patches
+        cls.engine_id_patches = (
+            # unfortunately we need to patch this directly in modules that import it as well
+            patch('corehq.apps.userreports.sql.connection.get_engine_id'),
+            patch('corehq.apps.userreports.sql.adapter.get_engine_id'),
+        )
+        cls.connection_string_patch = patch('corehq.db.connection_manager.get_connection_string')
+        for engine_id_patch in cls.engine_id_patches:
+            mock_engine_id_method = engine_id_patch.start()
+            mock_engine_id_method.side_effect = lambda x: x.engine_id
+
+
         def connection_string_for_engine(engine_id):
             if engine_id == 'engine-1':
                 return settings.SQL_REPORTING_DATABASE_URL
             else:
-                return '{}_2'.format(settings.SQL_REPORTING_DATABASE_URL)
-        mock_manager._get_connection_string.side_effect = connection_string_for_engine
+                return cls.db2_url
 
+        mock_manager = cls.connection_string_patch.start()
+        mock_manager.side_effect = connection_string_for_engine
+
+        # setup data sources
         data_source_template = get_sample_data_source()
         cls.ds_1 = DataSourceConfiguration.wrap(data_source_template.to_json())
         cls.ds_1.engine_id = 'engine-1'
         cls.ds_2 = DataSourceConfiguration.wrap(data_source_template.to_json())
         cls.ds_2.engine_id = 'engine-2'
 
+        # use db1 engine to create db2 http://stackoverflow.com/a/8977109/8207
+        cls.root_engine = create_engine(settings.SQL_REPORTING_DATABASE_URL)
+        conn = cls.root_engine.connect()
+        conn.execute('commit')
+        try:
+            conn.execute('CREATE DATABASE {}'.format(cls.db2_name))
+        except ProgrammingError:
+            # optimistically assume it failed because was already created.
+            pass
+        conn.close()
+
+        # initialize the UCR tables
+        cls.ds1_adapter= IndicatorSqlAdapter(cls.ds_1)
+        cls.ds2_adapter = IndicatorSqlAdapter(cls.ds_2)
+
+    def setUp(self):
+        pass
+        self.ds1_adapter.rebuild_table()
+        self.ds2_adapter.rebuild_table()
+        self.assertEqual(0, self.ds1_adapter.get_query_object().count())
+        self.assertEqual(0, self.ds2_adapter.get_query_object().count())
+
     @classmethod
     def tearDownClass(cls):
-        cls.engine_id_patch.stop()
-        cls.connection_manager_patch.stop()
+        # unpatch
+        for engine_id_patch in cls.engine_id_patches:
+            engine_id_patch.stop()
+        cls.connection_string_patch.stop()
+
+        # dispose secondary engine
+        cls.ds2_adapter.session_helper.engine.dispose()
+
+        # drop the secondary database
+        conn = cls.root_engine.connect()
+        conn.execute('commit')
+        try:
+            conn.execute('DROP DATABASE {}'.format(cls.db2_name))
+        finally:
+            conn.close()
+            cls.root_engine.dispose()
+
+    def tearDown(self):
+        self.ds1_adapter.session_helper.Session.remove()
+        self.ds2_adapter.session_helper.Session.remove()
+        self.ds1_adapter.drop_table()
+        self.ds2_adapter.drop_table()
 
     def test_patches(self):
         self.assertEqual('engine-1', connection.get_engine_id(self.ds_1))
         self.assertEqual('engine-2', connection.get_engine_id(self.ds_2))
 
         self.assertEqual(settings.SQL_REPORTING_DATABASE_URL,
-                         db.connection_manager._get_connection_string('engine-1'))
-        self.assertEqual('{}_2'.format(settings.SQL_REPORTING_DATABASE_URL),
-                         db.connection_manager._get_connection_string('engine-2'))
+                         db.connection_manager.get_connection_string('engine-1'))
+        self.assertEqual(self.db2_url,
+                         db.connection_manager.get_connection_string('engine-2'))
+
+        self.assertNotEqual(str(self.ds1_adapter.engine.url), str(self.ds2_adapter.engine.url))
+        self.assertEqual(settings.SQL_REPORTING_DATABASE_URL, str(self.ds1_adapter.engine.url))
+        self.assertEqual(self.db2_url, str(self.ds2_adapter.engine.url))
+
+    def test_save_to_multiple_databases(self):
+        self.assertNotEqual(self.ds1_adapter.engine.url, self.ds2_adapter.engine.url)
+        pillow = ConfigurableIndicatorPillow()
+        pillow.bootstrap(configs=[self.ds_1, self.ds_2])
+        self.assertNotEqual(self.ds1_adapter.engine.url, self.ds2_adapter.engine.url)
+        sample_doc, _ = get_sample_doc_and_indicators()
+        pillow.change_transport(sample_doc)
+        self.assertNotEqual(self.ds1_adapter.engine.url, self.ds2_adapter.engine.url)
+        self.assertEqual(1, self.ds1_adapter.get_query_object().count())
+        self.assertEqual(1, self.ds2_adapter.get_query_object().count())
+
+    def test_save_to_one_database_at_a_time(self):
+        pillow = ConfigurableIndicatorPillow()
+        pillow.bootstrap(configs=[self.ds_1])
+
+        sample_doc, _ = get_sample_doc_and_indicators()
+        pillow.change_transport(sample_doc)
+
+        self.assertEqual(1, self.ds1_adapter.get_query_object().count())
+        self.assertEqual(0, self.ds2_adapter.get_query_object().count())
+
+        # save to the other
+        pillow.bootstrap(configs=[self.ds_2])
+        sample_doc['_id'] = uuid.uuid4().hex
+        pillow.change_transport(sample_doc)
+        self.assertEqual(1, self.ds1_adapter.get_query_object().count())
+        self.assertEqual(1, self.ds2_adapter.get_query_object().count())
+        self.assertEqual(1, self.ds1_adapter.get_query_object().filter_by(doc_id='some-doc-id').count())
+        self.assertEqual(1, self.ds2_adapter.get_query_object().filter_by(doc_id=sample_doc['_id']).count())

--- a/corehq/apps/userreports/tests/test_multi_db.py
+++ b/corehq/apps/userreports/tests/test_multi_db.py
@@ -63,12 +63,11 @@ class UCRMultiDBTest(TestCase):
             pass
         conn.close()
 
-        # initialize the UCR tables
         cls.ds1_adapter = IndicatorSqlAdapter(cls.ds_1)
         cls.ds2_adapter = IndicatorSqlAdapter(cls.ds_2)
 
     def setUp(self):
-        pass
+        # initialize the tables
         self.ds1_adapter.rebuild_table()
         self.ds2_adapter.rebuild_table()
         self.assertEqual(0, self.ds1_adapter.get_query_object().count())

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -25,8 +25,6 @@ class IndicatorPillowTest(TestCase):
 
     def tearDown(self):
         self.adapter.drop_table()
-        # todo: remove this when pillow uses connection_manager
-        self.pillow.get_sql_engine().dispose()
 
     def test_filter(self):
         # note: this is a silly test now that python_filter always returns true

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -17,7 +17,6 @@ class IndicatorPillowTest(TestCase):
         self.pillow = ConfigurableIndicatorPillow()
         self.pillow.bootstrap(configs=[self.config])
         self.adapter = IndicatorSqlAdapter(self.config)
-        self.adapter.rebuild_table()
         self.fake_time_now = datetime(2015, 4, 24, 12, 30, 8, 24886)
 
     def tearDown(self):

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -68,9 +68,7 @@ class IndicatorPillowTest(TestCase):
                 'priority': bad_value
             })
         # make sure we saved rows to the table for everything
-        with self.engine.begin() as connection:
-            rows = connection.execute(sqlalchemy.select([self.adapter.get_table()]))
-            self.assertEqual(len(bad_ints), rows.rowcount)
+        self.assertEqual(len(bad_ints), self.adapter.get_query_object().count())
 
     @patch('corehq.apps.userreports.specs.datetime')
     def _check_sample_doc_state(self, datetime_mock):

--- a/corehq/apps/userreports/tests/utils.py
+++ b/corehq/apps/userreports/tests/utils.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from decimal import Decimal
 import json
 import os
@@ -22,7 +23,9 @@ def get_sample_data_source():
         return DataSourceConfiguration.wrap(structure)
 
 
-def get_sample_doc_and_indicators(fake_time_now):
+def get_sample_doc_and_indicators(fake_time_now=None):
+    if fake_time_now is None:
+        fake_time_now = datetime.utcnow()
     date_opened = "2014-06-21"
     sample_doc = dict(
         _id='some-doc-id',

--- a/corehq/db.py
+++ b/corehq/db.py
@@ -35,7 +35,7 @@ class ConnectionManager(object):
 
     def _get_or_create_helper(self, engine_id):
         if engine_id not in self._session_helpers:
-            self._session_helpers[engine_id] = SessionHelper(self._get_connection_string(engine_id))
+            self._session_helpers[engine_id] = SessionHelper(self.get_connection_string(engine_id))
         return self._session_helpers[engine_id]
 
     def get_session_helper(self, engine_id=DEFAULT_ENGINE_ID):
@@ -80,7 +80,7 @@ class ConnectionManager(object):
         for engine_id in self._session_helpers.keys():
             self.dispose_engine(engine_id)
 
-    def _get_connection_string(self, engine_id):
+    def get_connection_string(self, engine_id):
         # for now this just always returns the same connection string for any
         # engine_id, but in the future we could make this function more complicated
         return {


### PR DESCRIPTION
properly use report-defined engines in pillow and reports, and add tests for these things

probably easiest read commit-by-commit, though might want to read the new tests as a standalone file

@snopoke @NoahCarnahan 
