### PR TITLE
Print warning message when logger is changed

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -956,6 +956,10 @@ try:
             # localsettings.py will reveal the real error.
             for handler in LOGGING["handlers"].values():
                 if handler["class"].startswith("corehq."):
+                    print "{} logger is being changed to {}".format(
+                        handler['class'],
+                        'logging.StreamHandler'
+                    )
                     handler["class"] = "logging.StreamHandler"
 except ImportError:
     pass


### PR DESCRIPTION
@czue using `logging.debug` didn't print to the console so i figured it'd just be best to use a `print` statement
addition to: https://github.com/dimagi/commcare-hq/pull/7704
