### PR TITLE
added a utility to clean a fixture's field name

### DIFF
--- a/corehq/apps/fixtures/models.py
+++ b/corehq/apps/fixtures/models.py
@@ -4,6 +4,7 @@ from xml.etree import ElementTree
 from couchdbkit.exceptions import ResourceNotFound, ResourceConflict
 from django.db import models
 from corehq.apps.fixtures.exceptions import FixtureException, FixtureTypeCheckError
+from corehq.apps.fixtures.utils import clean_fixture_field_name
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.fixtures.exceptions import FixtureVersionError
 from dimagi.ext.couchdbkit import Document, DocumentSchema, DictProperty, StringProperty, StringListProperty, SchemaListProperty, IntegerProperty, BooleanProperty
@@ -277,12 +278,13 @@ class FixtureDataItem(Document):
                     % (self.data_type.tag, self.get_id)
                 )
         for field in self.data_type.fields:
+            escaped_field_name = clean_fixture_field_name(field.field_name)
             if not self.fields.has_key(field.field_name):
-                xField = ElementTree.SubElement(xData, field.field_name)
+                xField = ElementTree.SubElement(xData, escaped_field_name)
                 xField.text = ""
             else:
                 for field_with_attr in self.fields[field.field_name].field_list:
-                    xField = ElementTree.SubElement(xData, field.field_name)
+                    xField = ElementTree.SubElement(xData, escaped_field_name)
                     xField.text = _serialize(field_with_attr.field_value)
                     for attribute in field_with_attr.properties:
                         val = field_with_attr.properties[attribute]

--- a/corehq/apps/fixtures/templates/fixtures/partials/edit_table_modal.html
+++ b/corehq/apps/fixtures/templates/fixtures/partials/edit_table_modal.html
@@ -17,10 +17,10 @@
             <table class="table table-striped table-bordered" style="margin-bottom:0">
                 <thead>
                     <tr>
-                        <th>
+                        <th class="span10">
                             field_name
                         </th>
-                        <th>
+                        <th class="span2">
                             Delete Field?
                         </th>
                     </tr>
@@ -30,7 +30,25 @@
                     <tr>
                         <!-- ko ifnot: with_props -->
                         <td>
-                            <input type="text" class="input-small" data-bind="value: editTag, hasfocus: true"/>
+                            <input type="text" class="input-small" data-bind="value: tag, valueUpdate: 'afterkeydown', hasfocus: true"/>
+                            <p class="help-inline label label-warning" data-bind="visible: isDuplicate">
+                                <i class="icon icon-warning-sign"></i>
+                                {% blocktrans %}
+                                    "<span data-bind="text: tag"></span>" is a duplicate field name.
+                                {% endblocktrans %}
+                            </p>
+                            <p class="help-inline label label-warning" data-bind="visible: isBadSlug">
+                                <i class="icon icon-warning-sign"></i>
+                                {% blocktrans %}
+                                    Field name cannot contain \, /, <, >, or spaces.
+                                {% endblocktrans %}
+                            </p>
+                            <p class="help-inline label label-warning" data-bind="visible: noXMLStart">
+                                <i class="icon icon-warning-sign"></i>
+                                {% blocktrans %}
+                                    Field name cannot start with xml.
+                                {% endblocktrans %}
+                            </p>
                         </td>
                         <td>
                             <input type="checkbox" data-bind="checked: remove, visible: !is_new()"/>
@@ -43,7 +61,7 @@
                         <!-- /ko -->
                         <!-- ko if: with_props -->
                         <td>
-                            <input type="text" class="input-small" data-bind="value: editTag" readonly/>
+                            <input type="text" class="input-small" data-bind="value: tag" readonly/>
                         </td>
                         <td>
                             <span>(Not editable)</span>

