### PR TITLE
button & table bumping against right edge of browser

### DIFF
--- a/corehq/apps/reports_core/templates/reports_core/base_template_new.html
+++ b/corehq/apps/reports_core/templates/reports_core/base_template_new.html
@@ -185,12 +185,14 @@
 </section>
 {% endblock %}
 {% block reporttable %}
-<table id="report_table_{{ report.slug }}" class="table table-striped datatable">
-    <thead>
-    {{ headers.render_html|safe }}
-    </thead>
-    <tbody>
-    </tbody>
-</table>
+<div>
+    <table id="report_table_{{ report.slug }}" class="table table-striped datatable">
+        <thead>
+        {{ headers.render_html|safe }}
+        </thead>
+        <tbody>
+        </tbody>
+    </table>
+</div>
 {% endblock reporttable %}
 {% endblock %}

--- a/corehq/apps/userreports/templates/userreports/configurable_report.html
+++ b/corehq/apps/userreports/templates/userreports/configurable_report.html
@@ -99,13 +99,15 @@
         {% endblocktrans %}
     </div>
     {% if request|toggle_enabled:"USER_CONFIGURABLE_REPORTS" %}
-        <a class="btn btn-primary pull-right" href="
-            {% if report.spec.report_meta.created_by_builder %}
-                {% url 'edit_report_in_builder' domain report.report_config_id %}
-            {% else %}
-                {% url 'edit_configurable_report' domain report.report_config_id %}
-            {% endif %}
-        ">{% trans "Edit Report" %}</a>
+        <div class="pull-right">
+            <a class="btn btn-primary" href="
+                {% if report.spec.report_meta.created_by_builder %}
+                    {% url 'edit_report_in_builder' domain report.report_config_id %}
+                {% else %}
+                    {% url 'edit_configurable_report' domain report.report_config_id %}
+                {% endif %}
+            ">{% trans "Edit Report" %}</a>
+        </div>
     {% endif %}
     {{ block.super }}
 {% endblock %}


### PR DESCRIPTION
this was bothering me. would rather fix the table by adding `.hq-content:not(.hq-flush-content) > table` here: https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/style/static/style/less/bootstrap2/layouts.less#L48-L58 ...but adding margin to the table itself doesn't work, and this isn't important enough to spend time figuring out why.

before:
![screen shot 2015-08-04 at 12 07 02 pm](https://cloud.githubusercontent.com/assets/1486591/9065720/75080d1c-3aa1-11e5-8d5f-fc9f3bcfd8ae.png)

after:
![screen shot 2015-08-04 at 12 05 02 pm](https://cloud.githubusercontent.com/assets/1486591/9065726/7f556c60-3aa1-11e5-9886-f48a9b37060c.png)

@nickpell 
