### PR TITLE
add view to list all stock transactions in order

### DIFF
--- a/corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html
+++ b/corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html
@@ -1,0 +1,41 @@
+{% extends "settings/base_template.html" %}
+{% load i18n %}
+{% load hq_shared_tags %}
+
+{% block main_column %}
+    <table class="table">
+        <tr>
+            <th>Case</th>
+            <th>Section</th>
+            <th>Product</th>
+            <th>Date</th>
+            <th>Type</th>
+            <th>Quantity</th>
+            <th>Stock on Hand</th>
+        </tr>
+    {% for stock_transaction in stock_transactions %}
+        <tr>
+            <td>
+                {% ifchanged %}{{ stock_transaction.case_id }}{% endifchanged %}
+            </td>
+            <td>
+                {% ifchanged %}
+                    <!--{{ stock_transaction.case_id }}-->
+                    {{ stock_transaction.section_id }}
+                {% endifchanged %}
+            </td>
+            <td>
+                {% ifchanged %}
+                    <!--{{ stock_transaction.case_id }}-->
+                    <!--{{ stock_transaction.section_id }}-->
+                    {{ stock_transaction.sql_product.name }}
+                {% endifchanged %}
+            </td>
+                <td>{{ stock_transaction.report.date }} ({{ stock_transaction.pk }})</td>
+                <td>{{ stock_transaction.report.type }}</td>
+                <td>{{ stock_transaction.quantity }}</td>
+                <td>{{ stock_transaction.stock_on_hand }}</td>
+            </tr>
+    {% endfor %}
+    </table>
+{% endblock %}

--- a/corehq/apps/commtrack/urls.py
+++ b/corehq/apps/commtrack/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import patterns, url
 from corehq.apps.commtrack.views import (
     DefaultConsumptionView, SMSSettingsView, CommTrackSettingsView,
-    StockLevelsView
+    StockLevelsView, RebuildStockStateView,
 )
 
 # used in settings urls
@@ -11,4 +11,6 @@ settings_urls = patterns('corehq.apps.commtrack.views',
     url(r'^default_consumption/$', DefaultConsumptionView.as_view(), name=DefaultConsumptionView.urlname),
     url(r'^sms/$', SMSSettingsView.as_view(), name=SMSSettingsView.urlname),
     url(r'^stock_levels/$', StockLevelsView.as_view(), name=StockLevelsView.urlname),
+    url(r'^rebuild_stock_state/$', RebuildStockStateView.as_view(),
+        name=RebuildStockStateView.urlname),
 )


### PR DESCRIPTION
@czue This lists all stock transactions grouped by (case, section, product) and ordered by (date, pk) for a domain. I'm also planning on letting you do a dry-run rebuild on this page that shows what values will be after a rebuild—though if that ends up being hairy that's secondary. I do think that taking a snapshot of this page and comparing it to the page after rebuilding is a pretty important thing to be able to do regardless.
