### PR TITLE
New web user registration: fix hr_name fallback

### DIFF
--- a/corehq/apps/hqwebapp/utils.py
+++ b/corehq/apps/hqwebapp/utils.py
@@ -162,7 +162,7 @@ class InvitationView():
                     domain = Domain.get_by_name(invitation.domain)
                     form = NewWebUserRegistrationForm(initial={
                         'email': invitation.email,
-                        'hr_name': domain.hr_name if domain else invitation.domain,
+                        'hr_name': domain.display_name() if domain else invitation.domain,
                         'create_domain': False
                     })
                 else:

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -337,7 +337,7 @@ def _login(req, domain_name, template_name):
         domain = Domain.get_by_name(domain_name)
         context.update({
             'domain': domain_name,
-            'hr_name': domain.hr_name if domain else domain_name,
+            'hr_name': domain.display_name() if domain else domain_name,
             'next': req.REQUEST.get('next', '/a/%s/' % domain),
         })
 


### PR DESCRIPTION
Bug in https://github.com/dimagi/commcare-hq/pull/7322

domain.hr_name is often None, so code should fall back on domain.name
