### PR TITLE
Optimize PRBAC SQL queries

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1332,7 +1332,8 @@ class Subscription(models.Model):
     def _get_plan_by_subscriber(cls, subscriber):
         active_subscriptions = cls.objects\
             .filter(subscriber=subscriber, is_active=True)\
-            .order_by('-date_created')[:2]
+            .order_by('-date_created')[:2]\
+            .select_related('plan_version__role')
 
         if not active_subscriptions:
             return None, None

--- a/corehq/apps/accounting/tests/base_tests.py
+++ b/corehq/apps/accounting/tests/base_tests.py
@@ -2,10 +2,13 @@ from django.test import TestCase
 from corehq.apps.accounting import generator
 from corehq.apps.domain.models import Domain
 
+from django_prbac.models import Role
+
 
 class BaseAccountingTest(TestCase):
 
     def setUp(self):
+        Role.get_cache().clear()
         generator.instantiate_accounting_for_tests()
 
     def tearDown(self):

--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -171,7 +171,7 @@ from corehq.apps.app_manager.decorators import safe_download, no_conflict_requir
     require_can_edit_apps, require_deploy_apps
 from django.contrib import messages
 from django_prbac.exceptions import PermissionDenied
-from django_prbac.utils import ensure_request_has_privilege, has_privilege
+from django_prbac.utils import has_privilege
 # Numbers in paths is prohibited, hence the use of importlib
 import importlib
 from corehq.apps.style.decorators import use_bootstrap3
@@ -2390,9 +2390,7 @@ def edit_app_attr(request, domain, app_id, attr):
     if should_edit("cloudcare_enabled"):
         if app.get_doc_type() not in ("Application",):
             raise Exception("App type %s does not support cloudcare" % app.get_doc_type())
-        try:
-            ensure_request_has_privilege(request, privileges.CLOUDCARE)
-        except PermissionDenied:
+        if not has_privilege(request, privileges.CLOUDCARE):
             app.cloudcare_enabled = False
 
     if should_edit('show_user_registration'):

--- a/corehq/apps/data_interfaces/dispatcher.py
+++ b/corehq/apps/data_interfaces/dispatcher.py
@@ -5,7 +5,7 @@ from corehq.apps.reports.dispatcher import ReportDispatcher, ProjectReportDispat
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
 from django_prbac.exceptions import PermissionDenied
-from django_prbac.utils import ensure_request_has_privilege
+from django_prbac.utils import has_privilege
 
 
 require_can_edit_data = require_permission(Permissions.edit_data)
@@ -29,9 +29,7 @@ class DataInterfaceDispatcher(ProjectReportDispatcher):
         if is_navigation_check:
             from corehq.apps.reports.standard.export import DeidExportReport
             if report.split('.')[-1] in [DeidExportReport.__name__]:
-                try:
-                    ensure_request_has_privilege(request, privileges.DEIDENTIFIED_DATA)
-                except PermissionDenied:
+                if not has_privilege(request, privileges.DEIDENTIFIED_DATA):
                     return False
         return super(DataInterfaceDispatcher, self).permissions_check(report, request, domain)
 
@@ -56,8 +54,6 @@ class EditDataInterfaceDispatcher(ReportDispatcher):
         if is_navigation_check:
             from corehq.apps.importer.base import ImportCases
             if report.split('.')[-1] in [ImportCases.__name__]:
-                try:
-                    ensure_request_has_privilege(request, privileges.BULK_CASE_MANAGEMENT)
-                except PermissionDenied:
+                if not has_privilege(request, privileges.BULK_CASE_MANAGEMENT):
                     return False
         return request.couch_user.can_edit_data(domain)

--- a/corehq/apps/domain/middleware.py
+++ b/corehq/apps/domain/middleware.py
@@ -40,9 +40,10 @@ class CCHQPRBACMiddleware(object):
                 return None
             except AccountingError:
                 pass
-        try:
-            request.role = Role.get_privilege('community_plan_v0').role
-        except Role.DoesNotExist:
+        privilege = Role.get_privilege('community_plan_v0')
+        if privilege is not None:
+            request.role = privilege.role
+        else:
             request.role = Role()  # A fresh Role() has no privileges
 
 

--- a/corehq/apps/domain/middleware.py
+++ b/corehq/apps/domain/middleware.py
@@ -41,7 +41,7 @@ class CCHQPRBACMiddleware(object):
             except AccountingError:
                 pass
         try:
