### PR TITLE
Catch LockError during form processing

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -237,7 +237,7 @@ class CaseDbCache(object):
             if lock:
                 try:
                     lock.release()
-                except redis.ConnectionError:
+                except redis.RedisError:
                     pass
 
     def validate_doc(self, doc):
@@ -265,7 +265,7 @@ class CaseDbCache(object):
             elif self.lock:
                 try:
                     case_doc, lock = CommCareCase.get_locked_obj(_id=case_id)
-                except redis.ConnectionError:
+                except redis.RedisError:
                     case_doc = CommCareCase.get(case_id)
                 else:
                     self.locks.append(lock)


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?179502

It looks like the new redis API raises a `LockError` when you try to release a lock that's already timed out whereas before it just wouldn't do anything and wouldn't raise any exceptions.

By catching the `LockError`s, we return the form processing back to the previous behavior where no exceptions were raised for releasing locks that had already timed out.

But the fact that the locks are timing out means we should increase the timeout otherwise the locking mechanism isn't working properly.  Going to handle that in a separate PR, tracking it here: http://manage.dimagi.com/default.asp?179503

@benrudolph @dannyroberts 
cc @nickpell 
