### PR TITLE
Set id in locations tests

### DIFF
--- a/corehq/apps/locations/tests/test_location_fixtures.py
+++ b/corehq/apps/locations/tests/test_location_fixtures.py
@@ -39,6 +39,7 @@ class LocationFixturesTest(TestCase):
 
     def test_metadata(self):
         location = SQLLocation(
+            id="854208",
             location_id="unique-id",
             domain="test-domain",
             name="Braavos",

--- a/corehq/apps/locations/tests/test_location_set.py
+++ b/corehq/apps/locations/tests/test_location_set.py
@@ -19,11 +19,13 @@ class LocationSetTest(SimpleTestCase):
         )
 
         location1 = SQLLocation(
+            id="58302461",
             location_id="1",
             name="Some Parent Location",
             location_type=parent
         )
         location2 = SQLLocation(
+            id="39825",
             location_id="2",
             name="Some Child Location",
             location_type=child,


### PR DESCRIPTION
@esoergel 

Sets the location id in tests where `SQLLocation` isn't saved. Tested it in 1.7, but I don't see why this wouldn't work for 1.6 (wait for travis obviously)

cc: @czue 
