### PR TITLE
add sync_log_debugger

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/management/commands/sync_log_debugger.py
+++ b/corehq/ex-submodules/casexml/apps/phone/management/commands/sync_log_debugger.py
@@ -1,0 +1,45 @@
+import json
+import os
+from django.core.management import BaseCommand
+import sys
+from casexml.apps.phone.models import properly_wrap_sync_log, SyncLog, SimplifiedSyncLog
+
+
+class Command(BaseCommand):
+    """
+    lets you download sync logs as json and then compare them.
+    useful for checking state issues.
+    """
+
+    def handle(self, *args, **options):
+        if len(args) < 1:
+            print 'Usage: ./manage.py sync_log_debugger <filename1> [<filename2>] [<filename3>]...'
+            sys.exit(0)
+
+        logs = []
+        log_names = []
+        for filename in args:
+            log_name = os.path.basename(filename)
+            log_names.append(log_name)
+            with open(filename) as f:
+                wrapped_log = properly_wrap_sync_log(json.loads(f.read()))
+                logs.append(wrapped_log)
+                if isinstance(wrapped_log, SyncLog):
+                    log_names.append('migrated-{}'.format(log_name))
+                    logs.append(SimplifiedSyncLog.from_other_format(wrapped_log))
+
+        print 'state hashes'
+        for i in range(len(log_names)):
+            print '{}: {}'.format(log_names[i], logs[i].get_state_hash())
+
+        print '\ncase diffs'
+        for i in range(len(log_names)):
+            for j in range(len(log_names)):
+                if i != j:
+                    case_diff = logs[i].case_ids_on_phone - logs[j].case_ids_on_phone
+                    if case_diff:
+                        print 'cases on {} and not {}: {}'.format(
+                            log_names[i],
+                            log_names[j],
+                            ', '.join(case_diff)
+                        )

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -399,6 +399,11 @@ class SyncLog(AbstractSyncLog):
                 ))
                 raise
 
+    @property
+    def case_ids_on_phone(self):
+        # this just exists to allow us to easily compare this property with the new format
+        return set(self.get_footprint_of_cases_on_phone())
+
     def get_footprint_of_cases_on_phone(self):
         def children(case_state):
             return [self._get_case_state_from_anywhere(index.referenced_id)


### PR DESCRIPTION
guessing no one else will ever use this but figured i might as well put it here since i'm finding it helpful to debug [sync log assertion errors](http://manage.dimagi.com/default.asp?178527).

lets you download sync logs as json and then compare them. spits out an output like this:

```
state hashes
wmat.json: ccsh:8972210aff723211620753230fc5220d
wmat2.json: ccsh:0e55e00a2cc6df277d21439426f6987d
wmat-legacy.json: ccsh:0e55e00a2cc6df277d21439426f6987d
migrated-wmat-legacy.json: ccsh:0e55e00a2cc6df277d21439426f6987d

case diffs
cases on wmat.json and not wmat2.json: 16252a099f9a42cd8584710d83adb6bc, e54b5d49-464b-431f-b24f-e6dca94f72db, 932d6a14-7d71-4b34-9309-aafe2a6dccd0, 8873eccb-7e31-41b8-a39f-3391bd9156ba
cases on wmat.json and not wmat-legacy.json: 16252a099f9a42cd8584710d83adb6bc, e54b5d49-464b-431f-b24f-e6dca94f72db, 932d6a14-7d71-4b34-9309-aafe2a6dccd0, 8873eccb-7e31-41b8-a39f-3391bd9156ba
cases on wmat.json and not migrated-wmat-legacy.json: 16252a099f9a42cd8584710d83adb6bc, e54b5d49-464b-431f-b24f-e6dca94f72db, 932d6a14-7d71-4b34-9309-aafe2a6dccd0, 8873eccb-7e31-41b8-a39f-3391bd9156ba
```

@snopoke cc @benrudolph 
