### PR TITLE
Add stockreport server date

### DIFF
--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -321,6 +321,7 @@ class StockReportHelper(object):
         self.timestamp = timestamp
         self.tag = tag
         self.transactions = transactions
+        self.server_date = form.received_on
 
 
 class StockTransactionHelper(object):

--- a/corehq/apps/commtrack/processing.py
+++ b/corehq/apps/commtrack/processing.py
@@ -65,6 +65,7 @@ def _create_model_for_stock_report(domain, stock_report_helper):
         date=stock_report_helper.timestamp,
         type=stock_report_helper.tag,
         domain=domain,
+        server_date=stock_report_helper.server_date,
     )
 
 LedgerValues = namedtuple('LedgerValues', ['balance', 'delta'])

--- a/corehq/ex-submodules/casexml/apps/stock/models.py
+++ b/corehq/ex-submodules/casexml/apps/stock/models.py
@@ -27,6 +27,9 @@ class StockReport(models.Model):
     date = models.DateTimeField(db_index=True)
     type = models.CharField(max_length=20)  # currently "balance" or "transfer"
     domain = models.CharField(max_length=255, null=True)
+    # should always equal
+    # FormData.objects.get(instance_id=self.form_id).received_on
+    server_date = models.DateTimeField(db_index=True, null=True)
 
     # todo: there are properties like these that could be really useful for queries
     # and reports - should decide which ones we want to add if any.

--- a/corehq/ex-submodules/casexml/apps/stock/models.py
+++ b/corehq/ex-submodules/casexml/apps/stock/models.py
@@ -29,7 +29,7 @@ class StockReport(models.Model):
     domain = models.CharField(max_length=255, null=True)
     # should always equal
     # FormData.objects.get(instance_id=self.form_id).received_on
-    server_date = models.DateTimeField(db_index=True, null=True)
+    server_date = models.DateTimeField(null=True)
 
     # todo: there are properties like these that could be really useful for queries
     # and reports - should decide which ones we want to add if any.

--- a/corehq/ex-submodules/casexml/apps/stock/south_migrations/0015_auto__add_field_stockreport_server_date.py
+++ b/corehq/ex-submodules/casexml/apps/stock/south_migrations/0015_auto__add_field_stockreport_server_date.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'StockReport.server_date'
+        db.add_column(u'stock_stockreport', 'server_date',
+                      self.gf('django.db.models.fields.DateTimeField')(null=True, db_index=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'StockReport.server_date'
+        db.delete_column(u'stock_stockreport', 'server_date')
+
+
+    models = {
+        u'products.sqlproduct': {
+            'Meta': {'object_name': 'SQLProduct'},
+            'category': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '100', 'null': 'True'}),
+            'code': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '100', 'null': 'True'}),
+            'cost': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '20', 'decimal_places': '5'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True'}),
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_archived': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True'}),
+            'product_data': ('json_field.fields.JSONField', [], {'default': '{}'}),
+            'product_id': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100', 'db_index': 'True'}),
+            'program_id': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '100', 'null': 'True'}),
+            'units': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '100', 'null': 'True'})
+        },
+        u'stock.docdomainmapping': {
+            'Meta': {'object_name': 'DocDomainMapping'},
+            'doc_id': ('django.db.models.fields.CharField', [], {'max_length': '100', 'primary_key': 'True', 'db_index': 'True'}),
+            'doc_type': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'domain_name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'})
+        },
+        u'stock.stockreport': {
+            'Meta': {'object_name': 'StockReport'},
+            'date': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'}),
+            'domain': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            'form_id': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'server_date': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'db_index': 'True'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        },
+        u'stock.stocktransaction': {
+            'Meta': {'object_name': 'StockTransaction', 'index_together': "[['case_id', 'product_id', 'section_id']]"},
+            'case_id': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'product_id': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'quantity': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '20', 'decimal_places': '5'}),
+            'report': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['stock.StockReport']"}),
+            'section_id': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'sql_product': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['products.SQLProduct']"}),
+            'stock_on_hand': ('django.db.models.fields.DecimalField', [], {'max_digits': '20', 'decimal_places': '5'}),
+            'subtype': ('casexml.apps.stock.models.TruncatingCharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '20'})
+        }
+    }
+
+    complete_apps = ['stock']

--- a/corehq/ex-submodules/casexml/apps/stock/south_migrations/0015_auto__add_field_stockreport_server_date.py
+++ b/corehq/ex-submodules/casexml/apps/stock/south_migrations/0015_auto__add_field_stockreport_server_date.py
@@ -10,7 +10,7 @@ class Migration(SchemaMigration):
     def forwards(self, orm):
         # Adding field 'StockReport.server_date'
         db.add_column(u'stock_stockreport', 'server_date',
-                      self.gf('django.db.models.fields.DateTimeField')(null=True, db_index=True),
+                      self.gf('django.db.models.fields.DateTimeField')(null=True),
                       keep_default=False)
 
 
@@ -49,7 +49,7 @@ class Migration(SchemaMigration):
             'domain': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
             'form_id': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
             u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'server_date': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'db_index': 'True'}),
+            'server_date': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
             'type': ('django.db.models.fields.CharField', [], {'max_length': '20'})
         },
         u'stock.stocktransaction': {


### PR DESCRIPTION
My plan for this is
- merge and deploy this
- (after deploy) PR & merge https://github.com/dimagi/commcare-hq/compare/add_stockreport_server_date...backfill_stockreport_server_date on top of it
- preindex
- run `./manage.py migrate stock` in preindex directory, thus running this migration
