### PR TITLE
make state exceptions clearer about which hash belongs to which device

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/exceptions.py
+++ b/corehq/ex-submodules/casexml/apps/phone/exceptions.py
@@ -14,15 +14,15 @@ class BadStateException(RestoreException):
     """
     message = "Phone case list is inconsistant with server's records."
 
-    def __init__(self, expected, actual, case_ids, **kwargs):
+    def __init__(self, server_hash, phone_hash, case_ids, **kwargs):
         super(BadStateException, self).__init__(**kwargs)
-        self.expected = expected
-        self.actual = actual
+        self.server_hash = server_hash
+        self.phone_hash = phone_hash
         self.case_ids = case_ids
 
     def __str__(self):
-        return "Phone state hash mismatch. Expected %s but was %s. Cases: [%s]" % \
-            (self.expected, self.actual, ", ".join(self.case_ids))
+        return "Phone state hash mismatch. Server hash: %s, Phone hash: %s. Server cases: [%s]" % \
+            (self.server_hash, self.phone_hash, ", ".join(self.case_ids))
 
 
 class BadVersionException(RestoreException):

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -289,8 +289,8 @@ class RestoreState(object):
                     self.last_sync_log.save()
 
                     exception = BadStateException(
-                        expected=computed_hash,
-                        actual=parsed_hash,
+                        server_hash=computed_hash,
+                        phone_hash=parsed_hash,
                         case_ids=self.last_sync_log.get_footprint_of_cases_on_phone()
                     )
                     if self.last_sync_log.log_format == LOG_FORMAT_SIMPLIFIED:

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_state_hash.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_state_hash.py
@@ -42,8 +42,8 @@ class StateHashTest(TestCase):
             )
             self.fail("Call to generate a payload with a bad hash should fail!")
         except BadStateException, e:
-            self.assertEqual(empty_hash, e.expected)
-            self.assertEqual(wrong_hash, e.actual)
+            self.assertEqual(empty_hash, e.server_hash)
+            self.assertEqual(wrong_hash, e.phone_hash)
             self.assertEqual(0, len(e.case_ids))
 
         response = generate_restore_response(self.project, self.user, self.sync_log.get_id, version=V2,
@@ -74,8 +74,8 @@ class StateHashTest(TestCase):
                                      version=V2, state_hash=str(bad_hash))
             self.fail("Call to generate a payload with a bad hash should fail!")
         except BadStateException, e:
-            self.assertEqual(real_hash, e.expected)
-            self.assertEqual(bad_hash, e.actual)
+            self.assertEqual(real_hash, e.server_hash)
+            self.assertEqual(bad_hash, e.phone_hash)
             self.assertEqual(2, len(e.case_ids))
             self.assertTrue("abc123" in e.case_ids)
             self.assertTrue("123abc" in e.case_ids)


### PR DESCRIPTION
just was annoying me. anyone, cc @benrudolph 
