### PR TITLE
Count tracking-related click handlers

### DIFF
--- a/corehq/apps/style/templates/style/includes/analytics_google.html
+++ b/corehq/apps/style/templates/style/includes/analytics_google.html
@@ -47,8 +47,8 @@
                     // This page isn't being redirected
                     trackFunction();
                 } else {
-                    // Track how many tarckLinkHelper-related handlers
-                    // this event has, so we can only actually click
+                    // Track how many trackLinkHelper-related handlers
+                    // this event has, so we only actually click
                     // once, after they're all complete.
                     if (!event.data) {
                         event.data = {};

--- a/corehq/apps/style/templates/style/includes/analytics_google.html
+++ b/corehq/apps/style/templates/style/includes/analytics_google.html
@@ -50,12 +50,8 @@
                     // Track how many trackLinkHelper-related handlers
                     // this event has, so we only actually click
                     // once, after they're all complete.
-                    if (!event.data) {
-                        event.data = {};
-                    }
-                    if (!event.data.trackLinkCount) {
-                        event.data.trackLinkCount = 0;
-                    }
+                    event.data = event.data || {};
+                    event.data.trackLinkCount = event.data.trackLinkCount || 0;
                     event.data.trackLinkCount++;
 
                     event.preventDefault();

--- a/corehq/apps/style/templates/style/includes/analytics_google.html
+++ b/corehq/apps/style/templates/style/includes/analytics_google.html
@@ -47,11 +47,25 @@
                     // This page isn't being redirected
                     trackFunction();
                 } else {
+                    // Track how many tarckLinkHelper-related handlers
+                    // this event has, so we can only actually click
+                    // once, after they're all complete.
+                    if (!event.data) {
+                        event.data = {};
+                    }
+                    if (!event.data.trackLinkCount) {
+                        event.data.trackLinkCount = 0;
+                    }
+                    event.data.trackLinkCount++;
+
                     event.preventDefault();
                     var callbackCalled = false;
                     var callback = function () {
                         if (!callbackCalled) {
-                            document.location = $this.attr('href');
+                            event.data.trackLinkCount--;
+                            if (!event.data.trackLinkCount) {
+                                document.location = $this.attr('href');
+                            }
                             callbackCalled = true;
                         }
                     };


### PR DESCRIPTION
@NoahCarnahan This seemed like the cleanest way to allow both `gaTrackLink` and `trackWorkflowLink` to be called on the same link without clicking twice.

code buddy @benrudolph 
