### PR TITLE
Add rich text

### DIFF
--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -368,6 +368,13 @@ VELLUM_EXPERIMENTAL_UI = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
+VELLUM_RICH_TEXT = StaticToggle(
+    'rich_text',
+    "Enables rich text for the form builder",
+    TAG_EXPERIMENTAL,
+    [NAMESPACE_DOMAIN]
+)
+
 CACHE_AND_INDEX = StaticToggle(
     'cache_and_index',
     'Enable the "Cache and Index" format option when choosing sort properties '

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -340,13 +340,6 @@ VELLUM_TRANSACTION_QUESTION_TYPES = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
-VELLUM_HELP_MARKDOWN = StaticToggle(
-    'help_markdown',
-    "Use markdown for the help text in the form builder",
-    TAG_UNKNOWN,
-    [NAMESPACE_DOMAIN]
-)
-
 VELLUM_SAVE_TO_CASE = StaticToggle(
     'save_to_case',
     "Adds save to case as a question to the form builder",


### PR DESCRIPTION
@millerdev Got cold feet on adding this to experimental_ui flag. I'll add it there once rich text supports filters, but for now I think it could be useful to have two separate ones

also removes the old help markdown flag that hasn't been used since markdown was released

cc: @czue 