-            request.role = Role.objects.get(slug='community_plan_v0')
+            request.role = Role.get_privilege('community_plan_v0').role
         except Role.DoesNotExist:
             request.role = Role()  # A fresh Role() has no privileges
 

--- a/corehq/apps/export/custom_export_helpers.py
+++ b/corehq/apps/export/custom_export_helpers.py
@@ -1,7 +1,7 @@
 import json
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_enabled
 from django_prbac.exceptions import PermissionDenied
-from django_prbac.utils import ensure_request_has_privilege
+from django_prbac.utils import has_privilege
 from corehq import privileges
 from corehq.apps.export.exceptions import BadExportConfiguration
 from corehq.apps.reports.dbaccessors import touch_exports
@@ -206,11 +206,7 @@ class FormCustomExportHelper(CustomExportHelper):
 
     @property
     def allow_deid(self):
-        try:
-            ensure_request_has_privilege(self.request, privileges.DEIDENTIFIED_DATA)
-            return True
-        except PermissionDenied:
-            return False
+        return has_privilege(self.request, privileges.DEIDENTIFIED_DATA)
 
     def update_custom_params(self):
         p = self.post_data['custom_export']

--- a/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
+++ b/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
@@ -90,6 +90,7 @@ class Command(BaseCommand):
             grantee = Role.objects.get(slug=grantee_slug)
             priv = Role.objects.get(slug=priv_slug)
 
+            Role.get_cache().clear()
             if grantee.has_privilege(priv):
                 if self.verbose:
                     logger.info('Privilege already granted: %s => %s', grantee.slug, priv.slug)

--- a/corehq/apps/reports/dispatcher.py
+++ b/corehq/apps/reports/dispatcher.py
@@ -7,7 +7,7 @@ from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.domain.decorators import login_and_domain_required, cls_to_view
 from dimagi.utils.decorators.datespan import datespan_in_request
 from django_prbac.exceptions import PermissionDenied
-from django_prbac.utils import ensure_request_has_privilege
+from django_prbac.utils import has_privilege
 
 from corehq.apps.domain.models import Domain
 from corehq.apps.reports.exceptions import BadRequestError
@@ -247,11 +247,8 @@ class CustomProjectReportDispatcher(ProjectReportDispatcher):
         return super(CustomProjectReportDispatcher, self).dispatch(request, *args, **kwargs)
 
     def permissions_check(self, report, request, domain=None, is_navigation_check=False):
-        if is_navigation_check:
-            try:
-                ensure_request_has_privilege(request, privileges.CUSTOM_REPORTS)
-            except PermissionDenied:
-                return False
+        if is_navigation_check and not has_privilege(request, privileges.CUSTOM_REPORTS):
+            return False
         return super(CustomProjectReportDispatcher, self).permissions_check(report, request, domain)
 
 

--- a/corehq/apps/users/util.py
+++ b/corehq/apps/users/util.py
@@ -10,7 +10,7 @@ from corehq import privileges
 from dimagi.utils.couch.database import get_db
 from django.core.cache import cache
 from django_prbac.exceptions import PermissionDenied
