### PR TITLE
Revert "Caselistfilter"

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1557,9 +1557,6 @@ class ModuleBase(IndexedSchema, NavMenuItemMediaMixin):
         except IndexError:
             raise FormNotFoundException()
 
-    def has_forms(self):
-        return bool(len(self.forms))
-
     def get_child_modules(self):
         return [
             module for module in self.get_app().get_modules()

--- a/corehq/apps/app_manager/suite_xml.py
+++ b/corehq/apps/app_manager/suite_xml.py
@@ -1615,8 +1615,7 @@ class SuiteGenerator(SuiteGeneratorBase):
                     )
                 )
                 if isinstance(module, Module):
-                    use_filter = False if module.has_forms() else bool(module.case_details.short.filter)
-                    for datum_meta in self.get_datum_meta_module(module, use_filter=use_filter):
+                    for datum_meta in self.get_datum_meta_module(module, use_filter=False):
                         e.datums.append(datum_meta['datum'])
                 elif isinstance(module, AdvancedModule):
                     e.datums.append(SessionDatum(

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -8,7 +8,7 @@ from corehq.apps.app_manager.models import (
     AUTO_SELECT_RAW, WORKFLOW_MODULE, DetailColumn, ScheduleVisit, FormSchedule, Module, AdvancedModule,
     WORKFLOW_ROOT, AdvancedOpenCaseAction, SortElement, PreloadAction, MappingItem, OpenCaseAction,
     OpenSubCaseAction, FormActionCondition, UpdateCaseAction, WORKFLOW_FORM, FormLink, AUTO_SELECT_USERCASE,
-    ReportModule, ReportAppConfig, ParentSelect, Detail, DetailPair, CaseList)
+    ReportModule, ReportAppConfig, ParentSelect)
 from corehq.apps.app_manager.tests.util import TestFileMixin, commtrack_enabled
 from corehq.apps.app_manager.xpath import (dot_interpolate, UserCaseXPath,
                                            interpolate_xpath, session_var)
@@ -382,40 +382,6 @@ class SuiteTest(SimpleTestCase, TestFileMixin):
 
     def test_owner_name(self):
         self._test_generic_suite('owner-name')
-
-    def test_no_form_case_list_filter(self):
-        """
-        If a module has no forms but has case-list-filterint...
-        case-list filtering should be added to the case-list session datum
-        """
-        # setup a module with no forms
-        app = Application.new_app('domain', "Untitled Application", application_version=APP_V2)
-        module_0 = app.add_module(Module.new_module('module with no forms', None))
-        # setup case list menu and filtering
-        module_0.case_type = "doc"
-        module_0.case_list = CaseList(show=True, label={'en': "doctors"})
-        columns = [
-            DetailColumn(
-                header={'en': 'a'},
-                model='case',
-                field='a',
-                format='plain',
-                case_tile_field='header'
-            ),
-        ]
-        short = Detail(filter="name = 'sravan'", display='short', columns=columns)
-        long = Detail(display='long', columns=columns)
-        module_0.case_details = DetailPair(short=short, long=long)
-        # test that case-list session datum has right xml
-        session_xml = """
-        <partial>
-          <datum
-            id="case_id"
-            nodeset="instance('casedb')/casedb/case[@case_type='doc'][@status='open'][name = 'sravan']"
-            value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
-        </partial>
-        """
-        self.assertXmlPartialEqual(session_xml, app.create_suite(), './entry[1]/session/')
 
     def test_form_filter(self):
         """


### PR DESCRIPTION
Reverts dimagi/commcare-hq#7803

Looks like there is a ODK compatibility issue with this earlier change. Reverting this back, as this is affecting all apps that use case-list filter. See http://manage.dimagi.com/default.asp?178862#992773

@esoergel 
