### PR TITLE
App comments

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -704,6 +704,30 @@ class FormSchedule(DocumentSchema):
     termination_condition = SchemaProperty(FormActionCondition)
 
 
+class CommentMixin(DocumentSchema):
+    """
+    Documentation comment for app builders and maintainers
+    """
+    comment = StringProperty(default='')
+
+    @property
+    def short_comment(self):
+        """
+        Trim comment to 72 chars
+
+        >>> form = CommentMixin(
+        ...     comment=u"Twas bryllyg, and þe slythy toves "
+        ...             u"Did gyre and gymble in þe wabe: "
+        ...             u"All mimsy were þe borogoves; "
+        ...             u"And þe mome raths outgrabe."
+        ... )
+        >>> form.short_comment
+        u'Twas bryllyg, and \\xc3\\xbee slythy toves Did gyre and gymble in \\xc3\\xbee wabe: A...'
+
+        """
+        return self.comment if len(self.comment) <= 72 else self.comment[:69] + '...'
+
+
 class FormBase(DocumentSchema):
     """
     Part of a Managed Application; configuration for a form.
@@ -995,7 +1019,7 @@ class FormBase(DocumentSchema):
         return bool(self.case_list_modules)
 
 
-class IndexedFormBase(FormBase, IndexedSchema):
+class IndexedFormBase(FormBase, IndexedSchema, CommentMixin):
     def get_app(self):
         return self._parent._parent
 
@@ -1774,7 +1798,7 @@ class CaseListForm(NavMenuItemMediaMixin):
         _rename_key(self.label, old_lang, new_lang)
 
 
-class ModuleBase(IndexedSchema, NavMenuItemMediaMixin):
+class ModuleBase(IndexedSchema, NavMenuItemMediaMixin, CommentMixin):
     name = DictProperty(unicode)
     unique_id = StringProperty()
     case_type = StringProperty()
@@ -3706,7 +3730,8 @@ def absolute_url_property(method):
 
 
 class ApplicationBase(VersionedDoc, SnapshotMixin,
-                      CommCareFeatureSupportMixin):
+                      CommCareFeatureSupportMixin,
+                      CommentMixin):
     """
     Abstract base class for Application and RemoteApp.
     Contains methods for generating the various files and zipping them into CommCare.jar

--- a/corehq/apps/app_manager/static/app_manager/js/app_summary.ng.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_summary.ng.js
@@ -113,6 +113,7 @@
         $scope.showLabels = true;
         $scope.showCalculations = false;
         $scope.showRelevance = false;
