### PR TITLE
Only show Filtering and Sorting on case

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list.html
@@ -44,6 +44,7 @@
     {% include 'app_manager/partials/case_list_properties.html' %}
 </div>
 
+{% if detail.type == 'case' %}
 <legend>
     {% trans "Filtering and Sorting" %}
 </legend>
@@ -195,6 +196,7 @@
 
 {% endif %}
 </div>
+{% endif %}
 
 {% if detail.parent_select %}
 <div data-bind="with: parentSelect, DetailScreenConfig_notifyShortScreenOnChange: $root">


### PR DESCRIPTION
@snopoke just to be sure, Filtering and Sorting should only show when the `type` is `case` (the other condition could be `type != 'product'`).

http://manage.dimagi.com/default.asp?178819#992952
