### PR TITLE
quickcache get_by_username

### DIFF
--- a/corehq/apps/users/middleware.py
+++ b/corehq/apps/users/middleware.py
@@ -31,34 +31,7 @@ class UsersMiddleware(object):
         if 'org' in view_kwargs:
             request.org = view_kwargs['org']
         if request.user and hasattr(request.user, 'get_profile'):
-            sessionid = request.COOKIES.get('sessionid', None)
-            if sessionid:
-                # roundabout way to keep doc_id based caching consistent.
-                # get user doc_id from session_id
-                MISSING = object()
-                INTERRUPTED = object()
-                try:
-                    cached_user_doc_id = rcache.get(SESSION_USER_KEY_PREFIX % sessionid, MISSING)
-                except ConnectionInterrumped:
-                    cached_user_doc_id = INTERRUPTED
-
-                # disable session based couch user caching - to be enabled later.
-                if cached_user_doc_id not in (MISSING, INTERRUPTED):
-                    # cache hit
-                    couch_user = CouchUser.wrap_correctly(
-                        cache_core.cached_open_doc(
-                            CouchUser.get_db(), cached_user_doc_id
-                        )
-                    )
-                else:
-                    # cache miss, write to cache
-                    couch_user = CouchUser.from_django_user(request.user)
-                    if couch_user:
-                        cache_core.do_cache_doc(couch_user.to_json())
-                        if cached_user_doc_id is not INTERRUPTED:
-                            rcache.set(SESSION_USER_KEY_PREFIX % sessionid, couch_user.get_id)
-                request.couch_user = couch_user
-
+            request.couch_user = CouchUser.get_by_username(request.user.username)
             if 'domain' in view_kwargs:
                 domain = request.domain
                 if not request.couch_user:

--- a/corehq/apps/users/middleware.py
+++ b/corehq/apps/users/middleware.py
@@ -31,7 +31,8 @@ class UsersMiddleware(object):
         if 'org' in view_kwargs:
             request.org = view_kwargs['org']
         if request.user and hasattr(request.user, 'get_profile'):
-            request.couch_user = CouchUser.get_by_username(request.user.username)
+            request.couch_user = CouchUser.get_by_username(
+                request.user.username, strict=False)
             if 'domain' in view_kwargs:
                 domain = request.domain
                 if not request.couch_user:

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1155,13 +1155,14 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, EulaMi
             }[source['doc_type']].wrap(source)
 
     @classmethod
-    def get_by_username(cls, username):
+    @skippable_quickcache(['username'], skip_arg='strict')
+    def get_by_username(cls, username, strict=False):
         def get(stale, raise_if_none):
             result = cls.get_db().view('users/by_username',
                 key=username,
                 include_docs=True,
                 reduce=False,
-                #stale=stale,
+                stale=stale if not strict else None,
             )
             return result.one(except_all=raise_if_none)
         try:

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1180,6 +1180,9 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, EulaMi
         else:
             return None
 
+    def clear_quickcache_for_user(self):
+        self.get_by_username.clear(self.__class__, self.username)
+
     @classmethod
     def get_by_default_phone(cls, phone_number):
         result = cls.get_db().view('users/by_default_phone', key=phone_number, include_docs=True).one()
@@ -1252,6 +1255,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, EulaMi
         self.save()
 
     def save(self, **params):
+        self.clear_quickcache_for_user()
         # test no username conflict
         by_username = self.get_db().view('users/by_username', key=self.username, reduce=False).first()
         if by_username and by_username['id'] != self._id:

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1156,7 +1156,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, EulaMi
 
     @classmethod
     @skippable_quickcache(['username'], skip_arg='strict')
-    def get_by_username(cls, username, strict=False):
+    def get_by_username(cls, username, strict=True):
         def get(stale, raise_if_none):
             result = cls.get_db().view('users/by_username',
                 key=username,


### PR DESCRIPTION
and use that instead of cache_core lookup in middleware
- there's a new `strict` arg that's `True` by default, and only user middleware sets it to `False`. This avoids it affecting anything else that currently calls it.
