### PR TITLE
Code context in error email

### DIFF
--- a/corehq/apps/hqadmin/templates/hqadmin/email/error_email.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/email/error_email.html
@@ -28,6 +28,11 @@
 {% endif %}
 {% endfor %}
 
+<h3>Code Context</h3>
+{% if code %}
+<div>{{ code|safe }}</div>
+{% endif %}
+
 <h3>Parameters</h3>
 
 <h4>GET</h4>

--- a/corehq/apps/hqadmin/templates/hqadmin/email/error_email.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/email/error_email.html
@@ -31,6 +31,8 @@
 <h3>Code Context</h3>
 {% if code %}
 <div>{{ code|safe }}</div>
+{% else %}
+<div>Not available.</div>
 {% endif %}
 
 <h3>Parameters</h3>

--- a/corehq/util/log.py
+++ b/corehq/util/log.py
@@ -1,5 +1,11 @@
 from collections import defaultdict
+from itertools import islice
 import traceback
+
+from pygments import highlight
+from pygments.lexers import PythonLexer
+from pygments.formatters import HtmlFormatter
+
 from celery.utils.mail import ErrorMail
 from django.core import mail
 from django.utils.log import AdminEmailHandler
@@ -48,13 +54,16 @@ class HqAdminEmailHandler(AdminEmailHandler):
             request_repr = "Request repr() unavailable."
 
         tb_list = []
+        code = None
         if record.exc_info:
             etype, _value, tb = record.exc_info
             value = clean_exception(_value)
             tb_list = ['Traceback (most recent call first):\n']
             formatted_exception = traceback.format_exception_only(etype, value)
             tb_list.extend(formatted_exception)
-            tb_list.extend(traceback.format_list(reversed(traceback.extract_tb(tb))))
+            extracted_tb = reversed(traceback.extract_tb(tb))
+            code = self.get_code(extracted_tb)
+            tb_list.extend(traceback.format_list(extracted_tb))
             stack_trace = '\n'.join(tb_list)
             subject = '%s: %s' % (record.levelname,
                                   formatted_exception[0].strip() if formatted_exception else record.getMessage())
@@ -72,6 +81,7 @@ class HqAdminEmailHandler(AdminEmailHandler):
             'tb_list': tb_list,
             'request_repr': request_repr,
             'stack_trace': stack_trace,
+            'code': code,
         })
         if request:
             context.update({
@@ -99,6 +109,27 @@ class HqAdminEmailHandler(AdminEmailHandler):
         if details:
             formatted = '\n'.join('{item[0]}: {item[1]}'.format(item=item) for item in details.items())
             return 'Details:\n{}'.format(formatted)
+
+    def get_code(self, extracted_tb):
+        trace = next((trace for trace in extracted_tb if 'site-packages' not in trace[0]), None)
+        if not trace:
+            return None
+
+        filename = trace[0]
+        lineno = trace[1]
+        offset = 10
+        with open(filename) as f:
+            code_context = list(islice(f, lineno - offset, lineno + offset))
+
+        return highlight(''.join(code_context),
+            PythonLexer(),
+            HtmlFormatter(
+                noclasses=True,
+                linenos='table',
+                hl_lines=[offset, offset],
+                linenostart=(lineno - offset + 1),
+        )
+        )
 
 
 class NotifyExceptionEmailer(HqAdminEmailHandler):

--- a/corehq/util/log.py
+++ b/corehq/util/log.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from itertools import islice
+import logging
 import traceback
 
 from pygments import highlight
@@ -62,7 +63,12 @@ class HqAdminEmailHandler(AdminEmailHandler):
             formatted_exception = traceback.format_exception_only(etype, value)
             tb_list.extend(formatted_exception)
             extracted_tb = reversed(traceback.extract_tb(tb))
-            code = self.get_code(extracted_tb)
+            try:
+                code = self.get_code(extracted_tb)
+            except Exception, e:
+                logging.error('[EMAIL HANDLER] {}'.format(e))
+                code = None
+
             tb_list.extend(traceback.format_list(extracted_tb))
             stack_trace = '\n'.join(tb_list)
             subject = '%s: %s' % (record.levelname,

--- a/corehq/util/log.py
+++ b/corehq/util/log.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 from itertools import islice
-import logging
 import traceback
 
 from pygments import highlight
@@ -62,6 +61,7 @@ class HqAdminEmailHandler(AdminEmailHandler):
             tb_list = ['Traceback (most recent call first):\n']
             formatted_exception = traceback.format_exception_only(etype, value)
             tb_list.extend(formatted_exception)
+<<<<<<< HEAD
             extracted_tb = list(reversed(traceback.extract_tb(tb)))
             try:
                 code = self.get_code(extracted_tb)
@@ -69,6 +69,10 @@ class HqAdminEmailHandler(AdminEmailHandler):
                 logging.error('[EMAIL HANDLER] {}'.format(e))
                 code = None
 
+=======
+            extracted_tb = reversed(traceback.extract_tb(tb))
+            code = self.get_code(extracted_tb)
+>>>>>>> parent of 7e0785e... watch the watchers
             tb_list.extend(traceback.format_list(extracted_tb))
             stack_trace = '\n'.join(tb_list)
             subject = '%s: %s' % (record.levelname,

--- a/corehq/util/log.py
+++ b/corehq/util/log.py
@@ -62,7 +62,7 @@ class HqAdminEmailHandler(AdminEmailHandler):
             tb_list = ['Traceback (most recent call first):\n']
             formatted_exception = traceback.format_exception_only(etype, value)
             tb_list.extend(formatted_exception)
-            extracted_tb = reversed(traceback.extract_tb(tb))
+            extracted_tb = list(reversed(traceback.extract_tb(tb)))
             try:
                 code = self.get_code(extracted_tb)
             except Exception, e:

--- a/corehq/util/log.py
+++ b/corehq/util/log.py
@@ -61,18 +61,8 @@ class HqAdminEmailHandler(AdminEmailHandler):
             tb_list = ['Traceback (most recent call first):\n']
             formatted_exception = traceback.format_exception_only(etype, value)
             tb_list.extend(formatted_exception)
-<<<<<<< HEAD
             extracted_tb = list(reversed(traceback.extract_tb(tb)))
-            try:
-                code = self.get_code(extracted_tb)
-            except Exception, e:
-                logging.error('[EMAIL HANDLER] {}'.format(e))
-                code = None
-
-=======
-            extracted_tb = reversed(traceback.extract_tb(tb))
             code = self.get_code(extracted_tb)
->>>>>>> parent of 7e0785e... watch the watchers
             tb_list.extend(traceback.format_list(extracted_tb))
             stack_trace = '\n'.join(tb_list)
             subject = '%s: %s' % (record.levelname,

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -77,6 +77,7 @@ django-mptt==0.6.1
 jsonpath-rw==1.3.0
 pip==6.1.1
 git+git://github.com/smartfile/django-transfer.git@6e0dc94c3341c358fca8eb2bf74e23aee3983ec4
+Pygments==2.0.2
 
 # required by ctable
 SQLAlchemy==0.8.2


### PR DESCRIPTION
@snopoke was inspired by the opbeat error email. doesn't have git blame in it, but i think the code context is a nice addition to our error email. this requires `Pygments` so if we don't think it's worth the dep, that's fine too. fyi, @esoergel this is a PR into your branch

buddy: @orangejenny 

Screenshot:
<img width="1552" alt="screen shot 2015-07-29 at 12 08 14 pm" src="https://cloud.githubusercontent.com/assets/918514/8951382/da97339e-35ea-11e5-8fff-38feba87606d.png">
