### PR TITLE
Make report builder filter slugs unique

### DIFF
--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -729,11 +729,11 @@ class ConfigureNewReportBase(forms.Form):
             'Numeric': 'numeric'
         }
 
-        def _make_report_filter(conf):
+        def _make_report_filter(conf, index):
             col_id = self.data_source_properties[conf["property"]]['column_id']
             ret = {
                 "field": col_id,
-                "slug": col_id,
+                "slug": "{}-{}".format(col_id, index),
                 "display": conf["display_text"],
                 "type": filter_type_map[conf['format']]
             }
@@ -742,7 +742,7 @@ class ConfigureNewReportBase(forms.Form):
             return ret
 
         filter_configs = self.cleaned_data['filters']
-        filters = [_make_report_filter(f) for f in filter_configs]
+        filters = [_make_report_filter(f, i) for i, f in enumerate(filter_configs)]
         if self.source_type == 'case':
             # The UI doesn't support specifying "choice_list" filters, only "dynamic_choice_list" filters.
             # But, we want to make the open/closed filter a cleaner "choice_list" filter, so we do that here.


### PR DESCRIPTION
Addresses [Ticket #179537](http://manage.dimagi.com/default.asp?179537).

The UCR report config doesn't validate if two filters have the same slug. This could happen if two filters are created based on the same column. Appending a unique number to each filter slug solves the issue.

cc @orangejenny 
