### PR TITLE
add blank product title to product list/detail

### DIFF
--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -42,9 +42,11 @@ def _create_custom_app_strings(app, lang):
                 label = trans(module.case_label)
             elif detail_type.startswith('referral'):
                 label = trans(module.referral_label)
+            elif detail_type in ('product_short', 'product_long'):
+                label = ''
             else:
                 label = None
-            if label:
+            if label is not None:
                 yield id_strings.detail_title_locale(module, detail_type), label
 
             for column in detail.get_columns():


### PR DESCRIPTION
Fixes http://manage.dimagi.com/default.asp?179091

@NoahCarnahan not sure what you had in mind, but the shouldn't change behavior. It seems preferable to be able to specify Product Label the same way you specify Case Label; this is what shows up in the breadcrumbs at the top of the screen I believe, when you enter product list/detail.
CC @amsagoff 
