### PR TITLE
get correct Reason-Phrase's for http responses

### DIFF
--- a/corehq/apps/api/models.py
+++ b/corehq/apps/api/models.py
@@ -78,8 +78,7 @@ def _require_api_user(permission=None):
             if ApiUser.auth(request.POST.get('username', ''), request.POST.get('password', ''), permission):
                 response = fn(request, *args, **kwargs)
             else:
-                response = HttpResponse()
-                response.status_code = 401
+                response = HttpResponse(status=401)
             return response
         return _outer
     return _outer2

--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -2080,8 +2080,7 @@ def rename_language(request, domain, form_unique_id):
         app.save()
         return HttpResponse(json.dumps({"status": "ok"}))
     except XFormException as e:
-        response = HttpResponse(json.dumps({'status': 'error', 'message': unicode(e)}))
-        response.status_code = 409
+        response = HttpResponse(json.dumps({'status': 'error', 'message': unicode(e)}), status=409)
         return response
 
 @require_GET

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -137,8 +137,7 @@ def basicauth(realm=''):
             # Either they did not provide an authorization header or
             # something in the authorization attempt failed. Send a 401
             # back to them to ask them to authenticate.
-            response = HttpResponse()
-            response.status_code = 401
+            response = HttpResponse(status=401)
             response['WWW-Authenticate'] = 'Basic realm="%s"' % realm
             return response
         return wrapper


### PR DESCRIPTION
A quick fix for some Reason-Phrase's that do not match the status code.  Searching the codebase for `status_code =` contains a few other instances, but these are either in custom code or look a bit more complicated to change.

@dannyroberts @gcapalbo 
