### PR TITLE
Fix UCR/DataTables bug with "." in column ids

### DIFF
--- a/corehq/apps/userreports/sql/columns.py
+++ b/corehq/apps/userreports/sql/columns.py
@@ -121,17 +121,17 @@ def _expand_column(report_column, distinct_values, lang):
     :return:
     """
     columns = []
-    for val in distinct_values:
+    for index, val in enumerate(distinct_values):
         columns.append(DatabaseColumn(
             u"{}-{}".format(report_column.get_header(lang), val),
             SumWhen(
                 report_column.field,
                 whens={val: 1},
                 else_=0,
-                alias=u"{}-{}".format(report_column.column_id, val),
+                alias=u"{}-{}".format(report_column.column_id, index),
             ),
             sortable=False,
-            data_slug=u"{}-{}".format(report_column.column_id, val),
+            data_slug=u"{}-{}".format(report_column.column_id, index),
             format_fn=report_column.get_format_fn(),
             help_text=report_column.description
         ))


### PR DESCRIPTION
Addresses [Ticket #179520](http://manage.dimagi.com/default.asp?179520)

The DataTables plugin for jQuery that we use to render the tables in UCRs uses uses javascript objects to configure the columns of the table. Those objects have a property [`mDataProp`](http://legacy.datatables.net/usage/columns) that specifies key to use when retrieving data from the row objects. If the `mDataProp` value is a string, and if that string has a `.` in it, it interprets that value as a path into the row object. So, if you have keys in your row object that contain `.`, they can't be accessed by `mDataProp` (because it interprets those values as paths, not key names).

Unfortunately there is [no way to escape](https://datatables.net/forums/discussion/11606/mdata-property-with-dot-special-character) an `mDataProp` string value. You can use a function in place of the string though. However, we're passing the column configuration as json from the django view ([here](https://github.com/dimagi/commcare-hq/blob/7cdb0b412e525745c707104398269f5312c394d1/corehq/apps/reports_core/templates/reports_core/base_template_new.html#L44)), which makes it a bit messy to replace the strings with functions.

I took the easy route and just prevented `.` from appearing in the column ids in my particular case, but it would probably be good to implement a more general solution (probably in the `DataTablesHeader` class) at some point.

cc @orangejenny 
fyi @czue 
