### PR TITLE
Form display filter for user-case-only modules

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -68,7 +68,9 @@ from corehq.apps.app_manager.util import (
     save_xform,
     get_correct_app_class,
     ParentCasePropertyBuilder,
-    is_usercase_in_use)
+    is_usercase_in_use,
+    actions_use_usercase
+)
 from corehq.apps.app_manager.xform import XForm, parse_xml as _parse_xml, \
     validate_xform
 from corehq.apps.app_manager.templatetags.xforms_extras import trans
@@ -1690,6 +1692,7 @@ class ModuleBase(IndexedSchema, NavMenuItemMediaMixin):
         """
         return True
 
+
 class Module(ModuleBase):
     """
     A group of related forms, and configuration that applies to them all.
@@ -1927,6 +1930,24 @@ class Module(ModuleBase):
                 'type': 'no ref detail',
                 'module': module_info,
             }
+
+    def is_usercaseonly(self):
+        """
+        Return False is the usercase is unused, or if any forms update a
+        different case type. If the only case type updated in the module is
+        the usercase, return True.
+        """
+        def actions_use_another_case(actions):
+            return (actions.get('update_case', {'update': None})['update'] or
+                    actions.get('case_preload', {'preload': None})['preload'])
+
+        uses_usercase = False
+        for form in self.forms:
+            if actions_use_another_case(form.active_actions()):
+                return False
+            if actions_use_usercase(form.active_actions()):
+                uses_usercase = True
+        return uses_usercase
 
 
 class AdvancedForm(IndexedFormBase, NavMenuItemMediaMixin):
@@ -2397,6 +2418,22 @@ class AdvancedModule(ModuleBase):
                     })
 
         return errors
+
+    def is_usercaseonly(self):
+        """
+        Return False is the usercase is unused, or if any forms update a
+        different case type. If the only case type updated in the module is
+        the usercase, return True.
+        """
+        uses_usercase = False
+        for form in self.forms:
+            if form.actions.load_update_cases:
+                for action in form.actions.load_update_cases:
+                    if action.case_type == USERCASE_TYPE:
+                        uses_usercase = True
+                    else:
+                        return False
+        return uses_usercase
 
 
 class CareplanForm(IndexedFormBase, NavMenuItemMediaMixin):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2,6 +2,7 @@
 from distutils.version import LooseVersion
 from itertools import chain
 import tempfile
+from mock import Mock
 import os
 import logging
 import hashlib
@@ -1933,13 +1934,16 @@ class Module(ModuleBase):
 
     def is_usercaseonly(self):
         """
-        Return False is the usercase is unused, or if any forms update a
+        Return False if the usercase is unused, or if any forms update a
         different case type. If the only case type updated in the module is
         the usercase, return True.
         """
         def actions_use_another_case(actions):
-            return (actions.get('update_case', {'update': None})['update'] or
-                    actions.get('case_preload', {'preload': None})['preload'])
+            empty_action = Mock(update={}, preload={})
+            update_case = actions.get('update_case', empty_action)
+            case_preload = actions.get('case_preload', empty_action)
+            return ((update_case.update and update_case.condition.type != 'never') or
+                    (case_preload.preload and case_preload.condition.type != 'never'))
 
         uses_usercase = False
         for form in self.forms:

--- a/corehq/apps/app_manager/templates/app_manager/form_view_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view_base.html
@@ -159,10 +159,13 @@
             {% if app.application_version == '2.0' %}
                 {% if allow_form_filtering %}
                 var putInRoot = {{ module.put_in_root|BOOL }};
