### PR TITLE
disable 'Update' button on submit

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1290,13 +1290,17 @@ class InternalSubscriptionManagementForm(forms.Form):
 
     @property
     def form_actions(self):
-        return FormActions(
-            crispy.ButtonHolder(
-                crispy.Submit(
-                    self.slug,
-                    ugettext_noop('Update')
+        return (
+            crispy.Hidden('slug', self.slug),
+            FormActions(
+                crispy.ButtonHolder(
+                    crispy.Submit(
+                        self.slug,
+                        ugettext_noop('Update'),
+                        css_class='disable-on-submit',
+                    )
                 )
-            )
+            ),
         )
 
 
@@ -1316,7 +1320,7 @@ class DimagiOnlyEnterpriseForm(InternalSubscriptionManagementForm):
                 'sure this is an internal Dimagi test space, not in use by a '
                 'partner.'
             )),
-            self.form_actions
+            *self.form_actions
         )
 
     def process_subscription_management(self):
@@ -1400,7 +1404,7 @@ class AdvancedExtendedTrialForm(InternalSubscriptionManagementForm):
             ) % {
                 'end_date': end_date,
             }),
-            self.form_actions
+            *self.form_actions
         )
 
     def process_subscription_management(self):
@@ -1521,7 +1525,7 @@ class ContractedPartnerForm(InternalSubscriptionManagementForm):
                         'accounts_email': settings.ACCOUNTS_EMAIL,
                     }
                 ),
-                self.form_actions
+                *self.form_actions
             )
         else:
             self.fields['end_date'].initial = self.current_subscription.date_end
@@ -1543,7 +1547,7 @@ class ContractedPartnerForm(InternalSubscriptionManagementForm):
                     'Please use this page only to extend the existing services contract.</p>'
                     '</div>'
                 )),
-                self.form_actions
+                *self.form_actions
             )
 
     def process_subscription_management(self):

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1192,15 +1192,13 @@ class InternalSubscriptionManagementView(BaseAdminProjectSettingsView):
 
     @property
     def get_post_form(self):
-        for form_slug in self.slug_to_form:
-            if form_slug in self.request.POST:
-                return self.slug_to_form[form_slug]
+        return self.slug_to_form[self.request.POST.get('slug')]
 
     @property
     @memoized
     def slug_to_form(self):
         def create_form(form_class):
-            if self.request.method == 'POST' and form_class.slug in self.request.POST:
+            if self.request.method == 'POST' and form_class.slug == self.request.POST.get('slug'):
                 return form_class(self.domain, self.request.couch_user.username, self.request.POST)
             return form_class(self.domain, self.request.couch_user.username)
         return {form_class.slug: create_form(form_class) for form_class in self.form_classes}


### PR DESCRIPTION
Prevent the user from making double-submissions (which in turn creates duplicate subscriptions)

@gcapalbo @proteusvacuum 

@esoergel I wish I had attended the IoC AotW before implementing this feature ... I probably wouldn't refactor it until it starts to become unwieldy, but I think the code would have come out better if written more linearly.