-from django_prbac.utils import ensure_request_has_privilege
+from django_prbac.utils import has_privilege
 
 
 WEIRD_USER_IDS = [
@@ -152,9 +152,7 @@ def can_add_extra_mobile_workers(request):
     user_limit = request.plan.user_limit
     if user_limit == -1 or num_web_users < user_limit:
         return True
-    try:
-        ensure_request_has_privilege(request, privileges.ALLOW_EXCESS_USERS)
-    except PermissionDenied:
+    if not has_privilege(request, privileges.ALLOW_EXCESS_USERS):
         account = BillingAccount.get_account_by_domain(request.domain)
         if account is None or account.date_confirmed_extra_charges is None:
             return False

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -18,7 +18,7 @@ from corehq.apps.users.util import smart_query_string
 from corehq.elastic import ADD_TO_ES_FILTER, es_query, ES_URLS
 from dimagi.utils.decorators.memoized import memoized
 from django_prbac.exceptions import PermissionDenied
-from django_prbac.utils import ensure_request_has_privilege
+from django_prbac.utils import has_privilege
 import langcodes
 from datetime import datetime
 from couchdbkit.exceptions import ResourceNotFound
@@ -494,11 +494,8 @@ class NewListWebUsersView(JSONResponseMixin, BaseUserSettingsView):
 
     @property
     def can_edit_roles(self):
-        try:
-            ensure_request_has_privilege(self.request, privileges.ROLE_BASED_ACCESS)
-        except PermissionDenied:
-            return False
-        return self.couch_user.is_domain_admin
+        return has_privilege(self.request, privileges.ROLE_BASED_ACCESS) \
+                and self.couch_user.is_domain_admin
 
     @property
     @memoized
@@ -570,11 +567,8 @@ class ListWebUsersView(BaseUserSettingsView):
 
     @property
     def can_edit_roles(self):
-        try:
-            ensure_request_has_privilege(self.request, privileges.ROLE_BASED_ACCESS)
-        except PermissionDenied:
-            return False
-        return self.couch_user.is_domain_admin
+        return has_privilege(self.request, privileges.ROLE_BASED_ACCESS) \
+                and self.couch_user.is_domain_admin
 
     @property
     @memoized

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -495,7 +495,7 @@ class NewListWebUsersView(JSONResponseMixin, BaseUserSettingsView):
     @property
     def can_edit_roles(self):
         return has_privilege(self.request, privileges.ROLE_BASED_ACCESS) \
-                and self.couch_user.is_domain_admin
+            and self.couch_user.is_domain_admin
 
     @property
     @memoized
@@ -568,7 +568,7 @@ class ListWebUsersView(BaseUserSettingsView):
     @property
     def can_edit_roles(self):
         return has_privilege(self.request, privileges.ROLE_BASED_ACCESS) \
-                and self.couch_user.is_domain_admin
+            and self.couch_user.is_domain_admin
 
     @property
     @memoized

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -55,7 +55,7 @@ from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.html import format_html
 from dimagi.utils.excel import WorkbookJSONReader, WorksheetNotFound, JSONReaderError, HeaderValueError
 from django_prbac.exceptions import PermissionDenied
-from django_prbac.utils import ensure_request_has_privilege
+from django_prbac.utils import has_privilege
 from soil.exceptions import TaskFailedError
 from soil.util import get_download_context, expose_cached_download
 from .custom_data_fields import UserFieldsView
@@ -235,11 +235,7 @@ class ListCommCareUsersView(BaseUserSettingsView):
     def can_bulk_edit_users(self):
         if not user_can_edit_any_location(self.request.couch_user, self.request.project):
             return False
-        try:
-            ensure_request_has_privilege(self.request, privileges.BULK_USER_MANAGEMENT)
-        except PermissionDenied:
-            return False
-        return True
+        return has_privilege(self.request, privileges.BULK_USER_MANAGEMENT)
 
     @property
     def can_add_extra_users(self):

--- a/corehq/feature_previews.py
+++ b/corehq/feature_previews.py
@@ -17,13 +17,9 @@ class FeaturePreview(StaticToggle):
 
     e.g.
 
-    if feature_previews.BETA_FEATURE.enabled(domain):
-        try:
-            ensure_request_has_privilege(request, privileges.BETA_FEATURE)
-        except PermissionDenied:
-            pass
-        else:
-            # do cool thing for BETA_FEATURE
+    if feature_previews.BETA_FEATURE.enabled(domain) \
+            and has_privilege(request, privileges.BETA_FEATURE):
+        # do cool thing for BETA_FEATURE
     """
     def __init__(self, slug, label, description, help_link=None, privilege=None, save_fn=None):
         self.privilege = privilege


### PR DESCRIPTION
Review commits individually. Depends on https://github.com/dimagi/django-prbac/pull/14

Some things to consider:
- All roles and grants are stored in memory. However, the tables are pretty small. Here are the numbers from prod:
  - django_prbac_grant - 256 rows
  - django_prbac_role - 91 rows
  - django_prbac_userrole - 30 rows
  
  I think keeping them in memory is a reasonable tradeoff for the reduction it DB hits.
- This optimization focuses on the case where "role assignments" are not used. I checked, and none of our roles or grants are using assignments. However, things should continue to work if we start using assignments, but more optimization may be necessary.

Page used for testing http://localhost:8080/a/test/dashboard/project/
Profiling numbers come from django toolbar

Before:
- Cold cache  
  CPU Time: 15335.91 ms (maybe not accurate?)  
  212 SQL queries in 196.54ms
- Hot cache  
  CPU Time: 5509.83 ms  
  47 SQL queries in 44.86ms

After:
- Cold cache  
  CPU Time: 6499.19 ms  
  6 SQL queries in 11.87ms
- Hot cache  
  CPU Time: 4085.39 ms  
  4 SQL queries in 8.66 ms

@esoergel @biyeun cc @sravfeyn 
