### PR TITLE
Add separate handler for `notify_exception`

### DIFF
--- a/corehq/apps/hqadmin/templates/hqadmin/email/error_email.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/email/error_email.html
@@ -1,5 +1,6 @@
 <html>
 <body>
+<h3>{{ message }}</h3>
 {% if details %}
 <h3>Details</h3>
 <table>

--- a/settings.py
+++ b/settings.py
@@ -829,6 +829,11 @@ LOGGING = {
             'filters': ['require_debug_false'],
             'class': 'corehq.util.log.HqAdminEmailHandler',
         },
+        'notify_exception': {
+            'level': 'ERROR',
+            'filters': ['require_debug_false'],
+            'class': 'corehq.util.log.NotifyExceptionEmailer',
+        },
         'sentry': {
             'level': 'ERROR',
             'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler',
@@ -853,7 +858,7 @@ LOGGING = {
             'propagate': False,
         },
         'notify': {
-            'handlers': ['mail_admins'],
+            'handlers': ['notify_exception'],
             'level': 'ERROR',
             'propagate': True,
         },


### PR DESCRIPTION
@benrudolph @gcapalbo 
http://manage.dimagi.com/default.asp?177091
This splits apart the context generation and the actual email rendering so the former can be overridden.  I also added `record.getMessage()` to the emails.  The first commit does just the split-apart.  Might be easier to read that way.

Throwing on staging to test.
