### PR TITLE
make newrelic env vars a dict

### DIFF
--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -127,10 +127,13 @@ def format_env(current_env, extra=None):
     host = current_env.get('host_string')
     if host in current_env.get('new_relic_enabled', []):
         ret['new_relic_command'] = '%(virtualenv_root)s/bin/newrelic-admin run-program ' % env
-        ret['supervisor_env_vars'] = 'NEW_RELIC_CONFIG_FILE="%(root)s/newrelic.ini",NEW_RELIC_ENVIRONMENT="%(environment)s"' % env
+        ret['supervisor_env_vars'] = {
+            'NEW_RELIC_CONFIG_FILE': '%(root)s/newrelic.ini' % env,
+            'NEW_RELIC_ENVIRONMENT': '%(environment)s' % env
+        }
     else:
         ret['new_relic_command'] = ''
-        ret['supervisor_env_vars'] = ''
+        ret['supervisor_env_vars'] = []
 
     for prop in important_props:
         ret[prop] = current_env.get(prop, '')

--- a/fab/services/templates/supervisor_celery_background_queue.conf
+++ b/fab/services/templates/supervisor_celery_background_queue.conf
@@ -1,5 +1,5 @@
 [program:{{ project }}-{{ environment }}-celery_background_queue]
-environment={{ supervisor_env_vars }}
+environment={% for name, value in supervisor_env_vars.items %}{{ name }}="{{ value }}"{% if not forloop.last %},{% endif %}{% endfor %}
 command={{ new_relic_command }}{{ virtualenv_root }}/bin/python {{ code_root }}/manage.py celery worker --queues=background_queue --events --loglevel=INFO --hostname={{ host_string }}_background_queue --maxtasksperchild=5 --concurrency={{ celery_params.concurrency }} -Ofair
 directory={{ code_root }}
 user={{ sudo_user }}

--- a/fab/services/templates/supervisor_celery_email_queue.conf
+++ b/fab/services/templates/supervisor_celery_email_queue.conf
@@ -1,5 +1,5 @@
 [program:{{ project }}-{{ environment }}-celery_email_queue]
-environment={{ supervisor_env_vars }}
+environment={% for name, value in supervisor_env_vars.items %}{{ name }}="{{ value }}"{% if not forloop.last %},{% endif %}{% endfor %}
 command={{ new_relic_command }}{{ virtualenv_root }}/bin/python {{ code_root }}/manage.py celery worker --queues=email_queue --events --loglevel=INFO --hostname={{ host_string }}_email_queue --maxtasksperchild=5 --concurrency={{ celery_params.concurrency }} -Ofair
 directory={{ code_root }}
 user={{ sudo_user }}

--- a/fab/services/templates/supervisor_celery_main.conf
+++ b/fab/services/templates/supervisor_celery_main.conf
@@ -1,5 +1,5 @@
 [program:{{ project }}-{{ environment }}-celery_main]
-environment={{ supervisor_env_vars }}
+environment={% for name, value in supervisor_env_vars.items %}{{ name }}="{{ value }}"{% if not forloop.last %},{% endif %}{% endfor %}
 command={{ new_relic_command }}{{ virtualenv_root }}/bin/python {{ code_root }}/manage.py celery worker --queues=celery --events --loglevel=INFO --hostname={{ host_string }}_main --maxtasksperchild=5 --concurrency={{ celery_params.concurrency }} -Ofair
 directory={{ code_root }}
 user={{ sudo_user }}

--- a/fab/services/templates/supervisor_celery_periodic.conf
+++ b/fab/services/templates/supervisor_celery_periodic.conf
@@ -1,5 +1,5 @@
 [program:{{ project }}-{{ environment }}-celery_periodic]
-environment={{ supervisor_env_vars }}
+environment={% for name, value in supervisor_env_vars.items %}{{ name }}="{{ value }}"{% if not forloop.last %},{% endif %}{% endfor %}
 command={{ new_relic_command }}{{ virtualenv_root }}/bin/python {{ code_root }}/manage.py celery worker --queues=celery_periodic --events --loglevel=INFO --hostname={{ host_string }}_periodic --maxtasksperchild=50 --concurrency={{ celery_params.concurrency }} -Ofair
 directory={{ code_root }}
 user={{ sudo_user }}

--- a/fab/services/templates/supervisor_celery_pillow_retry_queue.conf
+++ b/fab/services/templates/supervisor_celery_pillow_retry_queue.conf
@@ -1,5 +1,5 @@
 [program:{{ project }}-{{ environment }}-celery_pillow_retry_queue]
-environment={{ supervisor_env_vars }}
+environment={% for name, value in supervisor_env_vars.items %}{{ name }}="{{ value }}"{% if not forloop.last %},{% endif %}{% endfor %}
 command={{ new_relic_command }}{{ virtualenv_root }}/bin/python {{ code_root }}/manage.py celery worker --queues=pillow_retry_queue --events --loglevel=INFO --hostname={{ host_string }}_pillow_retry_queue --maxtasksperchild=50 --concurrency={{ celery_params.concurrency }} -Ofair
 directory={{ code_root }}
 user={{ sudo_user }}

--- a/fab/services/templates/supervisor_celery_reminder_case_update_queue.conf
+++ b/fab/services/templates/supervisor_celery_reminder_case_update_queue.conf
@@ -1,5 +1,5 @@
 [program:{{ project }}-{{ environment }}-celery_reminder_case_update_queue]
