### PR TITLE
Allow future dates in reports

### DIFF
--- a/corehq/apps/reports/static/reports/javascripts/datepicker.js
+++ b/corehq/apps/reports/static/reports/javascripts/datepicker.js
@@ -15,7 +15,6 @@ $(function() {
         changeYear: true,
         showButtonPanel: true,
         dateFormat: 'yy-mm-dd',
-        maxDate: '0',
         numberOfMonths: 2
         /*onClose: function(dateText, inst) {
             var month = $("#ui-datepicker-div .ui-datepicker-month :selected").val();

--- a/corehq/apps/reports/static/reports/javascripts/daterangepicker.js
+++ b/corehq/apps/reports/static/reports/javascripts/daterangepicker.js
@@ -23,7 +23,6 @@ $(function() {
         $(this).daterangepicker({
             format: 'YYYY-MM-DD',
             showDropdowns: true,
-            maxDate: now,
             ranges: ranges,
             separator: separator
         });

--- a/corehq/apps/reports/static/reports/ko/saved_reports.js
+++ b/corehq/apps/reports/static/reports/ko/saved_reports.js
@@ -232,7 +232,6 @@ var ReportConfigsViewModel = function (options) {
             changeYear: true,
             showButtonPanel: true,
             dateFormat: 'yy-mm-dd',
-            maxDate: '0',
             numberOfMonths: 2
         });
     };


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?175884

If anyone knows of a place we _shouldn't_ be allowing future dates ( @czue ?), speak up...The commits where `maxDate` was set look like they're part of standard "set up the widget" commits, no comments on why the date range is limited:
daterangepicker.js: https://github.com/dimagi/commcare-hq/commit/68d1fd839c55baf16a6b7053a599b43cddfad5e2 @msienkiewicz
datepicker.js: https://github.com/dimagi/commcare-hq/commit/892940f129b8de5ca711a45b0b924558ce504cd8 @biyeun 
saved_reports.js: https://github.com/dimagi/commcare-hq/commit/3c2af13a50bb2ffd6e6e5244746528481725abee @emord 

code buddy @nickpell 
