### PR TITLE
quickcache _get_configurable_reports instead of GenerationCache

### DIFF
--- a/corehq/apps/cachehq/cachemodels.py
+++ b/corehq/apps/cachehq/cachemodels.py
@@ -130,11 +130,3 @@ class UserReportsDataSourceCache(GenerationCache):
     views = [
         'userreports/data_sources_by_build_info',
     ]
-
-
-class UserReportsReportConfigCache(GenerationCache):
-    generation_key = '#gen#userreports#reportconfig#'
-    doc_types = ['ReportConfiguration']
-    views = [
-        'userreports/report_configs_by_domain',
-    ]

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -341,6 +341,14 @@ class ReportConfiguration(UnicodeMixIn, CachedCouchDocumentMixin, Document):
     def all(cls):
         return get_all_report_configs()
 
+    def clear_related_caches(self):
+        from corehq import _get_configurable_reports
+        _get_configurable_reports.clear(self.domain)
+
+    def save(self, **params):
+        self.clear_related_caches()
+        super(ReportConfiguration, self).save(**params)
+
 
 class CustomDataSourceConfiguration(JsonObject):
     _datasource_id_prefix = 'custom-'

--- a/settings.py
+++ b/settings.py
@@ -1318,7 +1318,6 @@ COUCH_CACHE_BACKENDS = [
     'corehq.apps.cachehq.cachemodels.DomainInvitationGenerationCache',
     'corehq.apps.cachehq.cachemodels.CommtrackConfigGenerationCache',
     'corehq.apps.cachehq.cachemodels.UserReportsDataSourceCache',
-    'corehq.apps.cachehq.cachemodels.UserReportsReportConfigCache',
     'dimagi.utils.couch.cache.cache_core.gen.GlobalCache',
 ]
 


### PR DESCRIPTION
the GenerationCaches get invalidated way to frequently
this will do it by domain

and this was the only call to `userreports/report_configs_by_domain` that was worth caching
