### PR TITLE
Fix dynamic choice default

### DIFF
--- a/corehq/apps/reports_core/filters.py
+++ b/corehq/apps/reports_core/filters.py
@@ -236,7 +236,7 @@ class DynamicChoiceListFilter(BaseFilter):
             choices = selection.split(CHOICE_DELIMITER)
             typed_choices = [transform_from_datatype(self.datatype)(c) for c in choices]
             return [Choice(tc, c) for (tc, c) in zip(typed_choices, choices)]
-        return [Choice(SHOW_ALL_CHOICE, '')]
+        return self.default_value()
 
     def default_value(self):
         return [Choice(SHOW_ALL_CHOICE, '')]

--- a/corehq/apps/reports_core/filters.py
+++ b/corehq/apps/reports_core/filters.py
@@ -239,4 +239,4 @@ class DynamicChoiceListFilter(BaseFilter):
         return [Choice(SHOW_ALL_CHOICE, '')]
 
     def default_value(self):
-        return None
+        return [Choice(SHOW_ALL_CHOICE, '')]


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?179083 is manifesting itself when a saved report is created, the filter id of a dynamic choice filter is changed, and an invalid default value is assigned to the filter (whose new id is not present in the saved report).

@gcapalbo cc: @czue @NoahCarnahan 
