### PR TITLE
Filter invoices by domain

### DIFF
--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1127,14 +1127,14 @@ class BillingStatementPdfView(View):
             raise Http404()
 
         try:
-            invoice = Invoice.objects.get(pk=invoice_pdf.invoice_id)
+            invoice = Invoice.objects.get(pk=invoice_pdf.invoice_id,
+                                          subscription__subscriber__domain=domain)
         except Invoice.DoesNotExist:
             try:
-                invoice = WireInvoice.objects.get(pk=invoice_pdf.invoice_id)
+                invoice = WireInvoice.objects.get(pk=invoice_pdf.invoice_id,
+                                                  domain=domain)
             except WireInvoice.DoesNotExist:
                 raise Http404()
-        if invoice.get_domain() != domain:
-            raise Http404()
 
         if invoice.is_wire:
             edition = 'Bulk'


### PR DESCRIPTION
@biyeun @orangejenny @proteusvacuum

http://manage.dimagi.com/default.asp?176654
Since `WireInvoice`s and `Invoice`s are separate models, both using Django ORM style primary keys (integers starting at 0).  The possibility of collisions is very high.  This means if `invoice_pdf.invoice_id` refers to a `WireInvoice`, the first result you'd get would be an `Invoice` (the wrong one).  That was causing this to 404 when the domain was checked.

@benrudolph FYI
