### PR TITLE
Remove auth from direct ccz download

### DIFF
--- a/corehq/apps/app_manager/views.py
+++ b/corehq/apps/app_manager/views.py
@@ -3307,7 +3307,6 @@ def list_apps(request, domain):
 
 # Used by CommCare CLI
 @json_error
-@login_or_digest_or_basic
 def direct_ccz(request, domain):
     if 'app_id' in request.GET:
         app = get_app(domain, request.GET['app_id'])


### PR DESCRIPTION
@ctsims
This is what we do anyways for app downloads, and it makes the CLI workflow easier.
