### PR TITLE
Stale group views

### DIFF
--- a/corehq/apps/groups/dbaccessors.py
+++ b/corehq/apps/groups/dbaccessors.py
@@ -40,6 +40,15 @@ def stale_group_by_name(domain, name, include_docs=True, **kwargs):
     )
 
 
-def refresh_group_views(group):
-    group_by_domain(group.domain, include_docs=False, limit=1).fetch()
-    group_by_name(group.domain, group.name, include_docs=False, limit=1).fetch()
+def refresh_group_views():
+    from corehq.apps.groups.models import Group
+    Group.view(
+        'groups/by_domain',
+        include_docs=False,
+        limit=1,
+    ).fetch()
+    Group.view(
+        'groups/by_name',
+        include_docs=False,
+        limit=1,
+    ).fetch()

--- a/corehq/apps/groups/dbaccessors.py
+++ b/corehq/apps/groups/dbaccessors.py
@@ -41,5 +41,5 @@ def stale_group_by_name(domain, name, include_docs=True, **kwargs):
 
 
 def refresh_group_views(group):
-    group_by_domain(group.domain, include_docs=False, limit=1).all()
-    group_by_name(group.domain, group.name, include_docs=False, limit=1).all()
+    group_by_domain(group.domain, include_docs=False, limit=1).fetch()
+    group_by_name(group.domain, group.name, include_docs=False, limit=1).fetch()

--- a/corehq/apps/groups/dbaccessors.py
+++ b/corehq/apps/groups/dbaccessors.py
@@ -1,0 +1,44 @@
+import settings
+from corehq.apps.groups.models import Group
+
+
+def group_by_domain(domain, include_docs=True, **kwargs):
+    return Group.view(
+        'groups/by_domain',
+        key=domain,
+        include_docs=include_docs,
+        **kwargs
+    )
+
+
+def stale_group_by_domain(domain, include_docs=True, **kwargs):
+    return group_by_domain(
+        domain,
+        include_docs=include_docs,
+        stale=settings.COUCH_STALE_QUERY,
+        **kwargs
+    )
+
+
+def group_by_name(domain, name, include_docs=True, **kwargs):
+    return Group.view(
+        'groups/by_name',
+        key=[domain, name],
+        include_docs=include_docs,
+        **kwargs
+    )
+
+
+def stale_group_by_name(domain, name, include_docs=True, **kwargs):
+    return group_by_name(
+        domain,
+        name,
+        include_docs=include_docs,
+        stale=settings.COUCH_STALE_QUERY,
+        **kwargs
+    )
+
+
+def refresh_group_views(group):
+    group_by_domain(group.domain)
+    group_by_name(group.domain, group.name)

--- a/corehq/apps/groups/dbaccessors.py
+++ b/corehq/apps/groups/dbaccessors.py
@@ -1,8 +1,8 @@
 import settings
-from corehq.apps.groups.models import Group
 
 
 def group_by_domain(domain, include_docs=True, **kwargs):
