### PR TITLE
Optimize cloudcare api calls

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1109,6 +1109,14 @@ class Form(IndexedFormBase, NavMenuItemMediaMixin):
     def requires_referral(self):
         return self.requires == "referral"
 
+    def uses_parent_case(self):
+        """
+        Returns True if any of the load/update properties references the
+        parent case; False otherwise
+        """
+        return any([name.startswith('parent/')
+            for name in self.actions.all_property_names()])
+
     def is_registration_form(self, case_type=None):
         return not self.requires_case() and 'open_case' in self.active_actions() and \
             (not case_type or self.get_module().case_type == case_type)

--- a/corehq/apps/cloudcare/api.py
+++ b/corehq/apps/cloudcare/api.py
@@ -102,7 +102,7 @@ class CaseAPIHelper(object):
     Simple config object for querying the APIs
     """
     def __init__(self, domain, status=CASE_STATUS_OPEN, case_type=None, ids_only=False,
-                 footprint=False, strip_history=False, filters=None, include_children=False):
+                 footprint=False, strip_history=False, filters=None):
         if status not in [CASE_STATUS_ALL, CASE_STATUS_CLOSED, CASE_STATUS_OPEN]:
             raise ValueError("invalid case status %s" % status)
         self.domain = domain
@@ -113,7 +113,6 @@ class CaseAPIHelper(object):
         self.footprint = footprint
         self.strip_history = strip_history
         self.filters = filters
-        self.include_children = include_children
 
     def _case_results(self, case_id_list):
         def _filter(res):
@@ -129,7 +128,7 @@ class CaseAPIHelper(object):
                             return False
                 return True
 
-        if not self.ids_only or self.filters or self.footprint or self.include_children:
+        if not self.ids_only or self.filters or self.footprint:
             # optimization hack - we know we'll need the full cases eventually
             # so just grab them now.
             base_results = [CaseAPIResult(couch_doc=case, id_only=self.ids_only)
@@ -141,7 +140,7 @@ class CaseAPIHelper(object):
         if self.filters and not self.footprint:
             base_results = filter(_filter, base_results)
 
-        if not self.footprint and not self.include_children:
+        if not self.footprint:
             return base_results
 
         case_list = [res.couch_doc for res in base_results]
@@ -150,14 +149,6 @@ class CaseAPIHelper(object):
                             case_list,
                             self.domain,
                             strip_history=self.strip_history,
-                        ).values()
-
-        if self.include_children:
-            case_list = get_related_cases(
-                            case_list,
-                            self.domain,
-                            strip_history=self.strip_history,
-                            search_up=False,
                         ).values()
 
         return [CaseAPIResult(couch_doc=case, id_only=self.ids_only) for case in case_list]
@@ -214,13 +205,13 @@ class CaseAPIHelper(object):
 
 def get_filtered_cases(domain, status, user_id=None, case_type=None,
                        filters=None, footprint=False, ids_only=False,
-                       strip_history=True, include_children=False):
+                       strip_history=True):
 
     # a filter value of None means don't filter
     filters = dict((k, v) for k, v in (filters or {}).items() if v is not None)
     helper = CaseAPIHelper(domain, status, case_type=case_type, ids_only=ids_only,
                            footprint=footprint, strip_history=strip_history,
-                           filters=filters, include_children=include_children)
+                           filters=filters)
     if user_id:
         return helper.get_owned(user_id)
     else:
@@ -352,7 +343,7 @@ def get_filters_from_request(request, limit_top_level=None):
         filters = dict([(key, val) for key, val in filters.items() if '/' in key or key in limit_top_level])
 
     for system_property in ['user_id', 'closed', 'format', 'footprint',
-                            'ids_only', 'include_children', 'use_cache']:
+                            'ids_only', 'use_cache']:
         if system_property in filters:
             del filters[system_property]
     return filters

--- a/corehq/apps/cloudcare/tests/test_api.py
+++ b/corehq/apps/cloudcare/tests/test_api.py
@@ -166,21 +166,21 @@ class CaseAPITest(TestCase):
         # I don't think we can say anything super useful about this base set
 
     def testGetAllStripHistory(self):
-        list = get_filtered_cases(self.domain, status=CASE_STATUS_ALL, footprint=True, include_children=True,
+        list = get_filtered_cases(self.domain, status=CASE_STATUS_ALL, footprint=True,
                                   strip_history=True)
         self.assertEqual(self.expectedAll, len(list))
         self.assertListMatches(list, lambda c: len(c._couch_doc.actions) == 0)
         self.assertListMatches(list, lambda c: len(c._couch_doc.xform_ids) == 0)
 
     def testGetAllIdsOnly(self):
-        list = get_filtered_cases(self.domain, status=CASE_STATUS_ALL, footprint=True, include_children=True,
+        list = get_filtered_cases(self.domain, status=CASE_STATUS_ALL, footprint=True,
                                   ids_only=True)
         self.assertEqual(self.expectedAll, len(list))
         self.assertListMatches(list, lambda c: isinstance(c._couch_doc, dict))
         self.assertListMatches(list, lambda c: isinstance(c.to_json(), basestring))
 
     def testGetAllIdsOnlyStripHistory(self):
-        list = get_filtered_cases(self.domain, status=CASE_STATUS_ALL, footprint=True, include_children=True,
+        list = get_filtered_cases(self.domain, status=CASE_STATUS_ALL, footprint=True,
                                   ids_only=True, strip_history=True)
         self.assertEqual(self.expectedAll, len(list))
         self.assertListMatches(list, lambda c: isinstance(c._couch_doc, dict))

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -228,7 +228,6 @@ def get_cases_vary_on(request, domain):
         request.REQUEST.get('ids_only', 'false'),
         request.REQUEST.get('case_id', ''),
         request.REQUEST.get('footprint', 'false'),
-        request.REQUEST.get('include_children', 'false'),
         request.REQUEST.get('closed', 'false'),
         json.dumps(get_filters_from_request(request)),
         domain,
@@ -264,8 +263,7 @@ def get_cases(request, domain):
     ids_only = string_to_boolean(request.REQUEST.get("ids_only", "false"))
     case_id = request.REQUEST.get("case_id", "")
     footprint = string_to_boolean(request.REQUEST.get("footprint", "false"))
-    include_children = string_to_boolean(request.REQUEST.get("include_children", "false"))
-    if case_id and not footprint and not include_children:
+    if case_id and not footprint:
         # short circuit everything else and just return the case
         # NOTE: this allows any user in the domain to access any case given
         # they know its ID, which is slightly different from the previous
@@ -282,7 +280,7 @@ def get_cases(request, domain):
         cases = get_filtered_cases(domain, status=status, case_type=case_type,
                                    user_id=user_id, filters=filters,
                                    footprint=footprint, ids_only=ids_only,
-                                   strip_history=True, include_children=include_children)
+                                   strip_history=True)
     return json_response(cases)
 
 @cloudcare_api

--- a/corehq/apps/smsforms/app.py
+++ b/corehq/apps/smsforms/app.py
@@ -44,17 +44,16 @@ def start_session(domain, contact, app, module, form, case_id=None, yield_respon
     session_data = get_session_data(domain, contact, case_id, device_id=COMMCONNECT_DEVICE_ID)
     
     # since the API user is a superuser, force touchforms to query only
-    # the contact's cases by specifying it as an additional filterp
-    if contact.doc_type == "CommCareCase":
+    # the contact's cases by specifying it as an additional filter
+    if contact.doc_type == "CommCareCase" and form.requires_case():
         session_data["additional_filters"] = {
-            "case_id": contact.get_id,
-            "footprint": "True",
-            "include_children": "True" if case_for_case_submission else "False",
+            "case_id": case_id,
+            "footprint": "true" if form.uses_parent_case() else "false",
         }
-    else:
+    elif contact.doc_type in ("CommCareUser", "WebUser"):
         session_data["additional_filters"] = {
             "user_id": contact.get_id,
-            "footprint": "True"
+            "footprint": "true"
         }
     
     if app and form:


### PR DESCRIPTION
@czue @benrudolph 

Since the touchforms api user is making the calls to get case info when starting up smsforms sessions, any time we send a survey to a case (i.e., no user_id filter) with footprint=true, it queries and returns info for all the cases in the domain.  This PR makes the queries more targeted so that we don't use footprint=true for about 99% of the situations where we start smsforms sessions and there's no user_id. 

We still need to include footprint=true for a very small number of use cases (when a form is being filled out by a subcase and it references the parent case).  @czue see comment in this PR about a possible way to optimize that further.

cc @nickpell code review buddy
