### PR TITLE
Guarantee supply_point and program in DomainInvitation objects

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -2415,6 +2415,8 @@ class DomainInvitation(CachedCouchDocumentMixin, Invitation):
     domain = StringProperty()
     role = StringProperty()
     doc_type = "Invitation"
+    program = None
+    supply_point = None
 
     def send_activation_email(self, remaining_days=30):
         url = absolute_reverse("domain_accept_invitation",


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?177457

AttributeError: 'DomainInvitation' object has no attribute 'supply_point'

thrown from https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/users/views/__init__.py#L676

@benrudolph 