+    from corehq.apps.groups.models import Group
     return Group.view(
         'groups/by_domain',
         key=domain,
@@ -21,6 +21,7 @@ def stale_group_by_domain(domain, include_docs=True, **kwargs):
 
 
 def group_by_name(domain, name, include_docs=True, **kwargs):
+    from corehq.apps.groups.models import Group
     return Group.view(
         'groups/by_name',
         key=[domain, name],

--- a/corehq/apps/groups/dbaccessors.py
+++ b/corehq/apps/groups/dbaccessors.py
@@ -41,5 +41,5 @@ def stale_group_by_name(domain, name, include_docs=True, **kwargs):
 
 
 def refresh_group_views(group):
-    group_by_domain(group.domain)
-    group_by_name(group.domain, group.name)
+    group_by_domain(group.domain).all()
+    group_by_name(group.domain, group.name).all()

--- a/corehq/apps/groups/dbaccessors.py
+++ b/corehq/apps/groups/dbaccessors.py
@@ -41,5 +41,5 @@ def stale_group_by_name(domain, name, include_docs=True, **kwargs):
 
 
 def refresh_group_views(group):
-    group_by_domain(group.domain).all()
-    group_by_name(group.domain, group.name).all()
+    group_by_domain(group.domain, include_docs=False, limit=1).all()
+    group_by_name(group.domain, group.name, include_docs=False, limit=1).all()

--- a/corehq/apps/groups/dbaccessors.py
+++ b/corehq/apps/groups/dbaccessors.py
@@ -1,42 +1,53 @@
 import settings
 
 
-def group_by_domain(domain, include_docs=True, **kwargs):
+def _group_by_domain(domain, **kwargs):
     from corehq.apps.groups.models import Group
-    return Group.view(
+    return list(Group.view(
         'groups/by_domain',
         key=domain,
-        include_docs=include_docs,
         **kwargs
+    ))
+
+
+def group_by_domain(domain, include_docs=True):
+    return _group_by_domain(
+        domain,
+        include_docs=include_docs,
     )
 
 
-def stale_group_by_domain(domain, include_docs=True, **kwargs):
-    return group_by_domain(
+def stale_group_by_domain(domain, include_docs=True):
+    return _group_by_domain(
         domain,
         include_docs=include_docs,
         stale=settings.COUCH_STALE_QUERY,
-        **kwargs
     )
 
 
-def group_by_name(domain, name, include_docs=True, **kwargs):
+def _group_by_name(domain, name, **kwargs):
     from corehq.apps.groups.models import Group
-    return Group.view(
+    return list(Group.view(
         'groups/by_name',
         key=[domain, name],
-        include_docs=include_docs,
         **kwargs
+    ))
+
+
+def group_by_name(domain, name, include_docs=True):
+    return _group_by_name(
+        domain,
+        name,
+        include_docs=include_docs,
     )
 
 
-def stale_group_by_name(domain, name, include_docs=True, **kwargs):
-    return group_by_name(
+def stale_group_by_name(domain, name, include_docs=True):
+    return _group_by_name(
         domain,
         name,
         include_docs=include_docs,
         stale=settings.COUCH_STALE_QUERY,
-        **kwargs
     )
 
 

--- a/corehq/apps/groups/dbaccessors.py
+++ b/corehq/apps/groups/dbaccessors.py
@@ -53,13 +53,12 @@ def stale_group_by_name(domain, name, include_docs=True):
 
 def refresh_group_views():
     from corehq.apps.groups.models import Group
-    Group.view(
+    for view_name in [
         'groups/by_domain',
-        include_docs=False,
-        limit=1,
-    ).fetch()
-    Group.view(
         'groups/by_name',
-        include_docs=False,
-        limit=1,
-    ).fetch()
+    ]:
+        Group.view(
+            view_name,
+            include_docs=False,
+            limit=1,
+        ).fetch()

--- a/corehq/apps/groups/dbaccessors.py
+++ b/corehq/apps/groups/dbaccessors.py
@@ -1,4 +1,4 @@
-import settings
+from django.conf import settings
 
 
 def _group_by_domain(domain, **kwargs):

--- a/corehq/apps/groups/models.py
+++ b/corehq/apps/groups/models.py
@@ -66,6 +66,13 @@ class Group(UndoableDocument):
         super(Group, self).delete()
         refresh_group_views()
 
+    @classmethod
+    def delete_docs(cls, docs, **params):
+        super(Group, cls).delete_docs(docs, **params)
+        refresh_group_views()
+
+    bulk_delete = delete_docs
+
     def add_user(self, couch_user_id, save=True):
         if not isinstance(couch_user_id, basestring):
             couch_user_id = couch_user_id.user_id

--- a/corehq/apps/groups/models.py
+++ b/corehq/apps/groups/models.py
@@ -63,6 +63,9 @@ class Group(UndoableDocument):
 
     bulk_save = save_docs
 
+    def delete(self):
+        super(Group, self).delete()
+        refresh_group_views(self)
 
     def add_user(self, couch_user_id, save=True):
         if not isinstance(couch_user_id, basestring):

--- a/corehq/apps/groups/models.py
+++ b/corehq/apps/groups/models.py
@@ -48,9 +48,8 @@ class Group(UndoableDocument):
 
     def save(self, *args, **kwargs):
         self.last_modified = datetime.utcnow()
-        saved_group = super(Group, self).save(*args, **kwargs)
+        super(Group, self).save(*args, **kwargs)
         refresh_group_views(self)
-        return saved_group
 
     @classmethod
     def save_docs(cls, docs, use_uuids=True, all_or_nothing=False):

--- a/corehq/apps/groups/models.py
+++ b/corehq/apps/groups/models.py
@@ -57,8 +57,7 @@ class Group(UndoableDocument):
         for doc in docs:
             doc['last_modified'] = utcnow
         super(Group, cls).save_docs(docs, use_uuids, all_or_nothing)
-        for doc in docs:
-            refresh_group_views()
+        refresh_group_views()
 
     bulk_save = save_docs
 

--- a/corehq/apps/groups/models.py
+++ b/corehq/apps/groups/models.py
@@ -9,6 +9,8 @@ from dimagi.utils.couch.undo import UndoableDocument, DeleteDocRecord, DELETED_S
 from datetime import datetime
 from corehq.apps.groups.dbaccessors import (
     refresh_group_views,
+    stale_group_by_domain,
+    stale_group_by_name,
 )
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.groups.exceptions import CantSaveException
@@ -155,11 +157,7 @@ class Group(UndoableDocument):
 
     @classmethod
     def by_domain(cls, domain):
-        return cls.view('groups/by_domain',
-            key=domain,
-            include_docs=True,
-            #stale=settings.COUCH_STALE_QUERY,
-        ).all()
+        return stale_group_by_domain(domain).all()
 
     @classmethod
     def choices_by_domain(cls, domain):
@@ -178,11 +176,7 @@ class Group(UndoableDocument):
 
     @classmethod
     def by_name(cls, domain, name, one=True):
-        result = cls.view('groups/by_name',
-            key=[domain, name],
-            include_docs=True,
-            #stale=settings.COUCH_STALE_QUERY,
-        )
+        result = stale_group_by_name(domain, name)
         if one:
             return result.one()
         else:

--- a/corehq/apps/groups/models.py
+++ b/corehq/apps/groups/models.py
@@ -49,7 +49,7 @@ class Group(UndoableDocument):
     def save(self, *args, **kwargs):
         self.last_modified = datetime.utcnow()
         saved_group = super(Group, self).save(*args, **kwargs)
-        refresh_group_views(saved_group.domain, saved_group.name)
+        refresh_group_views(self)
         return saved_group
 
     @classmethod

--- a/corehq/apps/groups/models.py
+++ b/corehq/apps/groups/models.py
@@ -49,7 +49,7 @@ class Group(UndoableDocument):
     def save(self, *args, **kwargs):
         self.last_modified = datetime.utcnow()
         super(Group, self).save(*args, **kwargs)
-        refresh_group_views(self)
+        refresh_group_views()
 
     @classmethod
     def save_docs(cls, docs, use_uuids=True, all_or_nothing=False):
@@ -58,13 +58,13 @@ class Group(UndoableDocument):
             doc['last_modified'] = utcnow
         super(Group, cls).save_docs(docs, use_uuids, all_or_nothing)
         for doc in docs:
-            refresh_group_views(Group.wrap(doc))
+            refresh_group_views()
 
     bulk_save = save_docs
 
     def delete(self):
         super(Group, self).delete()
-        refresh_group_views(self)
+        refresh_group_views()
 
     def add_user(self, couch_user_id, save=True):
         if not isinstance(couch_user_id, basestring):

--- a/corehq/apps/groups/models.py
+++ b/corehq/apps/groups/models.py
@@ -172,10 +172,7 @@ class Group(UndoableDocument):
 
     @classmethod
     def ids_by_domain(cls, domain):
-        return [r['id'] for r in cls.get_db().view('groups/by_domain',
-            key=domain,
-            include_docs=False,
-        )]
+        return [r['id'] for r in stale_group_by_domain(domain, include_docs=False)]
 
     @classmethod
     def by_name(cls, domain, name, one=True):

--- a/corehq/apps/groups/models.py
+++ b/corehq/apps/groups/models.py
@@ -162,10 +162,9 @@ class Group(UndoableDocument):
     def get_static_users(self, is_active=True):
         return self.get_users(is_active)
 
-
     @classmethod
     def by_domain(cls, domain):
-        return stale_group_by_domain(domain).all()
+        return stale_group_by_domain(domain)
 
     @classmethod
     def choices_by_domain(cls, domain):
@@ -182,8 +181,8 @@ class Group(UndoableDocument):
     @classmethod
     def by_name(cls, domain, name, one=True):
         result = stale_group_by_name(domain, name)
-        if one:
-            return result.one()
+        if one and result:
+            return result[0]
         else:
             return result
 

--- a/corehq/apps/groups/views.py
+++ b/corehq/apps/groups/views.py
@@ -25,7 +25,7 @@ def add_group(request, domain):
             "please give it a name first"
         ))
         return HttpResponseRedirect(request.META['HTTP_REFERER'])
-    group = Group.by_name(domain, group_name, one=False).first()
+    group = Group.by_name(domain, group_name)
     if group:
         messages.warning(request, _(
             "A group with this name already exists: instead of making "
@@ -89,7 +89,7 @@ def edit_group(request, domain, group_id):
                 "but every group must have a name so we left it unchanged."
             ))
         elif group.name != name:
-            dupe = Group.by_name(domain, name, one=False).first()
+            dupe = Group.by_name(domain, name)
             if dupe:
                 messages.warning(request, _(
                     "We didn't rename your group because there's already "

--- a/corehq/util/couch.py
+++ b/corehq/util/couch.py
@@ -212,7 +212,7 @@ def send_keys_to_couch(db, keys):
     return r.json()['rows']
 
 
-def iter_update(db, fn, ids, max_retries=3, verbose=False):
+def iter_update(db, fn, ids, max_retries=3, verbose=False, refresh_view_funcs=None):
     """
     Map `fn` over every doc in `db` matching `ids`
 
@@ -247,7 +247,7 @@ def iter_update(db, fn, ids, max_retries=3, verbose=False):
     results = IterResults(set(), set(), set(), set(), set())
 
     def _iter_update(doc_ids, try_num):
-        with IterDB(db, chunksize=100) as iter_db:
+        with IterDB(db, chunksize=100, refresh_view_funcs=refresh_view_funcs) as iter_db:
             for chunk in chunked(set(doc_ids), 100):
                 for res in send_keys_to_couch(db, keys=chunk):
                     raw_doc = res.get('doc')

--- a/corehq/util/couch.py
+++ b/corehq/util/couch.py
@@ -114,10 +114,11 @@ class IterDB(object):
     `new_edits` param will be passed directly to db.bulk_save
     """
     def __init__(self, database, chunksize=100, throttle_secs=None,
-                 new_edits=None):
+                 new_edits=None, refresh_view_funcs=None):
         self.db = database
         self.chunksize = chunksize
         self.throttle_secs = throttle_secs
+        self.refresh_view_funcs = refresh_view_funcs or []
         self.saved_ids = set()
         self.deleted_ids = set()
         self.error_ids = set()
@@ -171,6 +172,8 @@ class IterDB(object):
             self._commit_save()
         if self.to_delete:
             self._commit_delete()
+        for refresh_view_func in self.refresh_view_funcs:
+            refresh_view_func()
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.commit()

--- a/corehq/util/tests/test_couch.py
+++ b/corehq/util/tests/test_couch.py
@@ -190,7 +190,7 @@ class IterDBTest(TestCase):
                 return DocUpdate(group, delete=True)
 
         ids = [g._id for g in self.groups] + ['NOT_REAL_ID']
-        res = iter_update(self.db, mark_cool, ids)
+        res = iter_update(self.db, mark_cool, ids, refresh_view_funcs=[refresh_group_views])
         self.assertEqual(res.not_found_ids, {'NOT_REAL_ID'})
         for result_ids, action in [
             (res.ignored_ids, 'IGNORE'),

--- a/corehq/util/tests/test_couch.py
+++ b/corehq/util/tests/test_couch.py
@@ -155,7 +155,7 @@ class IterDBTest(TestCase):
         self.assertEqual({old._id}, iter_db.error_ids)
 
     def test_delete(self):
-        with IterDB(self.db, chunksize=5, refresh_view_funcs=[refresh_group_views]) as iter_db:
+        with IterDB(self.db, chunksize=5) as iter_db:
             deleted_groups = set()
             for group in self.groups[:4]:
                 deleted_groups.add(group._id)
@@ -165,6 +165,7 @@ class IterDBTest(TestCase):
             for group in self.groups[4:]:
                 saved_groups.add(group._id)
                 iter_db.save(group)
+        refresh_group_views()
 
         self.assertEqual(deleted_groups, iter_db.deleted_ids)
         self.assertEqual(saved_groups, iter_db.saved_ids)
@@ -190,7 +191,8 @@ class IterDBTest(TestCase):
                 return DocUpdate(group, delete=True)
 
         ids = [g._id for g in self.groups] + ['NOT_REAL_ID']
-        res = iter_update(self.db, mark_cool, ids, refresh_view_funcs=[refresh_group_views])
+        res = iter_update(self.db, mark_cool, ids)
+        refresh_group_views()
         self.assertEqual(res.not_found_ids, {'NOT_REAL_ID'})
         for result_ids, action in [
             (res.ignored_ids, 'IGNORE'),

--- a/corehq/util/tests/test_couch.py
+++ b/corehq/util/tests/test_couch.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 from couchdbkit import ResourceNotFound
 from django.http import Http404
 from django.test import TestCase, SimpleTestCase
+from corehq.apps.groups.dbaccessors import refresh_group_views
 from corehq.apps.groups.models import Group
 from jsonobject.exceptions import WrappingAttributeError
 from mock import Mock
@@ -154,7 +155,7 @@ class IterDBTest(TestCase):
         self.assertEqual({old._id}, iter_db.error_ids)
 
     def test_delete(self):
-        with IterDB(self.db, chunksize=5) as iter_db:
+        with IterDB(self.db, chunksize=5, refresh_view_funcs=[refresh_group_views]) as iter_db:
             deleted_groups = set()
             for group in self.groups[:4]:
                 deleted_groups.add(group._id)


### PR DESCRIPTION
Start moving `Group` views into dbaccessors and using `stale=settings.COUCH_STALE_QUERY`.

Whenever a `Group` is saved or deleted, update the views that use the stale setting.  This has an advantage over the approach used in https://github.com/dimagi/commcare-hq/pull/7567 in that it doesn't require knowledge about how the model is used in order to guarantee that `by_domain` and `by_name` return up-to-date data.  The downside is that save/delete would take slightly longer but I think delays are preferable during saves than during page loads.

@gcapalbo @dannyroberts @czue 