--- a/corehq/apps/fixtures/tests.py
+++ b/corehq/apps/fixtures/tests.py
@@ -208,7 +208,7 @@ class FieldNameCleanTest(TestCase):
         self.data_item = FixtureDataItem(
             domain=self.domain,
             data_type_id=self.data_type.get_id,
-            fields= {
+            fields={
                 "will/crash": FieldList(
                     field_list=[
                         FixtureItemField(

--- a/corehq/apps/fixtures/tests.py
+++ b/corehq/apps/fixtures/tests.py
@@ -8,8 +8,9 @@ from corehq.apps.fixtures.dbaccessors import \
 from corehq.apps.fixtures.models import FixtureDataItem, FixtureDataType, FixtureOwnership, FixtureTypeField, \
     FixtureItemField, FieldList
 from corehq.apps.fixtures.exceptions import FixtureVersionError
+from corehq.apps.fixtures.utils import is_field_name_invalid
 from corehq.apps.users.models import CommCareUser
-from django.test import TestCase
+from django.test import TestCase, SimpleTestCase
 
 
 class FixtureDataTest(TestCase):
@@ -165,3 +166,142 @@ class DBAccessorTest(TestCase):
             [data_type.to_json() for data_type in self.data_types
              if data_type.domain == self.domain]
         )
+
+
+class FieldNameCleanTest(TestCase):
+    """Makes sure that bad characters are properly escaped in the xml
+    """
+
+    def setUp(self):
+        self.domain = 'dirty-fields'
+
+        self.data_type = FixtureDataType(
+            domain=self.domain,
+            tag='dirty_fields',
+            name="Dirty Fields",
+            fields=[
+                FixtureTypeField(
+                    field_name="will/crash",
+                    properties=[]
+                ),
+                FixtureTypeField(
+                    field_name="space cadet",
+                    properties=[]
+                ),
+                FixtureTypeField(
+                    field_name="yes\\no",
+                    properties=[]
+                ),
+                FixtureTypeField(
+                    field_name="<with>",
+                    properties=[]
+                ),
+                FixtureTypeField(
+                    field_name="<crazy / combo><d",
+                    properties=[]
+                )
+            ],
+            item_attributes=[],
+        )
+        self.data_type.save()
+
+        self.data_item = FixtureDataItem(
+            domain=self.domain,
+            data_type_id=self.data_type.get_id,
+            fields= {
+                "will/crash": FieldList(
+                    field_list=[
+                        FixtureItemField(
+                            field_value="yep",
+                            properties={}
+                        )
+                    ]
+                ),
+                "space cadet": FieldList(
+                    field_list=[
+                        FixtureItemField(
+                            field_value="major tom",
+                            properties={}
+                        )
+                    ]
+                ),
+                "yes\\no": FieldList(
+                    field_list=[
+                        FixtureItemField(
+                            field_value="no, duh",
+                            properties={}
+                        )
+                    ]
+                ),
+                "<with>": FieldList(
+                    field_list=[
+                        FixtureItemField(
+                            field_value="so fail",
+                            properties={}
+                        )
+                    ]
+                ),
+                "<crazy / combo><d": FieldList(
+                    field_list=[
+                        FixtureItemField(
+                            field_value="just why",
+                            properties={}
+                        )
+                    ]
+                ),
+                "xmlbad": FieldList(
+                    field_list=[
+                        FixtureItemField(
+                            field_value="badxml",
+                            properties={}
+                        )
+                    ]
+                )
+            },
+            item_attributes={},
+        )
+        self.data_item.save()
+
+    def tearDown(self):
+        self.data_type.delete()
+        self.data_item.delete()
+
+    def test_cleaner(self):
+        check_xml_line_by_line(self, """
+        <dirty_fields>
+            <will_crash>yep</will_crash>
+            <space_cadet>major tom</space_cadet>
+            <yes_no>no, duh</yes_no>
+            <_with_>so fail</_with_>
+            <_crazy___combo__d>just why</_crazy___combo__d>
+        </dirty_fields>
+        """, ElementTree.tostring(self.data_item.to_xml()))
+
+
+class FieldNameValidationTest(SimpleTestCase):
+    """Makes sure that the field name validator does what's expected.
+    """
+
+    def test_slash(self):
+        bad_name = "will/crash"
+        self.assertTrue(is_field_name_invalid(bad_name))
+
+    def test_space(self):
+        bad_name = "space cadet"
+        self.assertTrue(is_field_name_invalid(bad_name))
+
+    def test_backslash(self):
+        bad_name = "space\\cadet"
+        self.assertTrue(is_field_name_invalid(bad_name))
+
+    def test_brackets(self):
+        bad_name = "<space>"
+        self.assertTrue(is_field_name_invalid(bad_name))
+
+    def test_combo(self):
+        bad_name = "<space>\<dadgg sd"
+        self.assertTrue(is_field_name_invalid(bad_name))
+
+    def test_good(self):
+        good_name = "foobar"
+        self.assertFalse(is_field_name_invalid(good_name))

--- a/corehq/apps/fixtures/utils.py
+++ b/corehq/apps/fixtures/utils.py
@@ -1,6 +1,7 @@
 import re
 
 BAD_SLUG_PATTERN = '([/\\<>\s])'
+BAD_XML = '^xml+'
 
 
 def clean_fixture_field_name(field_name):
@@ -8,7 +9,7 @@ def clean_fixture_field_name(field_name):
     bad XML back from the phone. Ideally, the fixture name should be
     verified as a good slug before using it.
     """
-    return re.sub(BAD_SLUG_PATTERN, '_', field_name)
+    return re.sub(BAD_XML, re.sub(BAD_SLUG_PATTERN, '_', field_name), '')
 
 
 def is_field_name_invalid(field_name):

--- a/corehq/apps/fixtures/utils.py
+++ b/corehq/apps/fixtures/utils.py
@@ -1,7 +1,6 @@
 import re
 
-BAD_SLUG_PATTERN = '([/\\<>\s])'
-BAD_XML = '^xml+'
+BAD_SLUG_PATTERN = r"([/\\<>\s])"
 
 
 def clean_fixture_field_name(field_name):
@@ -9,7 +8,10 @@ def clean_fixture_field_name(field_name):
     bad XML back from the phone. Ideally, the fixture name should be
     verified as a good slug before using it.
     """
-    return re.sub(BAD_XML, re.sub(BAD_SLUG_PATTERN, '_', field_name), '')
+    subbed_string = re.sub(BAD_SLUG_PATTERN, '_', field_name)
+    if subbed_string.startswith('xml'):
+        subbed_string = subbed_string.replace('xml', '_', 1)
+    return subbed_string
 
 
 def is_field_name_invalid(field_name):

--- a/corehq/apps/fixtures/utils.py
+++ b/corehq/apps/fixtures/utils.py
@@ -1,10 +1,15 @@
 import re
 
+BAD_SLUG_PATTERN = '([/\\<>\s])'
+
 
 def clean_fixture_field_name(field_name):
     """Effectively slugifies a fixture's field name so that we don't send
     bad XML back from the phone. Ideally, the fixture name should be
     verified as a good slug before using it.
     """
-    pattern = '([/\\<> ])'
-    return re.sub(pattern, '_', field_name)
+    return re.sub(BAD_SLUG_PATTERN, '_', field_name)
+
+
+def is_field_name_invalid(field_name):
+    return bool(re.search(BAD_SLUG_PATTERN, field_name))

--- a/corehq/apps/fixtures/utils.py
+++ b/corehq/apps/fixtures/utils.py
@@ -1,0 +1,10 @@
+import re
+
+
+def clean_fixture_field_name(field_name):
+    """Effectively slugifies a fixture's field name so that we don't send
+    bad XML back from the phone. Ideally, the fixture name should be
+    verified as a good slug before using it.
+    """
+    pattern = '([/\\<> ])'
+    return re.sub(pattern, '_', field_name)

--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -8,7 +8,6 @@ from django.http import HttpResponseBadRequest, HttpResponseRedirect, Http404, H
 from django.http.response import HttpResponseServerError
 from django.shortcuts import render
 from django.utils.decorators import method_decorator
-from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _, ugettext_noop
 from django.views.decorators.http import require_POST
 from django.views.generic.base import TemplateView

--- a/corehq/apps/fixtures/views.py
+++ b/corehq/apps/fixtures/views.py
@@ -114,11 +114,11 @@ def update_tables(request, domain, data_type_id, test_patch=None):
             method = options.keys()
             if 'update' in method:
                 field_name = options['update']
-            if field_name.startswith('xml') and not 'remove' in method:
+            if field_name.startswith('xml') and 'remove' not in method:
                 validation_errors.append(
                     _("Field name \"%s\" cannot begin with 'xml'.") % field_name
                 )
-            if is_field_name_invalid(field_name) and not 'remove' in method:
+            if is_field_name_invalid(field_name) and 'remove' not in method:
                 validation_errors.append(
                     _("Field name \"%s\" cannot include /, "
                       "\\, <, >, or spaces.") % field_name


### PR DESCRIPTION
 so that bad xml is not sent down from a phone restore

addresses part of this ticket http://manage.dimagi.com/default.asp?176616#982925

did part 2 of this ticket:
- validation on the server and client side.
  examples:
  <img width="837" alt="screen shot 2015-07-24 at 12 48 26 pm" src="https://cloud.githubusercontent.com/assets/716573/8881254/68f467ac-320c-11e5-84ce-608c7dcc7be0.png">
  <img width="549" alt="screen shot 2015-07-24 at 12 48 18 pm" src="https://cloud.githubusercontent.com/assets/716573/8881253/68f3f3b2-320c-11e5-8da8-a5903520876c.png">
  <img width="550" alt="screen shot 2015-07-24 at 11 32 20 am" src="https://cloud.githubusercontent.com/assets/716573/8881257/68f73e32-320c-11e5-93fa-7f27d7254303.png">
  <img width="827" alt="screen shot 2015-07-24 at 11 32 08 am" src="https://cloud.githubusercontent.com/assets/716573/8881256/68f63d7a-320c-11e5-9303-e37cabfc67bf.png">
  <img width="552" alt="screen shot 2015-07-24 at 11 29 55 am" src="https://cloud.githubusercontent.com/assets/716573/8881255/68f51a4e-320c-11e5-8fd5-79ef6a9cc5e2.png">

@esoergel @orangejenny cc @kaapstorm 
