### PR TITLE
Pull in swahili translations from 8a30b51

### DIFF
--- a/corehq/apps/app_manager/tests/test_translations.py
+++ b/corehq/apps/app_manager/tests/test_translations.py
@@ -1,4 +1,4 @@
-# coding=utf8
+# coding=utf-8
 from lxml import etree
 from django.test import SimpleTestCase
 from corehq.apps.app_manager.translations import escape_output_value

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-29 19:37+0000\n"
+"POT-Creation-Date: 2015-08-05 17:43+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -35,7 +35,7 @@ msgstr ""
 
 #: corehq/__init__.py:61 corehq/feature_previews.py:91
 #: corehq/apps/hqwebapp/models.py:879 corehq/apps/reports/__init__.py:13
-#: corehq/apps/reports/models.py:52
+#: corehq/apps/reports/models.py:54
 #: corehq/apps/users/templates/users/edit_commcare_user.html:125
 #, fuzzy
 msgid "CommCare Supply"
@@ -57,9 +57,9 @@ msgstr ""
 msgid "Messaging"
 msgstr ""
 
-#: corehq/__init__.py:177 corehq/apps/app_manager/models.py:2900
+#: corehq/__init__.py:177 corehq/apps/app_manager/models.py:2974
 #: corehq/apps/dashboard/views.py:159 corehq/apps/hqwebapp/models.py:365
-#: corehq/apps/hqwebapp/models.py:1538 corehq/apps/hqwebapp/models.py:1608
+#: corehq/apps/hqwebapp/models.py:1533 corehq/apps/hqwebapp/models.py:1603
 #: corehq/apps/orgs/templates/orgs/report_base.html:26
 #: corehq/apps/reports/templates/reports/reportdata/case_details.html:68
 msgid "Reports"
@@ -78,7 +78,7 @@ msgstr ""
 msgid "Edit Data"
 msgstr ""
 
-#: corehq/__init__.py:198 corehq/privileges.py:71
+#: corehq/__init__.py:198 corehq/privileges.py:76
 #: corehq/apps/accounting/user_text.py:219 corehq/apps/fixtures/views.py:285
 msgid "Lookup Tables"
 msgstr ""
@@ -182,8 +182,8 @@ msgid ""
 "possible reasons for poor performance, and offer guidance towards solutions."
 msgstr ""
 
-#: corehq/feature_previews.py:128 corehq/privileges.py:88
-#: corehq/apps/hqwebapp/models.py:1140 corehq/apps/locations/views.py:75
+#: corehq/feature_previews.py:128 corehq/privileges.py:93
+#: corehq/apps/hqwebapp/models.py:1135 corehq/apps/locations/views.py:75
 #: corehq/apps/users/templates/users/edit_commcare_user.html:127
 msgid "Locations"
 msgstr ""
@@ -207,71 +207,71 @@ msgid ""
 "a>."
 msgstr ""
 
-#: corehq/privileges.py:72 corehq/apps/accounting/user_text.py:218
+#: corehq/privileges.py:77 corehq/apps/accounting/user_text.py:218
 msgid "API Access"
 msgstr ""
 
-#: corehq/privileges.py:73
+#: corehq/privileges.py:78
 msgid "Web-Based Apps (CloudCare)"
 msgstr ""
 
-#: corehq/privileges.py:74
+#: corehq/privileges.py:79
 msgid "Active Data Management"
 msgstr ""
 
-#: corehq/privileges.py:75 corehq/apps/accounting/user_text.py:221
+#: corehq/privileges.py:80 corehq/apps/accounting/user_text.py:221
 msgid "Custom Branding"
 msgstr ""
 
-#: corehq/privileges.py:76 corehq/apps/accounting/user_text.py:224
+#: corehq/privileges.py:81 corehq/apps/accounting/user_text.py:224
 msgid "Cross-Project Reports"
 msgstr ""
 
-#: corehq/privileges.py:77 corehq/apps/accounting/user_text.py:236
+#: corehq/privileges.py:82 corehq/apps/accounting/user_text.py:236
 msgid "Advanced Role-Based Access"
 msgstr ""
 
-#: corehq/privileges.py:78
+#: corehq/privileges.py:83
 msgid "Outgoing Messaging"
 msgstr ""
 
-#: corehq/privileges.py:79
+#: corehq/privileges.py:84
 msgid "Incoming Messaging"
 msgstr ""
 
-#: corehq/privileges.py:80
+#: corehq/privileges.py:85
 msgid "Reminders Framework"
 msgstr ""
 
-#: corehq/privileges.py:81
+#: corehq/privileges.py:86
 msgid "Custom Android Gateway"
 msgstr ""
 
-#: corehq/privileges.py:82
+#: corehq/privileges.py:87
 msgid "Bulk Case Management"
 msgstr ""
 
-#: corehq/privileges.py:83
+#: corehq/privileges.py:88
 msgid "Bulk User Management"
 msgstr ""
 
-#: corehq/privileges.py:84
+#: corehq/privileges.py:89
 msgid "Add Mobile Workers Above Limit"
 msgstr ""
 
-#: corehq/privileges.py:85
+#: corehq/privileges.py:90
 msgid "De-Identified Data"
 msgstr ""
 
-#: corehq/privileges.py:86 corehq/apps/accounting/user_text.py:238
+#: corehq/privileges.py:91 corehq/apps/accounting/user_text.py:238
 msgid "HIPAA Compliance Assurance"
 msgstr ""
 
-#: corehq/privileges.py:87
+#: corehq/privileges.py:92
 msgid "Custom CommCare Logo Uploader"
 msgstr ""
 
-#: corehq/privileges.py:89
+#: corehq/privileges.py:94
 #, fuzzy
 msgid "User Configurable Report Builder"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
@@ -382,6 +382,7 @@ msgstr "Criança com problemas de malnutrição"
 
 #: corehq/apps/accounting/filters.py:140 corehq/apps/accounting/forms.py:346
 #: corehq/apps/accounting/forms.py:634 corehq/apps/commtrack/models.py:535
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:57
 #: corehq/apps/domain/templates/domain/admin/media_manager.html:24
 #: corehq/apps/export/templates/export/customize_export.html:602
 #: corehq/apps/hqadmin/reports.py:839
@@ -528,7 +529,7 @@ msgstr ""
 #: corehq/apps/accounting/templates/accounting/subscriptions_tab.html:16
 #: corehq/apps/domain/forms.py:1455
 #: corehq/apps/domain/templates/domain/current_subscription.html:247
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:74
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:83
 msgid "Software Plan"
 msgstr ""
 
@@ -638,10 +639,10 @@ msgid "A name is required for this new role."
 msgstr ""
 
 #: corehq/apps/accounting/forms.py:1428 corehq/apps/app_manager/forms.py:11
-#: corehq/apps/app_manager/models.py:1737
-#: corehq/apps/app_manager/models.py:2167
-#: corehq/apps/app_manager/models.py:2525
-#: corehq/apps/app_manager/models.py:2574 corehq/apps/commtrack/models.py:531
+#: corehq/apps/app_manager/models.py:1738
+#: corehq/apps/app_manager/models.py:2193
+#: corehq/apps/app_manager/models.py:2574
+#: corehq/apps/app_manager/models.py:2623 corehq/apps/commtrack/models.py:531
 #: corehq/apps/domain/forms.py:126
 #: corehq/apps/domain/templates/domain/admin/commtrack_action_table.html:5
 #: corehq/apps/domain/templates/domain/partials/user_list.html:9
@@ -663,7 +664,7 @@ msgstr ""
 #: corehq/apps/toggle_ui/templates/toggle/flags.html:58
 #: corehq/apps/users/templates/users/web_users.b3.html:171
 #: corehq/apps/users/templates/users/web_users.b3.html:216
-#: corehq/ex-submodules/casexml/apps/case/models.py:853
+#: corehq/ex-submodules/casexml/apps/case/models.py:858
 #: corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_hierarchy.html:57
 #: custom/bihar/reports/indicators/clientlistdisplay.py:80
 #: custom/bihar/reports/indicators/clientlistdisplay.py:98
@@ -672,13 +673,13 @@ msgstr ""
 #: custom/ewsghana/reports/specific_reports/reporting_rates.py:199
 #: custom/ewsghana/reports/specific_reports/reporting_rates.py:241
 #: custom/fri/reports/reports.py:349
-#: custom/ilsgateway/tanzania/reports/delivery.py:27
-#: custom/ilsgateway/tanzania/reports/facility_details.py:70
-#: custom/ilsgateway/tanzania/reports/facility_details.py:116
-#: custom/ilsgateway/tanzania/reports/randr.py:82
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:81
-#: custom/ilsgateway/tanzania/reports/supervision.py:56
-#: custom/ilsgateway/tanzania/reports/supervision.py:120
+#: custom/ilsgateway/tanzania/reports/delivery.py:28
+#: custom/ilsgateway/tanzania/reports/facility_details.py:71
+#: custom/ilsgateway/tanzania/reports/facility_details.py:117
+#: custom/ilsgateway/tanzania/reports/randr.py:83
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:83
+#: custom/ilsgateway/tanzania/reports/supervision.py:57
+#: custom/ilsgateway/tanzania/reports/supervision.py:122
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:37
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:184
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:249
@@ -688,7 +689,7 @@ msgid "Name"
 msgstr ""
 
 #: corehq/apps/accounting/forms.py:1432 corehq/apps/accounting/models.py:357
-#: corehq/apps/prelogin/forms.py:28
+#: corehq/apps/prelogin/forms.py:29
 msgid "Company / Organization"
 msgstr ""
 
@@ -754,13 +755,13 @@ msgstr ""
 msgid "Messages"
 msgstr ""
 
-#: corehq/apps/accounting/models.py:341 corehq/apps/prelogin/forms.py:20
-#: corehq/apps/users/forms.py:145
+#: corehq/apps/accounting/models.py:341 corehq/apps/prelogin/forms.py:21
+#: corehq/apps/users/forms.py:144
 msgid "First Name"
 msgstr ""
 
-#: corehq/apps/accounting/models.py:344 corehq/apps/prelogin/forms.py:24
-#: corehq/apps/users/forms.py:146
+#: corehq/apps/accounting/models.py:344 corehq/apps/prelogin/forms.py:25
+#: corehq/apps/users/forms.py:145
 msgid "Last Name"
 msgstr ""
 
@@ -775,7 +776,7 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/accounting/models.py:353
-#: corehq/apps/data_interfaces/views.py:322 corehq/apps/prelogin/forms.py:36
+#: corehq/apps/data_interfaces/views.py:322 corehq/apps/prelogin/forms.py:37
 #: corehq/apps/reports/standard/ivr.py:46
 #: corehq/apps/reports/standard/sms.py:280
 #: corehq/apps/reports/standard/sms.py:617
@@ -808,7 +809,7 @@ msgstr ""
 msgid "Postal Code"
 msgstr ""
 
-#: corehq/apps/accounting/models.py:378 corehq/apps/prelogin/forms.py:40
+#: corehq/apps/accounting/models.py:378 corehq/apps/prelogin/forms.py:41
 msgid "Country"
 msgstr ""
 
@@ -1000,14 +1001,14 @@ msgstr ""
 
 #: corehq/apps/accounting/user_text.py:8
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/analytics.html:22
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:41
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:52
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/mobile.html:22
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:21
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/support.html:22
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/user.html:22
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/web.html:22
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:80
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:77
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:89
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:79
 msgid "Community"
 msgstr ""
 
@@ -1019,7 +1020,7 @@ msgstr ""
 
 #: corehq/apps/accounting/user_text.py:13
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/analytics.html:27
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:46
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:57
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/mobile.html:27
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:26
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/support.html:27
@@ -1036,16 +1037,16 @@ msgstr ""
 
 #: corehq/apps/accounting/user_text.py:18
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/analytics.html:32
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:51
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:62
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/mobile.html:32
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:31
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/support.html:32
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/user.html:32
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/web.html:32
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:90
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:98
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:87
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:95
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:99
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:107
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:89
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:97
 msgid "Pro"
 msgstr ""
 
@@ -1056,20 +1057,20 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:23
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:306
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:309
 #: corehq/apps/app_manager/templates/app_manager/module_view.html:294
 #: corehq/apps/importer/templates/importer/excel_config.html:114
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/analytics.html:37
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:56
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:67
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/mobile.html:37
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:36
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/support.html:37
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/user.html:37
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/web.html:37
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:106
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:114
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:103
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:111
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:115
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:123
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:105
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:113
 msgid "Advanced"
 msgstr ""
 
@@ -1082,7 +1083,7 @@ msgstr ""
 
 #: corehq/apps/accounting/user_text.py:29
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/analytics.html:42
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:61
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:72
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/mobile.html:42
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:41
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/support.html:42
@@ -1113,7 +1114,7 @@ msgstr ""
 #: corehq/apps/accounting/user_text.py:54
 #: corehq/apps/accounting/user_text.py:201
 #: corehq/apps/accounting/user_text.py:202
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:98
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:109
 msgid "Mobile Users"
 msgstr ""
 
@@ -1183,7 +1184,7 @@ msgid "SMS (CommConnect)"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:90
-#: corehq/apps/accounting/user_text.py:91 corehq/apps/commtrack/views.py:170
+#: corehq/apps/accounting/user_text.py:91 corehq/apps/commtrack/views.py:175
 #: corehq/apps/domain/forms.py:1624
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:13
 #: corehq/apps/reminders/forms.py:98 corehq/apps/reminders/forms.py:103
@@ -1340,24 +1341,24 @@ msgid "Dedicated Enterprise Account Management"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:255
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:71
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:83
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:80
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:82
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:92
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:82
 msgid "Free"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:255
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:76
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:87
 msgid "$100 /month"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:255
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:81
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:92
 msgid "$500 /month"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:255
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:86
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:97
 msgid "$1,000 /month"
 msgstr ""
 
@@ -1368,22 +1369,22 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:256
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:102
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:113
 msgid "50"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:256
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:107
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:118
 msgid "100"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:256
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:112
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:123
 msgid "500"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:256
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:117
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:128
 msgid "1,000"
 msgstr ""
 
@@ -1393,10 +1394,10 @@ msgid "Unlimited / Discounted Pricing"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:257
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:132
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:137
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:142
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:147
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:143
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:148
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:153
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:158
 msgid "1 USD /month"
 msgstr ""
 
@@ -1493,7 +1494,7 @@ msgstr "Manejo de Casos"
 #: corehq/apps/sms/templates/sms/default.html:47
 #: corehq/apps/unicel/forms.py:10
 #: corehq/apps/unicel/templates/unicel/backend.html:10
-#: corehq/apps/userhack/admin.py:14 corehq/apps/users/forms.py:184
+#: corehq/apps/userhack/admin.py:14 corehq/apps/users/forms.py:183
 #: corehq/apps/users/templates/users/edit_web_user.html:13
 #: corehq/apps/users/templates/users/mobile/users_list.html:209
 #: corehq/apps/users/templates/users/partial/basic_info_form.html:10
@@ -1514,6 +1515,7 @@ msgstr ""
 #: corehq/apps/reports/templates/reports/partials/hqexport_group_table.html:11
 #: corehq/apps/sms/templates/sms/add_gateway.html:42
 #: corehq/apps/sms/templates/sms/partials/day_time_windows.html:12
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:14
 msgid "Action"
 msgstr ""
 
@@ -1579,6 +1581,7 @@ msgstr ""
 #: corehq/apps/hqmedia/templates/hqmedia/bulk_upload.html:55
 #: corehq/apps/indicators/templates/indicators/forms/copy_to_domain.html:66
 #: corehq/apps/locations/templates/locations/manage/location.html:195
+#: corehq/apps/locations/templates/locations/manage/locations.html:266
 #: corehq/apps/orgs/templates/orgs/orgs_landing.html:184
 #: corehq/apps/orgs/templates/orgs/orgs_landing.html:203
 #: corehq/apps/orgs/templates/orgs/orgs_landing.html:230
@@ -1834,7 +1837,7 @@ msgstr ""
 #: corehq/apps/reports/standard/monitoring.py:479
 #: corehq/apps/reports/standard/monitoring.py:623
 #: corehq/apps/reports/standard/monitoring.py:1321
-#: custom/ilsgateway/tanzania/reports/delivery.py:171
+#: custom/ilsgateway/tanzania/reports/delivery.py:174
 #: custom/m4change/reports/aggregate_facility_web_hmis_report.py:38
 #: custom/m4change/reports/all_hmis_report.py:258
 #: custom/m4change/reports/anc_hmis_report.py:117
@@ -1895,7 +1898,7 @@ msgstr ""
 
 #: corehq/apps/accounting/templates/accounting/credits_tab.html:9
 #: corehq/apps/accounting/templates/accounting/subscriptions.html:55
-#: corehq/apps/hqwebapp/models.py:1302
+#: corehq/apps/hqwebapp/models.py:1297
 msgid "Subscription"
 msgstr ""
 
@@ -1943,8 +1946,8 @@ msgstr ""
 #: corehq/apps/reports/standard/sms.py:732
 #: corehq/apps/users/templates/users/web_users.b3.html:286
 #: corehq/apps/users/templates/users/web_users.html:128
-#: custom/ilsgateway/tanzania/reports/facility_details.py:118
-#: custom/ilsgateway/tanzania/reports/supervision.py:122
+#: custom/ilsgateway/tanzania/reports/facility_details.py:119
+#: custom/ilsgateway/tanzania/reports/supervision.py:124
 #: custom/intrahealth/sqldata.py:392
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:266
 msgid "Date"
@@ -2004,9 +2007,9 @@ msgstr ""
 #: corehq/apps/reports/templates/reports/messaging/survey_detail.html:33
 #: corehq/apps/settings/templates/settings/my_projects.html:12
 #: corehq/apps/sms/views.py:1022
-#: corehq/ex-submodules/casexml/apps/case/models.py:903
+#: corehq/ex-submodules/casexml/apps/case/models.py:908
 #: custom/_legacy/pact/models.py:329
-#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:55
+#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:65
 #: custom/m4change/reports/mcct_project_review.py:274
 #: custom/m4change/reports/mcct_project_review.py:401
 #: custom/m4change/reports/mcct_project_review.py:484
@@ -2368,7 +2371,7 @@ msgstr ""
 #: corehq/apps/reports/templates/reports/standard/base_template.html:108
 #: corehq/apps/reports/templates/reports/standard/export_download.html:99
 #: corehq/apps/reports_core/templates/reports_core/base_template_new.html:150
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:118
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:122
 msgid "Generating Report..."
 msgstr ""
 
@@ -2383,8 +2386,8 @@ msgstr ""
 #: corehq/apps/reports/templates/reports/standard/base_template.html:111
 #: corehq/apps/reports_core/templates/reports_core/base_template_new.html:151
 #: corehq/apps/reports_core/templates/reports_core/base_template_new.html:152
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:119
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:120
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:123
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:124
 msgid "Apply"
 msgstr ""
 
@@ -2492,11 +2495,11 @@ msgid "Delay Invoicing Until"
 msgstr ""
 
 #: corehq/apps/accounting/templates/accounting/subscriptions_tab.html:24
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:255
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:261
-#: corehq/apps/domain/templates/domain/admin/feature_flags.html:28
-#: corehq/apps/locations/templates/locations/manage/locations.html:148
-#: corehq/apps/reports/views.py:801
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:258
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:264
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:37
+#: corehq/apps/locations/templates/locations/manage/locations.html:167
+#: corehq/apps/reports/views.py:809
 #: corehq/apps/reports/templates/reports/reports_home.html:60
 #: corehq/apps/reports/templates/reports/reports_home.html:126
 #: corehq/apps/reports/templates/reports/partials/saved_custom_exports.html:9
@@ -2780,6 +2783,7 @@ msgstr ""
 #: corehq/apps/app_manager/fields.py:45
 #: corehq/apps/app_manager/templates/app_manager/managed_app.html:266
 #: corehq/apps/app_manager/templates/app_manager/ng_partials/case_summary_view.html:109
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:56
 #: corehq/apps/hqwebapp/doc_info.py:100
 #: corehq/apps/reports/filters/forms.py:684
 #: corehq/apps/reports/standard/inspect.py:89
@@ -2827,60 +2831,56 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:749
-msgid "Form referenced as the registration form for multiple modules."
-msgstr ""
-
-#: corehq/apps/app_manager/models.py:1743
-#: corehq/apps/app_manager/models.py:2174
-#: corehq/apps/app_manager/views.py:1412
+#: corehq/apps/app_manager/models.py:1744
+#: corehq/apps/app_manager/models.py:2200
+#: corehq/apps/app_manager/views.py:1414
 msgid "Untitled Module"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:1756
-#: corehq/apps/app_manager/models.py:2200
-#: corehq/apps/app_manager/views.py:1471
+#: corehq/apps/app_manager/models.py:1757
+#: corehq/apps/app_manager/models.py:2226
+#: corehq/apps/app_manager/views.py:1473
 msgid "Untitled Form"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:1849
+#: corehq/apps/app_manager/models.py:1850
 msgid "Case tiles may only be used for the case list (not the case details)."
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:1857
+#: corehq/apps/app_manager/models.py:1858
 msgid "A case property must be assigned to the \"{}\" tile field."
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2014
+#: corehq/apps/app_manager/models.py:2040
 msgid "Case property"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2015
+#: corehq/apps/app_manager/models.py:2041
 msgid "Lookup Table field"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2016
+#: corehq/apps/app_manager/models.py:2042
 msgid "custom user property"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2017
+#: corehq/apps/app_manager/models.py:2043
 msgid "custom XPath expression"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2024
+#: corehq/apps/app_manager/models.py:2050
 msgid "Case tag"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2025
+#: corehq/apps/app_manager/models.py:2051
 msgid "Lookup Table tag"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2063
+#: corehq/apps/app_manager/models.py:2089
 msgid "All forms in this module require a visit schedule."
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2186
-#: corehq/apps/app_manager/models.py:4198 corehq/apps/products/views.py:467
+#: corehq/apps/app_manager/models.py:2212
+#: corehq/apps/app_manager/models.py:4272 corehq/apps/products/views.py:467
 #: corehq/apps/products/templates/products/manage/products.html:110
 #: corehq/apps/programs/templates/programs/manage/program.html:77
 #: corehq/apps/reports/commtrack/standard.py:92
@@ -2892,9 +2892,9 @@ msgstr ""
 msgid "Product"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2521
-#: corehq/apps/app_manager/models.py:2575
-#: corehq/apps/app_manager/models.py:2637
+#: corehq/apps/app_manager/models.py:2570
+#: corehq/apps/app_manager/models.py:2624
+#: corehq/apps/app_manager/models.py:2686
 #: corehq/apps/appstore/templates/appstore/deployment_info.html:31
 #: corehq/apps/appstore/templates/appstore/project_info.html:140
 #: corehq/apps/appstore/templates/appstore/project_info.html:259
@@ -2910,72 +2910,74 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2522
-#: corehq/apps/app_manager/models.py:2570
+#: corehq/apps/app_manager/models.py:2571
+#: corehq/apps/app_manager/models.py:2619
 msgid "Followup date"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2527
-#: corehq/apps/app_manager/models.py:2580
+#: corehq/apps/app_manager/models.py:2576
+#: corehq/apps/app_manager/models.py:2629
 msgid "Close if"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2579
+#: corehq/apps/app_manager/models.py:2628
 #, fuzzy
 msgid "Latest report"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
-#: corehq/apps/app_manager/models.py:2600
+#: corehq/apps/app_manager/models.py:2649
 #: custom/_legacy/pact/templates/pact/patient/pactpatient_base.html:33
 #: custom/_legacy/pact/templates/pact/patient/pactpatient_submissions.html:31
 msgid "Care Plan"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2621
+#: corehq/apps/app_manager/models.py:2670
 #: corehq/apps/reports/standard/cases/careplan.py:124
 #: custom/_legacy/pact/models.py:357
 msgid "Goal"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2621
+#: corehq/apps/app_manager/models.py:2670
 #: corehq/apps/reports/standard/cases/careplan.py:138
 #: custom/_legacy/pact/models.py:375
 msgid "Task"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2630
+#: corehq/apps/app_manager/models.py:2679
 msgid "Followup"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2644
+#: corehq/apps/app_manager/models.py:2693
 msgid "Last update"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:3394
+#: corehq/apps/app_manager/models.py:3468
 msgid ""
 "Usage of lookup tables is not supported by your current subscription. Please "
 "upgrade your subscription before using this feature."
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:4171
+#: corehq/apps/app_manager/models.py:4245
 #, python-brace-format
 msgid "Copy of {name}"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:4408
+#: corehq/apps/app_manager/models.py:4482
 msgid "Error in case type hierarchy"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:4498
+#: corehq/apps/app_manager/models.py:4572
 msgid ""
 "Problem loading suite file from profile file. Is your profile file correct?"
 msgstr ""
 
-#: corehq/apps/app_manager/translations.py:46
-msgid "App Translation Failed! "
+#: corehq/apps/app_manager/translations.py:48
+msgid ""
+"App Translation Failed! Please make sure you are using a valid Excel 2007 or "
+"later (.xlsx) file. Error details: {}."
 msgstr ""
 
-#: corehq/apps/app_manager/translations.py:149
+#: corehq/apps/app_manager/translations.py:154
 msgid "App Translations Updated!"
 msgstr ""
 
@@ -2987,142 +2989,142 @@ msgstr ""
 msgid "You must submit the source data."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:526
+#: corehq/apps/app_manager/views.py:527
 #, fuzzy
 msgid "All Programs"
 msgstr "Diagnóstico de Casos"
 
-#: corehq/apps/app_manager/views.py:596
+#: corehq/apps/app_manager/views.py:597
 msgid "U​I translation"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:597
+#: corehq/apps/app_manager/views.py:598
 msgid "U​I translations"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:604
+#: corehq/apps/app_manager/views.py:605
 #, fuzzy
 msgid "app translation"
 msgstr "Criança com problemas de malnutrição"
 
-#: corehq/apps/app_manager/views.py:605
+#: corehq/apps/app_manager/views.py:606
 #, fuzzy
 msgid "app translations"
 msgstr "Criança com problemas de malnutrição"
 
-#: corehq/apps/app_manager/views.py:821
+#: corehq/apps/app_manager/views.py:822
 msgid "Don't Show"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:828
+#: corehq/apps/app_manager/views.py:829
 #: corehq/apps/reports/standard/cases/basic.py:211
 #: corehq/apps/reports/templates/reports/reportdata/case_details.html:71
 msgid "Case List"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:829
+#: corehq/apps/app_manager/views.py:830
 msgid "Case Detail"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:848
+#: corehq/apps/app_manager/views.py:849
 msgid "Product List"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:849
+#: corehq/apps/app_manager/views.py:850
 msgid "Product Detail"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:871
+#: corehq/apps/app_manager/views.py:872
 msgid "Goal List"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:872
+#: corehq/apps/app_manager/views.py:873
 msgid "Goal Detail"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:882
+#: corehq/apps/app_manager/views.py:883
 msgid "Task List"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:883
+#: corehq/apps/app_manager/views.py:884
 #, fuzzy
 msgid "Task Detail"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
-#: corehq/apps/app_manager/views.py:921
+#: corehq/apps/app_manager/views.py:923
 msgid ""
 "Your app contains references to reports that are deleted. These will be "
 "removed on save."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:1243
+#: corehq/apps/app_manager/views.py:1245
 msgid ""
 "You tried to edit this form in the Form Builder. However, your administrator "
 "has locked this form against editing in the form builder, so we have "
 "redirected you to the form's front page instead."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:1409
+#: corehq/apps/app_manager/views.py:1411
 msgid "Untitled Application"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:1458
+#: corehq/apps/app_manager/views.py:1460
 #, python-brace-format
 msgid "Please set the case type for the target module '{name}'."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:1464
+#: corehq/apps/app_manager/views.py:1466
 msgid "Caution: Care Plan modules are a labs feature"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:1476
+#: corehq/apps/app_manager/views.py:1478
 msgid "Caution: Advanced modules are a labs feature"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:1592
+#: corehq/apps/app_manager/views.py:1594
 msgid ""
 "We could not copy this form, because it is blank.In order to copy this form, "
 "please add some questions first."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:1596
+#: corehq/apps/app_manager/views.py:1598
 msgid ""
 "This form could not be copied because it is not compatible with the selected "
 "module."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:1765
+#: corehq/apps/app_manager/views.py:1767
 msgid "Unknown Module"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:2468
+#: corehq/apps/app_manager/views.py:2470
 msgid "The form can not be moved into the desired module."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:2473
+#: corehq/apps/app_manager/views.py:2475
 msgid ""
 "Oops. Looks like you got out of sync with us. The sidebar has been updated, "
 "so please try again."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:2628
+#: corehq/apps/app_manager/views.py:2630
 msgid ""
 "We were unable to get your files because your Application has errors. Please "
 "click <strong>Make New Version</strong> under <strong>Deploy</strong> for "
 "feedback on how to fix these errors."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:2658
+#: corehq/apps/app_manager/views.py:2660
 msgid ""
 "We were unable to get your files because your Application has errors. Please "
 "click Make New Version under Deploy for feedback on how to fix these errors."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:3022
+#: corehq/apps/app_manager/views.py:3024
 msgid "Summary"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:3060
+#: corehq/apps/app_manager/views.py:3062
 #: corehq/apps/app_manager/templates/app_manager/app_view.html:257
 #: corehq/apps/app_manager/templates/app_manager/apps_base.html:9
 #: corehq/apps/app_manager/templates/app_manager/apps_base.html:14
@@ -3133,23 +3135,23 @@ msgstr ""
 msgid "Applications"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:3211
+#: corehq/apps/app_manager/views.py:3213
 msgid "We found problem with following translations:"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:3222
+#: corehq/apps/app_manager/views.py:3224
 msgid "Something went wrong! Update failed. We're looking into it"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:3225
+#: corehq/apps/app_manager/views.py:3227
 msgid "UI Translations Updated!"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:3271
+#: corehq/apps/app_manager/views.py:3273
 msgid "Please upgrade you app to > 2.0 in order to add a Careplan module"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:3282
+#: corehq/apps/app_manager/views.py:3284
 msgid "This application already has a Careplan module"
 msgstr ""
 
@@ -3157,33 +3159,33 @@ msgstr ""
 msgid "Error parsing XML: {}"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:204
+#: corehq/apps/app_manager/xform.py:205
 #, python-brace-format
 msgid "Group already has node for lang: {0}"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:673
+#: corehq/apps/app_manager/xform.py:679
 msgid "There's no language called '{}'"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:675
+#: corehq/apps/app_manager/xform.py:681
 msgid "There's already a language called '{}'"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:720
+#: corehq/apps/app_manager/xform.py:726
 #, python-brace-format
 msgid "<translation lang=\"{lang}\"><text id=\"{id}\"> node has no <value>"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:827
+#: corehq/apps/app_manager/xform.py:833
 msgid "<item> ({}) has no <value>"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:948
+#: corehq/apps/app_manager/xform.py:954
 msgid "Node <{}> has no 'ref' or 'bind'"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:1122 corehq/apps/app_manager/xform.py:1379
+#: corehq/apps/app_manager/xform.py:1128 corehq/apps/app_manager/xform.py:1385
 msgid ""
 "Couldn't get the case XML from one of your forms. A common reason for this "
 "is if you don't have the xforms namespace defined in your form. Please "
@@ -3191,23 +3193,23 @@ msgid ""
 "your form."
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:1371
+#: corehq/apps/app_manager/xform.py:1377
 msgid ""
 "You cannot use the Case Management UI if you already have a case block in "
 "your form."
 msgstr ""
 
-#: corehq/apps/app_manager/xpath.py:205
+#: corehq/apps/app_manager/xpath.py:208
 #, python-brace-format
 msgid "Type {type} must be in list of domain types: {list}"
 msgstr ""
 
-#: corehq/apps/app_manager/xpath.py:213
+#: corehq/apps/app_manager/xpath.py:216
 #, python-brace-format
 msgid "Reference type {ref} cannot be a child of primary type {main}."
 msgstr ""
 
-#: corehq/apps/app_manager/xpath.py:226
+#: corehq/apps/app_manager/xpath.py:229
 msgid ""
 "Property not correctly formatted. Must be formatted like: loacation:mytype:"
 "referencetype/property. For example: location:outlet:state/name"
@@ -3259,49 +3261,49 @@ msgstr ""
 msgid "No thanks, get me out of here"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:177
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:180
 msgid "Home Screen"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:178
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:181
 msgid "Module Menu"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:179
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:182
 msgid "Module:"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:180
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:183
 msgid "Previous Screen"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:189
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:192
 msgid "Link to other form"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:239
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:242
 msgid "Delete Form"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:259
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:262
 msgid ""
 "Your administrator has locked this form from edits through the form builder"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:268
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:271
 msgid "Try in CloudCare"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:277
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:280
 msgid "User Registration Properties"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:284
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:287
 #: corehq/apps/app_manager/templates/app_manager/managed_app.html:162
 #: corehq/apps/app_manager/templates/app_manager/module_view.html:189
 #: corehq/apps/dashboard/views.py:217
 #: corehq/apps/grapevine/templates/grapevine/backend.html:5
-#: corehq/apps/hqwebapp/models.py:952 corehq/apps/hqwebapp/models.py:1630
+#: corehq/apps/hqwebapp/models.py:952 corehq/apps/hqwebapp/models.py:1625
 #: corehq/apps/mach/templates/mach/backend.html:5
 #: corehq/apps/megamobile/templates/megamobile/backend.html:5
 #: corehq/apps/sms/templates/sms/http_backend.html:33
@@ -3312,63 +3314,63 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:288
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:332
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:334
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:291
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:335
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:337
 #: corehq/apps/app_manager/templates/app_manager/module_view.html:190
 msgid "Case Management"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:294
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:358
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:360
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:297
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:361
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:363
 msgid "User Case Management"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:301
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:304
 msgid "Visit Scheduler"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:317
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:354
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:320
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:357
 msgid ""
 "There are errors in your form. Fix your form in order to view and edit Case "
 "Management."
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:322
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:324
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:325
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:327
 msgid "Cases and Referrals"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:325
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:335
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:328
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:338
 msgid ""
 "Cases give you a way to track patients, farms, etc. over time.  You can "
 "choose to save data from a form to the case, which will store the data "
 "locally on the phone to use later."
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:346
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:349
 #: corehq/apps/app_manager/templates/app_manager/partials/form_tab_visit_scheduler.html:97
 msgid ""
 "You have not created a form yet. Create a form in order to view and edit "
 "Case Management."
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:361
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:364
 msgid ""
 "The user case allows you to store data about the user in a case and use that "
 "data in forms."
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:371
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:374
 msgid ""
 "You have not created a form yet. Create a form in order to view and edit "
 "User Case Management."
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:396
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:399
 #: corehq/apps/app_manager/templates/app_manager/managed_app.html:213
 #: corehq/apps/reports/templates/reports/partials/form_name.html:5
 msgid "User Registration"
@@ -3524,7 +3526,7 @@ msgstr "Manejo de Casos"
 #: corehq/apps/app_manager/templates/app_manager/module_view.html:254
 #: corehq/apps/domain/views.py:340
 #: corehq/apps/locations/templates/locations/manage/location.html:84
-#: corehq/apps/users/forms.py:211
+#: corehq/apps/users/forms.py:210
 #: corehq/apps/users/templates/users/edit_commcare_user.html:122
 msgid "Basic"
 msgstr ""
@@ -3536,7 +3538,7 @@ msgstr ""
 #: corehq/apps/reports/filters/select.py:108
 #: corehq/apps/reports/standard/cases/basic.py:270
 #: corehq/apps/reports/templates/reports/reportdata/case_export_data.html:125
-#: corehq/ex-submodules/casexml/apps/case/models.py:877
+#: corehq/ex-submodules/casexml/apps/case/models.py:882
 msgid "Case Type"
 msgstr ""
 
@@ -3587,7 +3589,33 @@ msgstr ""
 msgid "Display"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:65
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:63
+#, fuzzy
+msgid "Chart Title"
+msgstr "Casos IRA Tratados"
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:66
+msgid "Graph type"
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:73
+#, fuzzy
+msgid "Configuration"
+msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:83
+msgid "Add Configuration Item"
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:88
+msgid "Series Configuration"
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:99
+msgid "Add Series Configuration Item"
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:109
 #: corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html:130
 #: corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html:174
 #: corehq/apps/data_interfaces/templates/data_interfaces/list_case_groups.html:21
@@ -3626,7 +3654,7 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:76
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:120
 #, fuzzy
 msgid "Add Report"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
@@ -3936,7 +3964,6 @@ msgstr ""
 #: custom/ewsghana/templates/ewsghana/facility_page_print_report.html:82
 #: custom/ewsghana/templates/ewsghana/reporting_rates_print_report.html:85
 #: custom/ewsghana/templates/ewsghana/stock_status_print_report.html:78
-#: custom/opm/templates/opm/hsr_print.html:57
 #: custom/opm/templates/opm/met_print_report.html:88
 #: custom/opm/templates/opm/new_hsr_print.html:65
 msgid "Loading ..."
@@ -4827,7 +4854,7 @@ msgstr ""
 #: corehq/apps/appstore/templates/appstore/appstore_base.html:278
 #: corehq/apps/reports/standard/monitoring.py:773
 #: corehq/apps/reports/templates/reports/reports_home.html:132
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:272
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:273
 #: corehq/apps/reports/templates/reports/messaging/survey_detail.html:40
 #: corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_hierarchy.html:118
 #: submodules/ctable-src/ctable_view/templates/ctable/list_mappings.html:115
@@ -4845,7 +4872,7 @@ msgstr ""
 
 #: corehq/apps/app_manager/templates/app_manager/partials/form_tab_advanced.html:51
 #: corehq/apps/cloudcare/templates/cloudcare/cloudcare_home.html:50
-#: corehq/apps/hqwebapp/views.py:715
+#: corehq/apps/hqwebapp/views.py:717
 msgid "Loading..."
 msgstr ""
 
@@ -5060,10 +5087,10 @@ msgstr ""
 #: corehq/apps/export/templates/export/dialogs/delete_custom_export_dialog.html:13
 #: corehq/apps/hqadmin/templates/hqadmin/partials/reset-pillow-checkpoint-modal.html:18
 #: corehq/apps/hqmedia/templates/hqmedia/partials/multimedia_uploader.html:34
-#: corehq/apps/prelogin/templates/prelogin/base.html:126
-#: corehq/apps/prelogin/templates/prelogin/base.html:143
-#: corehq/apps/prelogin/templates/prelogin/base.html:174
-#: corehq/apps/prelogin/templates/prelogin/base.html:213
+#: corehq/apps/prelogin/templates/prelogin/base.html:129
+#: corehq/apps/prelogin/templates/prelogin/base.html:146
+#: corehq/apps/prelogin/templates/prelogin/base.html:177
+#: corehq/apps/prelogin/templates/prelogin/base.html:216
 #: corehq/apps/registration/templates/registration/org_request.html:70
 #: corehq/apps/registration/templates/registration/partials/eula_modal.html:11
 #: corehq/apps/reports/templates/reports/partials/export_download_modal.html:15
@@ -5137,7 +5164,7 @@ msgstr ""
 #: corehq/apps/appstore/views.py:28
 #: corehq/apps/appstore/templates/appstore/project_info.html:148
 #: corehq/apps/reports/filters/select.py:43
-#: custom/ilsgateway/tanzania/reports/delivery.py:153
+#: custom/ilsgateway/tanzania/reports/delivery.py:156
 msgid "Category"
 msgstr ""
 
@@ -5183,8 +5210,8 @@ msgid "You must specify a name for the new project"
 msgstr ""
 
 #: corehq/apps/appstore/templates/appstore/appstore_base.html:7
-#: corehq/apps/domain/views.py:1636 corehq/apps/hqwebapp/models.py:1208
-#: corehq/apps/hqwebapp/models.py:1584
+#: corehq/apps/domain/views.py:1636 corehq/apps/hqwebapp/models.py:1203
+#: corehq/apps/hqwebapp/models.py:1579
 #: corehq/apps/style/templates/style/bootstrap2/partials/domain_list_dropdown.html:19
 #: corehq/apps/style/templates/style/bootstrap3/partials/domain_list_dropdown.html:34
 msgid "CommCare Exchange"
@@ -5249,7 +5276,7 @@ msgstr ""
 #: corehq/apps/export/forms.py:76 corehq/apps/export/forms.py:133
 #: corehq/apps/hqwebapp/templates/hqwebapp/partials/pagination.html:36
 #: corehq/apps/reports/templates/reports/filters/drilldown_options.html:24
-#: corehq/apps/userreports/reports/builder/forms.py:356
+#: corehq/apps/userreports/reports/builder/forms.py:357
 msgid "Next"
 msgstr ""
 
@@ -5313,7 +5340,7 @@ msgstr ""
 #: corehq/apps/appstore/templates/appstore/project_info.html:198
 #: corehq/apps/settings/templates/settings/my_projects.html:11
 #: corehq/apps/sms/templates/sms/list_backends.html:76
-#: corehq/apps/users/views/__init__.py:688
+#: corehq/apps/users/views/__init__.py:646
 msgid "Project"
 msgstr ""
 
@@ -5456,6 +5483,8 @@ msgstr ""
 #: corehq/apps/reminders/templates/reminders/partial/complex_message_table.html:18
 #: corehq/apps/reminders/templates/reminders/partial/complex_message_table.html:21
 #: corehq/apps/sms/templates/sms/default.html:50
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:12
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:17
 msgid "Time"
 msgstr ""
 
@@ -5469,11 +5498,11 @@ msgid ""
 "That app is no longer valid. Try using the navigation links to select an app."
 msgstr ""
 
-#: corehq/apps/cloudcare/views.py:313
+#: corehq/apps/cloudcare/views.py:312
 msgid "Something went wrong filtering your cases."
 msgstr ""
 
-#: corehq/apps/cloudcare/views.py:489 corehq/apps/hqwebapp/models.py:1045
+#: corehq/apps/cloudcare/views.py:488 corehq/apps/hqwebapp/models.py:1045
 msgid "CloudCare Permissions"
 msgstr ""
 
@@ -5725,7 +5754,7 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/commtrack/forms.py:66 corehq/apps/commtrack/forms.py:71
-#: corehq/apps/commtrack/views.py:231
+#: corehq/apps/commtrack/views.py:236
 msgid "Stock Levels"
 msgstr ""
 
@@ -5769,8 +5798,8 @@ msgid "Location Type"
 msgstr ""
 
 #: corehq/apps/commtrack/models.py:539
-#: custom/ilsgateway/tanzania/reports/delivery.py:81
-#: custom/ilsgateway/tanzania/reports/randr.py:170
+#: custom/ilsgateway/tanzania/reports/delivery.py:83
+#: custom/ilsgateway/tanzania/reports/randr.py:172
 msgid "Code"
 msgstr ""
 
@@ -5790,11 +5819,11 @@ msgstr "Casos IRA Tratados"
 msgid "Location"
 msgstr ""
 
-#: corehq/apps/commtrack/processing.py:159
+#: corehq/apps/commtrack/processing.py:160
 msgid "Product IDs must be set for all ledger updates!"
 msgstr ""
 
-#: corehq/apps/commtrack/processing.py:174
+#: corehq/apps/commtrack/processing.py:175
 msgid "Ledger transaction references invalid Case ID \"{}\""
 msgstr ""
 
@@ -5818,33 +5847,33 @@ msgstr ""
 msgid "uncategorized"
 msgstr ""
 
-#: corehq/apps/commtrack/views.py:36 corehq/apps/hqwebapp/models.py:425
+#: corehq/apps/commtrack/views.py:41 corehq/apps/hqwebapp/models.py:425
 msgid "Setup"
 msgstr ""
 
-#: corehq/apps/commtrack/views.py:49
+#: corehq/apps/commtrack/views.py:54
 msgid "Advanced Settings"
 msgstr ""
 
-#: corehq/apps/commtrack/views.py:132
+#: corehq/apps/commtrack/views.py:137
 msgid ""
 "Settings updated! Your updated consumption settings may take a few minutes "
 "to show up in reports and on phones."
 msgstr ""
 
-#: corehq/apps/commtrack/views.py:135
+#: corehq/apps/commtrack/views.py:140
 msgid "Settings updated!"
 msgstr ""
 
-#: corehq/apps/commtrack/views.py:143 custom/intrahealth/sqldata.py:484
+#: corehq/apps/commtrack/views.py:148 custom/intrahealth/sqldata.py:484
 msgid "Consumption"
 msgstr ""
 
-#: corehq/apps/commtrack/views.py:161
+#: corehq/apps/commtrack/views.py:166
 msgid "Default consumption values updated"
 msgstr ""
 
-#: corehq/apps/commtrack/views.py:291
+#: corehq/apps/commtrack/views.py:296
 #, fuzzy
 msgid "Rebuild Stock State"
 msgstr "Manejo de Casos"
@@ -5867,6 +5896,79 @@ msgstr ""
 
 #: corehq/apps/commtrack/templates/commtrack/manage/default_consumption.html:24
 msgid "Update Default Consumption Info"
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:8
+#, python-format
+msgid ""
+"\n"
+"    <strong>Warning:</strong>\n"
+"    You have more than %(stock_state_limit)s stocks in your project space.\n"
+"    Only %(stock_state_limit)s are shown.\n"
+"    "
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:18
+#, python-format
+msgid ""
+"\n"
+"    <strong>Warning:</strong>\n"
+"    You have more than %(stock_transaction_limit)s stock transactions in "
+"your project space.\n"
+"    Only %(stock_transaction_limit)s are shown.\n"
+"    "
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:33
+#, python-format
+msgid ""
+"\n"
+"                <strong>%(case_display)s</strong>\n"
+"                %(section_display)s\n"
+"                for <em>%(product_name)s</em>\n"
+"                "
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:43
+#, fuzzy
+msgid "Rebuild"
+msgstr "Manejo de Casos"
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:50
+#, fuzzy
+msgid "Current Values"
+msgstr "Manejo de Casos"
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:51
+#, fuzzy
+msgid "Rebuilt Values"
+msgstr "Manejo de Casos"
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:54
+#, fuzzy
+msgid "Server Date"
+msgstr "Casos IRA Tratados"
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:55
+#, fuzzy
+msgid "Self-reported Date"
+msgstr "Manejo de Casos"
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:58
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:60
+msgid "Quantity"
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:59
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:61
+#: corehq/apps/reports/commtrack/standard.py:297
+#: custom/ilsgateway/tanzania/reports/facility_details.py:27
+#, fuzzy
+msgid "Stock on Hand"
+msgstr "Balanço do Stock"
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:92
+msgid "(will be deleted)"
 msgstr ""
 
 #: corehq/apps/commtrack/templates/commtrack/manage/stock_levels.html:7
@@ -6075,7 +6177,7 @@ msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 #: corehq/apps/data_interfaces/interfaces.py:22
 #: corehq/apps/data_interfaces/views.py:58 corehq/apps/hqwebapp/models.py:553
 #: corehq/apps/settings/views.py:213
-#: corehq/apps/userreports/reports/builder/forms.py:350
+#: corehq/apps/userreports/reports/builder/forms.py:351
 msgid "Data"
 msgstr ""
 
@@ -6102,7 +6204,7 @@ msgstr ""
 
 #: corehq/apps/dashboard/views.py:206
 #: corehq/apps/dashboard/templates/dashboard/dashboard_new_user.html:73
-#: corehq/apps/hqwebapp/models.py:1576
+#: corehq/apps/hqwebapp/models.py:1571
 msgid "Exchange"
 msgstr ""
 
@@ -6165,6 +6267,7 @@ msgid "Welcome to CommCare Supply"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
 #: corehq/apps/dashboard/templates/dashboard/dashboard_new_user.html:64
+#: docs/_build/html/_sources/translations.txt:132
 msgid "Welcome to CommCare HQ"
 msgstr ""
 
@@ -6223,7 +6326,7 @@ msgstr ""
 #: corehq/apps/data_interfaces/interfaces.py:50
 #: corehq/apps/reports/standard/cases/basic.py:272
 #: corehq/apps/sms/templates/sms/list_backends.html:63
-#: corehq/ex-submodules/casexml/apps/case/models.py:887
+#: corehq/ex-submodules/casexml/apps/case/models.py:892
 msgid "Owner"
 msgstr ""
 
@@ -6703,7 +6806,7 @@ msgstr ""
 msgid "New owner's CommCare username"
 msgstr ""
 
-#: corehq/apps/domain/forms.py:362 corehq/apps/domain/views.py:2464
+#: corehq/apps/domain/forms.py:362 corehq/apps/domain/views.py:2465
 #, fuzzy
 msgid "Transfer Project"
 msgstr " Total transferidos no mês"
@@ -6814,7 +6917,7 @@ msgid "Secure submissions"
 msgstr ""
 
 #: corehq/apps/domain/forms.py:633 corehq/apps/hqadmin/reports.py:696
-#: corehq/apps/prelogin/templates/prelogin/base.html:81
+#: corehq/apps/prelogin/templates/prelogin/base.html:84
 msgid "Services"
 msgstr ""
 
@@ -6847,7 +6950,7 @@ msgstr " Total transferidos no mês"
 
 #: corehq/apps/domain/forms.py:652
 #: corehq/apps/reports/standard/deployments.py:43
-#: corehq/apps/reports/standard/deployments.py:215
+#: corehq/apps/reports/standard/deployments.py:226
 #: corehq/apps/reports/standard/sms.py:164
 #: corehq/apps/reports/standard/sms.py:415
 #: corehq/apps/reports/standard/sms.py:474
@@ -6948,7 +7051,7 @@ msgstr ""
 #: corehq/apps/domain/forms.py:978 corehq/apps/domain/forms.py:1075
 #: corehq/apps/reminders/forms.py:517 corehq/apps/reminders/forms.py:2152
 #: corehq/apps/styleguide/examples/simple_crispy_form/forms.py:63
-#: corehq/apps/users/forms.py:487
+#: corehq/apps/users/forms.py:486
 msgid "Basic Information"
 msgstr ""
 
@@ -6974,7 +7077,7 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/domain/forms.py:922 corehq/apps/domain/forms.py:986
-#: corehq/apps/domain/forms.py:1083 corehq/apps/users/forms.py:495
+#: corehq/apps/domain/forms.py:1083 corehq/apps/users/forms.py:494
 msgid "Mailing Address"
 msgstr ""
 
@@ -7162,15 +7265,15 @@ msgstr "Criança com problemas de malnutrição"
 msgid "Subscription Type"
 msgstr "Criança com problemas de malnutrição"
 
-#: corehq/apps/domain/models.py:1295
+#: corehq/apps/domain/models.py:1279
 msgid "Transfer domain request is no longer active"
 msgstr ""
 
-#: corehq/apps/domain/models.py:1327 corehq/apps/domain/models.py:1342
+#: corehq/apps/domain/models.py:1311 corehq/apps/domain/models.py:1326
 msgid "Transfer of ownership for CommCare project space."
 msgstr ""
 
-#: corehq/apps/domain/models.py:1368
+#: corehq/apps/domain/models.py:1352
 #, python-brace-format
 msgid "There has been a transfer of ownership of {domain}"
 msgstr ""
@@ -7202,7 +7305,7 @@ msgstr ""
 msgid "Sorry, you do not have access to %(feature_name)s"
 msgstr ""
 
-#: corehq/apps/domain/views.py:267 corehq/apps/hqwebapp/models.py:1146
+#: corehq/apps/domain/views.py:267 corehq/apps/hqwebapp/models.py:1141
 #: corehq/apps/hqwebapp/templates/hqwebapp/partials/global_navigation_bar.html:91
 #: corehq/apps/ota/views.py:121
 #: corehq/apps/style/templates/style/bootstrap3/partials/domain_list_dropdown.html:6
@@ -7347,9 +7450,7 @@ msgstr ""
 msgid "Privacy and Security"
 msgstr ""
 
-#: corehq/apps/domain/views.py:1329 corehq/apps/prelogin/forms.py:96
-#: corehq/apps/prelogin/templates/prelogin/base.html:128
-#: corehq/apps/prelogin/templates/prelogin/_sections/home/about_dimagi.html:42
+#: corehq/apps/domain/views.py:1329 corehq/apps/prelogin/forms.py:97
 msgid "Contact Dimagi"
 msgstr ""
 
@@ -7373,7 +7474,7 @@ msgstr ""
 
 #: corehq/apps/domain/views.py:1437
 #: corehq/apps/domain/templates/domain/confirm_subscription_renewal.html:43
-#: corehq/apps/users/forms.py:513
+#: corehq/apps/users/forms.py:512
 #: corehq/apps/users/templates/users/mobile/users_list.html:115
 #: corehq/apps/users/views/mobile/users.py:461
 msgid "Confirm Billing Information"
@@ -7450,7 +7551,7 @@ msgstr ""
 msgid "Created a new version of your app."
 msgstr ""
 
-#: corehq/apps/domain/views.py:1932 corehq/apps/hqwebapp/models.py:1212
+#: corehq/apps/domain/views.py:1932 corehq/apps/hqwebapp/models.py:1207
 msgid "Multimedia Sharing"
 msgstr ""
 
@@ -7481,7 +7582,7 @@ msgstr ""
 msgid "App Schema Changes"
 msgstr ""
 
-#: corehq/apps/domain/views.py:1987 corehq/apps/hqwebapp/models.py:1226
+#: corehq/apps/domain/views.py:1987 corehq/apps/hqwebapp/models.py:1221
 msgid "Data Forwarding"
 msgstr ""
 
@@ -7494,7 +7595,7 @@ msgstr ""
 msgid "Forwarding set up to %s"
 msgstr ""
 
-#: corehq/apps/domain/views.py:2152 corehq/apps/hqwebapp/models.py:1203
+#: corehq/apps/domain/views.py:2152 corehq/apps/hqwebapp/models.py:1198
 msgid "Project Information"
 msgstr ""
 
@@ -7517,28 +7618,28 @@ msgstr ""
 msgid "Feature Previews"
 msgstr ""
 
-#: corehq/apps/domain/views.py:2439 corehq/apps/hqwebapp/models.py:1510
-#: corehq/apps/hqwebapp/models.py:1534 corehq/apps/hqwebapp/models.py:1562
+#: corehq/apps/domain/views.py:2439 corehq/apps/hqwebapp/models.py:1505
+#: corehq/apps/hqwebapp/models.py:1529 corehq/apps/hqwebapp/models.py:1557
 #: corehq/apps/toggle_ui/templates/toggle/flags.html:6
 msgid "Feature Flags"
 msgstr ""
 
-#: corehq/apps/domain/views.py:2488
+#: corehq/apps/domain/views.py:2489
 #, python-brace-format
 msgid "Resent transfer request for project '{domain}'"
 msgstr ""
 
-#: corehq/apps/domain/views.py:2558
+#: corehq/apps/domain/views.py:2559
 #, python-brace-format
 msgid "Successfully transferred ownership of project '{domain}'"
 msgstr ""
 
-#: corehq/apps/domain/views.py:2590
+#: corehq/apps/domain/views.py:2591
 #, python-brace-format
 msgid "Declined ownership of project '{domain}'"
 msgstr ""
 
-#: corehq/apps/domain/views.py:2606 corehq/apps/domain/views.py:2626
+#: corehq/apps/domain/views.py:2607 corehq/apps/domain/views.py:2627
 msgid "SMS Rate Calculator"
 msgstr ""
 
@@ -7933,7 +8034,7 @@ msgid "Usage Summary"
 msgstr ""
 
 #: corehq/apps/domain/templates/domain/current_subscription.html:210
-#: corehq/apps/domain/templates/domain/admin/feature_flags.html:26
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:34
 msgid "Feature"
 msgstr ""
 
@@ -8256,35 +8357,38 @@ msgstr ""
 msgid "Add a forwarding location"
 msgstr ""
 
-#: corehq/apps/domain/templates/domain/admin/feature_flags.html:8
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:16
 #, python-format
 msgid ""
 "\n"
-"                    Feature Flags are superuser-only things that can be turn "
-"on features for individual users or projects.\n"
-"                    They can be edited manually at the <a href="
-"\"%(toggle_url)s\">Feature Flag edit UI</a> (also super-only).\n"
+"                    Feature Flags turn on features for individual users or "
+"projects. They are editable only by\n"
+"                    super users, in the <a href=\"%(toggle_url)s\">Feature "
+"Flag edit UI</a>.\n"
 "                    In addition, some feature flags are randomly enabled by "
-"a domain.\n"
-"                "
-msgstr ""
-
-#: corehq/apps/domain/templates/domain/admin/feature_flags.html:15
-msgid ""
-"\n"
-"                    You can see a list of all enabled flags for this domain "
-"here.\n"
-"                    This does not include any flags set for users within the "
 "domain.\n"
 "                "
 msgstr ""
 
-#: corehq/apps/domain/templates/domain/admin/feature_flags.html:27
-#: corehq/apps/toggle_ui/templates/toggle/edit_flag.html:165
-msgid "Enabled?"
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:23
+msgid ""
+"\n"
+"                    Following are all flags enabled for this domain and/or "
+"for you.\n"
+"                    This does not include any flags set for other users in "
+"this domain.\n"
+"                "
 msgstr ""
 
 #: corehq/apps/domain/templates/domain/admin/feature_flags.html:35
+msgid "Enabled for domain?"
+msgstr ""
+
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:36
+msgid "Enabled for me?"
+msgstr ""
+
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:45
 msgid "change"
 msgstr ""
 
@@ -8337,7 +8441,7 @@ msgid "SMS Pricing"
 msgstr ""
 
 #: corehq/apps/domain/templates/domain/admin/global_sms_rates.html:35
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:67
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:78
 msgid "Pricing"
 msgstr ""
 
@@ -8822,8 +8926,8 @@ msgstr ""
 #: corehq/apps/users/templates/users/web_users.b3.html:220
 #: corehq/apps/users/templates/users/web_users.b3.html:285
 #: corehq/apps/users/templates/users/web_users.html:127
-#: custom/ilsgateway/tanzania/reports/facility_details.py:71
-#: custom/ilsgateway/tanzania/reports/facility_details.py:117
+#: custom/ilsgateway/tanzania/reports/facility_details.py:72
+#: custom/ilsgateway/tanzania/reports/facility_details.py:118
 msgid "Role"
 msgstr ""
 
@@ -8899,7 +9003,7 @@ msgid "Forgot your password?"
 msgstr ""
 
 #: corehq/apps/domain/templates/login_and_password/partials/login_form.html:50
-#: corehq/apps/prelogin/templates/prelogin/base.html:74
+#: corehq/apps/prelogin/templates/prelogin/base.html:77
 #: corehq/apps/style/templates/style/bootstrap2/base.html:74
 #: corehq/apps/style/templates/style/bootstrap3/base.html:102
 msgid "Sign In"
@@ -9260,7 +9364,7 @@ msgstr ""
 #: corehq/apps/sms/forms.py:450
 #: corehq/apps/sms/templates/sms/backend_map.html:97
 #: corehq/apps/style/templates/style/bootstrap3/base.html:234
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:144
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:148
 #: corehq/apps/users/templates/users/web_users.b3.html:60
 #: custom/ewsghana/templates/ewsghana/partials/users_tables.html:102
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:212
@@ -9651,6 +9755,7 @@ msgstr ""
 
 #: corehq/apps/fixtures/templates/fixtures/manage_tables.html:66
 #: corehq/apps/fixtures/templates/fixtures/partials/edit_table_modal.html:9
+#: corehq/apps/userreports/ui/forms.py:87
 msgid "Table ID"
 msgstr ""
 
@@ -10027,7 +10132,7 @@ msgstr ""
 msgid "ADMINREPORT"
 msgstr ""
 
-#: corehq/apps/hqadmin/reports.py:642 corehq/apps/hqwebapp/models.py:1401
+#: corehq/apps/hqadmin/reports.py:642 corehq/apps/hqwebapp/models.py:1396
 msgid "Project Space List"
 msgstr ""
 
@@ -10265,7 +10370,7 @@ msgstr ""
 msgid "No Info"
 msgstr ""
 
-#: corehq/apps/hqadmin/reports.py:808 corehq/apps/hqwebapp/models.py:1403
+#: corehq/apps/hqadmin/reports.py:808 corehq/apps/hqwebapp/models.py:1398
 msgid "User List"
 msgstr ""
 
@@ -10298,7 +10403,7 @@ msgstr ""
 msgid "No Domain Data"
 msgstr ""
 
-#: corehq/apps/hqadmin/reports.py:876 corehq/apps/hqwebapp/models.py:1405
+#: corehq/apps/hqadmin/reports.py:876 corehq/apps/hqwebapp/models.py:1400
 msgid "Application List"
 msgstr ""
 
@@ -10426,7 +10531,7 @@ msgid "Print"
 msgstr ""
 
 #: corehq/apps/hqadmin/templates/hqadmin/hqadmin_base_report.html:33
-#: corehq/apps/hqwebapp/models.py:1371 corehq/apps/hqwebapp/models.py:1539
+#: corehq/apps/hqwebapp/models.py:1366 corehq/apps/hqwebapp/models.py:1534
 msgid "Admin Reports"
 msgstr ""
 
@@ -10519,12 +10624,12 @@ msgstr ""
 msgid "Audio"
 msgstr ""
 
-#: corehq/apps/hqmedia/models.py:815
+#: corehq/apps/hqmedia/models.py:818
 #, python-format
 msgid "Encountered an AttributeError for media: %s"
 msgstr ""
 
-#: corehq/apps/hqmedia/models.py:819
+#: corehq/apps/hqmedia/models.py:822
 #, python-format
 msgid ""
 "This application has unsupported text in one of it's media file label "
@@ -10568,7 +10673,7 @@ msgstr ""
 msgid "File {name}s has an incorrect file type {ext}."
 msgstr ""
 
-#: corehq/apps/hqmedia/views.py:579
+#: corehq/apps/hqmedia/views.py:575
 msgid ""
 "There was an issue retrieving the status from the cache. We are looking into "
 "it. Please try uploading again."
@@ -10948,7 +11053,7 @@ msgstr ""
 msgid "Error Type"
 msgstr ""
 
-#: corehq/apps/hqpillow_retry/views.py:41 corehq/apps/hqwebapp/models.py:1393
+#: corehq/apps/hqpillow_retry/views.py:41 corehq/apps/hqwebapp/models.py:1388
 msgid "PillowTop Errors"
 msgstr ""
 
@@ -11238,7 +11343,7 @@ msgstr ""
 msgid "New Survey"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:929 corehq/apps/hqwebapp/models.py:1490
+#: corehq/apps/hqwebapp/models.py:929 corehq/apps/hqwebapp/models.py:1485
 #: corehq/apps/sms/views.py:990
 #: corehq/apps/sms/templates/sms/add_backend.html:49
 #: corehq/apps/sms/templates/sms/add_backend.html:70
@@ -11249,11 +11354,11 @@ msgstr ""
 msgid "SMS Connectivity"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:933 corehq/apps/hqwebapp/models.py:1494
+#: corehq/apps/hqwebapp/models.py:933 corehq/apps/hqwebapp/models.py:1489
 msgid "Add Connection"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:937 corehq/apps/hqwebapp/models.py:1496
+#: corehq/apps/hqwebapp/models.py:937 corehq/apps/hqwebapp/models.py:1491
 msgid "Edit Connection"
 msgstr ""
 
@@ -11304,182 +11409,176 @@ msgstr ""
 msgid "Application Users"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1068
+#: corehq/apps/hqwebapp/models.py:1067
 msgid "Project Users"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1072
+#: corehq/apps/hqwebapp/models.py:1071
 msgid ""
 "Grant other CommCare HQ users access to your project and manage user roles."
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1075
+#: corehq/apps/hqwebapp/models.py:1074
 #: corehq/apps/users/templates/users/web_users.b3.html:136
 msgid "Invite Web User"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1083 corehq/apps/settings/views.py:93
-#: corehq/apps/settings/templates/settings/edit_my_account.b2.html:33
-#: corehq/apps/users/views/__init__.py:350
-msgid "My Information"
-msgstr ""
-
-#: corehq/apps/hqwebapp/models.py:1219
+#: corehq/apps/hqwebapp/models.py:1214
 msgid "Forward Forms"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1221
+#: corehq/apps/hqwebapp/models.py:1216
 msgid "Forward Form Stubs"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1223
+#: corehq/apps/hqwebapp/models.py:1218
 msgid "Forward Cases"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1250
+#: corehq/apps/hqwebapp/models.py:1245
 msgid "Project Administration"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1296
+#: corehq/apps/hqwebapp/models.py:1291
 msgid "Internal Subscription Management (Dimagi Only)"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1313
+#: corehq/apps/hqwebapp/models.py:1308
 msgid "Project Tools"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1334
+#: corehq/apps/hqwebapp/models.py:1329
 msgid "Internal Data (Dimagi Only)"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1340
+#: corehq/apps/hqwebapp/models.py:1335
 msgid "My Settings"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1352
+#: corehq/apps/hqwebapp/models.py:1347
 msgid "Manage My Settings"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1381 corehq/apps/hqwebapp/models.py:1400
+#: corehq/apps/hqwebapp/models.py:1376 corehq/apps/hqwebapp/models.py:1395
 msgid "Administrative Reports"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1382 corehq/apps/hqwebapp/models.py:1411
-#: corehq/apps/hqwebapp/models.py:1533 corehq/apps/hqwebapp/models.py:1540
+#: corehq/apps/hqwebapp/models.py:1377 corehq/apps/hqwebapp/models.py:1406
+#: corehq/apps/hqwebapp/models.py:1528 corehq/apps/hqwebapp/models.py:1535
 msgid "System Info"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1391
+#: corehq/apps/hqwebapp/models.py:1386
 msgid "Mass Email Users"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1396
+#: corehq/apps/hqwebapp/models.py:1391
 msgid "Login as another user"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1407
+#: corehq/apps/hqwebapp/models.py:1402
 msgid "Message Logs Across All Domains"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1409
+#: corehq/apps/hqwebapp/models.py:1404
 msgid "CommCare Versions"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1413
+#: corehq/apps/hqwebapp/models.py:1408
 #, fuzzy
 msgid "Loadtest Report"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
-#: corehq/apps/hqwebapp/models.py:1416
+#: corehq/apps/hqwebapp/models.py:1411
 msgid "Administrative Operations"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1417
+#: corehq/apps/hqwebapp/models.py:1412
 #, fuzzy
 msgid "CommCare Reports"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
-#: corehq/apps/hqwebapp/models.py:1439
+#: corehq/apps/hqwebapp/models.py:1434
 msgid "Accounting"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1482 corehq/apps/hqwebapp/models.py:1561
+#: corehq/apps/hqwebapp/models.py:1477 corehq/apps/hqwebapp/models.py:1556
 msgid "SMS Connectivity & Billing"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1491
+#: corehq/apps/hqwebapp/models.py:1486
 #: corehq/apps/sms/templates/sms/add_backend.html:52
 #: corehq/apps/sms/templates/sms/list_backends.html:39
 msgid "SMS Connections"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1499
+#: corehq/apps/hqwebapp/models.py:1494
 #: corehq/apps/sms/templates/sms/backend_map.html:5
 #: corehq/apps/sms/templates/sms/backend_map.html:64
 #: corehq/apps/sms/templates/sms/backend_map.html:72
 msgid "SMS Country-Connection Map"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1519
+#: corehq/apps/hqwebapp/models.py:1514
 msgid "Admin"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1541
+#: corehq/apps/hqwebapp/models.py:1536
 msgid "Management"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1542
+#: corehq/apps/hqwebapp/models.py:1537
 msgid "Commands"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1556
+#: corehq/apps/hqwebapp/models.py:1551
 msgid "Old SMS Billing"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1564
+#: corehq/apps/hqwebapp/models.py:1559
 msgid "Django Admin"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1586
+#: corehq/apps/hqwebapp/models.py:1581
 msgid "Publish this project"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1615
+#: corehq/apps/hqwebapp/models.py:1610
 #: corehq/apps/orgs/templates/orgs/report_base.html:28
 msgid "Projects Table"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1618
+#: corehq/apps/hqwebapp/models.py:1613
 #: corehq/apps/orgs/templates/orgs/report_base.html:29
 #: corehq/apps/reports/standard/monitoring.py:1026
 msgid "Form Data"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1621
+#: corehq/apps/hqwebapp/models.py:1616
 #: corehq/apps/orgs/templates/orgs/report_base.html:30
 #: corehq/apps/reports/standard/monitoring.py:1036
 msgid "Case Data"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1624
+#: corehq/apps/hqwebapp/models.py:1619
 #: corehq/apps/orgs/templates/orgs/report_base.html:31
 msgid "User Data"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1637
+#: corehq/apps/hqwebapp/models.py:1632
 #: corehq/apps/orgs/templates/orgs/orgs_team_members.html:84
 #: corehq/apps/orgs/templates/orgs/public.html:28
 #: corehq/apps/orgs/templates/orgs/partials/top_nav.html:6
 msgid "Projects"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1640
+#: corehq/apps/hqwebapp/models.py:1635
 #: corehq/apps/orgs/templates/orgs/public.html:31
 #: corehq/apps/orgs/templates/orgs/partials/top_nav.html:9
 msgid "Teams"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1643
+#: corehq/apps/hqwebapp/models.py:1638
 #: corehq/apps/orgs/templates/orgs/orgs_team_members.html:50
 #: corehq/apps/orgs/templates/orgs/public.html:34
 #: corehq/apps/orgs/templates/orgs/partials/top_nav.html:12
@@ -11530,44 +11629,44 @@ msgstr ""
 msgid "View All"
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:612
+#: corehq/apps/hqwebapp/views.py:614
 msgid ""
 "Check \"Opt out of emails about new features and other CommCare updates\" in "
 "your account settings and then click \"Update Information\" if you do not "
 "want to receive future emails from us."
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:713
+#: corehq/apps/hqwebapp/views.py:715
 msgid "items per page"
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:714
+#: corehq/apps/hqwebapp/views.py:716
 msgid "You have no items."
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:716
+#: corehq/apps/hqwebapp/views.py:718
 msgid "Deleted Items:"
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:717
+#: corehq/apps/hqwebapp/views.py:719
 msgid "New Items:"
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:840
+#: corehq/apps/hqwebapp/views.py:842
 #, python-format
 msgid "<strong>Problem Refreshing List:</strong> %s"
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:858
+#: corehq/apps/hqwebapp/views.py:860
 #, python-format
 msgid "<strong>Problem Deleting:</strong> %s"
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:866
+#: corehq/apps/hqwebapp/views.py:868
 msgid "The item's ID was not passed to the server."
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:976
+#: corehq/apps/hqwebapp/views.py:978
 #, python-format
 msgid "We've redirected you to the %s matching your query"
 msgstr ""
@@ -11846,11 +11945,11 @@ msgstr ""
 msgid "No properties found."
 msgstr ""
 
-#: corehq/apps/importer/base.py:5
+#: corehq/apps/importer/base.py:6
 msgid "Import Cases from Excel"
 msgstr ""
 
-#: corehq/apps/importer/base.py:7
+#: corehq/apps/importer/base.py:8
 msgid "Import case data from an external Excel file"
 msgstr ""
 
@@ -11877,6 +11976,11 @@ msgstr ""
 #: corehq/apps/importer/const.py:13
 msgid "Case Generation Error"
 msgstr ""
+
+#: corehq/apps/importer/const.py:14
+#, fuzzy
+msgid "Duplicated Location Name"
+msgstr "Manejo de Casos"
 
 #: corehq/apps/importer/util.py:213
 msgid ""
@@ -11912,19 +12016,26 @@ msgstr ""
 msgid "An invalid or unknown parent case was specified for the uploaded case."
 msgstr ""
 
-#: corehq/apps/importer/views.py:170
+#: corehq/apps/importer/util.py:234
+msgid ""
+"Owner ID was used in the mapping, but there were errors when uploading "
+"because of these values. There are multiple locations with this same name, "
+"try using site-code instead."
+msgstr ""
+
+#: corehq/apps/importer/views.py:169
 msgid ""
 "It looks like you may have accessed this page from a stale page. Please "
 "start over."
 msgstr ""
 
-#: corehq/apps/importer/views.py:274 corehq/apps/importer/views.py:331
+#: corehq/apps/importer/views.py:273 corehq/apps/importer/views.py:330
 msgid ""
 "The session containing the file you uploaded has expired - please upload a "
 "new one."
 msgstr ""
 
-#: corehq/apps/importer/views.py:349
+#: corehq/apps/importer/views.py:348
 msgid "Sorry, your session has expired. Please start over and try again."
 msgstr ""
 
@@ -11957,8 +12068,9 @@ msgid "Corresponding case field"
 msgstr ""
 
 #: corehq/apps/importer/templates/importer/excel_config.html:90
-#: corehq/ex-submodules/casexml/apps/case/models.py:892
-#: custom/opm/beneficiary.py:823 custom/opm/beneficiary.py:899
+#: corehq/ex-submodules/casexml/apps/case/models.py:897
+#: custom/opm/beneficiary.py:822 custom/opm/beneficiary.py:899
+#: custom/opm/beneficiary.py:921
 msgid "Case ID"
 msgstr ""
 
@@ -12009,7 +12121,8 @@ msgstr ""
 
 #: corehq/apps/importer/templates/importer/excel_config.html:192
 #: corehq/apps/importer/templates/importer/excel_fields.html:189
-#: corehq/apps/userreports/reports/builder/forms.py:458
+#: corehq/apps/userreports/reports/builder/forms.py:459
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:5
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:210
 #: submodules/ctable-src/ctable_view/templates/ctable/test_mapping.html:129
 msgid "Back"
@@ -12561,11 +12674,16 @@ msgstr ""
 msgid "Move"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:83
+#: corehq/apps/locations/templates/locations/manage/locations.html:40
+#, python-format
+msgid "You have successfully archived the location <%%=name%%>"
+msgstr ""
+
+#: corehq/apps/locations/templates/locations/manage/locations.html:102
 msgid "Manage Locations"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:85
+#: corehq/apps/locations/templates/locations/manage/locations.html:104
 msgid ""
 "\n"
 "                    Locations allow you to represent the real-world "
@@ -12578,42 +12696,43 @@ msgid ""
 "                "
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:95
+#: corehq/apps/locations/templates/locations/manage/locations.html:114
 msgid "Showing the Inactive Location List."
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:102
+#: corehq/apps/locations/templates/locations/manage/locations.html:121
 msgid "Show Archived Locations"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:106
+#: corehq/apps/locations/templates/locations/manage/locations.html:125
 msgid "Show Active Locations"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:119
-#: corehq/apps/locations/templates/locations/manage/locations.html:123
+#: corehq/apps/locations/templates/locations/manage/locations.html:138
+#: corehq/apps/locations/templates/locations/manage/locations.html:142
 msgid "Bulk Import Locations"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:127
+#: corehq/apps/locations/templates/locations/manage/locations.html:146
 msgid "Edit Location Types"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:130
+#: corehq/apps/locations/templates/locations/manage/locations.html:149
 msgid "Edit Location Fields"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:155
+#: corehq/apps/locations/templates/locations/manage/locations.html:174
 msgid "Unarchive"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:160
+#: corehq/apps/locations/templates/locations/manage/locations.html:179
+#: corehq/apps/locations/templates/locations/manage/locations.html:267
 #: corehq/apps/products/views.py:186
 #: corehq/apps/products/templates/products/manage/products.html:116
 msgid "Archive"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:216
+#: corehq/apps/locations/templates/locations/manage/locations.html:235
 #, python-format
 msgid ""
 "\n"
@@ -12621,6 +12740,23 @@ msgid ""
 "    <a href=\"%(location_types_url)s\">here</a>\n"
 "    for your project before creating any locations.\n"
 "    "
+msgstr ""
+
+#: corehq/apps/locations/templates/locations/manage/locations.html:253
+#, fuzzy
+msgid "Archive Location:"
+msgstr "Casos IRA Tratados"
+
+#: corehq/apps/locations/templates/locations/manage/locations.html:257
+msgid ""
+"\n"
+"            <strong>Warning!</strong> Archiving a location will unassign any "
+"users\n"
+"            which were associated with that location.  You can unarchive "
+"this\n"
+"            location at any point, but you will have to reassign the users\n"
+"            manually.\n"
+"            "
 msgstr ""
 
 #: corehq/apps/locations/templates/locations/manage/partials/autocomplete_select_widget.html:10
@@ -12827,33 +12963,33 @@ msgstr ""
 msgid "Prime Restore Cache"
 msgstr ""
 
-#: corehq/apps/prelogin/forms.py:32 corehq/apps/registration/forms.py:52
+#: corehq/apps/prelogin/forms.py:33 corehq/apps/registration/forms.py:52
 msgid "Email Address"
 msgstr ""
 
-#: corehq/apps/prelogin/forms.py:45
+#: corehq/apps/prelogin/forms.py:46
 msgid "What is your interest in CommCare and any specific questions you have?"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:57
+#: corehq/apps/prelogin/templates/prelogin/base.html:60
 msgid "Toggle Navigation"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:78
+#: corehq/apps/prelogin/templates/prelogin/base.html:81
 #, fuzzy
 msgid "Solutions"
 msgstr "Casos IRA Tratados"
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:79
+#: corehq/apps/prelogin/templates/prelogin/base.html:82
 msgid "Impact"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:80
+#: corehq/apps/prelogin/templates/prelogin/base.html:83
 #, fuzzy
 msgid "Software Pricing"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:108
+#: corehq/apps/prelogin/templates/prelogin/base.html:111
 #, python-format
 msgid ""
 "\n"
@@ -12864,11 +13000,15 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:145
+#: corehq/apps/prelogin/templates/prelogin/base.html:131
+msgid "Get in Touch With Us: Contact Dimagi"
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/base.html:148
 msgid "Thanks for contacting us!"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:150
+#: corehq/apps/prelogin/templates/prelogin/base.html:153
 msgid ""
 "\n"
 "                            Thank you for your interest in working with "
@@ -12876,7 +13016,7 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:155
+#: corehq/apps/prelogin/templates/prelogin/base.html:158
 msgid ""
 "\n"
 "                            One of our team members will get back to you "
@@ -12886,18 +13026,18 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:163
-#: corehq/apps/prelogin/templates/prelogin/base.html:202
+#: corehq/apps/prelogin/templates/prelogin/base.html:166
+#: corehq/apps/prelogin/templates/prelogin/base.html:205
 #: custom/_legacy/a5288/reports.py:102
 msgid "OK"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:176
-#: corehq/apps/prelogin/templates/prelogin/base.html:215
+#: corehq/apps/prelogin/templates/prelogin/base.html:179
+#: corehq/apps/prelogin/templates/prelogin/base.html:218
 msgid "Ooops!"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:181
+#: corehq/apps/prelogin/templates/prelogin/base.html:184
 msgid ""
 "\n"
 "                             We're terribly sorry! It seems like our servers "
@@ -12905,7 +13045,7 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:186
+#: corehq/apps/prelogin/templates/prelogin/base.html:189
 msgid ""
 "\n"
 "                                We've alerted one of our engineers of issues "
@@ -12916,7 +13056,7 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:193
+#: corehq/apps/prelogin/templates/prelogin/base.html:196
 msgid ""
 "\n"
 "                                You can send an email directly to\n"
@@ -12926,7 +13066,7 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:226
+#: corehq/apps/prelogin/templates/prelogin/base.html:229
 msgid ""
 "\n"
 "                                Please provide a valid e-mail address where "
@@ -12988,6 +13128,10 @@ msgid ""
 "contact\n"
 "                        Dimagi directly.\n"
 "                    "
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/home/about_dimagi.html:42
+msgid "Get in Touch With Us"
 msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/home/about_dimagi.html:50
@@ -13200,7 +13344,7 @@ msgstr ""
 #: corehq/apps/style/templates/style/includes/modal_report_issue.html:49
 #: corehq/apps/styleguide/examples/simple_crispy_form/forms.py:17
 #: custom/_legacy/pact/templates/pact/chw/pact_chw_profile_info.html:16
-#: custom/ilsgateway/tanzania/reports/facility_details.py:73
+#: custom/ilsgateway/tanzania/reports/facility_details.py:74
 msgid "Email"
 msgstr ""
 
@@ -13378,33 +13522,35 @@ msgstr ""
 #: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:12
 msgid ""
 "\n"
-"                        Read how organizations around the world use\n"
-"                        CommCare to improve frontline service delivery.\n"
+"                    <!--HubSpot Call-to-Action Code -->\n"
+"                    <span class=\"hs-cta-wrapper\" id=\"hs-cta-"
+"wrapper-071f4a7d-237d-49d8-b12d-c28fe204927d\">\n"
+"                        <span class=\"hs-cta-node hs-cta-071f4a7d-237d-49d8-"
+"b12d-c28fe204927d\" id=\"hs-cta-071f4a7d-237d-49d8-b12d-c28fe204927d\">\n"
+"                            <!--[if lte IE 8]><div id=\"hs-cta-ie-element"
+"\"></div><![endif]-->\n"
+"                            <a href=\"http://cta-redirect.hubspot.com/cta/"
+"redirect/503070/071f4a7d-237d-49d8-b12d-c28fe204927d\" ><img class=\"hs-cta-"
+"img\" id=\"hs-cta-img-071f4a7d-237d-49d8-b12d-c28fe204927d\" style=\"border-"
+"width:0px;\" src=\"https://no-cache.hubspot.com/cta/"
+"default/503070/071f4a7d-237d-49d8-b12d-c28fe204927d.png\"  alt=\"View All "
+"Case Studies\"/></a>\n"
+"                        </span>\n"
+"                        <script type=\"text/javascript\">\n"
+"                            hbspt.cta.load(503070, '071f4a7d-237d-49d8-b12d-"
+"c28fe204927d');\n"
+"                        </script>\n"
+"                    </span>\n"
+"                    <!-- end HubSpot Call-to-Action Code -->\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:24
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:39
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:54
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:69
-#, fuzzy
-msgid "Read Case Study"
-msgstr "Manejo de Casos"
-
 #: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:27
-msgid "Improving Community Health in Guatemala"
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:42
-msgid "An Integrated eDiagnostic Approach in Burkina Faso"
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:57
-msgid "Improving Maternal and Child Health in India"
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:72
-msgid "iCCM for Child Health in Mozambique"
+msgid ""
+"\n"
+"                        Read how organizations around the world use\n"
+"                        CommCare to improve frontline service delivery.\n"
+"                    "
 msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/impact/lead.html:9
@@ -13451,6 +13597,33 @@ msgstr ""
 #: corehq/apps/prelogin/templates/prelogin/_sections/impact/partners.html:12
 msgid ""
 "\n"
+"                    <!--HubSpot Call-to-Action Code -->\n"
+"                    <span class=\"hs-cta-wrapper\" id=\"hs-cta-wrapper-"
+"c34ae48e-2f1a-48ac-9170-31fc7c9e845b\">\n"
+"                        <span class=\"hs-cta-node hs-cta-"
+"c34ae48e-2f1a-48ac-9170-31fc7c9e845b\" id=\"hs-cta-"
+"c34ae48e-2f1a-48ac-9170-31fc7c9e845b\">\n"
+"                            <!--[if lte IE 8]><div id=\"hs-cta-ie-element"
+"\"></div><![endif]-->\n"
+"                            <a href=\"http://cta-redirect.hubspot.com/cta/"
+"redirect/503070/c34ae48e-2f1a-48ac-9170-31fc7c9e845b\"  target=\"_blank\" "
+"><img class=\"hs-cta-img\" id=\"hs-cta-img-"
+"c34ae48e-2f1a-48ac-9170-31fc7c9e845b\" style=\"border-width:0px;\" src="
+"\"https://no-cache.hubspot.com/cta/default/503070/"
+"c34ae48e-2f1a-48ac-9170-31fc7c9e845b.png\"  alt=\"See All Partners\"/></a>\n"
+"                        </span>\n"
+"                        <script type=\"text/javascript\">\n"
+"                            hbspt.cta.load(503070, "
+"'c34ae48e-2f1a-48ac-9170-31fc7c9e845b');\n"
+"                        </script>\n"
+"                    </span>\n"
+"                    <!-- end HubSpot Call-to-Action Code -->\n"
+"                    "
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/partners.html:27
+msgid ""
+"\n"
 "                        The following organizations have contributed\n"
 "                        to the development of CommCare.\n"
 "                    "
@@ -13466,14 +13639,36 @@ msgstr ""
 #: corehq/apps/prelogin/templates/prelogin/_sections/impact/publications.html:12
 msgid ""
 "\n"
+"                    <!--HubSpot Call-to-Action Code -->\n"
+"                    <span class=\"hs-cta-wrapper\" id=\"hs-cta-"
+"wrapper-23da92fd-b671-481f-9aee-bbc8a94b1f8b\">\n"
+"                        <span class=\"hs-cta-node hs-cta-23da92fd-"
+"b671-481f-9aee-bbc8a94b1f8b\" id=\"hs-cta-23da92fd-b671-481f-9aee-"
+"bbc8a94b1f8b\">\n"
+"                            <!--[if lte IE 8]><div id=\"hs-cta-ie-element"
+"\"></div><![endif]-->\n"
+"                            <a href=\"http://cta-redirect.hubspot.com/cta/"
+"redirect/503070/23da92fd-b671-481f-9aee-bbc8a94b1f8b\"  target=\"_blank\" "
+"><img class=\"hs-cta-img\" id=\"hs-cta-img-23da92fd-b671-481f-9aee-"
+"bbc8a94b1f8b\" style=\"border-width:0px;\" src=\"https://no-cache.hubspot."
+"com/cta/default/503070/23da92fd-b671-481f-9aee-bbc8a94b1f8b.png\"  alt="
+"\"View Research\"/></a>\n"
+"                        </span>\n"
+"                        <script type=\"text/javascript\">\n"
+"                            hbspt.cta.load(503070, '23da92fd-b671-481f-9aee-"
+"bbc8a94b1f8b');\n"
+"                        </script>\n"
+"                    </span>\n"
+"                    <!-- end HubSpot Call-to-Action Code -->\n"
+"                    "
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/publications.html:27
+msgid ""
+"\n"
 "                        Over 30+ peer-reviewed publications have been "
 "written\n"
-"                        about CommCare. For an overview of all CommCare\n"
-"                        publications, please see the\n"
-"                        <a href=\"https://help.commcarehq.org/display/"
-"commcarepublic/CommCare+Evidence+Base\"\n"
-"                           class=\"btn-primary-dark\">CommCare Evidence "
-"Base</a>.\n"
+"                        about CommCare.\n"
 "                    "
 msgstr ""
 
@@ -13484,67 +13679,94 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:27
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:12
+msgid ""
+"\n"
+"                    <!--HubSpot Call-to-Action Code -->\n"
+"                    <span class=\"hs-cta-wrapper\" id=\"hs-cta-wrapper-"
+"c21c3aed-90ee-4106-98d0-dbe846e8ca28\">\n"
+"                        <span class=\"hs-cta-node hs-cta-"
+"c21c3aed-90ee-4106-98d0-dbe846e8ca28\" id=\"hs-cta-c21c3aed-90ee-4106-98d0-"
+"dbe846e8ca28\">\n"
+"                            <!--[if lte IE 8]><div id=\"hs-cta-ie-element"
+"\"></div><![endif]-->\n"
+"                            <a href=\"http://cta-redirect.hubspot.com/cta/"
+"redirect/503070/c21c3aed-90ee-4106-98d0-dbe846e8ca28\"  target=\"_blank\" "
+"><img class=\"hs-cta-img\" id=\"hs-cta-img-c21c3aed-90ee-4106-98d0-"
+"dbe846e8ca28\" style=\"border-width:0px;\" src=\"https://no-cache.hubspot."
+"com/cta/default/503070/c21c3aed-90ee-4106-98d0-dbe846e8ca28.png\"  alt="
+"\"Learn More About Our Sectors\"/></a>\n"
+"                        </span>\n"
+"                        <script type=\"text/javascript\">\n"
+"                            hbspt.cta.load(503070, 'c21c3aed-90ee-4106-98d0-"
+"dbe846e8ca28');\n"
+"                        </script>\n"
+"                    </span>\n"
+"                    <!-- end HubSpot Call-to-Action Code -->\n"
+"                    "
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:35
 #, fuzzy
 msgid "Child Health"
 msgstr "Crianças (2 - 59 meses)"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:33
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:41
 msgid "HIV/AIDS"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:52
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:60
 msgid "Health"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:73
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:81
 msgid "Malaria"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:80
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:88
 #, fuzzy
 msgid "Nutrition"
 msgstr "Criança com problemas de malnutrição"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:91
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:99
 msgid "Cooperatives"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:98
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:106
 msgid "Finances"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:117
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:125
 msgid "Agriculture"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:138
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:146
 #, fuzzy
 msgid "Extension Programs"
 msgstr "Manejo de Casos"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:145
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:153
 msgid "Logistics"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:156
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:164
 msgid "Emergency Response"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:163
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:171
 msgid "Small Business"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:182
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:190
 msgid "Development"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:203
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:211
 #, fuzzy
 msgid "Education"
 msgstr "Total de TDR para Malária Realizados"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:210
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:218
 msgid "Logistics & Supply Chain"
 msgstr ""
 
@@ -13621,11 +13843,12 @@ msgid ""
 "\n"
 "                        <a href=\"#contactDimagi\"\n"
 "                           data-toggle=\"modal\"\n"
-"                           class=\"btn-primary-dark\">Contact Dimagi</a> or "
-"read our<br />\n"
-"                        pricing <a href=\"https://confluence.dimagi.com/"
-"display/commcarepublic/CommCare+Pricing+FAQs\" class=\"btn-primary-dark"
-"\">FAQs</a>.\n"
+"                           class=\"btn-success btn btn-xl\">Get in Touch "
+"With Us</a>\n"
+"                        <a href=\"https://confluence.dimagi.com/display/"
+"commcarepublic/CommCare+Pricing+FAQs\"\n"
+"                           class=\"btn btn-primary-dark btn-xl\">Read our "
+"Pricing FAQs</a>\n"
 "                    "
 msgstr ""
 
@@ -13634,21 +13857,19 @@ msgstr ""
 msgid "CommCare Software Plans"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:11
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:16
 msgid ""
 "\n"
-"                            Core Features are always FREE. Choose a plan\n"
-"                            to help your project scale.\n"
-"                        "
+"                        Core Features are always FREE. Choose a plan\n"
+"                        to help your project scale.\n"
+"                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:18
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:22
 msgid ""
 "\n"
-"                    <strong>Anyone can use CommCare for FREE up to 50 mobile "
-"workers.</strong><br />\n"
 "                    For additional questions, please see our\n"
-"                    <a class=\"btn-primary-dark\"\n"
+"                    <a class=\"lead-link\"\n"
 "                       href=\"https://confluence.dimagi.com/display/"
 "commcarepublic/CommCare+Pricing+FAQs?__hstc=187943799."
 "ba674a1a3cdef13c5d09b2a54d65c2b8.1431286503613.1435340206977.1435342587932.124&__hssc=187943799.6.1435342587932&__hsfp=312587752\">FAQs</"
@@ -13656,16 +13877,27 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:92
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:31
+msgid ""
+"\n"
+"                        Want to try CommCare for FREE?\n"
+"                    "
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:34
+msgid "Sign up for a FREE account"
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:103
 msgid "Contact Us"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:122
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:152
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:133
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:163
 msgid "Unlimited / Discounted"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:128
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:139
 msgid "Price Per Additional Mobile User"
 msgstr ""
 
@@ -13886,71 +14118,80 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:39
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:33
-msgid "Scope"
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:42
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:36
-msgid "Launch"
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:45
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:39
-msgid "Boost"
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:28
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:15
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:662
+msgid ""
+"\n"
+"                        Inquire About Dimagi's Implementation Bundles\n"
+"                        "
 msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:48
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:42
-msgid "Growth"
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:35
+msgid "Scope"
 msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:51
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:45
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:38
+msgid "Launch"
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:54
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:41
+msgid "Boost"
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:57
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:44
+msgid "Growth"
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:60
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:47
 msgid "Scale"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:56
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:53
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:65
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:55
 msgid "$10,000"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:59
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:56
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:68
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:58
 msgid "$35,000"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:62
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:59
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:71
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:61
 msgid "$50,000"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:65
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:62
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:74
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:64
 msgid "$80,000"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:68
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:65
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:77
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:67
 msgid "$150,000"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:92
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:100
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:108
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:89
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:97
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:105
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:101
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:109
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:117
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:91
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:99
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:107
 msgid "12 months"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:116
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:113
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:125
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:115
 msgid "18 months"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:123
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:132
 msgid ""
 "\n"
 "                                Application Development &amp; Implementation "
@@ -13958,19 +14199,19 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:130
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:139
 msgid "Workflow Design"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:131
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:140
 msgid "On-Site Scoping Visit"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:132
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:141
 msgid "Mobile System Workflow Design"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:138
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:147
 msgid ""
 "\n"
 "                                    Everything in<br />\n"
@@ -13978,19 +14219,19 @@ msgid ""
 "                                "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:143
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:152
 msgid "Build &amp; Launch Application"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:144
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:153
 msgid "Field Testing &amp; Iteration"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:145
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:154
 msgid "Users Training"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:151
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:160
 msgid ""
 "\n"
 "                                    Everything in<br />\n"
@@ -13998,16 +14239,16 @@ msgid ""
 "                                "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:156
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:62
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:165
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:69
 msgid "Technology for Outcomes Monitoring"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:157
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:166
 msgid "Capacity Building for Worker Performance Monitoring"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:163
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:172
 msgid ""
 "\n"
 "                                    Everything in<br />\n"
@@ -14015,19 +14256,19 @@ msgid ""
 "                                "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:168
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:177
 msgid "Refined Application"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:169
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:178
 msgid "Additional Supervisor App"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:170
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:179
 msgid "Application Troubleshooting Capacity Building"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:176
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:185
 msgid ""
 "\n"
 "                                    Everything in<br />\n"
@@ -14035,37 +14276,29 @@ msgid ""
 "                                "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:181
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:190
 msgid "Monitored Application Usage"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:182
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:191
 msgid "Additional Tech for Reminder Messages"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:183
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:40
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:192
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:47
 msgid "Training of Trainers"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:184
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:42
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:193
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:49
 msgid "Capacity to Build Applications"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:190
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:194
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:45
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:68
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:199
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:203
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:52
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:75
 msgid "See More..."
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:205
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:659
-msgid ""
-"\n"
-"                    Inquire About Dimagi's Implementation Bundles\n"
-"                    "
 msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:7
@@ -14092,7 +14325,11 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:31
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:27
+msgid "Inquire About Dimagi's Capacity Services"
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:38
 #: corehq/apps/products/forms.py:28
 #: corehq/apps/products/templates/products/manage/products.html:112
 #: corehq/apps/programs/templates/programs/manage/programs.html:62
@@ -14100,40 +14337,36 @@ msgstr ""
 msgid "Program"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:34
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:57
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:41
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:64
 msgid ""
 "\n"
 "                            $10,000 per capacity service\n"
 "                        "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:39
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:46
 msgid "Worker Performance Monitoring"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:41
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:48
 msgid "Capacity for Technical Support"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:54
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:61
 msgid "Technology"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:63
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:70
 msgid "Apps for Supportive Supervision"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:64
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:71
 msgid "App Refinement by Dimagi"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:65
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:72
 msgid "Technology for Reminder Messages"
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:81
-msgid "Inquire About Dimagi's Capacity Services"
 msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/services/faq.html:8
@@ -14150,8 +14383,8 @@ msgid ""
 "\n"
 "                        <a href=\"#contactDimagi\"\n"
 "                           data-toggle=\"modal\"\n"
-"                           class=\"btn-primary-dark\">Contact Dimagi</a> for "
-"more information.\n"
+"                           class=\"btn btn-success btn-xl\">Get in Touch "
+"With Us</a>\n"
 "                    "
 msgstr ""
 
@@ -14236,110 +14469,100 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:12
-msgid ""
-"\n"
-"                        If you have any additional questions, please\n"
-"                        <a href=\"#contactDimagi\"\n"
-"                           data-toggle=\"modal\">contact Dimagi</a> "
-"directly.\n"
-"                    "
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:50
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:52
 msgid "Cost"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:71
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:73
 msgid "Included Software Plan"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:119
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:121
 msgid "Application Development Support"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:125
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:127
 msgid ""
 "\n"
 "                                Workflow Design\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:160
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:162
 msgid ""
 "\n"
 "                                Launch &amp; Tested Application\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:195
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:197
 msgid ""
 "\n"
 "                                Additional Tech for Monitoring Outcomes\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:230
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:232
 msgid ""
 "\n"
 "                                Launched v2 application\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:265
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:267
 msgid ""
 "\n"
 "                                Supervisor Application\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:300
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:302
 msgid ""
 "\n"
 "                                Monitored app usage\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:335
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:337
 msgid ""
 "\n"
 "                                Additional Tech for Reminder Messages\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:369
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:371
 msgid "Implementation Services"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:375
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:377
 msgid ""
 "\n"
 "                                On-Site Scoping Visit\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:410
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:412
 msgid ""
 "\n"
 "                                Mobile System Workflow Design\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:445
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:447
 msgid ""
 "\n"
 "                                Field Testing &amp; Iteration\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:480
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:482
 msgid ""
 "\n"
 "                                Pilot Users Training\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:515
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:517
 msgid ""
 "\n"
 "                                Capacity Service: Worker Performance "
@@ -14347,7 +14570,7 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:550
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:552
 msgid ""
 "\n"
 "                                Capacity Service: Application "
@@ -14355,14 +14578,14 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:585
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:587
 msgid ""
 "\n"
 "                                Capacity Service: Training of Trainers\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:620
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:622
 msgid ""
 "\n"
 "                                Capacity Service: App Building\n"
@@ -14376,24 +14599,22 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:12
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:15
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:210
 msgid ""
 "\n"
-"                        If you have any additional questions, please\n"
-"                        <a href=\"#contactDimagi\"\n"
-"                           data-toggle=\"modal\">contact Dimagi</a>\n"
-"                        directly.\n"
-"                    "
+"                        Inquire About Dimagi's Capacity Services\n"
+"                        "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:24
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:25
 msgid ""
 "\n"
 "                        Program Capacity Services\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:29
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:30
 msgid ""
 "\n"
 "                        Dimagi travels on-site to build capacity, spending "
@@ -14402,22 +14623,22 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:35
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:125
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:37
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:128
 msgid ""
 "\n"
 "                        $10,000 per capacity service package.\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:44
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:46
 msgid ""
 "\n"
 "                        Worker Performance Monitoring\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:51
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:53
 msgid ""
 "\n"
 "                    Strategic implementation of standard CommCare HQ "
@@ -14426,14 +14647,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:61
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:63
 msgid ""
 "\n"
 "                        Training of Trainers\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:68
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:70
 msgid ""
 "\n"
 "                        Capacity building for organization’s trainers for "
@@ -14444,14 +14665,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:79
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:81
 msgid ""
 "\n"
 "                        Capacity for Technical Support\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:86
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:88
 msgid ""
 "\n"
 "                        Train technical staff about troubleshooting and "
@@ -14460,14 +14681,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:96
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:98
 msgid ""
 "\n"
 "                        Capacity to Build Applications\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:103
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:105
 msgid ""
 "\n"
 "                        Learn how to build your own applications,\n"
@@ -14476,14 +14697,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:114
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:116
 msgid ""
 "\n"
 "                        Technology Capacity Services\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:119
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:121
 msgid ""
 "\n"
 "                        Dimagi provides additional system refinement or new\n"
@@ -14491,14 +14712,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:134
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:137
 msgid ""
 "\n"
 "                        Technology for Outcomes Monitoring\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:141
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:144
 msgid ""
 "\n"
 "                        Create customized, offline Excel reports for 5-10\n"
@@ -14508,14 +14729,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:152
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:155
 msgid ""
 "\n"
 "                        Apps for Supportive Supervision\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:159
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:162
 msgid ""
 "\n"
 "                        Integrate a mobile application designed for field "
@@ -14526,14 +14747,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:170
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:173
 msgid ""
 "\n"
 "                        App Refinement by Dimagi\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:177
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:180
 msgid ""
 "\n"
 "                        Dimagi to make modifications to application based "
@@ -14542,14 +14763,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:187
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:190
 msgid ""
 "\n"
 "                        Technology for Reminder Messages\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:194
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:197
 msgid ""
 "\n"
 "                        Send SMS reminders directly to beneficiaries or\n"
@@ -14575,11 +14796,10 @@ msgstr ""
 #: corehq/apps/prelogin/templates/prelogin/_sections/solutions/last.html:13
 msgid ""
 "\n"
-"                        Contact us at\n"
-"                        <a class=\"btn-primary-dark\"\n"
-"                           href=\"mailto:commcare.supply@dimagi.com\">\n"
-"                            commcare.supply@dimagi.com\n"
-"                        </a>.\n"
+"                        <a href=\"#contactDimagi\"\n"
+"                           data-toggle=\"modal\"\n"
+"                           class=\"btn-success btn btn-xl\">Get in Touch "
+"With Us</a>\n"
 "                    "
 msgstr ""
 
@@ -14772,6 +14992,13 @@ msgid ""
 "                    International, including ILSGateway in Tanzania,\n"
 "                    the Early Warning System in Ghana, and cStock\n"
 "                    in Malawi.\n"
+"                    "
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/solutions/supply_intro.html:45
+msgid ""
+"\n"
+"                    Have questions or want to request a demo?\n"
 "                    "
 msgstr ""
 
@@ -16285,7 +16512,7 @@ msgstr ""
 
 #: corehq/apps/reminders/templates/reminders/partial/complex_message_table.html:30
 #: corehq/apps/reminders/templates/reminders/partial/complex_message_table.html:32
-#: custom/opm/beneficiary.py:814
+#: custom/opm/beneficiary.py:813 custom/opm/beneficiary.py:946
 msgid "Window"
 msgstr ""
 
@@ -16369,34 +16596,34 @@ msgstr ""
 msgid "CommTrack"
 msgstr "CommCare Supply"
 
-#: corehq/apps/reports/models.py:49
+#: corehq/apps/reports/models.py:51
 msgid "demo_user"
 msgstr ""
 
-#: corehq/apps/reports/models.py:50
+#: corehq/apps/reports/models.py:52
 msgid "admin"
 msgstr ""
 
-#: corehq/apps/reports/models.py:51
+#: corehq/apps/reports/models.py:53
 msgid "Unknown Users"
 msgstr ""
 
-#: corehq/apps/reports/models.py:381
+#: corehq/apps/reports/models.py:373
 msgid "Deleted Report"
 msgstr ""
 
-#: corehq/apps/reports/models.py:385
+#: corehq/apps/reports/models.py:377
 msgid "Unsupported Report"
 msgstr ""
 
-#: corehq/apps/reports/models.py:423
+#: corehq/apps/reports/models.py:415
 msgid ""
 "The report used to create this scheduled report is no longer available on "
 "CommCare HQ.  Please delete this scheduled report and create a new one using "
 "an available report."
 msgstr ""
 
-#: corehq/apps/reports/models.py:485
+#: corehq/apps/reports/models.py:477
 #, python-format
 msgid ""
 "We are sorry, but your saved report '%(config_name)s' is no longer "
@@ -16406,7 +16633,7 @@ msgid ""
 "%(saved_reports_url)s to remove this Emailed Report."
 msgstr ""
 
-#: corehq/apps/reports/models.py:498
+#: corehq/apps/reports/models.py:490
 #, python-format
 msgid ""
 "We are sorry, but your saved report '%(config_name)s' can not be generated "
@@ -16414,20 +16641,20 @@ msgid ""
 "Administrator about getting permissions for thisreport."
 msgstr ""
 
-#: corehq/apps/reports/models.py:509
+#: corehq/apps/reports/models.py:501
 msgid "An error occurred while generating this report."
 msgstr ""
 
-#: corehq/apps/reports/models.py:654
+#: corehq/apps/reports/models.py:649
 msgid "Every day"
 msgstr ""
 
-#: corehq/apps/reports/models.py:655
+#: corehq/apps/reports/models.py:650
 #, python-format
 msgid "Day %s of every month"
 msgstr ""
 
-#: corehq/apps/reports/models.py:699
+#: corehq/apps/reports/models.py:694
 #, fuzzy
 msgid "Scheduled report from CommCare HQ"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
@@ -16446,59 +16673,59 @@ msgstr ""
 msgid "Email report from CommCare HQ"
 msgstr ""
 
-#: corehq/apps/reports/views.py:798
+#: corehq/apps/reports/views.py:806
 #, fuzzy
 msgid "Create a new"
 msgstr "Manejo de Casos"
 
-#: corehq/apps/reports/views.py:799
+#: corehq/apps/reports/views.py:807
 #, fuzzy
 msgid "New Scheduled Report"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
-#: corehq/apps/reports/views.py:802
+#: corehq/apps/reports/views.py:810
 #, fuzzy
 msgid "Edit Scheduled Report"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
-#: corehq/apps/reports/views.py:910
+#: corehq/apps/reports/views.py:918
 #, fuzzy
 msgid "once off report"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
-#: corehq/apps/reports/views.py:910
+#: corehq/apps/reports/views.py:918
 #, fuzzy
 msgid "scheduled report"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
-#: corehq/apps/reports/views.py:934
+#: corehq/apps/reports/views.py:942
 msgid ""
 "The case creation form could not be found. Usually this happens if the form "
 "that created the case is archived but there are other forms that updated the "
 "case. To fix this you can archive the other forms listed here."
 msgstr ""
 
-#: corehq/apps/reports/views.py:979
+#: corehq/apps/reports/views.py:987
 msgid "unknown"
 msgstr ""
 
-#: corehq/apps/reports/views.py:992
+#: corehq/apps/reports/views.py:1000
 msgid "You don't have permission to access this page."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1014
+#: corehq/apps/reports/views.py:1022
 #, python-format
 msgid "Case %s was rebuilt from its forms."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1026
+#: corehq/apps/reports/views.py:1034
 #, python-format
 msgid ""
 "Case %s was successfully saved. Hopefully it will show up in all reports "
 "momentarily."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1040
+#: corehq/apps/reports/views.py:1048
 #, python-brace-format
 msgid ""
 "Case {name} has been closed.\n"
@@ -16513,90 +16740,90 @@ msgid ""
 "        "
 msgstr ""
 
-#: corehq/apps/reports/views.py:1080
+#: corehq/apps/reports/views.py:1088
 msgid "case id"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1081
+#: corehq/apps/reports/views.py:1089
 msgid "case name"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1082
+#: corehq/apps/reports/views.py:1090
 #, fuzzy
 msgid "section"
 msgstr "Total de TDR para Malária Realizados"
 
-#: corehq/apps/reports/views.py:1083
+#: corehq/apps/reports/views.py:1091
 msgid "date"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1084
+#: corehq/apps/reports/views.py:1092
 msgid "product_id"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1085
+#: corehq/apps/reports/views.py:1093
 msgid "product_name"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1086
+#: corehq/apps/reports/views.py:1094
 msgid "transaction amount"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1087
+#: corehq/apps/reports/views.py:1095
 msgid "type"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1088
+#: corehq/apps/reports/views.py:1096
 msgid "ending balance"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1098
+#: corehq/apps/reports/views.py:1106
 msgid "unknown product"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1301
+#: corehq/apps/reports/views.py:1309
 msgid "Could not detect the application/form for this submission."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1315
+#: corehq/apps/reports/views.py:1323
 msgid "Missing app, module or form information!"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1345
+#: corehq/apps/reports/views.py:1353
 #: corehq/apps/reports/templates/reports/form/edit_submission.html:26
 msgid "Edit Submission"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1376
+#: corehq/apps/reports/views.py:1384
 msgid "Form was successfully archived."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1378
+#: corehq/apps/reports/views.py:1386
 msgid "Form was already archived."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1380
+#: corehq/apps/reports/views.py:1388
 #, python-format
 msgid "Can't archive documents of type %s. How did you get here??"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1384
+#: corehq/apps/reports/views.py:1392
 msgid "Undo"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1423
+#: corehq/apps/reports/views.py:1431
 msgid "Form was successfully restored."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1438
+#: corehq/apps/reports/views.py:1446
 msgid "Form was successfully resaved. It should reappear in reports shortly."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1484
+#: corehq/apps/reports/views.py:1492
 msgid "We don't support this format"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1486
+#: corehq/apps/reports/views.py:1494
 msgid ""
 "That report was not found. Please remember that download links expire after "
 "24 hours."
@@ -16720,7 +16947,7 @@ msgid "Stock Status by Product"
 msgstr ""
 
 #: corehq/apps/reports/commtrack/standard.py:93
-#: custom/ilsgateway/tanzania/reports/delivery.py:154
+#: custom/ilsgateway/tanzania/reports/delivery.py:157
 msgid "# Facilities"
 msgstr ""
 
@@ -16801,12 +17028,6 @@ msgstr ""
 #: corehq/apps/reports/commtrack/standard.py:270
 msgid "Aggregate Inventory"
 msgstr ""
-
-#: corehq/apps/reports/commtrack/standard.py:297
-#: custom/ilsgateway/tanzania/reports/facility_details.py:27
-#, fuzzy
-msgid "Stock on Hand"
-msgstr "Balanço do Stock"
 
 #: corehq/apps/reports/commtrack/standard.py:298
 msgid "Total stock on hand for all locations matching the filters."
@@ -16901,7 +17122,7 @@ msgid "Date of last report for selected period"
 msgstr ""
 
 #: corehq/apps/reports/commtrack/standard.py:420
-#: corehq/apps/reports/standard/deployments.py:253
+#: corehq/apps/reports/standard/deployments.py:282
 msgid "Never"
 msgstr ""
 
@@ -17176,15 +17397,15 @@ msgstr ""
 msgid "Opened / Closed"
 msgstr ""
 
-#: corehq/apps/reports/filters/select.py:128 custom/opm/filters.py:153
+#: corehq/apps/reports/filters/select.py:128 custom/opm/filters.py:112
 msgid "Show All"
 msgstr ""
 
-#: corehq/apps/reports/filters/select.py:133 custom/opm/filters.py:154
+#: corehq/apps/reports/filters/select.py:133 custom/opm/filters.py:113
 msgid "Only Open"
 msgstr ""
 
-#: corehq/apps/reports/filters/select.py:134 custom/opm/filters.py:155
+#: corehq/apps/reports/filters/select.py:134 custom/opm/filters.py:114
 msgid "Only Closed"
 msgstr ""
 
@@ -17305,33 +17526,45 @@ msgstr ""
 msgid "Unknown App"
 msgstr ""
 
-#: corehq/apps/reports/standard/deployments.py:163
+#: corehq/apps/reports/standard/deployments.py:165
 msgid "User Sync History"
 msgstr ""
 
-#: corehq/apps/reports/standard/deployments.py:166
-msgid "Shows the last (up to) 10 times a user has synced."
+#: corehq/apps/reports/standard/deployments.py:171
+msgid "Shows the last (up to) {} times a user has synced."
 msgstr ""
 
-#: corehq/apps/reports/standard/deployments.py:172
+#: corehq/apps/reports/standard/deployments.py:180
 #, fuzzy
 msgid "Sync Date"
 msgstr "Casos IRA Tratados"
 
-#: corehq/apps/reports/standard/deployments.py:173
+#: corehq/apps/reports/standard/deployments.py:181
 #, fuzzy
 msgid "# of Cases"
 msgstr "Manejo de Casos"
 
-#: corehq/apps/reports/standard/deployments.py:174
+#: corehq/apps/reports/standard/deployments.py:182
 msgid "Sync Duration"
 msgstr ""
 
-#: corehq/apps/reports/standard/deployments.py:177
+#: corehq/apps/reports/standard/deployments.py:185
 msgid "Sync Log"
 msgstr ""
 
-#: corehq/apps/reports/standard/deployments.py:208
+#: corehq/apps/reports/standard/deployments.py:186
+msgid "Sync Log Type"
+msgstr ""
+
+#: corehq/apps/reports/standard/deployments.py:187
+msgid "Previous Sync Log"
+msgstr ""
+
+#: corehq/apps/reports/standard/deployments.py:188
+msgid "Error Info"
+msgstr ""
+
+#: corehq/apps/reports/standard/deployments.py:219
 msgid "{} seconds"
 msgstr ""
 
@@ -17448,7 +17681,7 @@ msgstr ""
 #: corehq/apps/reports/standard/sms.py:408
 #: corehq/apps/sms/templates/sms/default.html:59
 #: corehq/ex-submodules/casexml/apps/case/templates/case/partials/single_case.html:94
-#: custom/ilsgateway/tanzania/reports/delivery.py:170
+#: custom/ilsgateway/tanzania/reports/delivery.py:173
 msgid "Received"
 msgstr ""
 
@@ -17897,7 +18130,7 @@ msgid "Follow-Up Date"
 msgstr ""
 
 #: corehq/apps/reports/standard/cases/careplan.py:113
-#: corehq/ex-submodules/casexml/apps/case/models.py:913
+#: corehq/ex-submodules/casexml/apps/case/models.py:918
 #: custom/_legacy/pact/models.py:339
 msgid "Date Modified"
 msgstr ""
@@ -17924,17 +18157,17 @@ msgid "You can email a saved version<br />of this report."
 msgstr ""
 
 #: corehq/apps/reports/templates/reports/base_template.html:67
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:125
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:129
 msgid "Favorites"
 msgstr ""
 
 #: corehq/apps/reports/templates/reports/base_template.html:72
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:130
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:134
 msgid "You don't have any favorites"
 msgstr ""
 
 #: corehq/apps/reports/templates/reports/base_template.html:91
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:149
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:153
 msgid "Email Supported"
 msgstr ""
 
@@ -18222,112 +18455,112 @@ msgid ""
 "    "
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:135
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:136
 #, python-format
 msgid ""
 "\n"
-"            Submitted by %(auth_user)s on behalf of %(user)s\n"
-"        "
+"                Submitted by %(auth_user)s on behalf of %(user)s\n"
+"            "
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:140
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:141
 #, python-format
 msgid ""
 "\n"
-"            Submitted by %(auth_user)s\n"
-"        "
+"                Submitted by %(auth_user)s\n"
+"            "
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:147
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:148
 #, python-format
 msgid ""
 "\n"
-"        Submitted as %(user)s\n"
-"        "
+"            Submitted as %(user)s\n"
+"            "
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:155
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:157
 msgid "Form Properties"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:161
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:163
 msgid "Case Changes"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:169
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:171
 msgid "Form Metadata"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:177
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:179
 #: corehq/ex-submodules/casexml/apps/case/templates/case/partials/single_case.html:30
 msgid "Attachments"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:183
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:185
 msgid "Raw XML"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:194
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:195
 msgid "View standalone form"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:200
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:201
 msgid "Edit submission"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:206
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:207
 msgid "Archiving Forms"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:207
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:208
 msgid ""
 "Archived forms will no longer show up in reports and they will be removed "
 "from any relevant case histories. "
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:211
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:212
 msgid "Archive this form"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:220
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:221
 msgid "Restoring Forms"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:221
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:222
 msgid "Restoring this form will cause it to show up in reports again."
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:225
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:226
 msgid "Restore this form"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:234
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:235
 msgid "Resaving Forms"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:235
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:236
 msgid ""
 "Resaving a form can manually cause it to be reincluded in reports if "
 "something went wrong during initial processing."
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:239
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:240
 msgid "Resave this form"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:262
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:263
 msgid "Unknown/Deleted Case"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:269
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:270
 msgid "(this case)"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:315
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:316
 msgid "Open XML in New Window"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:318
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:319
 msgid "Double-click code below to select all:"
 msgstr ""
 
@@ -18358,7 +18591,7 @@ msgid "IVR"
 msgstr ""
 
 #: corehq/apps/reports/templates/reports/messaging/survey_detail.html:23
-#: custom/ilsgateway/tanzania/reports/randr.py:173
+#: custom/ilsgateway/tanzania/reports/randr.py:175
 msgid "Contact"
 msgstr ""
 
@@ -18400,6 +18633,7 @@ msgid "No data is available. Please submit more forms!"
 msgstr ""
 
 #: corehq/apps/reports/templates/reports/partials/hqexport_group_table.html:8
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:47
 msgid "File"
 msgstr ""
 
@@ -18892,6 +19126,11 @@ msgstr ""
 msgid "My Account"
 msgstr ""
 
+#: corehq/apps/settings/views.py:93
+#: corehq/apps/settings/templates/settings/edit_my_account.b2.html:33
+msgid "My Information"
+msgstr ""
+
 #: corehq/apps/settings/views.py:174
 #, python-format
 msgid "Unable remove membership because you are the admin of %s"
@@ -18915,6 +19154,7 @@ msgid "Your password was successfully changed!"
 msgstr ""
 
 #: corehq/apps/settings/templates/settings/change_my_password.html:9
+#: docs/_build/html/_sources/translations.txt:177
 msgid "Specify New Password"
 msgstr ""
 
@@ -18930,7 +19170,7 @@ msgstr ""
 #: corehq/apps/settings/templates/settings/edit_my_account.b2.html:42
 #: corehq/apps/telerivet/forms.py:10
 #: corehq/apps/telerivet/templates/telerivet/backend.html:10
-#: corehq/apps/users/forms.py:188
+#: corehq/apps/users/forms.py:187
 msgid "API Key"
 msgstr ""
 
@@ -20679,6 +20919,10 @@ msgstr ""
 msgid "All domain/toggle statuses"
 msgstr ""
 
+#: corehq/apps/toggle_ui/templates/toggle/edit_flag.html:165
+msgid "Enabled?"
+msgstr ""
+
 #: corehq/apps/toggle_ui/templates/toggle/flags.html:57
 msgid "Tag"
 msgstr ""
@@ -20735,8 +20979,8 @@ msgid "Create New Report"
 msgstr "Manejo de Casos"
 
 #: corehq/apps/userreports/views.py:124
-#: corehq/apps/userreports/reports/builder/forms.py:768
-#: corehq/apps/userreports/reports/builder/forms.py:823
+#: corehq/apps/userreports/reports/builder/forms.py:776
+#: corehq/apps/userreports/reports/builder/forms.py:831
 msgid "Chart"
 msgstr ""
 
@@ -20778,22 +21022,22 @@ msgid ""
 "choose the columns and rows."
 msgstr ""
 
-#: corehq/apps/userreports/views.py:230
+#: corehq/apps/userreports/views.py:234
 #, fuzzy
 msgid "Chart Report: {}"
 msgstr "Manejo de Casos"
 
-#: corehq/apps/userreports/views.py:247
+#: corehq/apps/userreports/views.py:251
 msgid "Choose the property you would like to add as a filter to this report."
 msgstr ""
 
-#: corehq/apps/userreports/views.py:248
+#: corehq/apps/userreports/views.py:252
 msgid ""
 "Web users viewing the report will see this display text instead of the "
 "property name. Name your filter something easy for users to understand."
 msgstr ""
 
-#: corehq/apps/userreports/views.py:249
+#: corehq/apps/userreports/views.py:253
 msgid ""
 "What type of property is this filter?<br/><br/><strong>Date</strong>: select "
 "this if the property is a date.<br/><strong>Choice</strong>: select this if "
@@ -20801,74 +21045,74 @@ msgid ""
 "select this if the property is a number."
 msgstr ""
 
-#: corehq/apps/userreports/views.py:291
+#: corehq/apps/userreports/views.py:295
 #, fuzzy
 msgid "List Report: {}"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
-#: corehq/apps/userreports/views.py:300
+#: corehq/apps/userreports/views.py:304
 #, fuzzy
 msgid "Table Report: {}"
 msgstr "Manejo de Casos"
 
-#: corehq/apps/userreports/views.py:309
+#: corehq/apps/userreports/views.py:313
 #, fuzzy
 msgid "Worker Report: {}"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
-#: corehq/apps/userreports/views.py:322
+#: corehq/apps/userreports/views.py:326
 msgid "Report \"{}\" saved!"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:350
+#: corehq/apps/userreports/views.py:354
 msgid "Report \"{}\" deleted!"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:370
+#: corehq/apps/userreports/views.py:374
 msgid "Report created!"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:373
+#: corehq/apps/userreports/views.py:377
 msgid "Bad report source: {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:375
+#: corehq/apps/userreports/views.py:379
 msgid "paste report source here"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:414 corehq/apps/userreports/views.py:420
+#: corehq/apps/userreports/views.py:418 corehq/apps/userreports/views.py:424
 msgid "Data source created for '{}'"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:437
+#: corehq/apps/userreports/views.py:441
 msgid "Data source \"{}\" saved!"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:465
+#: corehq/apps/userreports/views.py:469
 msgid "Data source \"{}\" has been deleted."
 msgstr ""
 
-#: corehq/apps/userreports/views.py:475
+#: corehq/apps/userreports/views.py:479
 msgid "Table \"{}\" is now being rebuilt. Data should start showing up soon"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:514
+#: corehq/apps/userreports/views.py:518
 msgid "You can only use 'lastndays' on date columns"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:524
+#: corehq/apps/userreports/views.py:528
 msgid "Ranges must have the format \"start..end\""
 msgstr ""
 
-#: corehq/apps/userreports/views.py:556
+#: corehq/apps/userreports/views.py:560
 msgid "No field named {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:563
+#: corehq/apps/userreports/views.py:567
 msgid "Invalid filter parameter: {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:597
+#: corehq/apps/userreports/views.py:601
 msgid ""
 "There was a problem executing your query, please make sure your parameters "
 "are valid."
@@ -20965,48 +21209,48 @@ msgid ""
 "the data source before viewing the report."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:304
+#: corehq/apps/userreports/reports/builder/forms.py:305
 msgid "Bar"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:305
+#: corehq/apps/userreports/reports/builder/forms.py:306
 msgid "Pie"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:318
+#: corehq/apps/userreports/reports/builder/forms.py:319
 msgid ""
 "<strong>Form</strong>: display data from form submissions.<br/><strong>Case</"
 "strong>: display data from your cases. You must be using case management for "
 "this option."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:319
+#: corehq/apps/userreports/reports/builder/forms.py:320
 msgid "Which application should the data come from?"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:320
+#: corehq/apps/userreports/reports/builder/forms.py:321
 msgid ""
 "Choose the case type or form from which to retrieve data for this report."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:332
+#: corehq/apps/userreports/reports/builder/forms.py:333
 msgid ""
 "<strong>Bar</strong> shows one vertical bar for each value in your case or "
 "form. <strong>Pie</strong> shows what percentage of the total each value is."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:345
+#: corehq/apps/userreports/reports/builder/forms.py:346
 #, fuzzy
 msgid "{} Report"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
-#: corehq/apps/userreports/reports/builder/forms.py:346
+#: corehq/apps/userreports/reports/builder/forms.py:347
 msgid ""
 "Web users will see this name in the \"Reports\" section of CommCareHQ and "
 "can click to view the report"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:388
+#: corehq/apps/userreports/reports/builder/forms.py:389
 msgid ""
 "Too many data sources!\n"
 "Creating this report would cause you to go over the maximum number of data "
@@ -21015,65 +21259,71 @@ msgid ""
 "itself) and try again. "
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:405
+#: corehq/apps/userreports/reports/builder/forms.py:406
 #: custom/bihar/reports/indicators/clientlistdisplay.py:146
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:345
 msgid "Done"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:417
+#: corehq/apps/userreports/reports/builder/forms.py:418
 #, fuzzy
 msgid "Update Report"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
-#: corehq/apps/userreports/reports/builder/forms.py:474
-#: corehq/apps/userreports/templates/userreports/edit_report_config.html:8
+#: corehq/apps/userreports/reports/builder/forms.py:475
+#: corehq/apps/userreports/templates/userreports/edit_report_config.html:18
 #, fuzzy
 msgid "Delete Report"
 msgstr "Manejo de Casos"
 
-#: corehq/apps/userreports/reports/builder/forms.py:518
+#: corehq/apps/userreports/reports/builder/forms.py:500
+msgid ""
+"Report builder data source doesn't reference an application. It is likely "
+"this report has been customized and it is no longer editable. "
+msgstr ""
+
+#: corehq/apps/userreports/reports/builder/forms.py:526
 msgid "Filters"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:519
+#: corehq/apps/userreports/reports/builder/forms.py:527
 msgid ""
 "Add filters to your report to allow viewers to select which data the report "
 "will display. These filters will be displayed at the top of your report."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:573
+#: corehq/apps/userreports/reports/builder/forms.py:581
 msgid ""
 "Editing this report would require a new data source. The limit is 5. To "
 "continue, first delete all of the reports using a particular data source (or "
 "the data source itself) and try again. "
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:769
+#: corehq/apps/userreports/reports/builder/forms.py:777
 msgid ""
 "The values of the selected property will be aggregated and shown as bars in "
 "the chart."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:824
+#: corehq/apps/userreports/reports/builder/forms.py:832
 msgid ""
 "The values of the selected property will be aggregated and shows as the "
 "sections of the pie chart."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:841
+#: corehq/apps/userreports/reports/builder/forms.py:849
 msgid ""
 "Add columns to your report to display information from cases or form "
 "submissions. You may rearrange the order of the columns by dragging the "
 "arrows next to the column."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:854
+#: corehq/apps/userreports/reports/builder/forms.py:862
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:179
 msgid "Columns"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:898
+#: corehq/apps/userreports/reports/builder/forms.py:906
 msgid ""
 "Add columns for this report to aggregate. Each property you add will create "
 "a column for every value of that property.  For example, if you add a column "
@@ -21081,23 +21331,37 @@ msgid ""
 "column for \"no.\""
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:907
+#: corehq/apps/userreports/reports/builder/forms.py:915
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:13
 msgid "Rows"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:908
+#: corehq/apps/userreports/reports/builder/forms.py:916
 msgid ""
 "Choose which property this report will group its results by. Each value of "
 "this property will be a row in the table. For example, if you choose a yes "
 "or no question, the report will show a row for \"yes\" and a row for \"no.\""
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:971
+#: corehq/apps/userreports/reports/builder/forms.py:979
 msgid ""
 "Add columns for this report to aggregate. Each property you add will create "
 "a column for every value of that property. For example, if you add a column "
 "for a yes or no question, the report will show a column for \"yes\" and a "
 "column for \"no\"."
+msgstr ""
+
+#: corehq/apps/userreports/sql/columns.py:60
+#, python-brace-format
+msgid ""
+"The \"{header}\" column had too many values to expand! Expansion limited to "
+"{max} distinct values."
+msgstr ""
+
+#: corehq/apps/userreports/sql/columns.py:94
+msgid ""
+"The column \"{}\" does not exist in the report source! Please double check "
+"your report configuration."
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/builder_report_type_select.html:37
@@ -21122,60 +21386,68 @@ msgid ""
 "        "
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:108
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:105
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:111
+#: corehq/apps/userreports/templates/userreports/edit_report_config.html:7
 #, fuzzy
 msgid "Edit Report"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
 #: corehq/apps/userreports/templates/userreports/configurable_reports_home.html:4
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:44
 #, fuzzy
 msgid "Configurable Reports"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
 #: corehq/apps/userreports/templates/userreports/configurable_reports_home.html:5
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:32
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:82
 msgid "Add data source"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/configurable_reports_home.html:6
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:16
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:64
 #, fuzzy
 msgid "Add report"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
 #: corehq/apps/userreports/templates/userreports/configurable_reports_home.html:7
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:20
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:68
 #, fuzzy
 msgid "Import report"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
 #: corehq/apps/userreports/templates/userreports/edit_data_source.html:7
+#, fuzzy
+msgid "Edit Data Source"
+msgstr "Manejo de Casos"
+
+#: corehq/apps/userreports/templates/userreports/edit_data_source.html:18
 msgid "This datasource is read only, any changes made can not be saved."
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/edit_data_source.html:14
+#: corehq/apps/userreports/templates/userreports/edit_data_source.html:25
 msgid "Delete Data Source"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/edit_data_source.html:18
+#: corehq/apps/userreports/templates/userreports/edit_data_source.html:29
 #, fuzzy
 msgid "Rebuild Data Source"
 msgstr "Manejo de Casos"
 
-#: corehq/apps/userreports/templates/userreports/edit_data_source.html:19
+#: corehq/apps/userreports/templates/userreports/edit_data_source.html:30
 msgid "Preview data"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/edit_data_source.html:20
+#: corehq/apps/userreports/templates/userreports/edit_data_source.html:31
 msgid "Data Source Source (Advanced)"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/edit_report_config.html:9
+#: corehq/apps/userreports/templates/userreports/edit_report_config.html:19
 #, fuzzy
 msgid "View report"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
-#: corehq/apps/userreports/templates/userreports/edit_report_config.html:10
+#: corehq/apps/userreports/templates/userreports/edit_report_config.html:20
 msgid "Report Source (Advanced)"
 msgstr ""
 
@@ -21194,17 +21466,17 @@ msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 msgid "Preview table: %(display_name)s (%(total_rows)s total rows)"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:7
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:53
 #: corehq/apps/users/templates/users/web_users.b3.html:390
 #, fuzzy
 msgid "Edit Reports"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:23
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:71
 msgid "Edit Data Sources"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:38
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:88
 #, fuzzy
 msgid "Data source from application"
 msgstr "Casos IRA Tratados"
@@ -21230,7 +21502,7 @@ msgid "Expected {} but was {}"
 msgstr ""
 
 #: corehq/apps/userreports/ui/forms.py:25
-#: corehq/apps/userreports/ui/forms.py:149
+#: corehq/apps/userreports/ui/forms.py:159
 msgid "Save Changes"
 msgstr ""
 
@@ -21251,23 +21523,81 @@ msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 msgid "Problem with report spec: {}"
 msgstr ""
 
-#: corehq/apps/userreports/ui/forms.py:95
+#: corehq/apps/userreports/ui/forms.py:91
+#, fuzzy
+msgid "Source Type"
+msgstr "Manejo de Casos"
+
+#: corehq/apps/userreports/ui/forms.py:92
+#, fuzzy
+msgid "Report Title"
+msgstr "Manejo de Casos"
+
+#: corehq/apps/userreports/ui/forms.py:103
 msgid "Named filters (optional)"
 msgstr ""
 
-#: corehq/apps/userreports/ui/forms.py:106
+#: corehq/apps/userreports/ui/forms.py:116
 msgid ""
 "Table id is too long. Your table id and domain name must add up to fewer "
 "than 40 characters"
 msgstr ""
 
-#: corehq/apps/userreports/ui/forms.py:111
+#: corehq/apps/userreports/ui/forms.py:121
 msgid ""
 "A data source with this table id already exists. Table ids must be unique"
 msgstr ""
 
-#: corehq/apps/userreports/ui/forms.py:128
+#: corehq/apps/userreports/ui/forms.py:138
 msgid "Problem with data source spec: {}"
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:4
+msgid ""
+"Choose something short, unique, and memorable using lowercase letters, "
+"numbers, and underscores"
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:7
+msgid ""
+"This is what the data source will be called in navigation, page title, etc."
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:9
+msgid "Write yourself a little note if you like, it's optional"
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:11
+msgid ""
+"You can leave this blank unless you are <a target=\"_blank\" href=\"https://"
+"github.com/dimagi/commcare-hq/blob/master/corehq/apps/userreports/README."
+"md#saving-repeat-data\">saving repeat data</a>"
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:16
+msgid ""
+"Look at <a target=\"_blank\" href=\"https://github.com/dimagi/commcare-hq/"
+"blob/master/corehq/apps/userreports/examples/examples.md#data-source-filters"
+"\">these examples</a> and <a target=\"_blank\" href=\"https://github.com/"
+"dimagi/commcare-hq/blob/master/corehq/apps/userreports/README.md#data-source-"
+"filtering\">these docs</a>"
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:24
+msgid ""
+"Look at <a target=\"_blank\" href=\"https://github.com/dimagi/commcare-hq/"
+"blob/master/corehq/apps/userreports/examples/examples.md#data-source-"
+"indicators\">these examples</a> and <a target=\"_blank\" href=\"https://"
+"github.com/dimagi/commcare-hq/blob/master/corehq/apps/userreports/README."
+"md#indicators\">these docs</a>"
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:32
+msgid ""
+"For this advanced and useful feature, give a dict where the keys are the "
+"variable names you choose and the values are filters according to the syntax "
+"of Configured Filters above. You can then reference these from Configured "
+"Filters as {\"type\": \"named\", \"name\": \"myvarname\"}"
 msgstr ""
 
 #: corehq/apps/users/bulkupload.py:52
@@ -21322,77 +21652,77 @@ msgstr ""
 msgid "Can't add to group '%s' (try adding it to your spreadsheet)"
 msgstr ""
 
-#: corehq/apps/users/forms.py:59
+#: corehq/apps/users/forms.py:58
 msgid "Please enter a valid two or three digit language code."
 msgstr ""
 
-#: corehq/apps/users/forms.py:132
+#: corehq/apps/users/forms.py:131
 msgid "System Super User"
 msgstr ""
 
-#: corehq/apps/users/forms.py:147
+#: corehq/apps/users/forms.py:146
 msgid "E-Mail"
 msgstr ""
 
-#: corehq/apps/users/forms.py:154
+#: corehq/apps/users/forms.py:153
 msgid ""
 "<i class=\"icon-info-sign\"></i> Becomes default language seen in CloudCare "
 "and reports (if applicable), but does not affect mobile applications. "
 "Supported languages for reports are en, fr (partial), and hin (partial)."
 msgstr ""
 
-#: corehq/apps/users/forms.py:171
+#: corehq/apps/users/forms.py:170
 msgid "Opt out of emails about CommCare updates."
 msgstr ""
 
-#: corehq/apps/users/forms.py:191
+#: corehq/apps/users/forms.py:190
 msgid "Generate API Key"
 msgstr ""
 
-#: corehq/apps/users/forms.py:199
+#: corehq/apps/users/forms.py:198
 msgid "My Language"
 msgstr ""
 
-#: corehq/apps/users/forms.py:219
+#: corehq/apps/users/forms.py:218
 msgid "Other Options"
 msgstr ""
 
-#: corehq/apps/users/forms.py:225
+#: corehq/apps/users/forms.py:224
 msgid "Update My Information"
 msgstr ""
 
-#: corehq/apps/users/forms.py:240
+#: corehq/apps/users/forms.py:239
 msgid ""
 "Multiply this user's case load by a number for load testing on phones. Leave "
 "blank for normal users."
 msgstr ""
 
-#: corehq/apps/users/forms.py:324
+#: corehq/apps/users/forms.py:323
 #, python-format
 msgid "%s is an invalid phone number."
 msgstr ""
 
-#: corehq/apps/users/forms.py:371 corehq/apps/users/forms.py:373
+#: corehq/apps/users/forms.py:370 corehq/apps/users/forms.py:372
 msgid "Username contains invalid characters."
 msgstr ""
 
-#: corehq/apps/users/forms.py:480
+#: corehq/apps/users/forms.py:479
 #, python-format
 msgid ""
 "I have read and agree to the <a href=\"%(pa_url)s\" target=\"_blank"
 "\">Software Product Subscription Agreement</a>."
 msgstr ""
 
-#: corehq/apps/users/forms.py:509
+#: corehq/apps/users/forms.py:508
 msgid "Back to Mobile Workers List"
 msgstr ""
 
-#: corehq/apps/users/forms.py:521
+#: corehq/apps/users/forms.py:520
 msgid ""
 "Please agree to the Product Subscription Agreement above before continuing."
 msgstr ""
 
-#: corehq/apps/users/models.py:2426
+#: corehq/apps/users/models.py:2446
 #, python-format
 msgid "Invitation from %s to join CommCareHQ"
 msgstr ""
@@ -21953,8 +22283,8 @@ msgstr ""
 
 #: corehq/apps/users/templates/users/mobile/users_list.html:212
 #: custom/_legacy/pact/templates/pact/chw/pact_chw_profile_info.html:12
-#: custom/ilsgateway/tanzania/reports/facility_details.py:72
-#: custom/ilsgateway/tanzania/reports/facility_details.py:119
+#: custom/ilsgateway/tanzania/reports/facility_details.py:73
+#: custom/ilsgateway/tanzania/reports/facility_details.py:120
 msgid "Phone"
 msgstr ""
 
@@ -22092,57 +22422,53 @@ msgstr ""
 msgid "Edit User Role"
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:291
+#: corehq/apps/users/views/__init__.py:289
 #, python-format
 msgid "Changed system permissions for user \"%s\""
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:340
+#: corehq/apps/users/views/__init__.py:338
 msgid "Phone number added!"
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:342
+#: corehq/apps/users/views/__init__.py:340
 msgid "Please enter digits only."
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:349
-msgid "Edit My Information"
-msgstr ""
-
-#: corehq/apps/users/views/__init__.py:388
-#: corehq/apps/users/views/__init__.py:534
+#: corehq/apps/users/views/__init__.py:346
+#: corehq/apps/users/views/__init__.py:492
 msgid "Web Users & Roles"
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:435
+#: corehq/apps/users/views/__init__.py:393
 msgid "Please provide pagination info."
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:736
+#: corehq/apps/users/views/__init__.py:694
 msgid "Invitation resent"
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:738
+#: corehq/apps/users/views/__init__.py:696
 msgid "Error while attempting resend"
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:768
+#: corehq/apps/users/views/__init__.py:726
 msgid "Invite Web User to Project"
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:866
+#: corehq/apps/users/views/__init__.py:818
 msgid "Cannot start verification workflow. Phone number is already in use."
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:868
+#: corehq/apps/users/views/__init__.py:820
 msgid "Phone number is already verified."
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:870
+#: corehq/apps/users/views/__init__.py:822
 msgid "Verification message resent."
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:872
+#: corehq/apps/users/views/__init__.py:824
 msgid "Verification workflow started."
 msgstr ""
 
@@ -22276,36 +22602,36 @@ msgid ""
 "The following groups have no name. Please name them before continuing: {}"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:228
+#: corehq/ex-submodules/casexml/apps/case/models.py:229
 msgid "Closed"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:228
+#: corehq/ex-submodules/casexml/apps/case/models.py:229
 msgid "Open"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:515
+#: corehq/ex-submodules/casexml/apps/case/models.py:516
 msgid "Sorry, referrals are no longer supported!"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:857
+#: corehq/ex-submodules/casexml/apps/case/models.py:862
 msgid "Opened On"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:863
+#: corehq/ex-submodules/casexml/apps/case/models.py:868
 msgid "Modified On"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:869
-#: custom/opm/beneficiary.py:824 custom/opm/beneficiary.py:901
+#: corehq/ex-submodules/casexml/apps/case/models.py:874
+#: custom/opm/beneficiary.py:823 custom/opm/beneficiary.py:901
 msgid "Closed On"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:882
+#: corehq/ex-submodules/casexml/apps/case/models.py:887
 msgid "Last Submitter"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:907
+#: corehq/ex-submodules/casexml/apps/case/models.py:912
 msgid "Date Opened"
 msgstr ""
 
@@ -22966,8 +23292,8 @@ msgstr ""
 msgid "Beneficiary Information"
 msgstr ""
 
-#: custom/bihar/reports/mch_reports.py:134 custom/opm/beneficiary.py:809
-#: custom/opm/beneficiary.py:885
+#: custom/bihar/reports/mch_reports.py:134 custom/opm/beneficiary.py:808
+#: custom/opm/beneficiary.py:885 custom/opm/beneficiary.py:930
 msgid "Husband Name"
 msgstr ""
 
@@ -23044,6 +23370,7 @@ msgstr ""
 #: custom/bihar/reports/mch_reports.py:151
 #: custom/bihar/reports/indicators/clientlistdisplay.py:80
 #: custom/bihar/reports/indicators/clientlistdisplay.py:98
+#: custom/opm/beneficiary.py:944
 msgid "EDD"
 msgstr ""
 
@@ -23244,7 +23571,7 @@ msgstr ""
 msgid "Migrate status "
 msgstr ""
 
-#: custom/bihar/reports/mch_reports.py:314 custom/opm/beneficiary.py:812
+#: custom/bihar/reports/mch_reports.py:314 custom/opm/beneficiary.py:811
 msgid "Child Name"
 msgstr ""
 
@@ -24317,46 +24644,46 @@ msgstr ""
 msgid "Dashboard report {0}"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:28
-#: custom/ilsgateway/tanzania/reports/delivery.py:86
+#: custom/ilsgateway/tanzania/reports/delivery.py:29
+#: custom/ilsgateway/tanzania/reports/delivery.py:88
 msgid "Average Lead Time In Days"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:82
-#: custom/ilsgateway/tanzania/reports/randr.py:171
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:251
+#: custom/ilsgateway/tanzania/reports/delivery.py:84
+#: custom/ilsgateway/tanzania/reports/randr.py:173
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:318
 #, fuzzy
 msgid "Facility Name"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:83
+#: custom/ilsgateway/tanzania/reports/delivery.py:85
 #, fuzzy
 msgid "Delivery Status"
 msgstr "Casos IRA Tratados"
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:84
+#: custom/ilsgateway/tanzania/reports/delivery.py:86
 #, fuzzy
 msgid "Delivery Date"
 msgstr "Casos IRA Tratados"
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:85
+#: custom/ilsgateway/tanzania/reports/delivery.py:87
 msgid "This Cycle Lead Time"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:155
+#: custom/ilsgateway/tanzania/reports/delivery.py:158
 #, fuzzy, python-format
 msgid "% of total"
 msgstr "Balanço do Stock"
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:167
+#: custom/ilsgateway/tanzania/reports/delivery.py:170
 msgid "Didn't Respond"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:169
+#: custom/ilsgateway/tanzania/reports/delivery.py:172
 msgid "Not Received"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:182
+#: custom/ilsgateway/tanzania/reports/delivery.py:185
 #, fuzzy, python-brace-format
 msgid "Delivery Report {0}"
 msgstr "Manejo de Casos"
@@ -24365,107 +24692,107 @@ msgstr "Manejo de Casos"
 msgid "Months of stock"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/facility_details.py:120
+#: custom/ilsgateway/tanzania/reports/facility_details.py:121
 msgid "Text"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:83
+#: custom/ilsgateway/tanzania/reports/randr.py:84
 msgid "% Facilities Submitting R&R On Time"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:84
+#: custom/ilsgateway/tanzania/reports/randr.py:85
 msgid "% Facilities Submitting R&R Late"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:85
+#: custom/ilsgateway/tanzania/reports/randr.py:86
 msgid "% Facilities With R&R Not Submitted"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:86
+#: custom/ilsgateway/tanzania/reports/randr.py:87
 msgid "% Facilities Not Responding To R&R Reminder"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:87
-#: custom/ilsgateway/tanzania/reports/randr.py:174
-#: custom/ilsgateway/tanzania/reports/supervision.py:60
-#: custom/ilsgateway/tanzania/reports/supervision.py:123
+#: custom/ilsgateway/tanzania/reports/randr.py:88
+#: custom/ilsgateway/tanzania/reports/randr.py:176
+#: custom/ilsgateway/tanzania/reports/supervision.py:61
+#: custom/ilsgateway/tanzania/reports/supervision.py:125
 msgid "Historical Response Rate"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:172
+#: custom/ilsgateway/tanzania/reports/randr.py:174
 msgid "R&R Status"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:185
+#: custom/ilsgateway/tanzania/reports/randr.py:187
 #, python-brace-format
 msgid "R & R {0}"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:82
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:84
 msgid "% Facilities Submitting Soh On Time"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:83
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:85
 msgid "% Facilities Submitting Soh Late"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:84
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:86
 msgid "% Facilities Not Responding To Soh"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:85
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:87
 msgid "% Facilities With 1 Or More Stockouts This Month"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:97
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:99
 #, python-format
 msgid "%s stock outs this %s"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:203
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:269
 msgid "Waiting for reply"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:250
-#: custom/ilsgateway/tanzania/reports/supervision.py:119
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:317
+#: custom/ilsgateway/tanzania/reports/supervision.py:121
 msgid "MSD Code"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:252
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:319
 msgid "DG"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:253
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:320
 #, fuzzy
 msgid "Last Reported"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:254
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:321
 msgid "Hist. Resp. Rate"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:406
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:422
 #, fuzzy, python-brace-format
 msgid "Stock On Hand {0}"
 msgstr "Balanço do Stock"
 
-#: custom/ilsgateway/tanzania/reports/supervision.py:57
+#: custom/ilsgateway/tanzania/reports/supervision.py:58
 msgid "% Supervision Received"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/supervision.py:58
+#: custom/ilsgateway/tanzania/reports/supervision.py:59
 msgid "% Supervision Not Received"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/supervision.py:59
+#: custom/ilsgateway/tanzania/reports/supervision.py:60
 msgid "% Supervision Not Responding"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/supervision.py:121
+#: custom/ilsgateway/tanzania/reports/supervision.py:123
 msgid "Supervision This Quarter"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/supervision.py:181
+#: custom/ilsgateway/tanzania/reports/supervision.py:183
 #, python-brace-format
 msgid "Supervision {0}"
 msgstr ""
@@ -24474,7 +24801,7 @@ msgstr ""
 msgid "Unrecognized SMS"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/utils.py:98
+#: custom/ilsgateway/tanzania/reports/utils.py:100
 msgid "No Data"
 msgstr ""
 
@@ -24558,17 +24885,17 @@ msgstr ""
 msgid " days"
 msgstr ""
 
-#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:55
+#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:65
 #, python-format
 msgid "%(status)s"
 msgstr ""
 
-#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:58
+#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:68
 #, fuzzy
 msgid "Last updated on"
 msgstr "Casos IRA Tratados"
 
-#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:63
+#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:73
 #, fuzzy
 msgid "No delivery status reported"
 msgstr "Casos IRA Tratados"
@@ -25652,119 +25979,123 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: custom/opm/beneficiary.py:742
+#: custom/opm/beneficiary.py:741
 msgid "Incorrect EDD"
 msgstr ""
 
-#: custom/opm/beneficiary.py:748
+#: custom/opm/beneficiary.py:747
 msgid "Incorrect DOD"
 msgstr ""
 
-#: custom/opm/beneficiary.py:753
+#: custom/opm/beneficiary.py:752
 msgid "Incorrect LMP date"
 msgstr ""
 
-#: custom/opm/beneficiary.py:758
+#: custom/opm/beneficiary.py:757
 msgid "Account number is the wrong length"
 msgstr ""
 
-#: custom/opm/beneficiary.py:763
+#: custom/opm/beneficiary.py:762
 msgid "IFSC {} incorrect"
 msgstr ""
 
-#: custom/opm/beneficiary.py:804
+#: custom/opm/beneficiary.py:803 custom/opm/beneficiary.py:919
 msgid "Serial number"
 msgstr ""
 
-#: custom/opm/beneficiary.py:805 custom/opm/beneficiary.py:884
+#: custom/opm/beneficiary.py:804 custom/opm/beneficiary.py:884
+#: custom/opm/beneficiary.py:920
 msgid "List of Beneficiaries"
 msgstr ""
 
-#: custom/opm/beneficiary.py:806 custom/opm/beneficiary.py:886
-#: custom/opm/health_status.py:89
+#: custom/opm/beneficiary.py:805 custom/opm/beneficiary.py:886
+#: custom/opm/beneficiary.py:922 custom/opm/health_status.py:18
 #, fuzzy
 msgid "AWC Name"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
-#: custom/opm/beneficiary.py:807 custom/opm/health_status.py:85
+#: custom/opm/beneficiary.py:806 custom/opm/beneficiary.py:923
+#: custom/opm/health_status.py:14
 #, fuzzy
 msgid "AWC Code"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
-#: custom/opm/beneficiary.py:808 custom/opm/beneficiary.py:891
+#: custom/opm/beneficiary.py:807 custom/opm/beneficiary.py:891
+#: custom/opm/beneficiary.py:924
 msgid "Block Name"
 msgstr ""
 
-#: custom/opm/beneficiary.py:810
+#: custom/opm/beneficiary.py:809 custom/opm/beneficiary.py:942
 msgid "Current status"
 msgstr ""
 
-#: custom/opm/beneficiary.py:811
+#: custom/opm/beneficiary.py:810
 msgid "Pregnancy Month"
 msgstr ""
 
-#: custom/opm/beneficiary.py:813
+#: custom/opm/beneficiary.py:812
 msgid "Child Age"
 msgstr ""
 
-#: custom/opm/beneficiary.py:815
+#: custom/opm/beneficiary.py:814
 #, fuzzy
 msgid "Condition 1"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
-#: custom/opm/beneficiary.py:816
+#: custom/opm/beneficiary.py:815
 #, fuzzy
 msgid "Condition 2"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
-#: custom/opm/beneficiary.py:817
+#: custom/opm/beneficiary.py:816
 #, fuzzy
 msgid "Condition 3"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
-#: custom/opm/beneficiary.py:818
+#: custom/opm/beneficiary.py:817
 #, fuzzy
 msgid "Condition 4"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
-#: custom/opm/beneficiary.py:819
+#: custom/opm/beneficiary.py:818
 #, fuzzy
 msgid "Condition 5"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
-#: custom/opm/beneficiary.py:820
+#: custom/opm/beneficiary.py:819
 #, fuzzy
 msgid "Payment amount this month (Rs.)"
 msgstr "Casos IRA Tratados"
 
-#: custom/opm/beneficiary.py:821
+#: custom/opm/beneficiary.py:820
 #, fuzzy
 msgid "Payment amount last month (Rs.)"
 msgstr "Casos IRA Tratados"
 
-#: custom/opm/beneficiary.py:822
+#: custom/opm/beneficiary.py:821 custom/opm/beneficiary.py:973
 #, fuzzy
 msgid "Cash received last month"
 msgstr "Casos IRA Tratados"
 
-#: custom/opm/beneficiary.py:825 custom/opm/beneficiary.py:904
+#: custom/opm/beneficiary.py:824 custom/opm/beneficiary.py:904
+#: custom/opm/beneficiary.py:974
 msgid "Issues"
 msgstr ""
 
-#: custom/opm/beneficiary.py:887
+#: custom/opm/beneficiary.py:887 custom/opm/beneficiary.py:937
 #, fuzzy
 msgid "Bank Name"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
-#: custom/opm/beneficiary.py:888
+#: custom/opm/beneficiary.py:888 custom/opm/beneficiary.py:939
 msgid "Bank Branch Name"
 msgstr ""
 
-#: custom/opm/beneficiary.py:889
+#: custom/opm/beneficiary.py:889 custom/opm/beneficiary.py:941
 msgid "IFS Code"
 msgstr ""
 
-#: custom/opm/beneficiary.py:890
+#: custom/opm/beneficiary.py:890 custom/opm/beneficiary.py:938
 msgid "Bank Account Number"
 msgstr ""
 
@@ -25810,447 +26141,661 @@ msgstr ""
 msgid "Payment last month"
 msgstr "Casos IRA Tratados"
 
-#: custom/opm/filters.py:113 custom/opm/filters.py:126
+#: custom/opm/beneficiary.py:925
+msgid "Gram Panchayat name"
+msgstr ""
+
+#: custom/opm/beneficiary.py:926
+#, fuzzy
+msgid "Village name"
+msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
+
+#: custom/opm/beneficiary.py:927
+msgid "Dob Known"
+msgstr ""
+
+#: custom/opm/beneficiary.py:928
+#, fuzzy
+msgid "Mother's Age"
+msgstr "Outros (negativos / indeterminados) "
+
+#: custom/opm/beneficiary.py:929
+#, fuzzy
+msgid "Caste tribe status"
+msgstr "Diagnóstico de Casos"
+
+#: custom/opm/beneficiary.py:931
+msgid "Prev pregnancies"
+msgstr ""
+
+#: custom/opm/beneficiary.py:932
+msgid "Prev live births"
+msgstr ""
+
+#: custom/opm/beneficiary.py:933
+msgid "Sons alive"
+msgstr ""
+
+#: custom/opm/beneficiary.py:934
+msgid "Daughters alive"
+msgstr ""
+
+#: custom/opm/beneficiary.py:935
+msgid "Sum children"
+msgstr ""
+
+#: custom/opm/beneficiary.py:936
+msgid "Contact phone number"
+msgstr ""
+
+#: custom/opm/beneficiary.py:940
+msgid "Bank Branch Code"
+msgstr ""
+
+#: custom/opm/beneficiary.py:943
+#, fuzzy
+msgid "Lmp Date"
+msgstr "Casos IRA Tratados"
+
+#: custom/opm/beneficiary.py:945
+#, fuzzy
+msgid "Pregnancy month"
+msgstr "Casos IRA Tratados"
+
+#: custom/opm/beneficiary.py:947
+#, fuzzy
+msgid "Child 1 Age"
+msgstr "Crianças (2 - 59 meses)"
+
+#: custom/opm/beneficiary.py:948
+#, fuzzy
+msgid "Child 1 Name"
+msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
+
+#: custom/opm/beneficiary.py:949
+#, fuzzy
+msgid "Child 1 Sex"
+msgstr "Crianças (2 - 59 meses)"
+
+#: custom/opm/beneficiary.py:950
+msgid "Child DOB"
+msgstr ""
+
+#: custom/opm/beneficiary.py:951
+#, fuzzy
+msgid "Child 2 Age"
+msgstr "Crianças (2 - 59 meses)"
+
+#: custom/opm/beneficiary.py:952
+#, fuzzy
+msgid "Child 2 Name"
+msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
+
+#: custom/opm/beneficiary.py:953
+#, fuzzy
+msgid "Child 2 Sex"
+msgstr "Crianças (2 - 59 meses)"
+
+#: custom/opm/beneficiary.py:954
+#, fuzzy
+msgid "Child 3 Age"
+msgstr "Crianças (2 - 59 meses)"
+
+#: custom/opm/beneficiary.py:955
+#, fuzzy
+msgid "Child 3 Name"
+msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
+
+#: custom/opm/beneficiary.py:956
+#, fuzzy
+msgid "Child 3 Sex"
+msgstr "Crianças (2 - 59 meses)"
+
+#: custom/opm/beneficiary.py:957
+msgid "Condition 1 / pregnant woman attended VHND"
+msgstr ""
+
+#: custom/opm/beneficiary.py:958
+msgid "Condition 2 /pregnant woman's weight taken in first trimester"
+msgstr ""
+
+#: custom/opm/beneficiary.py:959
+msgid "Condition 3/ Received 30 IFA pills"
+msgstr ""
+
+#: custom/opm/beneficiary.py:960
+msgid "Condition 2 /pregnant woman's weight taken in second trimester"
+msgstr ""
+
+#: custom/opm/beneficiary.py:961
+msgid "Condition 4/mother attended VHND with child"
+msgstr ""
+
+#: custom/opm/beneficiary.py:962
+msgid "Condition 5/child birth registered"
+msgstr ""
+
+#: custom/opm/beneficiary.py:963
+msgid "Condition 6/ child birth weight taken"
+msgstr ""
+
+#: custom/opm/beneficiary.py:964
+msgid "Condition 7 /exclusively breastfed for first 6 months"
+msgstr ""
+
+#: custom/opm/beneficiary.py:965
+msgid "Condition 8 /child weight monitored this month"
+msgstr ""
+
+#: custom/opm/beneficiary.py:966
+msgid "Condition 9 /ORS administered if child had diarrhea"
+msgstr ""
+
+#: custom/opm/beneficiary.py:967
+msgid "Condition 10/ Measles vaccine given before child turns 1"
+msgstr ""
+
+#: custom/opm/beneficiary.py:968
+msgid "Birth Spacing Bonus"
+msgstr ""
+
+#: custom/opm/beneficiary.py:969
+msgid "Weight This Month"
+msgstr ""
+
+#: custom/opm/beneficiary.py:970
+msgid "Nutritional Status This Month"
+msgstr ""
+
+#: custom/opm/beneficiary.py:971
+msgid "Nutritional Status Bonus"
+msgstr ""
+
+#: custom/opm/beneficiary.py:972
+#, fuzzy
+msgid "Payment amount for the month"
+msgstr "Casos IRA Tratados"
+
+#: custom/opm/beneficiary.py:975
+msgid "VHND held this month?"
+msgstr ""
+
+#: custom/opm/beneficiary.py:976
+msgid "Opened on"
+msgstr ""
+
+#: custom/opm/beneficiary.py:977
+#, fuzzy
+msgid "Closed on"
+msgstr "Casos IRA Tratados"
+
+#: custom/opm/beneficiary.py:978
+msgid "Close mother dup"
+msgstr ""
+
+#: custom/opm/beneficiary.py:979
+msgid "Close mother mo"
+msgstr ""
+
+#: custom/opm/beneficiary.py:980
+#, fuzzy
+msgid "Leave program"
+msgstr "Manejo de Casos"
+
+#: custom/opm/beneficiary.py:981
+msgid "Close mother dead"
+msgstr ""
+
+#: custom/opm/beneficiary.py:982
+msgid "Calendar year"
+msgstr ""
+
+#: custom/opm/beneficiary.py:983
+#, fuzzy
+msgid "Calendar month"
+msgstr "Casos IRA Tratados"
+
+#: custom/opm/filters.py:72 custom/opm/filters.py:85
 #: custom/up_nrhm/filters.py:37
 msgid "Hierarchy"
 msgstr ""
 
-#: custom/opm/health_status.py:93
+#: custom/opm/health_status.py:22
 msgid "Gram Panchayat"
 msgstr ""
 
-#: custom/opm/health_status.py:97
+#: custom/opm/health_status.py:26
 msgid "Registered Beneficiaries"
 msgstr ""
 
-#: custom/opm/health_status.py:98
+#: custom/opm/health_status.py:27
 msgid "Beneficiaries registered with BCSP"
 msgstr ""
 
-#: custom/opm/health_status.py:101
+#: custom/opm/health_status.py:30
 msgid "Registered pregnant women"
 msgstr ""
 
-#: custom/opm/health_status.py:102
+#: custom/opm/health_status.py:31
 msgid "Pregnant women registered with BCSP"
 msgstr ""
 
-#: custom/opm/health_status.py:105
+#: custom/opm/health_status.py:34
 msgid "Registered mothers"
 msgstr ""
 
-#: custom/opm/health_status.py:106
+#: custom/opm/health_status.py:35
 msgid "Mothers registered with BCSP"
 msgstr ""
 
-#: custom/opm/health_status.py:109
+#: custom/opm/health_status.py:38
 #, fuzzy
 msgid "Registered children"
 msgstr "Crianças (2 - 59 meses)"
 
-#: custom/opm/health_status.py:110
+#: custom/opm/health_status.py:39
 msgid "Children below 3 years of age registered with BCSP"
 msgstr ""
 
-#: custom/opm/health_status.py:113
+#: custom/opm/health_status.py:42
 msgid "Eligible for payment upon fulfillment of cash conditions"
 msgstr ""
 
-#: custom/opm/health_status.py:114
+#: custom/opm/health_status.py:43
 msgid ""
 "Registered beneficiaries eligilble for cash payment for the month upon "
 "fulfillment of cash conditions"
 msgstr ""
 
-#: custom/opm/health_status.py:118
+#: custom/opm/health_status.py:47
 msgid "Eligible for payment upon absence of services"
 msgstr ""
 
-#: custom/opm/health_status.py:119
+#: custom/opm/health_status.py:48
 msgid ""
 "Registered beneficiaries eligilble for cash payment for the month upon "
 "absence of services at VHND"
 msgstr ""
 
-#: custom/opm/health_status.py:122
+#: custom/opm/health_status.py:51
 msgid "Eligible for payment"
 msgstr ""
 
-#: custom/opm/health_status.py:123
+#: custom/opm/health_status.py:52
 msgid "Registered beneficiaries eligilble for cash payment for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:126
+#: custom/opm/health_status.py:55
 msgid "Total cash payment"
 msgstr ""
 
-#: custom/opm/health_status.py:127
+#: custom/opm/health_status.py:56
 msgid "Total cash payment made to registered beneficiaries for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:130
+#: custom/opm/health_status.py:59
 msgid "Pregnant women attended VHND"
 msgstr ""
 
-#: custom/opm/health_status.py:131
+#: custom/opm/health_status.py:60
 msgid "Registered pregnant women who attended VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:134
+#: custom/opm/health_status.py:63
 msgid "Children attended VHND"
 msgstr ""
 
-#: custom/opm/health_status.py:135
+#: custom/opm/health_status.py:64
 msgid ""
 "Registered children below 3 years of age who attended VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:138
+#: custom/opm/health_status.py:67
 msgid "Beneficiaries attended VHND"
 msgstr ""
 
-#: custom/opm/health_status.py:139
+#: custom/opm/health_status.py:68
 msgid "Registered beneficiaries who attended VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:142
+#: custom/opm/health_status.py:71
 msgid "Received at least 30 IFA tablets"
 msgstr ""
 
-#: custom/opm/health_status.py:143
+#: custom/opm/health_status.py:72
 msgid ""
 "Registered pregnant women (6 months pregnant) who received at least 30 IFA "
 "tablets in second trimester"
 msgstr ""
 
-#: custom/opm/health_status.py:147
+#: custom/opm/health_status.py:76
 msgid "Weight monitored in second trimester"
 msgstr ""
 
-#: custom/opm/health_status.py:148
+#: custom/opm/health_status.py:77
 msgid ""
 "Registered pregnant women (6 months pregnant) who got their weight monitored "
 "in second trimester"
 msgstr ""
 
-#: custom/opm/health_status.py:151
+#: custom/opm/health_status.py:80
 msgid "Weight monitored in third trimester"
 msgstr ""
 
-#: custom/opm/health_status.py:152
+#: custom/opm/health_status.py:81
 msgid ""
 "Registered pregnant women (9 months pregnant) who got their weight monitored "
 "in third trimester"
 msgstr ""
 
-#: custom/opm/health_status.py:155
+#: custom/opm/health_status.py:84
 msgid "Weight monitored at birth"
 msgstr ""
 
-#: custom/opm/health_status.py:156
+#: custom/opm/health_status.py:85
 msgid "Registered children (3 months old) whose weight was monitored at birth"
 msgstr ""
 
-#: custom/opm/health_status.py:159
+#: custom/opm/health_status.py:88
 msgid "Child birth registered"
 msgstr ""
 
-#: custom/opm/health_status.py:160
+#: custom/opm/health_status.py:89
 msgid ""
 "Registered children (6 months old) whose birth was registered in the first 6 "
 "months after birth"
 msgstr ""
 
-#: custom/opm/health_status.py:163
+#: custom/opm/health_status.py:92
 msgid "Growth monitoring when 0-3 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:164
+#: custom/opm/health_status.py:93
 msgid ""
 "Registered Children (3 months old) who have attended at least one growth "
 "monitoring session between the age 0-3 months"
 msgstr ""
 
-#: custom/opm/health_status.py:168
+#: custom/opm/health_status.py:97
 msgid "Growth Monitoring when 4-6 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:169
+#: custom/opm/health_status.py:98
 msgid ""
 "Registered Children (6 months old) who have attended at least one growth "
 "monitoring session between the age 4-6 months"
 msgstr ""
 
-#: custom/opm/health_status.py:173
+#: custom/opm/health_status.py:102
 msgid "Growth Monitoring when 7-9 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:174
+#: custom/opm/health_status.py:103
 msgid ""
 "Registered Children (9 months old) who have attended at least one growth "
 "monitoring session between the age 7-9 months"
 msgstr ""
 
-#: custom/opm/health_status.py:178
+#: custom/opm/health_status.py:107
 msgid "Growth Monitoring when 10-12 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:179
+#: custom/opm/health_status.py:108
 msgid ""
 "Registered Children (12 months old) who have attended at least one growth "
 "monitoring session between the age 10-12 months"
 msgstr ""
 
-#: custom/opm/health_status.py:183
+#: custom/opm/health_status.py:112
 msgid "Growth Monitoring when 13-15 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:184
+#: custom/opm/health_status.py:113
 msgid ""
 "Registered Children (15 months old) who have attended at least one growth "
 "monitoring session between the age 13-15 months"
 msgstr ""
 
-#: custom/opm/health_status.py:188
+#: custom/opm/health_status.py:117
 msgid "Growth Monitoring when 16-18 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:189
+#: custom/opm/health_status.py:118
 msgid ""
 "Registered Children (18 months old) who have attended at least one growth "
 "monitoring session between the age 16-18 months"
 msgstr ""
 
-#: custom/opm/health_status.py:193
+#: custom/opm/health_status.py:122
 msgid "Growth Monitoring when 19-21 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:194
+#: custom/opm/health_status.py:123
 msgid ""
 "Registered Children (21 months old) who have attended at least one growth "
 "monitoring session between the age 19-21 months"
 msgstr ""
 
-#: custom/opm/health_status.py:198
+#: custom/opm/health_status.py:127
 msgid "Growth Monitoring when 22-24 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:199
+#: custom/opm/health_status.py:128
 msgid ""
 "Registered Children (24 months old) who have attended at least one growth "
 "monitoring session between the age 22-24 months"
 msgstr ""
 
-#: custom/opm/health_status.py:203
+#: custom/opm/health_status.py:132
 msgid "Received ORS and Zinc treatment for diarrhoea"
 msgstr ""
 
-#: custom/opm/health_status.py:204
+#: custom/opm/health_status.py:133
 msgid ""
 "Registered children who received ORS and Zinc treatment if he/she contracts "
 "diarrhoea"
 msgstr ""
 
-#: custom/opm/health_status.py:207
+#: custom/opm/health_status.py:136
 msgid "Exclusively breastfed for first 6 months"
 msgstr ""
 
-#: custom/opm/health_status.py:208
+#: custom/opm/health_status.py:137
 msgid ""
 "Registered children (6 months old) who have been exclusively breastfed for "
 "first 6 months"
 msgstr ""
 
-#: custom/opm/health_status.py:211
+#: custom/opm/health_status.py:140
 msgid "Received Measles vaccine"
 msgstr ""
 
-#: custom/opm/health_status.py:212
+#: custom/opm/health_status.py:141
 msgid "Registered children (12 months old) who have received Measles vaccine"
 msgstr ""
 
-#: custom/opm/health_status.py:215
+#: custom/opm/health_status.py:144
 msgid "VHND organised"
 msgstr ""
 
-#: custom/opm/health_status.py:216
+#: custom/opm/health_status.py:145
 msgid "Whether VHND was organised at AWC for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:219
+#: custom/opm/health_status.py:148
 msgid "Adult Weighing Machine Available"
 msgstr ""
 
-#: custom/opm/health_status.py:220
+#: custom/opm/health_status.py:149
 msgid "Whether adult weighing machine was available for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:223
+#: custom/opm/health_status.py:152
 msgid "Adult Weighing Machine Functional"
 msgstr ""
 
-#: custom/opm/health_status.py:224
+#: custom/opm/health_status.py:153
 msgid "Whether adult weighing machine was functional for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:227
+#: custom/opm/health_status.py:156
 msgid "Child Weighing Machine Available"
 msgstr ""
 
-#: custom/opm/health_status.py:228
+#: custom/opm/health_status.py:157
 msgid "Whether child weighing machine was available for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:231
+#: custom/opm/health_status.py:160
 msgid "Child Weighing Machine Functional"
 msgstr ""
 
-#: custom/opm/health_status.py:232
+#: custom/opm/health_status.py:161
 msgid "Whether child weighing machine was functional for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:235
+#: custom/opm/health_status.py:164
 msgid "ANM Present"
 msgstr ""
 
-#: custom/opm/health_status.py:236
+#: custom/opm/health_status.py:165
 msgid "Whether ANM present at VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:239
+#: custom/opm/health_status.py:168
 msgid "ASHA Present"
 msgstr ""
 
-#: custom/opm/health_status.py:240
+#: custom/opm/health_status.py:169
 msgid "Whether ASHA present at VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:243
+#: custom/opm/health_status.py:172
 msgid "CMG Present"
 msgstr ""
 
-#: custom/opm/health_status.py:244
+#: custom/opm/health_status.py:173
 msgid "Whether CMG present at VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:247
+#: custom/opm/health_status.py:176
 #, fuzzy
 msgid "Stock of IFA tablets"
 msgstr "Balanço do Stock"
 
-#: custom/opm/health_status.py:248
+#: custom/opm/health_status.py:177
 msgid "Whether AWC has enough stock of IFA tablets for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:251
+#: custom/opm/health_status.py:180
 msgid "Stock of ORS packets"
 msgstr ""
 
-#: custom/opm/health_status.py:252
+#: custom/opm/health_status.py:181
 msgid "Whether AWC has enough stock of ORS packets for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:255
+#: custom/opm/health_status.py:184
 #, fuzzy
 msgid "Stock of ZINC tablets"
 msgstr "Balanço do Stock"
 
-#: custom/opm/health_status.py:256
+#: custom/opm/health_status.py:185
 msgid "Whether AWC has enough stock of Zinc Tablets for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:259
+#: custom/opm/health_status.py:188
 msgid "Stock of Measles Vaccine"
 msgstr ""
 
-#: custom/opm/health_status.py:260
+#: custom/opm/health_status.py:189
 msgid "Whether AWC has enough stock of measles vaccine for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:263
+#: custom/opm/health_status.py:192
 msgid "Eligilble for Birth Spacing bonus"
 msgstr ""
 
-#: custom/opm/health_status.py:264
+#: custom/opm/health_status.py:193
 msgid "Registered beneficiaries eligible for birth spacing bonus for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:267
+#: custom/opm/health_status.py:196
 msgid "Severely underweight"
 msgstr ""
 
-#: custom/opm/health_status.py:268
+#: custom/opm/health_status.py:197
 msgid ""
 "Registered children severely underweight (very low weight for age) for the "
 "month"
 msgstr ""
 
-#: custom/opm/health_status.py:271
+#: custom/opm/health_status.py:200
 msgid "Underweight"
 msgstr ""
 
-#: custom/opm/health_status.py:272
+#: custom/opm/health_status.py:201
 msgid "Registered children underweight (low weight for age) for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:275
+#: custom/opm/health_status.py:204
 msgid "Normal weight for age"
 msgstr ""
 
-#: custom/opm/health_status.py:276
+#: custom/opm/health_status.py:205
 msgid "Registered children with normal weight for age for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:279
+#: custom/opm/health_status.py:208
 msgid "Eligilble for Nutritional status bonus"
 msgstr ""
 
-#: custom/opm/health_status.py:280
+#: custom/opm/health_status.py:209
 msgid ""
 "Registered beneficiaries eligible for nutritonal status bonus for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:283
+#: custom/opm/health_status.py:212
 msgid "Pregnant women cases closed"
 msgstr ""
 
-#: custom/opm/health_status.py:284
+#: custom/opm/health_status.py:213
 #, fuzzy
 msgid "Registered pregnant women cases closed for the month"
 msgstr "Casos IRA Tratados"
 
-#: custom/opm/health_status.py:287
+#: custom/opm/health_status.py:216
 msgid "Mother cases closed"
 msgstr ""
 
-#: custom/opm/health_status.py:288
+#: custom/opm/health_status.py:217
 msgid "Registered mother cases closed for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:291
+#: custom/opm/health_status.py:220
 msgid "Children cases closed"
 msgstr ""
 
-#: custom/opm/health_status.py:292
+#: custom/opm/health_status.py:221
 msgid "Registered children cases closed for the month"
 msgstr ""
 
-#: custom/opm/reports.py:656 custom/opm/reports.py:657
-#: custom/opm/reports.py:917
+#: custom/opm/reports.py:457 custom/opm/reports.py:458
+#: custom/opm/reports.py:719
 #, fuzzy
 msgid "Reporting period incomplete"
 msgstr "Manejo de Casos"
 
-#: custom/opm/reports.py:876
+#: custom/opm/reports.py:679
 msgid "Duplicate account number"
 msgstr ""
 
-#: custom/opm/reports.py:885
+#: custom/opm/reports.py:688
 #, fuzzy
 msgid "Conditions Met Report"
 msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
-#: custom/opm/reports.py:924
+#: custom/opm/reports.py:726
 msgid "Total Payment"
 msgstr ""
 
@@ -27238,7 +27783,7 @@ msgstr ""
 
 #: custom/up_nrhm/reports/asha_functionality_checklist_report.py:61
 #, python-format
-msgid "Total number of ASHAs who are functional on at least 60% of the tasks"
+msgid "Total number of ASHAs who are functional on at least %s of the tasks"
 msgstr ""
 
 #: custom/up_nrhm/reports/asha_functionality_checklist_report.py:62
@@ -27324,11 +27869,87 @@ msgstr ""
 
 #: custom/up_nrhm/reports/district_functionality_report.py:34
 #, python-format
-msgid "% of ASHAs"
+msgid "%s of ASHAs"
 msgstr ""
 
-#: custom/up_nrhm/reports/district_functionality_report.py:35
+#: custom/up_nrhm/reports/district_functionality_report.py:36
 msgid "Grade of Block"
+msgstr ""
+
+#: docs/_build/html/_sources/translations.txt:141
+#, python-format
+msgid "This string will have %(value)s inside."
+msgstr ""
+
+#: docs/_build/html/_sources/translations.txt:147
+#, python-format
+msgid ""
+"\n"
+"        That will cost $ %(amount)s.\n"
+"    "
+msgstr ""
+
+#: docs/_build/html/_sources/translations.txt:155
+#, python-format
+msgid ""
+"\n"
+"        This will have %(myvar)s inside.\n"
+"    "
+msgstr ""
+
+#: docs/_build/html/_sources/translations.txt:167
+msgid ""
+"\n"
+"        Manage Mobile Workers <small>for CommCare Mobile and\n"
+"        CommCare HQ Reports</small>\n"
+"    "
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/couchpanel.py:89
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/couchpanel.py:92
+msgid "CouchDB"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:15
+msgid "Stacktrace"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:16
+#, fuzzy
+msgid "View Name"
+msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:17
+msgid "Request Params"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:45
+msgid "Line"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:46
+msgid "Method"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:6
+msgid "CouchDB View"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:11
+#, fuzzy
+msgid "Executed View"
+msgstr "Manejo de Casos"
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:13
+msgid "Parameters"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:15
+msgid "Total Rows"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:40
+msgid "Empty set"
 msgstr ""
 
 #: submodules/auditcare-src/auditcare/forms.py:14
@@ -27719,16 +28340,16 @@ msgstr ""
 msgid "Clearing data"
 msgstr ""
 
-#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:36
+#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:47
 #, python-format
 msgid "ERROR: Could not send \"%(subject)s\""
 msgstr ""
 
-#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:41
+#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:52
 msgid "Could not send email: file size is too large."
 msgstr ""
 
-#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:46
+#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:57
 #, python-format
 msgid "Please contact %(support_email)s for assistance."
 msgstr ""
@@ -27778,12 +28399,12 @@ msgid ""
 msgstr ""
 
 #, fuzzy
-#~ msgid "Last Update"
-#~ msgstr "Casos IRA Tratados"
+#~ msgid "Read Case Study"
+#~ msgstr "Manejo de Casos"
 
 #, fuzzy
-#~ msgid "Current Balance"
-#~ msgstr "Manejo de Casos"
+#~ msgid "Last Update"
+#~ msgstr "Casos IRA Tratados"
 
 #, fuzzy
 #~ msgid "Requisition Report"
@@ -27797,10 +28418,6 @@ msgstr ""
 #~ msgstr "CommCare Supply"
 
 #, fuzzy
-#~ msgid "mothers"
-#~ msgstr "Outros (negativos / indeterminados) "
-
-#, fuzzy
 #~ msgid "Create New Report > Configure Table Report"
 #~ msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
@@ -27811,10 +28428,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "New Mothers"
 #~ msgstr "Outros (negativos / indeterminados) "
-
-#, fuzzy
-#~ msgid "Closed by"
-#~ msgstr "Casos IRA Tratados"
 
 #, fuzzy
 #~ msgid "Manage SMS Backend Rates"

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CommCare HQ\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-29 19:37+0000\n"
+"POT-Creation-Date: 2015-08-05 17:43+0000\n"
 "PO-Revision-Date: 2015-06-26 09:30+0000\n"
 "Last-Translator: Dimagi Dev <devops@dimagi.com>\n"
 "Language-Team: Spanish (http://www.transifex.com/projects/p/commcare-hq/"
@@ -36,7 +36,7 @@ msgstr ""
 
 #: corehq/__init__.py:61 corehq/feature_previews.py:91
 #: corehq/apps/hqwebapp/models.py:879 corehq/apps/reports/__init__.py:13
-#: corehq/apps/reports/models.py:52
+#: corehq/apps/reports/models.py:54
 #: corehq/apps/users/templates/users/edit_commcare_user.html:125
 msgid "CommCare Supply"
 msgstr ""
@@ -57,9 +57,9 @@ msgstr ""
 msgid "Messaging"
 msgstr ""
 
-#: corehq/__init__.py:177 corehq/apps/app_manager/models.py:2900
+#: corehq/__init__.py:177 corehq/apps/app_manager/models.py:2974
 #: corehq/apps/dashboard/views.py:159 corehq/apps/hqwebapp/models.py:365
-#: corehq/apps/hqwebapp/models.py:1538 corehq/apps/hqwebapp/models.py:1608
+#: corehq/apps/hqwebapp/models.py:1533 corehq/apps/hqwebapp/models.py:1603
 #: corehq/apps/orgs/templates/orgs/report_base.html:26
 #: corehq/apps/reports/templates/reports/reportdata/case_details.html:68
 msgid "Reports"
@@ -78,7 +78,7 @@ msgstr ""
 msgid "Edit Data"
 msgstr ""
 
-#: corehq/__init__.py:198 corehq/privileges.py:71
+#: corehq/__init__.py:198 corehq/privileges.py:76
 #: corehq/apps/accounting/user_text.py:219 corehq/apps/fixtures/views.py:285
 msgid "Lookup Tables"
 msgstr ""
@@ -182,8 +182,8 @@ msgid ""
 "possible reasons for poor performance, and offer guidance towards solutions."
 msgstr ""
 
-#: corehq/feature_previews.py:128 corehq/privileges.py:88
-#: corehq/apps/hqwebapp/models.py:1140 corehq/apps/locations/views.py:75
+#: corehq/feature_previews.py:128 corehq/privileges.py:93
+#: corehq/apps/hqwebapp/models.py:1135 corehq/apps/locations/views.py:75
 #: corehq/apps/users/templates/users/edit_commcare_user.html:127
 msgid "Locations"
 msgstr ""
@@ -206,71 +206,71 @@ msgid ""
 "a>."
 msgstr ""
 
-#: corehq/privileges.py:72 corehq/apps/accounting/user_text.py:218
+#: corehq/privileges.py:77 corehq/apps/accounting/user_text.py:218
 msgid "API Access"
 msgstr ""
 
-#: corehq/privileges.py:73
+#: corehq/privileges.py:78
 msgid "Web-Based Apps (CloudCare)"
 msgstr ""
 
-#: corehq/privileges.py:74
+#: corehq/privileges.py:79
 msgid "Active Data Management"
 msgstr ""
 
-#: corehq/privileges.py:75 corehq/apps/accounting/user_text.py:221
+#: corehq/privileges.py:80 corehq/apps/accounting/user_text.py:221
 msgid "Custom Branding"
 msgstr ""
 
-#: corehq/privileges.py:76 corehq/apps/accounting/user_text.py:224
+#: corehq/privileges.py:81 corehq/apps/accounting/user_text.py:224
 msgid "Cross-Project Reports"
 msgstr ""
 
-#: corehq/privileges.py:77 corehq/apps/accounting/user_text.py:236
+#: corehq/privileges.py:82 corehq/apps/accounting/user_text.py:236
 msgid "Advanced Role-Based Access"
 msgstr ""
 
-#: corehq/privileges.py:78
+#: corehq/privileges.py:83
 msgid "Outgoing Messaging"
 msgstr ""
 
-#: corehq/privileges.py:79
+#: corehq/privileges.py:84
 msgid "Incoming Messaging"
 msgstr ""
 
-#: corehq/privileges.py:80
+#: corehq/privileges.py:85
 msgid "Reminders Framework"
 msgstr ""
 
-#: corehq/privileges.py:81
+#: corehq/privileges.py:86
 msgid "Custom Android Gateway"
 msgstr ""
 
-#: corehq/privileges.py:82
+#: corehq/privileges.py:87
 msgid "Bulk Case Management"
 msgstr ""
 
-#: corehq/privileges.py:83
+#: corehq/privileges.py:88
 msgid "Bulk User Management"
 msgstr ""
 
-#: corehq/privileges.py:84
+#: corehq/privileges.py:89
 msgid "Add Mobile Workers Above Limit"
 msgstr ""
 
-#: corehq/privileges.py:85
+#: corehq/privileges.py:90
 msgid "De-Identified Data"
 msgstr ""
 
-#: corehq/privileges.py:86 corehq/apps/accounting/user_text.py:238
+#: corehq/privileges.py:91 corehq/apps/accounting/user_text.py:238
 msgid "HIPAA Compliance Assurance"
 msgstr ""
 
-#: corehq/privileges.py:87
+#: corehq/privileges.py:92
 msgid "Custom CommCare Logo Uploader"
 msgstr ""
 
-#: corehq/privileges.py:89
+#: corehq/privileges.py:94
 msgid "User Configurable Report Builder"
 msgstr ""
 
@@ -378,6 +378,7 @@ msgstr ""
 
 #: corehq/apps/accounting/filters.py:140 corehq/apps/accounting/forms.py:346
 #: corehq/apps/accounting/forms.py:634 corehq/apps/commtrack/models.py:535
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:57
 #: corehq/apps/domain/templates/domain/admin/media_manager.html:24
 #: corehq/apps/export/templates/export/customize_export.html:602
 #: corehq/apps/hqadmin/reports.py:839
@@ -521,7 +522,7 @@ msgstr ""
 #: corehq/apps/accounting/templates/accounting/subscriptions_tab.html:16
 #: corehq/apps/domain/forms.py:1455
 #: corehq/apps/domain/templates/domain/current_subscription.html:247
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:74
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:83
 msgid "Software Plan"
 msgstr ""
 
@@ -630,10 +631,10 @@ msgid "A name is required for this new role."
 msgstr ""
 
 #: corehq/apps/accounting/forms.py:1428 corehq/apps/app_manager/forms.py:11
-#: corehq/apps/app_manager/models.py:1737
-#: corehq/apps/app_manager/models.py:2167
-#: corehq/apps/app_manager/models.py:2525
-#: corehq/apps/app_manager/models.py:2574 corehq/apps/commtrack/models.py:531
+#: corehq/apps/app_manager/models.py:1738
+#: corehq/apps/app_manager/models.py:2193
+#: corehq/apps/app_manager/models.py:2574
+#: corehq/apps/app_manager/models.py:2623 corehq/apps/commtrack/models.py:531
 #: corehq/apps/domain/forms.py:126
 #: corehq/apps/domain/templates/domain/admin/commtrack_action_table.html:5
 #: corehq/apps/domain/templates/domain/partials/user_list.html:9
@@ -655,7 +656,7 @@ msgstr ""
 #: corehq/apps/toggle_ui/templates/toggle/flags.html:58
 #: corehq/apps/users/templates/users/web_users.b3.html:171
 #: corehq/apps/users/templates/users/web_users.b3.html:216
-#: corehq/ex-submodules/casexml/apps/case/models.py:853
+#: corehq/ex-submodules/casexml/apps/case/models.py:858
 #: corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_hierarchy.html:57
 #: custom/bihar/reports/indicators/clientlistdisplay.py:80
 #: custom/bihar/reports/indicators/clientlistdisplay.py:98
@@ -664,13 +665,13 @@ msgstr ""
 #: custom/ewsghana/reports/specific_reports/reporting_rates.py:199
 #: custom/ewsghana/reports/specific_reports/reporting_rates.py:241
 #: custom/fri/reports/reports.py:349
-#: custom/ilsgateway/tanzania/reports/delivery.py:27
-#: custom/ilsgateway/tanzania/reports/facility_details.py:70
-#: custom/ilsgateway/tanzania/reports/facility_details.py:116
-#: custom/ilsgateway/tanzania/reports/randr.py:82
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:81
-#: custom/ilsgateway/tanzania/reports/supervision.py:56
-#: custom/ilsgateway/tanzania/reports/supervision.py:120
+#: custom/ilsgateway/tanzania/reports/delivery.py:28
+#: custom/ilsgateway/tanzania/reports/facility_details.py:71
+#: custom/ilsgateway/tanzania/reports/facility_details.py:117
+#: custom/ilsgateway/tanzania/reports/randr.py:83
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:83
+#: custom/ilsgateway/tanzania/reports/supervision.py:57
+#: custom/ilsgateway/tanzania/reports/supervision.py:122
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:37
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:184
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:249
@@ -680,7 +681,7 @@ msgid "Name"
 msgstr ""
 
 #: corehq/apps/accounting/forms.py:1432 corehq/apps/accounting/models.py:357
-#: corehq/apps/prelogin/forms.py:28
+#: corehq/apps/prelogin/forms.py:29
 msgid "Company / Organization"
 msgstr ""
 
@@ -746,13 +747,13 @@ msgstr ""
 msgid "Messages"
 msgstr ""
 
-#: corehq/apps/accounting/models.py:341 corehq/apps/prelogin/forms.py:20
-#: corehq/apps/users/forms.py:145
+#: corehq/apps/accounting/models.py:341 corehq/apps/prelogin/forms.py:21
+#: corehq/apps/users/forms.py:144
 msgid "First Name"
 msgstr ""
 
-#: corehq/apps/accounting/models.py:344 corehq/apps/prelogin/forms.py:24
-#: corehq/apps/users/forms.py:146
+#: corehq/apps/accounting/models.py:344 corehq/apps/prelogin/forms.py:25
+#: corehq/apps/users/forms.py:145
 msgid "Last Name"
 msgstr ""
 
@@ -767,7 +768,7 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/accounting/models.py:353
-#: corehq/apps/data_interfaces/views.py:322 corehq/apps/prelogin/forms.py:36
+#: corehq/apps/data_interfaces/views.py:322 corehq/apps/prelogin/forms.py:37
 #: corehq/apps/reports/standard/ivr.py:46
 #: corehq/apps/reports/standard/sms.py:280
 #: corehq/apps/reports/standard/sms.py:617
@@ -800,7 +801,7 @@ msgstr ""
 msgid "Postal Code"
 msgstr ""
 
-#: corehq/apps/accounting/models.py:378 corehq/apps/prelogin/forms.py:40
+#: corehq/apps/accounting/models.py:378 corehq/apps/prelogin/forms.py:41
 msgid "Country"
 msgstr ""
 
@@ -992,14 +993,14 @@ msgstr ""
 
 #: corehq/apps/accounting/user_text.py:8
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/analytics.html:22
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:41
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:52
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/mobile.html:22
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:21
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/support.html:22
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/user.html:22
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/web.html:22
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:80
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:77
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:89
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:79
 msgid "Community"
 msgstr ""
 
@@ -1011,7 +1012,7 @@ msgstr ""
 
 #: corehq/apps/accounting/user_text.py:13
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/analytics.html:27
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:46
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:57
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/mobile.html:27
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:26
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/support.html:27
@@ -1028,16 +1029,16 @@ msgstr ""
 
 #: corehq/apps/accounting/user_text.py:18
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/analytics.html:32
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:51
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:62
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/mobile.html:32
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:31
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/support.html:32
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/user.html:32
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/web.html:32
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:90
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:98
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:87
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:95
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:99
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:107
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:89
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:97
 msgid "Pro"
 msgstr ""
 
@@ -1048,20 +1049,20 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:23
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:306
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:309
 #: corehq/apps/app_manager/templates/app_manager/module_view.html:294
 #: corehq/apps/importer/templates/importer/excel_config.html:114
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/analytics.html:37
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:56
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:67
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/mobile.html:37
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:36
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/support.html:37
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/user.html:37
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/web.html:37
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:106
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:114
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:103
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:111
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:115
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:123
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:105
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:113
 msgid "Advanced"
 msgstr ""
 
@@ -1074,7 +1075,7 @@ msgstr ""
 
 #: corehq/apps/accounting/user_text.py:29
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/analytics.html:42
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:61
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:72
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/mobile.html:42
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:41
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/support.html:42
@@ -1105,7 +1106,7 @@ msgstr ""
 #: corehq/apps/accounting/user_text.py:54
 #: corehq/apps/accounting/user_text.py:201
 #: corehq/apps/accounting/user_text.py:202
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:98
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:109
 msgid "Mobile Users"
 msgstr ""
 
@@ -1175,7 +1176,7 @@ msgid "SMS (CommConnect)"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:90
-#: corehq/apps/accounting/user_text.py:91 corehq/apps/commtrack/views.py:170
+#: corehq/apps/accounting/user_text.py:91 corehq/apps/commtrack/views.py:175
 #: corehq/apps/domain/forms.py:1624
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:13
 #: corehq/apps/reminders/forms.py:98 corehq/apps/reminders/forms.py:103
@@ -1331,24 +1332,24 @@ msgid "Dedicated Enterprise Account Management"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:255
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:71
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:83
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:80
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:82
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:92
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:82
 msgid "Free"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:255
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:76
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:87
 msgid "$100 /month"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:255
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:81
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:92
 msgid "$500 /month"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:255
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:86
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:97
 msgid "$1,000 /month"
 msgstr ""
 
@@ -1359,22 +1360,22 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:256
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:102
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:113
 msgid "50"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:256
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:107
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:118
 msgid "100"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:256
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:112
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:123
 msgid "500"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:256
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:117
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:128
 msgid "1,000"
 msgstr ""
 
@@ -1384,10 +1385,10 @@ msgid "Unlimited / Discounted Pricing"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:257
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:132
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:137
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:142
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:147
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:143
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:148
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:153
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:158
 msgid "1 USD /month"
 msgstr ""
 
@@ -1482,7 +1483,7 @@ msgstr ""
 #: corehq/apps/sms/templates/sms/default.html:47
 #: corehq/apps/unicel/forms.py:10
 #: corehq/apps/unicel/templates/unicel/backend.html:10
-#: corehq/apps/userhack/admin.py:14 corehq/apps/users/forms.py:184
+#: corehq/apps/userhack/admin.py:14 corehq/apps/users/forms.py:183
 #: corehq/apps/users/templates/users/edit_web_user.html:13
 #: corehq/apps/users/templates/users/mobile/users_list.html:209
 #: corehq/apps/users/templates/users/partial/basic_info_form.html:10
@@ -1503,6 +1504,7 @@ msgstr ""
 #: corehq/apps/reports/templates/reports/partials/hqexport_group_table.html:11
 #: corehq/apps/sms/templates/sms/add_gateway.html:42
 #: corehq/apps/sms/templates/sms/partials/day_time_windows.html:12
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:14
 msgid "Action"
 msgstr ""
 
@@ -1568,6 +1570,7 @@ msgstr ""
 #: corehq/apps/hqmedia/templates/hqmedia/bulk_upload.html:55
 #: corehq/apps/indicators/templates/indicators/forms/copy_to_domain.html:66
 #: corehq/apps/locations/templates/locations/manage/location.html:195
+#: corehq/apps/locations/templates/locations/manage/locations.html:266
 #: corehq/apps/orgs/templates/orgs/orgs_landing.html:184
 #: corehq/apps/orgs/templates/orgs/orgs_landing.html:203
 #: corehq/apps/orgs/templates/orgs/orgs_landing.html:230
@@ -1820,7 +1823,7 @@ msgstr ""
 #: corehq/apps/reports/standard/monitoring.py:479
 #: corehq/apps/reports/standard/monitoring.py:623
 #: corehq/apps/reports/standard/monitoring.py:1321
-#: custom/ilsgateway/tanzania/reports/delivery.py:171
+#: custom/ilsgateway/tanzania/reports/delivery.py:174
 #: custom/m4change/reports/aggregate_facility_web_hmis_report.py:38
 #: custom/m4change/reports/all_hmis_report.py:258
 #: custom/m4change/reports/anc_hmis_report.py:117
@@ -1881,7 +1884,7 @@ msgstr ""
 
 #: corehq/apps/accounting/templates/accounting/credits_tab.html:9
 #: corehq/apps/accounting/templates/accounting/subscriptions.html:55
-#: corehq/apps/hqwebapp/models.py:1302
+#: corehq/apps/hqwebapp/models.py:1297
 msgid "Subscription"
 msgstr ""
 
@@ -1929,8 +1932,8 @@ msgstr ""
 #: corehq/apps/reports/standard/sms.py:732
 #: corehq/apps/users/templates/users/web_users.b3.html:286
 #: corehq/apps/users/templates/users/web_users.html:128
-#: custom/ilsgateway/tanzania/reports/facility_details.py:118
-#: custom/ilsgateway/tanzania/reports/supervision.py:122
+#: custom/ilsgateway/tanzania/reports/facility_details.py:119
+#: custom/ilsgateway/tanzania/reports/supervision.py:124
 #: custom/intrahealth/sqldata.py:392
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:266
 msgid "Date"
@@ -1990,9 +1993,9 @@ msgstr ""
 #: corehq/apps/reports/templates/reports/messaging/survey_detail.html:33
 #: corehq/apps/settings/templates/settings/my_projects.html:12
 #: corehq/apps/sms/views.py:1022
-#: corehq/ex-submodules/casexml/apps/case/models.py:903
+#: corehq/ex-submodules/casexml/apps/case/models.py:908
 #: custom/_legacy/pact/models.py:329
-#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:55
+#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:65
 #: custom/m4change/reports/mcct_project_review.py:274
 #: custom/m4change/reports/mcct_project_review.py:401
 #: custom/m4change/reports/mcct_project_review.py:484
@@ -2351,7 +2354,7 @@ msgstr ""
 #: corehq/apps/reports/templates/reports/standard/base_template.html:108
 #: corehq/apps/reports/templates/reports/standard/export_download.html:99
 #: corehq/apps/reports_core/templates/reports_core/base_template_new.html:150
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:118
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:122
 msgid "Generating Report..."
 msgstr ""
 
@@ -2366,8 +2369,8 @@ msgstr ""
 #: corehq/apps/reports/templates/reports/standard/base_template.html:111
 #: corehq/apps/reports_core/templates/reports_core/base_template_new.html:151
 #: corehq/apps/reports_core/templates/reports_core/base_template_new.html:152
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:119
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:120
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:123
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:124
 msgid "Apply"
 msgstr ""
 
@@ -2475,11 +2478,11 @@ msgid "Delay Invoicing Until"
 msgstr ""
 
 #: corehq/apps/accounting/templates/accounting/subscriptions_tab.html:24
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:255
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:261
-#: corehq/apps/domain/templates/domain/admin/feature_flags.html:28
-#: corehq/apps/locations/templates/locations/manage/locations.html:148
-#: corehq/apps/reports/views.py:801
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:258
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:264
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:37
+#: corehq/apps/locations/templates/locations/manage/locations.html:167
+#: corehq/apps/reports/views.py:809
 #: corehq/apps/reports/templates/reports/reports_home.html:60
 #: corehq/apps/reports/templates/reports/reports_home.html:126
 #: corehq/apps/reports/templates/reports/partials/saved_custom_exports.html:9
@@ -2763,6 +2766,7 @@ msgstr ""
 #: corehq/apps/app_manager/fields.py:45
 #: corehq/apps/app_manager/templates/app_manager/managed_app.html:266
 #: corehq/apps/app_manager/templates/app_manager/ng_partials/case_summary_view.html:109
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:56
 #: corehq/apps/hqwebapp/doc_info.py:100
 #: corehq/apps/reports/filters/forms.py:684
 #: corehq/apps/reports/standard/inspect.py:89
@@ -2809,60 +2813,56 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:749
-msgid "Form referenced as the registration form for multiple modules."
-msgstr ""
-
-#: corehq/apps/app_manager/models.py:1743
-#: corehq/apps/app_manager/models.py:2174
-#: corehq/apps/app_manager/views.py:1412
+#: corehq/apps/app_manager/models.py:1744
+#: corehq/apps/app_manager/models.py:2200
+#: corehq/apps/app_manager/views.py:1414
 msgid "Untitled Module"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:1756
-#: corehq/apps/app_manager/models.py:2200
-#: corehq/apps/app_manager/views.py:1471
+#: corehq/apps/app_manager/models.py:1757
+#: corehq/apps/app_manager/models.py:2226
+#: corehq/apps/app_manager/views.py:1473
 msgid "Untitled Form"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:1849
+#: corehq/apps/app_manager/models.py:1850
 msgid "Case tiles may only be used for the case list (not the case details)."
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:1857
+#: corehq/apps/app_manager/models.py:1858
 msgid "A case property must be assigned to the \"{}\" tile field."
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2014
+#: corehq/apps/app_manager/models.py:2040
 msgid "Case property"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2015
+#: corehq/apps/app_manager/models.py:2041
 msgid "Lookup Table field"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2016
+#: corehq/apps/app_manager/models.py:2042
 msgid "custom user property"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2017
+#: corehq/apps/app_manager/models.py:2043
 msgid "custom XPath expression"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2024
+#: corehq/apps/app_manager/models.py:2050
 msgid "Case tag"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2025
+#: corehq/apps/app_manager/models.py:2051
 msgid "Lookup Table tag"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2063
+#: corehq/apps/app_manager/models.py:2089
 msgid "All forms in this module require a visit schedule."
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2186
-#: corehq/apps/app_manager/models.py:4198 corehq/apps/products/views.py:467
+#: corehq/apps/app_manager/models.py:2212
+#: corehq/apps/app_manager/models.py:4272 corehq/apps/products/views.py:467
 #: corehq/apps/products/templates/products/manage/products.html:110
 #: corehq/apps/programs/templates/programs/manage/program.html:77
 #: corehq/apps/reports/commtrack/standard.py:92
@@ -2874,9 +2874,9 @@ msgstr ""
 msgid "Product"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2521
-#: corehq/apps/app_manager/models.py:2575
-#: corehq/apps/app_manager/models.py:2637
+#: corehq/apps/app_manager/models.py:2570
+#: corehq/apps/app_manager/models.py:2624
+#: corehq/apps/app_manager/models.py:2686
 #: corehq/apps/appstore/templates/appstore/deployment_info.html:31
 #: corehq/apps/appstore/templates/appstore/project_info.html:140
 #: corehq/apps/appstore/templates/appstore/project_info.html:259
@@ -2892,71 +2892,73 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2522
-#: corehq/apps/app_manager/models.py:2570
+#: corehq/apps/app_manager/models.py:2571
+#: corehq/apps/app_manager/models.py:2619
 msgid "Followup date"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2527
-#: corehq/apps/app_manager/models.py:2580
+#: corehq/apps/app_manager/models.py:2576
+#: corehq/apps/app_manager/models.py:2629
 msgid "Close if"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2579
+#: corehq/apps/app_manager/models.py:2628
 msgid "Latest report"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2600
+#: corehq/apps/app_manager/models.py:2649
 #: custom/_legacy/pact/templates/pact/patient/pactpatient_base.html:33
 #: custom/_legacy/pact/templates/pact/patient/pactpatient_submissions.html:31
 msgid "Care Plan"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2621
+#: corehq/apps/app_manager/models.py:2670
 #: corehq/apps/reports/standard/cases/careplan.py:124
 #: custom/_legacy/pact/models.py:357
 msgid "Goal"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2621
+#: corehq/apps/app_manager/models.py:2670
 #: corehq/apps/reports/standard/cases/careplan.py:138
 #: custom/_legacy/pact/models.py:375
 msgid "Task"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2630
+#: corehq/apps/app_manager/models.py:2679
 msgid "Followup"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2644
+#: corehq/apps/app_manager/models.py:2693
 msgid "Last update"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:3394
+#: corehq/apps/app_manager/models.py:3468
 msgid ""
 "Usage of lookup tables is not supported by your current subscription. Please "
 "upgrade your subscription before using this feature."
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:4171
+#: corehq/apps/app_manager/models.py:4245
 #, python-brace-format
 msgid "Copy of {name}"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:4408
+#: corehq/apps/app_manager/models.py:4482
 msgid "Error in case type hierarchy"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:4498
+#: corehq/apps/app_manager/models.py:4572
 msgid ""
 "Problem loading suite file from profile file. Is your profile file correct?"
 msgstr ""
 
-#: corehq/apps/app_manager/translations.py:46
-msgid "App Translation Failed! "
+#: corehq/apps/app_manager/translations.py:48
+msgid ""
+"App Translation Failed! Please make sure you are using a valid Excel 2007 or "
+"later (.xlsx) file. Error details: {}."
 msgstr ""
 
-#: corehq/apps/app_manager/translations.py:149
+#: corehq/apps/app_manager/translations.py:154
 msgid "App Translations Updated!"
 msgstr ""
 
@@ -2968,138 +2970,138 @@ msgstr ""
 msgid "You must submit the source data."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:526
+#: corehq/apps/app_manager/views.py:527
 msgid "All Programs"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:596
+#: corehq/apps/app_manager/views.py:597
 msgid "U​I translation"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:597
+#: corehq/apps/app_manager/views.py:598
 msgid "U​I translations"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:604
+#: corehq/apps/app_manager/views.py:605
 msgid "app translation"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:605
+#: corehq/apps/app_manager/views.py:606
 msgid "app translations"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:821
+#: corehq/apps/app_manager/views.py:822
 msgid "Don't Show"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:828
+#: corehq/apps/app_manager/views.py:829
 #: corehq/apps/reports/standard/cases/basic.py:211
 #: corehq/apps/reports/templates/reports/reportdata/case_details.html:71
 msgid "Case List"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:829
+#: corehq/apps/app_manager/views.py:830
 msgid "Case Detail"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:848
+#: corehq/apps/app_manager/views.py:849
 msgid "Product List"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:849
+#: corehq/apps/app_manager/views.py:850
 msgid "Product Detail"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:871
+#: corehq/apps/app_manager/views.py:872
 msgid "Goal List"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:872
+#: corehq/apps/app_manager/views.py:873
 msgid "Goal Detail"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:882
+#: corehq/apps/app_manager/views.py:883
 msgid "Task List"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:883
+#: corehq/apps/app_manager/views.py:884
 msgid "Task Detail"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:921
+#: corehq/apps/app_manager/views.py:923
 msgid ""
 "Your app contains references to reports that are deleted. These will be "
 "removed on save."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:1243
+#: corehq/apps/app_manager/views.py:1245
 msgid ""
 "You tried to edit this form in the Form Builder. However, your administrator "
 "has locked this form against editing in the form builder, so we have "
 "redirected you to the form's front page instead."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:1409
+#: corehq/apps/app_manager/views.py:1411
 msgid "Untitled Application"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:1458
+#: corehq/apps/app_manager/views.py:1460
 #, python-brace-format
 msgid "Please set the case type for the target module '{name}'."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:1464
+#: corehq/apps/app_manager/views.py:1466
 msgid "Caution: Care Plan modules are a labs feature"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:1476
+#: corehq/apps/app_manager/views.py:1478
 msgid "Caution: Advanced modules are a labs feature"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:1592
+#: corehq/apps/app_manager/views.py:1594
 msgid ""
 "We could not copy this form, because it is blank.In order to copy this form, "
 "please add some questions first."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:1596
+#: corehq/apps/app_manager/views.py:1598
 msgid ""
 "This form could not be copied because it is not compatible with the selected "
 "module."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:1765
+#: corehq/apps/app_manager/views.py:1767
 msgid "Unknown Module"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:2468
+#: corehq/apps/app_manager/views.py:2470
 msgid "The form can not be moved into the desired module."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:2473
+#: corehq/apps/app_manager/views.py:2475
 msgid ""
 "Oops. Looks like you got out of sync with us. The sidebar has been updated, "
 "so please try again."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:2628
+#: corehq/apps/app_manager/views.py:2630
 msgid ""
 "We were unable to get your files because your Application has errors. Please "
 "click <strong>Make New Version</strong> under <strong>Deploy</strong> for "
 "feedback on how to fix these errors."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:2658
+#: corehq/apps/app_manager/views.py:2660
 msgid ""
 "We were unable to get your files because your Application has errors. Please "
 "click Make New Version under Deploy for feedback on how to fix these errors."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:3022
+#: corehq/apps/app_manager/views.py:3024
 msgid "Summary"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:3060
+#: corehq/apps/app_manager/views.py:3062
 #: corehq/apps/app_manager/templates/app_manager/app_view.html:257
 #: corehq/apps/app_manager/templates/app_manager/apps_base.html:9
 #: corehq/apps/app_manager/templates/app_manager/apps_base.html:14
@@ -3110,23 +3112,23 @@ msgstr ""
 msgid "Applications"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:3211
+#: corehq/apps/app_manager/views.py:3213
 msgid "We found problem with following translations:"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:3222
+#: corehq/apps/app_manager/views.py:3224
 msgid "Something went wrong! Update failed. We're looking into it"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:3225
+#: corehq/apps/app_manager/views.py:3227
 msgid "UI Translations Updated!"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:3271
+#: corehq/apps/app_manager/views.py:3273
 msgid "Please upgrade you app to > 2.0 in order to add a Careplan module"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:3282
+#: corehq/apps/app_manager/views.py:3284
 msgid "This application already has a Careplan module"
 msgstr ""
 
@@ -3134,33 +3136,33 @@ msgstr ""
 msgid "Error parsing XML: {}"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:204
+#: corehq/apps/app_manager/xform.py:205
 #, python-brace-format
 msgid "Group already has node for lang: {0}"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:673
+#: corehq/apps/app_manager/xform.py:679
 msgid "There's no language called '{}'"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:675
+#: corehq/apps/app_manager/xform.py:681
 msgid "There's already a language called '{}'"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:720
+#: corehq/apps/app_manager/xform.py:726
 #, python-brace-format
 msgid "<translation lang=\"{lang}\"><text id=\"{id}\"> node has no <value>"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:827
+#: corehq/apps/app_manager/xform.py:833
 msgid "<item> ({}) has no <value>"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:948
+#: corehq/apps/app_manager/xform.py:954
 msgid "Node <{}> has no 'ref' or 'bind'"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:1122 corehq/apps/app_manager/xform.py:1379
+#: corehq/apps/app_manager/xform.py:1128 corehq/apps/app_manager/xform.py:1385
 msgid ""
 "Couldn't get the case XML from one of your forms. A common reason for this "
 "is if you don't have the xforms namespace defined in your form. Please "
@@ -3168,23 +3170,23 @@ msgid ""
 "your form."
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:1371
+#: corehq/apps/app_manager/xform.py:1377
 msgid ""
 "You cannot use the Case Management UI if you already have a case block in "
 "your form."
 msgstr ""
 
-#: corehq/apps/app_manager/xpath.py:205
+#: corehq/apps/app_manager/xpath.py:208
 #, python-brace-format
 msgid "Type {type} must be in list of domain types: {list}"
 msgstr ""
 
-#: corehq/apps/app_manager/xpath.py:213
+#: corehq/apps/app_manager/xpath.py:216
 #, python-brace-format
 msgid "Reference type {ref} cannot be a child of primary type {main}."
 msgstr ""
 
-#: corehq/apps/app_manager/xpath.py:226
+#: corehq/apps/app_manager/xpath.py:229
 msgid ""
 "Property not correctly formatted. Must be formatted like: loacation:mytype:"
 "referencetype/property. For example: location:outlet:state/name"
@@ -3236,49 +3238,49 @@ msgstr ""
 msgid "No thanks, get me out of here"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:177
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:180
 msgid "Home Screen"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:178
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:181
 msgid "Module Menu"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:179
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:182
 msgid "Module:"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:180
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:183
 msgid "Previous Screen"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:189
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:192
 msgid "Link to other form"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:239
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:242
 msgid "Delete Form"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:259
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:262
 msgid ""
 "Your administrator has locked this form from edits through the form builder"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:268
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:271
 msgid "Try in CloudCare"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:277
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:280
 msgid "User Registration Properties"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:284
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:287
 #: corehq/apps/app_manager/templates/app_manager/managed_app.html:162
 #: corehq/apps/app_manager/templates/app_manager/module_view.html:189
 #: corehq/apps/dashboard/views.py:217
 #: corehq/apps/grapevine/templates/grapevine/backend.html:5
-#: corehq/apps/hqwebapp/models.py:952 corehq/apps/hqwebapp/models.py:1630
+#: corehq/apps/hqwebapp/models.py:952 corehq/apps/hqwebapp/models.py:1625
 #: corehq/apps/mach/templates/mach/backend.html:5
 #: corehq/apps/megamobile/templates/megamobile/backend.html:5
 #: corehq/apps/sms/templates/sms/http_backend.html:33
@@ -3289,63 +3291,63 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:288
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:332
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:334
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:291
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:335
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:337
 #: corehq/apps/app_manager/templates/app_manager/module_view.html:190
 msgid "Case Management"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:294
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:358
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:360
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:297
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:361
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:363
 msgid "User Case Management"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:301
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:304
 msgid "Visit Scheduler"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:317
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:354
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:320
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:357
 msgid ""
 "There are errors in your form. Fix your form in order to view and edit Case "
 "Management."
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:322
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:324
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:325
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:327
 msgid "Cases and Referrals"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:325
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:335
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:328
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:338
 msgid ""
 "Cases give you a way to track patients, farms, etc. over time.  You can "
 "choose to save data from a form to the case, which will store the data "
 "locally on the phone to use later."
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:346
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:349
 #: corehq/apps/app_manager/templates/app_manager/partials/form_tab_visit_scheduler.html:97
 msgid ""
 "You have not created a form yet. Create a form in order to view and edit "
 "Case Management."
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:361
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:364
 msgid ""
 "The user case allows you to store data about the user in a case and use that "
 "data in forms."
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:371
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:374
 msgid ""
 "You have not created a form yet. Create a form in order to view and edit "
 "User Case Management."
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:396
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:399
 #: corehq/apps/app_manager/templates/app_manager/managed_app.html:213
 #: corehq/apps/reports/templates/reports/partials/form_name.html:5
 msgid "User Registration"
@@ -3498,7 +3500,7 @@ msgstr ""
 #: corehq/apps/app_manager/templates/app_manager/module_view.html:254
 #: corehq/apps/domain/views.py:340
 #: corehq/apps/locations/templates/locations/manage/location.html:84
-#: corehq/apps/users/forms.py:211
+#: corehq/apps/users/forms.py:210
 #: corehq/apps/users/templates/users/edit_commcare_user.html:122
 msgid "Basic"
 msgstr ""
@@ -3510,7 +3512,7 @@ msgstr ""
 #: corehq/apps/reports/filters/select.py:108
 #: corehq/apps/reports/standard/cases/basic.py:270
 #: corehq/apps/reports/templates/reports/reportdata/case_export_data.html:125
-#: corehq/ex-submodules/casexml/apps/case/models.py:877
+#: corehq/ex-submodules/casexml/apps/case/models.py:882
 msgid "Case Type"
 msgstr ""
 
@@ -3561,7 +3563,31 @@ msgstr ""
 msgid "Display"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:65
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:63
+msgid "Chart Title"
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:66
+msgid "Graph type"
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:73
+msgid "Configuration"
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:83
+msgid "Add Configuration Item"
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:88
+msgid "Series Configuration"
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:99
+msgid "Add Series Configuration Item"
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:109
 #: corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html:130
 #: corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html:174
 #: corehq/apps/data_interfaces/templates/data_interfaces/list_case_groups.html:21
@@ -3600,7 +3626,7 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:76
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:120
 msgid "Add Report"
 msgstr ""
 
@@ -3909,7 +3935,6 @@ msgstr ""
 #: custom/ewsghana/templates/ewsghana/facility_page_print_report.html:82
 #: custom/ewsghana/templates/ewsghana/reporting_rates_print_report.html:85
 #: custom/ewsghana/templates/ewsghana/stock_status_print_report.html:78
-#: custom/opm/templates/opm/hsr_print.html:57
 #: custom/opm/templates/opm/met_print_report.html:88
 #: custom/opm/templates/opm/new_hsr_print.html:65
 msgid "Loading ..."
@@ -4791,7 +4816,7 @@ msgstr ""
 #: corehq/apps/appstore/templates/appstore/appstore_base.html:278
 #: corehq/apps/reports/standard/monitoring.py:773
 #: corehq/apps/reports/templates/reports/reports_home.html:132
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:272
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:273
 #: corehq/apps/reports/templates/reports/messaging/survey_detail.html:40
 #: corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_hierarchy.html:118
 #: submodules/ctable-src/ctable_view/templates/ctable/list_mappings.html:115
@@ -4809,7 +4834,7 @@ msgstr ""
 
 #: corehq/apps/app_manager/templates/app_manager/partials/form_tab_advanced.html:51
 #: corehq/apps/cloudcare/templates/cloudcare/cloudcare_home.html:50
-#: corehq/apps/hqwebapp/views.py:715
+#: corehq/apps/hqwebapp/views.py:717
 msgid "Loading..."
 msgstr ""
 
@@ -5021,10 +5046,10 @@ msgstr ""
 #: corehq/apps/export/templates/export/dialogs/delete_custom_export_dialog.html:13
 #: corehq/apps/hqadmin/templates/hqadmin/partials/reset-pillow-checkpoint-modal.html:18
 #: corehq/apps/hqmedia/templates/hqmedia/partials/multimedia_uploader.html:34
-#: corehq/apps/prelogin/templates/prelogin/base.html:126
-#: corehq/apps/prelogin/templates/prelogin/base.html:143
-#: corehq/apps/prelogin/templates/prelogin/base.html:174
-#: corehq/apps/prelogin/templates/prelogin/base.html:213
+#: corehq/apps/prelogin/templates/prelogin/base.html:129
+#: corehq/apps/prelogin/templates/prelogin/base.html:146
+#: corehq/apps/prelogin/templates/prelogin/base.html:177
+#: corehq/apps/prelogin/templates/prelogin/base.html:216
 #: corehq/apps/registration/templates/registration/org_request.html:70
 #: corehq/apps/registration/templates/registration/partials/eula_modal.html:11
 #: corehq/apps/reports/templates/reports/partials/export_download_modal.html:15
@@ -5098,7 +5123,7 @@ msgstr ""
 #: corehq/apps/appstore/views.py:28
 #: corehq/apps/appstore/templates/appstore/project_info.html:148
 #: corehq/apps/reports/filters/select.py:43
-#: custom/ilsgateway/tanzania/reports/delivery.py:153
+#: custom/ilsgateway/tanzania/reports/delivery.py:156
 msgid "Category"
 msgstr ""
 
@@ -5144,8 +5169,8 @@ msgid "You must specify a name for the new project"
 msgstr ""
 
 #: corehq/apps/appstore/templates/appstore/appstore_base.html:7
-#: corehq/apps/domain/views.py:1636 corehq/apps/hqwebapp/models.py:1208
-#: corehq/apps/hqwebapp/models.py:1584
+#: corehq/apps/domain/views.py:1636 corehq/apps/hqwebapp/models.py:1203
+#: corehq/apps/hqwebapp/models.py:1579
 #: corehq/apps/style/templates/style/bootstrap2/partials/domain_list_dropdown.html:19
 #: corehq/apps/style/templates/style/bootstrap3/partials/domain_list_dropdown.html:34
 msgid "CommCare Exchange"
@@ -5208,7 +5233,7 @@ msgstr ""
 #: corehq/apps/export/forms.py:76 corehq/apps/export/forms.py:133
 #: corehq/apps/hqwebapp/templates/hqwebapp/partials/pagination.html:36
 #: corehq/apps/reports/templates/reports/filters/drilldown_options.html:24
-#: corehq/apps/userreports/reports/builder/forms.py:356
+#: corehq/apps/userreports/reports/builder/forms.py:357
 msgid "Next"
 msgstr ""
 
@@ -5272,7 +5297,7 @@ msgstr ""
 #: corehq/apps/appstore/templates/appstore/project_info.html:198
 #: corehq/apps/settings/templates/settings/my_projects.html:11
 #: corehq/apps/sms/templates/sms/list_backends.html:76
-#: corehq/apps/users/views/__init__.py:688
+#: corehq/apps/users/views/__init__.py:646
 msgid "Project"
 msgstr ""
 
@@ -5414,6 +5439,8 @@ msgstr ""
 #: corehq/apps/reminders/templates/reminders/partial/complex_message_table.html:18
 #: corehq/apps/reminders/templates/reminders/partial/complex_message_table.html:21
 #: corehq/apps/sms/templates/sms/default.html:50
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:12
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:17
 msgid "Time"
 msgstr ""
 
@@ -5427,11 +5454,11 @@ msgid ""
 "That app is no longer valid. Try using the navigation links to select an app."
 msgstr ""
 
-#: corehq/apps/cloudcare/views.py:313
+#: corehq/apps/cloudcare/views.py:312
 msgid "Something went wrong filtering your cases."
 msgstr ""
 
-#: corehq/apps/cloudcare/views.py:489 corehq/apps/hqwebapp/models.py:1045
+#: corehq/apps/cloudcare/views.py:488 corehq/apps/hqwebapp/models.py:1045
 msgid "CloudCare Permissions"
 msgstr ""
 
@@ -5681,7 +5708,7 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/commtrack/forms.py:66 corehq/apps/commtrack/forms.py:71
-#: corehq/apps/commtrack/views.py:231
+#: corehq/apps/commtrack/views.py:236
 msgid "Stock Levels"
 msgstr ""
 
@@ -5725,8 +5752,8 @@ msgid "Location Type"
 msgstr ""
 
 #: corehq/apps/commtrack/models.py:539
-#: custom/ilsgateway/tanzania/reports/delivery.py:81
-#: custom/ilsgateway/tanzania/reports/randr.py:170
+#: custom/ilsgateway/tanzania/reports/delivery.py:83
+#: custom/ilsgateway/tanzania/reports/randr.py:172
 msgid "Code"
 msgstr ""
 
@@ -5745,11 +5772,11 @@ msgstr ""
 msgid "Location"
 msgstr ""
 
-#: corehq/apps/commtrack/processing.py:159
+#: corehq/apps/commtrack/processing.py:160
 msgid "Product IDs must be set for all ledger updates!"
 msgstr ""
 
-#: corehq/apps/commtrack/processing.py:174
+#: corehq/apps/commtrack/processing.py:175
 msgid "Ledger transaction references invalid Case ID \"{}\""
 msgstr ""
 
@@ -5773,33 +5800,33 @@ msgstr ""
 msgid "uncategorized"
 msgstr ""
 
-#: corehq/apps/commtrack/views.py:36 corehq/apps/hqwebapp/models.py:425
+#: corehq/apps/commtrack/views.py:41 corehq/apps/hqwebapp/models.py:425
 msgid "Setup"
 msgstr ""
 
-#: corehq/apps/commtrack/views.py:49
+#: corehq/apps/commtrack/views.py:54
 msgid "Advanced Settings"
 msgstr ""
 
-#: corehq/apps/commtrack/views.py:132
+#: corehq/apps/commtrack/views.py:137
 msgid ""
 "Settings updated! Your updated consumption settings may take a few minutes "
 "to show up in reports and on phones."
 msgstr ""
 
-#: corehq/apps/commtrack/views.py:135
+#: corehq/apps/commtrack/views.py:140
 msgid "Settings updated!"
 msgstr ""
 
-#: corehq/apps/commtrack/views.py:143 custom/intrahealth/sqldata.py:484
+#: corehq/apps/commtrack/views.py:148 custom/intrahealth/sqldata.py:484
 msgid "Consumption"
 msgstr ""
 
-#: corehq/apps/commtrack/views.py:161
+#: corehq/apps/commtrack/views.py:166
 msgid "Default consumption values updated"
 msgstr ""
 
-#: corehq/apps/commtrack/views.py:291
+#: corehq/apps/commtrack/views.py:296
 msgid "Rebuild Stock State"
 msgstr ""
 
@@ -5821,6 +5848,73 @@ msgstr ""
 
 #: corehq/apps/commtrack/templates/commtrack/manage/default_consumption.html:24
 msgid "Update Default Consumption Info"
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:8
+#, python-format
+msgid ""
+"\n"
+"    <strong>Warning:</strong>\n"
+"    You have more than %(stock_state_limit)s stocks in your project space.\n"
+"    Only %(stock_state_limit)s are shown.\n"
+"    "
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:18
+#, python-format
+msgid ""
+"\n"
+"    <strong>Warning:</strong>\n"
+"    You have more than %(stock_transaction_limit)s stock transactions in "
+"your project space.\n"
+"    Only %(stock_transaction_limit)s are shown.\n"
+"    "
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:33
+#, python-format
+msgid ""
+"\n"
+"                <strong>%(case_display)s</strong>\n"
+"                %(section_display)s\n"
+"                for <em>%(product_name)s</em>\n"
+"                "
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:43
+msgid "Rebuild"
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:50
+msgid "Current Values"
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:51
+msgid "Rebuilt Values"
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:54
+msgid "Server Date"
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:55
+msgid "Self-reported Date"
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:58
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:60
+msgid "Quantity"
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:59
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:61
+#: corehq/apps/reports/commtrack/standard.py:297
+#: custom/ilsgateway/tanzania/reports/facility_details.py:27
+msgid "Stock on Hand"
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:92
+msgid "(will be deleted)"
 msgstr ""
 
 #: corehq/apps/commtrack/templates/commtrack/manage/stock_levels.html:7
@@ -6027,7 +6121,7 @@ msgstr ""
 #: corehq/apps/data_interfaces/interfaces.py:22
 #: corehq/apps/data_interfaces/views.py:58 corehq/apps/hqwebapp/models.py:553
 #: corehq/apps/settings/views.py:213
-#: corehq/apps/userreports/reports/builder/forms.py:350
+#: corehq/apps/userreports/reports/builder/forms.py:351
 msgid "Data"
 msgstr ""
 
@@ -6054,7 +6148,7 @@ msgstr ""
 
 #: corehq/apps/dashboard/views.py:206
 #: corehq/apps/dashboard/templates/dashboard/dashboard_new_user.html:73
-#: corehq/apps/hqwebapp/models.py:1576
+#: corehq/apps/hqwebapp/models.py:1571
 msgid "Exchange"
 msgstr ""
 
@@ -6116,6 +6210,7 @@ msgid "Welcome to CommCare Supply"
 msgstr ""
 
 #: corehq/apps/dashboard/templates/dashboard/dashboard_new_user.html:64
+#: docs/_build/html/_sources/translations.txt:132
 msgid "Welcome to CommCare HQ"
 msgstr ""
 
@@ -6174,7 +6269,7 @@ msgstr ""
 #: corehq/apps/data_interfaces/interfaces.py:50
 #: corehq/apps/reports/standard/cases/basic.py:272
 #: corehq/apps/sms/templates/sms/list_backends.html:63
-#: corehq/ex-submodules/casexml/apps/case/models.py:887
+#: corehq/ex-submodules/casexml/apps/case/models.py:892
 msgid "Owner"
 msgstr ""
 
@@ -6650,7 +6745,7 @@ msgstr ""
 msgid "New owner's CommCare username"
 msgstr ""
 
-#: corehq/apps/domain/forms.py:362 corehq/apps/domain/views.py:2464
+#: corehq/apps/domain/forms.py:362 corehq/apps/domain/views.py:2465
 msgid "Transfer Project"
 msgstr ""
 
@@ -6760,7 +6855,7 @@ msgid "Secure submissions"
 msgstr ""
 
 #: corehq/apps/domain/forms.py:633 corehq/apps/hqadmin/reports.py:696
-#: corehq/apps/prelogin/templates/prelogin/base.html:81
+#: corehq/apps/prelogin/templates/prelogin/base.html:84
 msgid "Services"
 msgstr ""
 
@@ -6792,7 +6887,7 @@ msgstr ""
 
 #: corehq/apps/domain/forms.py:652
 #: corehq/apps/reports/standard/deployments.py:43
-#: corehq/apps/reports/standard/deployments.py:215
+#: corehq/apps/reports/standard/deployments.py:226
 #: corehq/apps/reports/standard/sms.py:164
 #: corehq/apps/reports/standard/sms.py:415
 #: corehq/apps/reports/standard/sms.py:474
@@ -6891,7 +6986,7 @@ msgstr ""
 #: corehq/apps/domain/forms.py:978 corehq/apps/domain/forms.py:1075
 #: corehq/apps/reminders/forms.py:517 corehq/apps/reminders/forms.py:2152
 #: corehq/apps/styleguide/examples/simple_crispy_form/forms.py:63
-#: corehq/apps/users/forms.py:487
+#: corehq/apps/users/forms.py:486
 msgid "Basic Information"
 msgstr ""
 
@@ -6916,7 +7011,7 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/domain/forms.py:922 corehq/apps/domain/forms.py:986
-#: corehq/apps/domain/forms.py:1083 corehq/apps/users/forms.py:495
+#: corehq/apps/domain/forms.py:1083 corehq/apps/users/forms.py:494
 msgid "Mailing Address"
 msgstr ""
 
@@ -7100,15 +7195,15 @@ msgstr ""
 msgid "Subscription Type"
 msgstr ""
 
-#: corehq/apps/domain/models.py:1295
+#: corehq/apps/domain/models.py:1279
 msgid "Transfer domain request is no longer active"
 msgstr ""
 
-#: corehq/apps/domain/models.py:1327 corehq/apps/domain/models.py:1342
+#: corehq/apps/domain/models.py:1311 corehq/apps/domain/models.py:1326
 msgid "Transfer of ownership for CommCare project space."
 msgstr ""
 
-#: corehq/apps/domain/models.py:1368
+#: corehq/apps/domain/models.py:1352
 #, python-brace-format
 msgid "There has been a transfer of ownership of {domain}"
 msgstr ""
@@ -7140,7 +7235,7 @@ msgstr ""
 msgid "Sorry, you do not have access to %(feature_name)s"
 msgstr ""
 
-#: corehq/apps/domain/views.py:267 corehq/apps/hqwebapp/models.py:1146
+#: corehq/apps/domain/views.py:267 corehq/apps/hqwebapp/models.py:1141
 #: corehq/apps/hqwebapp/templates/hqwebapp/partials/global_navigation_bar.html:91
 #: corehq/apps/ota/views.py:121
 #: corehq/apps/style/templates/style/bootstrap3/partials/domain_list_dropdown.html:6
@@ -7285,9 +7380,7 @@ msgstr ""
 msgid "Privacy and Security"
 msgstr ""
 
-#: corehq/apps/domain/views.py:1329 corehq/apps/prelogin/forms.py:96
-#: corehq/apps/prelogin/templates/prelogin/base.html:128
-#: corehq/apps/prelogin/templates/prelogin/_sections/home/about_dimagi.html:42
+#: corehq/apps/domain/views.py:1329 corehq/apps/prelogin/forms.py:97
 msgid "Contact Dimagi"
 msgstr ""
 
@@ -7311,7 +7404,7 @@ msgstr ""
 
 #: corehq/apps/domain/views.py:1437
 #: corehq/apps/domain/templates/domain/confirm_subscription_renewal.html:43
-#: corehq/apps/users/forms.py:513
+#: corehq/apps/users/forms.py:512
 #: corehq/apps/users/templates/users/mobile/users_list.html:115
 #: corehq/apps/users/views/mobile/users.py:461
 msgid "Confirm Billing Information"
@@ -7388,7 +7481,7 @@ msgstr ""
 msgid "Created a new version of your app."
 msgstr ""
 
-#: corehq/apps/domain/views.py:1932 corehq/apps/hqwebapp/models.py:1212
+#: corehq/apps/domain/views.py:1932 corehq/apps/hqwebapp/models.py:1207
 msgid "Multimedia Sharing"
 msgstr ""
 
@@ -7419,7 +7512,7 @@ msgstr ""
 msgid "App Schema Changes"
 msgstr ""
 
-#: corehq/apps/domain/views.py:1987 corehq/apps/hqwebapp/models.py:1226
+#: corehq/apps/domain/views.py:1987 corehq/apps/hqwebapp/models.py:1221
 msgid "Data Forwarding"
 msgstr ""
 
@@ -7432,7 +7525,7 @@ msgstr ""
 msgid "Forwarding set up to %s"
 msgstr ""
 
-#: corehq/apps/domain/views.py:2152 corehq/apps/hqwebapp/models.py:1203
+#: corehq/apps/domain/views.py:2152 corehq/apps/hqwebapp/models.py:1198
 msgid "Project Information"
 msgstr ""
 
@@ -7455,28 +7548,28 @@ msgstr ""
 msgid "Feature Previews"
 msgstr ""
 
-#: corehq/apps/domain/views.py:2439 corehq/apps/hqwebapp/models.py:1510
-#: corehq/apps/hqwebapp/models.py:1534 corehq/apps/hqwebapp/models.py:1562
+#: corehq/apps/domain/views.py:2439 corehq/apps/hqwebapp/models.py:1505
+#: corehq/apps/hqwebapp/models.py:1529 corehq/apps/hqwebapp/models.py:1557
 #: corehq/apps/toggle_ui/templates/toggle/flags.html:6
 msgid "Feature Flags"
 msgstr ""
 
-#: corehq/apps/domain/views.py:2488
+#: corehq/apps/domain/views.py:2489
 #, python-brace-format
 msgid "Resent transfer request for project '{domain}'"
 msgstr ""
 
-#: corehq/apps/domain/views.py:2558
+#: corehq/apps/domain/views.py:2559
 #, python-brace-format
 msgid "Successfully transferred ownership of project '{domain}'"
 msgstr ""
 
-#: corehq/apps/domain/views.py:2590
+#: corehq/apps/domain/views.py:2591
 #, python-brace-format
 msgid "Declined ownership of project '{domain}'"
 msgstr ""
 
-#: corehq/apps/domain/views.py:2606 corehq/apps/domain/views.py:2626
+#: corehq/apps/domain/views.py:2607 corehq/apps/domain/views.py:2627
 msgid "SMS Rate Calculator"
 msgstr ""
 
@@ -7866,7 +7959,7 @@ msgid "Usage Summary"
 msgstr ""
 
 #: corehq/apps/domain/templates/domain/current_subscription.html:210
-#: corehq/apps/domain/templates/domain/admin/feature_flags.html:26
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:34
 msgid "Feature"
 msgstr ""
 
@@ -8188,35 +8281,38 @@ msgstr ""
 msgid "Add a forwarding location"
 msgstr ""
 
-#: corehq/apps/domain/templates/domain/admin/feature_flags.html:8
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:16
 #, python-format
 msgid ""
 "\n"
-"                    Feature Flags are superuser-only things that can be turn "
-"on features for individual users or projects.\n"
-"                    They can be edited manually at the <a href="
-"\"%(toggle_url)s\">Feature Flag edit UI</a> (also super-only).\n"
+"                    Feature Flags turn on features for individual users or "
+"projects. They are editable only by\n"
+"                    super users, in the <a href=\"%(toggle_url)s\">Feature "
+"Flag edit UI</a>.\n"
 "                    In addition, some feature flags are randomly enabled by "
-"a domain.\n"
-"                "
-msgstr ""
-
-#: corehq/apps/domain/templates/domain/admin/feature_flags.html:15
-msgid ""
-"\n"
-"                    You can see a list of all enabled flags for this domain "
-"here.\n"
-"                    This does not include any flags set for users within the "
 "domain.\n"
 "                "
 msgstr ""
 
-#: corehq/apps/domain/templates/domain/admin/feature_flags.html:27
-#: corehq/apps/toggle_ui/templates/toggle/edit_flag.html:165
-msgid "Enabled?"
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:23
+msgid ""
+"\n"
+"                    Following are all flags enabled for this domain and/or "
+"for you.\n"
+"                    This does not include any flags set for other users in "
+"this domain.\n"
+"                "
 msgstr ""
 
 #: corehq/apps/domain/templates/domain/admin/feature_flags.html:35
+msgid "Enabled for domain?"
+msgstr ""
+
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:36
+msgid "Enabled for me?"
+msgstr ""
+
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:45
 msgid "change"
 msgstr ""
 
@@ -8268,7 +8364,7 @@ msgid "SMS Pricing"
 msgstr ""
 
 #: corehq/apps/domain/templates/domain/admin/global_sms_rates.html:35
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:67
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:78
 msgid "Pricing"
 msgstr ""
 
@@ -8751,8 +8847,8 @@ msgstr ""
 #: corehq/apps/users/templates/users/web_users.b3.html:220
 #: corehq/apps/users/templates/users/web_users.b3.html:285
 #: corehq/apps/users/templates/users/web_users.html:127
-#: custom/ilsgateway/tanzania/reports/facility_details.py:71
-#: custom/ilsgateway/tanzania/reports/facility_details.py:117
+#: custom/ilsgateway/tanzania/reports/facility_details.py:72
+#: custom/ilsgateway/tanzania/reports/facility_details.py:118
 msgid "Role"
 msgstr ""
 
@@ -8828,7 +8924,7 @@ msgid "Forgot your password?"
 msgstr ""
 
 #: corehq/apps/domain/templates/login_and_password/partials/login_form.html:50
-#: corehq/apps/prelogin/templates/prelogin/base.html:74
+#: corehq/apps/prelogin/templates/prelogin/base.html:77
 #: corehq/apps/style/templates/style/bootstrap2/base.html:74
 #: corehq/apps/style/templates/style/bootstrap3/base.html:102
 msgid "Sign In"
@@ -9180,7 +9276,7 @@ msgstr ""
 #: corehq/apps/sms/forms.py:450
 #: corehq/apps/sms/templates/sms/backend_map.html:97
 #: corehq/apps/style/templates/style/bootstrap3/base.html:234
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:144
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:148
 #: corehq/apps/users/templates/users/web_users.b3.html:60
 #: custom/ewsghana/templates/ewsghana/partials/users_tables.html:102
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:212
@@ -9569,6 +9665,7 @@ msgstr ""
 
 #: corehq/apps/fixtures/templates/fixtures/manage_tables.html:66
 #: corehq/apps/fixtures/templates/fixtures/partials/edit_table_modal.html:9
+#: corehq/apps/userreports/ui/forms.py:87
 msgid "Table ID"
 msgstr ""
 
@@ -9945,7 +10042,7 @@ msgstr ""
 msgid "ADMINREPORT"
 msgstr ""
 
-#: corehq/apps/hqadmin/reports.py:642 corehq/apps/hqwebapp/models.py:1401
+#: corehq/apps/hqadmin/reports.py:642 corehq/apps/hqwebapp/models.py:1396
 msgid "Project Space List"
 msgstr ""
 
@@ -10179,7 +10276,7 @@ msgstr ""
 msgid "No Info"
 msgstr ""
 
-#: corehq/apps/hqadmin/reports.py:808 corehq/apps/hqwebapp/models.py:1403
+#: corehq/apps/hqadmin/reports.py:808 corehq/apps/hqwebapp/models.py:1398
 msgid "User List"
 msgstr ""
 
@@ -10212,7 +10309,7 @@ msgstr ""
 msgid "No Domain Data"
 msgstr ""
 
-#: corehq/apps/hqadmin/reports.py:876 corehq/apps/hqwebapp/models.py:1405
+#: corehq/apps/hqadmin/reports.py:876 corehq/apps/hqwebapp/models.py:1400
 msgid "Application List"
 msgstr ""
 
@@ -10338,7 +10435,7 @@ msgid "Print"
 msgstr ""
 
 #: corehq/apps/hqadmin/templates/hqadmin/hqadmin_base_report.html:33
-#: corehq/apps/hqwebapp/models.py:1371 corehq/apps/hqwebapp/models.py:1539
+#: corehq/apps/hqwebapp/models.py:1366 corehq/apps/hqwebapp/models.py:1534
 msgid "Admin Reports"
 msgstr ""
 
@@ -10431,12 +10528,12 @@ msgstr ""
 msgid "Audio"
 msgstr ""
 
-#: corehq/apps/hqmedia/models.py:815
+#: corehq/apps/hqmedia/models.py:818
 #, python-format
 msgid "Encountered an AttributeError for media: %s"
 msgstr ""
 
-#: corehq/apps/hqmedia/models.py:819
+#: corehq/apps/hqmedia/models.py:822
 #, python-format
 msgid ""
 "This application has unsupported text in one of it's media file label "
@@ -10480,7 +10577,7 @@ msgstr ""
 msgid "File {name}s has an incorrect file type {ext}."
 msgstr ""
 
-#: corehq/apps/hqmedia/views.py:579
+#: corehq/apps/hqmedia/views.py:575
 msgid ""
 "There was an issue retrieving the status from the cache. We are looking into "
 "it. Please try uploading again."
@@ -10860,7 +10957,7 @@ msgstr ""
 msgid "Error Type"
 msgstr ""
 
-#: corehq/apps/hqpillow_retry/views.py:41 corehq/apps/hqwebapp/models.py:1393
+#: corehq/apps/hqpillow_retry/views.py:41 corehq/apps/hqwebapp/models.py:1388
 msgid "PillowTop Errors"
 msgstr ""
 
@@ -11145,7 +11242,7 @@ msgstr ""
 msgid "New Survey"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:929 corehq/apps/hqwebapp/models.py:1490
+#: corehq/apps/hqwebapp/models.py:929 corehq/apps/hqwebapp/models.py:1485
 #: corehq/apps/sms/views.py:990
 #: corehq/apps/sms/templates/sms/add_backend.html:49
 #: corehq/apps/sms/templates/sms/add_backend.html:70
@@ -11156,11 +11253,11 @@ msgstr ""
 msgid "SMS Connectivity"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:933 corehq/apps/hqwebapp/models.py:1494
+#: corehq/apps/hqwebapp/models.py:933 corehq/apps/hqwebapp/models.py:1489
 msgid "Add Connection"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:937 corehq/apps/hqwebapp/models.py:1496
+#: corehq/apps/hqwebapp/models.py:937 corehq/apps/hqwebapp/models.py:1491
 msgid "Edit Connection"
 msgstr ""
 
@@ -11211,180 +11308,174 @@ msgstr ""
 msgid "Application Users"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1068
+#: corehq/apps/hqwebapp/models.py:1067
 msgid "Project Users"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1072
+#: corehq/apps/hqwebapp/models.py:1071
 msgid ""
 "Grant other CommCare HQ users access to your project and manage user roles."
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1075
+#: corehq/apps/hqwebapp/models.py:1074
 #: corehq/apps/users/templates/users/web_users.b3.html:136
 msgid "Invite Web User"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1083 corehq/apps/settings/views.py:93
-#: corehq/apps/settings/templates/settings/edit_my_account.b2.html:33
-#: corehq/apps/users/views/__init__.py:350
-msgid "My Information"
-msgstr ""
-
-#: corehq/apps/hqwebapp/models.py:1219
+#: corehq/apps/hqwebapp/models.py:1214
 msgid "Forward Forms"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1221
+#: corehq/apps/hqwebapp/models.py:1216
 msgid "Forward Form Stubs"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1223
+#: corehq/apps/hqwebapp/models.py:1218
 msgid "Forward Cases"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1250
+#: corehq/apps/hqwebapp/models.py:1245
 msgid "Project Administration"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1296
+#: corehq/apps/hqwebapp/models.py:1291
 msgid "Internal Subscription Management (Dimagi Only)"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1313
+#: corehq/apps/hqwebapp/models.py:1308
 msgid "Project Tools"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1334
+#: corehq/apps/hqwebapp/models.py:1329
 msgid "Internal Data (Dimagi Only)"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1340
+#: corehq/apps/hqwebapp/models.py:1335
 msgid "My Settings"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1352
+#: corehq/apps/hqwebapp/models.py:1347
 msgid "Manage My Settings"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1381 corehq/apps/hqwebapp/models.py:1400
+#: corehq/apps/hqwebapp/models.py:1376 corehq/apps/hqwebapp/models.py:1395
 msgid "Administrative Reports"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1382 corehq/apps/hqwebapp/models.py:1411
-#: corehq/apps/hqwebapp/models.py:1533 corehq/apps/hqwebapp/models.py:1540
+#: corehq/apps/hqwebapp/models.py:1377 corehq/apps/hqwebapp/models.py:1406
+#: corehq/apps/hqwebapp/models.py:1528 corehq/apps/hqwebapp/models.py:1535
 msgid "System Info"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1391
+#: corehq/apps/hqwebapp/models.py:1386
 msgid "Mass Email Users"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1396
+#: corehq/apps/hqwebapp/models.py:1391
 msgid "Login as another user"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1407
+#: corehq/apps/hqwebapp/models.py:1402
 msgid "Message Logs Across All Domains"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1409
+#: corehq/apps/hqwebapp/models.py:1404
 msgid "CommCare Versions"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1413
+#: corehq/apps/hqwebapp/models.py:1408
 msgid "Loadtest Report"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1416
+#: corehq/apps/hqwebapp/models.py:1411
 msgid "Administrative Operations"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1417
+#: corehq/apps/hqwebapp/models.py:1412
 msgid "CommCare Reports"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1439
+#: corehq/apps/hqwebapp/models.py:1434
 msgid "Accounting"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1482 corehq/apps/hqwebapp/models.py:1561
+#: corehq/apps/hqwebapp/models.py:1477 corehq/apps/hqwebapp/models.py:1556
 msgid "SMS Connectivity & Billing"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1491
+#: corehq/apps/hqwebapp/models.py:1486
 #: corehq/apps/sms/templates/sms/add_backend.html:52
 #: corehq/apps/sms/templates/sms/list_backends.html:39
 msgid "SMS Connections"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1499
+#: corehq/apps/hqwebapp/models.py:1494
 #: corehq/apps/sms/templates/sms/backend_map.html:5
 #: corehq/apps/sms/templates/sms/backend_map.html:64
 #: corehq/apps/sms/templates/sms/backend_map.html:72
 msgid "SMS Country-Connection Map"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1519
+#: corehq/apps/hqwebapp/models.py:1514
 msgid "Admin"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1541
+#: corehq/apps/hqwebapp/models.py:1536
 msgid "Management"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1542
+#: corehq/apps/hqwebapp/models.py:1537
 msgid "Commands"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1556
+#: corehq/apps/hqwebapp/models.py:1551
 msgid "Old SMS Billing"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1564
+#: corehq/apps/hqwebapp/models.py:1559
 msgid "Django Admin"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1586
+#: corehq/apps/hqwebapp/models.py:1581
 msgid "Publish this project"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1615
+#: corehq/apps/hqwebapp/models.py:1610
 #: corehq/apps/orgs/templates/orgs/report_base.html:28
 msgid "Projects Table"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1618
+#: corehq/apps/hqwebapp/models.py:1613
 #: corehq/apps/orgs/templates/orgs/report_base.html:29
 #: corehq/apps/reports/standard/monitoring.py:1026
 msgid "Form Data"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1621
+#: corehq/apps/hqwebapp/models.py:1616
 #: corehq/apps/orgs/templates/orgs/report_base.html:30
 #: corehq/apps/reports/standard/monitoring.py:1036
 msgid "Case Data"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1624
+#: corehq/apps/hqwebapp/models.py:1619
 #: corehq/apps/orgs/templates/orgs/report_base.html:31
 msgid "User Data"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1637
+#: corehq/apps/hqwebapp/models.py:1632
 #: corehq/apps/orgs/templates/orgs/orgs_team_members.html:84
 #: corehq/apps/orgs/templates/orgs/public.html:28
 #: corehq/apps/orgs/templates/orgs/partials/top_nav.html:6
 msgid "Projects"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1640
+#: corehq/apps/hqwebapp/models.py:1635
 #: corehq/apps/orgs/templates/orgs/public.html:31
 #: corehq/apps/orgs/templates/orgs/partials/top_nav.html:9
 msgid "Teams"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1643
+#: corehq/apps/hqwebapp/models.py:1638
 #: corehq/apps/orgs/templates/orgs/orgs_team_members.html:50
 #: corehq/apps/orgs/templates/orgs/public.html:34
 #: corehq/apps/orgs/templates/orgs/partials/top_nav.html:12
@@ -11435,44 +11526,44 @@ msgstr ""
 msgid "View All"
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:612
+#: corehq/apps/hqwebapp/views.py:614
 msgid ""
 "Check \"Opt out of emails about new features and other CommCare updates\" in "
 "your account settings and then click \"Update Information\" if you do not "
 "want to receive future emails from us."
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:713
+#: corehq/apps/hqwebapp/views.py:715
 msgid "items per page"
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:714
+#: corehq/apps/hqwebapp/views.py:716
 msgid "You have no items."
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:716
+#: corehq/apps/hqwebapp/views.py:718
 msgid "Deleted Items:"
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:717
+#: corehq/apps/hqwebapp/views.py:719
 msgid "New Items:"
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:840
+#: corehq/apps/hqwebapp/views.py:842
 #, python-format
 msgid "<strong>Problem Refreshing List:</strong> %s"
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:858
+#: corehq/apps/hqwebapp/views.py:860
 #, python-format
 msgid "<strong>Problem Deleting:</strong> %s"
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:866
+#: corehq/apps/hqwebapp/views.py:868
 msgid "The item's ID was not passed to the server."
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:976
+#: corehq/apps/hqwebapp/views.py:978
 #, python-format
 msgid "We've redirected you to the %s matching your query"
 msgstr ""
@@ -11750,11 +11841,11 @@ msgstr ""
 msgid "No properties found."
 msgstr ""
 
-#: corehq/apps/importer/base.py:5
+#: corehq/apps/importer/base.py:6
 msgid "Import Cases from Excel"
 msgstr ""
 
-#: corehq/apps/importer/base.py:7
+#: corehq/apps/importer/base.py:8
 msgid "Import case data from an external Excel file"
 msgstr ""
 
@@ -11780,6 +11871,10 @@ msgstr ""
 
 #: corehq/apps/importer/const.py:13
 msgid "Case Generation Error"
+msgstr ""
+
+#: corehq/apps/importer/const.py:14
+msgid "Duplicated Location Name"
 msgstr ""
 
 #: corehq/apps/importer/util.py:213
@@ -11816,19 +11911,26 @@ msgstr ""
 msgid "An invalid or unknown parent case was specified for the uploaded case."
 msgstr ""
 
-#: corehq/apps/importer/views.py:170
+#: corehq/apps/importer/util.py:234
+msgid ""
+"Owner ID was used in the mapping, but there were errors when uploading "
+"because of these values. There are multiple locations with this same name, "
+"try using site-code instead."
+msgstr ""
+
+#: corehq/apps/importer/views.py:169
 msgid ""
 "It looks like you may have accessed this page from a stale page. Please "
 "start over."
 msgstr ""
 
-#: corehq/apps/importer/views.py:274 corehq/apps/importer/views.py:331
+#: corehq/apps/importer/views.py:273 corehq/apps/importer/views.py:330
 msgid ""
 "The session containing the file you uploaded has expired - please upload a "
 "new one."
 msgstr ""
 
-#: corehq/apps/importer/views.py:349
+#: corehq/apps/importer/views.py:348
 msgid "Sorry, your session has expired. Please start over and try again."
 msgstr ""
 
@@ -11861,8 +11963,9 @@ msgid "Corresponding case field"
 msgstr ""
 
 #: corehq/apps/importer/templates/importer/excel_config.html:90
-#: corehq/ex-submodules/casexml/apps/case/models.py:892
-#: custom/opm/beneficiary.py:823 custom/opm/beneficiary.py:899
+#: corehq/ex-submodules/casexml/apps/case/models.py:897
+#: custom/opm/beneficiary.py:822 custom/opm/beneficiary.py:899
+#: custom/opm/beneficiary.py:921
 msgid "Case ID"
 msgstr ""
 
@@ -11913,7 +12016,8 @@ msgstr ""
 
 #: corehq/apps/importer/templates/importer/excel_config.html:192
 #: corehq/apps/importer/templates/importer/excel_fields.html:189
-#: corehq/apps/userreports/reports/builder/forms.py:458
+#: corehq/apps/userreports/reports/builder/forms.py:459
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:5
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:210
 #: submodules/ctable-src/ctable_view/templates/ctable/test_mapping.html:129
 msgid "Back"
@@ -12456,11 +12560,16 @@ msgstr ""
 msgid "Move"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:83
+#: corehq/apps/locations/templates/locations/manage/locations.html:40
+#, python-format
+msgid "You have successfully archived the location <%%=name%%>"
+msgstr ""
+
+#: corehq/apps/locations/templates/locations/manage/locations.html:102
 msgid "Manage Locations"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:85
+#: corehq/apps/locations/templates/locations/manage/locations.html:104
 msgid ""
 "\n"
 "                    Locations allow you to represent the real-world "
@@ -12473,42 +12582,43 @@ msgid ""
 "                "
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:95
+#: corehq/apps/locations/templates/locations/manage/locations.html:114
 msgid "Showing the Inactive Location List."
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:102
+#: corehq/apps/locations/templates/locations/manage/locations.html:121
 msgid "Show Archived Locations"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:106
+#: corehq/apps/locations/templates/locations/manage/locations.html:125
 msgid "Show Active Locations"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:119
-#: corehq/apps/locations/templates/locations/manage/locations.html:123
+#: corehq/apps/locations/templates/locations/manage/locations.html:138
+#: corehq/apps/locations/templates/locations/manage/locations.html:142
 msgid "Bulk Import Locations"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:127
+#: corehq/apps/locations/templates/locations/manage/locations.html:146
 msgid "Edit Location Types"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:130
+#: corehq/apps/locations/templates/locations/manage/locations.html:149
 msgid "Edit Location Fields"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:155
+#: corehq/apps/locations/templates/locations/manage/locations.html:174
 msgid "Unarchive"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:160
+#: corehq/apps/locations/templates/locations/manage/locations.html:179
+#: corehq/apps/locations/templates/locations/manage/locations.html:267
 #: corehq/apps/products/views.py:186
 #: corehq/apps/products/templates/products/manage/products.html:116
 msgid "Archive"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:216
+#: corehq/apps/locations/templates/locations/manage/locations.html:235
 #, python-format
 msgid ""
 "\n"
@@ -12516,6 +12626,22 @@ msgid ""
 "    <a href=\"%(location_types_url)s\">here</a>\n"
 "    for your project before creating any locations.\n"
 "    "
+msgstr ""
+
+#: corehq/apps/locations/templates/locations/manage/locations.html:253
+msgid "Archive Location:"
+msgstr ""
+
+#: corehq/apps/locations/templates/locations/manage/locations.html:257
+msgid ""
+"\n"
+"            <strong>Warning!</strong> Archiving a location will unassign any "
+"users\n"
+"            which were associated with that location.  You can unarchive "
+"this\n"
+"            location at any point, but you will have to reassign the users\n"
+"            manually.\n"
+"            "
 msgstr ""
 
 #: corehq/apps/locations/templates/locations/manage/partials/autocomplete_select_widget.html:10
@@ -12721,31 +12847,31 @@ msgstr ""
 msgid "Prime Restore Cache"
 msgstr ""
 
-#: corehq/apps/prelogin/forms.py:32 corehq/apps/registration/forms.py:52
+#: corehq/apps/prelogin/forms.py:33 corehq/apps/registration/forms.py:52
 msgid "Email Address"
 msgstr ""
 
-#: corehq/apps/prelogin/forms.py:45
+#: corehq/apps/prelogin/forms.py:46
 msgid "What is your interest in CommCare and any specific questions you have?"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:57
+#: corehq/apps/prelogin/templates/prelogin/base.html:60
 msgid "Toggle Navigation"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:78
+#: corehq/apps/prelogin/templates/prelogin/base.html:81
 msgid "Solutions"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:79
+#: corehq/apps/prelogin/templates/prelogin/base.html:82
 msgid "Impact"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:80
+#: corehq/apps/prelogin/templates/prelogin/base.html:83
 msgid "Software Pricing"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:108
+#: corehq/apps/prelogin/templates/prelogin/base.html:111
 #, python-format
 msgid ""
 "\n"
@@ -12756,11 +12882,15 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:145
+#: corehq/apps/prelogin/templates/prelogin/base.html:131
+msgid "Get in Touch With Us: Contact Dimagi"
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/base.html:148
 msgid "Thanks for contacting us!"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:150
+#: corehq/apps/prelogin/templates/prelogin/base.html:153
 msgid ""
 "\n"
 "                            Thank you for your interest in working with "
@@ -12768,7 +12898,7 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:155
+#: corehq/apps/prelogin/templates/prelogin/base.html:158
 msgid ""
 "\n"
 "                            One of our team members will get back to you "
@@ -12778,18 +12908,18 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:163
-#: corehq/apps/prelogin/templates/prelogin/base.html:202
+#: corehq/apps/prelogin/templates/prelogin/base.html:166
+#: corehq/apps/prelogin/templates/prelogin/base.html:205
 #: custom/_legacy/a5288/reports.py:102
 msgid "OK"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:176
-#: corehq/apps/prelogin/templates/prelogin/base.html:215
+#: corehq/apps/prelogin/templates/prelogin/base.html:179
+#: corehq/apps/prelogin/templates/prelogin/base.html:218
 msgid "Ooops!"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:181
+#: corehq/apps/prelogin/templates/prelogin/base.html:184
 msgid ""
 "\n"
 "                             We're terribly sorry! It seems like our servers "
@@ -12797,7 +12927,7 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:186
+#: corehq/apps/prelogin/templates/prelogin/base.html:189
 msgid ""
 "\n"
 "                                We've alerted one of our engineers of issues "
@@ -12808,7 +12938,7 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:193
+#: corehq/apps/prelogin/templates/prelogin/base.html:196
 msgid ""
 "\n"
 "                                You can send an email directly to\n"
@@ -12818,7 +12948,7 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:226
+#: corehq/apps/prelogin/templates/prelogin/base.html:229
 msgid ""
 "\n"
 "                                Please provide a valid e-mail address where "
@@ -12879,6 +13009,10 @@ msgid ""
 "contact\n"
 "                        Dimagi directly.\n"
 "                    "
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/home/about_dimagi.html:42
+msgid "Get in Touch With Us"
 msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/home/about_dimagi.html:50
@@ -13091,7 +13225,7 @@ msgstr ""
 #: corehq/apps/style/templates/style/includes/modal_report_issue.html:49
 #: corehq/apps/styleguide/examples/simple_crispy_form/forms.py:17
 #: custom/_legacy/pact/templates/pact/chw/pact_chw_profile_info.html:16
-#: custom/ilsgateway/tanzania/reports/facility_details.py:73
+#: custom/ilsgateway/tanzania/reports/facility_details.py:74
 msgid "Email"
 msgstr ""
 
@@ -13269,32 +13403,35 @@ msgstr ""
 #: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:12
 msgid ""
 "\n"
-"                        Read how organizations around the world use\n"
-"                        CommCare to improve frontline service delivery.\n"
+"                    <!--HubSpot Call-to-Action Code -->\n"
+"                    <span class=\"hs-cta-wrapper\" id=\"hs-cta-"
+"wrapper-071f4a7d-237d-49d8-b12d-c28fe204927d\">\n"
+"                        <span class=\"hs-cta-node hs-cta-071f4a7d-237d-49d8-"
+"b12d-c28fe204927d\" id=\"hs-cta-071f4a7d-237d-49d8-b12d-c28fe204927d\">\n"
+"                            <!--[if lte IE 8]><div id=\"hs-cta-ie-element"
+"\"></div><![endif]-->\n"
+"                            <a href=\"http://cta-redirect.hubspot.com/cta/"
+"redirect/503070/071f4a7d-237d-49d8-b12d-c28fe204927d\" ><img class=\"hs-cta-"
+"img\" id=\"hs-cta-img-071f4a7d-237d-49d8-b12d-c28fe204927d\" style=\"border-"
+"width:0px;\" src=\"https://no-cache.hubspot.com/cta/"
+"default/503070/071f4a7d-237d-49d8-b12d-c28fe204927d.png\"  alt=\"View All "
+"Case Studies\"/></a>\n"
+"                        </span>\n"
+"                        <script type=\"text/javascript\">\n"
+"                            hbspt.cta.load(503070, '071f4a7d-237d-49d8-b12d-"
+"c28fe204927d');\n"
+"                        </script>\n"
+"                    </span>\n"
+"                    <!-- end HubSpot Call-to-Action Code -->\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:24
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:39
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:54
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:69
-msgid "Read Case Study"
-msgstr ""
-
 #: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:27
-msgid "Improving Community Health in Guatemala"
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:42
-msgid "An Integrated eDiagnostic Approach in Burkina Faso"
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:57
-msgid "Improving Maternal and Child Health in India"
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:72
-msgid "iCCM for Child Health in Mozambique"
+msgid ""
+"\n"
+"                        Read how organizations around the world use\n"
+"                        CommCare to improve frontline service delivery.\n"
+"                    "
 msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/impact/lead.html:9
@@ -13339,6 +13476,33 @@ msgstr ""
 #: corehq/apps/prelogin/templates/prelogin/_sections/impact/partners.html:12
 msgid ""
 "\n"
+"                    <!--HubSpot Call-to-Action Code -->\n"
+"                    <span class=\"hs-cta-wrapper\" id=\"hs-cta-wrapper-"
+"c34ae48e-2f1a-48ac-9170-31fc7c9e845b\">\n"
+"                        <span class=\"hs-cta-node hs-cta-"
+"c34ae48e-2f1a-48ac-9170-31fc7c9e845b\" id=\"hs-cta-"
+"c34ae48e-2f1a-48ac-9170-31fc7c9e845b\">\n"
+"                            <!--[if lte IE 8]><div id=\"hs-cta-ie-element"
+"\"></div><![endif]-->\n"
+"                            <a href=\"http://cta-redirect.hubspot.com/cta/"
+"redirect/503070/c34ae48e-2f1a-48ac-9170-31fc7c9e845b\"  target=\"_blank\" "
+"><img class=\"hs-cta-img\" id=\"hs-cta-img-"
+"c34ae48e-2f1a-48ac-9170-31fc7c9e845b\" style=\"border-width:0px;\" src="
+"\"https://no-cache.hubspot.com/cta/default/503070/"
+"c34ae48e-2f1a-48ac-9170-31fc7c9e845b.png\"  alt=\"See All Partners\"/></a>\n"
+"                        </span>\n"
+"                        <script type=\"text/javascript\">\n"
+"                            hbspt.cta.load(503070, "
+"'c34ae48e-2f1a-48ac-9170-31fc7c9e845b');\n"
+"                        </script>\n"
+"                    </span>\n"
+"                    <!-- end HubSpot Call-to-Action Code -->\n"
+"                    "
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/partners.html:27
+msgid ""
+"\n"
 "                        The following organizations have contributed\n"
 "                        to the development of CommCare.\n"
 "                    "
@@ -13354,14 +13518,36 @@ msgstr ""
 #: corehq/apps/prelogin/templates/prelogin/_sections/impact/publications.html:12
 msgid ""
 "\n"
+"                    <!--HubSpot Call-to-Action Code -->\n"
+"                    <span class=\"hs-cta-wrapper\" id=\"hs-cta-"
+"wrapper-23da92fd-b671-481f-9aee-bbc8a94b1f8b\">\n"
+"                        <span class=\"hs-cta-node hs-cta-23da92fd-"
+"b671-481f-9aee-bbc8a94b1f8b\" id=\"hs-cta-23da92fd-b671-481f-9aee-"
+"bbc8a94b1f8b\">\n"
+"                            <!--[if lte IE 8]><div id=\"hs-cta-ie-element"
+"\"></div><![endif]-->\n"
+"                            <a href=\"http://cta-redirect.hubspot.com/cta/"
+"redirect/503070/23da92fd-b671-481f-9aee-bbc8a94b1f8b\"  target=\"_blank\" "
+"><img class=\"hs-cta-img\" id=\"hs-cta-img-23da92fd-b671-481f-9aee-"
+"bbc8a94b1f8b\" style=\"border-width:0px;\" src=\"https://no-cache.hubspot."
+"com/cta/default/503070/23da92fd-b671-481f-9aee-bbc8a94b1f8b.png\"  alt="
+"\"View Research\"/></a>\n"
+"                        </span>\n"
+"                        <script type=\"text/javascript\">\n"
+"                            hbspt.cta.load(503070, '23da92fd-b671-481f-9aee-"
+"bbc8a94b1f8b');\n"
+"                        </script>\n"
+"                    </span>\n"
+"                    <!-- end HubSpot Call-to-Action Code -->\n"
+"                    "
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/publications.html:27
+msgid ""
+"\n"
 "                        Over 30+ peer-reviewed publications have been "
 "written\n"
-"                        about CommCare. For an overview of all CommCare\n"
-"                        publications, please see the\n"
-"                        <a href=\"https://help.commcarehq.org/display/"
-"commcarepublic/CommCare+Evidence+Base\"\n"
-"                           class=\"btn-primary-dark\">CommCare Evidence "
-"Base</a>.\n"
+"                        about CommCare.\n"
 "                    "
 msgstr ""
 
@@ -13372,63 +13558,90 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:27
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:12
+msgid ""
+"\n"
+"                    <!--HubSpot Call-to-Action Code -->\n"
+"                    <span class=\"hs-cta-wrapper\" id=\"hs-cta-wrapper-"
+"c21c3aed-90ee-4106-98d0-dbe846e8ca28\">\n"
+"                        <span class=\"hs-cta-node hs-cta-"
+"c21c3aed-90ee-4106-98d0-dbe846e8ca28\" id=\"hs-cta-c21c3aed-90ee-4106-98d0-"
+"dbe846e8ca28\">\n"
+"                            <!--[if lte IE 8]><div id=\"hs-cta-ie-element"
+"\"></div><![endif]-->\n"
+"                            <a href=\"http://cta-redirect.hubspot.com/cta/"
+"redirect/503070/c21c3aed-90ee-4106-98d0-dbe846e8ca28\"  target=\"_blank\" "
+"><img class=\"hs-cta-img\" id=\"hs-cta-img-c21c3aed-90ee-4106-98d0-"
+"dbe846e8ca28\" style=\"border-width:0px;\" src=\"https://no-cache.hubspot."
+"com/cta/default/503070/c21c3aed-90ee-4106-98d0-dbe846e8ca28.png\"  alt="
+"\"Learn More About Our Sectors\"/></a>\n"
+"                        </span>\n"
+"                        <script type=\"text/javascript\">\n"
+"                            hbspt.cta.load(503070, 'c21c3aed-90ee-4106-98d0-"
+"dbe846e8ca28');\n"
+"                        </script>\n"
+"                    </span>\n"
+"                    <!-- end HubSpot Call-to-Action Code -->\n"
+"                    "
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:35
 msgid "Child Health"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:33
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:41
 msgid "HIV/AIDS"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:52
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:60
 msgid "Health"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:73
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:81
 msgid "Malaria"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:80
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:88
 msgid "Nutrition"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:91
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:99
 msgid "Cooperatives"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:98
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:106
 msgid "Finances"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:117
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:125
 msgid "Agriculture"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:138
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:146
 msgid "Extension Programs"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:145
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:153
 msgid "Logistics"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:156
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:164
 msgid "Emergency Response"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:163
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:171
 msgid "Small Business"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:182
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:190
 msgid "Development"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:203
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:211
 msgid "Education"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:210
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:218
 msgid "Logistics & Supply Chain"
 msgstr ""
 
@@ -13505,11 +13718,12 @@ msgid ""
 "\n"
 "                        <a href=\"#contactDimagi\"\n"
 "                           data-toggle=\"modal\"\n"
-"                           class=\"btn-primary-dark\">Contact Dimagi</a> or "
-"read our<br />\n"
-"                        pricing <a href=\"https://confluence.dimagi.com/"
-"display/commcarepublic/CommCare+Pricing+FAQs\" class=\"btn-primary-dark"
-"\">FAQs</a>.\n"
+"                           class=\"btn-success btn btn-xl\">Get in Touch "
+"With Us</a>\n"
+"                        <a href=\"https://confluence.dimagi.com/display/"
+"commcarepublic/CommCare+Pricing+FAQs\"\n"
+"                           class=\"btn btn-primary-dark btn-xl\">Read our "
+"Pricing FAQs</a>\n"
 "                    "
 msgstr ""
 
@@ -13517,21 +13731,19 @@ msgstr ""
 msgid "CommCare Software Plans"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:11
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:16
 msgid ""
 "\n"
-"                            Core Features are always FREE. Choose a plan\n"
-"                            to help your project scale.\n"
-"                        "
+"                        Core Features are always FREE. Choose a plan\n"
+"                        to help your project scale.\n"
+"                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:18
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:22
 msgid ""
 "\n"
-"                    <strong>Anyone can use CommCare for FREE up to 50 mobile "
-"workers.</strong><br />\n"
 "                    For additional questions, please see our\n"
-"                    <a class=\"btn-primary-dark\"\n"
+"                    <a class=\"lead-link\"\n"
 "                       href=\"https://confluence.dimagi.com/display/"
 "commcarepublic/CommCare+Pricing+FAQs?__hstc=187943799."
 "ba674a1a3cdef13c5d09b2a54d65c2b8.1431286503613.1435340206977.1435342587932.124&__hssc=187943799.6.1435342587932&__hsfp=312587752\">FAQs</"
@@ -13539,16 +13751,27 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:92
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:31
+msgid ""
+"\n"
+"                        Want to try CommCare for FREE?\n"
+"                    "
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:34
+msgid "Sign up for a FREE account"
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:103
 msgid "Contact Us"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:122
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:152
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:133
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:163
 msgid "Unlimited / Discounted"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:128
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:139
 msgid "Price Per Additional Mobile User"
 msgstr ""
 
@@ -13769,71 +13992,80 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:39
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:33
-msgid "Scope"
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:42
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:36
-msgid "Launch"
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:45
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:39
-msgid "Boost"
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:28
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:15
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:662
+msgid ""
+"\n"
+"                        Inquire About Dimagi's Implementation Bundles\n"
+"                        "
 msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:48
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:42
-msgid "Growth"
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:35
+msgid "Scope"
 msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:51
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:45
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:38
+msgid "Launch"
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:54
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:41
+msgid "Boost"
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:57
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:44
+msgid "Growth"
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:60
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:47
 msgid "Scale"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:56
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:53
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:65
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:55
 msgid "$10,000"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:59
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:56
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:68
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:58
 msgid "$35,000"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:62
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:59
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:71
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:61
 msgid "$50,000"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:65
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:62
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:74
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:64
 msgid "$80,000"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:68
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:65
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:77
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:67
 msgid "$150,000"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:92
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:100
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:108
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:89
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:97
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:105
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:101
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:109
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:117
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:91
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:99
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:107
 msgid "12 months"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:116
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:113
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:125
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:115
 msgid "18 months"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:123
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:132
 msgid ""
 "\n"
 "                                Application Development &amp; Implementation "
@@ -13841,19 +14073,19 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:130
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:139
 msgid "Workflow Design"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:131
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:140
 msgid "On-Site Scoping Visit"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:132
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:141
 msgid "Mobile System Workflow Design"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:138
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:147
 msgid ""
 "\n"
 "                                    Everything in<br />\n"
@@ -13861,19 +14093,19 @@ msgid ""
 "                                "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:143
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:152
 msgid "Build &amp; Launch Application"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:144
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:153
 msgid "Field Testing &amp; Iteration"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:145
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:154
 msgid "Users Training"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:151
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:160
 msgid ""
 "\n"
 "                                    Everything in<br />\n"
@@ -13881,16 +14113,16 @@ msgid ""
 "                                "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:156
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:62
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:165
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:69
 msgid "Technology for Outcomes Monitoring"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:157
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:166
 msgid "Capacity Building for Worker Performance Monitoring"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:163
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:172
 msgid ""
 "\n"
 "                                    Everything in<br />\n"
@@ -13898,19 +14130,19 @@ msgid ""
 "                                "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:168
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:177
 msgid "Refined Application"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:169
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:178
 msgid "Additional Supervisor App"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:170
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:179
 msgid "Application Troubleshooting Capacity Building"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:176
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:185
 msgid ""
 "\n"
 "                                    Everything in<br />\n"
@@ -13918,37 +14150,29 @@ msgid ""
 "                                "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:181
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:190
 msgid "Monitored Application Usage"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:182
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:191
 msgid "Additional Tech for Reminder Messages"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:183
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:40
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:192
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:47
 msgid "Training of Trainers"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:184
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:42
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:193
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:49
 msgid "Capacity to Build Applications"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:190
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:194
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:45
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:68
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:199
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:203
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:52
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:75
 msgid "See More..."
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:205
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:659
-msgid ""
-"\n"
-"                    Inquire About Dimagi's Implementation Bundles\n"
-"                    "
 msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:7
@@ -13975,7 +14199,11 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:31
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:27
+msgid "Inquire About Dimagi's Capacity Services"
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:38
 #: corehq/apps/products/forms.py:28
 #: corehq/apps/products/templates/products/manage/products.html:112
 #: corehq/apps/programs/templates/programs/manage/programs.html:62
@@ -13983,40 +14211,36 @@ msgstr ""
 msgid "Program"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:34
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:57
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:41
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:64
 msgid ""
 "\n"
 "                            $10,000 per capacity service\n"
 "                        "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:39
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:46
 msgid "Worker Performance Monitoring"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:41
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:48
 msgid "Capacity for Technical Support"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:54
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:61
 msgid "Technology"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:63
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:70
 msgid "Apps for Supportive Supervision"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:64
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:71
 msgid "App Refinement by Dimagi"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:65
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:72
 msgid "Technology for Reminder Messages"
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:81
-msgid "Inquire About Dimagi's Capacity Services"
 msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/services/faq.html:8
@@ -14033,8 +14257,8 @@ msgid ""
 "\n"
 "                        <a href=\"#contactDimagi\"\n"
 "                           data-toggle=\"modal\"\n"
-"                           class=\"btn-primary-dark\">Contact Dimagi</a> for "
-"more information.\n"
+"                           class=\"btn btn-success btn-xl\">Get in Touch "
+"With Us</a>\n"
 "                    "
 msgstr ""
 
@@ -14119,110 +14343,100 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:12
-msgid ""
-"\n"
-"                        If you have any additional questions, please\n"
-"                        <a href=\"#contactDimagi\"\n"
-"                           data-toggle=\"modal\">contact Dimagi</a> "
-"directly.\n"
-"                    "
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:50
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:52
 msgid "Cost"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:71
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:73
 msgid "Included Software Plan"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:119
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:121
 msgid "Application Development Support"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:125
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:127
 msgid ""
 "\n"
 "                                Workflow Design\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:160
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:162
 msgid ""
 "\n"
 "                                Launch &amp; Tested Application\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:195
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:197
 msgid ""
 "\n"
 "                                Additional Tech for Monitoring Outcomes\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:230
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:232
 msgid ""
 "\n"
 "                                Launched v2 application\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:265
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:267
 msgid ""
 "\n"
 "                                Supervisor Application\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:300
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:302
 msgid ""
 "\n"
 "                                Monitored app usage\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:335
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:337
 msgid ""
 "\n"
 "                                Additional Tech for Reminder Messages\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:369
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:371
 msgid "Implementation Services"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:375
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:377
 msgid ""
 "\n"
 "                                On-Site Scoping Visit\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:410
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:412
 msgid ""
 "\n"
 "                                Mobile System Workflow Design\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:445
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:447
 msgid ""
 "\n"
 "                                Field Testing &amp; Iteration\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:480
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:482
 msgid ""
 "\n"
 "                                Pilot Users Training\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:515
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:517
 msgid ""
 "\n"
 "                                Capacity Service: Worker Performance "
@@ -14230,7 +14444,7 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:550
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:552
 msgid ""
 "\n"
 "                                Capacity Service: Application "
@@ -14238,14 +14452,14 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:585
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:587
 msgid ""
 "\n"
 "                                Capacity Service: Training of Trainers\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:620
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:622
 msgid ""
 "\n"
 "                                Capacity Service: App Building\n"
@@ -14259,24 +14473,22 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:12
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:15
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:210
 msgid ""
 "\n"
-"                        If you have any additional questions, please\n"
-"                        <a href=\"#contactDimagi\"\n"
-"                           data-toggle=\"modal\">contact Dimagi</a>\n"
-"                        directly.\n"
-"                    "
+"                        Inquire About Dimagi's Capacity Services\n"
+"                        "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:24
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:25
 msgid ""
 "\n"
 "                        Program Capacity Services\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:29
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:30
 msgid ""
 "\n"
 "                        Dimagi travels on-site to build capacity, spending "
@@ -14285,22 +14497,22 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:35
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:125
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:37
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:128
 msgid ""
 "\n"
 "                        $10,000 per capacity service package.\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:44
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:46
 msgid ""
 "\n"
 "                        Worker Performance Monitoring\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:51
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:53
 msgid ""
 "\n"
 "                    Strategic implementation of standard CommCare HQ "
@@ -14309,14 +14521,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:61
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:63
 msgid ""
 "\n"
 "                        Training of Trainers\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:68
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:70
 msgid ""
 "\n"
 "                        Capacity building for organization’s trainers for "
@@ -14327,14 +14539,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:79
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:81
 msgid ""
 "\n"
 "                        Capacity for Technical Support\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:86
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:88
 msgid ""
 "\n"
 "                        Train technical staff about troubleshooting and "
@@ -14343,14 +14555,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:96
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:98
 msgid ""
 "\n"
 "                        Capacity to Build Applications\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:103
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:105
 msgid ""
 "\n"
 "                        Learn how to build your own applications,\n"
@@ -14359,14 +14571,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:114
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:116
 msgid ""
 "\n"
 "                        Technology Capacity Services\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:119
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:121
 msgid ""
 "\n"
 "                        Dimagi provides additional system refinement or new\n"
@@ -14374,14 +14586,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:134
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:137
 msgid ""
 "\n"
 "                        Technology for Outcomes Monitoring\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:141
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:144
 msgid ""
 "\n"
 "                        Create customized, offline Excel reports for 5-10\n"
@@ -14391,14 +14603,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:152
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:155
 msgid ""
 "\n"
 "                        Apps for Supportive Supervision\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:159
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:162
 msgid ""
 "\n"
 "                        Integrate a mobile application designed for field "
@@ -14409,14 +14621,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:170
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:173
 msgid ""
 "\n"
 "                        App Refinement by Dimagi\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:177
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:180
 msgid ""
 "\n"
 "                        Dimagi to make modifications to application based "
@@ -14425,14 +14637,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:187
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:190
 msgid ""
 "\n"
 "                        Technology for Reminder Messages\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:194
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:197
 msgid ""
 "\n"
 "                        Send SMS reminders directly to beneficiaries or\n"
@@ -14458,11 +14670,10 @@ msgstr ""
 #: corehq/apps/prelogin/templates/prelogin/_sections/solutions/last.html:13
 msgid ""
 "\n"
-"                        Contact us at\n"
-"                        <a class=\"btn-primary-dark\"\n"
-"                           href=\"mailto:commcare.supply@dimagi.com\">\n"
-"                            commcare.supply@dimagi.com\n"
-"                        </a>.\n"
+"                        <a href=\"#contactDimagi\"\n"
+"                           data-toggle=\"modal\"\n"
+"                           class=\"btn-success btn btn-xl\">Get in Touch "
+"With Us</a>\n"
 "                    "
 msgstr ""
 
@@ -14655,6 +14866,13 @@ msgid ""
 "                    International, including ILSGateway in Tanzania,\n"
 "                    the Early Warning System in Ghana, and cStock\n"
 "                    in Malawi.\n"
+"                    "
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/solutions/supply_intro.html:45
+msgid ""
+"\n"
+"                    Have questions or want to request a demo?\n"
 "                    "
 msgstr ""
 
@@ -16153,7 +16371,7 @@ msgstr ""
 
 #: corehq/apps/reminders/templates/reminders/partial/complex_message_table.html:30
 #: corehq/apps/reminders/templates/reminders/partial/complex_message_table.html:32
-#: custom/opm/beneficiary.py:814
+#: custom/opm/beneficiary.py:813 custom/opm/beneficiary.py:946
 msgid "Window"
 msgstr ""
 
@@ -16237,34 +16455,34 @@ msgstr ""
 msgid "CommTrack"
 msgstr ""
 
-#: corehq/apps/reports/models.py:49
+#: corehq/apps/reports/models.py:51
 msgid "demo_user"
 msgstr ""
 
-#: corehq/apps/reports/models.py:50
+#: corehq/apps/reports/models.py:52
 msgid "admin"
 msgstr ""
 
-#: corehq/apps/reports/models.py:51
+#: corehq/apps/reports/models.py:53
 msgid "Unknown Users"
 msgstr ""
 
-#: corehq/apps/reports/models.py:381
+#: corehq/apps/reports/models.py:373
 msgid "Deleted Report"
 msgstr ""
 
-#: corehq/apps/reports/models.py:385
+#: corehq/apps/reports/models.py:377
 msgid "Unsupported Report"
 msgstr ""
 
-#: corehq/apps/reports/models.py:423
+#: corehq/apps/reports/models.py:415
 msgid ""
 "The report used to create this scheduled report is no longer available on "
 "CommCare HQ.  Please delete this scheduled report and create a new one using "
 "an available report."
 msgstr ""
 
-#: corehq/apps/reports/models.py:485
+#: corehq/apps/reports/models.py:477
 #, python-format
 msgid ""
 "We are sorry, but your saved report '%(config_name)s' is no longer "
@@ -16274,7 +16492,7 @@ msgid ""
 "%(saved_reports_url)s to remove this Emailed Report."
 msgstr ""
 
-#: corehq/apps/reports/models.py:498
+#: corehq/apps/reports/models.py:490
 #, python-format
 msgid ""
 "We are sorry, but your saved report '%(config_name)s' can not be generated "
@@ -16282,20 +16500,20 @@ msgid ""
 "Administrator about getting permissions for thisreport."
 msgstr ""
 
-#: corehq/apps/reports/models.py:509
+#: corehq/apps/reports/models.py:501
 msgid "An error occurred while generating this report."
 msgstr ""
 
-#: corehq/apps/reports/models.py:654
+#: corehq/apps/reports/models.py:649
 msgid "Every day"
 msgstr ""
 
-#: corehq/apps/reports/models.py:655
+#: corehq/apps/reports/models.py:650
 #, python-format
 msgid "Day %s of every month"
 msgstr ""
 
-#: corehq/apps/reports/models.py:699
+#: corehq/apps/reports/models.py:694
 msgid "Scheduled report from CommCare HQ"
 msgstr ""
 
@@ -16313,54 +16531,54 @@ msgstr ""
 msgid "Email report from CommCare HQ"
 msgstr ""
 
-#: corehq/apps/reports/views.py:798
+#: corehq/apps/reports/views.py:806
 msgid "Create a new"
 msgstr ""
 
-#: corehq/apps/reports/views.py:799
+#: corehq/apps/reports/views.py:807
 msgid "New Scheduled Report"
 msgstr ""
 
-#: corehq/apps/reports/views.py:802
+#: corehq/apps/reports/views.py:810
 msgid "Edit Scheduled Report"
 msgstr ""
 
-#: corehq/apps/reports/views.py:910
+#: corehq/apps/reports/views.py:918
 msgid "once off report"
 msgstr ""
 
-#: corehq/apps/reports/views.py:910
+#: corehq/apps/reports/views.py:918
 msgid "scheduled report"
 msgstr ""
 
-#: corehq/apps/reports/views.py:934
+#: corehq/apps/reports/views.py:942
 msgid ""
 "The case creation form could not be found. Usually this happens if the form "
 "that created the case is archived but there are other forms that updated the "
 "case. To fix this you can archive the other forms listed here."
 msgstr ""
 
-#: corehq/apps/reports/views.py:979
+#: corehq/apps/reports/views.py:987
 msgid "unknown"
 msgstr ""
 
-#: corehq/apps/reports/views.py:992
+#: corehq/apps/reports/views.py:1000
 msgid "You don't have permission to access this page."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1014
+#: corehq/apps/reports/views.py:1022
 #, python-format
 msgid "Case %s was rebuilt from its forms."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1026
+#: corehq/apps/reports/views.py:1034
 #, python-format
 msgid ""
 "Case %s was successfully saved. Hopefully it will show up in all reports "
 "momentarily."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1040
+#: corehq/apps/reports/views.py:1048
 #, python-brace-format
 msgid ""
 "Case {name} has been closed.\n"
@@ -16375,89 +16593,89 @@ msgid ""
 "        "
 msgstr ""
 
-#: corehq/apps/reports/views.py:1080
+#: corehq/apps/reports/views.py:1088
 msgid "case id"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1081
+#: corehq/apps/reports/views.py:1089
 msgid "case name"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1082
+#: corehq/apps/reports/views.py:1090
 msgid "section"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1083
+#: corehq/apps/reports/views.py:1091
 msgid "date"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1084
+#: corehq/apps/reports/views.py:1092
 msgid "product_id"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1085
+#: corehq/apps/reports/views.py:1093
 msgid "product_name"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1086
+#: corehq/apps/reports/views.py:1094
 msgid "transaction amount"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1087
+#: corehq/apps/reports/views.py:1095
 msgid "type"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1088
+#: corehq/apps/reports/views.py:1096
 msgid "ending balance"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1098
+#: corehq/apps/reports/views.py:1106
 msgid "unknown product"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1301
+#: corehq/apps/reports/views.py:1309
 msgid "Could not detect the application/form for this submission."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1315
+#: corehq/apps/reports/views.py:1323
 msgid "Missing app, module or form information!"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1345
+#: corehq/apps/reports/views.py:1353
 #: corehq/apps/reports/templates/reports/form/edit_submission.html:26
 msgid "Edit Submission"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1376
+#: corehq/apps/reports/views.py:1384
 msgid "Form was successfully archived."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1378
+#: corehq/apps/reports/views.py:1386
 msgid "Form was already archived."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1380
+#: corehq/apps/reports/views.py:1388
 #, python-format
 msgid "Can't archive documents of type %s. How did you get here??"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1384
+#: corehq/apps/reports/views.py:1392
 msgid "Undo"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1423
+#: corehq/apps/reports/views.py:1431
 msgid "Form was successfully restored."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1438
+#: corehq/apps/reports/views.py:1446
 msgid "Form was successfully resaved. It should reappear in reports shortly."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1484
+#: corehq/apps/reports/views.py:1492
 msgid "We don't support this format"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1486
+#: corehq/apps/reports/views.py:1494
 msgid ""
 "That report was not found. Please remember that download links expire after "
 "24 hours."
@@ -16581,7 +16799,7 @@ msgid "Stock Status by Product"
 msgstr ""
 
 #: corehq/apps/reports/commtrack/standard.py:93
-#: custom/ilsgateway/tanzania/reports/delivery.py:154
+#: custom/ilsgateway/tanzania/reports/delivery.py:157
 msgid "# Facilities"
 msgstr ""
 
@@ -16661,11 +16879,6 @@ msgstr ""
 
 #: corehq/apps/reports/commtrack/standard.py:270
 msgid "Aggregate Inventory"
-msgstr ""
-
-#: corehq/apps/reports/commtrack/standard.py:297
-#: custom/ilsgateway/tanzania/reports/facility_details.py:27
-msgid "Stock on Hand"
 msgstr ""
 
 #: corehq/apps/reports/commtrack/standard.py:298
@@ -16760,7 +16973,7 @@ msgid "Date of last report for selected period"
 msgstr ""
 
 #: corehq/apps/reports/commtrack/standard.py:420
-#: corehq/apps/reports/standard/deployments.py:253
+#: corehq/apps/reports/standard/deployments.py:282
 msgid "Never"
 msgstr ""
 
@@ -17033,15 +17246,15 @@ msgstr ""
 msgid "Opened / Closed"
 msgstr ""
 
-#: corehq/apps/reports/filters/select.py:128 custom/opm/filters.py:153
+#: corehq/apps/reports/filters/select.py:128 custom/opm/filters.py:112
 msgid "Show All"
 msgstr ""
 
-#: corehq/apps/reports/filters/select.py:133 custom/opm/filters.py:154
+#: corehq/apps/reports/filters/select.py:133 custom/opm/filters.py:113
 msgid "Only Open"
 msgstr ""
 
-#: corehq/apps/reports/filters/select.py:134 custom/opm/filters.py:155
+#: corehq/apps/reports/filters/select.py:134 custom/opm/filters.py:114
 msgid "Only Closed"
 msgstr ""
 
@@ -17162,31 +17375,43 @@ msgstr ""
 msgid "Unknown App"
 msgstr ""
 
-#: corehq/apps/reports/standard/deployments.py:163
+#: corehq/apps/reports/standard/deployments.py:165
 msgid "User Sync History"
 msgstr ""
 
-#: corehq/apps/reports/standard/deployments.py:166
-msgid "Shows the last (up to) 10 times a user has synced."
+#: corehq/apps/reports/standard/deployments.py:171
+msgid "Shows the last (up to) {} times a user has synced."
 msgstr ""
 
-#: corehq/apps/reports/standard/deployments.py:172
+#: corehq/apps/reports/standard/deployments.py:180
 msgid "Sync Date"
 msgstr ""
 
-#: corehq/apps/reports/standard/deployments.py:173
+#: corehq/apps/reports/standard/deployments.py:181
 msgid "# of Cases"
 msgstr ""
 
-#: corehq/apps/reports/standard/deployments.py:174
+#: corehq/apps/reports/standard/deployments.py:182
 msgid "Sync Duration"
 msgstr ""
 
-#: corehq/apps/reports/standard/deployments.py:177
+#: corehq/apps/reports/standard/deployments.py:185
 msgid "Sync Log"
 msgstr ""
 
-#: corehq/apps/reports/standard/deployments.py:208
+#: corehq/apps/reports/standard/deployments.py:186
+msgid "Sync Log Type"
+msgstr ""
+
+#: corehq/apps/reports/standard/deployments.py:187
+msgid "Previous Sync Log"
+msgstr ""
+
+#: corehq/apps/reports/standard/deployments.py:188
+msgid "Error Info"
+msgstr ""
+
+#: corehq/apps/reports/standard/deployments.py:219
 msgid "{} seconds"
 msgstr ""
 
@@ -17298,7 +17523,7 @@ msgstr ""
 #: corehq/apps/reports/standard/sms.py:408
 #: corehq/apps/sms/templates/sms/default.html:59
 #: corehq/ex-submodules/casexml/apps/case/templates/case/partials/single_case.html:94
-#: custom/ilsgateway/tanzania/reports/delivery.py:170
+#: custom/ilsgateway/tanzania/reports/delivery.py:173
 msgid "Received"
 msgstr ""
 
@@ -17742,7 +17967,7 @@ msgid "Follow-Up Date"
 msgstr ""
 
 #: corehq/apps/reports/standard/cases/careplan.py:113
-#: corehq/ex-submodules/casexml/apps/case/models.py:913
+#: corehq/ex-submodules/casexml/apps/case/models.py:918
 #: custom/_legacy/pact/models.py:339
 msgid "Date Modified"
 msgstr ""
@@ -17769,17 +17994,17 @@ msgid "You can email a saved version<br />of this report."
 msgstr ""
 
 #: corehq/apps/reports/templates/reports/base_template.html:67
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:125
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:129
 msgid "Favorites"
 msgstr ""
 
 #: corehq/apps/reports/templates/reports/base_template.html:72
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:130
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:134
 msgid "You don't have any favorites"
 msgstr ""
 
 #: corehq/apps/reports/templates/reports/base_template.html:91
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:149
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:153
 msgid "Email Supported"
 msgstr ""
 
@@ -18065,112 +18290,112 @@ msgid ""
 "    "
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:135
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:136
 #, python-format
 msgid ""
 "\n"
-"            Submitted by %(auth_user)s on behalf of %(user)s\n"
-"        "
+"                Submitted by %(auth_user)s on behalf of %(user)s\n"
+"            "
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:140
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:141
 #, python-format
 msgid ""
 "\n"
-"            Submitted by %(auth_user)s\n"
-"        "
+"                Submitted by %(auth_user)s\n"
+"            "
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:147
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:148
 #, python-format
 msgid ""
 "\n"
-"        Submitted as %(user)s\n"
-"        "
+"            Submitted as %(user)s\n"
+"            "
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:155
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:157
 msgid "Form Properties"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:161
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:163
 msgid "Case Changes"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:169
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:171
 msgid "Form Metadata"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:177
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:179
 #: corehq/ex-submodules/casexml/apps/case/templates/case/partials/single_case.html:30
 msgid "Attachments"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:183
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:185
 msgid "Raw XML"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:194
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:195
 msgid "View standalone form"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:200
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:201
 msgid "Edit submission"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:206
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:207
 msgid "Archiving Forms"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:207
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:208
 msgid ""
 "Archived forms will no longer show up in reports and they will be removed "
 "from any relevant case histories. "
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:211
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:212
 msgid "Archive this form"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:220
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:221
 msgid "Restoring Forms"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:221
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:222
 msgid "Restoring this form will cause it to show up in reports again."
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:225
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:226
 msgid "Restore this form"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:234
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:235
 msgid "Resaving Forms"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:235
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:236
 msgid ""
 "Resaving a form can manually cause it to be reincluded in reports if "
 "something went wrong during initial processing."
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:239
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:240
 msgid "Resave this form"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:262
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:263
 msgid "Unknown/Deleted Case"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:269
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:270
 msgid "(this case)"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:315
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:316
 msgid "Open XML in New Window"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:318
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:319
 msgid "Double-click code below to select all:"
 msgstr ""
 
@@ -18199,7 +18424,7 @@ msgid "IVR"
 msgstr ""
 
 #: corehq/apps/reports/templates/reports/messaging/survey_detail.html:23
-#: custom/ilsgateway/tanzania/reports/randr.py:173
+#: custom/ilsgateway/tanzania/reports/randr.py:175
 msgid "Contact"
 msgstr ""
 
@@ -18240,6 +18465,7 @@ msgid "No data is available. Please submit more forms!"
 msgstr ""
 
 #: corehq/apps/reports/templates/reports/partials/hqexport_group_table.html:8
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:47
 msgid "File"
 msgstr ""
 
@@ -18727,6 +18953,11 @@ msgstr ""
 msgid "My Account"
 msgstr ""
 
+#: corehq/apps/settings/views.py:93
+#: corehq/apps/settings/templates/settings/edit_my_account.b2.html:33
+msgid "My Information"
+msgstr ""
+
 #: corehq/apps/settings/views.py:174
 #, python-format
 msgid "Unable remove membership because you are the admin of %s"
@@ -18750,6 +18981,7 @@ msgid "Your password was successfully changed!"
 msgstr ""
 
 #: corehq/apps/settings/templates/settings/change_my_password.html:9
+#: docs/_build/html/_sources/translations.txt:177
 msgid "Specify New Password"
 msgstr ""
 
@@ -18765,7 +18997,7 @@ msgstr ""
 #: corehq/apps/settings/templates/settings/edit_my_account.b2.html:42
 #: corehq/apps/telerivet/forms.py:10
 #: corehq/apps/telerivet/templates/telerivet/backend.html:10
-#: corehq/apps/users/forms.py:188
+#: corehq/apps/users/forms.py:187
 msgid "API Key"
 msgstr ""
 
@@ -20503,6 +20735,10 @@ msgstr ""
 msgid "All domain/toggle statuses"
 msgstr ""
 
+#: corehq/apps/toggle_ui/templates/toggle/edit_flag.html:165
+msgid "Enabled?"
+msgstr ""
+
 #: corehq/apps/toggle_ui/templates/toggle/flags.html:57
 msgid "Tag"
 msgstr ""
@@ -20558,8 +20794,8 @@ msgid "Create New Report"
 msgstr ""
 
 #: corehq/apps/userreports/views.py:124
-#: corehq/apps/userreports/reports/builder/forms.py:768
-#: corehq/apps/userreports/reports/builder/forms.py:823
+#: corehq/apps/userreports/reports/builder/forms.py:776
+#: corehq/apps/userreports/reports/builder/forms.py:831
 msgid "Chart"
 msgstr ""
 
@@ -20599,21 +20835,21 @@ msgid ""
 "choose the columns and rows."
 msgstr ""
 
-#: corehq/apps/userreports/views.py:230
+#: corehq/apps/userreports/views.py:234
 msgid "Chart Report: {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:247
+#: corehq/apps/userreports/views.py:251
 msgid "Choose the property you would like to add as a filter to this report."
 msgstr ""
 
-#: corehq/apps/userreports/views.py:248
+#: corehq/apps/userreports/views.py:252
 msgid ""
 "Web users viewing the report will see this display text instead of the "
 "property name. Name your filter something easy for users to understand."
 msgstr ""
 
-#: corehq/apps/userreports/views.py:249
+#: corehq/apps/userreports/views.py:253
 msgid ""
 "What type of property is this filter?<br/><br/><strong>Date</strong>: select "
 "this if the property is a date.<br/><strong>Choice</strong>: select this if "
@@ -20621,71 +20857,71 @@ msgid ""
 "select this if the property is a number."
 msgstr ""
 
-#: corehq/apps/userreports/views.py:291
+#: corehq/apps/userreports/views.py:295
 msgid "List Report: {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:300
+#: corehq/apps/userreports/views.py:304
 msgid "Table Report: {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:309
+#: corehq/apps/userreports/views.py:313
 msgid "Worker Report: {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:322
+#: corehq/apps/userreports/views.py:326
 msgid "Report \"{}\" saved!"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:350
+#: corehq/apps/userreports/views.py:354
 msgid "Report \"{}\" deleted!"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:370
+#: corehq/apps/userreports/views.py:374
 msgid "Report created!"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:373
+#: corehq/apps/userreports/views.py:377
 msgid "Bad report source: {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:375
+#: corehq/apps/userreports/views.py:379
 msgid "paste report source here"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:414 corehq/apps/userreports/views.py:420
+#: corehq/apps/userreports/views.py:418 corehq/apps/userreports/views.py:424
 msgid "Data source created for '{}'"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:437
+#: corehq/apps/userreports/views.py:441
 msgid "Data source \"{}\" saved!"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:465
+#: corehq/apps/userreports/views.py:469
 msgid "Data source \"{}\" has been deleted."
 msgstr ""
 
-#: corehq/apps/userreports/views.py:475
+#: corehq/apps/userreports/views.py:479
 msgid "Table \"{}\" is now being rebuilt. Data should start showing up soon"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:514
+#: corehq/apps/userreports/views.py:518
 msgid "You can only use 'lastndays' on date columns"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:524
+#: corehq/apps/userreports/views.py:528
 msgid "Ranges must have the format \"start..end\""
 msgstr ""
 
-#: corehq/apps/userreports/views.py:556
+#: corehq/apps/userreports/views.py:560
 msgid "No field named {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:563
+#: corehq/apps/userreports/views.py:567
 msgid "Invalid filter parameter: {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:597
+#: corehq/apps/userreports/views.py:601
 msgid ""
 "There was a problem executing your query, please make sure your parameters "
 "are valid."
@@ -20782,47 +21018,47 @@ msgid ""
 "the data source before viewing the report."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:304
+#: corehq/apps/userreports/reports/builder/forms.py:305
 msgid "Bar"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:305
+#: corehq/apps/userreports/reports/builder/forms.py:306
 msgid "Pie"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:318
+#: corehq/apps/userreports/reports/builder/forms.py:319
 msgid ""
 "<strong>Form</strong>: display data from form submissions.<br/><strong>Case</"
 "strong>: display data from your cases. You must be using case management for "
 "this option."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:319
+#: corehq/apps/userreports/reports/builder/forms.py:320
 msgid "Which application should the data come from?"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:320
+#: corehq/apps/userreports/reports/builder/forms.py:321
 msgid ""
 "Choose the case type or form from which to retrieve data for this report."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:332
+#: corehq/apps/userreports/reports/builder/forms.py:333
 msgid ""
 "<strong>Bar</strong> shows one vertical bar for each value in your case or "
 "form. <strong>Pie</strong> shows what percentage of the total each value is."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:345
+#: corehq/apps/userreports/reports/builder/forms.py:346
 msgid "{} Report"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:346
+#: corehq/apps/userreports/reports/builder/forms.py:347
 msgid ""
 "Web users will see this name in the \"Reports\" section of CommCareHQ and "
 "can click to view the report"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:388
+#: corehq/apps/userreports/reports/builder/forms.py:389
 msgid ""
 "Too many data sources!\n"
 "Creating this report would cause you to go over the maximum number of data "
@@ -20831,63 +21067,69 @@ msgid ""
 "itself) and try again. "
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:405
+#: corehq/apps/userreports/reports/builder/forms.py:406
 #: custom/bihar/reports/indicators/clientlistdisplay.py:146
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:345
 msgid "Done"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:417
+#: corehq/apps/userreports/reports/builder/forms.py:418
 msgid "Update Report"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:474
-#: corehq/apps/userreports/templates/userreports/edit_report_config.html:8
+#: corehq/apps/userreports/reports/builder/forms.py:475
+#: corehq/apps/userreports/templates/userreports/edit_report_config.html:18
 msgid "Delete Report"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:518
+#: corehq/apps/userreports/reports/builder/forms.py:500
+msgid ""
+"Report builder data source doesn't reference an application. It is likely "
+"this report has been customized and it is no longer editable. "
+msgstr ""
+
+#: corehq/apps/userreports/reports/builder/forms.py:526
 msgid "Filters"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:519
+#: corehq/apps/userreports/reports/builder/forms.py:527
 msgid ""
 "Add filters to your report to allow viewers to select which data the report "
 "will display. These filters will be displayed at the top of your report."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:573
+#: corehq/apps/userreports/reports/builder/forms.py:581
 msgid ""
 "Editing this report would require a new data source. The limit is 5. To "
 "continue, first delete all of the reports using a particular data source (or "
 "the data source itself) and try again. "
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:769
+#: corehq/apps/userreports/reports/builder/forms.py:777
 msgid ""
 "The values of the selected property will be aggregated and shown as bars in "
 "the chart."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:824
+#: corehq/apps/userreports/reports/builder/forms.py:832
 msgid ""
 "The values of the selected property will be aggregated and shows as the "
 "sections of the pie chart."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:841
+#: corehq/apps/userreports/reports/builder/forms.py:849
 msgid ""
 "Add columns to your report to display information from cases or form "
 "submissions. You may rearrange the order of the columns by dragging the "
 "arrows next to the column."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:854
+#: corehq/apps/userreports/reports/builder/forms.py:862
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:179
 msgid "Columns"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:898
+#: corehq/apps/userreports/reports/builder/forms.py:906
 msgid ""
 "Add columns for this report to aggregate. Each property you add will create "
 "a column for every value of that property.  For example, if you add a column "
@@ -20895,23 +21137,37 @@ msgid ""
 "column for \"no.\""
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:907
+#: corehq/apps/userreports/reports/builder/forms.py:915
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:13
 msgid "Rows"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:908
+#: corehq/apps/userreports/reports/builder/forms.py:916
 msgid ""
 "Choose which property this report will group its results by. Each value of "
 "this property will be a row in the table. For example, if you choose a yes "
 "or no question, the report will show a row for \"yes\" and a row for \"no.\""
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:971
+#: corehq/apps/userreports/reports/builder/forms.py:979
 msgid ""
 "Add columns for this report to aggregate. Each property you add will create "
 "a column for every value of that property. For example, if you add a column "
 "for a yes or no question, the report will show a column for \"yes\" and a "
 "column for \"no\"."
+msgstr ""
+
+#: corehq/apps/userreports/sql/columns.py:60
+#, python-brace-format
+msgid ""
+"The \"{header}\" column had too many values to expand! Expansion limited to "
+"{max} distinct values."
+msgstr ""
+
+#: corehq/apps/userreports/sql/columns.py:94
+msgid ""
+"The column \"{}\" does not exist in the report source! Please double check "
+"your report configuration."
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/builder_report_type_select.html:37
@@ -20936,54 +21192,61 @@ msgid ""
 "        "
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:108
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:105
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:111
+#: corehq/apps/userreports/templates/userreports/edit_report_config.html:7
 msgid "Edit Report"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/configurable_reports_home.html:4
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:44
 msgid "Configurable Reports"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/configurable_reports_home.html:5
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:32
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:82
 msgid "Add data source"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/configurable_reports_home.html:6
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:16
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:64
 msgid "Add report"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/configurable_reports_home.html:7
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:20
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:68
 msgid "Import report"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/edit_data_source.html:7
-msgid "This datasource is read only, any changes made can not be saved."
-msgstr ""
-
-#: corehq/apps/userreports/templates/userreports/edit_data_source.html:14
-msgid "Delete Data Source"
+msgid "Edit Data Source"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/edit_data_source.html:18
+msgid "This datasource is read only, any changes made can not be saved."
+msgstr ""
+
+#: corehq/apps/userreports/templates/userreports/edit_data_source.html:25
+msgid "Delete Data Source"
+msgstr ""
+
+#: corehq/apps/userreports/templates/userreports/edit_data_source.html:29
 msgid "Rebuild Data Source"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/edit_data_source.html:19
+#: corehq/apps/userreports/templates/userreports/edit_data_source.html:30
 msgid "Preview data"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/edit_data_source.html:20
+#: corehq/apps/userreports/templates/userreports/edit_data_source.html:31
 msgid "Data Source Source (Advanced)"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/edit_report_config.html:9
+#: corehq/apps/userreports/templates/userreports/edit_report_config.html:19
 msgid "View report"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/edit_report_config.html:10
+#: corehq/apps/userreports/templates/userreports/edit_report_config.html:20
 msgid "Report Source (Advanced)"
 msgstr ""
 
@@ -21000,16 +21263,16 @@ msgstr ""
 msgid "Preview table: %(display_name)s (%(total_rows)s total rows)"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:7
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:53
 #: corehq/apps/users/templates/users/web_users.b3.html:390
 msgid "Edit Reports"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:23
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:71
 msgid "Edit Data Sources"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:38
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:88
 msgid "Data source from application"
 msgstr ""
 
@@ -21034,7 +21297,7 @@ msgid "Expected {} but was {}"
 msgstr ""
 
 #: corehq/apps/userreports/ui/forms.py:25
-#: corehq/apps/userreports/ui/forms.py:149
+#: corehq/apps/userreports/ui/forms.py:159
 msgid "Save Changes"
 msgstr ""
 
@@ -21054,23 +21317,79 @@ msgstr ""
 msgid "Problem with report spec: {}"
 msgstr ""
 
-#: corehq/apps/userreports/ui/forms.py:95
+#: corehq/apps/userreports/ui/forms.py:91
+msgid "Source Type"
+msgstr ""
+
+#: corehq/apps/userreports/ui/forms.py:92
+msgid "Report Title"
+msgstr ""
+
+#: corehq/apps/userreports/ui/forms.py:103
 msgid "Named filters (optional)"
 msgstr ""
 
-#: corehq/apps/userreports/ui/forms.py:106
+#: corehq/apps/userreports/ui/forms.py:116
 msgid ""
 "Table id is too long. Your table id and domain name must add up to fewer "
 "than 40 characters"
 msgstr ""
 
-#: corehq/apps/userreports/ui/forms.py:111
+#: corehq/apps/userreports/ui/forms.py:121
 msgid ""
 "A data source with this table id already exists. Table ids must be unique"
 msgstr ""
 
-#: corehq/apps/userreports/ui/forms.py:128
+#: corehq/apps/userreports/ui/forms.py:138
 msgid "Problem with data source spec: {}"
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:4
+msgid ""
+"Choose something short, unique, and memorable using lowercase letters, "
+"numbers, and underscores"
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:7
+msgid ""
+"This is what the data source will be called in navigation, page title, etc."
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:9
+msgid "Write yourself a little note if you like, it's optional"
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:11
+msgid ""
+"You can leave this blank unless you are <a target=\"_blank\" href=\"https://"
+"github.com/dimagi/commcare-hq/blob/master/corehq/apps/userreports/README."
+"md#saving-repeat-data\">saving repeat data</a>"
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:16
+msgid ""
+"Look at <a target=\"_blank\" href=\"https://github.com/dimagi/commcare-hq/"
+"blob/master/corehq/apps/userreports/examples/examples.md#data-source-filters"
+"\">these examples</a> and <a target=\"_blank\" href=\"https://github.com/"
+"dimagi/commcare-hq/blob/master/corehq/apps/userreports/README.md#data-source-"
+"filtering\">these docs</a>"
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:24
+msgid ""
+"Look at <a target=\"_blank\" href=\"https://github.com/dimagi/commcare-hq/"
+"blob/master/corehq/apps/userreports/examples/examples.md#data-source-"
+"indicators\">these examples</a> and <a target=\"_blank\" href=\"https://"
+"github.com/dimagi/commcare-hq/blob/master/corehq/apps/userreports/README."
+"md#indicators\">these docs</a>"
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:32
+msgid ""
+"For this advanced and useful feature, give a dict where the keys are the "
+"variable names you choose and the values are filters according to the syntax "
+"of Configured Filters above. You can then reference these from Configured "
+"Filters as {\"type\": \"named\", \"name\": \"myvarname\"}"
 msgstr ""
 
 #: corehq/apps/users/bulkupload.py:52
@@ -21125,77 +21444,77 @@ msgstr ""
 msgid "Can't add to group '%s' (try adding it to your spreadsheet)"
 msgstr ""
 
-#: corehq/apps/users/forms.py:59
+#: corehq/apps/users/forms.py:58
 msgid "Please enter a valid two or three digit language code."
 msgstr ""
 
-#: corehq/apps/users/forms.py:132
+#: corehq/apps/users/forms.py:131
 msgid "System Super User"
 msgstr ""
 
-#: corehq/apps/users/forms.py:147
+#: corehq/apps/users/forms.py:146
 msgid "E-Mail"
 msgstr ""
 
-#: corehq/apps/users/forms.py:154
+#: corehq/apps/users/forms.py:153
 msgid ""
 "<i class=\"icon-info-sign\"></i> Becomes default language seen in CloudCare "
 "and reports (if applicable), but does not affect mobile applications. "
 "Supported languages for reports are en, fr (partial), and hin (partial)."
 msgstr ""
 
-#: corehq/apps/users/forms.py:171
+#: corehq/apps/users/forms.py:170
 msgid "Opt out of emails about CommCare updates."
 msgstr ""
 
-#: corehq/apps/users/forms.py:191
+#: corehq/apps/users/forms.py:190
 msgid "Generate API Key"
 msgstr ""
 
-#: corehq/apps/users/forms.py:199
+#: corehq/apps/users/forms.py:198
 msgid "My Language"
 msgstr ""
 
-#: corehq/apps/users/forms.py:219
+#: corehq/apps/users/forms.py:218
 msgid "Other Options"
 msgstr ""
 
-#: corehq/apps/users/forms.py:225
+#: corehq/apps/users/forms.py:224
 msgid "Update My Information"
 msgstr ""
 
-#: corehq/apps/users/forms.py:240
+#: corehq/apps/users/forms.py:239
 msgid ""
 "Multiply this user's case load by a number for load testing on phones. Leave "
 "blank for normal users."
 msgstr ""
 
-#: corehq/apps/users/forms.py:324
+#: corehq/apps/users/forms.py:323
 #, python-format
 msgid "%s is an invalid phone number."
 msgstr ""
 
-#: corehq/apps/users/forms.py:371 corehq/apps/users/forms.py:373
+#: corehq/apps/users/forms.py:370 corehq/apps/users/forms.py:372
 msgid "Username contains invalid characters."
 msgstr ""
 
-#: corehq/apps/users/forms.py:480
+#: corehq/apps/users/forms.py:479
 #, python-format
 msgid ""
 "I have read and agree to the <a href=\"%(pa_url)s\" target=\"_blank"
 "\">Software Product Subscription Agreement</a>."
 msgstr ""
 
-#: corehq/apps/users/forms.py:509
+#: corehq/apps/users/forms.py:508
 msgid "Back to Mobile Workers List"
 msgstr ""
 
-#: corehq/apps/users/forms.py:521
+#: corehq/apps/users/forms.py:520
 msgid ""
 "Please agree to the Product Subscription Agreement above before continuing."
 msgstr ""
 
-#: corehq/apps/users/models.py:2426
+#: corehq/apps/users/models.py:2446
 #, python-format
 msgid "Invitation from %s to join CommCareHQ"
 msgstr ""
@@ -21748,8 +22067,8 @@ msgstr ""
 
 #: corehq/apps/users/templates/users/mobile/users_list.html:212
 #: custom/_legacy/pact/templates/pact/chw/pact_chw_profile_info.html:12
-#: custom/ilsgateway/tanzania/reports/facility_details.py:72
-#: custom/ilsgateway/tanzania/reports/facility_details.py:119
+#: custom/ilsgateway/tanzania/reports/facility_details.py:73
+#: custom/ilsgateway/tanzania/reports/facility_details.py:120
 msgid "Phone"
 msgstr ""
 
@@ -21884,57 +22203,53 @@ msgstr ""
 msgid "Edit User Role"
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:291
+#: corehq/apps/users/views/__init__.py:289
 #, python-format
 msgid "Changed system permissions for user \"%s\""
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:340
+#: corehq/apps/users/views/__init__.py:338
 msgid "Phone number added!"
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:342
+#: corehq/apps/users/views/__init__.py:340
 msgid "Please enter digits only."
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:349
-msgid "Edit My Information"
-msgstr ""
-
-#: corehq/apps/users/views/__init__.py:388
-#: corehq/apps/users/views/__init__.py:534
+#: corehq/apps/users/views/__init__.py:346
+#: corehq/apps/users/views/__init__.py:492
 msgid "Web Users & Roles"
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:435
+#: corehq/apps/users/views/__init__.py:393
 msgid "Please provide pagination info."
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:736
+#: corehq/apps/users/views/__init__.py:694
 msgid "Invitation resent"
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:738
+#: corehq/apps/users/views/__init__.py:696
 msgid "Error while attempting resend"
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:768
+#: corehq/apps/users/views/__init__.py:726
 msgid "Invite Web User to Project"
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:866
+#: corehq/apps/users/views/__init__.py:818
 msgid "Cannot start verification workflow. Phone number is already in use."
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:868
+#: corehq/apps/users/views/__init__.py:820
 msgid "Phone number is already verified."
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:870
+#: corehq/apps/users/views/__init__.py:822
 msgid "Verification message resent."
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:872
+#: corehq/apps/users/views/__init__.py:824
 msgid "Verification workflow started."
 msgstr ""
 
@@ -22066,36 +22381,36 @@ msgid ""
 "The following groups have no name. Please name them before continuing: {}"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:228
+#: corehq/ex-submodules/casexml/apps/case/models.py:229
 msgid "Closed"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:228
+#: corehq/ex-submodules/casexml/apps/case/models.py:229
 msgid "Open"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:515
+#: corehq/ex-submodules/casexml/apps/case/models.py:516
 msgid "Sorry, referrals are no longer supported!"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:857
+#: corehq/ex-submodules/casexml/apps/case/models.py:862
 msgid "Opened On"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:863
+#: corehq/ex-submodules/casexml/apps/case/models.py:868
 msgid "Modified On"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:869
-#: custom/opm/beneficiary.py:824 custom/opm/beneficiary.py:901
+#: corehq/ex-submodules/casexml/apps/case/models.py:874
+#: custom/opm/beneficiary.py:823 custom/opm/beneficiary.py:901
 msgid "Closed On"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:882
+#: corehq/ex-submodules/casexml/apps/case/models.py:887
 msgid "Last Submitter"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:907
+#: corehq/ex-submodules/casexml/apps/case/models.py:912
 msgid "Date Opened"
 msgstr ""
 
@@ -22754,8 +23069,8 @@ msgstr ""
 msgid "Beneficiary Information"
 msgstr ""
 
-#: custom/bihar/reports/mch_reports.py:134 custom/opm/beneficiary.py:809
-#: custom/opm/beneficiary.py:885
+#: custom/bihar/reports/mch_reports.py:134 custom/opm/beneficiary.py:808
+#: custom/opm/beneficiary.py:885 custom/opm/beneficiary.py:930
 msgid "Husband Name"
 msgstr ""
 
@@ -22832,6 +23147,7 @@ msgstr ""
 #: custom/bihar/reports/mch_reports.py:151
 #: custom/bihar/reports/indicators/clientlistdisplay.py:80
 #: custom/bihar/reports/indicators/clientlistdisplay.py:98
+#: custom/opm/beneficiary.py:944
 msgid "EDD"
 msgstr ""
 
@@ -23032,7 +23348,7 @@ msgstr ""
 msgid "Migrate status "
 msgstr ""
 
-#: custom/bihar/reports/mch_reports.py:314 custom/opm/beneficiary.py:812
+#: custom/bihar/reports/mch_reports.py:314 custom/opm/beneficiary.py:811
 msgid "Child Name"
 msgstr ""
 
@@ -24087,43 +24403,43 @@ msgstr ""
 msgid "Dashboard report {0}"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:28
-#: custom/ilsgateway/tanzania/reports/delivery.py:86
+#: custom/ilsgateway/tanzania/reports/delivery.py:29
+#: custom/ilsgateway/tanzania/reports/delivery.py:88
 msgid "Average Lead Time In Days"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:82
-#: custom/ilsgateway/tanzania/reports/randr.py:171
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:251
+#: custom/ilsgateway/tanzania/reports/delivery.py:84
+#: custom/ilsgateway/tanzania/reports/randr.py:173
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:318
 msgid "Facility Name"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:83
+#: custom/ilsgateway/tanzania/reports/delivery.py:85
 msgid "Delivery Status"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:84
+#: custom/ilsgateway/tanzania/reports/delivery.py:86
 msgid "Delivery Date"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:85
+#: custom/ilsgateway/tanzania/reports/delivery.py:87
 msgid "This Cycle Lead Time"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:155
+#: custom/ilsgateway/tanzania/reports/delivery.py:158
 #, python-format
 msgid "% of total"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:167
+#: custom/ilsgateway/tanzania/reports/delivery.py:170
 msgid "Didn't Respond"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:169
+#: custom/ilsgateway/tanzania/reports/delivery.py:172
 msgid "Not Received"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:182
+#: custom/ilsgateway/tanzania/reports/delivery.py:185
 #, python-brace-format
 msgid "Delivery Report {0}"
 msgstr ""
@@ -24132,106 +24448,106 @@ msgstr ""
 msgid "Months of stock"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/facility_details.py:120
+#: custom/ilsgateway/tanzania/reports/facility_details.py:121
 msgid "Text"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:83
+#: custom/ilsgateway/tanzania/reports/randr.py:84
 msgid "% Facilities Submitting R&R On Time"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:84
+#: custom/ilsgateway/tanzania/reports/randr.py:85
 msgid "% Facilities Submitting R&R Late"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:85
+#: custom/ilsgateway/tanzania/reports/randr.py:86
 msgid "% Facilities With R&R Not Submitted"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:86
+#: custom/ilsgateway/tanzania/reports/randr.py:87
 msgid "% Facilities Not Responding To R&R Reminder"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:87
-#: custom/ilsgateway/tanzania/reports/randr.py:174
-#: custom/ilsgateway/tanzania/reports/supervision.py:60
-#: custom/ilsgateway/tanzania/reports/supervision.py:123
+#: custom/ilsgateway/tanzania/reports/randr.py:88
+#: custom/ilsgateway/tanzania/reports/randr.py:176
+#: custom/ilsgateway/tanzania/reports/supervision.py:61
+#: custom/ilsgateway/tanzania/reports/supervision.py:125
 msgid "Historical Response Rate"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:172
+#: custom/ilsgateway/tanzania/reports/randr.py:174
 msgid "R&R Status"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:185
+#: custom/ilsgateway/tanzania/reports/randr.py:187
 #, python-brace-format
 msgid "R & R {0}"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:82
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:84
 msgid "% Facilities Submitting Soh On Time"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:83
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:85
 msgid "% Facilities Submitting Soh Late"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:84
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:86
 msgid "% Facilities Not Responding To Soh"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:85
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:87
 msgid "% Facilities With 1 Or More Stockouts This Month"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:97
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:99
 #, python-format
 msgid "%s stock outs this %s"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:203
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:269
 msgid "Waiting for reply"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:250
-#: custom/ilsgateway/tanzania/reports/supervision.py:119
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:317
+#: custom/ilsgateway/tanzania/reports/supervision.py:121
 msgid "MSD Code"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:252
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:319
 msgid "DG"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:253
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:320
 msgid "Last Reported"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:254
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:321
 msgid "Hist. Resp. Rate"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:406
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:422
 #, python-brace-format
 msgid "Stock On Hand {0}"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/supervision.py:57
+#: custom/ilsgateway/tanzania/reports/supervision.py:58
 msgid "% Supervision Received"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/supervision.py:58
+#: custom/ilsgateway/tanzania/reports/supervision.py:59
 msgid "% Supervision Not Received"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/supervision.py:59
+#: custom/ilsgateway/tanzania/reports/supervision.py:60
 msgid "% Supervision Not Responding"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/supervision.py:121
+#: custom/ilsgateway/tanzania/reports/supervision.py:123
 msgid "Supervision This Quarter"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/supervision.py:181
+#: custom/ilsgateway/tanzania/reports/supervision.py:183
 #, python-brace-format
 msgid "Supervision {0}"
 msgstr ""
@@ -24240,7 +24556,7 @@ msgstr ""
 msgid "Unrecognized SMS"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/utils.py:98
+#: custom/ilsgateway/tanzania/reports/utils.py:100
 msgid "No Data"
 msgstr ""
 
@@ -24321,16 +24637,16 @@ msgstr ""
 msgid " days"
 msgstr ""
 
-#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:55
+#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:65
 #, python-format
 msgid "%(status)s"
 msgstr ""
 
-#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:58
+#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:68
 msgid "Last updated on"
 msgstr ""
 
-#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:63
+#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:73
 msgid "No delivery status reported"
 msgstr ""
 
@@ -25404,108 +25720,112 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: custom/opm/beneficiary.py:742
+#: custom/opm/beneficiary.py:741
 msgid "Incorrect EDD"
 msgstr ""
 
-#: custom/opm/beneficiary.py:748
+#: custom/opm/beneficiary.py:747
 msgid "Incorrect DOD"
 msgstr ""
 
-#: custom/opm/beneficiary.py:753
+#: custom/opm/beneficiary.py:752
 msgid "Incorrect LMP date"
 msgstr ""
 
-#: custom/opm/beneficiary.py:758
+#: custom/opm/beneficiary.py:757
 msgid "Account number is the wrong length"
 msgstr ""
 
-#: custom/opm/beneficiary.py:763
+#: custom/opm/beneficiary.py:762
 msgid "IFSC {} incorrect"
 msgstr ""
 
-#: custom/opm/beneficiary.py:804
+#: custom/opm/beneficiary.py:803 custom/opm/beneficiary.py:919
 msgid "Serial number"
 msgstr ""
 
-#: custom/opm/beneficiary.py:805 custom/opm/beneficiary.py:884
+#: custom/opm/beneficiary.py:804 custom/opm/beneficiary.py:884
+#: custom/opm/beneficiary.py:920
 msgid "List of Beneficiaries"
 msgstr ""
 
-#: custom/opm/beneficiary.py:806 custom/opm/beneficiary.py:886
-#: custom/opm/health_status.py:89
+#: custom/opm/beneficiary.py:805 custom/opm/beneficiary.py:886
+#: custom/opm/beneficiary.py:922 custom/opm/health_status.py:18
 msgid "AWC Name"
 msgstr ""
 
-#: custom/opm/beneficiary.py:807 custom/opm/health_status.py:85
+#: custom/opm/beneficiary.py:806 custom/opm/beneficiary.py:923
+#: custom/opm/health_status.py:14
 msgid "AWC Code"
 msgstr ""
 
-#: custom/opm/beneficiary.py:808 custom/opm/beneficiary.py:891
+#: custom/opm/beneficiary.py:807 custom/opm/beneficiary.py:891
+#: custom/opm/beneficiary.py:924
 msgid "Block Name"
 msgstr ""
 
-#: custom/opm/beneficiary.py:810
+#: custom/opm/beneficiary.py:809 custom/opm/beneficiary.py:942
 msgid "Current status"
 msgstr ""
 
-#: custom/opm/beneficiary.py:811
+#: custom/opm/beneficiary.py:810
 msgid "Pregnancy Month"
 msgstr ""
 
-#: custom/opm/beneficiary.py:813
+#: custom/opm/beneficiary.py:812
 msgid "Child Age"
 msgstr ""
 
-#: custom/opm/beneficiary.py:815
+#: custom/opm/beneficiary.py:814
 msgid "Condition 1"
 msgstr ""
 
-#: custom/opm/beneficiary.py:816
+#: custom/opm/beneficiary.py:815
 msgid "Condition 2"
 msgstr ""
 
-#: custom/opm/beneficiary.py:817
+#: custom/opm/beneficiary.py:816
 msgid "Condition 3"
 msgstr ""
 
-#: custom/opm/beneficiary.py:818
+#: custom/opm/beneficiary.py:817
 msgid "Condition 4"
 msgstr ""
 
-#: custom/opm/beneficiary.py:819
+#: custom/opm/beneficiary.py:818
 msgid "Condition 5"
 msgstr ""
 
-#: custom/opm/beneficiary.py:820
+#: custom/opm/beneficiary.py:819
 msgid "Payment amount this month (Rs.)"
 msgstr ""
 
-#: custom/opm/beneficiary.py:821
+#: custom/opm/beneficiary.py:820
 msgid "Payment amount last month (Rs.)"
 msgstr ""
 
-#: custom/opm/beneficiary.py:822
+#: custom/opm/beneficiary.py:821 custom/opm/beneficiary.py:973
 msgid "Cash received last month"
 msgstr ""
 
-#: custom/opm/beneficiary.py:825 custom/opm/beneficiary.py:904
+#: custom/opm/beneficiary.py:824 custom/opm/beneficiary.py:904
+#: custom/opm/beneficiary.py:974
 msgid "Issues"
 msgstr ""
 
-#: custom/opm/beneficiary.py:887
+#: custom/opm/beneficiary.py:887 custom/opm/beneficiary.py:937
 msgid "Bank Name"
 msgstr ""
 
-#: custom/opm/beneficiary.py:888
+#: custom/opm/beneficiary.py:888 custom/opm/beneficiary.py:939
 msgid "Bank Branch Name"
 msgstr ""
 
-#: custom/opm/beneficiary.py:889
+#: custom/opm/beneficiary.py:889 custom/opm/beneficiary.py:941
 msgid "IFS Code"
 msgstr ""
 
-#: custom/opm/beneficiary.py:890
+#: custom/opm/beneficiary.py:890 custom/opm/beneficiary.py:938
 msgid "Bank Account Number"
 msgstr ""
 
@@ -25549,441 +25869,639 @@ msgstr ""
 msgid "Payment last month"
 msgstr ""
 
-#: custom/opm/filters.py:113 custom/opm/filters.py:126
+#: custom/opm/beneficiary.py:925
+msgid "Gram Panchayat name"
+msgstr ""
+
+#: custom/opm/beneficiary.py:926
+msgid "Village name"
+msgstr ""
+
+#: custom/opm/beneficiary.py:927
+msgid "Dob Known"
+msgstr ""
+
+#: custom/opm/beneficiary.py:928
+#, fuzzy
+msgid "Mother's Age"
+msgstr "Outros (negativos / indeterminados) "
+
+#: custom/opm/beneficiary.py:929
+msgid "Caste tribe status"
+msgstr ""
+
+#: custom/opm/beneficiary.py:931
+msgid "Prev pregnancies"
+msgstr ""
+
+#: custom/opm/beneficiary.py:932
+msgid "Prev live births"
+msgstr ""
+
+#: custom/opm/beneficiary.py:933
+msgid "Sons alive"
+msgstr ""
+
+#: custom/opm/beneficiary.py:934
+msgid "Daughters alive"
+msgstr ""
+
+#: custom/opm/beneficiary.py:935
+msgid "Sum children"
+msgstr ""
+
+#: custom/opm/beneficiary.py:936
+msgid "Contact phone number"
+msgstr ""
+
+#: custom/opm/beneficiary.py:940
+msgid "Bank Branch Code"
+msgstr ""
+
+#: custom/opm/beneficiary.py:943
+msgid "Lmp Date"
+msgstr ""
+
+#: custom/opm/beneficiary.py:945
+msgid "Pregnancy month"
+msgstr ""
+
+#: custom/opm/beneficiary.py:947
+msgid "Child 1 Age"
+msgstr ""
+
+#: custom/opm/beneficiary.py:948
+msgid "Child 1 Name"
+msgstr ""
+
+#: custom/opm/beneficiary.py:949
+msgid "Child 1 Sex"
+msgstr ""
+
+#: custom/opm/beneficiary.py:950
+msgid "Child DOB"
+msgstr ""
+
+#: custom/opm/beneficiary.py:951
+msgid "Child 2 Age"
+msgstr ""
+
+#: custom/opm/beneficiary.py:952
+msgid "Child 2 Name"
+msgstr ""
+
+#: custom/opm/beneficiary.py:953
+msgid "Child 2 Sex"
+msgstr ""
+
+#: custom/opm/beneficiary.py:954
+msgid "Child 3 Age"
+msgstr ""
+
+#: custom/opm/beneficiary.py:955
+msgid "Child 3 Name"
+msgstr ""
+
+#: custom/opm/beneficiary.py:956
+msgid "Child 3 Sex"
+msgstr ""
+
+#: custom/opm/beneficiary.py:957
+msgid "Condition 1 / pregnant woman attended VHND"
+msgstr ""
+
+#: custom/opm/beneficiary.py:958
+msgid "Condition 2 /pregnant woman's weight taken in first trimester"
+msgstr ""
+
+#: custom/opm/beneficiary.py:959
+msgid "Condition 3/ Received 30 IFA pills"
+msgstr ""
+
+#: custom/opm/beneficiary.py:960
+msgid "Condition 2 /pregnant woman's weight taken in second trimester"
+msgstr ""
+
+#: custom/opm/beneficiary.py:961
+msgid "Condition 4/mother attended VHND with child"
+msgstr ""
+
+#: custom/opm/beneficiary.py:962
+msgid "Condition 5/child birth registered"
+msgstr ""
+
+#: custom/opm/beneficiary.py:963
+msgid "Condition 6/ child birth weight taken"
+msgstr ""
+
+#: custom/opm/beneficiary.py:964
+msgid "Condition 7 /exclusively breastfed for first 6 months"
+msgstr ""
+
+#: custom/opm/beneficiary.py:965
+msgid "Condition 8 /child weight monitored this month"
+msgstr ""
+
+#: custom/opm/beneficiary.py:966
+msgid "Condition 9 /ORS administered if child had diarrhea"
+msgstr ""
+
+#: custom/opm/beneficiary.py:967
+msgid "Condition 10/ Measles vaccine given before child turns 1"
+msgstr ""
+
+#: custom/opm/beneficiary.py:968
+msgid "Birth Spacing Bonus"
+msgstr ""
+
+#: custom/opm/beneficiary.py:969
+msgid "Weight This Month"
+msgstr ""
+
+#: custom/opm/beneficiary.py:970
+msgid "Nutritional Status This Month"
+msgstr ""
+
+#: custom/opm/beneficiary.py:971
+msgid "Nutritional Status Bonus"
+msgstr ""
+
+#: custom/opm/beneficiary.py:972
+msgid "Payment amount for the month"
+msgstr ""
+
+#: custom/opm/beneficiary.py:975
+msgid "VHND held this month?"
+msgstr ""
+
+#: custom/opm/beneficiary.py:976
+msgid "Opened on"
+msgstr ""
+
+#: custom/opm/beneficiary.py:977
+#, fuzzy
+msgid "Closed on"
+msgstr "Casos IRA Tratados"
+
+#: custom/opm/beneficiary.py:978
+msgid "Close mother dup"
+msgstr ""
+
+#: custom/opm/beneficiary.py:979
+msgid "Close mother mo"
+msgstr ""
+
+#: custom/opm/beneficiary.py:980
+msgid "Leave program"
+msgstr ""
+
+#: custom/opm/beneficiary.py:981
+msgid "Close mother dead"
+msgstr ""
+
+#: custom/opm/beneficiary.py:982
+msgid "Calendar year"
+msgstr ""
+
+#: custom/opm/beneficiary.py:983
+msgid "Calendar month"
+msgstr ""
+
+#: custom/opm/filters.py:72 custom/opm/filters.py:85
 #: custom/up_nrhm/filters.py:37
 msgid "Hierarchy"
 msgstr ""
 
-#: custom/opm/health_status.py:93
+#: custom/opm/health_status.py:22
 msgid "Gram Panchayat"
 msgstr ""
 
-#: custom/opm/health_status.py:97
+#: custom/opm/health_status.py:26
 msgid "Registered Beneficiaries"
 msgstr ""
 
-#: custom/opm/health_status.py:98
+#: custom/opm/health_status.py:27
 msgid "Beneficiaries registered with BCSP"
 msgstr ""
 
-#: custom/opm/health_status.py:101
+#: custom/opm/health_status.py:30
 msgid "Registered pregnant women"
 msgstr ""
 
-#: custom/opm/health_status.py:102
+#: custom/opm/health_status.py:31
 msgid "Pregnant women registered with BCSP"
 msgstr ""
 
-#: custom/opm/health_status.py:105
+#: custom/opm/health_status.py:34
 msgid "Registered mothers"
 msgstr ""
 
-#: custom/opm/health_status.py:106
+#: custom/opm/health_status.py:35
 msgid "Mothers registered with BCSP"
 msgstr ""
 
-#: custom/opm/health_status.py:109
+#: custom/opm/health_status.py:38
 msgid "Registered children"
 msgstr ""
 
-#: custom/opm/health_status.py:110
+#: custom/opm/health_status.py:39
 msgid "Children below 3 years of age registered with BCSP"
 msgstr ""
 
-#: custom/opm/health_status.py:113
+#: custom/opm/health_status.py:42
 msgid "Eligible for payment upon fulfillment of cash conditions"
 msgstr ""
 
-#: custom/opm/health_status.py:114
+#: custom/opm/health_status.py:43
 msgid ""
 "Registered beneficiaries eligilble for cash payment for the month upon "
 "fulfillment of cash conditions"
 msgstr ""
 
-#: custom/opm/health_status.py:118
+#: custom/opm/health_status.py:47
 msgid "Eligible for payment upon absence of services"
 msgstr ""
 
-#: custom/opm/health_status.py:119
+#: custom/opm/health_status.py:48
 msgid ""
 "Registered beneficiaries eligilble for cash payment for the month upon "
 "absence of services at VHND"
 msgstr ""
 
-#: custom/opm/health_status.py:122
+#: custom/opm/health_status.py:51
 msgid "Eligible for payment"
 msgstr ""
 
-#: custom/opm/health_status.py:123
+#: custom/opm/health_status.py:52
 msgid "Registered beneficiaries eligilble for cash payment for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:126
+#: custom/opm/health_status.py:55
 msgid "Total cash payment"
 msgstr ""
 
-#: custom/opm/health_status.py:127
+#: custom/opm/health_status.py:56
 msgid "Total cash payment made to registered beneficiaries for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:130
+#: custom/opm/health_status.py:59
 msgid "Pregnant women attended VHND"
 msgstr ""
 
-#: custom/opm/health_status.py:131
+#: custom/opm/health_status.py:60
 msgid "Registered pregnant women who attended VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:134
+#: custom/opm/health_status.py:63
 msgid "Children attended VHND"
 msgstr ""
 
-#: custom/opm/health_status.py:135
+#: custom/opm/health_status.py:64
 msgid ""
 "Registered children below 3 years of age who attended VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:138
+#: custom/opm/health_status.py:67
 msgid "Beneficiaries attended VHND"
 msgstr ""
 
-#: custom/opm/health_status.py:139
+#: custom/opm/health_status.py:68
 msgid "Registered beneficiaries who attended VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:142
+#: custom/opm/health_status.py:71
 msgid "Received at least 30 IFA tablets"
 msgstr ""
 
-#: custom/opm/health_status.py:143
+#: custom/opm/health_status.py:72
 msgid ""
 "Registered pregnant women (6 months pregnant) who received at least 30 IFA "
 "tablets in second trimester"
 msgstr ""
 
-#: custom/opm/health_status.py:147
+#: custom/opm/health_status.py:76
 msgid "Weight monitored in second trimester"
 msgstr ""
 
-#: custom/opm/health_status.py:148
+#: custom/opm/health_status.py:77
 msgid ""
 "Registered pregnant women (6 months pregnant) who got their weight monitored "
 "in second trimester"
 msgstr ""
 
-#: custom/opm/health_status.py:151
+#: custom/opm/health_status.py:80
 msgid "Weight monitored in third trimester"
 msgstr ""
 
-#: custom/opm/health_status.py:152
+#: custom/opm/health_status.py:81
 msgid ""
 "Registered pregnant women (9 months pregnant) who got their weight monitored "
 "in third trimester"
 msgstr ""
 
-#: custom/opm/health_status.py:155
+#: custom/opm/health_status.py:84
 msgid "Weight monitored at birth"
 msgstr ""
 
-#: custom/opm/health_status.py:156
+#: custom/opm/health_status.py:85
 msgid "Registered children (3 months old) whose weight was monitored at birth"
 msgstr ""
 
-#: custom/opm/health_status.py:159
+#: custom/opm/health_status.py:88
 msgid "Child birth registered"
 msgstr ""
 
-#: custom/opm/health_status.py:160
+#: custom/opm/health_status.py:89
 msgid ""
 "Registered children (6 months old) whose birth was registered in the first 6 "
 "months after birth"
 msgstr ""
 
-#: custom/opm/health_status.py:163
+#: custom/opm/health_status.py:92
 msgid "Growth monitoring when 0-3 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:164
+#: custom/opm/health_status.py:93
 msgid ""
 "Registered Children (3 months old) who have attended at least one growth "
 "monitoring session between the age 0-3 months"
 msgstr ""
 
-#: custom/opm/health_status.py:168
+#: custom/opm/health_status.py:97
 msgid "Growth Monitoring when 4-6 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:169
+#: custom/opm/health_status.py:98
 msgid ""
 "Registered Children (6 months old) who have attended at least one growth "
 "monitoring session between the age 4-6 months"
 msgstr ""
 
-#: custom/opm/health_status.py:173
+#: custom/opm/health_status.py:102
 msgid "Growth Monitoring when 7-9 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:174
+#: custom/opm/health_status.py:103
 msgid ""
 "Registered Children (9 months old) who have attended at least one growth "
 "monitoring session between the age 7-9 months"
 msgstr ""
 
-#: custom/opm/health_status.py:178
+#: custom/opm/health_status.py:107
 msgid "Growth Monitoring when 10-12 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:179
+#: custom/opm/health_status.py:108
 msgid ""
 "Registered Children (12 months old) who have attended at least one growth "
 "monitoring session between the age 10-12 months"
 msgstr ""
 
-#: custom/opm/health_status.py:183
+#: custom/opm/health_status.py:112
 msgid "Growth Monitoring when 13-15 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:184
+#: custom/opm/health_status.py:113
 msgid ""
 "Registered Children (15 months old) who have attended at least one growth "
 "monitoring session between the age 13-15 months"
 msgstr ""
 
-#: custom/opm/health_status.py:188
+#: custom/opm/health_status.py:117
 msgid "Growth Monitoring when 16-18 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:189
+#: custom/opm/health_status.py:118
 msgid ""
 "Registered Children (18 months old) who have attended at least one growth "
 "monitoring session between the age 16-18 months"
 msgstr ""
 
-#: custom/opm/health_status.py:193
+#: custom/opm/health_status.py:122
 msgid "Growth Monitoring when 19-21 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:194
+#: custom/opm/health_status.py:123
 msgid ""
 "Registered Children (21 months old) who have attended at least one growth "
 "monitoring session between the age 19-21 months"
 msgstr ""
 
-#: custom/opm/health_status.py:198
+#: custom/opm/health_status.py:127
 msgid "Growth Monitoring when 22-24 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:199
+#: custom/opm/health_status.py:128
 msgid ""
 "Registered Children (24 months old) who have attended at least one growth "
 "monitoring session between the age 22-24 months"
 msgstr ""
 
-#: custom/opm/health_status.py:203
+#: custom/opm/health_status.py:132
 msgid "Received ORS and Zinc treatment for diarrhoea"
 msgstr ""
 
-#: custom/opm/health_status.py:204
+#: custom/opm/health_status.py:133
 msgid ""
 "Registered children who received ORS and Zinc treatment if he/she contracts "
 "diarrhoea"
 msgstr ""
 
-#: custom/opm/health_status.py:207
+#: custom/opm/health_status.py:136
 msgid "Exclusively breastfed for first 6 months"
 msgstr ""
 
-#: custom/opm/health_status.py:208
+#: custom/opm/health_status.py:137
 msgid ""
 "Registered children (6 months old) who have been exclusively breastfed for "
 "first 6 months"
 msgstr ""
 
-#: custom/opm/health_status.py:211
+#: custom/opm/health_status.py:140
 msgid "Received Measles vaccine"
 msgstr ""
 
-#: custom/opm/health_status.py:212
+#: custom/opm/health_status.py:141
 msgid "Registered children (12 months old) who have received Measles vaccine"
 msgstr ""
 
-#: custom/opm/health_status.py:215
+#: custom/opm/health_status.py:144
 msgid "VHND organised"
 msgstr ""
 
-#: custom/opm/health_status.py:216
+#: custom/opm/health_status.py:145
 msgid "Whether VHND was organised at AWC for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:219
+#: custom/opm/health_status.py:148
 msgid "Adult Weighing Machine Available"
 msgstr ""
 
-#: custom/opm/health_status.py:220
+#: custom/opm/health_status.py:149
 msgid "Whether adult weighing machine was available for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:223
+#: custom/opm/health_status.py:152
 msgid "Adult Weighing Machine Functional"
 msgstr ""
 
-#: custom/opm/health_status.py:224
+#: custom/opm/health_status.py:153
 msgid "Whether adult weighing machine was functional for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:227
+#: custom/opm/health_status.py:156
 msgid "Child Weighing Machine Available"
 msgstr ""
 
-#: custom/opm/health_status.py:228
+#: custom/opm/health_status.py:157
 msgid "Whether child weighing machine was available for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:231
+#: custom/opm/health_status.py:160
 msgid "Child Weighing Machine Functional"
 msgstr ""
 
-#: custom/opm/health_status.py:232
+#: custom/opm/health_status.py:161
 msgid "Whether child weighing machine was functional for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:235
+#: custom/opm/health_status.py:164
 msgid "ANM Present"
 msgstr ""
 
-#: custom/opm/health_status.py:236
+#: custom/opm/health_status.py:165
 msgid "Whether ANM present at VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:239
+#: custom/opm/health_status.py:168
 msgid "ASHA Present"
 msgstr ""
 
-#: custom/opm/health_status.py:240
+#: custom/opm/health_status.py:169
 msgid "Whether ASHA present at VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:243
+#: custom/opm/health_status.py:172
 msgid "CMG Present"
 msgstr ""
 
-#: custom/opm/health_status.py:244
+#: custom/opm/health_status.py:173
 msgid "Whether CMG present at VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:247
+#: custom/opm/health_status.py:176
 msgid "Stock of IFA tablets"
 msgstr ""
 
-#: custom/opm/health_status.py:248
+#: custom/opm/health_status.py:177
 msgid "Whether AWC has enough stock of IFA tablets for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:251
+#: custom/opm/health_status.py:180
 msgid "Stock of ORS packets"
 msgstr ""
 
-#: custom/opm/health_status.py:252
+#: custom/opm/health_status.py:181
 msgid "Whether AWC has enough stock of ORS packets for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:255
+#: custom/opm/health_status.py:184
 msgid "Stock of ZINC tablets"
 msgstr ""
 
-#: custom/opm/health_status.py:256
+#: custom/opm/health_status.py:185
 msgid "Whether AWC has enough stock of Zinc Tablets for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:259
+#: custom/opm/health_status.py:188
 msgid "Stock of Measles Vaccine"
 msgstr ""
 
-#: custom/opm/health_status.py:260
+#: custom/opm/health_status.py:189
 msgid "Whether AWC has enough stock of measles vaccine for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:263
+#: custom/opm/health_status.py:192
 msgid "Eligilble for Birth Spacing bonus"
 msgstr ""
 
-#: custom/opm/health_status.py:264
+#: custom/opm/health_status.py:193
 msgid "Registered beneficiaries eligible for birth spacing bonus for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:267
+#: custom/opm/health_status.py:196
 msgid "Severely underweight"
 msgstr ""
 
-#: custom/opm/health_status.py:268
+#: custom/opm/health_status.py:197
 msgid ""
 "Registered children severely underweight (very low weight for age) for the "
 "month"
 msgstr ""
 
-#: custom/opm/health_status.py:271
+#: custom/opm/health_status.py:200
 msgid "Underweight"
 msgstr ""
 
-#: custom/opm/health_status.py:272
+#: custom/opm/health_status.py:201
 msgid "Registered children underweight (low weight for age) for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:275
+#: custom/opm/health_status.py:204
 msgid "Normal weight for age"
 msgstr ""
 
-#: custom/opm/health_status.py:276
+#: custom/opm/health_status.py:205
 msgid "Registered children with normal weight for age for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:279
+#: custom/opm/health_status.py:208
 msgid "Eligilble for Nutritional status bonus"
 msgstr ""
 
-#: custom/opm/health_status.py:280
+#: custom/opm/health_status.py:209
 msgid ""
 "Registered beneficiaries eligible for nutritonal status bonus for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:283
+#: custom/opm/health_status.py:212
 msgid "Pregnant women cases closed"
 msgstr ""
 
-#: custom/opm/health_status.py:284
+#: custom/opm/health_status.py:213
 msgid "Registered pregnant women cases closed for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:287
+#: custom/opm/health_status.py:216
 msgid "Mother cases closed"
 msgstr ""
 
-#: custom/opm/health_status.py:288
+#: custom/opm/health_status.py:217
 msgid "Registered mother cases closed for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:291
+#: custom/opm/health_status.py:220
 msgid "Children cases closed"
 msgstr ""
 
-#: custom/opm/health_status.py:292
+#: custom/opm/health_status.py:221
 msgid "Registered children cases closed for the month"
 msgstr ""
 
-#: custom/opm/reports.py:656 custom/opm/reports.py:657
-#: custom/opm/reports.py:917
+#: custom/opm/reports.py:457 custom/opm/reports.py:458
+#: custom/opm/reports.py:719
 msgid "Reporting period incomplete"
 msgstr ""
 
-#: custom/opm/reports.py:876
+#: custom/opm/reports.py:679
 msgid "Duplicate account number"
 msgstr ""
 
-#: custom/opm/reports.py:885
+#: custom/opm/reports.py:688
 msgid "Conditions Met Report"
 msgstr ""
 
-#: custom/opm/reports.py:924
+#: custom/opm/reports.py:726
 msgid "Total Payment"
 msgstr ""
 
@@ -26931,7 +27449,7 @@ msgstr ""
 
 #: custom/up_nrhm/reports/asha_functionality_checklist_report.py:61
 #, python-format
-msgid "Total number of ASHAs who are functional on at least 60% of the tasks"
+msgid "Total number of ASHAs who are functional on at least %s of the tasks"
 msgstr ""
 
 #: custom/up_nrhm/reports/asha_functionality_checklist_report.py:62
@@ -27017,11 +27535,85 @@ msgstr ""
 
 #: custom/up_nrhm/reports/district_functionality_report.py:34
 #, python-format
-msgid "% of ASHAs"
+msgid "%s of ASHAs"
 msgstr ""
 
-#: custom/up_nrhm/reports/district_functionality_report.py:35
+#: custom/up_nrhm/reports/district_functionality_report.py:36
 msgid "Grade of Block"
+msgstr ""
+
+#: docs/_build/html/_sources/translations.txt:141
+#, python-format
+msgid "This string will have %(value)s inside."
+msgstr ""
+
+#: docs/_build/html/_sources/translations.txt:147
+#, python-format
+msgid ""
+"\n"
+"        That will cost $ %(amount)s.\n"
+"    "
+msgstr ""
+
+#: docs/_build/html/_sources/translations.txt:155
+#, python-format
+msgid ""
+"\n"
+"        This will have %(myvar)s inside.\n"
+"    "
+msgstr ""
+
+#: docs/_build/html/_sources/translations.txt:167
+msgid ""
+"\n"
+"        Manage Mobile Workers <small>for CommCare Mobile and\n"
+"        CommCare HQ Reports</small>\n"
+"    "
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/couchpanel.py:89
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/couchpanel.py:92
+msgid "CouchDB"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:15
+msgid "Stacktrace"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:16
+msgid "View Name"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:17
+msgid "Request Params"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:45
+msgid "Line"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:46
+msgid "Method"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:6
+msgid "CouchDB View"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:11
+msgid "Executed View"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:13
+msgid "Parameters"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:15
+msgid "Total Rows"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:40
+msgid "Empty set"
 msgstr ""
 
 #: submodules/auditcare-src/auditcare/forms.py:14
@@ -27412,16 +28004,16 @@ msgstr ""
 msgid "Clearing data"
 msgstr ""
 
-#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:36
+#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:47
 #, python-format
 msgid "ERROR: Could not send \"%(subject)s\""
 msgstr ""
 
-#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:41
+#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:52
 msgid "Could not send email: file size is too large."
 msgstr ""
 
-#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:46
+#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:57
 #, python-format
 msgid "Please contact %(support_email)s for assistance."
 msgstr ""
@@ -27479,9 +28071,6 @@ msgstr ""
 #~ msgid "Commtrack"
 #~ msgstr "CommCare Supply"
 
-#~ msgid "mothers"
-#~ msgstr "Outros (negativos / indeterminados) "
-
 #~ msgid "Create New Report > Configure Table Report"
 #~ msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
@@ -27490,9 +28079,6 @@ msgstr ""
 
 #~ msgid "New Mothers"
 #~ msgstr "Outros (negativos / indeterminados) "
-
-#~ msgid "Closed by"
-#~ msgstr "Casos IRA Tratados"
 
 #~ msgid "Manage SMS Backend Rates"
 #~ msgstr "Diagnóstico de Casos"

--- a/locale/fra/LC_MESSAGES/django.po
+++ b/locale/fra/LC_MESSAGES/django.po
@@ -27,7 +27,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CommCare HQ\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-29 19:37+0000\n"
+"POT-Creation-Date: 2015-08-05 17:43+0000\n"
 "PO-Revision-Date: 2015-07-29 18:06+0000\n"
 "Last-Translator: Nathaniel Haduch <nhaduch@dimagi.com>\n"
 "Language-Team: French (http://www.transifex.com/projects/p/commcare-hq/"
@@ -56,7 +56,7 @@ msgstr "Démonstrations pour Visualiseurs"
 
 #: corehq/__init__.py:61 corehq/feature_previews.py:91
 #: corehq/apps/hqwebapp/models.py:879 corehq/apps/reports/__init__.py:13
-#: corehq/apps/reports/models.py:52
+#: corehq/apps/reports/models.py:54
 #: corehq/apps/users/templates/users/edit_commcare_user.html:125
 msgid "CommCare Supply"
 msgstr ""
@@ -77,9 +77,9 @@ msgstr "Plan de soins"
 msgid "Messaging"
 msgstr "Messagerie"
 
-#: corehq/__init__.py:177 corehq/apps/app_manager/models.py:2900
+#: corehq/__init__.py:177 corehq/apps/app_manager/models.py:2974
 #: corehq/apps/dashboard/views.py:159 corehq/apps/hqwebapp/models.py:365
-#: corehq/apps/hqwebapp/models.py:1538 corehq/apps/hqwebapp/models.py:1608
+#: corehq/apps/hqwebapp/models.py:1533 corehq/apps/hqwebapp/models.py:1603
 #: corehq/apps/orgs/templates/orgs/report_base.html:26
 #: corehq/apps/reports/templates/reports/reportdata/case_details.html:68
 msgid "Reports"
@@ -98,7 +98,7 @@ msgstr "Exporter des données"
 msgid "Edit Data"
 msgstr "Modifier des données"
 
-#: corehq/__init__.py:198 corehq/privileges.py:71
+#: corehq/__init__.py:198 corehq/privileges.py:76
 #: corehq/apps/accounting/user_text.py:219 corehq/apps/fixtures/views.py:285
 msgid "Lookup Tables"
 msgstr "Tables de Recherche"
@@ -218,8 +218,8 @@ msgstr ""
 "mauvaises performances et aussi donner des conseils pour résoudre les "
 "problèmes."
 
-#: corehq/feature_previews.py:128 corehq/privileges.py:88
-#: corehq/apps/hqwebapp/models.py:1140 corehq/apps/locations/views.py:75
+#: corehq/feature_previews.py:128 corehq/privileges.py:93
+#: corehq/apps/hqwebapp/models.py:1135 corehq/apps/locations/views.py:75
 #: corehq/apps/users/templates/users/edit_commcare_user.html:127
 msgid "Locations"
 msgstr "Sites"
@@ -242,71 +242,71 @@ msgid ""
 "a>."
 msgstr ""
 
-#: corehq/privileges.py:72 corehq/apps/accounting/user_text.py:218
+#: corehq/privileges.py:77 corehq/apps/accounting/user_text.py:218
 msgid "API Access"
 msgstr "L'accès aux APIs"
 
-#: corehq/privileges.py:73
+#: corehq/privileges.py:78
 msgid "Web-Based Apps (CloudCare)"
 msgstr "Application en version Web (CloudCare)"
 
-#: corehq/privileges.py:74
+#: corehq/privileges.py:79
 msgid "Active Data Management"
 msgstr "Active Data Management"
 
-#: corehq/privileges.py:75 corehq/apps/accounting/user_text.py:221
+#: corehq/privileges.py:80 corehq/apps/accounting/user_text.py:221
 msgid "Custom Branding"
 msgstr "Marquage personnalisé"
 
-#: corehq/privileges.py:76 corehq/apps/accounting/user_text.py:224
+#: corehq/privileges.py:81 corehq/apps/accounting/user_text.py:224
 msgid "Cross-Project Reports"
 msgstr "Rapport Cross-Project "
 
-#: corehq/privileges.py:77 corehq/apps/accounting/user_text.py:236
+#: corehq/privileges.py:82 corehq/apps/accounting/user_text.py:236
 msgid "Advanced Role-Based Access"
 msgstr "Accès Basé sur les Rôles"
 
-#: corehq/privileges.py:78
+#: corehq/privileges.py:83
 msgid "Outgoing Messaging"
 msgstr "Messagerie sortant"
 
-#: corehq/privileges.py:79
+#: corehq/privileges.py:84
 msgid "Incoming Messaging"
 msgstr "Messagerie entrant"
 
-#: corehq/privileges.py:80
+#: corehq/privileges.py:85
 msgid "Reminders Framework"
 msgstr "Cadre de rappels"
 
-#: corehq/privileges.py:81
+#: corehq/privileges.py:86
 msgid "Custom Android Gateway"
 msgstr "Porte Android Customisée"
 
-#: corehq/privileges.py:82
+#: corehq/privileges.py:87
 msgid "Bulk Case Management"
 msgstr "Gestion des dossiers en vrac"
 
-#: corehq/privileges.py:83
+#: corehq/privileges.py:88
 msgid "Bulk User Management"
 msgstr "Gestion en masse des utilisateurs"
 
-#: corehq/privileges.py:84
+#: corehq/privileges.py:89
 msgid "Add Mobile Workers Above Limit"
 msgstr "Ajouter utilisateur mobile au delà des limites"
 
-#: corehq/privileges.py:85
+#: corehq/privileges.py:90
 msgid "De-Identified Data"
 msgstr "Données Non-Identifiées"
 
-#: corehq/privileges.py:86 corehq/apps/accounting/user_text.py:238
+#: corehq/privileges.py:91 corehq/apps/accounting/user_text.py:238
 msgid "HIPAA Compliance Assurance"
 msgstr "Accordance avec HIPAA"
 
-#: corehq/privileges.py:87
+#: corehq/privileges.py:92
 msgid "Custom CommCare Logo Uploader"
 msgstr "Téléchargeur de CommCare Logo Personalissé "
 
-#: corehq/privileges.py:89
+#: corehq/privileges.py:94
 msgid "User Configurable Report Builder"
 msgstr "Constructeur de Rapport Configurable par l'Utilisateur "
 
@@ -414,6 +414,7 @@ msgstr "Afficher seulement les inscriptions en versions d'essai"
 
 #: corehq/apps/accounting/filters.py:140 corehq/apps/accounting/forms.py:346
 #: corehq/apps/accounting/forms.py:634 corehq/apps/commtrack/models.py:535
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:57
 #: corehq/apps/domain/templates/domain/admin/media_manager.html:24
 #: corehq/apps/export/templates/export/customize_export.html:602
 #: corehq/apps/hqadmin/reports.py:839
@@ -563,7 +564,7 @@ msgstr "Noyau de Produit"
 #: corehq/apps/accounting/templates/accounting/subscriptions_tab.html:16
 #: corehq/apps/domain/forms.py:1455
 #: corehq/apps/domain/templates/domain/current_subscription.html:247
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:74
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:83
 msgid "Software Plan"
 msgstr "Plan de logiciel"
 
@@ -673,10 +674,10 @@ msgid "A name is required for this new role."
 msgstr ""
 
 #: corehq/apps/accounting/forms.py:1428 corehq/apps/app_manager/forms.py:11
-#: corehq/apps/app_manager/models.py:1737
-#: corehq/apps/app_manager/models.py:2167
-#: corehq/apps/app_manager/models.py:2525
-#: corehq/apps/app_manager/models.py:2574 corehq/apps/commtrack/models.py:531
+#: corehq/apps/app_manager/models.py:1738
+#: corehq/apps/app_manager/models.py:2193
+#: corehq/apps/app_manager/models.py:2574
+#: corehq/apps/app_manager/models.py:2623 corehq/apps/commtrack/models.py:531
 #: corehq/apps/domain/forms.py:126
 #: corehq/apps/domain/templates/domain/admin/commtrack_action_table.html:5
 #: corehq/apps/domain/templates/domain/partials/user_list.html:9
@@ -698,7 +699,7 @@ msgstr ""
 #: corehq/apps/toggle_ui/templates/toggle/flags.html:58
 #: corehq/apps/users/templates/users/web_users.b3.html:171
 #: corehq/apps/users/templates/users/web_users.b3.html:216
-#: corehq/ex-submodules/casexml/apps/case/models.py:853
+#: corehq/ex-submodules/casexml/apps/case/models.py:858
 #: corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_hierarchy.html:57
 #: custom/bihar/reports/indicators/clientlistdisplay.py:80
 #: custom/bihar/reports/indicators/clientlistdisplay.py:98
@@ -707,13 +708,13 @@ msgstr ""
 #: custom/ewsghana/reports/specific_reports/reporting_rates.py:199
 #: custom/ewsghana/reports/specific_reports/reporting_rates.py:241
 #: custom/fri/reports/reports.py:349
-#: custom/ilsgateway/tanzania/reports/delivery.py:27
-#: custom/ilsgateway/tanzania/reports/facility_details.py:70
-#: custom/ilsgateway/tanzania/reports/facility_details.py:116
-#: custom/ilsgateway/tanzania/reports/randr.py:82
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:81
-#: custom/ilsgateway/tanzania/reports/supervision.py:56
-#: custom/ilsgateway/tanzania/reports/supervision.py:120
+#: custom/ilsgateway/tanzania/reports/delivery.py:28
+#: custom/ilsgateway/tanzania/reports/facility_details.py:71
+#: custom/ilsgateway/tanzania/reports/facility_details.py:117
+#: custom/ilsgateway/tanzania/reports/randr.py:83
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:83
+#: custom/ilsgateway/tanzania/reports/supervision.py:57
+#: custom/ilsgateway/tanzania/reports/supervision.py:122
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:37
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:184
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:249
@@ -723,7 +724,7 @@ msgid "Name"
 msgstr "Nom"
 
 #: corehq/apps/accounting/forms.py:1432 corehq/apps/accounting/models.py:357
-#: corehq/apps/prelogin/forms.py:28
+#: corehq/apps/prelogin/forms.py:29
 msgid "Company / Organization"
 msgstr "Compagnie / Organisation"
 
@@ -792,13 +793,13 @@ msgstr ""
 msgid "Messages"
 msgstr "Messages"
 
-#: corehq/apps/accounting/models.py:341 corehq/apps/prelogin/forms.py:20
-#: corehq/apps/users/forms.py:145
+#: corehq/apps/accounting/models.py:341 corehq/apps/prelogin/forms.py:21
+#: corehq/apps/users/forms.py:144
 msgid "First Name"
 msgstr "Prénom"
 
-#: corehq/apps/accounting/models.py:344 corehq/apps/prelogin/forms.py:24
-#: corehq/apps/users/forms.py:146
+#: corehq/apps/accounting/models.py:344 corehq/apps/prelogin/forms.py:25
+#: corehq/apps/users/forms.py:145
 msgid "Last Name"
 msgstr "Nom"
 
@@ -815,7 +816,7 @@ msgstr ""
 "emails indiqués ici."
 
 #: corehq/apps/accounting/models.py:353
-#: corehq/apps/data_interfaces/views.py:322 corehq/apps/prelogin/forms.py:36
+#: corehq/apps/data_interfaces/views.py:322 corehq/apps/prelogin/forms.py:37
 #: corehq/apps/reports/standard/ivr.py:46
 #: corehq/apps/reports/standard/sms.py:280
 #: corehq/apps/reports/standard/sms.py:617
@@ -848,7 +849,7 @@ msgstr "Etat / Province / Region"
 msgid "Postal Code"
 msgstr "Code Postale"
 
-#: corehq/apps/accounting/models.py:378 corehq/apps/prelogin/forms.py:40
+#: corehq/apps/accounting/models.py:378 corehq/apps/prelogin/forms.py:41
 msgid "Country"
 msgstr "Pays"
 
@@ -1086,14 +1087,14 @@ msgstr "Payement reçu - Merci"
 
 #: corehq/apps/accounting/user_text.py:8
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/analytics.html:22
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:41
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:52
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/mobile.html:22
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:21
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/support.html:22
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/user.html:22
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/web.html:22
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:80
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:77
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:89
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:79
 msgid "Community"
 msgstr "Communauté "
 
@@ -1107,7 +1108,7 @@ msgstr ""
 
 #: corehq/apps/accounting/user_text.py:13
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/analytics.html:27
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:46
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:57
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/mobile.html:27
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:26
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/support.html:27
@@ -1127,16 +1128,16 @@ msgstr ""
 
 #: corehq/apps/accounting/user_text.py:18
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/analytics.html:32
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:51
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:62
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/mobile.html:32
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:31
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/support.html:32
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/user.html:32
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/web.html:32
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:90
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:98
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:87
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:95
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:99
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:107
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:89
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:97
 msgid "Pro"
 msgstr "Professionnel"
 
@@ -1150,20 +1151,20 @@ msgstr ""
 "de rapports."
 
 #: corehq/apps/accounting/user_text.py:23
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:306
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:309
 #: corehq/apps/app_manager/templates/app_manager/module_view.html:294
 #: corehq/apps/importer/templates/importer/excel_config.html:114
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/analytics.html:37
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:56
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:67
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/mobile.html:37
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:36
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/support.html:37
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/user.html:37
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/web.html:37
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:106
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:114
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:103
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:111
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:115
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:123
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:105
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:113
 msgid "Advanced"
 msgstr "Avancés"
 
@@ -1179,7 +1180,7 @@ msgstr ""
 
 #: corehq/apps/accounting/user_text.py:29
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/analytics.html:42
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:61
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:72
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/mobile.html:42
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:41
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/support.html:42
@@ -1214,7 +1215,7 @@ msgstr "Utilisateurs mobiles"
 #: corehq/apps/accounting/user_text.py:54
 #: corehq/apps/accounting/user_text.py:201
 #: corehq/apps/accounting/user_text.py:202
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:98
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:109
 msgid "Mobile Users"
 msgstr "Utilisateurs Mobile"
 
@@ -1296,7 +1297,7 @@ msgid "SMS (CommConnect)"
 msgstr "SMS (CommConnect)"
 
 #: corehq/apps/accounting/user_text.py:90
-#: corehq/apps/accounting/user_text.py:91 corehq/apps/commtrack/views.py:170
+#: corehq/apps/accounting/user_text.py:91 corehq/apps/commtrack/views.py:175
 #: corehq/apps/domain/forms.py:1624
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:13
 #: corehq/apps/reminders/forms.py:98 corehq/apps/reminders/forms.py:103
@@ -1462,24 +1463,24 @@ msgid "Dedicated Enterprise Account Management"
 msgstr "Gestion des Comptes Enterprise Dédié"
 
 #: corehq/apps/accounting/user_text.py:255
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:71
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:83
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:80
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:82
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:92
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:82
 msgid "Free"
 msgstr "Gratuit"
 
 #: corehq/apps/accounting/user_text.py:255
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:76
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:87
 msgid "$100 /month"
 msgstr "100 $/mois"
 
 #: corehq/apps/accounting/user_text.py:255
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:81
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:92
 msgid "$500 /month"
 msgstr "500 $/mois"
 
 #: corehq/apps/accounting/user_text.py:255
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:86
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:97
 msgid "$1,000 /month"
 msgstr "1 000 $/mois"
 
@@ -1492,22 +1493,22 @@ msgstr ""
 "a>)"
 
 #: corehq/apps/accounting/user_text.py:256
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:102
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:113
 msgid "50"
 msgstr "50"
 
 #: corehq/apps/accounting/user_text.py:256
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:107
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:118
 msgid "100"
 msgstr "100"
 
 #: corehq/apps/accounting/user_text.py:256
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:112
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:123
 msgid "500"
 msgstr "500"
 
 #: corehq/apps/accounting/user_text.py:256
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:117
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:128
 msgid "1,000"
 msgstr "1 000"
 
@@ -1517,10 +1518,10 @@ msgid "Unlimited / Discounted Pricing"
 msgstr "Illimité / Prix Réduits"
 
 #: corehq/apps/accounting/user_text.py:257
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:132
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:137
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:142
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:147
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:143
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:148
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:153
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:158
 msgid "1 USD /month"
 msgstr "1 USD /mois"
 
@@ -1625,7 +1626,7 @@ msgstr "Ajouter les utilisateurs:"
 #: corehq/apps/sms/templates/sms/default.html:47
 #: corehq/apps/unicel/forms.py:10
 #: corehq/apps/unicel/templates/unicel/backend.html:10
-#: corehq/apps/userhack/admin.py:14 corehq/apps/users/forms.py:184
+#: corehq/apps/userhack/admin.py:14 corehq/apps/users/forms.py:183
 #: corehq/apps/users/templates/users/edit_web_user.html:13
 #: corehq/apps/users/templates/users/mobile/users_list.html:209
 #: corehq/apps/users/templates/users/partial/basic_info_form.html:10
@@ -1646,6 +1647,7 @@ msgstr "Nom d'utilisateur"
 #: corehq/apps/reports/templates/reports/partials/hqexport_group_table.html:11
 #: corehq/apps/sms/templates/sms/add_gateway.html:42
 #: corehq/apps/sms/templates/sms/partials/day_time_windows.html:12
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:14
 msgid "Action"
 msgstr "Action"
 
@@ -1724,6 +1726,7 @@ msgstr ""
 #: corehq/apps/hqmedia/templates/hqmedia/bulk_upload.html:55
 #: corehq/apps/indicators/templates/indicators/forms/copy_to_domain.html:66
 #: corehq/apps/locations/templates/locations/manage/location.html:195
+#: corehq/apps/locations/templates/locations/manage/locations.html:266
 #: corehq/apps/orgs/templates/orgs/orgs_landing.html:184
 #: corehq/apps/orgs/templates/orgs/orgs_landing.html:203
 #: corehq/apps/orgs/templates/orgs/orgs_landing.html:230
@@ -2018,7 +2021,7 @@ msgstr "Le Montant"
 #: corehq/apps/reports/standard/monitoring.py:479
 #: corehq/apps/reports/standard/monitoring.py:623
 #: corehq/apps/reports/standard/monitoring.py:1321
-#: custom/ilsgateway/tanzania/reports/delivery.py:171
+#: custom/ilsgateway/tanzania/reports/delivery.py:174
 #: custom/m4change/reports/aggregate_facility_web_hmis_report.py:38
 #: custom/m4change/reports/all_hmis_report.py:258
 #: custom/m4change/reports/anc_hmis_report.py:117
@@ -2102,7 +2105,7 @@ msgstr ""
 
 #: corehq/apps/accounting/templates/accounting/credits_tab.html:9
 #: corehq/apps/accounting/templates/accounting/subscriptions.html:55
-#: corehq/apps/hqwebapp/models.py:1302
+#: corehq/apps/hqwebapp/models.py:1297
 msgid "Subscription"
 msgstr "Souscription "
 
@@ -2153,8 +2156,8 @@ msgstr ""
 #: corehq/apps/reports/standard/sms.py:732
 #: corehq/apps/users/templates/users/web_users.b3.html:286
 #: corehq/apps/users/templates/users/web_users.html:128
-#: custom/ilsgateway/tanzania/reports/facility_details.py:118
-#: custom/ilsgateway/tanzania/reports/supervision.py:122
+#: custom/ilsgateway/tanzania/reports/facility_details.py:119
+#: custom/ilsgateway/tanzania/reports/supervision.py:124
 #: custom/intrahealth/sqldata.py:392
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:266
 msgid "Date"
@@ -2218,9 +2221,9 @@ msgstr "État Numero"
 #: corehq/apps/reports/templates/reports/messaging/survey_detail.html:33
 #: corehq/apps/settings/templates/settings/my_projects.html:12
 #: corehq/apps/sms/views.py:1022
-#: corehq/ex-submodules/casexml/apps/case/models.py:903
+#: corehq/ex-submodules/casexml/apps/case/models.py:908
 #: custom/_legacy/pact/models.py:329
-#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:55
+#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:65
 #: custom/m4change/reports/mcct_project_review.py:274
 #: custom/m4change/reports/mcct_project_review.py:401
 #: custom/m4change/reports/mcct_project_review.py:484
@@ -2607,7 +2610,7 @@ msgstr "Sommaire de la version"
 #: corehq/apps/reports/templates/reports/standard/base_template.html:108
 #: corehq/apps/reports/templates/reports/standard/export_download.html:99
 #: corehq/apps/reports_core/templates/reports_core/base_template_new.html:150
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:118
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:122
 msgid "Generating Report..."
 msgstr "Émission de rapport..."
 
@@ -2622,8 +2625,8 @@ msgstr "Émission de rapport..."
 #: corehq/apps/reports/templates/reports/standard/base_template.html:111
 #: corehq/apps/reports_core/templates/reports_core/base_template_new.html:151
 #: corehq/apps/reports_core/templates/reports_core/base_template_new.html:152
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:119
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:120
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:123
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:124
 msgid "Apply"
 msgstr "Appliquer"
 
@@ -2738,11 +2741,11 @@ msgid "Delay Invoicing Until"
 msgstr "Délai de Facturation depuis "
 
 #: corehq/apps/accounting/templates/accounting/subscriptions_tab.html:24
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:255
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:261
-#: corehq/apps/domain/templates/domain/admin/feature_flags.html:28
-#: corehq/apps/locations/templates/locations/manage/locations.html:148
-#: corehq/apps/reports/views.py:801
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:258
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:264
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:37
+#: corehq/apps/locations/templates/locations/manage/locations.html:167
+#: corehq/apps/reports/views.py:809
 #: corehq/apps/reports/templates/reports/reports_home.html:60
 #: corehq/apps/reports/templates/reports/reports_home.html:126
 #: corehq/apps/reports/templates/reports/partials/saved_custom_exports.html:9
@@ -3071,6 +3074,7 @@ msgstr "Dossier"
 #: corehq/apps/app_manager/fields.py:45
 #: corehq/apps/app_manager/templates/app_manager/managed_app.html:266
 #: corehq/apps/app_manager/templates/app_manager/ng_partials/case_summary_view.html:109
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:56
 #: corehq/apps/hqwebapp/doc_info.py:100
 #: corehq/apps/reports/filters/forms.py:684
 #: corehq/apps/reports/standard/inspect.py:89
@@ -3117,61 +3121,56 @@ msgstr "Copier l'application"
 msgid "Copy"
 msgstr "Copier"
 
-#: corehq/apps/app_manager/models.py:749
-msgid "Form referenced as the registration form for multiple modules."
-msgstr ""
-"Formulaire référé comme le formulaire registration pour plusieurs modules. "
-
-#: corehq/apps/app_manager/models.py:1743
-#: corehq/apps/app_manager/models.py:2174
-#: corehq/apps/app_manager/views.py:1412
+#: corehq/apps/app_manager/models.py:1744
+#: corehq/apps/app_manager/models.py:2200
+#: corehq/apps/app_manager/views.py:1414
 msgid "Untitled Module"
 msgstr "Module sans titre"
 
-#: corehq/apps/app_manager/models.py:1756
-#: corehq/apps/app_manager/models.py:2200
-#: corehq/apps/app_manager/views.py:1471
+#: corehq/apps/app_manager/models.py:1757
+#: corehq/apps/app_manager/models.py:2226
+#: corehq/apps/app_manager/views.py:1473
 msgid "Untitled Form"
 msgstr "Formulaire sans Titre"
 
-#: corehq/apps/app_manager/models.py:1849
+#: corehq/apps/app_manager/models.py:1850
 msgid "Case tiles may only be used for the case list (not the case details)."
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:1857
+#: corehq/apps/app_manager/models.py:1858
 msgid "A case property must be assigned to the \"{}\" tile field."
 msgstr "Une propriété dossier doit être assigné au \"{}\" champ de carreau."
 
-#: corehq/apps/app_manager/models.py:2014
+#: corehq/apps/app_manager/models.py:2040
 msgid "Case property"
 msgstr "Propriété de Cas"
 
-#: corehq/apps/app_manager/models.py:2015
+#: corehq/apps/app_manager/models.py:2041
 msgid "Lookup Table field"
 msgstr "Champs de Table de Recherche"
 
-#: corehq/apps/app_manager/models.py:2016
+#: corehq/apps/app_manager/models.py:2042
 msgid "custom user property"
 msgstr "Propriété d'utilisateur personalisée"
 
-#: corehq/apps/app_manager/models.py:2017
+#: corehq/apps/app_manager/models.py:2043
 msgid "custom XPath expression"
 msgstr "Expression de XPath personalisée"
 
-#: corehq/apps/app_manager/models.py:2024
+#: corehq/apps/app_manager/models.py:2050
 msgid "Case tag"
 msgstr "Etiquette de dossier"
 
-#: corehq/apps/app_manager/models.py:2025
+#: corehq/apps/app_manager/models.py:2051
 msgid "Lookup Table tag"
 msgstr "Balise de Table de Recherche"
 
-#: corehq/apps/app_manager/models.py:2063
+#: corehq/apps/app_manager/models.py:2089
 msgid "All forms in this module require a visit schedule."
 msgstr "Tout les formulaires dans ce module requière un plan de visite "
 
-#: corehq/apps/app_manager/models.py:2186
-#: corehq/apps/app_manager/models.py:4198 corehq/apps/products/views.py:467
+#: corehq/apps/app_manager/models.py:2212
+#: corehq/apps/app_manager/models.py:4272 corehq/apps/products/views.py:467
 #: corehq/apps/products/templates/products/manage/products.html:110
 #: corehq/apps/programs/templates/programs/manage/program.html:77
 #: corehq/apps/reports/commtrack/standard.py:92
@@ -3183,9 +3182,9 @@ msgstr "Tout les formulaires dans ce module requière un plan de visite "
 msgid "Product"
 msgstr "Produit"
 
-#: corehq/apps/app_manager/models.py:2521
-#: corehq/apps/app_manager/models.py:2575
-#: corehq/apps/app_manager/models.py:2637
+#: corehq/apps/app_manager/models.py:2570
+#: corehq/apps/app_manager/models.py:2624
+#: corehq/apps/app_manager/models.py:2686
 #: corehq/apps/appstore/templates/appstore/deployment_info.html:31
 #: corehq/apps/appstore/templates/appstore/project_info.html:140
 #: corehq/apps/appstore/templates/appstore/project_info.html:259
@@ -3201,47 +3200,47 @@ msgstr "Produit"
 msgid "Description"
 msgstr "Description"
 
-#: corehq/apps/app_manager/models.py:2522
-#: corehq/apps/app_manager/models.py:2570
+#: corehq/apps/app_manager/models.py:2571
+#: corehq/apps/app_manager/models.py:2619
 msgid "Followup date"
 msgstr "Date de suivi"
 
-#: corehq/apps/app_manager/models.py:2527
-#: corehq/apps/app_manager/models.py:2580
+#: corehq/apps/app_manager/models.py:2576
+#: corehq/apps/app_manager/models.py:2629
 msgid "Close if"
 msgstr "Fermer si"
 
-#: corehq/apps/app_manager/models.py:2579
+#: corehq/apps/app_manager/models.py:2628
 msgid "Latest report"
 msgstr "Rapport le plus récemment"
 
-#: corehq/apps/app_manager/models.py:2600
+#: corehq/apps/app_manager/models.py:2649
 #: custom/_legacy/pact/templates/pact/patient/pactpatient_base.html:33
 #: custom/_legacy/pact/templates/pact/patient/pactpatient_submissions.html:31
 msgid "Care Plan"
 msgstr "Plan de soins"
 
-#: corehq/apps/app_manager/models.py:2621
+#: corehq/apps/app_manager/models.py:2670
 #: corehq/apps/reports/standard/cases/careplan.py:124
 #: custom/_legacy/pact/models.py:357
 msgid "Goal"
 msgstr "Objectif"
 
-#: corehq/apps/app_manager/models.py:2621
+#: corehq/apps/app_manager/models.py:2670
 #: corehq/apps/reports/standard/cases/careplan.py:138
 #: custom/_legacy/pact/models.py:375
 msgid "Task"
 msgstr "Tâche"
 
-#: corehq/apps/app_manager/models.py:2630
+#: corehq/apps/app_manager/models.py:2679
 msgid "Followup"
 msgstr "Suivi"
 
-#: corehq/apps/app_manager/models.py:2644
+#: corehq/apps/app_manager/models.py:2693
 msgid "Last update"
 msgstr "Mise à jour la plus récente"
 
-#: corehq/apps/app_manager/models.py:3394
+#: corehq/apps/app_manager/models.py:3468
 msgid ""
 "Usage of lookup tables is not supported by your current subscription. Please "
 "upgrade your subscription before using this feature."
@@ -3250,27 +3249,29 @@ msgstr ""
 "actuelle. Veuillez mettre à jour votre inscription avant d'utiliser ces "
 "fonctions. "
 
-#: corehq/apps/app_manager/models.py:4171
+#: corehq/apps/app_manager/models.py:4245
 #, python-brace-format
 msgid "Copy of {name}"
 msgstr "Copie de {name}"
 
-#: corehq/apps/app_manager/models.py:4408
+#: corehq/apps/app_manager/models.py:4482
 msgid "Error in case type hierarchy"
 msgstr "Erreur dans la hiérarchie de type de cas"
 
-#: corehq/apps/app_manager/models.py:4498
+#: corehq/apps/app_manager/models.py:4572
 msgid ""
 "Problem loading suite file from profile file. Is your profile file correct?"
 msgstr ""
 "Un problème est survenu lors du chargement du fichier de suite à partir du "
 "fichier de profil. Est-ce que votre fichier de profil est correct?"
 
-#: corehq/apps/app_manager/translations.py:46
-msgid "App Translation Failed! "
-msgstr "Échec de traduction d'application!"
+#: corehq/apps/app_manager/translations.py:48
+msgid ""
+"App Translation Failed! Please make sure you are using a valid Excel 2007 or "
+"later (.xlsx) file. Error details: {}."
+msgstr ""
 
-#: corehq/apps/app_manager/translations.py:149
+#: corehq/apps/app_manager/translations.py:154
 msgid "App Translations Updated!"
 msgstr "Mise à jour de traduction d'application!"
 
@@ -3282,71 +3283,71 @@ msgstr "Vous devriez spécifier un titre pour l'application que vous copiez."
 msgid "You must submit the source data."
 msgstr "Vous devez fournir la source de donnée."
 
-#: corehq/apps/app_manager/views.py:526
+#: corehq/apps/app_manager/views.py:527
 msgid "All Programs"
 msgstr "Tous programmes"
 
-#: corehq/apps/app_manager/views.py:596
+#: corehq/apps/app_manager/views.py:597
 msgid "U​I translation"
 msgstr "Traduction d'UI"
 
-#: corehq/apps/app_manager/views.py:597
+#: corehq/apps/app_manager/views.py:598
 msgid "U​I translations"
 msgstr "Traductions d'UI"
 
-#: corehq/apps/app_manager/views.py:604
+#: corehq/apps/app_manager/views.py:605
 msgid "app translation"
 msgstr "traduction d'application"
 
-#: corehq/apps/app_manager/views.py:605
+#: corehq/apps/app_manager/views.py:606
 msgid "app translations"
 msgstr "Traductions d'application"
 
-#: corehq/apps/app_manager/views.py:821
+#: corehq/apps/app_manager/views.py:822
 msgid "Don't Show"
 msgstr "Ne pas montrer"
 
-#: corehq/apps/app_manager/views.py:828
+#: corehq/apps/app_manager/views.py:829
 #: corehq/apps/reports/standard/cases/basic.py:211
 #: corehq/apps/reports/templates/reports/reportdata/case_details.html:71
 msgid "Case List"
 msgstr "Liste de dossiers"
 
-#: corehq/apps/app_manager/views.py:829
+#: corehq/apps/app_manager/views.py:830
 msgid "Case Detail"
 msgstr "Détail de dossier"
 
-#: corehq/apps/app_manager/views.py:848
+#: corehq/apps/app_manager/views.py:849
 msgid "Product List"
 msgstr "Liste de produit"
 
-#: corehq/apps/app_manager/views.py:849
+#: corehq/apps/app_manager/views.py:850
 msgid "Product Detail"
 msgstr "Détail de produit"
 
-#: corehq/apps/app_manager/views.py:871
+#: corehq/apps/app_manager/views.py:872
 msgid "Goal List"
 msgstr "Liste de objectifs"
 
-#: corehq/apps/app_manager/views.py:872
+#: corehq/apps/app_manager/views.py:873
 msgid "Goal Detail"
 msgstr "Détail d'objectif"
 
-#: corehq/apps/app_manager/views.py:882
+#: corehq/apps/app_manager/views.py:883
 msgid "Task List"
 msgstr "Liste de tâches"
 
-#: corehq/apps/app_manager/views.py:883
+#: corehq/apps/app_manager/views.py:884
 msgid "Task Detail"
 msgstr "Détail de la tâche"
 
-#: corehq/apps/app_manager/views.py:921
+#: corehq/apps/app_manager/views.py:923
 msgid ""
 "Your app contains references to reports that are deleted. These will be "
 "removed on save."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:1243
+#: corehq/apps/app_manager/views.py:1245
 msgid ""
 "You tried to edit this form in the Form Builder. However, your administrator "
 "has locked this form against editing in the form builder, so we have "
@@ -3357,26 +3358,26 @@ msgstr ""
 "le form builder, donc plutôt nous vous avons redirigé au page principale du "
 "formulaire."
 
-#: corehq/apps/app_manager/views.py:1409
+#: corehq/apps/app_manager/views.py:1411
 msgid "Untitled Application"
 msgstr "Application sans titre"
 
-#: corehq/apps/app_manager/views.py:1458
+#: corehq/apps/app_manager/views.py:1460
 #, python-brace-format
 msgid "Please set the case type for the target module '{name}'."
 msgstr "Veuillez entrer un type de dossier pour le module cible '{name}'."
 
-#: corehq/apps/app_manager/views.py:1464
+#: corehq/apps/app_manager/views.py:1466
 msgid "Caution: Care Plan modules are a labs feature"
 msgstr ""
 "Avertissement : Les modules du plan de soins sont une fonctionnalité des "
 "labos"
 
-#: corehq/apps/app_manager/views.py:1476
+#: corehq/apps/app_manager/views.py:1478
 msgid "Caution: Advanced modules are a labs feature"
 msgstr "Avertissement: Les modules avancés sont une fonctionnalité des labos."
 
-#: corehq/apps/app_manager/views.py:1592
+#: corehq/apps/app_manager/views.py:1594
 msgid ""
 "We could not copy this form, because it is blank.In order to copy this form, "
 "please add some questions first."
@@ -3384,7 +3385,7 @@ msgstr ""
 "Nous n'avons pas pu copier ce formulaire parce qu'il est vide. Pour copier "
 "ce formulaire, veuillez d'abord ajouter des questions."
 
-#: corehq/apps/app_manager/views.py:1596
+#: corehq/apps/app_manager/views.py:1598
 msgid ""
 "This form could not be copied because it is not compatible with the selected "
 "module."
@@ -3392,15 +3393,15 @@ msgstr ""
 "Ce formulaire ne peut pas être copier pour cause d'incompatibilité avec le "
 "module choisie"
 
-#: corehq/apps/app_manager/views.py:1765
+#: corehq/apps/app_manager/views.py:1767
 msgid "Unknown Module"
 msgstr "Utilisateur inconnu"
 
-#: corehq/apps/app_manager/views.py:2468
+#: corehq/apps/app_manager/views.py:2470
 msgid "The form can not be moved into the desired module."
 msgstr "Le formulaire ne peu pas être déplacé dans module voulu."
 
-#: corehq/apps/app_manager/views.py:2473
+#: corehq/apps/app_manager/views.py:2475
 msgid ""
 "Oops. Looks like you got out of sync with us. The sidebar has been updated, "
 "so please try again."
@@ -3408,7 +3409,7 @@ msgstr ""
 "Oups ! Il semble que vous ne soyez plus synchronisé avec nous. L'encadré a "
 "été mis à jour. Veuillez donc essayer à nouveau."
 
-#: corehq/apps/app_manager/views.py:2628
+#: corehq/apps/app_manager/views.py:2630
 msgid ""
 "We were unable to get your files because your Application has errors. Please "
 "click <strong>Make New Version</strong> under <strong>Deploy</strong> for "
@@ -3419,17 +3420,17 @@ msgstr ""
 "Version</strong> sous<strong>Deploy</strong> pour obtenir des commentaires "
 "quant à la résolution de ces erreurs."
 
-#: corehq/apps/app_manager/views.py:2658
+#: corehq/apps/app_manager/views.py:2660
 msgid ""
 "We were unable to get your files because your Application has errors. Please "
 "click Make New Version under Deploy for feedback on how to fix these errors."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:3022
+#: corehq/apps/app_manager/views.py:3024
 msgid "Summary"
 msgstr "Sommaire"
 
-#: corehq/apps/app_manager/views.py:3060
+#: corehq/apps/app_manager/views.py:3062
 #: corehq/apps/app_manager/templates/app_manager/app_view.html:257
 #: corehq/apps/app_manager/templates/app_manager/apps_base.html:9
 #: corehq/apps/app_manager/templates/app_manager/apps_base.html:14
@@ -3440,27 +3441,27 @@ msgstr "Sommaire"
 msgid "Applications"
 msgstr "Applications"
 
-#: corehq/apps/app_manager/views.py:3211
+#: corehq/apps/app_manager/views.py:3213
 msgid "We found problem with following translations:"
 msgstr "Nous avons trouvé un erreur avec les traductions suivantes: "
 
-#: corehq/apps/app_manager/views.py:3222
+#: corehq/apps/app_manager/views.py:3224
 msgid "Something went wrong! Update failed. We're looking into it"
 msgstr ""
 "Une erreur est survenue ! La mise à jour a échoué. Nous tentons de "
 "déterminer de quoi il s'agit."
 
-#: corehq/apps/app_manager/views.py:3225
+#: corehq/apps/app_manager/views.py:3227
 msgid "UI Translations Updated!"
 msgstr "Les traductions des IU ont été mises à jour !"
 
-#: corehq/apps/app_manager/views.py:3271
+#: corehq/apps/app_manager/views.py:3273
 msgid "Please upgrade you app to > 2.0 in order to add a Careplan module"
 msgstr ""
 "Veuillez mettre à niveau votre application à la version supérieure à 2.0 "
 "afin de pouvoir ajouter le module du plan de soins"
 
-#: corehq/apps/app_manager/views.py:3282
+#: corehq/apps/app_manager/views.py:3284
 msgid "This application already has a Careplan module"
 msgstr "Cette application comporte déjà un module de plan de soins."
 
@@ -3468,33 +3469,33 @@ msgstr "Cette application comporte déjà un module de plan de soins."
 msgid "Error parsing XML: {}"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:204
+#: corehq/apps/app_manager/xform.py:205
 #, python-brace-format
 msgid "Group already has node for lang: {0}"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:673
+#: corehq/apps/app_manager/xform.py:679
 msgid "There's no language called '{}'"
 msgstr "Il n'y a pas une langue qui s'appelle '{}'"
 
-#: corehq/apps/app_manager/xform.py:675
+#: corehq/apps/app_manager/xform.py:681
 msgid "There's already a language called '{}'"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:720
+#: corehq/apps/app_manager/xform.py:726
 #, python-brace-format
 msgid "<translation lang=\"{lang}\"><text id=\"{id}\"> node has no <value>"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:827
+#: corehq/apps/app_manager/xform.py:833
 msgid "<item> ({}) has no <value>"
 msgstr "<item> ({}) n'a pas un <value>"
 
-#: corehq/apps/app_manager/xform.py:948
+#: corehq/apps/app_manager/xform.py:954
 msgid "Node <{}> has no 'ref' or 'bind'"
 msgstr "Node <{}> n'a pas un 'ref' ni un 'bind'"
 
-#: corehq/apps/app_manager/xform.py:1122 corehq/apps/app_manager/xform.py:1379
+#: corehq/apps/app_manager/xform.py:1128 corehq/apps/app_manager/xform.py:1385
 msgid ""
 "Couldn't get the case XML from one of your forms. A common reason for this "
 "is if you don't have the xforms namespace defined in your form. Please "
@@ -3502,7 +3503,7 @@ msgid ""
 "your form."
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:1371
+#: corehq/apps/app_manager/xform.py:1377
 msgid ""
 "You cannot use the Case Management UI if you already have a case block in "
 "your form."
@@ -3510,18 +3511,18 @@ msgstr ""
 "Vous ne pouvez pas utiliser l'IU de gestion de dossiers si vous avez déjà un "
 "case block dans le formulaire"
 
-#: corehq/apps/app_manager/xpath.py:205
+#: corehq/apps/app_manager/xpath.py:208
 #, python-brace-format
 msgid "Type {type} must be in list of domain types: {list}"
 msgstr "Type {type} doit faire partie de liste de types de domaines: {list}"
 
-#: corehq/apps/app_manager/xpath.py:213
+#: corehq/apps/app_manager/xpath.py:216
 #, python-brace-format
 msgid "Reference type {ref} cannot be a child of primary type {main}."
 msgstr ""
 "Type de référence {ref} ne peut pas être un enfant du type principal {main}."
 
-#: corehq/apps/app_manager/xpath.py:226
+#: corehq/apps/app_manager/xpath.py:229
 msgid ""
 "Property not correctly formatted. Must be formatted like: loacation:mytype:"
 "referencetype/property. For example: location:outlet:state/name"
@@ -3585,49 +3586,49 @@ msgstr "Restaurer"
 msgid "No thanks, get me out of here"
 msgstr "Non merci, sortez-moi d'ici"
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:177
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:180
 msgid "Home Screen"
 msgstr "Écran d'accueil"
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:178
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:181
 msgid "Module Menu"
 msgstr "Menu Module"
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:179
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:182
 msgid "Module:"
 msgstr "Module:"
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:180
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:183
 msgid "Previous Screen"
 msgstr "Écran précédent"
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:189
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:192
 msgid "Link to other form"
 msgstr "Ouvrir un autre formulaire"
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:239
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:242
 msgid "Delete Form"
 msgstr "Supprimer le formulaire"
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:259
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:262
 msgid ""
 "Your administrator has locked this form from edits through the form builder"
 msgstr "Votre administrateur a verrouillé ce formulaire  "
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:268
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:271
 msgid "Try in CloudCare"
 msgstr "Essayer avec CloudCare"
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:277
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:280
 msgid "User Registration Properties"
 msgstr "Propriétés d'inscription d'utilisateur"
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:284
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:287
 #: corehq/apps/app_manager/templates/app_manager/managed_app.html:162
 #: corehq/apps/app_manager/templates/app_manager/module_view.html:189
 #: corehq/apps/dashboard/views.py:217
 #: corehq/apps/grapevine/templates/grapevine/backend.html:5
-#: corehq/apps/hqwebapp/models.py:952 corehq/apps/hqwebapp/models.py:1630
+#: corehq/apps/hqwebapp/models.py:952 corehq/apps/hqwebapp/models.py:1625
 #: corehq/apps/mach/templates/mach/backend.html:5
 #: corehq/apps/megamobile/templates/megamobile/backend.html:5
 #: corehq/apps/sms/templates/sms/http_backend.html:33
@@ -3638,25 +3639,25 @@ msgstr "Propriétés d'inscription d'utilisateur"
 msgid "Settings"
 msgstr "Paramètres"
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:288
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:332
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:334
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:291
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:335
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:337
 #: corehq/apps/app_manager/templates/app_manager/module_view.html:190
 msgid "Case Management"
 msgstr "Gestion des dossiers"
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:294
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:358
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:360
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:297
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:361
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:363
 msgid "User Case Management"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:301
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:304
 msgid "Visit Scheduler"
 msgstr "Horaire de visites"
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:317
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:354
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:320
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:357
 msgid ""
 "There are errors in your form. Fix your form in order to view and edit Case "
 "Management."
@@ -3664,13 +3665,13 @@ msgstr ""
 "Votre formulaire comporte des erreurs. Modifiez votre formulaire pour "
 "visualiser et modifier la Gestion de dossiers."
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:322
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:324
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:325
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:327
 msgid "Cases and Referrals"
 msgstr "Dossiers et envois vers spécialistes"
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:325
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:335
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:328
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:338
 msgid ""
 "Cases give you a way to track patients, farms, etc. over time.  You can "
 "choose to save data from a form to the case, which will store the data "
@@ -3681,7 +3682,7 @@ msgstr ""
 "sur le dossier, ce qui enregistrera les données au niveau local sur le "
 "téléphone pour une utilisation ultérieure."
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:346
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:349
 #: corehq/apps/app_manager/templates/app_manager/partials/form_tab_visit_scheduler.html:97
 msgid ""
 "You have not created a form yet. Create a form in order to view and edit "
@@ -3690,19 +3691,19 @@ msgstr ""
 "Vous n'avez pas encore créé de formulaire. Créez un formulaire pour "
 "visualiser et modifier la Gestion de dossiers."
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:361
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:364
 msgid ""
 "The user case allows you to store data about the user in a case and use that "
 "data in forms."
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:371
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:374
 msgid ""
 "You have not created a form yet. Create a form in order to view and edit "
 "User Case Management."
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:396
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:399
 #: corehq/apps/app_manager/templates/app_manager/managed_app.html:213
 #: corehq/apps/reports/templates/reports/partials/form_name.html:5
 msgid "User Registration"
@@ -3868,7 +3869,7 @@ msgstr "Pas de parent"
 #: corehq/apps/app_manager/templates/app_manager/module_view.html:254
 #: corehq/apps/domain/views.py:340
 #: corehq/apps/locations/templates/locations/manage/location.html:84
-#: corehq/apps/users/forms.py:211
+#: corehq/apps/users/forms.py:210
 #: corehq/apps/users/templates/users/edit_commcare_user.html:122
 msgid "Basic"
 msgstr "De base"
@@ -3880,7 +3881,7 @@ msgstr "De base"
 #: corehq/apps/reports/filters/select.py:108
 #: corehq/apps/reports/standard/cases/basic.py:270
 #: corehq/apps/reports/templates/reports/reportdata/case_export_data.html:125
-#: corehq/ex-submodules/casexml/apps/case/models.py:877
+#: corehq/ex-submodules/casexml/apps/case/models.py:882
 msgid "Case Type"
 msgstr "Type de Dossier"
 
@@ -3939,7 +3940,37 @@ msgstr "Rapport"
 msgid "Display"
 msgstr "Afficher"
 
-#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:65
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:63
+#, fuzzy
+msgid "Chart Title"
+msgstr "Date de début"
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:66
+#, fuzzy
+msgid "Graph type"
+msgstr "Graphique"
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:73
+#, fuzzy
+msgid "Configuration"
+msgstr "Durée"
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:83
+#, fuzzy
+msgid "Add Configuration Item"
+msgstr "Ajouter une connexion"
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:88
+#, fuzzy
+msgid "Series Configuration"
+msgstr "Configuration de raccourcis de clavier"
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:99
+#, fuzzy
+msgid "Add Series Configuration Item"
+msgstr "Configuration de raccourcis de clavier"
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:109
 #: corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html:130
 #: corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html:174
 #: corehq/apps/data_interfaces/templates/data_interfaces/list_case_groups.html:21
@@ -3978,7 +4009,7 @@ msgstr "Afficher"
 msgid "Delete"
 msgstr "Supprimer"
 
-#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:76
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:120
 msgid "Add Report"
 msgstr ""
 
@@ -4326,7 +4357,6 @@ msgstr "Sommaire de dossier"
 #: custom/ewsghana/templates/ewsghana/facility_page_print_report.html:82
 #: custom/ewsghana/templates/ewsghana/reporting_rates_print_report.html:85
 #: custom/ewsghana/templates/ewsghana/stock_status_print_report.html:78
-#: custom/opm/templates/opm/hsr_print.html:57
 #: custom/opm/templates/opm/met_print_report.html:88
 #: custom/opm/templates/opm/new_hsr_print.html:65
 msgid "Loading ..."
@@ -5261,7 +5291,7 @@ msgstr "Uploader"
 #: corehq/apps/appstore/templates/appstore/appstore_base.html:278
 #: corehq/apps/reports/standard/monitoring.py:773
 #: corehq/apps/reports/templates/reports/reports_home.html:132
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:272
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:273
 #: corehq/apps/reports/templates/reports/messaging/survey_detail.html:40
 #: corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_hierarchy.html:118
 #: submodules/ctable-src/ctable_view/templates/ctable/list_mappings.html:115
@@ -5279,7 +5309,7 @@ msgstr "Vous pouvez modifier XForm ici."
 
 #: corehq/apps/app_manager/templates/app_manager/partials/form_tab_advanced.html:51
 #: corehq/apps/cloudcare/templates/cloudcare/cloudcare_home.html:50
-#: corehq/apps/hqwebapp/views.py:715
+#: corehq/apps/hqwebapp/views.py:717
 msgid "Loading..."
 msgstr "Téléchargement en cours..."
 
@@ -5504,10 +5534,10 @@ msgstr "L'icône courant"
 #: corehq/apps/export/templates/export/dialogs/delete_custom_export_dialog.html:13
 #: corehq/apps/hqadmin/templates/hqadmin/partials/reset-pillow-checkpoint-modal.html:18
 #: corehq/apps/hqmedia/templates/hqmedia/partials/multimedia_uploader.html:34
-#: corehq/apps/prelogin/templates/prelogin/base.html:126
-#: corehq/apps/prelogin/templates/prelogin/base.html:143
-#: corehq/apps/prelogin/templates/prelogin/base.html:174
-#: corehq/apps/prelogin/templates/prelogin/base.html:213
+#: corehq/apps/prelogin/templates/prelogin/base.html:129
+#: corehq/apps/prelogin/templates/prelogin/base.html:146
+#: corehq/apps/prelogin/templates/prelogin/base.html:177
+#: corehq/apps/prelogin/templates/prelogin/base.html:216
 #: corehq/apps/registration/templates/registration/org_request.html:70
 #: corehq/apps/registration/templates/registration/partials/eula_modal.html:11
 #: corehq/apps/reports/templates/reports/partials/export_download_modal.html:15
@@ -5581,7 +5611,7 @@ msgstr "S'il vous plaît enregistrez avant d'ajouter une autre langue"
 #: corehq/apps/appstore/views.py:28
 #: corehq/apps/appstore/templates/appstore/project_info.html:148
 #: corehq/apps/reports/filters/select.py:43
-#: custom/ilsgateway/tanzania/reports/delivery.py:153
+#: custom/ilsgateway/tanzania/reports/delivery.py:156
 msgid "Category"
 msgstr "Catégorie"
 
@@ -5627,8 +5657,8 @@ msgid "You must specify a name for the new project"
 msgstr "Vous devez spécifier un nom pour le nouveau projet"
 
 #: corehq/apps/appstore/templates/appstore/appstore_base.html:7
-#: corehq/apps/domain/views.py:1636 corehq/apps/hqwebapp/models.py:1208
-#: corehq/apps/hqwebapp/models.py:1584
+#: corehq/apps/domain/views.py:1636 corehq/apps/hqwebapp/models.py:1203
+#: corehq/apps/hqwebapp/models.py:1579
 #: corehq/apps/style/templates/style/bootstrap2/partials/domain_list_dropdown.html:19
 #: corehq/apps/style/templates/style/bootstrap3/partials/domain_list_dropdown.html:34
 msgid "CommCare Exchange"
@@ -5691,7 +5721,7 @@ msgstr "Précédent"
 #: corehq/apps/export/forms.py:76 corehq/apps/export/forms.py:133
 #: corehq/apps/hqwebapp/templates/hqwebapp/partials/pagination.html:36
 #: corehq/apps/reports/templates/reports/filters/drilldown_options.html:24
-#: corehq/apps/userreports/reports/builder/forms.py:356
+#: corehq/apps/userreports/reports/builder/forms.py:357
 msgid "Next"
 msgstr "Suivant"
 
@@ -5755,7 +5785,7 @@ msgstr "Téléchargements"
 #: corehq/apps/appstore/templates/appstore/project_info.html:198
 #: corehq/apps/settings/templates/settings/my_projects.html:11
 #: corehq/apps/sms/templates/sms/list_backends.html:76
-#: corehq/apps/users/views/__init__.py:688
+#: corehq/apps/users/views/__init__.py:646
 msgid "Project"
 msgstr "Projet"
 
@@ -5909,6 +5939,8 @@ msgstr "Numéro de construction"
 #: corehq/apps/reminders/templates/reminders/partial/complex_message_table.html:18
 #: corehq/apps/reminders/templates/reminders/partial/complex_message_table.html:21
 #: corehq/apps/sms/templates/sms/default.html:50
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:12
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:17
 msgid "Time"
 msgstr "Heure"
 
@@ -5924,11 +5956,11 @@ msgstr ""
 "Cette application n'est plus valide. Tentez d'utiliser les liens de "
 "navigation pour sélectionner une application."
 
-#: corehq/apps/cloudcare/views.py:313
+#: corehq/apps/cloudcare/views.py:312
 msgid "Something went wrong filtering your cases."
 msgstr "Une erreur est survenue lors du filtrage de vos dossiers."
 
-#: corehq/apps/cloudcare/views.py:489 corehq/apps/hqwebapp/models.py:1045
+#: corehq/apps/cloudcare/views.py:488 corehq/apps/hqwebapp/models.py:1045
 msgid "CloudCare Permissions"
 msgstr "Permissions CloudCare"
 
@@ -6240,7 +6272,7 @@ msgstr ""
 "valeur pour tous les paramètres de consommation."
 
 #: corehq/apps/commtrack/forms.py:66 corehq/apps/commtrack/forms.py:71
-#: corehq/apps/commtrack/views.py:231
+#: corehq/apps/commtrack/views.py:236
 msgid "Stock Levels"
 msgstr "Niveaux d'inventaire"
 
@@ -6285,8 +6317,8 @@ msgid "Location Type"
 msgstr "Type de Site"
 
 #: corehq/apps/commtrack/models.py:539
-#: custom/ilsgateway/tanzania/reports/delivery.py:81
-#: custom/ilsgateway/tanzania/reports/randr.py:170
+#: custom/ilsgateway/tanzania/reports/delivery.py:83
+#: custom/ilsgateway/tanzania/reports/randr.py:172
 msgid "Code"
 msgstr "Code"
 
@@ -6305,11 +6337,11 @@ msgstr ""
 msgid "Location"
 msgstr "Site"
 
-#: corehq/apps/commtrack/processing.py:159
+#: corehq/apps/commtrack/processing.py:160
 msgid "Product IDs must be set for all ledger updates!"
 msgstr ""
 
-#: corehq/apps/commtrack/processing.py:174
+#: corehq/apps/commtrack/processing.py:175
 msgid "Ledger transaction references invalid Case ID \"{}\""
 msgstr ""
 
@@ -6335,15 +6367,15 @@ msgstr "Non-catégorisé"
 msgid "uncategorized"
 msgstr "non-catégorisé"
 
-#: corehq/apps/commtrack/views.py:36 corehq/apps/hqwebapp/models.py:425
+#: corehq/apps/commtrack/views.py:41 corehq/apps/hqwebapp/models.py:425
 msgid "Setup"
 msgstr "Réglages"
 
-#: corehq/apps/commtrack/views.py:49
+#: corehq/apps/commtrack/views.py:54
 msgid "Advanced Settings"
 msgstr "Paramètres avancés"
 
-#: corehq/apps/commtrack/views.py:132
+#: corehq/apps/commtrack/views.py:137
 msgid ""
 "Settings updated! Your updated consumption settings may take a few minutes "
 "to show up in reports and on phones."
@@ -6351,19 +6383,19 @@ msgstr ""
 "Paramètres mis à jour! Vos nouveau paramètres de consommation prendront "
 "quelque minutes pour apparaitre sur des rapports et des téléphones."
 
-#: corehq/apps/commtrack/views.py:135
+#: corehq/apps/commtrack/views.py:140
 msgid "Settings updated!"
 msgstr "Paramètres mis à jour !"
 
-#: corehq/apps/commtrack/views.py:143 custom/intrahealth/sqldata.py:484
+#: corehq/apps/commtrack/views.py:148 custom/intrahealth/sqldata.py:484
 msgid "Consumption"
 msgstr "Consommation"
 
-#: corehq/apps/commtrack/views.py:161
+#: corehq/apps/commtrack/views.py:166
 msgid "Default consumption values updated"
 msgstr "Consommation par défaut mis à jour"
 
-#: corehq/apps/commtrack/views.py:291
+#: corehq/apps/commtrack/views.py:296
 #, fuzzy
 msgid "Rebuild Stock State"
 msgstr "État d'inventaire"
@@ -6391,6 +6423,82 @@ msgstr "Modifier la consommation mensuelle par défaut."
 #: corehq/apps/commtrack/templates/commtrack/manage/default_consumption.html:24
 msgid "Update Default Consumption Info"
 msgstr "Modifier l'information de consommation par défaut."
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:8
+#, python-format
+msgid ""
+"\n"
+"    <strong>Warning:</strong>\n"
+"    You have more than %(stock_state_limit)s stocks in your project space.\n"
+"    Only %(stock_state_limit)s are shown.\n"
+"    "
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:18
+#, python-format
+msgid ""
+"\n"
+"    <strong>Warning:</strong>\n"
+"    You have more than %(stock_transaction_limit)s stock transactions in "
+"your project space.\n"
+"    Only %(stock_transaction_limit)s are shown.\n"
+"    "
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:33
+#, fuzzy, python-format
+msgid ""
+"\n"
+"                <strong>%(case_display)s</strong>\n"
+"                %(section_display)s\n"
+"                for <em>%(product_name)s</em>\n"
+"                "
+msgstr ""
+"\n"
+"                        les lignes <strong>%(match_count)s</strong> ont été "
+"liées par correspondance et\n"
+"                        mises à jour."
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:43
+#, fuzzy
+msgid "Rebuild"
+msgstr "Recharger Dossier"
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:50
+#, fuzzy
+msgid "Current Values"
+msgstr "Manejo de Casos"
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:51
+#, fuzzy
+msgid "Rebuilt Values"
+msgstr "Recharger Dossier"
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:54
+#, fuzzy
+msgid "Server Date"
+msgstr "Date de Livraison"
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:55
+#, fuzzy
+msgid "Self-reported Date"
+msgstr "Date de création"
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:58
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:60
+msgid "Quantity"
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:59
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:61
+#: corehq/apps/reports/commtrack/standard.py:297
+#: custom/ilsgateway/tanzania/reports/facility_details.py:27
+msgid "Stock on Hand"
+msgstr "Total SOH"
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:92
+msgid "(will be deleted)"
+msgstr ""
 
 #: corehq/apps/commtrack/templates/commtrack/manage/stock_levels.html:7
 msgid "Configure Stock Levels Per Location Type"
@@ -6601,7 +6709,7 @@ msgstr ""
 #: corehq/apps/data_interfaces/interfaces.py:22
 #: corehq/apps/data_interfaces/views.py:58 corehq/apps/hqwebapp/models.py:553
 #: corehq/apps/settings/views.py:213
-#: corehq/apps/userreports/reports/builder/forms.py:350
+#: corehq/apps/userreports/reports/builder/forms.py:351
 msgid "Data"
 msgstr "Données"
 
@@ -6628,7 +6736,7 @@ msgstr "Configurer et planifier envoi des messages SMS et mots clés"
 
 #: corehq/apps/dashboard/views.py:206
 #: corehq/apps/dashboard/templates/dashboard/dashboard_new_user.html:73
-#: corehq/apps/hqwebapp/models.py:1576
+#: corehq/apps/hqwebapp/models.py:1571
 msgid "Exchange"
 msgstr "Exchange"
 
@@ -6697,6 +6805,7 @@ msgid "Welcome to CommCare Supply"
 msgstr ""
 
 #: corehq/apps/dashboard/templates/dashboard/dashboard_new_user.html:64
+#: docs/_build/html/_sources/translations.txt:132
 msgid "Welcome to CommCare HQ"
 msgstr "Bienvenue sur CommCare HQ"
 
@@ -6759,7 +6868,7 @@ msgstr "Nom de dossier"
 #: corehq/apps/data_interfaces/interfaces.py:50
 #: corehq/apps/reports/standard/cases/basic.py:272
 #: corehq/apps/sms/templates/sms/list_backends.html:63
-#: corehq/ex-submodules/casexml/apps/case/models.py:887
+#: corehq/ex-submodules/casexml/apps/case/models.py:892
 msgid "Owner"
 msgstr "Propriétaire"
 
@@ -7272,7 +7381,7 @@ msgstr "Saisir le nom du projet pour confirmer"
 msgid "New owner's CommCare username"
 msgstr "Nouveau utilisateur responsable Commcare"
 
-#: corehq/apps/domain/forms.py:362 corehq/apps/domain/views.py:2464
+#: corehq/apps/domain/forms.py:362 corehq/apps/domain/views.py:2465
 msgid "Transfer Project"
 msgstr "Transférer Projet"
 
@@ -7398,7 +7507,7 @@ msgid "Secure submissions"
 msgstr "Soumissions sécurisés"
 
 #: corehq/apps/domain/forms.py:633 corehq/apps/hqadmin/reports.py:696
-#: corehq/apps/prelogin/templates/prelogin/base.html:81
+#: corehq/apps/prelogin/templates/prelogin/base.html:84
 msgid "Services"
 msgstr "Services"
 
@@ -7434,7 +7543,7 @@ msgstr "Project Réél"
 
 #: corehq/apps/domain/forms.py:652
 #: corehq/apps/reports/standard/deployments.py:43
-#: corehq/apps/reports/standard/deployments.py:215
+#: corehq/apps/reports/standard/deployments.py:226
 #: corehq/apps/reports/standard/sms.py:164
 #: corehq/apps/reports/standard/sms.py:415
 #: corehq/apps/reports/standard/sms.py:474
@@ -7536,7 +7645,7 @@ msgstr "Peut il utiliser les données du Projet?"
 #: corehq/apps/domain/forms.py:978 corehq/apps/domain/forms.py:1075
 #: corehq/apps/reminders/forms.py:517 corehq/apps/reminders/forms.py:2152
 #: corehq/apps/styleguide/examples/simple_crispy_form/forms.py:63
-#: corehq/apps/users/forms.py:487
+#: corehq/apps/users/forms.py:486
 msgid "Basic Information"
 msgstr "Information de base"
 
@@ -7565,7 +7674,7 @@ msgstr ""
 "remettre le mot de passe."
 
 #: corehq/apps/domain/forms.py:922 corehq/apps/domain/forms.py:986
-#: corehq/apps/domain/forms.py:1083 corehq/apps/users/forms.py:495
+#: corehq/apps/domain/forms.py:1083 corehq/apps/users/forms.py:494
 msgid "Mailing Address"
 msgstr "Adresses Messagerie"
 
@@ -7761,15 +7870,15 @@ msgstr ""
 msgid "Subscription Type"
 msgstr ""
 
-#: corehq/apps/domain/models.py:1295
+#: corehq/apps/domain/models.py:1279
 msgid "Transfer domain request is no longer active"
 msgstr "Demande de transfert de domaine n'est plus active"
 
-#: corehq/apps/domain/models.py:1327 corehq/apps/domain/models.py:1342
+#: corehq/apps/domain/models.py:1311 corehq/apps/domain/models.py:1326
 msgid "Transfer of ownership for CommCare project space."
 msgstr "Transfert de propriété d'espace projet CommCare."
 
-#: corehq/apps/domain/models.py:1368
+#: corehq/apps/domain/models.py:1352
 #, python-brace-format
 msgid "There has been a transfer of ownership of {domain}"
 msgstr "Il y a eu un transfert de propriété de {domain}"
@@ -7803,7 +7912,7 @@ msgstr "Mis-à-jour requise"
 msgid "Sorry, you do not have access to %(feature_name)s"
 msgstr "Désolé, vous n'avez pas accès à %(feature_name)s"
 
-#: corehq/apps/domain/views.py:267 corehq/apps/hqwebapp/models.py:1146
+#: corehq/apps/domain/views.py:267 corehq/apps/hqwebapp/models.py:1141
 #: corehq/apps/hqwebapp/templates/hqwebapp/partials/global_navigation_bar.html:91
 #: corehq/apps/ota/views.py:121
 #: corehq/apps/style/templates/style/bootstrap3/partials/domain_list_dropdown.html:6
@@ -7950,9 +8059,7 @@ msgstr ""
 msgid "Privacy and Security"
 msgstr "Protection des données et sécurité"
 
-#: corehq/apps/domain/views.py:1329 corehq/apps/prelogin/forms.py:96
-#: corehq/apps/prelogin/templates/prelogin/base.html:128
-#: corehq/apps/prelogin/templates/prelogin/_sections/home/about_dimagi.html:42
+#: corehq/apps/domain/views.py:1329 corehq/apps/prelogin/forms.py:97
 msgid "Contact Dimagi"
 msgstr ""
 
@@ -7976,7 +8083,7 @@ msgstr ""
 
 #: corehq/apps/domain/views.py:1437
 #: corehq/apps/domain/templates/domain/confirm_subscription_renewal.html:43
-#: corehq/apps/users/forms.py:513
+#: corehq/apps/users/forms.py:512
 #: corehq/apps/users/templates/users/mobile/users_list.html:115
 #: corehq/apps/users/views/mobile/users.py:461
 msgid "Confirm Billing Information"
@@ -8058,7 +8165,7 @@ msgstr ""
 msgid "Created a new version of your app."
 msgstr "Créé une nouvelle version de votre application."
 
-#: corehq/apps/domain/views.py:1932 corehq/apps/hqwebapp/models.py:1212
+#: corehq/apps/domain/views.py:1932 corehq/apps/hqwebapp/models.py:1207
 msgid "Multimedia Sharing"
 msgstr "Partage multimédia"
 
@@ -8089,7 +8196,7 @@ msgstr "Form Stubs"
 msgid "App Schema Changes"
 msgstr "Modifications de schéma d'application"
 
-#: corehq/apps/domain/views.py:1987 corehq/apps/hqwebapp/models.py:1226
+#: corehq/apps/domain/views.py:1987 corehq/apps/hqwebapp/models.py:1221
 msgid "Data Forwarding"
 msgstr "Transfert de données"
 
@@ -8102,7 +8209,7 @@ msgstr "Transférer les données"
 msgid "Forwarding set up to %s"
 msgstr "Transfert de réglage vers %s"
 
-#: corehq/apps/domain/views.py:2152 corehq/apps/hqwebapp/models.py:1203
+#: corehq/apps/domain/views.py:2152 corehq/apps/hqwebapp/models.py:1198
 msgid "Project Information"
 msgstr "Informations sur le projet"
 
@@ -8127,28 +8234,28 @@ msgstr "Propriétés calculées"
 msgid "Feature Previews"
 msgstr ""
 
-#: corehq/apps/domain/views.py:2439 corehq/apps/hqwebapp/models.py:1510
-#: corehq/apps/hqwebapp/models.py:1534 corehq/apps/hqwebapp/models.py:1562
+#: corehq/apps/domain/views.py:2439 corehq/apps/hqwebapp/models.py:1505
+#: corehq/apps/hqwebapp/models.py:1529 corehq/apps/hqwebapp/models.py:1557
 #: corehq/apps/toggle_ui/templates/toggle/flags.html:6
 msgid "Feature Flags"
 msgstr ""
 
-#: corehq/apps/domain/views.py:2488
+#: corehq/apps/domain/views.py:2489
 #, python-brace-format
 msgid "Resent transfer request for project '{domain}'"
 msgstr ""
 
-#: corehq/apps/domain/views.py:2558
+#: corehq/apps/domain/views.py:2559
 #, python-brace-format
 msgid "Successfully transferred ownership of project '{domain}'"
 msgstr ""
 
-#: corehq/apps/domain/views.py:2590
+#: corehq/apps/domain/views.py:2591
 #, python-brace-format
 msgid "Declined ownership of project '{domain}'"
 msgstr ""
 
-#: corehq/apps/domain/views.py:2606 corehq/apps/domain/views.py:2626
+#: corehq/apps/domain/views.py:2607 corehq/apps/domain/views.py:2627
 msgid "SMS Rate Calculator"
 msgstr ""
 
@@ -8563,7 +8670,7 @@ msgid "Usage Summary"
 msgstr "Résumé d'utilisation"
 
 #: corehq/apps/domain/templates/domain/current_subscription.html:210
-#: corehq/apps/domain/templates/domain/admin/feature_flags.html:26
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:34
 msgid "Feature"
 msgstr "Fonctionnalité"
 
@@ -8922,35 +9029,44 @@ msgstr "Vous n'avez pas encore configuré des adresses URL à transférer."
 msgid "Add a forwarding location"
 msgstr "Ajouter un site de transfert"
 
-#: corehq/apps/domain/templates/domain/admin/feature_flags.html:8
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:16
 #, python-format
 msgid ""
 "\n"
-"                    Feature Flags are superuser-only things that can be turn "
-"on features for individual users or projects.\n"
-"                    They can be edited manually at the <a href="
-"\"%(toggle_url)s\">Feature Flag edit UI</a> (also super-only).\n"
+"                    Feature Flags turn on features for individual users or "
+"projects. They are editable only by\n"
+"                    super users, in the <a href=\"%(toggle_url)s\">Feature "
+"Flag edit UI</a>.\n"
 "                    In addition, some feature flags are randomly enabled by "
-"a domain.\n"
-"                "
-msgstr ""
-
-#: corehq/apps/domain/templates/domain/admin/feature_flags.html:15
-msgid ""
-"\n"
-"                    You can see a list of all enabled flags for this domain "
-"here.\n"
-"                    This does not include any flags set for users within the "
 "domain.\n"
 "                "
 msgstr ""
 
-#: corehq/apps/domain/templates/domain/admin/feature_flags.html:27
-#: corehq/apps/toggle_ui/templates/toggle/edit_flag.html:165
-msgid "Enabled?"
-msgstr "Activé?"
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:23
+#, fuzzy
+msgid ""
+"\n"
+"                    Following are all flags enabled for this domain and/or "
+"for you.\n"
+"                    This does not include any flags set for other users in "
+"this domain.\n"
+"                "
+msgstr ""
+"\n"
+"                    Un message de vérification a déjà été envoyé à ce "
+"téléphone.\n"
+"                    Ce téléphone n'a pas encore répondu. Envoyer à nouveau ?"
 
 #: corehq/apps/domain/templates/domain/admin/feature_flags.html:35
+msgid "Enabled for domain?"
+msgstr ""
+
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:36
+#, fuzzy
+msgid "Enabled for me?"
+msgstr "Activé?"
+
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:45
 msgid "change"
 msgstr ""
 
@@ -9002,7 +9118,7 @@ msgid "SMS Pricing"
 msgstr ""
 
 #: corehq/apps/domain/templates/domain/admin/global_sms_rates.html:35
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:67
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:78
 msgid "Pricing"
 msgstr "Prix"
 
@@ -9560,8 +9676,8 @@ msgstr "Courriel"
 #: corehq/apps/users/templates/users/web_users.b3.html:220
 #: corehq/apps/users/templates/users/web_users.b3.html:285
 #: corehq/apps/users/templates/users/web_users.html:127
-#: custom/ilsgateway/tanzania/reports/facility_details.py:71
-#: custom/ilsgateway/tanzania/reports/facility_details.py:117
+#: custom/ilsgateway/tanzania/reports/facility_details.py:72
+#: custom/ilsgateway/tanzania/reports/facility_details.py:118
 msgid "Role"
 msgstr "Rôle"
 
@@ -9644,7 +9760,7 @@ msgid "Forgot your password?"
 msgstr "Mot de passe oublié ?"
 
 #: corehq/apps/domain/templates/login_and_password/partials/login_form.html:50
-#: corehq/apps/prelogin/templates/prelogin/base.html:74
+#: corehq/apps/prelogin/templates/prelogin/base.html:77
 #: corehq/apps/style/templates/style/bootstrap2/base.html:74
 #: corehq/apps/style/templates/style/bootstrap3/base.html:102
 msgid "Sign In"
@@ -10010,7 +10126,7 @@ msgstr "Me permettre d'identifier les données sensibles"
 #: corehq/apps/sms/forms.py:450
 #: corehq/apps/sms/templates/sms/backend_map.html:97
 #: corehq/apps/style/templates/style/bootstrap3/base.html:234
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:144
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:148
 #: corehq/apps/users/templates/users/web_users.b3.html:60
 #: custom/ewsghana/templates/ewsghana/partials/users_tables.html:102
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:212
@@ -10462,6 +10578,7 @@ msgstr "Télécharger des Tables de Recherche "
 
 #: corehq/apps/fixtures/templates/fixtures/manage_tables.html:66
 #: corehq/apps/fixtures/templates/fixtures/partials/edit_table_modal.html:9
+#: corehq/apps/userreports/ui/forms.py:87
 msgid "Table ID"
 msgstr "Identification de Table"
 
@@ -10894,7 +11011,7 @@ msgstr ""
 msgid "ADMINREPORT"
 msgstr "ADMINREPORT"
 
-#: corehq/apps/hqadmin/reports.py:642 corehq/apps/hqwebapp/models.py:1401
+#: corehq/apps/hqadmin/reports.py:642 corehq/apps/hqwebapp/models.py:1396
 msgid "Project Space List"
 msgstr "Liste d'espace de projet"
 
@@ -11135,7 +11252,7 @@ msgstr "Aucune remarque"
 msgid "No Info"
 msgstr "Pas d'Information"
 
-#: corehq/apps/hqadmin/reports.py:808 corehq/apps/hqwebapp/models.py:1403
+#: corehq/apps/hqadmin/reports.py:808 corehq/apps/hqwebapp/models.py:1398
 msgid "User List"
 msgstr "Liste d'utilisateurs"
 
@@ -11168,7 +11285,7 @@ msgstr "SuperUser ?"
 msgid "No Domain Data"
 msgstr "Aucune donnée de domaine"
 
-#: corehq/apps/hqadmin/reports.py:876 corehq/apps/hqwebapp/models.py:1405
+#: corehq/apps/hqadmin/reports.py:876 corehq/apps/hqwebapp/models.py:1400
 msgid "Application List"
 msgstr "Liste d'applications"
 
@@ -11294,7 +11411,7 @@ msgid "Print"
 msgstr "Imprimer"
 
 #: corehq/apps/hqadmin/templates/hqadmin/hqadmin_base_report.html:33
-#: corehq/apps/hqwebapp/models.py:1371 corehq/apps/hqwebapp/models.py:1539
+#: corehq/apps/hqwebapp/models.py:1366 corehq/apps/hqwebapp/models.py:1534
 msgid "Admin Reports"
 msgstr "Rapports administratifs"
 
@@ -11394,12 +11511,12 @@ msgstr "Image"
 msgid "Audio"
 msgstr "Audio"
 
-#: corehq/apps/hqmedia/models.py:815
+#: corehq/apps/hqmedia/models.py:818
 #, python-format
 msgid "Encountered an AttributeError for media: %s"
 msgstr "Une erreur AttributeError a été rencontrée pour le fichier média : %s"
 
-#: corehq/apps/hqmedia/models.py:819
+#: corehq/apps/hqmedia/models.py:822
 #, python-format
 msgid ""
 "This application has unsupported text in one of it's media file label "
@@ -11449,7 +11566,7 @@ msgstr ""
 msgid "File {name}s has an incorrect file type {ext}."
 msgstr ""
 
-#: corehq/apps/hqmedia/views.py:579
+#: corehq/apps/hqmedia/views.py:575
 msgid ""
 "There was an issue retrieving the status from the cache. We are looking into "
 "it. Please try uploading again."
@@ -11873,7 +11990,7 @@ msgstr ""
 msgid "Error Type"
 msgstr "Type d'erreur"
 
-#: corehq/apps/hqpillow_retry/views.py:41 corehq/apps/hqwebapp/models.py:1393
+#: corehq/apps/hqpillow_retry/views.py:41 corehq/apps/hqwebapp/models.py:1388
 msgid "PillowTop Errors"
 msgstr ""
 
@@ -12158,7 +12275,7 @@ msgstr "Enquêtes"
 msgid "New Survey"
 msgstr "Nouvelle enquête"
 
-#: corehq/apps/hqwebapp/models.py:929 corehq/apps/hqwebapp/models.py:1490
+#: corehq/apps/hqwebapp/models.py:929 corehq/apps/hqwebapp/models.py:1485
 #: corehq/apps/sms/views.py:990
 #: corehq/apps/sms/templates/sms/add_backend.html:49
 #: corehq/apps/sms/templates/sms/add_backend.html:70
@@ -12169,11 +12286,11 @@ msgstr "Nouvelle enquête"
 msgid "SMS Connectivity"
 msgstr "Connectivité SMS"
 
-#: corehq/apps/hqwebapp/models.py:933 corehq/apps/hqwebapp/models.py:1494
+#: corehq/apps/hqwebapp/models.py:933 corehq/apps/hqwebapp/models.py:1489
 msgid "Add Connection"
 msgstr "Ajouter une connexion"
 
-#: corehq/apps/hqwebapp/models.py:937 corehq/apps/hqwebapp/models.py:1496
+#: corehq/apps/hqwebapp/models.py:937 corehq/apps/hqwebapp/models.py:1491
 msgid "Edit Connection"
 msgstr "Modifier la connexion"
 
@@ -12227,182 +12344,176 @@ msgstr "Infos d'adhésion"
 msgid "Application Users"
 msgstr "Utilisateurs de l'application"
 
-#: corehq/apps/hqwebapp/models.py:1068
+#: corehq/apps/hqwebapp/models.py:1067
 msgid "Project Users"
 msgstr "Utilisateurs de projet"
 
-#: corehq/apps/hqwebapp/models.py:1072
+#: corehq/apps/hqwebapp/models.py:1071
 msgid ""
 "Grant other CommCare HQ users access to your project and manage user roles."
 msgstr ""
 "Accorder l'accès aux autres utilisateurs de CommCare HQ à votre projet et "
 "gérer les rôles des utilisateurs."
 
-#: corehq/apps/hqwebapp/models.py:1075
+#: corehq/apps/hqwebapp/models.py:1074
 #: corehq/apps/users/templates/users/web_users.b3.html:136
 msgid "Invite Web User"
 msgstr "Inviter des utilisateurs Web"
 
-#: corehq/apps/hqwebapp/models.py:1083 corehq/apps/settings/views.py:93
-#: corehq/apps/settings/templates/settings/edit_my_account.b2.html:33
-#: corehq/apps/users/views/__init__.py:350
-msgid "My Information"
-msgstr "Mes informations"
-
-#: corehq/apps/hqwebapp/models.py:1219
+#: corehq/apps/hqwebapp/models.py:1214
 msgid "Forward Forms"
 msgstr "Transférer les formulaires"
 
-#: corehq/apps/hqwebapp/models.py:1221
+#: corehq/apps/hqwebapp/models.py:1216
 msgid "Forward Form Stubs"
 msgstr "Transférer les Form Stubs"
 
-#: corehq/apps/hqwebapp/models.py:1223
+#: corehq/apps/hqwebapp/models.py:1218
 msgid "Forward Cases"
 msgstr "Transférer les dossiers"
 
-#: corehq/apps/hqwebapp/models.py:1250
+#: corehq/apps/hqwebapp/models.py:1245
 msgid "Project Administration"
 msgstr "Administration du projet"
 
-#: corehq/apps/hqwebapp/models.py:1296
+#: corehq/apps/hqwebapp/models.py:1291
 msgid "Internal Subscription Management (Dimagi Only)"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1313
+#: corehq/apps/hqwebapp/models.py:1308
 msgid "Project Tools"
 msgstr "Outils Projet"
 
-#: corehq/apps/hqwebapp/models.py:1334
+#: corehq/apps/hqwebapp/models.py:1329
 msgid "Internal Data (Dimagi Only)"
 msgstr "Date interne (Dimagi seulement)"
 
-#: corehq/apps/hqwebapp/models.py:1340
+#: corehq/apps/hqwebapp/models.py:1335
 msgid "My Settings"
 msgstr "Mes paramètres"
 
-#: corehq/apps/hqwebapp/models.py:1352
+#: corehq/apps/hqwebapp/models.py:1347
 msgid "Manage My Settings"
 msgstr "Gérer mes paramètres"
 
-#: corehq/apps/hqwebapp/models.py:1381 corehq/apps/hqwebapp/models.py:1400
+#: corehq/apps/hqwebapp/models.py:1376 corehq/apps/hqwebapp/models.py:1395
 msgid "Administrative Reports"
 msgstr "Rapports administratifs"
 
-#: corehq/apps/hqwebapp/models.py:1382 corehq/apps/hqwebapp/models.py:1411
-#: corehq/apps/hqwebapp/models.py:1533 corehq/apps/hqwebapp/models.py:1540
+#: corehq/apps/hqwebapp/models.py:1377 corehq/apps/hqwebapp/models.py:1406
+#: corehq/apps/hqwebapp/models.py:1528 corehq/apps/hqwebapp/models.py:1535
 msgid "System Info"
 msgstr "Infos sur le système"
 
-#: corehq/apps/hqwebapp/models.py:1391
+#: corehq/apps/hqwebapp/models.py:1386
 msgid "Mass Email Users"
 msgstr "Utilisateurs d'envoi massif par courrier électronique"
 
-#: corehq/apps/hqwebapp/models.py:1396
+#: corehq/apps/hqwebapp/models.py:1391
 msgid "Login as another user"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1407
+#: corehq/apps/hqwebapp/models.py:1402
 msgid "Message Logs Across All Domains"
 msgstr "Journaux de messages pour tous les domaines"
 
-#: corehq/apps/hqwebapp/models.py:1409
+#: corehq/apps/hqwebapp/models.py:1404
 msgid "CommCare Versions"
 msgstr "Versions CommCare"
 
-#: corehq/apps/hqwebapp/models.py:1413
+#: corehq/apps/hqwebapp/models.py:1408
 msgid "Loadtest Report"
 msgstr "Rapport Test de Charge"
 
-#: corehq/apps/hqwebapp/models.py:1416
+#: corehq/apps/hqwebapp/models.py:1411
 msgid "Administrative Operations"
 msgstr "Opérations administratives"
 
-#: corehq/apps/hqwebapp/models.py:1417
+#: corehq/apps/hqwebapp/models.py:1412
 msgid "CommCare Reports"
 msgstr "Rapports CommCare"
 
-#: corehq/apps/hqwebapp/models.py:1439
+#: corehq/apps/hqwebapp/models.py:1434
 msgid "Accounting"
 msgstr "Comptabilité"
 
-#: corehq/apps/hqwebapp/models.py:1482 corehq/apps/hqwebapp/models.py:1561
+#: corehq/apps/hqwebapp/models.py:1477 corehq/apps/hqwebapp/models.py:1556
 msgid "SMS Connectivity & Billing"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1491
+#: corehq/apps/hqwebapp/models.py:1486
 #: corehq/apps/sms/templates/sms/add_backend.html:52
 #: corehq/apps/sms/templates/sms/list_backends.html:39
 msgid "SMS Connections"
 msgstr "Connexions SMS"
 
-#: corehq/apps/hqwebapp/models.py:1499
+#: corehq/apps/hqwebapp/models.py:1494
 #: corehq/apps/sms/templates/sms/backend_map.html:5
 #: corehq/apps/sms/templates/sms/backend_map.html:64
 #: corehq/apps/sms/templates/sms/backend_map.html:72
 msgid "SMS Country-Connection Map"
 msgstr "Carte de connexion-pays SMS"
 
-#: corehq/apps/hqwebapp/models.py:1519
+#: corehq/apps/hqwebapp/models.py:1514
 msgid "Admin"
 msgstr "Admin"
 
-#: corehq/apps/hqwebapp/models.py:1541
+#: corehq/apps/hqwebapp/models.py:1536
 msgid "Management"
 msgstr "Gestion"
 
-#: corehq/apps/hqwebapp/models.py:1542
+#: corehq/apps/hqwebapp/models.py:1537
 msgid "Commands"
 msgstr "Contrôles"
 
-#: corehq/apps/hqwebapp/models.py:1556
+#: corehq/apps/hqwebapp/models.py:1551
 msgid "Old SMS Billing"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1564
+#: corehq/apps/hqwebapp/models.py:1559
 msgid "Django Admin"
 msgstr "Admin Django"
 
-#: corehq/apps/hqwebapp/models.py:1586
+#: corehq/apps/hqwebapp/models.py:1581
 msgid "Publish this project"
 msgstr "Publier ce projet"
 
-#: corehq/apps/hqwebapp/models.py:1615
+#: corehq/apps/hqwebapp/models.py:1610
 #: corehq/apps/orgs/templates/orgs/report_base.html:28
 msgid "Projects Table"
 msgstr "Tableau des projets"
 
-#: corehq/apps/hqwebapp/models.py:1618
+#: corehq/apps/hqwebapp/models.py:1613
 #: corehq/apps/orgs/templates/orgs/report_base.html:29
 #: corehq/apps/reports/standard/monitoring.py:1026
 msgid "Form Data"
 msgstr "Données de formulaire"
 
-#: corehq/apps/hqwebapp/models.py:1621
+#: corehq/apps/hqwebapp/models.py:1616
 #: corehq/apps/orgs/templates/orgs/report_base.html:30
 #: corehq/apps/reports/standard/monitoring.py:1036
 msgid "Case Data"
 msgstr "Données de dossier"
 
-#: corehq/apps/hqwebapp/models.py:1624
+#: corehq/apps/hqwebapp/models.py:1619
 #: corehq/apps/orgs/templates/orgs/report_base.html:31
 msgid "User Data"
 msgstr "Données d'utilisateur"
 
-#: corehq/apps/hqwebapp/models.py:1637
+#: corehq/apps/hqwebapp/models.py:1632
 #: corehq/apps/orgs/templates/orgs/orgs_team_members.html:84
 #: corehq/apps/orgs/templates/orgs/public.html:28
 #: corehq/apps/orgs/templates/orgs/partials/top_nav.html:6
 msgid "Projects"
 msgstr "Projets"
 
-#: corehq/apps/hqwebapp/models.py:1640
+#: corehq/apps/hqwebapp/models.py:1635
 #: corehq/apps/orgs/templates/orgs/public.html:31
 #: corehq/apps/orgs/templates/orgs/partials/top_nav.html:9
 msgid "Teams"
 msgstr "Équipes"
 
-#: corehq/apps/hqwebapp/models.py:1643
+#: corehq/apps/hqwebapp/models.py:1638
 #: corehq/apps/orgs/templates/orgs/orgs_team_members.html:50
 #: corehq/apps/orgs/templates/orgs/public.html:34
 #: corehq/apps/orgs/templates/orgs/partials/top_nav.html:12
@@ -12464,7 +12575,7 @@ msgstr "Compte utilisateur pour %s créé ! Vous pouvez vous connecter."
 msgid "View All"
 msgstr "Tout Afficher"
 
-#: corehq/apps/hqwebapp/views.py:612
+#: corehq/apps/hqwebapp/views.py:614
 msgid ""
 "Check \"Opt out of emails about new features and other CommCare updates\" in "
 "your account settings and then click \"Update Information\" if you do not "
@@ -12475,38 +12586,38 @@ msgstr ""
 "compte puis cliquez sur \"Mettre à jour les informations\" si vous désirez "
 "ne plus recevoir de messages de notre part."
 
-#: corehq/apps/hqwebapp/views.py:713
+#: corehq/apps/hqwebapp/views.py:715
 msgid "items per page"
 msgstr "éléments par page"
 
-#: corehq/apps/hqwebapp/views.py:714
+#: corehq/apps/hqwebapp/views.py:716
 msgid "You have no items."
 msgstr "Vous n'avez aucun élément."
 
-#: corehq/apps/hqwebapp/views.py:716
+#: corehq/apps/hqwebapp/views.py:718
 msgid "Deleted Items:"
 msgstr "Éléments supprimés :"
 
-#: corehq/apps/hqwebapp/views.py:717
+#: corehq/apps/hqwebapp/views.py:719
 msgid "New Items:"
 msgstr "Nouveaux éléments :"
 
-#: corehq/apps/hqwebapp/views.py:840
+#: corehq/apps/hqwebapp/views.py:842
 #, python-format
 msgid "<strong>Problem Refreshing List:</strong> %s"
 msgstr ""
 "<strong>Problème survenu lors du rafraîchissement de la liste :</strong> %s"
 
-#: corehq/apps/hqwebapp/views.py:858
+#: corehq/apps/hqwebapp/views.py:860
 #, python-format
 msgid "<strong>Problem Deleting:</strong> %s"
 msgstr "<strong>Problème survenu lors de la suppression :</strong> %s"
 
-#: corehq/apps/hqwebapp/views.py:866
+#: corehq/apps/hqwebapp/views.py:868
 msgid "The item's ID was not passed to the server."
 msgstr "L'identifiant de l'élément n'a pas été transmis au serveur."
 
-#: corehq/apps/hqwebapp/views.py:976
+#: corehq/apps/hqwebapp/views.py:978
 #, python-format
 msgid "We've redirected you to the %s matching your query"
 msgstr "Nous vous avons redirigé vers le %s correspondant à votre requête"
@@ -12837,11 +12948,11 @@ msgstr "Aucune donnée"
 msgid "No properties found."
 msgstr "Aucune propriété trouvée."
 
-#: corehq/apps/importer/base.py:5
+#: corehq/apps/importer/base.py:6
 msgid "Import Cases from Excel"
 msgstr "Importer les dossiers à partir d'Excel"
 
-#: corehq/apps/importer/base.py:7
+#: corehq/apps/importer/base.py:8
 msgid "Import case data from an external Excel file"
 msgstr "Importer les données de dossier à partir du fichier Excel externe"
 
@@ -12868,6 +12979,11 @@ msgstr ""
 #: corehq/apps/importer/const.py:13
 msgid "Case Generation Error"
 msgstr ""
+
+#: corehq/apps/importer/const.py:14
+#, fuzzy
+msgid "Duplicated Location Name"
+msgstr "Dupliquer le nom de feuille"
 
 #: corehq/apps/importer/util.py:213
 msgid ""
@@ -12903,13 +13019,20 @@ msgstr ""
 msgid "An invalid or unknown parent case was specified for the uploaded case."
 msgstr ""
 
-#: corehq/apps/importer/views.py:170
+#: corehq/apps/importer/util.py:234
+msgid ""
+"Owner ID was used in the mapping, but there were errors when uploading "
+"because of these values. There are multiple locations with this same name, "
+"try using site-code instead."
+msgstr ""
+
+#: corehq/apps/importer/views.py:169
 msgid ""
 "It looks like you may have accessed this page from a stale page. Please "
 "start over."
 msgstr ""
 
-#: corehq/apps/importer/views.py:274 corehq/apps/importer/views.py:331
+#: corehq/apps/importer/views.py:273 corehq/apps/importer/views.py:330
 msgid ""
 "The session containing the file you uploaded has expired - please upload a "
 "new one."
@@ -12917,7 +13040,7 @@ msgstr ""
 "La session comportant le fichier que vous avez uploadé est expiré. Veuillez "
 "en uploader un nouveau."
 
-#: corehq/apps/importer/views.py:349
+#: corehq/apps/importer/views.py:348
 msgid "Sorry, your session has expired. Please start over and try again."
 msgstr ""
 "Désolé, votre session est expirée. Veuillez redémarrer et essayer à nouveau."
@@ -12951,8 +13074,9 @@ msgid "Corresponding case field"
 msgstr "Champ de dossier correspondant"
 
 #: corehq/apps/importer/templates/importer/excel_config.html:90
-#: corehq/ex-submodules/casexml/apps/case/models.py:892
-#: custom/opm/beneficiary.py:823 custom/opm/beneficiary.py:899
+#: corehq/ex-submodules/casexml/apps/case/models.py:897
+#: custom/opm/beneficiary.py:822 custom/opm/beneficiary.py:899
+#: custom/opm/beneficiary.py:921
 msgid "Case ID"
 msgstr "Identifiant de dossier"
 
@@ -13003,7 +13127,8 @@ msgstr "Colonne valeur"
 
 #: corehq/apps/importer/templates/importer/excel_config.html:192
 #: corehq/apps/importer/templates/importer/excel_fields.html:189
-#: corehq/apps/userreports/reports/builder/forms.py:458
+#: corehq/apps/userreports/reports/builder/forms.py:459
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:5
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:210
 #: submodules/ctable-src/ctable_view/templates/ctable/test_mapping.html:129
 msgid "Back"
@@ -13585,11 +13710,16 @@ msgstr ""
 msgid "Move"
 msgstr "Déplacer"
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:83
+#: corehq/apps/locations/templates/locations/manage/locations.html:40
+#, python-format
+msgid "You have successfully archived the location <%%=name%%>"
+msgstr ""
+
+#: corehq/apps/locations/templates/locations/manage/locations.html:102
 msgid "Manage Locations"
 msgstr "Gérer les sites"
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:85
+#: corehq/apps/locations/templates/locations/manage/locations.html:104
 msgid ""
 "\n"
 "                    Locations allow you to represent the real-world "
@@ -13602,42 +13732,43 @@ msgid ""
 "                "
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:95
+#: corehq/apps/locations/templates/locations/manage/locations.html:114
 msgid "Showing the Inactive Location List."
 msgstr "Affichez la Liste des Sites Desactivées"
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:102
+#: corehq/apps/locations/templates/locations/manage/locations.html:121
 msgid "Show Archived Locations"
 msgstr "Afficher les sites archivés"
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:106
+#: corehq/apps/locations/templates/locations/manage/locations.html:125
 msgid "Show Active Locations"
 msgstr "Afficher les Sites Actifs"
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:119
-#: corehq/apps/locations/templates/locations/manage/locations.html:123
+#: corehq/apps/locations/templates/locations/manage/locations.html:138
+#: corehq/apps/locations/templates/locations/manage/locations.html:142
 msgid "Bulk Import Locations"
 msgstr "Importer les sites en bloc"
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:127
+#: corehq/apps/locations/templates/locations/manage/locations.html:146
 msgid "Edit Location Types"
 msgstr "Modifier les types de site"
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:130
+#: corehq/apps/locations/templates/locations/manage/locations.html:149
 msgid "Edit Location Fields"
 msgstr "Modifier les Champs de Site"
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:155
+#: corehq/apps/locations/templates/locations/manage/locations.html:174
 msgid "Unarchive"
 msgstr "Desarchivez"
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:160
+#: corehq/apps/locations/templates/locations/manage/locations.html:179
+#: corehq/apps/locations/templates/locations/manage/locations.html:267
 #: corehq/apps/products/views.py:186
 #: corehq/apps/products/templates/products/manage/products.html:116
 msgid "Archive"
 msgstr "Archive"
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:216
+#: corehq/apps/locations/templates/locations/manage/locations.html:235
 #, python-format
 msgid ""
 "\n"
@@ -13645,6 +13776,23 @@ msgid ""
 "    <a href=\"%(location_types_url)s\">here</a>\n"
 "    for your project before creating any locations.\n"
 "    "
+msgstr ""
+
+#: corehq/apps/locations/templates/locations/manage/locations.html:253
+#, fuzzy
+msgid "Archive Location:"
+msgstr "Afficher les sites archivés"
+
+#: corehq/apps/locations/templates/locations/manage/locations.html:257
+msgid ""
+"\n"
+"            <strong>Warning!</strong> Archiving a location will unassign any "
+"users\n"
+"            which were associated with that location.  You can unarchive "
+"this\n"
+"            location at any point, but you will have to reassign the users\n"
+"            manually.\n"
+"            "
 msgstr ""
 
 #: corehq/apps/locations/templates/locations/manage/partials/autocomplete_select_widget.html:10
@@ -13853,31 +14001,31 @@ msgstr "Chargement du graphique cumulatif à données empilées"
 msgid "Prime Restore Cache"
 msgstr ""
 
-#: corehq/apps/prelogin/forms.py:32 corehq/apps/registration/forms.py:52
+#: corehq/apps/prelogin/forms.py:33 corehq/apps/registration/forms.py:52
 msgid "Email Address"
 msgstr "Adresse électronique"
 
-#: corehq/apps/prelogin/forms.py:45
+#: corehq/apps/prelogin/forms.py:46
 msgid "What is your interest in CommCare and any specific questions you have?"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:57
+#: corehq/apps/prelogin/templates/prelogin/base.html:60
 msgid "Toggle Navigation"
 msgstr "Bascule la navigation"
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:78
+#: corehq/apps/prelogin/templates/prelogin/base.html:81
 msgid "Solutions"
 msgstr "Solutions"
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:79
+#: corehq/apps/prelogin/templates/prelogin/base.html:82
 msgid "Impact"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:80
+#: corehq/apps/prelogin/templates/prelogin/base.html:83
 msgid "Software Pricing"
 msgstr "Tarif de logiciel"
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:108
+#: corehq/apps/prelogin/templates/prelogin/base.html:111
 #, python-format
 msgid ""
 "\n"
@@ -13888,11 +14036,15 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:145
+#: corehq/apps/prelogin/templates/prelogin/base.html:131
+msgid "Get in Touch With Us: Contact Dimagi"
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/base.html:148
 msgid "Thanks for contacting us!"
 msgstr "Merci de nous contacter."
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:150
+#: corehq/apps/prelogin/templates/prelogin/base.html:153
 msgid ""
 "\n"
 "                            Thank you for your interest in working with "
@@ -13902,7 +14054,7 @@ msgstr ""
 "\n"
 "Merci pour votre intérêt à travailler avec Dimagi."
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:155
+#: corehq/apps/prelogin/templates/prelogin/base.html:158
 msgid ""
 "\n"
 "                            One of our team members will get back to you "
@@ -13915,18 +14067,18 @@ msgstr ""
 "Un membre de notre équipe va revenir vers vous bientôt\n"
 "avec des réponses à vos questions ou plus de discussions."
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:163
-#: corehq/apps/prelogin/templates/prelogin/base.html:202
+#: corehq/apps/prelogin/templates/prelogin/base.html:166
+#: corehq/apps/prelogin/templates/prelogin/base.html:205
 #: custom/_legacy/a5288/reports.py:102
 msgid "OK"
 msgstr "OK"
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:176
-#: corehq/apps/prelogin/templates/prelogin/base.html:215
+#: corehq/apps/prelogin/templates/prelogin/base.html:179
+#: corehq/apps/prelogin/templates/prelogin/base.html:218
 msgid "Ooops!"
 msgstr "Oups!"
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:181
+#: corehq/apps/prelogin/templates/prelogin/base.html:184
 msgid ""
 "\n"
 "                             We're terribly sorry! It seems like our servers "
@@ -13937,7 +14089,7 @@ msgstr ""
 "Nous sommes désolés. Il paraît que nos serveurs ont des problèmes "
 "aujourd'hui."
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:186
+#: corehq/apps/prelogin/templates/prelogin/base.html:189
 msgid ""
 "\n"
 "                                We've alerted one of our engineers of issues "
@@ -13948,7 +14100,7 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:193
+#: corehq/apps/prelogin/templates/prelogin/base.html:196
 msgid ""
 "\n"
 "                                You can send an email directly to\n"
@@ -13958,7 +14110,7 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:226
+#: corehq/apps/prelogin/templates/prelogin/base.html:229
 msgid ""
 "\n"
 "                                Please provide a valid e-mail address where "
@@ -14019,6 +14171,10 @@ msgid ""
 "contact\n"
 "                        Dimagi directly.\n"
 "                    "
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/home/about_dimagi.html:42
+msgid "Get in Touch With Us"
 msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/home/about_dimagi.html:50
@@ -14254,7 +14410,7 @@ msgstr ""
 #: corehq/apps/style/templates/style/includes/modal_report_issue.html:49
 #: corehq/apps/styleguide/examples/simple_crispy_form/forms.py:17
 #: custom/_legacy/pact/templates/pact/chw/pact_chw_profile_info.html:16
-#: custom/ilsgateway/tanzania/reports/facility_details.py:73
+#: custom/ilsgateway/tanzania/reports/facility_details.py:74
 msgid "Email"
 msgstr "Courrier électronique"
 
@@ -14443,32 +14599,35 @@ msgstr ""
 #: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:12
 msgid ""
 "\n"
-"                        Read how organizations around the world use\n"
-"                        CommCare to improve frontline service delivery.\n"
+"                    <!--HubSpot Call-to-Action Code -->\n"
+"                    <span class=\"hs-cta-wrapper\" id=\"hs-cta-"
+"wrapper-071f4a7d-237d-49d8-b12d-c28fe204927d\">\n"
+"                        <span class=\"hs-cta-node hs-cta-071f4a7d-237d-49d8-"
+"b12d-c28fe204927d\" id=\"hs-cta-071f4a7d-237d-49d8-b12d-c28fe204927d\">\n"
+"                            <!--[if lte IE 8]><div id=\"hs-cta-ie-element"
+"\"></div><![endif]-->\n"
+"                            <a href=\"http://cta-redirect.hubspot.com/cta/"
+"redirect/503070/071f4a7d-237d-49d8-b12d-c28fe204927d\" ><img class=\"hs-cta-"
+"img\" id=\"hs-cta-img-071f4a7d-237d-49d8-b12d-c28fe204927d\" style=\"border-"
+"width:0px;\" src=\"https://no-cache.hubspot.com/cta/"
+"default/503070/071f4a7d-237d-49d8-b12d-c28fe204927d.png\"  alt=\"View All "
+"Case Studies\"/></a>\n"
+"                        </span>\n"
+"                        <script type=\"text/javascript\">\n"
+"                            hbspt.cta.load(503070, '071f4a7d-237d-49d8-b12d-"
+"c28fe204927d');\n"
+"                        </script>\n"
+"                    </span>\n"
+"                    <!-- end HubSpot Call-to-Action Code -->\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:24
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:39
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:54
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:69
-msgid "Read Case Study"
-msgstr ""
-
 #: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:27
-msgid "Improving Community Health in Guatemala"
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:42
-msgid "An Integrated eDiagnostic Approach in Burkina Faso"
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:57
-msgid "Improving Maternal and Child Health in India"
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:72
-msgid "iCCM for Child Health in Mozambique"
+msgid ""
+"\n"
+"                        Read how organizations around the world use\n"
+"                        CommCare to improve frontline service delivery.\n"
+"                    "
 msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/impact/lead.html:9
@@ -14518,6 +14677,33 @@ msgstr ""
 #: corehq/apps/prelogin/templates/prelogin/_sections/impact/partners.html:12
 msgid ""
 "\n"
+"                    <!--HubSpot Call-to-Action Code -->\n"
+"                    <span class=\"hs-cta-wrapper\" id=\"hs-cta-wrapper-"
+"c34ae48e-2f1a-48ac-9170-31fc7c9e845b\">\n"
+"                        <span class=\"hs-cta-node hs-cta-"
+"c34ae48e-2f1a-48ac-9170-31fc7c9e845b\" id=\"hs-cta-"
+"c34ae48e-2f1a-48ac-9170-31fc7c9e845b\">\n"
+"                            <!--[if lte IE 8]><div id=\"hs-cta-ie-element"
+"\"></div><![endif]-->\n"
+"                            <a href=\"http://cta-redirect.hubspot.com/cta/"
+"redirect/503070/c34ae48e-2f1a-48ac-9170-31fc7c9e845b\"  target=\"_blank\" "
+"><img class=\"hs-cta-img\" id=\"hs-cta-img-"
+"c34ae48e-2f1a-48ac-9170-31fc7c9e845b\" style=\"border-width:0px;\" src="
+"\"https://no-cache.hubspot.com/cta/default/503070/"
+"c34ae48e-2f1a-48ac-9170-31fc7c9e845b.png\"  alt=\"See All Partners\"/></a>\n"
+"                        </span>\n"
+"                        <script type=\"text/javascript\">\n"
+"                            hbspt.cta.load(503070, "
+"'c34ae48e-2f1a-48ac-9170-31fc7c9e845b');\n"
+"                        </script>\n"
+"                    </span>\n"
+"                    <!-- end HubSpot Call-to-Action Code -->\n"
+"                    "
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/partners.html:27
+msgid ""
+"\n"
 "                        The following organizations have contributed\n"
 "                        to the development of CommCare.\n"
 "                    "
@@ -14537,16 +14723,41 @@ msgstr ""
 #: corehq/apps/prelogin/templates/prelogin/_sections/impact/publications.html:12
 msgid ""
 "\n"
-"                        Over 30+ peer-reviewed publications have been "
-"written\n"
-"                        about CommCare. For an overview of all CommCare\n"
-"                        publications, please see the\n"
-"                        <a href=\"https://help.commcarehq.org/display/"
-"commcarepublic/CommCare+Evidence+Base\"\n"
-"                           class=\"btn-primary-dark\">CommCare Evidence "
-"Base</a>.\n"
+"                    <!--HubSpot Call-to-Action Code -->\n"
+"                    <span class=\"hs-cta-wrapper\" id=\"hs-cta-"
+"wrapper-23da92fd-b671-481f-9aee-bbc8a94b1f8b\">\n"
+"                        <span class=\"hs-cta-node hs-cta-23da92fd-"
+"b671-481f-9aee-bbc8a94b1f8b\" id=\"hs-cta-23da92fd-b671-481f-9aee-"
+"bbc8a94b1f8b\">\n"
+"                            <!--[if lte IE 8]><div id=\"hs-cta-ie-element"
+"\"></div><![endif]-->\n"
+"                            <a href=\"http://cta-redirect.hubspot.com/cta/"
+"redirect/503070/23da92fd-b671-481f-9aee-bbc8a94b1f8b\"  target=\"_blank\" "
+"><img class=\"hs-cta-img\" id=\"hs-cta-img-23da92fd-b671-481f-9aee-"
+"bbc8a94b1f8b\" style=\"border-width:0px;\" src=\"https://no-cache.hubspot."
+"com/cta/default/503070/23da92fd-b671-481f-9aee-bbc8a94b1f8b.png\"  alt="
+"\"View Research\"/></a>\n"
+"                        </span>\n"
+"                        <script type=\"text/javascript\">\n"
+"                            hbspt.cta.load(503070, '23da92fd-b671-481f-9aee-"
+"bbc8a94b1f8b');\n"
+"                        </script>\n"
+"                    </span>\n"
+"                    <!-- end HubSpot Call-to-Action Code -->\n"
 "                    "
 msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/publications.html:27
+#, fuzzy
+msgid ""
+"\n"
+"                        Over 30+ peer-reviewed publications have been "
+"written\n"
+"                        about CommCare.\n"
+"                    "
+msgstr ""
+"\n"
+"Les organisations suivantes ont contribué au développement de CommCare."
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:7
 msgid ""
@@ -14555,63 +14766,90 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:27
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:12
+msgid ""
+"\n"
+"                    <!--HubSpot Call-to-Action Code -->\n"
+"                    <span class=\"hs-cta-wrapper\" id=\"hs-cta-wrapper-"
+"c21c3aed-90ee-4106-98d0-dbe846e8ca28\">\n"
+"                        <span class=\"hs-cta-node hs-cta-"
+"c21c3aed-90ee-4106-98d0-dbe846e8ca28\" id=\"hs-cta-c21c3aed-90ee-4106-98d0-"
+"dbe846e8ca28\">\n"
+"                            <!--[if lte IE 8]><div id=\"hs-cta-ie-element"
+"\"></div><![endif]-->\n"
+"                            <a href=\"http://cta-redirect.hubspot.com/cta/"
+"redirect/503070/c21c3aed-90ee-4106-98d0-dbe846e8ca28\"  target=\"_blank\" "
+"><img class=\"hs-cta-img\" id=\"hs-cta-img-c21c3aed-90ee-4106-98d0-"
+"dbe846e8ca28\" style=\"border-width:0px;\" src=\"https://no-cache.hubspot."
+"com/cta/default/503070/c21c3aed-90ee-4106-98d0-dbe846e8ca28.png\"  alt="
+"\"Learn More About Our Sectors\"/></a>\n"
+"                        </span>\n"
+"                        <script type=\"text/javascript\">\n"
+"                            hbspt.cta.load(503070, 'c21c3aed-90ee-4106-98d0-"
+"dbe846e8ca28');\n"
+"                        </script>\n"
+"                    </span>\n"
+"                    <!-- end HubSpot Call-to-Action Code -->\n"
+"                    "
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:35
 msgid "Child Health"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:33
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:41
 msgid "HIV/AIDS"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:52
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:60
 msgid "Health"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:73
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:81
 msgid "Malaria"
 msgstr "Paludisme"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:80
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:88
 msgid "Nutrition"
 msgstr "Nutrition"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:91
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:99
 msgid "Cooperatives"
 msgstr "Coopératives"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:98
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:106
 msgid "Finances"
 msgstr "Finances"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:117
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:125
 msgid "Agriculture"
 msgstr "Agriculture"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:138
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:146
 msgid "Extension Programs"
 msgstr "Programmes d'extension"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:145
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:153
 msgid "Logistics"
 msgstr "Logistiques"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:156
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:164
 msgid "Emergency Response"
 msgstr "Réponse d'urgence"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:163
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:171
 msgid "Small Business"
 msgstr "Petite entreprise"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:182
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:190
 msgid "Development"
 msgstr "Développement"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:203
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:211
 msgid "Education"
 msgstr "Education"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:210
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:218
 msgid "Logistics & Supply Chain"
 msgstr ""
 
@@ -14688,15 +14926,17 @@ msgstr ""
 "Questions?"
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/last.html:13
+#, fuzzy
 msgid ""
 "\n"
 "                        <a href=\"#contactDimagi\"\n"
 "                           data-toggle=\"modal\"\n"
-"                           class=\"btn-primary-dark\">Contact Dimagi</a> or "
-"read our<br />\n"
-"                        pricing <a href=\"https://confluence.dimagi.com/"
-"display/commcarepublic/CommCare+Pricing+FAQs\" class=\"btn-primary-dark"
-"\">FAQs</a>.\n"
+"                           class=\"btn-success btn btn-xl\">Get in Touch "
+"With Us</a>\n"
+"                        <a href=\"https://confluence.dimagi.com/display/"
+"commcarepublic/CommCare+Pricing+FAQs\"\n"
+"                           class=\"btn btn-primary-dark btn-xl\">Read our "
+"Pricing FAQs</a>\n"
 "                    "
 msgstr ""
 "\n"
@@ -14710,21 +14950,23 @@ msgstr ""
 msgid "CommCare Software Plans"
 msgstr "Plans logiciel de CommCare"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:11
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:16
+#, fuzzy
 msgid ""
 "\n"
-"                            Core Features are always FREE. Choose a plan\n"
-"                            to help your project scale.\n"
-"                        "
+"                        Core Features are always FREE. Choose a plan\n"
+"                        to help your project scale.\n"
+"                    "
 msgstr ""
+"\n"
+"L'editeur de formulaire de CommCare est désigné pour tout le monde.\n"
+"Experience en IT n'est pas requise."
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:18
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:22
 msgid ""
 "\n"
-"                    <strong>Anyone can use CommCare for FREE up to 50 mobile "
-"workers.</strong><br />\n"
 "                    For additional questions, please see our\n"
-"                    <a class=\"btn-primary-dark\"\n"
+"                    <a class=\"lead-link\"\n"
 "                       href=\"https://confluence.dimagi.com/display/"
 "commcarepublic/CommCare+Pricing+FAQs?__hstc=187943799."
 "ba674a1a3cdef13c5d09b2a54d65c2b8.1431286503613.1435340206977.1435342587932.124&__hssc=187943799.6.1435342587932&__hsfp=312587752\">FAQs</"
@@ -14732,16 +14974,31 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:92
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:31
+#, fuzzy
+msgid ""
+"\n"
+"                        Want to try CommCare for FREE?\n"
+"                    "
+msgstr ""
+"\n"
+"Partenaires de CommCare"
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:34
+#, fuzzy
+msgid "Sign up for a FREE account"
+msgstr "S'inscrire à un nouveau compte"
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:103
 msgid "Contact Us"
 msgstr "Contactez nous"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:122
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:152
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:133
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:163
 msgid "Unlimited / Discounted"
 msgstr "Illimité / Prix Réduits"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:128
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:139
 msgid "Price Per Additional Mobile User"
 msgstr "La prix pour chaque utilisateur supplémentaire"
 
@@ -14980,71 +15237,83 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:39
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:33
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:28
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:15
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:662
+#, fuzzy
+msgid ""
+"\n"
+"                        Inquire About Dimagi's Implementation Bundles\n"
+"                        "
+msgstr ""
+"\n"
+"Questions?"
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:48
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:35
 msgid "Scope"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:42
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:36
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:51
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:38
 msgid "Launch"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:45
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:39
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:54
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:41
 msgid "Boost"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:48
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:42
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:57
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:44
 msgid "Growth"
 msgstr "Expansion"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:51
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:45
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:60
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:47
 msgid "Scale"
 msgstr "Echelle"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:56
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:53
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:65
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:55
 msgid "$10,000"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:59
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:56
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:68
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:58
 msgid "$35,000"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:62
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:59
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:71
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:61
 msgid "$50,000"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:65
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:62
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:74
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:64
 msgid "$80,000"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:68
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:65
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:77
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:67
 msgid "$150,000"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:92
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:100
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:108
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:89
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:97
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:105
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:101
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:109
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:117
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:91
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:99
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:107
 msgid "12 months"
 msgstr "12 mois"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:116
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:113
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:125
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:115
 msgid "18 months"
 msgstr "18 mois"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:123
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:132
 msgid ""
 "\n"
 "                                Application Development &amp; Implementation "
@@ -15052,19 +15321,19 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:130
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:139
 msgid "Workflow Design"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:131
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:140
 msgid "On-Site Scoping Visit"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:132
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:141
 msgid "Mobile System Workflow Design"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:138
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:147
 msgid ""
 "\n"
 "                                    Everything in<br />\n"
@@ -15072,19 +15341,19 @@ msgid ""
 "                                "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:143
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:152
 msgid "Build &amp; Launch Application"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:144
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:153
 msgid "Field Testing &amp; Iteration"
 msgstr "Test sur terrain &amp; Itération"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:145
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:154
 msgid "Users Training"
 msgstr "Formation d'utilisateurs"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:151
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:160
 msgid ""
 "\n"
 "                                    Everything in<br />\n"
@@ -15092,16 +15361,16 @@ msgid ""
 "                                "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:156
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:62
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:165
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:69
 msgid "Technology for Outcomes Monitoring"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:157
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:166
 msgid "Capacity Building for Worker Performance Monitoring"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:163
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:172
 msgid ""
 "\n"
 "                                    Everything in<br />\n"
@@ -15109,19 +15378,19 @@ msgid ""
 "                                "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:168
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:177
 msgid "Refined Application"
 msgstr "Application raffinée"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:169
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:178
 msgid "Additional Supervisor App"
 msgstr "Application de superviseur supplémentaire"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:170
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:179
 msgid "Application Troubleshooting Capacity Building"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:176
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:185
 msgid ""
 "\n"
 "                                    Everything in<br />\n"
@@ -15129,38 +15398,30 @@ msgid ""
 "                                "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:181
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:190
 msgid "Monitored Application Usage"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:182
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:191
 msgid "Additional Tech for Reminder Messages"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:183
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:40
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:192
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:47
 msgid "Training of Trainers"
 msgstr "Formation de formateurs"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:184
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:42
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:193
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:49
 msgid "Capacity to Build Applications"
 msgstr "Capacité de créer d'applications"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:190
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:194
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:45
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:68
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:199
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:203
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:52
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:75
 msgid "See More..."
 msgstr "Voir plus"
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:205
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:659
-msgid ""
-"\n"
-"                    Inquire About Dimagi's Implementation Bundles\n"
-"                    "
-msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:7
 msgid "Capacity Services"
@@ -15186,7 +15447,11 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:31
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:27
+msgid "Inquire About Dimagi's Capacity Services"
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:38
 #: corehq/apps/products/forms.py:28
 #: corehq/apps/products/templates/products/manage/products.html:112
 #: corehq/apps/programs/templates/programs/manage/programs.html:62
@@ -15194,8 +15459,8 @@ msgstr ""
 msgid "Program"
 msgstr "Programme"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:34
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:57
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:41
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:64
 msgid ""
 "\n"
 "                            $10,000 per capacity service\n"
@@ -15204,32 +15469,28 @@ msgstr ""
 "\n"
 "$10,000 par service de capacité"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:39
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:46
 msgid "Worker Performance Monitoring"
 msgstr "Surveillance de performance d'utilisateurs"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:41
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:48
 msgid "Capacity for Technical Support"
 msgstr "Capacité pour le support technique"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:54
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:61
 msgid "Technology"
 msgstr "Technologie"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:63
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:70
 msgid "Apps for Supportive Supervision"
 msgstr "Application pour la supervision qui soutient"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:64
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:71
 msgid "App Refinement by Dimagi"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:65
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:72
 msgid "Technology for Reminder Messages"
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:81
-msgid "Inquire About Dimagi's Capacity Services"
 msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/services/faq.html:8
@@ -15242,14 +15503,21 @@ msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/services/faq.html:13
 #: corehq/apps/prelogin/templates/prelogin/_sections/services_details/faq.html:13
+#, fuzzy
 msgid ""
 "\n"
 "                        <a href=\"#contactDimagi\"\n"
 "                           data-toggle=\"modal\"\n"
-"                           class=\"btn-primary-dark\">Contact Dimagi</a> for "
-"more information.\n"
+"                           class=\"btn btn-success btn-xl\">Get in Touch "
+"With Us</a>\n"
 "                    "
 msgstr ""
+"\n"
+"<a href=\"#contactDimagi\"\n"
+"data-toggle=\"modal\"\n"
+"class=\"btn-primary-dark\">Contacter Dimagi</a>ou lire nos<br />\n"
+"tarifs <a href=\"https://confluence.dimagi.com/display/commcarepublic/"
+"CommCare+Pricing+FAQs\" class=\"btn-primary-dark\">FAQs</a>."
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/services/lead.html:8
 msgid ""
@@ -15332,110 +15600,100 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:12
-msgid ""
-"\n"
-"                        If you have any additional questions, please\n"
-"                        <a href=\"#contactDimagi\"\n"
-"                           data-toggle=\"modal\">contact Dimagi</a> "
-"directly.\n"
-"                    "
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:50
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:52
 msgid "Cost"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:71
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:73
 msgid "Included Software Plan"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:119
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:121
 msgid "Application Development Support"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:125
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:127
 msgid ""
 "\n"
 "                                Workflow Design\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:160
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:162
 msgid ""
 "\n"
 "                                Launch &amp; Tested Application\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:195
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:197
 msgid ""
 "\n"
 "                                Additional Tech for Monitoring Outcomes\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:230
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:232
 msgid ""
 "\n"
 "                                Launched v2 application\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:265
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:267
 msgid ""
 "\n"
 "                                Supervisor Application\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:300
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:302
 msgid ""
 "\n"
 "                                Monitored app usage\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:335
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:337
 msgid ""
 "\n"
 "                                Additional Tech for Reminder Messages\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:369
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:371
 msgid "Implementation Services"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:375
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:377
 msgid ""
 "\n"
 "                                On-Site Scoping Visit\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:410
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:412
 msgid ""
 "\n"
 "                                Mobile System Workflow Design\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:445
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:447
 msgid ""
 "\n"
 "                                Field Testing &amp; Iteration\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:480
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:482
 msgid ""
 "\n"
 "                                Pilot Users Training\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:515
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:517
 msgid ""
 "\n"
 "                                Capacity Service: Worker Performance "
@@ -15443,7 +15701,7 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:550
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:552
 msgid ""
 "\n"
 "                                Capacity Service: Application "
@@ -15451,14 +15709,14 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:585
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:587
 msgid ""
 "\n"
 "                                Capacity Service: Training of Trainers\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:620
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:622
 msgid ""
 "\n"
 "                                Capacity Service: App Building\n"
@@ -15472,24 +15730,25 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:12
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:15
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:210
+#, fuzzy
 msgid ""
 "\n"
-"                        If you have any additional questions, please\n"
-"                        <a href=\"#contactDimagi\"\n"
-"                           data-toggle=\"modal\">contact Dimagi</a>\n"
-"                        directly.\n"
-"                    "
+"                        Inquire About Dimagi's Capacity Services\n"
+"                        "
 msgstr ""
+"\n"
+"$10,000 par service de capacité"
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:24
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:25
 msgid ""
 "\n"
 "                        Program Capacity Services\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:29
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:30
 msgid ""
 "\n"
 "                        Dimagi travels on-site to build capacity, spending "
@@ -15498,22 +15757,22 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:35
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:125
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:37
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:128
 msgid ""
 "\n"
 "                        $10,000 per capacity service package.\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:44
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:46
 msgid ""
 "\n"
 "                        Worker Performance Monitoring\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:51
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:53
 msgid ""
 "\n"
 "                    Strategic implementation of standard CommCare HQ "
@@ -15522,14 +15781,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:61
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:63
 msgid ""
 "\n"
 "                        Training of Trainers\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:68
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:70
 msgid ""
 "\n"
 "                        Capacity building for organization’s trainers for "
@@ -15540,14 +15799,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:79
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:81
 msgid ""
 "\n"
 "                        Capacity for Technical Support\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:86
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:88
 msgid ""
 "\n"
 "                        Train technical staff about troubleshooting and "
@@ -15556,14 +15815,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:96
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:98
 msgid ""
 "\n"
 "                        Capacity to Build Applications\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:103
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:105
 msgid ""
 "\n"
 "                        Learn how to build your own applications,\n"
@@ -15572,14 +15831,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:114
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:116
 msgid ""
 "\n"
 "                        Technology Capacity Services\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:119
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:121
 msgid ""
 "\n"
 "                        Dimagi provides additional system refinement or new\n"
@@ -15587,14 +15846,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:134
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:137
 msgid ""
 "\n"
 "                        Technology for Outcomes Monitoring\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:141
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:144
 msgid ""
 "\n"
 "                        Create customized, offline Excel reports for 5-10\n"
@@ -15604,14 +15863,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:152
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:155
 msgid ""
 "\n"
 "                        Apps for Supportive Supervision\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:159
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:162
 msgid ""
 "\n"
 "                        Integrate a mobile application designed for field "
@@ -15622,14 +15881,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:170
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:173
 msgid ""
 "\n"
 "                        App Refinement by Dimagi\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:177
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:180
 msgid ""
 "\n"
 "                        Dimagi to make modifications to application based "
@@ -15638,14 +15897,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:187
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:190
 msgid ""
 "\n"
 "                        Technology for Reminder Messages\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:194
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:197
 msgid ""
 "\n"
 "                        Send SMS reminders directly to beneficiaries or\n"
@@ -15669,15 +15928,21 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/solutions/last.html:13
+#, fuzzy
 msgid ""
 "\n"
-"                        Contact us at\n"
-"                        <a class=\"btn-primary-dark\"\n"
-"                           href=\"mailto:commcare.supply@dimagi.com\">\n"
-"                            commcare.supply@dimagi.com\n"
-"                        </a>.\n"
+"                        <a href=\"#contactDimagi\"\n"
+"                           data-toggle=\"modal\"\n"
+"                           class=\"btn-success btn btn-xl\">Get in Touch "
+"With Us</a>\n"
 "                    "
 msgstr ""
+"\n"
+"<a href=\"#contactDimagi\"\n"
+"data-toggle=\"modal\"\n"
+"class=\"btn-primary-dark\">Contacter Dimagi</a>ou lire nos<br />\n"
+"tarifs <a href=\"https://confluence.dimagi.com/display/commcarepublic/"
+"CommCare+Pricing+FAQs\" class=\"btn-primary-dark\">FAQs</a>."
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/solutions/lead.html:12
 msgid ""
@@ -15870,6 +16135,16 @@ msgid ""
 "                    in Malawi.\n"
 "                    "
 msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/solutions/supply_intro.html:45
+#, fuzzy
+msgid ""
+"\n"
+"                    Have questions or want to request a demo?\n"
+"                    "
+msgstr ""
+"\n"
+"Questions?"
 
 #: corehq/apps/products/bulk.py:26
 #, python-brace-format
@@ -17437,7 +17712,7 @@ msgstr ""
 
 #: corehq/apps/reminders/templates/reminders/partial/complex_message_table.html:30
 #: corehq/apps/reminders/templates/reminders/partial/complex_message_table.html:32
-#: custom/opm/beneficiary.py:814
+#: custom/opm/beneficiary.py:813 custom/opm/beneficiary.py:946
 msgid "Window"
 msgstr "Fenêtre"
 
@@ -17524,27 +17799,27 @@ msgstr "Données brutes"
 msgid "CommTrack"
 msgstr "CommTrack"
 
-#: corehq/apps/reports/models.py:49
+#: corehq/apps/reports/models.py:51
 msgid "demo_user"
 msgstr "demo_user"
 
-#: corehq/apps/reports/models.py:50
+#: corehq/apps/reports/models.py:52
 msgid "admin"
 msgstr "admin"
 
-#: corehq/apps/reports/models.py:51
+#: corehq/apps/reports/models.py:53
 msgid "Unknown Users"
 msgstr "Utilisateurs inconnus"
 
-#: corehq/apps/reports/models.py:381
+#: corehq/apps/reports/models.py:373
 msgid "Deleted Report"
 msgstr "Rapport supprimé"
 
-#: corehq/apps/reports/models.py:385
+#: corehq/apps/reports/models.py:377
 msgid "Unsupported Report"
 msgstr "Rapport non pris en charge"
 
-#: corehq/apps/reports/models.py:423
+#: corehq/apps/reports/models.py:415
 msgid ""
 "The report used to create this scheduled report is no longer available on "
 "CommCare HQ.  Please delete this scheduled report and create a new one using "
@@ -17554,7 +17829,7 @@ msgstr ""
 "CommCare HQ.  Veuillez supprimer ce rapport planifié et en créer un nouveau "
 "à l'aide d'un rapport disponible."
 
-#: corehq/apps/reports/models.py:485
+#: corehq/apps/reports/models.py:477
 #, python-format
 msgid ""
 "We are sorry, but your saved report '%(config_name)s' is no longer "
@@ -17564,7 +17839,7 @@ msgid ""
 "%(saved_reports_url)s to remove this Emailed Report."
 msgstr ""
 
-#: corehq/apps/reports/models.py:498
+#: corehq/apps/reports/models.py:490
 #, python-format
 msgid ""
 "We are sorry, but your saved report '%(config_name)s' can not be generated "
@@ -17572,20 +17847,20 @@ msgid ""
 "Administrator about getting permissions for thisreport."
 msgstr ""
 
-#: corehq/apps/reports/models.py:509
+#: corehq/apps/reports/models.py:501
 msgid "An error occurred while generating this report."
 msgstr "Une erreur est survenue lors de l'émission de ce rapport."
 
-#: corehq/apps/reports/models.py:654
+#: corehq/apps/reports/models.py:649
 msgid "Every day"
 msgstr "À tous les jours"
 
-#: corehq/apps/reports/models.py:655
+#: corehq/apps/reports/models.py:650
 #, python-format
 msgid "Day %s of every month"
 msgstr "Jour %s de chaque mois"
 
-#: corehq/apps/reports/models.py:699
+#: corehq/apps/reports/models.py:694
 #, fuzzy
 msgid "Scheduled report from CommCare HQ"
 msgstr "Envoyer le rapport par courrier électronique à partir de CommCare HQ"
@@ -17604,54 +17879,54 @@ msgstr "Rapport envoyé par courrier électronique"
 msgid "Email report from CommCare HQ"
 msgstr "Envoyer le rapport par courrier électronique à partir de CommCare HQ"
 
-#: corehq/apps/reports/views.py:798
+#: corehq/apps/reports/views.py:806
 msgid "Create a new"
 msgstr ""
 
-#: corehq/apps/reports/views.py:799
+#: corehq/apps/reports/views.py:807
 msgid "New Scheduled Report"
 msgstr ""
 
-#: corehq/apps/reports/views.py:802
+#: corehq/apps/reports/views.py:810
 msgid "Edit Scheduled Report"
 msgstr ""
 
-#: corehq/apps/reports/views.py:910
+#: corehq/apps/reports/views.py:918
 msgid "once off report"
 msgstr ""
 
-#: corehq/apps/reports/views.py:910
+#: corehq/apps/reports/views.py:918
 msgid "scheduled report"
 msgstr ""
 
-#: corehq/apps/reports/views.py:934
+#: corehq/apps/reports/views.py:942
 msgid ""
 "The case creation form could not be found. Usually this happens if the form "
 "that created the case is archived but there are other forms that updated the "
 "case. To fix this you can archive the other forms listed here."
 msgstr ""
 
-#: corehq/apps/reports/views.py:979
+#: corehq/apps/reports/views.py:987
 msgid "unknown"
 msgstr "inconnu"
 
-#: corehq/apps/reports/views.py:992
+#: corehq/apps/reports/views.py:1000
 msgid "You don't have permission to access this page."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1014
+#: corehq/apps/reports/views.py:1022
 #, python-format
 msgid "Case %s was rebuilt from its forms."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1026
+#: corehq/apps/reports/views.py:1034
 #, python-format
 msgid ""
 "Case %s was successfully saved. Hopefully it will show up in all reports "
 "momentarily."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1040
+#: corehq/apps/reports/views.py:1048
 #, python-brace-format
 msgid ""
 "Case {name} has been closed.\n"
@@ -17666,91 +17941,91 @@ msgid ""
 "        "
 msgstr ""
 
-#: corehq/apps/reports/views.py:1080
+#: corehq/apps/reports/views.py:1088
 msgid "case id"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1081
+#: corehq/apps/reports/views.py:1089
 msgid "case name"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1082
+#: corehq/apps/reports/views.py:1090
 msgid "section"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1083
+#: corehq/apps/reports/views.py:1091
 msgid "date"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1084
+#: corehq/apps/reports/views.py:1092
 msgid "product_id"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1085
+#: corehq/apps/reports/views.py:1093
 msgid "product_name"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1086
+#: corehq/apps/reports/views.py:1094
 msgid "transaction amount"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1087
+#: corehq/apps/reports/views.py:1095
 msgid "type"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1088
+#: corehq/apps/reports/views.py:1096
 msgid "ending balance"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1098
+#: corehq/apps/reports/views.py:1106
 msgid "unknown product"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1301
+#: corehq/apps/reports/views.py:1309
 msgid "Could not detect the application/form for this submission."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1315
+#: corehq/apps/reports/views.py:1323
 msgid "Missing app, module or form information!"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1345
+#: corehq/apps/reports/views.py:1353
 #: corehq/apps/reports/templates/reports/form/edit_submission.html:26
 msgid "Edit Submission"
 msgstr "Modifier soumission"
 
-#: corehq/apps/reports/views.py:1376
+#: corehq/apps/reports/views.py:1384
 msgid "Form was successfully archived."
 msgstr "Le formulaire a été archivé avec succès."
 
-#: corehq/apps/reports/views.py:1378
+#: corehq/apps/reports/views.py:1386
 msgid "Form was already archived."
 msgstr "Le formulaire a déjà été archivé."
 
-#: corehq/apps/reports/views.py:1380
+#: corehq/apps/reports/views.py:1388
 #, python-format
 msgid "Can't archive documents of type %s. How did you get here??"
 msgstr ""
 "Impossible d'archiver les documents de type %s. Comment êtes-vous arrivé "
 "ici ?"
 
-#: corehq/apps/reports/views.py:1384
+#: corehq/apps/reports/views.py:1392
 msgid "Undo"
 msgstr "Annuler"
 
-#: corehq/apps/reports/views.py:1423
+#: corehq/apps/reports/views.py:1431
 msgid "Form was successfully restored."
 msgstr "Le formulaire a été restauré avec succès."
 
-#: corehq/apps/reports/views.py:1438
+#: corehq/apps/reports/views.py:1446
 msgid "Form was successfully resaved. It should reappear in reports shortly."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1484
+#: corehq/apps/reports/views.py:1492
 msgid "We don't support this format"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1486
+#: corehq/apps/reports/views.py:1494
 msgid ""
 "That report was not found. Please remember that download links expire after "
 "24 hours."
@@ -17883,7 +18158,7 @@ msgid "Stock Status by Product"
 msgstr "État d'inventaire par produit"
 
 #: corehq/apps/reports/commtrack/standard.py:93
-#: custom/ilsgateway/tanzania/reports/delivery.py:154
+#: custom/ilsgateway/tanzania/reports/delivery.py:157
 msgid "# Facilities"
 msgstr "Nb. de sites"
 
@@ -17964,11 +18239,6 @@ msgstr ""
 #: corehq/apps/reports/commtrack/standard.py:270
 msgid "Aggregate Inventory"
 msgstr "Inventaire Total"
-
-#: corehq/apps/reports/commtrack/standard.py:297
-#: custom/ilsgateway/tanzania/reports/facility_details.py:27
-msgid "Stock on Hand"
-msgstr "Total SOH"
 
 #: corehq/apps/reports/commtrack/standard.py:298
 msgid "Total stock on hand for all locations matching the filters."
@@ -18062,7 +18332,7 @@ msgid "Date of last report for selected period"
 msgstr ""
 
 #: corehq/apps/reports/commtrack/standard.py:420
-#: corehq/apps/reports/standard/deployments.py:253
+#: corehq/apps/reports/standard/deployments.py:282
 msgid "Never"
 msgstr "Jamais"
 
@@ -18343,15 +18613,15 @@ msgstr "Cliquer pour sélectionner les types de dossier"
 msgid "Opened / Closed"
 msgstr "Ouvert / fermé"
 
-#: corehq/apps/reports/filters/select.py:128 custom/opm/filters.py:153
+#: corehq/apps/reports/filters/select.py:128 custom/opm/filters.py:112
 msgid "Show All"
 msgstr "Afficher tous"
 
-#: corehq/apps/reports/filters/select.py:133 custom/opm/filters.py:154
+#: corehq/apps/reports/filters/select.py:133 custom/opm/filters.py:113
 msgid "Only Open"
 msgstr "Seulement ouvert"
 
-#: corehq/apps/reports/filters/select.py:134 custom/opm/filters.py:155
+#: corehq/apps/reports/filters/select.py:134 custom/opm/filters.py:114
 msgid "Only Closed"
 msgstr "Seulement fermé"
 
@@ -18476,31 +18746,46 @@ msgstr ""
 msgid "Unknown App"
 msgstr "App. inconnue"
 
-#: corehq/apps/reports/standard/deployments.py:163
+#: corehq/apps/reports/standard/deployments.py:165
 msgid "User Sync History"
 msgstr "Historique de synchronisation de l'Utilisateur"
 
-#: corehq/apps/reports/standard/deployments.py:166
-msgid "Shows the last (up to) 10 times a user has synced."
+#: corehq/apps/reports/standard/deployments.py:171
+msgid "Shows the last (up to) {} times a user has synced."
 msgstr ""
 
-#: corehq/apps/reports/standard/deployments.py:172
+#: corehq/apps/reports/standard/deployments.py:180
 msgid "Sync Date"
 msgstr "Date de Synchronisation"
 
-#: corehq/apps/reports/standard/deployments.py:173
+#: corehq/apps/reports/standard/deployments.py:181
 msgid "# of Cases"
 msgstr "# de Dossiers"
 
-#: corehq/apps/reports/standard/deployments.py:174
+#: corehq/apps/reports/standard/deployments.py:182
 msgid "Sync Duration"
 msgstr "Durée de Synchronisation"
 
-#: corehq/apps/reports/standard/deployments.py:177
+#: corehq/apps/reports/standard/deployments.py:185
 msgid "Sync Log"
 msgstr "Log de Synchronisation"
 
-#: corehq/apps/reports/standard/deployments.py:208
+#: corehq/apps/reports/standard/deployments.py:186
+#, fuzzy
+msgid "Sync Log Type"
+msgstr "Log de Synchronisation"
+
+#: corehq/apps/reports/standard/deployments.py:187
+#, fuzzy
+msgid "Previous Sync Log"
+msgstr "Écran précédent"
+
+#: corehq/apps/reports/standard/deployments.py:188
+#, fuzzy
+msgid "Error Info"
+msgstr "Erreurs trouvées"
+
+#: corehq/apps/reports/standard/deployments.py:219
 msgid "{} seconds"
 msgstr "{} secondes"
 
@@ -18614,7 +18899,7 @@ msgstr "En attente"
 #: corehq/apps/reports/standard/sms.py:408
 #: corehq/apps/sms/templates/sms/default.html:59
 #: corehq/ex-submodules/casexml/apps/case/templates/case/partials/single_case.html:94
-#: custom/ilsgateway/tanzania/reports/delivery.py:170
+#: custom/ilsgateway/tanzania/reports/delivery.py:173
 msgid "Received"
 msgstr "Reçu"
 
@@ -19107,7 +19392,7 @@ msgid "Follow-Up Date"
 msgstr "Date de suivi"
 
 #: corehq/apps/reports/standard/cases/careplan.py:113
-#: corehq/ex-submodules/casexml/apps/case/models.py:913
+#: corehq/ex-submodules/casexml/apps/case/models.py:918
 #: custom/_legacy/pact/models.py:339
 msgid "Date Modified"
 msgstr "Date modifié"
@@ -19140,17 +19425,17 @@ msgstr ""
 "Vous pouvez envoyer par email une version<br />sauvegardée de ce rapport."
 
 #: corehq/apps/reports/templates/reports/base_template.html:67
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:125
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:129
 msgid "Favorites"
 msgstr "Favoris"
 
 #: corehq/apps/reports/templates/reports/base_template.html:72
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:130
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:134
 msgid "You don't have any favorites"
 msgstr "Vous n'avez aucun favori"
 
 #: corehq/apps/reports/templates/reports/base_template.html:91
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:149
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:153
 msgid "Email Supported"
 msgstr "Messagerie électronique"
 
@@ -19483,71 +19768,71 @@ msgid ""
 "    "
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:135
-#, python-format
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:136
+#, fuzzy, python-format
 msgid ""
 "\n"
-"            Submitted by %(auth_user)s on behalf of %(user)s\n"
-"        "
+"                Submitted by %(auth_user)s on behalf of %(user)s\n"
+"            "
 msgstr ""
 "\n"
 "            Soumis par %(auth_user)s au nom de %(user)s\n"
 "        "
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:140
-#, python-format
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:141
+#, fuzzy, python-format
 msgid ""
 "\n"
-"            Submitted by %(auth_user)s\n"
-"        "
+"                Submitted by %(auth_user)s\n"
+"            "
 msgstr ""
 "\n"
 "            Soumis par %(auth_user)s        "
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:147
-#, python-format
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:148
+#, fuzzy, python-format
 msgid ""
 "\n"
-"        Submitted as %(user)s\n"
-"        "
+"            Submitted as %(user)s\n"
+"            "
 msgstr ""
 "\n"
 "        Soumis en tant que %(user)s        "
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:155
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:157
 msgid "Form Properties"
 msgstr "Propriétés de formulaire"
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:161
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:163
 msgid "Case Changes"
 msgstr "Modifications de dossier"
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:169
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:171
 msgid "Form Metadata"
 msgstr "Métadonnées de formulaire"
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:177
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:179
 #: corehq/ex-submodules/casexml/apps/case/templates/case/partials/single_case.html:30
 msgid "Attachments"
 msgstr "Pièces jointes"
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:183
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:185
 msgid "Raw XML"
 msgstr "XML brut"
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:194
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:195
 msgid "View standalone form"
 msgstr "Visualiser le formulaire autonome"
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:200
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:201
 msgid "Edit submission"
 msgstr "Modifier soumission"
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:206
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:207
 msgid "Archiving Forms"
 msgstr "Archivage des formulaires en cours"
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:207
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:208
 msgid ""
 "Archived forms will no longer show up in reports and they will be removed "
 "from any relevant case histories. "
@@ -19555,29 +19840,29 @@ msgstr ""
 "Les formulaires archivés ne seront plus inclus dans les rapports et seront "
 "supprimés de tout historique de dossier correspondant. "
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:211
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:212
 msgid "Archive this form"
 msgstr "Archiver ce formulaire"
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:220
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:221
 msgid "Restoring Forms"
 msgstr "Restauration des formulaires"
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:221
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:222
 msgid "Restoring this form will cause it to show up in reports again."
 msgstr ""
 "La restauration de ce formulaire fera en sorte qu'il sera à nouveau inclus "
 "dans les rapports."
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:225
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:226
 msgid "Restore this form"
 msgstr "Restaurer ce formulaire"
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:234
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:235
 msgid "Resaving Forms"
 msgstr "Réenregistrement des Formulaires"
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:235
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:236
 msgid ""
 "Resaving a form can manually cause it to be reincluded in reports if "
 "something went wrong during initial processing."
@@ -19585,23 +19870,23 @@ msgstr ""
 "Ré-engistrer un formulaire manuellement peut le ré-inclure dans les rapports "
 "si il y a une erreur durant le traitement initial."
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:239
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:240
 msgid "Resave this form"
 msgstr "Réenregistrer ce formulaire"
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:262
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:263
 msgid "Unknown/Deleted Case"
 msgstr "Dossier inconnu / supprimé"
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:269
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:270
 msgid "(this case)"
 msgstr "(ce dossier)"
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:315
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:316
 msgid "Open XML in New Window"
 msgstr "Ouvrir XML dans une nouvelle fenêtre"
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:318
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:319
 msgid "Double-click code below to select all:"
 msgstr "Double cliquer le code ci-dessous pour tout sélectionner:"
 
@@ -19632,7 +19917,7 @@ msgid "IVR"
 msgstr ""
 
 #: corehq/apps/reports/templates/reports/messaging/survey_detail.html:23
-#: custom/ilsgateway/tanzania/reports/randr.py:173
+#: custom/ilsgateway/tanzania/reports/randr.py:175
 msgid "Contact"
 msgstr ""
 
@@ -19676,6 +19961,7 @@ msgstr ""
 "Aucune donnée disponible. Veuillez soumettre davantage de formulaires !"
 
 #: corehq/apps/reports/templates/reports/partials/hqexport_group_table.html:8
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:47
 msgid "File"
 msgstr "Fichier"
 
@@ -20205,6 +20491,11 @@ msgstr ""
 msgid "My Account"
 msgstr "Mon compte"
 
+#: corehq/apps/settings/views.py:93
+#: corehq/apps/settings/templates/settings/edit_my_account.b2.html:33
+msgid "My Information"
+msgstr "Mes informations"
+
 #: corehq/apps/settings/views.py:174
 #, python-format
 msgid "Unable remove membership because you are the admin of %s"
@@ -20230,6 +20521,7 @@ msgid "Your password was successfully changed!"
 msgstr "Votre mot de passe a été modifié avec succès !"
 
 #: corehq/apps/settings/templates/settings/change_my_password.html:9
+#: docs/_build/html/_sources/translations.txt:177
 msgid "Specify New Password"
 msgstr "Spécifiez le nouveau mot de passe"
 
@@ -20245,7 +20537,7 @@ msgstr "Sélection de la langue..."
 #: corehq/apps/settings/templates/settings/edit_my_account.b2.html:42
 #: corehq/apps/telerivet/forms.py:10
 #: corehq/apps/telerivet/templates/telerivet/backend.html:10
-#: corehq/apps/users/forms.py:188
+#: corehq/apps/users/forms.py:187
 msgid "API Key"
 msgstr "Clé API"
 
@@ -22054,6 +22346,10 @@ msgstr ""
 msgid "All domain/toggle statuses"
 msgstr ""
 
+#: corehq/apps/toggle_ui/templates/toggle/edit_flag.html:165
+msgid "Enabled?"
+msgstr "Activé?"
+
 #: corehq/apps/toggle_ui/templates/toggle/flags.html:57
 msgid "Tag"
 msgstr ""
@@ -22113,8 +22409,8 @@ msgid "Create New Report"
 msgstr "Créez un Nouveau Rapport"
 
 #: corehq/apps/userreports/views.py:124
-#: corehq/apps/userreports/reports/builder/forms.py:768
-#: corehq/apps/userreports/reports/builder/forms.py:823
+#: corehq/apps/userreports/reports/builder/forms.py:776
+#: corehq/apps/userreports/reports/builder/forms.py:831
 msgid "Chart"
 msgstr ""
 
@@ -22154,21 +22450,21 @@ msgid ""
 "choose the columns and rows."
 msgstr ""
 
-#: corehq/apps/userreports/views.py:230
+#: corehq/apps/userreports/views.py:234
 msgid "Chart Report: {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:247
+#: corehq/apps/userreports/views.py:251
 msgid "Choose the property you would like to add as a filter to this report."
 msgstr ""
 
-#: corehq/apps/userreports/views.py:248
+#: corehq/apps/userreports/views.py:252
 msgid ""
 "Web users viewing the report will see this display text instead of the "
 "property name. Name your filter something easy for users to understand."
 msgstr ""
 
-#: corehq/apps/userreports/views.py:249
+#: corehq/apps/userreports/views.py:253
 msgid ""
 "What type of property is this filter?<br/><br/><strong>Date</strong>: select "
 "this if the property is a date.<br/><strong>Choice</strong>: select this if "
@@ -22176,73 +22472,73 @@ msgid ""
 "select this if the property is a number."
 msgstr ""
 
-#: corehq/apps/userreports/views.py:291
+#: corehq/apps/userreports/views.py:295
 msgid "List Report: {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:300
+#: corehq/apps/userreports/views.py:304
 msgid "Table Report: {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:309
+#: corehq/apps/userreports/views.py:313
 msgid "Worker Report: {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:322
+#: corehq/apps/userreports/views.py:326
 msgid "Report \"{}\" saved!"
 msgstr "Rapport \"{}\" enregistré!"
 
-#: corehq/apps/userreports/views.py:350
+#: corehq/apps/userreports/views.py:354
 msgid "Report \"{}\" deleted!"
 msgstr "Rapport \"{}\" supprimé!"
 
-#: corehq/apps/userreports/views.py:370
+#: corehq/apps/userreports/views.py:374
 msgid "Report created!"
 msgstr "Rapport \"{}\" créé!"
 
-#: corehq/apps/userreports/views.py:373
+#: corehq/apps/userreports/views.py:377
 msgid "Bad report source: {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:375
+#: corehq/apps/userreports/views.py:379
 msgid "paste report source here"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:414 corehq/apps/userreports/views.py:420
+#: corehq/apps/userreports/views.py:418 corehq/apps/userreports/views.py:424
 msgid "Data source created for '{}'"
 msgstr "Source de Données créer par '{}' "
 
-#: corehq/apps/userreports/views.py:437
+#: corehq/apps/userreports/views.py:441
 msgid "Data source \"{}\" saved!"
 msgstr "Source de Données \"{}\" enregistrée!"
 
-#: corehq/apps/userreports/views.py:465
+#: corehq/apps/userreports/views.py:469
 msgid "Data source \"{}\" has been deleted."
 msgstr "Source de Données \"{}\" a été supprimé."
 
-#: corehq/apps/userreports/views.py:475
+#: corehq/apps/userreports/views.py:479
 msgid "Table \"{}\" is now being rebuilt. Data should start showing up soon"
 msgstr ""
 "Table \"{}\" est actuellement en reconstruction. L'affichage des données "
 "debutera bientot"
 
-#: corehq/apps/userreports/views.py:514
+#: corehq/apps/userreports/views.py:518
 msgid "You can only use 'lastndays' on date columns"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:524
+#: corehq/apps/userreports/views.py:528
 msgid "Ranges must have the format \"start..end\""
 msgstr ""
 
-#: corehq/apps/userreports/views.py:556
+#: corehq/apps/userreports/views.py:560
 msgid "No field named {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:563
+#: corehq/apps/userreports/views.py:567
 msgid "Invalid filter parameter: {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:597
+#: corehq/apps/userreports/views.py:601
 msgid ""
 "There was a problem executing your query, please make sure your parameters "
 "are valid."
@@ -22339,47 +22635,47 @@ msgid ""
 "the data source before viewing the report."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:304
+#: corehq/apps/userreports/reports/builder/forms.py:305
 msgid "Bar"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:305
+#: corehq/apps/userreports/reports/builder/forms.py:306
 msgid "Pie"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:318
+#: corehq/apps/userreports/reports/builder/forms.py:319
 msgid ""
 "<strong>Form</strong>: display data from form submissions.<br/><strong>Case</"
 "strong>: display data from your cases. You must be using case management for "
 "this option."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:319
+#: corehq/apps/userreports/reports/builder/forms.py:320
 msgid "Which application should the data come from?"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:320
+#: corehq/apps/userreports/reports/builder/forms.py:321
 msgid ""
 "Choose the case type or form from which to retrieve data for this report."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:332
+#: corehq/apps/userreports/reports/builder/forms.py:333
 msgid ""
 "<strong>Bar</strong> shows one vertical bar for each value in your case or "
 "form. <strong>Pie</strong> shows what percentage of the total each value is."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:345
+#: corehq/apps/userreports/reports/builder/forms.py:346
 msgid "{} Report"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:346
+#: corehq/apps/userreports/reports/builder/forms.py:347
 msgid ""
 "Web users will see this name in the \"Reports\" section of CommCareHQ and "
 "can click to view the report"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:388
+#: corehq/apps/userreports/reports/builder/forms.py:389
 msgid ""
 "Too many data sources!\n"
 "Creating this report would cause you to go over the maximum number of data "
@@ -22388,63 +22684,69 @@ msgid ""
 "itself) and try again. "
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:405
+#: corehq/apps/userreports/reports/builder/forms.py:406
 #: custom/bihar/reports/indicators/clientlistdisplay.py:146
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:345
 msgid "Done"
 msgstr "Terminé"
 
-#: corehq/apps/userreports/reports/builder/forms.py:417
+#: corehq/apps/userreports/reports/builder/forms.py:418
 msgid "Update Report"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:474
-#: corehq/apps/userreports/templates/userreports/edit_report_config.html:8
+#: corehq/apps/userreports/reports/builder/forms.py:475
+#: corehq/apps/userreports/templates/userreports/edit_report_config.html:18
 msgid "Delete Report"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:518
+#: corehq/apps/userreports/reports/builder/forms.py:500
+msgid ""
+"Report builder data source doesn't reference an application. It is likely "
+"this report has been customized and it is no longer editable. "
+msgstr ""
+
+#: corehq/apps/userreports/reports/builder/forms.py:526
 msgid "Filters"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:519
+#: corehq/apps/userreports/reports/builder/forms.py:527
 msgid ""
 "Add filters to your report to allow viewers to select which data the report "
 "will display. These filters will be displayed at the top of your report."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:573
+#: corehq/apps/userreports/reports/builder/forms.py:581
 msgid ""
 "Editing this report would require a new data source. The limit is 5. To "
 "continue, first delete all of the reports using a particular data source (or "
 "the data source itself) and try again. "
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:769
+#: corehq/apps/userreports/reports/builder/forms.py:777
 msgid ""
 "The values of the selected property will be aggregated and shown as bars in "
 "the chart."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:824
+#: corehq/apps/userreports/reports/builder/forms.py:832
 msgid ""
 "The values of the selected property will be aggregated and shows as the "
 "sections of the pie chart."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:841
+#: corehq/apps/userreports/reports/builder/forms.py:849
 msgid ""
 "Add columns to your report to display information from cases or form "
 "submissions. You may rearrange the order of the columns by dragging the "
 "arrows next to the column."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:854
+#: corehq/apps/userreports/reports/builder/forms.py:862
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:179
 msgid "Columns"
 msgstr "Colonnes"
 
-#: corehq/apps/userreports/reports/builder/forms.py:898
+#: corehq/apps/userreports/reports/builder/forms.py:906
 msgid ""
 "Add columns for this report to aggregate. Each property you add will create "
 "a column for every value of that property.  For example, if you add a column "
@@ -22452,23 +22754,37 @@ msgid ""
 "column for \"no.\""
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:907
+#: corehq/apps/userreports/reports/builder/forms.py:915
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:13
 msgid "Rows"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:908
+#: corehq/apps/userreports/reports/builder/forms.py:916
 msgid ""
 "Choose which property this report will group its results by. Each value of "
 "this property will be a row in the table. For example, if you choose a yes "
 "or no question, the report will show a row for \"yes\" and a row for \"no.\""
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:971
+#: corehq/apps/userreports/reports/builder/forms.py:979
 msgid ""
 "Add columns for this report to aggregate. Each property you add will create "
 "a column for every value of that property. For example, if you add a column "
 "for a yes or no question, the report will show a column for \"yes\" and a "
 "column for \"no\"."
+msgstr ""
+
+#: corehq/apps/userreports/sql/columns.py:60
+#, python-brace-format
+msgid ""
+"The \"{header}\" column had too many values to expand! Expansion limited to "
+"{max} distinct values."
+msgstr ""
+
+#: corehq/apps/userreports/sql/columns.py:94
+msgid ""
+"The column \"{}\" does not exist in the report source! Please double check "
+"your report configuration."
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/builder_report_type_select.html:37
@@ -22495,54 +22811,62 @@ msgid ""
 "        "
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:108
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:105
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:111
+#: corehq/apps/userreports/templates/userreports/edit_report_config.html:7
 msgid "Edit Report"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/configurable_reports_home.html:4
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:44
 msgid "Configurable Reports"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/configurable_reports_home.html:5
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:32
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:82
 msgid "Add data source"
 msgstr "jout de Source de Données "
 
 #: corehq/apps/userreports/templates/userreports/configurable_reports_home.html:6
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:16
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:64
 msgid "Add report"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/configurable_reports_home.html:7
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:20
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:68
 msgid "Import report"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/edit_data_source.html:7
+#, fuzzy
+msgid "Edit Data Source"
+msgstr "Modifier Source de Données "
+
+#: corehq/apps/userreports/templates/userreports/edit_data_source.html:18
 msgid "This datasource is read only, any changes made can not be saved."
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/edit_data_source.html:14
+#: corehq/apps/userreports/templates/userreports/edit_data_source.html:25
 msgid "Delete Data Source"
 msgstr "Supprimer Source de Données "
 
-#: corehq/apps/userreports/templates/userreports/edit_data_source.html:18
+#: corehq/apps/userreports/templates/userreports/edit_data_source.html:29
 msgid "Rebuild Data Source"
 msgstr "Reconstitution de Source de Données "
 
-#: corehq/apps/userreports/templates/userreports/edit_data_source.html:19
+#: corehq/apps/userreports/templates/userreports/edit_data_source.html:30
 msgid "Preview data"
 msgstr "Previsualisation de données"
 
-#: corehq/apps/userreports/templates/userreports/edit_data_source.html:20
+#: corehq/apps/userreports/templates/userreports/edit_data_source.html:31
 msgid "Data Source Source (Advanced)"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/edit_report_config.html:9
+#: corehq/apps/userreports/templates/userreports/edit_report_config.html:19
 msgid "View report"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/edit_report_config.html:10
+#: corehq/apps/userreports/templates/userreports/edit_report_config.html:20
 msgid "Report Source (Advanced)"
 msgstr ""
 
@@ -22559,16 +22883,16 @@ msgstr ""
 msgid "Preview table: %(display_name)s (%(total_rows)s total rows)"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:7
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:53
 #: corehq/apps/users/templates/users/web_users.b3.html:390
 msgid "Edit Reports"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:23
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:71
 msgid "Edit Data Sources"
 msgstr "Modifier Source de Données "
 
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:38
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:88
 msgid "Data source from application"
 msgstr "Sources de données de l'application"
 
@@ -22593,7 +22917,7 @@ msgid "Expected {} but was {}"
 msgstr ""
 
 #: corehq/apps/userreports/ui/forms.py:25
-#: corehq/apps/userreports/ui/forms.py:149
+#: corehq/apps/userreports/ui/forms.py:159
 msgid "Save Changes"
 msgstr "Enregistrer les changements"
 
@@ -22613,24 +22937,82 @@ msgstr ""
 msgid "Problem with report spec: {}"
 msgstr ""
 
-#: corehq/apps/userreports/ui/forms.py:95
+#: corehq/apps/userreports/ui/forms.py:91
+#, fuzzy
+msgid "Source Type"
+msgstr "Enquête"
+
+#: corehq/apps/userreports/ui/forms.py:92
+#, fuzzy
+msgid "Report Title"
+msgstr "Commentaires"
+
+#: corehq/apps/userreports/ui/forms.py:103
 msgid "Named filters (optional)"
 msgstr ""
 
-#: corehq/apps/userreports/ui/forms.py:106
+#: corehq/apps/userreports/ui/forms.py:116
 msgid ""
 "Table id is too long. Your table id and domain name must add up to fewer "
 "than 40 characters"
 msgstr ""
 
-#: corehq/apps/userreports/ui/forms.py:111
+#: corehq/apps/userreports/ui/forms.py:121
 msgid ""
 "A data source with this table id already exists. Table ids must be unique"
 msgstr ""
 
-#: corehq/apps/userreports/ui/forms.py:128
+#: corehq/apps/userreports/ui/forms.py:138
 msgid "Problem with data source spec: {}"
 msgstr "Probleme avec la Source de Données spécifiée: {}"
+
+#: corehq/apps/userreports/ui/help_text.py:4
+msgid ""
+"Choose something short, unique, and memorable using lowercase letters, "
+"numbers, and underscores"
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:7
+msgid ""
+"This is what the data source will be called in navigation, page title, etc."
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:9
+msgid "Write yourself a little note if you like, it's optional"
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:11
+msgid ""
+"You can leave this blank unless you are <a target=\"_blank\" href=\"https://"
+"github.com/dimagi/commcare-hq/blob/master/corehq/apps/userreports/README."
+"md#saving-repeat-data\">saving repeat data</a>"
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:16
+msgid ""
+"Look at <a target=\"_blank\" href=\"https://github.com/dimagi/commcare-hq/"
+"blob/master/corehq/apps/userreports/examples/examples.md#data-source-filters"
+"\">these examples</a> and <a target=\"_blank\" href=\"https://github.com/"
+"dimagi/commcare-hq/blob/master/corehq/apps/userreports/README.md#data-source-"
+"filtering\">these docs</a>"
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:24
+msgid ""
+"Look at <a target=\"_blank\" href=\"https://github.com/dimagi/commcare-hq/"
+"blob/master/corehq/apps/userreports/examples/examples.md#data-source-"
+"indicators\">these examples</a> and <a target=\"_blank\" href=\"https://"
+"github.com/dimagi/commcare-hq/blob/master/corehq/apps/userreports/README."
+"md#indicators\">these docs</a>"
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:32
+msgid ""
+"For this advanced and useful feature, give a dict where the keys are the "
+"variable names you choose and the values are filters according to the syntax "
+"of Configured Filters above. You can then reference these from Configured "
+"Filters as {\"type\": \"named\", \"name\": \"myvarname\"}"
+msgstr ""
 
 #: corehq/apps/users/bulkupload.py:52
 #, python-brace-format
@@ -22689,78 +23071,78 @@ msgstr ""
 "Impossible d'ajouter au groupe '%s' (essayez de l'ajouter à votre feuille de "
 "calcul)"
 
-#: corehq/apps/users/forms.py:59
+#: corehq/apps/users/forms.py:58
 msgid "Please enter a valid two or three digit language code."
 msgstr ""
 "Veuillez saisir un code de langue valide composé de deux ou trois caractères"
 
-#: corehq/apps/users/forms.py:132
+#: corehq/apps/users/forms.py:131
 msgid "System Super User"
 msgstr ""
 
-#: corehq/apps/users/forms.py:147
+#: corehq/apps/users/forms.py:146
 msgid "E-Mail"
 msgstr ""
 
-#: corehq/apps/users/forms.py:154
+#: corehq/apps/users/forms.py:153
 msgid ""
 "<i class=\"icon-info-sign\"></i> Becomes default language seen in CloudCare "
 "and reports (if applicable), but does not affect mobile applications. "
 "Supported languages for reports are en, fr (partial), and hin (partial)."
 msgstr ""
 
-#: corehq/apps/users/forms.py:171
+#: corehq/apps/users/forms.py:170
 msgid "Opt out of emails about CommCare updates."
 msgstr ""
 
-#: corehq/apps/users/forms.py:191
+#: corehq/apps/users/forms.py:190
 msgid "Generate API Key"
 msgstr ""
 
-#: corehq/apps/users/forms.py:199
+#: corehq/apps/users/forms.py:198
 msgid "My Language"
 msgstr ""
 
-#: corehq/apps/users/forms.py:219
+#: corehq/apps/users/forms.py:218
 msgid "Other Options"
 msgstr ""
 
-#: corehq/apps/users/forms.py:225
+#: corehq/apps/users/forms.py:224
 msgid "Update My Information"
 msgstr ""
 
-#: corehq/apps/users/forms.py:240
+#: corehq/apps/users/forms.py:239
 msgid ""
 "Multiply this user's case load by a number for load testing on phones. Leave "
 "blank for normal users."
 msgstr ""
 
-#: corehq/apps/users/forms.py:324
+#: corehq/apps/users/forms.py:323
 #, python-format
 msgid "%s is an invalid phone number."
 msgstr "%s n'est pas un numéro de téléphone valide."
 
-#: corehq/apps/users/forms.py:371 corehq/apps/users/forms.py:373
+#: corehq/apps/users/forms.py:370 corehq/apps/users/forms.py:372
 msgid "Username contains invalid characters."
 msgstr "Le nom d'utilisateur comporte des caractères no valides."
 
-#: corehq/apps/users/forms.py:480
+#: corehq/apps/users/forms.py:479
 #, python-format
 msgid ""
 "I have read and agree to the <a href=\"%(pa_url)s\" target=\"_blank"
 "\">Software Product Subscription Agreement</a>."
 msgstr ""
 
-#: corehq/apps/users/forms.py:509
+#: corehq/apps/users/forms.py:508
 msgid "Back to Mobile Workers List"
 msgstr ""
 
-#: corehq/apps/users/forms.py:521
+#: corehq/apps/users/forms.py:520
 msgid ""
 "Please agree to the Product Subscription Agreement above before continuing."
 msgstr ""
 
-#: corehq/apps/users/models.py:2426
+#: corehq/apps/users/models.py:2446
 #, python-format
 msgid "Invitation from %s to join CommCareHQ"
 msgstr "Invitation pour joinder CommCareHQ de la part de %s"
@@ -23371,8 +23753,8 @@ msgstr "Date d'inscription"
 
 #: corehq/apps/users/templates/users/mobile/users_list.html:212
 #: custom/_legacy/pact/templates/pact/chw/pact_chw_profile_info.html:12
-#: custom/ilsgateway/tanzania/reports/facility_details.py:72
-#: custom/ilsgateway/tanzania/reports/facility_details.py:119
+#: custom/ilsgateway/tanzania/reports/facility_details.py:73
+#: custom/ilsgateway/tanzania/reports/facility_details.py:120
 msgid "Phone"
 msgstr "Téléphone"
 
@@ -23521,59 +23903,55 @@ msgstr "Modifications enregistrées pour l'utilisateur \"%s\""
 msgid "Edit User Role"
 msgstr "Mettre à jour le rôle d'utilisateur"
 
-#: corehq/apps/users/views/__init__.py:291
+#: corehq/apps/users/views/__init__.py:289
 #, python-format
 msgid "Changed system permissions for user \"%s\""
 msgstr "Permissions du système pour l`utilsateur \"%s\" ont été changés"
 
-#: corehq/apps/users/views/__init__.py:340
+#: corehq/apps/users/views/__init__.py:338
 msgid "Phone number added!"
 msgstr "Numéro de téléphone ajouté !"
 
-#: corehq/apps/users/views/__init__.py:342
+#: corehq/apps/users/views/__init__.py:340
 msgid "Please enter digits only."
 msgstr "Veuillez entrer des chiffres seulement."
 
-#: corehq/apps/users/views/__init__.py:349
-msgid "Edit My Information"
-msgstr "Modifier mes informations"
-
-#: corehq/apps/users/views/__init__.py:388
-#: corehq/apps/users/views/__init__.py:534
+#: corehq/apps/users/views/__init__.py:346
+#: corehq/apps/users/views/__init__.py:492
 msgid "Web Users & Roles"
 msgstr "Utilisateurs et rôles Web"
 
-#: corehq/apps/users/views/__init__.py:435
+#: corehq/apps/users/views/__init__.py:393
 msgid "Please provide pagination info."
 msgstr "Veuillez donner les info sur la pagination"
 
-#: corehq/apps/users/views/__init__.py:736
+#: corehq/apps/users/views/__init__.py:694
 msgid "Invitation resent"
 msgstr "Invitation envoyée à nouveau"
 
-#: corehq/apps/users/views/__init__.py:738
+#: corehq/apps/users/views/__init__.py:696
 msgid "Error while attempting resend"
 msgstr "Une erreur est survenue lors de la tentative de nouvel envoi"
 
-#: corehq/apps/users/views/__init__.py:768
+#: corehq/apps/users/views/__init__.py:726
 msgid "Invite Web User to Project"
 msgstr "Inviter l'utilisateur Web au projet"
 
-#: corehq/apps/users/views/__init__.py:866
+#: corehq/apps/users/views/__init__.py:818
 msgid "Cannot start verification workflow. Phone number is already in use."
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:868
+#: corehq/apps/users/views/__init__.py:820
 #, fuzzy
 msgid "Phone number is already verified."
 msgstr "Numéro de téléphone ajouté !"
 
-#: corehq/apps/users/views/__init__.py:870
+#: corehq/apps/users/views/__init__.py:822
 #, fuzzy
 msgid "Verification message resent."
 msgstr "Aucun message n'a été envoyé."
 
-#: corehq/apps/users/views/__init__.py:872
+#: corehq/apps/users/views/__init__.py:824
 msgid "Verification workflow started."
 msgstr ""
 
@@ -23719,36 +24097,36 @@ msgstr ""
 "Les groupes suivants n'ont pas de nom. Veuillez les nommer avant de "
 "continuer : {}"
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:228
+#: corehq/ex-submodules/casexml/apps/case/models.py:229
 msgid "Closed"
 msgstr "Fermé"
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:228
+#: corehq/ex-submodules/casexml/apps/case/models.py:229
 msgid "Open"
 msgstr "Ouvert"
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:515
+#: corehq/ex-submodules/casexml/apps/case/models.py:516
 msgid "Sorry, referrals are no longer supported!"
 msgstr "Desolé, les références ne sont pas plus soutenus!"
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:857
+#: corehq/ex-submodules/casexml/apps/case/models.py:862
 msgid "Opened On"
 msgstr "Ouvert le"
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:863
+#: corehq/ex-submodules/casexml/apps/case/models.py:868
 msgid "Modified On"
 msgstr "Modifié le"
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:869
-#: custom/opm/beneficiary.py:824 custom/opm/beneficiary.py:901
+#: corehq/ex-submodules/casexml/apps/case/models.py:874
+#: custom/opm/beneficiary.py:823 custom/opm/beneficiary.py:901
 msgid "Closed On"
 msgstr "Fermé le"
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:882
+#: corehq/ex-submodules/casexml/apps/case/models.py:887
 msgid "Last Submitter"
 msgstr "Dernière operateur à soumettre"
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:907
+#: corehq/ex-submodules/casexml/apps/case/models.py:912
 msgid "Date Opened"
 msgstr "Date ouvert"
 
@@ -24431,8 +24809,8 @@ msgstr "Soin prévu dans 3 jours"
 msgid "Beneficiary Information"
 msgstr "Informations du bénéficiaire"
 
-#: custom/bihar/reports/mch_reports.py:134 custom/opm/beneficiary.py:809
-#: custom/opm/beneficiary.py:885
+#: custom/bihar/reports/mch_reports.py:134 custom/opm/beneficiary.py:808
+#: custom/opm/beneficiary.py:885 custom/opm/beneficiary.py:930
 msgid "Husband Name"
 msgstr "Nom du mari"
 
@@ -24509,6 +24887,7 @@ msgstr "LMP"
 #: custom/bihar/reports/mch_reports.py:151
 #: custom/bihar/reports/indicators/clientlistdisplay.py:80
 #: custom/bihar/reports/indicators/clientlistdisplay.py:98
+#: custom/opm/beneficiary.py:944
 msgid "EDD"
 msgstr "DPA"
 
@@ -24712,7 +25091,7 @@ msgstr "Détails Enfant 4"
 msgid "Migrate status "
 msgstr "État de la migration"
 
-#: custom/bihar/reports/mch_reports.py:314 custom/opm/beneficiary.py:812
+#: custom/bihar/reports/mch_reports.py:314 custom/opm/beneficiary.py:811
 msgid "Child Name"
 msgstr "Nom de l'enfant"
 
@@ -25792,43 +26171,43 @@ msgstr ""
 msgid "Dashboard report {0}"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:28
-#: custom/ilsgateway/tanzania/reports/delivery.py:86
+#: custom/ilsgateway/tanzania/reports/delivery.py:29
+#: custom/ilsgateway/tanzania/reports/delivery.py:88
 msgid "Average Lead Time In Days"
 msgstr "Temps Moyen de Mise en Oeuvre en jours"
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:82
-#: custom/ilsgateway/tanzania/reports/randr.py:171
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:251
+#: custom/ilsgateway/tanzania/reports/delivery.py:84
+#: custom/ilsgateway/tanzania/reports/randr.py:173
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:318
 msgid "Facility Name"
 msgstr "Nom Entrepôt"
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:83
+#: custom/ilsgateway/tanzania/reports/delivery.py:85
 msgid "Delivery Status"
 msgstr "Statut Livraison"
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:84
+#: custom/ilsgateway/tanzania/reports/delivery.py:86
 msgid "Delivery Date"
 msgstr "Date de Livraison"
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:85
+#: custom/ilsgateway/tanzania/reports/delivery.py:87
 msgid "This Cycle Lead Time"
 msgstr "Ce Cycle de Mise en Oeuvre"
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:155
+#: custom/ilsgateway/tanzania/reports/delivery.py:158
 #, python-format
 msgid "% of total"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:167
+#: custom/ilsgateway/tanzania/reports/delivery.py:170
 msgid "Didn't Respond"
 msgstr "Pas de réponse"
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:169
+#: custom/ilsgateway/tanzania/reports/delivery.py:172
 msgid "Not Received"
 msgstr "Pas reçu"
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:182
+#: custom/ilsgateway/tanzania/reports/delivery.py:185
 #, python-brace-format
 msgid "Delivery Report {0}"
 msgstr ""
@@ -25837,106 +26216,106 @@ msgstr ""
 msgid "Months of stock"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/facility_details.py:120
+#: custom/ilsgateway/tanzania/reports/facility_details.py:121
 msgid "Text"
 msgstr "Texte"
 
-#: custom/ilsgateway/tanzania/reports/randr.py:83
+#: custom/ilsgateway/tanzania/reports/randr.py:84
 msgid "% Facilities Submitting R&R On Time"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:84
+#: custom/ilsgateway/tanzania/reports/randr.py:85
 msgid "% Facilities Submitting R&R Late"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:85
+#: custom/ilsgateway/tanzania/reports/randr.py:86
 msgid "% Facilities With R&R Not Submitted"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:86
+#: custom/ilsgateway/tanzania/reports/randr.py:87
 msgid "% Facilities Not Responding To R&R Reminder"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:87
-#: custom/ilsgateway/tanzania/reports/randr.py:174
-#: custom/ilsgateway/tanzania/reports/supervision.py:60
-#: custom/ilsgateway/tanzania/reports/supervision.py:123
+#: custom/ilsgateway/tanzania/reports/randr.py:88
+#: custom/ilsgateway/tanzania/reports/randr.py:176
+#: custom/ilsgateway/tanzania/reports/supervision.py:61
+#: custom/ilsgateway/tanzania/reports/supervision.py:125
 msgid "Historical Response Rate"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:172
+#: custom/ilsgateway/tanzania/reports/randr.py:174
 msgid "R&R Status"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:185
+#: custom/ilsgateway/tanzania/reports/randr.py:187
 #, python-brace-format
 msgid "R & R {0}"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:82
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:84
 msgid "% Facilities Submitting Soh On Time"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:83
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:85
 msgid "% Facilities Submitting Soh Late"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:84
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:86
 msgid "% Facilities Not Responding To Soh"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:85
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:87
 msgid "% Facilities With 1 Or More Stockouts This Month"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:97
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:99
 #, python-format
 msgid "%s stock outs this %s"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:203
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:269
 msgid "Waiting for reply"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:250
-#: custom/ilsgateway/tanzania/reports/supervision.py:119
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:317
+#: custom/ilsgateway/tanzania/reports/supervision.py:121
 msgid "MSD Code"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:252
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:319
 msgid "DG"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:253
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:320
 msgid "Last Reported"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:254
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:321
 msgid "Hist. Resp. Rate"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:406
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:422
 #, python-brace-format
 msgid "Stock On Hand {0}"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/supervision.py:57
+#: custom/ilsgateway/tanzania/reports/supervision.py:58
 msgid "% Supervision Received"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/supervision.py:58
+#: custom/ilsgateway/tanzania/reports/supervision.py:59
 msgid "% Supervision Not Received"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/supervision.py:59
+#: custom/ilsgateway/tanzania/reports/supervision.py:60
 msgid "% Supervision Not Responding"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/supervision.py:121
+#: custom/ilsgateway/tanzania/reports/supervision.py:123
 msgid "Supervision This Quarter"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/supervision.py:181
+#: custom/ilsgateway/tanzania/reports/supervision.py:183
 #, python-brace-format
 msgid "Supervision {0}"
 msgstr ""
@@ -25945,7 +26324,7 @@ msgstr ""
 msgid "Unrecognized SMS"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/utils.py:98
+#: custom/ilsgateway/tanzania/reports/utils.py:100
 msgid "No Data"
 msgstr "Pas de données"
 
@@ -26026,16 +26405,16 @@ msgstr ""
 msgid " days"
 msgstr ""
 
-#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:55
+#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:65
 #, python-format
 msgid "%(status)s"
 msgstr ""
 
-#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:58
+#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:68
 msgid "Last updated on"
 msgstr ""
 
-#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:63
+#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:73
 msgid "No delivery status reported"
 msgstr ""
 
@@ -27109,108 +27488,112 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: custom/opm/beneficiary.py:742
+#: custom/opm/beneficiary.py:741
 msgid "Incorrect EDD"
 msgstr ""
 
-#: custom/opm/beneficiary.py:748
+#: custom/opm/beneficiary.py:747
 msgid "Incorrect DOD"
 msgstr ""
 
-#: custom/opm/beneficiary.py:753
+#: custom/opm/beneficiary.py:752
 msgid "Incorrect LMP date"
 msgstr ""
 
-#: custom/opm/beneficiary.py:758
+#: custom/opm/beneficiary.py:757
 msgid "Account number is the wrong length"
 msgstr ""
 
-#: custom/opm/beneficiary.py:763
+#: custom/opm/beneficiary.py:762
 msgid "IFSC {} incorrect"
 msgstr ""
 
-#: custom/opm/beneficiary.py:804
+#: custom/opm/beneficiary.py:803 custom/opm/beneficiary.py:919
 msgid "Serial number"
 msgstr ""
 
-#: custom/opm/beneficiary.py:805 custom/opm/beneficiary.py:884
+#: custom/opm/beneficiary.py:804 custom/opm/beneficiary.py:884
+#: custom/opm/beneficiary.py:920
 msgid "List of Beneficiaries"
 msgstr ""
 
-#: custom/opm/beneficiary.py:806 custom/opm/beneficiary.py:886
-#: custom/opm/health_status.py:89
+#: custom/opm/beneficiary.py:805 custom/opm/beneficiary.py:886
+#: custom/opm/beneficiary.py:922 custom/opm/health_status.py:18
 msgid "AWC Name"
 msgstr ""
 
-#: custom/opm/beneficiary.py:807 custom/opm/health_status.py:85
+#: custom/opm/beneficiary.py:806 custom/opm/beneficiary.py:923
+#: custom/opm/health_status.py:14
 msgid "AWC Code"
 msgstr ""
 
-#: custom/opm/beneficiary.py:808 custom/opm/beneficiary.py:891
+#: custom/opm/beneficiary.py:807 custom/opm/beneficiary.py:891
+#: custom/opm/beneficiary.py:924
 msgid "Block Name"
 msgstr ""
 
-#: custom/opm/beneficiary.py:810
+#: custom/opm/beneficiary.py:809 custom/opm/beneficiary.py:942
 msgid "Current status"
 msgstr ""
 
-#: custom/opm/beneficiary.py:811
+#: custom/opm/beneficiary.py:810
 msgid "Pregnancy Month"
 msgstr ""
 
-#: custom/opm/beneficiary.py:813
+#: custom/opm/beneficiary.py:812
 msgid "Child Age"
 msgstr ""
 
-#: custom/opm/beneficiary.py:815
+#: custom/opm/beneficiary.py:814
 msgid "Condition 1"
 msgstr ""
 
-#: custom/opm/beneficiary.py:816
+#: custom/opm/beneficiary.py:815
 msgid "Condition 2"
 msgstr ""
 
-#: custom/opm/beneficiary.py:817
+#: custom/opm/beneficiary.py:816
 msgid "Condition 3"
 msgstr ""
 
-#: custom/opm/beneficiary.py:818
+#: custom/opm/beneficiary.py:817
 msgid "Condition 4"
 msgstr ""
 
-#: custom/opm/beneficiary.py:819
+#: custom/opm/beneficiary.py:818
 msgid "Condition 5"
 msgstr ""
 
-#: custom/opm/beneficiary.py:820
+#: custom/opm/beneficiary.py:819
 msgid "Payment amount this month (Rs.)"
 msgstr ""
 
-#: custom/opm/beneficiary.py:821
+#: custom/opm/beneficiary.py:820
 msgid "Payment amount last month (Rs.)"
 msgstr ""
 
-#: custom/opm/beneficiary.py:822
+#: custom/opm/beneficiary.py:821 custom/opm/beneficiary.py:973
 msgid "Cash received last month"
 msgstr ""
 
-#: custom/opm/beneficiary.py:825 custom/opm/beneficiary.py:904
+#: custom/opm/beneficiary.py:824 custom/opm/beneficiary.py:904
+#: custom/opm/beneficiary.py:974
 msgid "Issues"
 msgstr ""
 
-#: custom/opm/beneficiary.py:887
+#: custom/opm/beneficiary.py:887 custom/opm/beneficiary.py:937
 msgid "Bank Name"
 msgstr ""
 
-#: custom/opm/beneficiary.py:888
+#: custom/opm/beneficiary.py:888 custom/opm/beneficiary.py:939
 msgid "Bank Branch Name"
 msgstr ""
 
-#: custom/opm/beneficiary.py:889
+#: custom/opm/beneficiary.py:889 custom/opm/beneficiary.py:941
 msgid "IFS Code"
 msgstr ""
 
-#: custom/opm/beneficiary.py:890
+#: custom/opm/beneficiary.py:890 custom/opm/beneficiary.py:938
 msgid "Bank Account Number"
 msgstr ""
 
@@ -27254,441 +27637,661 @@ msgstr ""
 msgid "Payment last month"
 msgstr ""
 
-#: custom/opm/filters.py:113 custom/opm/filters.py:126
+#: custom/opm/beneficiary.py:925
+msgid "Gram Panchayat name"
+msgstr ""
+
+#: custom/opm/beneficiary.py:926
+#, fuzzy
+msgid "Village name"
+msgstr "Village:"
+
+#: custom/opm/beneficiary.py:927
+msgid "Dob Known"
+msgstr ""
+
+#: custom/opm/beneficiary.py:928
+#, fuzzy
+msgid "Mother's Age"
+msgstr "Nom de la mère:"
+
+#: custom/opm/beneficiary.py:929
+#, fuzzy
+msgid "Caste tribe status"
+msgstr "Statut du patient"
+
+#: custom/opm/beneficiary.py:931
+msgid "Prev pregnancies"
+msgstr ""
+
+#: custom/opm/beneficiary.py:932
+#, fuzzy
+msgid "Prev live births"
+msgstr "Naissances prématurées"
+
+#: custom/opm/beneficiary.py:933
+msgid "Sons alive"
+msgstr ""
+
+#: custom/opm/beneficiary.py:934
+msgid "Daughters alive"
+msgstr ""
+
+#: custom/opm/beneficiary.py:935
+msgid "Sum children"
+msgstr ""
+
+#: custom/opm/beneficiary.py:936
+#, fuzzy
+msgid "Contact phone number"
+msgstr "Le destinataire n'a pas de numéro de téléphone."
+
+#: custom/opm/beneficiary.py:940
+msgid "Bank Branch Code"
+msgstr ""
+
+#: custom/opm/beneficiary.py:943
+#, fuzzy
+msgid "Lmp Date"
+msgstr "Date"
+
+#: custom/opm/beneficiary.py:945
+#, fuzzy
+msgid "Pregnancy month"
+msgstr "Résultat de la grossesse"
+
+#: custom/opm/beneficiary.py:947
+#, fuzzy
+msgid "Child 1 Age"
+msgstr "Détails Enfant 1"
+
+#: custom/opm/beneficiary.py:948
+#, fuzzy
+msgid "Child 1 Name"
+msgstr "Nom de l'enfant"
+
+#: custom/opm/beneficiary.py:949
+#, fuzzy
+msgid "Child 1 Sex"
+msgstr "Détails Enfant 1"
+
+#: custom/opm/beneficiary.py:950
+#, fuzzy
+msgid "Child DOB"
+msgstr "Enfant"
+
+#: custom/opm/beneficiary.py:951
+#, fuzzy
+msgid "Child 2 Age"
+msgstr "Détails Enfant 2"
+
+#: custom/opm/beneficiary.py:952
+#, fuzzy
+msgid "Child 2 Name"
+msgstr "Nom de l'enfant"
+
+#: custom/opm/beneficiary.py:953
+#, fuzzy
+msgid "Child 2 Sex"
+msgstr "Détails Enfant 2"
+
+#: custom/opm/beneficiary.py:954
+#, fuzzy
+msgid "Child 3 Age"
+msgstr "Détails Enfant 3"
+
+#: custom/opm/beneficiary.py:955
+#, fuzzy
+msgid "Child 3 Name"
+msgstr "Nom de l'enfant"
+
+#: custom/opm/beneficiary.py:956
+#, fuzzy
+msgid "Child 3 Sex"
+msgstr "Détails Enfant 3"
+
+#: custom/opm/beneficiary.py:957
+msgid "Condition 1 / pregnant woman attended VHND"
+msgstr ""
+
+#: custom/opm/beneficiary.py:958
+msgid "Condition 2 /pregnant woman's weight taken in first trimester"
+msgstr ""
+
+#: custom/opm/beneficiary.py:959
+msgid "Condition 3/ Received 30 IFA pills"
+msgstr ""
+
+#: custom/opm/beneficiary.py:960
+msgid "Condition 2 /pregnant woman's weight taken in second trimester"
+msgstr ""
+
+#: custom/opm/beneficiary.py:961
+msgid "Condition 4/mother attended VHND with child"
+msgstr ""
+
+#: custom/opm/beneficiary.py:962
+msgid "Condition 5/child birth registered"
+msgstr ""
+
+#: custom/opm/beneficiary.py:963
+msgid "Condition 6/ child birth weight taken"
+msgstr ""
+
+#: custom/opm/beneficiary.py:964
+msgid "Condition 7 /exclusively breastfed for first 6 months"
+msgstr ""
+
+#: custom/opm/beneficiary.py:965
+msgid "Condition 8 /child weight monitored this month"
+msgstr ""
+
+#: custom/opm/beneficiary.py:966
+msgid "Condition 9 /ORS administered if child had diarrhea"
+msgstr ""
+
+#: custom/opm/beneficiary.py:967
+msgid "Condition 10/ Measles vaccine given before child turns 1"
+msgstr ""
+
+#: custom/opm/beneficiary.py:968
+msgid "Birth Spacing Bonus"
+msgstr ""
+
+#: custom/opm/beneficiary.py:969
+msgid "Weight This Month"
+msgstr ""
+
+#: custom/opm/beneficiary.py:970
+msgid "Nutritional Status This Month"
+msgstr ""
+
+#: custom/opm/beneficiary.py:971
+#, fuzzy
+msgid "Nutritional Status Bonus"
+msgstr "Statu d'essai"
+
+#: custom/opm/beneficiary.py:972
+#, fuzzy
+msgid "Payment amount for the month"
+msgstr "Montant "
+
+#: custom/opm/beneficiary.py:975
+msgid "VHND held this month?"
+msgstr ""
+
+#: custom/opm/beneficiary.py:976
+#, fuzzy
+msgid "Opened on"
+msgstr "Ouvert le"
+
+#: custom/opm/beneficiary.py:977
+#, fuzzy
+msgid "Closed on"
+msgstr "Fermé le"
+
+#: custom/opm/beneficiary.py:978
+msgid "Close mother dup"
+msgstr ""
+
+#: custom/opm/beneficiary.py:979
+msgid "Close mother mo"
+msgstr ""
+
+#: custom/opm/beneficiary.py:980
+#, fuzzy
+msgid "Leave program"
+msgstr "Créer un programme"
+
+#: custom/opm/beneficiary.py:981
+#, fuzzy
+msgid "Close mother dead"
+msgstr "Mères décédées"
+
+#: custom/opm/beneficiary.py:982
+msgid "Calendar year"
+msgstr ""
+
+#: custom/opm/beneficiary.py:983
+#, fuzzy
+msgid "Calendar month"
+msgstr "Inclus chaque mois"
+
+#: custom/opm/filters.py:72 custom/opm/filters.py:85
 #: custom/up_nrhm/filters.py:37
 msgid "Hierarchy"
 msgstr ""
 
-#: custom/opm/health_status.py:93
+#: custom/opm/health_status.py:22
 msgid "Gram Panchayat"
 msgstr ""
 
-#: custom/opm/health_status.py:97
+#: custom/opm/health_status.py:26
 msgid "Registered Beneficiaries"
 msgstr ""
 
-#: custom/opm/health_status.py:98
+#: custom/opm/health_status.py:27
 msgid "Beneficiaries registered with BCSP"
 msgstr ""
 
-#: custom/opm/health_status.py:101
+#: custom/opm/health_status.py:30
 msgid "Registered pregnant women"
 msgstr ""
 
-#: custom/opm/health_status.py:102
+#: custom/opm/health_status.py:31
 msgid "Pregnant women registered with BCSP"
 msgstr ""
 
-#: custom/opm/health_status.py:105
+#: custom/opm/health_status.py:34
 msgid "Registered mothers"
 msgstr ""
 
-#: custom/opm/health_status.py:106
+#: custom/opm/health_status.py:35
 msgid "Mothers registered with BCSP"
 msgstr ""
 
-#: custom/opm/health_status.py:109
+#: custom/opm/health_status.py:38
 msgid "Registered children"
 msgstr ""
 
-#: custom/opm/health_status.py:110
+#: custom/opm/health_status.py:39
 msgid "Children below 3 years of age registered with BCSP"
 msgstr ""
 
-#: custom/opm/health_status.py:113
+#: custom/opm/health_status.py:42
 msgid "Eligible for payment upon fulfillment of cash conditions"
 msgstr ""
 
-#: custom/opm/health_status.py:114
+#: custom/opm/health_status.py:43
 msgid ""
 "Registered beneficiaries eligilble for cash payment for the month upon "
 "fulfillment of cash conditions"
 msgstr ""
 
-#: custom/opm/health_status.py:118
+#: custom/opm/health_status.py:47
 msgid "Eligible for payment upon absence of services"
 msgstr ""
 
-#: custom/opm/health_status.py:119
+#: custom/opm/health_status.py:48
 msgid ""
 "Registered beneficiaries eligilble for cash payment for the month upon "
 "absence of services at VHND"
 msgstr ""
 
-#: custom/opm/health_status.py:122
+#: custom/opm/health_status.py:51
 msgid "Eligible for payment"
 msgstr ""
 
-#: custom/opm/health_status.py:123
+#: custom/opm/health_status.py:52
 msgid "Registered beneficiaries eligilble for cash payment for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:126
+#: custom/opm/health_status.py:55
 msgid "Total cash payment"
 msgstr ""
 
-#: custom/opm/health_status.py:127
+#: custom/opm/health_status.py:56
 msgid "Total cash payment made to registered beneficiaries for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:130
+#: custom/opm/health_status.py:59
 msgid "Pregnant women attended VHND"
 msgstr ""
 
-#: custom/opm/health_status.py:131
+#: custom/opm/health_status.py:60
 msgid "Registered pregnant women who attended VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:134
+#: custom/opm/health_status.py:63
 msgid "Children attended VHND"
 msgstr ""
 
-#: custom/opm/health_status.py:135
+#: custom/opm/health_status.py:64
 msgid ""
 "Registered children below 3 years of age who attended VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:138
+#: custom/opm/health_status.py:67
 msgid "Beneficiaries attended VHND"
 msgstr ""
 
-#: custom/opm/health_status.py:139
+#: custom/opm/health_status.py:68
 msgid "Registered beneficiaries who attended VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:142
+#: custom/opm/health_status.py:71
 msgid "Received at least 30 IFA tablets"
 msgstr ""
 
-#: custom/opm/health_status.py:143
+#: custom/opm/health_status.py:72
 msgid ""
 "Registered pregnant women (6 months pregnant) who received at least 30 IFA "
 "tablets in second trimester"
 msgstr ""
 
-#: custom/opm/health_status.py:147
+#: custom/opm/health_status.py:76
 msgid "Weight monitored in second trimester"
 msgstr ""
 
-#: custom/opm/health_status.py:148
+#: custom/opm/health_status.py:77
 msgid ""
 "Registered pregnant women (6 months pregnant) who got their weight monitored "
 "in second trimester"
 msgstr ""
 
-#: custom/opm/health_status.py:151
+#: custom/opm/health_status.py:80
 msgid "Weight monitored in third trimester"
 msgstr ""
 
-#: custom/opm/health_status.py:152
+#: custom/opm/health_status.py:81
 msgid ""
 "Registered pregnant women (9 months pregnant) who got their weight monitored "
 "in third trimester"
 msgstr ""
 
-#: custom/opm/health_status.py:155
+#: custom/opm/health_status.py:84
 msgid "Weight monitored at birth"
 msgstr ""
 
-#: custom/opm/health_status.py:156
+#: custom/opm/health_status.py:85
 msgid "Registered children (3 months old) whose weight was monitored at birth"
 msgstr ""
 
-#: custom/opm/health_status.py:159
+#: custom/opm/health_status.py:88
 msgid "Child birth registered"
 msgstr ""
 
-#: custom/opm/health_status.py:160
+#: custom/opm/health_status.py:89
 msgid ""
 "Registered children (6 months old) whose birth was registered in the first 6 "
 "months after birth"
 msgstr ""
 
-#: custom/opm/health_status.py:163
+#: custom/opm/health_status.py:92
 msgid "Growth monitoring when 0-3 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:164
+#: custom/opm/health_status.py:93
 msgid ""
 "Registered Children (3 months old) who have attended at least one growth "
 "monitoring session between the age 0-3 months"
 msgstr ""
 
-#: custom/opm/health_status.py:168
+#: custom/opm/health_status.py:97
 msgid "Growth Monitoring when 4-6 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:169
+#: custom/opm/health_status.py:98
 msgid ""
 "Registered Children (6 months old) who have attended at least one growth "
 "monitoring session between the age 4-6 months"
 msgstr ""
 
-#: custom/opm/health_status.py:173
+#: custom/opm/health_status.py:102
 msgid "Growth Monitoring when 7-9 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:174
+#: custom/opm/health_status.py:103
 msgid ""
 "Registered Children (9 months old) who have attended at least one growth "
 "monitoring session between the age 7-9 months"
 msgstr ""
 
-#: custom/opm/health_status.py:178
+#: custom/opm/health_status.py:107
 msgid "Growth Monitoring when 10-12 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:179
+#: custom/opm/health_status.py:108
 msgid ""
 "Registered Children (12 months old) who have attended at least one growth "
 "monitoring session between the age 10-12 months"
 msgstr ""
 
-#: custom/opm/health_status.py:183
+#: custom/opm/health_status.py:112
 msgid "Growth Monitoring when 13-15 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:184
+#: custom/opm/health_status.py:113
 msgid ""
 "Registered Children (15 months old) who have attended at least one growth "
 "monitoring session between the age 13-15 months"
 msgstr ""
 
-#: custom/opm/health_status.py:188
+#: custom/opm/health_status.py:117
 msgid "Growth Monitoring when 16-18 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:189
+#: custom/opm/health_status.py:118
 msgid ""
 "Registered Children (18 months old) who have attended at least one growth "
 "monitoring session between the age 16-18 months"
 msgstr ""
 
-#: custom/opm/health_status.py:193
+#: custom/opm/health_status.py:122
 msgid "Growth Monitoring when 19-21 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:194
+#: custom/opm/health_status.py:123
 msgid ""
 "Registered Children (21 months old) who have attended at least one growth "
 "monitoring session between the age 19-21 months"
 msgstr ""
 
-#: custom/opm/health_status.py:198
+#: custom/opm/health_status.py:127
 msgid "Growth Monitoring when 22-24 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:199
+#: custom/opm/health_status.py:128
 msgid ""
 "Registered Children (24 months old) who have attended at least one growth "
 "monitoring session between the age 22-24 months"
 msgstr ""
 
-#: custom/opm/health_status.py:203
+#: custom/opm/health_status.py:132
 msgid "Received ORS and Zinc treatment for diarrhoea"
 msgstr ""
 
-#: custom/opm/health_status.py:204
+#: custom/opm/health_status.py:133
 msgid ""
 "Registered children who received ORS and Zinc treatment if he/she contracts "
 "diarrhoea"
 msgstr ""
 
-#: custom/opm/health_status.py:207
+#: custom/opm/health_status.py:136
 msgid "Exclusively breastfed for first 6 months"
 msgstr ""
 
-#: custom/opm/health_status.py:208
+#: custom/opm/health_status.py:137
 msgid ""
 "Registered children (6 months old) who have been exclusively breastfed for "
 "first 6 months"
 msgstr ""
 
-#: custom/opm/health_status.py:211
+#: custom/opm/health_status.py:140
 msgid "Received Measles vaccine"
 msgstr ""
 
-#: custom/opm/health_status.py:212
+#: custom/opm/health_status.py:141
 msgid "Registered children (12 months old) who have received Measles vaccine"
 msgstr ""
 
-#: custom/opm/health_status.py:215
+#: custom/opm/health_status.py:144
 msgid "VHND organised"
 msgstr ""
 
-#: custom/opm/health_status.py:216
+#: custom/opm/health_status.py:145
 msgid "Whether VHND was organised at AWC for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:219
+#: custom/opm/health_status.py:148
 msgid "Adult Weighing Machine Available"
 msgstr ""
 
-#: custom/opm/health_status.py:220
+#: custom/opm/health_status.py:149
 msgid "Whether adult weighing machine was available for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:223
+#: custom/opm/health_status.py:152
 msgid "Adult Weighing Machine Functional"
 msgstr ""
 
-#: custom/opm/health_status.py:224
+#: custom/opm/health_status.py:153
 msgid "Whether adult weighing machine was functional for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:227
+#: custom/opm/health_status.py:156
 msgid "Child Weighing Machine Available"
 msgstr ""
 
-#: custom/opm/health_status.py:228
+#: custom/opm/health_status.py:157
 msgid "Whether child weighing machine was available for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:231
+#: custom/opm/health_status.py:160
 msgid "Child Weighing Machine Functional"
 msgstr ""
 
-#: custom/opm/health_status.py:232
+#: custom/opm/health_status.py:161
 msgid "Whether child weighing machine was functional for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:235
+#: custom/opm/health_status.py:164
 msgid "ANM Present"
 msgstr ""
 
-#: custom/opm/health_status.py:236
+#: custom/opm/health_status.py:165
 msgid "Whether ANM present at VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:239
+#: custom/opm/health_status.py:168
 msgid "ASHA Present"
 msgstr ""
 
-#: custom/opm/health_status.py:240
+#: custom/opm/health_status.py:169
 msgid "Whether ASHA present at VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:243
+#: custom/opm/health_status.py:172
 msgid "CMG Present"
 msgstr ""
 
-#: custom/opm/health_status.py:244
+#: custom/opm/health_status.py:173
 msgid "Whether CMG present at VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:247
+#: custom/opm/health_status.py:176
 msgid "Stock of IFA tablets"
 msgstr ""
 
-#: custom/opm/health_status.py:248
+#: custom/opm/health_status.py:177
 msgid "Whether AWC has enough stock of IFA tablets for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:251
+#: custom/opm/health_status.py:180
 msgid "Stock of ORS packets"
 msgstr ""
 
-#: custom/opm/health_status.py:252
+#: custom/opm/health_status.py:181
 msgid "Whether AWC has enough stock of ORS packets for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:255
+#: custom/opm/health_status.py:184
 msgid "Stock of ZINC tablets"
 msgstr ""
 
-#: custom/opm/health_status.py:256
+#: custom/opm/health_status.py:185
 msgid "Whether AWC has enough stock of Zinc Tablets for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:259
+#: custom/opm/health_status.py:188
 msgid "Stock of Measles Vaccine"
 msgstr ""
 
-#: custom/opm/health_status.py:260
+#: custom/opm/health_status.py:189
 msgid "Whether AWC has enough stock of measles vaccine for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:263
+#: custom/opm/health_status.py:192
 msgid "Eligilble for Birth Spacing bonus"
 msgstr ""
 
-#: custom/opm/health_status.py:264
+#: custom/opm/health_status.py:193
 msgid "Registered beneficiaries eligible for birth spacing bonus for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:267
+#: custom/opm/health_status.py:196
 msgid "Severely underweight"
 msgstr ""
 
-#: custom/opm/health_status.py:268
+#: custom/opm/health_status.py:197
 msgid ""
 "Registered children severely underweight (very low weight for age) for the "
 "month"
 msgstr ""
 
-#: custom/opm/health_status.py:271
+#: custom/opm/health_status.py:200
 msgid "Underweight"
 msgstr ""
 
-#: custom/opm/health_status.py:272
+#: custom/opm/health_status.py:201
 msgid "Registered children underweight (low weight for age) for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:275
+#: custom/opm/health_status.py:204
 msgid "Normal weight for age"
 msgstr ""
 
-#: custom/opm/health_status.py:276
+#: custom/opm/health_status.py:205
 msgid "Registered children with normal weight for age for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:279
+#: custom/opm/health_status.py:208
 msgid "Eligilble for Nutritional status bonus"
 msgstr ""
 
-#: custom/opm/health_status.py:280
+#: custom/opm/health_status.py:209
 msgid ""
 "Registered beneficiaries eligible for nutritonal status bonus for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:283
+#: custom/opm/health_status.py:212
 msgid "Pregnant women cases closed"
 msgstr ""
 
-#: custom/opm/health_status.py:284
+#: custom/opm/health_status.py:213
 msgid "Registered pregnant women cases closed for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:287
+#: custom/opm/health_status.py:216
 msgid "Mother cases closed"
 msgstr ""
 
-#: custom/opm/health_status.py:288
+#: custom/opm/health_status.py:217
 msgid "Registered mother cases closed for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:291
+#: custom/opm/health_status.py:220
 msgid "Children cases closed"
 msgstr ""
 
-#: custom/opm/health_status.py:292
+#: custom/opm/health_status.py:221
 msgid "Registered children cases closed for the month"
 msgstr ""
 
-#: custom/opm/reports.py:656 custom/opm/reports.py:657
-#: custom/opm/reports.py:917
+#: custom/opm/reports.py:457 custom/opm/reports.py:458
+#: custom/opm/reports.py:719
 msgid "Reporting period incomplete"
 msgstr ""
 
-#: custom/opm/reports.py:876
+#: custom/opm/reports.py:679
 msgid "Duplicate account number"
 msgstr ""
 
-#: custom/opm/reports.py:885
+#: custom/opm/reports.py:688
 msgid "Conditions Met Report"
 msgstr ""
 
-#: custom/opm/reports.py:924
+#: custom/opm/reports.py:726
 msgid "Total Payment"
 msgstr ""
 
@@ -28668,7 +29271,7 @@ msgstr ""
 
 #: custom/up_nrhm/reports/asha_functionality_checklist_report.py:61
 #, python-format
-msgid "Total number of ASHAs who are functional on at least 60% of the tasks"
+msgid "Total number of ASHAs who are functional on at least %s of the tasks"
 msgstr ""
 
 #: custom/up_nrhm/reports/asha_functionality_checklist_report.py:62
@@ -28756,13 +29359,93 @@ msgstr ""
 
 #: custom/up_nrhm/reports/district_functionality_report.py:34
 #, fuzzy, python-format
-msgid "% of ASHAs"
+msgid "%s of ASHAs"
 msgstr "Nom d'ASHA :"
 
-#: custom/up_nrhm/reports/district_functionality_report.py:35
+#: custom/up_nrhm/reports/district_functionality_report.py:36
 #, fuzzy
 msgid "Grade of Block"
 msgstr "Nom du Bloc"
+
+#: docs/_build/html/_sources/translations.txt:141
+#, python-format
+msgid "This string will have %(value)s inside."
+msgstr ""
+
+#: docs/_build/html/_sources/translations.txt:147
+#, python-format
+msgid ""
+"\n"
+"        That will cost $ %(amount)s.\n"
+"    "
+msgstr ""
+
+#: docs/_build/html/_sources/translations.txt:155
+#, python-format
+msgid ""
+"\n"
+"        This will have %(myvar)s inside.\n"
+"    "
+msgstr ""
+
+#: docs/_build/html/_sources/translations.txt:167
+msgid ""
+"\n"
+"        Manage Mobile Workers <small>for CommCare Mobile and\n"
+"        CommCare HQ Reports</small>\n"
+"    "
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/couchpanel.py:89
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/couchpanel.py:92
+msgid "CouchDB"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:15
+msgid "Stacktrace"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:16
+#, fuzzy
+msgid "View Name"
+msgstr "Afficher Table"
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:17
+#, fuzzy
+msgid "Request Params"
+msgstr "Demandé le"
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:45
+msgid "Line"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:46
+msgid "Method"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:6
+#, fuzzy
+msgid "CouchDB View"
+msgstr "Visualisation Couch"
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:11
+msgid "Executed View"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:13
+#, fuzzy
+msgid "Parameters"
+msgstr "Ajouter un paramètre"
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:15
+#, fuzzy
+msgid "Total Rows"
+msgstr "Total sans réponse"
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:40
+#, fuzzy
+msgid "Empty set"
+msgstr "Dossier vide"
 
 #: submodules/auditcare-src/auditcare/forms.py:14
 msgid ""
@@ -29178,16 +29861,16 @@ msgstr "Effacer les données"
 msgid "Clearing data"
 msgstr "Suppression des données en cours"
 
-#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:36
+#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:47
 #, python-format
 msgid "ERROR: Could not send \"%(subject)s\""
 msgstr "ERREUR: Ne pourrait pas envoyé \"%(subject)s\""
 
-#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:41
+#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:52
 msgid "Could not send email: file size is too large."
 msgstr "Ne pourrait pas envoyé l'email: la taille de fichier est trop grande"
 
-#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:46
+#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:57
 #, python-format
 msgid "Please contact %(support_email)s for assistance."
 msgstr "Veuillez contacter %(support_email)s pour assistance"
@@ -29245,6 +29928,17 @@ msgstr ""
 "Une erreur est survenue en se connectent à CloudCare. Veuillez re-essayer. "
 "Si vous avez des problèmes pour remplir le formulaire, veuillez signaler ce "
 "problème."
+
+#~ msgid "Form referenced as the registration form for multiple modules."
+#~ msgstr ""
+#~ "Formulaire référé comme le formulaire registration pour plusieurs "
+#~ "modules. "
+
+#~ msgid "App Translation Failed! "
+#~ msgstr "Échec de traduction d'application!"
+
+#~ msgid "Edit My Information"
+#~ msgstr "Modifier mes informations"
 
 #~ msgid "%s Software Plan"
 #~ msgstr "%s Plan logiciel"
@@ -29368,9 +30062,6 @@ msgstr ""
 
 #~ msgid "Scheduled Date"
 #~ msgstr "Date prévue"
-
-#~ msgid "Current Balance"
-#~ msgstr "Manejo de Casos"
 
 #~ msgid "Reporting Rates"
 #~ msgstr "Manejo de Casos"

--- a/locale/hin/LC_MESSAGES/django.po
+++ b/locale/hin/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CommCare HQ\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-29 19:37+0000\n"
+"POT-Creation-Date: 2015-08-05 17:43+0000\n"
 "PO-Revision-Date: 2015-07-23 15:17+0000\n"
 "Last-Translator: Dimagi Dev <devops@dimagi.com>\n"
 "Language-Team: Hindi (http://www.transifex.com/projects/p/commcare-hq/"
@@ -37,7 +37,7 @@ msgstr ""
 
 #: corehq/__init__.py:61 corehq/feature_previews.py:91
 #: corehq/apps/hqwebapp/models.py:879 corehq/apps/reports/__init__.py:13
-#: corehq/apps/reports/models.py:52
+#: corehq/apps/reports/models.py:54
 #: corehq/apps/users/templates/users/edit_commcare_user.html:125
 msgid "CommCare Supply"
 msgstr ""
@@ -58,9 +58,9 @@ msgstr ""
 msgid "Messaging"
 msgstr ""
 
-#: corehq/__init__.py:177 corehq/apps/app_manager/models.py:2900
+#: corehq/__init__.py:177 corehq/apps/app_manager/models.py:2974
 #: corehq/apps/dashboard/views.py:159 corehq/apps/hqwebapp/models.py:365
-#: corehq/apps/hqwebapp/models.py:1538 corehq/apps/hqwebapp/models.py:1608
+#: corehq/apps/hqwebapp/models.py:1533 corehq/apps/hqwebapp/models.py:1603
 #: corehq/apps/orgs/templates/orgs/report_base.html:26
 #: corehq/apps/reports/templates/reports/reportdata/case_details.html:68
 msgid "Reports"
@@ -79,7 +79,7 @@ msgstr ""
 msgid "Edit Data"
 msgstr ""
 
-#: corehq/__init__.py:198 corehq/privileges.py:71
+#: corehq/__init__.py:198 corehq/privileges.py:76
 #: corehq/apps/accounting/user_text.py:219 corehq/apps/fixtures/views.py:285
 msgid "Lookup Tables"
 msgstr ""
@@ -183,8 +183,8 @@ msgid ""
 "possible reasons for poor performance, and offer guidance towards solutions."
 msgstr ""
 
-#: corehq/feature_previews.py:128 corehq/privileges.py:88
-#: corehq/apps/hqwebapp/models.py:1140 corehq/apps/locations/views.py:75
+#: corehq/feature_previews.py:128 corehq/privileges.py:93
+#: corehq/apps/hqwebapp/models.py:1135 corehq/apps/locations/views.py:75
 #: corehq/apps/users/templates/users/edit_commcare_user.html:127
 msgid "Locations"
 msgstr ""
@@ -207,71 +207,71 @@ msgid ""
 "a>."
 msgstr ""
 
-#: corehq/privileges.py:72 corehq/apps/accounting/user_text.py:218
+#: corehq/privileges.py:77 corehq/apps/accounting/user_text.py:218
 msgid "API Access"
 msgstr ""
 
-#: corehq/privileges.py:73
+#: corehq/privileges.py:78
 msgid "Web-Based Apps (CloudCare)"
 msgstr ""
 
-#: corehq/privileges.py:74
+#: corehq/privileges.py:79
 msgid "Active Data Management"
 msgstr ""
 
-#: corehq/privileges.py:75 corehq/apps/accounting/user_text.py:221
+#: corehq/privileges.py:80 corehq/apps/accounting/user_text.py:221
 msgid "Custom Branding"
 msgstr ""
 
-#: corehq/privileges.py:76 corehq/apps/accounting/user_text.py:224
+#: corehq/privileges.py:81 corehq/apps/accounting/user_text.py:224
 msgid "Cross-Project Reports"
 msgstr ""
 
-#: corehq/privileges.py:77 corehq/apps/accounting/user_text.py:236
+#: corehq/privileges.py:82 corehq/apps/accounting/user_text.py:236
 msgid "Advanced Role-Based Access"
 msgstr ""
 
-#: corehq/privileges.py:78
+#: corehq/privileges.py:83
 msgid "Outgoing Messaging"
 msgstr ""
 
-#: corehq/privileges.py:79
+#: corehq/privileges.py:84
 msgid "Incoming Messaging"
 msgstr ""
 
-#: corehq/privileges.py:80
+#: corehq/privileges.py:85
 msgid "Reminders Framework"
 msgstr ""
 
-#: corehq/privileges.py:81
+#: corehq/privileges.py:86
 msgid "Custom Android Gateway"
 msgstr ""
 
-#: corehq/privileges.py:82
+#: corehq/privileges.py:87
 msgid "Bulk Case Management"
 msgstr ""
 
-#: corehq/privileges.py:83
+#: corehq/privileges.py:88
 msgid "Bulk User Management"
 msgstr ""
 
-#: corehq/privileges.py:84
+#: corehq/privileges.py:89
 msgid "Add Mobile Workers Above Limit"
 msgstr ""
 
-#: corehq/privileges.py:85
+#: corehq/privileges.py:90
 msgid "De-Identified Data"
 msgstr ""
 
-#: corehq/privileges.py:86 corehq/apps/accounting/user_text.py:238
+#: corehq/privileges.py:91 corehq/apps/accounting/user_text.py:238
 msgid "HIPAA Compliance Assurance"
 msgstr ""
 
-#: corehq/privileges.py:87
+#: corehq/privileges.py:92
 msgid "Custom CommCare Logo Uploader"
 msgstr ""
 
-#: corehq/privileges.py:89
+#: corehq/privileges.py:94
 msgid "User Configurable Report Builder"
 msgstr ""
 
@@ -379,6 +379,7 @@ msgstr ""
 
 #: corehq/apps/accounting/filters.py:140 corehq/apps/accounting/forms.py:346
 #: corehq/apps/accounting/forms.py:634 corehq/apps/commtrack/models.py:535
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:57
 #: corehq/apps/domain/templates/domain/admin/media_manager.html:24
 #: corehq/apps/export/templates/export/customize_export.html:602
 #: corehq/apps/hqadmin/reports.py:839
@@ -522,7 +523,7 @@ msgstr ""
 #: corehq/apps/accounting/templates/accounting/subscriptions_tab.html:16
 #: corehq/apps/domain/forms.py:1455
 #: corehq/apps/domain/templates/domain/current_subscription.html:247
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:74
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:83
 msgid "Software Plan"
 msgstr ""
 
@@ -631,10 +632,10 @@ msgid "A name is required for this new role."
 msgstr ""
 
 #: corehq/apps/accounting/forms.py:1428 corehq/apps/app_manager/forms.py:11
-#: corehq/apps/app_manager/models.py:1737
-#: corehq/apps/app_manager/models.py:2167
-#: corehq/apps/app_manager/models.py:2525
-#: corehq/apps/app_manager/models.py:2574 corehq/apps/commtrack/models.py:531
+#: corehq/apps/app_manager/models.py:1738
+#: corehq/apps/app_manager/models.py:2193
+#: corehq/apps/app_manager/models.py:2574
+#: corehq/apps/app_manager/models.py:2623 corehq/apps/commtrack/models.py:531
 #: corehq/apps/domain/forms.py:126
 #: corehq/apps/domain/templates/domain/admin/commtrack_action_table.html:5
 #: corehq/apps/domain/templates/domain/partials/user_list.html:9
@@ -656,7 +657,7 @@ msgstr ""
 #: corehq/apps/toggle_ui/templates/toggle/flags.html:58
 #: corehq/apps/users/templates/users/web_users.b3.html:171
 #: corehq/apps/users/templates/users/web_users.b3.html:216
-#: corehq/ex-submodules/casexml/apps/case/models.py:853
+#: corehq/ex-submodules/casexml/apps/case/models.py:858
 #: corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_hierarchy.html:57
 #: custom/bihar/reports/indicators/clientlistdisplay.py:80
 #: custom/bihar/reports/indicators/clientlistdisplay.py:98
@@ -665,13 +666,13 @@ msgstr ""
 #: custom/ewsghana/reports/specific_reports/reporting_rates.py:199
 #: custom/ewsghana/reports/specific_reports/reporting_rates.py:241
 #: custom/fri/reports/reports.py:349
-#: custom/ilsgateway/tanzania/reports/delivery.py:27
-#: custom/ilsgateway/tanzania/reports/facility_details.py:70
-#: custom/ilsgateway/tanzania/reports/facility_details.py:116
-#: custom/ilsgateway/tanzania/reports/randr.py:82
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:81
-#: custom/ilsgateway/tanzania/reports/supervision.py:56
-#: custom/ilsgateway/tanzania/reports/supervision.py:120
+#: custom/ilsgateway/tanzania/reports/delivery.py:28
+#: custom/ilsgateway/tanzania/reports/facility_details.py:71
+#: custom/ilsgateway/tanzania/reports/facility_details.py:117
+#: custom/ilsgateway/tanzania/reports/randr.py:83
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:83
+#: custom/ilsgateway/tanzania/reports/supervision.py:57
+#: custom/ilsgateway/tanzania/reports/supervision.py:122
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:37
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:184
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:249
@@ -681,7 +682,7 @@ msgid "Name"
 msgstr "नाम"
 
 #: corehq/apps/accounting/forms.py:1432 corehq/apps/accounting/models.py:357
-#: corehq/apps/prelogin/forms.py:28
+#: corehq/apps/prelogin/forms.py:29
 msgid "Company / Organization"
 msgstr ""
 
@@ -747,13 +748,13 @@ msgstr ""
 msgid "Messages"
 msgstr ""
 
-#: corehq/apps/accounting/models.py:341 corehq/apps/prelogin/forms.py:20
-#: corehq/apps/users/forms.py:145
+#: corehq/apps/accounting/models.py:341 corehq/apps/prelogin/forms.py:21
+#: corehq/apps/users/forms.py:144
 msgid "First Name"
 msgstr ""
 
-#: corehq/apps/accounting/models.py:344 corehq/apps/prelogin/forms.py:24
-#: corehq/apps/users/forms.py:146
+#: corehq/apps/accounting/models.py:344 corehq/apps/prelogin/forms.py:25
+#: corehq/apps/users/forms.py:145
 msgid "Last Name"
 msgstr ""
 
@@ -768,7 +769,7 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/accounting/models.py:353
-#: corehq/apps/data_interfaces/views.py:322 corehq/apps/prelogin/forms.py:36
+#: corehq/apps/data_interfaces/views.py:322 corehq/apps/prelogin/forms.py:37
 #: corehq/apps/reports/standard/ivr.py:46
 #: corehq/apps/reports/standard/sms.py:280
 #: corehq/apps/reports/standard/sms.py:617
@@ -801,7 +802,7 @@ msgstr ""
 msgid "Postal Code"
 msgstr ""
 
-#: corehq/apps/accounting/models.py:378 corehq/apps/prelogin/forms.py:40
+#: corehq/apps/accounting/models.py:378 corehq/apps/prelogin/forms.py:41
 msgid "Country"
 msgstr ""
 
@@ -993,14 +994,14 @@ msgstr ""
 
 #: corehq/apps/accounting/user_text.py:8
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/analytics.html:22
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:41
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:52
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/mobile.html:22
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:21
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/support.html:22
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/user.html:22
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/web.html:22
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:80
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:77
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:89
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:79
 msgid "Community"
 msgstr ""
 
@@ -1012,7 +1013,7 @@ msgstr ""
 
 #: corehq/apps/accounting/user_text.py:13
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/analytics.html:27
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:46
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:57
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/mobile.html:27
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:26
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/support.html:27
@@ -1029,16 +1030,16 @@ msgstr ""
 
 #: corehq/apps/accounting/user_text.py:18
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/analytics.html:32
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:51
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:62
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/mobile.html:32
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:31
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/support.html:32
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/user.html:32
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/web.html:32
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:90
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:98
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:87
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:95
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:99
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:107
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:89
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:97
 msgid "Pro"
 msgstr ""
 
@@ -1049,20 +1050,20 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:23
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:306
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:309
 #: corehq/apps/app_manager/templates/app_manager/module_view.html:294
 #: corehq/apps/importer/templates/importer/excel_config.html:114
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/analytics.html:37
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:56
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:67
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/mobile.html:37
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:36
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/support.html:37
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/user.html:37
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/web.html:37
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:106
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:114
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:103
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:111
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:115
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:123
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:105
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:113
 msgid "Advanced"
 msgstr ""
 
@@ -1075,7 +1076,7 @@ msgstr ""
 
 #: corehq/apps/accounting/user_text.py:29
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/analytics.html:42
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:61
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:72
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/mobile.html:42
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:41
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/support.html:42
@@ -1106,7 +1107,7 @@ msgstr ""
 #: corehq/apps/accounting/user_text.py:54
 #: corehq/apps/accounting/user_text.py:201
 #: corehq/apps/accounting/user_text.py:202
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:98
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:109
 msgid "Mobile Users"
 msgstr ""
 
@@ -1176,7 +1177,7 @@ msgid "SMS (CommConnect)"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:90
-#: corehq/apps/accounting/user_text.py:91 corehq/apps/commtrack/views.py:170
+#: corehq/apps/accounting/user_text.py:91 corehq/apps/commtrack/views.py:175
 #: corehq/apps/domain/forms.py:1624
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:13
 #: corehq/apps/reminders/forms.py:98 corehq/apps/reminders/forms.py:103
@@ -1332,24 +1333,24 @@ msgid "Dedicated Enterprise Account Management"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:255
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:71
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:83
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:80
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:82
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:92
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:82
 msgid "Free"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:255
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:76
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:87
 msgid "$100 /month"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:255
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:81
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:92
 msgid "$500 /month"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:255
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:86
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:97
 msgid "$1,000 /month"
 msgstr ""
 
@@ -1360,22 +1361,22 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:256
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:102
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:113
 msgid "50"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:256
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:107
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:118
 msgid "100"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:256
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:112
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:123
 msgid "500"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:256
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:117
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:128
 msgid "1,000"
 msgstr ""
 
@@ -1385,10 +1386,10 @@ msgid "Unlimited / Discounted Pricing"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:257
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:132
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:137
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:142
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:147
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:143
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:148
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:153
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:158
 msgid "1 USD /month"
 msgstr ""
 
@@ -1483,7 +1484,7 @@ msgstr ""
 #: corehq/apps/sms/templates/sms/default.html:47
 #: corehq/apps/unicel/forms.py:10
 #: corehq/apps/unicel/templates/unicel/backend.html:10
-#: corehq/apps/userhack/admin.py:14 corehq/apps/users/forms.py:184
+#: corehq/apps/userhack/admin.py:14 corehq/apps/users/forms.py:183
 #: corehq/apps/users/templates/users/edit_web_user.html:13
 #: corehq/apps/users/templates/users/mobile/users_list.html:209
 #: corehq/apps/users/templates/users/partial/basic_info_form.html:10
@@ -1504,6 +1505,7 @@ msgstr ""
 #: corehq/apps/reports/templates/reports/partials/hqexport_group_table.html:11
 #: corehq/apps/sms/templates/sms/add_gateway.html:42
 #: corehq/apps/sms/templates/sms/partials/day_time_windows.html:12
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:14
 msgid "Action"
 msgstr ""
 
@@ -1569,6 +1571,7 @@ msgstr ""
 #: corehq/apps/hqmedia/templates/hqmedia/bulk_upload.html:55
 #: corehq/apps/indicators/templates/indicators/forms/copy_to_domain.html:66
 #: corehq/apps/locations/templates/locations/manage/location.html:195
+#: corehq/apps/locations/templates/locations/manage/locations.html:266
 #: corehq/apps/orgs/templates/orgs/orgs_landing.html:184
 #: corehq/apps/orgs/templates/orgs/orgs_landing.html:203
 #: corehq/apps/orgs/templates/orgs/orgs_landing.html:230
@@ -1821,7 +1824,7 @@ msgstr ""
 #: corehq/apps/reports/standard/monitoring.py:479
 #: corehq/apps/reports/standard/monitoring.py:623
 #: corehq/apps/reports/standard/monitoring.py:1321
-#: custom/ilsgateway/tanzania/reports/delivery.py:171
+#: custom/ilsgateway/tanzania/reports/delivery.py:174
 #: custom/m4change/reports/aggregate_facility_web_hmis_report.py:38
 #: custom/m4change/reports/all_hmis_report.py:258
 #: custom/m4change/reports/anc_hmis_report.py:117
@@ -1882,7 +1885,7 @@ msgstr ""
 
 #: corehq/apps/accounting/templates/accounting/credits_tab.html:9
 #: corehq/apps/accounting/templates/accounting/subscriptions.html:55
-#: corehq/apps/hqwebapp/models.py:1302
+#: corehq/apps/hqwebapp/models.py:1297
 msgid "Subscription"
 msgstr ""
 
@@ -1930,8 +1933,8 @@ msgstr ""
 #: corehq/apps/reports/standard/sms.py:732
 #: corehq/apps/users/templates/users/web_users.b3.html:286
 #: corehq/apps/users/templates/users/web_users.html:128
-#: custom/ilsgateway/tanzania/reports/facility_details.py:118
-#: custom/ilsgateway/tanzania/reports/supervision.py:122
+#: custom/ilsgateway/tanzania/reports/facility_details.py:119
+#: custom/ilsgateway/tanzania/reports/supervision.py:124
 #: custom/intrahealth/sqldata.py:392
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:266
 msgid "Date"
@@ -1991,9 +1994,9 @@ msgstr ""
 #: corehq/apps/reports/templates/reports/messaging/survey_detail.html:33
 #: corehq/apps/settings/templates/settings/my_projects.html:12
 #: corehq/apps/sms/views.py:1022
-#: corehq/ex-submodules/casexml/apps/case/models.py:903
+#: corehq/ex-submodules/casexml/apps/case/models.py:908
 #: custom/_legacy/pact/models.py:329
-#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:55
+#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:65
 #: custom/m4change/reports/mcct_project_review.py:274
 #: custom/m4change/reports/mcct_project_review.py:401
 #: custom/m4change/reports/mcct_project_review.py:484
@@ -2352,7 +2355,7 @@ msgstr ""
 #: corehq/apps/reports/templates/reports/standard/base_template.html:108
 #: corehq/apps/reports/templates/reports/standard/export_download.html:99
 #: corehq/apps/reports_core/templates/reports_core/base_template_new.html:150
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:118
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:122
 msgid "Generating Report..."
 msgstr ""
 
@@ -2367,8 +2370,8 @@ msgstr ""
 #: corehq/apps/reports/templates/reports/standard/base_template.html:111
 #: corehq/apps/reports_core/templates/reports_core/base_template_new.html:151
 #: corehq/apps/reports_core/templates/reports_core/base_template_new.html:152
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:119
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:120
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:123
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:124
 msgid "Apply"
 msgstr ""
 
@@ -2476,11 +2479,11 @@ msgid "Delay Invoicing Until"
 msgstr ""
 
 #: corehq/apps/accounting/templates/accounting/subscriptions_tab.html:24
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:255
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:261
-#: corehq/apps/domain/templates/domain/admin/feature_flags.html:28
-#: corehq/apps/locations/templates/locations/manage/locations.html:148
-#: corehq/apps/reports/views.py:801
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:258
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:264
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:37
+#: corehq/apps/locations/templates/locations/manage/locations.html:167
+#: corehq/apps/reports/views.py:809
 #: corehq/apps/reports/templates/reports/reports_home.html:60
 #: corehq/apps/reports/templates/reports/reports_home.html:126
 #: corehq/apps/reports/templates/reports/partials/saved_custom_exports.html:9
@@ -2764,6 +2767,7 @@ msgstr ""
 #: corehq/apps/app_manager/fields.py:45
 #: corehq/apps/app_manager/templates/app_manager/managed_app.html:266
 #: corehq/apps/app_manager/templates/app_manager/ng_partials/case_summary_view.html:109
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:56
 #: corehq/apps/hqwebapp/doc_info.py:100
 #: corehq/apps/reports/filters/forms.py:684
 #: corehq/apps/reports/standard/inspect.py:89
@@ -2810,60 +2814,56 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:749
-msgid "Form referenced as the registration form for multiple modules."
-msgstr ""
-
-#: corehq/apps/app_manager/models.py:1743
-#: corehq/apps/app_manager/models.py:2174
-#: corehq/apps/app_manager/views.py:1412
+#: corehq/apps/app_manager/models.py:1744
+#: corehq/apps/app_manager/models.py:2200
+#: corehq/apps/app_manager/views.py:1414
 msgid "Untitled Module"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:1756
-#: corehq/apps/app_manager/models.py:2200
-#: corehq/apps/app_manager/views.py:1471
+#: corehq/apps/app_manager/models.py:1757
+#: corehq/apps/app_manager/models.py:2226
+#: corehq/apps/app_manager/views.py:1473
 msgid "Untitled Form"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:1849
+#: corehq/apps/app_manager/models.py:1850
 msgid "Case tiles may only be used for the case list (not the case details)."
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:1857
+#: corehq/apps/app_manager/models.py:1858
 msgid "A case property must be assigned to the \"{}\" tile field."
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2014
+#: corehq/apps/app_manager/models.py:2040
 msgid "Case property"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2015
+#: corehq/apps/app_manager/models.py:2041
 msgid "Lookup Table field"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2016
+#: corehq/apps/app_manager/models.py:2042
 msgid "custom user property"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2017
+#: corehq/apps/app_manager/models.py:2043
 msgid "custom XPath expression"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2024
+#: corehq/apps/app_manager/models.py:2050
 msgid "Case tag"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2025
+#: corehq/apps/app_manager/models.py:2051
 msgid "Lookup Table tag"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2063
+#: corehq/apps/app_manager/models.py:2089
 msgid "All forms in this module require a visit schedule."
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2186
-#: corehq/apps/app_manager/models.py:4198 corehq/apps/products/views.py:467
+#: corehq/apps/app_manager/models.py:2212
+#: corehq/apps/app_manager/models.py:4272 corehq/apps/products/views.py:467
 #: corehq/apps/products/templates/products/manage/products.html:110
 #: corehq/apps/programs/templates/programs/manage/program.html:77
 #: corehq/apps/reports/commtrack/standard.py:92
@@ -2875,9 +2875,9 @@ msgstr ""
 msgid "Product"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2521
-#: corehq/apps/app_manager/models.py:2575
-#: corehq/apps/app_manager/models.py:2637
+#: corehq/apps/app_manager/models.py:2570
+#: corehq/apps/app_manager/models.py:2624
+#: corehq/apps/app_manager/models.py:2686
 #: corehq/apps/appstore/templates/appstore/deployment_info.html:31
 #: corehq/apps/appstore/templates/appstore/project_info.html:140
 #: corehq/apps/appstore/templates/appstore/project_info.html:259
@@ -2893,71 +2893,73 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2522
-#: corehq/apps/app_manager/models.py:2570
+#: corehq/apps/app_manager/models.py:2571
+#: corehq/apps/app_manager/models.py:2619
 msgid "Followup date"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2527
-#: corehq/apps/app_manager/models.py:2580
+#: corehq/apps/app_manager/models.py:2576
+#: corehq/apps/app_manager/models.py:2629
 msgid "Close if"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2579
+#: corehq/apps/app_manager/models.py:2628
 msgid "Latest report"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2600
+#: corehq/apps/app_manager/models.py:2649
 #: custom/_legacy/pact/templates/pact/patient/pactpatient_base.html:33
 #: custom/_legacy/pact/templates/pact/patient/pactpatient_submissions.html:31
 msgid "Care Plan"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2621
+#: corehq/apps/app_manager/models.py:2670
 #: corehq/apps/reports/standard/cases/careplan.py:124
 #: custom/_legacy/pact/models.py:357
 msgid "Goal"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2621
+#: corehq/apps/app_manager/models.py:2670
 #: corehq/apps/reports/standard/cases/careplan.py:138
 #: custom/_legacy/pact/models.py:375
 msgid "Task"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2630
+#: corehq/apps/app_manager/models.py:2679
 msgid "Followup"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2644
+#: corehq/apps/app_manager/models.py:2693
 msgid "Last update"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:3394
+#: corehq/apps/app_manager/models.py:3468
 msgid ""
 "Usage of lookup tables is not supported by your current subscription. Please "
 "upgrade your subscription before using this feature."
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:4171
+#: corehq/apps/app_manager/models.py:4245
 #, python-brace-format
 msgid "Copy of {name}"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:4408
+#: corehq/apps/app_manager/models.py:4482
 msgid "Error in case type hierarchy"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:4498
+#: corehq/apps/app_manager/models.py:4572
 msgid ""
 "Problem loading suite file from profile file. Is your profile file correct?"
 msgstr ""
 
-#: corehq/apps/app_manager/translations.py:46
-msgid "App Translation Failed! "
+#: corehq/apps/app_manager/translations.py:48
+msgid ""
+"App Translation Failed! Please make sure you are using a valid Excel 2007 or "
+"later (.xlsx) file. Error details: {}."
 msgstr ""
 
-#: corehq/apps/app_manager/translations.py:149
+#: corehq/apps/app_manager/translations.py:154
 msgid "App Translations Updated!"
 msgstr ""
 
@@ -2969,138 +2971,138 @@ msgstr ""
 msgid "You must submit the source data."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:526
+#: corehq/apps/app_manager/views.py:527
 msgid "All Programs"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:596
+#: corehq/apps/app_manager/views.py:597
 msgid "U​I translation"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:597
+#: corehq/apps/app_manager/views.py:598
 msgid "U​I translations"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:604
+#: corehq/apps/app_manager/views.py:605
 msgid "app translation"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:605
+#: corehq/apps/app_manager/views.py:606
 msgid "app translations"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:821
+#: corehq/apps/app_manager/views.py:822
 msgid "Don't Show"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:828
+#: corehq/apps/app_manager/views.py:829
 #: corehq/apps/reports/standard/cases/basic.py:211
 #: corehq/apps/reports/templates/reports/reportdata/case_details.html:71
 msgid "Case List"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:829
+#: corehq/apps/app_manager/views.py:830
 msgid "Case Detail"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:848
+#: corehq/apps/app_manager/views.py:849
 msgid "Product List"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:849
+#: corehq/apps/app_manager/views.py:850
 msgid "Product Detail"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:871
+#: corehq/apps/app_manager/views.py:872
 msgid "Goal List"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:872
+#: corehq/apps/app_manager/views.py:873
 msgid "Goal Detail"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:882
+#: corehq/apps/app_manager/views.py:883
 msgid "Task List"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:883
+#: corehq/apps/app_manager/views.py:884
 msgid "Task Detail"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:921
+#: corehq/apps/app_manager/views.py:923
 msgid ""
 "Your app contains references to reports that are deleted. These will be "
 "removed on save."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:1243
+#: corehq/apps/app_manager/views.py:1245
 msgid ""
 "You tried to edit this form in the Form Builder. However, your administrator "
 "has locked this form against editing in the form builder, so we have "
 "redirected you to the form's front page instead."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:1409
+#: corehq/apps/app_manager/views.py:1411
 msgid "Untitled Application"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:1458
+#: corehq/apps/app_manager/views.py:1460
 #, python-brace-format
 msgid "Please set the case type for the target module '{name}'."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:1464
+#: corehq/apps/app_manager/views.py:1466
 msgid "Caution: Care Plan modules are a labs feature"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:1476
+#: corehq/apps/app_manager/views.py:1478
 msgid "Caution: Advanced modules are a labs feature"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:1592
+#: corehq/apps/app_manager/views.py:1594
 msgid ""
 "We could not copy this form, because it is blank.In order to copy this form, "
 "please add some questions first."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:1596
+#: corehq/apps/app_manager/views.py:1598
 msgid ""
 "This form could not be copied because it is not compatible with the selected "
 "module."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:1765
+#: corehq/apps/app_manager/views.py:1767
 msgid "Unknown Module"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:2468
+#: corehq/apps/app_manager/views.py:2470
 msgid "The form can not be moved into the desired module."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:2473
+#: corehq/apps/app_manager/views.py:2475
 msgid ""
 "Oops. Looks like you got out of sync with us. The sidebar has been updated, "
 "so please try again."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:2628
+#: corehq/apps/app_manager/views.py:2630
 msgid ""
 "We were unable to get your files because your Application has errors. Please "
 "click <strong>Make New Version</strong> under <strong>Deploy</strong> for "
 "feedback on how to fix these errors."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:2658
+#: corehq/apps/app_manager/views.py:2660
 msgid ""
 "We were unable to get your files because your Application has errors. Please "
 "click Make New Version under Deploy for feedback on how to fix these errors."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:3022
+#: corehq/apps/app_manager/views.py:3024
 msgid "Summary"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:3060
+#: corehq/apps/app_manager/views.py:3062
 #: corehq/apps/app_manager/templates/app_manager/app_view.html:257
 #: corehq/apps/app_manager/templates/app_manager/apps_base.html:9
 #: corehq/apps/app_manager/templates/app_manager/apps_base.html:14
@@ -3111,23 +3113,23 @@ msgstr ""
 msgid "Applications"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:3211
+#: corehq/apps/app_manager/views.py:3213
 msgid "We found problem with following translations:"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:3222
+#: corehq/apps/app_manager/views.py:3224
 msgid "Something went wrong! Update failed. We're looking into it"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:3225
+#: corehq/apps/app_manager/views.py:3227
 msgid "UI Translations Updated!"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:3271
+#: corehq/apps/app_manager/views.py:3273
 msgid "Please upgrade you app to > 2.0 in order to add a Careplan module"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:3282
+#: corehq/apps/app_manager/views.py:3284
 msgid "This application already has a Careplan module"
 msgstr ""
 
@@ -3135,33 +3137,33 @@ msgstr ""
 msgid "Error parsing XML: {}"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:204
+#: corehq/apps/app_manager/xform.py:205
 #, python-brace-format
 msgid "Group already has node for lang: {0}"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:673
+#: corehq/apps/app_manager/xform.py:679
 msgid "There's no language called '{}'"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:675
+#: corehq/apps/app_manager/xform.py:681
 msgid "There's already a language called '{}'"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:720
+#: corehq/apps/app_manager/xform.py:726
 #, python-brace-format
 msgid "<translation lang=\"{lang}\"><text id=\"{id}\"> node has no <value>"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:827
+#: corehq/apps/app_manager/xform.py:833
 msgid "<item> ({}) has no <value>"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:948
+#: corehq/apps/app_manager/xform.py:954
 msgid "Node <{}> has no 'ref' or 'bind'"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:1122 corehq/apps/app_manager/xform.py:1379
+#: corehq/apps/app_manager/xform.py:1128 corehq/apps/app_manager/xform.py:1385
 msgid ""
 "Couldn't get the case XML from one of your forms. A common reason for this "
 "is if you don't have the xforms namespace defined in your form. Please "
@@ -3169,23 +3171,23 @@ msgid ""
 "your form."
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:1371
+#: corehq/apps/app_manager/xform.py:1377
 msgid ""
 "You cannot use the Case Management UI if you already have a case block in "
 "your form."
 msgstr ""
 
-#: corehq/apps/app_manager/xpath.py:205
+#: corehq/apps/app_manager/xpath.py:208
 #, python-brace-format
 msgid "Type {type} must be in list of domain types: {list}"
 msgstr ""
 
-#: corehq/apps/app_manager/xpath.py:213
+#: corehq/apps/app_manager/xpath.py:216
 #, python-brace-format
 msgid "Reference type {ref} cannot be a child of primary type {main}."
 msgstr ""
 
-#: corehq/apps/app_manager/xpath.py:226
+#: corehq/apps/app_manager/xpath.py:229
 msgid ""
 "Property not correctly formatted. Must be formatted like: loacation:mytype:"
 "referencetype/property. For example: location:outlet:state/name"
@@ -3237,49 +3239,49 @@ msgstr ""
 msgid "No thanks, get me out of here"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:177
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:180
 msgid "Home Screen"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:178
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:181
 msgid "Module Menu"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:179
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:182
 msgid "Module:"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:180
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:183
 msgid "Previous Screen"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:189
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:192
 msgid "Link to other form"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:239
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:242
 msgid "Delete Form"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:259
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:262
 msgid ""
 "Your administrator has locked this form from edits through the form builder"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:268
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:271
 msgid "Try in CloudCare"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:277
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:280
 msgid "User Registration Properties"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:284
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:287
 #: corehq/apps/app_manager/templates/app_manager/managed_app.html:162
 #: corehq/apps/app_manager/templates/app_manager/module_view.html:189
 #: corehq/apps/dashboard/views.py:217
 #: corehq/apps/grapevine/templates/grapevine/backend.html:5
-#: corehq/apps/hqwebapp/models.py:952 corehq/apps/hqwebapp/models.py:1630
+#: corehq/apps/hqwebapp/models.py:952 corehq/apps/hqwebapp/models.py:1625
 #: corehq/apps/mach/templates/mach/backend.html:5
 #: corehq/apps/megamobile/templates/megamobile/backend.html:5
 #: corehq/apps/sms/templates/sms/http_backend.html:33
@@ -3290,63 +3292,63 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:288
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:332
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:334
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:291
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:335
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:337
 #: corehq/apps/app_manager/templates/app_manager/module_view.html:190
 msgid "Case Management"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:294
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:358
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:360
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:297
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:361
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:363
 msgid "User Case Management"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:301
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:304
 msgid "Visit Scheduler"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:317
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:354
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:320
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:357
 msgid ""
 "There are errors in your form. Fix your form in order to view and edit Case "
 "Management."
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:322
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:324
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:325
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:327
 msgid "Cases and Referrals"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:325
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:335
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:328
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:338
 msgid ""
 "Cases give you a way to track patients, farms, etc. over time.  You can "
 "choose to save data from a form to the case, which will store the data "
 "locally on the phone to use later."
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:346
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:349
 #: corehq/apps/app_manager/templates/app_manager/partials/form_tab_visit_scheduler.html:97
 msgid ""
 "You have not created a form yet. Create a form in order to view and edit "
 "Case Management."
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:361
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:364
 msgid ""
 "The user case allows you to store data about the user in a case and use that "
 "data in forms."
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:371
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:374
 msgid ""
 "You have not created a form yet. Create a form in order to view and edit "
 "User Case Management."
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:396
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:399
 #: corehq/apps/app_manager/templates/app_manager/managed_app.html:213
 #: corehq/apps/reports/templates/reports/partials/form_name.html:5
 msgid "User Registration"
@@ -3499,7 +3501,7 @@ msgstr ""
 #: corehq/apps/app_manager/templates/app_manager/module_view.html:254
 #: corehq/apps/domain/views.py:340
 #: corehq/apps/locations/templates/locations/manage/location.html:84
-#: corehq/apps/users/forms.py:211
+#: corehq/apps/users/forms.py:210
 #: corehq/apps/users/templates/users/edit_commcare_user.html:122
 msgid "Basic"
 msgstr ""
@@ -3511,7 +3513,7 @@ msgstr ""
 #: corehq/apps/reports/filters/select.py:108
 #: corehq/apps/reports/standard/cases/basic.py:270
 #: corehq/apps/reports/templates/reports/reportdata/case_export_data.html:125
-#: corehq/ex-submodules/casexml/apps/case/models.py:877
+#: corehq/ex-submodules/casexml/apps/case/models.py:882
 msgid "Case Type"
 msgstr ""
 
@@ -3562,7 +3564,33 @@ msgstr ""
 msgid "Display"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:65
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:63
+msgid "Chart Title"
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:66
+msgid "Graph type"
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:73
+#, fuzzy
+msgid "Configuration"
+msgstr "शर्त 1"
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:83
+msgid "Add Configuration Item"
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:88
+#, fuzzy
+msgid "Series Configuration"
+msgstr "सेवा प्रदाता का विवरण"
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:99
+msgid "Add Series Configuration Item"
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:109
 #: corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html:130
 #: corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html:174
 #: corehq/apps/data_interfaces/templates/data_interfaces/list_case_groups.html:21
@@ -3601,7 +3629,7 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:76
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:120
 msgid "Add Report"
 msgstr ""
 
@@ -3910,7 +3938,6 @@ msgstr ""
 #: custom/ewsghana/templates/ewsghana/facility_page_print_report.html:82
 #: custom/ewsghana/templates/ewsghana/reporting_rates_print_report.html:85
 #: custom/ewsghana/templates/ewsghana/stock_status_print_report.html:78
-#: custom/opm/templates/opm/hsr_print.html:57
 #: custom/opm/templates/opm/met_print_report.html:88
 #: custom/opm/templates/opm/new_hsr_print.html:65
 msgid "Loading ..."
@@ -4792,7 +4819,7 @@ msgstr ""
 #: corehq/apps/appstore/templates/appstore/appstore_base.html:278
 #: corehq/apps/reports/standard/monitoring.py:773
 #: corehq/apps/reports/templates/reports/reports_home.html:132
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:272
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:273
 #: corehq/apps/reports/templates/reports/messaging/survey_detail.html:40
 #: corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_hierarchy.html:118
 #: submodules/ctable-src/ctable_view/templates/ctable/list_mappings.html:115
@@ -4810,7 +4837,7 @@ msgstr ""
 
 #: corehq/apps/app_manager/templates/app_manager/partials/form_tab_advanced.html:51
 #: corehq/apps/cloudcare/templates/cloudcare/cloudcare_home.html:50
-#: corehq/apps/hqwebapp/views.py:715
+#: corehq/apps/hqwebapp/views.py:717
 msgid "Loading..."
 msgstr ""
 
@@ -5022,10 +5049,10 @@ msgstr ""
 #: corehq/apps/export/templates/export/dialogs/delete_custom_export_dialog.html:13
 #: corehq/apps/hqadmin/templates/hqadmin/partials/reset-pillow-checkpoint-modal.html:18
 #: corehq/apps/hqmedia/templates/hqmedia/partials/multimedia_uploader.html:34
-#: corehq/apps/prelogin/templates/prelogin/base.html:126
-#: corehq/apps/prelogin/templates/prelogin/base.html:143
-#: corehq/apps/prelogin/templates/prelogin/base.html:174
-#: corehq/apps/prelogin/templates/prelogin/base.html:213
+#: corehq/apps/prelogin/templates/prelogin/base.html:129
+#: corehq/apps/prelogin/templates/prelogin/base.html:146
+#: corehq/apps/prelogin/templates/prelogin/base.html:177
+#: corehq/apps/prelogin/templates/prelogin/base.html:216
 #: corehq/apps/registration/templates/registration/org_request.html:70
 #: corehq/apps/registration/templates/registration/partials/eula_modal.html:11
 #: corehq/apps/reports/templates/reports/partials/export_download_modal.html:15
@@ -5099,7 +5126,7 @@ msgstr ""
 #: corehq/apps/appstore/views.py:28
 #: corehq/apps/appstore/templates/appstore/project_info.html:148
 #: corehq/apps/reports/filters/select.py:43
-#: custom/ilsgateway/tanzania/reports/delivery.py:153
+#: custom/ilsgateway/tanzania/reports/delivery.py:156
 msgid "Category"
 msgstr ""
 
@@ -5145,8 +5172,8 @@ msgid "You must specify a name for the new project"
 msgstr ""
 
 #: corehq/apps/appstore/templates/appstore/appstore_base.html:7
-#: corehq/apps/domain/views.py:1636 corehq/apps/hqwebapp/models.py:1208
-#: corehq/apps/hqwebapp/models.py:1584
+#: corehq/apps/domain/views.py:1636 corehq/apps/hqwebapp/models.py:1203
+#: corehq/apps/hqwebapp/models.py:1579
 #: corehq/apps/style/templates/style/bootstrap2/partials/domain_list_dropdown.html:19
 #: corehq/apps/style/templates/style/bootstrap3/partials/domain_list_dropdown.html:34
 msgid "CommCare Exchange"
@@ -5209,7 +5236,7 @@ msgstr ""
 #: corehq/apps/export/forms.py:76 corehq/apps/export/forms.py:133
 #: corehq/apps/hqwebapp/templates/hqwebapp/partials/pagination.html:36
 #: corehq/apps/reports/templates/reports/filters/drilldown_options.html:24
-#: corehq/apps/userreports/reports/builder/forms.py:356
+#: corehq/apps/userreports/reports/builder/forms.py:357
 msgid "Next"
 msgstr ""
 
@@ -5273,7 +5300,7 @@ msgstr ""
 #: corehq/apps/appstore/templates/appstore/project_info.html:198
 #: corehq/apps/settings/templates/settings/my_projects.html:11
 #: corehq/apps/sms/templates/sms/list_backends.html:76
-#: corehq/apps/users/views/__init__.py:688
+#: corehq/apps/users/views/__init__.py:646
 msgid "Project"
 msgstr ""
 
@@ -5415,6 +5442,8 @@ msgstr ""
 #: corehq/apps/reminders/templates/reminders/partial/complex_message_table.html:18
 #: corehq/apps/reminders/templates/reminders/partial/complex_message_table.html:21
 #: corehq/apps/sms/templates/sms/default.html:50
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:12
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:17
 msgid "Time"
 msgstr ""
 
@@ -5428,11 +5457,11 @@ msgid ""
 "That app is no longer valid. Try using the navigation links to select an app."
 msgstr ""
 
-#: corehq/apps/cloudcare/views.py:313
+#: corehq/apps/cloudcare/views.py:312
 msgid "Something went wrong filtering your cases."
 msgstr ""
 
-#: corehq/apps/cloudcare/views.py:489 corehq/apps/hqwebapp/models.py:1045
+#: corehq/apps/cloudcare/views.py:488 corehq/apps/hqwebapp/models.py:1045
 msgid "CloudCare Permissions"
 msgstr ""
 
@@ -5682,7 +5711,7 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/commtrack/forms.py:66 corehq/apps/commtrack/forms.py:71
-#: corehq/apps/commtrack/views.py:231
+#: corehq/apps/commtrack/views.py:236
 msgid "Stock Levels"
 msgstr ""
 
@@ -5726,8 +5755,8 @@ msgid "Location Type"
 msgstr ""
 
 #: corehq/apps/commtrack/models.py:539
-#: custom/ilsgateway/tanzania/reports/delivery.py:81
-#: custom/ilsgateway/tanzania/reports/randr.py:170
+#: custom/ilsgateway/tanzania/reports/delivery.py:83
+#: custom/ilsgateway/tanzania/reports/randr.py:172
 msgid "Code"
 msgstr ""
 
@@ -5746,11 +5775,11 @@ msgstr ""
 msgid "Location"
 msgstr ""
 
-#: corehq/apps/commtrack/processing.py:159
+#: corehq/apps/commtrack/processing.py:160
 msgid "Product IDs must be set for all ledger updates!"
 msgstr ""
 
-#: corehq/apps/commtrack/processing.py:174
+#: corehq/apps/commtrack/processing.py:175
 msgid "Ledger transaction references invalid Case ID \"{}\""
 msgstr ""
 
@@ -5774,33 +5803,33 @@ msgstr ""
 msgid "uncategorized"
 msgstr ""
 
-#: corehq/apps/commtrack/views.py:36 corehq/apps/hqwebapp/models.py:425
+#: corehq/apps/commtrack/views.py:41 corehq/apps/hqwebapp/models.py:425
 msgid "Setup"
 msgstr ""
 
-#: corehq/apps/commtrack/views.py:49
+#: corehq/apps/commtrack/views.py:54
 msgid "Advanced Settings"
 msgstr ""
 
-#: corehq/apps/commtrack/views.py:132
+#: corehq/apps/commtrack/views.py:137
 msgid ""
 "Settings updated! Your updated consumption settings may take a few minutes "
 "to show up in reports and on phones."
 msgstr ""
 
-#: corehq/apps/commtrack/views.py:135
+#: corehq/apps/commtrack/views.py:140
 msgid "Settings updated!"
 msgstr ""
 
-#: corehq/apps/commtrack/views.py:143 custom/intrahealth/sqldata.py:484
+#: corehq/apps/commtrack/views.py:148 custom/intrahealth/sqldata.py:484
 msgid "Consumption"
 msgstr ""
 
-#: corehq/apps/commtrack/views.py:161
+#: corehq/apps/commtrack/views.py:166
 msgid "Default consumption values updated"
 msgstr ""
 
-#: corehq/apps/commtrack/views.py:291
+#: corehq/apps/commtrack/views.py:296
 msgid "Rebuild Stock State"
 msgstr ""
 
@@ -5822,6 +5851,74 @@ msgstr ""
 
 #: corehq/apps/commtrack/templates/commtrack/manage/default_consumption.html:24
 msgid "Update Default Consumption Info"
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:8
+#, python-format
+msgid ""
+"\n"
+"    <strong>Warning:</strong>\n"
+"    You have more than %(stock_state_limit)s stocks in your project space.\n"
+"    Only %(stock_state_limit)s are shown.\n"
+"    "
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:18
+#, python-format
+msgid ""
+"\n"
+"    <strong>Warning:</strong>\n"
+"    You have more than %(stock_transaction_limit)s stock transactions in "
+"your project space.\n"
+"    Only %(stock_transaction_limit)s are shown.\n"
+"    "
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:33
+#, python-format
+msgid ""
+"\n"
+"                <strong>%(case_display)s</strong>\n"
+"                %(section_display)s\n"
+"                for <em>%(product_name)s</em>\n"
+"                "
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:43
+msgid "Rebuild"
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:50
+#, fuzzy
+msgid "Current Values"
+msgstr "गर्भवती या धात्री"
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:51
+msgid "Rebuilt Values"
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:54
+msgid "Server Date"
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:55
+msgid "Self-reported Date"
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:58
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:60
+msgid "Quantity"
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:59
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:61
+#: corehq/apps/reports/commtrack/standard.py:297
+#: custom/ilsgateway/tanzania/reports/facility_details.py:27
+msgid "Stock on Hand"
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:92
+msgid "(will be deleted)"
 msgstr ""
 
 #: corehq/apps/commtrack/templates/commtrack/manage/stock_levels.html:7
@@ -6028,7 +6125,7 @@ msgstr ""
 #: corehq/apps/data_interfaces/interfaces.py:22
 #: corehq/apps/data_interfaces/views.py:58 corehq/apps/hqwebapp/models.py:553
 #: corehq/apps/settings/views.py:213
-#: corehq/apps/userreports/reports/builder/forms.py:350
+#: corehq/apps/userreports/reports/builder/forms.py:351
 msgid "Data"
 msgstr ""
 
@@ -6055,7 +6152,7 @@ msgstr ""
 
 #: corehq/apps/dashboard/views.py:206
 #: corehq/apps/dashboard/templates/dashboard/dashboard_new_user.html:73
-#: corehq/apps/hqwebapp/models.py:1576
+#: corehq/apps/hqwebapp/models.py:1571
 msgid "Exchange"
 msgstr ""
 
@@ -6117,6 +6214,7 @@ msgid "Welcome to CommCare Supply"
 msgstr ""
 
 #: corehq/apps/dashboard/templates/dashboard/dashboard_new_user.html:64
+#: docs/_build/html/_sources/translations.txt:132
 msgid "Welcome to CommCare HQ"
 msgstr ""
 
@@ -6175,7 +6273,7 @@ msgstr ""
 #: corehq/apps/data_interfaces/interfaces.py:50
 #: corehq/apps/reports/standard/cases/basic.py:272
 #: corehq/apps/sms/templates/sms/list_backends.html:63
-#: corehq/ex-submodules/casexml/apps/case/models.py:887
+#: corehq/ex-submodules/casexml/apps/case/models.py:892
 msgid "Owner"
 msgstr ""
 
@@ -6651,7 +6749,7 @@ msgstr ""
 msgid "New owner's CommCare username"
 msgstr ""
 
-#: corehq/apps/domain/forms.py:362 corehq/apps/domain/views.py:2464
+#: corehq/apps/domain/forms.py:362 corehq/apps/domain/views.py:2465
 msgid "Transfer Project"
 msgstr ""
 
@@ -6761,7 +6859,7 @@ msgid "Secure submissions"
 msgstr ""
 
 #: corehq/apps/domain/forms.py:633 corehq/apps/hqadmin/reports.py:696
-#: corehq/apps/prelogin/templates/prelogin/base.html:81
+#: corehq/apps/prelogin/templates/prelogin/base.html:84
 msgid "Services"
 msgstr ""
 
@@ -6793,7 +6891,7 @@ msgstr ""
 
 #: corehq/apps/domain/forms.py:652
 #: corehq/apps/reports/standard/deployments.py:43
-#: corehq/apps/reports/standard/deployments.py:215
+#: corehq/apps/reports/standard/deployments.py:226
 #: corehq/apps/reports/standard/sms.py:164
 #: corehq/apps/reports/standard/sms.py:415
 #: corehq/apps/reports/standard/sms.py:474
@@ -6892,7 +6990,7 @@ msgstr ""
 #: corehq/apps/domain/forms.py:978 corehq/apps/domain/forms.py:1075
 #: corehq/apps/reminders/forms.py:517 corehq/apps/reminders/forms.py:2152
 #: corehq/apps/styleguide/examples/simple_crispy_form/forms.py:63
-#: corehq/apps/users/forms.py:487
+#: corehq/apps/users/forms.py:486
 msgid "Basic Information"
 msgstr ""
 
@@ -6917,7 +7015,7 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/domain/forms.py:922 corehq/apps/domain/forms.py:986
-#: corehq/apps/domain/forms.py:1083 corehq/apps/users/forms.py:495
+#: corehq/apps/domain/forms.py:1083 corehq/apps/users/forms.py:494
 msgid "Mailing Address"
 msgstr ""
 
@@ -7101,15 +7199,15 @@ msgstr ""
 msgid "Subscription Type"
 msgstr ""
 
-#: corehq/apps/domain/models.py:1295
+#: corehq/apps/domain/models.py:1279
 msgid "Transfer domain request is no longer active"
 msgstr ""
 
-#: corehq/apps/domain/models.py:1327 corehq/apps/domain/models.py:1342
+#: corehq/apps/domain/models.py:1311 corehq/apps/domain/models.py:1326
 msgid "Transfer of ownership for CommCare project space."
 msgstr ""
 
-#: corehq/apps/domain/models.py:1368
+#: corehq/apps/domain/models.py:1352
 #, python-brace-format
 msgid "There has been a transfer of ownership of {domain}"
 msgstr ""
@@ -7141,7 +7239,7 @@ msgstr ""
 msgid "Sorry, you do not have access to %(feature_name)s"
 msgstr ""
 
-#: corehq/apps/domain/views.py:267 corehq/apps/hqwebapp/models.py:1146
+#: corehq/apps/domain/views.py:267 corehq/apps/hqwebapp/models.py:1141
 #: corehq/apps/hqwebapp/templates/hqwebapp/partials/global_navigation_bar.html:91
 #: corehq/apps/ota/views.py:121
 #: corehq/apps/style/templates/style/bootstrap3/partials/domain_list_dropdown.html:6
@@ -7286,9 +7384,7 @@ msgstr ""
 msgid "Privacy and Security"
 msgstr ""
 
-#: corehq/apps/domain/views.py:1329 corehq/apps/prelogin/forms.py:96
-#: corehq/apps/prelogin/templates/prelogin/base.html:128
-#: corehq/apps/prelogin/templates/prelogin/_sections/home/about_dimagi.html:42
+#: corehq/apps/domain/views.py:1329 corehq/apps/prelogin/forms.py:97
 msgid "Contact Dimagi"
 msgstr ""
 
@@ -7312,7 +7408,7 @@ msgstr ""
 
 #: corehq/apps/domain/views.py:1437
 #: corehq/apps/domain/templates/domain/confirm_subscription_renewal.html:43
-#: corehq/apps/users/forms.py:513
+#: corehq/apps/users/forms.py:512
 #: corehq/apps/users/templates/users/mobile/users_list.html:115
 #: corehq/apps/users/views/mobile/users.py:461
 msgid "Confirm Billing Information"
@@ -7389,7 +7485,7 @@ msgstr ""
 msgid "Created a new version of your app."
 msgstr ""
 
-#: corehq/apps/domain/views.py:1932 corehq/apps/hqwebapp/models.py:1212
+#: corehq/apps/domain/views.py:1932 corehq/apps/hqwebapp/models.py:1207
 msgid "Multimedia Sharing"
 msgstr ""
 
@@ -7420,7 +7516,7 @@ msgstr ""
 msgid "App Schema Changes"
 msgstr ""
 
-#: corehq/apps/domain/views.py:1987 corehq/apps/hqwebapp/models.py:1226
+#: corehq/apps/domain/views.py:1987 corehq/apps/hqwebapp/models.py:1221
 msgid "Data Forwarding"
 msgstr ""
 
@@ -7433,7 +7529,7 @@ msgstr ""
 msgid "Forwarding set up to %s"
 msgstr ""
 
-#: corehq/apps/domain/views.py:2152 corehq/apps/hqwebapp/models.py:1203
+#: corehq/apps/domain/views.py:2152 corehq/apps/hqwebapp/models.py:1198
 msgid "Project Information"
 msgstr ""
 
@@ -7456,28 +7552,28 @@ msgstr ""
 msgid "Feature Previews"
 msgstr ""
 
-#: corehq/apps/domain/views.py:2439 corehq/apps/hqwebapp/models.py:1510
-#: corehq/apps/hqwebapp/models.py:1534 corehq/apps/hqwebapp/models.py:1562
+#: corehq/apps/domain/views.py:2439 corehq/apps/hqwebapp/models.py:1505
+#: corehq/apps/hqwebapp/models.py:1529 corehq/apps/hqwebapp/models.py:1557
 #: corehq/apps/toggle_ui/templates/toggle/flags.html:6
 msgid "Feature Flags"
 msgstr ""
 
-#: corehq/apps/domain/views.py:2488
+#: corehq/apps/domain/views.py:2489
 #, python-brace-format
 msgid "Resent transfer request for project '{domain}'"
 msgstr ""
 
-#: corehq/apps/domain/views.py:2558
+#: corehq/apps/domain/views.py:2559
 #, python-brace-format
 msgid "Successfully transferred ownership of project '{domain}'"
 msgstr ""
 
-#: corehq/apps/domain/views.py:2590
+#: corehq/apps/domain/views.py:2591
 #, python-brace-format
 msgid "Declined ownership of project '{domain}'"
 msgstr ""
 
-#: corehq/apps/domain/views.py:2606 corehq/apps/domain/views.py:2626
+#: corehq/apps/domain/views.py:2607 corehq/apps/domain/views.py:2627
 msgid "SMS Rate Calculator"
 msgstr ""
 
@@ -7867,7 +7963,7 @@ msgid "Usage Summary"
 msgstr ""
 
 #: corehq/apps/domain/templates/domain/current_subscription.html:210
-#: corehq/apps/domain/templates/domain/admin/feature_flags.html:26
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:34
 msgid "Feature"
 msgstr ""
 
@@ -8191,35 +8287,38 @@ msgstr ""
 msgid "Add a forwarding location"
 msgstr ""
 
-#: corehq/apps/domain/templates/domain/admin/feature_flags.html:8
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:16
 #, python-format
 msgid ""
 "\n"
-"                    Feature Flags are superuser-only things that can be turn "
-"on features for individual users or projects.\n"
-"                    They can be edited manually at the <a href="
-"\"%(toggle_url)s\">Feature Flag edit UI</a> (also super-only).\n"
+"                    Feature Flags turn on features for individual users or "
+"projects. They are editable only by\n"
+"                    super users, in the <a href=\"%(toggle_url)s\">Feature "
+"Flag edit UI</a>.\n"
 "                    In addition, some feature flags are randomly enabled by "
-"a domain.\n"
-"                "
-msgstr ""
-
-#: corehq/apps/domain/templates/domain/admin/feature_flags.html:15
-msgid ""
-"\n"
-"                    You can see a list of all enabled flags for this domain "
-"here.\n"
-"                    This does not include any flags set for users within the "
 "domain.\n"
 "                "
 msgstr ""
 
-#: corehq/apps/domain/templates/domain/admin/feature_flags.html:27
-#: corehq/apps/toggle_ui/templates/toggle/edit_flag.html:165
-msgid "Enabled?"
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:23
+msgid ""
+"\n"
+"                    Following are all flags enabled for this domain and/or "
+"for you.\n"
+"                    This does not include any flags set for other users in "
+"this domain.\n"
+"                "
 msgstr ""
 
 #: corehq/apps/domain/templates/domain/admin/feature_flags.html:35
+msgid "Enabled for domain?"
+msgstr ""
+
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:36
+msgid "Enabled for me?"
+msgstr ""
+
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:45
 msgid "change"
 msgstr ""
 
@@ -8271,7 +8370,7 @@ msgid "SMS Pricing"
 msgstr ""
 
 #: corehq/apps/domain/templates/domain/admin/global_sms_rates.html:35
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:67
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:78
 msgid "Pricing"
 msgstr ""
 
@@ -8754,8 +8853,8 @@ msgstr ""
 #: corehq/apps/users/templates/users/web_users.b3.html:220
 #: corehq/apps/users/templates/users/web_users.b3.html:285
 #: corehq/apps/users/templates/users/web_users.html:127
-#: custom/ilsgateway/tanzania/reports/facility_details.py:71
-#: custom/ilsgateway/tanzania/reports/facility_details.py:117
+#: custom/ilsgateway/tanzania/reports/facility_details.py:72
+#: custom/ilsgateway/tanzania/reports/facility_details.py:118
 msgid "Role"
 msgstr ""
 
@@ -8831,7 +8930,7 @@ msgid "Forgot your password?"
 msgstr ""
 
 #: corehq/apps/domain/templates/login_and_password/partials/login_form.html:50
-#: corehq/apps/prelogin/templates/prelogin/base.html:74
+#: corehq/apps/prelogin/templates/prelogin/base.html:77
 #: corehq/apps/style/templates/style/bootstrap2/base.html:74
 #: corehq/apps/style/templates/style/bootstrap3/base.html:102
 msgid "Sign In"
@@ -9183,7 +9282,7 @@ msgstr ""
 #: corehq/apps/sms/forms.py:450
 #: corehq/apps/sms/templates/sms/backend_map.html:97
 #: corehq/apps/style/templates/style/bootstrap3/base.html:234
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:144
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:148
 #: corehq/apps/users/templates/users/web_users.b3.html:60
 #: custom/ewsghana/templates/ewsghana/partials/users_tables.html:102
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:212
@@ -9572,6 +9671,7 @@ msgstr ""
 
 #: corehq/apps/fixtures/templates/fixtures/manage_tables.html:66
 #: corehq/apps/fixtures/templates/fixtures/partials/edit_table_modal.html:9
+#: corehq/apps/userreports/ui/forms.py:87
 msgid "Table ID"
 msgstr ""
 
@@ -9948,7 +10048,7 @@ msgstr ""
 msgid "ADMINREPORT"
 msgstr ""
 
-#: corehq/apps/hqadmin/reports.py:642 corehq/apps/hqwebapp/models.py:1401
+#: corehq/apps/hqadmin/reports.py:642 corehq/apps/hqwebapp/models.py:1396
 msgid "Project Space List"
 msgstr ""
 
@@ -10182,7 +10282,7 @@ msgstr ""
 msgid "No Info"
 msgstr ""
 
-#: corehq/apps/hqadmin/reports.py:808 corehq/apps/hqwebapp/models.py:1403
+#: corehq/apps/hqadmin/reports.py:808 corehq/apps/hqwebapp/models.py:1398
 msgid "User List"
 msgstr ""
 
@@ -10215,7 +10315,7 @@ msgstr ""
 msgid "No Domain Data"
 msgstr ""
 
-#: corehq/apps/hqadmin/reports.py:876 corehq/apps/hqwebapp/models.py:1405
+#: corehq/apps/hqadmin/reports.py:876 corehq/apps/hqwebapp/models.py:1400
 msgid "Application List"
 msgstr ""
 
@@ -10341,7 +10441,7 @@ msgid "Print"
 msgstr ""
 
 #: corehq/apps/hqadmin/templates/hqadmin/hqadmin_base_report.html:33
-#: corehq/apps/hqwebapp/models.py:1371 corehq/apps/hqwebapp/models.py:1539
+#: corehq/apps/hqwebapp/models.py:1366 corehq/apps/hqwebapp/models.py:1534
 msgid "Admin Reports"
 msgstr ""
 
@@ -10434,12 +10534,12 @@ msgstr ""
 msgid "Audio"
 msgstr ""
 
-#: corehq/apps/hqmedia/models.py:815
+#: corehq/apps/hqmedia/models.py:818
 #, python-format
 msgid "Encountered an AttributeError for media: %s"
 msgstr ""
 
-#: corehq/apps/hqmedia/models.py:819
+#: corehq/apps/hqmedia/models.py:822
 #, python-format
 msgid ""
 "This application has unsupported text in one of it's media file label "
@@ -10483,7 +10583,7 @@ msgstr ""
 msgid "File {name}s has an incorrect file type {ext}."
 msgstr ""
 
-#: corehq/apps/hqmedia/views.py:579
+#: corehq/apps/hqmedia/views.py:575
 msgid ""
 "There was an issue retrieving the status from the cache. We are looking into "
 "it. Please try uploading again."
@@ -10863,7 +10963,7 @@ msgstr ""
 msgid "Error Type"
 msgstr ""
 
-#: corehq/apps/hqpillow_retry/views.py:41 corehq/apps/hqwebapp/models.py:1393
+#: corehq/apps/hqpillow_retry/views.py:41 corehq/apps/hqwebapp/models.py:1388
 msgid "PillowTop Errors"
 msgstr ""
 
@@ -11148,7 +11248,7 @@ msgstr ""
 msgid "New Survey"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:929 corehq/apps/hqwebapp/models.py:1490
+#: corehq/apps/hqwebapp/models.py:929 corehq/apps/hqwebapp/models.py:1485
 #: corehq/apps/sms/views.py:990
 #: corehq/apps/sms/templates/sms/add_backend.html:49
 #: corehq/apps/sms/templates/sms/add_backend.html:70
@@ -11159,11 +11259,11 @@ msgstr ""
 msgid "SMS Connectivity"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:933 corehq/apps/hqwebapp/models.py:1494
+#: corehq/apps/hqwebapp/models.py:933 corehq/apps/hqwebapp/models.py:1489
 msgid "Add Connection"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:937 corehq/apps/hqwebapp/models.py:1496
+#: corehq/apps/hqwebapp/models.py:937 corehq/apps/hqwebapp/models.py:1491
 msgid "Edit Connection"
 msgstr ""
 
@@ -11214,180 +11314,174 @@ msgstr ""
 msgid "Application Users"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1068
+#: corehq/apps/hqwebapp/models.py:1067
 msgid "Project Users"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1072
+#: corehq/apps/hqwebapp/models.py:1071
 msgid ""
 "Grant other CommCare HQ users access to your project and manage user roles."
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1075
+#: corehq/apps/hqwebapp/models.py:1074
 #: corehq/apps/users/templates/users/web_users.b3.html:136
 msgid "Invite Web User"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1083 corehq/apps/settings/views.py:93
-#: corehq/apps/settings/templates/settings/edit_my_account.b2.html:33
-#: corehq/apps/users/views/__init__.py:350
-msgid "My Information"
-msgstr ""
-
-#: corehq/apps/hqwebapp/models.py:1219
+#: corehq/apps/hqwebapp/models.py:1214
 msgid "Forward Forms"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1221
+#: corehq/apps/hqwebapp/models.py:1216
 msgid "Forward Form Stubs"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1223
+#: corehq/apps/hqwebapp/models.py:1218
 msgid "Forward Cases"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1250
+#: corehq/apps/hqwebapp/models.py:1245
 msgid "Project Administration"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1296
+#: corehq/apps/hqwebapp/models.py:1291
 msgid "Internal Subscription Management (Dimagi Only)"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1313
+#: corehq/apps/hqwebapp/models.py:1308
 msgid "Project Tools"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1334
+#: corehq/apps/hqwebapp/models.py:1329
 msgid "Internal Data (Dimagi Only)"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1340
+#: corehq/apps/hqwebapp/models.py:1335
 msgid "My Settings"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1352
+#: corehq/apps/hqwebapp/models.py:1347
 msgid "Manage My Settings"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1381 corehq/apps/hqwebapp/models.py:1400
+#: corehq/apps/hqwebapp/models.py:1376 corehq/apps/hqwebapp/models.py:1395
 msgid "Administrative Reports"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1382 corehq/apps/hqwebapp/models.py:1411
-#: corehq/apps/hqwebapp/models.py:1533 corehq/apps/hqwebapp/models.py:1540
+#: corehq/apps/hqwebapp/models.py:1377 corehq/apps/hqwebapp/models.py:1406
+#: corehq/apps/hqwebapp/models.py:1528 corehq/apps/hqwebapp/models.py:1535
 msgid "System Info"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1391
+#: corehq/apps/hqwebapp/models.py:1386
 msgid "Mass Email Users"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1396
+#: corehq/apps/hqwebapp/models.py:1391
 msgid "Login as another user"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1407
+#: corehq/apps/hqwebapp/models.py:1402
 msgid "Message Logs Across All Domains"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1409
+#: corehq/apps/hqwebapp/models.py:1404
 msgid "CommCare Versions"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1413
+#: corehq/apps/hqwebapp/models.py:1408
 msgid "Loadtest Report"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1416
+#: corehq/apps/hqwebapp/models.py:1411
 msgid "Administrative Operations"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1417
+#: corehq/apps/hqwebapp/models.py:1412
 msgid "CommCare Reports"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1439
+#: corehq/apps/hqwebapp/models.py:1434
 msgid "Accounting"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1482 corehq/apps/hqwebapp/models.py:1561
+#: corehq/apps/hqwebapp/models.py:1477 corehq/apps/hqwebapp/models.py:1556
 msgid "SMS Connectivity & Billing"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1491
+#: corehq/apps/hqwebapp/models.py:1486
 #: corehq/apps/sms/templates/sms/add_backend.html:52
 #: corehq/apps/sms/templates/sms/list_backends.html:39
 msgid "SMS Connections"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1499
+#: corehq/apps/hqwebapp/models.py:1494
 #: corehq/apps/sms/templates/sms/backend_map.html:5
 #: corehq/apps/sms/templates/sms/backend_map.html:64
 #: corehq/apps/sms/templates/sms/backend_map.html:72
 msgid "SMS Country-Connection Map"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1519
+#: corehq/apps/hqwebapp/models.py:1514
 msgid "Admin"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1541
+#: corehq/apps/hqwebapp/models.py:1536
 msgid "Management"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1542
+#: corehq/apps/hqwebapp/models.py:1537
 msgid "Commands"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1556
+#: corehq/apps/hqwebapp/models.py:1551
 msgid "Old SMS Billing"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1564
+#: corehq/apps/hqwebapp/models.py:1559
 msgid "Django Admin"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1586
+#: corehq/apps/hqwebapp/models.py:1581
 msgid "Publish this project"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1615
+#: corehq/apps/hqwebapp/models.py:1610
 #: corehq/apps/orgs/templates/orgs/report_base.html:28
 msgid "Projects Table"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1618
+#: corehq/apps/hqwebapp/models.py:1613
 #: corehq/apps/orgs/templates/orgs/report_base.html:29
 #: corehq/apps/reports/standard/monitoring.py:1026
 msgid "Form Data"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1621
+#: corehq/apps/hqwebapp/models.py:1616
 #: corehq/apps/orgs/templates/orgs/report_base.html:30
 #: corehq/apps/reports/standard/monitoring.py:1036
 msgid "Case Data"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1624
+#: corehq/apps/hqwebapp/models.py:1619
 #: corehq/apps/orgs/templates/orgs/report_base.html:31
 msgid "User Data"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1637
+#: corehq/apps/hqwebapp/models.py:1632
 #: corehq/apps/orgs/templates/orgs/orgs_team_members.html:84
 #: corehq/apps/orgs/templates/orgs/public.html:28
 #: corehq/apps/orgs/templates/orgs/partials/top_nav.html:6
 msgid "Projects"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1640
+#: corehq/apps/hqwebapp/models.py:1635
 #: corehq/apps/orgs/templates/orgs/public.html:31
 #: corehq/apps/orgs/templates/orgs/partials/top_nav.html:9
 msgid "Teams"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1643
+#: corehq/apps/hqwebapp/models.py:1638
 #: corehq/apps/orgs/templates/orgs/orgs_team_members.html:50
 #: corehq/apps/orgs/templates/orgs/public.html:34
 #: corehq/apps/orgs/templates/orgs/partials/top_nav.html:12
@@ -11438,44 +11532,44 @@ msgstr ""
 msgid "View All"
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:612
+#: corehq/apps/hqwebapp/views.py:614
 msgid ""
 "Check \"Opt out of emails about new features and other CommCare updates\" in "
 "your account settings and then click \"Update Information\" if you do not "
 "want to receive future emails from us."
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:713
+#: corehq/apps/hqwebapp/views.py:715
 msgid "items per page"
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:714
+#: corehq/apps/hqwebapp/views.py:716
 msgid "You have no items."
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:716
+#: corehq/apps/hqwebapp/views.py:718
 msgid "Deleted Items:"
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:717
+#: corehq/apps/hqwebapp/views.py:719
 msgid "New Items:"
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:840
+#: corehq/apps/hqwebapp/views.py:842
 #, python-format
 msgid "<strong>Problem Refreshing List:</strong> %s"
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:858
+#: corehq/apps/hqwebapp/views.py:860
 #, python-format
 msgid "<strong>Problem Deleting:</strong> %s"
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:866
+#: corehq/apps/hqwebapp/views.py:868
 msgid "The item's ID was not passed to the server."
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:976
+#: corehq/apps/hqwebapp/views.py:978
 #, python-format
 msgid "We've redirected you to the %s matching your query"
 msgstr ""
@@ -11753,11 +11847,11 @@ msgstr ""
 msgid "No properties found."
 msgstr ""
 
-#: corehq/apps/importer/base.py:5
+#: corehq/apps/importer/base.py:6
 msgid "Import Cases from Excel"
 msgstr ""
 
-#: corehq/apps/importer/base.py:7
+#: corehq/apps/importer/base.py:8
 msgid "Import case data from an external Excel file"
 msgstr ""
 
@@ -11784,6 +11878,11 @@ msgstr ""
 #: corehq/apps/importer/const.py:13
 msgid "Case Generation Error"
 msgstr ""
+
+#: corehq/apps/importer/const.py:14
+#, fuzzy
+msgid "Duplicated Location Name"
+msgstr "टीके का नाम"
 
 #: corehq/apps/importer/util.py:213
 msgid ""
@@ -11819,19 +11918,26 @@ msgstr ""
 msgid "An invalid or unknown parent case was specified for the uploaded case."
 msgstr ""
 
-#: corehq/apps/importer/views.py:170
+#: corehq/apps/importer/util.py:234
+msgid ""
+"Owner ID was used in the mapping, but there were errors when uploading "
+"because of these values. There are multiple locations with this same name, "
+"try using site-code instead."
+msgstr ""
+
+#: corehq/apps/importer/views.py:169
 msgid ""
 "It looks like you may have accessed this page from a stale page. Please "
 "start over."
 msgstr ""
 
-#: corehq/apps/importer/views.py:274 corehq/apps/importer/views.py:331
+#: corehq/apps/importer/views.py:273 corehq/apps/importer/views.py:330
 msgid ""
 "The session containing the file you uploaded has expired - please upload a "
 "new one."
 msgstr ""
 
-#: corehq/apps/importer/views.py:349
+#: corehq/apps/importer/views.py:348
 msgid "Sorry, your session has expired. Please start over and try again."
 msgstr ""
 
@@ -11864,8 +11970,9 @@ msgid "Corresponding case field"
 msgstr ""
 
 #: corehq/apps/importer/templates/importer/excel_config.html:90
-#: corehq/ex-submodules/casexml/apps/case/models.py:892
-#: custom/opm/beneficiary.py:823 custom/opm/beneficiary.py:899
+#: corehq/ex-submodules/casexml/apps/case/models.py:897
+#: custom/opm/beneficiary.py:822 custom/opm/beneficiary.py:899
+#: custom/opm/beneficiary.py:921
 msgid "Case ID"
 msgstr ""
 
@@ -11916,7 +12023,8 @@ msgstr ""
 
 #: corehq/apps/importer/templates/importer/excel_config.html:192
 #: corehq/apps/importer/templates/importer/excel_fields.html:189
-#: corehq/apps/userreports/reports/builder/forms.py:458
+#: corehq/apps/userreports/reports/builder/forms.py:459
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:5
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:210
 #: submodules/ctable-src/ctable_view/templates/ctable/test_mapping.html:129
 msgid "Back"
@@ -12459,11 +12567,16 @@ msgstr ""
 msgid "Move"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:83
+#: corehq/apps/locations/templates/locations/manage/locations.html:40
+#, python-format
+msgid "You have successfully archived the location <%%=name%%>"
+msgstr ""
+
+#: corehq/apps/locations/templates/locations/manage/locations.html:102
 msgid "Manage Locations"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:85
+#: corehq/apps/locations/templates/locations/manage/locations.html:104
 msgid ""
 "\n"
 "                    Locations allow you to represent the real-world "
@@ -12476,42 +12589,43 @@ msgid ""
 "                "
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:95
+#: corehq/apps/locations/templates/locations/manage/locations.html:114
 msgid "Showing the Inactive Location List."
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:102
+#: corehq/apps/locations/templates/locations/manage/locations.html:121
 msgid "Show Archived Locations"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:106
+#: corehq/apps/locations/templates/locations/manage/locations.html:125
 msgid "Show Active Locations"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:119
-#: corehq/apps/locations/templates/locations/manage/locations.html:123
+#: corehq/apps/locations/templates/locations/manage/locations.html:138
+#: corehq/apps/locations/templates/locations/manage/locations.html:142
 msgid "Bulk Import Locations"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:127
+#: corehq/apps/locations/templates/locations/manage/locations.html:146
 msgid "Edit Location Types"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:130
+#: corehq/apps/locations/templates/locations/manage/locations.html:149
 msgid "Edit Location Fields"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:155
+#: corehq/apps/locations/templates/locations/manage/locations.html:174
 msgid "Unarchive"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:160
+#: corehq/apps/locations/templates/locations/manage/locations.html:179
+#: corehq/apps/locations/templates/locations/manage/locations.html:267
 #: corehq/apps/products/views.py:186
 #: corehq/apps/products/templates/products/manage/products.html:116
 msgid "Archive"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:216
+#: corehq/apps/locations/templates/locations/manage/locations.html:235
 #, python-format
 msgid ""
 "\n"
@@ -12519,6 +12633,22 @@ msgid ""
 "    <a href=\"%(location_types_url)s\">here</a>\n"
 "    for your project before creating any locations.\n"
 "    "
+msgstr ""
+
+#: corehq/apps/locations/templates/locations/manage/locations.html:253
+msgid "Archive Location:"
+msgstr ""
+
+#: corehq/apps/locations/templates/locations/manage/locations.html:257
+msgid ""
+"\n"
+"            <strong>Warning!</strong> Archiving a location will unassign any "
+"users\n"
+"            which were associated with that location.  You can unarchive "
+"this\n"
+"            location at any point, but you will have to reassign the users\n"
+"            manually.\n"
+"            "
 msgstr ""
 
 #: corehq/apps/locations/templates/locations/manage/partials/autocomplete_select_widget.html:10
@@ -12724,31 +12854,31 @@ msgstr ""
 msgid "Prime Restore Cache"
 msgstr ""
 
-#: corehq/apps/prelogin/forms.py:32 corehq/apps/registration/forms.py:52
+#: corehq/apps/prelogin/forms.py:33 corehq/apps/registration/forms.py:52
 msgid "Email Address"
 msgstr ""
 
-#: corehq/apps/prelogin/forms.py:45
+#: corehq/apps/prelogin/forms.py:46
 msgid "What is your interest in CommCare and any specific questions you have?"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:57
+#: corehq/apps/prelogin/templates/prelogin/base.html:60
 msgid "Toggle Navigation"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:78
+#: corehq/apps/prelogin/templates/prelogin/base.html:81
 msgid "Solutions"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:79
+#: corehq/apps/prelogin/templates/prelogin/base.html:82
 msgid "Impact"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:80
+#: corehq/apps/prelogin/templates/prelogin/base.html:83
 msgid "Software Pricing"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:108
+#: corehq/apps/prelogin/templates/prelogin/base.html:111
 #, python-format
 msgid ""
 "\n"
@@ -12759,11 +12889,15 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:145
+#: corehq/apps/prelogin/templates/prelogin/base.html:131
+msgid "Get in Touch With Us: Contact Dimagi"
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/base.html:148
 msgid "Thanks for contacting us!"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:150
+#: corehq/apps/prelogin/templates/prelogin/base.html:153
 msgid ""
 "\n"
 "                            Thank you for your interest in working with "
@@ -12771,7 +12905,7 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:155
+#: corehq/apps/prelogin/templates/prelogin/base.html:158
 msgid ""
 "\n"
 "                            One of our team members will get back to you "
@@ -12781,18 +12915,18 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:163
-#: corehq/apps/prelogin/templates/prelogin/base.html:202
+#: corehq/apps/prelogin/templates/prelogin/base.html:166
+#: corehq/apps/prelogin/templates/prelogin/base.html:205
 #: custom/_legacy/a5288/reports.py:102
 msgid "OK"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:176
-#: corehq/apps/prelogin/templates/prelogin/base.html:215
+#: corehq/apps/prelogin/templates/prelogin/base.html:179
+#: corehq/apps/prelogin/templates/prelogin/base.html:218
 msgid "Ooops!"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:181
+#: corehq/apps/prelogin/templates/prelogin/base.html:184
 msgid ""
 "\n"
 "                             We're terribly sorry! It seems like our servers "
@@ -12800,7 +12934,7 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:186
+#: corehq/apps/prelogin/templates/prelogin/base.html:189
 msgid ""
 "\n"
 "                                We've alerted one of our engineers of issues "
@@ -12811,7 +12945,7 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:193
+#: corehq/apps/prelogin/templates/prelogin/base.html:196
 msgid ""
 "\n"
 "                                You can send an email directly to\n"
@@ -12821,7 +12955,7 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:226
+#: corehq/apps/prelogin/templates/prelogin/base.html:229
 msgid ""
 "\n"
 "                                Please provide a valid e-mail address where "
@@ -12882,6 +13016,10 @@ msgid ""
 "contact\n"
 "                        Dimagi directly.\n"
 "                    "
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/home/about_dimagi.html:42
+msgid "Get in Touch With Us"
 msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/home/about_dimagi.html:50
@@ -13094,7 +13232,7 @@ msgstr ""
 #: corehq/apps/style/templates/style/includes/modal_report_issue.html:49
 #: corehq/apps/styleguide/examples/simple_crispy_form/forms.py:17
 #: custom/_legacy/pact/templates/pact/chw/pact_chw_profile_info.html:16
-#: custom/ilsgateway/tanzania/reports/facility_details.py:73
+#: custom/ilsgateway/tanzania/reports/facility_details.py:74
 msgid "Email"
 msgstr ""
 
@@ -13272,32 +13410,35 @@ msgstr ""
 #: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:12
 msgid ""
 "\n"
-"                        Read how organizations around the world use\n"
-"                        CommCare to improve frontline service delivery.\n"
+"                    <!--HubSpot Call-to-Action Code -->\n"
+"                    <span class=\"hs-cta-wrapper\" id=\"hs-cta-"
+"wrapper-071f4a7d-237d-49d8-b12d-c28fe204927d\">\n"
+"                        <span class=\"hs-cta-node hs-cta-071f4a7d-237d-49d8-"
+"b12d-c28fe204927d\" id=\"hs-cta-071f4a7d-237d-49d8-b12d-c28fe204927d\">\n"
+"                            <!--[if lte IE 8]><div id=\"hs-cta-ie-element"
+"\"></div><![endif]-->\n"
+"                            <a href=\"http://cta-redirect.hubspot.com/cta/"
+"redirect/503070/071f4a7d-237d-49d8-b12d-c28fe204927d\" ><img class=\"hs-cta-"
+"img\" id=\"hs-cta-img-071f4a7d-237d-49d8-b12d-c28fe204927d\" style=\"border-"
+"width:0px;\" src=\"https://no-cache.hubspot.com/cta/"
+"default/503070/071f4a7d-237d-49d8-b12d-c28fe204927d.png\"  alt=\"View All "
+"Case Studies\"/></a>\n"
+"                        </span>\n"
+"                        <script type=\"text/javascript\">\n"
+"                            hbspt.cta.load(503070, '071f4a7d-237d-49d8-b12d-"
+"c28fe204927d');\n"
+"                        </script>\n"
+"                    </span>\n"
+"                    <!-- end HubSpot Call-to-Action Code -->\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:24
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:39
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:54
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:69
-msgid "Read Case Study"
-msgstr ""
-
 #: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:27
-msgid "Improving Community Health in Guatemala"
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:42
-msgid "An Integrated eDiagnostic Approach in Burkina Faso"
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:57
-msgid "Improving Maternal and Child Health in India"
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:72
-msgid "iCCM for Child Health in Mozambique"
+msgid ""
+"\n"
+"                        Read how organizations around the world use\n"
+"                        CommCare to improve frontline service delivery.\n"
+"                    "
 msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/impact/lead.html:9
@@ -13342,6 +13483,33 @@ msgstr ""
 #: corehq/apps/prelogin/templates/prelogin/_sections/impact/partners.html:12
 msgid ""
 "\n"
+"                    <!--HubSpot Call-to-Action Code -->\n"
+"                    <span class=\"hs-cta-wrapper\" id=\"hs-cta-wrapper-"
+"c34ae48e-2f1a-48ac-9170-31fc7c9e845b\">\n"
+"                        <span class=\"hs-cta-node hs-cta-"
+"c34ae48e-2f1a-48ac-9170-31fc7c9e845b\" id=\"hs-cta-"
+"c34ae48e-2f1a-48ac-9170-31fc7c9e845b\">\n"
+"                            <!--[if lte IE 8]><div id=\"hs-cta-ie-element"
+"\"></div><![endif]-->\n"
+"                            <a href=\"http://cta-redirect.hubspot.com/cta/"
+"redirect/503070/c34ae48e-2f1a-48ac-9170-31fc7c9e845b\"  target=\"_blank\" "
+"><img class=\"hs-cta-img\" id=\"hs-cta-img-"
+"c34ae48e-2f1a-48ac-9170-31fc7c9e845b\" style=\"border-width:0px;\" src="
+"\"https://no-cache.hubspot.com/cta/default/503070/"
+"c34ae48e-2f1a-48ac-9170-31fc7c9e845b.png\"  alt=\"See All Partners\"/></a>\n"
+"                        </span>\n"
+"                        <script type=\"text/javascript\">\n"
+"                            hbspt.cta.load(503070, "
+"'c34ae48e-2f1a-48ac-9170-31fc7c9e845b');\n"
+"                        </script>\n"
+"                    </span>\n"
+"                    <!-- end HubSpot Call-to-Action Code -->\n"
+"                    "
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/partners.html:27
+msgid ""
+"\n"
 "                        The following organizations have contributed\n"
 "                        to the development of CommCare.\n"
 "                    "
@@ -13357,14 +13525,36 @@ msgstr ""
 #: corehq/apps/prelogin/templates/prelogin/_sections/impact/publications.html:12
 msgid ""
 "\n"
+"                    <!--HubSpot Call-to-Action Code -->\n"
+"                    <span class=\"hs-cta-wrapper\" id=\"hs-cta-"
+"wrapper-23da92fd-b671-481f-9aee-bbc8a94b1f8b\">\n"
+"                        <span class=\"hs-cta-node hs-cta-23da92fd-"
+"b671-481f-9aee-bbc8a94b1f8b\" id=\"hs-cta-23da92fd-b671-481f-9aee-"
+"bbc8a94b1f8b\">\n"
+"                            <!--[if lte IE 8]><div id=\"hs-cta-ie-element"
+"\"></div><![endif]-->\n"
+"                            <a href=\"http://cta-redirect.hubspot.com/cta/"
+"redirect/503070/23da92fd-b671-481f-9aee-bbc8a94b1f8b\"  target=\"_blank\" "
+"><img class=\"hs-cta-img\" id=\"hs-cta-img-23da92fd-b671-481f-9aee-"
+"bbc8a94b1f8b\" style=\"border-width:0px;\" src=\"https://no-cache.hubspot."
+"com/cta/default/503070/23da92fd-b671-481f-9aee-bbc8a94b1f8b.png\"  alt="
+"\"View Research\"/></a>\n"
+"                        </span>\n"
+"                        <script type=\"text/javascript\">\n"
+"                            hbspt.cta.load(503070, '23da92fd-b671-481f-9aee-"
+"bbc8a94b1f8b');\n"
+"                        </script>\n"
+"                    </span>\n"
+"                    <!-- end HubSpot Call-to-Action Code -->\n"
+"                    "
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/publications.html:27
+msgid ""
+"\n"
 "                        Over 30+ peer-reviewed publications have been "
 "written\n"
-"                        about CommCare. For an overview of all CommCare\n"
-"                        publications, please see the\n"
-"                        <a href=\"https://help.commcarehq.org/display/"
-"commcarepublic/CommCare+Evidence+Base\"\n"
-"                           class=\"btn-primary-dark\">CommCare Evidence "
-"Base</a>.\n"
+"                        about CommCare.\n"
 "                    "
 msgstr ""
 
@@ -13375,63 +13565,90 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:27
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:12
+msgid ""
+"\n"
+"                    <!--HubSpot Call-to-Action Code -->\n"
+"                    <span class=\"hs-cta-wrapper\" id=\"hs-cta-wrapper-"
+"c21c3aed-90ee-4106-98d0-dbe846e8ca28\">\n"
+"                        <span class=\"hs-cta-node hs-cta-"
+"c21c3aed-90ee-4106-98d0-dbe846e8ca28\" id=\"hs-cta-c21c3aed-90ee-4106-98d0-"
+"dbe846e8ca28\">\n"
+"                            <!--[if lte IE 8]><div id=\"hs-cta-ie-element"
+"\"></div><![endif]-->\n"
+"                            <a href=\"http://cta-redirect.hubspot.com/cta/"
+"redirect/503070/c21c3aed-90ee-4106-98d0-dbe846e8ca28\"  target=\"_blank\" "
+"><img class=\"hs-cta-img\" id=\"hs-cta-img-c21c3aed-90ee-4106-98d0-"
+"dbe846e8ca28\" style=\"border-width:0px;\" src=\"https://no-cache.hubspot."
+"com/cta/default/503070/c21c3aed-90ee-4106-98d0-dbe846e8ca28.png\"  alt="
+"\"Learn More About Our Sectors\"/></a>\n"
+"                        </span>\n"
+"                        <script type=\"text/javascript\">\n"
+"                            hbspt.cta.load(503070, 'c21c3aed-90ee-4106-98d0-"
+"dbe846e8ca28');\n"
+"                        </script>\n"
+"                    </span>\n"
+"                    <!-- end HubSpot Call-to-Action Code -->\n"
+"                    "
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:35
 msgid "Child Health"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:33
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:41
 msgid "HIV/AIDS"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:52
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:60
 msgid "Health"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:73
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:81
 msgid "Malaria"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:80
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:88
 msgid "Nutrition"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:91
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:99
 msgid "Cooperatives"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:98
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:106
 msgid "Finances"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:117
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:125
 msgid "Agriculture"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:138
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:146
 msgid "Extension Programs"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:145
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:153
 msgid "Logistics"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:156
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:164
 msgid "Emergency Response"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:163
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:171
 msgid "Small Business"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:182
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:190
 msgid "Development"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:203
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:211
 msgid "Education"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:210
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:218
 msgid "Logistics & Supply Chain"
 msgstr ""
 
@@ -13508,11 +13725,12 @@ msgid ""
 "\n"
 "                        <a href=\"#contactDimagi\"\n"
 "                           data-toggle=\"modal\"\n"
-"                           class=\"btn-primary-dark\">Contact Dimagi</a> or "
-"read our<br />\n"
-"                        pricing <a href=\"https://confluence.dimagi.com/"
-"display/commcarepublic/CommCare+Pricing+FAQs\" class=\"btn-primary-dark"
-"\">FAQs</a>.\n"
+"                           class=\"btn-success btn btn-xl\">Get in Touch "
+"With Us</a>\n"
+"                        <a href=\"https://confluence.dimagi.com/display/"
+"commcarepublic/CommCare+Pricing+FAQs\"\n"
+"                           class=\"btn btn-primary-dark btn-xl\">Read our "
+"Pricing FAQs</a>\n"
 "                    "
 msgstr ""
 
@@ -13520,21 +13738,19 @@ msgstr ""
 msgid "CommCare Software Plans"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:11
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:16
 msgid ""
 "\n"
-"                            Core Features are always FREE. Choose a plan\n"
-"                            to help your project scale.\n"
-"                        "
+"                        Core Features are always FREE. Choose a plan\n"
+"                        to help your project scale.\n"
+"                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:18
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:22
 msgid ""
 "\n"
-"                    <strong>Anyone can use CommCare for FREE up to 50 mobile "
-"workers.</strong><br />\n"
 "                    For additional questions, please see our\n"
-"                    <a class=\"btn-primary-dark\"\n"
+"                    <a class=\"lead-link\"\n"
 "                       href=\"https://confluence.dimagi.com/display/"
 "commcarepublic/CommCare+Pricing+FAQs?__hstc=187943799."
 "ba674a1a3cdef13c5d09b2a54d65c2b8.1431286503613.1435340206977.1435342587932.124&__hssc=187943799.6.1435342587932&__hsfp=312587752\">FAQs</"
@@ -13542,16 +13758,27 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:92
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:31
+msgid ""
+"\n"
+"                        Want to try CommCare for FREE?\n"
+"                    "
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:34
+msgid "Sign up for a FREE account"
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:103
 msgid "Contact Us"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:122
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:152
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:133
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:163
 msgid "Unlimited / Discounted"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:128
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:139
 msgid "Price Per Additional Mobile User"
 msgstr ""
 
@@ -13772,71 +13999,80 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:39
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:33
-msgid "Scope"
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:42
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:36
-msgid "Launch"
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:45
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:39
-msgid "Boost"
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:28
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:15
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:662
+msgid ""
+"\n"
+"                        Inquire About Dimagi's Implementation Bundles\n"
+"                        "
 msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:48
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:42
-msgid "Growth"
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:35
+msgid "Scope"
 msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:51
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:45
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:38
+msgid "Launch"
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:54
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:41
+msgid "Boost"
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:57
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:44
+msgid "Growth"
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:60
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:47
 msgid "Scale"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:56
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:53
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:65
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:55
 msgid "$10,000"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:59
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:56
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:68
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:58
 msgid "$35,000"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:62
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:59
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:71
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:61
 msgid "$50,000"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:65
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:62
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:74
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:64
 msgid "$80,000"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:68
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:65
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:77
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:67
 msgid "$150,000"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:92
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:100
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:108
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:89
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:97
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:105
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:101
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:109
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:117
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:91
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:99
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:107
 msgid "12 months"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:116
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:113
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:125
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:115
 msgid "18 months"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:123
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:132
 msgid ""
 "\n"
 "                                Application Development &amp; Implementation "
@@ -13844,19 +14080,19 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:130
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:139
 msgid "Workflow Design"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:131
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:140
 msgid "On-Site Scoping Visit"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:132
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:141
 msgid "Mobile System Workflow Design"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:138
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:147
 msgid ""
 "\n"
 "                                    Everything in<br />\n"
@@ -13864,19 +14100,19 @@ msgid ""
 "                                "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:143
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:152
 msgid "Build &amp; Launch Application"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:144
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:153
 msgid "Field Testing &amp; Iteration"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:145
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:154
 msgid "Users Training"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:151
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:160
 msgid ""
 "\n"
 "                                    Everything in<br />\n"
@@ -13884,16 +14120,16 @@ msgid ""
 "                                "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:156
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:62
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:165
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:69
 msgid "Technology for Outcomes Monitoring"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:157
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:166
 msgid "Capacity Building for Worker Performance Monitoring"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:163
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:172
 msgid ""
 "\n"
 "                                    Everything in<br />\n"
@@ -13901,19 +14137,19 @@ msgid ""
 "                                "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:168
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:177
 msgid "Refined Application"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:169
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:178
 msgid "Additional Supervisor App"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:170
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:179
 msgid "Application Troubleshooting Capacity Building"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:176
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:185
 msgid ""
 "\n"
 "                                    Everything in<br />\n"
@@ -13921,37 +14157,29 @@ msgid ""
 "                                "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:181
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:190
 msgid "Monitored Application Usage"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:182
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:191
 msgid "Additional Tech for Reminder Messages"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:183
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:40
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:192
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:47
 msgid "Training of Trainers"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:184
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:42
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:193
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:49
 msgid "Capacity to Build Applications"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:190
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:194
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:45
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:68
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:199
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:203
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:52
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:75
 msgid "See More..."
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:205
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:659
-msgid ""
-"\n"
-"                    Inquire About Dimagi's Implementation Bundles\n"
-"                    "
 msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:7
@@ -13978,7 +14206,11 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:31
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:27
+msgid "Inquire About Dimagi's Capacity Services"
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:38
 #: corehq/apps/products/forms.py:28
 #: corehq/apps/products/templates/products/manage/products.html:112
 #: corehq/apps/programs/templates/programs/manage/programs.html:62
@@ -13986,40 +14218,36 @@ msgstr ""
 msgid "Program"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:34
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:57
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:41
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:64
 msgid ""
 "\n"
 "                            $10,000 per capacity service\n"
 "                        "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:39
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:46
 msgid "Worker Performance Monitoring"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:41
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:48
 msgid "Capacity for Technical Support"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:54
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:61
 msgid "Technology"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:63
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:70
 msgid "Apps for Supportive Supervision"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:64
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:71
 msgid "App Refinement by Dimagi"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:65
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:72
 msgid "Technology for Reminder Messages"
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:81
-msgid "Inquire About Dimagi's Capacity Services"
 msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/services/faq.html:8
@@ -14036,8 +14264,8 @@ msgid ""
 "\n"
 "                        <a href=\"#contactDimagi\"\n"
 "                           data-toggle=\"modal\"\n"
-"                           class=\"btn-primary-dark\">Contact Dimagi</a> for "
-"more information.\n"
+"                           class=\"btn btn-success btn-xl\">Get in Touch "
+"With Us</a>\n"
 "                    "
 msgstr ""
 
@@ -14122,110 +14350,100 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:12
-msgid ""
-"\n"
-"                        If you have any additional questions, please\n"
-"                        <a href=\"#contactDimagi\"\n"
-"                           data-toggle=\"modal\">contact Dimagi</a> "
-"directly.\n"
-"                    "
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:50
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:52
 msgid "Cost"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:71
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:73
 msgid "Included Software Plan"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:119
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:121
 msgid "Application Development Support"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:125
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:127
 msgid ""
 "\n"
 "                                Workflow Design\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:160
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:162
 msgid ""
 "\n"
 "                                Launch &amp; Tested Application\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:195
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:197
 msgid ""
 "\n"
 "                                Additional Tech for Monitoring Outcomes\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:230
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:232
 msgid ""
 "\n"
 "                                Launched v2 application\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:265
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:267
 msgid ""
 "\n"
 "                                Supervisor Application\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:300
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:302
 msgid ""
 "\n"
 "                                Monitored app usage\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:335
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:337
 msgid ""
 "\n"
 "                                Additional Tech for Reminder Messages\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:369
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:371
 msgid "Implementation Services"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:375
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:377
 msgid ""
 "\n"
 "                                On-Site Scoping Visit\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:410
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:412
 msgid ""
 "\n"
 "                                Mobile System Workflow Design\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:445
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:447
 msgid ""
 "\n"
 "                                Field Testing &amp; Iteration\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:480
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:482
 msgid ""
 "\n"
 "                                Pilot Users Training\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:515
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:517
 msgid ""
 "\n"
 "                                Capacity Service: Worker Performance "
@@ -14233,7 +14451,7 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:550
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:552
 msgid ""
 "\n"
 "                                Capacity Service: Application "
@@ -14241,14 +14459,14 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:585
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:587
 msgid ""
 "\n"
 "                                Capacity Service: Training of Trainers\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:620
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:622
 msgid ""
 "\n"
 "                                Capacity Service: App Building\n"
@@ -14262,24 +14480,22 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:12
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:15
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:210
 msgid ""
 "\n"
-"                        If you have any additional questions, please\n"
-"                        <a href=\"#contactDimagi\"\n"
-"                           data-toggle=\"modal\">contact Dimagi</a>\n"
-"                        directly.\n"
-"                    "
+"                        Inquire About Dimagi's Capacity Services\n"
+"                        "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:24
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:25
 msgid ""
 "\n"
 "                        Program Capacity Services\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:29
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:30
 msgid ""
 "\n"
 "                        Dimagi travels on-site to build capacity, spending "
@@ -14288,22 +14504,22 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:35
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:125
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:37
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:128
 msgid ""
 "\n"
 "                        $10,000 per capacity service package.\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:44
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:46
 msgid ""
 "\n"
 "                        Worker Performance Monitoring\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:51
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:53
 msgid ""
 "\n"
 "                    Strategic implementation of standard CommCare HQ "
@@ -14312,14 +14528,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:61
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:63
 msgid ""
 "\n"
 "                        Training of Trainers\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:68
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:70
 msgid ""
 "\n"
 "                        Capacity building for organization’s trainers for "
@@ -14330,14 +14546,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:79
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:81
 msgid ""
 "\n"
 "                        Capacity for Technical Support\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:86
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:88
 msgid ""
 "\n"
 "                        Train technical staff about troubleshooting and "
@@ -14346,14 +14562,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:96
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:98
 msgid ""
 "\n"
 "                        Capacity to Build Applications\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:103
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:105
 msgid ""
 "\n"
 "                        Learn how to build your own applications,\n"
@@ -14362,14 +14578,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:114
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:116
 msgid ""
 "\n"
 "                        Technology Capacity Services\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:119
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:121
 msgid ""
 "\n"
 "                        Dimagi provides additional system refinement or new\n"
@@ -14377,14 +14593,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:134
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:137
 msgid ""
 "\n"
 "                        Technology for Outcomes Monitoring\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:141
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:144
 msgid ""
 "\n"
 "                        Create customized, offline Excel reports for 5-10\n"
@@ -14394,14 +14610,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:152
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:155
 msgid ""
 "\n"
 "                        Apps for Supportive Supervision\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:159
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:162
 msgid ""
 "\n"
 "                        Integrate a mobile application designed for field "
@@ -14412,14 +14628,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:170
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:173
 msgid ""
 "\n"
 "                        App Refinement by Dimagi\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:177
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:180
 msgid ""
 "\n"
 "                        Dimagi to make modifications to application based "
@@ -14428,14 +14644,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:187
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:190
 msgid ""
 "\n"
 "                        Technology for Reminder Messages\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:194
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:197
 msgid ""
 "\n"
 "                        Send SMS reminders directly to beneficiaries or\n"
@@ -14461,11 +14677,10 @@ msgstr ""
 #: corehq/apps/prelogin/templates/prelogin/_sections/solutions/last.html:13
 msgid ""
 "\n"
-"                        Contact us at\n"
-"                        <a class=\"btn-primary-dark\"\n"
-"                           href=\"mailto:commcare.supply@dimagi.com\">\n"
-"                            commcare.supply@dimagi.com\n"
-"                        </a>.\n"
+"                        <a href=\"#contactDimagi\"\n"
+"                           data-toggle=\"modal\"\n"
+"                           class=\"btn-success btn btn-xl\">Get in Touch "
+"With Us</a>\n"
 "                    "
 msgstr ""
 
@@ -14658,6 +14873,13 @@ msgid ""
 "                    International, including ILSGateway in Tanzania,\n"
 "                    the Early Warning System in Ghana, and cStock\n"
 "                    in Malawi.\n"
+"                    "
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/solutions/supply_intro.html:45
+msgid ""
+"\n"
+"                    Have questions or want to request a demo?\n"
 "                    "
 msgstr ""
 
@@ -16156,7 +16378,7 @@ msgstr ""
 
 #: corehq/apps/reminders/templates/reminders/partial/complex_message_table.html:30
 #: corehq/apps/reminders/templates/reminders/partial/complex_message_table.html:32
-#: custom/opm/beneficiary.py:814
+#: custom/opm/beneficiary.py:813 custom/opm/beneficiary.py:946
 msgid "Window"
 msgstr "शर्त की खिड़की"
 
@@ -16240,34 +16462,34 @@ msgstr ""
 msgid "CommTrack"
 msgstr ""
 
-#: corehq/apps/reports/models.py:49
+#: corehq/apps/reports/models.py:51
 msgid "demo_user"
 msgstr ""
 
-#: corehq/apps/reports/models.py:50
+#: corehq/apps/reports/models.py:52
 msgid "admin"
 msgstr ""
 
-#: corehq/apps/reports/models.py:51
+#: corehq/apps/reports/models.py:53
 msgid "Unknown Users"
 msgstr ""
 
-#: corehq/apps/reports/models.py:381
+#: corehq/apps/reports/models.py:373
 msgid "Deleted Report"
 msgstr ""
 
-#: corehq/apps/reports/models.py:385
+#: corehq/apps/reports/models.py:377
 msgid "Unsupported Report"
 msgstr ""
 
-#: corehq/apps/reports/models.py:423
+#: corehq/apps/reports/models.py:415
 msgid ""
 "The report used to create this scheduled report is no longer available on "
 "CommCare HQ.  Please delete this scheduled report and create a new one using "
 "an available report."
 msgstr ""
 
-#: corehq/apps/reports/models.py:485
+#: corehq/apps/reports/models.py:477
 #, python-format
 msgid ""
 "We are sorry, but your saved report '%(config_name)s' is no longer "
@@ -16277,7 +16499,7 @@ msgid ""
 "%(saved_reports_url)s to remove this Emailed Report."
 msgstr ""
 
-#: corehq/apps/reports/models.py:498
+#: corehq/apps/reports/models.py:490
 #, python-format
 msgid ""
 "We are sorry, but your saved report '%(config_name)s' can not be generated "
@@ -16285,20 +16507,20 @@ msgid ""
 "Administrator about getting permissions for thisreport."
 msgstr ""
 
-#: corehq/apps/reports/models.py:509
+#: corehq/apps/reports/models.py:501
 msgid "An error occurred while generating this report."
 msgstr ""
 
-#: corehq/apps/reports/models.py:654
+#: corehq/apps/reports/models.py:649
 msgid "Every day"
 msgstr ""
 
-#: corehq/apps/reports/models.py:655
+#: corehq/apps/reports/models.py:650
 #, python-format
 msgid "Day %s of every month"
 msgstr ""
 
-#: corehq/apps/reports/models.py:699
+#: corehq/apps/reports/models.py:694
 msgid "Scheduled report from CommCare HQ"
 msgstr ""
 
@@ -16316,54 +16538,54 @@ msgstr ""
 msgid "Email report from CommCare HQ"
 msgstr ""
 
-#: corehq/apps/reports/views.py:798
+#: corehq/apps/reports/views.py:806
 msgid "Create a new"
 msgstr ""
 
-#: corehq/apps/reports/views.py:799
+#: corehq/apps/reports/views.py:807
 msgid "New Scheduled Report"
 msgstr ""
 
-#: corehq/apps/reports/views.py:802
+#: corehq/apps/reports/views.py:810
 msgid "Edit Scheduled Report"
 msgstr ""
 
-#: corehq/apps/reports/views.py:910
+#: corehq/apps/reports/views.py:918
 msgid "once off report"
 msgstr ""
 
-#: corehq/apps/reports/views.py:910
+#: corehq/apps/reports/views.py:918
 msgid "scheduled report"
 msgstr ""
 
-#: corehq/apps/reports/views.py:934
+#: corehq/apps/reports/views.py:942
 msgid ""
 "The case creation form could not be found. Usually this happens if the form "
 "that created the case is archived but there are other forms that updated the "
 "case. To fix this you can archive the other forms listed here."
 msgstr ""
 
-#: corehq/apps/reports/views.py:979
+#: corehq/apps/reports/views.py:987
 msgid "unknown"
 msgstr ""
 
-#: corehq/apps/reports/views.py:992
+#: corehq/apps/reports/views.py:1000
 msgid "You don't have permission to access this page."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1014
+#: corehq/apps/reports/views.py:1022
 #, python-format
 msgid "Case %s was rebuilt from its forms."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1026
+#: corehq/apps/reports/views.py:1034
 #, python-format
 msgid ""
 "Case %s was successfully saved. Hopefully it will show up in all reports "
 "momentarily."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1040
+#: corehq/apps/reports/views.py:1048
 #, python-brace-format
 msgid ""
 "Case {name} has been closed.\n"
@@ -16378,89 +16600,89 @@ msgid ""
 "        "
 msgstr ""
 
-#: corehq/apps/reports/views.py:1080
+#: corehq/apps/reports/views.py:1088
 msgid "case id"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1081
+#: corehq/apps/reports/views.py:1089
 msgid "case name"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1082
+#: corehq/apps/reports/views.py:1090
 msgid "section"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1083
+#: corehq/apps/reports/views.py:1091
 msgid "date"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1084
+#: corehq/apps/reports/views.py:1092
 msgid "product_id"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1085
+#: corehq/apps/reports/views.py:1093
 msgid "product_name"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1086
+#: corehq/apps/reports/views.py:1094
 msgid "transaction amount"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1087
+#: corehq/apps/reports/views.py:1095
 msgid "type"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1088
+#: corehq/apps/reports/views.py:1096
 msgid "ending balance"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1098
+#: corehq/apps/reports/views.py:1106
 msgid "unknown product"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1301
+#: corehq/apps/reports/views.py:1309
 msgid "Could not detect the application/form for this submission."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1315
+#: corehq/apps/reports/views.py:1323
 msgid "Missing app, module or form information!"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1345
+#: corehq/apps/reports/views.py:1353
 #: corehq/apps/reports/templates/reports/form/edit_submission.html:26
 msgid "Edit Submission"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1376
+#: corehq/apps/reports/views.py:1384
 msgid "Form was successfully archived."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1378
+#: corehq/apps/reports/views.py:1386
 msgid "Form was already archived."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1380
+#: corehq/apps/reports/views.py:1388
 #, python-format
 msgid "Can't archive documents of type %s. How did you get here??"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1384
+#: corehq/apps/reports/views.py:1392
 msgid "Undo"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1423
+#: corehq/apps/reports/views.py:1431
 msgid "Form was successfully restored."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1438
+#: corehq/apps/reports/views.py:1446
 msgid "Form was successfully resaved. It should reappear in reports shortly."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1484
+#: corehq/apps/reports/views.py:1492
 msgid "We don't support this format"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1486
+#: corehq/apps/reports/views.py:1494
 msgid ""
 "That report was not found. Please remember that download links expire after "
 "24 hours."
@@ -16584,7 +16806,7 @@ msgid "Stock Status by Product"
 msgstr ""
 
 #: corehq/apps/reports/commtrack/standard.py:93
-#: custom/ilsgateway/tanzania/reports/delivery.py:154
+#: custom/ilsgateway/tanzania/reports/delivery.py:157
 msgid "# Facilities"
 msgstr ""
 
@@ -16664,11 +16886,6 @@ msgstr ""
 
 #: corehq/apps/reports/commtrack/standard.py:270
 msgid "Aggregate Inventory"
-msgstr ""
-
-#: corehq/apps/reports/commtrack/standard.py:297
-#: custom/ilsgateway/tanzania/reports/facility_details.py:27
-msgid "Stock on Hand"
 msgstr ""
 
 #: corehq/apps/reports/commtrack/standard.py:298
@@ -16763,7 +16980,7 @@ msgid "Date of last report for selected period"
 msgstr ""
 
 #: corehq/apps/reports/commtrack/standard.py:420
-#: corehq/apps/reports/standard/deployments.py:253
+#: corehq/apps/reports/standard/deployments.py:282
 msgid "Never"
 msgstr ""
 
@@ -17036,15 +17253,15 @@ msgstr ""
 msgid "Opened / Closed"
 msgstr ""
 
-#: corehq/apps/reports/filters/select.py:128 custom/opm/filters.py:153
+#: corehq/apps/reports/filters/select.py:128 custom/opm/filters.py:112
 msgid "Show All"
 msgstr ""
 
-#: corehq/apps/reports/filters/select.py:133 custom/opm/filters.py:154
+#: corehq/apps/reports/filters/select.py:133 custom/opm/filters.py:113
 msgid "Only Open"
 msgstr ""
 
-#: corehq/apps/reports/filters/select.py:134 custom/opm/filters.py:155
+#: corehq/apps/reports/filters/select.py:134 custom/opm/filters.py:114
 msgid "Only Closed"
 msgstr ""
 
@@ -17165,31 +17382,43 @@ msgstr ""
 msgid "Unknown App"
 msgstr ""
 
-#: corehq/apps/reports/standard/deployments.py:163
+#: corehq/apps/reports/standard/deployments.py:165
 msgid "User Sync History"
 msgstr ""
 
-#: corehq/apps/reports/standard/deployments.py:166
-msgid "Shows the last (up to) 10 times a user has synced."
+#: corehq/apps/reports/standard/deployments.py:171
+msgid "Shows the last (up to) {} times a user has synced."
 msgstr ""
 
-#: corehq/apps/reports/standard/deployments.py:172
+#: corehq/apps/reports/standard/deployments.py:180
 msgid "Sync Date"
 msgstr ""
 
-#: corehq/apps/reports/standard/deployments.py:173
+#: corehq/apps/reports/standard/deployments.py:181
 msgid "# of Cases"
 msgstr ""
 
-#: corehq/apps/reports/standard/deployments.py:174
+#: corehq/apps/reports/standard/deployments.py:182
 msgid "Sync Duration"
 msgstr ""
 
-#: corehq/apps/reports/standard/deployments.py:177
+#: corehq/apps/reports/standard/deployments.py:185
 msgid "Sync Log"
 msgstr ""
 
-#: corehq/apps/reports/standard/deployments.py:208
+#: corehq/apps/reports/standard/deployments.py:186
+msgid "Sync Log Type"
+msgstr ""
+
+#: corehq/apps/reports/standard/deployments.py:187
+msgid "Previous Sync Log"
+msgstr ""
+
+#: corehq/apps/reports/standard/deployments.py:188
+msgid "Error Info"
+msgstr ""
+
+#: corehq/apps/reports/standard/deployments.py:219
 msgid "{} seconds"
 msgstr ""
 
@@ -17301,7 +17530,7 @@ msgstr ""
 #: corehq/apps/reports/standard/sms.py:408
 #: corehq/apps/sms/templates/sms/default.html:59
 #: corehq/ex-submodules/casexml/apps/case/templates/case/partials/single_case.html:94
-#: custom/ilsgateway/tanzania/reports/delivery.py:170
+#: custom/ilsgateway/tanzania/reports/delivery.py:173
 msgid "Received"
 msgstr ""
 
@@ -17745,7 +17974,7 @@ msgid "Follow-Up Date"
 msgstr ""
 
 #: corehq/apps/reports/standard/cases/careplan.py:113
-#: corehq/ex-submodules/casexml/apps/case/models.py:913
+#: corehq/ex-submodules/casexml/apps/case/models.py:918
 #: custom/_legacy/pact/models.py:339
 msgid "Date Modified"
 msgstr ""
@@ -17772,17 +18001,17 @@ msgid "You can email a saved version<br />of this report."
 msgstr ""
 
 #: corehq/apps/reports/templates/reports/base_template.html:67
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:125
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:129
 msgid "Favorites"
 msgstr ""
 
 #: corehq/apps/reports/templates/reports/base_template.html:72
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:130
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:134
 msgid "You don't have any favorites"
 msgstr ""
 
 #: corehq/apps/reports/templates/reports/base_template.html:91
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:149
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:153
 msgid "Email Supported"
 msgstr ""
 
@@ -18068,112 +18297,112 @@ msgid ""
 "    "
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:135
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:136
 #, python-format
 msgid ""
 "\n"
-"            Submitted by %(auth_user)s on behalf of %(user)s\n"
-"        "
+"                Submitted by %(auth_user)s on behalf of %(user)s\n"
+"            "
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:140
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:141
 #, python-format
 msgid ""
 "\n"
-"            Submitted by %(auth_user)s\n"
-"        "
+"                Submitted by %(auth_user)s\n"
+"            "
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:147
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:148
 #, python-format
 msgid ""
 "\n"
-"        Submitted as %(user)s\n"
-"        "
+"            Submitted as %(user)s\n"
+"            "
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:155
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:157
 msgid "Form Properties"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:161
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:163
 msgid "Case Changes"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:169
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:171
 msgid "Form Metadata"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:177
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:179
 #: corehq/ex-submodules/casexml/apps/case/templates/case/partials/single_case.html:30
 msgid "Attachments"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:183
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:185
 msgid "Raw XML"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:194
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:195
 msgid "View standalone form"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:200
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:201
 msgid "Edit submission"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:206
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:207
 msgid "Archiving Forms"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:207
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:208
 msgid ""
 "Archived forms will no longer show up in reports and they will be removed "
 "from any relevant case histories. "
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:211
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:212
 msgid "Archive this form"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:220
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:221
 msgid "Restoring Forms"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:221
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:222
 msgid "Restoring this form will cause it to show up in reports again."
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:225
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:226
 msgid "Restore this form"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:234
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:235
 msgid "Resaving Forms"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:235
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:236
 msgid ""
 "Resaving a form can manually cause it to be reincluded in reports if "
 "something went wrong during initial processing."
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:239
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:240
 msgid "Resave this form"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:262
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:263
 msgid "Unknown/Deleted Case"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:269
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:270
 msgid "(this case)"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:315
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:316
 msgid "Open XML in New Window"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:318
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:319
 msgid "Double-click code below to select all:"
 msgstr ""
 
@@ -18202,7 +18431,7 @@ msgid "IVR"
 msgstr ""
 
 #: corehq/apps/reports/templates/reports/messaging/survey_detail.html:23
-#: custom/ilsgateway/tanzania/reports/randr.py:173
+#: custom/ilsgateway/tanzania/reports/randr.py:175
 msgid "Contact"
 msgstr ""
 
@@ -18244,6 +18473,7 @@ msgid "No data is available. Please submit more forms!"
 msgstr ""
 
 #: corehq/apps/reports/templates/reports/partials/hqexport_group_table.html:8
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:47
 msgid "File"
 msgstr ""
 
@@ -18731,6 +18961,11 @@ msgstr ""
 msgid "My Account"
 msgstr ""
 
+#: corehq/apps/settings/views.py:93
+#: corehq/apps/settings/templates/settings/edit_my_account.b2.html:33
+msgid "My Information"
+msgstr ""
+
 #: corehq/apps/settings/views.py:174
 #, python-format
 msgid "Unable remove membership because you are the admin of %s"
@@ -18754,6 +18989,7 @@ msgid "Your password was successfully changed!"
 msgstr ""
 
 #: corehq/apps/settings/templates/settings/change_my_password.html:9
+#: docs/_build/html/_sources/translations.txt:177
 msgid "Specify New Password"
 msgstr ""
 
@@ -18769,7 +19005,7 @@ msgstr ""
 #: corehq/apps/settings/templates/settings/edit_my_account.b2.html:42
 #: corehq/apps/telerivet/forms.py:10
 #: corehq/apps/telerivet/templates/telerivet/backend.html:10
-#: corehq/apps/users/forms.py:188
+#: corehq/apps/users/forms.py:187
 msgid "API Key"
 msgstr ""
 
@@ -20509,6 +20745,10 @@ msgstr ""
 msgid "All domain/toggle statuses"
 msgstr ""
 
+#: corehq/apps/toggle_ui/templates/toggle/edit_flag.html:165
+msgid "Enabled?"
+msgstr ""
+
 #: corehq/apps/toggle_ui/templates/toggle/flags.html:57
 msgid "Tag"
 msgstr ""
@@ -20564,8 +20804,8 @@ msgid "Create New Report"
 msgstr ""
 
 #: corehq/apps/userreports/views.py:124
-#: corehq/apps/userreports/reports/builder/forms.py:768
-#: corehq/apps/userreports/reports/builder/forms.py:823
+#: corehq/apps/userreports/reports/builder/forms.py:776
+#: corehq/apps/userreports/reports/builder/forms.py:831
 msgid "Chart"
 msgstr ""
 
@@ -20605,21 +20845,21 @@ msgid ""
 "choose the columns and rows."
 msgstr ""
 
-#: corehq/apps/userreports/views.py:230
+#: corehq/apps/userreports/views.py:234
 msgid "Chart Report: {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:247
+#: corehq/apps/userreports/views.py:251
 msgid "Choose the property you would like to add as a filter to this report."
 msgstr ""
 
-#: corehq/apps/userreports/views.py:248
+#: corehq/apps/userreports/views.py:252
 msgid ""
 "Web users viewing the report will see this display text instead of the "
 "property name. Name your filter something easy for users to understand."
 msgstr ""
 
-#: corehq/apps/userreports/views.py:249
+#: corehq/apps/userreports/views.py:253
 msgid ""
 "What type of property is this filter?<br/><br/><strong>Date</strong>: select "
 "this if the property is a date.<br/><strong>Choice</strong>: select this if "
@@ -20627,71 +20867,71 @@ msgid ""
 "select this if the property is a number."
 msgstr ""
 
-#: corehq/apps/userreports/views.py:291
+#: corehq/apps/userreports/views.py:295
 msgid "List Report: {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:300
+#: corehq/apps/userreports/views.py:304
 msgid "Table Report: {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:309
+#: corehq/apps/userreports/views.py:313
 msgid "Worker Report: {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:322
+#: corehq/apps/userreports/views.py:326
 msgid "Report \"{}\" saved!"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:350
+#: corehq/apps/userreports/views.py:354
 msgid "Report \"{}\" deleted!"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:370
+#: corehq/apps/userreports/views.py:374
 msgid "Report created!"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:373
+#: corehq/apps/userreports/views.py:377
 msgid "Bad report source: {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:375
+#: corehq/apps/userreports/views.py:379
 msgid "paste report source here"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:414 corehq/apps/userreports/views.py:420
+#: corehq/apps/userreports/views.py:418 corehq/apps/userreports/views.py:424
 msgid "Data source created for '{}'"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:437
+#: corehq/apps/userreports/views.py:441
 msgid "Data source \"{}\" saved!"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:465
+#: corehq/apps/userreports/views.py:469
 msgid "Data source \"{}\" has been deleted."
 msgstr ""
 
-#: corehq/apps/userreports/views.py:475
+#: corehq/apps/userreports/views.py:479
 msgid "Table \"{}\" is now being rebuilt. Data should start showing up soon"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:514
+#: corehq/apps/userreports/views.py:518
 msgid "You can only use 'lastndays' on date columns"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:524
+#: corehq/apps/userreports/views.py:528
 msgid "Ranges must have the format \"start..end\""
 msgstr ""
 
-#: corehq/apps/userreports/views.py:556
+#: corehq/apps/userreports/views.py:560
 msgid "No field named {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:563
+#: corehq/apps/userreports/views.py:567
 msgid "Invalid filter parameter: {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:597
+#: corehq/apps/userreports/views.py:601
 msgid ""
 "There was a problem executing your query, please make sure your parameters "
 "are valid."
@@ -20788,47 +21028,47 @@ msgid ""
 "the data source before viewing the report."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:304
+#: corehq/apps/userreports/reports/builder/forms.py:305
 msgid "Bar"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:305
+#: corehq/apps/userreports/reports/builder/forms.py:306
 msgid "Pie"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:318
+#: corehq/apps/userreports/reports/builder/forms.py:319
 msgid ""
 "<strong>Form</strong>: display data from form submissions.<br/><strong>Case</"
 "strong>: display data from your cases. You must be using case management for "
 "this option."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:319
+#: corehq/apps/userreports/reports/builder/forms.py:320
 msgid "Which application should the data come from?"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:320
+#: corehq/apps/userreports/reports/builder/forms.py:321
 msgid ""
 "Choose the case type or form from which to retrieve data for this report."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:332
+#: corehq/apps/userreports/reports/builder/forms.py:333
 msgid ""
 "<strong>Bar</strong> shows one vertical bar for each value in your case or "
 "form. <strong>Pie</strong> shows what percentage of the total each value is."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:345
+#: corehq/apps/userreports/reports/builder/forms.py:346
 msgid "{} Report"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:346
+#: corehq/apps/userreports/reports/builder/forms.py:347
 msgid ""
 "Web users will see this name in the \"Reports\" section of CommCareHQ and "
 "can click to view the report"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:388
+#: corehq/apps/userreports/reports/builder/forms.py:389
 msgid ""
 "Too many data sources!\n"
 "Creating this report would cause you to go over the maximum number of data "
@@ -20837,63 +21077,69 @@ msgid ""
 "itself) and try again. "
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:405
+#: corehq/apps/userreports/reports/builder/forms.py:406
 #: custom/bihar/reports/indicators/clientlistdisplay.py:146
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:345
 msgid "Done"
 msgstr "समाप्त"
 
-#: corehq/apps/userreports/reports/builder/forms.py:417
+#: corehq/apps/userreports/reports/builder/forms.py:418
 msgid "Update Report"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:474
-#: corehq/apps/userreports/templates/userreports/edit_report_config.html:8
+#: corehq/apps/userreports/reports/builder/forms.py:475
+#: corehq/apps/userreports/templates/userreports/edit_report_config.html:18
 msgid "Delete Report"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:518
+#: corehq/apps/userreports/reports/builder/forms.py:500
+msgid ""
+"Report builder data source doesn't reference an application. It is likely "
+"this report has been customized and it is no longer editable. "
+msgstr ""
+
+#: corehq/apps/userreports/reports/builder/forms.py:526
 msgid "Filters"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:519
+#: corehq/apps/userreports/reports/builder/forms.py:527
 msgid ""
 "Add filters to your report to allow viewers to select which data the report "
 "will display. These filters will be displayed at the top of your report."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:573
+#: corehq/apps/userreports/reports/builder/forms.py:581
 msgid ""
 "Editing this report would require a new data source. The limit is 5. To "
 "continue, first delete all of the reports using a particular data source (or "
 "the data source itself) and try again. "
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:769
+#: corehq/apps/userreports/reports/builder/forms.py:777
 msgid ""
 "The values of the selected property will be aggregated and shown as bars in "
 "the chart."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:824
+#: corehq/apps/userreports/reports/builder/forms.py:832
 msgid ""
 "The values of the selected property will be aggregated and shows as the "
 "sections of the pie chart."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:841
+#: corehq/apps/userreports/reports/builder/forms.py:849
 msgid ""
 "Add columns to your report to display information from cases or form "
 "submissions. You may rearrange the order of the columns by dragging the "
 "arrows next to the column."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:854
+#: corehq/apps/userreports/reports/builder/forms.py:862
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:179
 msgid "Columns"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:898
+#: corehq/apps/userreports/reports/builder/forms.py:906
 msgid ""
 "Add columns for this report to aggregate. Each property you add will create "
 "a column for every value of that property.  For example, if you add a column "
@@ -20901,23 +21147,37 @@ msgid ""
 "column for \"no.\""
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:907
+#: corehq/apps/userreports/reports/builder/forms.py:915
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:13
 msgid "Rows"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:908
+#: corehq/apps/userreports/reports/builder/forms.py:916
 msgid ""
 "Choose which property this report will group its results by. Each value of "
 "this property will be a row in the table. For example, if you choose a yes "
 "or no question, the report will show a row for \"yes\" and a row for \"no.\""
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:971
+#: corehq/apps/userreports/reports/builder/forms.py:979
 msgid ""
 "Add columns for this report to aggregate. Each property you add will create "
 "a column for every value of that property. For example, if you add a column "
 "for a yes or no question, the report will show a column for \"yes\" and a "
 "column for \"no\"."
+msgstr ""
+
+#: corehq/apps/userreports/sql/columns.py:60
+#, python-brace-format
+msgid ""
+"The \"{header}\" column had too many values to expand! Expansion limited to "
+"{max} distinct values."
+msgstr ""
+
+#: corehq/apps/userreports/sql/columns.py:94
+msgid ""
+"The column \"{}\" does not exist in the report source! Please double check "
+"your report configuration."
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/builder_report_type_select.html:37
@@ -20942,54 +21202,61 @@ msgid ""
 "        "
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:108
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:105
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:111
+#: corehq/apps/userreports/templates/userreports/edit_report_config.html:7
 msgid "Edit Report"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/configurable_reports_home.html:4
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:44
 msgid "Configurable Reports"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/configurable_reports_home.html:5
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:32
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:82
 msgid "Add data source"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/configurable_reports_home.html:6
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:16
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:64
 msgid "Add report"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/configurable_reports_home.html:7
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:20
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:68
 msgid "Import report"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/edit_data_source.html:7
-msgid "This datasource is read only, any changes made can not be saved."
-msgstr ""
-
-#: corehq/apps/userreports/templates/userreports/edit_data_source.html:14
-msgid "Delete Data Source"
+msgid "Edit Data Source"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/edit_data_source.html:18
+msgid "This datasource is read only, any changes made can not be saved."
+msgstr ""
+
+#: corehq/apps/userreports/templates/userreports/edit_data_source.html:25
+msgid "Delete Data Source"
+msgstr ""
+
+#: corehq/apps/userreports/templates/userreports/edit_data_source.html:29
 msgid "Rebuild Data Source"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/edit_data_source.html:19
+#: corehq/apps/userreports/templates/userreports/edit_data_source.html:30
 msgid "Preview data"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/edit_data_source.html:20
+#: corehq/apps/userreports/templates/userreports/edit_data_source.html:31
 msgid "Data Source Source (Advanced)"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/edit_report_config.html:9
+#: corehq/apps/userreports/templates/userreports/edit_report_config.html:19
 msgid "View report"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/edit_report_config.html:10
+#: corehq/apps/userreports/templates/userreports/edit_report_config.html:20
 msgid "Report Source (Advanced)"
 msgstr ""
 
@@ -21006,16 +21273,16 @@ msgstr ""
 msgid "Preview table: %(display_name)s (%(total_rows)s total rows)"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:7
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:53
 #: corehq/apps/users/templates/users/web_users.b3.html:390
 msgid "Edit Reports"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:23
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:71
 msgid "Edit Data Sources"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:38
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:88
 msgid "Data source from application"
 msgstr ""
 
@@ -21040,7 +21307,7 @@ msgid "Expected {} but was {}"
 msgstr ""
 
 #: corehq/apps/userreports/ui/forms.py:25
-#: corehq/apps/userreports/ui/forms.py:149
+#: corehq/apps/userreports/ui/forms.py:159
 msgid "Save Changes"
 msgstr ""
 
@@ -21060,23 +21327,80 @@ msgstr ""
 msgid "Problem with report spec: {}"
 msgstr ""
 
-#: corehq/apps/userreports/ui/forms.py:95
+#: corehq/apps/userreports/ui/forms.py:91
+msgid "Source Type"
+msgstr ""
+
+#: corehq/apps/userreports/ui/forms.py:92
+#, fuzzy
+msgid "Report Title"
+msgstr "Manejo de Casos"
+
+#: corehq/apps/userreports/ui/forms.py:103
 msgid "Named filters (optional)"
 msgstr ""
 
-#: corehq/apps/userreports/ui/forms.py:106
+#: corehq/apps/userreports/ui/forms.py:116
 msgid ""
 "Table id is too long. Your table id and domain name must add up to fewer "
 "than 40 characters"
 msgstr ""
 
-#: corehq/apps/userreports/ui/forms.py:111
+#: corehq/apps/userreports/ui/forms.py:121
 msgid ""
 "A data source with this table id already exists. Table ids must be unique"
 msgstr ""
 
-#: corehq/apps/userreports/ui/forms.py:128
+#: corehq/apps/userreports/ui/forms.py:138
 msgid "Problem with data source spec: {}"
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:4
+msgid ""
+"Choose something short, unique, and memorable using lowercase letters, "
+"numbers, and underscores"
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:7
+msgid ""
+"This is what the data source will be called in navigation, page title, etc."
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:9
+msgid "Write yourself a little note if you like, it's optional"
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:11
+msgid ""
+"You can leave this blank unless you are <a target=\"_blank\" href=\"https://"
+"github.com/dimagi/commcare-hq/blob/master/corehq/apps/userreports/README."
+"md#saving-repeat-data\">saving repeat data</a>"
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:16
+msgid ""
+"Look at <a target=\"_blank\" href=\"https://github.com/dimagi/commcare-hq/"
+"blob/master/corehq/apps/userreports/examples/examples.md#data-source-filters"
+"\">these examples</a> and <a target=\"_blank\" href=\"https://github.com/"
+"dimagi/commcare-hq/blob/master/corehq/apps/userreports/README.md#data-source-"
+"filtering\">these docs</a>"
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:24
+msgid ""
+"Look at <a target=\"_blank\" href=\"https://github.com/dimagi/commcare-hq/"
+"blob/master/corehq/apps/userreports/examples/examples.md#data-source-"
+"indicators\">these examples</a> and <a target=\"_blank\" href=\"https://"
+"github.com/dimagi/commcare-hq/blob/master/corehq/apps/userreports/README."
+"md#indicators\">these docs</a>"
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:32
+msgid ""
+"For this advanced and useful feature, give a dict where the keys are the "
+"variable names you choose and the values are filters according to the syntax "
+"of Configured Filters above. You can then reference these from Configured "
+"Filters as {\"type\": \"named\", \"name\": \"myvarname\"}"
 msgstr ""
 
 #: corehq/apps/users/bulkupload.py:52
@@ -21131,77 +21455,77 @@ msgstr ""
 msgid "Can't add to group '%s' (try adding it to your spreadsheet)"
 msgstr ""
 
-#: corehq/apps/users/forms.py:59
+#: corehq/apps/users/forms.py:58
 msgid "Please enter a valid two or three digit language code."
 msgstr ""
 
-#: corehq/apps/users/forms.py:132
+#: corehq/apps/users/forms.py:131
 msgid "System Super User"
 msgstr ""
 
-#: corehq/apps/users/forms.py:147
+#: corehq/apps/users/forms.py:146
 msgid "E-Mail"
 msgstr ""
 
-#: corehq/apps/users/forms.py:154
+#: corehq/apps/users/forms.py:153
 msgid ""
 "<i class=\"icon-info-sign\"></i> Becomes default language seen in CloudCare "
 "and reports (if applicable), but does not affect mobile applications. "
 "Supported languages for reports are en, fr (partial), and hin (partial)."
 msgstr ""
 
-#: corehq/apps/users/forms.py:171
+#: corehq/apps/users/forms.py:170
 msgid "Opt out of emails about CommCare updates."
 msgstr ""
 
-#: corehq/apps/users/forms.py:191
+#: corehq/apps/users/forms.py:190
 msgid "Generate API Key"
 msgstr ""
 
-#: corehq/apps/users/forms.py:199
+#: corehq/apps/users/forms.py:198
 msgid "My Language"
 msgstr ""
 
-#: corehq/apps/users/forms.py:219
+#: corehq/apps/users/forms.py:218
 msgid "Other Options"
 msgstr ""
 
-#: corehq/apps/users/forms.py:225
+#: corehq/apps/users/forms.py:224
 msgid "Update My Information"
 msgstr ""
 
-#: corehq/apps/users/forms.py:240
+#: corehq/apps/users/forms.py:239
 msgid ""
 "Multiply this user's case load by a number for load testing on phones. Leave "
 "blank for normal users."
 msgstr ""
 
-#: corehq/apps/users/forms.py:324
+#: corehq/apps/users/forms.py:323
 #, python-format
 msgid "%s is an invalid phone number."
 msgstr ""
 
-#: corehq/apps/users/forms.py:371 corehq/apps/users/forms.py:373
+#: corehq/apps/users/forms.py:370 corehq/apps/users/forms.py:372
 msgid "Username contains invalid characters."
 msgstr ""
 
-#: corehq/apps/users/forms.py:480
+#: corehq/apps/users/forms.py:479
 #, python-format
 msgid ""
 "I have read and agree to the <a href=\"%(pa_url)s\" target=\"_blank"
 "\">Software Product Subscription Agreement</a>."
 msgstr ""
 
-#: corehq/apps/users/forms.py:509
+#: corehq/apps/users/forms.py:508
 msgid "Back to Mobile Workers List"
 msgstr ""
 
-#: corehq/apps/users/forms.py:521
+#: corehq/apps/users/forms.py:520
 msgid ""
 "Please agree to the Product Subscription Agreement above before continuing."
 msgstr ""
 
-#: corehq/apps/users/models.py:2426
+#: corehq/apps/users/models.py:2446
 #, python-format
 msgid "Invitation from %s to join CommCareHQ"
 msgstr ""
@@ -21754,8 +22078,8 @@ msgstr ""
 
 #: corehq/apps/users/templates/users/mobile/users_list.html:212
 #: custom/_legacy/pact/templates/pact/chw/pact_chw_profile_info.html:12
-#: custom/ilsgateway/tanzania/reports/facility_details.py:72
-#: custom/ilsgateway/tanzania/reports/facility_details.py:119
+#: custom/ilsgateway/tanzania/reports/facility_details.py:73
+#: custom/ilsgateway/tanzania/reports/facility_details.py:120
 msgid "Phone"
 msgstr ""
 
@@ -21890,57 +22214,53 @@ msgstr ""
 msgid "Edit User Role"
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:291
+#: corehq/apps/users/views/__init__.py:289
 #, python-format
 msgid "Changed system permissions for user \"%s\""
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:340
+#: corehq/apps/users/views/__init__.py:338
 msgid "Phone number added!"
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:342
+#: corehq/apps/users/views/__init__.py:340
 msgid "Please enter digits only."
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:349
-msgid "Edit My Information"
-msgstr ""
-
-#: corehq/apps/users/views/__init__.py:388
-#: corehq/apps/users/views/__init__.py:534
+#: corehq/apps/users/views/__init__.py:346
+#: corehq/apps/users/views/__init__.py:492
 msgid "Web Users & Roles"
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:435
+#: corehq/apps/users/views/__init__.py:393
 msgid "Please provide pagination info."
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:736
+#: corehq/apps/users/views/__init__.py:694
 msgid "Invitation resent"
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:738
+#: corehq/apps/users/views/__init__.py:696
 msgid "Error while attempting resend"
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:768
+#: corehq/apps/users/views/__init__.py:726
 msgid "Invite Web User to Project"
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:866
+#: corehq/apps/users/views/__init__.py:818
 msgid "Cannot start verification workflow. Phone number is already in use."
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:868
+#: corehq/apps/users/views/__init__.py:820
 msgid "Phone number is already verified."
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:870
+#: corehq/apps/users/views/__init__.py:822
 msgid "Verification message resent."
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:872
+#: corehq/apps/users/views/__init__.py:824
 msgid "Verification workflow started."
 msgstr ""
 
@@ -22072,36 +22392,36 @@ msgid ""
 "The following groups have no name. Please name them before continuing: {}"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:228
+#: corehq/ex-submodules/casexml/apps/case/models.py:229
 msgid "Closed"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:228
+#: corehq/ex-submodules/casexml/apps/case/models.py:229
 msgid "Open"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:515
+#: corehq/ex-submodules/casexml/apps/case/models.py:516
 msgid "Sorry, referrals are no longer supported!"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:857
+#: corehq/ex-submodules/casexml/apps/case/models.py:862
 msgid "Opened On"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:863
+#: corehq/ex-submodules/casexml/apps/case/models.py:868
 msgid "Modified On"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:869
-#: custom/opm/beneficiary.py:824 custom/opm/beneficiary.py:901
+#: corehq/ex-submodules/casexml/apps/case/models.py:874
+#: custom/opm/beneficiary.py:823 custom/opm/beneficiary.py:901
 msgid "Closed On"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:882
+#: corehq/ex-submodules/casexml/apps/case/models.py:887
 msgid "Last Submitter"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:907
+#: corehq/ex-submodules/casexml/apps/case/models.py:912
 msgid "Date Opened"
 msgstr ""
 
@@ -22764,8 +23084,8 @@ msgstr "देखभाल तीन दिन में"
 msgid "Beneficiary Information"
 msgstr "लाभार्थी के पहचान हेतु आवश्यक जानकारी"
 
-#: custom/bihar/reports/mch_reports.py:134 custom/opm/beneficiary.py:809
-#: custom/opm/beneficiary.py:885
+#: custom/bihar/reports/mch_reports.py:134 custom/opm/beneficiary.py:808
+#: custom/opm/beneficiary.py:885 custom/opm/beneficiary.py:930
 msgid "Husband Name"
 msgstr "पति का नाम"
 
@@ -22842,6 +23162,7 @@ msgstr "अन्तिम माहवारी की तिथि"
 #: custom/bihar/reports/mch_reports.py:151
 #: custom/bihar/reports/indicators/clientlistdisplay.py:80
 #: custom/bihar/reports/indicators/clientlistdisplay.py:98
+#: custom/opm/beneficiary.py:944
 msgid "EDD"
 msgstr "प्रसव की संभावित तिथि"
 
@@ -23044,7 +23365,7 @@ msgstr "नवजात शिशु 4 की जानकारी "
 msgid "Migrate status "
 msgstr "Migrate  Status (out/in)"
 
-#: custom/bihar/reports/mch_reports.py:314 custom/opm/beneficiary.py:812
+#: custom/bihar/reports/mch_reports.py:314 custom/opm/beneficiary.py:811
 msgid "Child Name"
 msgstr "बच्चे का नाम "
 
@@ -24107,43 +24428,43 @@ msgstr ""
 msgid "Dashboard report {0}"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:28
-#: custom/ilsgateway/tanzania/reports/delivery.py:86
+#: custom/ilsgateway/tanzania/reports/delivery.py:29
+#: custom/ilsgateway/tanzania/reports/delivery.py:88
 msgid "Average Lead Time In Days"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:82
-#: custom/ilsgateway/tanzania/reports/randr.py:171
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:251
+#: custom/ilsgateway/tanzania/reports/delivery.py:84
+#: custom/ilsgateway/tanzania/reports/randr.py:173
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:318
 msgid "Facility Name"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:83
+#: custom/ilsgateway/tanzania/reports/delivery.py:85
 msgid "Delivery Status"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:84
+#: custom/ilsgateway/tanzania/reports/delivery.py:86
 msgid "Delivery Date"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:85
+#: custom/ilsgateway/tanzania/reports/delivery.py:87
 msgid "This Cycle Lead Time"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:155
+#: custom/ilsgateway/tanzania/reports/delivery.py:158
 #, python-format
 msgid "% of total"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:167
+#: custom/ilsgateway/tanzania/reports/delivery.py:170
 msgid "Didn't Respond"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:169
+#: custom/ilsgateway/tanzania/reports/delivery.py:172
 msgid "Not Received"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:182
+#: custom/ilsgateway/tanzania/reports/delivery.py:185
 #, python-brace-format
 msgid "Delivery Report {0}"
 msgstr ""
@@ -24152,106 +24473,106 @@ msgstr ""
 msgid "Months of stock"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/facility_details.py:120
+#: custom/ilsgateway/tanzania/reports/facility_details.py:121
 msgid "Text"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:83
+#: custom/ilsgateway/tanzania/reports/randr.py:84
 msgid "% Facilities Submitting R&R On Time"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:84
+#: custom/ilsgateway/tanzania/reports/randr.py:85
 msgid "% Facilities Submitting R&R Late"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:85
+#: custom/ilsgateway/tanzania/reports/randr.py:86
 msgid "% Facilities With R&R Not Submitted"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:86
+#: custom/ilsgateway/tanzania/reports/randr.py:87
 msgid "% Facilities Not Responding To R&R Reminder"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:87
-#: custom/ilsgateway/tanzania/reports/randr.py:174
-#: custom/ilsgateway/tanzania/reports/supervision.py:60
-#: custom/ilsgateway/tanzania/reports/supervision.py:123
+#: custom/ilsgateway/tanzania/reports/randr.py:88
+#: custom/ilsgateway/tanzania/reports/randr.py:176
+#: custom/ilsgateway/tanzania/reports/supervision.py:61
+#: custom/ilsgateway/tanzania/reports/supervision.py:125
 msgid "Historical Response Rate"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:172
+#: custom/ilsgateway/tanzania/reports/randr.py:174
 msgid "R&R Status"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:185
+#: custom/ilsgateway/tanzania/reports/randr.py:187
 #, python-brace-format
 msgid "R & R {0}"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:82
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:84
 msgid "% Facilities Submitting Soh On Time"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:83
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:85
 msgid "% Facilities Submitting Soh Late"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:84
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:86
 msgid "% Facilities Not Responding To Soh"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:85
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:87
 msgid "% Facilities With 1 Or More Stockouts This Month"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:97
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:99
 #, python-format
 msgid "%s stock outs this %s"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:203
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:269
 msgid "Waiting for reply"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:250
-#: custom/ilsgateway/tanzania/reports/supervision.py:119
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:317
+#: custom/ilsgateway/tanzania/reports/supervision.py:121
 msgid "MSD Code"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:252
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:319
 msgid "DG"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:253
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:320
 msgid "Last Reported"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:254
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:321
 msgid "Hist. Resp. Rate"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:406
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:422
 #, python-brace-format
 msgid "Stock On Hand {0}"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/supervision.py:57
+#: custom/ilsgateway/tanzania/reports/supervision.py:58
 msgid "% Supervision Received"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/supervision.py:58
+#: custom/ilsgateway/tanzania/reports/supervision.py:59
 msgid "% Supervision Not Received"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/supervision.py:59
+#: custom/ilsgateway/tanzania/reports/supervision.py:60
 msgid "% Supervision Not Responding"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/supervision.py:121
+#: custom/ilsgateway/tanzania/reports/supervision.py:123
 msgid "Supervision This Quarter"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/supervision.py:181
+#: custom/ilsgateway/tanzania/reports/supervision.py:183
 #, python-brace-format
 msgid "Supervision {0}"
 msgstr ""
@@ -24260,7 +24581,7 @@ msgstr ""
 msgid "Unrecognized SMS"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/utils.py:98
+#: custom/ilsgateway/tanzania/reports/utils.py:100
 msgid "No Data"
 msgstr ""
 
@@ -24341,16 +24662,16 @@ msgstr ""
 msgid " days"
 msgstr ""
 
-#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:55
+#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:65
 #, python-format
 msgid "%(status)s"
 msgstr ""
 
-#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:58
+#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:68
 msgid "Last updated on"
 msgstr ""
 
-#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:63
+#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:73
 msgid "No delivery status reported"
 msgstr ""
 
@@ -25424,108 +25745,112 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: custom/opm/beneficiary.py:742
+#: custom/opm/beneficiary.py:741
 msgid "Incorrect EDD"
 msgstr ""
 
-#: custom/opm/beneficiary.py:748
+#: custom/opm/beneficiary.py:747
 msgid "Incorrect DOD"
 msgstr ""
 
-#: custom/opm/beneficiary.py:753
+#: custom/opm/beneficiary.py:752
 msgid "Incorrect LMP date"
 msgstr ""
 
-#: custom/opm/beneficiary.py:758
+#: custom/opm/beneficiary.py:757
 msgid "Account number is the wrong length"
 msgstr ""
 
-#: custom/opm/beneficiary.py:763
+#: custom/opm/beneficiary.py:762
 msgid "IFSC {} incorrect"
 msgstr ""
 
-#: custom/opm/beneficiary.py:804
+#: custom/opm/beneficiary.py:803 custom/opm/beneficiary.py:919
 msgid "Serial number"
 msgstr "क्रम संख्या"
 
-#: custom/opm/beneficiary.py:805 custom/opm/beneficiary.py:884
+#: custom/opm/beneficiary.py:804 custom/opm/beneficiary.py:884
+#: custom/opm/beneficiary.py:920
 msgid "List of Beneficiaries"
 msgstr "लाभार्थी का नामै"
 
-#: custom/opm/beneficiary.py:806 custom/opm/beneficiary.py:886
-#: custom/opm/health_status.py:89
+#: custom/opm/beneficiary.py:805 custom/opm/beneficiary.py:886
+#: custom/opm/beneficiary.py:922 custom/opm/health_status.py:18
 msgid "AWC Name"
 msgstr "आंगनवाडी केंद्र का नाम"
 
-#: custom/opm/beneficiary.py:807 custom/opm/health_status.py:85
+#: custom/opm/beneficiary.py:806 custom/opm/beneficiary.py:923
+#: custom/opm/health_status.py:14
 msgid "AWC Code"
 msgstr "आंगनवाडी केंद्र का कोड"
 
-#: custom/opm/beneficiary.py:808 custom/opm/beneficiary.py:891
+#: custom/opm/beneficiary.py:807 custom/opm/beneficiary.py:891
+#: custom/opm/beneficiary.py:924
 msgid "Block Name"
 msgstr "तहसील का नाम"
 
-#: custom/opm/beneficiary.py:810
+#: custom/opm/beneficiary.py:809 custom/opm/beneficiary.py:942
 msgid "Current status"
 msgstr "गर्भवती या धात्री"
 
-#: custom/opm/beneficiary.py:811
+#: custom/opm/beneficiary.py:810
 msgid "Pregnancy Month"
 msgstr "गर्भ का महिना"
 
-#: custom/opm/beneficiary.py:813
+#: custom/opm/beneficiary.py:812
 msgid "Child Age"
 msgstr "बच्चे की उम्र"
 
-#: custom/opm/beneficiary.py:815
+#: custom/opm/beneficiary.py:814
 msgid "Condition 1"
 msgstr "शर्त 1"
 
-#: custom/opm/beneficiary.py:816
+#: custom/opm/beneficiary.py:815
 msgid "Condition 2"
 msgstr "शर्त 2"
 
-#: custom/opm/beneficiary.py:817
+#: custom/opm/beneficiary.py:816
 msgid "Condition 3"
 msgstr "शर्त 3"
 
-#: custom/opm/beneficiary.py:818
+#: custom/opm/beneficiary.py:817
 msgid "Condition 4"
 msgstr "शर्त 4"
 
-#: custom/opm/beneficiary.py:819
+#: custom/opm/beneficiary.py:818
 msgid "Condition 5"
 msgstr "शर्त 5"
 
-#: custom/opm/beneficiary.py:820
+#: custom/opm/beneficiary.py:819
 msgid "Payment amount this month (Rs.)"
 msgstr "नकद प्राप्त इस महीने (Rs.)"
 
-#: custom/opm/beneficiary.py:821
+#: custom/opm/beneficiary.py:820
 msgid "Payment amount last month (Rs.)"
 msgstr "नकद प्राप्त पिछले महीने (Rs.)"
 
-#: custom/opm/beneficiary.py:822
+#: custom/opm/beneficiary.py:821 custom/opm/beneficiary.py:973
 msgid "Cash received last month"
 msgstr "पिछले महीने भुगतान प्राप्त"
 
-#: custom/opm/beneficiary.py:825 custom/opm/beneficiary.py:904
+#: custom/opm/beneficiary.py:824 custom/opm/beneficiary.py:904
+#: custom/opm/beneficiary.py:974
 msgid "Issues"
 msgstr ""
 
-#: custom/opm/beneficiary.py:887
+#: custom/opm/beneficiary.py:887 custom/opm/beneficiary.py:937
 msgid "Bank Name"
 msgstr ""
 
-#: custom/opm/beneficiary.py:888
+#: custom/opm/beneficiary.py:888 custom/opm/beneficiary.py:939
 msgid "Bank Branch Name"
 msgstr ""
 
-#: custom/opm/beneficiary.py:889
+#: custom/opm/beneficiary.py:889 custom/opm/beneficiary.py:941
 msgid "IFS Code"
 msgstr ""
 
-#: custom/opm/beneficiary.py:890
+#: custom/opm/beneficiary.py:890 custom/opm/beneficiary.py:938
 msgid "Bank Account Number"
 msgstr ""
 
@@ -25569,441 +25894,655 @@ msgstr ""
 msgid "Payment last month"
 msgstr ""
 
-#: custom/opm/filters.py:113 custom/opm/filters.py:126
+#: custom/opm/beneficiary.py:925
+msgid "Gram Panchayat name"
+msgstr ""
+
+#: custom/opm/beneficiary.py:926
+msgid "Village name"
+msgstr ""
+
+#: custom/opm/beneficiary.py:927
+msgid "Dob Known"
+msgstr ""
+
+#: custom/opm/beneficiary.py:928
+#, fuzzy
+msgid "Mother's Age"
+msgstr "मात्र मृत्यु"
+
+#: custom/opm/beneficiary.py:929
+#, fuzzy
+msgid "Caste tribe status"
+msgstr "गर्भवती या धात्री"
+
+#: custom/opm/beneficiary.py:931
+msgid "Prev pregnancies"
+msgstr ""
+
+#: custom/opm/beneficiary.py:932
+#, fuzzy
+msgid "Prev live births"
+msgstr "समय से पूर्व "
+
+#: custom/opm/beneficiary.py:933
+msgid "Sons alive"
+msgstr ""
+
+#: custom/opm/beneficiary.py:934
+msgid "Daughters alive"
+msgstr ""
+
+#: custom/opm/beneficiary.py:935
+msgid "Sum children"
+msgstr ""
+
+#: custom/opm/beneficiary.py:936
+#, fuzzy
+msgid "Contact phone number"
+msgstr "आँगनवाड़ी सेविका की दूरभाष संख्या"
+
+#: custom/opm/beneficiary.py:940
+msgid "Bank Branch Code"
+msgstr ""
+
+#: custom/opm/beneficiary.py:943
+msgid "Lmp Date"
+msgstr ""
+
+#: custom/opm/beneficiary.py:945
+#, fuzzy
+msgid "Pregnancy month"
+msgstr "गर्भ का महिना"
+
+#: custom/opm/beneficiary.py:947
+#, fuzzy
+msgid "Child 1 Age"
+msgstr "बच्चे की उम्र"
+
+#: custom/opm/beneficiary.py:948
+#, fuzzy
+msgid "Child 1 Name"
+msgstr "बच्चे का नाम "
+
+#: custom/opm/beneficiary.py:949
+#, fuzzy
+msgid "Child 1 Sex"
+msgstr "बच्चे की उम्र"
+
+#: custom/opm/beneficiary.py:950
+#, fuzzy
+msgid "Child DOB"
+msgstr "बच्चा"
+
+#: custom/opm/beneficiary.py:951
+#, fuzzy
+msgid "Child 2 Age"
+msgstr "बच्चे की उम्र"
+
+#: custom/opm/beneficiary.py:952
+#, fuzzy
+msgid "Child 2 Name"
+msgstr "बच्चे का नाम "
+
+#: custom/opm/beneficiary.py:953
+#, fuzzy
+msgid "Child 2 Sex"
+msgstr "बच्चे की उम्र"
+
+#: custom/opm/beneficiary.py:954
+#, fuzzy
+msgid "Child 3 Age"
+msgstr "बच्चे की उम्र"
+
+#: custom/opm/beneficiary.py:955
+#, fuzzy
+msgid "Child 3 Name"
+msgstr "बच्चे का नाम "
+
+#: custom/opm/beneficiary.py:956
+#, fuzzy
+msgid "Child 3 Sex"
+msgstr "बच्चे की उम्र"
+
+#: custom/opm/beneficiary.py:957
+msgid "Condition 1 / pregnant woman attended VHND"
+msgstr ""
+
+#: custom/opm/beneficiary.py:958
+msgid "Condition 2 /pregnant woman's weight taken in first trimester"
+msgstr ""
+
+#: custom/opm/beneficiary.py:959
+msgid "Condition 3/ Received 30 IFA pills"
+msgstr ""
+
+#: custom/opm/beneficiary.py:960
+msgid "Condition 2 /pregnant woman's weight taken in second trimester"
+msgstr ""
+
+#: custom/opm/beneficiary.py:961
+msgid "Condition 4/mother attended VHND with child"
+msgstr ""
+
+#: custom/opm/beneficiary.py:962
+msgid "Condition 5/child birth registered"
+msgstr ""
+
+#: custom/opm/beneficiary.py:963
+msgid "Condition 6/ child birth weight taken"
+msgstr ""
+
+#: custom/opm/beneficiary.py:964
+msgid "Condition 7 /exclusively breastfed for first 6 months"
+msgstr ""
+
+#: custom/opm/beneficiary.py:965
+msgid "Condition 8 /child weight monitored this month"
+msgstr ""
+
+#: custom/opm/beneficiary.py:966
+msgid "Condition 9 /ORS administered if child had diarrhea"
+msgstr ""
+
+#: custom/opm/beneficiary.py:967
+msgid "Condition 10/ Measles vaccine given before child turns 1"
+msgstr ""
+
+#: custom/opm/beneficiary.py:968
+msgid "Birth Spacing Bonus"
+msgstr ""
+
+#: custom/opm/beneficiary.py:969
+msgid "Weight This Month"
+msgstr ""
+
+#: custom/opm/beneficiary.py:970
+msgid "Nutritional Status This Month"
+msgstr ""
+
+#: custom/opm/beneficiary.py:971
+msgid "Nutritional Status Bonus"
+msgstr ""
+
+#: custom/opm/beneficiary.py:972
+#, fuzzy
+msgid "Payment amount for the month"
+msgstr "नकद प्राप्त इस महीने (Rs.)"
+
+#: custom/opm/beneficiary.py:975
+msgid "VHND held this month?"
+msgstr ""
+
+#: custom/opm/beneficiary.py:976
+msgid "Opened on"
+msgstr ""
+
+#: custom/opm/beneficiary.py:977
+#, fuzzy
+msgid "Closed on"
+msgstr "Casos IRA Tratados"
+
+#: custom/opm/beneficiary.py:978
+msgid "Close mother dup"
+msgstr ""
+
+#: custom/opm/beneficiary.py:979
+msgid "Close mother mo"
+msgstr ""
+
+#: custom/opm/beneficiary.py:980
+msgid "Leave program"
+msgstr ""
+
+#: custom/opm/beneficiary.py:981
+#, fuzzy
+msgid "Close mother dead"
+msgstr "मात्र मृत्यु"
+
+#: custom/opm/beneficiary.py:982
+msgid "Calendar year"
+msgstr ""
+
+#: custom/opm/beneficiary.py:983
+msgid "Calendar month"
+msgstr ""
+
+#: custom/opm/filters.py:72 custom/opm/filters.py:85
 #: custom/up_nrhm/filters.py:37
 msgid "Hierarchy"
 msgstr ""
 
-#: custom/opm/health_status.py:93
+#: custom/opm/health_status.py:22
 msgid "Gram Panchayat"
 msgstr ""
 
-#: custom/opm/health_status.py:97
+#: custom/opm/health_status.py:26
 msgid "Registered Beneficiaries"
 msgstr ""
 
-#: custom/opm/health_status.py:98
+#: custom/opm/health_status.py:27
 msgid "Beneficiaries registered with BCSP"
 msgstr ""
 
-#: custom/opm/health_status.py:101
+#: custom/opm/health_status.py:30
 msgid "Registered pregnant women"
 msgstr ""
 
-#: custom/opm/health_status.py:102
+#: custom/opm/health_status.py:31
 msgid "Pregnant women registered with BCSP"
 msgstr ""
 
-#: custom/opm/health_status.py:105
+#: custom/opm/health_status.py:34
 msgid "Registered mothers"
 msgstr ""
 
-#: custom/opm/health_status.py:106
+#: custom/opm/health_status.py:35
 msgid "Mothers registered with BCSP"
 msgstr ""
 
-#: custom/opm/health_status.py:109
+#: custom/opm/health_status.py:38
 msgid "Registered children"
 msgstr ""
 
-#: custom/opm/health_status.py:110
+#: custom/opm/health_status.py:39
 msgid "Children below 3 years of age registered with BCSP"
 msgstr ""
 
-#: custom/opm/health_status.py:113
+#: custom/opm/health_status.py:42
 msgid "Eligible for payment upon fulfillment of cash conditions"
 msgstr ""
 
-#: custom/opm/health_status.py:114
+#: custom/opm/health_status.py:43
 msgid ""
 "Registered beneficiaries eligilble for cash payment for the month upon "
 "fulfillment of cash conditions"
 msgstr ""
 
-#: custom/opm/health_status.py:118
+#: custom/opm/health_status.py:47
 msgid "Eligible for payment upon absence of services"
 msgstr ""
 
-#: custom/opm/health_status.py:119
+#: custom/opm/health_status.py:48
 msgid ""
 "Registered beneficiaries eligilble for cash payment for the month upon "
 "absence of services at VHND"
 msgstr ""
 
-#: custom/opm/health_status.py:122
+#: custom/opm/health_status.py:51
 msgid "Eligible for payment"
 msgstr ""
 
-#: custom/opm/health_status.py:123
+#: custom/opm/health_status.py:52
 msgid "Registered beneficiaries eligilble for cash payment for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:126
+#: custom/opm/health_status.py:55
 msgid "Total cash payment"
 msgstr ""
 
-#: custom/opm/health_status.py:127
+#: custom/opm/health_status.py:56
 msgid "Total cash payment made to registered beneficiaries for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:130
+#: custom/opm/health_status.py:59
 msgid "Pregnant women attended VHND"
 msgstr ""
 
-#: custom/opm/health_status.py:131
+#: custom/opm/health_status.py:60
 msgid "Registered pregnant women who attended VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:134
+#: custom/opm/health_status.py:63
 msgid "Children attended VHND"
 msgstr ""
 
-#: custom/opm/health_status.py:135
+#: custom/opm/health_status.py:64
 msgid ""
 "Registered children below 3 years of age who attended VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:138
+#: custom/opm/health_status.py:67
 msgid "Beneficiaries attended VHND"
 msgstr ""
 
-#: custom/opm/health_status.py:139
+#: custom/opm/health_status.py:68
 msgid "Registered beneficiaries who attended VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:142
+#: custom/opm/health_status.py:71
 msgid "Received at least 30 IFA tablets"
 msgstr ""
 
-#: custom/opm/health_status.py:143
+#: custom/opm/health_status.py:72
 msgid ""
 "Registered pregnant women (6 months pregnant) who received at least 30 IFA "
 "tablets in second trimester"
 msgstr ""
 
-#: custom/opm/health_status.py:147
+#: custom/opm/health_status.py:76
 msgid "Weight monitored in second trimester"
 msgstr ""
 
-#: custom/opm/health_status.py:148
+#: custom/opm/health_status.py:77
 msgid ""
 "Registered pregnant women (6 months pregnant) who got their weight monitored "
 "in second trimester"
 msgstr ""
 
-#: custom/opm/health_status.py:151
+#: custom/opm/health_status.py:80
 msgid "Weight monitored in third trimester"
 msgstr ""
 
-#: custom/opm/health_status.py:152
+#: custom/opm/health_status.py:81
 msgid ""
 "Registered pregnant women (9 months pregnant) who got their weight monitored "
 "in third trimester"
 msgstr ""
 
-#: custom/opm/health_status.py:155
+#: custom/opm/health_status.py:84
 msgid "Weight monitored at birth"
 msgstr ""
 
-#: custom/opm/health_status.py:156
+#: custom/opm/health_status.py:85
 msgid "Registered children (3 months old) whose weight was monitored at birth"
 msgstr ""
 
-#: custom/opm/health_status.py:159
+#: custom/opm/health_status.py:88
 msgid "Child birth registered"
 msgstr ""
 
-#: custom/opm/health_status.py:160
+#: custom/opm/health_status.py:89
 msgid ""
 "Registered children (6 months old) whose birth was registered in the first 6 "
 "months after birth"
 msgstr ""
 
-#: custom/opm/health_status.py:163
+#: custom/opm/health_status.py:92
 msgid "Growth monitoring when 0-3 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:164
+#: custom/opm/health_status.py:93
 msgid ""
 "Registered Children (3 months old) who have attended at least one growth "
 "monitoring session between the age 0-3 months"
 msgstr ""
 
-#: custom/opm/health_status.py:168
+#: custom/opm/health_status.py:97
 msgid "Growth Monitoring when 4-6 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:169
+#: custom/opm/health_status.py:98
 msgid ""
 "Registered Children (6 months old) who have attended at least one growth "
 "monitoring session between the age 4-6 months"
 msgstr ""
 
-#: custom/opm/health_status.py:173
+#: custom/opm/health_status.py:102
 msgid "Growth Monitoring when 7-9 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:174
+#: custom/opm/health_status.py:103
 msgid ""
 "Registered Children (9 months old) who have attended at least one growth "
 "monitoring session between the age 7-9 months"
 msgstr ""
 
-#: custom/opm/health_status.py:178
+#: custom/opm/health_status.py:107
 msgid "Growth Monitoring when 10-12 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:179
+#: custom/opm/health_status.py:108
 msgid ""
 "Registered Children (12 months old) who have attended at least one growth "
 "monitoring session between the age 10-12 months"
 msgstr ""
 
-#: custom/opm/health_status.py:183
+#: custom/opm/health_status.py:112
 msgid "Growth Monitoring when 13-15 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:184
+#: custom/opm/health_status.py:113
 msgid ""
 "Registered Children (15 months old) who have attended at least one growth "
 "monitoring session between the age 13-15 months"
 msgstr ""
 
-#: custom/opm/health_status.py:188
+#: custom/opm/health_status.py:117
 msgid "Growth Monitoring when 16-18 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:189
+#: custom/opm/health_status.py:118
 msgid ""
 "Registered Children (18 months old) who have attended at least one growth "
 "monitoring session between the age 16-18 months"
 msgstr ""
 
-#: custom/opm/health_status.py:193
+#: custom/opm/health_status.py:122
 msgid "Growth Monitoring when 19-21 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:194
+#: custom/opm/health_status.py:123
 msgid ""
 "Registered Children (21 months old) who have attended at least one growth "
 "monitoring session between the age 19-21 months"
 msgstr ""
 
-#: custom/opm/health_status.py:198
+#: custom/opm/health_status.py:127
 msgid "Growth Monitoring when 22-24 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:199
+#: custom/opm/health_status.py:128
 msgid ""
 "Registered Children (24 months old) who have attended at least one growth "
 "monitoring session between the age 22-24 months"
 msgstr ""
 
-#: custom/opm/health_status.py:203
+#: custom/opm/health_status.py:132
 msgid "Received ORS and Zinc treatment for diarrhoea"
 msgstr ""
 
-#: custom/opm/health_status.py:204
+#: custom/opm/health_status.py:133
 msgid ""
 "Registered children who received ORS and Zinc treatment if he/she contracts "
 "diarrhoea"
 msgstr ""
 
-#: custom/opm/health_status.py:207
+#: custom/opm/health_status.py:136
 msgid "Exclusively breastfed for first 6 months"
 msgstr ""
 
-#: custom/opm/health_status.py:208
+#: custom/opm/health_status.py:137
 msgid ""
 "Registered children (6 months old) who have been exclusively breastfed for "
 "first 6 months"
 msgstr ""
 
-#: custom/opm/health_status.py:211
+#: custom/opm/health_status.py:140
 msgid "Received Measles vaccine"
 msgstr ""
 
-#: custom/opm/health_status.py:212
+#: custom/opm/health_status.py:141
 msgid "Registered children (12 months old) who have received Measles vaccine"
 msgstr ""
 
-#: custom/opm/health_status.py:215
+#: custom/opm/health_status.py:144
 msgid "VHND organised"
 msgstr ""
 
-#: custom/opm/health_status.py:216
+#: custom/opm/health_status.py:145
 msgid "Whether VHND was organised at AWC for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:219
+#: custom/opm/health_status.py:148
 msgid "Adult Weighing Machine Available"
 msgstr ""
 
-#: custom/opm/health_status.py:220
+#: custom/opm/health_status.py:149
 msgid "Whether adult weighing machine was available for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:223
+#: custom/opm/health_status.py:152
 msgid "Adult Weighing Machine Functional"
 msgstr ""
 
-#: custom/opm/health_status.py:224
+#: custom/opm/health_status.py:153
 msgid "Whether adult weighing machine was functional for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:227
+#: custom/opm/health_status.py:156
 msgid "Child Weighing Machine Available"
 msgstr ""
 
-#: custom/opm/health_status.py:228
+#: custom/opm/health_status.py:157
 msgid "Whether child weighing machine was available for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:231
+#: custom/opm/health_status.py:160
 msgid "Child Weighing Machine Functional"
 msgstr ""
 
-#: custom/opm/health_status.py:232
+#: custom/opm/health_status.py:161
 msgid "Whether child weighing machine was functional for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:235
+#: custom/opm/health_status.py:164
 msgid "ANM Present"
 msgstr ""
 
-#: custom/opm/health_status.py:236
+#: custom/opm/health_status.py:165
 msgid "Whether ANM present at VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:239
+#: custom/opm/health_status.py:168
 msgid "ASHA Present"
 msgstr ""
 
-#: custom/opm/health_status.py:240
+#: custom/opm/health_status.py:169
 msgid "Whether ASHA present at VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:243
+#: custom/opm/health_status.py:172
 msgid "CMG Present"
 msgstr ""
 
-#: custom/opm/health_status.py:244
+#: custom/opm/health_status.py:173
 msgid "Whether CMG present at VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:247
+#: custom/opm/health_status.py:176
 msgid "Stock of IFA tablets"
 msgstr ""
 
-#: custom/opm/health_status.py:248
+#: custom/opm/health_status.py:177
 msgid "Whether AWC has enough stock of IFA tablets for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:251
+#: custom/opm/health_status.py:180
 msgid "Stock of ORS packets"
 msgstr ""
 
-#: custom/opm/health_status.py:252
+#: custom/opm/health_status.py:181
 msgid "Whether AWC has enough stock of ORS packets for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:255
+#: custom/opm/health_status.py:184
 msgid "Stock of ZINC tablets"
 msgstr ""
 
-#: custom/opm/health_status.py:256
+#: custom/opm/health_status.py:185
 msgid "Whether AWC has enough stock of Zinc Tablets for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:259
+#: custom/opm/health_status.py:188
 msgid "Stock of Measles Vaccine"
 msgstr ""
 
-#: custom/opm/health_status.py:260
+#: custom/opm/health_status.py:189
 msgid "Whether AWC has enough stock of measles vaccine for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:263
+#: custom/opm/health_status.py:192
 msgid "Eligilble for Birth Spacing bonus"
 msgstr ""
 
-#: custom/opm/health_status.py:264
+#: custom/opm/health_status.py:193
 msgid "Registered beneficiaries eligible for birth spacing bonus for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:267
+#: custom/opm/health_status.py:196
 msgid "Severely underweight"
 msgstr ""
 
-#: custom/opm/health_status.py:268
+#: custom/opm/health_status.py:197
 msgid ""
 "Registered children severely underweight (very low weight for age) for the "
 "month"
 msgstr ""
 
-#: custom/opm/health_status.py:271
+#: custom/opm/health_status.py:200
 msgid "Underweight"
 msgstr ""
 
-#: custom/opm/health_status.py:272
+#: custom/opm/health_status.py:201
 msgid "Registered children underweight (low weight for age) for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:275
+#: custom/opm/health_status.py:204
 msgid "Normal weight for age"
 msgstr ""
 
-#: custom/opm/health_status.py:276
+#: custom/opm/health_status.py:205
 msgid "Registered children with normal weight for age for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:279
+#: custom/opm/health_status.py:208
 msgid "Eligilble for Nutritional status bonus"
 msgstr ""
 
-#: custom/opm/health_status.py:280
+#: custom/opm/health_status.py:209
 msgid ""
 "Registered beneficiaries eligible for nutritonal status bonus for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:283
+#: custom/opm/health_status.py:212
 msgid "Pregnant women cases closed"
 msgstr ""
 
-#: custom/opm/health_status.py:284
+#: custom/opm/health_status.py:213
 msgid "Registered pregnant women cases closed for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:287
+#: custom/opm/health_status.py:216
 msgid "Mother cases closed"
 msgstr ""
 
-#: custom/opm/health_status.py:288
+#: custom/opm/health_status.py:217
 msgid "Registered mother cases closed for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:291
+#: custom/opm/health_status.py:220
 msgid "Children cases closed"
 msgstr ""
 
-#: custom/opm/health_status.py:292
+#: custom/opm/health_status.py:221
 msgid "Registered children cases closed for the month"
 msgstr ""
 
-#: custom/opm/reports.py:656 custom/opm/reports.py:657
-#: custom/opm/reports.py:917
+#: custom/opm/reports.py:457 custom/opm/reports.py:458
+#: custom/opm/reports.py:719
 msgid "Reporting period incomplete"
 msgstr ""
 
-#: custom/opm/reports.py:876
+#: custom/opm/reports.py:679
 msgid "Duplicate account number"
 msgstr ""
 
-#: custom/opm/reports.py:885
+#: custom/opm/reports.py:688
 msgid "Conditions Met Report"
 msgstr ""
 
-#: custom/opm/reports.py:924
+#: custom/opm/reports.py:726
 msgid "Total Payment"
 msgstr "कुल भुगतान"
 
@@ -26953,7 +27492,7 @@ msgstr ""
 
 #: custom/up_nrhm/reports/asha_functionality_checklist_report.py:61
 #, python-format
-msgid "Total number of ASHAs who are functional on at least 60% of the tasks"
+msgid "Total number of ASHAs who are functional on at least %s of the tasks"
 msgstr ""
 
 #: custom/up_nrhm/reports/asha_functionality_checklist_report.py:62
@@ -27038,12 +27577,88 @@ msgid ""
 msgstr ""
 
 #: custom/up_nrhm/reports/district_functionality_report.py:34
-#, python-format
-msgid "% of ASHAs"
+#, fuzzy, python-format
+msgid "%s of ASHAs"
+msgstr "आशा"
+
+#: custom/up_nrhm/reports/district_functionality_report.py:36
+msgid "Grade of Block"
 msgstr ""
 
-#: custom/up_nrhm/reports/district_functionality_report.py:35
-msgid "Grade of Block"
+#: docs/_build/html/_sources/translations.txt:141
+#, python-format
+msgid "This string will have %(value)s inside."
+msgstr ""
+
+#: docs/_build/html/_sources/translations.txt:147
+#, python-format
+msgid ""
+"\n"
+"        That will cost $ %(amount)s.\n"
+"    "
+msgstr ""
+
+#: docs/_build/html/_sources/translations.txt:155
+#, python-format
+msgid ""
+"\n"
+"        This will have %(myvar)s inside.\n"
+"    "
+msgstr ""
+
+#: docs/_build/html/_sources/translations.txt:167
+msgid ""
+"\n"
+"        Manage Mobile Workers <small>for CommCare Mobile and\n"
+"        CommCare HQ Reports</small>\n"
+"    "
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/couchpanel.py:89
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/couchpanel.py:92
+msgid "CouchDB"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:15
+msgid "Stacktrace"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:16
+#, fuzzy
+msgid "View Name"
+msgstr "टीम का नाम"
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:17
+msgid "Request Params"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:45
+msgid "Line"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:46
+msgid "Method"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:6
+msgid "CouchDB View"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:11
+msgid "Executed View"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:13
+msgid "Parameters"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:15
+#, fuzzy
+msgid "Total Rows"
+msgstr "कुल लाभार्थी"
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:40
+msgid "Empty set"
 msgstr ""
 
 #: submodules/auditcare-src/auditcare/forms.py:14
@@ -27434,16 +28049,16 @@ msgstr ""
 msgid "Clearing data"
 msgstr ""
 
-#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:36
+#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:47
 #, python-format
 msgid "ERROR: Could not send \"%(subject)s\""
 msgstr ""
 
-#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:41
+#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:52
 msgid "Could not send email: file size is too large."
 msgstr ""
 
-#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:46
+#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:57
 #, python-format
 msgid "Please contact %(support_email)s for assistance."
 msgstr ""
@@ -27518,9 +28133,6 @@ msgstr ""
 
 #~ msgid "New Mothers"
 #~ msgstr "Outros (negativos / indeterminados) "
-
-#~ msgid "Closed by"
-#~ msgstr "Casos IRA Tratados"
 
 #~ msgid "Manage SMS Backend Rates"
 #~ msgstr "Diagnóstico de Casos"

--- a/locale/por/LC_MESSAGES/django.po
+++ b/locale/por/LC_MESSAGES/django.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CommCare HQ\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-29 19:37+0000\n"
+"POT-Creation-Date: 2015-08-05 17:43+0000\n"
 "PO-Revision-Date: 2015-06-26 09:30+0000\n"
 "Last-Translator: Dimagi Dev <devops@dimagi.com>\n"
 "Language-Team: Portuguese (http://www.transifex.com/projects/p/commcare-hq/"
@@ -38,7 +38,7 @@ msgstr "Demos para Visualização"
 
 #: corehq/__init__.py:61 corehq/feature_previews.py:91
 #: corehq/apps/hqwebapp/models.py:879 corehq/apps/reports/__init__.py:13
-#: corehq/apps/reports/models.py:52
+#: corehq/apps/reports/models.py:54
 #: corehq/apps/users/templates/users/edit_commcare_user.html:125
 msgid "CommCare Supply"
 msgstr ""
@@ -59,9 +59,9 @@ msgstr "Planos de Assistência"
 msgid "Messaging"
 msgstr "Mensagens"
 
-#: corehq/__init__.py:177 corehq/apps/app_manager/models.py:2900
+#: corehq/__init__.py:177 corehq/apps/app_manager/models.py:2974
 #: corehq/apps/dashboard/views.py:159 corehq/apps/hqwebapp/models.py:365
-#: corehq/apps/hqwebapp/models.py:1538 corehq/apps/hqwebapp/models.py:1608
+#: corehq/apps/hqwebapp/models.py:1533 corehq/apps/hqwebapp/models.py:1603
 #: corehq/apps/orgs/templates/orgs/report_base.html:26
 #: corehq/apps/reports/templates/reports/reportdata/case_details.html:68
 msgid "Reports"
@@ -80,7 +80,7 @@ msgstr "Exportar Dados"
 msgid "Edit Data"
 msgstr "Editar Dados"
 
-#: corehq/__init__.py:198 corehq/privileges.py:71
+#: corehq/__init__.py:198 corehq/privileges.py:76
 #: corehq/apps/accounting/user_text.py:219 corehq/apps/fixtures/views.py:285
 msgid "Lookup Tables"
 msgstr ""
@@ -192,8 +192,8 @@ msgid ""
 "possible reasons for poor performance, and offer guidance towards solutions."
 msgstr ""
 
-#: corehq/feature_previews.py:128 corehq/privileges.py:88
-#: corehq/apps/hqwebapp/models.py:1140 corehq/apps/locations/views.py:75
+#: corehq/feature_previews.py:128 corehq/privileges.py:93
+#: corehq/apps/hqwebapp/models.py:1135 corehq/apps/locations/views.py:75
 #: corehq/apps/users/templates/users/edit_commcare_user.html:127
 msgid "Locations"
 msgstr "Localizações"
@@ -216,71 +216,71 @@ msgid ""
 "a>."
 msgstr ""
 
-#: corehq/privileges.py:72 corehq/apps/accounting/user_text.py:218
+#: corehq/privileges.py:77 corehq/apps/accounting/user_text.py:218
 msgid "API Access"
 msgstr ""
 
-#: corehq/privileges.py:73
+#: corehq/privileges.py:78
 msgid "Web-Based Apps (CloudCare)"
 msgstr "Aplicativos da Rede (CloudCare)"
 
-#: corehq/privileges.py:74
+#: corehq/privileges.py:79
 msgid "Active Data Management"
 msgstr "Gestão Ativa de Dados"
 
-#: corehq/privileges.py:75 corehq/apps/accounting/user_text.py:221
+#: corehq/privileges.py:80 corehq/apps/accounting/user_text.py:221
 msgid "Custom Branding"
 msgstr "Marca Personalizada"
 
-#: corehq/privileges.py:76 corehq/apps/accounting/user_text.py:224
+#: corehq/privileges.py:81 corehq/apps/accounting/user_text.py:224
 msgid "Cross-Project Reports"
 msgstr ""
 
-#: corehq/privileges.py:77 corehq/apps/accounting/user_text.py:236
+#: corehq/privileges.py:82 corehq/apps/accounting/user_text.py:236
 msgid "Advanced Role-Based Access"
 msgstr ""
 
-#: corehq/privileges.py:78
+#: corehq/privileges.py:83
 msgid "Outgoing Messaging"
 msgstr "Mensagens de Saída."
 
-#: corehq/privileges.py:79
+#: corehq/privileges.py:84
 msgid "Incoming Messaging"
 msgstr "Mensagens de Entrada"
 
-#: corehq/privileges.py:80
+#: corehq/privileges.py:85
 msgid "Reminders Framework"
 msgstr "Estrutura de Lembretes"
 
-#: corehq/privileges.py:81
+#: corehq/privileges.py:86
 msgid "Custom Android Gateway"
 msgstr ""
 
-#: corehq/privileges.py:82
+#: corehq/privileges.py:87
 msgid "Bulk Case Management"
 msgstr "Gestão de Casos em Massa"
 
-#: corehq/privileges.py:83
+#: corehq/privileges.py:88
 msgid "Bulk User Management"
 msgstr "Gestão de Usuários em Massa"
 
-#: corehq/privileges.py:84
+#: corehq/privileges.py:89
 msgid "Add Mobile Workers Above Limit"
 msgstr "Adicionar Trabalhadores Móveis Acima do Limite"
 
-#: corehq/privileges.py:85
+#: corehq/privileges.py:90
 msgid "De-Identified Data"
 msgstr "Dados De-identificados"
 
-#: corehq/privileges.py:86 corehq/apps/accounting/user_text.py:238
+#: corehq/privileges.py:91 corehq/apps/accounting/user_text.py:238
 msgid "HIPAA Compliance Assurance"
 msgstr "Garantia de Cumprimento a HIPAA"
 
-#: corehq/privileges.py:87
+#: corehq/privileges.py:92
 msgid "Custom CommCare Logo Uploader"
 msgstr ""
 
-#: corehq/privileges.py:89
+#: corehq/privileges.py:94
 msgid "User Configurable Report Builder"
 msgstr ""
 
@@ -388,6 +388,7 @@ msgstr ""
 
 #: corehq/apps/accounting/filters.py:140 corehq/apps/accounting/forms.py:346
 #: corehq/apps/accounting/forms.py:634 corehq/apps/commtrack/models.py:535
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:57
 #: corehq/apps/domain/templates/domain/admin/media_manager.html:24
 #: corehq/apps/export/templates/export/customize_export.html:602
 #: corehq/apps/hqadmin/reports.py:839
@@ -536,7 +537,7 @@ msgstr ""
 #: corehq/apps/accounting/templates/accounting/subscriptions_tab.html:16
 #: corehq/apps/domain/forms.py:1455
 #: corehq/apps/domain/templates/domain/current_subscription.html:247
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:74
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:83
 msgid "Software Plan"
 msgstr "Plano de Software"
 
@@ -646,10 +647,10 @@ msgid "A name is required for this new role."
 msgstr ""
 
 #: corehq/apps/accounting/forms.py:1428 corehq/apps/app_manager/forms.py:11
-#: corehq/apps/app_manager/models.py:1737
-#: corehq/apps/app_manager/models.py:2167
-#: corehq/apps/app_manager/models.py:2525
-#: corehq/apps/app_manager/models.py:2574 corehq/apps/commtrack/models.py:531
+#: corehq/apps/app_manager/models.py:1738
+#: corehq/apps/app_manager/models.py:2193
+#: corehq/apps/app_manager/models.py:2574
+#: corehq/apps/app_manager/models.py:2623 corehq/apps/commtrack/models.py:531
 #: corehq/apps/domain/forms.py:126
 #: corehq/apps/domain/templates/domain/admin/commtrack_action_table.html:5
 #: corehq/apps/domain/templates/domain/partials/user_list.html:9
@@ -671,7 +672,7 @@ msgstr ""
 #: corehq/apps/toggle_ui/templates/toggle/flags.html:58
 #: corehq/apps/users/templates/users/web_users.b3.html:171
 #: corehq/apps/users/templates/users/web_users.b3.html:216
-#: corehq/ex-submodules/casexml/apps/case/models.py:853
+#: corehq/ex-submodules/casexml/apps/case/models.py:858
 #: corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_hierarchy.html:57
 #: custom/bihar/reports/indicators/clientlistdisplay.py:80
 #: custom/bihar/reports/indicators/clientlistdisplay.py:98
@@ -680,13 +681,13 @@ msgstr ""
 #: custom/ewsghana/reports/specific_reports/reporting_rates.py:199
 #: custom/ewsghana/reports/specific_reports/reporting_rates.py:241
 #: custom/fri/reports/reports.py:349
-#: custom/ilsgateway/tanzania/reports/delivery.py:27
-#: custom/ilsgateway/tanzania/reports/facility_details.py:70
-#: custom/ilsgateway/tanzania/reports/facility_details.py:116
-#: custom/ilsgateway/tanzania/reports/randr.py:82
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:81
-#: custom/ilsgateway/tanzania/reports/supervision.py:56
-#: custom/ilsgateway/tanzania/reports/supervision.py:120
+#: custom/ilsgateway/tanzania/reports/delivery.py:28
+#: custom/ilsgateway/tanzania/reports/facility_details.py:71
+#: custom/ilsgateway/tanzania/reports/facility_details.py:117
+#: custom/ilsgateway/tanzania/reports/randr.py:83
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:83
+#: custom/ilsgateway/tanzania/reports/supervision.py:57
+#: custom/ilsgateway/tanzania/reports/supervision.py:122
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:37
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:184
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:249
@@ -696,7 +697,7 @@ msgid "Name"
 msgstr ""
 
 #: corehq/apps/accounting/forms.py:1432 corehq/apps/accounting/models.py:357
-#: corehq/apps/prelogin/forms.py:28
+#: corehq/apps/prelogin/forms.py:29
 msgid "Company / Organization"
 msgstr ""
 
@@ -762,13 +763,13 @@ msgstr ""
 msgid "Messages"
 msgstr ""
 
-#: corehq/apps/accounting/models.py:341 corehq/apps/prelogin/forms.py:20
-#: corehq/apps/users/forms.py:145
+#: corehq/apps/accounting/models.py:341 corehq/apps/prelogin/forms.py:21
+#: corehq/apps/users/forms.py:144
 msgid "First Name"
 msgstr ""
 
-#: corehq/apps/accounting/models.py:344 corehq/apps/prelogin/forms.py:24
-#: corehq/apps/users/forms.py:146
+#: corehq/apps/accounting/models.py:344 corehq/apps/prelogin/forms.py:25
+#: corehq/apps/users/forms.py:145
 msgid "Last Name"
 msgstr ""
 
@@ -783,7 +784,7 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/accounting/models.py:353
-#: corehq/apps/data_interfaces/views.py:322 corehq/apps/prelogin/forms.py:36
+#: corehq/apps/data_interfaces/views.py:322 corehq/apps/prelogin/forms.py:37
 #: corehq/apps/reports/standard/ivr.py:46
 #: corehq/apps/reports/standard/sms.py:280
 #: corehq/apps/reports/standard/sms.py:617
@@ -816,7 +817,7 @@ msgstr ""
 msgid "Postal Code"
 msgstr ""
 
-#: corehq/apps/accounting/models.py:378 corehq/apps/prelogin/forms.py:40
+#: corehq/apps/accounting/models.py:378 corehq/apps/prelogin/forms.py:41
 msgid "Country"
 msgstr ""
 
@@ -1009,14 +1010,14 @@ msgstr ""
 
 #: corehq/apps/accounting/user_text.py:8
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/analytics.html:22
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:41
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:52
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/mobile.html:22
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:21
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/support.html:22
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/user.html:22
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/web.html:22
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:80
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:77
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:89
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:79
 msgid "Community"
 msgstr ""
 
@@ -1028,7 +1029,7 @@ msgstr ""
 
 #: corehq/apps/accounting/user_text.py:13
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/analytics.html:27
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:46
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:57
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/mobile.html:27
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:26
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/support.html:27
@@ -1045,16 +1046,16 @@ msgstr ""
 
 #: corehq/apps/accounting/user_text.py:18
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/analytics.html:32
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:51
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:62
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/mobile.html:32
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:31
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/support.html:32
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/user.html:32
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/web.html:32
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:90
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:98
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:87
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:95
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:99
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:107
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:89
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:97
 msgid "Pro"
 msgstr ""
 
@@ -1065,20 +1066,20 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:23
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:306
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:309
 #: corehq/apps/app_manager/templates/app_manager/module_view.html:294
 #: corehq/apps/importer/templates/importer/excel_config.html:114
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/analytics.html:37
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:56
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:67
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/mobile.html:37
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:36
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/support.html:37
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/user.html:37
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/web.html:37
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:106
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:114
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:103
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:111
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:115
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:123
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:105
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:113
 msgid "Advanced"
 msgstr ""
 
@@ -1091,7 +1092,7 @@ msgstr ""
 
 #: corehq/apps/accounting/user_text.py:29
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/analytics.html:42
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:61
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:72
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/mobile.html:42
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:41
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/support.html:42
@@ -1122,7 +1123,7 @@ msgstr ""
 #: corehq/apps/accounting/user_text.py:54
 #: corehq/apps/accounting/user_text.py:201
 #: corehq/apps/accounting/user_text.py:202
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:98
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:109
 msgid "Mobile Users"
 msgstr ""
 
@@ -1192,7 +1193,7 @@ msgid "SMS (CommConnect)"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:90
-#: corehq/apps/accounting/user_text.py:91 corehq/apps/commtrack/views.py:170
+#: corehq/apps/accounting/user_text.py:91 corehq/apps/commtrack/views.py:175
 #: corehq/apps/domain/forms.py:1624
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:13
 #: corehq/apps/reminders/forms.py:98 corehq/apps/reminders/forms.py:103
@@ -1354,24 +1355,24 @@ msgid "Dedicated Enterprise Account Management"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:255
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:71
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:83
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:80
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:82
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:92
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:82
 msgid "Free"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:255
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:76
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:87
 msgid "$100 /month"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:255
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:81
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:92
 msgid "$500 /month"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:255
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:86
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:97
 msgid "$1,000 /month"
 msgstr ""
 
@@ -1382,22 +1383,22 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:256
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:102
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:113
 msgid "50"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:256
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:107
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:118
 msgid "100"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:256
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:112
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:123
 msgid "500"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:256
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:117
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:128
 msgid "1,000"
 msgstr ""
 
@@ -1407,10 +1408,10 @@ msgid "Unlimited / Discounted Pricing"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:257
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:132
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:137
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:142
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:147
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:143
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:148
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:153
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:158
 msgid "1 USD /month"
 msgstr ""
 
@@ -1505,7 +1506,7 @@ msgstr ""
 #: corehq/apps/sms/templates/sms/default.html:47
 #: corehq/apps/unicel/forms.py:10
 #: corehq/apps/unicel/templates/unicel/backend.html:10
-#: corehq/apps/userhack/admin.py:14 corehq/apps/users/forms.py:184
+#: corehq/apps/userhack/admin.py:14 corehq/apps/users/forms.py:183
 #: corehq/apps/users/templates/users/edit_web_user.html:13
 #: corehq/apps/users/templates/users/mobile/users_list.html:209
 #: corehq/apps/users/templates/users/partial/basic_info_form.html:10
@@ -1526,6 +1527,7 @@ msgstr ""
 #: corehq/apps/reports/templates/reports/partials/hqexport_group_table.html:11
 #: corehq/apps/sms/templates/sms/add_gateway.html:42
 #: corehq/apps/sms/templates/sms/partials/day_time_windows.html:12
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:14
 msgid "Action"
 msgstr ""
 
@@ -1591,6 +1593,7 @@ msgstr ""
 #: corehq/apps/hqmedia/templates/hqmedia/bulk_upload.html:55
 #: corehq/apps/indicators/templates/indicators/forms/copy_to_domain.html:66
 #: corehq/apps/locations/templates/locations/manage/location.html:195
+#: corehq/apps/locations/templates/locations/manage/locations.html:266
 #: corehq/apps/orgs/templates/orgs/orgs_landing.html:184
 #: corehq/apps/orgs/templates/orgs/orgs_landing.html:203
 #: corehq/apps/orgs/templates/orgs/orgs_landing.html:230
@@ -1843,7 +1846,7 @@ msgstr ""
 #: corehq/apps/reports/standard/monitoring.py:479
 #: corehq/apps/reports/standard/monitoring.py:623
 #: corehq/apps/reports/standard/monitoring.py:1321
-#: custom/ilsgateway/tanzania/reports/delivery.py:171
+#: custom/ilsgateway/tanzania/reports/delivery.py:174
 #: custom/m4change/reports/aggregate_facility_web_hmis_report.py:38
 #: custom/m4change/reports/all_hmis_report.py:258
 #: custom/m4change/reports/anc_hmis_report.py:117
@@ -1904,7 +1907,7 @@ msgstr ""
 
 #: corehq/apps/accounting/templates/accounting/credits_tab.html:9
 #: corehq/apps/accounting/templates/accounting/subscriptions.html:55
-#: corehq/apps/hqwebapp/models.py:1302
+#: corehq/apps/hqwebapp/models.py:1297
 msgid "Subscription"
 msgstr ""
 
@@ -1952,8 +1955,8 @@ msgstr ""
 #: corehq/apps/reports/standard/sms.py:732
 #: corehq/apps/users/templates/users/web_users.b3.html:286
 #: corehq/apps/users/templates/users/web_users.html:128
-#: custom/ilsgateway/tanzania/reports/facility_details.py:118
-#: custom/ilsgateway/tanzania/reports/supervision.py:122
+#: custom/ilsgateway/tanzania/reports/facility_details.py:119
+#: custom/ilsgateway/tanzania/reports/supervision.py:124
 #: custom/intrahealth/sqldata.py:392
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:266
 msgid "Date"
@@ -2013,9 +2016,9 @@ msgstr ""
 #: corehq/apps/reports/templates/reports/messaging/survey_detail.html:33
 #: corehq/apps/settings/templates/settings/my_projects.html:12
 #: corehq/apps/sms/views.py:1022
-#: corehq/ex-submodules/casexml/apps/case/models.py:903
+#: corehq/ex-submodules/casexml/apps/case/models.py:908
 #: custom/_legacy/pact/models.py:329
-#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:55
+#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:65
 #: custom/m4change/reports/mcct_project_review.py:274
 #: custom/m4change/reports/mcct_project_review.py:401
 #: custom/m4change/reports/mcct_project_review.py:484
@@ -2374,7 +2377,7 @@ msgstr ""
 #: corehq/apps/reports/templates/reports/standard/base_template.html:108
 #: corehq/apps/reports/templates/reports/standard/export_download.html:99
 #: corehq/apps/reports_core/templates/reports_core/base_template_new.html:150
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:118
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:122
 msgid "Generating Report..."
 msgstr ""
 
@@ -2389,8 +2392,8 @@ msgstr ""
 #: corehq/apps/reports/templates/reports/standard/base_template.html:111
 #: corehq/apps/reports_core/templates/reports_core/base_template_new.html:151
 #: corehq/apps/reports_core/templates/reports_core/base_template_new.html:152
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:119
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:120
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:123
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:124
 msgid "Apply"
 msgstr ""
 
@@ -2498,11 +2501,11 @@ msgid "Delay Invoicing Until"
 msgstr ""
 
 #: corehq/apps/accounting/templates/accounting/subscriptions_tab.html:24
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:255
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:261
-#: corehq/apps/domain/templates/domain/admin/feature_flags.html:28
-#: corehq/apps/locations/templates/locations/manage/locations.html:148
-#: corehq/apps/reports/views.py:801
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:258
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:264
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:37
+#: corehq/apps/locations/templates/locations/manage/locations.html:167
+#: corehq/apps/reports/views.py:809
 #: corehq/apps/reports/templates/reports/reports_home.html:60
 #: corehq/apps/reports/templates/reports/reports_home.html:126
 #: corehq/apps/reports/templates/reports/partials/saved_custom_exports.html:9
@@ -2786,6 +2789,7 @@ msgstr ""
 #: corehq/apps/app_manager/fields.py:45
 #: corehq/apps/app_manager/templates/app_manager/managed_app.html:266
 #: corehq/apps/app_manager/templates/app_manager/ng_partials/case_summary_view.html:109
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:56
 #: corehq/apps/hqwebapp/doc_info.py:100
 #: corehq/apps/reports/filters/forms.py:684
 #: corehq/apps/reports/standard/inspect.py:89
@@ -2832,60 +2836,56 @@ msgstr "Copiar Aplicativo"
 msgid "Copy"
 msgstr "Copiar"
 
-#: corehq/apps/app_manager/models.py:749
-msgid "Form referenced as the registration form for multiple modules."
-msgstr ""
-
-#: corehq/apps/app_manager/models.py:1743
-#: corehq/apps/app_manager/models.py:2174
-#: corehq/apps/app_manager/views.py:1412
+#: corehq/apps/app_manager/models.py:1744
+#: corehq/apps/app_manager/models.py:2200
+#: corehq/apps/app_manager/views.py:1414
 msgid "Untitled Module"
 msgstr "Módulo sem Nome"
 
-#: corehq/apps/app_manager/models.py:1756
-#: corehq/apps/app_manager/models.py:2200
-#: corehq/apps/app_manager/views.py:1471
+#: corehq/apps/app_manager/models.py:1757
+#: corehq/apps/app_manager/models.py:2226
+#: corehq/apps/app_manager/views.py:1473
 msgid "Untitled Form"
 msgstr "Formulário sem Nome"
 
-#: corehq/apps/app_manager/models.py:1849
+#: corehq/apps/app_manager/models.py:1850
 msgid "Case tiles may only be used for the case list (not the case details)."
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:1857
+#: corehq/apps/app_manager/models.py:1858
 msgid "A case property must be assigned to the \"{}\" tile field."
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2014
+#: corehq/apps/app_manager/models.py:2040
 msgid "Case property"
 msgstr "Propriedade do Caso"
 
-#: corehq/apps/app_manager/models.py:2015
+#: corehq/apps/app_manager/models.py:2041
 msgid "Lookup Table field"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2016
+#: corehq/apps/app_manager/models.py:2042
 msgid "custom user property"
 msgstr "Propriedade do usuário personalizada"
 
-#: corehq/apps/app_manager/models.py:2017
+#: corehq/apps/app_manager/models.py:2043
 msgid "custom XPath expression"
 msgstr "expressão XPath personalizada"
 
-#: corehq/apps/app_manager/models.py:2024
+#: corehq/apps/app_manager/models.py:2050
 msgid "Case tag"
 msgstr "Marcador do caso"
 
-#: corehq/apps/app_manager/models.py:2025
+#: corehq/apps/app_manager/models.py:2051
 msgid "Lookup Table tag"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2063
+#: corehq/apps/app_manager/models.py:2089
 msgid "All forms in this module require a visit schedule."
 msgstr "Todos os formulários deste módulo exigir um calendário de visitas."
 
-#: corehq/apps/app_manager/models.py:2186
-#: corehq/apps/app_manager/models.py:4198 corehq/apps/products/views.py:467
+#: corehq/apps/app_manager/models.py:2212
+#: corehq/apps/app_manager/models.py:4272 corehq/apps/products/views.py:467
 #: corehq/apps/products/templates/products/manage/products.html:110
 #: corehq/apps/programs/templates/programs/manage/program.html:77
 #: corehq/apps/reports/commtrack/standard.py:92
@@ -2897,9 +2897,9 @@ msgstr "Todos os formulários deste módulo exigir um calendário de visitas."
 msgid "Product"
 msgstr "Producto"
 
-#: corehq/apps/app_manager/models.py:2521
-#: corehq/apps/app_manager/models.py:2575
-#: corehq/apps/app_manager/models.py:2637
+#: corehq/apps/app_manager/models.py:2570
+#: corehq/apps/app_manager/models.py:2624
+#: corehq/apps/app_manager/models.py:2686
 #: corehq/apps/appstore/templates/appstore/deployment_info.html:31
 #: corehq/apps/appstore/templates/appstore/project_info.html:140
 #: corehq/apps/appstore/templates/appstore/project_info.html:259
@@ -2915,47 +2915,47 @@ msgstr "Producto"
 msgid "Description"
 msgstr "Descrição"
 
-#: corehq/apps/app_manager/models.py:2522
-#: corehq/apps/app_manager/models.py:2570
+#: corehq/apps/app_manager/models.py:2571
+#: corehq/apps/app_manager/models.py:2619
 msgid "Followup date"
 msgstr "Data de acompanhamento"
 
-#: corehq/apps/app_manager/models.py:2527
-#: corehq/apps/app_manager/models.py:2580
+#: corehq/apps/app_manager/models.py:2576
+#: corehq/apps/app_manager/models.py:2629
 msgid "Close if"
 msgstr "Fechar se"
 
-#: corehq/apps/app_manager/models.py:2579
+#: corehq/apps/app_manager/models.py:2628
 msgid "Latest report"
 msgstr "Último relatório"
 
-#: corehq/apps/app_manager/models.py:2600
+#: corehq/apps/app_manager/models.py:2649
 #: custom/_legacy/pact/templates/pact/patient/pactpatient_base.html:33
 #: custom/_legacy/pact/templates/pact/patient/pactpatient_submissions.html:31
 msgid "Care Plan"
 msgstr "Plano de Assistência"
 
-#: corehq/apps/app_manager/models.py:2621
+#: corehq/apps/app_manager/models.py:2670
 #: corehq/apps/reports/standard/cases/careplan.py:124
 #: custom/_legacy/pact/models.py:357
 msgid "Goal"
 msgstr "Objetivo"
 
-#: corehq/apps/app_manager/models.py:2621
+#: corehq/apps/app_manager/models.py:2670
 #: corehq/apps/reports/standard/cases/careplan.py:138
 #: custom/_legacy/pact/models.py:375
 msgid "Task"
 msgstr "Tarefa"
 
-#: corehq/apps/app_manager/models.py:2630
+#: corehq/apps/app_manager/models.py:2679
 msgid "Followup"
 msgstr "Acompanhamento"
 
-#: corehq/apps/app_manager/models.py:2644
+#: corehq/apps/app_manager/models.py:2693
 msgid "Last update"
 msgstr "Ultima atualização"
 
-#: corehq/apps/app_manager/models.py:3394
+#: corehq/apps/app_manager/models.py:3468
 msgid ""
 "Usage of lookup tables is not supported by your current subscription. Please "
 "upgrade your subscription before using this feature."
@@ -2963,25 +2963,27 @@ msgstr ""
 "O uso de tabelas de pesquisa não é suportado por sua assinatura atual. Por "
 "favor, atualize sua assinatura antes de usar esse recurso."
 
-#: corehq/apps/app_manager/models.py:4171
+#: corehq/apps/app_manager/models.py:4245
 #, python-brace-format
 msgid "Copy of {name}"
 msgstr "Cópia de {name}"
 
-#: corehq/apps/app_manager/models.py:4408
+#: corehq/apps/app_manager/models.py:4482
 msgid "Error in case type hierarchy"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:4498
+#: corehq/apps/app_manager/models.py:4572
 msgid ""
 "Problem loading suite file from profile file. Is your profile file correct?"
 msgstr ""
 
-#: corehq/apps/app_manager/translations.py:46
-msgid "App Translation Failed! "
-msgstr "Tradução do aplicativo falhou!"
+#: corehq/apps/app_manager/translations.py:48
+msgid ""
+"App Translation Failed! Please make sure you are using a valid Excel 2007 or "
+"later (.xlsx) file. Error details: {}."
+msgstr ""
 
-#: corehq/apps/app_manager/translations.py:149
+#: corehq/apps/app_manager/translations.py:154
 msgid "App Translations Updated!"
 msgstr "Tradução do aplicativo sucedeu!"
 
@@ -2993,71 +2995,71 @@ msgstr "Você deve submeter um nome para o aplicativo que você está importando
 msgid "You must submit the source data."
 msgstr "Você deve submeter os dados de origem."
 
-#: corehq/apps/app_manager/views.py:526
+#: corehq/apps/app_manager/views.py:527
 msgid "All Programs"
 msgstr "Todos os Programas"
 
-#: corehq/apps/app_manager/views.py:596
+#: corehq/apps/app_manager/views.py:597
 msgid "U​I translation"
 msgstr "Tradução de UI"
 
-#: corehq/apps/app_manager/views.py:597
+#: corehq/apps/app_manager/views.py:598
 msgid "U​I translations"
 msgstr "Tradução de UI"
 
-#: corehq/apps/app_manager/views.py:604
+#: corehq/apps/app_manager/views.py:605
 msgid "app translation"
 msgstr "tradução do aplicativo"
 
-#: corehq/apps/app_manager/views.py:605
+#: corehq/apps/app_manager/views.py:606
 msgid "app translations"
 msgstr "traduções de aplicativos"
 
-#: corehq/apps/app_manager/views.py:821
+#: corehq/apps/app_manager/views.py:822
 msgid "Don't Show"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:828
+#: corehq/apps/app_manager/views.py:829
 #: corehq/apps/reports/standard/cases/basic.py:211
 #: corehq/apps/reports/templates/reports/reportdata/case_details.html:71
 msgid "Case List"
 msgstr "Lista de Casos"
 
-#: corehq/apps/app_manager/views.py:829
+#: corehq/apps/app_manager/views.py:830
 msgid "Case Detail"
 msgstr "Detalhes do Caso"
 
-#: corehq/apps/app_manager/views.py:848
+#: corehq/apps/app_manager/views.py:849
 msgid "Product List"
 msgstr "Lista de Productos"
 
-#: corehq/apps/app_manager/views.py:849
+#: corehq/apps/app_manager/views.py:850
 msgid "Product Detail"
 msgstr "Detalhes do Producto"
 
-#: corehq/apps/app_manager/views.py:871
+#: corehq/apps/app_manager/views.py:872
 msgid "Goal List"
 msgstr "Lista de Objetivos"
 
-#: corehq/apps/app_manager/views.py:872
+#: corehq/apps/app_manager/views.py:873
 msgid "Goal Detail"
 msgstr "Detalhes dos Objetivos"
 
-#: corehq/apps/app_manager/views.py:882
+#: corehq/apps/app_manager/views.py:883
 msgid "Task List"
 msgstr "Lista das Tarefas"
 
-#: corehq/apps/app_manager/views.py:883
+#: corehq/apps/app_manager/views.py:884
 msgid "Task Detail"
 msgstr "Detalhes das Tarefas"
 
-#: corehq/apps/app_manager/views.py:921
+#: corehq/apps/app_manager/views.py:923
 msgid ""
 "Your app contains references to reports that are deleted. These will be "
 "removed on save."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:1243
+#: corehq/apps/app_manager/views.py:1245
 msgid ""
 "You tried to edit this form in the Form Builder. However, your administrator "
 "has locked this form against editing in the form builder, so we have "
@@ -3068,24 +3070,24 @@ msgstr ""
 "temos que lhe redirecionamos para a página inicial do formulário em seu "
 "lugar."
 
-#: corehq/apps/app_manager/views.py:1409
+#: corehq/apps/app_manager/views.py:1411
 msgid "Untitled Application"
 msgstr "Aplicativo sem Nome"
 
-#: corehq/apps/app_manager/views.py:1458
+#: corehq/apps/app_manager/views.py:1460
 #, python-brace-format
 msgid "Please set the case type for the target module '{name}'."
 msgstr "Por favor digitar o tipo de caso por modulo '{name}'."
 
-#: corehq/apps/app_manager/views.py:1464
+#: corehq/apps/app_manager/views.py:1466
 msgid "Caution: Care Plan modules are a labs feature"
 msgstr "Advertência: Planos de assistência são função de laboratório"
 
-#: corehq/apps/app_manager/views.py:1476
+#: corehq/apps/app_manager/views.py:1478
 msgid "Caution: Advanced modules are a labs feature"
 msgstr "Advertência: Planos de assistência são função de laboratório"
 
-#: corehq/apps/app_manager/views.py:1592
+#: corehq/apps/app_manager/views.py:1594
 msgid ""
 "We could not copy this form, because it is blank.In order to copy this form, "
 "please add some questions first."
@@ -3093,7 +3095,7 @@ msgstr ""
 "Nós não poderíamos copiar este formulário, porque está em branco. Para "
 "copiar este formulário, por favor, adicione algumas questões primeiro."
 
-#: corehq/apps/app_manager/views.py:1596
+#: corehq/apps/app_manager/views.py:1598
 msgid ""
 "This form could not be copied because it is not compatible with the selected "
 "module."
@@ -3101,15 +3103,15 @@ msgstr ""
 "Este formulário não pode ser copiado, porque não é compatível com o módulo "
 "escolhido."
 
-#: corehq/apps/app_manager/views.py:1765
+#: corehq/apps/app_manager/views.py:1767
 msgid "Unknown Module"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:2468
+#: corehq/apps/app_manager/views.py:2470
 msgid "The form can not be moved into the desired module."
 msgstr "O formulário não pode ser movido para o módulo desejado."
 
-#: corehq/apps/app_manager/views.py:2473
+#: corehq/apps/app_manager/views.py:2475
 msgid ""
 "Oops. Looks like you got out of sync with us. The sidebar has been updated, "
 "so please try again."
@@ -3117,7 +3119,7 @@ msgstr ""
 "Epa. Parece que você tem fora de sincronia com nos. A barra lateral foi "
 "atualizado, por favor, tente novamente."
 
-#: corehq/apps/app_manager/views.py:2628
+#: corehq/apps/app_manager/views.py:2630
 msgid ""
 "We were unable to get your files because your Application has errors. Please "
 "click <strong>Make New Version</strong> under <strong>Deploy</strong> for "
@@ -3127,17 +3129,17 @@ msgstr ""
 "Por favor, clique em <strong> Faça Nova Versão </ strong> em <strong> "
 "Lançamento </ strong> para feedback sobre como corrigir esses erros."
 
-#: corehq/apps/app_manager/views.py:2658
+#: corehq/apps/app_manager/views.py:2660
 msgid ""
 "We were unable to get your files because your Application has errors. Please "
 "click Make New Version under Deploy for feedback on how to fix these errors."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:3022
+#: corehq/apps/app_manager/views.py:3024
 msgid "Summary"
 msgstr "Sumário"
 
-#: corehq/apps/app_manager/views.py:3060
+#: corehq/apps/app_manager/views.py:3062
 #: corehq/apps/app_manager/templates/app_manager/app_view.html:257
 #: corehq/apps/app_manager/templates/app_manager/apps_base.html:9
 #: corehq/apps/app_manager/templates/app_manager/apps_base.html:14
@@ -3148,25 +3150,25 @@ msgstr "Sumário"
 msgid "Applications"
 msgstr "Aplicativos"
 
-#: corehq/apps/app_manager/views.py:3211
+#: corehq/apps/app_manager/views.py:3213
 msgid "We found problem with following translations:"
 msgstr "Encontramos um problema com as seguintes traduções:"
 
-#: corehq/apps/app_manager/views.py:3222
+#: corehq/apps/app_manager/views.py:3224
 msgid "Something went wrong! Update failed. We're looking into it"
 msgstr "Algo deu errado! Falha na atualização. Nós estamos a olhar para ele."
 
-#: corehq/apps/app_manager/views.py:3225
+#: corehq/apps/app_manager/views.py:3227
 msgid "UI Translations Updated!"
 msgstr "Traduções de UI atualizadas!"
 
-#: corehq/apps/app_manager/views.py:3271
+#: corehq/apps/app_manager/views.py:3273
 msgid "Please upgrade you app to > 2.0 in order to add a Careplan module"
 msgstr ""
 "Por favor, atualize seu aplicativo para> 2,0, a fim de adicionar um módulo "
 "de plano de assistência"
 
-#: corehq/apps/app_manager/views.py:3282
+#: corehq/apps/app_manager/views.py:3284
 msgid "This application already has a Careplan module"
 msgstr "Este aplicativo já tiver um módulo de Plano de Assistência"
 
@@ -3174,33 +3176,33 @@ msgstr "Este aplicativo já tiver um módulo de Plano de Assistência"
 msgid "Error parsing XML: {}"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:204
+#: corehq/apps/app_manager/xform.py:205
 #, python-brace-format
 msgid "Group already has node for lang: {0}"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:673
+#: corehq/apps/app_manager/xform.py:679
 msgid "There's no language called '{}'"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:675
+#: corehq/apps/app_manager/xform.py:681
 msgid "There's already a language called '{}'"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:720
+#: corehq/apps/app_manager/xform.py:726
 #, python-brace-format
 msgid "<translation lang=\"{lang}\"><text id=\"{id}\"> node has no <value>"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:827
+#: corehq/apps/app_manager/xform.py:833
 msgid "<item> ({}) has no <value>"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:948
+#: corehq/apps/app_manager/xform.py:954
 msgid "Node <{}> has no 'ref' or 'bind'"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:1122 corehq/apps/app_manager/xform.py:1379
+#: corehq/apps/app_manager/xform.py:1128 corehq/apps/app_manager/xform.py:1385
 msgid ""
 "Couldn't get the case XML from one of your forms. A common reason for this "
 "is if you don't have the xforms namespace defined in your form. Please "
@@ -3208,24 +3210,24 @@ msgid ""
 "your form."
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:1371
+#: corehq/apps/app_manager/xform.py:1377
 msgid ""
 "You cannot use the Case Management UI if you already have a case block in "
 "your form."
 msgstr ""
 
-#: corehq/apps/app_manager/xpath.py:205
+#: corehq/apps/app_manager/xpath.py:208
 #, python-brace-format
 msgid "Type {type} must be in list of domain types: {list}"
 msgstr "Tipo {type} deve ser em lista de tipos de domínio: {list}"
 
-#: corehq/apps/app_manager/xpath.py:213
+#: corehq/apps/app_manager/xpath.py:216
 #, python-brace-format
 msgid "Reference type {ref} cannot be a child of primary type {main}."
 msgstr ""
 "Tipo de referência {ref} não pode ser um filho do tipo primário {main}."
 
-#: corehq/apps/app_manager/xpath.py:226
+#: corehq/apps/app_manager/xpath.py:229
 msgid ""
 "Property not correctly formatted. Must be formatted like: loacation:mytype:"
 "referencetype/property. For example: location:outlet:state/name"
@@ -3285,50 +3287,50 @@ msgstr "Restaurar"
 msgid "No thanks, get me out of here"
 msgstr "Não, obrigado, me tire daqui"
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:177
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:180
 msgid "Home Screen"
 msgstr "Tela Inicial"
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:178
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:181
 msgid "Module Menu"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:179
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:182
 msgid "Module:"
 msgstr "Módulo:"
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:180
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:183
 msgid "Previous Screen"
 msgstr "Tela Anterior"
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:189
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:192
 msgid "Link to other form"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:239
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:242
 msgid "Delete Form"
 msgstr "Apagar Formulário"
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:259
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:262
 msgid ""
 "Your administrator has locked this form from edits through the form builder"
 msgstr ""
 "O administrador bloqueou este formulário de edições através do Form Builder"
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:268
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:271
 msgid "Try in CloudCare"
 msgstr "Tentar em CloudCare"
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:277
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:280
 msgid "User Registration Properties"
 msgstr "Propiedades de registro de usuários"
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:284
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:287
 #: corehq/apps/app_manager/templates/app_manager/managed_app.html:162
 #: corehq/apps/app_manager/templates/app_manager/module_view.html:189
 #: corehq/apps/dashboard/views.py:217
 #: corehq/apps/grapevine/templates/grapevine/backend.html:5
-#: corehq/apps/hqwebapp/models.py:952 corehq/apps/hqwebapp/models.py:1630
+#: corehq/apps/hqwebapp/models.py:952 corehq/apps/hqwebapp/models.py:1625
 #: corehq/apps/mach/templates/mach/backend.html:5
 #: corehq/apps/megamobile/templates/megamobile/backend.html:5
 #: corehq/apps/sms/templates/sms/http_backend.html:33
@@ -3339,25 +3341,25 @@ msgstr "Propiedades de registro de usuários"
 msgid "Settings"
 msgstr "Configuração"
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:288
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:332
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:334
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:291
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:335
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:337
 #: corehq/apps/app_manager/templates/app_manager/module_view.html:190
 msgid "Case Management"
 msgstr "Gestão de Casos"
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:294
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:358
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:360
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:297
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:361
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:363
 msgid "User Case Management"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:301
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:304
 msgid "Visit Scheduler"
 msgstr "Organizador das Visitas"
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:317
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:354
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:320
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:357
 msgid ""
 "There are errors in your form. Fix your form in order to view and edit Case "
 "Management."
@@ -3365,13 +3367,13 @@ msgstr ""
 "Existem erros no seu formulário. Corrigir o seu formulário, a fim de "
 "visualizar e editar Gestão de Casos."
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:322
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:324
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:325
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:327
 msgid "Cases and Referrals"
 msgstr "Casos e Encaminhamentos"
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:325
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:335
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:328
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:338
 msgid ""
 "Cases give you a way to track patients, farms, etc. over time.  You can "
 "choose to save data from a form to the case, which will store the data "
@@ -3381,7 +3383,7 @@ msgstr ""
 "do tempo. Você pode optar por guardar dados de um formulário para o caso, "
 "que irá armazenar os dados localmente no telefone para usar mais tarde."
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:346
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:349
 #: corehq/apps/app_manager/templates/app_manager/partials/form_tab_visit_scheduler.html:97
 msgid ""
 "You have not created a form yet. Create a form in order to view and edit "
@@ -3390,19 +3392,19 @@ msgstr ""
 "Você não criou um formulário ainda. Crie um formulário, a fim de visualizar "
 "e editar Gestão de Casos."
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:361
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:364
 msgid ""
 "The user case allows you to store data about the user in a case and use that "
 "data in forms."
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:371
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:374
 msgid ""
 "You have not created a form yet. Create a form in order to view and edit "
 "User Case Management."
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:396
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:399
 #: corehq/apps/app_manager/templates/app_manager/managed_app.html:213
 #: corehq/apps/reports/templates/reports/partials/form_name.html:5
 msgid "User Registration"
@@ -3563,7 +3565,7 @@ msgstr ""
 #: corehq/apps/app_manager/templates/app_manager/module_view.html:254
 #: corehq/apps/domain/views.py:340
 #: corehq/apps/locations/templates/locations/manage/location.html:84
-#: corehq/apps/users/forms.py:211
+#: corehq/apps/users/forms.py:210
 #: corehq/apps/users/templates/users/edit_commcare_user.html:122
 msgid "Basic"
 msgstr "Básico"
@@ -3575,7 +3577,7 @@ msgstr "Básico"
 #: corehq/apps/reports/filters/select.py:108
 #: corehq/apps/reports/standard/cases/basic.py:270
 #: corehq/apps/reports/templates/reports/reportdata/case_export_data.html:125
-#: corehq/ex-submodules/casexml/apps/case/models.py:877
+#: corehq/ex-submodules/casexml/apps/case/models.py:882
 msgid "Case Type"
 msgstr "Típo de Caso"
 
@@ -3630,7 +3632,33 @@ msgstr ""
 msgid "Display"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:65
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:63
+#, fuzzy
+msgid "Chart Title"
+msgstr "Data de Começo"
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:66
+#, fuzzy
+msgid "Graph type"
+msgstr "Tipo de dados"
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:73
+msgid "Configuration"
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:83
+msgid "Add Configuration Item"
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:88
+msgid "Series Configuration"
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:99
+msgid "Add Series Configuration Item"
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:109
 #: corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html:130
 #: corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html:174
 #: corehq/apps/data_interfaces/templates/data_interfaces/list_case_groups.html:21
@@ -3669,7 +3697,7 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:76
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:120
 msgid "Add Report"
 msgstr ""
 
@@ -3979,7 +4007,6 @@ msgstr ""
 #: custom/ewsghana/templates/ewsghana/facility_page_print_report.html:82
 #: custom/ewsghana/templates/ewsghana/reporting_rates_print_report.html:85
 #: custom/ewsghana/templates/ewsghana/stock_status_print_report.html:78
-#: custom/opm/templates/opm/hsr_print.html:57
 #: custom/opm/templates/opm/met_print_report.html:88
 #: custom/opm/templates/opm/new_hsr_print.html:65
 msgid "Loading ..."
@@ -4861,7 +4888,7 @@ msgstr ""
 #: corehq/apps/appstore/templates/appstore/appstore_base.html:278
 #: corehq/apps/reports/standard/monitoring.py:773
 #: corehq/apps/reports/templates/reports/reports_home.html:132
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:272
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:273
 #: corehq/apps/reports/templates/reports/messaging/survey_detail.html:40
 #: corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_hierarchy.html:118
 #: submodules/ctable-src/ctable_view/templates/ctable/list_mappings.html:115
@@ -4879,7 +4906,7 @@ msgstr ""
 
 #: corehq/apps/app_manager/templates/app_manager/partials/form_tab_advanced.html:51
 #: corehq/apps/cloudcare/templates/cloudcare/cloudcare_home.html:50
-#: corehq/apps/hqwebapp/views.py:715
+#: corehq/apps/hqwebapp/views.py:717
 msgid "Loading..."
 msgstr ""
 
@@ -5091,10 +5118,10 @@ msgstr ""
 #: corehq/apps/export/templates/export/dialogs/delete_custom_export_dialog.html:13
 #: corehq/apps/hqadmin/templates/hqadmin/partials/reset-pillow-checkpoint-modal.html:18
 #: corehq/apps/hqmedia/templates/hqmedia/partials/multimedia_uploader.html:34
-#: corehq/apps/prelogin/templates/prelogin/base.html:126
-#: corehq/apps/prelogin/templates/prelogin/base.html:143
-#: corehq/apps/prelogin/templates/prelogin/base.html:174
-#: corehq/apps/prelogin/templates/prelogin/base.html:213
+#: corehq/apps/prelogin/templates/prelogin/base.html:129
+#: corehq/apps/prelogin/templates/prelogin/base.html:146
+#: corehq/apps/prelogin/templates/prelogin/base.html:177
+#: corehq/apps/prelogin/templates/prelogin/base.html:216
 #: corehq/apps/registration/templates/registration/org_request.html:70
 #: corehq/apps/registration/templates/registration/partials/eula_modal.html:11
 #: corehq/apps/reports/templates/reports/partials/export_download_modal.html:15
@@ -5168,7 +5195,7 @@ msgstr ""
 #: corehq/apps/appstore/views.py:28
 #: corehq/apps/appstore/templates/appstore/project_info.html:148
 #: corehq/apps/reports/filters/select.py:43
-#: custom/ilsgateway/tanzania/reports/delivery.py:153
+#: custom/ilsgateway/tanzania/reports/delivery.py:156
 msgid "Category"
 msgstr ""
 
@@ -5214,8 +5241,8 @@ msgid "You must specify a name for the new project"
 msgstr ""
 
 #: corehq/apps/appstore/templates/appstore/appstore_base.html:7
-#: corehq/apps/domain/views.py:1636 corehq/apps/hqwebapp/models.py:1208
-#: corehq/apps/hqwebapp/models.py:1584
+#: corehq/apps/domain/views.py:1636 corehq/apps/hqwebapp/models.py:1203
+#: corehq/apps/hqwebapp/models.py:1579
 #: corehq/apps/style/templates/style/bootstrap2/partials/domain_list_dropdown.html:19
 #: corehq/apps/style/templates/style/bootstrap3/partials/domain_list_dropdown.html:34
 msgid "CommCare Exchange"
@@ -5278,7 +5305,7 @@ msgstr ""
 #: corehq/apps/export/forms.py:76 corehq/apps/export/forms.py:133
 #: corehq/apps/hqwebapp/templates/hqwebapp/partials/pagination.html:36
 #: corehq/apps/reports/templates/reports/filters/drilldown_options.html:24
-#: corehq/apps/userreports/reports/builder/forms.py:356
+#: corehq/apps/userreports/reports/builder/forms.py:357
 msgid "Next"
 msgstr ""
 
@@ -5342,7 +5369,7 @@ msgstr ""
 #: corehq/apps/appstore/templates/appstore/project_info.html:198
 #: corehq/apps/settings/templates/settings/my_projects.html:11
 #: corehq/apps/sms/templates/sms/list_backends.html:76
-#: corehq/apps/users/views/__init__.py:688
+#: corehq/apps/users/views/__init__.py:646
 msgid "Project"
 msgstr ""
 
@@ -5484,6 +5511,8 @@ msgstr ""
 #: corehq/apps/reminders/templates/reminders/partial/complex_message_table.html:18
 #: corehq/apps/reminders/templates/reminders/partial/complex_message_table.html:21
 #: corehq/apps/sms/templates/sms/default.html:50
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:12
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:17
 msgid "Time"
 msgstr ""
 
@@ -5497,11 +5526,11 @@ msgid ""
 "That app is no longer valid. Try using the navigation links to select an app."
 msgstr ""
 
-#: corehq/apps/cloudcare/views.py:313
+#: corehq/apps/cloudcare/views.py:312
 msgid "Something went wrong filtering your cases."
 msgstr ""
 
-#: corehq/apps/cloudcare/views.py:489 corehq/apps/hqwebapp/models.py:1045
+#: corehq/apps/cloudcare/views.py:488 corehq/apps/hqwebapp/models.py:1045
 msgid "CloudCare Permissions"
 msgstr ""
 
@@ -5751,7 +5780,7 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/commtrack/forms.py:66 corehq/apps/commtrack/forms.py:71
-#: corehq/apps/commtrack/views.py:231
+#: corehq/apps/commtrack/views.py:236
 msgid "Stock Levels"
 msgstr ""
 
@@ -5795,8 +5824,8 @@ msgid "Location Type"
 msgstr ""
 
 #: corehq/apps/commtrack/models.py:539
-#: custom/ilsgateway/tanzania/reports/delivery.py:81
-#: custom/ilsgateway/tanzania/reports/randr.py:170
+#: custom/ilsgateway/tanzania/reports/delivery.py:83
+#: custom/ilsgateway/tanzania/reports/randr.py:172
 msgid "Code"
 msgstr ""
 
@@ -5815,11 +5844,11 @@ msgstr ""
 msgid "Location"
 msgstr ""
 
-#: corehq/apps/commtrack/processing.py:159
+#: corehq/apps/commtrack/processing.py:160
 msgid "Product IDs must be set for all ledger updates!"
 msgstr ""
 
-#: corehq/apps/commtrack/processing.py:174
+#: corehq/apps/commtrack/processing.py:175
 msgid "Ledger transaction references invalid Case ID \"{}\""
 msgstr ""
 
@@ -5843,33 +5872,33 @@ msgstr ""
 msgid "uncategorized"
 msgstr ""
 
-#: corehq/apps/commtrack/views.py:36 corehq/apps/hqwebapp/models.py:425
+#: corehq/apps/commtrack/views.py:41 corehq/apps/hqwebapp/models.py:425
 msgid "Setup"
 msgstr ""
 
-#: corehq/apps/commtrack/views.py:49
+#: corehq/apps/commtrack/views.py:54
 msgid "Advanced Settings"
 msgstr ""
 
-#: corehq/apps/commtrack/views.py:132
+#: corehq/apps/commtrack/views.py:137
 msgid ""
 "Settings updated! Your updated consumption settings may take a few minutes "
 "to show up in reports and on phones."
 msgstr ""
 
-#: corehq/apps/commtrack/views.py:135
+#: corehq/apps/commtrack/views.py:140
 msgid "Settings updated!"
 msgstr ""
 
-#: corehq/apps/commtrack/views.py:143 custom/intrahealth/sqldata.py:484
+#: corehq/apps/commtrack/views.py:148 custom/intrahealth/sqldata.py:484
 msgid "Consumption"
 msgstr ""
 
-#: corehq/apps/commtrack/views.py:161
+#: corehq/apps/commtrack/views.py:166
 msgid "Default consumption values updated"
 msgstr ""
 
-#: corehq/apps/commtrack/views.py:291
+#: corehq/apps/commtrack/views.py:296
 msgid "Rebuild Stock State"
 msgstr ""
 
@@ -5891,6 +5920,75 @@ msgstr ""
 
 #: corehq/apps/commtrack/templates/commtrack/manage/default_consumption.html:24
 msgid "Update Default Consumption Info"
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:8
+#, python-format
+msgid ""
+"\n"
+"    <strong>Warning:</strong>\n"
+"    You have more than %(stock_state_limit)s stocks in your project space.\n"
+"    Only %(stock_state_limit)s are shown.\n"
+"    "
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:18
+#, python-format
+msgid ""
+"\n"
+"    <strong>Warning:</strong>\n"
+"    You have more than %(stock_transaction_limit)s stock transactions in "
+"your project space.\n"
+"    Only %(stock_transaction_limit)s are shown.\n"
+"    "
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:33
+#, python-format
+msgid ""
+"\n"
+"                <strong>%(case_display)s</strong>\n"
+"                %(section_display)s\n"
+"                for <em>%(product_name)s</em>\n"
+"                "
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:43
+msgid "Rebuild"
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:50
+msgid "Current Values"
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:51
+msgid "Rebuilt Values"
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:54
+#, fuzzy
+msgid "Server Date"
+msgstr "Data de Começo"
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:55
+#, fuzzy
+msgid "Self-reported Date"
+msgstr "Data do termino"
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:58
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:60
+msgid "Quantity"
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:59
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:61
+#: corehq/apps/reports/commtrack/standard.py:297
+#: custom/ilsgateway/tanzania/reports/facility_details.py:27
+msgid "Stock on Hand"
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:92
+msgid "(will be deleted)"
 msgstr ""
 
 #: corehq/apps/commtrack/templates/commtrack/manage/stock_levels.html:7
@@ -6097,7 +6195,7 @@ msgstr ""
 #: corehq/apps/data_interfaces/interfaces.py:22
 #: corehq/apps/data_interfaces/views.py:58 corehq/apps/hqwebapp/models.py:553
 #: corehq/apps/settings/views.py:213
-#: corehq/apps/userreports/reports/builder/forms.py:350
+#: corehq/apps/userreports/reports/builder/forms.py:351
 msgid "Data"
 msgstr ""
 
@@ -6124,7 +6222,7 @@ msgstr ""
 
 #: corehq/apps/dashboard/views.py:206
 #: corehq/apps/dashboard/templates/dashboard/dashboard_new_user.html:73
-#: corehq/apps/hqwebapp/models.py:1576
+#: corehq/apps/hqwebapp/models.py:1571
 msgid "Exchange"
 msgstr ""
 
@@ -6186,6 +6284,7 @@ msgid "Welcome to CommCare Supply"
 msgstr ""
 
 #: corehq/apps/dashboard/templates/dashboard/dashboard_new_user.html:64
+#: docs/_build/html/_sources/translations.txt:132
 msgid "Welcome to CommCare HQ"
 msgstr ""
 
@@ -6244,7 +6343,7 @@ msgstr ""
 #: corehq/apps/data_interfaces/interfaces.py:50
 #: corehq/apps/reports/standard/cases/basic.py:272
 #: corehq/apps/sms/templates/sms/list_backends.html:63
-#: corehq/ex-submodules/casexml/apps/case/models.py:887
+#: corehq/ex-submodules/casexml/apps/case/models.py:892
 msgid "Owner"
 msgstr ""
 
@@ -6720,7 +6819,7 @@ msgstr ""
 msgid "New owner's CommCare username"
 msgstr ""
 
-#: corehq/apps/domain/forms.py:362 corehq/apps/domain/views.py:2464
+#: corehq/apps/domain/forms.py:362 corehq/apps/domain/views.py:2465
 msgid "Transfer Project"
 msgstr ""
 
@@ -6830,7 +6929,7 @@ msgid "Secure submissions"
 msgstr ""
 
 #: corehq/apps/domain/forms.py:633 corehq/apps/hqadmin/reports.py:696
-#: corehq/apps/prelogin/templates/prelogin/base.html:81
+#: corehq/apps/prelogin/templates/prelogin/base.html:84
 msgid "Services"
 msgstr ""
 
@@ -6862,7 +6961,7 @@ msgstr ""
 
 #: corehq/apps/domain/forms.py:652
 #: corehq/apps/reports/standard/deployments.py:43
-#: corehq/apps/reports/standard/deployments.py:215
+#: corehq/apps/reports/standard/deployments.py:226
 #: corehq/apps/reports/standard/sms.py:164
 #: corehq/apps/reports/standard/sms.py:415
 #: corehq/apps/reports/standard/sms.py:474
@@ -6961,7 +7060,7 @@ msgstr ""
 #: corehq/apps/domain/forms.py:978 corehq/apps/domain/forms.py:1075
 #: corehq/apps/reminders/forms.py:517 corehq/apps/reminders/forms.py:2152
 #: corehq/apps/styleguide/examples/simple_crispy_form/forms.py:63
-#: corehq/apps/users/forms.py:487
+#: corehq/apps/users/forms.py:486
 msgid "Basic Information"
 msgstr ""
 
@@ -6986,7 +7085,7 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/domain/forms.py:922 corehq/apps/domain/forms.py:986
-#: corehq/apps/domain/forms.py:1083 corehq/apps/users/forms.py:495
+#: corehq/apps/domain/forms.py:1083 corehq/apps/users/forms.py:494
 msgid "Mailing Address"
 msgstr ""
 
@@ -7170,15 +7269,15 @@ msgstr ""
 msgid "Subscription Type"
 msgstr ""
 
-#: corehq/apps/domain/models.py:1295
+#: corehq/apps/domain/models.py:1279
 msgid "Transfer domain request is no longer active"
 msgstr ""
 
-#: corehq/apps/domain/models.py:1327 corehq/apps/domain/models.py:1342
+#: corehq/apps/domain/models.py:1311 corehq/apps/domain/models.py:1326
 msgid "Transfer of ownership for CommCare project space."
 msgstr ""
 
-#: corehq/apps/domain/models.py:1368
+#: corehq/apps/domain/models.py:1352
 #, python-brace-format
 msgid "There has been a transfer of ownership of {domain}"
 msgstr ""
@@ -7210,7 +7309,7 @@ msgstr ""
 msgid "Sorry, you do not have access to %(feature_name)s"
 msgstr ""
 
-#: corehq/apps/domain/views.py:267 corehq/apps/hqwebapp/models.py:1146
+#: corehq/apps/domain/views.py:267 corehq/apps/hqwebapp/models.py:1141
 #: corehq/apps/hqwebapp/templates/hqwebapp/partials/global_navigation_bar.html:91
 #: corehq/apps/ota/views.py:121
 #: corehq/apps/style/templates/style/bootstrap3/partials/domain_list_dropdown.html:6
@@ -7355,9 +7454,7 @@ msgstr ""
 msgid "Privacy and Security"
 msgstr ""
 
-#: corehq/apps/domain/views.py:1329 corehq/apps/prelogin/forms.py:96
-#: corehq/apps/prelogin/templates/prelogin/base.html:128
-#: corehq/apps/prelogin/templates/prelogin/_sections/home/about_dimagi.html:42
+#: corehq/apps/domain/views.py:1329 corehq/apps/prelogin/forms.py:97
 msgid "Contact Dimagi"
 msgstr ""
 
@@ -7381,7 +7478,7 @@ msgstr ""
 
 #: corehq/apps/domain/views.py:1437
 #: corehq/apps/domain/templates/domain/confirm_subscription_renewal.html:43
-#: corehq/apps/users/forms.py:513
+#: corehq/apps/users/forms.py:512
 #: corehq/apps/users/templates/users/mobile/users_list.html:115
 #: corehq/apps/users/views/mobile/users.py:461
 msgid "Confirm Billing Information"
@@ -7458,7 +7555,7 @@ msgstr ""
 msgid "Created a new version of your app."
 msgstr ""
 
-#: corehq/apps/domain/views.py:1932 corehq/apps/hqwebapp/models.py:1212
+#: corehq/apps/domain/views.py:1932 corehq/apps/hqwebapp/models.py:1207
 msgid "Multimedia Sharing"
 msgstr ""
 
@@ -7489,7 +7586,7 @@ msgstr ""
 msgid "App Schema Changes"
 msgstr ""
 
-#: corehq/apps/domain/views.py:1987 corehq/apps/hqwebapp/models.py:1226
+#: corehq/apps/domain/views.py:1987 corehq/apps/hqwebapp/models.py:1221
 msgid "Data Forwarding"
 msgstr ""
 
@@ -7502,7 +7599,7 @@ msgstr ""
 msgid "Forwarding set up to %s"
 msgstr ""
 
-#: corehq/apps/domain/views.py:2152 corehq/apps/hqwebapp/models.py:1203
+#: corehq/apps/domain/views.py:2152 corehq/apps/hqwebapp/models.py:1198
 msgid "Project Information"
 msgstr ""
 
@@ -7525,28 +7622,28 @@ msgstr ""
 msgid "Feature Previews"
 msgstr ""
 
-#: corehq/apps/domain/views.py:2439 corehq/apps/hqwebapp/models.py:1510
-#: corehq/apps/hqwebapp/models.py:1534 corehq/apps/hqwebapp/models.py:1562
+#: corehq/apps/domain/views.py:2439 corehq/apps/hqwebapp/models.py:1505
+#: corehq/apps/hqwebapp/models.py:1529 corehq/apps/hqwebapp/models.py:1557
 #: corehq/apps/toggle_ui/templates/toggle/flags.html:6
 msgid "Feature Flags"
 msgstr ""
 
-#: corehq/apps/domain/views.py:2488
+#: corehq/apps/domain/views.py:2489
 #, python-brace-format
 msgid "Resent transfer request for project '{domain}'"
 msgstr ""
 
-#: corehq/apps/domain/views.py:2558
+#: corehq/apps/domain/views.py:2559
 #, python-brace-format
 msgid "Successfully transferred ownership of project '{domain}'"
 msgstr ""
 
-#: corehq/apps/domain/views.py:2590
+#: corehq/apps/domain/views.py:2591
 #, python-brace-format
 msgid "Declined ownership of project '{domain}'"
 msgstr ""
 
-#: corehq/apps/domain/views.py:2606 corehq/apps/domain/views.py:2626
+#: corehq/apps/domain/views.py:2607 corehq/apps/domain/views.py:2627
 msgid "SMS Rate Calculator"
 msgstr ""
 
@@ -7936,7 +8033,7 @@ msgid "Usage Summary"
 msgstr ""
 
 #: corehq/apps/domain/templates/domain/current_subscription.html:210
-#: corehq/apps/domain/templates/domain/admin/feature_flags.html:26
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:34
 msgid "Feature"
 msgstr ""
 
@@ -8258,35 +8355,39 @@ msgstr ""
 msgid "Add a forwarding location"
 msgstr ""
 
-#: corehq/apps/domain/templates/domain/admin/feature_flags.html:8
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:16
 #, python-format
 msgid ""
 "\n"
-"                    Feature Flags are superuser-only things that can be turn "
-"on features for individual users or projects.\n"
-"                    They can be edited manually at the <a href="
-"\"%(toggle_url)s\">Feature Flag edit UI</a> (also super-only).\n"
+"                    Feature Flags turn on features for individual users or "
+"projects. They are editable only by\n"
+"                    super users, in the <a href=\"%(toggle_url)s\">Feature "
+"Flag edit UI</a>.\n"
 "                    In addition, some feature flags are randomly enabled by "
-"a domain.\n"
-"                "
-msgstr ""
-
-#: corehq/apps/domain/templates/domain/admin/feature_flags.html:15
-msgid ""
-"\n"
-"                    You can see a list of all enabled flags for this domain "
-"here.\n"
-"                    This does not include any flags set for users within the "
 "domain.\n"
 "                "
 msgstr ""
 
-#: corehq/apps/domain/templates/domain/admin/feature_flags.html:27
-#: corehq/apps/toggle_ui/templates/toggle/edit_flag.html:165
-msgid "Enabled?"
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:23
+msgid ""
+"\n"
+"                    Following are all flags enabled for this domain and/or "
+"for you.\n"
+"                    This does not include any flags set for other users in "
+"this domain.\n"
+"                "
 msgstr ""
 
 #: corehq/apps/domain/templates/domain/admin/feature_flags.html:35
+msgid "Enabled for domain?"
+msgstr ""
+
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:36
+#, fuzzy
+msgid "Enabled for me?"
+msgstr "Estiqueta por Casos"
+
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:45
 msgid "change"
 msgstr ""
 
@@ -8345,7 +8446,7 @@ msgid "SMS Pricing"
 msgstr ""
 
 #: corehq/apps/domain/templates/domain/admin/global_sms_rates.html:35
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:67
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:78
 msgid "Pricing"
 msgstr ""
 
@@ -8828,8 +8929,8 @@ msgstr ""
 #: corehq/apps/users/templates/users/web_users.b3.html:220
 #: corehq/apps/users/templates/users/web_users.b3.html:285
 #: corehq/apps/users/templates/users/web_users.html:127
-#: custom/ilsgateway/tanzania/reports/facility_details.py:71
-#: custom/ilsgateway/tanzania/reports/facility_details.py:117
+#: custom/ilsgateway/tanzania/reports/facility_details.py:72
+#: custom/ilsgateway/tanzania/reports/facility_details.py:118
 msgid "Role"
 msgstr ""
 
@@ -8905,7 +9006,7 @@ msgid "Forgot your password?"
 msgstr ""
 
 #: corehq/apps/domain/templates/login_and_password/partials/login_form.html:50
-#: corehq/apps/prelogin/templates/prelogin/base.html:74
+#: corehq/apps/prelogin/templates/prelogin/base.html:77
 #: corehq/apps/style/templates/style/bootstrap2/base.html:74
 #: corehq/apps/style/templates/style/bootstrap3/base.html:102
 msgid "Sign In"
@@ -9266,7 +9367,7 @@ msgstr ""
 #: corehq/apps/sms/forms.py:450
 #: corehq/apps/sms/templates/sms/backend_map.html:97
 #: corehq/apps/style/templates/style/bootstrap3/base.html:234
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:144
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:148
 #: corehq/apps/users/templates/users/web_users.b3.html:60
 #: custom/ewsghana/templates/ewsghana/partials/users_tables.html:102
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:212
@@ -9655,6 +9756,7 @@ msgstr ""
 
 #: corehq/apps/fixtures/templates/fixtures/manage_tables.html:66
 #: corehq/apps/fixtures/templates/fixtures/partials/edit_table_modal.html:9
+#: corehq/apps/userreports/ui/forms.py:87
 msgid "Table ID"
 msgstr ""
 
@@ -10031,7 +10133,7 @@ msgstr ""
 msgid "ADMINREPORT"
 msgstr ""
 
-#: corehq/apps/hqadmin/reports.py:642 corehq/apps/hqwebapp/models.py:1401
+#: corehq/apps/hqadmin/reports.py:642 corehq/apps/hqwebapp/models.py:1396
 msgid "Project Space List"
 msgstr ""
 
@@ -10265,7 +10367,7 @@ msgstr ""
 msgid "No Info"
 msgstr ""
 
-#: corehq/apps/hqadmin/reports.py:808 corehq/apps/hqwebapp/models.py:1403
+#: corehq/apps/hqadmin/reports.py:808 corehq/apps/hqwebapp/models.py:1398
 msgid "User List"
 msgstr ""
 
@@ -10298,7 +10400,7 @@ msgstr ""
 msgid "No Domain Data"
 msgstr ""
 
-#: corehq/apps/hqadmin/reports.py:876 corehq/apps/hqwebapp/models.py:1405
+#: corehq/apps/hqadmin/reports.py:876 corehq/apps/hqwebapp/models.py:1400
 msgid "Application List"
 msgstr ""
 
@@ -10424,7 +10526,7 @@ msgid "Print"
 msgstr ""
 
 #: corehq/apps/hqadmin/templates/hqadmin/hqadmin_base_report.html:33
-#: corehq/apps/hqwebapp/models.py:1371 corehq/apps/hqwebapp/models.py:1539
+#: corehq/apps/hqwebapp/models.py:1366 corehq/apps/hqwebapp/models.py:1534
 msgid "Admin Reports"
 msgstr ""
 
@@ -10517,12 +10619,12 @@ msgstr ""
 msgid "Audio"
 msgstr ""
 
-#: corehq/apps/hqmedia/models.py:815
+#: corehq/apps/hqmedia/models.py:818
 #, python-format
 msgid "Encountered an AttributeError for media: %s"
 msgstr ""
 
-#: corehq/apps/hqmedia/models.py:819
+#: corehq/apps/hqmedia/models.py:822
 #, python-format
 msgid ""
 "This application has unsupported text in one of it's media file label "
@@ -10566,7 +10668,7 @@ msgstr ""
 msgid "File {name}s has an incorrect file type {ext}."
 msgstr ""
 
-#: corehq/apps/hqmedia/views.py:579
+#: corehq/apps/hqmedia/views.py:575
 msgid ""
 "There was an issue retrieving the status from the cache. We are looking into "
 "it. Please try uploading again."
@@ -10946,7 +11048,7 @@ msgstr ""
 msgid "Error Type"
 msgstr ""
 
-#: corehq/apps/hqpillow_retry/views.py:41 corehq/apps/hqwebapp/models.py:1393
+#: corehq/apps/hqpillow_retry/views.py:41 corehq/apps/hqwebapp/models.py:1388
 msgid "PillowTop Errors"
 msgstr ""
 
@@ -11231,7 +11333,7 @@ msgstr ""
 msgid "New Survey"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:929 corehq/apps/hqwebapp/models.py:1490
+#: corehq/apps/hqwebapp/models.py:929 corehq/apps/hqwebapp/models.py:1485
 #: corehq/apps/sms/views.py:990
 #: corehq/apps/sms/templates/sms/add_backend.html:49
 #: corehq/apps/sms/templates/sms/add_backend.html:70
@@ -11242,11 +11344,11 @@ msgstr ""
 msgid "SMS Connectivity"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:933 corehq/apps/hqwebapp/models.py:1494
+#: corehq/apps/hqwebapp/models.py:933 corehq/apps/hqwebapp/models.py:1489
 msgid "Add Connection"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:937 corehq/apps/hqwebapp/models.py:1496
+#: corehq/apps/hqwebapp/models.py:937 corehq/apps/hqwebapp/models.py:1491
 msgid "Edit Connection"
 msgstr ""
 
@@ -11297,180 +11399,174 @@ msgstr ""
 msgid "Application Users"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1068
+#: corehq/apps/hqwebapp/models.py:1067
 msgid "Project Users"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1072
+#: corehq/apps/hqwebapp/models.py:1071
 msgid ""
 "Grant other CommCare HQ users access to your project and manage user roles."
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1075
+#: corehq/apps/hqwebapp/models.py:1074
 #: corehq/apps/users/templates/users/web_users.b3.html:136
 msgid "Invite Web User"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1083 corehq/apps/settings/views.py:93
-#: corehq/apps/settings/templates/settings/edit_my_account.b2.html:33
-#: corehq/apps/users/views/__init__.py:350
-msgid "My Information"
-msgstr ""
-
-#: corehq/apps/hqwebapp/models.py:1219
+#: corehq/apps/hqwebapp/models.py:1214
 msgid "Forward Forms"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1221
+#: corehq/apps/hqwebapp/models.py:1216
 msgid "Forward Form Stubs"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1223
+#: corehq/apps/hqwebapp/models.py:1218
 msgid "Forward Cases"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1250
+#: corehq/apps/hqwebapp/models.py:1245
 msgid "Project Administration"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1296
+#: corehq/apps/hqwebapp/models.py:1291
 msgid "Internal Subscription Management (Dimagi Only)"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1313
+#: corehq/apps/hqwebapp/models.py:1308
 msgid "Project Tools"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1334
+#: corehq/apps/hqwebapp/models.py:1329
 msgid "Internal Data (Dimagi Only)"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1340
+#: corehq/apps/hqwebapp/models.py:1335
 msgid "My Settings"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1352
+#: corehq/apps/hqwebapp/models.py:1347
 msgid "Manage My Settings"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1381 corehq/apps/hqwebapp/models.py:1400
+#: corehq/apps/hqwebapp/models.py:1376 corehq/apps/hqwebapp/models.py:1395
 msgid "Administrative Reports"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1382 corehq/apps/hqwebapp/models.py:1411
-#: corehq/apps/hqwebapp/models.py:1533 corehq/apps/hqwebapp/models.py:1540
+#: corehq/apps/hqwebapp/models.py:1377 corehq/apps/hqwebapp/models.py:1406
+#: corehq/apps/hqwebapp/models.py:1528 corehq/apps/hqwebapp/models.py:1535
 msgid "System Info"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1391
+#: corehq/apps/hqwebapp/models.py:1386
 msgid "Mass Email Users"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1396
+#: corehq/apps/hqwebapp/models.py:1391
 msgid "Login as another user"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1407
+#: corehq/apps/hqwebapp/models.py:1402
 msgid "Message Logs Across All Domains"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1409
+#: corehq/apps/hqwebapp/models.py:1404
 msgid "CommCare Versions"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1413
+#: corehq/apps/hqwebapp/models.py:1408
 msgid "Loadtest Report"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1416
+#: corehq/apps/hqwebapp/models.py:1411
 msgid "Administrative Operations"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1417
+#: corehq/apps/hqwebapp/models.py:1412
 msgid "CommCare Reports"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1439
+#: corehq/apps/hqwebapp/models.py:1434
 msgid "Accounting"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1482 corehq/apps/hqwebapp/models.py:1561
+#: corehq/apps/hqwebapp/models.py:1477 corehq/apps/hqwebapp/models.py:1556
 msgid "SMS Connectivity & Billing"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1491
+#: corehq/apps/hqwebapp/models.py:1486
 #: corehq/apps/sms/templates/sms/add_backend.html:52
 #: corehq/apps/sms/templates/sms/list_backends.html:39
 msgid "SMS Connections"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1499
+#: corehq/apps/hqwebapp/models.py:1494
 #: corehq/apps/sms/templates/sms/backend_map.html:5
 #: corehq/apps/sms/templates/sms/backend_map.html:64
 #: corehq/apps/sms/templates/sms/backend_map.html:72
 msgid "SMS Country-Connection Map"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1519
+#: corehq/apps/hqwebapp/models.py:1514
 msgid "Admin"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1541
+#: corehq/apps/hqwebapp/models.py:1536
 msgid "Management"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1542
+#: corehq/apps/hqwebapp/models.py:1537
 msgid "Commands"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1556
+#: corehq/apps/hqwebapp/models.py:1551
 msgid "Old SMS Billing"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1564
+#: corehq/apps/hqwebapp/models.py:1559
 msgid "Django Admin"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1586
+#: corehq/apps/hqwebapp/models.py:1581
 msgid "Publish this project"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1615
+#: corehq/apps/hqwebapp/models.py:1610
 #: corehq/apps/orgs/templates/orgs/report_base.html:28
 msgid "Projects Table"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1618
+#: corehq/apps/hqwebapp/models.py:1613
 #: corehq/apps/orgs/templates/orgs/report_base.html:29
 #: corehq/apps/reports/standard/monitoring.py:1026
 msgid "Form Data"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1621
+#: corehq/apps/hqwebapp/models.py:1616
 #: corehq/apps/orgs/templates/orgs/report_base.html:30
 #: corehq/apps/reports/standard/monitoring.py:1036
 msgid "Case Data"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1624
+#: corehq/apps/hqwebapp/models.py:1619
 #: corehq/apps/orgs/templates/orgs/report_base.html:31
 msgid "User Data"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1637
+#: corehq/apps/hqwebapp/models.py:1632
 #: corehq/apps/orgs/templates/orgs/orgs_team_members.html:84
 #: corehq/apps/orgs/templates/orgs/public.html:28
 #: corehq/apps/orgs/templates/orgs/partials/top_nav.html:6
 msgid "Projects"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1640
+#: corehq/apps/hqwebapp/models.py:1635
 #: corehq/apps/orgs/templates/orgs/public.html:31
 #: corehq/apps/orgs/templates/orgs/partials/top_nav.html:9
 msgid "Teams"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1643
+#: corehq/apps/hqwebapp/models.py:1638
 #: corehq/apps/orgs/templates/orgs/orgs_team_members.html:50
 #: corehq/apps/orgs/templates/orgs/public.html:34
 #: corehq/apps/orgs/templates/orgs/partials/top_nav.html:12
@@ -11521,44 +11617,44 @@ msgstr ""
 msgid "View All"
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:612
+#: corehq/apps/hqwebapp/views.py:614
 msgid ""
 "Check \"Opt out of emails about new features and other CommCare updates\" in "
 "your account settings and then click \"Update Information\" if you do not "
 "want to receive future emails from us."
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:713
+#: corehq/apps/hqwebapp/views.py:715
 msgid "items per page"
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:714
+#: corehq/apps/hqwebapp/views.py:716
 msgid "You have no items."
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:716
+#: corehq/apps/hqwebapp/views.py:718
 msgid "Deleted Items:"
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:717
+#: corehq/apps/hqwebapp/views.py:719
 msgid "New Items:"
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:840
+#: corehq/apps/hqwebapp/views.py:842
 #, python-format
 msgid "<strong>Problem Refreshing List:</strong> %s"
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:858
+#: corehq/apps/hqwebapp/views.py:860
 #, python-format
 msgid "<strong>Problem Deleting:</strong> %s"
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:866
+#: corehq/apps/hqwebapp/views.py:868
 msgid "The item's ID was not passed to the server."
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:976
+#: corehq/apps/hqwebapp/views.py:978
 #, python-format
 msgid "We've redirected you to the %s matching your query"
 msgstr ""
@@ -11836,11 +11932,11 @@ msgstr ""
 msgid "No properties found."
 msgstr ""
 
-#: corehq/apps/importer/base.py:5
+#: corehq/apps/importer/base.py:6
 msgid "Import Cases from Excel"
 msgstr ""
 
-#: corehq/apps/importer/base.py:7
+#: corehq/apps/importer/base.py:8
 msgid "Import case data from an external Excel file"
 msgstr ""
 
@@ -11866,6 +11962,10 @@ msgstr ""
 
 #: corehq/apps/importer/const.py:13
 msgid "Case Generation Error"
+msgstr ""
+
+#: corehq/apps/importer/const.py:14
+msgid "Duplicated Location Name"
 msgstr ""
 
 #: corehq/apps/importer/util.py:213
@@ -11902,19 +12002,26 @@ msgstr ""
 msgid "An invalid or unknown parent case was specified for the uploaded case."
 msgstr ""
 
-#: corehq/apps/importer/views.py:170
+#: corehq/apps/importer/util.py:234
+msgid ""
+"Owner ID was used in the mapping, but there were errors when uploading "
+"because of these values. There are multiple locations with this same name, "
+"try using site-code instead."
+msgstr ""
+
+#: corehq/apps/importer/views.py:169
 msgid ""
 "It looks like you may have accessed this page from a stale page. Please "
 "start over."
 msgstr ""
 
-#: corehq/apps/importer/views.py:274 corehq/apps/importer/views.py:331
+#: corehq/apps/importer/views.py:273 corehq/apps/importer/views.py:330
 msgid ""
 "The session containing the file you uploaded has expired - please upload a "
 "new one."
 msgstr ""
 
-#: corehq/apps/importer/views.py:349
+#: corehq/apps/importer/views.py:348
 msgid "Sorry, your session has expired. Please start over and try again."
 msgstr ""
 
@@ -11947,8 +12054,9 @@ msgid "Corresponding case field"
 msgstr ""
 
 #: corehq/apps/importer/templates/importer/excel_config.html:90
-#: corehq/ex-submodules/casexml/apps/case/models.py:892
-#: custom/opm/beneficiary.py:823 custom/opm/beneficiary.py:899
+#: corehq/ex-submodules/casexml/apps/case/models.py:897
+#: custom/opm/beneficiary.py:822 custom/opm/beneficiary.py:899
+#: custom/opm/beneficiary.py:921
 msgid "Case ID"
 msgstr ""
 
@@ -11999,7 +12107,8 @@ msgstr ""
 
 #: corehq/apps/importer/templates/importer/excel_config.html:192
 #: corehq/apps/importer/templates/importer/excel_fields.html:189
-#: corehq/apps/userreports/reports/builder/forms.py:458
+#: corehq/apps/userreports/reports/builder/forms.py:459
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:5
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:210
 #: submodules/ctable-src/ctable_view/templates/ctable/test_mapping.html:129
 msgid "Back"
@@ -12543,11 +12652,16 @@ msgstr ""
 msgid "Move"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:83
+#: corehq/apps/locations/templates/locations/manage/locations.html:40
+#, python-format
+msgid "You have successfully archived the location <%%=name%%>"
+msgstr ""
+
+#: corehq/apps/locations/templates/locations/manage/locations.html:102
 msgid "Manage Locations"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:85
+#: corehq/apps/locations/templates/locations/manage/locations.html:104
 msgid ""
 "\n"
 "                    Locations allow you to represent the real-world "
@@ -12560,42 +12674,43 @@ msgid ""
 "                "
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:95
+#: corehq/apps/locations/templates/locations/manage/locations.html:114
 msgid "Showing the Inactive Location List."
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:102
+#: corehq/apps/locations/templates/locations/manage/locations.html:121
 msgid "Show Archived Locations"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:106
+#: corehq/apps/locations/templates/locations/manage/locations.html:125
 msgid "Show Active Locations"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:119
-#: corehq/apps/locations/templates/locations/manage/locations.html:123
+#: corehq/apps/locations/templates/locations/manage/locations.html:138
+#: corehq/apps/locations/templates/locations/manage/locations.html:142
 msgid "Bulk Import Locations"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:127
+#: corehq/apps/locations/templates/locations/manage/locations.html:146
 msgid "Edit Location Types"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:130
+#: corehq/apps/locations/templates/locations/manage/locations.html:149
 msgid "Edit Location Fields"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:155
+#: corehq/apps/locations/templates/locations/manage/locations.html:174
 msgid "Unarchive"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:160
+#: corehq/apps/locations/templates/locations/manage/locations.html:179
+#: corehq/apps/locations/templates/locations/manage/locations.html:267
 #: corehq/apps/products/views.py:186
 #: corehq/apps/products/templates/products/manage/products.html:116
 msgid "Archive"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:216
+#: corehq/apps/locations/templates/locations/manage/locations.html:235
 #, python-format
 msgid ""
 "\n"
@@ -12603,6 +12718,23 @@ msgid ""
 "    <a href=\"%(location_types_url)s\">here</a>\n"
 "    for your project before creating any locations.\n"
 "    "
+msgstr ""
+
+#: corehq/apps/locations/templates/locations/manage/locations.html:253
+#, fuzzy
+msgid "Archive Location:"
+msgstr "Localizações"
+
+#: corehq/apps/locations/templates/locations/manage/locations.html:257
+msgid ""
+"\n"
+"            <strong>Warning!</strong> Archiving a location will unassign any "
+"users\n"
+"            which were associated with that location.  You can unarchive "
+"this\n"
+"            location at any point, but you will have to reassign the users\n"
+"            manually.\n"
+"            "
 msgstr ""
 
 #: corehq/apps/locations/templates/locations/manage/partials/autocomplete_select_widget.html:10
@@ -12808,31 +12940,31 @@ msgstr ""
 msgid "Prime Restore Cache"
 msgstr ""
 
-#: corehq/apps/prelogin/forms.py:32 corehq/apps/registration/forms.py:52
+#: corehq/apps/prelogin/forms.py:33 corehq/apps/registration/forms.py:52
 msgid "Email Address"
 msgstr ""
 
-#: corehq/apps/prelogin/forms.py:45
+#: corehq/apps/prelogin/forms.py:46
 msgid "What is your interest in CommCare and any specific questions you have?"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:57
+#: corehq/apps/prelogin/templates/prelogin/base.html:60
 msgid "Toggle Navigation"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:78
+#: corehq/apps/prelogin/templates/prelogin/base.html:81
 msgid "Solutions"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:79
+#: corehq/apps/prelogin/templates/prelogin/base.html:82
 msgid "Impact"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:80
+#: corehq/apps/prelogin/templates/prelogin/base.html:83
 msgid "Software Pricing"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:108
+#: corehq/apps/prelogin/templates/prelogin/base.html:111
 #, python-format
 msgid ""
 "\n"
@@ -12843,11 +12975,15 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:145
+#: corehq/apps/prelogin/templates/prelogin/base.html:131
+msgid "Get in Touch With Us: Contact Dimagi"
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/base.html:148
 msgid "Thanks for contacting us!"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:150
+#: corehq/apps/prelogin/templates/prelogin/base.html:153
 msgid ""
 "\n"
 "                            Thank you for your interest in working with "
@@ -12855,7 +12991,7 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:155
+#: corehq/apps/prelogin/templates/prelogin/base.html:158
 msgid ""
 "\n"
 "                            One of our team members will get back to you "
@@ -12865,18 +13001,18 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:163
-#: corehq/apps/prelogin/templates/prelogin/base.html:202
+#: corehq/apps/prelogin/templates/prelogin/base.html:166
+#: corehq/apps/prelogin/templates/prelogin/base.html:205
 #: custom/_legacy/a5288/reports.py:102
 msgid "OK"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:176
-#: corehq/apps/prelogin/templates/prelogin/base.html:215
+#: corehq/apps/prelogin/templates/prelogin/base.html:179
+#: corehq/apps/prelogin/templates/prelogin/base.html:218
 msgid "Ooops!"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:181
+#: corehq/apps/prelogin/templates/prelogin/base.html:184
 msgid ""
 "\n"
 "                             We're terribly sorry! It seems like our servers "
@@ -12884,7 +13020,7 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:186
+#: corehq/apps/prelogin/templates/prelogin/base.html:189
 msgid ""
 "\n"
 "                                We've alerted one of our engineers of issues "
@@ -12895,7 +13031,7 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:193
+#: corehq/apps/prelogin/templates/prelogin/base.html:196
 msgid ""
 "\n"
 "                                You can send an email directly to\n"
@@ -12905,7 +13041,7 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:226
+#: corehq/apps/prelogin/templates/prelogin/base.html:229
 msgid ""
 "\n"
 "                                Please provide a valid e-mail address where "
@@ -12966,6 +13102,10 @@ msgid ""
 "contact\n"
 "                        Dimagi directly.\n"
 "                    "
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/home/about_dimagi.html:42
+msgid "Get in Touch With Us"
 msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/home/about_dimagi.html:50
@@ -13178,7 +13318,7 @@ msgstr ""
 #: corehq/apps/style/templates/style/includes/modal_report_issue.html:49
 #: corehq/apps/styleguide/examples/simple_crispy_form/forms.py:17
 #: custom/_legacy/pact/templates/pact/chw/pact_chw_profile_info.html:16
-#: custom/ilsgateway/tanzania/reports/facility_details.py:73
+#: custom/ilsgateway/tanzania/reports/facility_details.py:74
 msgid "Email"
 msgstr ""
 
@@ -13356,32 +13496,35 @@ msgstr ""
 #: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:12
 msgid ""
 "\n"
-"                        Read how organizations around the world use\n"
-"                        CommCare to improve frontline service delivery.\n"
+"                    <!--HubSpot Call-to-Action Code -->\n"
+"                    <span class=\"hs-cta-wrapper\" id=\"hs-cta-"
+"wrapper-071f4a7d-237d-49d8-b12d-c28fe204927d\">\n"
+"                        <span class=\"hs-cta-node hs-cta-071f4a7d-237d-49d8-"
+"b12d-c28fe204927d\" id=\"hs-cta-071f4a7d-237d-49d8-b12d-c28fe204927d\">\n"
+"                            <!--[if lte IE 8]><div id=\"hs-cta-ie-element"
+"\"></div><![endif]-->\n"
+"                            <a href=\"http://cta-redirect.hubspot.com/cta/"
+"redirect/503070/071f4a7d-237d-49d8-b12d-c28fe204927d\" ><img class=\"hs-cta-"
+"img\" id=\"hs-cta-img-071f4a7d-237d-49d8-b12d-c28fe204927d\" style=\"border-"
+"width:0px;\" src=\"https://no-cache.hubspot.com/cta/"
+"default/503070/071f4a7d-237d-49d8-b12d-c28fe204927d.png\"  alt=\"View All "
+"Case Studies\"/></a>\n"
+"                        </span>\n"
+"                        <script type=\"text/javascript\">\n"
+"                            hbspt.cta.load(503070, '071f4a7d-237d-49d8-b12d-"
+"c28fe204927d');\n"
+"                        </script>\n"
+"                    </span>\n"
+"                    <!-- end HubSpot Call-to-Action Code -->\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:24
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:39
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:54
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:69
-msgid "Read Case Study"
-msgstr ""
-
 #: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:27
-msgid "Improving Community Health in Guatemala"
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:42
-msgid "An Integrated eDiagnostic Approach in Burkina Faso"
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:57
-msgid "Improving Maternal and Child Health in India"
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:72
-msgid "iCCM for Child Health in Mozambique"
+msgid ""
+"\n"
+"                        Read how organizations around the world use\n"
+"                        CommCare to improve frontline service delivery.\n"
+"                    "
 msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/impact/lead.html:9
@@ -13426,6 +13569,33 @@ msgstr ""
 #: corehq/apps/prelogin/templates/prelogin/_sections/impact/partners.html:12
 msgid ""
 "\n"
+"                    <!--HubSpot Call-to-Action Code -->\n"
+"                    <span class=\"hs-cta-wrapper\" id=\"hs-cta-wrapper-"
+"c34ae48e-2f1a-48ac-9170-31fc7c9e845b\">\n"
+"                        <span class=\"hs-cta-node hs-cta-"
+"c34ae48e-2f1a-48ac-9170-31fc7c9e845b\" id=\"hs-cta-"
+"c34ae48e-2f1a-48ac-9170-31fc7c9e845b\">\n"
+"                            <!--[if lte IE 8]><div id=\"hs-cta-ie-element"
+"\"></div><![endif]-->\n"
+"                            <a href=\"http://cta-redirect.hubspot.com/cta/"
+"redirect/503070/c34ae48e-2f1a-48ac-9170-31fc7c9e845b\"  target=\"_blank\" "
+"><img class=\"hs-cta-img\" id=\"hs-cta-img-"
+"c34ae48e-2f1a-48ac-9170-31fc7c9e845b\" style=\"border-width:0px;\" src="
+"\"https://no-cache.hubspot.com/cta/default/503070/"
+"c34ae48e-2f1a-48ac-9170-31fc7c9e845b.png\"  alt=\"See All Partners\"/></a>\n"
+"                        </span>\n"
+"                        <script type=\"text/javascript\">\n"
+"                            hbspt.cta.load(503070, "
+"'c34ae48e-2f1a-48ac-9170-31fc7c9e845b');\n"
+"                        </script>\n"
+"                    </span>\n"
+"                    <!-- end HubSpot Call-to-Action Code -->\n"
+"                    "
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/partners.html:27
+msgid ""
+"\n"
 "                        The following organizations have contributed\n"
 "                        to the development of CommCare.\n"
 "                    "
@@ -13441,14 +13611,36 @@ msgstr ""
 #: corehq/apps/prelogin/templates/prelogin/_sections/impact/publications.html:12
 msgid ""
 "\n"
+"                    <!--HubSpot Call-to-Action Code -->\n"
+"                    <span class=\"hs-cta-wrapper\" id=\"hs-cta-"
+"wrapper-23da92fd-b671-481f-9aee-bbc8a94b1f8b\">\n"
+"                        <span class=\"hs-cta-node hs-cta-23da92fd-"
+"b671-481f-9aee-bbc8a94b1f8b\" id=\"hs-cta-23da92fd-b671-481f-9aee-"
+"bbc8a94b1f8b\">\n"
+"                            <!--[if lte IE 8]><div id=\"hs-cta-ie-element"
+"\"></div><![endif]-->\n"
+"                            <a href=\"http://cta-redirect.hubspot.com/cta/"
+"redirect/503070/23da92fd-b671-481f-9aee-bbc8a94b1f8b\"  target=\"_blank\" "
+"><img class=\"hs-cta-img\" id=\"hs-cta-img-23da92fd-b671-481f-9aee-"
+"bbc8a94b1f8b\" style=\"border-width:0px;\" src=\"https://no-cache.hubspot."
+"com/cta/default/503070/23da92fd-b671-481f-9aee-bbc8a94b1f8b.png\"  alt="
+"\"View Research\"/></a>\n"
+"                        </span>\n"
+"                        <script type=\"text/javascript\">\n"
+"                            hbspt.cta.load(503070, '23da92fd-b671-481f-9aee-"
+"bbc8a94b1f8b');\n"
+"                        </script>\n"
+"                    </span>\n"
+"                    <!-- end HubSpot Call-to-Action Code -->\n"
+"                    "
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/publications.html:27
+msgid ""
+"\n"
 "                        Over 30+ peer-reviewed publications have been "
 "written\n"
-"                        about CommCare. For an overview of all CommCare\n"
-"                        publications, please see the\n"
-"                        <a href=\"https://help.commcarehq.org/display/"
-"commcarepublic/CommCare+Evidence+Base\"\n"
-"                           class=\"btn-primary-dark\">CommCare Evidence "
-"Base</a>.\n"
+"                        about CommCare.\n"
 "                    "
 msgstr ""
 
@@ -13459,63 +13651,90 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:27
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:12
+msgid ""
+"\n"
+"                    <!--HubSpot Call-to-Action Code -->\n"
+"                    <span class=\"hs-cta-wrapper\" id=\"hs-cta-wrapper-"
+"c21c3aed-90ee-4106-98d0-dbe846e8ca28\">\n"
+"                        <span class=\"hs-cta-node hs-cta-"
+"c21c3aed-90ee-4106-98d0-dbe846e8ca28\" id=\"hs-cta-c21c3aed-90ee-4106-98d0-"
+"dbe846e8ca28\">\n"
+"                            <!--[if lte IE 8]><div id=\"hs-cta-ie-element"
+"\"></div><![endif]-->\n"
+"                            <a href=\"http://cta-redirect.hubspot.com/cta/"
+"redirect/503070/c21c3aed-90ee-4106-98d0-dbe846e8ca28\"  target=\"_blank\" "
+"><img class=\"hs-cta-img\" id=\"hs-cta-img-c21c3aed-90ee-4106-98d0-"
+"dbe846e8ca28\" style=\"border-width:0px;\" src=\"https://no-cache.hubspot."
+"com/cta/default/503070/c21c3aed-90ee-4106-98d0-dbe846e8ca28.png\"  alt="
+"\"Learn More About Our Sectors\"/></a>\n"
+"                        </span>\n"
+"                        <script type=\"text/javascript\">\n"
+"                            hbspt.cta.load(503070, 'c21c3aed-90ee-4106-98d0-"
+"dbe846e8ca28');\n"
+"                        </script>\n"
+"                    </span>\n"
+"                    <!-- end HubSpot Call-to-Action Code -->\n"
+"                    "
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:35
 msgid "Child Health"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:33
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:41
 msgid "HIV/AIDS"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:52
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:60
 msgid "Health"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:73
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:81
 msgid "Malaria"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:80
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:88
 msgid "Nutrition"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:91
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:99
 msgid "Cooperatives"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:98
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:106
 msgid "Finances"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:117
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:125
 msgid "Agriculture"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:138
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:146
 msgid "Extension Programs"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:145
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:153
 msgid "Logistics"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:156
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:164
 msgid "Emergency Response"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:163
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:171
 msgid "Small Business"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:182
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:190
 msgid "Development"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:203
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:211
 msgid "Education"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:210
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:218
 msgid "Logistics & Supply Chain"
 msgstr ""
 
@@ -13592,11 +13811,12 @@ msgid ""
 "\n"
 "                        <a href=\"#contactDimagi\"\n"
 "                           data-toggle=\"modal\"\n"
-"                           class=\"btn-primary-dark\">Contact Dimagi</a> or "
-"read our<br />\n"
-"                        pricing <a href=\"https://confluence.dimagi.com/"
-"display/commcarepublic/CommCare+Pricing+FAQs\" class=\"btn-primary-dark"
-"\">FAQs</a>.\n"
+"                           class=\"btn-success btn btn-xl\">Get in Touch "
+"With Us</a>\n"
+"                        <a href=\"https://confluence.dimagi.com/display/"
+"commcarepublic/CommCare+Pricing+FAQs\"\n"
+"                           class=\"btn btn-primary-dark btn-xl\">Read our "
+"Pricing FAQs</a>\n"
 "                    "
 msgstr ""
 
@@ -13604,21 +13824,19 @@ msgstr ""
 msgid "CommCare Software Plans"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:11
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:16
 msgid ""
 "\n"
-"                            Core Features are always FREE. Choose a plan\n"
-"                            to help your project scale.\n"
-"                        "
+"                        Core Features are always FREE. Choose a plan\n"
+"                        to help your project scale.\n"
+"                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:18
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:22
 msgid ""
 "\n"
-"                    <strong>Anyone can use CommCare for FREE up to 50 mobile "
-"workers.</strong><br />\n"
 "                    For additional questions, please see our\n"
-"                    <a class=\"btn-primary-dark\"\n"
+"                    <a class=\"lead-link\"\n"
 "                       href=\"https://confluence.dimagi.com/display/"
 "commcarepublic/CommCare+Pricing+FAQs?__hstc=187943799."
 "ba674a1a3cdef13c5d09b2a54d65c2b8.1431286503613.1435340206977.1435342587932.124&__hssc=187943799.6.1435342587932&__hsfp=312587752\">FAQs</"
@@ -13626,16 +13844,27 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:92
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:31
+msgid ""
+"\n"
+"                        Want to try CommCare for FREE?\n"
+"                    "
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:34
+msgid "Sign up for a FREE account"
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:103
 msgid "Contact Us"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:122
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:152
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:133
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:163
 msgid "Unlimited / Discounted"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:128
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:139
 msgid "Price Per Additional Mobile User"
 msgstr ""
 
@@ -13856,71 +14085,80 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:39
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:33
-msgid "Scope"
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:42
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:36
-msgid "Launch"
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:45
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:39
-msgid "Boost"
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:28
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:15
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:662
+msgid ""
+"\n"
+"                        Inquire About Dimagi's Implementation Bundles\n"
+"                        "
 msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:48
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:42
-msgid "Growth"
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:35
+msgid "Scope"
 msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:51
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:45
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:38
+msgid "Launch"
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:54
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:41
+msgid "Boost"
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:57
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:44
+msgid "Growth"
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:60
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:47
 msgid "Scale"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:56
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:53
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:65
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:55
 msgid "$10,000"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:59
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:56
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:68
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:58
 msgid "$35,000"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:62
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:59
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:71
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:61
 msgid "$50,000"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:65
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:62
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:74
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:64
 msgid "$80,000"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:68
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:65
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:77
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:67
 msgid "$150,000"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:92
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:100
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:108
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:89
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:97
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:105
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:101
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:109
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:117
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:91
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:99
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:107
 msgid "12 months"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:116
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:113
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:125
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:115
 msgid "18 months"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:123
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:132
 msgid ""
 "\n"
 "                                Application Development &amp; Implementation "
@@ -13928,19 +14166,19 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:130
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:139
 msgid "Workflow Design"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:131
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:140
 msgid "On-Site Scoping Visit"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:132
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:141
 msgid "Mobile System Workflow Design"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:138
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:147
 msgid ""
 "\n"
 "                                    Everything in<br />\n"
@@ -13948,19 +14186,19 @@ msgid ""
 "                                "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:143
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:152
 msgid "Build &amp; Launch Application"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:144
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:153
 msgid "Field Testing &amp; Iteration"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:145
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:154
 msgid "Users Training"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:151
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:160
 msgid ""
 "\n"
 "                                    Everything in<br />\n"
@@ -13968,16 +14206,16 @@ msgid ""
 "                                "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:156
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:62
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:165
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:69
 msgid "Technology for Outcomes Monitoring"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:157
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:166
 msgid "Capacity Building for Worker Performance Monitoring"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:163
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:172
 msgid ""
 "\n"
 "                                    Everything in<br />\n"
@@ -13985,19 +14223,19 @@ msgid ""
 "                                "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:168
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:177
 msgid "Refined Application"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:169
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:178
 msgid "Additional Supervisor App"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:170
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:179
 msgid "Application Troubleshooting Capacity Building"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:176
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:185
 msgid ""
 "\n"
 "                                    Everything in<br />\n"
@@ -14005,37 +14243,29 @@ msgid ""
 "                                "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:181
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:190
 msgid "Monitored Application Usage"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:182
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:191
 msgid "Additional Tech for Reminder Messages"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:183
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:40
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:192
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:47
 msgid "Training of Trainers"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:184
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:42
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:193
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:49
 msgid "Capacity to Build Applications"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:190
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:194
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:45
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:68
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:199
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:203
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:52
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:75
 msgid "See More..."
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:205
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:659
-msgid ""
-"\n"
-"                    Inquire About Dimagi's Implementation Bundles\n"
-"                    "
 msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:7
@@ -14062,7 +14292,11 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:31
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:27
+msgid "Inquire About Dimagi's Capacity Services"
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:38
 #: corehq/apps/products/forms.py:28
 #: corehq/apps/products/templates/products/manage/products.html:112
 #: corehq/apps/programs/templates/programs/manage/programs.html:62
@@ -14070,40 +14304,36 @@ msgstr ""
 msgid "Program"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:34
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:57
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:41
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:64
 msgid ""
 "\n"
 "                            $10,000 per capacity service\n"
 "                        "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:39
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:46
 msgid "Worker Performance Monitoring"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:41
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:48
 msgid "Capacity for Technical Support"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:54
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:61
 msgid "Technology"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:63
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:70
 msgid "Apps for Supportive Supervision"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:64
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:71
 msgid "App Refinement by Dimagi"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:65
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:72
 msgid "Technology for Reminder Messages"
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:81
-msgid "Inquire About Dimagi's Capacity Services"
 msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/services/faq.html:8
@@ -14120,8 +14350,8 @@ msgid ""
 "\n"
 "                        <a href=\"#contactDimagi\"\n"
 "                           data-toggle=\"modal\"\n"
-"                           class=\"btn-primary-dark\">Contact Dimagi</a> for "
-"more information.\n"
+"                           class=\"btn btn-success btn-xl\">Get in Touch "
+"With Us</a>\n"
 "                    "
 msgstr ""
 
@@ -14206,110 +14436,100 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:12
-msgid ""
-"\n"
-"                        If you have any additional questions, please\n"
-"                        <a href=\"#contactDimagi\"\n"
-"                           data-toggle=\"modal\">contact Dimagi</a> "
-"directly.\n"
-"                    "
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:50
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:52
 msgid "Cost"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:71
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:73
 msgid "Included Software Plan"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:119
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:121
 msgid "Application Development Support"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:125
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:127
 msgid ""
 "\n"
 "                                Workflow Design\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:160
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:162
 msgid ""
 "\n"
 "                                Launch &amp; Tested Application\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:195
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:197
 msgid ""
 "\n"
 "                                Additional Tech for Monitoring Outcomes\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:230
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:232
 msgid ""
 "\n"
 "                                Launched v2 application\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:265
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:267
 msgid ""
 "\n"
 "                                Supervisor Application\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:300
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:302
 msgid ""
 "\n"
 "                                Monitored app usage\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:335
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:337
 msgid ""
 "\n"
 "                                Additional Tech for Reminder Messages\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:369
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:371
 msgid "Implementation Services"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:375
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:377
 msgid ""
 "\n"
 "                                On-Site Scoping Visit\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:410
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:412
 msgid ""
 "\n"
 "                                Mobile System Workflow Design\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:445
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:447
 msgid ""
 "\n"
 "                                Field Testing &amp; Iteration\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:480
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:482
 msgid ""
 "\n"
 "                                Pilot Users Training\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:515
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:517
 msgid ""
 "\n"
 "                                Capacity Service: Worker Performance "
@@ -14317,7 +14537,7 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:550
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:552
 msgid ""
 "\n"
 "                                Capacity Service: Application "
@@ -14325,14 +14545,14 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:585
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:587
 msgid ""
 "\n"
 "                                Capacity Service: Training of Trainers\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:620
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:622
 msgid ""
 "\n"
 "                                Capacity Service: App Building\n"
@@ -14346,24 +14566,22 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:12
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:15
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:210
 msgid ""
 "\n"
-"                        If you have any additional questions, please\n"
-"                        <a href=\"#contactDimagi\"\n"
-"                           data-toggle=\"modal\">contact Dimagi</a>\n"
-"                        directly.\n"
-"                    "
+"                        Inquire About Dimagi's Capacity Services\n"
+"                        "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:24
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:25
 msgid ""
 "\n"
 "                        Program Capacity Services\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:29
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:30
 msgid ""
 "\n"
 "                        Dimagi travels on-site to build capacity, spending "
@@ -14372,22 +14590,22 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:35
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:125
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:37
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:128
 msgid ""
 "\n"
 "                        $10,000 per capacity service package.\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:44
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:46
 msgid ""
 "\n"
 "                        Worker Performance Monitoring\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:51
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:53
 msgid ""
 "\n"
 "                    Strategic implementation of standard CommCare HQ "
@@ -14396,14 +14614,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:61
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:63
 msgid ""
 "\n"
 "                        Training of Trainers\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:68
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:70
 msgid ""
 "\n"
 "                        Capacity building for organization’s trainers for "
@@ -14414,14 +14632,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:79
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:81
 msgid ""
 "\n"
 "                        Capacity for Technical Support\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:86
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:88
 msgid ""
 "\n"
 "                        Train technical staff about troubleshooting and "
@@ -14430,14 +14648,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:96
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:98
 msgid ""
 "\n"
 "                        Capacity to Build Applications\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:103
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:105
 msgid ""
 "\n"
 "                        Learn how to build your own applications,\n"
@@ -14446,14 +14664,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:114
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:116
 msgid ""
 "\n"
 "                        Technology Capacity Services\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:119
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:121
 msgid ""
 "\n"
 "                        Dimagi provides additional system refinement or new\n"
@@ -14461,14 +14679,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:134
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:137
 msgid ""
 "\n"
 "                        Technology for Outcomes Monitoring\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:141
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:144
 msgid ""
 "\n"
 "                        Create customized, offline Excel reports for 5-10\n"
@@ -14478,14 +14696,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:152
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:155
 msgid ""
 "\n"
 "                        Apps for Supportive Supervision\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:159
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:162
 msgid ""
 "\n"
 "                        Integrate a mobile application designed for field "
@@ -14496,14 +14714,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:170
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:173
 msgid ""
 "\n"
 "                        App Refinement by Dimagi\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:177
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:180
 msgid ""
 "\n"
 "                        Dimagi to make modifications to application based "
@@ -14512,14 +14730,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:187
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:190
 msgid ""
 "\n"
 "                        Technology for Reminder Messages\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:194
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:197
 msgid ""
 "\n"
 "                        Send SMS reminders directly to beneficiaries or\n"
@@ -14545,11 +14763,10 @@ msgstr ""
 #: corehq/apps/prelogin/templates/prelogin/_sections/solutions/last.html:13
 msgid ""
 "\n"
-"                        Contact us at\n"
-"                        <a class=\"btn-primary-dark\"\n"
-"                           href=\"mailto:commcare.supply@dimagi.com\">\n"
-"                            commcare.supply@dimagi.com\n"
-"                        </a>.\n"
+"                        <a href=\"#contactDimagi\"\n"
+"                           data-toggle=\"modal\"\n"
+"                           class=\"btn-success btn btn-xl\">Get in Touch "
+"With Us</a>\n"
 "                    "
 msgstr ""
 
@@ -14742,6 +14959,13 @@ msgid ""
 "                    International, including ILSGateway in Tanzania,\n"
 "                    the Early Warning System in Ghana, and cStock\n"
 "                    in Malawi.\n"
+"                    "
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/solutions/supply_intro.html:45
+msgid ""
+"\n"
+"                    Have questions or want to request a demo?\n"
 "                    "
 msgstr ""
 
@@ -16241,7 +16465,7 @@ msgstr ""
 
 #: corehq/apps/reminders/templates/reminders/partial/complex_message_table.html:30
 #: corehq/apps/reminders/templates/reminders/partial/complex_message_table.html:32
-#: custom/opm/beneficiary.py:814
+#: custom/opm/beneficiary.py:813 custom/opm/beneficiary.py:946
 msgid "Window"
 msgstr ""
 
@@ -16325,34 +16549,34 @@ msgstr ""
 msgid "CommTrack"
 msgstr "CommTrack"
 
-#: corehq/apps/reports/models.py:49
+#: corehq/apps/reports/models.py:51
 msgid "demo_user"
 msgstr ""
 
-#: corehq/apps/reports/models.py:50
+#: corehq/apps/reports/models.py:52
 msgid "admin"
 msgstr ""
 
-#: corehq/apps/reports/models.py:51
+#: corehq/apps/reports/models.py:53
 msgid "Unknown Users"
 msgstr ""
 
-#: corehq/apps/reports/models.py:381
+#: corehq/apps/reports/models.py:373
 msgid "Deleted Report"
 msgstr ""
 
-#: corehq/apps/reports/models.py:385
+#: corehq/apps/reports/models.py:377
 msgid "Unsupported Report"
 msgstr ""
 
-#: corehq/apps/reports/models.py:423
+#: corehq/apps/reports/models.py:415
 msgid ""
 "The report used to create this scheduled report is no longer available on "
 "CommCare HQ.  Please delete this scheduled report and create a new one using "
 "an available report."
 msgstr ""
 
-#: corehq/apps/reports/models.py:485
+#: corehq/apps/reports/models.py:477
 #, python-format
 msgid ""
 "We are sorry, but your saved report '%(config_name)s' is no longer "
@@ -16362,7 +16586,7 @@ msgid ""
 "%(saved_reports_url)s to remove this Emailed Report."
 msgstr ""
 
-#: corehq/apps/reports/models.py:498
+#: corehq/apps/reports/models.py:490
 #, python-format
 msgid ""
 "We are sorry, but your saved report '%(config_name)s' can not be generated "
@@ -16370,20 +16594,20 @@ msgid ""
 "Administrator about getting permissions for thisreport."
 msgstr ""
 
-#: corehq/apps/reports/models.py:509
+#: corehq/apps/reports/models.py:501
 msgid "An error occurred while generating this report."
 msgstr ""
 
-#: corehq/apps/reports/models.py:654
+#: corehq/apps/reports/models.py:649
 msgid "Every day"
 msgstr ""
 
-#: corehq/apps/reports/models.py:655
+#: corehq/apps/reports/models.py:650
 #, python-format
 msgid "Day %s of every month"
 msgstr ""
 
-#: corehq/apps/reports/models.py:699
+#: corehq/apps/reports/models.py:694
 msgid "Scheduled report from CommCare HQ"
 msgstr ""
 
@@ -16401,54 +16625,54 @@ msgstr ""
 msgid "Email report from CommCare HQ"
 msgstr ""
 
-#: corehq/apps/reports/views.py:798
+#: corehq/apps/reports/views.py:806
 msgid "Create a new"
 msgstr ""
 
-#: corehq/apps/reports/views.py:799
+#: corehq/apps/reports/views.py:807
 msgid "New Scheduled Report"
 msgstr ""
 
-#: corehq/apps/reports/views.py:802
+#: corehq/apps/reports/views.py:810
 msgid "Edit Scheduled Report"
 msgstr ""
 
-#: corehq/apps/reports/views.py:910
+#: corehq/apps/reports/views.py:918
 msgid "once off report"
 msgstr ""
 
-#: corehq/apps/reports/views.py:910
+#: corehq/apps/reports/views.py:918
 msgid "scheduled report"
 msgstr ""
 
-#: corehq/apps/reports/views.py:934
+#: corehq/apps/reports/views.py:942
 msgid ""
 "The case creation form could not be found. Usually this happens if the form "
 "that created the case is archived but there are other forms that updated the "
 "case. To fix this you can archive the other forms listed here."
 msgstr ""
 
-#: corehq/apps/reports/views.py:979
+#: corehq/apps/reports/views.py:987
 msgid "unknown"
 msgstr ""
 
-#: corehq/apps/reports/views.py:992
+#: corehq/apps/reports/views.py:1000
 msgid "You don't have permission to access this page."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1014
+#: corehq/apps/reports/views.py:1022
 #, python-format
 msgid "Case %s was rebuilt from its forms."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1026
+#: corehq/apps/reports/views.py:1034
 #, python-format
 msgid ""
 "Case %s was successfully saved. Hopefully it will show up in all reports "
 "momentarily."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1040
+#: corehq/apps/reports/views.py:1048
 #, python-brace-format
 msgid ""
 "Case {name} has been closed.\n"
@@ -16463,89 +16687,89 @@ msgid ""
 "        "
 msgstr ""
 
-#: corehq/apps/reports/views.py:1080
+#: corehq/apps/reports/views.py:1088
 msgid "case id"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1081
+#: corehq/apps/reports/views.py:1089
 msgid "case name"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1082
+#: corehq/apps/reports/views.py:1090
 msgid "section"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1083
+#: corehq/apps/reports/views.py:1091
 msgid "date"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1084
+#: corehq/apps/reports/views.py:1092
 msgid "product_id"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1085
+#: corehq/apps/reports/views.py:1093
 msgid "product_name"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1086
+#: corehq/apps/reports/views.py:1094
 msgid "transaction amount"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1087
+#: corehq/apps/reports/views.py:1095
 msgid "type"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1088
+#: corehq/apps/reports/views.py:1096
 msgid "ending balance"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1098
+#: corehq/apps/reports/views.py:1106
 msgid "unknown product"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1301
+#: corehq/apps/reports/views.py:1309
 msgid "Could not detect the application/form for this submission."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1315
+#: corehq/apps/reports/views.py:1323
 msgid "Missing app, module or form information!"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1345
+#: corehq/apps/reports/views.py:1353
 #: corehq/apps/reports/templates/reports/form/edit_submission.html:26
 msgid "Edit Submission"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1376
+#: corehq/apps/reports/views.py:1384
 msgid "Form was successfully archived."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1378
+#: corehq/apps/reports/views.py:1386
 msgid "Form was already archived."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1380
+#: corehq/apps/reports/views.py:1388
 #, python-format
 msgid "Can't archive documents of type %s. How did you get here??"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1384
+#: corehq/apps/reports/views.py:1392
 msgid "Undo"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1423
+#: corehq/apps/reports/views.py:1431
 msgid "Form was successfully restored."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1438
+#: corehq/apps/reports/views.py:1446
 msgid "Form was successfully resaved. It should reappear in reports shortly."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1484
+#: corehq/apps/reports/views.py:1492
 msgid "We don't support this format"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1486
+#: corehq/apps/reports/views.py:1494
 msgid ""
 "That report was not found. Please remember that download links expire after "
 "24 hours."
@@ -16669,7 +16893,7 @@ msgid "Stock Status by Product"
 msgstr ""
 
 #: corehq/apps/reports/commtrack/standard.py:93
-#: custom/ilsgateway/tanzania/reports/delivery.py:154
+#: custom/ilsgateway/tanzania/reports/delivery.py:157
 msgid "# Facilities"
 msgstr ""
 
@@ -16749,11 +16973,6 @@ msgstr ""
 
 #: corehq/apps/reports/commtrack/standard.py:270
 msgid "Aggregate Inventory"
-msgstr ""
-
-#: corehq/apps/reports/commtrack/standard.py:297
-#: custom/ilsgateway/tanzania/reports/facility_details.py:27
-msgid "Stock on Hand"
 msgstr ""
 
 #: corehq/apps/reports/commtrack/standard.py:298
@@ -16848,7 +17067,7 @@ msgid "Date of last report for selected period"
 msgstr ""
 
 #: corehq/apps/reports/commtrack/standard.py:420
-#: corehq/apps/reports/standard/deployments.py:253
+#: corehq/apps/reports/standard/deployments.py:282
 msgid "Never"
 msgstr ""
 
@@ -17121,15 +17340,15 @@ msgstr ""
 msgid "Opened / Closed"
 msgstr ""
 
-#: corehq/apps/reports/filters/select.py:128 custom/opm/filters.py:153
+#: corehq/apps/reports/filters/select.py:128 custom/opm/filters.py:112
 msgid "Show All"
 msgstr ""
 
-#: corehq/apps/reports/filters/select.py:133 custom/opm/filters.py:154
+#: corehq/apps/reports/filters/select.py:133 custom/opm/filters.py:113
 msgid "Only Open"
 msgstr ""
 
-#: corehq/apps/reports/filters/select.py:134 custom/opm/filters.py:155
+#: corehq/apps/reports/filters/select.py:134 custom/opm/filters.py:114
 msgid "Only Closed"
 msgstr ""
 
@@ -17250,31 +17469,44 @@ msgstr ""
 msgid "Unknown App"
 msgstr ""
 
-#: corehq/apps/reports/standard/deployments.py:163
+#: corehq/apps/reports/standard/deployments.py:165
 msgid "User Sync History"
 msgstr ""
 
-#: corehq/apps/reports/standard/deployments.py:166
-msgid "Shows the last (up to) 10 times a user has synced."
+#: corehq/apps/reports/standard/deployments.py:171
+msgid "Shows the last (up to) {} times a user has synced."
 msgstr ""
 
-#: corehq/apps/reports/standard/deployments.py:172
+#: corehq/apps/reports/standard/deployments.py:180
 msgid "Sync Date"
 msgstr ""
 
-#: corehq/apps/reports/standard/deployments.py:173
+#: corehq/apps/reports/standard/deployments.py:181
 msgid "# of Cases"
 msgstr ""
 
-#: corehq/apps/reports/standard/deployments.py:174
+#: corehq/apps/reports/standard/deployments.py:182
 msgid "Sync Duration"
 msgstr ""
 
-#: corehq/apps/reports/standard/deployments.py:177
+#: corehq/apps/reports/standard/deployments.py:185
 msgid "Sync Log"
 msgstr ""
 
-#: corehq/apps/reports/standard/deployments.py:208
+#: corehq/apps/reports/standard/deployments.py:186
+msgid "Sync Log Type"
+msgstr ""
+
+#: corehq/apps/reports/standard/deployments.py:187
+#, fuzzy
+msgid "Previous Sync Log"
+msgstr "Tela Anterior"
+
+#: corehq/apps/reports/standard/deployments.py:188
+msgid "Error Info"
+msgstr ""
+
+#: corehq/apps/reports/standard/deployments.py:219
 msgid "{} seconds"
 msgstr ""
 
@@ -17389,7 +17621,7 @@ msgstr ""
 #: corehq/apps/reports/standard/sms.py:408
 #: corehq/apps/sms/templates/sms/default.html:59
 #: corehq/ex-submodules/casexml/apps/case/templates/case/partials/single_case.html:94
-#: custom/ilsgateway/tanzania/reports/delivery.py:170
+#: custom/ilsgateway/tanzania/reports/delivery.py:173
 msgid "Received"
 msgstr ""
 
@@ -17837,7 +18069,7 @@ msgid "Follow-Up Date"
 msgstr ""
 
 #: corehq/apps/reports/standard/cases/careplan.py:113
-#: corehq/ex-submodules/casexml/apps/case/models.py:913
+#: corehq/ex-submodules/casexml/apps/case/models.py:918
 #: custom/_legacy/pact/models.py:339
 msgid "Date Modified"
 msgstr ""
@@ -17864,17 +18096,17 @@ msgid "You can email a saved version<br />of this report."
 msgstr ""
 
 #: corehq/apps/reports/templates/reports/base_template.html:67
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:125
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:129
 msgid "Favorites"
 msgstr ""
 
 #: corehq/apps/reports/templates/reports/base_template.html:72
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:130
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:134
 msgid "You don't have any favorites"
 msgstr ""
 
 #: corehq/apps/reports/templates/reports/base_template.html:91
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:149
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:153
 msgid "Email Supported"
 msgstr ""
 
@@ -18160,112 +18392,112 @@ msgid ""
 "    "
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:135
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:136
 #, python-format
 msgid ""
 "\n"
-"            Submitted by %(auth_user)s on behalf of %(user)s\n"
-"        "
+"                Submitted by %(auth_user)s on behalf of %(user)s\n"
+"            "
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:140
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:141
 #, python-format
 msgid ""
 "\n"
-"            Submitted by %(auth_user)s\n"
-"        "
+"                Submitted by %(auth_user)s\n"
+"            "
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:147
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:148
 #, python-format
 msgid ""
 "\n"
-"        Submitted as %(user)s\n"
-"        "
+"            Submitted as %(user)s\n"
+"            "
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:155
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:157
 msgid "Form Properties"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:161
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:163
 msgid "Case Changes"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:169
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:171
 msgid "Form Metadata"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:177
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:179
 #: corehq/ex-submodules/casexml/apps/case/templates/case/partials/single_case.html:30
 msgid "Attachments"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:183
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:185
 msgid "Raw XML"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:194
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:195
 msgid "View standalone form"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:200
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:201
 msgid "Edit submission"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:206
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:207
 msgid "Archiving Forms"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:207
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:208
 msgid ""
 "Archived forms will no longer show up in reports and they will be removed "
 "from any relevant case histories. "
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:211
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:212
 msgid "Archive this form"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:220
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:221
 msgid "Restoring Forms"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:221
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:222
 msgid "Restoring this form will cause it to show up in reports again."
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:225
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:226
 msgid "Restore this form"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:234
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:235
 msgid "Resaving Forms"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:235
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:236
 msgid ""
 "Resaving a form can manually cause it to be reincluded in reports if "
 "something went wrong during initial processing."
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:239
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:240
 msgid "Resave this form"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:262
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:263
 msgid "Unknown/Deleted Case"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:269
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:270
 msgid "(this case)"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:315
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:316
 msgid "Open XML in New Window"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:318
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:319
 msgid "Double-click code below to select all:"
 msgstr ""
 
@@ -18296,7 +18528,7 @@ msgid "IVR"
 msgstr ""
 
 #: corehq/apps/reports/templates/reports/messaging/survey_detail.html:23
-#: custom/ilsgateway/tanzania/reports/randr.py:173
+#: custom/ilsgateway/tanzania/reports/randr.py:175
 msgid "Contact"
 msgstr ""
 
@@ -18338,6 +18570,7 @@ msgid "No data is available. Please submit more forms!"
 msgstr ""
 
 #: corehq/apps/reports/templates/reports/partials/hqexport_group_table.html:8
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:47
 msgid "File"
 msgstr ""
 
@@ -18825,6 +19058,11 @@ msgstr ""
 msgid "My Account"
 msgstr ""
 
+#: corehq/apps/settings/views.py:93
+#: corehq/apps/settings/templates/settings/edit_my_account.b2.html:33
+msgid "My Information"
+msgstr ""
+
 #: corehq/apps/settings/views.py:174
 #, python-format
 msgid "Unable remove membership because you are the admin of %s"
@@ -18848,6 +19086,7 @@ msgid "Your password was successfully changed!"
 msgstr ""
 
 #: corehq/apps/settings/templates/settings/change_my_password.html:9
+#: docs/_build/html/_sources/translations.txt:177
 msgid "Specify New Password"
 msgstr ""
 
@@ -18863,7 +19102,7 @@ msgstr ""
 #: corehq/apps/settings/templates/settings/edit_my_account.b2.html:42
 #: corehq/apps/telerivet/forms.py:10
 #: corehq/apps/telerivet/templates/telerivet/backend.html:10
-#: corehq/apps/users/forms.py:188
+#: corehq/apps/users/forms.py:187
 msgid "API Key"
 msgstr ""
 
@@ -20609,6 +20848,10 @@ msgstr ""
 msgid "All domain/toggle statuses"
 msgstr ""
 
+#: corehq/apps/toggle_ui/templates/toggle/edit_flag.html:165
+msgid "Enabled?"
+msgstr ""
+
 #: corehq/apps/toggle_ui/templates/toggle/flags.html:57
 msgid "Tag"
 msgstr ""
@@ -20664,8 +20907,8 @@ msgid "Create New Report"
 msgstr ""
 
 #: corehq/apps/userreports/views.py:124
-#: corehq/apps/userreports/reports/builder/forms.py:768
-#: corehq/apps/userreports/reports/builder/forms.py:823
+#: corehq/apps/userreports/reports/builder/forms.py:776
+#: corehq/apps/userreports/reports/builder/forms.py:831
 msgid "Chart"
 msgstr ""
 
@@ -20705,21 +20948,21 @@ msgid ""
 "choose the columns and rows."
 msgstr ""
 
-#: corehq/apps/userreports/views.py:230
+#: corehq/apps/userreports/views.py:234
 msgid "Chart Report: {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:247
+#: corehq/apps/userreports/views.py:251
 msgid "Choose the property you would like to add as a filter to this report."
 msgstr ""
 
-#: corehq/apps/userreports/views.py:248
+#: corehq/apps/userreports/views.py:252
 msgid ""
 "Web users viewing the report will see this display text instead of the "
 "property name. Name your filter something easy for users to understand."
 msgstr ""
 
-#: corehq/apps/userreports/views.py:249
+#: corehq/apps/userreports/views.py:253
 msgid ""
 "What type of property is this filter?<br/><br/><strong>Date</strong>: select "
 "this if the property is a date.<br/><strong>Choice</strong>: select this if "
@@ -20727,71 +20970,71 @@ msgid ""
 "select this if the property is a number."
 msgstr ""
 
-#: corehq/apps/userreports/views.py:291
+#: corehq/apps/userreports/views.py:295
 msgid "List Report: {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:300
+#: corehq/apps/userreports/views.py:304
 msgid "Table Report: {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:309
+#: corehq/apps/userreports/views.py:313
 msgid "Worker Report: {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:322
+#: corehq/apps/userreports/views.py:326
 msgid "Report \"{}\" saved!"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:350
+#: corehq/apps/userreports/views.py:354
 msgid "Report \"{}\" deleted!"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:370
+#: corehq/apps/userreports/views.py:374
 msgid "Report created!"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:373
+#: corehq/apps/userreports/views.py:377
 msgid "Bad report source: {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:375
+#: corehq/apps/userreports/views.py:379
 msgid "paste report source here"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:414 corehq/apps/userreports/views.py:420
+#: corehq/apps/userreports/views.py:418 corehq/apps/userreports/views.py:424
 msgid "Data source created for '{}'"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:437
+#: corehq/apps/userreports/views.py:441
 msgid "Data source \"{}\" saved!"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:465
+#: corehq/apps/userreports/views.py:469
 msgid "Data source \"{}\" has been deleted."
 msgstr ""
 
-#: corehq/apps/userreports/views.py:475
+#: corehq/apps/userreports/views.py:479
 msgid "Table \"{}\" is now being rebuilt. Data should start showing up soon"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:514
+#: corehq/apps/userreports/views.py:518
 msgid "You can only use 'lastndays' on date columns"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:524
+#: corehq/apps/userreports/views.py:528
 msgid "Ranges must have the format \"start..end\""
 msgstr ""
 
-#: corehq/apps/userreports/views.py:556
+#: corehq/apps/userreports/views.py:560
 msgid "No field named {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:563
+#: corehq/apps/userreports/views.py:567
 msgid "Invalid filter parameter: {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:597
+#: corehq/apps/userreports/views.py:601
 msgid ""
 "There was a problem executing your query, please make sure your parameters "
 "are valid."
@@ -20888,47 +21131,47 @@ msgid ""
 "the data source before viewing the report."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:304
+#: corehq/apps/userreports/reports/builder/forms.py:305
 msgid "Bar"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:305
+#: corehq/apps/userreports/reports/builder/forms.py:306
 msgid "Pie"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:318
+#: corehq/apps/userreports/reports/builder/forms.py:319
 msgid ""
 "<strong>Form</strong>: display data from form submissions.<br/><strong>Case</"
 "strong>: display data from your cases. You must be using case management for "
 "this option."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:319
+#: corehq/apps/userreports/reports/builder/forms.py:320
 msgid "Which application should the data come from?"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:320
+#: corehq/apps/userreports/reports/builder/forms.py:321
 msgid ""
 "Choose the case type or form from which to retrieve data for this report."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:332
+#: corehq/apps/userreports/reports/builder/forms.py:333
 msgid ""
 "<strong>Bar</strong> shows one vertical bar for each value in your case or "
 "form. <strong>Pie</strong> shows what percentage of the total each value is."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:345
+#: corehq/apps/userreports/reports/builder/forms.py:346
 msgid "{} Report"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:346
+#: corehq/apps/userreports/reports/builder/forms.py:347
 msgid ""
 "Web users will see this name in the \"Reports\" section of CommCareHQ and "
 "can click to view the report"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:388
+#: corehq/apps/userreports/reports/builder/forms.py:389
 msgid ""
 "Too many data sources!\n"
 "Creating this report would cause you to go over the maximum number of data "
@@ -20937,63 +21180,69 @@ msgid ""
 "itself) and try again. "
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:405
+#: corehq/apps/userreports/reports/builder/forms.py:406
 #: custom/bihar/reports/indicators/clientlistdisplay.py:146
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:345
 msgid "Done"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:417
+#: corehq/apps/userreports/reports/builder/forms.py:418
 msgid "Update Report"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:474
-#: corehq/apps/userreports/templates/userreports/edit_report_config.html:8
+#: corehq/apps/userreports/reports/builder/forms.py:475
+#: corehq/apps/userreports/templates/userreports/edit_report_config.html:18
 msgid "Delete Report"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:518
+#: corehq/apps/userreports/reports/builder/forms.py:500
+msgid ""
+"Report builder data source doesn't reference an application. It is likely "
+"this report has been customized and it is no longer editable. "
+msgstr ""
+
+#: corehq/apps/userreports/reports/builder/forms.py:526
 msgid "Filters"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:519
+#: corehq/apps/userreports/reports/builder/forms.py:527
 msgid ""
 "Add filters to your report to allow viewers to select which data the report "
 "will display. These filters will be displayed at the top of your report."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:573
+#: corehq/apps/userreports/reports/builder/forms.py:581
 msgid ""
 "Editing this report would require a new data source. The limit is 5. To "
 "continue, first delete all of the reports using a particular data source (or "
 "the data source itself) and try again. "
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:769
+#: corehq/apps/userreports/reports/builder/forms.py:777
 msgid ""
 "The values of the selected property will be aggregated and shown as bars in "
 "the chart."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:824
+#: corehq/apps/userreports/reports/builder/forms.py:832
 msgid ""
 "The values of the selected property will be aggregated and shows as the "
 "sections of the pie chart."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:841
+#: corehq/apps/userreports/reports/builder/forms.py:849
 msgid ""
 "Add columns to your report to display information from cases or form "
 "submissions. You may rearrange the order of the columns by dragging the "
 "arrows next to the column."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:854
+#: corehq/apps/userreports/reports/builder/forms.py:862
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:179
 msgid "Columns"
 msgstr "Colunas"
 
-#: corehq/apps/userreports/reports/builder/forms.py:898
+#: corehq/apps/userreports/reports/builder/forms.py:906
 msgid ""
 "Add columns for this report to aggregate. Each property you add will create "
 "a column for every value of that property.  For example, if you add a column "
@@ -21001,23 +21250,37 @@ msgid ""
 "column for \"no.\""
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:907
+#: corehq/apps/userreports/reports/builder/forms.py:915
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:13
 msgid "Rows"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:908
+#: corehq/apps/userreports/reports/builder/forms.py:916
 msgid ""
 "Choose which property this report will group its results by. Each value of "
 "this property will be a row in the table. For example, if you choose a yes "
 "or no question, the report will show a row for \"yes\" and a row for \"no.\""
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:971
+#: corehq/apps/userreports/reports/builder/forms.py:979
 msgid ""
 "Add columns for this report to aggregate. Each property you add will create "
 "a column for every value of that property. For example, if you add a column "
 "for a yes or no question, the report will show a column for \"yes\" and a "
 "column for \"no\"."
+msgstr ""
+
+#: corehq/apps/userreports/sql/columns.py:60
+#, python-brace-format
+msgid ""
+"The \"{header}\" column had too many values to expand! Expansion limited to "
+"{max} distinct values."
+msgstr ""
+
+#: corehq/apps/userreports/sql/columns.py:94
+msgid ""
+"The column \"{}\" does not exist in the report source! Please double check "
+"your report configuration."
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/builder_report_type_select.html:37
@@ -21042,54 +21305,62 @@ msgid ""
 "        "
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:108
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:105
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:111
+#: corehq/apps/userreports/templates/userreports/edit_report_config.html:7
 msgid "Edit Report"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/configurable_reports_home.html:4
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:44
 msgid "Configurable Reports"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/configurable_reports_home.html:5
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:32
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:82
 msgid "Add data source"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/configurable_reports_home.html:6
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:16
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:64
 msgid "Add report"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/configurable_reports_home.html:7
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:20
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:68
 msgid "Import report"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/edit_data_source.html:7
+#, fuzzy
+msgid "Edit Data Source"
+msgstr "Editar Dados"
+
+#: corehq/apps/userreports/templates/userreports/edit_data_source.html:18
 msgid "This datasource is read only, any changes made can not be saved."
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/edit_data_source.html:14
+#: corehq/apps/userreports/templates/userreports/edit_data_source.html:25
 msgid "Delete Data Source"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/edit_data_source.html:18
+#: corehq/apps/userreports/templates/userreports/edit_data_source.html:29
 msgid "Rebuild Data Source"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/edit_data_source.html:19
+#: corehq/apps/userreports/templates/userreports/edit_data_source.html:30
 msgid "Preview data"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/edit_data_source.html:20
+#: corehq/apps/userreports/templates/userreports/edit_data_source.html:31
 msgid "Data Source Source (Advanced)"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/edit_report_config.html:9
+#: corehq/apps/userreports/templates/userreports/edit_report_config.html:19
 msgid "View report"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/edit_report_config.html:10
+#: corehq/apps/userreports/templates/userreports/edit_report_config.html:20
 msgid "Report Source (Advanced)"
 msgstr ""
 
@@ -21106,16 +21377,16 @@ msgstr ""
 msgid "Preview table: %(display_name)s (%(total_rows)s total rows)"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:7
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:53
 #: corehq/apps/users/templates/users/web_users.b3.html:390
 msgid "Edit Reports"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:23
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:71
 msgid "Edit Data Sources"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:38
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:88
 msgid "Data source from application"
 msgstr ""
 
@@ -21140,7 +21411,7 @@ msgid "Expected {} but was {}"
 msgstr ""
 
 #: corehq/apps/userreports/ui/forms.py:25
-#: corehq/apps/userreports/ui/forms.py:149
+#: corehq/apps/userreports/ui/forms.py:159
 msgid "Save Changes"
 msgstr ""
 
@@ -21160,23 +21431,81 @@ msgstr ""
 msgid "Problem with report spec: {}"
 msgstr ""
 
-#: corehq/apps/userreports/ui/forms.py:95
+#: corehq/apps/userreports/ui/forms.py:91
+#, fuzzy
+msgid "Source Type"
+msgstr "Típo de Caso"
+
+#: corehq/apps/userreports/ui/forms.py:92
+#, fuzzy
+msgid "Report Title"
+msgstr "Tipo de dados"
+
+#: corehq/apps/userreports/ui/forms.py:103
 msgid "Named filters (optional)"
 msgstr ""
 
-#: corehq/apps/userreports/ui/forms.py:106
+#: corehq/apps/userreports/ui/forms.py:116
 msgid ""
 "Table id is too long. Your table id and domain name must add up to fewer "
 "than 40 characters"
 msgstr ""
 
-#: corehq/apps/userreports/ui/forms.py:111
+#: corehq/apps/userreports/ui/forms.py:121
 msgid ""
 "A data source with this table id already exists. Table ids must be unique"
 msgstr ""
 
-#: corehq/apps/userreports/ui/forms.py:128
+#: corehq/apps/userreports/ui/forms.py:138
 msgid "Problem with data source spec: {}"
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:4
+msgid ""
+"Choose something short, unique, and memorable using lowercase letters, "
+"numbers, and underscores"
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:7
+msgid ""
+"This is what the data source will be called in navigation, page title, etc."
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:9
+msgid "Write yourself a little note if you like, it's optional"
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:11
+msgid ""
+"You can leave this blank unless you are <a target=\"_blank\" href=\"https://"
+"github.com/dimagi/commcare-hq/blob/master/corehq/apps/userreports/README."
+"md#saving-repeat-data\">saving repeat data</a>"
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:16
+msgid ""
+"Look at <a target=\"_blank\" href=\"https://github.com/dimagi/commcare-hq/"
+"blob/master/corehq/apps/userreports/examples/examples.md#data-source-filters"
+"\">these examples</a> and <a target=\"_blank\" href=\"https://github.com/"
+"dimagi/commcare-hq/blob/master/corehq/apps/userreports/README.md#data-source-"
+"filtering\">these docs</a>"
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:24
+msgid ""
+"Look at <a target=\"_blank\" href=\"https://github.com/dimagi/commcare-hq/"
+"blob/master/corehq/apps/userreports/examples/examples.md#data-source-"
+"indicators\">these examples</a> and <a target=\"_blank\" href=\"https://"
+"github.com/dimagi/commcare-hq/blob/master/corehq/apps/userreports/README."
+"md#indicators\">these docs</a>"
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:32
+msgid ""
+"For this advanced and useful feature, give a dict where the keys are the "
+"variable names you choose and the values are filters according to the syntax "
+"of Configured Filters above. You can then reference these from Configured "
+"Filters as {\"type\": \"named\", \"name\": \"myvarname\"}"
 msgstr ""
 
 #: corehq/apps/users/bulkupload.py:52
@@ -21231,77 +21560,77 @@ msgstr ""
 msgid "Can't add to group '%s' (try adding it to your spreadsheet)"
 msgstr ""
 
-#: corehq/apps/users/forms.py:59
+#: corehq/apps/users/forms.py:58
 msgid "Please enter a valid two or three digit language code."
 msgstr ""
 
-#: corehq/apps/users/forms.py:132
+#: corehq/apps/users/forms.py:131
 msgid "System Super User"
 msgstr ""
 
-#: corehq/apps/users/forms.py:147
+#: corehq/apps/users/forms.py:146
 msgid "E-Mail"
 msgstr ""
 
-#: corehq/apps/users/forms.py:154
+#: corehq/apps/users/forms.py:153
 msgid ""
 "<i class=\"icon-info-sign\"></i> Becomes default language seen in CloudCare "
 "and reports (if applicable), but does not affect mobile applications. "
 "Supported languages for reports are en, fr (partial), and hin (partial)."
 msgstr ""
 
-#: corehq/apps/users/forms.py:171
+#: corehq/apps/users/forms.py:170
 msgid "Opt out of emails about CommCare updates."
 msgstr ""
 
-#: corehq/apps/users/forms.py:191
+#: corehq/apps/users/forms.py:190
 msgid "Generate API Key"
 msgstr ""
 
-#: corehq/apps/users/forms.py:199
+#: corehq/apps/users/forms.py:198
 msgid "My Language"
 msgstr ""
 
-#: corehq/apps/users/forms.py:219
+#: corehq/apps/users/forms.py:218
 msgid "Other Options"
 msgstr ""
 
-#: corehq/apps/users/forms.py:225
+#: corehq/apps/users/forms.py:224
 msgid "Update My Information"
 msgstr ""
 
-#: corehq/apps/users/forms.py:240
+#: corehq/apps/users/forms.py:239
 msgid ""
 "Multiply this user's case load by a number for load testing on phones. Leave "
 "blank for normal users."
 msgstr ""
 
-#: corehq/apps/users/forms.py:324
+#: corehq/apps/users/forms.py:323
 #, python-format
 msgid "%s is an invalid phone number."
 msgstr ""
 
-#: corehq/apps/users/forms.py:371 corehq/apps/users/forms.py:373
+#: corehq/apps/users/forms.py:370 corehq/apps/users/forms.py:372
 msgid "Username contains invalid characters."
 msgstr ""
 
-#: corehq/apps/users/forms.py:480
+#: corehq/apps/users/forms.py:479
 #, python-format
 msgid ""
 "I have read and agree to the <a href=\"%(pa_url)s\" target=\"_blank"
 "\">Software Product Subscription Agreement</a>."
 msgstr ""
 
-#: corehq/apps/users/forms.py:509
+#: corehq/apps/users/forms.py:508
 msgid "Back to Mobile Workers List"
 msgstr ""
 
-#: corehq/apps/users/forms.py:521
+#: corehq/apps/users/forms.py:520
 msgid ""
 "Please agree to the Product Subscription Agreement above before continuing."
 msgstr ""
 
-#: corehq/apps/users/models.py:2426
+#: corehq/apps/users/models.py:2446
 #, python-format
 msgid "Invitation from %s to join CommCareHQ"
 msgstr ""
@@ -21854,8 +22183,8 @@ msgstr ""
 
 #: corehq/apps/users/templates/users/mobile/users_list.html:212
 #: custom/_legacy/pact/templates/pact/chw/pact_chw_profile_info.html:12
-#: custom/ilsgateway/tanzania/reports/facility_details.py:72
-#: custom/ilsgateway/tanzania/reports/facility_details.py:119
+#: custom/ilsgateway/tanzania/reports/facility_details.py:73
+#: custom/ilsgateway/tanzania/reports/facility_details.py:120
 msgid "Phone"
 msgstr ""
 
@@ -21990,57 +22319,53 @@ msgstr ""
 msgid "Edit User Role"
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:291
+#: corehq/apps/users/views/__init__.py:289
 #, python-format
 msgid "Changed system permissions for user \"%s\""
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:340
+#: corehq/apps/users/views/__init__.py:338
 msgid "Phone number added!"
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:342
+#: corehq/apps/users/views/__init__.py:340
 msgid "Please enter digits only."
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:349
-msgid "Edit My Information"
-msgstr ""
-
-#: corehq/apps/users/views/__init__.py:388
-#: corehq/apps/users/views/__init__.py:534
+#: corehq/apps/users/views/__init__.py:346
+#: corehq/apps/users/views/__init__.py:492
 msgid "Web Users & Roles"
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:435
+#: corehq/apps/users/views/__init__.py:393
 msgid "Please provide pagination info."
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:736
+#: corehq/apps/users/views/__init__.py:694
 msgid "Invitation resent"
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:738
+#: corehq/apps/users/views/__init__.py:696
 msgid "Error while attempting resend"
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:768
+#: corehq/apps/users/views/__init__.py:726
 msgid "Invite Web User to Project"
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:866
+#: corehq/apps/users/views/__init__.py:818
 msgid "Cannot start verification workflow. Phone number is already in use."
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:868
+#: corehq/apps/users/views/__init__.py:820
 msgid "Phone number is already verified."
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:870
+#: corehq/apps/users/views/__init__.py:822
 msgid "Verification message resent."
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:872
+#: corehq/apps/users/views/__init__.py:824
 msgid "Verification workflow started."
 msgstr ""
 
@@ -22172,36 +22497,36 @@ msgid ""
 "The following groups have no name. Please name them before continuing: {}"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:228
+#: corehq/ex-submodules/casexml/apps/case/models.py:229
 msgid "Closed"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:228
+#: corehq/ex-submodules/casexml/apps/case/models.py:229
 msgid "Open"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:515
+#: corehq/ex-submodules/casexml/apps/case/models.py:516
 msgid "Sorry, referrals are no longer supported!"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:857
+#: corehq/ex-submodules/casexml/apps/case/models.py:862
 msgid "Opened On"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:863
+#: corehq/ex-submodules/casexml/apps/case/models.py:868
 msgid "Modified On"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:869
-#: custom/opm/beneficiary.py:824 custom/opm/beneficiary.py:901
+#: corehq/ex-submodules/casexml/apps/case/models.py:874
+#: custom/opm/beneficiary.py:823 custom/opm/beneficiary.py:901
 msgid "Closed On"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:882
+#: corehq/ex-submodules/casexml/apps/case/models.py:887
 msgid "Last Submitter"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:907
+#: corehq/ex-submodules/casexml/apps/case/models.py:912
 msgid "Date Opened"
 msgstr ""
 
@@ -22860,8 +23185,8 @@ msgstr ""
 msgid "Beneficiary Information"
 msgstr ""
 
-#: custom/bihar/reports/mch_reports.py:134 custom/opm/beneficiary.py:809
-#: custom/opm/beneficiary.py:885
+#: custom/bihar/reports/mch_reports.py:134 custom/opm/beneficiary.py:808
+#: custom/opm/beneficiary.py:885 custom/opm/beneficiary.py:930
 msgid "Husband Name"
 msgstr ""
 
@@ -22938,6 +23263,7 @@ msgstr ""
 #: custom/bihar/reports/mch_reports.py:151
 #: custom/bihar/reports/indicators/clientlistdisplay.py:80
 #: custom/bihar/reports/indicators/clientlistdisplay.py:98
+#: custom/opm/beneficiary.py:944
 msgid "EDD"
 msgstr ""
 
@@ -23138,7 +23464,7 @@ msgstr ""
 msgid "Migrate status "
 msgstr ""
 
-#: custom/bihar/reports/mch_reports.py:314 custom/opm/beneficiary.py:812
+#: custom/bihar/reports/mch_reports.py:314 custom/opm/beneficiary.py:811
 msgid "Child Name"
 msgstr ""
 
@@ -24193,43 +24519,43 @@ msgstr ""
 msgid "Dashboard report {0}"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:28
-#: custom/ilsgateway/tanzania/reports/delivery.py:86
+#: custom/ilsgateway/tanzania/reports/delivery.py:29
+#: custom/ilsgateway/tanzania/reports/delivery.py:88
 msgid "Average Lead Time In Days"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:82
-#: custom/ilsgateway/tanzania/reports/randr.py:171
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:251
+#: custom/ilsgateway/tanzania/reports/delivery.py:84
+#: custom/ilsgateway/tanzania/reports/randr.py:173
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:318
 msgid "Facility Name"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:83
+#: custom/ilsgateway/tanzania/reports/delivery.py:85
 msgid "Delivery Status"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:84
+#: custom/ilsgateway/tanzania/reports/delivery.py:86
 msgid "Delivery Date"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:85
+#: custom/ilsgateway/tanzania/reports/delivery.py:87
 msgid "This Cycle Lead Time"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:155
+#: custom/ilsgateway/tanzania/reports/delivery.py:158
 #, python-format
 msgid "% of total"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:167
+#: custom/ilsgateway/tanzania/reports/delivery.py:170
 msgid "Didn't Respond"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:169
+#: custom/ilsgateway/tanzania/reports/delivery.py:172
 msgid "Not Received"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:182
+#: custom/ilsgateway/tanzania/reports/delivery.py:185
 #, python-brace-format
 msgid "Delivery Report {0}"
 msgstr ""
@@ -24238,106 +24564,106 @@ msgstr ""
 msgid "Months of stock"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/facility_details.py:120
+#: custom/ilsgateway/tanzania/reports/facility_details.py:121
 msgid "Text"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:83
+#: custom/ilsgateway/tanzania/reports/randr.py:84
 msgid "% Facilities Submitting R&R On Time"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:84
+#: custom/ilsgateway/tanzania/reports/randr.py:85
 msgid "% Facilities Submitting R&R Late"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:85
+#: custom/ilsgateway/tanzania/reports/randr.py:86
 msgid "% Facilities With R&R Not Submitted"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:86
+#: custom/ilsgateway/tanzania/reports/randr.py:87
 msgid "% Facilities Not Responding To R&R Reminder"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:87
-#: custom/ilsgateway/tanzania/reports/randr.py:174
-#: custom/ilsgateway/tanzania/reports/supervision.py:60
-#: custom/ilsgateway/tanzania/reports/supervision.py:123
+#: custom/ilsgateway/tanzania/reports/randr.py:88
+#: custom/ilsgateway/tanzania/reports/randr.py:176
+#: custom/ilsgateway/tanzania/reports/supervision.py:61
+#: custom/ilsgateway/tanzania/reports/supervision.py:125
 msgid "Historical Response Rate"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:172
+#: custom/ilsgateway/tanzania/reports/randr.py:174
 msgid "R&R Status"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:185
+#: custom/ilsgateway/tanzania/reports/randr.py:187
 #, python-brace-format
 msgid "R & R {0}"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:82
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:84
 msgid "% Facilities Submitting Soh On Time"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:83
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:85
 msgid "% Facilities Submitting Soh Late"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:84
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:86
 msgid "% Facilities Not Responding To Soh"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:85
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:87
 msgid "% Facilities With 1 Or More Stockouts This Month"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:97
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:99
 #, python-format
 msgid "%s stock outs this %s"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:203
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:269
 msgid "Waiting for reply"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:250
-#: custom/ilsgateway/tanzania/reports/supervision.py:119
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:317
+#: custom/ilsgateway/tanzania/reports/supervision.py:121
 msgid "MSD Code"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:252
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:319
 msgid "DG"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:253
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:320
 msgid "Last Reported"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:254
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:321
 msgid "Hist. Resp. Rate"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:406
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:422
 #, python-brace-format
 msgid "Stock On Hand {0}"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/supervision.py:57
+#: custom/ilsgateway/tanzania/reports/supervision.py:58
 msgid "% Supervision Received"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/supervision.py:58
+#: custom/ilsgateway/tanzania/reports/supervision.py:59
 msgid "% Supervision Not Received"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/supervision.py:59
+#: custom/ilsgateway/tanzania/reports/supervision.py:60
 msgid "% Supervision Not Responding"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/supervision.py:121
+#: custom/ilsgateway/tanzania/reports/supervision.py:123
 msgid "Supervision This Quarter"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/supervision.py:181
+#: custom/ilsgateway/tanzania/reports/supervision.py:183
 #, python-brace-format
 msgid "Supervision {0}"
 msgstr ""
@@ -24346,7 +24672,7 @@ msgstr ""
 msgid "Unrecognized SMS"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/utils.py:98
+#: custom/ilsgateway/tanzania/reports/utils.py:100
 msgid "No Data"
 msgstr ""
 
@@ -24427,16 +24753,16 @@ msgstr ""
 msgid " days"
 msgstr ""
 
-#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:55
+#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:65
 #, python-format
 msgid "%(status)s"
 msgstr ""
 
-#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:58
+#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:68
 msgid "Last updated on"
 msgstr ""
 
-#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:63
+#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:73
 msgid "No delivery status reported"
 msgstr ""
 
@@ -25510,108 +25836,112 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: custom/opm/beneficiary.py:742
+#: custom/opm/beneficiary.py:741
 msgid "Incorrect EDD"
 msgstr ""
 
-#: custom/opm/beneficiary.py:748
+#: custom/opm/beneficiary.py:747
 msgid "Incorrect DOD"
 msgstr ""
 
-#: custom/opm/beneficiary.py:753
+#: custom/opm/beneficiary.py:752
 msgid "Incorrect LMP date"
 msgstr ""
 
-#: custom/opm/beneficiary.py:758
+#: custom/opm/beneficiary.py:757
 msgid "Account number is the wrong length"
 msgstr ""
 
-#: custom/opm/beneficiary.py:763
+#: custom/opm/beneficiary.py:762
 msgid "IFSC {} incorrect"
 msgstr ""
 
-#: custom/opm/beneficiary.py:804
+#: custom/opm/beneficiary.py:803 custom/opm/beneficiary.py:919
 msgid "Serial number"
 msgstr ""
 
-#: custom/opm/beneficiary.py:805 custom/opm/beneficiary.py:884
+#: custom/opm/beneficiary.py:804 custom/opm/beneficiary.py:884
+#: custom/opm/beneficiary.py:920
 msgid "List of Beneficiaries"
 msgstr ""
 
-#: custom/opm/beneficiary.py:806 custom/opm/beneficiary.py:886
-#: custom/opm/health_status.py:89
+#: custom/opm/beneficiary.py:805 custom/opm/beneficiary.py:886
+#: custom/opm/beneficiary.py:922 custom/opm/health_status.py:18
 msgid "AWC Name"
 msgstr ""
 
-#: custom/opm/beneficiary.py:807 custom/opm/health_status.py:85
+#: custom/opm/beneficiary.py:806 custom/opm/beneficiary.py:923
+#: custom/opm/health_status.py:14
 msgid "AWC Code"
 msgstr ""
 
-#: custom/opm/beneficiary.py:808 custom/opm/beneficiary.py:891
+#: custom/opm/beneficiary.py:807 custom/opm/beneficiary.py:891
+#: custom/opm/beneficiary.py:924
 msgid "Block Name"
 msgstr ""
 
-#: custom/opm/beneficiary.py:810
+#: custom/opm/beneficiary.py:809 custom/opm/beneficiary.py:942
 msgid "Current status"
 msgstr ""
 
-#: custom/opm/beneficiary.py:811
+#: custom/opm/beneficiary.py:810
 msgid "Pregnancy Month"
 msgstr ""
 
-#: custom/opm/beneficiary.py:813
+#: custom/opm/beneficiary.py:812
 msgid "Child Age"
 msgstr ""
 
-#: custom/opm/beneficiary.py:815
+#: custom/opm/beneficiary.py:814
 msgid "Condition 1"
 msgstr ""
 
-#: custom/opm/beneficiary.py:816
+#: custom/opm/beneficiary.py:815
 msgid "Condition 2"
 msgstr ""
 
-#: custom/opm/beneficiary.py:817
+#: custom/opm/beneficiary.py:816
 msgid "Condition 3"
 msgstr ""
 
-#: custom/opm/beneficiary.py:818
+#: custom/opm/beneficiary.py:817
 msgid "Condition 4"
 msgstr ""
 
-#: custom/opm/beneficiary.py:819
+#: custom/opm/beneficiary.py:818
 msgid "Condition 5"
 msgstr ""
 
-#: custom/opm/beneficiary.py:820
+#: custom/opm/beneficiary.py:819
 msgid "Payment amount this month (Rs.)"
 msgstr ""
 
-#: custom/opm/beneficiary.py:821
+#: custom/opm/beneficiary.py:820
 msgid "Payment amount last month (Rs.)"
 msgstr ""
 
-#: custom/opm/beneficiary.py:822
+#: custom/opm/beneficiary.py:821 custom/opm/beneficiary.py:973
 msgid "Cash received last month"
 msgstr ""
 
-#: custom/opm/beneficiary.py:825 custom/opm/beneficiary.py:904
+#: custom/opm/beneficiary.py:824 custom/opm/beneficiary.py:904
+#: custom/opm/beneficiary.py:974
 msgid "Issues"
 msgstr ""
 
-#: custom/opm/beneficiary.py:887
+#: custom/opm/beneficiary.py:887 custom/opm/beneficiary.py:937
 msgid "Bank Name"
 msgstr ""
 
-#: custom/opm/beneficiary.py:888
+#: custom/opm/beneficiary.py:888 custom/opm/beneficiary.py:939
 msgid "Bank Branch Name"
 msgstr ""
 
-#: custom/opm/beneficiary.py:889
+#: custom/opm/beneficiary.py:889 custom/opm/beneficiary.py:941
 msgid "IFS Code"
 msgstr ""
 
-#: custom/opm/beneficiary.py:890
+#: custom/opm/beneficiary.py:890 custom/opm/beneficiary.py:938
 msgid "Bank Account Number"
 msgstr ""
 
@@ -25655,441 +25985,645 @@ msgstr ""
 msgid "Payment last month"
 msgstr ""
 
-#: custom/opm/filters.py:113 custom/opm/filters.py:126
+#: custom/opm/beneficiary.py:925
+msgid "Gram Panchayat name"
+msgstr ""
+
+#: custom/opm/beneficiary.py:926
+#, fuzzy
+msgid "Village name"
+msgstr "Nome da tabela "
+
+#: custom/opm/beneficiary.py:927
+msgid "Dob Known"
+msgstr ""
+
+#: custom/opm/beneficiary.py:928
+#, fuzzy
+msgid "Mother's Age"
+msgstr "Outros (negativos / indeterminados) "
+
+#: custom/opm/beneficiary.py:929
+#, fuzzy
+msgid "Caste tribe status"
+msgstr "O estado do paciente"
+
+#: custom/opm/beneficiary.py:931
+msgid "Prev pregnancies"
+msgstr ""
+
+#: custom/opm/beneficiary.py:932
+msgid "Prev live births"
+msgstr ""
+
+#: custom/opm/beneficiary.py:933
+msgid "Sons alive"
+msgstr ""
+
+#: custom/opm/beneficiary.py:934
+msgid "Daughters alive"
+msgstr ""
+
+#: custom/opm/beneficiary.py:935
+msgid "Sum children"
+msgstr ""
+
+#: custom/opm/beneficiary.py:936
+#, fuzzy
+msgid "Contact phone number"
+msgstr "Número de telefone:"
+
+#: custom/opm/beneficiary.py:940
+msgid "Bank Branch Code"
+msgstr ""
+
+#: custom/opm/beneficiary.py:943
+#, fuzzy
+msgid "Lmp Date"
+msgstr "Data do termino"
+
+#: custom/opm/beneficiary.py:945
+msgid "Pregnancy month"
+msgstr ""
+
+#: custom/opm/beneficiary.py:947
+msgid "Child 1 Age"
+msgstr ""
+
+#: custom/opm/beneficiary.py:948
+msgid "Child 1 Name"
+msgstr ""
+
+#: custom/opm/beneficiary.py:949
+msgid "Child 1 Sex"
+msgstr ""
+
+#: custom/opm/beneficiary.py:950
+msgid "Child DOB"
+msgstr ""
+
+#: custom/opm/beneficiary.py:951
+msgid "Child 2 Age"
+msgstr ""
+
+#: custom/opm/beneficiary.py:952
+msgid "Child 2 Name"
+msgstr ""
+
+#: custom/opm/beneficiary.py:953
+msgid "Child 2 Sex"
+msgstr ""
+
+#: custom/opm/beneficiary.py:954
+msgid "Child 3 Age"
+msgstr ""
+
+#: custom/opm/beneficiary.py:955
+msgid "Child 3 Name"
+msgstr ""
+
+#: custom/opm/beneficiary.py:956
+msgid "Child 3 Sex"
+msgstr ""
+
+#: custom/opm/beneficiary.py:957
+msgid "Condition 1 / pregnant woman attended VHND"
+msgstr ""
+
+#: custom/opm/beneficiary.py:958
+msgid "Condition 2 /pregnant woman's weight taken in first trimester"
+msgstr ""
+
+#: custom/opm/beneficiary.py:959
+msgid "Condition 3/ Received 30 IFA pills"
+msgstr ""
+
+#: custom/opm/beneficiary.py:960
+msgid "Condition 2 /pregnant woman's weight taken in second trimester"
+msgstr ""
+
+#: custom/opm/beneficiary.py:961
+msgid "Condition 4/mother attended VHND with child"
+msgstr ""
+
+#: custom/opm/beneficiary.py:962
+msgid "Condition 5/child birth registered"
+msgstr ""
+
+#: custom/opm/beneficiary.py:963
+msgid "Condition 6/ child birth weight taken"
+msgstr ""
+
+#: custom/opm/beneficiary.py:964
+msgid "Condition 7 /exclusively breastfed for first 6 months"
+msgstr ""
+
+#: custom/opm/beneficiary.py:965
+msgid "Condition 8 /child weight monitored this month"
+msgstr ""
+
+#: custom/opm/beneficiary.py:966
+msgid "Condition 9 /ORS administered if child had diarrhea"
+msgstr ""
+
+#: custom/opm/beneficiary.py:967
+msgid "Condition 10/ Measles vaccine given before child turns 1"
+msgstr ""
+
+#: custom/opm/beneficiary.py:968
+msgid "Birth Spacing Bonus"
+msgstr ""
+
+#: custom/opm/beneficiary.py:969
+msgid "Weight This Month"
+msgstr ""
+
+#: custom/opm/beneficiary.py:970
+msgid "Nutritional Status This Month"
+msgstr ""
+
+#: custom/opm/beneficiary.py:971
+#, fuzzy
+msgid "Nutritional Status Bonus"
+msgstr "Estado Experimental"
+
+#: custom/opm/beneficiary.py:972
+msgid "Payment amount for the month"
+msgstr ""
+
+#: custom/opm/beneficiary.py:975
+msgid "VHND held this month?"
+msgstr ""
+
+#: custom/opm/beneficiary.py:976
+#, fuzzy
+msgid "Opened on"
+msgstr "Forma aberta"
+
+#: custom/opm/beneficiary.py:977
+#, fuzzy
+msgid "Closed on"
+msgstr "Casos IRA Tratados"
+
+#: custom/opm/beneficiary.py:978
+msgid "Close mother dup"
+msgstr ""
+
+#: custom/opm/beneficiary.py:979
+msgid "Close mother mo"
+msgstr ""
+
+#: custom/opm/beneficiary.py:980
+msgid "Leave program"
+msgstr ""
+
+#: custom/opm/beneficiary.py:981
+msgid "Close mother dead"
+msgstr ""
+
+#: custom/opm/beneficiary.py:982
+msgid "Calendar year"
+msgstr ""
+
+#: custom/opm/beneficiary.py:983
+msgid "Calendar month"
+msgstr ""
+
+#: custom/opm/filters.py:72 custom/opm/filters.py:85
 #: custom/up_nrhm/filters.py:37
 msgid "Hierarchy"
 msgstr ""
 
-#: custom/opm/health_status.py:93
+#: custom/opm/health_status.py:22
 msgid "Gram Panchayat"
 msgstr ""
 
-#: custom/opm/health_status.py:97
+#: custom/opm/health_status.py:26
 msgid "Registered Beneficiaries"
 msgstr ""
 
-#: custom/opm/health_status.py:98
+#: custom/opm/health_status.py:27
 msgid "Beneficiaries registered with BCSP"
 msgstr ""
 
-#: custom/opm/health_status.py:101
+#: custom/opm/health_status.py:30
 msgid "Registered pregnant women"
 msgstr ""
 
-#: custom/opm/health_status.py:102
+#: custom/opm/health_status.py:31
 msgid "Pregnant women registered with BCSP"
 msgstr ""
 
-#: custom/opm/health_status.py:105
+#: custom/opm/health_status.py:34
 msgid "Registered mothers"
 msgstr ""
 
-#: custom/opm/health_status.py:106
+#: custom/opm/health_status.py:35
 msgid "Mothers registered with BCSP"
 msgstr ""
 
-#: custom/opm/health_status.py:109
+#: custom/opm/health_status.py:38
 msgid "Registered children"
 msgstr ""
 
-#: custom/opm/health_status.py:110
+#: custom/opm/health_status.py:39
 msgid "Children below 3 years of age registered with BCSP"
 msgstr ""
 
-#: custom/opm/health_status.py:113
+#: custom/opm/health_status.py:42
 msgid "Eligible for payment upon fulfillment of cash conditions"
 msgstr ""
 
-#: custom/opm/health_status.py:114
+#: custom/opm/health_status.py:43
 msgid ""
 "Registered beneficiaries eligilble for cash payment for the month upon "
 "fulfillment of cash conditions"
 msgstr ""
 
-#: custom/opm/health_status.py:118
+#: custom/opm/health_status.py:47
 msgid "Eligible for payment upon absence of services"
 msgstr ""
 
-#: custom/opm/health_status.py:119
+#: custom/opm/health_status.py:48
 msgid ""
 "Registered beneficiaries eligilble for cash payment for the month upon "
 "absence of services at VHND"
 msgstr ""
 
-#: custom/opm/health_status.py:122
+#: custom/opm/health_status.py:51
 msgid "Eligible for payment"
 msgstr ""
 
-#: custom/opm/health_status.py:123
+#: custom/opm/health_status.py:52
 msgid "Registered beneficiaries eligilble for cash payment for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:126
+#: custom/opm/health_status.py:55
 msgid "Total cash payment"
 msgstr ""
 
-#: custom/opm/health_status.py:127
+#: custom/opm/health_status.py:56
 msgid "Total cash payment made to registered beneficiaries for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:130
+#: custom/opm/health_status.py:59
 msgid "Pregnant women attended VHND"
 msgstr ""
 
-#: custom/opm/health_status.py:131
+#: custom/opm/health_status.py:60
 msgid "Registered pregnant women who attended VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:134
+#: custom/opm/health_status.py:63
 msgid "Children attended VHND"
 msgstr ""
 
-#: custom/opm/health_status.py:135
+#: custom/opm/health_status.py:64
 msgid ""
 "Registered children below 3 years of age who attended VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:138
+#: custom/opm/health_status.py:67
 msgid "Beneficiaries attended VHND"
 msgstr ""
 
-#: custom/opm/health_status.py:139
+#: custom/opm/health_status.py:68
 msgid "Registered beneficiaries who attended VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:142
+#: custom/opm/health_status.py:71
 msgid "Received at least 30 IFA tablets"
 msgstr ""
 
-#: custom/opm/health_status.py:143
+#: custom/opm/health_status.py:72
 msgid ""
 "Registered pregnant women (6 months pregnant) who received at least 30 IFA "
 "tablets in second trimester"
 msgstr ""
 
-#: custom/opm/health_status.py:147
+#: custom/opm/health_status.py:76
 msgid "Weight monitored in second trimester"
 msgstr ""
 
-#: custom/opm/health_status.py:148
+#: custom/opm/health_status.py:77
 msgid ""
 "Registered pregnant women (6 months pregnant) who got their weight monitored "
 "in second trimester"
 msgstr ""
 
-#: custom/opm/health_status.py:151
+#: custom/opm/health_status.py:80
 msgid "Weight monitored in third trimester"
 msgstr ""
 
-#: custom/opm/health_status.py:152
+#: custom/opm/health_status.py:81
 msgid ""
 "Registered pregnant women (9 months pregnant) who got their weight monitored "
 "in third trimester"
 msgstr ""
 
-#: custom/opm/health_status.py:155
+#: custom/opm/health_status.py:84
 msgid "Weight monitored at birth"
 msgstr ""
 
-#: custom/opm/health_status.py:156
+#: custom/opm/health_status.py:85
 msgid "Registered children (3 months old) whose weight was monitored at birth"
 msgstr ""
 
-#: custom/opm/health_status.py:159
+#: custom/opm/health_status.py:88
 msgid "Child birth registered"
 msgstr ""
 
-#: custom/opm/health_status.py:160
+#: custom/opm/health_status.py:89
 msgid ""
 "Registered children (6 months old) whose birth was registered in the first 6 "
 "months after birth"
 msgstr ""
 
-#: custom/opm/health_status.py:163
+#: custom/opm/health_status.py:92
 msgid "Growth monitoring when 0-3 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:164
+#: custom/opm/health_status.py:93
 msgid ""
 "Registered Children (3 months old) who have attended at least one growth "
 "monitoring session between the age 0-3 months"
 msgstr ""
 
-#: custom/opm/health_status.py:168
+#: custom/opm/health_status.py:97
 msgid "Growth Monitoring when 4-6 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:169
+#: custom/opm/health_status.py:98
 msgid ""
 "Registered Children (6 months old) who have attended at least one growth "
 "monitoring session between the age 4-6 months"
 msgstr ""
 
-#: custom/opm/health_status.py:173
+#: custom/opm/health_status.py:102
 msgid "Growth Monitoring when 7-9 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:174
+#: custom/opm/health_status.py:103
 msgid ""
 "Registered Children (9 months old) who have attended at least one growth "
 "monitoring session between the age 7-9 months"
 msgstr ""
 
-#: custom/opm/health_status.py:178
+#: custom/opm/health_status.py:107
 msgid "Growth Monitoring when 10-12 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:179
+#: custom/opm/health_status.py:108
 msgid ""
 "Registered Children (12 months old) who have attended at least one growth "
 "monitoring session between the age 10-12 months"
 msgstr ""
 
-#: custom/opm/health_status.py:183
+#: custom/opm/health_status.py:112
 msgid "Growth Monitoring when 13-15 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:184
+#: custom/opm/health_status.py:113
 msgid ""
 "Registered Children (15 months old) who have attended at least one growth "
 "monitoring session between the age 13-15 months"
 msgstr ""
 
-#: custom/opm/health_status.py:188
+#: custom/opm/health_status.py:117
 msgid "Growth Monitoring when 16-18 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:189
+#: custom/opm/health_status.py:118
 msgid ""
 "Registered Children (18 months old) who have attended at least one growth "
 "monitoring session between the age 16-18 months"
 msgstr ""
 
-#: custom/opm/health_status.py:193
+#: custom/opm/health_status.py:122
 msgid "Growth Monitoring when 19-21 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:194
+#: custom/opm/health_status.py:123
 msgid ""
 "Registered Children (21 months old) who have attended at least one growth "
 "monitoring session between the age 19-21 months"
 msgstr ""
 
-#: custom/opm/health_status.py:198
+#: custom/opm/health_status.py:127
 msgid "Growth Monitoring when 22-24 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:199
+#: custom/opm/health_status.py:128
 msgid ""
 "Registered Children (24 months old) who have attended at least one growth "
 "monitoring session between the age 22-24 months"
 msgstr ""
 
-#: custom/opm/health_status.py:203
+#: custom/opm/health_status.py:132
 msgid "Received ORS and Zinc treatment for diarrhoea"
 msgstr ""
 
-#: custom/opm/health_status.py:204
+#: custom/opm/health_status.py:133
 msgid ""
 "Registered children who received ORS and Zinc treatment if he/she contracts "
 "diarrhoea"
 msgstr ""
 
-#: custom/opm/health_status.py:207
+#: custom/opm/health_status.py:136
 msgid "Exclusively breastfed for first 6 months"
 msgstr ""
 
-#: custom/opm/health_status.py:208
+#: custom/opm/health_status.py:137
 msgid ""
 "Registered children (6 months old) who have been exclusively breastfed for "
 "first 6 months"
 msgstr ""
 
-#: custom/opm/health_status.py:211
+#: custom/opm/health_status.py:140
 msgid "Received Measles vaccine"
 msgstr ""
 
-#: custom/opm/health_status.py:212
+#: custom/opm/health_status.py:141
 msgid "Registered children (12 months old) who have received Measles vaccine"
 msgstr ""
 
-#: custom/opm/health_status.py:215
+#: custom/opm/health_status.py:144
 msgid "VHND organised"
 msgstr ""
 
-#: custom/opm/health_status.py:216
+#: custom/opm/health_status.py:145
 msgid "Whether VHND was organised at AWC for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:219
+#: custom/opm/health_status.py:148
 msgid "Adult Weighing Machine Available"
 msgstr ""
 
-#: custom/opm/health_status.py:220
+#: custom/opm/health_status.py:149
 msgid "Whether adult weighing machine was available for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:223
+#: custom/opm/health_status.py:152
 msgid "Adult Weighing Machine Functional"
 msgstr ""
 
-#: custom/opm/health_status.py:224
+#: custom/opm/health_status.py:153
 msgid "Whether adult weighing machine was functional for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:227
+#: custom/opm/health_status.py:156
 msgid "Child Weighing Machine Available"
 msgstr ""
 
-#: custom/opm/health_status.py:228
+#: custom/opm/health_status.py:157
 msgid "Whether child weighing machine was available for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:231
+#: custom/opm/health_status.py:160
 msgid "Child Weighing Machine Functional"
 msgstr ""
 
-#: custom/opm/health_status.py:232
+#: custom/opm/health_status.py:161
 msgid "Whether child weighing machine was functional for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:235
+#: custom/opm/health_status.py:164
 msgid "ANM Present"
 msgstr ""
 
-#: custom/opm/health_status.py:236
+#: custom/opm/health_status.py:165
 msgid "Whether ANM present at VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:239
+#: custom/opm/health_status.py:168
 msgid "ASHA Present"
 msgstr ""
 
-#: custom/opm/health_status.py:240
+#: custom/opm/health_status.py:169
 msgid "Whether ASHA present at VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:243
+#: custom/opm/health_status.py:172
 msgid "CMG Present"
 msgstr ""
 
-#: custom/opm/health_status.py:244
+#: custom/opm/health_status.py:173
 msgid "Whether CMG present at VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:247
+#: custom/opm/health_status.py:176
 msgid "Stock of IFA tablets"
 msgstr ""
 
-#: custom/opm/health_status.py:248
+#: custom/opm/health_status.py:177
 msgid "Whether AWC has enough stock of IFA tablets for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:251
+#: custom/opm/health_status.py:180
 msgid "Stock of ORS packets"
 msgstr ""
 
-#: custom/opm/health_status.py:252
+#: custom/opm/health_status.py:181
 msgid "Whether AWC has enough stock of ORS packets for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:255
+#: custom/opm/health_status.py:184
 msgid "Stock of ZINC tablets"
 msgstr ""
 
-#: custom/opm/health_status.py:256
+#: custom/opm/health_status.py:185
 msgid "Whether AWC has enough stock of Zinc Tablets for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:259
+#: custom/opm/health_status.py:188
 msgid "Stock of Measles Vaccine"
 msgstr ""
 
-#: custom/opm/health_status.py:260
+#: custom/opm/health_status.py:189
 msgid "Whether AWC has enough stock of measles vaccine for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:263
+#: custom/opm/health_status.py:192
 msgid "Eligilble for Birth Spacing bonus"
 msgstr ""
 
-#: custom/opm/health_status.py:264
+#: custom/opm/health_status.py:193
 msgid "Registered beneficiaries eligible for birth spacing bonus for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:267
+#: custom/opm/health_status.py:196
 msgid "Severely underweight"
 msgstr ""
 
-#: custom/opm/health_status.py:268
+#: custom/opm/health_status.py:197
 msgid ""
 "Registered children severely underweight (very low weight for age) for the "
 "month"
 msgstr ""
 
-#: custom/opm/health_status.py:271
+#: custom/opm/health_status.py:200
 msgid "Underweight"
 msgstr ""
 
-#: custom/opm/health_status.py:272
+#: custom/opm/health_status.py:201
 msgid "Registered children underweight (low weight for age) for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:275
+#: custom/opm/health_status.py:204
 msgid "Normal weight for age"
 msgstr ""
 
-#: custom/opm/health_status.py:276
+#: custom/opm/health_status.py:205
 msgid "Registered children with normal weight for age for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:279
+#: custom/opm/health_status.py:208
 msgid "Eligilble for Nutritional status bonus"
 msgstr ""
 
-#: custom/opm/health_status.py:280
+#: custom/opm/health_status.py:209
 msgid ""
 "Registered beneficiaries eligible for nutritonal status bonus for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:283
+#: custom/opm/health_status.py:212
 msgid "Pregnant women cases closed"
 msgstr ""
 
-#: custom/opm/health_status.py:284
+#: custom/opm/health_status.py:213
 msgid "Registered pregnant women cases closed for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:287
+#: custom/opm/health_status.py:216
 msgid "Mother cases closed"
 msgstr ""
 
-#: custom/opm/health_status.py:288
+#: custom/opm/health_status.py:217
 msgid "Registered mother cases closed for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:291
+#: custom/opm/health_status.py:220
 msgid "Children cases closed"
 msgstr ""
 
-#: custom/opm/health_status.py:292
+#: custom/opm/health_status.py:221
 msgid "Registered children cases closed for the month"
 msgstr ""
 
-#: custom/opm/reports.py:656 custom/opm/reports.py:657
-#: custom/opm/reports.py:917
+#: custom/opm/reports.py:457 custom/opm/reports.py:458
+#: custom/opm/reports.py:719
 msgid "Reporting period incomplete"
 msgstr ""
 
-#: custom/opm/reports.py:876
+#: custom/opm/reports.py:679
 msgid "Duplicate account number"
 msgstr ""
 
-#: custom/opm/reports.py:885
+#: custom/opm/reports.py:688
 msgid "Conditions Met Report"
 msgstr ""
 
-#: custom/opm/reports.py:924
+#: custom/opm/reports.py:726
 msgid "Total Payment"
 msgstr ""
 
@@ -27068,7 +27602,7 @@ msgstr ""
 
 #: custom/up_nrhm/reports/asha_functionality_checklist_report.py:61
 #, python-format
-msgid "Total number of ASHAs who are functional on at least 60% of the tasks"
+msgid "Total number of ASHAs who are functional on at least %s of the tasks"
 msgstr ""
 
 #: custom/up_nrhm/reports/asha_functionality_checklist_report.py:62
@@ -27155,11 +27689,86 @@ msgstr ""
 
 #: custom/up_nrhm/reports/district_functionality_report.py:34
 #, python-format
-msgid "% of ASHAs"
+msgid "%s of ASHAs"
 msgstr ""
 
-#: custom/up_nrhm/reports/district_functionality_report.py:35
+#: custom/up_nrhm/reports/district_functionality_report.py:36
 msgid "Grade of Block"
+msgstr ""
+
+#: docs/_build/html/_sources/translations.txt:141
+#, python-format
+msgid "This string will have %(value)s inside."
+msgstr ""
+
+#: docs/_build/html/_sources/translations.txt:147
+#, python-format
+msgid ""
+"\n"
+"        That will cost $ %(amount)s.\n"
+"    "
+msgstr ""
+
+#: docs/_build/html/_sources/translations.txt:155
+#, python-format
+msgid ""
+"\n"
+"        This will have %(myvar)s inside.\n"
+"    "
+msgstr ""
+
+#: docs/_build/html/_sources/translations.txt:167
+msgid ""
+"\n"
+"        Manage Mobile Workers <small>for CommCare Mobile and\n"
+"        CommCare HQ Reports</small>\n"
+"    "
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/couchpanel.py:89
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/couchpanel.py:92
+msgid "CouchDB"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:15
+msgid "Stacktrace"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:16
+#, fuzzy
+msgid "View Name"
+msgstr "Nome da visita"
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:17
+msgid "Request Params"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:45
+msgid "Line"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:46
+msgid "Method"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:6
+msgid "CouchDB View"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:11
+msgid "Executed View"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:13
+msgid "Parameters"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:15
+msgid "Total Rows"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:40
+msgid "Empty set"
 msgstr ""
 
 #: submodules/auditcare-src/auditcare/forms.py:14
@@ -27560,16 +28169,16 @@ msgstr "Dados limpos"
 msgid "Clearing data"
 msgstr "Esclarecimento de dados"
 
-#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:36
+#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:47
 #, python-format
 msgid "ERROR: Could not send \"%(subject)s\""
 msgstr ""
 
-#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:41
+#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:52
 msgid "Could not send email: file size is too large."
 msgstr ""
 
-#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:46
+#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:57
 #, python-format
 msgid "Please contact %(support_email)s for assistance."
 msgstr ""
@@ -27621,6 +28230,9 @@ msgstr ""
 "problemas para preencher o restante do formulário por favor envie  um "
 "relatorio do problema usando os links de abaixo."
 
+#~ msgid "App Translation Failed! "
+#~ msgstr "Tradução do aplicativo falhou!"
+
 #~ msgid "Care Manager"
 #~ msgstr "Gerente de atendimento"
 
@@ -27653,9 +28265,6 @@ msgstr ""
 #~ msgid "Commtrack"
 #~ msgstr "CommCare Supply"
 
-#~ msgid "mothers"
-#~ msgstr "Outros (negativos / indeterminados) "
-
 #~ msgid "Create New Report > Configure Table Report"
 #~ msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
@@ -27667,9 +28276,6 @@ msgstr ""
 
 #~ msgid "New Mothers"
 #~ msgstr "Outros (negativos / indeterminados) "
-
-#~ msgid "Closed by"
-#~ msgstr "Casos IRA Tratados"
 
 #~ msgid "Manage SMS Backend Rates"
 #~ msgstr "Diagnóstico de Casos"

--- a/locale/sw/LC_MESSAGES/django.po
+++ b/locale/sw/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CommCare HQ\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-07-29 19:37+0000\n"
+"POT-Creation-Date: 2015-08-05 17:43+0000\n"
 "PO-Revision-Date: 2015-06-26 09:30+0000\n"
 "Last-Translator: Dimagi Dev <devops@dimagi.com>\n"
 "Language-Team: Swahili (http://www.transifex.com/projects/p/commcare-hq/"
@@ -36,7 +36,7 @@ msgstr ""
 
 #: corehq/__init__.py:61 corehq/feature_previews.py:91
 #: corehq/apps/hqwebapp/models.py:879 corehq/apps/reports/__init__.py:13
-#: corehq/apps/reports/models.py:52
+#: corehq/apps/reports/models.py:54
 #: corehq/apps/users/templates/users/edit_commcare_user.html:125
 msgid "CommCare Supply"
 msgstr ""
@@ -57,9 +57,9 @@ msgstr ""
 msgid "Messaging"
 msgstr ""
 
-#: corehq/__init__.py:177 corehq/apps/app_manager/models.py:2900
+#: corehq/__init__.py:177 corehq/apps/app_manager/models.py:2974
 #: corehq/apps/dashboard/views.py:159 corehq/apps/hqwebapp/models.py:365
-#: corehq/apps/hqwebapp/models.py:1538 corehq/apps/hqwebapp/models.py:1608
+#: corehq/apps/hqwebapp/models.py:1533 corehq/apps/hqwebapp/models.py:1603
 #: corehq/apps/orgs/templates/orgs/report_base.html:26
 #: corehq/apps/reports/templates/reports/reportdata/case_details.html:68
 msgid "Reports"
@@ -78,7 +78,7 @@ msgstr ""
 msgid "Edit Data"
 msgstr ""
 
-#: corehq/__init__.py:198 corehq/privileges.py:71
+#: corehq/__init__.py:198 corehq/privileges.py:76
 #: corehq/apps/accounting/user_text.py:219 corehq/apps/fixtures/views.py:285
 msgid "Lookup Tables"
 msgstr ""
@@ -182,8 +182,8 @@ msgid ""
 "possible reasons for poor performance, and offer guidance towards solutions."
 msgstr ""
 
-#: corehq/feature_previews.py:128 corehq/privileges.py:88
-#: corehq/apps/hqwebapp/models.py:1140 corehq/apps/locations/views.py:75
+#: corehq/feature_previews.py:128 corehq/privileges.py:93
+#: corehq/apps/hqwebapp/models.py:1135 corehq/apps/locations/views.py:75
 #: corehq/apps/users/templates/users/edit_commcare_user.html:127
 msgid "Locations"
 msgstr ""
@@ -206,71 +206,71 @@ msgid ""
 "a>."
 msgstr ""
 
-#: corehq/privileges.py:72 corehq/apps/accounting/user_text.py:218
+#: corehq/privileges.py:77 corehq/apps/accounting/user_text.py:218
 msgid "API Access"
 msgstr ""
 
-#: corehq/privileges.py:73
+#: corehq/privileges.py:78
 msgid "Web-Based Apps (CloudCare)"
 msgstr ""
 
-#: corehq/privileges.py:74
+#: corehq/privileges.py:79
 msgid "Active Data Management"
 msgstr ""
 
-#: corehq/privileges.py:75 corehq/apps/accounting/user_text.py:221
+#: corehq/privileges.py:80 corehq/apps/accounting/user_text.py:221
 msgid "Custom Branding"
 msgstr ""
 
-#: corehq/privileges.py:76 corehq/apps/accounting/user_text.py:224
+#: corehq/privileges.py:81 corehq/apps/accounting/user_text.py:224
 msgid "Cross-Project Reports"
 msgstr ""
 
-#: corehq/privileges.py:77 corehq/apps/accounting/user_text.py:236
+#: corehq/privileges.py:82 corehq/apps/accounting/user_text.py:236
 msgid "Advanced Role-Based Access"
 msgstr ""
 
-#: corehq/privileges.py:78
+#: corehq/privileges.py:83
 msgid "Outgoing Messaging"
 msgstr ""
 
-#: corehq/privileges.py:79
+#: corehq/privileges.py:84
 msgid "Incoming Messaging"
 msgstr ""
 
-#: corehq/privileges.py:80
+#: corehq/privileges.py:85
 msgid "Reminders Framework"
 msgstr ""
 
-#: corehq/privileges.py:81
+#: corehq/privileges.py:86
 msgid "Custom Android Gateway"
 msgstr ""
 
-#: corehq/privileges.py:82
+#: corehq/privileges.py:87
 msgid "Bulk Case Management"
 msgstr ""
 
-#: corehq/privileges.py:83
+#: corehq/privileges.py:88
 msgid "Bulk User Management"
 msgstr ""
 
-#: corehq/privileges.py:84
+#: corehq/privileges.py:89
 msgid "Add Mobile Workers Above Limit"
 msgstr ""
 
-#: corehq/privileges.py:85
+#: corehq/privileges.py:90
 msgid "De-Identified Data"
 msgstr ""
 
-#: corehq/privileges.py:86 corehq/apps/accounting/user_text.py:238
+#: corehq/privileges.py:91 corehq/apps/accounting/user_text.py:238
 msgid "HIPAA Compliance Assurance"
 msgstr ""
 
-#: corehq/privileges.py:87
+#: corehq/privileges.py:92
 msgid "Custom CommCare Logo Uploader"
 msgstr ""
 
-#: corehq/privileges.py:89
+#: corehq/privileges.py:94
 msgid "User Configurable Report Builder"
 msgstr ""
 
@@ -378,6 +378,7 @@ msgstr ""
 
 #: corehq/apps/accounting/filters.py:140 corehq/apps/accounting/forms.py:346
 #: corehq/apps/accounting/forms.py:634 corehq/apps/commtrack/models.py:535
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:57
 #: corehq/apps/domain/templates/domain/admin/media_manager.html:24
 #: corehq/apps/export/templates/export/customize_export.html:602
 #: corehq/apps/hqadmin/reports.py:839
@@ -521,7 +522,7 @@ msgstr ""
 #: corehq/apps/accounting/templates/accounting/subscriptions_tab.html:16
 #: corehq/apps/domain/forms.py:1455
 #: corehq/apps/domain/templates/domain/current_subscription.html:247
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:74
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:83
 msgid "Software Plan"
 msgstr ""
 
@@ -630,10 +631,10 @@ msgid "A name is required for this new role."
 msgstr ""
 
 #: corehq/apps/accounting/forms.py:1428 corehq/apps/app_manager/forms.py:11
-#: corehq/apps/app_manager/models.py:1737
-#: corehq/apps/app_manager/models.py:2167
-#: corehq/apps/app_manager/models.py:2525
-#: corehq/apps/app_manager/models.py:2574 corehq/apps/commtrack/models.py:531
+#: corehq/apps/app_manager/models.py:1738
+#: corehq/apps/app_manager/models.py:2193
+#: corehq/apps/app_manager/models.py:2574
+#: corehq/apps/app_manager/models.py:2623 corehq/apps/commtrack/models.py:531
 #: corehq/apps/domain/forms.py:126
 #: corehq/apps/domain/templates/domain/admin/commtrack_action_table.html:5
 #: corehq/apps/domain/templates/domain/partials/user_list.html:9
@@ -655,7 +656,7 @@ msgstr ""
 #: corehq/apps/toggle_ui/templates/toggle/flags.html:58
 #: corehq/apps/users/templates/users/web_users.b3.html:171
 #: corehq/apps/users/templates/users/web_users.b3.html:216
-#: corehq/ex-submodules/casexml/apps/case/models.py:853
+#: corehq/ex-submodules/casexml/apps/case/models.py:858
 #: corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_hierarchy.html:57
 #: custom/bihar/reports/indicators/clientlistdisplay.py:80
 #: custom/bihar/reports/indicators/clientlistdisplay.py:98
@@ -664,13 +665,13 @@ msgstr ""
 #: custom/ewsghana/reports/specific_reports/reporting_rates.py:199
 #: custom/ewsghana/reports/specific_reports/reporting_rates.py:241
 #: custom/fri/reports/reports.py:349
-#: custom/ilsgateway/tanzania/reports/delivery.py:27
-#: custom/ilsgateway/tanzania/reports/facility_details.py:70
-#: custom/ilsgateway/tanzania/reports/facility_details.py:116
-#: custom/ilsgateway/tanzania/reports/randr.py:82
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:81
-#: custom/ilsgateway/tanzania/reports/supervision.py:56
-#: custom/ilsgateway/tanzania/reports/supervision.py:120
+#: custom/ilsgateway/tanzania/reports/delivery.py:28
+#: custom/ilsgateway/tanzania/reports/facility_details.py:71
+#: custom/ilsgateway/tanzania/reports/facility_details.py:117
+#: custom/ilsgateway/tanzania/reports/randr.py:83
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:83
+#: custom/ilsgateway/tanzania/reports/supervision.py:57
+#: custom/ilsgateway/tanzania/reports/supervision.py:122
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:37
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:184
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:249
@@ -680,7 +681,7 @@ msgid "Name"
 msgstr ""
 
 #: corehq/apps/accounting/forms.py:1432 corehq/apps/accounting/models.py:357
-#: corehq/apps/prelogin/forms.py:28
+#: corehq/apps/prelogin/forms.py:29
 msgid "Company / Organization"
 msgstr ""
 
@@ -746,13 +747,13 @@ msgstr ""
 msgid "Messages"
 msgstr ""
 
-#: corehq/apps/accounting/models.py:341 corehq/apps/prelogin/forms.py:20
-#: corehq/apps/users/forms.py:145
+#: corehq/apps/accounting/models.py:341 corehq/apps/prelogin/forms.py:21
+#: corehq/apps/users/forms.py:144
 msgid "First Name"
 msgstr ""
 
-#: corehq/apps/accounting/models.py:344 corehq/apps/prelogin/forms.py:24
-#: corehq/apps/users/forms.py:146
+#: corehq/apps/accounting/models.py:344 corehq/apps/prelogin/forms.py:25
+#: corehq/apps/users/forms.py:145
 msgid "Last Name"
 msgstr ""
 
@@ -767,7 +768,7 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/accounting/models.py:353
-#: corehq/apps/data_interfaces/views.py:322 corehq/apps/prelogin/forms.py:36
+#: corehq/apps/data_interfaces/views.py:322 corehq/apps/prelogin/forms.py:37
 #: corehq/apps/reports/standard/ivr.py:46
 #: corehq/apps/reports/standard/sms.py:280
 #: corehq/apps/reports/standard/sms.py:617
@@ -800,7 +801,7 @@ msgstr ""
 msgid "Postal Code"
 msgstr ""
 
-#: corehq/apps/accounting/models.py:378 corehq/apps/prelogin/forms.py:40
+#: corehq/apps/accounting/models.py:378 corehq/apps/prelogin/forms.py:41
 msgid "Country"
 msgstr ""
 
@@ -992,14 +993,14 @@ msgstr ""
 
 #: corehq/apps/accounting/user_text.py:8
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/analytics.html:22
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:41
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:52
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/mobile.html:22
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:21
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/support.html:22
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/user.html:22
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/web.html:22
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:80
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:77
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:89
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:79
 msgid "Community"
 msgstr ""
 
@@ -1011,7 +1012,7 @@ msgstr ""
 
 #: corehq/apps/accounting/user_text.py:13
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/analytics.html:27
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:46
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:57
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/mobile.html:27
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:26
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/support.html:27
@@ -1028,16 +1029,16 @@ msgstr ""
 
 #: corehq/apps/accounting/user_text.py:18
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/analytics.html:32
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:51
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:62
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/mobile.html:32
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:31
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/support.html:32
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/user.html:32
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/web.html:32
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:90
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:98
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:87
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:95
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:99
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:107
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:89
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:97
 msgid "Pro"
 msgstr ""
 
@@ -1048,20 +1049,20 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:23
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:306
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:309
 #: corehq/apps/app_manager/templates/app_manager/module_view.html:294
 #: corehq/apps/importer/templates/importer/excel_config.html:114
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/analytics.html:37
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:56
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:67
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/mobile.html:37
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:36
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/support.html:37
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/user.html:37
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/web.html:37
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:106
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:114
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:103
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:111
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:115
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:123
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:105
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:113
 msgid "Advanced"
 msgstr ""
 
@@ -1074,7 +1075,7 @@ msgstr ""
 
 #: corehq/apps/accounting/user_text.py:29
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/analytics.html:42
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:61
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:72
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/mobile.html:42
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:41
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/support.html:42
@@ -1105,7 +1106,7 @@ msgstr ""
 #: corehq/apps/accounting/user_text.py:54
 #: corehq/apps/accounting/user_text.py:201
 #: corehq/apps/accounting/user_text.py:202
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:98
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:109
 msgid "Mobile Users"
 msgstr ""
 
@@ -1175,7 +1176,7 @@ msgid "SMS (CommConnect)"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:90
-#: corehq/apps/accounting/user_text.py:91 corehq/apps/commtrack/views.py:170
+#: corehq/apps/accounting/user_text.py:91 corehq/apps/commtrack/views.py:175
 #: corehq/apps/domain/forms.py:1624
 #: corehq/apps/prelogin/templates/prelogin/_sections/pricing/sms.html:13
 #: corehq/apps/reminders/forms.py:98 corehq/apps/reminders/forms.py:103
@@ -1331,24 +1332,24 @@ msgid "Dedicated Enterprise Account Management"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:255
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:71
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:83
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:80
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:82
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:92
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:82
 msgid "Free"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:255
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:76
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:87
 msgid "$100 /month"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:255
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:81
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:92
 msgid "$500 /month"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:255
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:86
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:97
 msgid "$1,000 /month"
 msgstr ""
 
@@ -1359,22 +1360,22 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:256
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:102
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:113
 msgid "50"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:256
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:107
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:118
 msgid "100"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:256
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:112
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:123
 msgid "500"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:256
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:117
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:128
 msgid "1,000"
 msgstr ""
 
@@ -1384,10 +1385,10 @@ msgid "Unlimited / Discounted Pricing"
 msgstr ""
 
 #: corehq/apps/accounting/user_text.py:257
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:132
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:137
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:142
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:147
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:143
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:148
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:153
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:158
 msgid "1 USD /month"
 msgstr ""
 
@@ -1482,7 +1483,7 @@ msgstr ""
 #: corehq/apps/sms/templates/sms/default.html:47
 #: corehq/apps/unicel/forms.py:10
 #: corehq/apps/unicel/templates/unicel/backend.html:10
-#: corehq/apps/userhack/admin.py:14 corehq/apps/users/forms.py:184
+#: corehq/apps/userhack/admin.py:14 corehq/apps/users/forms.py:183
 #: corehq/apps/users/templates/users/edit_web_user.html:13
 #: corehq/apps/users/templates/users/mobile/users_list.html:209
 #: corehq/apps/users/templates/users/partial/basic_info_form.html:10
@@ -1503,6 +1504,7 @@ msgstr ""
 #: corehq/apps/reports/templates/reports/partials/hqexport_group_table.html:11
 #: corehq/apps/sms/templates/sms/add_gateway.html:42
 #: corehq/apps/sms/templates/sms/partials/day_time_windows.html:12
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:14
 msgid "Action"
 msgstr ""
 
@@ -1568,6 +1570,7 @@ msgstr ""
 #: corehq/apps/hqmedia/templates/hqmedia/bulk_upload.html:55
 #: corehq/apps/indicators/templates/indicators/forms/copy_to_domain.html:66
 #: corehq/apps/locations/templates/locations/manage/location.html:195
+#: corehq/apps/locations/templates/locations/manage/locations.html:266
 #: corehq/apps/orgs/templates/orgs/orgs_landing.html:184
 #: corehq/apps/orgs/templates/orgs/orgs_landing.html:203
 #: corehq/apps/orgs/templates/orgs/orgs_landing.html:230
@@ -1820,7 +1823,7 @@ msgstr ""
 #: corehq/apps/reports/standard/monitoring.py:479
 #: corehq/apps/reports/standard/monitoring.py:623
 #: corehq/apps/reports/standard/monitoring.py:1321
-#: custom/ilsgateway/tanzania/reports/delivery.py:171
+#: custom/ilsgateway/tanzania/reports/delivery.py:174
 #: custom/m4change/reports/aggregate_facility_web_hmis_report.py:38
 #: custom/m4change/reports/all_hmis_report.py:258
 #: custom/m4change/reports/anc_hmis_report.py:117
@@ -1881,7 +1884,7 @@ msgstr ""
 
 #: corehq/apps/accounting/templates/accounting/credits_tab.html:9
 #: corehq/apps/accounting/templates/accounting/subscriptions.html:55
-#: corehq/apps/hqwebapp/models.py:1302
+#: corehq/apps/hqwebapp/models.py:1297
 msgid "Subscription"
 msgstr ""
 
@@ -1929,8 +1932,8 @@ msgstr ""
 #: corehq/apps/reports/standard/sms.py:732
 #: corehq/apps/users/templates/users/web_users.b3.html:286
 #: corehq/apps/users/templates/users/web_users.html:128
-#: custom/ilsgateway/tanzania/reports/facility_details.py:118
-#: custom/ilsgateway/tanzania/reports/supervision.py:122
+#: custom/ilsgateway/tanzania/reports/facility_details.py:119
+#: custom/ilsgateway/tanzania/reports/supervision.py:124
 #: custom/intrahealth/sqldata.py:392
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:266
 msgid "Date"
@@ -1990,9 +1993,9 @@ msgstr ""
 #: corehq/apps/reports/templates/reports/messaging/survey_detail.html:33
 #: corehq/apps/settings/templates/settings/my_projects.html:12
 #: corehq/apps/sms/views.py:1022
-#: corehq/ex-submodules/casexml/apps/case/models.py:903
+#: corehq/ex-submodules/casexml/apps/case/models.py:908
 #: custom/_legacy/pact/models.py:329
-#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:55
+#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:65
 #: custom/m4change/reports/mcct_project_review.py:274
 #: custom/m4change/reports/mcct_project_review.py:401
 #: custom/m4change/reports/mcct_project_review.py:484
@@ -2351,7 +2354,7 @@ msgstr ""
 #: corehq/apps/reports/templates/reports/standard/base_template.html:108
 #: corehq/apps/reports/templates/reports/standard/export_download.html:99
 #: corehq/apps/reports_core/templates/reports_core/base_template_new.html:150
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:118
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:122
 msgid "Generating Report..."
 msgstr ""
 
@@ -2366,8 +2369,8 @@ msgstr ""
 #: corehq/apps/reports/templates/reports/standard/base_template.html:111
 #: corehq/apps/reports_core/templates/reports_core/base_template_new.html:151
 #: corehq/apps/reports_core/templates/reports_core/base_template_new.html:152
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:119
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:120
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:123
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:124
 msgid "Apply"
 msgstr ""
 
@@ -2475,11 +2478,11 @@ msgid "Delay Invoicing Until"
 msgstr ""
 
 #: corehq/apps/accounting/templates/accounting/subscriptions_tab.html:24
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:255
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:261
-#: corehq/apps/domain/templates/domain/admin/feature_flags.html:28
-#: corehq/apps/locations/templates/locations/manage/locations.html:148
-#: corehq/apps/reports/views.py:801
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:258
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:264
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:37
+#: corehq/apps/locations/templates/locations/manage/locations.html:167
+#: corehq/apps/reports/views.py:809
 #: corehq/apps/reports/templates/reports/reports_home.html:60
 #: corehq/apps/reports/templates/reports/reports_home.html:126
 #: corehq/apps/reports/templates/reports/partials/saved_custom_exports.html:9
@@ -2763,6 +2766,7 @@ msgstr ""
 #: corehq/apps/app_manager/fields.py:45
 #: corehq/apps/app_manager/templates/app_manager/managed_app.html:266
 #: corehq/apps/app_manager/templates/app_manager/ng_partials/case_summary_view.html:109
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:56
 #: corehq/apps/hqwebapp/doc_info.py:100
 #: corehq/apps/reports/filters/forms.py:684
 #: corehq/apps/reports/standard/inspect.py:89
@@ -2809,60 +2813,56 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:749
-msgid "Form referenced as the registration form for multiple modules."
-msgstr ""
-
-#: corehq/apps/app_manager/models.py:1743
-#: corehq/apps/app_manager/models.py:2174
-#: corehq/apps/app_manager/views.py:1412
+#: corehq/apps/app_manager/models.py:1744
+#: corehq/apps/app_manager/models.py:2200
+#: corehq/apps/app_manager/views.py:1414
 msgid "Untitled Module"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:1756
-#: corehq/apps/app_manager/models.py:2200
-#: corehq/apps/app_manager/views.py:1471
+#: corehq/apps/app_manager/models.py:1757
+#: corehq/apps/app_manager/models.py:2226
+#: corehq/apps/app_manager/views.py:1473
 msgid "Untitled Form"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:1849
+#: corehq/apps/app_manager/models.py:1850
 msgid "Case tiles may only be used for the case list (not the case details)."
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:1857
+#: corehq/apps/app_manager/models.py:1858
 msgid "A case property must be assigned to the \"{}\" tile field."
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2014
+#: corehq/apps/app_manager/models.py:2040
 msgid "Case property"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2015
+#: corehq/apps/app_manager/models.py:2041
 msgid "Lookup Table field"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2016
+#: corehq/apps/app_manager/models.py:2042
 msgid "custom user property"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2017
+#: corehq/apps/app_manager/models.py:2043
 msgid "custom XPath expression"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2024
+#: corehq/apps/app_manager/models.py:2050
 msgid "Case tag"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2025
+#: corehq/apps/app_manager/models.py:2051
 msgid "Lookup Table tag"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2063
+#: corehq/apps/app_manager/models.py:2089
 msgid "All forms in this module require a visit schedule."
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2186
-#: corehq/apps/app_manager/models.py:4198 corehq/apps/products/views.py:467
+#: corehq/apps/app_manager/models.py:2212
+#: corehq/apps/app_manager/models.py:4272 corehq/apps/products/views.py:467
 #: corehq/apps/products/templates/products/manage/products.html:110
 #: corehq/apps/programs/templates/programs/manage/program.html:77
 #: corehq/apps/reports/commtrack/standard.py:92
@@ -2874,9 +2874,9 @@ msgstr ""
 msgid "Product"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2521
-#: corehq/apps/app_manager/models.py:2575
-#: corehq/apps/app_manager/models.py:2637
+#: corehq/apps/app_manager/models.py:2570
+#: corehq/apps/app_manager/models.py:2624
+#: corehq/apps/app_manager/models.py:2686
 #: corehq/apps/appstore/templates/appstore/deployment_info.html:31
 #: corehq/apps/appstore/templates/appstore/project_info.html:140
 #: corehq/apps/appstore/templates/appstore/project_info.html:259
@@ -2892,71 +2892,73 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2522
-#: corehq/apps/app_manager/models.py:2570
+#: corehq/apps/app_manager/models.py:2571
+#: corehq/apps/app_manager/models.py:2619
 msgid "Followup date"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2527
-#: corehq/apps/app_manager/models.py:2580
+#: corehq/apps/app_manager/models.py:2576
+#: corehq/apps/app_manager/models.py:2629
 msgid "Close if"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2579
+#: corehq/apps/app_manager/models.py:2628
 msgid "Latest report"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2600
+#: corehq/apps/app_manager/models.py:2649
 #: custom/_legacy/pact/templates/pact/patient/pactpatient_base.html:33
 #: custom/_legacy/pact/templates/pact/patient/pactpatient_submissions.html:31
 msgid "Care Plan"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2621
+#: corehq/apps/app_manager/models.py:2670
 #: corehq/apps/reports/standard/cases/careplan.py:124
 #: custom/_legacy/pact/models.py:357
 msgid "Goal"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2621
+#: corehq/apps/app_manager/models.py:2670
 #: corehq/apps/reports/standard/cases/careplan.py:138
 #: custom/_legacy/pact/models.py:375
 msgid "Task"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2630
+#: corehq/apps/app_manager/models.py:2679
 msgid "Followup"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:2644
+#: corehq/apps/app_manager/models.py:2693
 msgid "Last update"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:3394
+#: corehq/apps/app_manager/models.py:3468
 msgid ""
 "Usage of lookup tables is not supported by your current subscription. Please "
 "upgrade your subscription before using this feature."
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:4171
+#: corehq/apps/app_manager/models.py:4245
 #, python-brace-format
 msgid "Copy of {name}"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:4408
+#: corehq/apps/app_manager/models.py:4482
 msgid "Error in case type hierarchy"
 msgstr ""
 
-#: corehq/apps/app_manager/models.py:4498
+#: corehq/apps/app_manager/models.py:4572
 msgid ""
 "Problem loading suite file from profile file. Is your profile file correct?"
 msgstr ""
 
-#: corehq/apps/app_manager/translations.py:46
-msgid "App Translation Failed! "
+#: corehq/apps/app_manager/translations.py:48
+msgid ""
+"App Translation Failed! Please make sure you are using a valid Excel 2007 or "
+"later (.xlsx) file. Error details: {}."
 msgstr ""
 
-#: corehq/apps/app_manager/translations.py:149
+#: corehq/apps/app_manager/translations.py:154
 msgid "App Translations Updated!"
 msgstr ""
 
@@ -2968,138 +2970,138 @@ msgstr ""
 msgid "You must submit the source data."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:526
+#: corehq/apps/app_manager/views.py:527
 msgid "All Programs"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:596
+#: corehq/apps/app_manager/views.py:597
 msgid "U​I translation"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:597
+#: corehq/apps/app_manager/views.py:598
 msgid "U​I translations"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:604
+#: corehq/apps/app_manager/views.py:605
 msgid "app translation"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:605
+#: corehq/apps/app_manager/views.py:606
 msgid "app translations"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:821
+#: corehq/apps/app_manager/views.py:822
 msgid "Don't Show"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:828
+#: corehq/apps/app_manager/views.py:829
 #: corehq/apps/reports/standard/cases/basic.py:211
 #: corehq/apps/reports/templates/reports/reportdata/case_details.html:71
 msgid "Case List"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:829
+#: corehq/apps/app_manager/views.py:830
 msgid "Case Detail"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:848
+#: corehq/apps/app_manager/views.py:849
 msgid "Product List"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:849
+#: corehq/apps/app_manager/views.py:850
 msgid "Product Detail"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:871
+#: corehq/apps/app_manager/views.py:872
 msgid "Goal List"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:872
+#: corehq/apps/app_manager/views.py:873
 msgid "Goal Detail"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:882
+#: corehq/apps/app_manager/views.py:883
 msgid "Task List"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:883
+#: corehq/apps/app_manager/views.py:884
 msgid "Task Detail"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:921
+#: corehq/apps/app_manager/views.py:923
 msgid ""
 "Your app contains references to reports that are deleted. These will be "
 "removed on save."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:1243
+#: corehq/apps/app_manager/views.py:1245
 msgid ""
 "You tried to edit this form in the Form Builder. However, your administrator "
 "has locked this form against editing in the form builder, so we have "
 "redirected you to the form's front page instead."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:1409
+#: corehq/apps/app_manager/views.py:1411
 msgid "Untitled Application"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:1458
+#: corehq/apps/app_manager/views.py:1460
 #, python-brace-format
 msgid "Please set the case type for the target module '{name}'."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:1464
+#: corehq/apps/app_manager/views.py:1466
 msgid "Caution: Care Plan modules are a labs feature"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:1476
+#: corehq/apps/app_manager/views.py:1478
 msgid "Caution: Advanced modules are a labs feature"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:1592
+#: corehq/apps/app_manager/views.py:1594
 msgid ""
 "We could not copy this form, because it is blank.In order to copy this form, "
 "please add some questions first."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:1596
+#: corehq/apps/app_manager/views.py:1598
 msgid ""
 "This form could not be copied because it is not compatible with the selected "
 "module."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:1765
+#: corehq/apps/app_manager/views.py:1767
 msgid "Unknown Module"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:2468
+#: corehq/apps/app_manager/views.py:2470
 msgid "The form can not be moved into the desired module."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:2473
+#: corehq/apps/app_manager/views.py:2475
 msgid ""
 "Oops. Looks like you got out of sync with us. The sidebar has been updated, "
 "so please try again."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:2628
+#: corehq/apps/app_manager/views.py:2630
 msgid ""
 "We were unable to get your files because your Application has errors. Please "
 "click <strong>Make New Version</strong> under <strong>Deploy</strong> for "
 "feedback on how to fix these errors."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:2658
+#: corehq/apps/app_manager/views.py:2660
 msgid ""
 "We were unable to get your files because your Application has errors. Please "
 "click Make New Version under Deploy for feedback on how to fix these errors."
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:3022
+#: corehq/apps/app_manager/views.py:3024
 msgid "Summary"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:3060
+#: corehq/apps/app_manager/views.py:3062
 #: corehq/apps/app_manager/templates/app_manager/app_view.html:257
 #: corehq/apps/app_manager/templates/app_manager/apps_base.html:9
 #: corehq/apps/app_manager/templates/app_manager/apps_base.html:14
@@ -3110,23 +3112,23 @@ msgstr ""
 msgid "Applications"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:3211
+#: corehq/apps/app_manager/views.py:3213
 msgid "We found problem with following translations:"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:3222
+#: corehq/apps/app_manager/views.py:3224
 msgid "Something went wrong! Update failed. We're looking into it"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:3225
+#: corehq/apps/app_manager/views.py:3227
 msgid "UI Translations Updated!"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:3271
+#: corehq/apps/app_manager/views.py:3273
 msgid "Please upgrade you app to > 2.0 in order to add a Careplan module"
 msgstr ""
 
-#: corehq/apps/app_manager/views.py:3282
+#: corehq/apps/app_manager/views.py:3284
 msgid "This application already has a Careplan module"
 msgstr ""
 
@@ -3134,33 +3136,33 @@ msgstr ""
 msgid "Error parsing XML: {}"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:204
+#: corehq/apps/app_manager/xform.py:205
 #, python-brace-format
 msgid "Group already has node for lang: {0}"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:673
+#: corehq/apps/app_manager/xform.py:679
 msgid "There's no language called '{}'"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:675
+#: corehq/apps/app_manager/xform.py:681
 msgid "There's already a language called '{}'"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:720
+#: corehq/apps/app_manager/xform.py:726
 #, python-brace-format
 msgid "<translation lang=\"{lang}\"><text id=\"{id}\"> node has no <value>"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:827
+#: corehq/apps/app_manager/xform.py:833
 msgid "<item> ({}) has no <value>"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:948
+#: corehq/apps/app_manager/xform.py:954
 msgid "Node <{}> has no 'ref' or 'bind'"
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:1122 corehq/apps/app_manager/xform.py:1379
+#: corehq/apps/app_manager/xform.py:1128 corehq/apps/app_manager/xform.py:1385
 msgid ""
 "Couldn't get the case XML from one of your forms. A common reason for this "
 "is if you don't have the xforms namespace defined in your form. Please "
@@ -3168,23 +3170,23 @@ msgid ""
 "your form."
 msgstr ""
 
-#: corehq/apps/app_manager/xform.py:1371
+#: corehq/apps/app_manager/xform.py:1377
 msgid ""
 "You cannot use the Case Management UI if you already have a case block in "
 "your form."
 msgstr ""
 
-#: corehq/apps/app_manager/xpath.py:205
+#: corehq/apps/app_manager/xpath.py:208
 #, python-brace-format
 msgid "Type {type} must be in list of domain types: {list}"
 msgstr ""
 
-#: corehq/apps/app_manager/xpath.py:213
+#: corehq/apps/app_manager/xpath.py:216
 #, python-brace-format
 msgid "Reference type {ref} cannot be a child of primary type {main}."
 msgstr ""
 
-#: corehq/apps/app_manager/xpath.py:226
+#: corehq/apps/app_manager/xpath.py:229
 msgid ""
 "Property not correctly formatted. Must be formatted like: loacation:mytype:"
 "referencetype/property. For example: location:outlet:state/name"
@@ -3236,49 +3238,49 @@ msgstr ""
 msgid "No thanks, get me out of here"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:177
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:180
 msgid "Home Screen"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:178
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:181
 msgid "Module Menu"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:179
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:182
 msgid "Module:"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:180
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:183
 msgid "Previous Screen"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:189
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:192
 msgid "Link to other form"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:239
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:242
 msgid "Delete Form"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:259
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:262
 msgid ""
 "Your administrator has locked this form from edits through the form builder"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:268
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:271
 msgid "Try in CloudCare"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:277
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:280
 msgid "User Registration Properties"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:284
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:287
 #: corehq/apps/app_manager/templates/app_manager/managed_app.html:162
 #: corehq/apps/app_manager/templates/app_manager/module_view.html:189
 #: corehq/apps/dashboard/views.py:217
 #: corehq/apps/grapevine/templates/grapevine/backend.html:5
-#: corehq/apps/hqwebapp/models.py:952 corehq/apps/hqwebapp/models.py:1630
+#: corehq/apps/hqwebapp/models.py:952 corehq/apps/hqwebapp/models.py:1625
 #: corehq/apps/mach/templates/mach/backend.html:5
 #: corehq/apps/megamobile/templates/megamobile/backend.html:5
 #: corehq/apps/sms/templates/sms/http_backend.html:33
@@ -3289,63 +3291,63 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:288
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:332
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:334
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:291
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:335
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:337
 #: corehq/apps/app_manager/templates/app_manager/module_view.html:190
 msgid "Case Management"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:294
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:358
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:360
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:297
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:361
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:363
 msgid "User Case Management"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:301
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:304
 msgid "Visit Scheduler"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:317
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:354
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:320
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:357
 msgid ""
 "There are errors in your form. Fix your form in order to view and edit Case "
 "Management."
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:322
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:324
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:325
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:327
 msgid "Cases and Referrals"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:325
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:335
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:328
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:338
 msgid ""
 "Cases give you a way to track patients, farms, etc. over time.  You can "
 "choose to save data from a form to the case, which will store the data "
 "locally on the phone to use later."
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:346
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:349
 #: corehq/apps/app_manager/templates/app_manager/partials/form_tab_visit_scheduler.html:97
 msgid ""
 "You have not created a form yet. Create a form in order to view and edit "
 "Case Management."
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:361
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:364
 msgid ""
 "The user case allows you to store data about the user in a case and use that "
 "data in forms."
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:371
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:374
 msgid ""
 "You have not created a form yet. Create a form in order to view and edit "
 "User Case Management."
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:396
+#: corehq/apps/app_manager/templates/app_manager/form_view_base.html:399
 #: corehq/apps/app_manager/templates/app_manager/managed_app.html:213
 #: corehq/apps/reports/templates/reports/partials/form_name.html:5
 msgid "User Registration"
@@ -3498,7 +3500,7 @@ msgstr ""
 #: corehq/apps/app_manager/templates/app_manager/module_view.html:254
 #: corehq/apps/domain/views.py:340
 #: corehq/apps/locations/templates/locations/manage/location.html:84
-#: corehq/apps/users/forms.py:211
+#: corehq/apps/users/forms.py:210
 #: corehq/apps/users/templates/users/edit_commcare_user.html:122
 msgid "Basic"
 msgstr ""
@@ -3510,7 +3512,7 @@ msgstr ""
 #: corehq/apps/reports/filters/select.py:108
 #: corehq/apps/reports/standard/cases/basic.py:270
 #: corehq/apps/reports/templates/reports/reportdata/case_export_data.html:125
-#: corehq/ex-submodules/casexml/apps/case/models.py:877
+#: corehq/ex-submodules/casexml/apps/case/models.py:882
 msgid "Case Type"
 msgstr ""
 
@@ -3561,7 +3563,31 @@ msgstr ""
 msgid "Display"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:65
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:63
+msgid "Chart Title"
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:66
+msgid "Graph type"
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:73
+msgid "Configuration"
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:83
+msgid "Add Configuration Item"
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:88
+msgid "Series Configuration"
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:99
+msgid "Add Series Configuration Item"
+msgstr ""
+
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:109
 #: corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html:130
 #: corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html:174
 #: corehq/apps/data_interfaces/templates/data_interfaces/list_case_groups.html:21
@@ -3600,7 +3626,7 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:76
+#: corehq/apps/app_manager/templates/app_manager/module_view_report.html:120
 msgid "Add Report"
 msgstr ""
 
@@ -3909,7 +3935,6 @@ msgstr ""
 #: custom/ewsghana/templates/ewsghana/facility_page_print_report.html:82
 #: custom/ewsghana/templates/ewsghana/reporting_rates_print_report.html:85
 #: custom/ewsghana/templates/ewsghana/stock_status_print_report.html:78
-#: custom/opm/templates/opm/hsr_print.html:57
 #: custom/opm/templates/opm/met_print_report.html:88
 #: custom/opm/templates/opm/new_hsr_print.html:65
 msgid "Loading ..."
@@ -4791,7 +4816,7 @@ msgstr ""
 #: corehq/apps/appstore/templates/appstore/appstore_base.html:278
 #: corehq/apps/reports/standard/monitoring.py:773
 #: corehq/apps/reports/templates/reports/reports_home.html:132
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:272
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:273
 #: corehq/apps/reports/templates/reports/messaging/survey_detail.html:40
 #: corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_hierarchy.html:118
 #: submodules/ctable-src/ctable_view/templates/ctable/list_mappings.html:115
@@ -4809,7 +4834,7 @@ msgstr ""
 
 #: corehq/apps/app_manager/templates/app_manager/partials/form_tab_advanced.html:51
 #: corehq/apps/cloudcare/templates/cloudcare/cloudcare_home.html:50
-#: corehq/apps/hqwebapp/views.py:715
+#: corehq/apps/hqwebapp/views.py:717
 msgid "Loading..."
 msgstr ""
 
@@ -5021,10 +5046,10 @@ msgstr ""
 #: corehq/apps/export/templates/export/dialogs/delete_custom_export_dialog.html:13
 #: corehq/apps/hqadmin/templates/hqadmin/partials/reset-pillow-checkpoint-modal.html:18
 #: corehq/apps/hqmedia/templates/hqmedia/partials/multimedia_uploader.html:34
-#: corehq/apps/prelogin/templates/prelogin/base.html:126
-#: corehq/apps/prelogin/templates/prelogin/base.html:143
-#: corehq/apps/prelogin/templates/prelogin/base.html:174
-#: corehq/apps/prelogin/templates/prelogin/base.html:213
+#: corehq/apps/prelogin/templates/prelogin/base.html:129
+#: corehq/apps/prelogin/templates/prelogin/base.html:146
+#: corehq/apps/prelogin/templates/prelogin/base.html:177
+#: corehq/apps/prelogin/templates/prelogin/base.html:216
 #: corehq/apps/registration/templates/registration/org_request.html:70
 #: corehq/apps/registration/templates/registration/partials/eula_modal.html:11
 #: corehq/apps/reports/templates/reports/partials/export_download_modal.html:15
@@ -5098,7 +5123,7 @@ msgstr ""
 #: corehq/apps/appstore/views.py:28
 #: corehq/apps/appstore/templates/appstore/project_info.html:148
 #: corehq/apps/reports/filters/select.py:43
-#: custom/ilsgateway/tanzania/reports/delivery.py:153
+#: custom/ilsgateway/tanzania/reports/delivery.py:156
 msgid "Category"
 msgstr ""
 
@@ -5144,8 +5169,8 @@ msgid "You must specify a name for the new project"
 msgstr ""
 
 #: corehq/apps/appstore/templates/appstore/appstore_base.html:7
-#: corehq/apps/domain/views.py:1636 corehq/apps/hqwebapp/models.py:1208
-#: corehq/apps/hqwebapp/models.py:1584
+#: corehq/apps/domain/views.py:1636 corehq/apps/hqwebapp/models.py:1203
+#: corehq/apps/hqwebapp/models.py:1579
 #: corehq/apps/style/templates/style/bootstrap2/partials/domain_list_dropdown.html:19
 #: corehq/apps/style/templates/style/bootstrap3/partials/domain_list_dropdown.html:34
 msgid "CommCare Exchange"
@@ -5208,7 +5233,7 @@ msgstr ""
 #: corehq/apps/export/forms.py:76 corehq/apps/export/forms.py:133
 #: corehq/apps/hqwebapp/templates/hqwebapp/partials/pagination.html:36
 #: corehq/apps/reports/templates/reports/filters/drilldown_options.html:24
-#: corehq/apps/userreports/reports/builder/forms.py:356
+#: corehq/apps/userreports/reports/builder/forms.py:357
 msgid "Next"
 msgstr ""
 
@@ -5272,7 +5297,7 @@ msgstr ""
 #: corehq/apps/appstore/templates/appstore/project_info.html:198
 #: corehq/apps/settings/templates/settings/my_projects.html:11
 #: corehq/apps/sms/templates/sms/list_backends.html:76
-#: corehq/apps/users/views/__init__.py:688
+#: corehq/apps/users/views/__init__.py:646
 msgid "Project"
 msgstr ""
 
@@ -5414,6 +5439,8 @@ msgstr ""
 #: corehq/apps/reminders/templates/reminders/partial/complex_message_table.html:18
 #: corehq/apps/reminders/templates/reminders/partial/complex_message_table.html:21
 #: corehq/apps/sms/templates/sms/default.html:50
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:12
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:17
 msgid "Time"
 msgstr ""
 
@@ -5427,11 +5454,11 @@ msgid ""
 "That app is no longer valid. Try using the navigation links to select an app."
 msgstr ""
 
-#: corehq/apps/cloudcare/views.py:313
+#: corehq/apps/cloudcare/views.py:312
 msgid "Something went wrong filtering your cases."
 msgstr ""
 
-#: corehq/apps/cloudcare/views.py:489 corehq/apps/hqwebapp/models.py:1045
+#: corehq/apps/cloudcare/views.py:488 corehq/apps/hqwebapp/models.py:1045
 msgid "CloudCare Permissions"
 msgstr ""
 
@@ -5681,7 +5708,7 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/commtrack/forms.py:66 corehq/apps/commtrack/forms.py:71
-#: corehq/apps/commtrack/views.py:231
+#: corehq/apps/commtrack/views.py:236
 msgid "Stock Levels"
 msgstr ""
 
@@ -5725,8 +5752,8 @@ msgid "Location Type"
 msgstr ""
 
 #: corehq/apps/commtrack/models.py:539
-#: custom/ilsgateway/tanzania/reports/delivery.py:81
-#: custom/ilsgateway/tanzania/reports/randr.py:170
+#: custom/ilsgateway/tanzania/reports/delivery.py:83
+#: custom/ilsgateway/tanzania/reports/randr.py:172
 msgid "Code"
 msgstr ""
 
@@ -5745,11 +5772,11 @@ msgstr ""
 msgid "Location"
 msgstr ""
 
-#: corehq/apps/commtrack/processing.py:159
+#: corehq/apps/commtrack/processing.py:160
 msgid "Product IDs must be set for all ledger updates!"
 msgstr ""
 
-#: corehq/apps/commtrack/processing.py:174
+#: corehq/apps/commtrack/processing.py:175
 msgid "Ledger transaction references invalid Case ID \"{}\""
 msgstr ""
 
@@ -5773,33 +5800,33 @@ msgstr ""
 msgid "uncategorized"
 msgstr ""
 
-#: corehq/apps/commtrack/views.py:36 corehq/apps/hqwebapp/models.py:425
+#: corehq/apps/commtrack/views.py:41 corehq/apps/hqwebapp/models.py:425
 msgid "Setup"
 msgstr ""
 
-#: corehq/apps/commtrack/views.py:49
+#: corehq/apps/commtrack/views.py:54
 msgid "Advanced Settings"
 msgstr ""
 
-#: corehq/apps/commtrack/views.py:132
+#: corehq/apps/commtrack/views.py:137
 msgid ""
 "Settings updated! Your updated consumption settings may take a few minutes "
 "to show up in reports and on phones."
 msgstr ""
 
-#: corehq/apps/commtrack/views.py:135
+#: corehq/apps/commtrack/views.py:140
 msgid "Settings updated!"
 msgstr ""
 
-#: corehq/apps/commtrack/views.py:143 custom/intrahealth/sqldata.py:484
+#: corehq/apps/commtrack/views.py:148 custom/intrahealth/sqldata.py:484
 msgid "Consumption"
 msgstr ""
 
-#: corehq/apps/commtrack/views.py:161
+#: corehq/apps/commtrack/views.py:166
 msgid "Default consumption values updated"
 msgstr ""
 
-#: corehq/apps/commtrack/views.py:291
+#: corehq/apps/commtrack/views.py:296
 msgid "Rebuild Stock State"
 msgstr ""
 
@@ -5821,6 +5848,73 @@ msgstr ""
 
 #: corehq/apps/commtrack/templates/commtrack/manage/default_consumption.html:24
 msgid "Update Default Consumption Info"
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:8
+#, python-format
+msgid ""
+"\n"
+"    <strong>Warning:</strong>\n"
+"    You have more than %(stock_state_limit)s stocks in your project space.\n"
+"    Only %(stock_state_limit)s are shown.\n"
+"    "
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:18
+#, python-format
+msgid ""
+"\n"
+"    <strong>Warning:</strong>\n"
+"    You have more than %(stock_transaction_limit)s stock transactions in "
+"your project space.\n"
+"    Only %(stock_transaction_limit)s are shown.\n"
+"    "
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:33
+#, python-format
+msgid ""
+"\n"
+"                <strong>%(case_display)s</strong>\n"
+"                %(section_display)s\n"
+"                for <em>%(product_name)s</em>\n"
+"                "
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:43
+msgid "Rebuild"
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:50
+msgid "Current Values"
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:51
+msgid "Rebuilt Values"
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:54
+msgid "Server Date"
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:55
+msgid "Self-reported Date"
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:58
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:60
+msgid "Quantity"
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:59
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:61
+#: corehq/apps/reports/commtrack/standard.py:297
+#: custom/ilsgateway/tanzania/reports/facility_details.py:27
+msgid "Stock on Hand"
+msgstr ""
+
+#: corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html:92
+msgid "(will be deleted)"
 msgstr ""
 
 #: corehq/apps/commtrack/templates/commtrack/manage/stock_levels.html:7
@@ -6027,7 +6121,7 @@ msgstr ""
 #: corehq/apps/data_interfaces/interfaces.py:22
 #: corehq/apps/data_interfaces/views.py:58 corehq/apps/hqwebapp/models.py:553
 #: corehq/apps/settings/views.py:213
-#: corehq/apps/userreports/reports/builder/forms.py:350
+#: corehq/apps/userreports/reports/builder/forms.py:351
 msgid "Data"
 msgstr ""
 
@@ -6054,7 +6148,7 @@ msgstr ""
 
 #: corehq/apps/dashboard/views.py:206
 #: corehq/apps/dashboard/templates/dashboard/dashboard_new_user.html:73
-#: corehq/apps/hqwebapp/models.py:1576
+#: corehq/apps/hqwebapp/models.py:1571
 msgid "Exchange"
 msgstr ""
 
@@ -6116,6 +6210,7 @@ msgid "Welcome to CommCare Supply"
 msgstr ""
 
 #: corehq/apps/dashboard/templates/dashboard/dashboard_new_user.html:64
+#: docs/_build/html/_sources/translations.txt:132
 msgid "Welcome to CommCare HQ"
 msgstr ""
 
@@ -6174,7 +6269,7 @@ msgstr ""
 #: corehq/apps/data_interfaces/interfaces.py:50
 #: corehq/apps/reports/standard/cases/basic.py:272
 #: corehq/apps/sms/templates/sms/list_backends.html:63
-#: corehq/ex-submodules/casexml/apps/case/models.py:887
+#: corehq/ex-submodules/casexml/apps/case/models.py:892
 msgid "Owner"
 msgstr ""
 
@@ -6650,7 +6745,7 @@ msgstr ""
 msgid "New owner's CommCare username"
 msgstr ""
 
-#: corehq/apps/domain/forms.py:362 corehq/apps/domain/views.py:2464
+#: corehq/apps/domain/forms.py:362 corehq/apps/domain/views.py:2465
 msgid "Transfer Project"
 msgstr ""
 
@@ -6760,7 +6855,7 @@ msgid "Secure submissions"
 msgstr ""
 
 #: corehq/apps/domain/forms.py:633 corehq/apps/hqadmin/reports.py:696
-#: corehq/apps/prelogin/templates/prelogin/base.html:81
+#: corehq/apps/prelogin/templates/prelogin/base.html:84
 msgid "Services"
 msgstr ""
 
@@ -6792,7 +6887,7 @@ msgstr ""
 
 #: corehq/apps/domain/forms.py:652
 #: corehq/apps/reports/standard/deployments.py:43
-#: corehq/apps/reports/standard/deployments.py:215
+#: corehq/apps/reports/standard/deployments.py:226
 #: corehq/apps/reports/standard/sms.py:164
 #: corehq/apps/reports/standard/sms.py:415
 #: corehq/apps/reports/standard/sms.py:474
@@ -6891,7 +6986,7 @@ msgstr ""
 #: corehq/apps/domain/forms.py:978 corehq/apps/domain/forms.py:1075
 #: corehq/apps/reminders/forms.py:517 corehq/apps/reminders/forms.py:2152
 #: corehq/apps/styleguide/examples/simple_crispy_form/forms.py:63
-#: corehq/apps/users/forms.py:487
+#: corehq/apps/users/forms.py:486
 msgid "Basic Information"
 msgstr ""
 
@@ -6916,7 +7011,7 @@ msgid ""
 msgstr ""
 
 #: corehq/apps/domain/forms.py:922 corehq/apps/domain/forms.py:986
-#: corehq/apps/domain/forms.py:1083 corehq/apps/users/forms.py:495
+#: corehq/apps/domain/forms.py:1083 corehq/apps/users/forms.py:494
 msgid "Mailing Address"
 msgstr ""
 
@@ -7100,15 +7195,15 @@ msgstr ""
 msgid "Subscription Type"
 msgstr ""
 
-#: corehq/apps/domain/models.py:1295
+#: corehq/apps/domain/models.py:1279
 msgid "Transfer domain request is no longer active"
 msgstr ""
 
-#: corehq/apps/domain/models.py:1327 corehq/apps/domain/models.py:1342
+#: corehq/apps/domain/models.py:1311 corehq/apps/domain/models.py:1326
 msgid "Transfer of ownership for CommCare project space."
 msgstr ""
 
-#: corehq/apps/domain/models.py:1368
+#: corehq/apps/domain/models.py:1352
 #, python-brace-format
 msgid "There has been a transfer of ownership of {domain}"
 msgstr ""
@@ -7140,7 +7235,7 @@ msgstr ""
 msgid "Sorry, you do not have access to %(feature_name)s"
 msgstr ""
 
-#: corehq/apps/domain/views.py:267 corehq/apps/hqwebapp/models.py:1146
+#: corehq/apps/domain/views.py:267 corehq/apps/hqwebapp/models.py:1141
 #: corehq/apps/hqwebapp/templates/hqwebapp/partials/global_navigation_bar.html:91
 #: corehq/apps/ota/views.py:121
 #: corehq/apps/style/templates/style/bootstrap3/partials/domain_list_dropdown.html:6
@@ -7285,9 +7380,7 @@ msgstr ""
 msgid "Privacy and Security"
 msgstr ""
 
-#: corehq/apps/domain/views.py:1329 corehq/apps/prelogin/forms.py:96
-#: corehq/apps/prelogin/templates/prelogin/base.html:128
-#: corehq/apps/prelogin/templates/prelogin/_sections/home/about_dimagi.html:42
+#: corehq/apps/domain/views.py:1329 corehq/apps/prelogin/forms.py:97
 msgid "Contact Dimagi"
 msgstr ""
 
@@ -7311,7 +7404,7 @@ msgstr ""
 
 #: corehq/apps/domain/views.py:1437
 #: corehq/apps/domain/templates/domain/confirm_subscription_renewal.html:43
-#: corehq/apps/users/forms.py:513
+#: corehq/apps/users/forms.py:512
 #: corehq/apps/users/templates/users/mobile/users_list.html:115
 #: corehq/apps/users/views/mobile/users.py:461
 msgid "Confirm Billing Information"
@@ -7388,7 +7481,7 @@ msgstr ""
 msgid "Created a new version of your app."
 msgstr ""
 
-#: corehq/apps/domain/views.py:1932 corehq/apps/hqwebapp/models.py:1212
+#: corehq/apps/domain/views.py:1932 corehq/apps/hqwebapp/models.py:1207
 msgid "Multimedia Sharing"
 msgstr ""
 
@@ -7419,7 +7512,7 @@ msgstr ""
 msgid "App Schema Changes"
 msgstr ""
 
-#: corehq/apps/domain/views.py:1987 corehq/apps/hqwebapp/models.py:1226
+#: corehq/apps/domain/views.py:1987 corehq/apps/hqwebapp/models.py:1221
 msgid "Data Forwarding"
 msgstr ""
 
@@ -7432,7 +7525,7 @@ msgstr ""
 msgid "Forwarding set up to %s"
 msgstr ""
 
-#: corehq/apps/domain/views.py:2152 corehq/apps/hqwebapp/models.py:1203
+#: corehq/apps/domain/views.py:2152 corehq/apps/hqwebapp/models.py:1198
 msgid "Project Information"
 msgstr ""
 
@@ -7455,28 +7548,28 @@ msgstr ""
 msgid "Feature Previews"
 msgstr ""
 
-#: corehq/apps/domain/views.py:2439 corehq/apps/hqwebapp/models.py:1510
-#: corehq/apps/hqwebapp/models.py:1534 corehq/apps/hqwebapp/models.py:1562
+#: corehq/apps/domain/views.py:2439 corehq/apps/hqwebapp/models.py:1505
+#: corehq/apps/hqwebapp/models.py:1529 corehq/apps/hqwebapp/models.py:1557
 #: corehq/apps/toggle_ui/templates/toggle/flags.html:6
 msgid "Feature Flags"
 msgstr ""
 
-#: corehq/apps/domain/views.py:2488
+#: corehq/apps/domain/views.py:2489
 #, python-brace-format
 msgid "Resent transfer request for project '{domain}'"
 msgstr ""
 
-#: corehq/apps/domain/views.py:2558
+#: corehq/apps/domain/views.py:2559
 #, python-brace-format
 msgid "Successfully transferred ownership of project '{domain}'"
 msgstr ""
 
-#: corehq/apps/domain/views.py:2590
+#: corehq/apps/domain/views.py:2591
 #, python-brace-format
 msgid "Declined ownership of project '{domain}'"
 msgstr ""
 
-#: corehq/apps/domain/views.py:2606 corehq/apps/domain/views.py:2626
+#: corehq/apps/domain/views.py:2607 corehq/apps/domain/views.py:2627
 msgid "SMS Rate Calculator"
 msgstr ""
 
@@ -7866,7 +7959,7 @@ msgid "Usage Summary"
 msgstr ""
 
 #: corehq/apps/domain/templates/domain/current_subscription.html:210
-#: corehq/apps/domain/templates/domain/admin/feature_flags.html:26
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:34
 msgid "Feature"
 msgstr ""
 
@@ -8188,35 +8281,38 @@ msgstr ""
 msgid "Add a forwarding location"
 msgstr ""
 
-#: corehq/apps/domain/templates/domain/admin/feature_flags.html:8
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:16
 #, python-format
 msgid ""
 "\n"
-"                    Feature Flags are superuser-only things that can be turn "
-"on features for individual users or projects.\n"
-"                    They can be edited manually at the <a href="
-"\"%(toggle_url)s\">Feature Flag edit UI</a> (also super-only).\n"
+"                    Feature Flags turn on features for individual users or "
+"projects. They are editable only by\n"
+"                    super users, in the <a href=\"%(toggle_url)s\">Feature "
+"Flag edit UI</a>.\n"
 "                    In addition, some feature flags are randomly enabled by "
-"a domain.\n"
-"                "
-msgstr ""
-
-#: corehq/apps/domain/templates/domain/admin/feature_flags.html:15
-msgid ""
-"\n"
-"                    You can see a list of all enabled flags for this domain "
-"here.\n"
-"                    This does not include any flags set for users within the "
 "domain.\n"
 "                "
 msgstr ""
 
-#: corehq/apps/domain/templates/domain/admin/feature_flags.html:27
-#: corehq/apps/toggle_ui/templates/toggle/edit_flag.html:165
-msgid "Enabled?"
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:23
+msgid ""
+"\n"
+"                    Following are all flags enabled for this domain and/or "
+"for you.\n"
+"                    This does not include any flags set for other users in "
+"this domain.\n"
+"                "
 msgstr ""
 
 #: corehq/apps/domain/templates/domain/admin/feature_flags.html:35
+msgid "Enabled for domain?"
+msgstr ""
+
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:36
+msgid "Enabled for me?"
+msgstr ""
+
+#: corehq/apps/domain/templates/domain/admin/feature_flags.html:45
 msgid "change"
 msgstr ""
 
@@ -8268,7 +8364,7 @@ msgid "SMS Pricing"
 msgstr ""
 
 #: corehq/apps/domain/templates/domain/admin/global_sms_rates.html:35
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:67
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:78
 msgid "Pricing"
 msgstr ""
 
@@ -8751,8 +8847,8 @@ msgstr ""
 #: corehq/apps/users/templates/users/web_users.b3.html:220
 #: corehq/apps/users/templates/users/web_users.b3.html:285
 #: corehq/apps/users/templates/users/web_users.html:127
-#: custom/ilsgateway/tanzania/reports/facility_details.py:71
-#: custom/ilsgateway/tanzania/reports/facility_details.py:117
+#: custom/ilsgateway/tanzania/reports/facility_details.py:72
+#: custom/ilsgateway/tanzania/reports/facility_details.py:118
 msgid "Role"
 msgstr ""
 
@@ -8828,7 +8924,7 @@ msgid "Forgot your password?"
 msgstr ""
 
 #: corehq/apps/domain/templates/login_and_password/partials/login_form.html:50
-#: corehq/apps/prelogin/templates/prelogin/base.html:74
+#: corehq/apps/prelogin/templates/prelogin/base.html:77
 #: corehq/apps/style/templates/style/bootstrap2/base.html:74
 #: corehq/apps/style/templates/style/bootstrap3/base.html:102
 msgid "Sign In"
@@ -9180,7 +9276,7 @@ msgstr ""
 #: corehq/apps/sms/forms.py:450
 #: corehq/apps/sms/templates/sms/backend_map.html:97
 #: corehq/apps/style/templates/style/bootstrap3/base.html:234
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:144
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:148
 #: corehq/apps/users/templates/users/web_users.b3.html:60
 #: custom/ewsghana/templates/ewsghana/partials/users_tables.html:102
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:212
@@ -9569,6 +9665,7 @@ msgstr ""
 
 #: corehq/apps/fixtures/templates/fixtures/manage_tables.html:66
 #: corehq/apps/fixtures/templates/fixtures/partials/edit_table_modal.html:9
+#: corehq/apps/userreports/ui/forms.py:87
 msgid "Table ID"
 msgstr ""
 
@@ -9945,7 +10042,7 @@ msgstr ""
 msgid "ADMINREPORT"
 msgstr ""
 
-#: corehq/apps/hqadmin/reports.py:642 corehq/apps/hqwebapp/models.py:1401
+#: corehq/apps/hqadmin/reports.py:642 corehq/apps/hqwebapp/models.py:1396
 msgid "Project Space List"
 msgstr ""
 
@@ -10179,7 +10276,7 @@ msgstr ""
 msgid "No Info"
 msgstr ""
 
-#: corehq/apps/hqadmin/reports.py:808 corehq/apps/hqwebapp/models.py:1403
+#: corehq/apps/hqadmin/reports.py:808 corehq/apps/hqwebapp/models.py:1398
 msgid "User List"
 msgstr ""
 
@@ -10212,7 +10309,7 @@ msgstr ""
 msgid "No Domain Data"
 msgstr ""
 
-#: corehq/apps/hqadmin/reports.py:876 corehq/apps/hqwebapp/models.py:1405
+#: corehq/apps/hqadmin/reports.py:876 corehq/apps/hqwebapp/models.py:1400
 msgid "Application List"
 msgstr ""
 
@@ -10338,7 +10435,7 @@ msgid "Print"
 msgstr ""
 
 #: corehq/apps/hqadmin/templates/hqadmin/hqadmin_base_report.html:33
-#: corehq/apps/hqwebapp/models.py:1371 corehq/apps/hqwebapp/models.py:1539
+#: corehq/apps/hqwebapp/models.py:1366 corehq/apps/hqwebapp/models.py:1534
 msgid "Admin Reports"
 msgstr ""
 
@@ -10431,12 +10528,12 @@ msgstr ""
 msgid "Audio"
 msgstr ""
 
-#: corehq/apps/hqmedia/models.py:815
+#: corehq/apps/hqmedia/models.py:818
 #, python-format
 msgid "Encountered an AttributeError for media: %s"
 msgstr ""
 
-#: corehq/apps/hqmedia/models.py:819
+#: corehq/apps/hqmedia/models.py:822
 #, python-format
 msgid ""
 "This application has unsupported text in one of it's media file label "
@@ -10480,7 +10577,7 @@ msgstr ""
 msgid "File {name}s has an incorrect file type {ext}."
 msgstr ""
 
-#: corehq/apps/hqmedia/views.py:579
+#: corehq/apps/hqmedia/views.py:575
 msgid ""
 "There was an issue retrieving the status from the cache. We are looking into "
 "it. Please try uploading again."
@@ -10860,7 +10957,7 @@ msgstr ""
 msgid "Error Type"
 msgstr ""
 
-#: corehq/apps/hqpillow_retry/views.py:41 corehq/apps/hqwebapp/models.py:1393
+#: corehq/apps/hqpillow_retry/views.py:41 corehq/apps/hqwebapp/models.py:1388
 msgid "PillowTop Errors"
 msgstr ""
 
@@ -11145,7 +11242,7 @@ msgstr ""
 msgid "New Survey"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:929 corehq/apps/hqwebapp/models.py:1490
+#: corehq/apps/hqwebapp/models.py:929 corehq/apps/hqwebapp/models.py:1485
 #: corehq/apps/sms/views.py:990
 #: corehq/apps/sms/templates/sms/add_backend.html:49
 #: corehq/apps/sms/templates/sms/add_backend.html:70
@@ -11156,11 +11253,11 @@ msgstr ""
 msgid "SMS Connectivity"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:933 corehq/apps/hqwebapp/models.py:1494
+#: corehq/apps/hqwebapp/models.py:933 corehq/apps/hqwebapp/models.py:1489
 msgid "Add Connection"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:937 corehq/apps/hqwebapp/models.py:1496
+#: corehq/apps/hqwebapp/models.py:937 corehq/apps/hqwebapp/models.py:1491
 msgid "Edit Connection"
 msgstr ""
 
@@ -11211,180 +11308,174 @@ msgstr ""
 msgid "Application Users"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1068
+#: corehq/apps/hqwebapp/models.py:1067
 msgid "Project Users"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1072
+#: corehq/apps/hqwebapp/models.py:1071
 msgid ""
 "Grant other CommCare HQ users access to your project and manage user roles."
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1075
+#: corehq/apps/hqwebapp/models.py:1074
 #: corehq/apps/users/templates/users/web_users.b3.html:136
 msgid "Invite Web User"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1083 corehq/apps/settings/views.py:93
-#: corehq/apps/settings/templates/settings/edit_my_account.b2.html:33
-#: corehq/apps/users/views/__init__.py:350
-msgid "My Information"
-msgstr ""
-
-#: corehq/apps/hqwebapp/models.py:1219
+#: corehq/apps/hqwebapp/models.py:1214
 msgid "Forward Forms"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1221
+#: corehq/apps/hqwebapp/models.py:1216
 msgid "Forward Form Stubs"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1223
+#: corehq/apps/hqwebapp/models.py:1218
 msgid "Forward Cases"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1250
+#: corehq/apps/hqwebapp/models.py:1245
 msgid "Project Administration"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1296
+#: corehq/apps/hqwebapp/models.py:1291
 msgid "Internal Subscription Management (Dimagi Only)"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1313
+#: corehq/apps/hqwebapp/models.py:1308
 msgid "Project Tools"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1334
+#: corehq/apps/hqwebapp/models.py:1329
 msgid "Internal Data (Dimagi Only)"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1340
+#: corehq/apps/hqwebapp/models.py:1335
 msgid "My Settings"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1352
+#: corehq/apps/hqwebapp/models.py:1347
 msgid "Manage My Settings"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1381 corehq/apps/hqwebapp/models.py:1400
+#: corehq/apps/hqwebapp/models.py:1376 corehq/apps/hqwebapp/models.py:1395
 msgid "Administrative Reports"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1382 corehq/apps/hqwebapp/models.py:1411
-#: corehq/apps/hqwebapp/models.py:1533 corehq/apps/hqwebapp/models.py:1540
+#: corehq/apps/hqwebapp/models.py:1377 corehq/apps/hqwebapp/models.py:1406
+#: corehq/apps/hqwebapp/models.py:1528 corehq/apps/hqwebapp/models.py:1535
 msgid "System Info"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1391
+#: corehq/apps/hqwebapp/models.py:1386
 msgid "Mass Email Users"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1396
+#: corehq/apps/hqwebapp/models.py:1391
 msgid "Login as another user"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1407
+#: corehq/apps/hqwebapp/models.py:1402
 msgid "Message Logs Across All Domains"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1409
+#: corehq/apps/hqwebapp/models.py:1404
 msgid "CommCare Versions"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1413
+#: corehq/apps/hqwebapp/models.py:1408
 msgid "Loadtest Report"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1416
+#: corehq/apps/hqwebapp/models.py:1411
 msgid "Administrative Operations"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1417
+#: corehq/apps/hqwebapp/models.py:1412
 msgid "CommCare Reports"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1439
+#: corehq/apps/hqwebapp/models.py:1434
 msgid "Accounting"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1482 corehq/apps/hqwebapp/models.py:1561
+#: corehq/apps/hqwebapp/models.py:1477 corehq/apps/hqwebapp/models.py:1556
 msgid "SMS Connectivity & Billing"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1491
+#: corehq/apps/hqwebapp/models.py:1486
 #: corehq/apps/sms/templates/sms/add_backend.html:52
 #: corehq/apps/sms/templates/sms/list_backends.html:39
 msgid "SMS Connections"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1499
+#: corehq/apps/hqwebapp/models.py:1494
 #: corehq/apps/sms/templates/sms/backend_map.html:5
 #: corehq/apps/sms/templates/sms/backend_map.html:64
 #: corehq/apps/sms/templates/sms/backend_map.html:72
 msgid "SMS Country-Connection Map"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1519
+#: corehq/apps/hqwebapp/models.py:1514
 msgid "Admin"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1541
+#: corehq/apps/hqwebapp/models.py:1536
 msgid "Management"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1542
+#: corehq/apps/hqwebapp/models.py:1537
 msgid "Commands"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1556
+#: corehq/apps/hqwebapp/models.py:1551
 msgid "Old SMS Billing"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1564
+#: corehq/apps/hqwebapp/models.py:1559
 msgid "Django Admin"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1586
+#: corehq/apps/hqwebapp/models.py:1581
 msgid "Publish this project"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1615
+#: corehq/apps/hqwebapp/models.py:1610
 #: corehq/apps/orgs/templates/orgs/report_base.html:28
 msgid "Projects Table"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1618
+#: corehq/apps/hqwebapp/models.py:1613
 #: corehq/apps/orgs/templates/orgs/report_base.html:29
 #: corehq/apps/reports/standard/monitoring.py:1026
 msgid "Form Data"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1621
+#: corehq/apps/hqwebapp/models.py:1616
 #: corehq/apps/orgs/templates/orgs/report_base.html:30
 #: corehq/apps/reports/standard/monitoring.py:1036
 msgid "Case Data"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1624
+#: corehq/apps/hqwebapp/models.py:1619
 #: corehq/apps/orgs/templates/orgs/report_base.html:31
 msgid "User Data"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1637
+#: corehq/apps/hqwebapp/models.py:1632
 #: corehq/apps/orgs/templates/orgs/orgs_team_members.html:84
 #: corehq/apps/orgs/templates/orgs/public.html:28
 #: corehq/apps/orgs/templates/orgs/partials/top_nav.html:6
 msgid "Projects"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1640
+#: corehq/apps/hqwebapp/models.py:1635
 #: corehq/apps/orgs/templates/orgs/public.html:31
 #: corehq/apps/orgs/templates/orgs/partials/top_nav.html:9
 msgid "Teams"
 msgstr ""
 
-#: corehq/apps/hqwebapp/models.py:1643
+#: corehq/apps/hqwebapp/models.py:1638
 #: corehq/apps/orgs/templates/orgs/orgs_team_members.html:50
 #: corehq/apps/orgs/templates/orgs/public.html:34
 #: corehq/apps/orgs/templates/orgs/partials/top_nav.html:12
@@ -11435,44 +11526,44 @@ msgstr ""
 msgid "View All"
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:612
+#: corehq/apps/hqwebapp/views.py:614
 msgid ""
 "Check \"Opt out of emails about new features and other CommCare updates\" in "
 "your account settings and then click \"Update Information\" if you do not "
 "want to receive future emails from us."
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:713
+#: corehq/apps/hqwebapp/views.py:715
 msgid "items per page"
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:714
+#: corehq/apps/hqwebapp/views.py:716
 msgid "You have no items."
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:716
+#: corehq/apps/hqwebapp/views.py:718
 msgid "Deleted Items:"
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:717
+#: corehq/apps/hqwebapp/views.py:719
 msgid "New Items:"
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:840
+#: corehq/apps/hqwebapp/views.py:842
 #, python-format
 msgid "<strong>Problem Refreshing List:</strong> %s"
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:858
+#: corehq/apps/hqwebapp/views.py:860
 #, python-format
 msgid "<strong>Problem Deleting:</strong> %s"
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:866
+#: corehq/apps/hqwebapp/views.py:868
 msgid "The item's ID was not passed to the server."
 msgstr ""
 
-#: corehq/apps/hqwebapp/views.py:976
+#: corehq/apps/hqwebapp/views.py:978
 #, python-format
 msgid "We've redirected you to the %s matching your query"
 msgstr ""
@@ -11750,11 +11841,11 @@ msgstr ""
 msgid "No properties found."
 msgstr ""
 
-#: corehq/apps/importer/base.py:5
+#: corehq/apps/importer/base.py:6
 msgid "Import Cases from Excel"
 msgstr ""
 
-#: corehq/apps/importer/base.py:7
+#: corehq/apps/importer/base.py:8
 msgid "Import case data from an external Excel file"
 msgstr ""
 
@@ -11780,6 +11871,10 @@ msgstr ""
 
 #: corehq/apps/importer/const.py:13
 msgid "Case Generation Error"
+msgstr ""
+
+#: corehq/apps/importer/const.py:14
+msgid "Duplicated Location Name"
 msgstr ""
 
 #: corehq/apps/importer/util.py:213
@@ -11816,19 +11911,26 @@ msgstr ""
 msgid "An invalid or unknown parent case was specified for the uploaded case."
 msgstr ""
 
-#: corehq/apps/importer/views.py:170
+#: corehq/apps/importer/util.py:234
+msgid ""
+"Owner ID was used in the mapping, but there were errors when uploading "
+"because of these values. There are multiple locations with this same name, "
+"try using site-code instead."
+msgstr ""
+
+#: corehq/apps/importer/views.py:169
 msgid ""
 "It looks like you may have accessed this page from a stale page. Please "
 "start over."
 msgstr ""
 
-#: corehq/apps/importer/views.py:274 corehq/apps/importer/views.py:331
+#: corehq/apps/importer/views.py:273 corehq/apps/importer/views.py:330
 msgid ""
 "The session containing the file you uploaded has expired - please upload a "
 "new one."
 msgstr ""
 
-#: corehq/apps/importer/views.py:349
+#: corehq/apps/importer/views.py:348
 msgid "Sorry, your session has expired. Please start over and try again."
 msgstr ""
 
@@ -11861,8 +11963,9 @@ msgid "Corresponding case field"
 msgstr ""
 
 #: corehq/apps/importer/templates/importer/excel_config.html:90
-#: corehq/ex-submodules/casexml/apps/case/models.py:892
-#: custom/opm/beneficiary.py:823 custom/opm/beneficiary.py:899
+#: corehq/ex-submodules/casexml/apps/case/models.py:897
+#: custom/opm/beneficiary.py:822 custom/opm/beneficiary.py:899
+#: custom/opm/beneficiary.py:921
 msgid "Case ID"
 msgstr ""
 
@@ -11913,7 +12016,8 @@ msgstr ""
 
 #: corehq/apps/importer/templates/importer/excel_config.html:192
 #: corehq/apps/importer/templates/importer/excel_fields.html:189
-#: corehq/apps/userreports/reports/builder/forms.py:458
+#: corehq/apps/userreports/reports/builder/forms.py:459
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:5
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:210
 #: submodules/ctable-src/ctable_view/templates/ctable/test_mapping.html:129
 msgid "Back"
@@ -12456,11 +12560,16 @@ msgstr ""
 msgid "Move"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:83
+#: corehq/apps/locations/templates/locations/manage/locations.html:40
+#, python-format
+msgid "You have successfully archived the location <%%=name%%>"
+msgstr ""
+
+#: corehq/apps/locations/templates/locations/manage/locations.html:102
 msgid "Manage Locations"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:85
+#: corehq/apps/locations/templates/locations/manage/locations.html:104
 msgid ""
 "\n"
 "                    Locations allow you to represent the real-world "
@@ -12473,42 +12582,43 @@ msgid ""
 "                "
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:95
+#: corehq/apps/locations/templates/locations/manage/locations.html:114
 msgid "Showing the Inactive Location List."
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:102
+#: corehq/apps/locations/templates/locations/manage/locations.html:121
 msgid "Show Archived Locations"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:106
+#: corehq/apps/locations/templates/locations/manage/locations.html:125
 msgid "Show Active Locations"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:119
-#: corehq/apps/locations/templates/locations/manage/locations.html:123
+#: corehq/apps/locations/templates/locations/manage/locations.html:138
+#: corehq/apps/locations/templates/locations/manage/locations.html:142
 msgid "Bulk Import Locations"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:127
+#: corehq/apps/locations/templates/locations/manage/locations.html:146
 msgid "Edit Location Types"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:130
+#: corehq/apps/locations/templates/locations/manage/locations.html:149
 msgid "Edit Location Fields"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:155
+#: corehq/apps/locations/templates/locations/manage/locations.html:174
 msgid "Unarchive"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:160
+#: corehq/apps/locations/templates/locations/manage/locations.html:179
+#: corehq/apps/locations/templates/locations/manage/locations.html:267
 #: corehq/apps/products/views.py:186
 #: corehq/apps/products/templates/products/manage/products.html:116
 msgid "Archive"
 msgstr ""
 
-#: corehq/apps/locations/templates/locations/manage/locations.html:216
+#: corehq/apps/locations/templates/locations/manage/locations.html:235
 #, python-format
 msgid ""
 "\n"
@@ -12516,6 +12626,22 @@ msgid ""
 "    <a href=\"%(location_types_url)s\">here</a>\n"
 "    for your project before creating any locations.\n"
 "    "
+msgstr ""
+
+#: corehq/apps/locations/templates/locations/manage/locations.html:253
+msgid "Archive Location:"
+msgstr ""
+
+#: corehq/apps/locations/templates/locations/manage/locations.html:257
+msgid ""
+"\n"
+"            <strong>Warning!</strong> Archiving a location will unassign any "
+"users\n"
+"            which were associated with that location.  You can unarchive "
+"this\n"
+"            location at any point, but you will have to reassign the users\n"
+"            manually.\n"
+"            "
 msgstr ""
 
 #: corehq/apps/locations/templates/locations/manage/partials/autocomplete_select_widget.html:10
@@ -12721,31 +12847,31 @@ msgstr ""
 msgid "Prime Restore Cache"
 msgstr ""
 
-#: corehq/apps/prelogin/forms.py:32 corehq/apps/registration/forms.py:52
+#: corehq/apps/prelogin/forms.py:33 corehq/apps/registration/forms.py:52
 msgid "Email Address"
 msgstr ""
 
-#: corehq/apps/prelogin/forms.py:45
+#: corehq/apps/prelogin/forms.py:46
 msgid "What is your interest in CommCare and any specific questions you have?"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:57
+#: corehq/apps/prelogin/templates/prelogin/base.html:60
 msgid "Toggle Navigation"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:78
+#: corehq/apps/prelogin/templates/prelogin/base.html:81
 msgid "Solutions"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:79
+#: corehq/apps/prelogin/templates/prelogin/base.html:82
 msgid "Impact"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:80
+#: corehq/apps/prelogin/templates/prelogin/base.html:83
 msgid "Software Pricing"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:108
+#: corehq/apps/prelogin/templates/prelogin/base.html:111
 #, python-format
 msgid ""
 "\n"
@@ -12756,11 +12882,15 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:145
+#: corehq/apps/prelogin/templates/prelogin/base.html:131
+msgid "Get in Touch With Us: Contact Dimagi"
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/base.html:148
 msgid "Thanks for contacting us!"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:150
+#: corehq/apps/prelogin/templates/prelogin/base.html:153
 msgid ""
 "\n"
 "                            Thank you for your interest in working with "
@@ -12768,7 +12898,7 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:155
+#: corehq/apps/prelogin/templates/prelogin/base.html:158
 msgid ""
 "\n"
 "                            One of our team members will get back to you "
@@ -12778,18 +12908,18 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:163
-#: corehq/apps/prelogin/templates/prelogin/base.html:202
+#: corehq/apps/prelogin/templates/prelogin/base.html:166
+#: corehq/apps/prelogin/templates/prelogin/base.html:205
 #: custom/_legacy/a5288/reports.py:102
 msgid "OK"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:176
-#: corehq/apps/prelogin/templates/prelogin/base.html:215
+#: corehq/apps/prelogin/templates/prelogin/base.html:179
+#: corehq/apps/prelogin/templates/prelogin/base.html:218
 msgid "Ooops!"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:181
+#: corehq/apps/prelogin/templates/prelogin/base.html:184
 msgid ""
 "\n"
 "                             We're terribly sorry! It seems like our servers "
@@ -12797,7 +12927,7 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:186
+#: corehq/apps/prelogin/templates/prelogin/base.html:189
 msgid ""
 "\n"
 "                                We've alerted one of our engineers of issues "
@@ -12808,7 +12938,7 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:193
+#: corehq/apps/prelogin/templates/prelogin/base.html:196
 msgid ""
 "\n"
 "                                You can send an email directly to\n"
@@ -12818,7 +12948,7 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/base.html:226
+#: corehq/apps/prelogin/templates/prelogin/base.html:229
 msgid ""
 "\n"
 "                                Please provide a valid e-mail address where "
@@ -12879,6 +13009,10 @@ msgid ""
 "contact\n"
 "                        Dimagi directly.\n"
 "                    "
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/home/about_dimagi.html:42
+msgid "Get in Touch With Us"
 msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/home/about_dimagi.html:50
@@ -13091,7 +13225,7 @@ msgstr ""
 #: corehq/apps/style/templates/style/includes/modal_report_issue.html:49
 #: corehq/apps/styleguide/examples/simple_crispy_form/forms.py:17
 #: custom/_legacy/pact/templates/pact/chw/pact_chw_profile_info.html:16
-#: custom/ilsgateway/tanzania/reports/facility_details.py:73
+#: custom/ilsgateway/tanzania/reports/facility_details.py:74
 msgid "Email"
 msgstr ""
 
@@ -13269,32 +13403,35 @@ msgstr ""
 #: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:12
 msgid ""
 "\n"
-"                        Read how organizations around the world use\n"
-"                        CommCare to improve frontline service delivery.\n"
+"                    <!--HubSpot Call-to-Action Code -->\n"
+"                    <span class=\"hs-cta-wrapper\" id=\"hs-cta-"
+"wrapper-071f4a7d-237d-49d8-b12d-c28fe204927d\">\n"
+"                        <span class=\"hs-cta-node hs-cta-071f4a7d-237d-49d8-"
+"b12d-c28fe204927d\" id=\"hs-cta-071f4a7d-237d-49d8-b12d-c28fe204927d\">\n"
+"                            <!--[if lte IE 8]><div id=\"hs-cta-ie-element"
+"\"></div><![endif]-->\n"
+"                            <a href=\"http://cta-redirect.hubspot.com/cta/"
+"redirect/503070/071f4a7d-237d-49d8-b12d-c28fe204927d\" ><img class=\"hs-cta-"
+"img\" id=\"hs-cta-img-071f4a7d-237d-49d8-b12d-c28fe204927d\" style=\"border-"
+"width:0px;\" src=\"https://no-cache.hubspot.com/cta/"
+"default/503070/071f4a7d-237d-49d8-b12d-c28fe204927d.png\"  alt=\"View All "
+"Case Studies\"/></a>\n"
+"                        </span>\n"
+"                        <script type=\"text/javascript\">\n"
+"                            hbspt.cta.load(503070, '071f4a7d-237d-49d8-b12d-"
+"c28fe204927d');\n"
+"                        </script>\n"
+"                    </span>\n"
+"                    <!-- end HubSpot Call-to-Action Code -->\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:24
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:39
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:54
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:69
-msgid "Read Case Study"
-msgstr ""
-
 #: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:27
-msgid "Improving Community Health in Guatemala"
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:42
-msgid "An Integrated eDiagnostic Approach in Burkina Faso"
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:57
-msgid "Improving Maternal and Child Health in India"
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/case_studies.html:72
-msgid "iCCM for Child Health in Mozambique"
+msgid ""
+"\n"
+"                        Read how organizations around the world use\n"
+"                        CommCare to improve frontline service delivery.\n"
+"                    "
 msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/impact/lead.html:9
@@ -13339,6 +13476,33 @@ msgstr ""
 #: corehq/apps/prelogin/templates/prelogin/_sections/impact/partners.html:12
 msgid ""
 "\n"
+"                    <!--HubSpot Call-to-Action Code -->\n"
+"                    <span class=\"hs-cta-wrapper\" id=\"hs-cta-wrapper-"
+"c34ae48e-2f1a-48ac-9170-31fc7c9e845b\">\n"
+"                        <span class=\"hs-cta-node hs-cta-"
+"c34ae48e-2f1a-48ac-9170-31fc7c9e845b\" id=\"hs-cta-"
+"c34ae48e-2f1a-48ac-9170-31fc7c9e845b\">\n"
+"                            <!--[if lte IE 8]><div id=\"hs-cta-ie-element"
+"\"></div><![endif]-->\n"
+"                            <a href=\"http://cta-redirect.hubspot.com/cta/"
+"redirect/503070/c34ae48e-2f1a-48ac-9170-31fc7c9e845b\"  target=\"_blank\" "
+"><img class=\"hs-cta-img\" id=\"hs-cta-img-"
+"c34ae48e-2f1a-48ac-9170-31fc7c9e845b\" style=\"border-width:0px;\" src="
+"\"https://no-cache.hubspot.com/cta/default/503070/"
+"c34ae48e-2f1a-48ac-9170-31fc7c9e845b.png\"  alt=\"See All Partners\"/></a>\n"
+"                        </span>\n"
+"                        <script type=\"text/javascript\">\n"
+"                            hbspt.cta.load(503070, "
+"'c34ae48e-2f1a-48ac-9170-31fc7c9e845b');\n"
+"                        </script>\n"
+"                    </span>\n"
+"                    <!-- end HubSpot Call-to-Action Code -->\n"
+"                    "
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/partners.html:27
+msgid ""
+"\n"
 "                        The following organizations have contributed\n"
 "                        to the development of CommCare.\n"
 "                    "
@@ -13354,14 +13518,36 @@ msgstr ""
 #: corehq/apps/prelogin/templates/prelogin/_sections/impact/publications.html:12
 msgid ""
 "\n"
+"                    <!--HubSpot Call-to-Action Code -->\n"
+"                    <span class=\"hs-cta-wrapper\" id=\"hs-cta-"
+"wrapper-23da92fd-b671-481f-9aee-bbc8a94b1f8b\">\n"
+"                        <span class=\"hs-cta-node hs-cta-23da92fd-"
+"b671-481f-9aee-bbc8a94b1f8b\" id=\"hs-cta-23da92fd-b671-481f-9aee-"
+"bbc8a94b1f8b\">\n"
+"                            <!--[if lte IE 8]><div id=\"hs-cta-ie-element"
+"\"></div><![endif]-->\n"
+"                            <a href=\"http://cta-redirect.hubspot.com/cta/"
+"redirect/503070/23da92fd-b671-481f-9aee-bbc8a94b1f8b\"  target=\"_blank\" "
+"><img class=\"hs-cta-img\" id=\"hs-cta-img-23da92fd-b671-481f-9aee-"
+"bbc8a94b1f8b\" style=\"border-width:0px;\" src=\"https://no-cache.hubspot."
+"com/cta/default/503070/23da92fd-b671-481f-9aee-bbc8a94b1f8b.png\"  alt="
+"\"View Research\"/></a>\n"
+"                        </span>\n"
+"                        <script type=\"text/javascript\">\n"
+"                            hbspt.cta.load(503070, '23da92fd-b671-481f-9aee-"
+"bbc8a94b1f8b');\n"
+"                        </script>\n"
+"                    </span>\n"
+"                    <!-- end HubSpot Call-to-Action Code -->\n"
+"                    "
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/publications.html:27
+msgid ""
+"\n"
 "                        Over 30+ peer-reviewed publications have been "
 "written\n"
-"                        about CommCare. For an overview of all CommCare\n"
-"                        publications, please see the\n"
-"                        <a href=\"https://help.commcarehq.org/display/"
-"commcarepublic/CommCare+Evidence+Base\"\n"
-"                           class=\"btn-primary-dark\">CommCare Evidence "
-"Base</a>.\n"
+"                        about CommCare.\n"
 "                    "
 msgstr ""
 
@@ -13372,63 +13558,90 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:27
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:12
+msgid ""
+"\n"
+"                    <!--HubSpot Call-to-Action Code -->\n"
+"                    <span class=\"hs-cta-wrapper\" id=\"hs-cta-wrapper-"
+"c21c3aed-90ee-4106-98d0-dbe846e8ca28\">\n"
+"                        <span class=\"hs-cta-node hs-cta-"
+"c21c3aed-90ee-4106-98d0-dbe846e8ca28\" id=\"hs-cta-c21c3aed-90ee-4106-98d0-"
+"dbe846e8ca28\">\n"
+"                            <!--[if lte IE 8]><div id=\"hs-cta-ie-element"
+"\"></div><![endif]-->\n"
+"                            <a href=\"http://cta-redirect.hubspot.com/cta/"
+"redirect/503070/c21c3aed-90ee-4106-98d0-dbe846e8ca28\"  target=\"_blank\" "
+"><img class=\"hs-cta-img\" id=\"hs-cta-img-c21c3aed-90ee-4106-98d0-"
+"dbe846e8ca28\" style=\"border-width:0px;\" src=\"https://no-cache.hubspot."
+"com/cta/default/503070/c21c3aed-90ee-4106-98d0-dbe846e8ca28.png\"  alt="
+"\"Learn More About Our Sectors\"/></a>\n"
+"                        </span>\n"
+"                        <script type=\"text/javascript\">\n"
+"                            hbspt.cta.load(503070, 'c21c3aed-90ee-4106-98d0-"
+"dbe846e8ca28');\n"
+"                        </script>\n"
+"                    </span>\n"
+"                    <!-- end HubSpot Call-to-Action Code -->\n"
+"                    "
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:35
 msgid "Child Health"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:33
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:41
 msgid "HIV/AIDS"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:52
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:60
 msgid "Health"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:73
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:81
 msgid "Malaria"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:80
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:88
 msgid "Nutrition"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:91
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:99
 msgid "Cooperatives"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:98
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:106
 msgid "Finances"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:117
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:125
 msgid "Agriculture"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:138
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:146
 msgid "Extension Programs"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:145
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:153
 msgid "Logistics"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:156
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:164
 msgid "Emergency Response"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:163
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:171
 msgid "Small Business"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:182
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:190
 msgid "Development"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:203
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:211
 msgid "Education"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:210
+#: corehq/apps/prelogin/templates/prelogin/_sections/impact/sectors.html:218
 msgid "Logistics & Supply Chain"
 msgstr ""
 
@@ -13505,11 +13718,12 @@ msgid ""
 "\n"
 "                        <a href=\"#contactDimagi\"\n"
 "                           data-toggle=\"modal\"\n"
-"                           class=\"btn-primary-dark\">Contact Dimagi</a> or "
-"read our<br />\n"
-"                        pricing <a href=\"https://confluence.dimagi.com/"
-"display/commcarepublic/CommCare+Pricing+FAQs\" class=\"btn-primary-dark"
-"\">FAQs</a>.\n"
+"                           class=\"btn-success btn btn-xl\">Get in Touch "
+"With Us</a>\n"
+"                        <a href=\"https://confluence.dimagi.com/display/"
+"commcarepublic/CommCare+Pricing+FAQs\"\n"
+"                           class=\"btn btn-primary-dark btn-xl\">Read our "
+"Pricing FAQs</a>\n"
 "                    "
 msgstr ""
 
@@ -13517,21 +13731,19 @@ msgstr ""
 msgid "CommCare Software Plans"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:11
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:16
 msgid ""
 "\n"
-"                            Core Features are always FREE. Choose a plan\n"
-"                            to help your project scale.\n"
-"                        "
+"                        Core Features are always FREE. Choose a plan\n"
+"                        to help your project scale.\n"
+"                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:18
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:22
 msgid ""
 "\n"
-"                    <strong>Anyone can use CommCare for FREE up to 50 mobile "
-"workers.</strong><br />\n"
 "                    For additional questions, please see our\n"
-"                    <a class=\"btn-primary-dark\"\n"
+"                    <a class=\"lead-link\"\n"
 "                       href=\"https://confluence.dimagi.com/display/"
 "commcarepublic/CommCare+Pricing+FAQs?__hstc=187943799."
 "ba674a1a3cdef13c5d09b2a54d65c2b8.1431286503613.1435340206977.1435342587932.124&__hssc=187943799.6.1435342587932&__hsfp=312587752\">FAQs</"
@@ -13539,16 +13751,27 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:92
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:31
+msgid ""
+"\n"
+"                        Want to try CommCare for FREE?\n"
+"                    "
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:34
+msgid "Sign up for a FREE account"
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:103
 msgid "Contact Us"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:122
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:152
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:133
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:163
 msgid "Unlimited / Discounted"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:128
+#: corehq/apps/prelogin/templates/prelogin/_sections/pricing/lead.html:139
 msgid "Price Per Additional Mobile User"
 msgstr ""
 
@@ -13769,71 +13992,80 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:39
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:33
-msgid "Scope"
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:42
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:36
-msgid "Launch"
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:45
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:39
-msgid "Boost"
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:28
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:15
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:662
+msgid ""
+"\n"
+"                        Inquire About Dimagi's Implementation Bundles\n"
+"                        "
 msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:48
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:42
-msgid "Growth"
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:35
+msgid "Scope"
 msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:51
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:45
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:38
+msgid "Launch"
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:54
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:41
+msgid "Boost"
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:57
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:44
+msgid "Growth"
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:60
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:47
 msgid "Scale"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:56
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:53
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:65
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:55
 msgid "$10,000"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:59
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:56
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:68
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:58
 msgid "$35,000"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:62
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:59
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:71
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:61
 msgid "$50,000"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:65
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:62
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:74
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:64
 msgid "$80,000"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:68
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:65
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:77
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:67
 msgid "$150,000"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:92
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:100
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:108
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:89
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:97
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:105
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:101
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:109
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:117
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:91
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:99
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:107
 msgid "12 months"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:116
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:113
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:125
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:115
 msgid "18 months"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:123
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:132
 msgid ""
 "\n"
 "                                Application Development &amp; Implementation "
@@ -13841,19 +14073,19 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:130
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:139
 msgid "Workflow Design"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:131
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:140
 msgid "On-Site Scoping Visit"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:132
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:141
 msgid "Mobile System Workflow Design"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:138
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:147
 msgid ""
 "\n"
 "                                    Everything in<br />\n"
@@ -13861,19 +14093,19 @@ msgid ""
 "                                "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:143
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:152
 msgid "Build &amp; Launch Application"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:144
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:153
 msgid "Field Testing &amp; Iteration"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:145
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:154
 msgid "Users Training"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:151
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:160
 msgid ""
 "\n"
 "                                    Everything in<br />\n"
@@ -13881,16 +14113,16 @@ msgid ""
 "                                "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:156
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:62
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:165
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:69
 msgid "Technology for Outcomes Monitoring"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:157
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:166
 msgid "Capacity Building for Worker Performance Monitoring"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:163
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:172
 msgid ""
 "\n"
 "                                    Everything in<br />\n"
@@ -13898,19 +14130,19 @@ msgid ""
 "                                "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:168
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:177
 msgid "Refined Application"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:169
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:178
 msgid "Additional Supervisor App"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:170
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:179
 msgid "Application Troubleshooting Capacity Building"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:176
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:185
 msgid ""
 "\n"
 "                                    Everything in<br />\n"
@@ -13918,37 +14150,29 @@ msgid ""
 "                                "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:181
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:190
 msgid "Monitored Application Usage"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:182
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:191
 msgid "Additional Tech for Reminder Messages"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:183
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:40
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:192
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:47
 msgid "Training of Trainers"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:184
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:42
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:193
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:49
 msgid "Capacity to Build Applications"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:190
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:194
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:45
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:68
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:199
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:203
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:52
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:75
 msgid "See More..."
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/bundles.html:205
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:659
-msgid ""
-"\n"
-"                    Inquire About Dimagi's Implementation Bundles\n"
-"                    "
 msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:7
@@ -13975,7 +14199,11 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:31
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:27
+msgid "Inquire About Dimagi's Capacity Services"
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:38
 #: corehq/apps/products/forms.py:28
 #: corehq/apps/products/templates/products/manage/products.html:112
 #: corehq/apps/programs/templates/programs/manage/programs.html:62
@@ -13983,40 +14211,36 @@ msgstr ""
 msgid "Program"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:34
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:57
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:41
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:64
 msgid ""
 "\n"
 "                            $10,000 per capacity service\n"
 "                        "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:39
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:46
 msgid "Worker Performance Monitoring"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:41
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:48
 msgid "Capacity for Technical Support"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:54
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:61
 msgid "Technology"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:63
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:70
 msgid "Apps for Supportive Supervision"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:64
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:71
 msgid "App Refinement by Dimagi"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:65
+#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:72
 msgid "Technology for Reminder Messages"
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/services/capacity.html:81
-msgid "Inquire About Dimagi's Capacity Services"
 msgstr ""
 
 #: corehq/apps/prelogin/templates/prelogin/_sections/services/faq.html:8
@@ -14033,8 +14257,8 @@ msgid ""
 "\n"
 "                        <a href=\"#contactDimagi\"\n"
 "                           data-toggle=\"modal\"\n"
-"                           class=\"btn-primary-dark\">Contact Dimagi</a> for "
-"more information.\n"
+"                           class=\"btn btn-success btn-xl\">Get in Touch "
+"With Us</a>\n"
 "                    "
 msgstr ""
 
@@ -14119,110 +14343,100 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:12
-msgid ""
-"\n"
-"                        If you have any additional questions, please\n"
-"                        <a href=\"#contactDimagi\"\n"
-"                           data-toggle=\"modal\">contact Dimagi</a> "
-"directly.\n"
-"                    "
-msgstr ""
-
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:50
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:52
 msgid "Cost"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:71
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:73
 msgid "Included Software Plan"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:119
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:121
 msgid "Application Development Support"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:125
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:127
 msgid ""
 "\n"
 "                                Workflow Design\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:160
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:162
 msgid ""
 "\n"
 "                                Launch &amp; Tested Application\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:195
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:197
 msgid ""
 "\n"
 "                                Additional Tech for Monitoring Outcomes\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:230
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:232
 msgid ""
 "\n"
 "                                Launched v2 application\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:265
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:267
 msgid ""
 "\n"
 "                                Supervisor Application\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:300
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:302
 msgid ""
 "\n"
 "                                Monitored app usage\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:335
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:337
 msgid ""
 "\n"
 "                                Additional Tech for Reminder Messages\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:369
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:371
 msgid "Implementation Services"
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:375
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:377
 msgid ""
 "\n"
 "                                On-Site Scoping Visit\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:410
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:412
 msgid ""
 "\n"
 "                                Mobile System Workflow Design\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:445
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:447
 msgid ""
 "\n"
 "                                Field Testing &amp; Iteration\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:480
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:482
 msgid ""
 "\n"
 "                                Pilot Users Training\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:515
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:517
 msgid ""
 "\n"
 "                                Capacity Service: Worker Performance "
@@ -14230,7 +14444,7 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:550
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:552
 msgid ""
 "\n"
 "                                Capacity Service: Application "
@@ -14238,14 +14452,14 @@ msgid ""
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:585
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:587
 msgid ""
 "\n"
 "                                Capacity Service: Training of Trainers\n"
 "                            "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:620
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/bundles.html:622
 msgid ""
 "\n"
 "                                Capacity Service: App Building\n"
@@ -14259,24 +14473,22 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:12
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:15
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:210
 msgid ""
 "\n"
-"                        If you have any additional questions, please\n"
-"                        <a href=\"#contactDimagi\"\n"
-"                           data-toggle=\"modal\">contact Dimagi</a>\n"
-"                        directly.\n"
-"                    "
+"                        Inquire About Dimagi's Capacity Services\n"
+"                        "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:24
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:25
 msgid ""
 "\n"
 "                        Program Capacity Services\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:29
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:30
 msgid ""
 "\n"
 "                        Dimagi travels on-site to build capacity, spending "
@@ -14285,22 +14497,22 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:35
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:125
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:37
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:128
 msgid ""
 "\n"
 "                        $10,000 per capacity service package.\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:44
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:46
 msgid ""
 "\n"
 "                        Worker Performance Monitoring\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:51
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:53
 msgid ""
 "\n"
 "                    Strategic implementation of standard CommCare HQ "
@@ -14309,14 +14521,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:61
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:63
 msgid ""
 "\n"
 "                        Training of Trainers\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:68
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:70
 msgid ""
 "\n"
 "                        Capacity building for organization’s trainers for "
@@ -14327,14 +14539,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:79
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:81
 msgid ""
 "\n"
 "                        Capacity for Technical Support\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:86
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:88
 msgid ""
 "\n"
 "                        Train technical staff about troubleshooting and "
@@ -14343,14 +14555,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:96
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:98
 msgid ""
 "\n"
 "                        Capacity to Build Applications\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:103
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:105
 msgid ""
 "\n"
 "                        Learn how to build your own applications,\n"
@@ -14359,14 +14571,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:114
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:116
 msgid ""
 "\n"
 "                        Technology Capacity Services\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:119
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:121
 msgid ""
 "\n"
 "                        Dimagi provides additional system refinement or new\n"
@@ -14374,14 +14586,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:134
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:137
 msgid ""
 "\n"
 "                        Technology for Outcomes Monitoring\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:141
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:144
 msgid ""
 "\n"
 "                        Create customized, offline Excel reports for 5-10\n"
@@ -14391,14 +14603,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:152
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:155
 msgid ""
 "\n"
 "                        Apps for Supportive Supervision\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:159
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:162
 msgid ""
 "\n"
 "                        Integrate a mobile application designed for field "
@@ -14409,14 +14621,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:170
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:173
 msgid ""
 "\n"
 "                        App Refinement by Dimagi\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:177
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:180
 msgid ""
 "\n"
 "                        Dimagi to make modifications to application based "
@@ -14425,14 +14637,14 @@ msgid ""
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:187
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:190
 msgid ""
 "\n"
 "                        Technology for Reminder Messages\n"
 "                    "
 msgstr ""
 
-#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:194
+#: corehq/apps/prelogin/templates/prelogin/_sections/services_details/capacity.html:197
 msgid ""
 "\n"
 "                        Send SMS reminders directly to beneficiaries or\n"
@@ -14458,11 +14670,10 @@ msgstr ""
 #: corehq/apps/prelogin/templates/prelogin/_sections/solutions/last.html:13
 msgid ""
 "\n"
-"                        Contact us at\n"
-"                        <a class=\"btn-primary-dark\"\n"
-"                           href=\"mailto:commcare.supply@dimagi.com\">\n"
-"                            commcare.supply@dimagi.com\n"
-"                        </a>.\n"
+"                        <a href=\"#contactDimagi\"\n"
+"                           data-toggle=\"modal\"\n"
+"                           class=\"btn-success btn btn-xl\">Get in Touch "
+"With Us</a>\n"
 "                    "
 msgstr ""
 
@@ -14655,6 +14866,13 @@ msgid ""
 "                    International, including ILSGateway in Tanzania,\n"
 "                    the Early Warning System in Ghana, and cStock\n"
 "                    in Malawi.\n"
+"                    "
+msgstr ""
+
+#: corehq/apps/prelogin/templates/prelogin/_sections/solutions/supply_intro.html:45
+msgid ""
+"\n"
+"                    Have questions or want to request a demo?\n"
 "                    "
 msgstr ""
 
@@ -16153,7 +16371,7 @@ msgstr ""
 
 #: corehq/apps/reminders/templates/reminders/partial/complex_message_table.html:30
 #: corehq/apps/reminders/templates/reminders/partial/complex_message_table.html:32
-#: custom/opm/beneficiary.py:814
+#: custom/opm/beneficiary.py:813 custom/opm/beneficiary.py:946
 msgid "Window"
 msgstr ""
 
@@ -16237,34 +16455,34 @@ msgstr ""
 msgid "CommTrack"
 msgstr ""
 
-#: corehq/apps/reports/models.py:49
+#: corehq/apps/reports/models.py:51
 msgid "demo_user"
 msgstr ""
 
-#: corehq/apps/reports/models.py:50
+#: corehq/apps/reports/models.py:52
 msgid "admin"
 msgstr ""
 
-#: corehq/apps/reports/models.py:51
+#: corehq/apps/reports/models.py:53
 msgid "Unknown Users"
 msgstr ""
 
-#: corehq/apps/reports/models.py:381
+#: corehq/apps/reports/models.py:373
 msgid "Deleted Report"
 msgstr ""
 
-#: corehq/apps/reports/models.py:385
+#: corehq/apps/reports/models.py:377
 msgid "Unsupported Report"
 msgstr ""
 
-#: corehq/apps/reports/models.py:423
+#: corehq/apps/reports/models.py:415
 msgid ""
 "The report used to create this scheduled report is no longer available on "
 "CommCare HQ.  Please delete this scheduled report and create a new one using "
 "an available report."
 msgstr ""
 
-#: corehq/apps/reports/models.py:485
+#: corehq/apps/reports/models.py:477
 #, python-format
 msgid ""
 "We are sorry, but your saved report '%(config_name)s' is no longer "
@@ -16274,7 +16492,7 @@ msgid ""
 "%(saved_reports_url)s to remove this Emailed Report."
 msgstr ""
 
-#: corehq/apps/reports/models.py:498
+#: corehq/apps/reports/models.py:490
 #, python-format
 msgid ""
 "We are sorry, but your saved report '%(config_name)s' can not be generated "
@@ -16282,20 +16500,20 @@ msgid ""
 "Administrator about getting permissions for thisreport."
 msgstr ""
 
-#: corehq/apps/reports/models.py:509
+#: corehq/apps/reports/models.py:501
 msgid "An error occurred while generating this report."
 msgstr ""
 
-#: corehq/apps/reports/models.py:654
+#: corehq/apps/reports/models.py:649
 msgid "Every day"
 msgstr ""
 
-#: corehq/apps/reports/models.py:655
+#: corehq/apps/reports/models.py:650
 #, python-format
 msgid "Day %s of every month"
 msgstr ""
 
-#: corehq/apps/reports/models.py:699
+#: corehq/apps/reports/models.py:694
 msgid "Scheduled report from CommCare HQ"
 msgstr ""
 
@@ -16313,54 +16531,54 @@ msgstr ""
 msgid "Email report from CommCare HQ"
 msgstr ""
 
-#: corehq/apps/reports/views.py:798
+#: corehq/apps/reports/views.py:806
 msgid "Create a new"
 msgstr ""
 
-#: corehq/apps/reports/views.py:799
+#: corehq/apps/reports/views.py:807
 msgid "New Scheduled Report"
 msgstr ""
 
-#: corehq/apps/reports/views.py:802
+#: corehq/apps/reports/views.py:810
 msgid "Edit Scheduled Report"
 msgstr ""
 
-#: corehq/apps/reports/views.py:910
+#: corehq/apps/reports/views.py:918
 msgid "once off report"
 msgstr ""
 
-#: corehq/apps/reports/views.py:910
+#: corehq/apps/reports/views.py:918
 msgid "scheduled report"
 msgstr ""
 
-#: corehq/apps/reports/views.py:934
+#: corehq/apps/reports/views.py:942
 msgid ""
 "The case creation form could not be found. Usually this happens if the form "
 "that created the case is archived but there are other forms that updated the "
 "case. To fix this you can archive the other forms listed here."
 msgstr ""
 
-#: corehq/apps/reports/views.py:979
+#: corehq/apps/reports/views.py:987
 msgid "unknown"
 msgstr ""
 
-#: corehq/apps/reports/views.py:992
+#: corehq/apps/reports/views.py:1000
 msgid "You don't have permission to access this page."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1014
+#: corehq/apps/reports/views.py:1022
 #, python-format
 msgid "Case %s was rebuilt from its forms."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1026
+#: corehq/apps/reports/views.py:1034
 #, python-format
 msgid ""
 "Case %s was successfully saved. Hopefully it will show up in all reports "
 "momentarily."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1040
+#: corehq/apps/reports/views.py:1048
 #, python-brace-format
 msgid ""
 "Case {name} has been closed.\n"
@@ -16375,89 +16593,89 @@ msgid ""
 "        "
 msgstr ""
 
-#: corehq/apps/reports/views.py:1080
+#: corehq/apps/reports/views.py:1088
 msgid "case id"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1081
+#: corehq/apps/reports/views.py:1089
 msgid "case name"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1082
+#: corehq/apps/reports/views.py:1090
 msgid "section"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1083
+#: corehq/apps/reports/views.py:1091
 msgid "date"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1084
+#: corehq/apps/reports/views.py:1092
 msgid "product_id"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1085
+#: corehq/apps/reports/views.py:1093
 msgid "product_name"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1086
+#: corehq/apps/reports/views.py:1094
 msgid "transaction amount"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1087
+#: corehq/apps/reports/views.py:1095
 msgid "type"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1088
+#: corehq/apps/reports/views.py:1096
 msgid "ending balance"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1098
+#: corehq/apps/reports/views.py:1106
 msgid "unknown product"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1301
+#: corehq/apps/reports/views.py:1309
 msgid "Could not detect the application/form for this submission."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1315
+#: corehq/apps/reports/views.py:1323
 msgid "Missing app, module or form information!"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1345
+#: corehq/apps/reports/views.py:1353
 #: corehq/apps/reports/templates/reports/form/edit_submission.html:26
 msgid "Edit Submission"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1376
+#: corehq/apps/reports/views.py:1384
 msgid "Form was successfully archived."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1378
+#: corehq/apps/reports/views.py:1386
 msgid "Form was already archived."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1380
+#: corehq/apps/reports/views.py:1388
 #, python-format
 msgid "Can't archive documents of type %s. How did you get here??"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1384
+#: corehq/apps/reports/views.py:1392
 msgid "Undo"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1423
+#: corehq/apps/reports/views.py:1431
 msgid "Form was successfully restored."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1438
+#: corehq/apps/reports/views.py:1446
 msgid "Form was successfully resaved. It should reappear in reports shortly."
 msgstr ""
 
-#: corehq/apps/reports/views.py:1484
+#: corehq/apps/reports/views.py:1492
 msgid "We don't support this format"
 msgstr ""
 
-#: corehq/apps/reports/views.py:1486
+#: corehq/apps/reports/views.py:1494
 msgid ""
 "That report was not found. Please remember that download links expire after "
 "24 hours."
@@ -16581,7 +16799,7 @@ msgid "Stock Status by Product"
 msgstr ""
 
 #: corehq/apps/reports/commtrack/standard.py:93
-#: custom/ilsgateway/tanzania/reports/delivery.py:154
+#: custom/ilsgateway/tanzania/reports/delivery.py:157
 msgid "# Facilities"
 msgstr ""
 
@@ -16661,11 +16879,6 @@ msgstr ""
 
 #: corehq/apps/reports/commtrack/standard.py:270
 msgid "Aggregate Inventory"
-msgstr ""
-
-#: corehq/apps/reports/commtrack/standard.py:297
-#: custom/ilsgateway/tanzania/reports/facility_details.py:27
-msgid "Stock on Hand"
 msgstr ""
 
 #: corehq/apps/reports/commtrack/standard.py:298
@@ -16760,7 +16973,7 @@ msgid "Date of last report for selected period"
 msgstr ""
 
 #: corehq/apps/reports/commtrack/standard.py:420
-#: corehq/apps/reports/standard/deployments.py:253
+#: corehq/apps/reports/standard/deployments.py:282
 msgid "Never"
 msgstr ""
 
@@ -17033,15 +17246,15 @@ msgstr ""
 msgid "Opened / Closed"
 msgstr ""
 
-#: corehq/apps/reports/filters/select.py:128 custom/opm/filters.py:153
+#: corehq/apps/reports/filters/select.py:128 custom/opm/filters.py:112
 msgid "Show All"
 msgstr ""
 
-#: corehq/apps/reports/filters/select.py:133 custom/opm/filters.py:154
+#: corehq/apps/reports/filters/select.py:133 custom/opm/filters.py:113
 msgid "Only Open"
 msgstr ""
 
-#: corehq/apps/reports/filters/select.py:134 custom/opm/filters.py:155
+#: corehq/apps/reports/filters/select.py:134 custom/opm/filters.py:114
 msgid "Only Closed"
 msgstr ""
 
@@ -17162,31 +17375,43 @@ msgstr ""
 msgid "Unknown App"
 msgstr ""
 
-#: corehq/apps/reports/standard/deployments.py:163
+#: corehq/apps/reports/standard/deployments.py:165
 msgid "User Sync History"
 msgstr ""
 
-#: corehq/apps/reports/standard/deployments.py:166
-msgid "Shows the last (up to) 10 times a user has synced."
+#: corehq/apps/reports/standard/deployments.py:171
+msgid "Shows the last (up to) {} times a user has synced."
 msgstr ""
 
-#: corehq/apps/reports/standard/deployments.py:172
+#: corehq/apps/reports/standard/deployments.py:180
 msgid "Sync Date"
 msgstr ""
 
-#: corehq/apps/reports/standard/deployments.py:173
+#: corehq/apps/reports/standard/deployments.py:181
 msgid "# of Cases"
 msgstr ""
 
-#: corehq/apps/reports/standard/deployments.py:174
+#: corehq/apps/reports/standard/deployments.py:182
 msgid "Sync Duration"
 msgstr ""
 
-#: corehq/apps/reports/standard/deployments.py:177
+#: corehq/apps/reports/standard/deployments.py:185
 msgid "Sync Log"
 msgstr ""
 
-#: corehq/apps/reports/standard/deployments.py:208
+#: corehq/apps/reports/standard/deployments.py:186
+msgid "Sync Log Type"
+msgstr ""
+
+#: corehq/apps/reports/standard/deployments.py:187
+msgid "Previous Sync Log"
+msgstr ""
+
+#: corehq/apps/reports/standard/deployments.py:188
+msgid "Error Info"
+msgstr ""
+
+#: corehq/apps/reports/standard/deployments.py:219
 msgid "{} seconds"
 msgstr ""
 
@@ -17298,7 +17523,7 @@ msgstr ""
 #: corehq/apps/reports/standard/sms.py:408
 #: corehq/apps/sms/templates/sms/default.html:59
 #: corehq/ex-submodules/casexml/apps/case/templates/case/partials/single_case.html:94
-#: custom/ilsgateway/tanzania/reports/delivery.py:170
+#: custom/ilsgateway/tanzania/reports/delivery.py:173
 msgid "Received"
 msgstr ""
 
@@ -17742,7 +17967,7 @@ msgid "Follow-Up Date"
 msgstr ""
 
 #: corehq/apps/reports/standard/cases/careplan.py:113
-#: corehq/ex-submodules/casexml/apps/case/models.py:913
+#: corehq/ex-submodules/casexml/apps/case/models.py:918
 #: custom/_legacy/pact/models.py:339
 msgid "Date Modified"
 msgstr ""
@@ -17769,17 +17994,17 @@ msgid "You can email a saved version<br />of this report."
 msgstr ""
 
 #: corehq/apps/reports/templates/reports/base_template.html:67
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:125
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:129
 msgid "Favorites"
 msgstr ""
 
 #: corehq/apps/reports/templates/reports/base_template.html:72
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:130
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:134
 msgid "You don't have any favorites"
 msgstr ""
 
 #: corehq/apps/reports/templates/reports/base_template.html:91
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:149
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:153
 msgid "Email Supported"
 msgstr ""
 
@@ -18065,112 +18290,112 @@ msgid ""
 "    "
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:135
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:136
 #, python-format
 msgid ""
 "\n"
-"            Submitted by %(auth_user)s on behalf of %(user)s\n"
-"        "
+"                Submitted by %(auth_user)s on behalf of %(user)s\n"
+"            "
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:140
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:141
 #, python-format
 msgid ""
 "\n"
-"            Submitted by %(auth_user)s\n"
-"        "
+"                Submitted by %(auth_user)s\n"
+"            "
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:147
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:148
 #, python-format
 msgid ""
 "\n"
-"        Submitted as %(user)s\n"
-"        "
+"            Submitted as %(user)s\n"
+"            "
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:155
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:157
 msgid "Form Properties"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:161
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:163
 msgid "Case Changes"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:169
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:171
 msgid "Form Metadata"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:177
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:179
 #: corehq/ex-submodules/casexml/apps/case/templates/case/partials/single_case.html:30
 msgid "Attachments"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:183
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:185
 msgid "Raw XML"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:194
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:195
 msgid "View standalone form"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:200
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:201
 msgid "Edit submission"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:206
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:207
 msgid "Archiving Forms"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:207
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:208
 msgid ""
 "Archived forms will no longer show up in reports and they will be removed "
 "from any relevant case histories. "
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:211
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:212
 msgid "Archive this form"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:220
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:221
 msgid "Restoring Forms"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:221
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:222
 msgid "Restoring this form will cause it to show up in reports again."
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:225
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:226
 msgid "Restore this form"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:234
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:235
 msgid "Resaving Forms"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:235
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:236
 msgid ""
 "Resaving a form can manually cause it to be reincluded in reports if "
 "something went wrong during initial processing."
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:239
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:240
 msgid "Resave this form"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:262
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:263
 msgid "Unknown/Deleted Case"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:269
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:270
 msgid "(this case)"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:315
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:316
 msgid "Open XML in New Window"
 msgstr ""
 
-#: corehq/apps/reports/templates/reports/form/partials/single_form.html:318
+#: corehq/apps/reports/templates/reports/form/partials/single_form.html:319
 msgid "Double-click code below to select all:"
 msgstr ""
 
@@ -18199,7 +18424,7 @@ msgid "IVR"
 msgstr ""
 
 #: corehq/apps/reports/templates/reports/messaging/survey_detail.html:23
-#: custom/ilsgateway/tanzania/reports/randr.py:173
+#: custom/ilsgateway/tanzania/reports/randr.py:175
 msgid "Contact"
 msgstr ""
 
@@ -18240,6 +18465,7 @@ msgid "No data is available. Please submit more forms!"
 msgstr ""
 
 #: corehq/apps/reports/templates/reports/partials/hqexport_group_table.html:8
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:47
 msgid "File"
 msgstr ""
 
@@ -18727,6 +18953,11 @@ msgstr ""
 msgid "My Account"
 msgstr ""
 
+#: corehq/apps/settings/views.py:93
+#: corehq/apps/settings/templates/settings/edit_my_account.b2.html:33
+msgid "My Information"
+msgstr ""
+
 #: corehq/apps/settings/views.py:174
 #, python-format
 msgid "Unable remove membership because you are the admin of %s"
@@ -18750,6 +18981,7 @@ msgid "Your password was successfully changed!"
 msgstr ""
 
 #: corehq/apps/settings/templates/settings/change_my_password.html:9
+#: docs/_build/html/_sources/translations.txt:177
 msgid "Specify New Password"
 msgstr ""
 
@@ -18765,7 +18997,7 @@ msgstr ""
 #: corehq/apps/settings/templates/settings/edit_my_account.b2.html:42
 #: corehq/apps/telerivet/forms.py:10
 #: corehq/apps/telerivet/templates/telerivet/backend.html:10
-#: corehq/apps/users/forms.py:188
+#: corehq/apps/users/forms.py:187
 msgid "API Key"
 msgstr ""
 
@@ -20503,6 +20735,10 @@ msgstr ""
 msgid "All domain/toggle statuses"
 msgstr ""
 
+#: corehq/apps/toggle_ui/templates/toggle/edit_flag.html:165
+msgid "Enabled?"
+msgstr ""
+
 #: corehq/apps/toggle_ui/templates/toggle/flags.html:57
 msgid "Tag"
 msgstr ""
@@ -20558,8 +20794,8 @@ msgid "Create New Report"
 msgstr ""
 
 #: corehq/apps/userreports/views.py:124
-#: corehq/apps/userreports/reports/builder/forms.py:768
-#: corehq/apps/userreports/reports/builder/forms.py:823
+#: corehq/apps/userreports/reports/builder/forms.py:776
+#: corehq/apps/userreports/reports/builder/forms.py:831
 msgid "Chart"
 msgstr ""
 
@@ -20599,21 +20835,21 @@ msgid ""
 "choose the columns and rows."
 msgstr ""
 
-#: corehq/apps/userreports/views.py:230
+#: corehq/apps/userreports/views.py:234
 msgid "Chart Report: {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:247
+#: corehq/apps/userreports/views.py:251
 msgid "Choose the property you would like to add as a filter to this report."
 msgstr ""
 
-#: corehq/apps/userreports/views.py:248
+#: corehq/apps/userreports/views.py:252
 msgid ""
 "Web users viewing the report will see this display text instead of the "
 "property name. Name your filter something easy for users to understand."
 msgstr ""
 
-#: corehq/apps/userreports/views.py:249
+#: corehq/apps/userreports/views.py:253
 msgid ""
 "What type of property is this filter?<br/><br/><strong>Date</strong>: select "
 "this if the property is a date.<br/><strong>Choice</strong>: select this if "
@@ -20621,71 +20857,71 @@ msgid ""
 "select this if the property is a number."
 msgstr ""
 
-#: corehq/apps/userreports/views.py:291
+#: corehq/apps/userreports/views.py:295
 msgid "List Report: {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:300
+#: corehq/apps/userreports/views.py:304
 msgid "Table Report: {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:309
+#: corehq/apps/userreports/views.py:313
 msgid "Worker Report: {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:322
+#: corehq/apps/userreports/views.py:326
 msgid "Report \"{}\" saved!"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:350
+#: corehq/apps/userreports/views.py:354
 msgid "Report \"{}\" deleted!"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:370
+#: corehq/apps/userreports/views.py:374
 msgid "Report created!"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:373
+#: corehq/apps/userreports/views.py:377
 msgid "Bad report source: {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:375
+#: corehq/apps/userreports/views.py:379
 msgid "paste report source here"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:414 corehq/apps/userreports/views.py:420
+#: corehq/apps/userreports/views.py:418 corehq/apps/userreports/views.py:424
 msgid "Data source created for '{}'"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:437
+#: corehq/apps/userreports/views.py:441
 msgid "Data source \"{}\" saved!"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:465
+#: corehq/apps/userreports/views.py:469
 msgid "Data source \"{}\" has been deleted."
 msgstr ""
 
-#: corehq/apps/userreports/views.py:475
+#: corehq/apps/userreports/views.py:479
 msgid "Table \"{}\" is now being rebuilt. Data should start showing up soon"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:514
+#: corehq/apps/userreports/views.py:518
 msgid "You can only use 'lastndays' on date columns"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:524
+#: corehq/apps/userreports/views.py:528
 msgid "Ranges must have the format \"start..end\""
 msgstr ""
 
-#: corehq/apps/userreports/views.py:556
+#: corehq/apps/userreports/views.py:560
 msgid "No field named {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:563
+#: corehq/apps/userreports/views.py:567
 msgid "Invalid filter parameter: {}"
 msgstr ""
 
-#: corehq/apps/userreports/views.py:597
+#: corehq/apps/userreports/views.py:601
 msgid ""
 "There was a problem executing your query, please make sure your parameters "
 "are valid."
@@ -20782,47 +21018,47 @@ msgid ""
 "the data source before viewing the report."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:304
+#: corehq/apps/userreports/reports/builder/forms.py:305
 msgid "Bar"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:305
+#: corehq/apps/userreports/reports/builder/forms.py:306
 msgid "Pie"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:318
+#: corehq/apps/userreports/reports/builder/forms.py:319
 msgid ""
 "<strong>Form</strong>: display data from form submissions.<br/><strong>Case</"
 "strong>: display data from your cases. You must be using case management for "
 "this option."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:319
+#: corehq/apps/userreports/reports/builder/forms.py:320
 msgid "Which application should the data come from?"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:320
+#: corehq/apps/userreports/reports/builder/forms.py:321
 msgid ""
 "Choose the case type or form from which to retrieve data for this report."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:332
+#: corehq/apps/userreports/reports/builder/forms.py:333
 msgid ""
 "<strong>Bar</strong> shows one vertical bar for each value in your case or "
 "form. <strong>Pie</strong> shows what percentage of the total each value is."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:345
+#: corehq/apps/userreports/reports/builder/forms.py:346
 msgid "{} Report"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:346
+#: corehq/apps/userreports/reports/builder/forms.py:347
 msgid ""
 "Web users will see this name in the \"Reports\" section of CommCareHQ and "
 "can click to view the report"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:388
+#: corehq/apps/userreports/reports/builder/forms.py:389
 msgid ""
 "Too many data sources!\n"
 "Creating this report would cause you to go over the maximum number of data "
@@ -20831,63 +21067,69 @@ msgid ""
 "itself) and try again. "
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:405
+#: corehq/apps/userreports/reports/builder/forms.py:406
 #: custom/bihar/reports/indicators/clientlistdisplay.py:146
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:345
 msgid "Done"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:417
+#: corehq/apps/userreports/reports/builder/forms.py:418
 msgid "Update Report"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:474
-#: corehq/apps/userreports/templates/userreports/edit_report_config.html:8
+#: corehq/apps/userreports/reports/builder/forms.py:475
+#: corehq/apps/userreports/templates/userreports/edit_report_config.html:18
 msgid "Delete Report"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:518
+#: corehq/apps/userreports/reports/builder/forms.py:500
+msgid ""
+"Report builder data source doesn't reference an application. It is likely "
+"this report has been customized and it is no longer editable. "
+msgstr ""
+
+#: corehq/apps/userreports/reports/builder/forms.py:526
 msgid "Filters"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:519
+#: corehq/apps/userreports/reports/builder/forms.py:527
 msgid ""
 "Add filters to your report to allow viewers to select which data the report "
 "will display. These filters will be displayed at the top of your report."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:573
+#: corehq/apps/userreports/reports/builder/forms.py:581
 msgid ""
 "Editing this report would require a new data source. The limit is 5. To "
 "continue, first delete all of the reports using a particular data source (or "
 "the data source itself) and try again. "
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:769
+#: corehq/apps/userreports/reports/builder/forms.py:777
 msgid ""
 "The values of the selected property will be aggregated and shown as bars in "
 "the chart."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:824
+#: corehq/apps/userreports/reports/builder/forms.py:832
 msgid ""
 "The values of the selected property will be aggregated and shows as the "
 "sections of the pie chart."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:841
+#: corehq/apps/userreports/reports/builder/forms.py:849
 msgid ""
 "Add columns to your report to display information from cases or form "
 "submissions. You may rearrange the order of the columns by dragging the "
 "arrows next to the column."
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:854
+#: corehq/apps/userreports/reports/builder/forms.py:862
 #: submodules/ctable-src/ctable_view/templates/ctable/edit_mapping.html:179
 msgid "Columns"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:898
+#: corehq/apps/userreports/reports/builder/forms.py:906
 msgid ""
 "Add columns for this report to aggregate. Each property you add will create "
 "a column for every value of that property.  For example, if you add a column "
@@ -20895,23 +21137,37 @@ msgid ""
 "column for \"no.\""
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:907
+#: corehq/apps/userreports/reports/builder/forms.py:915
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:13
 msgid "Rows"
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:908
+#: corehq/apps/userreports/reports/builder/forms.py:916
 msgid ""
 "Choose which property this report will group its results by. Each value of "
 "this property will be a row in the table. For example, if you choose a yes "
 "or no question, the report will show a row for \"yes\" and a row for \"no.\""
 msgstr ""
 
-#: corehq/apps/userreports/reports/builder/forms.py:971
+#: corehq/apps/userreports/reports/builder/forms.py:979
 msgid ""
 "Add columns for this report to aggregate. Each property you add will create "
 "a column for every value of that property. For example, if you add a column "
 "for a yes or no question, the report will show a column for \"yes\" and a "
 "column for \"no\"."
+msgstr ""
+
+#: corehq/apps/userreports/sql/columns.py:60
+#, python-brace-format
+msgid ""
+"The \"{header}\" column had too many values to expand! Expansion limited to "
+"{max} distinct values."
+msgstr ""
+
+#: corehq/apps/userreports/sql/columns.py:94
+msgid ""
+"The column \"{}\" does not exist in the report source! Please double check "
+"your report configuration."
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/builder_report_type_select.html:37
@@ -20936,54 +21192,61 @@ msgid ""
 "        "
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/configurable_report.html:108
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:105
+#: corehq/apps/userreports/templates/userreports/configurable_report.html:111
+#: corehq/apps/userreports/templates/userreports/edit_report_config.html:7
 msgid "Edit Report"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/configurable_reports_home.html:4
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:44
 msgid "Configurable Reports"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/configurable_reports_home.html:5
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:32
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:82
 msgid "Add data source"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/configurable_reports_home.html:6
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:16
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:64
 msgid "Add report"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/configurable_reports_home.html:7
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:20
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:68
 msgid "Import report"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/edit_data_source.html:7
-msgid "This datasource is read only, any changes made can not be saved."
-msgstr ""
-
-#: corehq/apps/userreports/templates/userreports/edit_data_source.html:14
-msgid "Delete Data Source"
+msgid "Edit Data Source"
 msgstr ""
 
 #: corehq/apps/userreports/templates/userreports/edit_data_source.html:18
+msgid "This datasource is read only, any changes made can not be saved."
+msgstr ""
+
+#: corehq/apps/userreports/templates/userreports/edit_data_source.html:25
+msgid "Delete Data Source"
+msgstr ""
+
+#: corehq/apps/userreports/templates/userreports/edit_data_source.html:29
 msgid "Rebuild Data Source"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/edit_data_source.html:19
+#: corehq/apps/userreports/templates/userreports/edit_data_source.html:30
 msgid "Preview data"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/edit_data_source.html:20
+#: corehq/apps/userreports/templates/userreports/edit_data_source.html:31
 msgid "Data Source Source (Advanced)"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/edit_report_config.html:9
+#: corehq/apps/userreports/templates/userreports/edit_report_config.html:19
 msgid "View report"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/edit_report_config.html:10
+#: corehq/apps/userreports/templates/userreports/edit_report_config.html:20
 msgid "Report Source (Advanced)"
 msgstr ""
 
@@ -21000,16 +21263,16 @@ msgstr ""
 msgid "Preview table: %(display_name)s (%(total_rows)s total rows)"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:7
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:53
 #: corehq/apps/users/templates/users/web_users.b3.html:390
 msgid "Edit Reports"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:23
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:71
 msgid "Edit Data Sources"
 msgstr ""
 
-#: corehq/apps/userreports/templates/userreports/userreports_base.html:38
+#: corehq/apps/userreports/templates/userreports/userreports_base.html:88
 msgid "Data source from application"
 msgstr ""
 
@@ -21034,7 +21297,7 @@ msgid "Expected {} but was {}"
 msgstr ""
 
 #: corehq/apps/userreports/ui/forms.py:25
-#: corehq/apps/userreports/ui/forms.py:149
+#: corehq/apps/userreports/ui/forms.py:159
 msgid "Save Changes"
 msgstr ""
 
@@ -21054,23 +21317,79 @@ msgstr ""
 msgid "Problem with report spec: {}"
 msgstr ""
 
-#: corehq/apps/userreports/ui/forms.py:95
+#: corehq/apps/userreports/ui/forms.py:91
+msgid "Source Type"
+msgstr ""
+
+#: corehq/apps/userreports/ui/forms.py:92
+msgid "Report Title"
+msgstr ""
+
+#: corehq/apps/userreports/ui/forms.py:103
 msgid "Named filters (optional)"
 msgstr ""
 
-#: corehq/apps/userreports/ui/forms.py:106
+#: corehq/apps/userreports/ui/forms.py:116
 msgid ""
 "Table id is too long. Your table id and domain name must add up to fewer "
 "than 40 characters"
 msgstr ""
 
-#: corehq/apps/userreports/ui/forms.py:111
+#: corehq/apps/userreports/ui/forms.py:121
 msgid ""
 "A data source with this table id already exists. Table ids must be unique"
 msgstr ""
 
-#: corehq/apps/userreports/ui/forms.py:128
+#: corehq/apps/userreports/ui/forms.py:138
 msgid "Problem with data source spec: {}"
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:4
+msgid ""
+"Choose something short, unique, and memorable using lowercase letters, "
+"numbers, and underscores"
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:7
+msgid ""
+"This is what the data source will be called in navigation, page title, etc."
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:9
+msgid "Write yourself a little note if you like, it's optional"
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:11
+msgid ""
+"You can leave this blank unless you are <a target=\"_blank\" href=\"https://"
+"github.com/dimagi/commcare-hq/blob/master/corehq/apps/userreports/README."
+"md#saving-repeat-data\">saving repeat data</a>"
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:16
+msgid ""
+"Look at <a target=\"_blank\" href=\"https://github.com/dimagi/commcare-hq/"
+"blob/master/corehq/apps/userreports/examples/examples.md#data-source-filters"
+"\">these examples</a> and <a target=\"_blank\" href=\"https://github.com/"
+"dimagi/commcare-hq/blob/master/corehq/apps/userreports/README.md#data-source-"
+"filtering\">these docs</a>"
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:24
+msgid ""
+"Look at <a target=\"_blank\" href=\"https://github.com/dimagi/commcare-hq/"
+"blob/master/corehq/apps/userreports/examples/examples.md#data-source-"
+"indicators\">these examples</a> and <a target=\"_blank\" href=\"https://"
+"github.com/dimagi/commcare-hq/blob/master/corehq/apps/userreports/README."
+"md#indicators\">these docs</a>"
+msgstr ""
+
+#: corehq/apps/userreports/ui/help_text.py:32
+msgid ""
+"For this advanced and useful feature, give a dict where the keys are the "
+"variable names you choose and the values are filters according to the syntax "
+"of Configured Filters above. You can then reference these from Configured "
+"Filters as {\"type\": \"named\", \"name\": \"myvarname\"}"
 msgstr ""
 
 #: corehq/apps/users/bulkupload.py:52
@@ -21125,77 +21444,77 @@ msgstr ""
 msgid "Can't add to group '%s' (try adding it to your spreadsheet)"
 msgstr ""
 
-#: corehq/apps/users/forms.py:59
+#: corehq/apps/users/forms.py:58
 msgid "Please enter a valid two or three digit language code."
 msgstr ""
 
-#: corehq/apps/users/forms.py:132
+#: corehq/apps/users/forms.py:131
 msgid "System Super User"
 msgstr ""
 
-#: corehq/apps/users/forms.py:147
+#: corehq/apps/users/forms.py:146
 msgid "E-Mail"
 msgstr ""
 
-#: corehq/apps/users/forms.py:154
+#: corehq/apps/users/forms.py:153
 msgid ""
 "<i class=\"icon-info-sign\"></i> Becomes default language seen in CloudCare "
 "and reports (if applicable), but does not affect mobile applications. "
 "Supported languages for reports are en, fr (partial), and hin (partial)."
 msgstr ""
 
-#: corehq/apps/users/forms.py:171
+#: corehq/apps/users/forms.py:170
 msgid "Opt out of emails about CommCare updates."
 msgstr ""
 
-#: corehq/apps/users/forms.py:191
+#: corehq/apps/users/forms.py:190
 msgid "Generate API Key"
 msgstr ""
 
-#: corehq/apps/users/forms.py:199
+#: corehq/apps/users/forms.py:198
 msgid "My Language"
 msgstr ""
 
-#: corehq/apps/users/forms.py:219
+#: corehq/apps/users/forms.py:218
 msgid "Other Options"
 msgstr ""
 
-#: corehq/apps/users/forms.py:225
+#: corehq/apps/users/forms.py:224
 msgid "Update My Information"
 msgstr ""
 
-#: corehq/apps/users/forms.py:240
+#: corehq/apps/users/forms.py:239
 msgid ""
 "Multiply this user's case load by a number for load testing on phones. Leave "
 "blank for normal users."
 msgstr ""
 
-#: corehq/apps/users/forms.py:324
+#: corehq/apps/users/forms.py:323
 #, python-format
 msgid "%s is an invalid phone number."
 msgstr ""
 
-#: corehq/apps/users/forms.py:371 corehq/apps/users/forms.py:373
+#: corehq/apps/users/forms.py:370 corehq/apps/users/forms.py:372
 msgid "Username contains invalid characters."
 msgstr ""
 
-#: corehq/apps/users/forms.py:480
+#: corehq/apps/users/forms.py:479
 #, python-format
 msgid ""
 "I have read and agree to the <a href=\"%(pa_url)s\" target=\"_blank"
 "\">Software Product Subscription Agreement</a>."
 msgstr ""
 
-#: corehq/apps/users/forms.py:509
+#: corehq/apps/users/forms.py:508
 msgid "Back to Mobile Workers List"
 msgstr ""
 
-#: corehq/apps/users/forms.py:521
+#: corehq/apps/users/forms.py:520
 msgid ""
 "Please agree to the Product Subscription Agreement above before continuing."
 msgstr ""
 
-#: corehq/apps/users/models.py:2426
+#: corehq/apps/users/models.py:2446
 #, python-format
 msgid "Invitation from %s to join CommCareHQ"
 msgstr ""
@@ -21748,8 +22067,8 @@ msgstr ""
 
 #: corehq/apps/users/templates/users/mobile/users_list.html:212
 #: custom/_legacy/pact/templates/pact/chw/pact_chw_profile_info.html:12
-#: custom/ilsgateway/tanzania/reports/facility_details.py:72
-#: custom/ilsgateway/tanzania/reports/facility_details.py:119
+#: custom/ilsgateway/tanzania/reports/facility_details.py:73
+#: custom/ilsgateway/tanzania/reports/facility_details.py:120
 msgid "Phone"
 msgstr ""
 
@@ -21884,57 +22203,53 @@ msgstr ""
 msgid "Edit User Role"
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:291
+#: corehq/apps/users/views/__init__.py:289
 #, python-format
 msgid "Changed system permissions for user \"%s\""
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:340
+#: corehq/apps/users/views/__init__.py:338
 msgid "Phone number added!"
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:342
+#: corehq/apps/users/views/__init__.py:340
 msgid "Please enter digits only."
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:349
-msgid "Edit My Information"
-msgstr ""
-
-#: corehq/apps/users/views/__init__.py:388
-#: corehq/apps/users/views/__init__.py:534
+#: corehq/apps/users/views/__init__.py:346
+#: corehq/apps/users/views/__init__.py:492
 msgid "Web Users & Roles"
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:435
+#: corehq/apps/users/views/__init__.py:393
 msgid "Please provide pagination info."
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:736
+#: corehq/apps/users/views/__init__.py:694
 msgid "Invitation resent"
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:738
+#: corehq/apps/users/views/__init__.py:696
 msgid "Error while attempting resend"
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:768
+#: corehq/apps/users/views/__init__.py:726
 msgid "Invite Web User to Project"
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:866
+#: corehq/apps/users/views/__init__.py:818
 msgid "Cannot start verification workflow. Phone number is already in use."
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:868
+#: corehq/apps/users/views/__init__.py:820
 msgid "Phone number is already verified."
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:870
+#: corehq/apps/users/views/__init__.py:822
 msgid "Verification message resent."
 msgstr ""
 
-#: corehq/apps/users/views/__init__.py:872
+#: corehq/apps/users/views/__init__.py:824
 msgid "Verification workflow started."
 msgstr ""
 
@@ -22066,36 +22381,36 @@ msgid ""
 "The following groups have no name. Please name them before continuing: {}"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:228
+#: corehq/ex-submodules/casexml/apps/case/models.py:229
 msgid "Closed"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:228
+#: corehq/ex-submodules/casexml/apps/case/models.py:229
 msgid "Open"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:515
+#: corehq/ex-submodules/casexml/apps/case/models.py:516
 msgid "Sorry, referrals are no longer supported!"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:857
+#: corehq/ex-submodules/casexml/apps/case/models.py:862
 msgid "Opened On"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:863
+#: corehq/ex-submodules/casexml/apps/case/models.py:868
 msgid "Modified On"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:869
-#: custom/opm/beneficiary.py:824 custom/opm/beneficiary.py:901
+#: corehq/ex-submodules/casexml/apps/case/models.py:874
+#: custom/opm/beneficiary.py:823 custom/opm/beneficiary.py:901
 msgid "Closed On"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:882
+#: corehq/ex-submodules/casexml/apps/case/models.py:887
 msgid "Last Submitter"
 msgstr ""
 
-#: corehq/ex-submodules/casexml/apps/case/models.py:907
+#: corehq/ex-submodules/casexml/apps/case/models.py:912
 msgid "Date Opened"
 msgstr ""
 
@@ -22754,8 +23069,8 @@ msgstr ""
 msgid "Beneficiary Information"
 msgstr ""
 
-#: custom/bihar/reports/mch_reports.py:134 custom/opm/beneficiary.py:809
-#: custom/opm/beneficiary.py:885
+#: custom/bihar/reports/mch_reports.py:134 custom/opm/beneficiary.py:808
+#: custom/opm/beneficiary.py:885 custom/opm/beneficiary.py:930
 msgid "Husband Name"
 msgstr ""
 
@@ -22832,6 +23147,7 @@ msgstr ""
 #: custom/bihar/reports/mch_reports.py:151
 #: custom/bihar/reports/indicators/clientlistdisplay.py:80
 #: custom/bihar/reports/indicators/clientlistdisplay.py:98
+#: custom/opm/beneficiary.py:944
 msgid "EDD"
 msgstr ""
 
@@ -23032,7 +23348,7 @@ msgstr ""
 msgid "Migrate status "
 msgstr ""
 
-#: custom/bihar/reports/mch_reports.py:314 custom/opm/beneficiary.py:812
+#: custom/bihar/reports/mch_reports.py:314 custom/opm/beneficiary.py:811
 msgid "Child Name"
 msgstr ""
 
@@ -24087,43 +24403,43 @@ msgstr ""
 msgid "Dashboard report {0}"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:28
-#: custom/ilsgateway/tanzania/reports/delivery.py:86
+#: custom/ilsgateway/tanzania/reports/delivery.py:29
+#: custom/ilsgateway/tanzania/reports/delivery.py:88
 msgid "Average Lead Time In Days"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:82
-#: custom/ilsgateway/tanzania/reports/randr.py:171
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:251
+#: custom/ilsgateway/tanzania/reports/delivery.py:84
+#: custom/ilsgateway/tanzania/reports/randr.py:173
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:318
 msgid "Facility Name"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:83
+#: custom/ilsgateway/tanzania/reports/delivery.py:85
 msgid "Delivery Status"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:84
+#: custom/ilsgateway/tanzania/reports/delivery.py:86
 msgid "Delivery Date"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:85
+#: custom/ilsgateway/tanzania/reports/delivery.py:87
 msgid "This Cycle Lead Time"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:155
+#: custom/ilsgateway/tanzania/reports/delivery.py:158
 #, python-format
 msgid "% of total"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:167
+#: custom/ilsgateway/tanzania/reports/delivery.py:170
 msgid "Didn't Respond"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:169
+#: custom/ilsgateway/tanzania/reports/delivery.py:172
 msgid "Not Received"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/delivery.py:182
+#: custom/ilsgateway/tanzania/reports/delivery.py:185
 #, python-brace-format
 msgid "Delivery Report {0}"
 msgstr ""
@@ -24132,106 +24448,106 @@ msgstr ""
 msgid "Months of stock"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/facility_details.py:120
+#: custom/ilsgateway/tanzania/reports/facility_details.py:121
 msgid "Text"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:83
+#: custom/ilsgateway/tanzania/reports/randr.py:84
 msgid "% Facilities Submitting R&R On Time"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:84
+#: custom/ilsgateway/tanzania/reports/randr.py:85
 msgid "% Facilities Submitting R&R Late"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:85
+#: custom/ilsgateway/tanzania/reports/randr.py:86
 msgid "% Facilities With R&R Not Submitted"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:86
+#: custom/ilsgateway/tanzania/reports/randr.py:87
 msgid "% Facilities Not Responding To R&R Reminder"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:87
-#: custom/ilsgateway/tanzania/reports/randr.py:174
-#: custom/ilsgateway/tanzania/reports/supervision.py:60
-#: custom/ilsgateway/tanzania/reports/supervision.py:123
+#: custom/ilsgateway/tanzania/reports/randr.py:88
+#: custom/ilsgateway/tanzania/reports/randr.py:176
+#: custom/ilsgateway/tanzania/reports/supervision.py:61
+#: custom/ilsgateway/tanzania/reports/supervision.py:125
 msgid "Historical Response Rate"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:172
+#: custom/ilsgateway/tanzania/reports/randr.py:174
 msgid "R&R Status"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/randr.py:185
+#: custom/ilsgateway/tanzania/reports/randr.py:187
 #, python-brace-format
 msgid "R & R {0}"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:82
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:84
 msgid "% Facilities Submitting Soh On Time"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:83
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:85
 msgid "% Facilities Submitting Soh Late"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:84
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:86
 msgid "% Facilities Not Responding To Soh"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:85
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:87
 msgid "% Facilities With 1 Or More Stockouts This Month"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:97
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:99
 #, python-format
 msgid "%s stock outs this %s"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:203
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:269
 msgid "Waiting for reply"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:250
-#: custom/ilsgateway/tanzania/reports/supervision.py:119
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:317
+#: custom/ilsgateway/tanzania/reports/supervision.py:121
 msgid "MSD Code"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:252
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:319
 msgid "DG"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:253
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:320
 msgid "Last Reported"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:254
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:321
 msgid "Hist. Resp. Rate"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:406
+#: custom/ilsgateway/tanzania/reports/stock_on_hand.py:422
 #, python-brace-format
 msgid "Stock On Hand {0}"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/supervision.py:57
+#: custom/ilsgateway/tanzania/reports/supervision.py:58
 msgid "% Supervision Received"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/supervision.py:58
+#: custom/ilsgateway/tanzania/reports/supervision.py:59
 msgid "% Supervision Not Received"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/supervision.py:59
+#: custom/ilsgateway/tanzania/reports/supervision.py:60
 msgid "% Supervision Not Responding"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/supervision.py:121
+#: custom/ilsgateway/tanzania/reports/supervision.py:123
 msgid "Supervision This Quarter"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/supervision.py:181
+#: custom/ilsgateway/tanzania/reports/supervision.py:183
 #, python-brace-format
 msgid "Supervision {0}"
 msgstr ""
@@ -24240,7 +24556,7 @@ msgstr ""
 msgid "Unrecognized SMS"
 msgstr ""
 
-#: custom/ilsgateway/tanzania/reports/utils.py:98
+#: custom/ilsgateway/tanzania/reports/utils.py:100
 msgid "No Data"
 msgstr ""
 
@@ -24321,16 +24637,16 @@ msgstr ""
 msgid " days"
 msgstr ""
 
-#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:55
+#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:65
 #, python-format
 msgid "%(status)s"
 msgstr ""
 
-#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:58
+#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:68
 msgid "Last updated on"
 msgstr ""
 
-#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:63
+#: custom/ilsgateway/templates/ilsgateway/partials/report_table_with_tabs.html:73
 msgid "No delivery status reported"
 msgstr ""
 
@@ -25404,108 +25720,112 @@ msgstr ""
 msgid "Reject"
 msgstr ""
 
-#: custom/opm/beneficiary.py:742
+#: custom/opm/beneficiary.py:741
 msgid "Incorrect EDD"
 msgstr ""
 
-#: custom/opm/beneficiary.py:748
+#: custom/opm/beneficiary.py:747
 msgid "Incorrect DOD"
 msgstr ""
 
-#: custom/opm/beneficiary.py:753
+#: custom/opm/beneficiary.py:752
 msgid "Incorrect LMP date"
 msgstr ""
 
-#: custom/opm/beneficiary.py:758
+#: custom/opm/beneficiary.py:757
 msgid "Account number is the wrong length"
 msgstr ""
 
-#: custom/opm/beneficiary.py:763
+#: custom/opm/beneficiary.py:762
 msgid "IFSC {} incorrect"
 msgstr ""
 
-#: custom/opm/beneficiary.py:804
+#: custom/opm/beneficiary.py:803 custom/opm/beneficiary.py:919
 msgid "Serial number"
 msgstr ""
 
-#: custom/opm/beneficiary.py:805 custom/opm/beneficiary.py:884
+#: custom/opm/beneficiary.py:804 custom/opm/beneficiary.py:884
+#: custom/opm/beneficiary.py:920
 msgid "List of Beneficiaries"
 msgstr ""
 
-#: custom/opm/beneficiary.py:806 custom/opm/beneficiary.py:886
-#: custom/opm/health_status.py:89
+#: custom/opm/beneficiary.py:805 custom/opm/beneficiary.py:886
+#: custom/opm/beneficiary.py:922 custom/opm/health_status.py:18
 msgid "AWC Name"
 msgstr ""
 
-#: custom/opm/beneficiary.py:807 custom/opm/health_status.py:85
+#: custom/opm/beneficiary.py:806 custom/opm/beneficiary.py:923
+#: custom/opm/health_status.py:14
 msgid "AWC Code"
 msgstr ""
 
-#: custom/opm/beneficiary.py:808 custom/opm/beneficiary.py:891
+#: custom/opm/beneficiary.py:807 custom/opm/beneficiary.py:891
+#: custom/opm/beneficiary.py:924
 msgid "Block Name"
 msgstr ""
 
-#: custom/opm/beneficiary.py:810
+#: custom/opm/beneficiary.py:809 custom/opm/beneficiary.py:942
 msgid "Current status"
 msgstr ""
 
-#: custom/opm/beneficiary.py:811
+#: custom/opm/beneficiary.py:810
 msgid "Pregnancy Month"
 msgstr ""
 
-#: custom/opm/beneficiary.py:813
+#: custom/opm/beneficiary.py:812
 msgid "Child Age"
 msgstr ""
 
-#: custom/opm/beneficiary.py:815
+#: custom/opm/beneficiary.py:814
 msgid "Condition 1"
 msgstr ""
 
-#: custom/opm/beneficiary.py:816
+#: custom/opm/beneficiary.py:815
 msgid "Condition 2"
 msgstr ""
 
-#: custom/opm/beneficiary.py:817
+#: custom/opm/beneficiary.py:816
 msgid "Condition 3"
 msgstr ""
 
-#: custom/opm/beneficiary.py:818
+#: custom/opm/beneficiary.py:817
 msgid "Condition 4"
 msgstr ""
 
-#: custom/opm/beneficiary.py:819
+#: custom/opm/beneficiary.py:818
 msgid "Condition 5"
 msgstr ""
 
-#: custom/opm/beneficiary.py:820
+#: custom/opm/beneficiary.py:819
 msgid "Payment amount this month (Rs.)"
 msgstr ""
 
-#: custom/opm/beneficiary.py:821
+#: custom/opm/beneficiary.py:820
 msgid "Payment amount last month (Rs.)"
 msgstr ""
 
-#: custom/opm/beneficiary.py:822
+#: custom/opm/beneficiary.py:821 custom/opm/beneficiary.py:973
 msgid "Cash received last month"
 msgstr ""
 
-#: custom/opm/beneficiary.py:825 custom/opm/beneficiary.py:904
+#: custom/opm/beneficiary.py:824 custom/opm/beneficiary.py:904
+#: custom/opm/beneficiary.py:974
 msgid "Issues"
 msgstr ""
 
-#: custom/opm/beneficiary.py:887
+#: custom/opm/beneficiary.py:887 custom/opm/beneficiary.py:937
 msgid "Bank Name"
 msgstr ""
 
-#: custom/opm/beneficiary.py:888
+#: custom/opm/beneficiary.py:888 custom/opm/beneficiary.py:939
 msgid "Bank Branch Name"
 msgstr ""
 
-#: custom/opm/beneficiary.py:889
+#: custom/opm/beneficiary.py:889 custom/opm/beneficiary.py:941
 msgid "IFS Code"
 msgstr ""
 
-#: custom/opm/beneficiary.py:890
+#: custom/opm/beneficiary.py:890 custom/opm/beneficiary.py:938
 msgid "Bank Account Number"
 msgstr ""
 
@@ -25549,441 +25869,639 @@ msgstr ""
 msgid "Payment last month"
 msgstr ""
 
-#: custom/opm/filters.py:113 custom/opm/filters.py:126
+#: custom/opm/beneficiary.py:925
+msgid "Gram Panchayat name"
+msgstr ""
+
+#: custom/opm/beneficiary.py:926
+msgid "Village name"
+msgstr ""
+
+#: custom/opm/beneficiary.py:927
+msgid "Dob Known"
+msgstr ""
+
+#: custom/opm/beneficiary.py:928
+#, fuzzy
+msgid "Mother's Age"
+msgstr "Outros (negativos / indeterminados) "
+
+#: custom/opm/beneficiary.py:929
+msgid "Caste tribe status"
+msgstr ""
+
+#: custom/opm/beneficiary.py:931
+msgid "Prev pregnancies"
+msgstr ""
+
+#: custom/opm/beneficiary.py:932
+msgid "Prev live births"
+msgstr ""
+
+#: custom/opm/beneficiary.py:933
+msgid "Sons alive"
+msgstr ""
+
+#: custom/opm/beneficiary.py:934
+msgid "Daughters alive"
+msgstr ""
+
+#: custom/opm/beneficiary.py:935
+msgid "Sum children"
+msgstr ""
+
+#: custom/opm/beneficiary.py:936
+msgid "Contact phone number"
+msgstr ""
+
+#: custom/opm/beneficiary.py:940
+msgid "Bank Branch Code"
+msgstr ""
+
+#: custom/opm/beneficiary.py:943
+msgid "Lmp Date"
+msgstr ""
+
+#: custom/opm/beneficiary.py:945
+msgid "Pregnancy month"
+msgstr ""
+
+#: custom/opm/beneficiary.py:947
+msgid "Child 1 Age"
+msgstr ""
+
+#: custom/opm/beneficiary.py:948
+msgid "Child 1 Name"
+msgstr ""
+
+#: custom/opm/beneficiary.py:949
+msgid "Child 1 Sex"
+msgstr ""
+
+#: custom/opm/beneficiary.py:950
+msgid "Child DOB"
+msgstr ""
+
+#: custom/opm/beneficiary.py:951
+msgid "Child 2 Age"
+msgstr ""
+
+#: custom/opm/beneficiary.py:952
+msgid "Child 2 Name"
+msgstr ""
+
+#: custom/opm/beneficiary.py:953
+msgid "Child 2 Sex"
+msgstr ""
+
+#: custom/opm/beneficiary.py:954
+msgid "Child 3 Age"
+msgstr ""
+
+#: custom/opm/beneficiary.py:955
+msgid "Child 3 Name"
+msgstr ""
+
+#: custom/opm/beneficiary.py:956
+msgid "Child 3 Sex"
+msgstr ""
+
+#: custom/opm/beneficiary.py:957
+msgid "Condition 1 / pregnant woman attended VHND"
+msgstr ""
+
+#: custom/opm/beneficiary.py:958
+msgid "Condition 2 /pregnant woman's weight taken in first trimester"
+msgstr ""
+
+#: custom/opm/beneficiary.py:959
+msgid "Condition 3/ Received 30 IFA pills"
+msgstr ""
+
+#: custom/opm/beneficiary.py:960
+msgid "Condition 2 /pregnant woman's weight taken in second trimester"
+msgstr ""
+
+#: custom/opm/beneficiary.py:961
+msgid "Condition 4/mother attended VHND with child"
+msgstr ""
+
+#: custom/opm/beneficiary.py:962
+msgid "Condition 5/child birth registered"
+msgstr ""
+
+#: custom/opm/beneficiary.py:963
+msgid "Condition 6/ child birth weight taken"
+msgstr ""
+
+#: custom/opm/beneficiary.py:964
+msgid "Condition 7 /exclusively breastfed for first 6 months"
+msgstr ""
+
+#: custom/opm/beneficiary.py:965
+msgid "Condition 8 /child weight monitored this month"
+msgstr ""
+
+#: custom/opm/beneficiary.py:966
+msgid "Condition 9 /ORS administered if child had diarrhea"
+msgstr ""
+
+#: custom/opm/beneficiary.py:967
+msgid "Condition 10/ Measles vaccine given before child turns 1"
+msgstr ""
+
+#: custom/opm/beneficiary.py:968
+msgid "Birth Spacing Bonus"
+msgstr ""
+
+#: custom/opm/beneficiary.py:969
+msgid "Weight This Month"
+msgstr ""
+
+#: custom/opm/beneficiary.py:970
+msgid "Nutritional Status This Month"
+msgstr ""
+
+#: custom/opm/beneficiary.py:971
+msgid "Nutritional Status Bonus"
+msgstr ""
+
+#: custom/opm/beneficiary.py:972
+msgid "Payment amount for the month"
+msgstr ""
+
+#: custom/opm/beneficiary.py:975
+msgid "VHND held this month?"
+msgstr ""
+
+#: custom/opm/beneficiary.py:976
+msgid "Opened on"
+msgstr ""
+
+#: custom/opm/beneficiary.py:977
+#, fuzzy
+msgid "Closed on"
+msgstr "Casos IRA Tratados"
+
+#: custom/opm/beneficiary.py:978
+msgid "Close mother dup"
+msgstr ""
+
+#: custom/opm/beneficiary.py:979
+msgid "Close mother mo"
+msgstr ""
+
+#: custom/opm/beneficiary.py:980
+msgid "Leave program"
+msgstr ""
+
+#: custom/opm/beneficiary.py:981
+msgid "Close mother dead"
+msgstr ""
+
+#: custom/opm/beneficiary.py:982
+msgid "Calendar year"
+msgstr ""
+
+#: custom/opm/beneficiary.py:983
+msgid "Calendar month"
+msgstr ""
+
+#: custom/opm/filters.py:72 custom/opm/filters.py:85
 #: custom/up_nrhm/filters.py:37
 msgid "Hierarchy"
 msgstr ""
 
-#: custom/opm/health_status.py:93
+#: custom/opm/health_status.py:22
 msgid "Gram Panchayat"
 msgstr ""
 
-#: custom/opm/health_status.py:97
+#: custom/opm/health_status.py:26
 msgid "Registered Beneficiaries"
 msgstr ""
 
-#: custom/opm/health_status.py:98
+#: custom/opm/health_status.py:27
 msgid "Beneficiaries registered with BCSP"
 msgstr ""
 
-#: custom/opm/health_status.py:101
+#: custom/opm/health_status.py:30
 msgid "Registered pregnant women"
 msgstr ""
 
-#: custom/opm/health_status.py:102
+#: custom/opm/health_status.py:31
 msgid "Pregnant women registered with BCSP"
 msgstr ""
 
-#: custom/opm/health_status.py:105
+#: custom/opm/health_status.py:34
 msgid "Registered mothers"
 msgstr ""
 
-#: custom/opm/health_status.py:106
+#: custom/opm/health_status.py:35
 msgid "Mothers registered with BCSP"
 msgstr ""
 
-#: custom/opm/health_status.py:109
+#: custom/opm/health_status.py:38
 msgid "Registered children"
 msgstr ""
 
-#: custom/opm/health_status.py:110
+#: custom/opm/health_status.py:39
 msgid "Children below 3 years of age registered with BCSP"
 msgstr ""
 
-#: custom/opm/health_status.py:113
+#: custom/opm/health_status.py:42
 msgid "Eligible for payment upon fulfillment of cash conditions"
 msgstr ""
 
-#: custom/opm/health_status.py:114
+#: custom/opm/health_status.py:43
 msgid ""
 "Registered beneficiaries eligilble for cash payment for the month upon "
 "fulfillment of cash conditions"
 msgstr ""
 
-#: custom/opm/health_status.py:118
+#: custom/opm/health_status.py:47
 msgid "Eligible for payment upon absence of services"
 msgstr ""
 
-#: custom/opm/health_status.py:119
+#: custom/opm/health_status.py:48
 msgid ""
 "Registered beneficiaries eligilble for cash payment for the month upon "
 "absence of services at VHND"
 msgstr ""
 
-#: custom/opm/health_status.py:122
+#: custom/opm/health_status.py:51
 msgid "Eligible for payment"
 msgstr ""
 
-#: custom/opm/health_status.py:123
+#: custom/opm/health_status.py:52
 msgid "Registered beneficiaries eligilble for cash payment for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:126
+#: custom/opm/health_status.py:55
 msgid "Total cash payment"
 msgstr ""
 
-#: custom/opm/health_status.py:127
+#: custom/opm/health_status.py:56
 msgid "Total cash payment made to registered beneficiaries for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:130
+#: custom/opm/health_status.py:59
 msgid "Pregnant women attended VHND"
 msgstr ""
 
-#: custom/opm/health_status.py:131
+#: custom/opm/health_status.py:60
 msgid "Registered pregnant women who attended VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:134
+#: custom/opm/health_status.py:63
 msgid "Children attended VHND"
 msgstr ""
 
-#: custom/opm/health_status.py:135
+#: custom/opm/health_status.py:64
 msgid ""
 "Registered children below 3 years of age who attended VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:138
+#: custom/opm/health_status.py:67
 msgid "Beneficiaries attended VHND"
 msgstr ""
 
-#: custom/opm/health_status.py:139
+#: custom/opm/health_status.py:68
 msgid "Registered beneficiaries who attended VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:142
+#: custom/opm/health_status.py:71
 msgid "Received at least 30 IFA tablets"
 msgstr ""
 
-#: custom/opm/health_status.py:143
+#: custom/opm/health_status.py:72
 msgid ""
 "Registered pregnant women (6 months pregnant) who received at least 30 IFA "
 "tablets in second trimester"
 msgstr ""
 
-#: custom/opm/health_status.py:147
+#: custom/opm/health_status.py:76
 msgid "Weight monitored in second trimester"
 msgstr ""
 
-#: custom/opm/health_status.py:148
+#: custom/opm/health_status.py:77
 msgid ""
 "Registered pregnant women (6 months pregnant) who got their weight monitored "
 "in second trimester"
 msgstr ""
 
-#: custom/opm/health_status.py:151
+#: custom/opm/health_status.py:80
 msgid "Weight monitored in third trimester"
 msgstr ""
 
-#: custom/opm/health_status.py:152
+#: custom/opm/health_status.py:81
 msgid ""
 "Registered pregnant women (9 months pregnant) who got their weight monitored "
 "in third trimester"
 msgstr ""
 
-#: custom/opm/health_status.py:155
+#: custom/opm/health_status.py:84
 msgid "Weight monitored at birth"
 msgstr ""
 
-#: custom/opm/health_status.py:156
+#: custom/opm/health_status.py:85
 msgid "Registered children (3 months old) whose weight was monitored at birth"
 msgstr ""
 
-#: custom/opm/health_status.py:159
+#: custom/opm/health_status.py:88
 msgid "Child birth registered"
 msgstr ""
 
-#: custom/opm/health_status.py:160
+#: custom/opm/health_status.py:89
 msgid ""
 "Registered children (6 months old) whose birth was registered in the first 6 "
 "months after birth"
 msgstr ""
 
-#: custom/opm/health_status.py:163
+#: custom/opm/health_status.py:92
 msgid "Growth monitoring when 0-3 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:164
+#: custom/opm/health_status.py:93
 msgid ""
 "Registered Children (3 months old) who have attended at least one growth "
 "monitoring session between the age 0-3 months"
 msgstr ""
 
-#: custom/opm/health_status.py:168
+#: custom/opm/health_status.py:97
 msgid "Growth Monitoring when 4-6 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:169
+#: custom/opm/health_status.py:98
 msgid ""
 "Registered Children (6 months old) who have attended at least one growth "
 "monitoring session between the age 4-6 months"
 msgstr ""
 
-#: custom/opm/health_status.py:173
+#: custom/opm/health_status.py:102
 msgid "Growth Monitoring when 7-9 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:174
+#: custom/opm/health_status.py:103
 msgid ""
 "Registered Children (9 months old) who have attended at least one growth "
 "monitoring session between the age 7-9 months"
 msgstr ""
 
-#: custom/opm/health_status.py:178
+#: custom/opm/health_status.py:107
 msgid "Growth Monitoring when 10-12 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:179
+#: custom/opm/health_status.py:108
 msgid ""
 "Registered Children (12 months old) who have attended at least one growth "
 "monitoring session between the age 10-12 months"
 msgstr ""
 
-#: custom/opm/health_status.py:183
+#: custom/opm/health_status.py:112
 msgid "Growth Monitoring when 13-15 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:184
+#: custom/opm/health_status.py:113
 msgid ""
 "Registered Children (15 months old) who have attended at least one growth "
 "monitoring session between the age 13-15 months"
 msgstr ""
 
-#: custom/opm/health_status.py:188
+#: custom/opm/health_status.py:117
 msgid "Growth Monitoring when 16-18 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:189
+#: custom/opm/health_status.py:118
 msgid ""
 "Registered Children (18 months old) who have attended at least one growth "
 "monitoring session between the age 16-18 months"
 msgstr ""
 
-#: custom/opm/health_status.py:193
+#: custom/opm/health_status.py:122
 msgid "Growth Monitoring when 19-21 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:194
+#: custom/opm/health_status.py:123
 msgid ""
 "Registered Children (21 months old) who have attended at least one growth "
 "monitoring session between the age 19-21 months"
 msgstr ""
 
-#: custom/opm/health_status.py:198
+#: custom/opm/health_status.py:127
 msgid "Growth Monitoring when 22-24 months old"
 msgstr ""
 
-#: custom/opm/health_status.py:199
+#: custom/opm/health_status.py:128
 msgid ""
 "Registered Children (24 months old) who have attended at least one growth "
 "monitoring session between the age 22-24 months"
 msgstr ""
 
-#: custom/opm/health_status.py:203
+#: custom/opm/health_status.py:132
 msgid "Received ORS and Zinc treatment for diarrhoea"
 msgstr ""
 
-#: custom/opm/health_status.py:204
+#: custom/opm/health_status.py:133
 msgid ""
 "Registered children who received ORS and Zinc treatment if he/she contracts "
 "diarrhoea"
 msgstr ""
 
-#: custom/opm/health_status.py:207
+#: custom/opm/health_status.py:136
 msgid "Exclusively breastfed for first 6 months"
 msgstr ""
 
-#: custom/opm/health_status.py:208
+#: custom/opm/health_status.py:137
 msgid ""
 "Registered children (6 months old) who have been exclusively breastfed for "
 "first 6 months"
 msgstr ""
 
-#: custom/opm/health_status.py:211
+#: custom/opm/health_status.py:140
 msgid "Received Measles vaccine"
 msgstr ""
 
-#: custom/opm/health_status.py:212
+#: custom/opm/health_status.py:141
 msgid "Registered children (12 months old) who have received Measles vaccine"
 msgstr ""
 
-#: custom/opm/health_status.py:215
+#: custom/opm/health_status.py:144
 msgid "VHND organised"
 msgstr ""
 
-#: custom/opm/health_status.py:216
+#: custom/opm/health_status.py:145
 msgid "Whether VHND was organised at AWC for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:219
+#: custom/opm/health_status.py:148
 msgid "Adult Weighing Machine Available"
 msgstr ""
 
-#: custom/opm/health_status.py:220
+#: custom/opm/health_status.py:149
 msgid "Whether adult weighing machine was available for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:223
+#: custom/opm/health_status.py:152
 msgid "Adult Weighing Machine Functional"
 msgstr ""
 
-#: custom/opm/health_status.py:224
+#: custom/opm/health_status.py:153
 msgid "Whether adult weighing machine was functional for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:227
+#: custom/opm/health_status.py:156
 msgid "Child Weighing Machine Available"
 msgstr ""
 
-#: custom/opm/health_status.py:228
+#: custom/opm/health_status.py:157
 msgid "Whether child weighing machine was available for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:231
+#: custom/opm/health_status.py:160
 msgid "Child Weighing Machine Functional"
 msgstr ""
 
-#: custom/opm/health_status.py:232
+#: custom/opm/health_status.py:161
 msgid "Whether child weighing machine was functional for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:235
+#: custom/opm/health_status.py:164
 msgid "ANM Present"
 msgstr ""
 
-#: custom/opm/health_status.py:236
+#: custom/opm/health_status.py:165
 msgid "Whether ANM present at VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:239
+#: custom/opm/health_status.py:168
 msgid "ASHA Present"
 msgstr ""
 
-#: custom/opm/health_status.py:240
+#: custom/opm/health_status.py:169
 msgid "Whether ASHA present at VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:243
+#: custom/opm/health_status.py:172
 msgid "CMG Present"
 msgstr ""
 
-#: custom/opm/health_status.py:244
+#: custom/opm/health_status.py:173
 msgid "Whether CMG present at VHND for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:247
+#: custom/opm/health_status.py:176
 msgid "Stock of IFA tablets"
 msgstr ""
 
-#: custom/opm/health_status.py:248
+#: custom/opm/health_status.py:177
 msgid "Whether AWC has enough stock of IFA tablets for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:251
+#: custom/opm/health_status.py:180
 msgid "Stock of ORS packets"
 msgstr ""
 
-#: custom/opm/health_status.py:252
+#: custom/opm/health_status.py:181
 msgid "Whether AWC has enough stock of ORS packets for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:255
+#: custom/opm/health_status.py:184
 msgid "Stock of ZINC tablets"
 msgstr ""
 
-#: custom/opm/health_status.py:256
+#: custom/opm/health_status.py:185
 msgid "Whether AWC has enough stock of Zinc Tablets for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:259
+#: custom/opm/health_status.py:188
 msgid "Stock of Measles Vaccine"
 msgstr ""
 
-#: custom/opm/health_status.py:260
+#: custom/opm/health_status.py:189
 msgid "Whether AWC has enough stock of measles vaccine for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:263
+#: custom/opm/health_status.py:192
 msgid "Eligilble for Birth Spacing bonus"
 msgstr ""
 
-#: custom/opm/health_status.py:264
+#: custom/opm/health_status.py:193
 msgid "Registered beneficiaries eligible for birth spacing bonus for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:267
+#: custom/opm/health_status.py:196
 msgid "Severely underweight"
 msgstr ""
 
-#: custom/opm/health_status.py:268
+#: custom/opm/health_status.py:197
 msgid ""
 "Registered children severely underweight (very low weight for age) for the "
 "month"
 msgstr ""
 
-#: custom/opm/health_status.py:271
+#: custom/opm/health_status.py:200
 msgid "Underweight"
 msgstr ""
 
-#: custom/opm/health_status.py:272
+#: custom/opm/health_status.py:201
 msgid "Registered children underweight (low weight for age) for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:275
+#: custom/opm/health_status.py:204
 msgid "Normal weight for age"
 msgstr ""
 
-#: custom/opm/health_status.py:276
+#: custom/opm/health_status.py:205
 msgid "Registered children with normal weight for age for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:279
+#: custom/opm/health_status.py:208
 msgid "Eligilble for Nutritional status bonus"
 msgstr ""
 
-#: custom/opm/health_status.py:280
+#: custom/opm/health_status.py:209
 msgid ""
 "Registered beneficiaries eligible for nutritonal status bonus for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:283
+#: custom/opm/health_status.py:212
 msgid "Pregnant women cases closed"
 msgstr ""
 
-#: custom/opm/health_status.py:284
+#: custom/opm/health_status.py:213
 msgid "Registered pregnant women cases closed for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:287
+#: custom/opm/health_status.py:216
 msgid "Mother cases closed"
 msgstr ""
 
-#: custom/opm/health_status.py:288
+#: custom/opm/health_status.py:217
 msgid "Registered mother cases closed for the month"
 msgstr ""
 
-#: custom/opm/health_status.py:291
+#: custom/opm/health_status.py:220
 msgid "Children cases closed"
 msgstr ""
 
-#: custom/opm/health_status.py:292
+#: custom/opm/health_status.py:221
 msgid "Registered children cases closed for the month"
 msgstr ""
 
-#: custom/opm/reports.py:656 custom/opm/reports.py:657
-#: custom/opm/reports.py:917
+#: custom/opm/reports.py:457 custom/opm/reports.py:458
+#: custom/opm/reports.py:719
 msgid "Reporting period incomplete"
 msgstr ""
 
-#: custom/opm/reports.py:876
+#: custom/opm/reports.py:679
 msgid "Duplicate account number"
 msgstr ""
 
-#: custom/opm/reports.py:885
+#: custom/opm/reports.py:688
 msgid "Conditions Met Report"
 msgstr ""
 
-#: custom/opm/reports.py:924
+#: custom/opm/reports.py:726
 msgid "Total Payment"
 msgstr ""
 
@@ -26931,7 +27449,7 @@ msgstr ""
 
 #: custom/up_nrhm/reports/asha_functionality_checklist_report.py:61
 #, python-format
-msgid "Total number of ASHAs who are functional on at least 60% of the tasks"
+msgid "Total number of ASHAs who are functional on at least %s of the tasks"
 msgstr ""
 
 #: custom/up_nrhm/reports/asha_functionality_checklist_report.py:62
@@ -27017,11 +27535,85 @@ msgstr ""
 
 #: custom/up_nrhm/reports/district_functionality_report.py:34
 #, python-format
-msgid "% of ASHAs"
+msgid "%s of ASHAs"
 msgstr ""
 
-#: custom/up_nrhm/reports/district_functionality_report.py:35
+#: custom/up_nrhm/reports/district_functionality_report.py:36
 msgid "Grade of Block"
+msgstr ""
+
+#: docs/_build/html/_sources/translations.txt:141
+#, python-format
+msgid "This string will have %(value)s inside."
+msgstr ""
+
+#: docs/_build/html/_sources/translations.txt:147
+#, python-format
+msgid ""
+"\n"
+"        That will cost $ %(amount)s.\n"
+"    "
+msgstr ""
+
+#: docs/_build/html/_sources/translations.txt:155
+#, python-format
+msgid ""
+"\n"
+"        This will have %(myvar)s inside.\n"
+"    "
+msgstr ""
+
+#: docs/_build/html/_sources/translations.txt:167
+msgid ""
+"\n"
+"        Manage Mobile Workers <small>for CommCare Mobile and\n"
+"        CommCare HQ Reports</small>\n"
+"    "
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/couchpanel.py:89
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/couchpanel.py:92
+msgid "CouchDB"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:15
+msgid "Stacktrace"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:16
+msgid "View Name"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:17
+msgid "Request Params"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:45
+msgid "Line"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch.html:46
+msgid "Method"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:6
+msgid "CouchDB View"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:11
+msgid "Executed View"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:13
+msgid "Parameters"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:15
+msgid "Total Rows"
+msgstr ""
+
+#: packages-local/couchdbkit-debugpanel/couchdebugpanel/templates/couchdebugpanel/couch_select.html:40
+msgid "Empty set"
 msgstr ""
 
 #: submodules/auditcare-src/auditcare/forms.py:14
@@ -27412,16 +28004,16 @@ msgstr ""
 msgid "Clearing data"
 msgstr ""
 
-#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:36
+#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:47
 #, python-format
 msgid "ERROR: Could not send \"%(subject)s\""
 msgstr ""
 
-#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:41
+#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:52
 msgid "Could not send email: file size is too large."
 msgstr ""
 
-#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:46
+#: submodules/dimagi-utils-src/dimagi/utils/django/email.py:57
 #, python-format
 msgid "Please contact %(support_email)s for assistance."
 msgstr ""
@@ -27479,9 +28071,6 @@ msgstr ""
 #~ msgid "Commtrack"
 #~ msgstr "CommCare Supply"
 
-#~ msgid "mothers"
-#~ msgstr "Outros (negativos / indeterminados) "
-
 #~ msgid "Create New Report > Configure Table Report"
 #~ msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
 
@@ -27490,9 +28079,6 @@ msgstr ""
 
 #~ msgid "New Mothers"
 #~ msgstr "Outros (negativos / indeterminados) "
-
-#~ msgid "Closed by"
-#~ msgstr "Casos IRA Tratados"
 
 #~ msgid "Manage SMS Backend Rates"
 #~ msgstr "Diagnóstico de Casos"

--- a/locale/sw/LC_MESSAGES/django.po
+++ b/locale/sw/LC_MESSAGES/django.po
@@ -1,14 +1,10 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-#
 # Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: CommCare HQ\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-08-05 17:43+0000\n"
-"PO-Revision-Date: 2015-06-26 09:30+0000\n"
+"POT-Creation-Date: 2015-08-05 18:00+0000\n"
+"PO-Revision-Date: 2015-08-05 18:00+0000\n"
 "Last-Translator: Dimagi Dev <devops@dimagi.com>\n"
 "Language-Team: Swahili (http://www.transifex.com/projects/p/commcare-hq/"
 "language/sw/)\n"
@@ -491,9 +487,9 @@ msgid "Name '%s' is already taken."
 msgstr ""
 
 #: corehq/apps/accounting/forms.py:183
-#, python-format
+#, fuzzy, python-format
 msgid "Invalid emails: %s"
-msgstr ""
+msgstr "Namba ya MSD sio sahihi %(code)s"
 
 #: corehq/apps/accounting/forms.py:194
 msgid ""
@@ -17912,9 +17908,8 @@ msgid "(Deleted Reminder)"
 msgstr ""
 
 #: corehq/apps/reports/standard/sms.py:480
-#, fuzzy
 msgid "View Details"
-msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
+msgstr ""
 
 #: corehq/apps/reports/standard/sms.py:502
 msgid "Past Events"
@@ -25882,9 +25877,8 @@ msgid "Dob Known"
 msgstr ""
 
 #: custom/opm/beneficiary.py:928
-#, fuzzy
 msgid "Mother's Age"
-msgstr "Outros (negativos / indeterminados) "
+msgstr ""
 
 #: custom/opm/beneficiary.py:929
 msgid "Caste tribe status"
@@ -26039,9 +26033,8 @@ msgid "Opened on"
 msgstr ""
 
 #: custom/opm/beneficiary.py:977
-#, fuzzy
 msgid "Closed on"
-msgstr "Casos IRA Tratados"
+msgstr ""
 
 #: custom/opm/beneficiary.py:978
 msgid "Close mother dup"
@@ -28062,26 +28055,196 @@ msgid ""
 "have problems filling in the rest of your form please report an issue."
 msgstr ""
 
-#~ msgid "Requisition Report"
-#~ msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
+#~ msgid ""
+#~ "To register send reg <name> <msd code> or reg <name> at <district name>. "
+#~ "Example:reg john patel d34002 or reg john patel : tandahimba"
+#~ msgstr ""
+#~ "Kujisajili tuma sajili <Jina> <namba ya MSD> au sajili <jina> kwa <jina "
+#~ "la wilaya>. Mfano: sajili John Patel d34002 au sajili John Patel : "
+#~ "tandahimba"
 
-#~ msgid "Date Closed"
-#~ msgstr "Casos IRA Tratados"
+#~ msgid ""
+#~ "I didn't recognize your msd code.  To register, send register <name> <msd "
+#~ "code>. example: register Peter Juma d34002"
+#~ msgstr ""
+#~ "msd code yako haitambuliki, Kujisajili, andika 'sajili<nafasi><jina "
+#~ "lako><nafasi><msd code ya kituo chako>. Mfano 'sajili Peter Juma d34002'"
 
-#~ msgid "Commtrack"
-#~ msgstr "CommCare Supply"
+#~ msgid "Sorry, can't find the location with MSD CODE %(msd_code)s"
+#~ msgstr "Samahani, Eneo lenye MSD CODE %(msd_code)s halipo"
 
-#~ msgid "Create New Report > Configure Table Report"
-#~ msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
+#~ msgid "Sorry, can't find the location with the name %(name)s"
+#~ msgstr "Samahani sioni jina linaloendana na eneo %(name)s"
 
-#~ msgid "No more visits"
-#~ msgstr "Visitas Domiciliáres"
+#~ msgid ""
+#~ "Thank you for registering at %(sdp_name)s, %(msd_code)s, %(contact_name)s"
+#~ msgstr ""
+#~ "Asante kwa kujisajili katika %(sdp_name)s, %(msd_code)s, %(contact_name)s"
 
-#~ msgid "New Mothers"
-#~ msgstr "Outros (negativos / indeterminados) "
+#~ msgid "Thank you for registering at %(sdp_name)s, %(contact_name)s"
+#~ msgstr "Asante kwa kujisajili katika %(sdp_name)s, %(contact_name)s"
 
-#~ msgid "Manage SMS Backend Rates"
-#~ msgstr "Diagnóstico de Casos"
+#~ msgid ""
+#~ "Please send in your stock on hand information in the format 'soh "
+#~ "<product> <amount> <product> <amount>...'"
+#~ msgstr ""
+#~ "Tafadhali tuma hesabu ya mkono ya vifaaa vilivyopo katika mpangilio huu "
+#~ "'hmk <jina la vifaa> <idadi> <jina la vifaa> <idadi>...'"
 
-#~ msgid "Company Name"
-#~ msgstr "Relatorio Semanal aos Coordinadores do Distrito e os NEDs"
+#~ msgid ""
+#~ "Have you sent in your R&R form yet for this quarter? Please reply "
+#~ "\"submitted\" or \"not submitted\""
+#~ msgstr ""
+#~ "Je? Umetuma R&R fomu yako kwa kota hii? Tafadhal jibu \"nimetuma\" au "
+#~ "\"sijatuma\""
+
+#~ msgid ""
+#~ "How many R&R forms have you submitted to MSD? Reply with 'submitted A "
+#~ "<number of R&Rs submitted for group A> B <number of R&Rs submitted for "
+#~ "group B>'"
+#~ msgstr ""
+#~ "Ni R&R fomu ngapi umetuma MSD mpaka sasa? tafadhali jibu 'nimetuma A "
+#~ "<idadi ya R&R fomu za kundi a> B <idadi ya R&R fomu za kundi B>...'"
+
+#~ msgid ""
+#~ "Did you receive your delivery yet? Please reply 'delivered <product> "
+#~ "<amount> <product> <amount>...'"
+#~ msgstr ""
+#~ "Je? Umekwishapokea vifaa ulivyoagiza robo mwaka huu, kama umepokea jibu "
+#~ "'nimepokea <jina la vifaa> <idadi ya vifaa>...', kama haujapokea jibu "
+#~ "'sijapokea'"
+
+#~ msgid ""
+#~ "Did you receive your delivery yet? Please reply 'delivered' or 'not "
+#~ "delivered'"
+#~ msgstr ""
+#~ "Je? Umekwishapokea vifaa ulivyoagiza robo mwaka huu, kama umepokea jibu "
+#~ "'nimepokea', kama haujapokea jibu 'sijapokea'"
+
+#~ msgid ""
+#~ "Have you received supervision this month? Please reply 'supervision yes' "
+#~ "or 'supervision no'"
+#~ msgstr ""
+#~ "Asante. Je umefanyiwa usimamizi kwa mwezi huu? Tafadhali jibu 'usimamizi "
+#~ "ndiyo' au 'usimamizi hapana'"
+
+#~ msgid "Thank you for reporting your stock on hand this month"
+#~ msgstr "Asante kwa kutoa taarifa za hesabu ya mkono kwa mwezi huu"
+
+#~ msgid ""
+#~ "Supervision reminders will come monthly, and you can respond 'supervision "
+#~ "yes' if you have received supervision or 'supervision no' if you have not"
+#~ msgstr ""
+#~ "Ujumbe wa usimamizi hutumwa kila mwisho wa mwezi, tafadhali jibu "
+#~ "'usimamizi ndiyo' kama umefanyiwa usimamizi au 'usimamizi hapana' kama "
+#~ "haujafanyiwa usimamizi."
+
+#~ msgid ""
+#~ "Thank you %(contact_name)s for reporting your delivery for "
+#~ "%(facility_name)s"
+#~ msgstr ""
+#~ "Asante %(contact_name)s kwa kutuma taarifa ya kupokea vifaa vya "
+#~ "%(facility_name)s"
+
+#~ msgid ""
+#~ "To record a delivery, respond with \"delivered product amount product "
+#~ "amount...\""
+#~ msgstr ""
+#~ "Kutuma taarifa za kupokea vifaa, jibu  \"nimepokea<acha nafasi><jina la "
+#~ "kifaa><acha nafasi><idadi ya kifaa><acha nafasi>...\""
+
+#~ msgid ""
+#~ "Facility deliveries for group %(group_name)s (out of %(group_total)d): "
+#~ "%(not_responded_count)d haven't responded and %(not_received_count)d have "
+#~ "reported not receiving. See ilsgateway.com"
+#~ msgstr ""
+#~ "Vituo vya kundi la upokeaji %(group_name)s (kati ya %(group_total)d): "
+#~ "%(not_responded_count)d havijajibu na %(not_received_count)d vimetoa "
+#~ "taarifa kua havijapokea vifaa. Tizama kwenye ilsgateway.com"
+
+#~ msgid ""
+#~ "%(district_name)s has submitted their R&R forms to MSD: %(group_a)s for "
+#~ "Group A, %(group_b)s for Group B, %(group_c)s for Group C"
+#~ msgstr ""
+#~ "%(district_name)s imetuma R&R fomu kwenda MSD: %(group_a)s kwa ajili ya "
+#~ "Kundi A, %(group_b)s kwa ajili ya Kundi B %(group_c)s kwa ajili ya Kundi C"
+
+#~ msgid ""
+#~ "District %(district_name)s has reported that they sent their R&R forms to "
+#~ "MSD"
+#~ msgstr ""
+#~ "Wilaya %(district_name)s imetoa taarifa kuwa fomu za R&R zimewasilishwa "
+#~ "MSD"
+
+#~ msgid "Thank you for confirming your arrival at the health facility."
+#~ msgstr "Asante kwa kuthibitisha kufika kwako katika Kituo cha Afya"
+
+#~ msgid "Thank you for confirming your arrival at %(facility)s."
+#~ msgstr "Asante kwa kuthibitisha kufika kwako katika %(facility)s"
+
+#~ msgid ""
+#~ "Welcome to ILSGateway. Available commands are soh, delivered, not "
+#~ "delivered, submitted, not submitted, language, sw, en, stop, supervision, "
+#~ "la"
+#~ msgstr ""
+#~ "Karibu kwenye mfumo wa ILSGateway.maneno yaliyopo ya kuamrisha ni hmk, "
+#~ "nimepokea, sijapokea, nimetuma, sijatuma, lugha sw, lugha en, acha, "
+#~ "usimamizi, um"
+
+#~ msgid "To set your language, send LANGUAGE <CODE>"
+#~ msgstr "Kubadilisha lugha, tuma LUGHA <KIFUPISHO>"
+
+#~ msgid ""
+#~ "You must JOIN or IDENTIFY yourself before you can set your language "
+#~ "preference"
+#~ msgstr "Lazima kujiunga kwanza kabla ya kuchagua lugha unayotaka"
+
+#~ msgid "I will speak to you in %(language)s."
+#~ msgstr "Nitaongea na wewe kwa %(language)s."
+
+#~ msgid "Sorry, I don't speak \"%(language)s\"."
+#~ msgstr "Samahani, sielewi \"%(language)s\""
+
+#~ msgid ""
+#~ "You have requested to stop reminders to this number.  Send 'help' to this "
+#~ "number for instructions on how to reactivate."
+#~ msgstr ""
+#~ "Umesitisha kukumbushwa kwenye hii namba. tafadhali tuma 'msaada' kupata "
+#~ "maelekezo jinsi ya kujiunga tena"
+
+#~ msgid ""
+#~ "If you have submitted your R&R, respond \"submitted\".  If you have "
+#~ "received your delivery, respond \"delivered\""
+#~ msgstr ""
+#~ "Kama umetuma R&R fomu yako jibu 'nimetuma', kama umepokea vifaa jibu "
+#~ "'nimepokea'"
+
+#~ msgid ""
+#~ "To test a reminder, send \"test [remindername] [msd code]\"; valid tests "
+#~ "are soh, delivery, randr. Remember to setup your contact details!"
+#~ msgstr ""
+#~ "_To test a reminder, send \"test [remindername] [msd code]\"; valid tests "
+#~ "are soh, delivery, randr. Remember to setup your contact details!"
+
+#~ msgid ""
+#~ "R&R - %(submitted)s/%(total)s submitted, %(not_submitted)s/%(total)s did "
+#~ "not submit, %(not_responding)s/%(total)s did not reply"
+#~ msgstr ""
+#~ "Uwasilishaji wa R&R: %(submitted)s/%(total)s wamewasilisha R&R, "
+#~ "%(not_submitted)s/%(total)s hawajawasilisha R&R, %(not_responding)s/"
+#~ "%(total)s hawajajibu ujumbe"
+
+#~ msgid ""
+#~ "SOH - %(submitted)s/%(total)s reported, %(not_responding)s/%(total)s did "
+#~ "not reply"
+#~ msgstr ""
+#~ "Hesabu ya mkono: %(submitted)s/%(total)s wametoa taarifa ya hmk, "
+#~ "%(not_responding)s/%(total)s hawajajibu ujumbe"
+
+#~ msgid ""
+#~ "Deliveries - %(received)s/%(total)s received, %(not_received)s/%(total)s "
+#~ "did not receive, %(not_responding)s/%(total)s did not reply"
+#~ msgstr ""
+#~ "Upokeaji wa Shehena: %(received)s/%(total)s wamepokea shehena, "
+#~ "%(not_received)s/%(total)s hawajapokea shehena, %(not_responding)s/"
+#~ "%(total)s hawajajibu ujumbe"


### PR DESCRIPTION
@sravfeyn
I found the old swahili translations in 8a30b51.  They had been overwritten
by pulls from transifex.  I ran makemessages on that after pulling them in,
so the code references are up-to-date.  Looks like the strings are no
longer marked for translation, so those translations are commented out.
They are still here though, and I've confirmed that retagging those strings
for translation and running makemessages will uncomment those translations,
so they're here when we need 'em.
