### PR TITLE
Plan stock rebuild

### DIFF
--- a/corehq/apps/commtrack/processing.py
+++ b/corehq/apps/commtrack/processing.py
@@ -230,7 +230,10 @@ def plan_rebuild_stock_state(case_id, section_id, product_id):
     facilitating doing a dry run
 
     Warning: since some important things are still done through signals
-    rather than here explicitly,
+    rather than here explicitly, there may be some effects that aren't
+    represented in the plan. For example, inferred transaction creation
+    will not be represented, nor will updates to the StockState object.
+
     """
 
     # these come out latest first, so reverse them below

--- a/corehq/apps/commtrack/processing.py
+++ b/corehq/apps/commtrack/processing.py
@@ -88,6 +88,7 @@ def compute_ledger_values(lazy_original_balance, report_type, quantity):
     """
     if report_type == stockconst.REPORT_TYPE_BALANCE:
         new_balance = quantity
+        # this is currently always 0 because of inferred transactions
         new_delta = 0
     elif report_type == stockconst.REPORT_TYPE_TRANSFER:
         original_balance = lazy_original_balance()

--- a/corehq/apps/commtrack/processing.py
+++ b/corehq/apps/commtrack/processing.py
@@ -214,7 +214,6 @@ def _compute_ledger_values(original_balance, stock_transaction):
 
     return ledger_values
 
