### PR TITLE
Wire invoice resolution

### DIFF
--- a/corehq/apps/accounting/management/commands/migrate_wire_invoice_pdfs.py
+++ b/corehq/apps/accounting/management/commands/migrate_wire_invoice_pdfs.py
@@ -1,4 +1,3 @@
-from optparse import make_option
 from django.core.management import BaseCommand
 
 from dimagi.utils.couch.database import iter_docs

--- a/corehq/apps/accounting/management/commands/migrate_wire_invoice_pdfs.py
+++ b/corehq/apps/accounting/management/commands/migrate_wire_invoice_pdfs.py
@@ -1,0 +1,28 @@
+from optparse import make_option
+from django.core.management import BaseCommand
+
+from dimagi.utils.couch.database import iter_docs
+from corehq.apps.accounting.models import InvoicePdf, WireBillingRecord
+from corehq.util.couch import IterDB
+
+
+class Command(BaseCommand):
+    help = ("Migrate InvoicePdfs to have is_wire field")
+
+    def handle(self, *args, **options):
+        invoice_ids = WireBillingRecord.objects.values_list('pdf_data_id', flat=True)
+        db = InvoicePdf.get_db()
+
+        with IterDB(db) as iter_db:
+            for doc in iter_docs(db, invoice_ids):
+                doc['is_wire'] = True
+                iter_db.save(doc)
+
+        if iter_db.saved_ids:
+            print '{}/{} docs saved correctly!'.format(len(iter_db.saved_ids), len(invoice_ids))
+        if iter_db.error_ids:
+            print 'There were {} errors. There were errors when saving the following:'.format(
+                len(iter_db.error_ids)
+            )
+            for error_id in iter_db.error_ids:
+                print error_id

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -5,7 +5,7 @@ from tempfile import NamedTemporaryFile
 from decimal import Decimal
 from couchdbkit import ResourceNotFound
 from corehq.util.global_request import get_request
-from dimagi.ext.couchdbkit import DateTimeProperty, StringProperty, SafeSaveDocument
+from dimagi.ext.couchdbkit import DateTimeProperty, StringProperty, SafeSaveDocument, BooleanProperty
 
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
@@ -1963,6 +1963,7 @@ class BillingRecord(BillingRecordBase):
 class InvoicePdf(SafeSaveDocument):
     invoice_id = StringProperty()
     date_created = DateTimeProperty()
+    is_wire = BooleanProperty(default=False)
 
     def generate_pdf(self, invoice):
         self.save()
@@ -2023,6 +2024,7 @@ class InvoicePdf(SafeSaveDocument):
 
         self.invoice_id = str(invoice.id)
         self.date_created = datetime.datetime.utcnow()
+        self.is_wire = invoice.is_wire
         self.save()
 
     def get_filename(self, invoice):

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1127,14 +1127,18 @@ class BillingStatementPdfView(View):
             raise Http404()
 
         try:
-            invoice = Invoice.objects.get(pk=invoice_pdf.invoice_id,
-                                          subscription__subscriber__domain=domain)
-        except Invoice.DoesNotExist:
-            try:
-                invoice = WireInvoice.objects.get(pk=invoice_pdf.invoice_id,
-                                                  domain=domain)
-            except WireInvoice.DoesNotExist:
-                raise Http404()
+            if invoice_pdf.is_wire:
+                invoice = WireInvoice.objects.get(
+                    pk=invoice_pdf.invoice_id,
+                    domain=domain
+                )
+            else:
+                invoice = Invoice.objects.get(
+                    pk=invoice_pdf.invoice_id,
+                    subscription__subscriber__domain=domain
+                )
+        except (Invoice.DoesNotExist, WireInvoice.DoesNotExist):
+            raise Http404()
 
         if invoice.is_wire:
             edition = 'Bulk'


### PR DESCRIPTION
@esoergel this should migrate all the InvoicePdfs as well make sure any new ones that are created properly have the `is_wire` field. There are a total of 14 wire invoices on prod, so IterDB is a bit of overkill, but was neat to use!
http://manage.dimagi.com/default.asp?177208#984768
buddy: @orangejenny 
