### PR TITLE
Direct ccz download

### DIFF
--- a/corehq/apps/app_manager/urls.py
+++ b/corehq/apps/app_manager/urls.py
@@ -128,6 +128,7 @@ urlpatterns = patterns('corehq.apps.app_manager.views',
     url(r'^revert/(?P<app_id>[\w-]+)/$', 'revert_to_copy'),
     url(r'^delete_copy/(?P<app_id>[\w-]+)/$', 'delete_copy'),
 
+    url(r'^api/list_apps/$', 'list_apps', name='list_apps'),
     url(r'^download/(?P<app_id>[\w-]+)/$', 'download_index', name='download_index'),
     # the order of these download urls is important
     url(r'^download/(?P<app_id>[\w-]+)/CommCare.ccz$', DownloadCCZ.as_view(),

--- a/corehq/apps/app_manager/urls.py
+++ b/corehq/apps/app_manager/urls.py
@@ -129,6 +129,7 @@ urlpatterns = patterns('corehq.apps.app_manager.views',
     url(r'^delete_copy/(?P<app_id>[\w-]+)/$', 'delete_copy'),
 
     url(r'^api/list_apps/$', 'list_apps', name='list_apps'),
+    url(r'^api/download_ccz/$', 'direct_ccz', name='direct_ccz'),
     url(r'^download/(?P<app_id>[\w-]+)/$', 'download_index', name='download_index'),
     # the order of these download urls is important
     url(r'^download/(?P<app_id>[\w-]+)/CommCare.ccz$', DownloadCCZ.as_view(),

--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -3257,6 +3257,7 @@ def upload_bulk_app_translations(request, domain, app_id):
         reverse('app_languages', args=[domain, app_id])
     )
 
+
 @require_deploy_apps
 def update_build_comment(request, domain, app_id):
     build_id = request.POST.get('build_id')
@@ -3267,6 +3268,17 @@ def update_build_comment(request, domain, app_id):
     build.build_comment = request.POST.get('comment')
     build.save()
     return json_response({'status': 'success'})
+
+
+@require_deploy_apps
+def list_apps(request, domain):
+    return json_response({
+        'status': 'success',
+        'applications': [
+            {'name': app.name, 'version': app.version, 'app_id': app.get_id}
+            for app in Domain.get_by_name(domain).applications()
+        ],
+    })
 
 
 common_module_validations = [


### PR DESCRIPTION
Add a view to directly download the latest ccz for an application.  Also add a JSON view listing all the applications on a domain (name, version, id, and ccz download link).

Both views currently require that the user be logged in to the domain.  @ctsims let me know if that doesn't work for you and we can talk about options.

Pinging @snopoke as he did recent work on this and might have thoughts about the implementation.
@proteusvacuum @emord 
