### PR TITLE
Adds cached usercase_id property to CommCareUser

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -13,6 +13,7 @@ from django.core.urlresolvers import reverse
 from django.core.exceptions import ValidationError
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext as _
+from corehq.apps.app_manager.const import USERCASE_TYPE
 from corehq.apps.commtrack.dbaccessors import get_supply_point_case_by_location
 from corehq.apps.hqcase.dbaccessors import get_case_ids_in_domain_by_owner
 from corehq.apps.sofabed.models import CaseData
@@ -1380,6 +1381,10 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
 
         return self
 
+    def clear_quickcache_for_user(self):
+        self.usercase_id.clear(self)
+        super(CommCareUser, self).clear_quickcache_for_user()
+
     def save(self, **params):
         super(CommCareUser, self).save(**params)
 
@@ -2049,6 +2054,13 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
             class_name=self.__class__.__name__,
             self=self
         ))
+
+    @property
+    @skippable_quickcache(['self._id'], lambda _: settings.UNIT_TESTING)
+    def usercase_id(self):
+        from corehq.apps.hqcase.utils import get_case_by_domain_hq_user_id
+        usercase = get_case_by_domain_hq_user_id(self.domain, self._id, USERCASE_TYPE)
+        return usercase.case_id if usercase else None
 
 
 class OrgMembershipMixin(DocumentSchema):

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1382,7 +1382,7 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         return self
 
     def clear_quickcache_for_user(self):
-        self.usercase_id.clear(self)
+        self.get_usercase_id.clear(self)
         super(CommCareUser, self).clear_quickcache_for_user()
 
     def save(self, **params):
@@ -2055,9 +2055,8 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
             self=self
         ))
 
-    @property
     @skippable_quickcache(['self._id'], lambda _: settings.UNIT_TESTING)
-    def usercase_id(self):
+    def get_usercase_id(self):
         from corehq.apps.hqcase.utils import get_case_by_domain_hq_user_id
         usercase = get_case_by_domain_hq_user_id(self.domain, self._id, USERCASE_TYPE)
         return usercase.case_id if usercase else None


### PR DESCRIPTION
[FB 179258](http://manage.dimagi.com/default.asp?179258)

This just returns and caches the ID. We will still need to reset the cache on `save` because initially the user won't have a user case.

@czue @benrudolph @snopoke 
buddies @gcapalbo @emord 
