### PR TITLE
speed up accounting tests

### DIFF
--- a/corehq/apps/accounting/tests/base_tests.py
+++ b/corehq/apps/accounting/tests/base_tests.py
@@ -6,11 +6,14 @@ from django_prbac.models import Role
 
 
 class BaseAccountingTest(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        generator.instantiate_accounting_for_tests()
 
     def setUp(self):
         Role.get_cache().clear()
-        generator.instantiate_accounting_for_tests()
 
-    def tearDown(self):
+    @classmethod
+    def tearDownClass(cls):
         for domain in Domain.get_all():
             domain.delete()


### PR DESCRIPTION
Running tests to see what effect this has. Locally it shaves off a few seconds per accounting test.
For the full suite of accounting tests, locally:
Before: 3:20
After: 1:58