+                var usercaseonlyModule = {{ module.is_usercaseonly|BOOL }}
                 var formFilter = {{ form.form_filter|JSON }};
                 var allOtherFormsRequireACase = {{ form.all_other_forms_require_a_case|BOOL }};
                 var formFilterAllowed = ko.computed(function () {
-                    return allOtherFormsRequireACase && form_requires() === 'case' && !putInRoot;
+                    return (allOtherFormsRequireACase &&
+                            form_requires() === 'case' ||
+                            usercaseonlyModule) && !putInRoot;
                 });
                 ko.applyBindings({
                         formFilter: ko.observable(formFilter),

--- a/corehq/apps/app_manager/tests/__init__.py
+++ b/corehq/apps/app_manager/tests/__init__.py
@@ -19,6 +19,7 @@ try:
     from corehq.apps.app_manager.tests.test_brief_view import *
     from corehq.apps.app_manager.tests.test_xpath import *
     from corehq.apps.app_manager.tests.test_bulk_app_translation import *
+    from corehq.apps.app_manager.tests.test_models import *
     from .test_location_xpath import *
     from .test_get_questions import *
     from .test_repeater import *

--- a/corehq/apps/app_manager/tests/test_models.py
+++ b/corehq/apps/app_manager/tests/test_models.py
@@ -1,0 +1,85 @@
+from corehq.apps.app_manager.const import APP_V2, USERCASE_TYPE
+from corehq.apps.app_manager.models import Application, Module, UpdateCaseAction, AdvancedModule, LoadUpdateAction
+from django.test import SimpleTestCase
+from mock import patch
+
+
+class ModuleTests(SimpleTestCase):
+
+    def setUp(self):
+        self.is_usercase_in_use_patch = patch('corehq.apps.app_manager.models.is_usercase_in_use')
+        self.is_usercase_in_use_mock = self.is_usercase_in_use_patch.start()
+        self.is_usercase_in_use_mock.return_value = True
+
+        self.app = Application.new_app('domain', "Untitled Application", application_version=APP_V2)
+        self.module = self.app.add_module(Module.new_module('Untitled Module', None))
+        self.module.case_type = 'another_case_type'
+        self.form = self.module.new_form("Untitled Form", None)
+
+    def tearDown(self):
+        self.is_usercase_in_use_patch.stop()
+
+    def test_is_usercaseonly_no_usercase(self):
+        """
+        is_usercaseonly should return False if the usercase is not updated
+        """
+        self.assertFalse(self.module.is_usercaseonly())
+
+    def test_is_usercaseonly_other_case(self):
+        """
+        is_usercaseonly should return False if another case type is updated
+        """
+        self.form.requires = 'case'
+        self.form.actions.update_case = UpdateCaseAction(update={'name': '/data/question1'})
+        self.form.actions.update_case.condition.type = 'always'
+        self.form.actions.usercase_update = UpdateCaseAction(update={'name': '/data/question1'})
+        self.form.actions.usercase_update.condition.type = 'always'
+        self.assertFalse(self.module.is_usercaseonly())
+
+    def test_is_usercaseonly_usercaseonly(self):
+        """
+        is_usercaseonly should return True if only the usercase is updated
+        """
+        self.form.actions.usercase_update = UpdateCaseAction(update={'name': '/data/question1'})
+        self.form.actions.usercase_update.condition.type = 'always'
+        self.assertTrue(self.module.is_usercaseonly())
+
+
+class AdvancedModuleTests(SimpleTestCase):
+
+    def setUp(self):
+        self.is_usercase_in_use_patch = patch('corehq.apps.app_manager.models.is_usercase_in_use')
+        self.is_usercase_in_use_mock = self.is_usercase_in_use_patch.start()
+        self.is_usercase_in_use_mock.return_value = True
+
+        self.app = Application.new_app('domain', "Untitled Application", application_version=APP_V2)
+        self.module = self.app.add_module(AdvancedModule.new_module('Untitled Module', None))
+        self.form = self.module.new_form("Untitled Form", None)
+        self.case_type = 'another_case_type'
+
+    def tearDown(self):
+        self.is_usercase_in_use_patch.stop()
+
+    def test_is_usercaseonly_no_usercase(self):
+        """
+        is_usercaseonly should return False if the usercase is not updated
+        """
+        self.assertFalse(self.module.is_usercaseonly())
+
+    def test_is_usercaseonly_other_case(self):
+        """
+        is_usercaseonly should return False if another case type is updated
+        """
+        action = LoadUpdateAction(case_tag=self.case_type, case_type=self.case_type)
+        self.form.actions.load_update_cases.append(action)
+        action = LoadUpdateAction(case_tag=USERCASE_TYPE, case_type=USERCASE_TYPE)
+        self.form.actions.load_update_cases.append(action)
+        self.assertFalse(self.module.is_usercaseonly())
+
+    def test_is_usercaseonly_usercaseonly(self):
+        """
+        is_usercaseonly should return True if only the usercase is updated
+        """
+        action = LoadUpdateAction(case_tag=USERCASE_TYPE, case_type=USERCASE_TYPE)
+        self.form.actions.load_update_cases.append(action)
+        self.assertTrue(self.module.is_usercaseonly())


### PR DESCRIPTION
Modules that update the user case should allow its forms to be filtered, as it does if any other case type is updated.

[FB 177406](http://manage.dimagi.com/default.asp?177406)

@snopoke, cc @biyeun 
