### PR TITLE
small sync test updates

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -567,9 +567,10 @@ class SimplifiedSyncLog(AbstractSyncLog):
 
     def update_phone_lists(self, xform, case_list):
         made_changes = False
-        logger.debug('syncing {}'.format(self.user_id))
+        logger.debug('updating sync log for {}'.format(self.user_id))
         logger.debug('case ids before update: {}'.format(', '.join(self.case_ids_on_phone)))
         logger.debug('dependent case ids before update: {}'.format(', '.join(self.dependent_case_ids_on_phone)))
+        logger.debug('index tree before update: {}'.format(self.index_tree))
         for case in case_list:
             actions = case.get_actions_for_form(xform.get_id)
             for action in actions:
@@ -612,9 +613,11 @@ class SimplifiedSyncLog(AbstractSyncLog):
 
         logger.debug('case ids after update: {}'.format(', '.join(self.case_ids_on_phone)))
         logger.debug('dependent case ids after update: {}'.format(', '.join(self.dependent_case_ids_on_phone)))
+        logger.debug('index tree after update: {}'.format(self.index_tree))
         if made_changes or case_list:
             try:
                 if made_changes:
+                    logger.debug('made changes, saving.')
                     self.save()
                 if case_list:
                     self.invalidate_cached_payloads()

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -295,7 +295,7 @@ class SyncTokenUpdateTest(SyncBaseTest):
         # make IDs both human readable and globally unique to this test
         uid = uuid.uuid4().hex
         child_id = 'child_id-{}'.format(uid)
-        parent_id_1 = 'parent_id={}'.format(uid)
+        parent_id_1 = 'parent_id-{}'.format(uid)
         index_id_1 = 'parent_index_id-{}'.format(uid)
         parent_id_2 = 'parent_id_2-{}'.format(uid)
         index_id_2 = 'parent_index_id_2-{}'.format(uid)

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -88,8 +88,8 @@ class SyncBaseTest(TestCase):
             caseblocks = [caseblocks]
         return post_case_blocks(caseblocks, form_extras={"last_sync_token": token_id})
 
-    def _checkLists(self, l1, l2):
-        self.assertEqual(set(l1), set(l2))
+    def _checkLists(self, l1, l2, msg=None):
+        self.assertEqual(set(l1), set(l2), msg)
 
     def _testUpdate(self, sync_id, case_id_map, dependent_case_id_map=None):
         dependent_case_id_map = dependent_case_id_map or {}
@@ -104,7 +104,8 @@ class SyncBaseTest(TestCase):
             for case_id, indices in case_id_map.items():
                 if indices:
                     index_ids = [i.referenced_id for i in case_id_map[case_id]]
-                    self._checkLists(index_ids, sync_log.index_tree.indices[case_id].values())
+                    self._checkLists(index_ids, sync_log.index_tree.indices[case_id].values(),
+                                     'case {} has unexpected indices'.format(case_id))
             for case_id, indices in dependent_case_id_map.items():
                 if indices:
                     index_ids = [i.referenced_id for i in case_id_map[case_id]]

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -290,7 +290,7 @@ class SyncTokenUpdateTest(SyncBaseTest):
         self._postFakeWithSyncToken(child, self.sync_log.get_id)
         self._testUpdate(self.sync_log.get_id, {parent_id: [], child_id: []})
 
-    # @run_with_all_restore_configs
+    @run_with_all_restore_configs
     def test_delete_one_of_multiple_indices(self):
         # make IDs both human readable and globally unique to this test
         uid = uuid.uuid4().hex


### PR DESCRIPTION
The main relevant change is https://github.com/dimagi/commcare-hq/commit/0014a6029f6a5ae0177cace8724571144b713126 which just reenables the broken test that I've been [wrestling with](https://github.com/dimagi/commcare-hq/pull/7448) [for a while](https://github.com/dimagi/commcare-hq/pull/7442). The rest is just minor test cleanup.
## Backstory for those who are interested

(The rest of this note is not specific to this PR, but is just me bran dumping for posterity. Please don't let the length of this note deter you from merging since the PR itself is very simple/straightforward.)

So this is a small set of changes pulled out from https://github.com/dimagi/commcare-hq/pull/7508 which is an entertaining saga of me trying to track down the intermittent test failure that's been bugging me for over a month.

I don't have a complete story but I'm pretty sure that the root culprit of those test failures is that the travis machines can intermittently get a stale version of `jsonobject` running in the venv. Specifically one that doesn't properly support the pop method that @NoahCarnahan implemented here: https://github.com/dimagi/jsonobject/pull/117

I was able to reproduce the failures down to a [pretty simple test case](https://github.com/dimagi/commcare-hq/pull/7508/files#diff-691758bf253b4cfef0bf952314f3c15eR224), and then I was never able to get that test to fail locally unless I installed `jsonobject==0.6.0` in which case it failed every time. This is consistent with the fact that whether or not the same test passed on travis seemed to be dependent on a property of the _environment_ and not the _test_ (so it either passed all 10 times or failed on the first time).

I don't have a complete story for why this version of `jsonobject` was ever getting installed. I think it might have to do with the [minimum requirement of couchdbkit](https://github.com/dimagi/couchdbkit/blob/jsonobject/setup.py#L56) and some odd install/uninstall-order. That said, I feel pretty confident that https://github.com/dimagi/commcarehq-venv/pull/6 will fix it. The reason is just based on pure brute force. Namely, the way I was getting builds to fail on https://github.com/dimagi/commcare-hq/pull/7508 was just by restarting travis over and over again until it passed (usually in about 1-5 times), and I've now run the build with the latest venv probably 8-10 times with it showing no sign of failing.

fyi @dannyroberts @snopoke and cc @dimagi/team-commcare-hq just because this was one of the hardest, oddest, most annoying issues I've tracked down in a long time and I figured it couldn't hurt to share my story. I did find that, once I had a streamlined build and logging setup, iterating directly on travis wasn't super-duper painful, so if you ever need to do that you can use https://github.com/dimagi/commcare-hq/pull/7508/ as a blueprint.
