### PR TITLE
Speed up form and case counts

### DIFF
--- a/corehq/apps/hqadmin/views.py
+++ b/corehq/apps/hqadmin/views.py
@@ -464,13 +464,13 @@ def db_comparisons(request):
             'es_query': FormES().remove_default_filter('has_xmlns')
                 .remove_default_filter('has_user')
                 .size(0),
-            'sql_rows': FormData.objects.count(),
+            'sql_rows': FormData.objects.exclude(domain__isnull=True).count(),
         },
         {
             'description': 'Cases (doc_type is "CommCareCase")',
             'couch_docs': get_total_case_count(),
             'es_query': CaseES().size(0),
-            'sql_rows': CaseData.objects.count(),
+            'sql_rows': CaseData.objects.exclude(domain__isnull=True).count(),
         }
     ]
 


### PR DESCRIPTION
@snopoke took a look at the new relic links you sent out. good stuff, found that we were doing some slow queries in the `db_comparison` view. it was our top query according to new relic. tried this out locally and it speeds it up a ton. granted i'm assuming every form/case has a domain, which i think is a reasonable assumption and was true on my local machine (~60,000 forms). ref: https://wiki.postgresql.org/wiki/Slow_Counting

buddy @orangejenny 
