### PR TITLE
Add user flags to feature flag summary page

### DIFF
--- a/corehq/apps/domain/templates/domain/admin/feature_flags.html
+++ b/corehq/apps/domain/templates/domain/admin/feature_flags.html
@@ -1,37 +1,47 @@
 {% extends "settings/base_template.html" %}
 {% load i18n %}
+{% block head %}{{ block.super }}
+<style type="text/css">
+    th.checkmark-column, td.checkmark-column {
+        white-space: nowrap;
+        text-align: center;
+    }
+</style>
+{% endblock %}
 {% block main_column %}
     <div class="row-fluid">
         <div class="span6">
             <p>
                 {% url 'toggle_list' as toggle_url %}
                 {% blocktrans %}
-                    Feature Flags are superuser-only things that can be turn on features for individual users or projects.
-                    They can be edited manually at the <a href="{{ toggle_url }}">Feature Flag edit UI</a> (also super-only).
-                    In addition, some feature flags are randomly enabled by a domain.
+                    Feature Flags turn on features for individual users or projects. They are editable only by
+                    super users, in the <a href="{{ toggle_url }}">Feature Flag edit UI</a>.
+                    In addition, some feature flags are randomly enabled by domain.
                 {% endblocktrans %}
             </p>
             <p>
                 {% blocktrans %}
-                    You can see a list of all enabled flags for this domain here.
-                    This does not include any flags set for users within the domain.
+                    Following are all flags enabled for this domain and/or for you.
+                    This does not include any flags set for other users in this domain.
                 {% endblocktrans %}
             </p>
         </div>
     </div>
     <div class="row-fluid">
-        <div class="span6">
+        <div class="span8">
             <table class="table table-striped">
                 <thead>
                     <th>{% trans "Feature" %}</th>
-                    <th>{% trans "Enabled?" %}</th>
+                    <th class="checkmark-column">{% trans "Enabled for domain?" %}</th>
+                    <th class="checkmark-column">{% trans "Enabled for me?" %}</th>
                     <th>{% trans "Edit" %}</th>
                 </thead>
                 <tbody>
-                    {% for feature, enabled in flags %}
-                    <tr {% if enabled %}class="info"{% endif %}>
+                    {% for feature, enabled_for_domain, enabled_for_user in flags %}
+                    <tr class="{% if enabled_for_domain %}success{% elif enabled_for_user %}info{% endif %}">
                         <td>{{ feature.label }}</td>
-                        <td>{{ enabled }}</td>
+                        <td class="checkmark-column">{% if enabled_for_domain %}<i class="icon-ok"></i>{% endif %}</td>
+                        <td class="checkmark-column">{% if enabled_for_user %}<i class="icon-ok"></i>{% endif %}</td>
                         <td><a href="{% url 'edit_toggle' feature.slug %}">{% trans "change" %}</a></td>
                     </tr>
                     {% endfor %}

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -2444,7 +2444,6 @@ class FeatureFlagsView(BaseAdminProjectSettingsView):
         return super(FeatureFlagsView, self).dispatch(request, *args, **kwargs)
 
     @memoized
-    #jls
     def enabled_flags(self):
         #request.couch_user.get_id
         def _sort_key(toggle_enabled_tuple):

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -2445,7 +2445,6 @@ class FeatureFlagsView(BaseAdminProjectSettingsView):
 
     @memoized
     def enabled_flags(self):
-        #request.couch_user.get_id
         def _sort_key(toggle_enabled_tuple):
             return (not toggle_enabled_tuple[1], not toggle_enabled_tuple[2], toggle_enabled_tuple[0].label)
         return sorted(

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -2444,11 +2444,14 @@ class FeatureFlagsView(BaseAdminProjectSettingsView):
         return super(FeatureFlagsView, self).dispatch(request, *args, **kwargs)
 
     @memoized
+    #jls
     def enabled_flags(self):
+        #request.couch_user.get_id
         def _sort_key(toggle_enabled_tuple):
-            return (not toggle_enabled_tuple[1], toggle_enabled_tuple[0].label)
+            return (not toggle_enabled_tuple[1], not toggle_enabled_tuple[2], toggle_enabled_tuple[0].label)
         return sorted(
-            [(toggle, toggle.enabled(self.domain)) for toggle in all_toggles()],
+            [(toggle, toggle.enabled(self.domain), toggle.enabled(self.request.couch_user.username))
+                for toggle in all_toggles()],
             key=_sort_key,
         )
 


### PR DESCRIPTION
Added user-specific flags to the summary of domain-specific flags. Figured it'd be useful to be able to see both at one time, and that this combined view should still live in the domain app, since domain-specific flags are preferred over user-specific ones.

code friend @nickpell 

cc @amsagoff

Before:
![screen shot 2015-08-04 at 1 33 21 pm](https://cloud.githubusercontent.com/assets/1486591/9067768/74a0fd5a-3aad-11e5-8fc1-e85fa3eedf2d.png)

After:
![screen shot 2015-08-04 at 1 31 19 pm](https://cloud.githubusercontent.com/assets/1486591/9067784/84c5cc38-3aad-11e5-9ec7-254e97eb59dc.png)
