### PR TITLE
Create search_string_query function for elasticsearch

### DIFF
--- a/corehq/apps/es/__init__.py
+++ b/corehq/apps/es/__init__.py
@@ -4,6 +4,7 @@ from . import cases
 from . import domains
 from . import forms
 from . import users
+from . import queries
 
 CaseES = cases.CaseES
 DomainES = domains.DomainES

--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -197,11 +197,13 @@ class ESQuery(object):
         es.es_query['query']['filtered']['query'] = query
         return es
 
-    def user_query_string(self, query, default_fields=None):
+    def search_string_query(self, search_string, default_fields=None):
         """
-        Accepts a user-defined query.
+        Accepts a user-defined search string
         """
-        return self.set_query(queries.user_query_string(query, default_fields))
+        return self.set_query(
+            queries.search_string_query(search_string, default_fields)
+        )
 
     def _assemble(self):
         """

--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -66,6 +66,7 @@ from corehq.elastic import ES_URLS, ESError, run_query, SIZE_LIMIT
 
 from . import facets
 from . import filters
+from . import queries
 
 
 class ESQuery(object):
@@ -105,7 +106,7 @@ class ESQuery(object):
         self.es_query = {"query": {
             "filtered": {
                 "filter": {"and": []},
-                "query": {'match_all': {}}
+                "query": queries.match_all()
             }
         }}
 
@@ -195,6 +196,12 @@ class ESQuery(object):
         es = deepcopy(self)
         es.es_query['query']['filtered']['query'] = query
         return es
+
+    def user_query_string(self, query, default_fields=None):
+        """
+        Accepts a user-defined query.
+        """
+        return self.set_query(queries.user_query_string(query, default_fields))
 
     def _assemble(self):
         """

--- a/corehq/apps/es/queries.py
+++ b/corehq/apps/es/queries.py
@@ -1,4 +1,22 @@
-from corehq.apps.users.util import smart_query_string
+import re
+
+
+def match_all():
+    """
+    No-op query used because a default must be specified
+    """
+    return {"match_all": {}}
+
+
+def _smart_query_string(query):
+    special_chars = ['&&', '||', '!', '(', ')', '{', '}', '[', ']', '^', '"',
+                     '~', '*', '?', ':', '\\', '/']
+    for char in special_chars:
+        if char in query:
+            return False, query
+    r = re.compile(r'\w+')
+    tokens = r.findall(query)
+    return True, "*{}*".format("* *".join(tokens))
 
 
 def user_query_string(query, default_fields=None):
@@ -7,11 +25,14 @@ def user_query_string(query, default_fields=None):
     default to doing an infix search for each term.
     returns (is_simple, query)
     """
-    is_simple, query = smart_query_string(query)
+    if not query:
+        return match_all()
+
+    is_simple, query = _smart_query_string(query)
     return {
         "query_string": {
             "query": query,
             "default_operator": "AND",
-            #  "fields": default_fields if is_simple else None
+            "fields": default_fields if is_simple else None
         }
     }

--- a/corehq/apps/es/queries.py
+++ b/corehq/apps/es/queries.py
@@ -8,30 +8,30 @@ def match_all():
     return {"match_all": {}}
 
 
-def _smart_query_string(query):
+def _smart_query_string(search_string):
     special_chars = ['&&', '||', '!', '(', ')', '{', '}', '[', ']', '^', '"',
                      '~', '*', '?', ':', '\\', '/']
     for char in special_chars:
-        if char in query:
-            return False, query
+        if char in search_string:
+            return False, search_string
     r = re.compile(r'\w+')
-    tokens = r.findall(query)
+    tokens = r.findall(search_string)
     return True, "*{}*".format("* *".join(tokens))
 
 
-def user_query_string(query, default_fields=None):
+def search_string_query(search_string, default_fields=None):
     """
