### PR TITLE
Remove sensitive information from error emails

### DIFF
--- a/corehq/util/log.py
+++ b/corehq/util/log.py
@@ -7,6 +7,24 @@ from django.views.debug import get_exception_reporter_filter
 from django.template.loader import render_to_string
 
 
+def clean_exception(exception):
+    """
+    Takes an Exception instance and strips potentially sensitive information
+    """
+    from django.conf import settings
+    if settings.DEBUG:
+        return exception
+
+    # couchdbkit doesn't provide a better way for us to catch this exception
+    if exception.message.startswith('received an invalid response of type'):
+        message = ("It looks like couch returned an invalid response to "
+                   "couchdbkit.  This could contain sensitive information, "
+                   "so it's being redacted.")
+    else:
+        message = exception.message
+    return exception.__class__(message)
+
+
 class HqAdminEmailHandler(AdminEmailHandler):
     """
     Custom AdminEmailHandler to include additional details which can be supplied as follows:
@@ -33,7 +51,8 @@ class HqAdminEmailHandler(AdminEmailHandler):
         tb_list = []
         if record.exc_info:
             exc_info = record.exc_info
-            etype, value, tb = exc_info
+            etype, _value, tb = exc_info
+            value = clean_exception(_value)
             tb_list = ['Traceback (most recent call first):\n']
             formatted_exception = traceback.format_exception_only(etype, value)
             tb_list.extend(formatted_exception)

--- a/corehq/util/tests/__init__.py
+++ b/corehq/util/tests/__init__.py
@@ -1,4 +1,5 @@
 from test_couch import *
+from test_log import *
 from test_toggle import *
 from test_quickcache import *
 from test_timezone_conversions import *

--- a/corehq/util/tests/test_log.py
+++ b/corehq/util/tests/test_log.py
@@ -1,0 +1,21 @@
+from django.test import SimpleTestCase
+from ..log import clean_exception
+
+
+class TestLogging(SimpleTestCase):
+    def test_bad_traceback(self):
+        result = "JJackson's SSN: 555-55-5555"
+        try:
+            # copied from couchdbkit/client.py
+            assert isinstance(result, dict), 'received an invalid ' \
+                'response of type %s: %s' % (type(result), repr(result))
+        except AssertionError as e:
+            pass
+        self.assertIn(result, e.message)
+        self.assertNotIn(result, clean_exception(e).message)
+
+    def test_that_I_didnt_break_anything(self):
+        exception = AssertionError("foo")
+        cleaned_exception = clean_exception(exception)
+        self.assertEqual(exception.__class__, cleaned_exception.__class__)
+        self.assertEqual(exception.message, cleaned_exception.message)


### PR DESCRIPTION
@proteusvacuum
http://manage.dimagi.com/default.asp?176891
Couch occasionally returns a bad response to couchdbkit, and couchdbkit sends that entire response to us in an error message.  That can contain potentially sensitive information.  It's difficult to catch, so this purges that from error messages before sending in an error email.
