### PR TITLE
fix bad selector on web users list

### DIFF
--- a/corehq/apps/users/templates/users/web_users.html
+++ b/corehq/apps/users/templates/users/web_users.html
@@ -82,7 +82,7 @@
                     var post_url = '{% url "delete_invitation" domain %}';
                     $.post(post_url, {invite: id},
                         function(data) {
-                            $("a[data-id]=" + id).parents("tr").remove();
+                            $("a[data-id=" + id + "]").parents("tr").remove();
                             $('#modal-dialog').data('id', id).modal('hide');
                              $(this).removeClass('disabled');
                         }


### PR DESCRIPTION
On the web users list, deleting one invitation causes all invitations to disappear from the UI.

![screen shot 2015-07-21 at 6 31 18 pm](https://cloud.githubusercontent.com/assets/1486591/8814079/b66ff254-2fd6-11e5-85b0-9715353438e3.png)

@benrudolph 
