### PR TITLE
add fab target to run supervisorctl commands directly on whatever machines

### DIFF
--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -347,6 +347,12 @@ def env_common():
     }
     env.roles = ['deploy']
     env.hosts = env.roledefs['deploy']
+    env.supervisor_roles = ROLES_ALL_SRC
+
+
+@task
+def webworkers():
+    env.supervisor_roles = ROLES_DJANGO
 
 
 @task
@@ -900,6 +906,18 @@ def netstat_plnt():
     """run netstat -plnt on a remote host"""
     _require_target()
     sudo('netstat -plnt', user='root')
+
+
+@task
+def supervisorctl(command):
+    require('supervisor_roles',
+            provided_by=('staging', 'preview', 'production', 'india', 'zambia'))
+
+    @roles(env.supervisor_roles)
+    def _inner():
+        _supervisor_command(command)
+
+    execute(_inner)
 
 
 @roles(ROLES_ALL_SERVICES)


### PR DESCRIPTION
supports an environment, e.g.

`fab production supervisorctl:"stop all"`

as well as just the webworkers, e.g.

`fab production webworkers supervisorctl:"stop all"`

@dimagi/team-commcare-hq this seemed like a useful tool to have for firefighting
