### PR TITLE
update ucr sort default behavior

### DIFF
--- a/corehq/apps/userreports/reports/data_source.py
+++ b/corehq/apps/userreports/reports/data_source.py
@@ -158,7 +158,7 @@ class ConfigurableReportDataSource(SqlData):
 
                     def sort_by(row):
                         value = row.get(sort_column_id, None)
-                        return value or get_default_sort_value(datatype, order)
+                        return value or get_default_sort_value(datatype)
 
                     ret.sort(
                         key=sort_by,

--- a/corehq/apps/userreports/reports/sorting.py
+++ b/corehq/apps/userreports/reports/sorting.py
@@ -5,24 +5,15 @@ ASCENDING = "ASC"
 DESCENDING = "DESC"
 
 
-def get_default_sort_value(datatype, order):
+def get_default_sort_value(datatype):
     """
-    Gets a default sort value based on a datatype and order
+    Gets a default sort value based on a datatype and order for null values.
 
-    order must be one of ASCENDING or DESCENDING fro mreports
+    Generally tries to return the first possible value
     """
     defaults = {
-        "date": {
-            ASCENDING: datetime.date.max,
-            DESCENDING: datetime.date.min,
-        },
-        "datetime": {
-            ASCENDING: datetime.datetime.max,
-            DESCENDING: datetime.datetime.min,
-        },
+        'date': datetime.date.min,
+        'datetime': datetime.datetime.min,
+        'string': ''
     }
-    global_defaults = {
-        ASCENDING: None,
-        DESCENDING: None
-    }
-    return defaults.get(datatype, global_defaults)[order]
+    return defaults.get(datatype, None)

--- a/corehq/apps/userreports/tests/test_sorting.py
+++ b/corehq/apps/userreports/tests/test_sorting.py
@@ -5,14 +5,14 @@ from corehq.apps.userreports.reports.sorting import get_default_sort_value, ASCE
 
 class SortingTestCase(SimpleTestCase):
 
-    def test_date_defaults(self):
-        self.assertTrue(get_default_sort_value('date', ASCENDING) > datetime.datetime.now().date())
-        self.assertTrue(get_default_sort_value('date', DESCENDING) < datetime.datetime.now().date())
+    def test_date_default(self):
+        self.assertTrue(get_default_sort_value('date') < datetime.datetime.now().date())
 
-    def test_datetime_defaults(self):
-        self.assertTrue(get_default_sort_value('datetime', ASCENDING) > datetime.datetime.now())
-        self.assertTrue(get_default_sort_value('datetime', DESCENDING) < datetime.datetime.now())
+    def test_datetime_default(self):
+        self.assertTrue(get_default_sort_value('datetime') < datetime.datetime.now())
+
+    def test_string_default(self):
+        self.assertEqual('', get_default_sort_value('string'))
 
     def test_other_defaults(self):
-        self.assertEqual(None, get_default_sort_value('missing_type', ASCENDING))
-        self.assertEqual(None, get_default_sort_value('missing_type', DESCENDING))
+        self.assertEqual(None, get_default_sort_value('missing_type'))


### PR DESCRIPTION
@nickpell I was thinking about this more and I don't actually think we should always default to last in the list.

it seems to break sorting semantics if it's not consistent between ascending and descending (like if some rows are always last in both orders).

this changes is so None always comes first in ascending order, and always last in descending.

thoughts?
