### PR TITLE
kill cache_core.get_cached_prop

### DIFF
--- a/corehq/apps/cachehq/cachemodels.py
+++ b/corehq/apps/cachehq/cachemodels.py
@@ -12,7 +12,6 @@ class DomainGenerationCache(GenerationCache):
         "domain/with_deployment",
         "domain/domains",
         "domain/fields_by_prefix",
-        "domain/by_status",
         "domain/by_organization",
     ]
 

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -132,19 +132,7 @@ def domains_for_user(context, request, selected_domain=None):
     """
     domain_list = []
     if selected_domain != 'public':
-        cached_domains = cache_core.get_cached_prop(request.couch_user.get_id, 'domain_list')
-        if cached_domains:
-            domain_list = [Domain.wrap(x) for x in cached_domains]
-        else:
-            try:
-                domain_list = Domain.active_for_user(request.couch_user)
-                cache_core.cache_doc_prop(request.couch_user.get_id, 'domain_list', [x.to_json() for x in domain_list])
-            except Exception:
-                if settings.DEBUG:
-                    raise
-                else:
-                    domain_list = Domain.active_for_user(request.user)
-                    notify_exception(request)
+        domain_list = Domain.active_for_user(request.couch_user)
     domain_list = [dict(
         url=reverse('domain_homepage', args=[d.name]),
         name=d.long_display_name()

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1182,6 +1182,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, EulaMi
 
     def clear_quickcache_for_user(self):
         self.get_by_username.clear(self.__class__, self.username)
+        Domain.active_for_couch_user.clear(self)
 
     @classmethod
     def get_by_default_phone(cls, phone_number):


### PR DESCRIPTION
was only being used in one place
rewritten with quickcache

it was doing a redis somekey:somekey:\* lookup every time a (any?) doc was changed
