### PR TITLE
Better warning of broken CC features

### DIFF
--- a/corehq/apps/cloudcare/templates/cloudcare/cloudcare_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/cloudcare_home.html
@@ -152,9 +152,13 @@
             <a class="close" data-dismiss="alert" href="#">&times;</a>
                 {% blocktrans %}
                     You are using CloudCare as a Web User!
-                    Any data you submit will show up in reports as submitted by "Unknown User".
-                    Features that rely on mobile workers, like case sharing, lookup tables and user-as-a-case,
-                    will not work properly.
+                    Any data you submit will show up in reports as submitted by "Unknown User". There are a
+                    few a features that rely on mobile workers and will not work properly:
+                    <ul>
+                        <li>Case sharing</li>
+                        <li>Lookup tables</li>
+                        <li>User-as-a-case</li>
+                    </ul>
                     For the best experience please logout and login as a Mobile Worker.
                     More information on CloudCare can be found at the <a href="https://help.commcarehq.org/display/commcarepublic/CloudCare+-+Web+Data+Entry">CommCare Help Site</a>.
                 {% endblocktrans %}

--- a/corehq/apps/cloudcare/templates/cloudcare/cloudcare_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/cloudcare_home.html
@@ -153,7 +153,7 @@
                 {% blocktrans %}
                     You are using CloudCare as a Web User!
                     Any data you submit will show up in reports as submitted by "Unknown User". There are a
-                    few a features that rely on mobile workers and will not work properly:
+                    few features that rely on mobile workers and will not work properly:
                     <ul>
                         <li>Case sharing</li>
                         <li>Lookup tables</li>


### PR DESCRIPTION
Before:
<img width="1158" alt="screen shot 2015-08-14 at 1 13 50 pm" src="https://cloud.githubusercontent.com/assets/918514/9279552/5a08a714-4286-11e5-9f95-cfcafa62a22c.png">
After:
<img width="1173" alt="screen shot 2015-08-14 at 1 12 27 pm" src="https://cloud.githubusercontent.com/assets/918514/9279557/5e672448-4286-11e5-854d-9bba8786acea.png">

http://manage.dimagi.com/default.asp?178564#994810

@biyeun 
