### PR TITLE
Cache user role lookup in memory during request

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -26,7 +26,7 @@ from dimagi.utils.logging import notify_exception
 from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.make_uuid import random_hex
 from dimagi.utils.modules import to_function
-from corehq.util.quickcache import skippable_quickcache
+from corehq.util.quickcache import skippable_quickcache, quickcache
 from casexml.apps.case.xml import V2
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.models import CommCareCase
@@ -229,6 +229,11 @@ class UserRole(Document):
     name = StringProperty()
     permissions = SchemaProperty(Permissions)
     is_archived = BooleanProperty(default=False)
+
+    @classmethod
+    @quickcache(['doc_id'], timeout=0)
+    def get(cls, doc_id):
+        return super(UserRole, cls).get(doc_id)
 
     def get_qualified_id(self):
         return 'user-role:%s' % self.get_id

--- a/corehq/util/quickcache.py
+++ b/corehq/util/quickcache.py
@@ -270,12 +270,15 @@ def quickcache(vary_on, timeout=None, memoize_timeout=None, cache=None,
         raise ValueError('You can only use timeout '
                          'when not overriding the cache')
 
-    timeout = timeout or 5 * 60
+    timeout = timeout if timeout is not None else 5 * 60
     memoize_timeout = memoize_timeout or 10
 
     if cache is None:
-        cache = TieredCache([get_cache('django.core.cache.backends.locmem.LocMemCache', timeout=memoize_timeout),
-                             get_cache('default', timeout=timeout)])
+        caches = [get_cache('django.core.cache.backends.locmem.LocMemCache',
+                            timeout=memoize_timeout)]
+        if timeout != 0:
+            caches.append(get_cache('default', timeout=timeout))
+        cache = TieredCache(caches)
 
     def decorator(fn):
         helper = helper_class(fn, vary_on=vary_on, cache=cache)


### PR DESCRIPTION
The web users page loads user roles for all users, which results in many duplicate gets.  I have a local domain with only 20 users, and this saved about 1.9 seconds on that page load.

This also makes `quickcache('..', timeout=0)` not send to redis.

@dannyroberts @proteusvacuum
