### PR TITLE
Migrate DomainInvitation and OrgInvitation to postgres

### DIFF
--- a/corehq/apps/orgs/models.py
+++ b/corehq/apps/orgs/models.py
@@ -1,8 +1,9 @@
 from couchdbkit import MultipleResultsFound
 from dimagi.ext.couchdbkit import *
 from django.conf import settings
+from django.db import models
 from django.template.loader import render_to_string
-from corehq.apps.users.models import WebUser, MultiMembershipMixin, Invitation
+from corehq.apps.users.models import WebUser, MultiMembershipMixin, Invitation, SQLInvitation
 from corehq.util.view_utils import absolute_reverse
 from dimagi.utils.couch.cache import cache_core
 from dimagi.utils.couch.undo import UndoableDocument, DeleteDocRecord
@@ -101,6 +102,21 @@ class Team(UndoableDocument, MultiMembershipMixin):
 class DeleteTeamRecord(DeleteDocRecord):
     def get_doc(self):
         return Team.get(self.doc_id)
+
+
+class SQLOrgInvitation(SQLInvitation):
+    organization = models.CharField(max_length=255)
+
+    def send_activation_email(self):
+        url = absolute_reverse("orgs_accept_invitation",
+                               args=[self.organization, self.id])
+        params = {"organization": self.organization, "url": url,
+                  "inviter": self.get_inviter().formatted_name}
+        text_content = render_to_string("orgs/email/org_invite.txt", params)
+        html_content = render_to_string("orgs/email/org_invite.html", params)
+        subject = 'Invitation from %s to join CommCareHQ' % self.get_inviter().formatted_name
+        send_HTML_email(subject, self.email, html_content, text_content=text_content,
+                        email_from=settings.DEFAULT_FROM_EMAIL)
 
 
 class OrgInvitation(Invitation):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -10,6 +10,7 @@ from restkit.errors import NoMoreData
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.core.exceptions import ValidationError
+from django.db import models
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext as _
 from corehq.apps.commtrack.dbaccessors import get_supply_point_case_by_location
@@ -2374,6 +2375,25 @@ class InvalidUser(FakeUser):
 #
 # Django  models go here
 #
+class SQLInvitation(models.Model):
+    email = models.CharField(max_length=100, db_index=True)
+    invited_by = models.CharField(max_length=32)
+    invited_on = models.DateTimeField()
+    is_accepted = models.BooleanField(default=False)
+
+    _inviter = None
+    def get_inviter(self):
+        if self._inviter is None:
+            self._inviter = CouchUser.get_by_user_id(self.invited_by)
+            if self._inviter.user_id != self.invited_by:
+                self.invited_by = self._inviter.user_id
+                self.save()
+        return self._inviter
+
+    def send_activation_email(self):
+        raise NotImplementedError
+
+
 class Invitation(Document):
     email = StringProperty()
     invited_by = StringProperty()
@@ -2391,6 +2411,34 @@ class Invitation(Document):
 
     def send_activation_email(self):
         raise NotImplementedError
+
+
+class SQLDomainInvitation(SQLInvitation):
+    """
+    When we invite someone to a domain it gets stored here.
+    """
+    domain = models.CharField(max_length=255, db_index=True)
+    role = SchemaProperty(UserRole)
+
+    def send_activation_email(self, remaining_days=30):
+        url = absolute_reverse("domain_accept_invitation",
+                               args=[self.domain, self.id])
+        params = {"domain": self.domain, "url": url, 'days': remaining_days,
+                  "inviter": self.get_inviter().formatted_name}
+        text_content = render_to_string("domain/email/domain_invite.txt", params)
+        html_content = render_to_string("domain/email/domain_invite.html", params)
+        subject = _('Invitation from %s to join CommCareHQ') % self.get_inviter().formatted_name
+        send_HTML_email(subject, self.email, html_content, text_content=text_content,
+                        cc=[self.get_inviter().get_email()],
+                        email_from=settings.DEFAULT_FROM_EMAIL)
+
+    @classmethod
+    def by_domain(cls, domain, is_active=True):
+        return SQLDomainInvitation.objects.filter(domain=domain, is_accepted=False)
+
+    @classmethod
+    def by_email(cls, email, is_active=True):
+        return SQLDomainInvitation.objects.filter(email=email, is_accepted=False)
 
 
 class DomainInvitation(CachedCouchDocumentMixin, Invitation):

--- a/corehq/apps/users/tests/__init__.py
+++ b/corehq/apps/users/tests/__init__.py
@@ -6,6 +6,7 @@ from .sync import *
 from .permissions import *
 from .bulk_upload import *
 from .retire import *
+from .test_invitation_migration import *
 from .test_models import *
 from .fixture_status import *
 from .test_db_accessors import *

