### PR TITLE
simpler and more robust deletion error handling

### DIFF
--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -66,6 +66,7 @@ def tag_forms_as_deleted_rebuild_associated_cases(formlist, deletion_id,
     for case in cases_to_rebuild - deleted_cases:
         _rebuild_case_with_retries.delay(case)
 
+
 @task(bind=True, rate_limit=2, queue='background_queue', ignore_result=True,
       default_retry_delay=5, max_retries=3)
 def _rebuild_case_with_retries(self, case_id):

--- a/corehq/apps/users/tasks.py
+++ b/corehq/apps/users/tasks.py
@@ -4,14 +4,13 @@ from celery.schedules import crontab
 from celery.task import task
 from celery.task.base import periodic_task
 from celery.utils.log import get_task_logger
+from couchdbkit import ResourceConflict
 from corehq.util.log import SensitiveErrorMail
 from couchforms.exceptions import UnexpectedDeletedXForm
-import settings
 from corehq.apps.domain.models import Domain
 from dimagi.utils.couch.undo import DELETED_SUFFIX
-from django.core.cache import cache
-import uuid
-from soil import CachedDownload, DownloadBase
+from dimagi.utils.logging import notify_exception
+from soil import DownloadBase
 
 from casexml.apps.case.xform import get_case_ids_from_form
 from couchforms.models import XFormInstance
@@ -44,9 +43,9 @@ def tag_docs_as_deleted(cls, docs, deletion_id):
     cls.get_db().bulk_save(docs)
 
 
-@task(bind=True, rate_limit=2, queue='background_queue', ignore_result=True,
+@task(rate_limit=2, queue='background_queue', ignore_result=True,
       default_retry_delay=5 * 60, max_retries=3)
-def tag_forms_as_deleted_rebuild_associated_cases(self, formlist, deletion_id,
+def tag_forms_as_deleted_rebuild_associated_cases(formlist, deletion_id,
                                                   deleted_cases=None):
     """ Upon user deletion, mark associated forms as deleted and prep cases
     for a rebuild.
@@ -54,7 +53,6 @@ def tag_forms_as_deleted_rebuild_associated_cases(self, formlist, deletion_id,
     - retry in 5 min if failure occurs after (default_retry_delay)
     - retry a total of 3 times
     """
-    from casexml.apps.case.cleanup import rebuild_case
     if deleted_cases is None:
         deleted_cases = set()
 
@@ -65,16 +63,23 @@ def tag_forms_as_deleted_rebuild_associated_cases(self, formlist, deletion_id,
         cases_to_rebuild.update(get_case_ids_from_form(form))
     XFormInstance.get_db().bulk_save(formlist)
 
+    for case in cases_to_rebuild - deleted_cases:
+        _rebuild_case_with_retries.delay(case)
+
+@task(bind=True, rate_limit=2, queue='background_queue', ignore_result=True,
+      default_retry_delay=5, max_retries=3)
+def _rebuild_case_with_retries(self, case_id):
+    from casexml.apps.case.cleanup import rebuild_case
     try:
-        for case in cases_to_rebuild - deleted_cases:
-            rebuild_case(case)
-    except UnexpectedDeletedXForm as exc:
+        rebuild_case(case_id)
+    except (UnexpectedDeletedXForm, ResourceConflict) as exc:
         try:
             self.retry(exc=exc)
         except MaxRetriesExceededError:
-            logger.error("Maximum Retries Exceeded for tag_forms_as_deleted. "
-                         "Deleted XForms found preventing cases from being "
-                         "rebuilt.")
+            notify_exception(
+                "Maximum Retries Exceeded while rebuilding case {} during deletion.".format(case_id)
+            )
+
 
 @periodic_task(
     run_every=crontab(hour=23, minute=55),


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?177171

a few changes bundled together
- don't have one failing case break the whole process
- only retry cases that fail
- trap `ResourceConflict` in addition to weird form deletions
- lower delay
