### PR TITLE
Cut down on number of threads

### DIFF
--- a/deployment/gunicorn/gunicorn_conf.py
+++ b/deployment/gunicorn/gunicorn_conf.py
@@ -1,6 +1,6 @@
 import multiprocessing
 preload_app = True
-workers = multiprocessing.cpu_count() * 2 + 1
+workers = multiprocessing.cpu_count() + 1
 worker_class = 'gevent'
 keepalive = 60
 timeout = 900


### PR DESCRIPTION
@dannyroberts @czue measured my django process to be around ~170MB on startup. 170 \* 11 is ~ 1.9GB of the 4GB we have. this'll cut down the number we use