--- a/corehq/apps/users/tests/test_invitation_migration.py
+++ b/corehq/apps/users/tests/test_invitation_migration.py
@@ -1,0 +1,109 @@
+from corehq.apps.users.models import DomainInvitation, SQLDomainInvitation
+from couchdbkit.exceptions import ResourceNotFound
+from datetime import datetime
+from django.test import TestCase
+from time import sleep
+
+
+class InvitationMigrationTestCase(TestCase):
+    def setUp(self):
+        self.domain = 'test-domain-invitation-migration'
+
+    def tearDown(self):
+        for invitation in DomainInvitation.view(
+            'users/open_invitations_by_domain',
+            startkey=[self.domain],
+            endkey=[self.domain, {}],
+            include_docs=True,
+            reduce=False,
+        ).all():
+            invitation.delete()
+
+        SQLDomainInvitation.objects.filter(domain=self.domain).delete()
+
+    def getCouchCount(self):
+        result = DomainInvitation.view(
+            'users/open_invitations_by_domain',
+            startkey=[self.domain],
+            endkey=[self.domain, {}],
+            include_docs=False,
+            reduce=True,
+        ).all()
+        if result:
+            return result[0]['value']
+        return 0
+
+    def getSQLCount(self):
+        return SQLDomainInvitation.objects.filter(domain=self.domain).count()
+
+    def testCRUD(self):
+        initialCouchCount = self.getCouchCount()
+        initialSQLCount = self.getSQLCount()
+
+        # Creating couch should create SQL
+        couch = DomainInvitation()
+        couch.email = 'one@dimagi.com'
+        couch.role = 'role1'
+        couch.invited_by = 'fake_user_id'
+        couch.invited_on = datetime.now()
+        couch.domain = self.domain
+        couch.save()
+        sleep(1)
+        couch_copy = SQLDomainInvitation.objects.get(couch_id=couch.get_id)
+        self.assertEquals(couch_copy.email, 'one@dimagi.com')
+        self.assertEquals(couch_copy.role, 'role1')
+        self.assertEquals(self.getCouchCount(), initialCouchCount + 1)
+        self.assertEquals(self.getSQLCount(), initialSQLCount + 1)
+
+        # Creating SQL should create couch
+        sql = SQLDomainInvitation()
+        sql.email = 'two@dimagi.com'
+        sql.role = 'role2'
+        sql.invited_by = 'fake_user_id'
+        sql.invited_on = datetime.now()
+        sql.domain = self.domain
+        sql.save()
+        sleep(1)
+        sql_copy = DomainInvitation.get(sql.couch_id)
+        self.assertEquals(sql_copy.email, 'two@dimagi.com')
+        self.assertEquals(sql_copy.role, 'role2')
+        self.assertEquals(self.getCouchCount(), initialCouchCount + 2)
+        self.assertEquals(self.getSQLCount(), initialSQLCount + 2)
+
+        # Updating Couch should update SQL
+        couch.email = 'three@dimagi.com'
+        couch.role = 'role3'
+        couch.save()
+        sleep(1)
+        couch_copy = SQLDomainInvitation.objects.get(couch_id=couch.get_id)
+        self.assertEquals(couch_copy.email, 'three@dimagi.com')
+        self.assertEquals(couch_copy.role, 'role3')
+        self.assertEquals(self.getCouchCount(), initialCouchCount + 2)
+        self.assertEquals(self.getSQLCount(), initialSQLCount + 2)
+
+        # Updating SQL should update couch
+        sql.email = 'four@dimagi.com'
+        sql.role = 'role4'
+        sql.save()
+        sleep(1)
+        sql_copy = DomainInvitation.get(sql.couch_id)
+        self.assertEquals(sql_copy.email, 'four@dimagi.com')
+        self.assertEquals(sql_copy.role, 'role4')
+        self.assertEquals(self.getCouchCount(), initialCouchCount + 2)
+        self.assertEquals(self.getSQLCount(), initialSQLCount + 2)
+
+        # Deleting SQL should delete couch
+        couch_id = couch.get_id
+        couch.delete()
+        with self.assertRaises(ResourceNotFound):
+            DomainInvitation.get(couch_id)
+        self.assertEquals(self.getCouchCount(), initialCouchCount + 1)
+        self.assertEquals(self.getSQLCount(), initialSQLCount + 1)
+
+        # Deleting couch should delete SQL
+        couch_id = sql.couch_id
+        sql.delete()
+        with self.assertRaises(SQLDomainInvitation.DoesNotExist):
+            SQLDomainInvitation.objects.get(couch_id=couch_id)
+        self.assertEquals(self.getCouchCount(), initialCouchCount)
+        self.assertEquals(self.getSQLCount(), initialSQLCount)


### PR DESCRIPTION
Part 1 of 4:
1. Create postgres models. Write to both couch & postgres. Continue reading from couch.
2. Migrate old couch data to postgres
3. Read from postgres. Drop couch models.
4. Delete old couch docs & views (users/open_invitations_by_email, users/open_invitations_by_domain)

Depends on https://github.com/dimagi/dimagi-utils/pull/291

@benrudolph / @gcapalbo / @esoergel 