-
 _DeleteStockTransaction = namedtuple(
     '_DeleteStockTransaction', ['stock_transaction'])
 _SaveStockTransaction = namedtuple(

--- a/corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html
+++ b/corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html
@@ -10,31 +10,33 @@
         {% if forloop.first %}
         <tr>
             <td colspan="6" style="text-align: center">
-                <strong>{{ case_doc_info|pretty_doc_info }}</strong>
-                {{ stock_transaction.section_id }}
-                for <em>{{ stock_transaction.sql_product.name }}</em>
+                {% blocktrans with case_display=case_doc_info|pretty_doc_info section_display=stock_transaction.section_id product_name=stock_transaction.sql_product.name %}
+                <strong>{{ case_display }}</strong>
+                {{ section_display }}
+                for <em>{{ product_name }}</em>
+                {% endblocktrans %}
                 {% if request.user.is_superuser and request|toggle_enabled:'SUPPORT' %}
                 <form method="post" action="" class="pull-right">
                     <input type="hidden" name="case_id" value="{{ key.case_id }}">
                     <input type="hidden" name="section_id" value="{{ key.section_id }}">
                     <input type="hidden" name="product_id" value="{{ key.product_id }}">
-                    <input type="submit" class="btn btn-primary" value="Rebuild"/>
+                    <input type="submit" class="btn btn-primary" value="{% trans "Rebuild" %}"/>
                 </form>
                 {% endif %}
             </td>
         </tr>
         <tr>
             <th colspan="2"></th>
-            <th colspan="2">Current Values</th>
-            <th colspan="2">Rebuilt Values</th>
+            <th colspan="2">{% trans "Current Values" %}</th>
+            <th colspan="2">{% trans "Rebuilt Values" %}</th>
         </tr>
         <tr>
-            <th>Date</th>
-            <th>Type</th>
-            <th>Quantity</th>
-            <th>Stock on Hand</th>
-            <th>Quantity</th>
-            <th>Stock on Hand</th>
+            <th>{% trans "Date" %}</th>
+            <th>{% trans "Type" %}</th>
+            <th>{% trans "Quantity" %}</th>
+            <th>{% trans "Stock on Hand" %}</th>
+            <th>{% trans "Quantity" %}</th>
+            <th>{% trans "Stock on Hand" %}</th>
         </tr>
         {% endif %}
         <tr>
@@ -60,7 +62,7 @@
                 {{ action.ledger_values.balance }}</span>
             </td>
             {% else %}
-            <td colspan="2">(will be deleted)</td>
+            <td colspan="2">{% trans "(will be deleted)" %}</td>
             {% endif %}
         </tr>
         {% endwith %}

--- a/corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html
+++ b/corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html
@@ -3,6 +3,26 @@
 {% load hq_shared_tags %}
 
 {% block main_column %}
+    {% if stock_state_limit_exceeded %}
+    <div class="alert alert-warning">
+    {% blocktrans %}
+    <strong>Warning:</strong>
+    You have more than {{ stock_state_limit }} stocks in your project space.
+    Only {{ stock_state_limit }} are shown.
+    {% endblocktrans %}
+    </div>
+    {% endif %}
+
+    {% if stock_transaction_limit_exceeded %}
+    <div class="alert alert-warning">
+    {% blocktrans %}
+    <strong>Warning:</strong>
+    You have more than {{ stock_transaction_limit }} stock transactions in your project space.
+    Only {{ stock_transaction_limit }} are shown.
+    {% endblocktrans %}
+    </div>
+    {% endif %}
+
     <table class="table table-bordered table-striped">
     {% for key, actions, case_doc_info in actions_by_stock_state_key %}
     {% for action_type, action in actions %}

--- a/corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html
+++ b/corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html
@@ -13,6 +13,14 @@
                 <strong>{{ case_doc_info|pretty_doc_info }}</strong>
                 {{ stock_transaction.section_id }}
                 for <em>{{ stock_transaction.sql_product.name }}</em>
+                {% if request.user.is_superuser and request|toggle_enabled:'SUPPORT' %}
+                <form method="post" action="" class="pull-right">
+                    <input type="hidden" name="case_id" value="{{ key.case_id }}">
+                    <input type="hidden" name="section_id" value="{{ key.section_id }}">
+                    <input type="hidden" name="product_id" value="{{ key.product_id }}">
+                    <input type="submit" class="btn btn-primary" value="Rebuild"/>
+                </form>
+                {% endif %}
             </td>
         </tr>
         <tr>
@@ -56,7 +64,17 @@
             {% endif %}
         </tr>
         {% endwith %}
+        {% if forloop.last and not forloop.counter|divisibleby:2 %}
+            {# this is to get the striping right on each table section #}
+            <tr></tr>
+        {% endif %}
     {% endfor %}
+    {# this is to put space between each table section #}
+    {# while still having the columns between sections line up #}
+    <tr>
+        <td style="border-left: 0; border-right: 0;
+         padding: 20px; background: transparent;" colspan="6"></td>
+    </tr>
     {% endfor %}
     </table>
 {% endblock %}

--- a/corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html
+++ b/corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html
@@ -3,39 +3,60 @@
 {% load hq_shared_tags %}
 
 {% block main_column %}
-    <table class="table">
+    <table class="table table-bordered table-striped">
+    {% for key, actions, case_doc_info in actions_by_stock_state_key %}
+    {% for action_type, action in actions %}
+        {% with action.stock_transaction as stock_transaction %}
+        {% if forloop.first %}
         <tr>
-            <th>Case</th>
-            <th>Section</th>
-            <th>Product</th>
+            <td colspan="6" style="text-align: center">
+                <strong>{{ case_doc_info|pretty_doc_info }}</strong>
+                {{ stock_transaction.section_id }}
+                for <em>{{ stock_transaction.sql_product.name }}</em>
+            </td>
+        </tr>
+        <tr>
+            <th colspan="2"></th>
+            <th colspan="2">Current Values</th>
+            <th colspan="2">Rebuilt Values</th>
+        </tr>
+        <tr>
             <th>Date</th>
             <th>Type</th>
             <th>Quantity</th>
             <th>Stock on Hand</th>
+            <th>Quantity</th>
+            <th>Stock on Hand</th>
         </tr>
-    {% for stock_transaction in stock_transactions %}
+        {% endif %}
         <tr>
+            <td>{{ stock_transaction.report.date }}</td>
+            <td>{{ stock_transaction.report.type }}</td>
+            <td>{{ stock_transaction.quantity }}</td>
+            <td>{{ stock_transaction.stock_on_hand }}</td>
+            {% if action_type == '_SaveStockTransaction' %}
             <td>
-                {% ifchanged %}{{ stock_transaction.case_id }}{% endifchanged %}
+                {% if stock_transaction.quantity != action.ledger_values.delta %}
+                <span class="text-error">
+                {% else %}
+                <span class="muted">
+                {% endif %}
+                {{ action.ledger_values.delta }}</span>
             </td>
             <td>
-                {% ifchanged %}
-                    <!--{{ stock_transaction.case_id }}-->
-                    {{ stock_transaction.section_id }}
-                {% endifchanged %}
+                {% if stock_transaction.stock_on_hand != action.ledger_values.balance %}
+                <span class="text-error">
+                {% else %}
+                <span class="muted">
+                {% endif %}
+                {{ action.ledger_values.balance }}</span>
             </td>
-            <td>
-                {% ifchanged %}
-                    <!--{{ stock_transaction.case_id }}-->
-                    <!--{{ stock_transaction.section_id }}-->
-                    {{ stock_transaction.sql_product.name }}
-                {% endifchanged %}
-            </td>
-                <td>{{ stock_transaction.report.date }} ({{ stock_transaction.pk }})</td>
-                <td>{{ stock_transaction.report.type }}</td>
-                <td>{{ stock_transaction.quantity }}</td>
-                <td>{{ stock_transaction.stock_on_hand }}</td>
-            </tr>
+            {% else %}
+            <td colspan="2">(will be deleted)</td>
+            {% endif %}
+        </tr>
+        {% endwith %}
+    {% endfor %}
     {% endfor %}
     </table>
 {% endblock %}


### PR DESCRIPTION
This adds columns to the stock state view that shows projected changes from rebuilding state for a particular stock.

(This view is still totally not scalable, as it just loads every stock transaction of a domain at once. For the purposes of the domain I'm looking at, though, it's fine, and we can figure out what we want to do in terms of pagination later.)

It does this by (as you can see in the first two commits) breaking the rebuild function into two steps—planning and executing—and then only calling the planning part and reporting the proposed modifications.