-environment={{ supervisor_env_vars }}
+environment={% for name, value in supervisor_env_vars.items %}{{ name }}="{{ value }}"{% if not forloop.last %},{% endif %}{% endfor %}
 command={{ new_relic_command }}{{ virtualenv_root }}/bin/python {{ code_root }}/manage.py celery worker --queues=reminder_case_update_queue --events --loglevel=INFO --hostname={{ host_string }}_reminder_case_update_queue --maxtasksperchild=50 --concurrency={{ celery_params.concurrency }} -Ofair
 directory={{ code_root }}
 user={{ sudo_user }}

--- a/fab/services/templates/supervisor_celery_reminder_queue.conf
+++ b/fab/services/templates/supervisor_celery_reminder_queue.conf
@@ -1,5 +1,5 @@
 [program:{{ project }}-{{ environment }}-celery_reminder_queue]
-environment={{ supervisor_env_vars }}
+environment={% for name, value in supervisor_env_vars.items %}{{ name }}="{{ value }}"{% if not forloop.last %},{% endif %}{% endfor %}
 command={{ new_relic_command }}{{ virtualenv_root }}/bin/python {{ code_root }}/manage.py celery worker --queues=reminder_queue --events --loglevel=INFO --hostname={{ host_string }}_reminder_queue --maxtasksperchild=50 --concurrency={{ celery_params.concurrency }} -Ofair
 directory={{ code_root }}
 user={{ sudo_user }}

--- a/fab/services/templates/supervisor_celery_reminder_rule_queue.conf
+++ b/fab/services/templates/supervisor_celery_reminder_rule_queue.conf
@@ -1,5 +1,5 @@
 [program:{{ project }}-{{ environment }}-celery_reminder_rule_queue]
-environment={{ supervisor_env_vars }}
+environment={% for name, value in supervisor_env_vars.items %}{{ name }}="{{ value }}"{% if not forloop.last %},{% endif %}{% endfor %}
 command={{ new_relic_command }}{{ virtualenv_root }}/bin/python {{ code_root }}/manage.py celery worker --queues=reminder_rule_queue --events --loglevel=INFO --hostname={{ host_string }}_reminder_rule_queue --maxtasksperchild=50 --concurrency={{ celery_params.concurrency }} -Ofair
 directory={{ code_root }}
 user={{ sudo_user }}

--- a/fab/services/templates/supervisor_celery_saved_exports_queue.conf
+++ b/fab/services/templates/supervisor_celery_saved_exports_queue.conf
@@ -1,5 +1,5 @@
 [program:{{ project }}-{{ environment }}-celery_saved_exports_queue]
-environment={{ supervisor_env_vars }}
+environment={% for name, value in supervisor_env_vars.items %}{{ name }}="{{ value }}"{% if not forloop.last %},{% endif %}{% endfor %}
 command={{ new_relic_command }}{{ virtualenv_root }}/bin/python {{ code_root }}/manage.py celery worker --queues=saved_exports_queue --events --loglevel=INFO --hostname={{ host_string }}_saved_exports_queue --maxtasksperchild=5 --concurrency={{ celery_params.concurrency }} -Ofair
 directory={{ code_root }}
 user={{ sudo_user }}

--- a/fab/services/templates/supervisor_celery_sms_queue.conf
+++ b/fab/services/templates/supervisor_celery_sms_queue.conf
@@ -1,5 +1,5 @@
 [program:{{ project }}-{{ environment }}-celery_sms_queue]
-environment={{ supervisor_env_vars }}
+environment={% for name, value in supervisor_env_vars.items %}{{ name }}="{{ value }}"{% if not forloop.last %},{% endif %}{% endfor %}
 command={{ new_relic_command }}{{ virtualenv_root }}/bin/python {{ code_root }}/manage.py celery worker --queues=sms_queue --events --loglevel=INFO --hostname={{ host_string }}_sms_queue --maxtasksperchild=50 --concurrency={{ celery_params.concurrency }} -Ofair
 directory={{ code_root }}
 user={{ sudo_user }}

--- a/fab/services/templates/supervisor_celery_ucr_queue.conf
+++ b/fab/services/templates/supervisor_celery_ucr_queue.conf
@@ -1,5 +1,5 @@
 [program:{{ project }}-{{ environment }}-celery_ucr_queue]
-environment={{ supervisor_env_vars }}
+environment={% for name, value in supervisor_env_vars.items %}{{ name }}="{{ value }}"{% if not forloop.last %},{% endif %}{% endfor %}
 command={{ new_relic_command }}{{ virtualenv_root }}/bin/python {{ code_root }}/manage.py celery worker --queues=ucr_queue --events --loglevel=INFO --hostname={{ host_string }}_ucr_queue --maxtasksperchild=5 --concurrency={{ celery_params.concurrency }} -Ofair
 directory={{ code_root }}
 user={{ sudo_user }}

--- a/fab/services/templates/supervisor_django.conf
+++ b/fab/services/templates/supervisor_django.conf
@@ -1,7 +1,7 @@
 [program:{{ project }}-{{ environment }}-django]
 directory={{ code_root }}/
 ; gunicorn
-environment={{ supervisor_env_vars|safe }}
+environment={% for name, value in supervisor_env_vars.items %}{{ name }}="{{ value }}"{% if not forloop.last %},{% endif %}{% endfor %}
 command={{ new_relic_command }}{{ virtualenv_root }}/bin/python manage.py run_gunicorn -c deployment/gunicorn/gunicorn_conf.py -k gevent --bind {{ django_bind }}:{{ django_port }} --log-file {{ log_dir }}/{{ project }}.gunicorn.log --log-level debug
 user={{ sudo_user }}
 autostart=true


### PR DESCRIPTION
@TylerSheffels 

The escaped quotes were getting lost when fabric sends the command over the wire so rather handle the quoting in the template (which seems cleaner anyway)