-    If query does not use the ES query string syntax,
+    If search_string does not use the ES query string syntax,
     default to doing an infix search for each term.
     returns (is_simple, query)
     """
-    if not query:
+    if not search_string:
         return match_all()
 
-    is_simple, query = _smart_query_string(query)
+    is_simple, query_string = _smart_query_string(search_string)
     return {
         "query_string": {
-            "query": query,
+            "query": query_string,
             "default_operator": "AND",
             "fields": default_fields if is_simple else None
         }

--- a/corehq/apps/es/queries.py
+++ b/corehq/apps/es/queries.py
@@ -1,0 +1,17 @@
+from corehq.apps.users.util import smart_query_string
+
+
+def user_query_string(query, default_fields=None):
+    """
+    If query does not use the ES query string syntax,
+    default to doing an infix search for each term.
+    returns (is_simple, query)
+    """
+    is_simple, query = smart_query_string(query)
+    return {
+        "query_string": {
+            "query": query,
+            "default_operator": "AND",
+            #  "fields": default_fields if is_simple else None
+        }
+    }

--- a/corehq/apps/es/tests.py
+++ b/corehq/apps/es/tests.py
@@ -11,9 +11,9 @@ from . import forms, users
 class ElasticTestMixin(object):
     def checkQuery(self, query, json_output):
         msg = "Expected Query:\n{}\nGenerated Query:\n{}".format(
-                json.dumps(json_output, indent=4),
-                query.dumps(pretty=True),
-            )
+            json.dumps(json_output, indent=4),
+            query.dumps(pretty=True),
+        )
         # NOTE: This method thinks [a, b, c] != [b, c, a]
         self.assertEqual(query.raw_query, json_output, msg=msg)
 
@@ -262,19 +262,55 @@ class TestESFacet(ElasticTestMixin, TestCase):
             HQESQuery('forms')\
                 .terms_facet('form.meta.userID', 'form.meta.userID', size=10)
 
+
+class TestQueries(TestCase):
+    def assertHasQuery(self, es_query, desired_query):
+        generated = es_query.raw_query['query']['filtered']['query']
+        msg = "Expected to find query\n{}\nInstead found\n{}".format(
+            json.dumps(desired_query, indent=4),
+            json.dumps(generated, indent=4),
+        )
+        self.assertEqual(generated, desired_query, msg=msg)
+
     def test_query(self):
-        json_output = {
-            "query": {
-                "filtered": {
-                    "filter": {
-                        "and": [
-                            {"match_all": {}}
-                        ]
-                    },
-                    "query": {"fancy_query": {"foo": "bar"}}
-                }
-            },
-            "size": SIZE_LIMIT
-        }
         query = HQESQuery('forms').set_query({"fancy_query": {"foo": "bar"}})
-        self.checkQuery(query, json_output)
+        self.assertHasQuery(query, {"fancy_query": {"foo": "bar"}})
+
+    def test_null_query_string_queries(self):
+        query = HQESQuery('forms').user_query_string("")
+        self.assertHasQuery(query, {"match_all": {}})
+
+        query = HQESQuery('forms').user_query_string(None)
+        self.assertHasQuery(query, {"match_all": {}})
+
+    def test_basic_query_string_query(self):
+        query = HQESQuery('forms').user_query_string("foo")
+        self.assertHasQuery(query, {
+            "query_string": {
+                "query": "*foo*",
+                "default_operator": "AND",
+                "fields": None,
+            }
+        })
+
+    def test_query_with_fields(self):
+        default_fields = ['name', 'type', 'date']
+        query = HQESQuery('forms').user_query_string("foo", default_fields)
+        self.assertHasQuery(query, {
+            "query_string": {
+                "query": "*foo*",
+                "default_operator": "AND",
+                "fields": ['name', 'type', 'date'],
+            }
+        })
+
+    def test_complex_query_with_fields(self):
+        default_fields = ['name', 'type', 'date']
+        query = HQESQuery('forms').user_query_string("name: foo", default_fields)
+        self.assertHasQuery(query, {
+            "query_string": {
+                "query": "name: foo",
+                "default_operator": "AND",
+                "fields": None,
+            }
+        })

--- a/corehq/apps/es/tests.py
+++ b/corehq/apps/es/tests.py
@@ -277,14 +277,14 @@ class TestQueries(TestCase):
         self.assertHasQuery(query, {"fancy_query": {"foo": "bar"}})
 
     def test_null_query_string_queries(self):
-        query = HQESQuery('forms').user_query_string("")
+        query = HQESQuery('forms').search_string_query("")
         self.assertHasQuery(query, {"match_all": {}})
 
-        query = HQESQuery('forms').user_query_string(None)
+        query = HQESQuery('forms').search_string_query(None)
         self.assertHasQuery(query, {"match_all": {}})
 
     def test_basic_query_string_query(self):
-        query = HQESQuery('forms').user_query_string("foo")
+        query = HQESQuery('forms').search_string_query("foo")
         self.assertHasQuery(query, {
             "query_string": {
                 "query": "*foo*",
@@ -295,7 +295,7 @@ class TestQueries(TestCase):
 
     def test_query_with_fields(self):
         default_fields = ['name', 'type', 'date']
-        query = HQESQuery('forms').user_query_string("foo", default_fields)
+        query = HQESQuery('forms').search_string_query("foo", default_fields)
         self.assertHasQuery(query, {
             "query_string": {
                 "query": "*foo*",
@@ -306,7 +306,8 @@ class TestQueries(TestCase):
 
     def test_complex_query_with_fields(self):
         default_fields = ['name', 'type', 'date']
-        query = HQESQuery('forms').user_query_string("name: foo", default_fields)
+        query = (HQESQuery('forms')
+                 .search_string_query("name: foo", default_fields))
         self.assertHasQuery(query, {
             "query_string": {
                 "query": "name: foo",

--- a/corehq/apps/users/util.py
+++ b/corehq/apps/users/util.py
@@ -9,7 +9,6 @@ from corehq import privileges
 
 from dimagi.utils.couch.database import get_db
 from django.core.cache import cache
-from django_prbac.exceptions import PermissionDenied
 from django_prbac.utils import has_privilege
 
 

--- a/corehq/apps/users/util.py
+++ b/corehq/apps/users/util.py
@@ -161,22 +161,6 @@ def can_add_extra_mobile_workers(request):
     return True
 
 
-def smart_query_string(query):
-    """
-    If query does not use the ES query string syntax,
-    default to doing an infix search for each term.
-    returns (is_simple, query)
-    """
-    special_chars = ['&&', '||', '!', '(', ')', '{', '}', '[', ']', '^', '"',
-                     '~', '*', '?', ':', '\\', '/']
-    for char in special_chars:
-        if char in query:
-            return False, query
-    r = re.compile(r'\w+')
-    tokens = r.findall(query)
-    return True, "*{}*".format("* *".join(tokens))
-
-
 def user_display_string(username, first_name="", last_name=""):
     full_name = u"{} {}".format(first_name or u'', last_name or u'').strip()
 

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -9,12 +9,12 @@ from corehq import Domain, privileges, toggles
 from corehq.apps.app_manager.models import Application
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.domain.views import BaseDomainView
+from corehq.apps.es.queries import user_query_string
 from corehq.apps.style.decorators import (
     use_bootstrap3,
     use_knockout_js,
 )
 from corehq.apps.users.decorators import require_can_edit_web_users, require_permission_to_edit_user
-from corehq.apps.users.util import smart_query_string
 from corehq.elastic import ADD_TO_ES_FILTER, es_query, ES_URLS
 from dimagi.utils.decorators.memoized import memoized
 from django_prbac.exceptions import PermissionDenied
@@ -353,23 +353,17 @@ class NewListWebUsersView(JSONResponseMixin, BaseUserSettingsView):
         return super(NewListWebUsersView, self).dispatch(request, *args, **kwargs)
 
     def query_es(self, limit, skip, query=None):
-        is_simple, query = smart_query_string(query or '')
-
         web_user_filter = [
             {"term": {"user.domain_memberships.domain": self.domain}},
         ]
         web_user_filter.extend(ADD_TO_ES_FILTER['web_users'])
 
-        default_fields = ["username", "last_name", "first_name"]
         q = {
-            "query": {"query_string": {
-                "query": query,
-                "default_operator": "AND",
-                "fields": default_fields if is_simple else None
-            }},
             "filter": {"and": web_user_filter},
             "sort": {'username.exact': 'asc'},
         }
+        default_fields = ["username", "last_name", "first_name"]
+        q["query"] = user_query_string(query, default_fields)
         return es_query(
             params={}, q=q, es_url=ES_URLS["users"],
             size=limit, start_at=skip,

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -9,7 +9,7 @@ from corehq import Domain, privileges, toggles
 from corehq.apps.app_manager.models import Application
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.domain.views import BaseDomainView
-from corehq.apps.es.queries import user_query_string
+from corehq.apps.es.queries import search_string_query
 from corehq.apps.style.decorators import (
     use_bootstrap3,
     use_knockout_js,
@@ -17,7 +17,6 @@ from corehq.apps.style.decorators import (
 from corehq.apps.users.decorators import require_can_edit_web_users, require_permission_to_edit_user
 from corehq.elastic import ADD_TO_ES_FILTER, es_query, ES_URLS
 from dimagi.utils.decorators.memoized import memoized
-from django_prbac.exceptions import PermissionDenied
 from django_prbac.utils import has_privilege
 import langcodes
 from datetime import datetime
@@ -363,7 +362,7 @@ class NewListWebUsersView(JSONResponseMixin, BaseUserSettingsView):
             "sort": {'username.exact': 'asc'},
         }
         default_fields = ["username", "last_name", "first_name"]
-        q["query"] = user_query_string(query, default_fields)
+        q["query"] = search_string_query(query, default_fields)
         return es_query(
             params={}, q=q, es_url=ES_URLS["users"],
             size=limit, start_at=skip,

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -32,8 +32,7 @@ from corehq.apps.accounting.models import (
     EntryPoint,
 )
 from corehq.apps.accounting.utils import domain_has_privilege
-from corehq.apps.es import UserES
-from corehq.apps.es.queries import user_query_string
+from corehq.apps.es.queries import search_string_query
 from corehq.apps.hqwebapp.async_handler import AsyncHandlerMixin
 from corehq.apps.hqwebapp.utils import get_bulk_upload_form
 from corehq.apps.locations.models import Location
@@ -382,7 +381,7 @@ class AsyncListCommCareUsersView(ListCommCareUsersView):
             "sort": {'username.exact': 'asc'},
         }
         default_fields = ["username.exact", "last_name", "first_name"]
-        q["query"] = user_query_string(query, default_fields)
+        q["query"] = search_string_query(self.query, default_fields)
         params = {
             "domain": self.domain,
             "is_active": not self.show_inactive,


### PR DESCRIPTION
Needed this for the search bar on the new mobile workers page, and saw this being copy-pasted in a few places.  This is cherry-picked out of that branch, because the functionality is distinct and it'd be nice to review/merge on its own.

I'm also thinking it would be nice to use this as a go-to for handling user-specified query strings, that way behavior is consistent across the various search fields that support advanced syntax.  It might also be a good idea to use a different type of query than a query_string query if the user doesn't specify special syntax.  Currently this uses infix matching, but something like Levenshtein distance might make more sense.  That's kind of a separate question though.

@proteusvacuum @emord 
