### PR TITLE
Make Reporting Rate Map appear

### DIFF
--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -10,7 +10,6 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 from django.http import QueryDict
 from corehq.apps.domain.models import Domain
-from dimagi.utils.couch.cache import cache_core
 from dimagi.utils.logging import notify_exception
 from dimagi.utils.web import json_handler
 
@@ -25,7 +24,13 @@ def JSON(obj):
     # json.dumps does not properly convert QueryDict array parameter to json
     if isinstance(obj, QueryDict):
         obj = dict(obj)
-    return mark_safe(json.dumps(obj, default=json_handler))
+    try:
+        return mark_safe(json.dumps(obj, default=json_handler))
+    except TypeError as e:
+        msg = ("Unserializable data was sent to the `|JSON` template tag.  "
+               "If DEBUG is off, Django will silently swallow this error.")
+        notify_exception(None, message=msg)
+        raise e
 
 
 @register.filter

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -10,7 +10,7 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 from django.http import QueryDict
 from corehq.apps.domain.models import Domain
-from dimagi.utils.logging import notify_exception
+from corehq.util.soft_assert import soft_assert
 from dimagi.utils.web import json_handler
 
 import corehq.apps.style.utils as style_utils
@@ -28,8 +28,9 @@ def JSON(obj):
         return mark_safe(json.dumps(obj, default=json_handler))
     except TypeError as e:
         msg = ("Unserializable data was sent to the `|JSON` template tag.  "
-               "If DEBUG is off, Django will silently swallow this error.")
-        notify_exception(None, message=msg)
+               "If DEBUG is off, Django will silently swallow this error.  "
+               "{}".format(e.message))
+        soft_assert(notify_admins=True)(False, msg)
         raise e
 
 

--- a/corehq/apps/reports/commtrack/data_sources.py
+++ b/corehq/apps/reports/commtrack/data_sources.py
@@ -464,7 +464,7 @@ class ReportingStatusDataSource(ReportDataSource, CommtrackDataSourceMixin, Mult
                     try:
                         if XFormInstance.get(form_id).xmlns in form_xmlnses:
                             yield {
-                                'loc': loc,
+                                'parent_name': loc.parent.name if loc.parent else '',
                                 'loc_id': loc.location_id,
                                 'loc_path': loc.path,
                                 'name': loc.name,
@@ -487,7 +487,7 @@ class ReportingStatusDataSource(ReportDataSource, CommtrackDataSourceMixin, Mult
                         'date'
                     ).order_by('-date')[:1]
                     yield {
-                        'loc': loc,
+                        'parent_name': loc.parent.name if loc.parent else '',
                         'loc_id': loc.location_id,
                         'loc_path': loc.path,
                         'name': loc.name,

--- a/corehq/apps/reports/commtrack/standard.py
+++ b/corehq/apps/reports/commtrack/standard.py
@@ -416,7 +416,7 @@ class ReportingRatesReport(GenericTabularReport, CommtrackReportMixin):
         for status in statuses:
             results.append([
                 status['name'],
-                status['loc'].parent.name if status['loc'].parent else '',
+                status['parent_name'],
                 status['last_reporting_date'].date() if status['last_reporting_date'] else _('Never'),
                 _('Yes') if status['reporting_status'] == 'reporting' else _('No'),
             ])

--- a/corehq/apps/reports/standard/maps.py
+++ b/corehq/apps/reports/standard/maps.py
@@ -10,16 +10,7 @@ from corehq.apps.reports.generic import GenericReportView, GenericTabularReport,
 from corehq.apps.reports.standard import ProjectReport, ProjectReportParametersMixin
 from corehq.apps.reports.standard.cases.basic import CaseListMixin, CaseListReport
 from dimagi.utils.modules import to_function
-from dimagi.utils.web import json_handler
 from django.template.loader import render_to_string
-
-
-def is_serializable(v):
-    try:
-        json.dumps(v, default=json_handler)
-        return True
-    except TypeError:
-        return False
 
 
 class GenericMapReport(ProjectReport, ProjectReportParametersMixin):
@@ -84,8 +75,7 @@ class GenericMapReport(ProjectReport, ProjectReportParametersMixin):
                         depth += 1
                     feature_type = 'MultiPolygon' if depth == 4 else 'Polygon'
 
-                properties = {k: v for k, v in row.iteritems()
-                              if k != geo_col and is_serializable(v)}
+                properties = dict((k, v) for k, v in row.iteritems() if k != geo_col)
                 # handle 'display value / raw value' fields (for backwards compatibility with
                 # existing data sources)
                 # note: this is not ideal for the maps report, as we have no idea how to properly

--- a/corehq/apps/reports/standard/maps.py
+++ b/corehq/apps/reports/standard/maps.py
@@ -10,7 +10,16 @@ from corehq.apps.reports.generic import GenericReportView, GenericTabularReport,
 from corehq.apps.reports.standard import ProjectReport, ProjectReportParametersMixin
 from corehq.apps.reports.standard.cases.basic import CaseListMixin, CaseListReport
 from dimagi.utils.modules import to_function
+from dimagi.utils.web import json_handler
 from django.template.loader import render_to_string
+
+
+def is_serializable(v):
+    try:
+        json.dumps(v, default=json_handler)
+        return True
+    except TypeError:
+        return False
 
 
 class GenericMapReport(ProjectReport, ProjectReportParametersMixin):
@@ -75,7 +84,8 @@ class GenericMapReport(ProjectReport, ProjectReportParametersMixin):
                         depth += 1
                     feature_type = 'MultiPolygon' if depth == 4 else 'Polygon'
 
-                properties = dict((k, v) for k, v in row.iteritems() if k != geo_col)
+                properties = {k: v for k, v in row.iteritems()
+                              if k != geo_col and is_serializable(v)}
                 # handle 'display value / raw value' fields (for backwards compatibility with
                 # existing data sources)
                 # note: this is not ideal for the maps report, as we have no idea how to properly


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?177165
@orangejenny @biyeun @proteusvacuum
The commits are granular, but this is pretty small anyways.  This thing was a bitch to figure out.  The report data sources are used for multiple reports.  The location object itself was added to a the `get_data` method a while ago for one of the reports to use, but incidentally causing it to be converted to json and sent the the client.  This worked only because the location object was a JsonObject instance, so when I converted it to a SQLLocation, this stopped working.

What happens then is that when the data is rendered in a template to the `|JSON` template tag, it fails hard locally, but because it's a template, django swallows the error and continues rendering the template.  That's why we saw a blank page in production.

This PR makes the `|JSON` template tag notify us if the serialization fails.  I'm a little nervous to see how often that's been happening without our knowledge.

This also simplifies the return value of `get_data` to only simple data structures.

At first I added a commit to make sure that each of the properties sent over the wire is json serializable, but I think it's preferable to keep the current behavior and notify us whenever that happens.
