### PR TITLE
Properly translate a bunch of strings

### DIFF
--- a/corehq/__init__.py
+++ b/corehq/__init__.py
@@ -22,7 +22,7 @@ import hashlib
 from dimagi.utils.modules import to_function
 import logging
 import toggles
-from django.utils.translation import ugettext_lazy as _, ugettext_lazy
+from django.utils.translation import ugettext_lazy as _
 
 def REPORTS(project):
     from corehq.apps.reports.standard.cases.basic import CaseListReport
@@ -34,7 +34,7 @@ def REPORTS(project):
     reports.extend(_get_configurable_reports(project))
 
     reports.extend([
-        (ugettext_lazy("Monitor Workers"), (
+        (_("Monitor Workers"), (
             monitoring.WorkerActivityReport,
             monitoring.DailyFormStatsReport,
             monitoring.SubmissionsByFormReport,
@@ -43,22 +43,22 @@ def REPORTS(project):
             monitoring.FormCompletionVsSubmissionTrendsReport,
             monitoring.WorkerActivityTimes,
         )),
-        (ugettext_lazy("Inspect Data"), (
+        (_("Inspect Data"), (
             inspect.SubmitHistory, CaseListReport,
         )),
-        (ugettext_lazy("Manage Deployments"), (
+        (_("Manage Deployments"), (
             deployments.ApplicationStatusReport,
             receiverwrapper.SubmissionErrorReport,
             phonelog.DeviceLogDetailsReport,
             deployments.SyncHistoryReport,
         )),
-        (ugettext_lazy("Demos for Previewers"), (
+        (_("Demos for Previewers"), (
             DemoMapReport, DemoMapReport2, DemoMapCaseList,
         )),
     ])
 
     if project.commtrack_enabled:
-        reports.insert(0, (ugettext_lazy("CommCare Supply"), (
+        reports.insert(0, (_("CommCare Supply"), (
             commtrack_reports.SimplifiedInventoryReport,
             commtrack_reports.InventoryReport,
             commtrack_reports.CurrentStockStatusReport,
@@ -72,7 +72,7 @@ def REPORTS(project):
         config = CareplanConfig.for_domain(project.name)
         if config:
             cp_reports = tuple(make_careplan_reports(config))
-            reports.insert(0, (ugettext_lazy("Care Plans"), cp_reports))
+            reports.insert(0, (_("Care Plans"), cp_reports))
 
     from corehq.apps.accounting.utils import domain_has_privilege
     messaging_reports = []
@@ -105,7 +105,7 @@ def REPORTS(project):
         ])
 
     messaging_reports += getattr(Domain.get_module_by_name(project.name), 'MESSAGING_REPORTS', ())
-    messaging = (ugettext_lazy("Messaging"), messaging_reports)
+    messaging = (_("Messaging"), messaging_reports)
     reports.append(messaging)
 
     reports.extend(_get_dynamic_reports(project))
@@ -180,7 +180,7 @@ from corehq.apps.data_interfaces.interfaces import CaseReassignmentInterface
 from corehq.apps.importer.base import ImportCases
 
 DATA_INTERFACES = (
-    (ugettext_lazy("Export Data"), (
+    (_("Export Data"), (
         export.ExcelExportReport,
         export.CaseExportReport,
         export.DeidExportReport,
@@ -188,7 +188,7 @@ DATA_INTERFACES = (
 )
 
 EDIT_DATA_INTERFACES = (
-    (ugettext_lazy('Edit Data'), (
+    (_('Edit Data'), (
         CaseReassignmentInterface,
         ImportCases,
     )),

--- a/corehq/__init__.py
+++ b/corehq/__init__.py
@@ -22,7 +22,7 @@ import hashlib
 from dimagi.utils.modules import to_function
 import logging
 import toggles
-from django.utils.translation import ugettext_noop as _, ugettext_lazy
+from django.utils.translation import ugettext_lazy as _, ugettext_lazy
 
 def REPORTS(project):
     from corehq.apps.reports.standard.cases.basic import CaseListReport

--- a/corehq/apps/accounting/filters.py
+++ b/corehq/apps/accounting/filters.py
@@ -15,7 +15,7 @@ from corehq.apps.reports.filters.base import (
 from corehq.apps.reports.filters.search import SearchFilter
 from corehq.util.dates import iso_string_to_date
 from dimagi.utils.dates import DateSpan
-from django.utils.translation import ugettext_noop as _
+from django.utils.translation import ugettext_lazy as _
 
 
 class BaseAccountingSingleOptionFilter(BaseSingleOptionFilter):

--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -14,7 +14,7 @@ from django.forms.util import ErrorList
 from django.template.loader import render_to_string
 from django.utils.dates import MONTHS
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_noop, ugettext as _, ugettext
+from django.utils.translation import ugettext_lazy, ugettext as _, ugettext
 
 from crispy_forms.bootstrap import FormActions, StrictButton, InlineField
 from crispy_forms.helper import FormHelper
@@ -1425,15 +1425,15 @@ class ProductRateForm(forms.ModelForm):
 
 class EnterprisePlanContactForm(forms.Form):
     name = forms.CharField(
-        label=ugettext_noop("Name")
+        label=ugettext_lazy("Name")
     )
     company_name = forms.CharField(
         required=False,
-        label=ugettext_noop("Company / Organization")
+        label=ugettext_lazy("Company / Organization")
     )
     message = forms.CharField(
         required=False,
-        label=ugettext_noop("Message"),
+        label=ugettext_lazy("Message"),
         widget=forms.Textarea
     )
 

--- a/corehq/apps/accounting/user_text.py
+++ b/corehq/apps/accounting/user_text.py
@@ -1,6 +1,6 @@
 from django.core.urlresolvers import reverse
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy, ugettext_lazy as _
+from django.utils.translation import ugettext_lazy as _
 from corehq.apps.accounting.models import SoftwarePlanEdition as Edition, SoftwareProductType as Product, FeatureType
 
 DESC_BY_EDITION = {
@@ -319,14 +319,14 @@ class PricingTable(object):
             PricingTableCategories.SUPPORT,
         ),
     }
-    VISIT_WIKI_TEXT = ugettext_lazy("Visit the help site to learn more.")
+    VISIT_WIKI_TEXT = _("Visit the help site to learn more.")
 
     @classmethod
     def get_footer_by_product(cls, product, domain=None):
         ensure_product(product)
         from corehq.apps.domain.views import ProBonoStaticView
         return (
-            ugettext_lazy(
+            _(
                 mark_safe(
                     _('*Local taxes and other country-specific fees not included. Dimagi provides pro-bono '
                       'software plans on a needs basis. To learn more about this opportunity or see if your '

--- a/corehq/apps/accounting/user_text.py
+++ b/corehq/apps/accounting/user_text.py
@@ -1,6 +1,6 @@
 from django.core.urlresolvers import reverse
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_noop, ugettext_lazy as _
+from django.utils.translation import ugettext_lazy, ugettext_lazy as _
 from corehq.apps.accounting.models import SoftwarePlanEdition as Edition, SoftwareProductType as Product, FeatureType
 
 DESC_BY_EDITION = {
@@ -319,14 +319,14 @@ class PricingTable(object):
             PricingTableCategories.SUPPORT,
         ),
     }
-    VISIT_WIKI_TEXT = ugettext_noop("Visit the help site to learn more.")
+    VISIT_WIKI_TEXT = ugettext_lazy("Visit the help site to learn more.")
 
     @classmethod
     def get_footer_by_product(cls, product, domain=None):
         ensure_product(product)
         from corehq.apps.domain.views import ProBonoStaticView
         return (
-            ugettext_noop(
+            ugettext_lazy(
                 mark_safe(
                     _('*Local taxes and other country-specific fees not included. Dimagi provides pro-bono '
                       'software plans on a needs basis. To learn more about this opportunity or see if your '

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -14,7 +14,7 @@ from django.http import (
     Http404,
 )
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext as _, ugettext_noop
+from django.utils.translation import ugettext as _, ugettext_lazy
 from django.views.generic import View
 from corehq.apps.hqwebapp.async_handler import AsyncHandlerMixin
 from corehq.apps.hqwebapp.encoders import LazyEncoder
@@ -833,14 +833,14 @@ class InvoiceSummaryView(InvoiceSummaryViewBase):
 class ManageAccountingAdminsView(AccountingSectionView, CRUDPaginatedViewMixin):
     template_name = 'accounting/accounting_admins.html'
     urlname = 'accounting_manage_admins'
-    page_title = ugettext_noop("Accounting Admins")
+    page_title = ugettext_lazy("Accounting Admins")
 
-    limit_text = ugettext_noop("Admins per page")
-    empty_notification = ugettext_noop("You haven't specified any accounting admins. "
+    limit_text = ugettext_lazy("Admins per page")
+    empty_notification = ugettext_lazy("You haven't specified any accounting admins. "
                                        "How are you viewing this page??! x_x")
-    loading_message = ugettext_noop("Loading admin list...")
-    deleted_items_header = ugettext_noop("Removed Users:")
-    new_items_header = ugettext_noop("Added Users:")
+    loading_message = ugettext_lazy("Loading admin list...")
+    deleted_items_header = ugettext_lazy("Removed Users:")
+    new_items_header = ugettext_lazy("Added Users:")
 
     @property
     def page_url(self):

--- a/corehq/apps/app_manager/commcare_settings.py
+++ b/corehq/apps/app_manager/commcare_settings.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 import re
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 import os
 import yaml
 
@@ -24,7 +24,7 @@ def load_custom_commcare_settings():
         if not setting.get('widget'):
             setting['widget'] = 'select'
         # i18n; not statically analyzable
-        setting['name'] = ugettext_noop(setting['name'])
+        setting['name'] = ugettext_lazy(setting['name'])
     return settings
 
 
@@ -39,7 +39,7 @@ def load_commcare_settings_layout(doc_type):
 
     for section in layout:
         # i18n; not statically analyzable
-        section['title'] = ugettext_noop(section['title'])
+        section['title'] = ugettext_lazy(section['title'])
         for i, key in enumerate(section['settings']):
             setting = settings.pop(key)
             if doc_type == 'Application' or setting['type'] == 'hq':

--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -15,7 +15,7 @@ from xml.dom.minidom import parseString
 from diff_match_patch import diff_match_patch
 from django.core.cache import cache
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext as _, get_language, ugettext_noop
+from django.utils.translation import ugettext as _, get_language, ugettext_lazy
 from django.views.decorators.cache import cache_control
 from corehq import ApplicationsTab, toggles, privileges, feature_previews, ReportConfiguration
 from corehq.apps.accounting.utils import domain_has_privilege
@@ -3002,7 +3002,7 @@ def _questions_for_form(request, form, langs):
 
 class AppSummaryView(JSONResponseMixin, LoginAndDomainMixin, BasePageView, ApplicationViewMixin):
     urlname = 'app_summary'
-    page_title = ugettext_noop("Summary")
+    page_title = ugettext_lazy("Summary")
     template_name = 'app_manager/summary.html'
 
     @method_decorator(use_bootstrap3())

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -39,7 +39,7 @@ from xml.etree import ElementTree
 from corehq.apps.cloudcare.decorators import require_cloudcare_access
 import HTMLParser
 from django.contrib import messages
-from django.utils.translation import ugettext as _, ugettext_noop
+from django.utils.translation import ugettext as _, ugettext_lazy
 from touchforms.formplayer.models import EntrySession
 from xml2json.lib import xml2json
 import requests
@@ -499,7 +499,7 @@ class HttpResponseConflict(HttpResponse):
 class EditCloudcareUserPermissionsView(BaseUserSettingsView):
     template_name = 'cloudcare/config.html'
     urlname = 'cloudcare_app_settings'
-    page_title = ugettext_noop("CloudCare Permissions")
+    page_title = ugettext_lazy("CloudCare Permissions")
 
     @method_decorator(domain_admin_required)
     @method_decorator(requires_privilege_with_fallback(privileges.CLOUDCARE))

--- a/corehq/apps/commtrack/forms.py
+++ b/corehq/apps/commtrack/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_noop, ugettext as _, ugettext_lazy
+from django.utils.translation import ugettext_lazy, ugettext as _, ugettext_lazy
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Layout, Fieldset, ButtonHolder, Submit, HTML
 
@@ -12,7 +12,7 @@ from django.core.urlresolvers import reverse
 
 class CommTrackSettingsForm(forms.Form):
     use_auto_emergency_levels = forms.BooleanField(
-        label=ugettext_noop("Use default emergency levels"), required=False)
+        label=ugettext_lazy("Use default emergency levels"), required=False)
 
     stock_emergency_level = forms.DecimalField(
         label=ugettext_lazy("Emergency Level (months)"), required=False)
@@ -141,15 +141,15 @@ class LocationTypeStockLevels(forms.Form):
     Sub form for configuring stock levels for a specific location type
     """
     emergency_level = forms.DecimalField(
-        label=ugettext_noop("Emergency Level (months)"),
+        label=ugettext_lazy("Emergency Level (months)"),
         required=True,
     )
     understock_threshold = forms.DecimalField(
-        label=ugettext_noop("Low Stock Level (months)"),
+        label=ugettext_lazy("Low Stock Level (months)"),
         required=True,
     )
     overstock_threshold = forms.DecimalField(
-        label=ugettext_noop("Overstock Level (months)"),
+        label=ugettext_lazy("Overstock Level (months)"),
         required=True,
     )
 

--- a/corehq/apps/commtrack/forms.py
+++ b/corehq/apps/commtrack/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_lazy, ugettext as _, ugettext_lazy
+from django.utils.translation import ugettext as _, ugettext_lazy
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Layout, Fieldset, ButtonHolder, Submit, HTML
 

--- a/corehq/apps/commtrack/views.py
+++ b/corehq/apps/commtrack/views.py
@@ -5,7 +5,7 @@ from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect, Http404
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext as _, ugettext_noop
+from django.utils.translation import ugettext as _, ugettext_lazy
 from corehq.apps.commtrack.const import SUPPLY_POINT_CASE_TYPE
 
 from dimagi.utils.decorators.memoized import memoized
@@ -32,7 +32,7 @@ def default(request, domain):
 
 
 class BaseCommTrackManageView(BaseDomainView):
-    section_name = ugettext_noop("Setup")
+    section_name = ugettext_lazy("Setup")
 
     @property
     def section_url(self):
@@ -45,7 +45,7 @@ class BaseCommTrackManageView(BaseDomainView):
 
 class CommTrackSettingsView(BaseCommTrackManageView):
     urlname = 'commtrack_settings'
-    page_title = ugettext_noop("Advanced Settings")
+    page_title = ugettext_lazy("Advanced Settings")
     template_name = 'domain/admin/commtrack_settings.html'
 
     @property
@@ -139,7 +139,7 @@ class CommTrackSettingsView(BaseCommTrackManageView):
 class DefaultConsumptionView(BaseCommTrackManageView):
     urlname = 'update_default_consumption'
     template_name = 'commtrack/manage/default_consumption.html'
-    page_title = ugettext_noop("Consumption")
+    page_title = ugettext_lazy("Consumption")
 
     @property
     @memoized
@@ -166,7 +166,7 @@ class DefaultConsumptionView(BaseCommTrackManageView):
 
 class SMSSettingsView(BaseCommTrackManageView):
     urlname = 'commtrack_sms_settings'
-    page_title = ugettext_noop("SMS")
+    page_title = ugettext_lazy("SMS")
     template_name = 'domain/admin/sms_settings.html'
 
     @property
@@ -227,7 +227,7 @@ class SMSSettingsView(BaseCommTrackManageView):
 
 class StockLevelsView(BaseCommTrackManageView):
     urlname = 'stock_levels'
-    page_title = ugettext_noop("Stock Levels")
+    page_title = ugettext_lazy("Stock Levels")
     template_name = 'commtrack/manage/stock_levels.html'
 
     def get_existing_stock_levels(self):

--- a/corehq/apps/dashboard/views.py
+++ b/corehq/apps/dashboard/views.py
@@ -1,7 +1,7 @@
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext_noop, ugettext as _
+from django.utils.translation import ugettext_lazy, ugettext as _
 from djangular.views.mixins import JSONResponseMixin, allow_remote_invocation
 
 from corehq import privileges
@@ -66,13 +66,13 @@ class BaseDashboardView(LoginAndDomainMixin, BasePageView, DomainViewMixin):
 
 class NewUserDashboardView(BaseDashboardView):
     urlname = 'dashboard_new_user'
-    page_title = ugettext_noop("HQ Dashboard")
+    page_title = ugettext_lazy("HQ Dashboard")
     template_name = 'dashboard/dashboard_new_user.html'
 
 
 class DomainDashboardView(JSONResponseMixin, BaseDashboardView):
     urlname = 'dashboard_domain'
-    page_title = ugettext_noop("HQ Dashboard")
+    page_title = ugettext_lazy("HQ Dashboard")
     template_name = 'dashboard/dashboard_domain.html'
 
     @property

--- a/corehq/apps/data_interfaces/forms.py
+++ b/corehq/apps/data_interfaces/forms.py
@@ -4,12 +4,12 @@ from django import forms
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Layout, Field, HTML, Div, Fieldset
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext as _, ugettext_noop
+from django.utils.translation import ugettext as _, ugettext_lazy
 from corehq.apps.casegroups.models import CommCareCaseGroup
 
 
 class AddCaseGroupForm(forms.Form):
-    name = forms.CharField(required=True, label=ugettext_noop("Group Name"))
+    name = forms.CharField(required=True, label=ugettext_lazy("Group Name"))
 
     def __init__(self, *args, **kwargs):
         super(AddCaseGroupForm, self).__init__(*args, **kwargs)
@@ -76,7 +76,7 @@ class UpdateCaseGroupForm(AddCaseGroupForm):
 
 
 class AddCaseToGroupForm(forms.Form):
-    case_identifier = forms.CharField(label=ugettext_noop("Case ID, External ID, or Phone Number"))
+    case_identifier = forms.CharField(label=ugettext_lazy("Case ID, External ID, or Phone Number"))
 
     def __init__(self, *args, **kwargs):
         super(AddCaseToGroupForm, self).__init__(*args, **kwargs)

--- a/corehq/apps/data_interfaces/interfaces.py
+++ b/corehq/apps/data_interfaces/interfaces.py
@@ -2,7 +2,7 @@ from django.contrib.humanize.templatetags.humanize import naturaltime
 from django.core.urlresolvers import reverse
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 
 from dimagi.utils.decorators.memoized import memoized
 
@@ -19,7 +19,7 @@ from .dispatcher import EditDataInterfaceDispatcher
 
 class DataInterface(GenericReportView):
     # overriding properties from GenericReportView
-    section_name = ugettext_noop("Data")
+    section_name = ugettext_lazy("Data")
     base_template = "reports/standard/base_template.html"
     asynchronous = True
     dispatcher = EditDataInterfaceDispatcher
@@ -31,7 +31,7 @@ class DataInterface(GenericReportView):
 
 
 class CaseReassignmentInterface(CaseListMixin, DataInterface):
-    name = ugettext_noop("Reassign Cases")
+    name = ugettext_lazy("Reassign Cases")
     slug = "reassign_cases"
 
     report_template_path = 'data_interfaces/interfaces/case_management.html'

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -29,7 +29,7 @@ from corehq.apps.data_interfaces.dispatcher import (DataInterfaceDispatcher, Edi
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect, Http404
 from dimagi.utils.decorators.memoized import memoized
-from django.utils.translation import ugettext as _, ugettext_lazy, ugettext_lazy
+from django.utils.translation import ugettext as _, ugettext_lazy
 
 
 @login_and_domain_required

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -29,7 +29,7 @@ from corehq.apps.data_interfaces.dispatcher import (DataInterfaceDispatcher, Edi
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect, Http404
 from dimagi.utils.decorators.memoized import memoized
-from django.utils.translation import ugettext as _, ugettext_noop, ugettext_lazy
+from django.utils.translation import ugettext as _, ugettext_lazy, ugettext_lazy
 
 
 @login_and_domain_required
@@ -55,7 +55,7 @@ class BulkUploadCasesException(Exception):
 
 
 class DataInterfaceSection(BaseDomainView):
-    section_name = ugettext_noop("Data")
+    section_name = ugettext_lazy("Data")
 
     @method_decorator(require_can_edit_data)
     def dispatch(self, request, *args, **kwargs):
@@ -162,7 +162,7 @@ class CaseGroupListView(DataInterfaceSection, CRUDPaginatedViewMixin):
 class ArchiveFormView(DataInterfaceSection):
     template_name = 'data_interfaces/interfaces/import_forms.html'
     urlname = 'archive_forms'
-    page_title = ugettext_noop("Bulk Archive Forms")
+    page_title = ugettext_lazy("Bulk Archive Forms")
 
     ONE_MB = 1000000
     MAX_SIZE = 3 * ONE_MB
@@ -241,13 +241,13 @@ class ArchiveFormView(DataInterfaceSection):
 class CaseGroupCaseManagementView(DataInterfaceSection, CRUDPaginatedViewMixin):
     template_name = 'data_interfaces/manage_case_groups.html'
     urlname = 'manage_case_groups'
-    page_title = ugettext_noop("Manage Case Group")
+    page_title = ugettext_lazy("Manage Case Group")
 
-    limit_text = ugettext_noop("cases per page")
-    empty_notification = ugettext_noop("You have no cases in your group.")
-    loading_message = ugettext_noop("Loading cases...")
-    deleted_items_header = ugettext_noop("Removed Cases:")
-    new_items_header = ugettext_noop("Added Cases:")
+    limit_text = ugettext_lazy("cases per page")
+    empty_notification = ugettext_lazy("You have no cases in your group.")
+    loading_message = ugettext_lazy("Loading cases...")
+    deleted_items_header = ugettext_lazy("Removed Cases:")
+    new_items_header = ugettext_lazy("Added Cases:")
 
     @property
     def group_id(self):

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -61,7 +61,7 @@ from dimagi.utils.django.email import send_HTML_email
 from corehq.util.timezones.fields import TimeZoneField
 from corehq.util.timezones.forms import TimeZoneChoiceField
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext_noop, ugettext as _
+from django.utils.translation import ugettext_lazy, ugettext as _
 from corehq.apps.style.forms.widgets import BootstrapCheckboxInput, BootstrapDisabledInput
 import django
 
@@ -94,7 +94,7 @@ class ProjectSettingsForm(forms.Form):
         label="",
         widget=BootstrapCheckboxInput(
             attrs={'data-bind': 'checked: override_tz, event: {change: updateForm}'},
-            inline_label=ugettext_noop("Override project's timezone setting just for me.")))
+            inline_label=ugettext_lazy("Override project's timezone setting just for me.")))
     user_timezone = TimeZoneChoiceField(
         label="My Timezone",
         initial=global_timezone.initial,
@@ -120,16 +120,16 @@ class ProjectSettingsForm(forms.Form):
 
 
 class SnapshotApplicationForm(forms.Form):
-    publish = BooleanField(label=ugettext_noop("Publish?"), required=False)
-    name = CharField(label=ugettext_noop("Name"), required=True)
-    description = CharField(label=ugettext_noop("Description"), required=False, widget=forms.Textarea,
-        help_text=ugettext_noop("A detailed technical description of the application"))
-    deployment_date = CharField(label=ugettext_noop("Deployment date"), required=False)
-    phone_model = CharField(label=ugettext_noop("Phone model"), required=False)
-    user_type = CharField(label=ugettext_noop("User type"), required=False,
-        help_text=ugettext_noop("e.g. CHW, ASHA, RA, etc"))
-    attribution_notes = CharField(label=ugettext_noop("Attribution notes"), required=False,
-        help_text=ugettext_noop(
+    publish = BooleanField(label=ugettext_lazy("Publish?"), required=False)
+    name = CharField(label=ugettext_lazy("Name"), required=True)
+    description = CharField(label=ugettext_lazy("Description"), required=False, widget=forms.Textarea,
+        help_text=ugettext_lazy("A detailed technical description of the application"))
+    deployment_date = CharField(label=ugettext_lazy("Deployment date"), required=False)
+    phone_model = CharField(label=ugettext_lazy("Phone model"), required=False)
+    user_type = CharField(label=ugettext_lazy("User type"), required=False,
+        help_text=ugettext_lazy("e.g. CHW, ASHA, RA, etc"))
+    attribution_notes = CharField(label=ugettext_lazy("Attribution notes"), required=False,
+        help_text=ugettext_lazy(
             "Enter any special instructions to users here. "
             "This will be shown just before users copy your project."),
         widget=forms.Textarea)
@@ -150,9 +150,9 @@ class SnapshotApplicationForm(forms.Form):
 
 
 class SnapshotFixtureForm(forms.Form):
-    publish = BooleanField(label=ugettext_noop("Publish?"), required=False)
-    description = CharField(label=ugettext_noop("Description"), required=False, widget=forms.Textarea,
-        help_text=ugettext_noop("A detailed technical description of the table"))
+    publish = BooleanField(label=ugettext_lazy("Publish?"), required=False)
+    description = CharField(label=ugettext_lazy("Description"), required=False, widget=forms.Textarea,
+        help_text=ugettext_lazy("A detailed technical description of the table"))
 
     def __init__(self, *args, **kwargs):
         super(SnapshotFixtureForm, self).__init__(*args, **kwargs)
@@ -165,36 +165,36 @@ class SnapshotFixtureForm(forms.Form):
 
 
 class SnapshotSettingsForm(forms.Form):
-    title = CharField(label=ugettext_noop("Title"), required=True, max_length=100)
+    title = CharField(label=ugettext_lazy("Title"), required=True, max_length=100)
     project_type = CharField(
-        label=ugettext_noop("Project Category"),
+        label=ugettext_lazy("Project Category"),
         required=True,
-        help_text=ugettext_noop("e.g. MCH, HIV, etc.")
+        help_text=ugettext_lazy("e.g. MCH, HIV, etc.")
     )
-    license = ChoiceField(label=ugettext_noop("License"), required=True, choices=LICENSES.items(),
+    license = ChoiceField(label=ugettext_lazy("License"), required=True, choices=LICENSES.items(),
                           widget=Select(attrs={'class': 'input-xxlarge'}))
     description = CharField(
-        label=ugettext_noop("Long Description"), required=False, widget=forms.Textarea,
-        help_text=ugettext_noop("A high-level overview of your project as a whole"))
+        label=ugettext_lazy("Long Description"), required=False, widget=forms.Textarea,
+        help_text=ugettext_lazy("A high-level overview of your project as a whole"))
     short_description = CharField(
-        label=ugettext_noop("Short Description"), required=False,
+        label=ugettext_lazy("Short Description"), required=False,
         widget=forms.Textarea(attrs={'maxlength': 200}),
-        help_text=ugettext_noop("A brief description of your project (max. 200 characters)"))
-    share_multimedia = BooleanField(label=ugettext_noop("Share all multimedia?"), required=False,
-        help_text=ugettext_noop("This will allow any user to see and use all multimedia in this project"))
-    share_reminders = BooleanField(label=ugettext_noop("Share Reminders?"), required=False,
-        help_text=ugettext_noop("This will publish reminders along with this project"))
-    image = forms.ImageField(label=ugettext_noop("Exchange image"), required=False,
-        help_text=ugettext_noop("An optional image to show other users your logo or what your app looks like"))
+        help_text=ugettext_lazy("A brief description of your project (max. 200 characters)"))
+    share_multimedia = BooleanField(label=ugettext_lazy("Share all multimedia?"), required=False,
+        help_text=ugettext_lazy("This will allow any user to see and use all multimedia in this project"))
+    share_reminders = BooleanField(label=ugettext_lazy("Share Reminders?"), required=False,
+        help_text=ugettext_lazy("This will publish reminders along with this project"))
+    image = forms.ImageField(label=ugettext_lazy("Exchange image"), required=False,
+        help_text=ugettext_lazy("An optional image to show other users your logo or what your app looks like"))
     old_image = forms.BooleanField(required=False)
 
-    video = CharField(label=ugettext_noop("Youtube Video"), required=False,
-        help_text=ugettext_noop("An optional youtube clip to tell users about your app. Please copy and paste a URL to a youtube video"))
-    documentation_file = forms.FileField(label=ugettext_noop("Documentation File"), required=False,
-        help_text=ugettext_noop("An optional file to tell users more about your app."))
+    video = CharField(label=ugettext_lazy("Youtube Video"), required=False,
+        help_text=ugettext_lazy("An optional youtube clip to tell users about your app. Please copy and paste a URL to a youtube video"))
+    documentation_file = forms.FileField(label=ugettext_lazy("Documentation File"), required=False,
+        help_text=ugettext_lazy("An optional file to tell users more about your app."))
     old_documentation_file = forms.BooleanField(required=False)
-    cda_confirmed = BooleanField(required=False, label=ugettext_noop("Content Distribution Agreement"))
-    is_starter_app = BooleanField(required=False, label=ugettext_noop("This is a starter application"))
+    cda_confirmed = BooleanField(required=False, label=ugettext_lazy("Content Distribution Agreement"))
+    is_starter_app = BooleanField(required=False, label=ugettext_lazy("This is a starter application"))
 
     def __init__(self, *args, **kw):
         self.dom = kw.pop("domain", None)
@@ -410,7 +410,7 @@ class SubAreaMixin():
 
 class DomainGlobalSettingsForm(forms.Form):
     hr_name = forms.CharField(label=_("Project Name"))
-    default_timezone = TimeZoneChoiceField(label=ugettext_noop("Default Timezone"), initial="UTC")
+    default_timezone = TimeZoneChoiceField(label=ugettext_lazy("Default Timezone"), initial="UTC")
 
     logo = ImageField(
         label=_("Custom Logo"),
@@ -626,23 +626,23 @@ class PrivacySecurityForm(forms.Form):
 
 
 class DomainInternalForm(forms.Form, SubAreaMixin):
-    sf_contract_id = CharField(label=ugettext_noop("Salesforce Contract ID"), required=False)
-    sf_account_id = CharField(label=ugettext_noop("Salesforce Account ID"), required=False)
-    services = ChoiceField(label=ugettext_noop("Services"), required=False,
+    sf_contract_id = CharField(label=ugettext_lazy("Salesforce Contract ID"), required=False)
+    sf_account_id = CharField(label=ugettext_lazy("Salesforce Account ID"), required=False)
+    services = ChoiceField(label=ugettext_lazy("Services"), required=False,
                            choices=tuple_of_copies(["basic", "plus", "full", "custom"]))
-    initiative = forms.MultipleChoiceField(label=ugettext_noop("Initiative"),
+    initiative = forms.MultipleChoiceField(label=ugettext_lazy("Initiative"),
                                            widget=forms.CheckboxSelectMultiple(),
                                            choices=tuple_of_copies(DATA_DICT["initiatives"], blank=False),
                                            required=False)
     workshop_region = CharField(
-        label=ugettext_noop("Workshop Region"),
+        label=ugettext_lazy("Workshop Region"),
         required=False,
-        help_text=ugettext_noop("e.g. US, LAC, SA, Sub-Saharan Africa, Southeast Asia, etc."))
+        help_text=ugettext_lazy("e.g. US, LAC, SA, Sub-Saharan Africa, Southeast Asia, etc."))
     self_started = ChoiceField(
-        label=ugettext_noop("Self Started?"),
+        label=ugettext_lazy("Self Started?"),
         choices=tf_choices('Yes', 'No'),
         required=False,
-        help_text=ugettext_noop(
+        help_text=ugettext_lazy(
             "The organization built and deployed their app themselves. Dimagi may have provided indirect support"
         ))
     is_test = ChoiceField(
@@ -652,41 +652,41 @@ class DomainInternalForm(forms.Form, SubAreaMixin):
                  ('false', _('Real')),)
     )
     area = ChoiceField(
-        label=ugettext_noop("Sector*"),
+        label=ugettext_lazy("Sector*"),
         required=False,
         choices=tuple_of_copies(AREA_CHOICES))
     sub_area = ChoiceField(
-        label=ugettext_noop("Sub-Sector*"),
+        label=ugettext_lazy("Sub-Sector*"),
         required=False,
         choices=tuple_of_copies(SUB_AREA_CHOICES))
     organization_name = CharField(
-        label=ugettext_noop("Organization Name*"),
+        label=ugettext_lazy("Organization Name*"),
         required=False,
         help_text=_("Quick 1-2 sentence summary of the project."),
     )
-    notes = CharField(label=ugettext_noop("Notes*"), required=False, widget=forms.Textarea)
+    notes = CharField(label=ugettext_lazy("Notes*"), required=False, widget=forms.Textarea)
     phone_model = CharField(
-        label=ugettext_noop("Device Model"),
+        label=ugettext_lazy("Device Model"),
         help_text=_("Add CloudCare, if this project is using CloudCare as well"),
         required=False,
     )
     deployment_date = CharField(
-        label=ugettext_noop("Deployment date"),
+        label=ugettext_lazy("Deployment date"),
         required=False,
         help_text=_("Date that the project went live (usually right after training).")
     )
     business_unit = forms.ChoiceField(
-        label=ugettext_noop('Business Unit'),
+        label=ugettext_lazy('Business Unit'),
         choices=tuple_of_copies(BUSINESS_UNITS),
         required=False,
     )
     countries = forms.MultipleChoiceField(
-        label=ugettext_noop("Countries"),
+        label=ugettext_lazy("Countries"),
         choices=sorted(COUNTRIES.items(), key=lambda x: x[0]),
         required=False,
     )
     commtrack_domain = ChoiceField(
-        label=ugettext_noop("CommCare Supply Project"),
+        label=ugettext_lazy("CommCare Supply Project"),
         choices=tf_choices('Yes', 'No'),
         required=False,
         help_text=_("This app aims to improve the supply of goods and materials")
@@ -699,13 +699,13 @@ class DomainInternalForm(forms.Form, SubAreaMixin):
         if self.can_edit_eula:
             additional_fields = ['custom_eula', 'can_use_data']
             self.fields['custom_eula'] = ChoiceField(
-                label=ugettext_noop("Custom Eula?"),
+                label=ugettext_lazy("Custom Eula?"),
                 choices=tf_choices(_('Yes'), _('No')),
                 required=False,
                 help_text='Set to "yes" if this project has a customized EULA as per their contract.'
             )
             self.fields['can_use_data'] = ChoiceField(
-                label=ugettext_noop("Can use project data?"),
+                label=ugettext_lazy("Can use project data?"),
                 choices=tf_choices('Yes', 'No'),
                 required=False,
                 help_text='Set to "no" if this project opts out of data usage. Defaults to "yes".'
@@ -1016,7 +1016,7 @@ class ConfirmSubscriptionRenewalForm(EditBillingAccountInfoForm):
         )
         self.renewed_version = renewed_version
         self.fields['plan_edition'].initial = renewed_version.plan.edition
-        self.fields['confirm_legal'].label = mark_safe(ugettext_noop(
+        self.fields['confirm_legal'].label = mark_safe(ugettext_lazy(
             'I have read and agree to the <a href="%(pa_url)s" '
             'target="_blank">Software Product Agreement</a>.'
         ) % {
@@ -1249,7 +1249,7 @@ class InternalSubscriptionManagementForm(forms.Form):
             crispy.ButtonHolder(
                 crispy.Submit(
                     self.slug,
-                    ugettext_noop('Update')
+                    ugettext_lazy('Update')
                 )
             )
         )
@@ -1257,7 +1257,7 @@ class InternalSubscriptionManagementForm(forms.Form):
 
 class DimagiOnlyEnterpriseForm(InternalSubscriptionManagementForm):
     slug = 'dimagi_only_enterprise'
-    subscription_type = ugettext_noop('Test or Demo Project')
+    subscription_type = ugettext_lazy('Test or Demo Project')
 
     def __init__(self, domain, web_user, *args, **kwargs):
         super(DimagiOnlyEnterpriseForm, self).__init__(domain, web_user, *args, **kwargs)
@@ -1265,7 +1265,7 @@ class DimagiOnlyEnterpriseForm(InternalSubscriptionManagementForm):
         self.helper = FormHelper()
         self.helper.form_class = 'form-horizontal'
         self.helper.layout = crispy.Layout(
-            crispy.HTML(ugettext_noop(
+            crispy.HTML(ugettext_lazy(
                 '<i class="icon-info-sign"></i> You will have access to all '
                 'features for free as soon as you hit "Update".  Please make '
                 'sure this is an internal Dimagi test space, not in use by a '
@@ -1308,15 +1308,15 @@ class DimagiOnlyEnterpriseForm(InternalSubscriptionManagementForm):
 
 class AdvancedExtendedTrialForm(InternalSubscriptionManagementForm):
     slug = 'advanced_extended_trial'
-    subscription_type = ugettext_noop('3 Month Trial')
+    subscription_type = ugettext_lazy('3 Month Trial')
 
     organization_name = forms.CharField(
-        label=ugettext_noop('Organization Name'),
+        label=ugettext_lazy('Organization Name'),
         max_length=BillingAccount._meta.get_field('name').max_length,
     )
 
     emails = forms.CharField(
-        label=ugettext_noop('Partner Contact Emails'),
+        label=ugettext_lazy('Partner Contact Emails'),
         max_length=BillingContactInfo._meta.get_field('emails').max_length
     )
 
@@ -1399,7 +1399,7 @@ class AdvancedExtendedTrialForm(InternalSubscriptionManagementForm):
 
 class ContractedPartnerForm(InternalSubscriptionManagementForm):
     slug = 'contracted_partner'
-    subscription_type = ugettext_noop('Contracted Partner')
+    subscription_type = ugettext_lazy('Contracted Partner')
 
     software_plan_edition = forms.ChoiceField(
         choices=(
@@ -1407,43 +1407,43 @@ class ContractedPartnerForm(InternalSubscriptionManagementForm):
             (SoftwarePlanEdition.PRO, SoftwarePlanEdition.PRO),
             (SoftwarePlanEdition.ADVANCED, SoftwarePlanEdition.ADVANCED),
         ),
-        label=ugettext_noop('Software Plan'),
+        label=ugettext_lazy('Software Plan'),
     )
 
     fogbugz_client_name = forms.CharField(
-        label=ugettext_noop('Fogbugz Client Name'),
+        label=ugettext_lazy('Fogbugz Client Name'),
         max_length=BillingAccount._meta.get_field('name').max_length,
     )
 
     emails = forms.CharField(
-        help_text=ugettext_noop(
+        help_text=ugettext_lazy(
             'This is who will receive invoices if the Client exceeds the user '
             'or SMS limits in their plan.'
         ),
-        label=ugettext_noop('Partner Contact Emails'),
+        label=ugettext_lazy('Partner Contact Emails'),
         max_length=BillingContactInfo._meta.get_field('emails').max_length,
     )
 
     start_date = forms.DateField(
-        help_text=ugettext_noop('Date the project needs access to features.'),
-        label=ugettext_noop('Start Date'),
+        help_text=ugettext_lazy('Date the project needs access to features.'),
+        label=ugettext_lazy('Start Date'),
     )
 
     end_date = forms.DateField(
-        help_text=ugettext_noop(
+        help_text=ugettext_lazy(
             '1 year after the deployment date (date the project goes live).'
         ),
-        label=ugettext_noop('End Date'),
+        label=ugettext_lazy('End Date'),
     )
 
     sms_credits = forms.DecimalField(
         initial=0,
-        label=ugettext_noop('SMS Credits'),
+        label=ugettext_lazy('SMS Credits'),
     )
 
     user_credits = forms.IntegerField(
         initial=0,
-        label=ugettext_noop('User Credits'),
+        label=ugettext_lazy('User Credits'),
     )
 
     def __init__(self, domain, web_user, *args, **kwargs):
@@ -1603,12 +1603,12 @@ INTERNAL_SUBSCRIPTION_MANAGEMENT_FORMS = [
 class SelectSubscriptionTypeForm(forms.Form):
     subscription_type = forms.ChoiceField(
         choices=[
-            ('', ugettext_noop('Select a subscription type...'))
+            ('', ugettext_lazy('Select a subscription type...'))
         ] + [
             (form.slug, form.subscription_type)
             for form in INTERNAL_SUBSCRIPTION_MANAGEMENT_FORMS
         ],
-        label=ugettext_noop('Subscription Type'),
+        label=ugettext_lazy('Subscription Type'),
         required=False,
     )
 

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -98,7 +98,7 @@ import json
 from dimagi.utils.post import simple_post
 import cStringIO
 from PIL import Image
-from django.utils.translation import ugettext as _, ugettext_noop
+from django.utils.translation import ugettext as _, ugettext_lazy
 from toggle.models import Toggle
 
 
@@ -193,7 +193,7 @@ class LoginAndDomainMixin(object):
 
 class SubscriptionUpgradeRequiredView(LoginAndDomainMixin, BasePageView,
                                       DomainViewMixin):
-    page_title = ugettext_noop("Upgrade Required")
+    page_title = ugettext_lazy("Upgrade Required")
     template_name = "domain/insufficient_privilege_notification.html"
 
     @property
@@ -263,7 +263,7 @@ class BaseDomainView(LoginAndDomainMixin, BaseSectionPageView, DomainViewMixin):
 
 
 class BaseProjectSettingsView(BaseDomainView):
-    section_name = ugettext_noop("Project Settings")
+    section_name = ugettext_lazy("Project Settings")
     template_name = "settings/base_template.html"
 
     @property
@@ -336,7 +336,7 @@ class BaseEditProjectInfoView(BaseAdminProjectSettingsView):
 class EditBasicProjectInfoView(BaseEditProjectInfoView):
     template_name = 'domain/admin/info_basic.html'
     urlname = 'domain_basic_info'
-    page_title = ugettext_noop("Basic")
+    page_title = ugettext_lazy("Basic")
 
     @property
     def can_user_see_meta(self):
@@ -410,7 +410,7 @@ class EditBasicProjectInfoView(BaseEditProjectInfoView):
 class EditMyProjectSettingsView(BaseProjectSettingsView):
     template_name = 'domain/admin/my_project_settings.html'
     urlname = 'my_project_settings'
-    page_title = ugettext_noop("My Timezone")
+    page_title = ugettext_lazy("My Timezone")
 
     @property
     @memoized
@@ -455,7 +455,7 @@ class EditMyProjectSettingsView(BaseProjectSettingsView):
 class EditDhis2SettingsView(BaseProjectSettingsView):
     template_name = 'domain/admin/dhis2_settings.html'
     urlname = 'dhis2_settings'
-    page_title = ugettext_noop("DHIS2 API settings")
+    page_title = ugettext_lazy("DHIS2 API settings")
 
     @property
     @memoized
@@ -572,7 +572,7 @@ class DomainAccountingSettings(BaseAdminProjectSettingsView):
 class DomainSubscriptionView(DomainAccountingSettings):
     urlname = 'domain_subscription_view'
     template_name = 'domain/current_subscription.html'
-    page_title = ugettext_noop("Current Subscription")
+    page_title = ugettext_lazy("Current Subscription")
 
     @property
     def can_purchase_credits(self):
@@ -734,7 +734,7 @@ class DomainSubscriptionView(DomainAccountingSettings):
 class EditExistingBillingAccountView(DomainAccountingSettings, AsyncHandlerMixin):
     template_name = 'domain/update_billing_contact_info.html'
     urlname = 'domain_update_billing_info'
-    page_title = ugettext_noop("Billing Contact Information")
+    page_title = ugettext_lazy("Billing Contact Information")
     async_handlers = [
         Select2BillingInfoHandler,
     ]
@@ -780,11 +780,11 @@ class EditExistingBillingAccountView(DomainAccountingSettings, AsyncHandlerMixin
 class DomainBillingStatementsView(DomainAccountingSettings, CRUDPaginatedViewMixin):
     template_name = 'domain/billing_statements.html'
     urlname = 'domain_billing_statements'
-    page_title = ugettext_noop("Billing Statements")
+    page_title = ugettext_lazy("Billing Statements")
 
-    limit_text = ugettext_noop("statements per page")
-    empty_notification = ugettext_noop("No Billing Statements match the current criteria.")
-    loading_message = ugettext_noop("Loading statements...")
+    limit_text = ugettext_lazy("statements per page")
+    empty_notification = ugettext_lazy("No Billing Statements match the current criteria.")
+    loading_message = ugettext_lazy("Loading statements...")
 
     @property
     def parameters(self):
@@ -1162,7 +1162,7 @@ class BillingStatementPdfView(View):
 class InternalSubscriptionManagementView(BaseAdminProjectSettingsView):
     template_name = 'domain/internal_subscription_management.html'
     urlname = 'internal_subscription_mgmt'
-    page_title = ugettext_noop("Dimagi Internal Subscription Management")
+    page_title = ugettext_lazy("Dimagi Internal Subscription Management")
     form_classes = INTERNAL_SUBSCRIPTION_MANAGEMENT_FORMS
 
     @method_decorator(require_superuser)
@@ -1233,10 +1233,10 @@ class InternalSubscriptionManagementView(BaseAdminProjectSettingsView):
 class SelectPlanView(DomainAccountingSettings):
     template_name = 'domain/select_plan.html'
     urlname = 'domain_select_plan'
-    page_title = ugettext_noop("Change Plan")
-    step_title = ugettext_noop("Select Plan")
+    page_title = ugettext_lazy("Change Plan")
+    step_title = ugettext_lazy("Select Plan")
     edition = None
-    lead_text = ugettext_noop("Please select a plan below that fits your organization's needs.")
+    lead_text = ugettext_lazy("Please select a plan below that fits your organization's needs.")
 
     @property
     def edition_name(self):
@@ -1295,7 +1295,7 @@ class SelectPlanView(DomainAccountingSettings):
 class EditPrivacySecurityView(BaseAdminProjectSettingsView):
     template_name = "domain/admin/project_privacy.html"
     urlname = "privacy_info"
-    page_title = ugettext_noop("Privacy and Security")
+    page_title = ugettext_lazy("Privacy and Security")
 
     @property
     @memoized
@@ -1324,7 +1324,7 @@ class EditPrivacySecurityView(BaseAdminProjectSettingsView):
 class SelectedEnterprisePlanView(SelectPlanView):
     template_name = 'domain/selected_enterprise_plan.html'
     urlname = 'enterprise_request_quote'
-    step_title = ugettext_noop("Contact Dimagi")
+    step_title = ugettext_lazy("Contact Dimagi")
     edition = SoftwarePlanEdition.ENTERPRISE
 
     @property
@@ -1366,7 +1366,7 @@ class SelectedEnterprisePlanView(SelectPlanView):
 class ConfirmSelectedPlanView(SelectPlanView):
     template_name = 'domain/confirm_plan.html'
     urlname = 'confirm_selected_plan'
-    step_title = ugettext_noop("Confirm Plan")
+    step_title = ugettext_lazy("Confirm Plan")
 
     @property
     def steps(self):
@@ -1432,7 +1432,7 @@ class ConfirmSelectedPlanView(SelectPlanView):
 class ConfirmBillingAccountInfoView(ConfirmSelectedPlanView, AsyncHandlerMixin):
     template_name = 'domain/confirm_billing_info.html'
     urlname = 'confirm_billing_account_info'
-    step_title = ugettext_noop("Confirm Billing Information")
+    step_title = ugettext_lazy("Confirm Billing Information")
     is_new = False
     async_handlers = [
         Select2BillingInfoHandler,
@@ -1529,12 +1529,12 @@ class SubscriptionMixin(object):
 
 class SubscriptionRenewalView(SelectPlanView, SubscriptionMixin):
     urlname = "domain_subscription_renewal"
-    page_title = ugettext_noop("Renew Plan")
-    step_title = ugettext_noop("Renew or Change Plan")
+    page_title = ugettext_lazy("Renew Plan")
+    step_title = ugettext_lazy("Renew or Change Plan")
 
     @property
     def lead_text(self):
-        return ugettext_noop("Based on your current usage we recommend you use the <strong>{plan}</strong> plan"
+        return ugettext_lazy("Based on your current usage we recommend you use the <strong>{plan}</strong> plan"
                              .format(plan=self.current_subscription.plan_version.plan.edition))
 
     @property
@@ -1562,7 +1562,7 @@ class SubscriptionRenewalView(SelectPlanView, SubscriptionMixin):
 class ConfirmSubscriptionRenewalView(DomainAccountingSettings, AsyncHandlerMixin, SubscriptionMixin):
     template_name = 'domain/confirm_subscription_renewal.html'
     urlname = 'domain_subscription_renewal_confirmation'
-    page_title = ugettext_noop("Renew Plan")
+    page_title = ugettext_lazy("Renew Plan")
     async_handlers = [
         Select2BillingInfoHandler,
     ]
@@ -1631,7 +1631,7 @@ class ConfirmSubscriptionRenewalView(DomainAccountingSettings, AsyncHandlerMixin
 class ExchangeSnapshotsView(BaseAdminProjectSettingsView):
     template_name = 'domain/snapshot_settings.html'
     urlname = 'domain_snapshot_settings'
-    page_title = ugettext_noop("CommCare Exchange")
+    page_title = ugettext_lazy("CommCare Exchange")
 
     @property
     def page_context(self):
@@ -1645,7 +1645,7 @@ class ExchangeSnapshotsView(BaseAdminProjectSettingsView):
 class CreateNewExchangeSnapshotView(BaseAdminProjectSettingsView):
     template_name = 'domain/create_snapshot.html'
     urlname = 'domain_create_snapshot'
-    page_title = ugettext_noop("Publish New Version")
+    page_title = ugettext_lazy("Publish New Version")
     strict_domain_fetching = True
 
     @property
@@ -1927,7 +1927,7 @@ class CreateNewExchangeSnapshotView(BaseAdminProjectSettingsView):
 
 class ManageProjectMediaView(BaseAdminProjectSettingsView):
     urlname = 'domain_manage_multimedia'
-    page_title = ugettext_noop("Multimedia Sharing")
+    page_title = ugettext_lazy("Multimedia Sharing")
     template_name = 'domain/admin/media_manager.html'
 
     @property
@@ -1982,7 +1982,7 @@ class RepeaterMixin(object):
 
 class DomainForwardingOptionsView(BaseAdminProjectSettingsView, RepeaterMixin):
     urlname = 'domain_forwarding'
-    page_title = ugettext_noop("Data Forwarding")
+    page_title = ugettext_lazy("Data Forwarding")
     template_name = 'domain/admin/domain_forwarding.html'
 
     @property
@@ -2003,7 +2003,7 @@ class DomainForwardingOptionsView(BaseAdminProjectSettingsView, RepeaterMixin):
 
 class AddRepeaterView(BaseAdminProjectSettingsView, RepeaterMixin):
     urlname = 'add_repeater'
-    page_title = ugettext_noop("Forward Data")
+    page_title = ugettext_lazy("Forward Data")
     template_name = 'domain/admin/add_form_repeater.html'
     repeater_form_class = GenericRepeaterForm
 
@@ -2093,7 +2093,7 @@ class AddFormRepeaterView(AddRepeaterView):
 class OrgSettingsView(BaseAdminProjectSettingsView):
     template_name = 'domain/orgs_settings.html'
     urlname = 'domain_org_settings'
-    page_title = ugettext_noop("Organization")
+    page_title = ugettext_lazy("Organization")
 
     @method_decorator(requires_privilege_with_fallback(privileges.CROSS_PROJECT_REPORTS))
     def dispatch(self, request, *args, **kwargs):
@@ -2147,7 +2147,7 @@ class BaseInternalDomainSettingsView(BaseProjectSettingsView):
 
 class EditInternalDomainInfoView(BaseInternalDomainSettingsView):
     urlname = 'domain_internal_settings'
-    page_title = ugettext_noop("Project Information")
+    page_title = ugettext_lazy("Project Information")
     template_name = 'domain/internal_settings.html'
     strict_domain_fetching = True
 
@@ -2236,7 +2236,7 @@ class EditInternalDomainInfoView(BaseInternalDomainSettingsView):
 
 class EditInternalCalculationsView(BaseInternalDomainSettingsView):
     urlname = 'domain_internal_calculations'
-    page_title = ugettext_noop("Calculated Properties")
+    page_title = ugettext_lazy("Calculated Properties")
     template_name = 'domain/internal_calculations.html'
 
     @property
@@ -2320,7 +2320,7 @@ def set_published_snapshot(request, domain, snapshot_name=''):
 
 
 class ProBonoMixin():
-    page_title = ugettext_noop("Pro-Bono Application")
+    page_title = ugettext_lazy("Pro-Bono Application")
     is_submitted = False
 
     url_name = None
@@ -2389,7 +2389,7 @@ class ProBonoView(ProBonoMixin, DomainAccountingSettings):
 
 class FeaturePreviewsView(BaseAdminProjectSettingsView):
     urlname = 'feature_previews'
-    page_title = ugettext_noop("Feature Previews")
+    page_title = ugettext_lazy("Feature Previews")
     template_name = 'domain/admin/feature_previews.html'
 
     @memoized
@@ -2432,7 +2432,7 @@ class FeaturePreviewsView(BaseAdminProjectSettingsView):
 
 class FeatureFlagsView(BaseAdminProjectSettingsView):
     urlname = 'domain_feature_flags'
-    page_title = ugettext_noop("Feature Flags")
+    page_title = ugettext_lazy("Feature Flags")
     template_name = 'domain/admin/feature_flags.html'
 
     @method_decorator(require_superuser)
@@ -2457,7 +2457,7 @@ class FeatureFlagsView(BaseAdminProjectSettingsView):
 
 class TransferDomainView(BaseAdminProjectSettingsView):
     urlname = 'transfer_domain_view'
-    page_title = ugettext_noop("Transfer Project")
+    page_title = ugettext_lazy("Transfer Project")
     template_name = 'domain/admin/transfer_domain.html'
 
     @property
@@ -2599,7 +2599,7 @@ from corehq.apps.smsbillables.async_handlers import PublicSMSRatesAsyncHandler
 
 class PublicSMSRatesView(BasePageView, AsyncHandlerMixin):
     urlname = 'public_sms_rates_view'
-    page_title = ugettext_noop("SMS Rate Calculator")
+    page_title = ugettext_lazy("SMS Rate Calculator")
     template_name = 'domain/admin/global_sms_rates.html'
     async_handlers = [PublicSMSRatesAsyncHandler]
 
@@ -2619,7 +2619,7 @@ class PublicSMSRatesView(BasePageView, AsyncHandlerMixin):
 
 class SMSRatesView(BaseAdminProjectSettingsView, AsyncHandlerMixin):
     urlname = 'domain_sms_rates_view'
-    page_title = ugettext_noop("SMS Rate Calculator")
+    page_title = ugettext_lazy("SMS Rate Calculator")
     template_name = 'domain/admin/sms_rates.html'
     async_handlers = [
         SMSRatesAsyncHandler,

--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -25,7 +25,7 @@ from corehq.apps.users.models import Permissions
 from couchexport.models import SavedExportSchema, ExportSchema
 from couchexport.schema import build_latest_schema
 from dimagi.utils.decorators.memoized import memoized
-from django.utils.translation import ugettext as _, ugettext_lazy, ugettext_lazy
+from django.utils.translation import ugettext as _, ugettext_lazy
 from dimagi.utils.logging import notify_exception
 from dimagi.utils.parsing import json_format_date
 from dimagi.utils.web import json_response

--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -25,7 +25,7 @@ from corehq.apps.users.models import Permissions
 from couchexport.models import SavedExportSchema, ExportSchema
 from couchexport.schema import build_latest_schema
 from dimagi.utils.decorators.memoized import memoized
-from django.utils.translation import ugettext as _, ugettext_noop, ugettext_lazy
+from django.utils.translation import ugettext as _, ugettext_lazy, ugettext_lazy
 from dimagi.utils.logging import notify_exception
 from dimagi.utils.parsing import json_format_date
 from dimagi.utils.web import json_response
@@ -218,13 +218,13 @@ class BaseEditCustomExportView(BaseModifyCustomExportView):
 
 class EditCustomFormExportView(BaseEditCustomExportView):
     urlname = 'edit_custom_export_form'
-    page_title = ugettext_noop("Edit Form Custom Export")
+    page_title = ugettext_lazy("Edit Form Custom Export")
     export_type = 'form'
 
 
 class EditCustomCaseExportView(BaseEditCustomExportView):
     urlname = 'edit_custom_export_case'
-    page_title = ugettext_noop("Edit Case Custom Export")
+    page_title = ugettext_lazy("Edit Case Custom Export")
     export_type = 'case'
 
 
@@ -302,7 +302,7 @@ def create_basic_form_checkpoint(index):
 
 class CreateFormExportView(BaseProjectDataView):
     urlname = 'create_form_export'
-    page_title = ugettext_noop("Create Form Export: Select Form")
+    page_title = ugettext_lazy("Create Form Export: Select Form")
     template_name = 'export/create_form_export.html'
 
     @property
@@ -380,7 +380,7 @@ class CreateFormExportView(BaseProjectDataView):
 
 class CreateCaseExportView(BaseProjectDataView):
     urlname = 'create_case_export'
-    page_title = ugettext_noop('Create Case Export')
+    page_title = ugettext_lazy('Create Case Export')
     template_name = 'export/create_case_export.html'
 
     @property

--- a/corehq/apps/fixtures/interface.py
+++ b/corehq/apps/fixtures/interface.py
@@ -8,7 +8,7 @@ from corehq.apps.reports.filters.base import BaseSingleOptionFilter
 from corehq.apps.fixtures.dispatcher import FixtureInterfaceDispatcher
 from corehq.apps.fixtures.models import FixtureDataType, _id_from_doc
 from dimagi.utils.decorators.memoized import memoized
-from django.utils.translation import ugettext_noop, ugettext as _
+from django.utils.translation import ugettext_lazy, ugettext as _
 
 
 class FixtureInterface(FixtureViewMixIn, GenericReportView):
@@ -43,7 +43,7 @@ class FixtureSelectFilter(BaseSingleOptionFilter):
 
 
 class FixtureViewInterface(GenericTabularReport, FixtureInterface):
-    name = ugettext_noop("View Tables")
+    name = ugettext_lazy("View Tables")
     slug = "view_lookup_tables"
 
     report_template_path = 'fixtures/view_table.html'
@@ -102,7 +102,7 @@ class FixtureViewInterface(GenericTabularReport, FixtureInterface):
 
 
 class FixtureEditInterface(FixtureInterface):
-    name = ugettext_noop("Manage Tables")
+    name = ugettext_lazy("Manage Tables")
     slug = "edit_lookup_tables"
 
     report_template_path = 'fixtures/manage_tables.html'

--- a/corehq/apps/fixtures/upload.py
+++ b/corehq/apps/fixtures/upload.py
@@ -2,7 +2,7 @@ from couchdbkit import ResourceNotFound
 from corehq.apps.fixtures.exceptions import FixtureUploadError, ExcelMalformatException, \
     DuplicateFixtureTagException, FixtureAPIException
 from django.core.validators import ValidationError
-from django.utils.translation import ugettext as _, ugettext_noop
+from django.utils.translation import ugettext as _, ugettext_lazy
 from corehq.apps.fixtures.models import FixtureTypeField, FixtureDataType, FixtureDataItem, FixtureItemField, \
     FieldList
 from corehq.apps.users.bulkupload import GroupMemoizer
@@ -16,46 +16,46 @@ from corehq.apps.locations.models import SQLLocation
 
 DELETE_HEADER = "Delete(Y/N)"
 FAILURE_MESSAGES = {
-    "has_no_column": ugettext_noop(
+    "has_no_column": ugettext_lazy(
         "Workbook 'types' has no column '{column_name}'."
     ),
-    "neither_fields_nor_attributes": ugettext_noop(
+    "neither_fields_nor_attributes": ugettext_lazy(
         "Lookup-tables can not have empty fields and empty properties on items. table_id '{tag}' has no fields and no properties"
     ),
-    "duplicate_tag": ugettext_noop(
+    "duplicate_tag": ugettext_lazy(
         "Lookup-tables should have unique 'table_id'. There are two rows with table_id '{tag}' in 'types' sheet."
     ),
-    "has_no_field_column": ugettext_noop(
+    "has_no_field_column": ugettext_lazy(
         "Excel-sheet '{tag}' does not contain the column '{field}' "
         "as specified in its 'types' definition"
     ),
-    "has_extra_column": ugettext_noop(
+    "has_extra_column": ugettext_lazy(
         "Excel-sheet '{tag}' has an extra column"
         "'{field}' that's not defined in its 'types' definition"
     ),
-    "wrong_property_syntax": ugettext_noop(
+    "wrong_property_syntax": ugettext_lazy(
         "Properties should be specified as 'field 1: property 1'. In 'types' sheet, "
         "'{prop_key}' is not correctly formatted"
     ),
-    "sheet_has_no_property": ugettext_noop(
+    "sheet_has_no_property": ugettext_lazy(
         "Excel-sheet '{tag}' does not contain property "
         "'{property}' of the field '{field}' as specified in its 'types' definition"
     ),
-    "sheet_has_extra_property": ugettext_noop(
+    "sheet_has_extra_property": ugettext_lazy(
         "Excel-sheet '{tag}'' has an extra property "
         "'{property}' for the field '{field}' that's not defined in its 'types' definition. "
         "Re-check the formatting"
     ),
-    "invalid_field_with_property": ugettext_noop(
+    "invalid_field_with_property": ugettext_lazy(
         "Fields with attributes should be numbered as 'field: {field} integer"
     ),
-    "invalid_property": ugettext_noop(
+    "invalid_property": ugettext_lazy(
         "Attribute should be written as '{field}: {prop} interger'"
     ),
-    "wrong_field_property_combos": ugettext_noop(
+    "wrong_field_property_combos": ugettext_lazy(
         "Number of values for field '{field}' and attribute '{prop}' should be same"
     ),
-    "replace_with_UID": ugettext_noop(
+    "replace_with_UID": ugettext_lazy(
         "Rows shouldn't contain UIDs while using replace option. Excel sheet '{tag}' contains UID in a row."
     ),
 }

--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -8,7 +8,7 @@ from django.http import HttpResponseBadRequest, HttpResponseRedirect, Http404, H
 from django.http.response import HttpResponseServerError
 from django.shortcuts import render
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext as _, ugettext_noop
+from django.utils.translation import ugettext as _, ugettext_lazy
 from django.views.decorators.http import require_POST
 from django.views.generic.base import TemplateView
 
@@ -257,7 +257,7 @@ def fixtures_home(domain):
 
 
 class FixtureViewMixIn(object):
-    section_name = ugettext_noop("Lookup Tables")
+    section_name = ugettext_lazy("Lookup Tables")
 
     @property
     def section_url(self):
@@ -311,7 +311,7 @@ class UploadItemLists(TemplateView):
 
 class FixtureUploadStatusView(FixtureViewMixIn, BaseDomainView):
     urlname = 'fixture_upload_status'
-    page_title = ugettext_noop('Lookup Table Upload Status')
+    page_title = ugettext_lazy('Lookup Table Upload Status')
 
     def get(self, request, *args, **kwargs):
         context = super(FixtureUploadStatusView, self).main_context

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -11,7 +11,7 @@ from corehq.apps.reports.datatables import DataTablesHeader, DataTablesColumn
 from corehq.apps.reports.dispatcher import AdminReportDispatcher
 from corehq.apps.reports.generic import ElasticTabularReport, GenericTabularReport
 from corehq.apps.reports.standard.domains import DomainStatsReport, es_domain_query
-from django.utils.translation import ugettext as _, ugettext_noop
+from django.utils.translation import ugettext as _, ugettext_lazy
 from corehq.apps.users.models import WebUser
 from corehq.elastic import es_query, parse_args_for_es, fill_mapping_with_facets
 from corehq.pillows.mappings.app_mapping import APP_INDEX
@@ -552,7 +552,7 @@ class AdminFacetedReport(AdminReport, ElasticTabularReport):
     es_queried = False
     es_facet_list = []
     es_facet_mapping = []
-    section_name = ugettext_noop("ADMINREPORT")
+    section_name = ugettext_lazy("ADMINREPORT")
     es_url = ''
 
     @property
@@ -639,9 +639,9 @@ class AdminDomainStatsReport(AdminFacetedReport, DomainStatsReport):
     slug = "domains"
     es_facet_list = DOMAIN_FACETS
     es_facet_mapping = FACET_MAPPING
-    name = ugettext_noop('Project Space List')
-    facet_title = ugettext_noop("Project Facets")
-    search_for = ugettext_noop("projects...")
+    name = ugettext_lazy('Project Space List')
+    facet_title = ugettext_lazy("Project Facets")
+    search_for = ugettext_lazy("projects...")
     base_template = "hqadmin/domain_faceted_report.html"
 
     @property
@@ -805,9 +805,9 @@ class AdminDomainStatsReport(AdminFacetedReport, DomainStatsReport):
 
 class AdminUserReport(AdminFacetedReport):
     slug = "user_list"
-    name = ugettext_noop('User List')
-    facet_title = ugettext_noop("User Facets")
-    search_for = ugettext_noop("users...")
+    name = ugettext_lazy('User List')
+    facet_title = ugettext_lazy("User Facets")
+    search_for = ugettext_lazy("users...")
     default_sort = {'username.exact': 'asc'}
     es_url = USER_INDEX + '/user/_search'
 
@@ -873,9 +873,9 @@ def create_mapping_from_list(l, name="", expand_outer=False, expand_inner=False,
 
 class AdminAppReport(AdminFacetedReport):
     slug = "app_list"
-    name = ugettext_noop('Application List')
-    facet_title = ugettext_noop("App Facets")
-    search_for = ugettext_noop("apps...")
+    name = ugettext_lazy('Application List')
+    facet_title = ugettext_lazy("App Facets")
+    search_for = ugettext_lazy("apps...")
     default_sort = {'name.exact': 'asc'}
     es_url = APP_INDEX + '/app/_search'
 
@@ -925,7 +925,7 @@ class AdminAppReport(AdminFacetedReport):
 
 class GlobalAdminReports(AdminDomainStatsReport):
     base_template = "hqadmin/indicator_report.html"
-    section_name = ugettext_noop("ADMINREPORT")  # not sure why ...
+    section_name = ugettext_lazy("ADMINREPORT")  # not sure why ...
 
     @property
     def template_context(self):
@@ -957,7 +957,7 @@ class GlobalAdminReports(AdminDomainStatsReport):
 
 class RealProjectSpacesReport(GlobalAdminReports):
     slug = 'real_project_spaces'
-    name = ugettext_noop('All Project Spaces')
+    name = ugettext_lazy('All Project Spaces')
     default_params = {'es_is_test': 'false'}
     indicators = [
         'domain_count',
@@ -981,7 +981,7 @@ class RealProjectSpacesReport(GlobalAdminReports):
 
 class CommConnectProjectSpacesReport(GlobalAdminReports):
     slug = 'commconnect_project_spaces'
-    name = ugettext_noop('Project Spaces Using Messaging')
+    name = ugettext_lazy('Project Spaces Using Messaging')
     default_params = {
         'es_is_test': 'false',
         'es_cp_sms_ever': 'T',
@@ -1006,7 +1006,7 @@ class CommConnectProjectSpacesReport(GlobalAdminReports):
 
 class CommTrackProjectSpacesReport(GlobalAdminReports):
     slug = 'commtrack_project_spaces'
-    name = ugettext_noop('CommCare Supply Project Spaces')
+    name = ugettext_lazy('CommCare Supply Project Spaces')
     default_params = {
         'es_is_test': 'false',
         'es_internal.commtrack_domain': 'T',

--- a/corehq/apps/hqmedia/controller.py
+++ b/corehq/apps/hqmedia/controller.py
@@ -1,5 +1,5 @@
 from django.core.urlresolvers import reverse
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 
 
 class BaseMultimediaUploadController(object):
@@ -43,7 +43,7 @@ class BaseMultimediaUploadController(object):
 class MultimediaBulkUploadController(BaseMultimediaUploadController):
     is_multi_file = True
     uploader_type = "bulk"
-    media_type = ugettext_noop("zip")
+    media_type = ugettext_lazy("zip")
 
     queue_template = "hqmedia/uploader/queue_multi.html"
     status_template = "hqmedia/uploader/status_multi.html"
@@ -65,7 +65,7 @@ class BaseMultimediaFileUploadController(BaseMultimediaUploadController):
 
 
 class MultimediaImageUploadController(BaseMultimediaFileUploadController):
-    media_type = ugettext_noop("image")
+    media_type = ugettext_lazy("image")
     existing_file_template = "hqmedia/uploader/preview_image_single.html"
 
     @property
@@ -79,11 +79,11 @@ class MultimediaImageUploadController(BaseMultimediaFileUploadController):
 
 
 class MultimediaLogoUploadController(MultimediaImageUploadController):
-    media_type = ugettext_noop("logo")
+    media_type = ugettext_lazy("logo")
 
 
 class MultimediaAudioUploadController(BaseMultimediaFileUploadController):
-    media_type = ugettext_noop("audio")
+    media_type = ugettext_lazy("audio")
 
     existing_file_template = "hqmedia/uploader/preview_audio_single.html"
 
@@ -98,7 +98,7 @@ class MultimediaAudioUploadController(BaseMultimediaFileUploadController):
 
 
 class MultimediaVideoUploadController(BaseMultimediaFileUploadController):
-    media_type = ugettext_noop("video")
+    media_type = ugettext_lazy("video")
 
     existing_file_template = "hqmedia/uploader/preview_video_single.html"
 

--- a/corehq/apps/hqpillow_retry/filters.py
+++ b/corehq/apps/hqpillow_retry/filters.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from django.db.models.aggregates import Count
 from corehq.apps.reports.filters.base import BaseSingleOptionFilter, CheckboxFilter, BaseDrilldownOptionFilter
-from django.utils.translation import ugettext_noop as _
+from django.utils.translation import ugettext_lazy as _
 from pillow_retry.models import PillowError
 
 

--- a/corehq/apps/hqpillow_retry/views.py
+++ b/corehq/apps/hqpillow_retry/views.py
@@ -9,7 +9,7 @@ from django.http.response import Http404
 from django.shortcuts import redirect
 from django.template.loader import render_to_string
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext_noop as _
+from django.utils.translation import ugettext_lazy as _
 from corehq.apps.domain.decorators import require_superuser
 from corehq.apps.hqwebapp.views import BasePageView
 from corehq.apps.hqpillow_retry.filters import PillowErrorFilter

--- a/corehq/apps/hqwebapp/models.py
+++ b/corehq/apps/hqwebapp/models.py
@@ -6,7 +6,7 @@ from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe, mark_for_escaping
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _, get_language
-from django.utils.translation import ugettext_lazy, ugettext_lazy
+from django.utils.translation import ugettext_lazy
 from django.core.cache import cache
 
 from corehq import toggles, privileges, Domain, feature_previews

--- a/corehq/apps/hqwebapp/models.py
+++ b/corehq/apps/hqwebapp/models.py
@@ -6,7 +6,7 @@ from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe, mark_for_escaping
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _, get_language
-from django.utils.translation import ugettext_noop, ugettext_lazy
+from django.utils.translation import ugettext_lazy, ugettext_lazy
 from django.core.cache import cache
 
 from corehq import toggles, privileges, Domain, feature_previews
@@ -256,7 +256,7 @@ class UITab(object):
 
 
 class ProjectReportsTab(UITab):
-    title = ugettext_noop("Project Reports")
+    title = ugettext_lazy("Project Reports")
     view = "corehq.apps.reports.views.default"
 
     @property
@@ -306,7 +306,7 @@ class ProjectReportsTab(UITab):
 
 
 class IndicatorAdminTab(UITab):
-    title = ugettext_noop("Administer Indicators")
+    title = ugettext_lazy("Administer Indicators")
     view = "corehq.apps.indicators.views.default_admin"
     dispatcher = IndicatorAdminInterfaceDispatcher
 
@@ -342,7 +342,7 @@ class IndicatorAdminTab(UITab):
 
 
 class DashboardTab(UITab):
-    title = ugettext_noop("Dashboard")
+    title = ugettext_lazy("Dashboard")
     view = 'corehq.apps.dashboard.views.dashboard_default'
 
     @property
@@ -355,7 +355,7 @@ class DashboardTab(UITab):
 
 
 class ReportsTab(UITab):
-    title = ugettext_noop("Reports")
+    title = ugettext_lazy("Reports")
     subtab_classes = (ProjectReportsTab, IndicatorAdminTab)
 
     @property
@@ -406,7 +406,7 @@ class ReportsTab(UITab):
 
 
 class ProjectInfoTab(UITab):
-    title = ugettext_noop("Project Info")
+    title = ugettext_lazy("Project Info")
     view = "corehq.apps.appstore.views.project_info"
 
     @property
@@ -415,7 +415,7 @@ class ProjectInfoTab(UITab):
 
 
 class SetupTab(UITab):
-    title = ugettext_noop("Setup")
+    title = ugettext_lazy("Setup")
     view = "corehq.apps.commtrack.views.default"
 
     @property
@@ -543,7 +543,7 @@ class SetupTab(UITab):
 
 
 class ProjectDataTab(UITab):
-    title = ugettext_noop("Data")
+    title = ugettext_lazy("Data")
     view = "corehq.apps.data_interfaces.views.default"
 
     @property
@@ -703,7 +703,7 @@ class ApplicationsTab(UITab):
 
 
 class CloudcareTab(UITab):
-    title = ugettext_noop("CloudCare")
+    title = ugettext_lazy("CloudCare")
     view = "corehq.apps.cloudcare.views.default"
 
     ga_tracker = GaTracker('CloudCare', 'Click Cloud-Care top-level nav')
@@ -718,7 +718,7 @@ class CloudcareTab(UITab):
 
 
 class MessagingTab(UITab):
-    title = ugettext_noop("Messaging")
+    title = ugettext_lazy("Messaging")
     view = "corehq.apps.sms.views.default"
 
     @property
@@ -948,7 +948,7 @@ class MessagingTab(UITab):
 
 
 class ProjectUsersTab(UITab):
-    title = ugettext_noop("Users")
+    title = ugettext_lazy("Users")
     view = "users_default"
 
     @property
@@ -1136,7 +1136,7 @@ class ProjectUsersTab(UITab):
 
 
 class ProjectSettingsTab(UITab):
-    title = ugettext_noop("Project Settings")
+    title = ugettext_lazy("Project Settings")
     view = 'domain_settings_default'
 
     @property
@@ -1330,7 +1330,7 @@ class ProjectSettingsTab(UITab):
 
 
 class MySettingsTab(UITab):
-    title = ugettext_noop("My Settings")
+    title = ugettext_lazy("My Settings")
     view = 'default_my_settings'
 
     @property
@@ -1361,7 +1361,7 @@ class MySettingsTab(UITab):
 
 
 class AdminReportsTab(UITab):
-    title = ugettext_noop("Admin Reports")
+    title = ugettext_lazy("Admin Reports")
     view = "corehq.apps.hqadmin.views.default"
 
     @property
@@ -1429,7 +1429,7 @@ class AdminReportsTab(UITab):
 
 
 class AccountingTab(UITab):
-    title = ugettext_noop("Accounting")
+    title = ugettext_lazy("Accounting")
     view = "accounting_default"
     dispatcher = AccountingAdminInterfaceDispatcher
 
@@ -1472,7 +1472,7 @@ class AccountingTab(UITab):
 
 
 class SMSAdminTab(UITab):
-    title = ugettext_noop("SMS Connectivity & Billing")
+    title = ugettext_lazy("SMS Connectivity & Billing")
     view = "default_sms_admin_interface"
     dispatcher = SMSAdminInterfaceDispatcher
 
@@ -1500,7 +1500,7 @@ class SMSAdminTab(UITab):
 
 
 class FeatureFlagsTab(UITab):
-    title = ugettext_noop("Feature Flags")
+    title = ugettext_lazy("Feature Flags")
     view = "toggle_list"
 
     @property
@@ -1509,7 +1509,7 @@ class FeatureFlagsTab(UITab):
 
 
 class AdminTab(UITab):
-    title = ugettext_noop("Admin")
+    title = ugettext_lazy("Admin")
     view = "corehq.apps.hqadmin.views.default"
     subtab_classes = (
         AdminReportsTab,
@@ -1566,7 +1566,7 @@ class AdminTab(UITab):
 
 
 class ExchangeTab(UITab):
-    title = ugettext_noop("Exchange")
+    title = ugettext_lazy("Exchange")
     view = "corehq.apps.appstore.views.appstore"
 
     @property
@@ -1598,7 +1598,7 @@ class OrgTab(UITab):
 
 
 class OrgReportTab(OrgTab):
-    title = ugettext_noop("Reports")
+    title = ugettext_lazy("Reports")
     view = "corehq.apps.orgs.views.base_report"
 
     @property
@@ -1620,7 +1620,7 @@ class OrgReportTab(OrgTab):
 
 
 class OrgSettingsTab(OrgTab):
-    title = ugettext_noop("Settings")
+    title = ugettext_lazy("Settings")
     view = "corehq.apps.orgs.views.orgs_landing"
 
     @property

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -24,7 +24,7 @@ from django.http import HttpResponseRedirect, HttpResponse, Http404,\
 from django.shortcuts import redirect, render
 from django.views.generic import TemplateView
 from couchdbkit import ResourceNotFound
-from django.utils.translation import ugettext as _, ugettext_noop
+from django.utils.translation import ugettext as _, ugettext_lazy
 from django.core.urlresolvers import reverse
 from django.core.mail.message import EmailMessage
 from django.template import loader
@@ -662,11 +662,11 @@ class CRUDPaginatedViewMixin(object):
     """
     DEFAULT_LIMIT = 10
 
-    limit_text = ugettext_noop("items per page")
-    empty_notification = ugettext_noop("You have no items.")
-    loading_message = ugettext_noop("Loading...")
-    deleted_items_header = ugettext_noop("Deleted Items:")
-    new_items_header = ugettext_noop("New Items:")
+    limit_text = ugettext_lazy("items per page")
+    empty_notification = ugettext_lazy("You have no items.")
+    loading_message = ugettext_lazy("Loading...")
+    deleted_items_header = ugettext_lazy("Deleted Items:")
+    new_items_header = ugettext_lazy("New Items:")
 
     def _safe_escape(self, expression, default):
         try:

--- a/corehq/apps/importer/const.py
+++ b/corehq/apps/importer/const.py
@@ -1,13 +1,13 @@
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 
 class LookupErrors:
     NotFound, MultipleResults = range(2)
 
 
 class ImportErrors:
-    InvalidOwnerName = ugettext_noop('Invalid Owner Name')
-    InvalidOwnerId = ugettext_noop('Invalid Owner ID')
-    InvalidParentId = ugettext_noop('Invalid Parent ID')
-    InvalidDate = ugettext_noop('Invalid Date')
-    BlankExternalId = ugettext_noop('Blank External ID')
-    CaseGeneration = ugettext_noop('Case Generation Error')
+    InvalidOwnerName = ugettext_lazy('Invalid Owner Name')
+    InvalidOwnerId = ugettext_lazy('Invalid Owner ID')
+    InvalidParentId = ugettext_lazy('Invalid Parent ID')
+    InvalidDate = ugettext_lazy('Invalid Date')
+    BlankExternalId = ugettext_lazy('Blank External ID')
+    CaseGeneration = ugettext_lazy('Case Generation Error')

--- a/corehq/apps/indicators/forms.py
+++ b/corehq/apps/indicators/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_noop, ugettext as _
+from django.utils.translation import ugettext_lazy, ugettext as _
 
 # todo proper B3 Handle
 from crispy_forms import bootstrap as twbs
@@ -11,11 +11,11 @@ from corehq.apps.style.crispy import FormActions
 
 class ImportIndicatorsFromJsonFileForm(forms.Form):
     json_file = forms.FileField(
-        label=ugettext_noop("Exported File"),
+        label=ugettext_lazy("Exported File"),
         required=False,
     )
     override_existing = forms.BooleanField(
-        label=ugettext_noop("Override Existing Indicators"),
+        label=ugettext_lazy("Override Existing Indicators"),
         required=False,
     )
 

--- a/corehq/apps/indicators/views.py
+++ b/corehq/apps/indicators/views.py
@@ -4,7 +4,7 @@ from django.core.urlresolvers import reverse
 from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext_noop, ugettext as _
+from django.utils.translation import ugettext_lazy, ugettext as _
 from django.views.generic import TemplateView, View
 from tastypie.http import HttpBadRequest
 from corehq.apps.crud.views import BaseCRUDFormView
@@ -130,8 +130,8 @@ class BulkExportIndicatorsView(View):
 
 class BulkImportIndicatorsView(BaseSectionPageView, DomainViewMixin):
     urlname = 'indicators_upload_bulk'
-    section_name = ugettext_noop("Administer Indicators")
-    page_title = ugettext_noop("Bulk Import Indicators")
+    section_name = ugettext_lazy("Administer Indicators")
+    page_title = ugettext_lazy("Bulk Import Indicators")
     template_name = 'indicators/bulk_import.html'
 
     @method_decorator(login_and_domain_required)

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -7,7 +7,7 @@ from django.http.response import HttpResponseServerError
 from django.shortcuts import render
 from django.utils.decorators import method_decorator
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext as _, ugettext_noop
+from django.utils.translation import ugettext as _, ugettext_lazy
 from django.views.decorators.http import require_POST
 
 from couchdbkit import ResourceNotFound, MultipleResultsFound
@@ -72,7 +72,7 @@ class BaseLocationView(BaseDomainView):
 
 class LocationsListView(BaseLocationView):
     urlname = 'manage_locations'
-    page_title = ugettext_noop("Locations")
+    page_title = ugettext_lazy("Locations")
     template_name = 'locations/manage/locations.html'
 
     @property
@@ -109,7 +109,7 @@ class LocationFieldsView(CustomDataModelMixin, BaseLocationView):
 
 class LocationTypesView(BaseLocationView):
     urlname = 'location_types'
-    page_title = ugettext_noop("Location Types")
+    page_title = ugettext_lazy("Location Types")
     template_name = 'locations/settings.html'
 
     @method_decorator(can_edit_location_types)
@@ -259,7 +259,7 @@ class LocationTypesView(BaseLocationView):
 
 class NewLocationView(BaseLocationView):
     urlname = 'create_location'
-    page_title = ugettext_noop("New Location")
+    page_title = ugettext_lazy("New Location")
     template_name = 'locations/manage/location.html'
     creates_new_location = True
     form_tab = 'basic'
@@ -384,7 +384,7 @@ def unarchive_location(request, domain, loc_id):
 
 class EditLocationView(NewLocationView):
     urlname = 'edit_location'
-    page_title = ugettext_noop("Edit Location")
+    page_title = ugettext_lazy("Edit Location")
     creates_new_location = False
 
     @method_decorator(can_edit_location)
@@ -573,14 +573,14 @@ class BaseSyncView(BaseLocationView):
 class FacilitySyncView(BaseSyncView):
     urlname = 'sync_facilities'
     sync_urlname = 'sync_openlmis'
-    page_title = ugettext_noop("OpenLMIS")
+    page_title = ugettext_lazy("OpenLMIS")
     template_name = 'locations/facility_sync.html'
     source = 'openlmis'
 
 
 class LocationImportStatusView(BaseLocationView):
     urlname = 'location_import_status'
-    page_title = ugettext_noop('Location Import Status')
+    page_title = ugettext_lazy('Location Import Status')
     template_name = 'style/bootstrap2/soil_status_full.html'
 
     def get(self, request, *args, **kwargs):
@@ -601,7 +601,7 @@ class LocationImportStatusView(BaseLocationView):
 
 class LocationImportView(BaseLocationView):
     urlname = 'location_import'
-    page_title = ugettext_noop('Upload Locations from Excel')
+    page_title = ugettext_lazy('Upload Locations from Excel')
     template_name = 'locations/manage/import.html'
 
     @method_decorator(can_edit_any_location)

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -20,7 +20,6 @@ from soil.util import expose_cached_download, get_download_context
 
 from corehq import toggles
 from corehq.apps.commtrack.exceptions import MultipleSupplyPointException
-from corehq.apps.commtrack.models import SupplyPointCase
 from corehq.apps.commtrack.tasks import import_locations_async
 from corehq.apps.consumption.shortcuts import get_default_monthly_consumption
 from corehq.apps.custom_data_fields import CustomDataModelMixin

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -1,7 +1,7 @@
 from django.core.urlresolvers import reverse
 from django.shortcuts import redirect
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from casexml.apps.case.xml import V2
 from corehq import toggles
 from corehq.apps.domain.decorators import login_or_digest_ex, domain_admin_required
@@ -117,8 +117,8 @@ def historical_forms(request, domain):
 
 
 class PrimeRestoreCacheView(BaseB3SectionPageView, DomainViewMixin):
-    page_title = ugettext_noop("Prime Restore Cache")
-    section_name = ugettext_noop("Project Settings")
+    page_title = ugettext_lazy("Prime Restore Cache")
+    section_name = ugettext_lazy("Project Settings")
     urlname = 'prime_restore_cache'
     template_name = "ota/prime_restore_cache.html"
 

--- a/corehq/apps/products/forms.py
+++ b/corehq/apps/products/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 
 from corehq.apps.programs.models import Program
 from corehq.apps.products.models import Product
@@ -22,10 +22,10 @@ class CurrencyField(forms.DecimalField):
 
 class ProductForm(forms.Form):
     name = forms.CharField(max_length=100)
-    code = forms.CharField(label=ugettext_noop("Product ID"), max_length=10, required=False)
+    code = forms.CharField(label=ugettext_lazy("Product ID"), max_length=10, required=False)
     description = forms.CharField(max_length=500, required=False, widget=forms.Textarea)
-    unit = forms.CharField(label=ugettext_noop("Units"), max_length=100, required=False)
-    program_id = forms.ChoiceField(label=ugettext_noop("Program"), choices=(), required=True)
+    unit = forms.CharField(label=ugettext_lazy("Units"), max_length=100, required=False)
+    program_id = forms.ChoiceField(label=ugettext_lazy("Program"), choices=(), required=True)
     cost = CurrencyField(max_digits=8, decimal_places=2, required=False)
 
     def __init__(self, product, *args, **kwargs):

--- a/corehq/apps/products/views.py
+++ b/corehq/apps/products/views.py
@@ -9,7 +9,7 @@ from django.views.decorators.http import require_POST
 from django.core.urlresolvers import reverse
 from django.shortcuts import render
 from django.http import HttpResponse, HttpResponseRedirect, Http404
-from django.utils.translation import ugettext as _, ugettext_noop
+from django.utils.translation import ugettext as _, ugettext_lazy
 from django.contrib import messages
 from soil.exceptions import TaskFailedError
 from soil.util import expose_cached_download, get_download_context
@@ -82,7 +82,7 @@ class ProductListView(BaseCommTrackManageView):
     # todo mobile workers shares this type of view too---maybe there should be a class for this?
     urlname = 'commtrack_product_list'
     template_name = 'products/manage/products.html'
-    page_title = ugettext_noop("Products")
+    page_title = ugettext_lazy("Products")
 
     DEFAULT_LIMIT = 10
 
@@ -203,7 +203,7 @@ class FetchProductListView(ProductListView):
 
 class NewProductView(BaseCommTrackManageView):
     urlname = 'commtrack_product_new'
-    page_title = ugettext_noop("New Product")
+    page_title = ugettext_lazy("New Product")
     template_name = 'products/manage/product.html'
 
     @property
@@ -255,7 +255,7 @@ class NewProductView(BaseCommTrackManageView):
 
 class UploadProductView(BaseCommTrackManageView):
     urlname = 'commtrack_upload_products'
-    page_title = ugettext_noop("Import Products")
+    page_title = ugettext_lazy("Import Products")
     template_name = 'products/manage/upload_products.html'
 
     @property
@@ -306,7 +306,7 @@ class UploadProductView(BaseCommTrackManageView):
 
 class ProductImportStatusView(BaseCommTrackManageView):
     urlname = 'product_import_status'
-    page_title = ugettext_noop('Product Import Status')
+    page_title = ugettext_lazy('Product Import Status')
 
     def get(self, request, *args, **kwargs):
         context = super(ProductImportStatusView, self).main_context
@@ -425,7 +425,7 @@ def download_products(request, domain):
 
 class EditProductView(NewProductView):
     urlname = 'commtrack_product_edit'
-    page_title = ugettext_noop("Edit Product")
+    page_title = ugettext_lazy("Edit Product")
 
     @property
     def product_id(self):

--- a/corehq/apps/programs/views.py
+++ b/corehq/apps/programs/views.py
@@ -5,7 +5,7 @@ from django.contrib import messages
 from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.web import json_response
 from django.views.decorators.http import require_POST
-from django.utils.translation import ugettext as _, ugettext_noop
+from django.utils.translation import ugettext as _, ugettext_lazy
 from django.core.urlresolvers import reverse
 from corehq.apps.domain.decorators import domain_admin_required
 from corehq.apps.commtrack.views import BaseCommTrackManageView
@@ -30,7 +30,7 @@ def delete_program(request, domain, prog_id):
 class ProgramListView(BaseCommTrackManageView):
     urlname = 'commtrack_program_list'
     template_name = 'programs/manage/programs.html'
-    page_title = ugettext_noop("Programs")
+    page_title = ugettext_lazy("Programs")
 
 
 class FetchProgramListView(ProgramListView):
@@ -57,7 +57,7 @@ class FetchProgramListView(ProgramListView):
 
 class NewProgramView(BaseCommTrackManageView):
     urlname = 'commtrack_program_new'
-    page_title = ugettext_noop("New Program")
+    page_title = ugettext_lazy("New Program")
     template_name = 'programs/manage/program.html'
 
     @property
@@ -96,7 +96,7 @@ class NewProgramView(BaseCommTrackManageView):
 
 class EditProgramView(NewProgramView):
     urlname = 'commtrack_program_edit'
-    page_title = ugettext_noop("Edit Program")
+    page_title = ugettext_lazy("Edit Program")
 
     DEFAULT_LIMIT = 10
 

--- a/corehq/apps/receiverwrapper/filters.py
+++ b/corehq/apps/receiverwrapper/filters.py
@@ -1,7 +1,7 @@
 from corehq.apps.reports.filters.base import BaseReportFilter
 from corehq.apps.reports.models import HQToggle
 from django.utils.translation import ugettext as _
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 
 class SubmitToggle(HQToggle):
     
@@ -19,12 +19,12 @@ class SubmissionErrorType(object):
     ARCHIVED = 5
     
     doc_types = ["XFormInstance", "XFormError", "XFormDuplicate", "XFormDeprecated", "SubmissionErrorLog", "XFormArchived"]
-    human_readable = [ugettext_noop("Normal Form"),
-                      ugettext_noop("Form with Errors"),
-                      ugettext_noop("Duplicate Form"),
-                      ugettext_noop("Overwritten Form"),
-                      ugettext_noop("Generic Error"),
-                      ugettext_noop("Archived Form")]
+    human_readable = [ugettext_lazy("Normal Form"),
+                      ugettext_lazy("Form with Errors"),
+                      ugettext_lazy("Duplicate Form"),
+                      ugettext_lazy("Overwritten Form"),
+                      ugettext_lazy("Generic Error"),
+                      ugettext_lazy("Archived Form")]
     
     error_defaults = [False, True, False, False, True, False]
     success_defaults = [True, False, False, False, False, False]
@@ -58,7 +58,7 @@ class SubmissionTypeFilter(BaseReportFilter):
     # don't use this as an example / best practice
     # todo: cleanup
     slug = "submitfilter"
-    label = ugettext_noop("Submission Type")
+    label = ugettext_lazy("Submission Type")
     template = "reports/filters/submit_error_types.html"
 
     @property

--- a/corehq/apps/receiverwrapper/reports.py
+++ b/corehq/apps/receiverwrapper/reports.py
@@ -9,7 +9,7 @@ from corehq.apps.receiverwrapper.filters import SubmissionErrorType, \
     SubmissionTypeFilter
 from dimagi.utils.couch.pagination import FilteredPaginator, CouchFilter
 from corehq.apps.reports.display import xmlns_to_name
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from django.utils.translation import ugettext as _
 
 
@@ -39,7 +39,7 @@ class SubmitFilter(CouchFilter):
 
 
 class SubmissionErrorReport(DeploymentsReport):
-    name = ugettext_noop("Raw Forms, Errors & Duplicates")
+    name = ugettext_lazy("Raw Forms, Errors & Duplicates")
     slug = "submit_errors"
     ajax_pagination = True
     asynchronous = False

--- a/corehq/apps/reminders/event_handlers.py
+++ b/corehq/apps/reminders/event_handlers.py
@@ -24,17 +24,17 @@ from corehq.apps.app_manager.models import Form
 from corehq.apps.ivr.tasks import initiate_outbound_call
 from dimagi.utils.parsing import json_format_datetime
 from dimagi.utils.couch import CriticalSection
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from casexml.apps.case.models import CommCareCase
 from dimagi.utils.modules import to_function
 
-ERROR_RENDERING_MESSAGE = ugettext_noop("Error rendering templated message for language '%s'. Please check message syntax.")
-ERROR_NO_VERIFIED_NUMBER = ugettext_noop("Recipient has no phone number.")
-ERROR_NO_OTHER_NUMBERS = ugettext_noop("Recipient has no phone number.")
-ERROR_FORM = ugettext_noop("Can't load form. Please check configuration.")
-ERROR_NO_RECIPIENTS = ugettext_noop("No recipient(s).")
-ERROR_FINDING_CUSTOM_CONTENT_HANDLER = ugettext_noop("Error looking up custom content handler.")
-ERROR_INVALID_CUSTOM_CONTENT_HANDLER = ugettext_noop("Invalid custom content handler.")
+ERROR_RENDERING_MESSAGE = ugettext_lazy("Error rendering templated message for language '%s'. Please check message syntax.")
+ERROR_NO_VERIFIED_NUMBER = ugettext_lazy("Recipient has no phone number.")
+ERROR_NO_OTHER_NUMBERS = ugettext_lazy("Recipient has no phone number.")
+ERROR_FORM = ugettext_lazy("Can't load form. Please check configuration.")
+ERROR_NO_RECIPIENTS = ugettext_lazy("No recipient(s).")
+ERROR_FINDING_CUSTOM_CONTENT_HANDLER = ugettext_lazy("Error looking up custom content handler.")
+ERROR_INVALID_CUSTOM_CONTENT_HANDLER = ugettext_lazy("Invalid custom content handler.")
 
 
 """

--- a/corehq/apps/reminders/forms.py
+++ b/corehq/apps/reminders/forms.py
@@ -74,7 +74,7 @@ from corehq.util.timezones.forms import TimeZoneChoiceField
 from dateutil.parser import parse
 from dimagi.utils.excel import WorkbookJSONReader, WorksheetNotFound
 from openpyxl.shared.exc import InvalidFileException
-from django.utils.translation import ugettext as _, ugettext_noop
+from django.utils.translation import ugettext as _, ugettext_lazy
 from corehq.apps.app_manager.models import Form as CCHQForm
 from dimagi.utils.django.fields import TrimmedCharField
 from corehq.util.timezones.utils import get_timezone_for_user
@@ -247,9 +247,9 @@ def validate_phone_number(value):
 
 
 MATCH_TYPE_CHOICES = (
-    (MATCH_ANY_VALUE, ugettext_noop("exists.")),
-    (MATCH_EXACT, ugettext_noop("equals")),
-    (MATCH_REGEX, ugettext_noop("matches regular expression")),
+    (MATCH_ANY_VALUE, ugettext_lazy("exists.")),
+    (MATCH_EXACT, ugettext_lazy("equals")),
+    (MATCH_REGEX, ugettext_lazy("matches regular expression")),
 )
 
 START_REMINDER_ALL_CASES = 'start_all_cases'
@@ -279,9 +279,9 @@ class BaseScheduleCaseReminderForm(forms.Form):
     This form creates a new CaseReminder. It is the most basic version, no advanced options (like language).
     """
     nickname = forms.CharField(
-        label=ugettext_noop("Name"),
+        label=ugettext_lazy("Name"),
         error_messages={
-            'required': ugettext_noop("Please enter a name for this reminder."),
+            'required': ugettext_lazy("Please enter a name for this reminder."),
         }
     )
 
@@ -289,20 +289,20 @@ class BaseScheduleCaseReminderForm(forms.Form):
     # simple has start_condition_type = CASE_CRITERIA by default
     case_type = forms.CharField(
         required=False,
-        label=ugettext_noop("Send For Case Type"),
+        label=ugettext_lazy("Send For Case Type"),
     )
     start_reminder_on = forms.ChoiceField(
-        label=ugettext_noop("Send Reminder For"),
+        label=ugettext_lazy("Send Reminder For"),
         required=False,
         choices=(
-            (START_REMINDER_ALL_CASES, ugettext_noop("All Cases")),
-            (START_REMINDER_ON_CASE_PROPERTY, ugettext_noop("Only Cases in Following State")),
+            (START_REMINDER_ALL_CASES, ugettext_lazy("All Cases")),
+            (START_REMINDER_ON_CASE_PROPERTY, ugettext_lazy("Only Cases in Following State")),
         ),
     )
     ## send options > start_reminder_on = case_date
     start_property = forms.CharField(
         required=False,
-        label=ugettext_noop("Enter a Case Property"),
+        label=ugettext_lazy("Enter a Case Property"),
     )
     start_match_type = forms.ChoiceField(
         required=False,
@@ -311,16 +311,16 @@ class BaseScheduleCaseReminderForm(forms.Form):
     # only shows up if start_match_type != MATCH_ANY_VALUE
     start_value = forms.CharField(
         required=False,
-        label=ugettext_noop("Value")
+        label=ugettext_lazy("Value")
     )
     # this is a UI control that determines how start_offset is calculated (0 or an integer)
     start_property_offset_type = forms.ChoiceField(
         required=False,
         choices=(
-            (START_PROPERTY_OFFSET_IMMEDIATE, ugettext_noop("Immediately")),
-            (START_PROPERTY_OFFSET_DELAY, ugettext_noop("Delay By")),
-            (START_REMINDER_ON_CASE_DATE, ugettext_noop("Date in Case")),
-            (START_REMINDER_ON_DAY_OF_WEEK, ugettext_noop("Specific Day of Week")),
+            (START_PROPERTY_OFFSET_IMMEDIATE, ugettext_lazy("Immediately")),
+            (START_PROPERTY_OFFSET_DELAY, ugettext_lazy("Delay By")),
+            (START_REMINDER_ON_CASE_DATE, ugettext_lazy("Date in Case")),
+            (START_REMINDER_ON_DAY_OF_WEEK, ugettext_lazy("Specific Day of Week")),
         )
     )
     # becomes start_offset
@@ -331,25 +331,25 @@ class BaseScheduleCaseReminderForm(forms.Form):
     ## send options > start_reminder_on = case_property
     start_date = forms.CharField(
         required=False,
-        label=ugettext_noop("Enter a Case Property"),
+        label=ugettext_lazy("Enter a Case Property"),
     )
     start_date_offset_type = forms.ChoiceField(
         required=False,
         choices=(
-            (START_DATE_OFFSET_BEFORE, ugettext_noop("Before Date By")),
-            (START_DATE_OFFSET_AFTER, ugettext_noop("After Date By")),
+            (START_DATE_OFFSET_BEFORE, ugettext_lazy("Before Date By")),
+            (START_DATE_OFFSET_AFTER, ugettext_lazy("After Date By")),
         )
     )
     start_day_of_week = forms.ChoiceField(
         required=False,
         choices=(
-            (DAY_SUN, ugettext_noop("Sunday")),
-            (DAY_MON, ugettext_noop("Monday")),
-            (DAY_TUE, ugettext_noop("Tuesday")),
-            (DAY_WED, ugettext_noop("Wednesday")),
-            (DAY_THU, ugettext_noop("Thursday")),
-            (DAY_FRI, ugettext_noop("Friday")),
-            (DAY_SAT, ugettext_noop("Saturday")),
+            (DAY_SUN, ugettext_lazy("Sunday")),
+            (DAY_MON, ugettext_lazy("Monday")),
+            (DAY_TUE, ugettext_lazy("Tuesday")),
+            (DAY_WED, ugettext_lazy("Wednesday")),
+            (DAY_THU, ugettext_lazy("Thursday")),
+            (DAY_FRI, ugettext_lazy("Friday")),
+            (DAY_SAT, ugettext_lazy("Saturday")),
         )
     )
     # becomes start_offset
@@ -361,18 +361,18 @@ class BaseScheduleCaseReminderForm(forms.Form):
     # Fieldset: Recipient
     recipient = forms.ChoiceField(
         choices=(
-            (RECIPIENT_CASE, ugettext_noop("Case")),
-            (RECIPIENT_OWNER, ugettext_noop("Case Owner")),
-            (RECIPIENT_USER, ugettext_noop("Last User Who Modified Case")),
-            (RECIPIENT_USER_GROUP, ugettext_noop("Mobile Worker Group")),
-            (RECIPIENT_ALL_SUBCASES, ugettext_noop("All Child Cases")),
-            (RECIPIENT_SUBCASE, ugettext_noop("Specific Child Case")),
-            (RECIPIENT_PARENT_CASE, ugettext_noop("Parent Case")),
+            (RECIPIENT_CASE, ugettext_lazy("Case")),
+            (RECIPIENT_OWNER, ugettext_lazy("Case Owner")),
+            (RECIPIENT_USER, ugettext_lazy("Last User Who Modified Case")),
+            (RECIPIENT_USER_GROUP, ugettext_lazy("Mobile Worker Group")),
+            (RECIPIENT_ALL_SUBCASES, ugettext_lazy("All Child Cases")),
+            (RECIPIENT_SUBCASE, ugettext_lazy("Specific Child Case")),
+            (RECIPIENT_PARENT_CASE, ugettext_lazy("Parent Case")),
         ),
     )
     ## recipient = RECIPIENT_SUBCASE
     recipient_case_match_property = forms.CharField(
-        label=ugettext_noop("Enter a Case Property"),
+        label=ugettext_lazy("Enter a Case Property"),
         required=False
     )
     recipient_case_match_type = forms.ChoiceField(
@@ -380,46 +380,46 @@ class BaseScheduleCaseReminderForm(forms.Form):
         choices=MATCH_TYPE_CHOICES,
     )
     recipient_case_match_value = forms.CharField(
-        label=ugettext_noop("Value"),
+        label=ugettext_lazy("Value"),
         required=False
     )
     ## recipient = RECIPIENT_USER_GROUP
     user_group_id = ChoiceField(
         required=False,
-        label=ugettext_noop("Mobile Worker Group"),
+        label=ugettext_lazy("Mobile Worker Group"),
     )
 
     # Fieldset: Message Content
     method = forms.ChoiceField(
-        label=ugettext_noop("Send"),
+        label=ugettext_lazy("Send"),
         choices=(
-            (METHOD_SMS, ugettext_noop("SMS")),
+            (METHOD_SMS, ugettext_lazy("SMS")),
         ),
     )
 
     global_timeouts = forms.CharField(
-        label=ugettext_noop("Timeouts"),
+        label=ugettext_lazy("Timeouts"),
         required=False,
     )
 
     default_lang = forms.ChoiceField(
         required=False,
-        label=ugettext_noop("Default Language"),
+        label=ugettext_lazy("Default Language"),
         choices=(
-            ('en', ugettext_noop("English (en)")),
+            ('en', ugettext_lazy("English (en)")),
         )
     )
 
     event_timing = forms.ChoiceField(
-        label=ugettext_noop("Time of Day"),
+        label=ugettext_lazy("Time of Day"),
     )
 
     event_interpretation = forms.ChoiceField(
-        label=ugettext_noop("Schedule Type"),
+        label=ugettext_lazy("Schedule Type"),
         initial=EVENT_AS_OFFSET,
         choices=(
-            (EVENT_AS_OFFSET, ugettext_noop("Offset-based")),
-            (EVENT_AS_SCHEDULE, ugettext_noop("Schedule-based")),
+            (EVENT_AS_OFFSET, ugettext_lazy("Offset-based")),
+            (EVENT_AS_SCHEDULE, ugettext_lazy("Schedule-based")),
         ),
         widget=forms.HiddenInput  # validate as choice, but don't show the widget.
     )
@@ -433,46 +433,46 @@ class BaseScheduleCaseReminderForm(forms.Form):
     # Fieldset: Repeat
     repeat_type = forms.ChoiceField(
         required=False,
-        label=ugettext_noop("Repeat Reminder"),
+        label=ugettext_lazy("Repeat Reminder"),
         initial=REPEAT_TYPE_NO,
         choices=(
-            (REPEAT_TYPE_NO, ugettext_noop("No")),  # reminder_type = ONE_TIME
-            (REPEAT_TYPE_INDEFINITE, ugettext_noop("Indefinitely")),  # reminder_type = DEFAULT, max_iteration_count = -1
-            (REPEAT_TYPE_SPECIFIC, ugettext_noop("Specific Number of Times")),
+            (REPEAT_TYPE_NO, ugettext_lazy("No")),  # reminder_type = ONE_TIME
+            (REPEAT_TYPE_INDEFINITE, ugettext_lazy("Indefinitely")),  # reminder_type = DEFAULT, max_iteration_count = -1
+            (REPEAT_TYPE_SPECIFIC, ugettext_lazy("Specific Number of Times")),
         )
     )
     # shown if repeat_type != 'no_repeat'
     schedule_length = forms.IntegerField(
         required=False,
-        label=ugettext_noop("Repeat Every"),
+        label=ugettext_lazy("Repeat Every"),
     )
     # shown if repeat_type == 'specific' (0 if no_repeat, -1 if indefinite)
     max_iteration_count = forms.IntegerField(
         required=False,
-        label=ugettext_noop("Number of Times"),
+        label=ugettext_lazy("Number of Times"),
     )
     # shown if repeat_type != 'no_repeat'
     stop_condition = forms.ChoiceField(
         required=False,
         label="",
         choices=(
-            ('', ugettext_noop('(none)')),
-            (STOP_CONDITION_CASE_PROPERTY, ugettext_noop('Based on Case Property')),
+            ('', ugettext_lazy('(none)')),
+            (STOP_CONDITION_CASE_PROPERTY, ugettext_lazy('Based on Case Property')),
         )
     )
     until = forms.CharField(
         required=False,
-        label=ugettext_noop("Enter a Case Property"),
+        label=ugettext_lazy("Enter a Case Property"),
     )
 
     # Advanced Toggle
     submit_partial_forms = forms.BooleanField(
         required=False,
-        label=ugettext_noop("Submit Partial Forms"),
+        label=ugettext_lazy("Submit Partial Forms"),
     )
     include_case_side_effects = forms.BooleanField(
         required=False,
-        label=ugettext_noop("Include Case Changes for Partial Forms"),
+        label=ugettext_lazy("Include Case Changes for Partial Forms"),
     )
     # only show if SMS_SURVEY or IVR_SURVEY is chosen
     max_question_retries = forms.ChoiceField(
@@ -482,17 +482,17 @@ class BaseScheduleCaseReminderForm(forms.Form):
 
     force_surveys_to_use_triggered_case = forms.BooleanField(
         required=False,
-        label=ugettext_noop("For Surveys, force answers to affect "
+        label=ugettext_lazy("For Surveys, force answers to affect "
                               "case sending the survey."),
     )
 
     use_custom_content_handler = BooleanField(
         required=False,
-        label=ugettext_noop("Use Custom Content Handler")
+        label=ugettext_lazy("Use Custom Content Handler")
     )
     custom_content_handler = TrimmedCharField(
         required=False,
-        label=ugettext_noop("Please Specify Custom Content Handler")
+        label=ugettext_lazy("Please Specify Custom Content Handler")
     )
 
     def __init__(self, data=None, is_previewer=False,
@@ -1584,9 +1584,9 @@ class CaseReminderEventForm(forms.Form):
     """
     fire_time_type = forms.ChoiceField(
         choices=(
-            (FIRE_TIME_DEFAULT, ugettext_noop("Default")),
-            (FIRE_TIME_CASE_PROPERTY, ugettext_noop("Case Property")),  # not valid when method != EVENT_AS_SCHEDULE
-            (FIRE_TIME_RANDOM, ugettext_noop("Random")),  # not valid when method != EVENT_AS_SCHEDULE
+            (FIRE_TIME_DEFAULT, ugettext_lazy("Default")),
+            (FIRE_TIME_CASE_PROPERTY, ugettext_lazy("Case Property")),  # not valid when method != EVENT_AS_SCHEDULE
+            (FIRE_TIME_RANDOM, ugettext_lazy("Random")),  # not valid when method != EVENT_AS_SCHEDULE
         ),
         widget=forms.HiddenInput,  # don't actually display this widget to the user for now, but validate as choice
     )
@@ -1602,17 +1602,17 @@ class CaseReminderEventForm(forms.Form):
     # EVENT_AS_SCHEDULE: time of day
     fire_time = forms.TimeField(
         required=False,
-        label=ugettext_noop("HH:MM:SS"),
+        label=ugettext_lazy("HH:MM:SS"),
     )
 
     # method must be EVENT_AS_SCHEDULE
     fire_time_aux = forms.CharField(
         required=False,
-        label=ugettext_noop("Enter a Case Property"),
+        label=ugettext_lazy("Enter a Case Property"),
     )
 
     time_window_length = forms.IntegerField(
-        label=ugettext_noop("Window Length (minutes)"),
+        label=ugettext_lazy("Window Length (minutes)"),
         required=False
     )
 
@@ -1626,7 +1626,7 @@ class CaseReminderEventForm(forms.Form):
     # form_unique_id is visible when the method of the reminder is SMS_SURVEY or IVR_SURVEY
     form_unique_id = forms.CharField(
         required=False,
-        label=ugettext_noop("Survey"),
+        label=ugettext_lazy("Survey"),
     )
 
     callback_timeout_intervals = forms.CharField(
@@ -2022,84 +2022,84 @@ class RemindersInErrorForm(Form):
 class KeywordForm(Form):
     _cchq_domain = None
     _sk_id = None
-    keyword = CharField(label=ugettext_noop("Keyword"))
-    description = TrimmedCharField(label=ugettext_noop("Description"))
+    keyword = CharField(label=ugettext_lazy("Keyword"))
+    description = TrimmedCharField(label=ugettext_lazy("Description"))
     override_open_sessions = BooleanField(
         required=False,
         initial=False,
-        label=ugettext_noop("Override open SMS Surveys"),
+        label=ugettext_lazy("Override open SMS Surveys"),
     )
     allow_keyword_use_by = ChoiceField(
         required=False,
-        label=ugettext_noop("Allow Keyword Use By"),
+        label=ugettext_lazy("Allow Keyword Use By"),
         initial='any',
         choices=(
-            ('any', ugettext_noop("Both Mobile Workers and Cases")),
-            ('users', ugettext_noop("Mobile Workers Only")),
-            ('cases', ugettext_noop("Cases Only")),
+            ('any', ugettext_lazy("Both Mobile Workers and Cases")),
+            ('users', ugettext_lazy("Mobile Workers Only")),
+            ('cases', ugettext_lazy("Cases Only")),
         )
     )
     sender_content_type = ChoiceField(
-        label=ugettext_noop("Send to Sender"),
+        label=ugettext_lazy("Send to Sender"),
     )
     sender_message = TrimmedCharField(
         required=False,
-        label=ugettext_noop("Message"),
+        label=ugettext_lazy("Message"),
     )
     sender_form_unique_id = ChoiceField(
         required=False,
-        label=ugettext_noop("Survey"),
+        label=ugettext_lazy("Survey"),
     )
     other_recipient_content_type = ChoiceField(
         required=False,
-        label=ugettext_noop("Notify Another Person"),
+        label=ugettext_lazy("Notify Another Person"),
         initial=NO_RESPONSE,
     )
     other_recipient_type = ChoiceField(
         required=False,
         initial=False,
-        label=ugettext_noop("Recipient"),
+        label=ugettext_lazy("Recipient"),
         choices=KEYWORD_RECIPIENT_CHOICES,
     )
     other_recipient_id = ChoiceField(
         required=False,
-        label=ugettext_noop("Group Name"),
+        label=ugettext_lazy("Group Name"),
     )
     other_recipient_message = TrimmedCharField(
         required=False,
-        label=ugettext_noop("Message"),
+        label=ugettext_lazy("Message"),
     )
     other_recipient_form_unique_id = ChoiceField(
         required=False,
-        label=ugettext_noop("Survey"),
+        label=ugettext_lazy("Survey"),
     )
     process_structured_sms = BooleanField(
         required=False,
-        label=ugettext_noop("Process incoming keywords as a Structured Message"),
+        label=ugettext_lazy("Process incoming keywords as a Structured Message"),
     )
     structured_sms_form_unique_id = ChoiceField(
         required=False,
-        label=ugettext_noop("Survey"),
+        label=ugettext_lazy("Survey"),
     )
     use_custom_delimiter = BooleanField(
         required=False,
-        label=ugettext_noop("Use Custom Delimiter"),
+        label=ugettext_lazy("Use Custom Delimiter"),
     )
     delimiter = TrimmedCharField(
         required=False,
-        label=ugettext_noop("Please Specify Delimiter"),
+        label=ugettext_lazy("Please Specify Delimiter"),
     )
     use_named_args_separator = BooleanField(
         required=False,
-        label=ugettext_noop("Use Joining Character"),
+        label=ugettext_lazy("Use Joining Character"),
     )
     use_named_args = BooleanField(
         required=False,
-        label=ugettext_noop("Use Named Answers"),
+        label=ugettext_lazy("Use Named Answers"),
     )
     named_args_separator = TrimmedCharField(
         required=False,
-        label=ugettext_noop("Please Specify Joining Characcter"),
+        label=ugettext_lazy("Please Specify Joining Characcter"),
     )
     named_args = RecordListField(
         input_name="named_args",

--- a/corehq/apps/reminders/views.py
+++ b/corehq/apps/reminders/views.py
@@ -14,7 +14,7 @@ from corehq.const import SERVER_DATETIME_FORMAT
 from corehq.util.timezones.conversions import ServerTime
 from dimagi.utils.couch.cache.cache_core import get_redis_client
 from dimagi.utils.couch import CriticalSection
-from django.utils.translation import ugettext as _, ugettext_noop
+from django.utils.translation import ugettext as _, ugettext_lazy
 from corehq import privileges
 from corehq.apps.accounting.decorators import requires_privilege_with_fallback
 from corehq.apps.app_manager.models import Application, Form
@@ -341,7 +341,7 @@ def scheduled_reminders(request, domain, template="reminders/partial/scheduled_r
 
 class CreateScheduledReminderView(BaseMessagingSectionView):
     urlname = 'create_reminder_schedule'
-    page_title = ugettext_noop("Schedule Reminder")
+    page_title = ugettext_lazy("Schedule Reminder")
     template_name = 'reminders/manage_scheduled_reminder.html'
     ui_type = UI_SIMPLE_FIXED
 
@@ -576,13 +576,13 @@ class CreateScheduledReminderView(BaseMessagingSectionView):
 
 class CreateComplexScheduledReminderView(CreateScheduledReminderView):
     urlname = 'create_complex_reminder_schedule'
-    page_title = ugettext_noop("Schedule Multi Event Reminder")
+    page_title = ugettext_lazy("Schedule Multi Event Reminder")
     ui_type = UI_COMPLEX
 
 
 class EditScheduledReminderView(CreateScheduledReminderView):
     urlname = 'edit_reminder_schedule'
-    page_title = ugettext_noop("Edit Scheduled Reminder")
+    page_title = ugettext_lazy("Edit Scheduled Reminder")
 
     @property
     def handler_id(self):
@@ -693,7 +693,7 @@ class EditScheduledReminderView(CreateScheduledReminderView):
 
 class AddStructuredKeywordView(BaseMessagingSectionView):
     urlname = 'add_structured_keyword'
-    page_title = ugettext_noop("New Structured Keyword")
+    page_title = ugettext_lazy("New Structured Keyword")
     template_name = 'reminders/keyword.html'
     process_structured_message = True
 
@@ -789,13 +789,13 @@ class AddStructuredKeywordView(BaseMessagingSectionView):
 
 class AddNormalKeywordView(AddStructuredKeywordView):
     urlname = 'add_normal_keyword'
-    page_title = ugettext_noop("New Keyword")
+    page_title = ugettext_lazy("New Keyword")
     process_structured_message = False
 
 
 class EditStructuredKeywordView(AddStructuredKeywordView):
     urlname = 'edit_structured_keyword'
-    page_title = ugettext_noop("Edit Structured Keyword")
+    page_title = ugettext_lazy("Edit Structured Keyword")
 
     @property
     def page_url(self):
@@ -879,7 +879,7 @@ class EditStructuredKeywordView(AddStructuredKeywordView):
 
 class EditNormalKeywordView(EditStructuredKeywordView):
     urlname = 'edit_normal_keyword'
-    page_title = ugettext_noop("Edit Normal Keyword")
+    page_title = ugettext_lazy("Edit Normal Keyword")
     process_structured_message = False
 
     @property
@@ -1331,7 +1331,7 @@ def reminders_in_error(request, domain):
 class RemindersListView(BaseMessagingSectionView):
     template_name = 'reminders/reminders_list.html'
     urlname = "list_reminders_new"
-    page_title = ugettext_noop("Reminder Definitions")
+    page_title = ugettext_lazy("Reminder Definitions")
 
     @property
     def page_url(self):
@@ -1416,11 +1416,11 @@ class RemindersListView(BaseMessagingSectionView):
 class KeywordsListView(BaseMessagingSectionView, CRUDPaginatedViewMixin):
     template_name = 'reminders/keyword_list.html'
     urlname = 'keyword_list'
-    page_title = ugettext_noop("Keywords")
+    page_title = ugettext_lazy("Keywords")
 
-    limit_text = ugettext_noop("keywords per page")
-    empty_notification = ugettext_noop("You have no keywords. Please add one!")
-    loading_message = ugettext_noop("Loading keywords...")
+    limit_text = ugettext_lazy("keywords per page")
+    empty_notification = ugettext_lazy("You have no keywords. Please add one!")
+    loading_message = ugettext_lazy("Loading keywords...")
 
     @property
     def page_url(self):

--- a/corehq/apps/reports/__init__.py
+++ b/corehq/apps/reports/__init__.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_noop as _
+from django.utils.translation import ugettext_lazy as _
 
 
 # this is just here to mark some strings from settings for translation

--- a/corehq/apps/reports/commconnect/system_overview.py
+++ b/corehq/apps/reports/commconnect/system_overview.py
@@ -1,5 +1,5 @@
 from django.utils.translation import ugettext as _
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from corehq.apps.reminders.models import REMINDER_TYPE_ONE_TIME
 from corehq.apps.reports.commconnect import div, CommConnectReport
 from corehq.apps.reports.datatables import DataTablesHeader, DataTablesColumn, DataTablesColumnGroup
@@ -20,9 +20,9 @@ class BaseSystemOverviewReport(CommConnectReport):
 
 class SystemOverviewReport(BaseSystemOverviewReport):
     slug = 'system_overview'
-    name = ugettext_noop("Overview")
-    description = ugettext_noop("Summary of the different types of messages sent and received by the system.")
-    section_name = ugettext_noop("Overview")
+    name = ugettext_lazy("Overview")
+    description = ugettext_lazy("Summary of the different types of messages sent and received by the system.")
+    section_name = ugettext_lazy("Overview")
 
     def workflow_query(self, workflow=None, additional_facets=None):
         additional_facets = additional_facets or []
@@ -124,9 +124,9 @@ class SystemOverviewReport(BaseSystemOverviewReport):
 
 class SystemUsersReport(BaseSystemOverviewReport):
     slug = 'user_summary'
-    name = ugettext_noop("User Summary")
-    description = ugettext_noop("Summary of recipient information including number of active recipients and  message usage by type of recipient (case vs. mobile worker)")
-    section_name = ugettext_noop("User Summary")
+    name = ugettext_lazy("User Summary")
+    description = ugettext_lazy("Summary of recipient information including number of active recipients and  message usage by type of recipient (case vs. mobile worker)")
+    section_name = ugettext_lazy("User Summary")
 
     def active_query(self, recipient_type):
         q = self.base_query

--- a/corehq/apps/reports/commtrack/maps.py
+++ b/corehq/apps/reports/commtrack/maps.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from corehq.apps.products.models import Product
 from django.template.loader import render_to_string
 from corehq.apps.reports.commtrack.standard import CommtrackReportMixin
@@ -6,7 +6,7 @@ from corehq.apps.reports.standard.maps import GenericMapReport
 
 
 class StockStatusMapReport(GenericMapReport, CommtrackReportMixin):
-    name = ugettext_noop("Stock Status (map)")
+    name = ugettext_lazy("Stock Status (map)")
     slug = "stockstatus_map"
 
     fields = [
@@ -138,7 +138,7 @@ class StockStatusMapReport(GenericMapReport, CommtrackReportMixin):
 
 
 class ReportingStatusMapReport(GenericMapReport, CommtrackReportMixin):
-    name = ugettext_noop("Reporting Status (map)")
+    name = ugettext_lazy("Reporting Status (map)")
     slug = "reportingstatus_map"
 
     fields = [

--- a/corehq/apps/reports/commtrack/standard.py
+++ b/corehq/apps/reports/commtrack/standard.py
@@ -9,7 +9,7 @@ from corehq.apps.reports.filters.commtrack import SelectReportingType
 from dimagi.utils.couch.loosechange import map_reduce
 from corehq.apps.locations.models import Location, SQLLocation
 from dimagi.utils.decorators.memoized import memoized
-from django.utils.translation import ugettext as _, ugettext_noop
+from django.utils.translation import ugettext as _, ugettext_lazy
 from corehq.apps.reports.commtrack.util import get_relevant_supply_point_ids, product_ids_filtered_by_program
 from corehq.apps.reports.commtrack.const import STOCK_SECTION_TYPE
 from corehq.apps.reports.filters.commtrack import AdvancedColumns
@@ -72,7 +72,7 @@ class CommtrackReportMixin(ProjectReport, ProjectReportParametersMixin, Datespan
 
 
 class CurrentStockStatusReport(GenericTabularReport, CommtrackReportMixin):
-    name = ugettext_noop('Stock Status by Product')
+    name = ugettext_lazy('Stock Status by Product')
     slug = 'current_stock_status'
     fields = [
         'corehq.apps.reports.filters.fixtures.AsyncLocationFilter',
@@ -212,9 +212,9 @@ class CurrentStockStatusReport(GenericTabularReport, CommtrackReportMixin):
 
 
 class SimplifiedInventoryReport(GenericTabularReport, CommtrackReportMixin):
-    name = ugettext_noop('Inventory by Location')
+    name = ugettext_lazy('Inventory by Location')
     slug = SimplifiedInventoryDataSource.slug
-    special_notice = ugettext_noop('A maximum of 100 locations will be shown. Filter by location if you need to see more.')
+    special_notice = ugettext_lazy('A maximum of 100 locations will be shown. Filter by location if you need to see more.')
     exportable = True
     emailable = True
     fields = [
@@ -267,7 +267,7 @@ class SimplifiedInventoryReport(GenericTabularReport, CommtrackReportMixin):
 
 
 class InventoryReport(GenericTabularReport, CommtrackReportMixin):
-    name = ugettext_noop('Aggregate Inventory')
+    name = ugettext_lazy('Aggregate Inventory')
     slug = StockStatusDataSource.slug
     fields = [
         'corehq.apps.reports.filters.fixtures.AsyncLocationFilter',
@@ -358,7 +358,7 @@ class InventoryReport(GenericTabularReport, CommtrackReportMixin):
 
 
 class ReportingRatesReport(GenericTabularReport, CommtrackReportMixin):
-    name = ugettext_noop('Reporting Rate')
+    name = ugettext_lazy('Reporting Rate')
     slug = 'reporting_rate'
     fields = [
         'corehq.apps.reports.filters.fixtures.AsyncLocationFilter',

--- a/corehq/apps/reports/dont_use/fields.py
+++ b/corehq/apps/reports/dont_use/fields.py
@@ -11,7 +11,7 @@ from corehq.apps.reports import util
 from corehq.apps.groups.models import Group
 from corehq.apps.reports.filters.users import get_user_toggle
 from corehq.apps.reports.models import HQUserType
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from django.utils.translation import ugettext as _
 import uuid
 from corehq.apps.users.models import WebUser
@@ -49,9 +49,9 @@ class ReportField(object):
 
 class ReportSelectField(ReportField):
     slug = "generic_select"
-    name = ugettext_noop("Generic Select")
+    name = ugettext_lazy("Generic Select")
     template = "reports/dont_use_fields/select_generic.html"
-    default_option = ugettext_noop("Select Something...")
+    default_option = ugettext_lazy("Select Something...")
     options = [dict(val="val", text="text")]
     cssId = "generic_select_box"
     cssClasses = "span4"
@@ -107,7 +107,7 @@ class FilterUsersField(ReportField):
 
 class SelectMobileWorkerMixin(object):
     slug = "select_mw"
-    name = ugettext_noop("Select Mobile Worker")
+    name = ugettext_lazy("Select Mobile Worker")
 
     @classmethod
     def get_default_text(cls, user_filter, default_option=None):
@@ -120,7 +120,7 @@ class SelectMobileWorkerMixin(object):
 
 class SelectMobileWorkerField(SelectMobileWorkerMixin, ReportField):
     template = "reports/dont_use_fields/select_mobile_worker.html"
-    default_option = ugettext_noop("All Mobile Workers")
+    default_option = ugettext_lazy("All Mobile Workers")
     filter_users_field_class = FilterUsersField
 
     def __init__(self, request, domain=None, timezone=pytz.utc, parent_report=None, filter_users_field_class=None):
@@ -153,9 +153,9 @@ class SelectFilteredMobileWorkerField(SelectMobileWorkerField):
         is selected.
     """
     slug = "select_filtered_mw"
-    name = ugettext_noop("Select Mobile Worker")
+    name = ugettext_lazy("Select Mobile Worker")
     template = "reports/dont_use_fields/select_filtered_mobile_worker.html"
-    default_option = ugettext_noop("All Mobile Workers...")
+    default_option = ugettext_lazy("All Mobile Workers...")
 
     # Whether to display both the default option and "Only <group> Mobile
     # Workers" or just the default option (useful when using a single
@@ -216,7 +216,7 @@ class UserOrGroupField(ReportSelectField):
         To Use: Subclass and specify what the field options should be
     """
     slug = "view_by"
-    name = ugettext_noop("View by Users or Groups")
+    name = ugettext_lazy("View by Users or Groups")
     cssId = "view_by_select"
     cssClasses = "span2"
     default_option = "Users"
@@ -228,7 +228,7 @@ class UserOrGroupField(ReportSelectField):
 
 class SelectProgramField(ReportSelectField):
     slug = "program"
-    name = ugettext_noop("Program")
+    name = ugettext_lazy("Program")
     cssId = "program_select"
     default_option = 'All'
 
@@ -246,7 +246,7 @@ class SelectProgramField(ReportSelectField):
 
 class GroupFieldMixin():
     slug = "group"
-    name = ugettext_noop("Group")
+    name = ugettext_lazy("Group")
     cssId = "group_select"
 
 

--- a/corehq/apps/reports/filters/base.py
+++ b/corehq/apps/reports/filters/base.py
@@ -3,7 +3,7 @@ from django.template.loader import render_to_string
 from dimagi.utils.decorators.memoized import memoized
 # For translations
 from django.utils.translation import ugettext as _
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 
 
 class BaseReportFilter(object):
@@ -93,7 +93,7 @@ class BaseSingleOptionFilter(BaseReportFilter):
         Displays a select field.
     """
     template = "reports/filters/single_option.html"
-    default_text = ugettext_noop("Filter by...")
+    default_text = ugettext_lazy("Filter by...")
     placeholder = ''
     is_paginated = False
     pagination_source = None  # url for paginated data
@@ -189,7 +189,7 @@ class BaseDrilldownOptionFilter(BaseReportFilter):
     """
     template = "reports/filters/drilldown_options.html"
     use_only_last = False
-    drilldown_empty_text = ugettext_noop("No Data Available")
+    drilldown_empty_text = ugettext_lazy("No Data Available")
     is_cacheable = True
 
     @property

--- a/corehq/apps/reports/filters/commtrack.py
+++ b/corehq/apps/reports/filters/commtrack.py
@@ -1,5 +1,5 @@
 from corehq.apps.reports.filters.base import BaseSingleOptionFilter, CheckboxFilter
-from django.utils.translation import ugettext_lazy, ugettext_lazy
+from django.utils.translation import ugettext_lazy
 
 
 class SelectReportingType(BaseSingleOptionFilter):

--- a/corehq/apps/reports/filters/commtrack.py
+++ b/corehq/apps/reports/filters/commtrack.py
@@ -1,11 +1,11 @@
 from corehq.apps.reports.filters.base import BaseSingleOptionFilter, CheckboxFilter
-from django.utils.translation import ugettext_lazy, ugettext_noop
+from django.utils.translation import ugettext_lazy, ugettext_lazy
 
 
 class SelectReportingType(BaseSingleOptionFilter):
     slug = "report_type"
-    label = ugettext_noop("Reporting data type")
-    default_text = ugettext_noop("Show aggregate data")
+    label = ugettext_lazy("Reporting data type")
+    default_text = ugettext_lazy("Show aggregate data")
 
     @property
     def options(self):

--- a/corehq/apps/reports/filters/devicelog.py
+++ b/corehq/apps/reports/filters/devicelog.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from corehq.apps.reports.filters.base import BaseReportFilter
 from corehq.util.queries import fast_distinct
 from phonelog.models import DeviceReportEntry
@@ -7,7 +7,7 @@ from phonelog.models import DeviceReportEntry
 class DeviceLogTagFilter(BaseReportFilter):
     # todo: clean this up
     slug = "logtag"
-    label = ugettext_noop("Filter Logs by Tag")
+    label = ugettext_lazy("Filter Logs by Tag")
     errors_only_slug = "errors_only"
     template = "reports/filters/devicelog_tags.html"
 
@@ -36,7 +36,7 @@ class BaseDeviceLogFilter(BaseReportFilter):
     slug = "logfilter"
     template = "reports/filters/devicelog_filter.html"
     field = None
-    label = ugettext_noop("Filter Logs By")
+    label = ugettext_lazy("Filter Logs By")
     url_param_map = {'Unknown': None}
 
     def get_filters(self, selected):
@@ -76,11 +76,11 @@ class BaseDeviceLogFilter(BaseReportFilter):
 
 class DeviceLogUsersFilter(BaseDeviceLogFilter):
     slug = "loguser"
-    label = ugettext_noop("Filter Logs by Username")
+    label = ugettext_lazy("Filter Logs by Username")
     field = 'username'
 
 
 class DeviceLogDevicesFilter(BaseDeviceLogFilter):
     slug = "logdevice"
-    label = ugettext_noop("Filter Logs by Device")
+    label = ugettext_lazy("Filter Logs by Device")
     field = 'device_id'

--- a/corehq/apps/reports/filters/fixtures.py
+++ b/corehq/apps/reports/filters/fixtures.py
@@ -1,6 +1,6 @@
 import json
 from django.core.urlresolvers import reverse
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from corehq import Domain
 from corehq.apps.fixtures.models import FixtureDataType, FixtureDataItem
 from corehq.apps.locations.util import load_locs_json, location_hierarchy_config
@@ -102,7 +102,7 @@ class AsyncDrillableFilter(BaseReportFilter):
 
 class AsyncLocationFilter(BaseReportFilter):
     # todo: cleanup template
-    label = ugettext_noop("Location")
+    label = ugettext_lazy("Location")
     slug = "location_async"
     template = "reports/filters/location_async.html"
 

--- a/corehq/apps/reports/filters/forms.py
+++ b/corehq/apps/reports/filters/forms.py
@@ -9,7 +9,7 @@ from dimagi.utils.decorators.memoized import memoized
 
 # For translations
 from django.utils.translation import ugettext as _
-from django.utils.translation import ugettext_noop, ugettext_lazy
+from django.utils.translation import ugettext_lazy, ugettext_lazy
 import settings
 
 REMOTE_APP_WILDCARD = "http://(.+).commcarehq.org"
@@ -698,7 +698,7 @@ class SingleFormByApplicationFilter(FormsByApplicationFilter):
     """
         Same as its superclass, except you _must_ select one form by the end of it.
     """
-    label = ugettext_noop("Choose a Form")
+    label = ugettext_lazy("Choose a Form")
     use_only_last = True
     show_global_hide_fuzzy_checkbox = False
 
@@ -720,11 +720,11 @@ class SingleFormByApplicationFilter(FormsByApplicationFilter):
 
 class CompletionOrSubmissionTimeFilter(BaseSingleOptionFilter):
     slug = "sub_time"
-    label = ugettext_noop("Filter Dates By")
+    label = ugettext_lazy("Filter Dates By")
     css_class = "span2"
-    help_text = mark_safe("%s<br />%s" % (ugettext_noop("<strong>Completion</strong> time is when the form is completed on the phone."),
-                                          ugettext_noop("<strong>Submission</strong> time is when CommCare HQ receives the form.")))
-    default_text = ugettext_noop("Completion Time")
+    help_text = mark_safe("%s<br />%s" % (ugettext_lazy("<strong>Completion</strong> time is when the form is completed on the phone."),
+                                          ugettext_lazy("<strong>Submission</strong> time is when CommCare HQ receives the form.")))
+    default_text = ugettext_lazy("Completion Time")
 
     @property
     def options(self):
@@ -738,7 +738,7 @@ class FormDataFilter(BaseTagsFilter):
     label = "Form Data"
     advanced = True
     help_text = "Filter by the value of a question in the form. Exact matches only."
-    placeholder = ugettext_noop("question id:value")
+    placeholder = ugettext_lazy("question id:value")
 
 
 class CustomFieldFilter(BaseTagsFilter):
@@ -746,4 +746,4 @@ class CustomFieldFilter(BaseTagsFilter):
     label = "Columns"
     advanced = True
     help_text = "Question ids entered here will appear as additonal columns in the report."
-    placeholder = ugettext_noop("question id")
+    placeholder = ugettext_lazy("question id")

--- a/corehq/apps/reports/filters/forms.py
+++ b/corehq/apps/reports/filters/forms.py
@@ -9,7 +9,7 @@ from dimagi.utils.decorators.memoized import memoized
 
 # For translations
 from django.utils.translation import ugettext as _
-from django.utils.translation import ugettext_lazy, ugettext_lazy
+from django.utils.translation import ugettext_lazy
 import settings
 
 REMOTE_APP_WILDCARD = "http://(.+).commcarehq.org"

--- a/corehq/apps/reports/filters/search.py
+++ b/corehq/apps/reports/filters/search.py
@@ -1,19 +1,18 @@
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from corehq.apps.reports.filters.base import BaseReportFilter
 
 
 class SearchFilter(BaseReportFilter):
     slug = "search_query"
     template = "reports/filters/search.html"
-    label = ugettext_noop("Search")
+    label = ugettext_lazy("Search")
 
-    #bubble help, should be noop'ed
+    # bubble help, should use ugettext_lazy
     search_help_title = None
     search_help_content = None
 
-    #inline help text, should be noop'ed
+    # inline help text, should use ugettext_lazy
     search_help_inline = None
-
 
     @property
     def filter_context(self):

--- a/corehq/apps/reports/filters/select.py
+++ b/corehq/apps/reports/filters/select.py
@@ -2,8 +2,7 @@ import datetime
 import calendar
 
 from django.conf import settings
-from django.utils.translation import ugettext_noop, ugettext_lazy
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy, ugettext as _
 from corehq.apps.casegroups.dbaccessors import get_case_group_meta_in_domain
 
 from corehq.apps.hqcase.dbaccessors import get_case_types_for_domain
@@ -17,8 +16,8 @@ from corehq.apps.reports.filters.base import BaseSingleOptionFilter, BaseMultipl
 
 class SelectRegionFilter(BaseSingleOptionFilter):
     slug = "region"
-    label = ugettext_noop("Region")
-    default_text = ugettext_noop("All Regions")
+    label = ugettext_lazy("Region")
+    default_text = ugettext_lazy("All Regions")
 
     @property
     def options(self):
@@ -31,8 +30,8 @@ class SelectRegionFilter(BaseSingleOptionFilter):
 
 class SelectLicenseFilter(BaseSingleOptionFilter):
     slug = "license"
-    label = ugettext_noop("License")
-    default_text = ugettext_noop("All Licenses")
+    label = ugettext_lazy("License")
+    default_text = ugettext_lazy("All Licenses")
 
     @property
     def options(self):
@@ -41,8 +40,8 @@ class SelectLicenseFilter(BaseSingleOptionFilter):
 
 class SelectCategoryFilter(BaseSingleOptionFilter):
     slug = "category"
-    label = ugettext_noop("Category")
-    default_text = ugettext_noop("All Categories")
+    label = ugettext_lazy("Category")
+    default_text = ugettext_lazy("All Categories")
 
     @property
     def options(self):
@@ -55,8 +54,8 @@ class SelectCategoryFilter(BaseSingleOptionFilter):
 
 class SelectOrganizationFilter(BaseSingleOptionFilter):
     slug = "org"
-    label = ugettext_noop("Organization")
-    default_text = ugettext_noop("All Organizations")
+    label = ugettext_lazy("Organization")
+    default_text = ugettext_lazy("All Organizations")
 
     @property
     def options(self):
@@ -66,7 +65,7 @@ class SelectOrganizationFilter(BaseSingleOptionFilter):
 class GroupFilterMixin(object):
     slug = "group"
     label = ugettext_lazy("Group")
-    default_text = ugettext_noop("Everybody")
+    default_text = ugettext_lazy("Everybody")
 
     @property
     def options(self):
@@ -74,16 +73,16 @@ class GroupFilterMixin(object):
 
 
 class GroupFilter(GroupFilterMixin, BaseSingleOptionFilter):
-    placeholder = ugettext_noop('Click to select a group')
+    placeholder = ugettext_lazy('Click to select a group')
 
 
 class MultiGroupFilter(GroupFilterMixin, BaseMultipleOptionFilter):
-    placeholder = ugettext_noop('Click to select groups')
+    placeholder = ugettext_lazy('Click to select groups')
 
 
 class YearFilter(BaseSingleOptionFilter):
     slug = "year"
-    label = ugettext_noop("Year")
+    label = ugettext_lazy("Year")
     default_text = None
 
     @property
@@ -96,7 +95,7 @@ class YearFilter(BaseSingleOptionFilter):
 
 class MonthFilter(BaseSingleOptionFilter):
     slug = "month"
-    label = ugettext_noop("Month")
+    label = ugettext_lazy("Month")
     default_text = None
 
     @property
@@ -116,15 +115,17 @@ class CaseTypeMixin(object):
 
 
 class CaseTypeFilter(CaseTypeMixin, BaseSingleOptionFilter):
-    placeholder = ugettext_noop('Click to select a case type')
+    placeholder = ugettext_lazy('Click to select a case type')
+
 
 class MultiCaseTypeFilter(CaseTypeMixin, BaseMultipleOptionFilter):
-    placeholder = ugettext_noop('Click to select case types')
+    placeholder = ugettext_lazy('Click to select case types')
+
 
 class SelectOpenCloseFilter(BaseSingleOptionFilter):
     slug = "is_open"
-    label = ugettext_noop("Opened / Closed")
-    default_text = ugettext_noop("Show All")
+    label = ugettext_lazy("Opened / Closed")
+    default_text = ugettext_lazy("Show All")
 
     @property
     def options(self):
@@ -154,9 +155,9 @@ class SelectApplicationFilter(BaseSingleOptionFilter):
 
 class MultiCaseGroupFilter(BaseMultipleOptionFilter):
     slug = "case_group"
-    label = ugettext_noop("Case Group")
-    default_text = ugettext_noop("All Case Groups")
-    placeholder = ugettext_noop('Click to select case groups')
+    label = ugettext_lazy("Case Group")
+    default_text = ugettext_lazy("All Case Groups")
+    placeholder = ugettext_lazy('Click to select case groups')
 
     @property
     def options(self):

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -1,5 +1,5 @@
 from django.core.urlresolvers import reverse
-from django.utils.translation import ugettext_noop, ugettext_lazy
+from django.utils.translation import ugettext_lazy, ugettext_lazy
 from django.utils.translation import ugettext as _
 
 from corehq.apps.es import users as user_es, filters
@@ -46,8 +46,8 @@ class UserTypeFilter(BaseReportFilter):
 
 class SelectMobileWorkerFilter(BaseSingleOptionTypeaheadFilter):
     slug = 'individual'
-    label = ugettext_noop("Select Mobile Worker")
-    default_text = ugettext_noop("All Mobile Workers")
+    label = ugettext_lazy("Select Mobile Worker")
+    default_text = ugettext_lazy("All Mobile Workers")
 
     @property
     def filter_context(self):
@@ -75,12 +75,12 @@ class SelectMobileWorkerFilter(BaseSingleOptionTypeaheadFilter):
 
 
 class AltPlaceholderMobileWorkerFilter(SelectMobileWorkerFilter):
-    default_text = ugettext_noop('Enter a worker')
+    default_text = ugettext_lazy('Enter a worker')
 
 
 class SelectCaseOwnerFilter(SelectMobileWorkerFilter):
-    label = ugettext_noop("Select Case Owner")
-    default_text = ugettext_noop("All Case Owners")
+    label = ugettext_lazy("Select Case Owner")
+    default_text = ugettext_lazy("All Case Owners")
 
     @property
     def options(self):

--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -1,5 +1,5 @@
 from django.core.urlresolvers import reverse
-from django.utils.translation import ugettext_lazy, ugettext_lazy
+from django.utils.translation import ugettext_lazy
 from django.utils.translation import ugettext as _
 
 from corehq.apps.es import users as user_es, filters

--- a/corehq/apps/reports/models.py
+++ b/corehq/apps/reports/models.py
@@ -33,7 +33,7 @@ from corehq.apps.reports.dispatcher import ProjectReportDispatcher, CustomProjec
 import json
 import calendar
 from django.utils.translation import ugettext as _
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from dimagi.utils.logging import notify_exception
 from django_prbac.exceptions import PermissionDenied
 
@@ -45,10 +45,10 @@ class HQUserType(object):
     UNKNOWN = 3
     COMMTRACK = 4
     human_readable = [settings.COMMCARE_USER_TERM,
-                      ugettext_noop("demo_user"),
-                      ugettext_noop("admin"),
-                      ugettext_noop("Unknown Users"),
-                      ugettext_noop("CommCare Supply")]
+                      ugettext_lazy("demo_user"),
+                      ugettext_lazy("admin"),
+                      ugettext_lazy("Unknown Users"),
+                      ugettext_lazy("CommCare Supply")]
     toggle_defaults = (True, False, False, False, False)
     count = len(human_readable)
     included_defaults = (True, True, True, True, False)

--- a/corehq/apps/reports/standard/__init__.py
+++ b/corehq/apps/reports/standard/__init__.py
@@ -14,13 +14,13 @@ from corehq.apps.reports.models import HQUserType
 from corehq.apps.reports.filters.select import MonthFilter, YearFilter
 from corehq.apps.users.models import CommCareUser
 from dimagi.utils.dates import DateSpan
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from dimagi.utils.decorators.memoized import memoized
 
 
 class ProjectReport(GenericReportView):
     # overriding properties from GenericReportView
-    section_name = ugettext_noop("Project Reports")
+    section_name = ugettext_lazy("Project Reports")
     base_template = 'reports/base_template.html'
     dispatcher = ProjectReportDispatcher
     asynchronous = True

--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -2,7 +2,7 @@ import logging
 import json
 
 from django.utils.translation import ugettext as _
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 
 from corehq.const import SERVER_DATETIME_FORMAT
 from corehq.util.timezones.conversions import PhoneTime
@@ -208,7 +208,7 @@ class CaseListReport(CaseListMixin, ProjectInspectionReport, ReportDataSource):
     # point is the decouple generating the raw report data from the report view/django
     # request. but currently these are too tightly bound to decouple
 
-    name = ugettext_noop('Case List')
+    name = ugettext_lazy('Case List')
     slug = 'case_list'
 
     @classmethod

--- a/corehq/apps/reports/standard/cases/careplan.py
+++ b/corehq/apps/reports/standard/cases/careplan.py
@@ -1,5 +1,5 @@
 import uuid
-from django.utils.translation import ugettext_noop, ugettext as _
+from django.utils.translation import ugettext_lazy, ugettext as _
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.reports.generic import GenericReportView
 from corehq.apps.reports.standard import ProjectReportParametersMixin, ProjectReport
@@ -21,7 +21,7 @@ class CareplanCaseDisplay(CaseDisplay):
 
 
 class CareplanCaseListReport(CaseListReport):
-    name = ugettext_noop('Care Plan Case List')
+    name = ugettext_lazy('Care Plan Case List')
     slug = "careplan_caselist"
 
     def case_detail_url(self, case_id):

--- a/corehq/apps/reports/standard/cases/filters.py
+++ b/corehq/apps/reports/standard/cases/filters.py
@@ -1,6 +1,11 @@
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from corehq.apps.reports.filters.search import SearchFilter
 
+
 class CaseSearchFilter(SearchFilter):
-    search_help_inline = mark_safe(ugettext_noop("""Search any text, or use a targeted query. For more info see the <a href='https://wiki.commcarehq.org/display/commcarepublic/Advanced+Case+Search' target='_blank'>Case Search</a> help page"""))
+    search_help_inline = mark_safe(ugettext_lazy(
+        'Search any text, or use a targeted query. For more info see the '
+        '<a href="https://wiki.commcarehq.org/display/commcarepublic/'
+        'Advanced+Case+Search" target="_blank">Case Search</a> help page'
+    ))

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -18,7 +18,7 @@ from corehq.apps.reports.util import make_form_couch_key, format_datatables_data
 from corehq.apps.users.models import CommCareUser
 from corehq.util.couch import get_document_or_404
 from couchforms.models import XFormInstance
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from django.utils.translation import ugettext as _
 from dimagi.utils.couch.database import iter_docs
 
@@ -64,7 +64,7 @@ def _build_html(version, version_source):
 
 
 class ApplicationStatusReport(DeploymentsReport):
-    name = ugettext_noop("Application Status")
+    name = ugettext_lazy("Application Status")
     slug = "app_status"
     emailable = True
     exportable = True
@@ -141,10 +141,10 @@ class ApplicationStatusReport(DeploymentsReport):
 
 
 class SyncHistoryReport(DeploymentsReport):
-    name = ugettext_noop("User Sync History")
+    name = ugettext_lazy("User Sync History")
     slug = "sync_history"
     fields = ['corehq.apps.reports.filters.users.AltPlaceholderMobileWorkerFilter']
-    report_subtitles = [ugettext_noop('Shows the last (up to) 10 times a user has synced.')]
+    report_subtitles = [ugettext_lazy('Shows the last (up to) 10 times a user has synced.')]
     disable_pagination = True
 
     @property

--- a/corehq/apps/reports/standard/domains.py
+++ b/corehq/apps/reports/standard/domains.py
@@ -1,6 +1,6 @@
 from corehq.elastic import es_query
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from corehq.apps.reports.datatables import DataTablesHeader, DataTablesColumn, DTSortType
 from corehq.apps.reports.dispatcher import BasicReportDispatcher
 from corehq.apps.reports.generic import GenericTabularReport
@@ -26,7 +26,7 @@ class DomainStatsReport(GenericTabularReport):
     custom_params = []
     es_queried = False
 
-    name = ugettext_noop('Domain Statistics')
+    name = ugettext_lazy('Domain Statistics')
     slug = 'dom_stats'
 
     def get_domains(self):

--- a/corehq/apps/reports/standard/export.py
+++ b/corehq/apps/reports/standard/export.py
@@ -5,7 +5,7 @@ from datetime import timedelta, datetime
 from django.conf import settings
 
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy, ugettext_lazy
+from django.utils.translation import ugettext_lazy
 from django.http import Http404
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.hqcase.dbaccessors import get_case_types_for_domain

--- a/corehq/apps/reports/standard/export.py
+++ b/corehq/apps/reports/standard/export.py
@@ -5,7 +5,7 @@ from datetime import timedelta, datetime
 from django.conf import settings
 
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_noop, ugettext_lazy
+from django.utils.translation import ugettext_lazy, ugettext_lazy
 from django.http import Http404
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.hqcase.dbaccessors import get_case_types_for_domain
@@ -102,7 +102,7 @@ def sizeof_fmt(num):
 
 
 class ExcelExportReport(FormExportReportBase):
-    name = ugettext_noop("Export Forms")
+    name = ugettext_lazy("Export Forms")
     slug = "excel_export_data"
     report_template_path = "reports/reportdata/excel_export_data.html"
     icon = "icon-list-alt"
@@ -451,10 +451,10 @@ class DataExportInterface(GenericReportView):
 
 
 class FormExportInterface(DataExportInterface):
-    name = ugettext_noop('Export Forms')
+    name = ugettext_lazy('Export Forms')
     slug = 'forms'
 
-    bulk_download_notice_text = ugettext_noop('Form Export')
+    bulk_download_notice_text = ugettext_lazy('Form Export')
     create_export_view_name = 'create_form_export'
     edit_export_view_name = 'edit_custom_export_form'
     export_schema = FormExportSchema
@@ -466,10 +466,10 @@ class FormExportInterface(DataExportInterface):
 
 
 class CaseExportInterface(DataExportInterface):
-    name = ugettext_noop('Export Cases')
+    name = ugettext_lazy('Export Cases')
     slug = 'cases'
 
-    bulk_download_notice_text = ugettext_noop('Case Export')
+    bulk_download_notice_text = ugettext_lazy('Case Export')
     create_export_view_name = 'create_case_export'
     edit_export_view_name = 'edit_custom_export_case'
     export_schema = CaseExportSchema
@@ -483,8 +483,8 @@ class CaseExportInterface(DataExportInterface):
 class FormExportReport(FormExportReportBase):
     base_template = 'reports/standard/export_download.html'
     report_template_path = 'reports/partials/download_form_export.html'
-    name = ugettext_noop('Download Forms')
-    section_name = ugettext_noop("Export Data")
+    name = ugettext_lazy('Download Forms')
+    section_name = ugettext_lazy("Export Data")
     slug = 'form_export'
 
     dispatcher = DataDownloadInterfaceDispatcher
@@ -497,7 +497,7 @@ class FormExportReport(FormExportReportBase):
             'export': self.exports[0],
             'exports': self.exports,
             "use_bulk": len(self.export_ids) > 1,
-            "filter_title": ugettext_noop("Export Filters"),
+            "filter_title": ugettext_lazy("Export Filters"),
             "back_url": FormExportInterface.get_url(domain=self.domain),
             'additional_params': mark_safe(
                 '&'.join('export_id=%(export_id)s' % {
@@ -505,7 +505,7 @@ class FormExportReport(FormExportReportBase):
                 } for export_id in self.export_ids)
             ),
             'selected_exports_data': self.selected_exports_data,
-            'bulk_download_notice_text': ugettext_noop('Form Exports'),
+            'bulk_download_notice_text': ugettext_lazy('Form Exports'),
         })
         return context
 
@@ -541,8 +541,8 @@ class FormExportReport(FormExportReportBase):
 class NewCaseExportReport(CaseExportReport):
     base_template = 'reports/standard/export_download.html'
     report_template_path = 'reports/partials/download_case_export.html'
-    name = ugettext_noop('Download Cases')
-    section_name = ugettext_noop('Export Data')
+    name = ugettext_lazy('Download Cases')
+    section_name = ugettext_lazy('Export Data')
     slug = 'case_export'
 
     dispatcher = DataDownloadInterfaceDispatcher
@@ -561,7 +561,7 @@ class NewCaseExportReport(CaseExportReport):
                 } for export_id in self.export_ids)
             ),
             # 'selected_exports_data': self.selected_exports_data,
-            # 'bulk_download_notice_text': ugettext_noop('Case Exports'),
+            # 'bulk_download_notice_text': ugettext_lazy('Case Exports'),
         })
         return context
 

--- a/corehq/apps/reports/standard/inspect.py
+++ b/corehq/apps/reports/standard/inspect.py
@@ -1,7 +1,7 @@
 import functools
 from couchdbkit.exceptions import ResourceNotFound
 from django.utils.translation import ugettext as _
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from corehq.util.dates import iso_string_to_datetime
 
 from corehq.apps.reports import util
@@ -42,7 +42,7 @@ class SubmitHistory(ElasticProjectInspectionReport, ProjectReport,
                     ProjectReportParametersMixin,
                     CompletionOrSubmissionTimeMixin,  MultiFormDrilldownMixin,
                     DatespanMixin):
-    name = ugettext_noop('Submit History')
+    name = ugettext_lazy('Submit History')
     slug = 'submit_history'
     fields = [
         'corehq.apps.reports.filters.users.ExpandedMobileWorkerFilter',

--- a/corehq/apps/reports/standard/ivr.py
+++ b/corehq/apps/reports/standard/ivr.py
@@ -1,5 +1,5 @@
 import cgi
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from django.utils.translation import ugettext as _
 from corehq.apps.reports.standard import DatespanMixin, ProjectReport,\
     ProjectReportParametersMixin
@@ -32,7 +32,7 @@ class CallLogReport(BaseCommConnectLogReport):
     """
     Displays all calls for the given domain and date range.
     """
-    name = ugettext_noop('Call Log')
+    name = ugettext_lazy('Call Log')
     slug = 'call_log'
     fields = ['corehq.apps.reports.filters.dates.DatespanFilter']
     exportable = True
@@ -162,7 +162,7 @@ class ExpectedCallbackReport(ProjectReport, ProjectReportParametersMixin, Generi
     """
     Displays all expected callbacks for the given time period.
     """
-    name = ugettext_noop('Expected Callbacks')
+    name = ugettext_lazy('Expected Callbacks')
     slug = 'expected_callbacks'
     fields = ['corehq.apps.reports.filters.dates.DatespanFilter']
     exportable = True

--- a/corehq/apps/reports/standard/maps.py
+++ b/corehq/apps/reports/standard/maps.py
@@ -2,7 +2,7 @@ import json
 import os.path
 import re
 from django.conf import settings
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.reports.api import ReportDataSource
 from corehq.apps.reports.datatables import DataTablesHeader, DataTablesColumn
@@ -290,7 +290,7 @@ class DemoMapReport(GenericMapReport):
     it uses a static dataset
     """
 
-    name = ugettext_noop("Maps: Highest Mountains")
+    name = ugettext_lazy("Maps: Highest Mountains")
     slug = "maps_demo"
     data_source = {
         "adapter": "csv",
@@ -486,7 +486,7 @@ class DemoMapReport2(GenericMapReport):
     it uses a static dataset
     """
 
-    name = ugettext_noop("Maps: States of India")
+    name = ugettext_lazy("Maps: States of India")
     slug = "maps_demo2"
     data_source = {
         "adapter": "geojson",
@@ -627,7 +627,7 @@ class GenericCaseListMap(GenericMapReport):
         return static_config
 
 class DemoMapCaseList(GenericCaseListMap):
-    name = ugettext_noop("Maps: Case List")
+    name = ugettext_lazy("Maps: Case List")
     slug = "maps_demo_caselist"
 
     case_config = {

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -27,7 +27,7 @@ from dimagi.utils.dates import DateSpan, today_or_tomorrow
 from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.parsing import string_to_datetime, json_format_date
 from django.utils.translation import ugettext as _
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 
 
 class WorkerMonitoringReportTableBase(GenericTabularReport, ProjectReport, ProjectReportParametersMixin):
@@ -113,14 +113,14 @@ class CaseActivityReport(WorkerMonitoringCaseReportTableBase):
     danny   5 (25%)         10 (50%)        20 (100%)       17                          6
     (name)  (modified_since(x)/[active + closed_since(x)])  (open & modified_since(120)) (open & !modified_since(120))
     """
-    name = ugettext_noop('Case Activity')
+    name = ugettext_lazy('Case Activity')
     slug = 'case_activity'
     fields = ['corehq.apps.reports.filters.users.ExpandedMobileWorkerFilter',
               'corehq.apps.reports.filters.select.CaseTypeFilter']
     all_users = None
     display_data = ['percent']
     emailable = True
-    description = ugettext_noop("Followup rates on active cases.")
+    description = ugettext_lazy("Followup rates on active cases.")
     is_cacheable = True
 
     @classmethod
@@ -329,7 +329,7 @@ class CaseActivityReport(WorkerMonitoringCaseReportTableBase):
 
 class SubmissionsByFormReport(WorkerMonitoringFormReportTableBase,
                               MultiFormDrilldownMixin, DatespanMixin):
-    name = ugettext_noop("Submissions By Form")
+    name = ugettext_lazy("Submissions By Form")
     slug = "submissions_by_form"
     fields = [
         'corehq.apps.reports.filters.users.ExpandedMobileWorkerFilter',
@@ -339,7 +339,7 @@ class SubmissionsByFormReport(WorkerMonitoringFormReportTableBase,
     fix_left_col = True
     emailable = True
     is_cacheable = True
-    description = ugettext_noop("Number of submissions by form.")
+    description = ugettext_lazy("Number of submissions by form.")
 
     @classmethod
     def display_in_dropdown(cls, domain=None, project=None, user=None):
@@ -438,8 +438,8 @@ class SubmissionsByFormReport(WorkerMonitoringFormReportTableBase,
 
 class DailyFormStatsReport(WorkerMonitoringCaseReportTableBase, CompletionOrSubmissionTimeMixin, DatespanMixin):
     slug = "daily_form_stats"
-    name = ugettext_noop("Daily Form Activity")
-    bad_request_error_text = ugettext_noop("Your search query was invalid. If you're using a large date range, try using a smaller one.")
+    name = ugettext_lazy("Daily Form Activity")
+    bad_request_error_text = ugettext_lazy("Your search query was invalid. If you're using a large date range, try using a smaller one.")
 
     fields = [
         'corehq.apps.reports.filters.users.ExpandedMobileWorkerFilter',
@@ -447,7 +447,7 @@ class DailyFormStatsReport(WorkerMonitoringCaseReportTableBase, CompletionOrSubm
         'corehq.apps.reports.filters.dates.DatespanFilter',
     ]
 
-    description = ugettext_noop("Number of submissions per day.")
+    description = ugettext_lazy("Number of submissions per day.")
 
     fix_left_col = False
     emailable = True
@@ -630,14 +630,14 @@ class DailyFormStatsReport(WorkerMonitoringCaseReportTableBase, CompletionOrSubm
 
 class FormCompletionTimeReport(WorkerMonitoringFormReportTableBase, DatespanMixin,
                                CompletionOrSubmissionTimeMixin):
-    name = ugettext_noop("Form Completion Time")
+    name = ugettext_lazy("Form Completion Time")
     slug = "completion_times"
     fields = ['corehq.apps.reports.filters.users.ExpandedMobileWorkerFilter',
               'corehq.apps.reports.filters.forms.SingleFormByApplicationFilter',
               'corehq.apps.reports.filters.forms.CompletionOrSubmissionTimeFilter',
               'corehq.apps.reports.filters.dates.DatespanFilter']
 
-    description = ugettext_noop("Statistics on time spent on a particular form.")
+    description = ugettext_lazy("Statistics on time spent on a particular form.")
     is_cacheable = True
 
     @property
@@ -752,11 +752,11 @@ class FormCompletionTimeReport(WorkerMonitoringFormReportTableBase, DatespanMixi
 
 class FormCompletionVsSubmissionTrendsReport(WorkerMonitoringFormReportTableBase,
                                              MultiFormDrilldownMixin, DatespanMixin):
-    name = ugettext_noop("Form Completion vs. Submission Trends")
+    name = ugettext_lazy("Form Completion vs. Submission Trends")
     slug = "completion_vs_submission"
     is_cacheable = True
 
-    description = ugettext_noop("Time lag between when forms were completed and when forms were successfully "
+    description = ugettext_lazy("Time lag between when forms were completed and when forms were successfully "
                                 "sent to CommCare HQ.")
 
     fields = ['corehq.apps.reports.filters.users.ExpandedMobileWorkerFilter',
@@ -880,11 +880,11 @@ class WorkerMonitoringChartBase(ProjectReport, ProjectReportParametersMixin):
 
 class WorkerActivityTimes(WorkerMonitoringChartBase,
     MultiFormDrilldownMixin, CompletionOrSubmissionTimeMixin, DatespanMixin):
-    name = ugettext_noop("Worker Activity Times")
+    name = ugettext_lazy("Worker Activity Times")
     slug = "worker_activity_times"
     is_cacheable = True
 
-    description = ugettext_noop("Graphical representation of when forms are "
+    description = ugettext_lazy("Graphical representation of when forms are "
                                 "completed or submitted.")
 
     fields = [
@@ -983,9 +983,9 @@ class WorkerActivityTimes(WorkerMonitoringChartBase,
 
 class WorkerActivityReport(WorkerMonitoringCaseReportTableBase, DatespanMixin):
     slug = 'worker_activity'
-    name = ugettext_noop("Worker Activity")
-    description = ugettext_noop("Summary of form and case activity by user or group.")
-    section_name = ugettext_noop("Project Reports")
+    name = ugettext_lazy("Worker Activity")
+    description = ugettext_lazy("Summary of form and case activity by user or group.")
+    section_name = ugettext_lazy("Project Reports")
     num_avg_intervals = 3 # how many duration intervals we go back to calculate averages
     is_cacheable = True
 

--- a/corehq/apps/reports/standard/sms.py
+++ b/corehq/apps/reports/standard/sms.py
@@ -2,7 +2,7 @@ import cgi
 from django.db.models import Q
 from django.core.urlresolvers import reverse
 from django.http import Http404
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from django.utils.translation import ugettext as _
 from couchdbkit.resource import ResourceNotFound
 from corehq.apps.domain.models import Domain
@@ -56,12 +56,12 @@ from couchforms.models import XFormInstance
 
 
 class MessagesReport(ProjectReport, ProjectReportParametersMixin, GenericTabularReport, DatespanMixin):
-    name = ugettext_noop('SMS Usage')
+    name = ugettext_lazy('SMS Usage')
     slug = 'messages'
     fields = ['corehq.apps.reports.filters.select.GroupFilter',
               'corehq.apps.reports.filters.dates.DatespanFilter']
 
-    special_notice = ugettext_noop(
+    special_notice = ugettext_lazy(
         "This report will only show data for users whose phone numbers have "
         "been verified. Phone numbers can be verified from the Settings and "
         "Users tab.")
@@ -221,7 +221,7 @@ So, to have this report abbreviate the phone number to only the first four digit
 the domain to the list in settings.MESSAGE_LOG_OPTIONS["abbreviated_phone_number_domains"]
 """
 class MessageLogReport(BaseCommConnectLogReport):
-    name = ugettext_noop('Message Log')
+    name = ugettext_lazy('Message Log')
     slug = 'message_log'
 
     exportable = True
@@ -499,7 +499,7 @@ class BaseMessagingEventReport(BaseCommConnectLogReport):
 
 
 class MessagingEventsReport(BaseMessagingEventReport):
-    name = ugettext_noop('Past Events')
+    name = ugettext_lazy('Past Events')
     slug = 'messaging_events'
     fields = [
         DatespanFilter,
@@ -587,9 +587,9 @@ class MessagingEventsReport(BaseMessagingEventReport):
 
 
 class MessageEventDetailReport(BaseMessagingEventReport):
-    name = ugettext_noop('Message Event Detail')
+    name = ugettext_lazy('Message Event Detail')
     slug = 'message_event_detail'
-    description = ugettext_noop('Displays the detail for a given messaging event.')
+    description = ugettext_lazy('Displays the detail for a given messaging event.')
     emailable = False
     exportable = False
     hide_filters = True
@@ -691,9 +691,9 @@ class MessageEventDetailReport(BaseMessagingEventReport):
 
 
 class SurveyDetailReport(BaseMessagingEventReport):
-    name = ugettext_noop('Survey Detail')
+    name = ugettext_lazy('Survey Detail')
     slug = 'survey_detail'
-    description = ugettext_noop('Displays the detail for a given messaging survey.')
+    description = ugettext_lazy('Displays the detail for a given messaging survey.')
     emailable = False
     exportable = False
     hide_filters = True

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -8,7 +8,7 @@ import langcodes
 
 from django.http import HttpResponseRedirect, HttpResponse
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext as _, ugettext_noop, ugettext_lazy
+from django.utils.translation import ugettext as _, ugettext_lazy, ugettext_lazy
 from corehq import MySettingsTab
 from corehq.apps.domain.decorators import (login_and_domain_required, require_superuser,
                                            login_required)
@@ -210,7 +210,7 @@ class ChangeMyPasswordView(BaseMyAccountView):
 
 
 class BaseProjectDataView(BaseDomainView):
-    section_name = ugettext_noop("Data")
+    section_name = ugettext_lazy("Data")
 
     @property
     def section_url(self):

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -8,7 +8,7 @@ import langcodes
 
 from django.http import HttpResponseRedirect, HttpResponse
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext as _, ugettext_lazy, ugettext_lazy
+from django.utils.translation import ugettext as _, ugettext_lazy
 from corehq import MySettingsTab
 from corehq.apps.domain.decorators import (login_and_domain_required, require_superuser,
                                            login_required)

--- a/corehq/apps/sms/backend/http_api.py
+++ b/corehq/apps/sms/backend/http_api.py
@@ -10,7 +10,7 @@ from django.core.exceptions import ValidationError
 from dimagi.ext.couchdbkit import *
 from dimagi.utils.django.fields import TrimmedCharField
 from corehq.apps.sms.util import clean_phone_number, strip_plus
-from django.utils.translation import ugettext as _, ugettext_noop
+from django.utils.translation import ugettext as _, ugettext_lazy
 from crispy_forms import layout as crispy
 from django.conf import settings
 
@@ -26,20 +26,20 @@ BANNED_URL_REGEX = (
 
 class HttpBackendForm(BackendForm):
     url = TrimmedCharField(
-        label=ugettext_noop("URL"),
+        label=ugettext_lazy("URL"),
     )
     message_param = TrimmedCharField(
-        label=ugettext_noop("Message Parameter"),
+        label=ugettext_lazy("Message Parameter"),
     )
     number_param = TrimmedCharField(
-        label=ugettext_noop("Phone Number Parameter"),
+        label=ugettext_lazy("Phone Number Parameter"),
     )
     include_plus = BooleanField(
         required=False,
-        label=ugettext_noop("Include '+' in Phone Number"),
+        label=ugettext_lazy("Include '+' in Phone Number"),
     )
     method = ChoiceField(
-        label=ugettext_noop("HTTP Request Method"),
+        label=ugettext_lazy("HTTP Request Method"),
         choices=(
             ("GET","GET"),
             ("POST","POST")
@@ -47,7 +47,7 @@ class HttpBackendForm(BackendForm):
     )
     additional_params = RecordListField(
         input_name="additional_params",
-        label=ugettext_noop("Additional Parameters"),
+        label=ugettext_lazy("Additional Parameters"),
     )
 
     def __init__(self, *args, **kwargs):

--- a/corehq/apps/sms/filters.py
+++ b/corehq/apps/sms/filters.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from corehq.apps.reports.filters.base import BaseMultipleOptionFilter
 from corehq.apps.sms.models import (
     WORKFLOW_REMINDER,
@@ -11,34 +11,34 @@ from corehq.apps.sms.models import (
 
 
 class MessageTypeFilter(BaseMultipleOptionFilter):
-    label = ugettext_noop("Message Type")
-    default_text = ugettext_noop("Select Message Type...")
+    label = ugettext_lazy("Message Type")
+    default_text = ugettext_lazy("Select Message Type...")
     slug = 'log_type'
     OPTION_SURVEY = 'survey'
     OPTION_OTHER = 'other'
     options = (
-        (WORKFLOW_REMINDER, ugettext_noop('Reminder')),
-        (WORKFLOW_KEYWORD, ugettext_noop('Keyword')),
-        (WORKFLOW_BROADCAST, ugettext_noop('Broadcast')),
-        (WORKFLOW_CALLBACK, ugettext_noop('Callback')),
-        (OPTION_SURVEY, ugettext_noop('Survey')),
-        (WORKFLOW_DEFAULT, ugettext_noop('Default')),
-        (OPTION_OTHER, ugettext_noop('Other')),
+        (WORKFLOW_REMINDER, ugettext_lazy('Reminder')),
+        (WORKFLOW_KEYWORD, ugettext_lazy('Keyword')),
+        (WORKFLOW_BROADCAST, ugettext_lazy('Broadcast')),
+        (WORKFLOW_CALLBACK, ugettext_lazy('Callback')),
+        (OPTION_SURVEY, ugettext_lazy('Survey')),
+        (WORKFLOW_DEFAULT, ugettext_lazy('Default')),
+        (OPTION_OTHER, ugettext_lazy('Other')),
     )
 
 
 class EventTypeFilter(BaseMultipleOptionFilter):
-    label = ugettext_noop('Communication Type')
-    default_text = ugettext_noop('Select Communication Type...')
+    label = ugettext_lazy('Communication Type')
+    default_text = ugettext_lazy('Select Communication Type...')
     slug = 'event_type'
     options = [
-        (MessagingEvent.SOURCE_BROADCAST, ugettext_noop('Broadcast')),
-        (MessagingEvent.SOURCE_KEYWORD, ugettext_noop('Keyword')),
-        (MessagingEvent.SOURCE_REMINDER, ugettext_noop('Reminder')),
-        (MessagingEvent.CONTENT_SMS_SURVEY, ugettext_noop('Survey')),
-        (MessagingEvent.CONTENT_SMS_CALLBACK, ugettext_noop('Callback')),
-        (MessagingEvent.SOURCE_UNRECOGNIZED, ugettext_noop('Unrecognized')),
-        (MessagingEvent.SOURCE_OTHER, ugettext_noop('Other')),
+        (MessagingEvent.SOURCE_BROADCAST, ugettext_lazy('Broadcast')),
+        (MessagingEvent.SOURCE_KEYWORD, ugettext_lazy('Keyword')),
+        (MessagingEvent.SOURCE_REMINDER, ugettext_lazy('Reminder')),
+        (MessagingEvent.CONTENT_SMS_SURVEY, ugettext_lazy('Survey')),
+        (MessagingEvent.CONTENT_SMS_CALLBACK, ugettext_lazy('Callback')),
+        (MessagingEvent.SOURCE_UNRECOGNIZED, ugettext_lazy('Unrecognized')),
+        (MessagingEvent.SOURCE_OTHER, ugettext_lazy('Other')),
     ]
     default_options = [
         MessagingEvent.SOURCE_BROADCAST,

--- a/corehq/apps/sms/forms.py
+++ b/corehq/apps/sms/forms.py
@@ -14,7 +14,7 @@ from corehq.apps.sms.models import FORWARD_ALL, FORWARD_BY_KEYWORD
 from django.core.exceptions import ValidationError
 from corehq.apps.sms.mixin import SMSBackend
 from corehq.apps.reminders.forms import RecordListField, validate_time
-from django.utils.translation import ugettext as _, ugettext_lazy, ugettext_lazy
+from django.utils.translation import ugettext as _, ugettext_lazy
 from corehq.apps.sms.util import get_available_backends, validate_phone_number
 from corehq.apps.domain.models import DayTimeWindow
 from corehq.apps.users.models import CommCareUser

--- a/corehq/apps/sms/forms.py
+++ b/corehq/apps/sms/forms.py
@@ -14,7 +14,7 @@ from corehq.apps.sms.models import FORWARD_ALL, FORWARD_BY_KEYWORD
 from django.core.exceptions import ValidationError
 from corehq.apps.sms.mixin import SMSBackend
 from corehq.apps.reminders.forms import RecordListField, validate_time
-from django.utils.translation import ugettext as _, ugettext_noop, ugettext_lazy
+from django.utils.translation import ugettext as _, ugettext_lazy, ugettext_lazy
 from corehq.apps.sms.util import get_available_backends, validate_phone_number
 from corehq.apps.domain.models import DayTimeWindow
 from corehq.apps.users.models import CommCareUser
@@ -23,29 +23,29 @@ from dimagi.utils.django.fields import TrimmedCharField
 from django.conf import settings
 
 FORWARDING_CHOICES = (
-    (FORWARD_ALL, ugettext_noop("All messages")),
-    (FORWARD_BY_KEYWORD, ugettext_noop("All messages starting with a keyword")),
+    (FORWARD_ALL, ugettext_lazy("All messages")),
+    (FORWARD_BY_KEYWORD, ugettext_lazy("All messages starting with a keyword")),
 )
 
 ENABLED = "ENABLED"
 DISABLED = "DISABLED"
 
 ENABLED_DISABLED_CHOICES = (
-    (DISABLED, ugettext_noop("Disabled")),
-    (ENABLED, ugettext_noop("Enabled")),
+    (DISABLED, ugettext_lazy("Disabled")),
+    (ENABLED, ugettext_lazy("Enabled")),
 )
 
 DEFAULT = "DEFAULT"
 CUSTOM = "CUSTOM"
 
 DEFAULT_CUSTOM_CHOICES = (
-    (DEFAULT, ugettext_noop("Default")),
-    (CUSTOM, ugettext_noop("Specify:")),
+    (DEFAULT, ugettext_lazy("Default")),
+    (CUSTOM, ugettext_lazy("Specify:")),
 )
 
 MESSAGE_COUNTER_CHOICES = (
-    (DEFAULT, ugettext_noop("Don't use counter")),
-    (CUSTOM, ugettext_noop("Use counter with threshold:")),
+    (DEFAULT, ugettext_lazy("Don't use counter")),
+    (CUSTOM, ugettext_lazy("Use counter with threshold:")),
 )
 
 SMS_CONVERSATION_LENGTH_CHOICES = (
@@ -116,7 +116,7 @@ class SettingsForm(Form):
     # General Settings
     use_default_sms_response = ChoiceField(
         required=False,
-        label=ugettext_noop("Default SMS Response"),
+        label=ugettext_lazy("Default SMS Response"),
         choices=ENABLED_DISABLED_CHOICES,
     )
     default_sms_response = TrimmedCharField(
@@ -125,10 +125,10 @@ class SettingsForm(Form):
     )
     use_restricted_sms_times = ChoiceField(
         required=False,
-        label=ugettext_noop("Send SMS on..."),
+        label=ugettext_lazy("Send SMS on..."),
         choices=(
-            (DISABLED, ugettext_noop("any day, at any time")),
-            (ENABLED, ugettext_noop("only specific days and times")),
+            (DISABLED, ugettext_lazy("any day, at any time")),
+            (ENABLED, ugettext_lazy("only specific days and times")),
         ),
     )
     restricted_sms_times_json = CharField(
@@ -137,7 +137,7 @@ class SettingsForm(Form):
     )
     send_to_duplicated_case_numbers = ChoiceField(
         required=False,
-        label=ugettext_noop("Send Messages to Non-Unique Phone Numbers"),
+        label=ugettext_lazy("Send Messages to Non-Unique Phone Numbers"),
         choices=ENABLED_DISABLED_CHOICES,
     )
 
@@ -148,7 +148,7 @@ class SettingsForm(Form):
     )
     custom_case_username = TrimmedCharField(
         required=False,
-        label=ugettext_noop("Enter a Case Property"),
+        label=ugettext_lazy("Enter a Case Property"),
     )
     use_custom_message_count_threshold = ChoiceField(
         required=False,
@@ -156,11 +156,11 @@ class SettingsForm(Form):
     )
     custom_message_count_threshold = IntegerField(
         required=False,
-        label=ugettext_noop("Enter a Number"),
+        label=ugettext_lazy("Enter a Number"),
     )
     use_sms_conversation_times = ChoiceField(
         required=False,
-        label=ugettext_noop("Delay Automated SMS"),
+        label=ugettext_lazy("Delay Automated SMS"),
         choices=ENABLED_DISABLED_CHOICES,
     )
     sms_conversation_times_json = CharField(
@@ -169,25 +169,25 @@ class SettingsForm(Form):
     )
     sms_conversation_length = ChoiceField(
         required=False,
-        label=ugettext_noop("Conversation Duration"),
+        label=ugettext_lazy("Conversation Duration"),
         choices=SMS_CONVERSATION_LENGTH_CHOICES,
     )
     survey_traffic_option = ChoiceField(
         required=False,
-        label=ugettext_noop("Survey Traffic"),
+        label=ugettext_lazy("Survey Traffic"),
         choices=(
-            (SHOW_ALL, ugettext_noop("Show all survey traffic")),
-            (SHOW_INVALID, ugettext_noop("Hide all survey traffic except "
+            (SHOW_ALL, ugettext_lazy("Show all survey traffic")),
+            (SHOW_INVALID, ugettext_lazy("Hide all survey traffic except "
                                          "invalid responses")),
-            (HIDE_ALL, ugettext_noop("Hide all survey traffic")),
+            (HIDE_ALL, ugettext_lazy("Hide all survey traffic")),
         ),
     )
     count_messages_as_read_by_anyone = ChoiceField(
         required=False,
-        label=ugettext_noop("A Message is Read..."),
+        label=ugettext_lazy("A Message is Read..."),
         choices=(
-            (ENABLED, ugettext_noop("when it is read by anyone")),
-            (DISABLED, ugettext_noop("only for the user that reads it")),
+            (ENABLED, ugettext_lazy("when it is read by anyone")),
+            (DISABLED, ugettext_lazy("only for the user that reads it")),
         ),
     )
     use_custom_chat_template = ChoiceField(
@@ -196,30 +196,30 @@ class SettingsForm(Form):
     )
     custom_chat_template = TrimmedCharField(
         required=False,
-        label=ugettext_noop("Enter Chat Template Identifier"),
+        label=ugettext_lazy("Enter Chat Template Identifier"),
     )
     sms_case_registration_enabled = ChoiceField(
         required=False,
         choices=ENABLED_DISABLED_CHOICES,
-        label=ugettext_noop("Case Self-Registration"),
+        label=ugettext_lazy("Case Self-Registration"),
     )
     sms_case_registration_type = TrimmedCharField(
         required=False,
-        label=ugettext_noop("Default Case Type"),
+        label=ugettext_lazy("Default Case Type"),
     )
     sms_case_registration_owner_id = ChoiceField(
         required=False,
-        label=ugettext_noop("Default Case Owner"),
+        label=ugettext_lazy("Default Case Owner"),
     )
     sms_case_registration_user_id = ChoiceField(
         required=False,
-        label=ugettext_noop("Registration Submitter"),
+        label=ugettext_lazy("Registration Submitter"),
     )
 
     sms_mobile_worker_registration_enabled = ChoiceField(
         required=False,
         choices=ENABLED_DISABLED_CHOICES,
-        label=ugettext_noop("SMS Mobile Worker Registration"),
+        label=ugettext_lazy("SMS Mobile Worker Registration"),
     )
 
 
@@ -656,24 +656,24 @@ class BackendForm(Form):
     _cchq_domain = None
     _cchq_backend_id = None
     name = CharField(
-        label=ugettext_noop("Name")
+        label=ugettext_lazy("Name")
     )
     description = CharField(
-        label=ugettext_noop("Description"),
+        label=ugettext_lazy("Description"),
         widget=forms.Textarea,
         required=False,
     )
     give_other_domains_access = BooleanField(
         required=False,
-        label=ugettext_noop("Give other domains access.")
+        label=ugettext_lazy("Give other domains access.")
     )
     authorized_domains = CharField(
         required=False,
-        label=ugettext_noop("List of authorized domains")
+        label=ugettext_lazy("List of authorized domains")
     )
     reply_to_phone_number = CharField(
         required=False,
-        label=ugettext_noop("Reply-To Phone Number"),
+        label=ugettext_lazy("Reply-To Phone Number"),
     )
 
     def __init__(self, *args, **kwargs):

--- a/corehq/apps/sms/messages.py
+++ b/corehq/apps/sms/messages.py
@@ -1,6 +1,6 @@
 from corehq.apps.translations.models import StandaloneTranslationDoc
 from corehq.util.translation import localize
-from django.utils.translation import ugettext as _, ugettext_noop
+from django.utils.translation import ugettext as _, ugettext_lazy
 
 MSG_MULTIPLE_SESSIONS = "sms.survey.restart"
 MSG_TOUCHFORMS_DOWN = "sms.survey.temporarilydown"
@@ -31,36 +31,36 @@ MSG_DUPLICATE_USERNAME = "sms.validation.duplicateusername"
 MSG_USERNAME_TOO_LONG = "sms.validation.usernametoolong"
 
 _MESSAGES = {
-    MSG_MULTIPLE_SESSIONS: ugettext_noop("An error has occurred. Please try restarting the survey."),
-    MSG_TOUCHFORMS_DOWN: ugettext_noop("An error has occurred. Please try again later. If the problem persists, try restarting the survey."),
-    MSG_TOUCHFORMS_ERROR: ugettext_noop("Internal server error."),
-    MSG_CHOICE_OUT_OF_RANGE: ugettext_noop("Answer is out of range."),
-    MSG_INVALID_CHOICE: ugettext_noop("Invalid choice."),
-    MSG_INVALID_INT: ugettext_noop("Invalid integer entered."),
-    MSG_INVALID_FLOAT: ugettext_noop("Invalid decimal number entered."),
-    MSG_INVALID_LONG: ugettext_noop("Invalid long integer entered."),
-    MSG_INVALID_DATE: ugettext_noop("Invalid date format: expected YYYYMMDD."),
-    MSG_INVALID_TIME: ugettext_noop("Invalid time format: expected HHMM (24-hour)."),
-    MSG_KEYWORD_NOT_FOUND: ugettext_noop("Keyword not found: '{0}'"),
-    MSG_START_KEYWORD_USAGE: ugettext_noop("Usage: {0} <keyword>"),
-    MSG_UNKNOWN_GLOBAL_KEYWORD: ugettext_noop("Unknown command: '{0}'"),
-    MSG_FIELD_REQUIRED: ugettext_noop("This field is required."),
-    MSG_EXPECTED_NAMED_ARGS_SEPARATOR: ugettext_noop("Expected name and value to be joined by '{0}'."),
-    MSG_MULTIPLE_ANSWERS_FOUND: ugettext_noop("More than one answer found for '{0}'"),
-    MSG_MULTIPLE_QUESTIONS_MATCH: ugettext_noop("More than one question matches '{0}'"),
-    MSG_MISSING_EXTERNAL_ID: ugettext_noop("Please provide an external id for the case."),
-    MSG_CASE_NOT_FOUND: ugettext_noop("Case with the given external id was not found."),
-    MSG_MULTIPLE_CASES_FOUND: ugettext_noop("More than one case was found with the given external id."),
-    MSG_FIELD_DESCRIPTOR: ugettext_noop("Field '{0}': "),
-    MSG_FORM_NOT_FOUND: ugettext_noop("Could not find the survey being requested."),
-    MSG_FORM_ERROR: ugettext_noop("There is a configuration error with this survey. "
+    MSG_MULTIPLE_SESSIONS: ugettext_lazy("An error has occurred. Please try restarting the survey."),
+    MSG_TOUCHFORMS_DOWN: ugettext_lazy("An error has occurred. Please try again later. If the problem persists, try restarting the survey."),
+    MSG_TOUCHFORMS_ERROR: ugettext_lazy("Internal server error."),
+    MSG_CHOICE_OUT_OF_RANGE: ugettext_lazy("Answer is out of range."),
+    MSG_INVALID_CHOICE: ugettext_lazy("Invalid choice."),
+    MSG_INVALID_INT: ugettext_lazy("Invalid integer entered."),
+    MSG_INVALID_FLOAT: ugettext_lazy("Invalid decimal number entered."),
+    MSG_INVALID_LONG: ugettext_lazy("Invalid long integer entered."),
+    MSG_INVALID_DATE: ugettext_lazy("Invalid date format: expected YYYYMMDD."),
+    MSG_INVALID_TIME: ugettext_lazy("Invalid time format: expected HHMM (24-hour)."),
+    MSG_KEYWORD_NOT_FOUND: ugettext_lazy("Keyword not found: '{0}'"),
+    MSG_START_KEYWORD_USAGE: ugettext_lazy("Usage: {0} <keyword>"),
+    MSG_UNKNOWN_GLOBAL_KEYWORD: ugettext_lazy("Unknown command: '{0}'"),
+    MSG_FIELD_REQUIRED: ugettext_lazy("This field is required."),
+    MSG_EXPECTED_NAMED_ARGS_SEPARATOR: ugettext_lazy("Expected name and value to be joined by '{0}'."),
+    MSG_MULTIPLE_ANSWERS_FOUND: ugettext_lazy("More than one answer found for '{0}'"),
+    MSG_MULTIPLE_QUESTIONS_MATCH: ugettext_lazy("More than one question matches '{0}'"),
+    MSG_MISSING_EXTERNAL_ID: ugettext_lazy("Please provide an external id for the case."),
+    MSG_CASE_NOT_FOUND: ugettext_lazy("Case with the given external id was not found."),
+    MSG_MULTIPLE_CASES_FOUND: ugettext_lazy("More than one case was found with the given external id."),
+    MSG_FIELD_DESCRIPTOR: ugettext_lazy("Field '{0}': "),
+    MSG_FORM_NOT_FOUND: ugettext_lazy("Could not find the survey being requested."),
+    MSG_FORM_ERROR: ugettext_lazy("There is a configuration error with this survey. "
         "Please contact your administrator."),
-    MSG_OPTED_IN: ugettext_noop("You have opted-in to receive messages from"
+    MSG_OPTED_IN: ugettext_lazy("You have opted-in to receive messages from"
         " CommCareHQ. To opt-out, reply to this number with {0}"),
-    MSG_OPTED_OUT: ugettext_noop("You have opted-out from receiving"
+    MSG_OPTED_OUT: ugettext_lazy("You have opted-out from receiving"
         " messages from CommCareHQ. To opt-in, reply to this number with {0}"),
-    MSG_DUPLICATE_USERNAME: ugettext_noop("CommCare user {0} already exists"),
-    MSG_USERNAME_TOO_LONG: ugettext_noop("Username {0} is too long.  Must be under {1} characters."),
+    MSG_DUPLICATE_USERNAME: ugettext_lazy("CommCare user {0} already exists"),
+    MSG_USERNAME_TOO_LONG: ugettext_lazy("Username {0} is too long.  Must be under {1} characters."),
 }
 
 def get_message(msg_id, verified_number=None, context=None):

--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -17,7 +17,7 @@ from .mixin import CommCareMobileContactMixin, MobileBackend, PhoneNumberInUseEx
 from corehq.apps.sms import util as smsutil
 from dimagi.utils.couch.undo import DELETED_SUFFIX
 from dimagi.utils.couch import CouchDocLockableMixIn
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 
 INCOMING = "I"
 OUTGOING = "O"
@@ -256,13 +256,13 @@ class SMS(SyncSQLToCouchMixin, models.Model):
 
     ERROR_MESSAGES = {
         ERROR_TOO_MANY_UNSUCCESSFUL_ATTEMPTS:
-            ugettext_noop('Gateway error.'),
+            ugettext_lazy('Gateway error.'),
         ERROR_MESSAGE_IS_STALE:
-            ugettext_noop('Message is stale and will not be processed.'),
+            ugettext_lazy('Message is stale and will not be processed.'),
         ERROR_INVALID_DIRECTION:
-            ugettext_noop('Unknown message direction.'),
+            ugettext_lazy('Unknown message direction.'),
         ERROR_PHONE_NUMBER_OPTED_OUT:
-            ugettext_noop('Phone number has opted out of receiving SMS.'),
+            ugettext_lazy('Phone number has opted out of receiving SMS.'),
     }
 
     couch_id = models.CharField(max_length=126, null=True, db_index=True)
@@ -724,10 +724,10 @@ class MessagingEvent(models.Model, MessagingStatusMixin):
     STATUS_ERROR = 'ERR'
 
     STATUS_CHOICES = (
-        (STATUS_IN_PROGRESS, ugettext_noop('In Progress')),
-        (STATUS_COMPLETED, ugettext_noop('Completed')),
-        (STATUS_NOT_COMPLETED, ugettext_noop('Not Completed')),
-        (STATUS_ERROR, ugettext_noop('Error')),
+        (STATUS_IN_PROGRESS, ugettext_lazy('In Progress')),
+        (STATUS_COMPLETED, ugettext_lazy('Completed')),
+        (STATUS_NOT_COMPLETED, ugettext_lazy('Not Completed')),
+        (STATUS_ERROR, ugettext_lazy('Error')),
     )
 
     SOURCE_BROADCAST = 'BRD'
@@ -738,12 +738,12 @@ class MessagingEvent(models.Model, MessagingStatusMixin):
     SOURCE_OTHER = 'OTH'
 
     SOURCE_CHOICES = (
-        (SOURCE_BROADCAST, ugettext_noop('Broadcast')),
-        (SOURCE_KEYWORD, ugettext_noop('Keyword')),
-        (SOURCE_REMINDER, ugettext_noop('Reminder')),
-        (SOURCE_UNRECOGNIZED, ugettext_noop('Unrecognized')),
-        (SOURCE_FORWARDED, ugettext_noop('Forwarded Message')),
-        (SOURCE_OTHER, ugettext_noop('Other')),
+        (SOURCE_BROADCAST, ugettext_lazy('Broadcast')),
+        (SOURCE_KEYWORD, ugettext_lazy('Keyword')),
+        (SOURCE_REMINDER, ugettext_lazy('Reminder')),
+        (SOURCE_UNRECOGNIZED, ugettext_lazy('Unrecognized')),
+        (SOURCE_FORWARDED, ugettext_lazy('Forwarded Message')),
+        (SOURCE_OTHER, ugettext_lazy('Other')),
     )
 
     CONTENT_NONE = 'NOP'
@@ -757,15 +757,15 @@ class MessagingEvent(models.Model, MessagingStatusMixin):
     CONTENT_CHAT_SMS = 'CHT'
 
     CONTENT_CHOICES = (
-        (CONTENT_NONE, ugettext_noop('None')),
-        (CONTENT_SMS, ugettext_noop('SMS Message')),
-        (CONTENT_SMS_CALLBACK, ugettext_noop('SMS Expecting Callback')),
-        (CONTENT_SMS_SURVEY, ugettext_noop('SMS Survey')),
-        (CONTENT_IVR_SURVEY, ugettext_noop('IVR Survey')),
-        (CONTENT_PHONE_VERIFICATION, ugettext_noop('Phone Verification')),
-        (CONTENT_ADHOC_SMS, ugettext_noop('Manually Sent Message')),
-        (CONTENT_API_SMS, ugettext_noop('Message Sent Via API')),
-        (CONTENT_CHAT_SMS, ugettext_noop('Message Sent Via Chat')),
+        (CONTENT_NONE, ugettext_lazy('None')),
+        (CONTENT_SMS, ugettext_lazy('SMS Message')),
+        (CONTENT_SMS_CALLBACK, ugettext_lazy('SMS Expecting Callback')),
+        (CONTENT_SMS_SURVEY, ugettext_lazy('SMS Survey')),
+        (CONTENT_IVR_SURVEY, ugettext_lazy('IVR Survey')),
+        (CONTENT_PHONE_VERIFICATION, ugettext_lazy('Phone Verification')),
+        (CONTENT_ADHOC_SMS, ugettext_lazy('Manually Sent Message')),
+        (CONTENT_API_SMS, ugettext_lazy('Message Sent Via API')),
+        (CONTENT_CHAT_SMS, ugettext_lazy('Message Sent Via Chat')),
     )
 
     RECIPIENT_CASE = 'CAS'
@@ -777,13 +777,13 @@ class MessagingEvent(models.Model, MessagingStatusMixin):
     RECIPIENT_UNKNOWN = 'UNK'
 
     RECIPIENT_CHOICES = (
-        (RECIPIENT_CASE, ugettext_noop('Case')),
-        (RECIPIENT_MOBILE_WORKER, ugettext_noop('Mobile Worker')),
-        (RECIPIENT_WEB_USER, ugettext_noop('Web User')),
-        (RECIPIENT_USER_GROUP, ugettext_noop('User Group')),
-        (RECIPIENT_CASE_GROUP, ugettext_noop('Case Group')),
-        (RECIPIENT_VARIOUS, ugettext_noop('Multiple Recipients')),
-        (RECIPIENT_UNKNOWN, ugettext_noop('Unknown Contact')),
+        (RECIPIENT_CASE, ugettext_lazy('Case')),
+        (RECIPIENT_MOBILE_WORKER, ugettext_lazy('Mobile Worker')),
+        (RECIPIENT_WEB_USER, ugettext_lazy('Web User')),
+        (RECIPIENT_USER_GROUP, ugettext_lazy('User Group')),
+        (RECIPIENT_CASE_GROUP, ugettext_lazy('Case Group')),
+        (RECIPIENT_VARIOUS, ugettext_lazy('Multiple Recipients')),
+        (RECIPIENT_UNKNOWN, ugettext_lazy('Unknown Contact')),
     )
 
     ERROR_NO_RECIPIENT = 'NO_RECIPIENT'
@@ -808,45 +808,45 @@ class MessagingEvent(models.Model, MessagingStatusMixin):
 
     ERROR_MESSAGES = {
         ERROR_NO_RECIPIENT:
-            ugettext_noop('No recipient'),
+            ugettext_lazy('No recipient'),
         ERROR_CANNOT_RENDER_MESSAGE:
-            ugettext_noop('Error rendering message; please check syntax.'),
+            ugettext_lazy('Error rendering message; please check syntax.'),
         ERROR_UNSUPPORTED_COUNTRY:
-            ugettext_noop('Gateway does not support the destination country.'),
+            ugettext_lazy('Gateway does not support the destination country.'),
         ERROR_NO_PHONE_NUMBER:
-            ugettext_noop('Contact has no phone number.'),
+            ugettext_lazy('Contact has no phone number.'),
         ERROR_NO_TWO_WAY_PHONE_NUMBER:
-            ugettext_noop('Contact has no two-way phone number.'),
+            ugettext_lazy('Contact has no two-way phone number.'),
         ERROR_INVALID_CUSTOM_CONTENT_HANDLER:
-            ugettext_noop('Invalid custom content handler.'),
+            ugettext_lazy('Invalid custom content handler.'),
         ERROR_CANNOT_LOAD_CUSTOM_CONTENT_HANDLER:
-            ugettext_noop('Cannot load custom content handler.'),
+            ugettext_lazy('Cannot load custom content handler.'),
         ERROR_CANNOT_FIND_FORM:
-            ugettext_noop('Cannot find form.'),
+            ugettext_lazy('Cannot find form.'),
         ERROR_FORM_HAS_NO_QUESTIONS:
-            ugettext_noop('No questions were available in the form. Please '
+            ugettext_lazy('No questions were available in the form. Please '
                 'check that the form has questions and that display conditions '
                 'are not preventing questions from being asked.'),
         ERROR_CASE_EXTERNAL_ID_NOT_FOUND:
-            ugettext_noop('The case with the given external ID was not found.'),
+            ugettext_lazy('The case with the given external ID was not found.'),
         ERROR_MULTIPLE_CASES_WITH_EXTERNAL_ID_FOUND:
-            ugettext_noop('Multiple cases were found with the given external ID.'),
+            ugettext_lazy('Multiple cases were found with the given external ID.'),
         ERROR_NO_CASE_GIVEN:
-            ugettext_noop('The form requires a case but no case was provided.'),
+            ugettext_lazy('The form requires a case but no case was provided.'),
         ERROR_NO_EXTERNAL_ID_GIVEN:
-            ugettext_noop('No external ID given; please include case external ID after keyword.'),
+            ugettext_lazy('No external ID given; please include case external ID after keyword.'),
         ERROR_COULD_NOT_PROCESS_STRUCTURED_SMS:
-            ugettext_noop('Error processing structured SMS.'),
+            ugettext_lazy('Error processing structured SMS.'),
         ERROR_SUBEVENT_ERROR:
-            ugettext_noop('View details for more information.'),
+            ugettext_lazy('View details for more information.'),
         ERROR_TOUCHFORMS_ERROR:
-            ugettext_noop('An error occurred in the formplayer service.'),
+            ugettext_lazy('An error occurred in the formplayer service.'),
         ERROR_INTERNAL_SERVER_ERROR:
-            ugettext_noop('Internal Server Error'),
+            ugettext_lazy('Internal Server Error'),
         ERROR_GATEWAY_ERROR:
-            ugettext_noop('Gateway error.'),
+            ugettext_lazy('Gateway error.'),
         ERROR_NO_SUITABLE_GATEWAY:
-            ugettext_noop('No suitable gateway could be found.'),
+            ugettext_lazy('No suitable gateway could be found.'),
     }
 
     domain = models.CharField(max_length=126, null=False, db_index=True)
@@ -1129,9 +1129,9 @@ class MessagingSubEvent(models.Model, MessagingStatusMixin):
     Used to track the status of a MessagingEvent for each of its recipients.
     """
     RECIPIENT_CHOICES = (
-        (MessagingEvent.RECIPIENT_CASE, ugettext_noop('Case')),
-        (MessagingEvent.RECIPIENT_MOBILE_WORKER, ugettext_noop('Mobile Worker')),
-        (MessagingEvent.RECIPIENT_WEB_USER, ugettext_noop('Web User')),
+        (MessagingEvent.RECIPIENT_CASE, ugettext_lazy('Case')),
+        (MessagingEvent.RECIPIENT_MOBILE_WORKER, ugettext_lazy('Mobile Worker')),
+        (MessagingEvent.RECIPIENT_WEB_USER, ugettext_lazy('Web User')),
     )
 
     parent = models.ForeignKey('MessagingEvent')

--- a/corehq/apps/sms/verify.py
+++ b/corehq/apps/sms/verify.py
@@ -1,5 +1,5 @@
 from dimagi.utils.couch import CriticalSection
-from django.utils.translation import ugettext as _, ugettext_noop
+from django.utils.translation import ugettext as _, ugettext_lazy
 from corehq import privileges
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.sms.api import (send_sms, send_sms_to_verified_number,
@@ -10,8 +10,8 @@ from corehq.apps.sms import util
 from corehq.apps.sms.models import MessagingEvent
 from corehq.util.translation import localize
 
-OUTGOING = ugettext_noop("Welcome to CommCareHQ! Is this phone used by %(name)s? If yes, reply '123'%(replyto)s to start using SMS with CommCareHQ.")
-CONFIRM = ugettext_noop("Thank you. This phone has been verified for using SMS with CommCareHQ")
+OUTGOING = ugettext_lazy("Welcome to CommCareHQ! Is this phone used by %(name)s? If yes, reply '123'%(replyto)s to start using SMS with CommCareHQ.")
+CONFIRM = ugettext_lazy("Thank you. This phone has been verified for using SMS with CommCareHQ")
 
 VERIFICATION__ALREADY_IN_USE = 1
 VERIFICATION__ALREADY_VERIFIED = 2

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -62,7 +62,7 @@ from django.contrib import messages
 from corehq.util.timezones.utils import get_timezone_for_user
 from django.views.decorators.csrf import csrf_exempt
 from corehq.apps.domain.models import Domain
-from django.utils.translation import ugettext as _, ugettext_noop
+from django.utils.translation import ugettext as _, ugettext_lazy
 from dimagi.utils.parsing import json_format_datetime, string_to_boolean
 from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.decorators.view import get_file
@@ -80,9 +80,9 @@ from couchexport.shortcuts import export_response
 
 # Tuple of (description, days in the past)
 SMS_CHAT_HISTORY_CHOICES = (
-    (ugettext_noop("Yesterday"), 1),
-    (ugettext_noop("1 Week"), 7),
-    (ugettext_noop("30 Days"), 30),
+    (ugettext_lazy("Yesterday"), 1),
+    (ugettext_lazy("1 Week"), 7),
+    (ugettext_lazy("30 Days"), 30),
 )
 
 @login_and_domain_required
@@ -91,7 +91,7 @@ def default(request, domain):
 
 
 class BaseMessagingSectionView(BaseDomainView):
-    section_name = ugettext_noop("Messaging")
+    section_name = ugettext_lazy("Messaging")
 
     @method_decorator(requires_privilege_with_fallback(privileges.OUTBOUND_SMS))
     def dispatch(self, *args, **kwargs):
@@ -987,7 +987,7 @@ def api_last_read_message(request, domain):
 class DomainSmsGatewayListView(CRUDPaginatedViewMixin, BaseMessagingSectionView):
     template_name = "sms/gateway_list.html"
     urlname = 'list_domain_backends'
-    page_title = ugettext_noop("SMS Connectivity")
+    page_title = ugettext_lazy("SMS Connectivity")
     strict_domain_fetching = True
 
     @property
@@ -1148,7 +1148,7 @@ class DomainSmsGatewayListView(CRUDPaginatedViewMixin, BaseMessagingSectionView)
 class AddDomainGatewayView(BaseMessagingSectionView):
     urlname = 'add_domain_gateway'
     template_name = 'sms/add_gateway.html'
-    page_title = ugettext_noop("Add SMS Connection")
+    page_title = ugettext_lazy("Add SMS Connection")
 
     @property
     def is_superuser(self):
@@ -1243,7 +1243,7 @@ class AddDomainGatewayView(BaseMessagingSectionView):
 
 class EditDomainGatewayView(AddDomainGatewayView):
     urlname = 'edit_domain_gateway'
-    page_title = ugettext_noop("Edit SMS Connection")
+    page_title = ugettext_lazy("Edit SMS Connection")
 
     @property
     def backend_id(self):
@@ -1301,7 +1301,7 @@ class EditDomainGatewayView(AddDomainGatewayView):
 class SubscribeSMSView(BaseMessagingSectionView):
     template_name = "sms/subscribe_sms.html"
     urlname = 'subscribe_sms'
-    page_title = ugettext_noop("Subscribe SMS")
+    page_title = ugettext_lazy("Subscribe SMS")
 
     @property
     def commtrack_settings(self):
@@ -1466,7 +1466,7 @@ def upload_sms_translations(request, domain):
 class SMSSettingsView(BaseMessagingSectionView):
     urlname = "sms_settings"
     template_name = "sms/settings.html"
-    page_title = ugettext_noop("SMS Settings")
+    page_title = ugettext_lazy("SMS Settings")
 
     @property
     def page_name(self):

--- a/corehq/apps/smsbillables/filters.py
+++ b/corehq/apps/smsbillables/filters.py
@@ -3,7 +3,7 @@ from corehq.apps.accounting.filters import (
     clean_options,
     DateRangeFilter,
 )
-from django.utils.translation import ugettext_noop as _
+from django.utils.translation import ugettext_lazy as _
 from corehq.apps.reports.filters.base import BaseSingleOptionFilter
 from corehq.apps.sms.models import DIRECTION_CHOICES
 from corehq.apps.smsbillables.models import SmsGatewayFeeCriteria, SmsBillable

--- a/corehq/apps/smsforms/models.py
+++ b/corehq/apps/smsforms/models.py
@@ -3,7 +3,7 @@ from couchdbkit import MultipleResultsFound
 from couchforms.models import XFormInstance
 from django.db import models
 from django.db.models import Q
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 
 
 XFORMS_SESSION_SMS = "SMS"
@@ -61,14 +61,14 @@ class SQLXFormsSession(models.Model):
 
         if xform_instance:
             if xform_instance.partial_submission:
-                return ugettext_noop('Completed (Partially Completed Submission)')
+                return ugettext_lazy('Completed (Partially Completed Submission)')
             else:
-                return ugettext_noop('Completed')
+                return ugettext_lazy('Completed')
         else:
             if self.is_open and self.session_type == XFORMS_SESSION_SMS:
-                return ugettext_noop('In Progress')
+                return ugettext_lazy('In Progress')
             else:
-                return ugettext_noop('Not Finished')
+                return ugettext_lazy('Not Finished')
 
     @property
     def is_open(self):

--- a/corehq/apps/styleguide/examples/controls_demo/forms.py
+++ b/corehq/apps/styleguide/examples/controls_demo/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_noop, ugettext as _
+from django.utils.translation import ugettext_lazy, ugettext as _
 from crispy_forms.helper import FormHelper
 from crispy_forms import layout as crispy
 from crispy_forms import bootstrap as twbscrispy
@@ -17,23 +17,23 @@ class SelectControlDemoForm(forms.Form):
     """This form demonstrates the use of different types of selects.
     """
     office = forms.ChoiceField(
-        label=ugettext_noop("Dimagi Office (Single Select)"),
+        label=ugettext_lazy("Dimagi Office (Single Select)"),
         required=False,
         # only do this if the choices are static:
         choices=[(o, o) for o in OFFICES]
     )
     colors = forms.MultipleChoiceField(
-        label=ugettext_noop("Favorite Colors (Multi Select)"),
+        label=ugettext_lazy("Favorite Colors (Multi Select)"),
         required=False,
         # only do this if the choices are static:
         choices=[(c, c) for c in COLORS]
     )
     language = forms.ChoiceField(
-        label=ugettext_noop("Language (Select2 Single)"),
+        label=ugettext_lazy("Language (Select2 Single)"),
         required=False,
     )
     genres = forms.MultipleChoiceField(
-        label=ugettext_noop("Music Genre (Select2 Multi)"),
+        label=ugettext_lazy("Music Genre (Select2 Multi)"),
         required=False,
     )
 

--- a/corehq/apps/styleguide/examples/controls_demo/views.py
+++ b/corehq/apps/styleguide/examples/controls_demo/views.py
@@ -2,7 +2,7 @@ from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext_noop, ugettext as _
+from django.utils.translation import ugettext_lazy, ugettext as _
 from corehq.apps.domain.decorators import login_required
 from corehq.apps.style.decorators import use_select2
 from corehq.apps.style.views import BaseB3SectionPageView
@@ -13,7 +13,7 @@ from dimagi.utils.decorators.memoized import memoized
 
 
 class BaseControlDemoFormsView(BaseB3SectionPageView):
-    section_name = ugettext_noop("Simple Crispy Form Example")
+    section_name = ugettext_lazy("Simple Crispy Form Example")
 
     def section_url(self):
         return reverse(DefaultControlsDemoFormsView.urlname)
@@ -38,7 +38,7 @@ class DefaultControlsDemoFormsView(BaseControlDemoFormsView):
 class SelectControlDemoView(BaseControlDemoFormsView):
     """This shows example usage for crispy forms in an HQ template view.
     """
-    page_title = ugettext_noop("Using the Selects")
+    page_title = ugettext_lazy("Using the Selects")
     urlname = 'ex_controls_demo'
     template_name = 'styleguide/examples/controls_demo/selects.html'
 

--- a/corehq/apps/styleguide/examples/simple_crispy_form/forms.py
+++ b/corehq/apps/styleguide/examples/simple_crispy_form/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_noop, ugettext as _
+from django.utils.translation import ugettext_lazy, ugettext as _
 from crispy_forms.helper import FormHelper
 from crispy_forms import layout as crispy
 from crispy_forms import bootstrap as twbscrispy
@@ -11,29 +11,29 @@ class ExampleUserLoginForm(forms.Form):
     This is an EXAMPLE form that demonstrates the use of Crispy Forms in HQ.
     """
     full_name = forms.CharField(
-        label=ugettext_noop("Full Name"),
+        label=ugettext_lazy("Full Name"),
     )
     email = forms.EmailField(
-        label=ugettext_noop("Email"),
+        label=ugettext_lazy("Email"),
     )
     password = forms.CharField(
-        label=ugettext_noop("Password"),
+        label=ugettext_lazy("Password"),
         widget=forms.PasswordInput(),
     )
     password_repeat = forms.CharField(
-        label=ugettext_noop("Password (Repeat)"),
+        label=ugettext_lazy("Password (Repeat)"),
         widget=forms.PasswordInput(),
     )
     phone_number = forms.CharField(
-        label=ugettext_noop("Phone Number"),
+        label=ugettext_lazy("Phone Number"),
         required=False,
     )
     is_staff = forms.BooleanField(
-        label=ugettext_noop("Has Staff Privileges"),
+        label=ugettext_lazy("Has Staff Privileges"),
         required=False,
     )
     language = forms.ChoiceField(
-        label=ugettext_noop("Language"),
+        label=ugettext_lazy("Language"),
         required=False,
     )
 

--- a/corehq/apps/styleguide/examples/simple_crispy_form/views.py
+++ b/corehq/apps/styleguide/examples/simple_crispy_form/views.py
@@ -2,7 +2,7 @@ from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext_noop, ugettext as _
+from django.utils.translation import ugettext_lazy, ugettext as _
 from corehq.apps.domain.decorators import login_required
 from corehq.apps.style.views import BaseB3SectionPageView
 from corehq.apps.styleguide.examples.simple_crispy_form.forms import ExampleUserLoginForm
@@ -10,7 +10,7 @@ from dimagi.utils.decorators.memoized import memoized
 
 
 class BaseSimpleCrispyFormSectionView(BaseB3SectionPageView):
-    section_name = ugettext_noop("Simple Crispy Form Example")
+    section_name = ugettext_lazy("Simple Crispy Form Example")
 
     def section_url(self):
         return reverse(DefaultSimpleCrispyFormSectionView.urlname)
@@ -35,7 +35,7 @@ class DefaultSimpleCrispyFormSectionView(BaseSimpleCrispyFormSectionView):
 class SimpleCrispyFormView(BaseSimpleCrispyFormSectionView):
     """This shows example usage for crispy forms in an HQ template view.
     """
-    page_title = ugettext_noop("Register a New User")
+    page_title = ugettext_lazy("Register a New User")
     urlname = 'ex_simple_crispy_forms'
     template_name = 'styleguide/examples/simple_crispy_form/base.html'
 

--- a/corehq/apps/styleguide/tabs.py
+++ b/corehq/apps/styleguide/tabs.py
@@ -1,5 +1,5 @@
 from django.core.urlresolvers import reverse
-from django.utils.translation import ugettext_noop, ugettext as _
+from django.utils.translation import ugettext_lazy, ugettext as _
 
 from dimagi.utils.decorators.memoized import memoized
 
@@ -34,7 +34,7 @@ class BaseSGTab(UITab):
 
 
 class SimpleCrispyFormSGExample(BaseSGTab):
-    title = ugettext_noop("Simple Crispy Form")
+    title = ugettext_lazy("Simple Crispy Form")
     view = DefaultSimpleCrispyFormSectionView.urlname
 
     @property
@@ -67,7 +67,7 @@ class SimpleCrispyFormSGExample(BaseSGTab):
 
 
 class ControlsDemoSGExample(BaseSGTab):
-    title = ugettext_noop("Form Controls")
+    title = ugettext_lazy("Form Controls")
     view = DefaultControlsDemoFormsView.urlname
 
     @property
@@ -101,7 +101,7 @@ class ControlsDemoSGExample(BaseSGTab):
 
 
 class SGExampleTab(BaseSGTab):
-    title = ugettext_noop("Style Guide")
+    title = ugettext_lazy("Style Guide")
     view = 'corehq.apps.styleguide.views.docs.default'
     subtab_classes = (
         SimpleCrispyFormSGExample,

--- a/corehq/apps/styleguide/templates/styleguide/_includes/forms/best_practices.html
+++ b/corehq/apps/styleguide/templates/styleguide/_includes/forms/best_practices.html
@@ -17,7 +17,7 @@
         <li>
             Your imports should generally look like:
             <pre><code class="python">from django import forms
-from django.utils.translation import ugettext_noop, ugettext as _
+from django.utils.translation import ugettext_lazy, ugettext as _
 from crispy_forms.helper import FormHelper
 from crispy_forms import layout as crispy
 from crispy_forms import bootstrap as twbscrispy

--- a/corehq/apps/styleguide/templates/styleguide/docs/controls_demo/forms.html
+++ b/corehq/apps/styleguide/templates/styleguide/docs/controls_demo/forms.html
@@ -4,7 +4,7 @@
     <div class="row">
         <div class="col-lg-4"></div>
         <div class="col-lg-8"><div class="highlight"><pre><span class="kn">from</span> <span class="nn">django</span> <span class="kn">import</span> <span class="n">forms</span>
-<span class="kn">from</span> <span class="nn">django.utils.translation</span> <span class="kn">import</span> <span class="n">ugettext_noop</span><span class="p">,</span> <span class="n">ugettext</span> <span class="k">as</span> <span class="n">_</span>
+<span class="kn">from</span> <span class="nn">django.utils.translation</span> <span class="kn">import</span> <span class="n">ugettext_lazy</span><span class="p">,</span> <span class="n">ugettext</span> <span class="k">as</span> <span class="n">_</span>
 <span class="kn">from</span> <span class="nn">crispy_forms.helper</span> <span class="kn">import</span> <span class="n">FormHelper</span>
 <span class="kn">from</span> <span class="nn">crispy_forms</span> <span class="kn">import</span> <span class="n">layout</span> <span class="k">as</span> <span class="n">crispy</span>
 <span class="kn">from</span> <span class="nn">crispy_forms</span> <span class="kn">import</span> <span class="n">bootstrap</span> <span class="k">as</span> <span class="n">twbscrispy</span>
@@ -24,7 +24,7 @@
     <div class="row">
         <div class="col-lg-4"></div>
         <div class="col-lg-8"><div class="highlight"><pre>    <span class="n">office</span> <span class="o">=</span> <span class="n">forms</span><span class="o">.</span><span class="n">ChoiceField</span><span class="p">(</span>
-        <span class="n">label</span><span class="o">=</span><span class="n">ugettext_noop</span><span class="p">(</span><span class="s">&quot;Dimagi Office (Single Select)&quot;</span><span class="p">),</span>
+        <span class="n">label</span><span class="o">=</span><span class="n">ugettext_lazy</span><span class="p">(</span><span class="s">&quot;Dimagi Office (Single Select)&quot;</span><span class="p">),</span>
         <span class="n">required</span><span class="o">=</span><span class="bp">False</span><span class="p">,</span></pre></div></div>
     </div>
     <div class="row">
@@ -32,7 +32,7 @@
         <div class="col-lg-8"><div class="highlight"><pre>        <span class="n">choices</span><span class="o">=</span><span class="p">[(</span><span class="n">o</span><span class="p">,</span> <span class="n">o</span><span class="p">)</span> <span class="k">for</span> <span class="n">o</span> <span class="ow">in</span> <span class="n">OFFICES</span><span class="p">]</span>
     <span class="p">)</span>
     <span class="n">colors</span> <span class="o">=</span> <span class="n">forms</span><span class="o">.</span><span class="n">MultipleChoiceField</span><span class="p">(</span>
-        <span class="n">label</span><span class="o">=</span><span class="n">ugettext_noop</span><span class="p">(</span><span class="s">&quot;Favorite Colors (Multi Select)&quot;</span><span class="p">),</span>
+        <span class="n">label</span><span class="o">=</span><span class="n">ugettext_lazy</span><span class="p">(</span><span class="s">&quot;Favorite Colors (Multi Select)&quot;</span><span class="p">),</span>
         <span class="n">required</span><span class="o">=</span><span class="bp">False</span><span class="p">,</span></pre></div></div>
     </div>
     <div class="row">
@@ -40,11 +40,11 @@
         <div class="col-lg-8"><div class="highlight"><pre>        <span class="n">choices</span><span class="o">=</span><span class="p">[(</span><span class="n">c</span><span class="p">,</span> <span class="n">c</span><span class="p">)</span> <span class="k">for</span> <span class="n">c</span> <span class="ow">in</span> <span class="n">COLORS</span><span class="p">]</span>
     <span class="p">)</span>
     <span class="n">language</span> <span class="o">=</span> <span class="n">forms</span><span class="o">.</span><span class="n">ChoiceField</span><span class="p">(</span>
-        <span class="n">label</span><span class="o">=</span><span class="n">ugettext_noop</span><span class="p">(</span><span class="s">&quot;Language (Select2 Single)&quot;</span><span class="p">),</span>
+        <span class="n">label</span><span class="o">=</span><span class="n">ugettext_lazy</span><span class="p">(</span><span class="s">&quot;Language (Select2 Single)&quot;</span><span class="p">),</span>
         <span class="n">required</span><span class="o">=</span><span class="bp">False</span><span class="p">,</span>
     <span class="p">)</span>
     <span class="n">genres</span> <span class="o">=</span> <span class="n">forms</span><span class="o">.</span><span class="n">MultipleChoiceField</span><span class="p">(</span>
-        <span class="n">label</span><span class="o">=</span><span class="n">ugettext_noop</span><span class="p">(</span><span class="s">&quot;Music Genre (Select2 Multi)&quot;</span><span class="p">),</span>
+        <span class="n">label</span><span class="o">=</span><span class="n">ugettext_lazy</span><span class="p">(</span><span class="s">&quot;Music Genre (Select2 Multi)&quot;</span><span class="p">),</span>
         <span class="n">required</span><span class="o">=</span><span class="bp">False</span><span class="p">,</span>
     <span class="p">)</span></pre></div></div>
     </div>

--- a/corehq/apps/styleguide/templates/styleguide/docs/controls_demo/views.html
+++ b/corehq/apps/styleguide/templates/styleguide/docs/controls_demo/views.html
@@ -7,7 +7,7 @@
 <span class="kn">from</span> <span class="nn">django.core.urlresolvers</span> <span class="kn">import</span> <span class="n">reverse</span>
 <span class="kn">from</span> <span class="nn">django.http</span> <span class="kn">import</span> <span class="n">HttpResponseRedirect</span>
 <span class="kn">from</span> <span class="nn">django.utils.decorators</span> <span class="kn">import</span> <span class="n">method_decorator</span>
-<span class="kn">from</span> <span class="nn">django.utils.translation</span> <span class="kn">import</span> <span class="n">ugettext_noop</span><span class="p">,</span> <span class="n">ugettext</span> <span class="k">as</span> <span class="n">_</span>
+<span class="kn">from</span> <span class="nn">django.utils.translation</span> <span class="kn">import</span> <span class="n">ugettext_lazy</span><span class="p">,</span> <span class="n">ugettext</span> <span class="k">as</span> <span class="n">_</span>
 <span class="kn">from</span> <span class="nn">corehq.apps.domain.decorators</span> <span class="kn">import</span> <span class="n">login_required</span>
 <span class="kn">from</span> <span class="nn">corehq.apps.style.decorators</span> <span class="kn">import</span> <span class="n">use_select2</span>
 <span class="kn">from</span> <span class="nn">corehq.apps.style.views</span> <span class="kn">import</span> <span class="n">BaseB3SectionPageView</span>
@@ -19,7 +19,7 @@
     <div class="row">
         <div class="col-lg-4"></div>
         <div class="col-lg-8"><div class="highlight"><pre><span class="k">class</span> <span class="nc">BaseControlDemoFormsView</span><span class="p">(</span><span class="n">BaseB3SectionPageView</span><span class="p">):</span>
-    <span class="n">section_name</span> <span class="o">=</span> <span class="n">ugettext_noop</span><span class="p">(</span><span class="s">&quot;Simple Crispy Form Example&quot;</span><span class="p">)</span></pre></div></div>
+    <span class="n">section_name</span> <span class="o">=</span> <span class="n">ugettext_lazy</span><span class="p">(</span><span class="s">&quot;Simple Crispy Form Example&quot;</span><span class="p">)</span></pre></div></div>
     </div>
     <div class="row">
         <div class="col-lg-4"></div>
@@ -52,7 +52,7 @@
     </div>
     <div class="row">
         <div class="col-lg-4"></div>
-        <div class="col-lg-8"><div class="highlight"><pre>    <span class="n">page_title</span> <span class="o">=</span> <span class="n">ugettext_noop</span><span class="p">(</span><span class="s">&quot;Using the Selects&quot;</span><span class="p">)</span>
+        <div class="col-lg-8"><div class="highlight"><pre>    <span class="n">page_title</span> <span class="o">=</span> <span class="n">ugettext_lazy</span><span class="p">(</span><span class="s">&quot;Using the Selects&quot;</span><span class="p">)</span>
     <span class="n">urlname</span> <span class="o">=</span> <span class="s">&#39;ex_controls_demo&#39;</span>
     <span class="n">template_name</span> <span class="o">=</span> <span class="s">&#39;styleguide/examples/controls_demo/selects.html&#39;</span></pre></div></div>
     </div>

--- a/corehq/apps/styleguide/templates/styleguide/docs/simple_crispy_form/forms.html
+++ b/corehq/apps/styleguide/templates/styleguide/docs/simple_crispy_form/forms.html
@@ -4,7 +4,7 @@
     <div class="row">
         <div class="col-lg-4"></div>
         <div class="col-lg-8"><div class="highlight"><pre><span class="kn">from</span> <span class="nn">django</span> <span class="kn">import</span> <span class="n">forms</span>
-<span class="kn">from</span> <span class="nn">django.utils.translation</span> <span class="kn">import</span> <span class="n">ugettext_noop</span><span class="p">,</span> <span class="n">ugettext</span> <span class="k">as</span> <span class="n">_</span>
+<span class="kn">from</span> <span class="nn">django.utils.translation</span> <span class="kn">import</span> <span class="n">ugettext_lazy</span><span class="p">,</span> <span class="n">ugettext</span> <span class="k">as</span> <span class="n">_</span>
 <span class="kn">from</span> <span class="nn">crispy_forms.helper</span> <span class="kn">import</span> <span class="n">FormHelper</span>
 <span class="kn">from</span> <span class="nn">crispy_forms</span> <span class="kn">import</span> <span class="n">layout</span> <span class="k">as</span> <span class="n">crispy</span>
 <span class="kn">from</span> <span class="nn">crispy_forms</span> <span class="kn">import</span> <span class="n">bootstrap</span> <span class="k">as</span> <span class="n">twbscrispy</span>
@@ -17,29 +17,29 @@
     <div class="row">
         <div class="col-lg-4"></div>
         <div class="col-lg-8"><div class="highlight"><pre>    <span class="n">full_name</span> <span class="o">=</span> <span class="n">forms</span><span class="o">.</span><span class="n">CharField</span><span class="p">(</span>
-        <span class="n">label</span><span class="o">=</span><span class="n">ugettext_noop</span><span class="p">(</span><span class="s">&quot;Full Name&quot;</span><span class="p">),</span>
+        <span class="n">label</span><span class="o">=</span><span class="n">ugettext_lazy</span><span class="p">(</span><span class="s">&quot;Full Name&quot;</span><span class="p">),</span>
     <span class="p">)</span>
     <span class="n">email</span> <span class="o">=</span> <span class="n">forms</span><span class="o">.</span><span class="n">EmailField</span><span class="p">(</span>
-        <span class="n">label</span><span class="o">=</span><span class="n">ugettext_noop</span><span class="p">(</span><span class="s">&quot;Email&quot;</span><span class="p">),</span>
+        <span class="n">label</span><span class="o">=</span><span class="n">ugettext_lazy</span><span class="p">(</span><span class="s">&quot;Email&quot;</span><span class="p">),</span>
     <span class="p">)</span>
     <span class="n">password</span> <span class="o">=</span> <span class="n">forms</span><span class="o">.</span><span class="n">CharField</span><span class="p">(</span>
-        <span class="n">label</span><span class="o">=</span><span class="n">ugettext_noop</span><span class="p">(</span><span class="s">&quot;Password&quot;</span><span class="p">),</span>
+        <span class="n">label</span><span class="o">=</span><span class="n">ugettext_lazy</span><span class="p">(</span><span class="s">&quot;Password&quot;</span><span class="p">),</span>
         <span class="n">widget</span><span class="o">=</span><span class="n">forms</span><span class="o">.</span><span class="n">PasswordInput</span><span class="p">(),</span>
     <span class="p">)</span>
     <span class="n">password_repeat</span> <span class="o">=</span> <span class="n">forms</span><span class="o">.</span><span class="n">CharField</span><span class="p">(</span>
-        <span class="n">label</span><span class="o">=</span><span class="n">ugettext_noop</span><span class="p">(</span><span class="s">&quot;Password (Repeat)&quot;</span><span class="p">),</span>
+        <span class="n">label</span><span class="o">=</span><span class="n">ugettext_lazy</span><span class="p">(</span><span class="s">&quot;Password (Repeat)&quot;</span><span class="p">),</span>
         <span class="n">widget</span><span class="o">=</span><span class="n">forms</span><span class="o">.</span><span class="n">PasswordInput</span><span class="p">(),</span>
     <span class="p">)</span>
     <span class="n">phone_number</span> <span class="o">=</span> <span class="n">forms</span><span class="o">.</span><span class="n">CharField</span><span class="p">(</span>
-        <span class="n">label</span><span class="o">=</span><span class="n">ugettext_noop</span><span class="p">(</span><span class="s">&quot;Phone Number&quot;</span><span class="p">),</span>
+        <span class="n">label</span><span class="o">=</span><span class="n">ugettext_lazy</span><span class="p">(</span><span class="s">&quot;Phone Number&quot;</span><span class="p">),</span>
         <span class="n">required</span><span class="o">=</span><span class="bp">False</span><span class="p">,</span>
     <span class="p">)</span>
     <span class="n">is_staff</span> <span class="o">=</span> <span class="n">forms</span><span class="o">.</span><span class="n">BooleanField</span><span class="p">(</span>
-        <span class="n">label</span><span class="o">=</span><span class="n">ugettext_noop</span><span class="p">(</span><span class="s">&quot;Has Staff Privileges&quot;</span><span class="p">),</span>
+        <span class="n">label</span><span class="o">=</span><span class="n">ugettext_lazy</span><span class="p">(</span><span class="s">&quot;Has Staff Privileges&quot;</span><span class="p">),</span>
         <span class="n">required</span><span class="o">=</span><span class="bp">False</span><span class="p">,</span>
     <span class="p">)</span>
     <span class="n">language</span> <span class="o">=</span> <span class="n">forms</span><span class="o">.</span><span class="n">ChoiceField</span><span class="p">(</span>
-        <span class="n">label</span><span class="o">=</span><span class="n">ugettext_noop</span><span class="p">(</span><span class="s">&quot;Language&quot;</span><span class="p">),</span>
+        <span class="n">label</span><span class="o">=</span><span class="n">ugettext_lazy</span><span class="p">(</span><span class="s">&quot;Language&quot;</span><span class="p">),</span>
         <span class="n">required</span><span class="o">=</span><span class="bp">False</span><span class="p">,</span>
     <span class="p">)</span></pre></div></div>
     </div>

--- a/corehq/apps/styleguide/templates/styleguide/docs/simple_crispy_form/views.html
+++ b/corehq/apps/styleguide/templates/styleguide/docs/simple_crispy_form/views.html
@@ -7,7 +7,7 @@
 <span class="kn">from</span> <span class="nn">django.core.urlresolvers</span> <span class="kn">import</span> <span class="n">reverse</span>
 <span class="kn">from</span> <span class="nn">django.http</span> <span class="kn">import</span> <span class="n">HttpResponseRedirect</span>
 <span class="kn">from</span> <span class="nn">django.utils.decorators</span> <span class="kn">import</span> <span class="n">method_decorator</span>
-<span class="kn">from</span> <span class="nn">django.utils.translation</span> <span class="kn">import</span> <span class="n">ugettext_noop</span><span class="p">,</span> <span class="n">ugettext</span> <span class="k">as</span> <span class="n">_</span>
+<span class="kn">from</span> <span class="nn">django.utils.translation</span> <span class="kn">import</span> <span class="n">ugettext_lazy</span><span class="p">,</span> <span class="n">ugettext</span> <span class="k">as</span> <span class="n">_</span>
 <span class="kn">from</span> <span class="nn">corehq.apps.domain.decorators</span> <span class="kn">import</span> <span class="n">login_required</span>
 <span class="kn">from</span> <span class="nn">corehq.apps.style.views</span> <span class="kn">import</span> <span class="n">BaseB3SectionPageView</span>
 <span class="kn">from</span> <span class="nn">corehq.apps.styleguide.examples.simple_crispy_form.forms</span> <span class="kn">import</span> <span class="n">ExampleUserLoginForm</span>
@@ -16,7 +16,7 @@
     <div class="row">
         <div class="col-lg-4"></div>
         <div class="col-lg-8"><div class="highlight"><pre><span class="k">class</span> <span class="nc">BaseSimpleCrispyFormSectionView</span><span class="p">(</span><span class="n">BaseB3SectionPageView</span><span class="p">):</span>
-    <span class="n">section_name</span> <span class="o">=</span> <span class="n">ugettext_noop</span><span class="p">(</span><span class="s">&quot;Simple Crispy Form Example&quot;</span><span class="p">)</span></pre></div></div>
+    <span class="n">section_name</span> <span class="o">=</span> <span class="n">ugettext_lazy</span><span class="p">(</span><span class="s">&quot;Simple Crispy Form Example&quot;</span><span class="p">)</span></pre></div></div>
     </div>
     <div class="row">
         <div class="col-lg-4"></div>
@@ -49,7 +49,7 @@
     </div>
     <div class="row">
         <div class="col-lg-4"></div>
-        <div class="col-lg-8"><div class="highlight"><pre>    <span class="n">page_title</span> <span class="o">=</span> <span class="n">ugettext_noop</span><span class="p">(</span><span class="s">&quot;Register a New User&quot;</span><span class="p">)</span>
+        <div class="col-lg-8"><div class="highlight"><pre>    <span class="n">page_title</span> <span class="o">=</span> <span class="n">ugettext_lazy</span><span class="p">(</span><span class="s">&quot;Register a New User&quot;</span><span class="p">)</span>
     <span class="n">urlname</span> <span class="o">=</span> <span class="s">&#39;ex_simple_crispy_forms&#39;</span>
     <span class="n">template_name</span> <span class="o">=</span> <span class="s">&#39;styleguide/examples/simple_crispy_form/base.html&#39;</span></pre></div></div>
     </div>

--- a/corehq/apps/styleguide/views/docs.py
+++ b/corehq/apps/styleguide/views/docs.py
@@ -1,5 +1,5 @@
 from django.http import HttpResponse
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from corehq.apps.styleguide.examples.simple_crispy_form.views import \
     BaseSimpleCrispyFormSectionView
 
@@ -11,22 +11,22 @@ def default(request):
 class FormsSimpleCrispyFormExampleView(BaseSimpleCrispyFormSectionView):
     urlname = 'ex_simple_crispy_form_doc_forms'
     template_name = 'styleguide/docs/simple_crispy_form/forms.html'
-    page_title = ugettext_noop("forms.py")
+    page_title = ugettext_lazy("forms.py")
 
 
 class ViewsSimpleCrispyFormExampleView(BaseSimpleCrispyFormSectionView):
     urlname = 'ex_simple_crispy_form_doc_views'
     template_name = 'styleguide/docs/simple_crispy_form/views.html'
-    page_title = ugettext_noop("views.py")
+    page_title = ugettext_lazy("views.py")
 
 
 class SelectControlFormExampleView(BaseSimpleCrispyFormSectionView):
     urlname = 'ex_controls_demo_doc_forms'
     template_name = 'styleguide/docs/controls_demo/forms.html'
-    page_title = ugettext_noop("forms.py")
+    page_title = ugettext_lazy("forms.py")
 
 
 class SelectControlViewExampleView(BaseSimpleCrispyFormSectionView):
     urlname = 'ex_controls_demo_doc_views'
     template_name = 'styleguide/docs/controls_demo/views.html'
-    page_title = ugettext_noop("views.py")
+    page_title = ugettext_lazy("views.py")

--- a/corehq/apps/telerivet/forms.py
+++ b/corehq/apps/telerivet/forms.py
@@ -2,21 +2,21 @@ from django.forms.fields import *
 from corehq.apps.sms.forms import BackendForm
 from dimagi.utils.django.fields import TrimmedCharField
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext as _, ugettext_noop
+from django.utils.translation import ugettext as _, ugettext_lazy
 from crispy_forms import layout as crispy
 
 class TelerivetBackendForm(BackendForm):
     api_key = TrimmedCharField(
-        label=ugettext_noop("API Key"),
+        label=ugettext_lazy("API Key"),
     )
     project_id = TrimmedCharField(
-        label=ugettext_noop("Project ID"),
+        label=ugettext_lazy("Project ID"),
     )
     phone_id = TrimmedCharField(
-        label=ugettext_noop("Phone ID"),
+        label=ugettext_lazy("Phone ID"),
     )
     webhook_secret = TrimmedCharField(
-        label=ugettext_noop("Webhook Secret"),
+        label=ugettext_lazy("Webhook Secret"),
     )
 
     @property

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -9,7 +9,7 @@ from django.forms import Widget
 from django.forms.util import flatatt
 from django.template.loader import render_to_string
 from django.utils.html import format_html
-from django.utils.translation import ugettext_noop as _
+from django.utils.translation import ugettext_lazy as _
 
 from crispy_forms import layout as crispy
 from crispy_forms.bootstrap import FormActions

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse
-from django.utils.translation import ugettext_noop as _
+from django.utils.translation import ugettext_lazy as _
 from django.views.generic.base import TemplateView
 from braces.views import JSONResponseMixin
 from corehq.apps.reports.dispatcher import cls_to_view_login_and_domain

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -8,7 +8,7 @@ from django.core.validators import EmailValidator
 from django.core.urlresolvers import reverse
 from django.forms.widgets import PasswordInput, HiddenInput
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext as _, ugettext_noop, ugettext_lazy
+from django.utils.translation import ugettext as _, ugettext_lazy, ugettext_lazy
 from django.template.loader import get_template
 from django.template import Context
 from django_countries.data import COUNTRIES
@@ -168,7 +168,7 @@ class BaseUserInfoForm(forms.Form):
 class UpdateMyAccountInfoForm(BaseUpdateUserForm, BaseUserInfoForm):
     email_opt_out = forms.BooleanField(
         required=False,
-        label=ugettext_noop("Opt out of emails about CommCare updates."),
+        label=ugettext_lazy("Opt out of emails about CommCare updates."),
     )
 
     def __init__(self, *args, **kwargs):

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -8,7 +8,7 @@ from django.core.validators import EmailValidator
 from django.core.urlresolvers import reverse
 from django.forms.widgets import PasswordInput, HiddenInput
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext as _, ugettext_lazy, ugettext_lazy
+from django.utils.translation import ugettext as _, ugettext_lazy
 from django.template.loader import get_template
 from django.template import Context
 from django_countries.data import COUNTRIES

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -54,7 +54,7 @@ from corehq.apps.sms.verify import (
 )
 from corehq.util.couch import get_document_or_404
 
-from django.utils.translation import ugettext as _, ugettext_noop, ugettext_lazy
+from django.utils.translation import ugettext as _, ugettext_lazy, ugettext_lazy
 
 
 def _users_context(request, domain):
@@ -78,7 +78,7 @@ def _users_context(request, domain):
 
 
 class BaseUserSettingsView(BaseDomainView):
-    section_name = ugettext_noop("Users")
+    section_name = ugettext_lazy("Users")
 
     @property
     @memoized
@@ -233,7 +233,7 @@ class BaseEditUserView(BaseUserSettingsView):
 class EditWebUserView(BaseEditUserView):
     template_name = "users/edit_web_user.html"
     urlname = "user_account"
-    page_title = ugettext_noop("Edit User Role")
+    page_title = ugettext_lazy("Edit User Role")
     user_update_form_class = UpdateUserRoleForm
 
     @property
@@ -344,8 +344,8 @@ class BaseFullEditUserView(BaseEditUserView):
 class EditMyAccountDomainView(BaseFullEditUserView):
     template_name = "users/edit_full_user.html"
     urlname = "domain_my_account"
-    page_title = ugettext_noop("Edit My Information")
-    edit_user_form_title = ugettext_noop("My Information")
+    page_title = ugettext_lazy("Edit My Information")
+    edit_user_form_title = ugettext_lazy("My Information")
     user_update_form_class = UpdateMyAccountInfoForm
 
     @property
@@ -767,7 +767,7 @@ class BaseManageWebUserView(BaseUserSettingsView):
 class InviteWebUserView(BaseManageWebUserView):
     template_name = "users/invite_web_user.html"
     urlname = 'invite_web_user'
-    page_title = ugettext_noop("Invite Web User to Project")
+    page_title = ugettext_lazy("Invite Web User to Project")
 
     @property
     @memoized

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -54,7 +54,7 @@ from corehq.apps.sms.verify import (
 )
 from corehq.util.couch import get_document_or_404
 
-from django.utils.translation import ugettext as _, ugettext_lazy, ugettext_lazy
+from django.utils.translation import ugettext as _, ugettext_lazy
 
 
 def _users_context(request, domain):

--- a/corehq/apps/users/views/mobile/groups.py
+++ b/corehq/apps/users/views/mobile/groups.py
@@ -3,7 +3,7 @@ from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.http import Http404, HttpResponseRedirect
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext as _, ugettext_noop
+from django.utils.translation import ugettext as _, ugettext_lazy
 from corehq.apps.accounting.decorators import requires_privilege_with_fallback
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.domain.views import BaseDomainView
@@ -132,13 +132,13 @@ class BaseGroupsView(BaseUserSettingsView):
 
 class EditGroupsView(BaseGroupsView):
     template_name = "groups/all_groups.html"
-    page_title = ugettext_noop("Groups")
+    page_title = ugettext_lazy("Groups")
     urlname = 'all_groups'
 
 
 class EditGroupMembersView(BaseGroupsView):
     urlname = 'group_members'
-    page_title = ugettext_noop("Edit Group")
+    page_title = ugettext_lazy("Edit Group")
     template_name = 'groups/group_members.html'
 
     @property

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -15,7 +15,7 @@ from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect, HttpResponse,\
     HttpResponseForbidden, HttpResponseBadRequest, Http404
 from django.utils.decorators import method_decorator
-from django.utils.translation import ugettext as _, ugettext_noop
+from django.utils.translation import ugettext as _, ugettext_lazy
 from django.views.decorators.http import require_POST
 from django.contrib import messages
 from corehq import privileges
@@ -71,7 +71,7 @@ class EditCommCareUserView(BaseFullEditUserView):
     template_name = "users/edit_commcare_user.html"
     urlname = "edit_commcare_user"
     user_update_form_class = UpdateCommCareUserInfoForm
-    page_title = ugettext_noop("Edit Mobile Worker")
+    page_title = ugettext_lazy("Edit Mobile Worker")
 
     @method_decorator(require_can_edit_commcare_users)
     def dispatch(self, request, *args, **kwargs):
@@ -223,7 +223,7 @@ class EditCommCareUserView(BaseFullEditUserView):
 class ListCommCareUsersView(BaseUserSettingsView):
     template_name = "users/mobile/users_list.html"
     urlname = 'commcare_users'
-    page_title = ugettext_noop("Mobile Workers")
+    page_title = ugettext_lazy("Mobile Workers")
 
     DEFAULT_LIMIT = 10
 
@@ -462,7 +462,7 @@ class AsyncListCommCareUsersView(ListCommCareUsersView):
 class ConfirmBillingAccountForExtraUsersView(BaseUserSettingsView, AsyncHandlerMixin):
     urlname = 'extra_users_confirm_billing'
     template_name = 'users/extra_users_confirm_billing.html'
-    page_title = ugettext_noop("Confirm Billing Information")
+    page_title = ugettext_lazy("Confirm Billing Information")
     async_handlers = [
         Select2BillingInfoHandler,
     ]
@@ -619,7 +619,7 @@ class BaseManageCommCareUserView(BaseUserSettingsView):
 class CreateCommCareUserView(BaseManageCommCareUserView):
     template_name = "users/add_commcare_account.html"
     urlname = 'add_commcare_account'
-    page_title = ugettext_noop("New Mobile Worker")
+    page_title = ugettext_lazy("New Mobile Worker")
 
     @property
     def password_format(self):
@@ -685,7 +685,7 @@ class CreateCommCareUserView(BaseManageCommCareUserView):
 class UploadCommCareUsers(BaseManageCommCareUserView):
     template_name = 'users/upload_commcare_users.html'
     urlname = 'upload_commcare_users'
-    page_title = ugettext_noop("Bulk Upload Mobile Workers")
+    page_title = ugettext_lazy("Bulk Upload Mobile Workers")
 
     @method_decorator(requires_privilege_with_fallback(privileges.BULK_USER_MANAGEMENT))
     def dispatch(self, request, *args, **kwargs):
@@ -780,7 +780,7 @@ class UploadCommCareUsers(BaseManageCommCareUserView):
 
 class UserUploadStatusView(BaseManageCommCareUserView):
     urlname = 'user_upload_status'
-    page_title = ugettext_noop('Mobile Worker Upload Status')
+    page_title = ugettext_lazy('Mobile Worker Upload Status')
 
     def get(self, request, *args, **kwargs):
         context = super(UserUploadStatusView, self).main_context

--- a/corehq/ex-submodules/phonelog/reports.py
+++ b/corehq/ex-submodules/phonelog/reports.py
@@ -22,13 +22,13 @@ from corehq.apps.users.models import CommCareUser
 from corehq.util.timezones.conversions import ServerTime
 from dimagi.utils.decorators.memoized import memoized
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from .models import DeviceReportEntry
 from .utils import device_users_by_xform
 
 logger = logging.getLogger(__name__)
 
-DATA_NOTICE = ugettext_noop(
+DATA_NOTICE = ugettext_lazy(
     "This report will only show data for the past 60 days. Furthermore the report may not "
     "always show the latest log data but will be updated over time",
 )
@@ -40,7 +40,7 @@ TAGS = {
 
 
 class DeviceLogDetailsReport(GetParamsMixin, DeploymentsReport, DatespanMixin, PaginatedReportMixin):
-    name = ugettext_noop("Device Log Details")
+    name = ugettext_lazy("Device Log Details")
     slug = "log_details"
     fields = ['corehq.apps.reports.filters.dates.DatespanFilter',
               'corehq.apps.reports.filters.devicelog.DeviceLogTagFilter',

--- a/custom/_legacy/a5288/reports.py
+++ b/custom/_legacy/a5288/reports.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from django.utils.translation import ugettext as _
 import pytz
 from corehq.apps.hqcase.dbaccessors import get_cases_in_domain
@@ -13,9 +13,9 @@ from dimagi.utils.parsing import json_format_date
 
 
 class MissedCallbackReport(CustomProjectReport, GenericTabularReport):
-    name = ugettext_noop("Missed Callbacks")
+    name = ugettext_lazy("Missed Callbacks")
     slug = "missed_callbacks"
-    description = ugettext_noop("Summarizes two weeks of SMS / Callback interactions for all participants.")
+    description = ugettext_lazy("Summarizes two weeks of SMS / Callback interactions for all participants.")
     flush_layout = True
     
     def get_past_two_weeks(self):

--- a/custom/apps/crs_reports/__init__.py
+++ b/custom/apps/crs_reports/__init__.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_noop as _
+from django.utils.translation import ugettext_lazy as _
 
 from custom.apps.crs_reports.reports import HBNCMotherReport
 

--- a/custom/apps/crs_reports/fields.py
+++ b/custom/apps/crs_reports/fields.py
@@ -1,6 +1,6 @@
 from corehq.apps.reports.dont_use.fields import ReportSelectField
 from corehq.apps.reports.filters.users import SelectCaseOwnerFilter
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from corehq.apps.groups.models import Group
 from dimagi.utils.couch.database import get_db
 from django.utils.translation import ugettext as _
@@ -8,7 +8,7 @@ from django.utils.translation import ugettext as _
 
 class SelectBlockField(ReportSelectField):
     slug = "block"
-    name = ugettext_noop("Name of the Block")
+    name = ugettext_lazy("Name of the Block")
     cssId = "opened_closed"
     cssClasses = "span3"
 
@@ -34,7 +34,7 @@ class SelectBlockField(ReportSelectField):
 
 class SelectSubCenterField(ReportSelectField):
     slug = "sub_center"
-    name = ugettext_noop("Sub Center")
+    name = ugettext_lazy("Sub Center")
     cssId = "opened_closed"
     cssClasses = "span3"
     default_option = "Select Sub Center"
@@ -42,5 +42,5 @@ class SelectSubCenterField(ReportSelectField):
 
 
 class SelectASHAField(SelectCaseOwnerFilter):
-    name = ugettext_noop("ASHA")
-    default_option = ugettext_noop("Type ASHA name")
+    name = ugettext_lazy("ASHA")
+    default_option = ugettext_lazy("Type ASHA name")

--- a/custom/apps/crs_reports/reports.py
+++ b/custom/apps/crs_reports/reports.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 import datetime
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from django.utils import html
 from casexml.apps.case.models import CommCareCase
 from django.core.urlresolvers import reverse, NoReverseMatch
@@ -198,7 +198,7 @@ class BaseHNBCReport(CustomProjectReport, CaseListReport):
 
 class HBNCMotherReport(BaseHNBCReport):
 
-    name = ugettext_noop('Mother HBNC Form')
+    name = ugettext_lazy('Mother HBNC Form')
     slug = 'hbnc_mother_report'
     report_template_name = 'mothers_form_reports_template'
     default_case_type = 'pregnant_mother'

--- a/custom/apps/cvsu/filters.py
+++ b/custom/apps/cvsu/filters.py
@@ -1,5 +1,5 @@
 from corehq.apps.reports.filters.base import BaseSingleOptionFilter, BaseDrilldownOptionFilter
-from django.utils.translation import ugettext_noop as _
+from django.utils.translation import ugettext_lazy as _
 from corehq.apps.groups.models import Group
 
 ALL_DISTRICTS = 'All Districts'

--- a/custom/bihar/calculations/familyplanning.py
+++ b/custom/bihar/calculations/familyplanning.py
@@ -1,5 +1,5 @@
 import datetime
-from django.utils.translation import ugettext_noop as _
+from django.utils.translation import ugettext_lazy as _
 from custom.bihar.calculations.newborn import is_recently_delivered
 from custom.bihar.calculations.types import DoneDueCalculator, TotalCalculator, AddCalculator
 from custom.bihar.calculations.utils.filters import get_add, A_MONTH, is_pregnant_mother, get_edd

--- a/custom/bihar/calculations/mortality.py
+++ b/custom/bihar/calculations/mortality.py
@@ -1,6 +1,6 @@
 import datetime
 import logging
-from django.utils.translation import ugettext_noop as _
+from django.utils.translation import ugettext_lazy as _
 from custom.bihar.calculations.pregnancy import BirthPlace
 from custom.bihar.calculations.types import TotalCalculator, AddCalculator
 from custom.bihar.calculations.utils.calculations import get_actions, get_forms

--- a/custom/bihar/calculations/newborn.py
+++ b/custom/bihar/calculations/newborn.py
@@ -4,7 +4,7 @@ from custom.bihar.calculations.utils.calculations import get_related_prop
 from custom.bihar.calculations.utils.filters import is_pregnant_mother, get_add, A_MONTH
 from custom.bihar.calculations.utils.xmlns import REGISTRATION
 from custom.bihar.calculations.utils.calculations import get_form
-from django.utils.translation import ugettext_noop as _
+from django.utils.translation import ugettext_lazy as _
 import fluff
 
 

--- a/custom/bihar/fields.py
+++ b/custom/bihar/fields.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from corehq.apps.groups.models import Group
 from corehq.apps.reports.filters.select import GroupFilter
 

--- a/custom/bihar/reports/__init__.py
+++ b/custom/bihar/reports/__init__.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_noop as _
+from django.utils.translation import ugettext_lazy as _
 # some static strings go here
 
 _("Active Cases")

--- a/custom/bihar/reports/due_list.py
+++ b/custom/bihar/reports/due_list.py
@@ -4,7 +4,7 @@ from corehq.util.dates import iso_string_to_date
 from dimagi.utils.couch.database import iter_docs
 from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.html import format_html
-from django.utils.translation import ugettext_noop, ugettext as _
+from django.utils.translation import ugettext_lazy, ugettext as _
 from custom.bihar.reports.indicators.reports import ClientListBase
 from custom.bihar.reports.supervisor import (SubCenterSelectionReport, BiharNavReport, GroupReferenceMixIn,
                                       shared_bihar_context, team_member_context, BiharSummaryReport,
@@ -22,7 +22,7 @@ MAX_ES_RESULTS = 1000000
 DUE_LIST_CONFIG = [
     {
         'slug': 'anc',
-        'title': ugettext_noop('ANC'),
+        'title': ugettext_lazy('ANC'),
         'tasks': [
             "anc_1",
             "anc_2",
@@ -32,7 +32,7 @@ DUE_LIST_CONFIG = [
     },
     {
         'slug': 'tt',
-        'title': ugettext_noop('TT'),
+        'title': ugettext_lazy('TT'),
         'tasks': [
             "tt_1",
             "tt_2",
@@ -41,12 +41,12 @@ DUE_LIST_CONFIG = [
     },
     {
         'slug': 'bcg',
-        'title': ugettext_noop('BCG'),
+        'title': ugettext_lazy('BCG'),
         'tasks': ["bcg",]
     },
     {
         'slug': 'opv',
-        'title': ugettext_noop('OPV'),
+        'title': ugettext_lazy('OPV'),
         'tasks': [
             "opv_0",
             "opv_1",
@@ -57,7 +57,7 @@ DUE_LIST_CONFIG = [
     },
     {
         'slug': 'dpt',
-        'title': ugettext_noop('DPT'),
+        'title': ugettext_lazy('DPT'),
         'tasks': ["dpt_1",
                   "dpt_2",
                   "dpt_3",
@@ -66,7 +66,7 @@ DUE_LIST_CONFIG = [
     },
     {
         'slug': 'hepb',
-        'title': ugettext_noop('Hepatitis B'),
+        'title': ugettext_lazy('Hepatitis B'),
         'tasks': ["hep_0",
                   "hep_1",
                   "hep_2",
@@ -75,12 +75,12 @@ DUE_LIST_CONFIG = [
     },
     {
         'slug': 'measles',
-        'title': ugettext_noop('Measles'),
+        'title': ugettext_lazy('Measles'),
         'tasks': ["measles",]
     },
     {
         'slug': 'vita',
-        'title': ugettext_noop('Vitamin A'),
+        'title': ugettext_lazy('Vitamin A'),
         'tasks': ["vita_1",]
     },
     # test - to ignore: ["hep_b_0", "je", "vit_a_1"]
@@ -93,8 +93,8 @@ def get_config_item_by_slug(slug):
 
 class DueListNav(GroupReferenceMixIn, BiharNavReport):
     slug = "duelistnav"
-    name = ugettext_noop("Due List")
-    description = ugettext_noop("Indicator navigation")
+    name = ugettext_lazy("Due List")
+    description = ugettext_lazy("Indicator navigation")
     preserve_url_params = True
     report_template_path = "bihar/team_listing_tabular.html"
 
@@ -109,7 +109,7 @@ class DueListNav(GroupReferenceMixIn, BiharNavReport):
         return self.group_display
 
 class VaccinationSummary(GroupReferenceMixIn, BiharSummaryReport):
-    name = ugettext_noop("Care Due")
+    name = ugettext_lazy("Care Due")
     slug = "vaccinationsummary"
     description = "Vaccination summary report"
     base_template_mobile = "bihar/bihar_summary.html"
@@ -149,7 +149,7 @@ class VaccinationSummary(GroupReferenceMixIn, BiharSummaryReport):
         return list(format_results(by_task_name))
 
 class VaccinationClientList(ClientListBase):
-    name = ugettext_noop("Vaccination Client List")
+    name = ugettext_lazy("Vaccination Client List")
     slug = "vacdetails"
     description = "Vaccination client list report"
 
@@ -284,31 +284,31 @@ def get_due_list_records(target_date, owner_id=None, task_types=None, case_es=No
 
 # TODO: this is pretty silly but doing this without classes would be a bit of extra work
 class VaccinationSummaryToday(VaccinationSummary):
-    name = ugettext_noop("Care Due Today")
+    name = ugettext_lazy("Care Due Today")
     slug = "vacstoday"
     def get_date(self):
         return datetime.today()
 
 class VaccinationSummaryTomorrow(VaccinationSummary):
-    name = ugettext_noop("Care Due Tomorrow")
+    name = ugettext_lazy("Care Due Tomorrow")
     slug = "vacstomorrow"
     def get_date(self):
         return datetime.today() + timedelta(days=1)
 
 class VaccinationSummaryTomorrow(VaccinationSummary):
-    name = ugettext_noop("Care Due Tomorrow")
+    name = ugettext_lazy("Care Due Tomorrow")
     slug = "vacstomorrow"
     def get_date(self):
         return datetime.today() + timedelta(days=1)
 
 class VaccinationSummary2Days(VaccinationSummary):
-    name = ugettext_noop("Care Due In 2 Days")
+    name = ugettext_lazy("Care Due In 2 Days")
     slug = "vacs2days"
     def get_date(self):
         return datetime.today() + timedelta(days=2)
 
 class VaccinationSummary3Days(VaccinationSummary):
-    name = ugettext_noop("Care Due In 3 Days")
+    name = ugettext_lazy("Care Due In 3 Days")
     slug = "vacs3days"
     def get_date(self):
         return datetime.today() + timedelta(days=3)
@@ -316,7 +316,7 @@ class VaccinationSummary3Days(VaccinationSummary):
 
 class DueListSelectionReport(SubCenterSelectionReport):
     slug = "duelistselect"
-    name = ugettext_noop("Due List")
+    name = ugettext_lazy("Due List")
 
     next_report_slug = DueListNav.slug
     next_report_class = DueListNav

--- a/custom/bihar/reports/indicators/clientlistdisplay.py
+++ b/custom/bihar/reports/indicators/clientlistdisplay.py
@@ -1,6 +1,6 @@
 from custom.bihar.calculations.utils.filters import get_add, get_edd
 import datetime
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from django.utils.translation import ugettext as _
 from . import display
 from custom.bihar.reports.indicators.display import next_visit_date, days_overdue
@@ -34,9 +34,9 @@ class SummaryValueMixIn(ClientListDisplay):
 
     Also provides sensible defaults.
     """
-    numerator_text = ugettext_noop("Yes")
-    denominator_text = ugettext_noop("No")
-    neither_text = ugettext_noop("N/A")
+    numerator_text = ugettext_lazy("Yes")
+    denominator_text = ugettext_lazy("No")
+    neither_text = ugettext_lazy("N/A")
     summary_header = "Value?"
 
     @property
@@ -142,9 +142,9 @@ class PostDeliverySummaryCLD(PostDeliveryCLD, SummaryValueMixIn):
 
 
 class DoneDueMixIn(SummaryValueMixIn):
-    summary_header = ugettext_noop("Visit Status")
-    numerator_text = ugettext_noop("Done")
-    denominator_text = ugettext_noop("Due")
+    summary_header = ugettext_lazy("Visit Status")
+    numerator_text = ugettext_lazy("Done")
+    denominator_text = ugettext_lazy("Due")
 
     def sortkey(self, case, context):
         return display.in_numerator(case, context)

--- a/custom/bihar/reports/indicators/indicators.py
+++ b/custom/bihar/reports/indicators/indicators.py
@@ -5,7 +5,7 @@ from custom.bihar.calculations.types import DoneDueCalculator, TotalCalculator
 from custom.bihar.models import CareBiharFluff
 from custom.bihar.utils import get_all_owner_ids_from_group
 from custom.bihar.reports.indicators.clientlistdisplay import PreDeliveryDoneDueCLD, PreDeliveryCLD, PreDeliverySummaryCLD, PostDeliverySummaryCLD, ComplicationsCalculator, PostDeliveryDoneDueCLD
-from django.utils.translation import ugettext_noop as _
+from django.utils.translation import ugettext_lazy as _
 from django.utils.datastructures import SortedDict
 
 

--- a/custom/bihar/reports/indicators/reports.py
+++ b/custom/bihar/reports/indicators/reports.py
@@ -9,7 +9,7 @@ from corehq.apps.reports.generic import GenericTabularReport, summary_context
 from corehq.apps.reports.standard import CustomProjectReport
 from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.html import format_html
-from django.utils.translation import ugettext as _, ugettext_noop
+from django.utils.translation import ugettext as _, ugettext_lazy
 from custom.bihar.reports.indicators.mixins import IndicatorSetMixIn, IndicatorMixIn
 from custom.bihar.utils import groups_for_user, get_all_owner_ids_from_group
 
@@ -17,9 +17,9 @@ DEFAULT_EMPTY = "?"
 
 
 class IndicatorNav(GroupReferenceMixIn, BiharNavReport):
-    name = ugettext_noop("Indicator Options")
+    name = ugettext_lazy("Indicator Options")
     slug = "indicatornav"
-    description = ugettext_noop("Indicator navigation")
+    description = ugettext_lazy("Indicator navigation")
     preserve_url_params = True
     report_template_path = "bihar/team_listing_tabular.html"
     
@@ -36,7 +36,7 @@ class IndicatorNav(GroupReferenceMixIn, BiharNavReport):
 class IndicatorSummaryReport(GroupReferenceMixIn, BiharSummaryReport,
                              IndicatorSetMixIn):
     
-    name = ugettext_noop("Indicators")
+    name = ugettext_lazy("Indicators")
     slug = "indicatorsummary"
     description = "Indicator details report"
     base_template_mobile = "bihar/indicator_summary.html"
@@ -81,7 +81,7 @@ class IndicatorSummaryReport(GroupReferenceMixIn, BiharSummaryReport,
 
 
 class MyPerformanceReport(BiharSummaryReport):
-    name = ugettext_noop('My Performance')
+    name = ugettext_lazy('My Performance')
     slug = 'myperformance'
     description = "My performance indicators report"
     set_slug = 'homevisit'  # hard coded to homevisit indicators
@@ -123,13 +123,13 @@ class MyPerformanceReport(BiharSummaryReport):
 
 
 class IndicatorCharts(MockEmptyReport):
-    name = ugettext_noop("Charts")
+    name = ugettext_lazy("Charts")
     slug = "indicatorcharts"
 
 
 class IndicatorClientSelectNav(GroupReferenceMixIn, BiharSummaryReport,
                                IndicatorSetMixIn):
-    name = ugettext_noop("Select Client List")
+    name = ugettext_lazy("Select Client List")
     slug = "clients"
     is_cacheable = True
     
@@ -185,7 +185,7 @@ class ClientListBase(GroupReferenceMixIn, ConvenientBaseMixIn,
 class IndicatorClientList(ClientListBase, IndicatorMixIn):
     is_cacheable = True
     slug = "indicatorclientlist"
-    name = ugettext_noop("Client List") 
+    name = ugettext_lazy("Client List") 
 
     extra_context_providers = [shared_bihar_context, name_context]
 

--- a/custom/bihar/reports/supervisor.py
+++ b/custom/bihar/reports/supervisor.py
@@ -4,8 +4,7 @@ from datetime import datetime, timedelta
 from dimagi.utils.couch.database import iter_docs
 
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext_lazy
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy, ugettext as _
 from corehq.apps.hqcase.dbaccessors import get_case_ids_in_domain_by_owner
 from corehq.util.soft_assert import soft_assert
 from custom.bihar.utils import (get_team_members, get_all_owner_ids_from_group, SUPERVISOR_ROLES, FLW_ROLES,

--- a/custom/bihar/reports/supervisor.py
+++ b/custom/bihar/reports/supervisor.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from dimagi.utils.couch.database import iter_docs
 
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from django.utils.translation import ugettext as _
 from corehq.apps.hqcase.dbaccessors import get_case_ids_in_domain_by_owner
 from corehq.util.soft_assert import soft_assert
@@ -203,13 +203,13 @@ class MockEmptyReport(BiharSummaryReport):
 
 class SubCenterSelectionReport(ConvenientBaseMixIn, GenericTabularReport,
                                CustomProjectReport, ReportReferenceMixIn):
-    name = ugettext_noop("Select Subcenter")
+    name = ugettext_lazy("Select Subcenter")
     slug = "subcenter"
-    description = ugettext_noop("Subcenter selection report")
+    description = ugettext_lazy("Subcenter selection report")
 
     _headers = {
-        'supervisor': [ugettext_noop("Team Name"), ugettext_noop("AWCC")],
-        'manager': [ugettext_noop("Subcentre")],
+        'supervisor': [ugettext_lazy("Team Name"), ugettext_lazy("AWCC")],
+        'manager': [ugettext_lazy("Subcentre")],
     }
 
     @memoized
@@ -240,9 +240,9 @@ class SubCenterSelectionReport(ConvenientBaseMixIn, GenericTabularReport,
 
 
 class MainNavReport(BiharSummaryReport, IndicatorConfigMixIn):
-    name = ugettext_noop("Main Menu")
+    name = ugettext_lazy("Main Menu")
     slug = "mainnav"
-    description = ugettext_noop("Main navigation")
+    description = ugettext_lazy("Main navigation")
 
     @classmethod
     def additional_reports(cls):
@@ -280,7 +280,7 @@ class MainNavReport(BiharSummaryReport, IndicatorConfigMixIn):
 
 
 class ToolsNavReport(BiharSummaryReport):
-    name = ugettext_noop("Tools Menu")
+    name = ugettext_lazy("Tools Menu")
     slug = "tools"
 
     _headers = [" ", " ", " "]
@@ -303,7 +303,7 @@ class ToolsNavReport(BiharSummaryReport):
 
 
 class ReferralListReport(GroupReferenceMixIn, MockEmptyReport):
-    name = ugettext_noop("Referrals")
+    name = ugettext_lazy("Referrals")
     slug = "referrals"
 
     _headers = []
@@ -354,13 +354,13 @@ class InputReport(MockEmptyReport):
 
 
 class EDDCalcReport(InputReport):
-    name = ugettext_noop("EDD Calculator")
+    name = ugettext_lazy("EDD Calculator")
     slug = "eddcalc"
     _inputs = [
         {
             "name": "lmp",
             "type": "text",
-            "label": ugettext_noop("Enter LMP (DD-MM-YYYY)")
+            "label": ugettext_lazy("Enter LMP (DD-MM-YYYY)")
         }
     ]
 
@@ -377,18 +377,18 @@ class EDDCalcReport(InputReport):
 
 
 class BMICalcReport(InputReport):
-    name = ugettext_noop("BMI Calculator")
+    name = ugettext_lazy("BMI Calculator")
     slug = "bmicalc"
     _inputs = [
         {
             "name": "weight",
             "type": "text",
-            "label": ugettext_noop("Enter weight in kilograms:")
+            "label": ugettext_lazy("Enter weight in kilograms:")
         },
         {
             "name": "height",
             "type": "text",
-            "label": ugettext_noop("Enter height in meters:")
+            "label": ugettext_lazy("Enter height in meters:")
         }
     ]
 

--- a/custom/bihar/utils.py
+++ b/custom/bihar/utils.py
@@ -1,13 +1,13 @@
 from operator import attrgetter
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from corehq.apps.groups.models import Group
 from redis_cache.cache import RedisCache
 from dimagi.utils.couch.cache import cache_core
 
-ASHA_ROLE = ugettext_noop('ASHA')
-AWW_ROLE = ugettext_noop('AWW')
-ANM_ROLE = ugettext_noop('ANM')
-LS_ROLE = ugettext_noop('LS')
+ASHA_ROLE = ugettext_lazy('ASHA')
+AWW_ROLE = ugettext_lazy('AWW')
+ANM_ROLE = ugettext_lazy('ANM')
+LS_ROLE = ugettext_lazy('LS')
 
 FLW_ROLES = (ASHA_ROLE, AWW_ROLE)
 SUPERVISOR_ROLES = (ANM_ROLE, LS_ROLE)

--- a/custom/care_pathways/__init__.py
+++ b/custom/care_pathways/__init__.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_noop as _
+from django.utils.translation import ugettext_lazy as _
 from custom.care_pathways.reports.adoption_bar_char_report import AdoptionBarChartReport
 from custom.care_pathways.reports.adoption_disaggregated_report import AdoptionDisaggregatedReport
 from custom.care_pathways.reports.table_card_report import TableCardReport

--- a/custom/care_pathways/filters.py
+++ b/custom/care_pathways/filters.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from corehq.apps.reports.filters.base import BaseDrilldownOptionFilter, BaseSingleOptionFilter
 from corehq.apps.reports.filters.select import YearFilter
 from corehq.apps.users.models import CommCareUser
@@ -44,7 +44,7 @@ class CareBaseDrilldownOptionFilter(BaseDrilldownOptionFilter):
 
 
 class GeographyFilter(CareBaseDrilldownOptionFilter):
-    label = ugettext_noop("Geography")
+    label = ugettext_lazy("Geography")
     slug = "geography"
     template = "care_pathways/filters/drilldown_options.html"
 
@@ -124,7 +124,7 @@ class GroupLeadershipFilter(BaseSingleOptionFilter):
 
 class CBTNameFilter(BaseSingleOptionFilter):
     slug = 'cbt_name'
-    label = ugettext_noop('CBT Name')
+    label = ugettext_lazy('CBT Name')
     default_text = "All"
     template = "care_pathways/filters/single_option_with_helper.html"
     help_text = "Community Based Trainer"

--- a/custom/ewsghana/filters.py
+++ b/custom/ewsghana/filters.py
@@ -2,7 +2,7 @@ import calendar
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
 from dateutil.rrule import *
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.locations.util import location_hierarchy_config, load_locs_json
 from corehq.apps.products.models import SQLProduct
@@ -21,7 +21,7 @@ class ProductByProgramFilter(BaseDrilldownOptionFilter):
     slug = "filter_by"
     single_option_select = 0
     template = "common/drilldown_options.html"
-    label = ugettext_noop("Filter By")
+    label = ugettext_lazy("Filter By")
 
     @property
     def drilldown_map(self):
@@ -66,7 +66,7 @@ class ProductByProgramFilter(BaseDrilldownOptionFilter):
 
 
 class ViewReportFilter(BaseSingleOptionFilter):
-    default_text = ugettext_noop("Product Availability")
+    default_text = ugettext_lazy("Product Availability")
     slug = 'report_type'
     label = 'View'
 

--- a/custom/ewsghana/reports/maps.py
+++ b/custom/ewsghana/reports/maps.py
@@ -1,5 +1,5 @@
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from corehq.apps.commtrack.models import StockState, CommtrackConfig
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.products.models import Product, SQLProduct
@@ -104,8 +104,8 @@ class EWSStockStatusBySupplyPointDataSource(StockStatusBySupplyPointDataSource):
 
 
 class EWSMapReport(CustomProjectReport, StockStatusMapReport):
-    name = ugettext_noop("Maps")
-    title = ugettext_noop("Maps")
+    name = ugettext_lazy("Maps")
+    title = ugettext_lazy("Maps")
     slug = "ews_mapreport"
     template_report = 'ewsghana/map_template.html'
 

--- a/custom/ewsghana/views.py
+++ b/custom/ewsghana/views.py
@@ -5,7 +5,7 @@ from django.core.exceptions import PermissionDenied
 from django.forms.formsets import formset_factory
 from django.http import HttpResponse, HttpResponseRedirect
 from django.http.response import Http404
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from django.views.decorators.http import require_POST, require_GET
 from corehq.apps.commtrack import const
 from corehq.apps.commtrack.models import StockState, StockTransactionHelper
@@ -51,7 +51,7 @@ class EWSConfigView(BaseConfigView):
     sync_urlname = 'sync_ewsghana'
     sync_stock_url = 'ews_sync_stock_data'
     clear_stock_url = 'ews_clear_stock_data'
-    page_title = ugettext_noop("EWS Ghana")
+    page_title = ugettext_lazy("EWS Ghana")
     template_name = 'ewsghana/ewsconfig.html'
     source = 'ewsghana'
 

--- a/custom/fri/forms.py
+++ b/custom/fri/forms.py
@@ -3,7 +3,7 @@ from django.forms.fields import *
 from django.core.exceptions import ValidationError
 from dimagi.utils.excel import WorkbookJSONReader, WorksheetNotFound
 from openpyxl.shared.exc import InvalidFileException
-from django.utils.translation import ugettext as _, ugettext_noop
+from django.utils.translation import ugettext as _, ugettext_lazy
 
 class MessageBankForm(Form):
     message_bank_file = FileField(required=False)

--- a/custom/fri/reports/reports.py
+++ b/custom/fri/reports/reports.py
@@ -1,7 +1,7 @@
 import pytz
 import cgi
 from datetime import datetime, time, timedelta
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from django.utils.translation import ugettext as _
 from corehq.apps.domain.models import Domain
 from corehq.apps.hqcase.dbaccessors import get_cases_in_domain
@@ -53,9 +53,9 @@ class FRIReport(CustomProjectReport, GenericTabularReport):
         return self._interactive_participants
 
 class MessageBankReport(FRIReport):
-    name = ugettext_noop("Message Bank")
+    name = ugettext_lazy("Message Bank")
     slug = "fri_message_bank"
-    description = ugettext_noop("Displays the message bank.")
+    description = ugettext_lazy("Displays the message bank.")
     emailable = False
     fields = (
         "custom.fri.reports.filters.RiskProfileFilter",
@@ -143,7 +143,7 @@ class MessageBankReport(FRIReport):
         return self.table_cell(val1, '<span style="display: none;">%s</span><span>%s</span>' % (val1, val2))
 
 class MessageReport(FRIReport, DatespanMixin):
-    name = ugettext_noop('Message Report')
+    name = ugettext_lazy('Message Report')
     slug = 'fri_message_report'
     fields = [
         DatespanMixin.datespan_field,
@@ -274,9 +274,9 @@ class MessageReport(FRIReport, DatespanMixin):
         )
 
 class PHEDashboardReport(FRIReport):
-    name = ugettext_noop("PHE Dashboard")
+    name = ugettext_lazy("PHE Dashboard")
     slug = "fri_phe_dashboard"
-    description = ugettext_noop("Displays a list of active, arm A, participants.")
+    description = ugettext_lazy("Displays a list of active, arm A, participants.")
     emailable = False
     exportable = False
     report_template_path = "fri/phe_dashboard.html"
@@ -330,9 +330,9 @@ class PHEDashboardReport(FRIReport):
         return "window.open('%s', '_blank', 'location=no,menubar=no,scrollbars=no,status=no,toolbar=no,height=400,width=400');" % url
 
 class SurveyResponsesReport(FRIReport):
-    name = ugettext_noop("Survey Responses")
+    name = ugettext_lazy("Survey Responses")
     slug = "fri_survey_responses"
-    description = ugettext_noop("Shows information pertaining to survey responses.")
+    description = ugettext_lazy("Shows information pertaining to survey responses.")
     emailable = False
     fields = [
         "custom.fri.reports.filters.SurveyDateSelector",

--- a/custom/fri/views.py
+++ b/custom/fri/views.py
@@ -7,7 +7,7 @@ from corehq.apps.domain.decorators import require_previewer, login_and_domain_re
 from django.http import HttpResponseRedirect, Http404
 from django.core.urlresolvers import reverse
 from django.contrib import messages
-from django.utils.translation import ugettext as _, ugettext_noop
+from django.utils.translation import ugettext as _, ugettext_lazy
 
 @require_previewer
 @login_and_domain_required

--- a/custom/ilsgateway/filters.py
+++ b/custom/ilsgateway/filters.py
@@ -1,6 +1,6 @@
 import calendar
 from datetime import datetime
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from corehq.apps.products.models import SQLProduct
 from corehq.apps.programs.models import Program
 from corehq.apps.reports.filters.base import BaseDrilldownOptionFilter, BaseSingleOptionFilter, BaseReportFilter
@@ -12,7 +12,7 @@ class ProductByProgramFilter(BaseDrilldownOptionFilter):
     slug = "filter_by"
     single_option_select = 0
     template = "common/drilldown_options.html"
-    label = ugettext_noop("Filter By")
+    label = ugettext_lazy("Filter By")
 
     @property
     def drilldown_map(self):

--- a/custom/ilsgateway/tanzania/reports/unrecognized_sms.py
+++ b/custom/ilsgateway/tanzania/reports/unrecognized_sms.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.hqwebapp.doc_info import get_doc_info
 from corehq.apps.locations.models import SQLLocation
@@ -28,7 +28,7 @@ def _fmt(val):
 
 class UnrecognizedSMSReport(CustomProjectReport, ProjectReportParametersMixin,
                             GenericTabularReport, DatespanMixin):
-    name = ugettext_noop('Unrecognized SMS')
+    name = ugettext_lazy('Unrecognized SMS')
     slug = 'unrecognized_sms'
     fields = [AsyncLocationFilter, DatespanFilter]
     exportable = True

--- a/custom/ilsgateway/views.py
+++ b/custom/ilsgateway/views.py
@@ -19,7 +19,7 @@ from corehq.apps.sms.models import SMSLog
 from corehq.apps.sms.util import clean_phone_number
 from corehq.apps.users.models import CommCareUser, WebUser, UserRole
 from django.http import HttpResponse
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from django.views.decorators.http import require_POST
 from corehq.apps.domain.decorators import domain_admin_required
 from corehq.const import SERVER_DATETIME_FORMAT_NO_SEC
@@ -118,7 +118,7 @@ class ILSConfigView(BaseConfigView):
     sync_urlname = 'sync_ilsgateway'
     sync_stock_url = 'ils_sync_stock_data'
     clear_stock_url = 'ils_clear_stock_data'
-    page_title = ugettext_noop("ILSGateway")
+    page_title = ugettext_lazy("ILSGateway")
     template_name = 'ilsgateway/ilsconfig.html'
     source = 'ilsgateway'
 

--- a/custom/intrahealth/filters.py
+++ b/custom/intrahealth/filters.py
@@ -1,7 +1,7 @@
 import calendar
 import json
 from django.core.urlresolvers import reverse
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from corehq.apps.locations.util import location_hierarchy_config, load_locs_json
 from corehq.apps.reports.filters.fixtures import AsyncLocationFilter
 from corehq.apps.reports.filters.select import YearFilter, MonthFilter
@@ -10,7 +10,7 @@ from django.utils.translation import ugettext as _
 
 
 class LocationFilter(AsyncLocationFilter):
-    label = ugettext_noop("Region")
+    label = ugettext_lazy("Region")
     slug = "ih_location_async"
     template = 'intrahealth/location_filter.html'
     required = 0
@@ -59,11 +59,11 @@ class RecapPassageLocationFilter(LocationFilter):
         return context
 
 class FRYearFilter(YearFilter):
-    label = ugettext_noop(u"Ann\xe9e")
+    label = ugettext_lazy(u"Ann\xe9e")
 
 
 class FRMonthFilter(MonthFilter):
-    label = ugettext_noop("Mois")
+    label = ugettext_lazy("Mois")
 
     @property
     def options(self):

--- a/custom/m4change/fields.py
+++ b/custom/m4change/fields.py
@@ -2,12 +2,12 @@ import datetime
 from corehq.util.dates import iso_string_to_date
 from dimagi.utils.dates import DateSpan
 import json
-from django.utils.translation import ugettext as _, ugettext_noop
+from django.utils.translation import ugettext as _, ugettext_lazy
 from corehq.apps.reports.dont_use.fields import ReportField
 
 
 class DateRangeField(ReportField):
-    name = ugettext_noop("Date Range")
+    name = ugettext_lazy("Date Range")
     slug = "datespan"
     template = "m4change/fields/daterange.html"
     inclusive = True
@@ -44,7 +44,7 @@ class DateRangeField(ReportField):
 
 
 class CaseSearchField(ReportField):
-    name = ugettext_noop("Case Search")
+    name = ugettext_lazy("Case Search")
     slug = "case_search"
     template = "reports/filters/search.html"
 

--- a/custom/m4change/filters.py
+++ b/custom/m4change/filters.py
@@ -1,10 +1,10 @@
-from django.utils.translation import ugettext_noop, ugettext as _
+from django.utils.translation import ugettext_lazy, ugettext as _
 from corehq.apps.reports.filters.base import BaseSingleOptionFilter
 
 
 class FacilityHmisFilter(BaseSingleOptionFilter):
     slug = "facility_hmis_filter"
-    label = ugettext_noop("Facility HMIS Report")
+    label = ugettext_lazy("Facility HMIS Report")
     default_text = None
 
     @property
@@ -20,7 +20,7 @@ class FacilityHmisFilter(BaseSingleOptionFilter):
 
 class ServiceTypeFilter(BaseSingleOptionFilter):
     slug = "service_type_filter"
-    label = ugettext_noop("Service type")
+    label = ugettext_lazy("Service type")
     default_text = None
 
     @property

--- a/custom/opm/filters.py
+++ b/custom/opm/filters.py
@@ -1,6 +1,6 @@
 from custom.common import ALL_OPTION
 
-from django.utils.translation import ugettext_noop, ugettext as _
+from django.utils.translation import ugettext_lazy, ugettext as _
 from sqlagg.columns import SimpleColumn
 
 from dimagi.utils.decorators.memoized import memoized
@@ -110,7 +110,7 @@ class OpmBaseDrilldownOptionFilter(BaseDrilldownOptionFilter):
 
 class HierarchyFilter(OpmBaseDrilldownOptionFilter):
     single_option_select = 0
-    label = ugettext_noop("Hierarchy")
+    label = ugettext_lazy("Hierarchy")
     slug = "hierarchy"
 
     @property
@@ -123,7 +123,7 @@ class HierarchyFilter(OpmBaseDrilldownOptionFilter):
 
 class MetHierarchyFilter(OpmBaseDrilldownOptionFilter):
     single_option_select = 0
-    label = ugettext_noop("Hierarchy")
+    label = ugettext_lazy("Hierarchy")
     slug = "hierarchy"
 
     @property

--- a/custom/opm/reports.py
+++ b/custom/opm/reports.py
@@ -18,7 +18,7 @@ from dateutil import parser
 from django.http import HttpResponse
 from django.template import RequestContext
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext_noop, ugettext as _
+from django.utils.translation import ugettext_lazy, ugettext as _
 from sqlagg.filters import RawFilter, IN, EQFilter
 from corehq.const import SERVER_DATETIME_FORMAT
 from couchexport.models import Format
@@ -882,7 +882,7 @@ class BeneficiaryPaymentReport(CaseReportMixin, BaseReport):
 
 
 class MetReport(CaseReportMixin, BaseReport):
-    name = ugettext_noop("Conditions Met Report")
+    name = ugettext_lazy("Conditions Met Report")
     report_template_path = "opm/met_report.html"
     slug = "met_report"
     model = ConditionsMet

--- a/custom/reports/mc/reports/definitions.py
+++ b/custom/reports/mc/reports/definitions.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_noop as _
+from django.utils.translation import ugettext_lazy as _
 from custom.reports.mc.models import WEEKLY_SUMMARY_XMLNS
 
 HF_MONTHLY_REPORT = [

--- a/custom/reports/mc/reports/fields.py
+++ b/custom/reports/mc/reports/fields.py
@@ -1,14 +1,14 @@
 from corehq.apps.reports.filters.fixtures import AsyncDrillableFilter
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 
 
 class DistrictField(AsyncDrillableFilter):
-    label = ugettext_noop("District")
+    label = ugettext_lazy("District")
     slug = "location"
     hierarchy = [{"type": "district", "display": "name"}]
 
 class HealthFacilityField(AsyncDrillableFilter):
-    label = ugettext_noop("Health Facility")
+    label = ugettext_lazy("Health Facility")
     slug = "location"
     hierarchy = [
         {"type": "district", "display": "name"},

--- a/custom/reports/mc/reports/sql.py
+++ b/custom/reports/mc/reports/sql.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from corehq.apps.reports.util import make_ctable_table_name
 from dimagi.utils.decorators.memoized import memoized
 from sqlagg.columns import *
-from django.utils.translation import ugettext as _, ugettext_noop
+from django.utils.translation import ugettext as _, ugettext_lazy
 from corehq.apps.fixtures.models import FixtureDataType, FixtureDataItem
 from corehq.apps.reports.datatables import DataTablesHeader, DataTablesColumn
 from corehq.apps.reports.sqlreport import DatabaseColumn, SqlData, AggregateColumn, DataFormatter, TableDataFormat
@@ -418,7 +418,7 @@ class HeathFacilityMonthly(MCBase):
         'corehq.apps.reports.filters.dates.DatespanFilter',
         'custom.reports.mc.reports.fields.HealthFacilityField',
     ]
-    name = ugettext_noop("mc_report_hf_monthly")
+    name = ugettext_lazy("mc_report_hf_monthly")
     SECTIONS = HF_MONTHLY_REPORT
     format_class = UserDataFormat
 
@@ -428,7 +428,7 @@ class DistrictMonthly(MCBase):
         'custom.reports.mc.reports.fields.DistrictField',
     ]
     slug = 'district_monthly'
-    name = ugettext_noop("mc_report_dist_monthly")
+    name = ugettext_lazy("mc_report_dist_monthly")
     SECTIONS = DISTRICT_MONTHLY_REPORT
     format_class = FacilityDataFormat
 
@@ -438,7 +438,7 @@ class DistrictWeekly(MCBase):
         'custom.reports.mc.reports.fields.DistrictField',
     ]
     slug = 'district_weekly'
-    name = ugettext_noop("mc_report_dist_weekly")
+    name = ugettext_lazy("mc_report_dist_weekly")
     SECTIONS = DISTRICT_WEEKLY_REPORT
     format_class = FacilityDataFormat
 
@@ -505,6 +505,6 @@ class HealthFacilityWeekly(MCBase):
         'custom.reports.mc.reports.fields.HealthFacilityField',
     ]
     slug = 'hf_weekly'
-    name = ugettext_noop("mc_report_hf_weekly")
+    name = ugettext_lazy("mc_report_hf_weekly")
     SECTIONS = HF_WEEKLY_REPORT
     format_class = UserDataFormat

--- a/custom/succeed/__init__.py
+++ b/custom/succeed/__init__.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_noop as _
+from django.utils.translation import ugettext_lazy as _
 from custom.succeed.reports.all_patients import PatientListReport
 from custom.succeed.reports.patient_Info import PatientInfoReport
 from custom.succeed.reports.patient_interactions import PatientInteractionsReport

--- a/custom/succeed/fields.py
+++ b/custom/succeed/fields.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from corehq.apps.reports.dont_use.fields import ReportSelectField
 from corehq.apps.reports.filters.base import BaseSingleOptionFilter
 from corehq.elastic import es_query
@@ -11,7 +11,7 @@ from custom.succeed.utils import (
 
 class CareSite(ReportSelectField):
     slug = "care_site_display"
-    name = ugettext_noop("Care Site")
+    name = ugettext_lazy("Care Site")
     cssId = "opened_closed"
     cssClasses = "span3"
     default_option = "All Sites"
@@ -30,31 +30,31 @@ class CareSite(ReportSelectField):
 
 class ResponsibleParty(ReportSelectField):
     slug = "responsible_party"
-    name = ugettext_noop("Responsible Party")
+    name = ugettext_lazy("Responsible Party")
     cssId = "opened_closed"
     cssClasses = "span3"
-    default_option = ugettext_noop("All Roles")
+    default_option = ugettext_lazy("All Roles")
 
     @property
     def options(self):
         return [
-            dict(val=CONFIG['cm_role'], text=ugettext_noop("Care Manager")),
-            dict(val=CONFIG['chw_role'], text=ugettext_noop("Community Health Worker")),
+            dict(val=CONFIG['cm_role'], text=ugettext_lazy("Care Manager")),
+            dict(val=CONFIG['chw_role'], text=ugettext_lazy("Community Health Worker")),
         ]
 
 
 class PatientStatus(ReportSelectField):
     slug = "patient_status"
-    name = ugettext_noop("Patient Status")
+    name = ugettext_lazy("Patient Status")
     cssId = "opened_closed"
     cssClasses = "span3"
     default_option = "All Patients"
-    options = [dict(val="active", text=ugettext_noop("Active")),
-               dict(val="not_active", text=ugettext_noop("Not Active"))]
+    options = [dict(val="active", text=ugettext_lazy("Active")),
+               dict(val="not_active", text=ugettext_lazy("Not Active"))]
 
 
 class PatientFormNameFilter(BaseSingleOptionFilter):
-    label = ugettext_noop("Form Group")
+    label = ugettext_lazy("Form Group")
     slug = "form_name"
     css_class = "span5"
     default_text = 'All Forms'
@@ -71,8 +71,8 @@ class PatientFormNameFilter(BaseSingleOptionFilter):
 
 class PatientNameFilterMixin(object):
     slug = "patient_id"
-    label = ugettext_noop("Patient Name")
-    default_text = ugettext_noop("All Patients")
+    label = ugettext_lazy("Patient Name")
+    default_text = ugettext_lazy("All Patients")
 
     @property
     def options(self):
@@ -111,18 +111,18 @@ class PatientNameFilterMixin(object):
         return [(case['_source']['_id'], case['_source']['full_name']['#value']) for case in es_results['hits'].get('hits', [])]
 
 class PatientName(PatientNameFilterMixin, BaseSingleOptionFilter):
-    placeholder = ugettext_noop('Click to select a patient')
+    placeholder = ugettext_lazy('Click to select a patient')
 
 class TaskStatus(ReportSelectField):
     slug = "task_status"
-    name = ugettext_noop("Task Status")
+    name = ugettext_lazy("Task Status")
     cssId = "opened_closed"
     cssClasses = "span3"
-    default_option = ugettext_noop("All Tasks")
+    default_option = ugettext_lazy("All Tasks")
 
     @property
     def options(self):
         return [
-            dict(val='open', text=ugettext_noop("Only Open Tasks")),
-            dict(val='closed', text=ugettext_noop("Only Closed Tasks")),
+            dict(val='open', text=ugettext_lazy("Only Open Tasks")),
+            dict(val='closed', text=ugettext_lazy("Only Closed Tasks")),
         ]

--- a/custom/succeed/reports/all_patients.py
+++ b/custom/succeed/reports/all_patients.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 from couchdbkit import ResourceNotFound
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from sqlagg.base import AliasColumn
 from sqlagg.columns import SimpleColumn
 from sqlagg.filters import EQ, IN
@@ -111,7 +111,7 @@ def tasks(case_id):
 
 class PatientListReport(SqlTabularReport, CustomProjectReport, ProjectReportParametersMixin):
 
-    name = ugettext_noop('Patient List')
+    name = ugettext_lazy('Patient List')
     slug = 'patient_list'
     use_datatables = True
     table_name = 'fluff_UCLAPatientFluff'

--- a/custom/succeed/reports/patient_task_list.py
+++ b/custom/succeed/reports/patient_task_list.py
@@ -3,7 +3,7 @@ import logging
 
 from django.core.urlresolvers import reverse
 from django.utils import html
-from django.utils.translation import ugettext as _, ugettext_noop
+from django.utils.translation import ugettext as _, ugettext_lazy
 import json
 
 from corehq.apps.api.es import ReportCaseES
@@ -157,7 +157,7 @@ class PatientTaskListReportDisplay(CaseDisplay):
 
 class PatientTaskListReport(CustomProjectReport, ElasticProjectInspectionReport, ProjectReportParametersMixin):
     ajax_pagination = True
-    name = ugettext_noop('Patient Tasks')
+    name = ugettext_lazy('Patient Tasks')
     slug = 'patient_task_list'
     default_sort = {'task_due.#value': 'asc'}
     base_template_filters = 'succeed/report.html'

--- a/custom/succeed/utils.py
+++ b/custom/succeed/utils.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext as _, ugettext_noop
+from django.utils.translation import ugettext as _, ugettext_lazy
 import dateutil
 from corehq.apps.app_manager.models import ApplicationBase
 from corehq.apps.domain.models import Domain
@@ -14,10 +14,10 @@ SUCCEED_CHW_APPNAME = 'SUCCEED CHW app'
 
 CONFIG = {
     'groups': [
-        dict(val="harbor", text=ugettext_noop("Harbor UCLA")),
-        dict(val="lac-usc", text=ugettext_noop("LAC-USC")),
-        dict(val="oliveview", text=ugettext_noop("Olive View Medical Center")),
-        dict(val="rancho", text=ugettext_noop("Rancho Los Amigos")),
+        dict(val="harbor", text=ugettext_lazy("Harbor UCLA")),
+        dict(val="lac-usc", text=ugettext_lazy("LAC-USC")),
+        dict(val="oliveview", text=ugettext_lazy("Olive View Medical Center")),
+        dict(val="rancho", text=ugettext_lazy("Rancho Los Amigos")),
     ],
     'succeed_admin': 'SUCCEED Admin',
     'pm_role': 'Project Manager',

--- a/custom/tdh/reports/child_consultation_history.py
+++ b/custom/tdh/reports/child_consultation_history.py
@@ -1,11 +1,11 @@
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from custom.tdh.reports import TDHReport
 from custom.tdh.sqldata import ChildConsultationHistoryComplete, ChildConsultationHistory
 
 
 class ChildConsultationHistoryReport(TDHReport):
-    name = ugettext_noop('Child Consultation History')
-    title = ugettext_noop('Child Consultation History')
+    name = ugettext_lazy('Child Consultation History')
+    title = ugettext_lazy('Child Consultation History')
     slug = 'child_consultation_history'
     base_template = "tdh/tdh_template.html"
 

--- a/custom/tdh/reports/infant_consultation_history.py
+++ b/custom/tdh/reports/infant_consultation_history.py
@@ -1,12 +1,12 @@
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from custom.tdh.reports import TDHReport
 from custom.tdh.sqldata import InfantConsultationHistory, InfantConsultationHistoryComplete
 
 
 class InfantConsultationHistoryReport(TDHReport):
-    name = ugettext_noop('Infant Consultation History')
+    name = ugettext_lazy('Infant Consultation History')
     slug = 'infant_consultation_history'
-    title = ugettext_noop('Infant Consultation History')
+    title = ugettext_lazy('Infant Consultation History')
     base_template = "tdh/tdh_template.html"
 
     @property

--- a/custom/tdh/reports/newborn_consultation_history.py
+++ b/custom/tdh/reports/newborn_consultation_history.py
@@ -1,12 +1,12 @@
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from custom.tdh.reports import TDHReport
 from custom.tdh.sqldata import NewbornConsultationHistory, NewbornConsultationHistoryComplete
 
 
 class NewbornConsultationHistoryReport(TDHReport):
-    name = ugettext_noop('Newborn Consultation History')
+    name = ugettext_lazy('Newborn Consultation History')
     slug = 'newborn_consultation_history'
-    title = ugettext_noop('Newborn Consultation History')
+    title = ugettext_lazy('Newborn Consultation History')
     base_template = "tdh/tdh_template.html"
 
     @property

--- a/custom/up_nrhm/__init__.py
+++ b/custom/up_nrhm/__init__.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_noop as _
+from django.utils.translation import ugettext_lazy as _
 from custom.up_nrhm.reports.asha_functionality_checklist_report import ASHAFunctionalityChecklistReport
 from custom.up_nrhm.reports.asha_reports import ASHAReports
 

--- a/custom/up_nrhm/filters.py
+++ b/custom/up_nrhm/filters.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from corehq.apps.reports.filters.select import MonthFilter
 from corehq.apps.userreports.sql import get_table_name
 from dimagi.utils.decorators.memoized import memoized
@@ -34,7 +34,7 @@ class HierarchySqlData(SqlData):
 
 
 class DrillDownOptionFilter(BaseDrilldownOptionFilter):
-    label = ugettext_noop("Hierarchy")
+    label = ugettext_lazy("Hierarchy")
     slug = "hierarchy"
 
     @property

--- a/custom/world_vision/filters.py
+++ b/custom/world_vision/filters.py
@@ -1,11 +1,11 @@
-from django.utils.translation import ugettext_noop
+from django.utils.translation import ugettext_lazy
 from corehq.apps.reports.filters.base import BaseDrilldownOptionFilter
 from corehq.apps.reports.filters.dates import DatespanFilter
 from custom.world_vision.sqldata import LocationSqlData, LOCATION_HIERARCHY
 
 
 class LocationFilter(BaseDrilldownOptionFilter):
-    label = ugettext_noop("Location")
+    label = ugettext_lazy("Location")
     slug = "location"
     template = "world_vision/location_filter.html"
 

--- a/docs/translations.rst
+++ b/docs/translations.rst
@@ -3,11 +3,26 @@ Internationalization
 
 This page contains the most common techniques needed for managing CommCare HQ
 localization strings. For more comprehensive information, consult the
-`Django Docs translations page <https://docs.djangoproject.com/en/dev/topics/i18n/translation/>`_.
+`Django Docs translations page <https://docs.djangoproject.com/en/dev/topics/i18n/translation/>`_
+or `this helpful blog post <http://blog.bessas.me/post/65775299341/using-gettext-in-django>`_.
 
 
 Tagging strings in views
 ------------------------
+
+There are three ugettext functions you should be aware of:
+
+* ``ugettext``: The function returns the translation for the currently selected
+  language.
+* ``ugettext_lazy``: The function marks the string as translation string, but only
+  fetches the translated string when it is used in a string context, such as
+  when rendering a template.
+* ``ugettext_noop``: This function only marks a string as translation string, it
+  does not have any other effect; that is, it always returns the string itself.
+  This should be considered an advanced tool and generally avoided.  It could
+  be useful if you need access to both the translated and untranslated strings.
+
+**TL;DR**: ``ugettext`` should be used in code that will be run per-request.  ``ugettext_lazy`` should be used in top-level code.
 
 The most common case is just wrapping text with ugettext.
 
@@ -19,10 +34,10 @@ The most common case is just wrapping text with ugettext.
         messages.success(request, _("Welcome!"))
 
 
-Sometimes it isn't always so simple, for example with report or settings
-section names. Two methods (`ugettext_noop` and `ugettext_lazy`) are available to mark
-a string for translation but not store the translated string value. These solve
-slightly different cases but are often interchangeable.
+When a string will be read by python as soon as the code is parsed, there is
+not yet a user whose locale can be used for translations, so it must be
+delayed.  This is where `ugettext_lazy` comes in.  It will mark a string for
+translation, but delay the actual translation as long as possible.
 
 .. code-block:: python
 

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -30713,9 +30713,6 @@ msgstr ""
 #~ msgid "registration profiles"
 #~ msgstr "profils d'enregistrement"
 
-#~ msgid "ugettext_noop"
-#~ msgstr "ugettext_noop"
-
 #~ msgid "open"
 #~ msgstr "ouvrir"
 


### PR DESCRIPTION
bulk-replace `ugettext_noop` with `ugettext_lazy` and hope for the best

Found this good explanation http://blog.bessas.me/post/65775299341/using-gettext-in-django

``` python
import logging
from django.http import HttpResponse
from django.utils.translation import ugettext as _

def view(request):
    msg = ugettext_noop("An error has occurred")
    logging.error(msg)
    return HttpResponse(_(msg))
```

basically, `ugettext_noop` lets you mark the string for translation, and pass it around untranslated, that way you can log it in English, but you still need to actually translate before displaying to the user.  Normally you wouldn't pass dynamic args to `ugettext`, but in this case you know msg to be a static string.
My read of that is that we should only use `ugettext_noop` in instances where we have a good reason to keep the untranslated string around.  It looks like most of our usages of that are wrong, and we should be using `ugettext_lazy` instead.
This PR does a bulk replace of `ugettext_noop` for `ugettext_lazy` and some related cleanup to remove duplicate imports and such.  The bulk replace is committed separately so you can skip that commit when reviewing.
I'm throwing this on staging, but I'd love to hear a reason why this isn't needed, so if you've got an idea, send it my way.  Anyways, we should really try to get this sorted quickly, because the merge conflicts are gonna be horrific.