+        $scope.showComments = false;
         $scope.appLangs = summaryConfig.appLangs;
 
         self.init = function () {

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yaml
@@ -174,3 +174,10 @@
   default: false
   since: "2.24"
   toggle: GRID_MENUS
+
+- id: comment
+  name: 'Comment'
+  description: >
+    A comment to document or explain this application for other app builders or maintainers.
+  default: ''
+  widget: text

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yaml
@@ -180,4 +180,4 @@
   description: >
     A comment to document or explain this application for other app builders or maintainers.
   default: ''
-  widget: text
+  widget: textarea

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-settings-layout.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-settings-layout.yaml
@@ -2,6 +2,7 @@
   id: app-settings-basic
   settings:
     - hq.name  # Name
+    - hq.comment  # To explain this app for other app builders
     - hq.application_version # App Version (disabled)
     # Application
     - hq.case_sharing  # Case Sharing

--- a/corehq/apps/app_manager/templates/app_manager/form_view_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view_base.html
@@ -246,6 +246,7 @@
 
 {% block form-view %}
     <div id="build_errors"></div>
+    <div id="form_short_comment" class="app-comment">{{ form.short_comment }}</div>
     {% if not is_user_registration %}
         <div class="delete-me">
             <form action="{% url "delete_form" domain app.id module.unique_id form.unique_id %}" method="post">

--- a/corehq/apps/app_manager/templates/app_manager/module_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/module_view.html
@@ -270,6 +270,12 @@
                     </div>
                 </div>
                 {% endif %}
+                <div class="control-group">
+                    <label class="control-label" for="comment-id">{% trans "Comment" %}</label>
+                    <div class="controls">
+                        <textarea id="comment-id" name="comment" rows="9">{{ module.comment }}</textarea>
+                    </div>
+                </div>
                 {% endblock %}
             </fieldset>
         </form>

--- a/corehq/apps/app_manager/templates/app_manager/module_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/module_view.html
@@ -273,7 +273,7 @@
                 <div class="control-group">
                     <label class="control-label" for="comment-id">{% trans "Comment" %}</label>
                     <div class="controls">
-                        <textarea id="comment-id" name="comment" rows="9">{{ module.comment }}</textarea>
+                        <textarea id="comment-id" name="comment">{{ module.comment }}</textarea>
                     </div>
                 </div>
                 {% endblock %}

--- a/corehq/apps/app_manager/templates/app_manager/ng_partials/form_summary_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/ng_partials/form_summary_view.html
@@ -75,6 +75,12 @@
                             <i class="fa fa-code-fork" ng-class="showRelevance ? 'hq-icon' : ''"></i>
                             &nbsp;{% trans "Show Display Conditions" %}
                         </button>
+                        <button type="button" class="btn btn-default"
+                                ng-click="showComments = !showComments"
+                                ng-class="{ 'active': showComments }">
+                            <i class="fa fa-quote-left" ng-class="showComments ? 'hq-icon' : ''"></i>
+                            &nbsp;{% trans "Show Comments" %}
+                        </button>
                     </div>
                 </div>
              </div>
@@ -84,11 +90,17 @@
         <loading></loading>
         <ul>
             <li ng-repeat="module in modules|filter:moduleSearch">
-                 <h4><i class="hq-icon fa fa-folder-open"></i> {% verbatim %}{{ getFormModuleLabel(module) }}{% endverbatim %}</h4>
+                 <h4>
+                     <i class="hq-icon fa fa-folder-open"></i> {% verbatim %}{{ getFormModuleLabel(module) }}{% endverbatim %}
+                     <span class="text-muted" ng-show="showComments"> &nbsp; {{ module.short_comment }}</span>
+                 </h4>
 
                 <ul>
                     <li ng-repeat="form in module.forms|filter:formSearch">
-                    <h5>{% verbatim %}{{ getFormModuleLabel(form) }}{% endverbatim %}</h5>
+                    <h5>
+                        {% verbatim %}{{ getFormModuleLabel(form) }}{% endverbatim %}
+                        <span class="text-muted" ng-show="showComments"> &nbsp; {{ form.short_comment }}</span>
+                    </h5>
                         <ol>
                             <li ng-repeat="question in form.questions|filter:questionSearch">
                                 {% verbatim %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/app-settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/app-settings.html
@@ -150,6 +150,7 @@ todo fix
 {% endcomment %}
 
 <div class="tab-pane" id="commcare-settings">
+    <div id="app_short_comment" class="app-comment">{{ app.short_comment }}</div>
     <div class="clearfix" id="settings-save-btn" data-bind="saveButton2: state, saveOptions: saveOptions"></div>
     <form class="form-horizontal">
         <div data-bind="foreach: sections">

--- a/corehq/apps/app_manager/templates/app_manager/partials/form_tab_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/form_tab_settings.html
@@ -10,6 +10,18 @@
                 {% input_trans form.name langs %}
             </div>
         </div>
+        <div class="control-group">
+            <label class="control-label" for="comment-id">
+                {% trans "Comment" %}
+                <span class="hq-help-template"
+                      data-title="{% trans "Comment" %}"
+                      data-content="{% blocktrans %}Comments to document or explain this form for other app builders or maintainers.{% endblocktrans %}"
+                ></span>
+            </label>
+            <div id="form-comment" class="controls">
+                <textarea id="comment-id" name="comment" rows="9">{{ form.comment }}</textarea>
+            </div>
+        </div>
 
         <legend>
         <a class="accordion-toggle collapsed" data-toggle="collapse" data-bind="attr: {href: '#' + id}, css: {collapsed: reallyCollapse}" href="#form-settings-multimedia">
@@ -82,5 +94,6 @@
             </div>
             {% endif %}
         </div>
+
     </form>
 </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/form_tab_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/form_tab_settings.html
@@ -19,7 +19,7 @@
                 ></span>
             </label>
             <div id="form-comment" class="controls">
-                <textarea id="comment-id" name="comment" rows="9">{{ form.comment }}</textarea>
+                <textarea id="comment-id" name="comment">{{ form.comment }}</textarea>
             </div>
         </div>
 

--- a/corehq/apps/app_manager/templates/app_manager/partials/module_view_heading.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/module_view_heading.html
@@ -1,6 +1,7 @@
 {% load i18n %}
 {% load xforms_extras %}
 <div id="build_errors"></div>
+<div id="module_short_comment" class="app-comment">{{ module.short_comment }}</div>
 <div class="delete-me">
     <form action="{% url "delete_module" domain app.id module.unique_id %}" method="post">
         <button type="submit" class="disable-on-submit btn btn-danger">

--- a/corehq/apps/app_manager/tests/__init__.py
+++ b/corehq/apps/app_manager/tests/__init__.py
@@ -46,7 +46,7 @@ except ImportError, e:
     logging.exception(e)
     raise
 
-from corehq.apps.app_manager.models import validate_property
+from corehq.apps.app_manager.models import validate_property, CommentMixin
 from corehq.apps.app_manager.util import is_valid_case_type, version_key
 from corehq.apps.app_manager.id_strings import _format_to_regex
 from corehq.apps.app_manager import xform_builder
@@ -57,4 +57,5 @@ __test__ = {
     '_format_to_regex': _format_to_regex,
     'validate_property': validate_property,
     'xform_builder': xform_builder,
+    'CommentMixinTest': CommentMixin,
 }

--- a/corehq/apps/app_manager/views/app_summary.py
+++ b/corehq/apps/app_manager/views/app_summary.py
@@ -86,12 +86,14 @@ class AppSummaryView(JSONResponseMixin, LoginAndDomainMixin, BasePageView, Appli
                 forms.append({
                     'id': form.unique_id,
                     'name': form.name,
+                    'short_comment': form.short_comment,
                     'questions': [FormQuestionResponse(q).to_json() for q in questions],
                 })
 
             modules.append({
                 'id': module.unique_id,
                 'name': module.name,
+                'short_comment': module.short_comment,
                 'forms': forms
             })
         return {

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -548,6 +548,7 @@ def edit_app_attr(request, domain, app_id, attr):
         'text_input', 'platform', 'build_spec', 'show_user_registration',
         'use_custom_suite', 'custom_suite',
         'admin_password',
+        'comment',
         # Application only
         'cloudcare_enabled',
         'application_version',
@@ -583,6 +584,7 @@ def edit_app_attr(request, domain, app_id, attr):
         ('amplifies_workers', None),
         ('amplifies_project', None),
         ('use_grid_menus', None),
+        ('comment', None),
     )
     for attribute, transformation in easy_attrs:
         if should_edit(attribute):

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -237,6 +237,8 @@ def edit_form_attr(request, domain, app_id, unique_form_id, attr):
             xform.set_name(name)
             save_xform(app, form, xform.render())
         resp['update'] = {'.variable-form_name': form.name[lang]}
+    if should_edit('comment'):
+        form.comment = request.POST['comment']
     if should_edit("xform"):
         try:
             # support FILES for upload and POST for ajax post from Vellum

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -329,6 +329,7 @@ def edit_module_attr(request, domain, app_id, module_id, attr):
         "case_list_form_media_audio": None,
         "case_list_form_media_image": None,
         "case_type": None,
+        'comment': None,
         "display_separately": None,
         "has_schedule": None,
         "media_audio": None,
@@ -445,6 +446,8 @@ def edit_module_attr(request, domain, app_id, module_id, attr):
             module[attribute][lang] = name
             if should_edit("name"):
                 resp['update'].update({'.variable-module_name': module.name[lang]})
+    if should_edit('comment'):
+        module.comment = request.POST.get('comment')
     for SLUG in ('case_list', 'task_list'):
         show = '{SLUG}-show'.format(SLUG=SLUG)
         label = '{SLUG}-label'.format(SLUG=SLUG)

--- a/corehq/apps/style/static/style/less/legacy/app_manager.less
+++ b/corehq/apps/style/static/style/less/legacy/app_manager.less
@@ -3,6 +3,13 @@
   top: 1.5em;
 }
 
+.app-comment {
+    font-size: 12pt;
+    font-style: italic;
+    padding-bottom: 1em;
+    color: #666;
+}
+
 /* has to be more specific than the existing rule */
 #xform-source .syntaxhighlighter {
     overflow: visible !important;


### PR DESCRIPTION
Adds a `comment` attribute to Application, Form and Module, and shows them in the app summary.

Potential improvements: 
- Add comments to form questions
- Include the app comment in the Exchange
- Make the comment at the top of the form, module and app settings pages an observable, so that it updates as the comment is changed.

@czue, buddies @gcapalbo @emord 

![form_summary_comments](https://cloud.githubusercontent.com/assets/708421/9251177/335dee1c-41d2-11e5-8c5c-6836aa63e9fa.png)
