### PR TITLE
fix sorting in Form Completion vs. Submission report

### DIFF
--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -17,6 +17,7 @@ from corehq.apps.reports.generic import GenericTabularReport
 from corehq.apps.reports.util import make_form_couch_key, friendly_timedelta, format_datatables_data
 from corehq.apps.sofabed.models import FormData, CaseData
 from corehq.apps.users.models import CommCareUser
+from corehq.const import SERVER_DATETIME_FORMAT
 from corehq.elastic import es_query
 from corehq.pillows.mappings.case_mapping import CASE_INDEX
 from corehq.util.dates import iso_string_to_datetime
@@ -766,8 +767,8 @@ class FormCompletionVsSubmissionTrendsReport(WorkerMonitoringFormReportTableBase
     @property
     def headers(self):
         return DataTablesHeader(DataTablesColumn(_("User")),
-            DataTablesColumn(_("Completion Time")),
-            DataTablesColumn(_("Submission Time")),
+            DataTablesColumn(_("Completion Time"), sort_type=DTSortType.DATE),
+            DataTablesColumn(_("Submission Time"), sort_type=DTSortType.DATE),
             DataTablesColumn(_("Form Name")),
             DataTablesColumn(_("View"), sortable=False),
             DataTablesColumn(_("Difference"), sort_type=DTSortType.NUMERIC)
@@ -831,8 +832,8 @@ class FormCompletionVsSubmissionTrendsReport(WorkerMonitoringFormReportTableBase
         """
 
         return self.table_cell(
-            date,
-            ServerTime(date).user_time(self.timezone).ui_string()
+            ServerTime(date).user_time(self.timezone).ui_string(fmt=SERVER_DATETIME_FORMAT),
+            ServerTime(date).user_time(self.timezone).ui_string(),
         )
 
     def _format_td_status(self, td, use_label=True):

--- a/corehq/apps/reports/static/reports/javascripts/config.dataTables.bootstrap.js
+++ b/corehq/apps/reports/static/reports/javascripts/config.dataTables.bootstrap.js
@@ -251,7 +251,7 @@ function convertNum(k) {
 
 function convertDate(k) {
     var m = k.match(/title="*(.+)"/);
-    return new Date(m);
+    return new Date(m[1]);
 }
 
 jQuery.fn.dataTableExt.oSort['title-numeric-asc'] = function(a, b) { return sortSpecial(a, b, true, convertNum); };


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?177092

Three problems here:
- Columns weren't marked as dates
- JS sorting code was trying to form dates out of "title='July 23, 2014, 1:12 p.m.'" instead of just the date portion
- JS can't actually parse "July 23, 2014, 1:12 p.m." and needs a different format. The default, USER_DATETIME_FORMAT, is comprehensible to JS, but I figured the server format is at less risk of us changing it.

@benrudolph 
