### PR TITLE
fix for sync log assertions on dependent cases

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -350,7 +350,7 @@ class SyncLog(AbstractSyncLog):
                         removed_states[case._id] = starter_state
                 elif action.action_type == const.CASE_ACTION_UPDATE:
                     self._assert(
-                        self.phone_has_case(case._id),
+                        self.phone_is_holding_case(case._id),
                         "phone doesn't have case being updated: %s" % case._id,
                         case._id,
                     )

--- a/corehq/ex-submodules/casexml/apps/phone/tests/__init__.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/__init__.py
@@ -6,6 +6,7 @@ try:
     from .test_ota_restore import *
     from .test_ota_restore_v3 import *
     from .test_state_hash import *
+    from .test_sync_log_assertions import *
     from .test_sync_logs import *
     from .test_sync_mode import *
     from .test_batched_mode import BatchRestoreTests

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_log_assertions.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_log_assertions.py
@@ -1,0 +1,31 @@
+import uuid
+from django.test import TestCase
+from mock import patch
+from casexml.apps.case.const import CASE_ACTION_UPDATE
+from casexml.apps.case.models import CommCareCase, CommCareCaseAction
+from casexml.apps.case.sharedmodels import CommCareCaseIndex
+from casexml.apps.phone.models import SyncLog, CaseState, SimplifiedSyncLog
+from couchforms.models import XFormInstance
+
+
+class SyncLogAssertionTest(TestCase):
+
+    def test_update_dependent_case(self):
+        sync_log = SyncLog(
+            cases_on_phone=[
+                CaseState(
+                    case_id='bran',
+                    indices=[CommCareCaseIndex(identifier='legs', referenced_id='hodor')],
+                ),
+            ],
+            dependent_cases_on_phone=[CaseState(case_id='hodor')]
+        )
+        xform_id = uuid.uuid4().hex
+        xform = XFormInstance(_id=xform_id)
+        form_actions = [CommCareCaseAction(action_type=CASE_ACTION_UPDATE,)]
+        with patch.object(CommCareCase, 'get_actions_for_form', return_value=form_actions):
+            parent_case = CommCareCase(_id='hodor')
+            # before this test was added, the following call raised a SyncLogAssertionError on legacy logs.
+            # this test just ensures it doesn't still do that.
+            for log in [sync_log, SimplifiedSyncLog.from_other_format(sync_log)]:
+                log.update_phone_lists(xform, [parent_case])


### PR DESCRIPTION
this is a pretty horrifying bug that's been in the codebase for ages.

related to:
- http://manage.dimagi.com/default.asp?178637
- http://manage.dimagi.com/default.asp?178530
- http://manage.dimagi.com/default.asp?178729

basically any time you update a case that is only on a phone because of dependencies (aka a parent of a delegate case) it was firing a sync log assertion error. combined with commtrack workflows that 1) use delegates to get the supply point on the phone and 2) have frequent updates to the parent case, this has been unnecessarily triggering huge rebuilds that go through every form ever submitted against the case and reapply them. the end result is huge bulk updates to couch, duplicate actions in forms, and doc update conflicts and timeouts

this bug only existed on legacy sync code. the new sync code only uses hard assertions and doesn't bother with any of this rebuild stuff, so after we fully switch over we can get rid of the entire workflow that triggers these issues in case there are more.

@dannyroberts @snopoke - wait for tests
