### PR TITLE
Prevent usercase modules

### DIFF
--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -91,8 +91,11 @@ def is_valid_case_type(case_type):
     False
     >>> is_valid_case_type(None)
     False
+    >>> is_valid_case_type('commcare-user')
+    False
+
     """
-    return bool(_case_type_regex.match(case_type or ''))
+    return bool(_case_type_regex.match(case_type or '')) and case_type != USERCASE_TYPE
 
 
 class ParentCasePropertyBuilder(object):

--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -1644,7 +1644,6 @@ def edit_module_attr(request, domain, app_id, module_id, attr):
     if should_edit("case_type"):
         case_type = request.POST.get("case_type", None)
         if is_valid_case_type(case_type):
-            # todo: something better than nothing when invalid
             old_case_type = module["case_type"]
             module["case_type"] = case_type
             for cp_mod in (mod for mod in app.modules if isinstance(mod, CareplanModule)):
@@ -1663,6 +1662,8 @@ def edit_module_attr(request, domain, app_id, module_id, attr):
                 if ad_mod.unique_id != module.unique_id and ad_mod.case_type != old_case_type:
                     # only apply change if the module's case_type does not reference the old value
                     rename_action_case_type(ad_mod)
+        elif case_type == USERCASE_TYPE:
+            return HttpResponseBadRequest('"{}" is a reserved case type'.format(USERCASE_TYPE))
         else:
             return HttpResponseBadRequest("case type is improperly formatted")
     if should_edit("put_in_root"):


### PR DESCRIPTION
Whether we choose to offer usercase subcases or not, we shouldn't allow a module case type to be set to "commcare-user". 

(Commit was cherry-picked from usercase_subcases branch.)

@snopoke, ping @czue, cc @millerdev 
