### PR TITLE
improve error messaging on bulk user upload

### DIFF
--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -756,7 +756,8 @@ class UploadCommCareUsers(BaseManageCommCareUserView):
         try:
             check_headers(self.user_specs)
         except UserUploadError as e:
-            return HttpResponseBadRequest(e)
+            messages.error(request, _(e.message))
+            return HttpResponseRedirect(reverse(UploadCommCareUsers.urlname, args=[self.domain]))
 
         task_ref = expose_cached_download(None, expiry=1*60*60)
         task = bulk_upload_async.delay(
@@ -787,6 +788,8 @@ class UserUploadStatusView(BaseManageCommCareUserView):
             'title': _("Mobile Worker Upload Status"),
             'progress_text': _("Importing your data. This may take some time..."),
             'error_text': _("Problem importing data! Please try again or report an issue."),
+            'next_url': reverse(ListCommCareUsersView.urlname, args=[self.domain]),
+            'next_url_text': _("Return to manage mobile workers"),
         })
         return render(request, 'style/bootstrap2/soil_status_full.html', context)
 


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?174641

Before:
![screen shot 2015-08-05 at 6 07 16 pm](https://cloud.githubusercontent.com/assets/1486591/9099213/ee9c1f78-3b9c-11e5-9581-7e1cb182b31c.png)

After:
![screen shot 2015-08-05 at 6 07 25 pm](https://cloud.githubusercontent.com/assets/1486591/9099219/f6817b7a-3b9c-11e5-9691-a25256ce34f1.png)

Also added link out of the successful upload page, back to main mobile workers management page.

@nickpell 
