### PR TITLE
Store count on originalEvent instead of event

### DIFF
--- a/corehq/apps/style/templates/style/includes/analytics_google.html
+++ b/corehq/apps/style/templates/style/includes/analytics_google.html
@@ -50,16 +50,16 @@
                     // Track how many trackLinkHelper-related handlers
                     // this event has, so we only actually click
                     // once, after they're all complete.
-                    event.data = event.data || {};
-                    event.data.trackLinkCount = event.data.trackLinkCount || 0;
-                    event.data.trackLinkCount++;
+                    var originalEventData = event.originalEvent.data || {};
+                    originalEventData.trackLinkCount = originalEventData.trackLinkCount || 0;
+                    originalEventData.trackLinkCount++;
 
                     event.preventDefault();
                     var callbackCalled = false;
                     var callback = function () {
                         if (!callbackCalled) {
-                            event.data.trackLinkCount--;
-                            if (!event.data.trackLinkCount) {
+                            originalEventData.trackLinkCount--;
+                            if (!originalEventData.trackLinkCount) {
                                 document.location = $this.attr('href');
                             }
                             callbackCalled = true;


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/pull/7738 isn't working reliably. For one, the deploy page's "View Source Files" link dies with a js error. Storing the count on the originalEvent works better, though I wish I knew why.

@NoahCarnahan / @nickpell 
