### PR TITLE
Re-enable report builder submit button if form is invalid

### DIFF
--- a/corehq/apps/userreports/templates/userreports/partials/report_builder_configure_report.html
+++ b/corehq/apps/userreports/templates/userreports/partials/report_builder_configure_report.html
@@ -172,6 +172,9 @@
                 isValid = that.columnsList.validate() && isValid;
                 if (!isValid){
                     alert('Invalid report configuration. Please fix the issues and try again.');
+                    // The event handler that disables the button is triggered
+                    // after this handler is invoked. Therefore, we use _.defer()
+                    // to re-enable it immediately after the call stack clears.
                     _.defer(function(el){
                         $(el).find('.disable-on-submit').enableButton();
                     }, formElement);

--- a/corehq/apps/userreports/templates/userreports/partials/report_builder_configure_report.html
+++ b/corehq/apps/userreports/templates/userreports/partials/report_builder_configure_report.html
@@ -166,12 +166,15 @@
                 initialCols: initialColumns,
                 buttonText: 'Add Column'
             });
-            this.submitHandler = function(){
+            this.submitHandler = function(formElement){
                 var isValid = true;
                 isValid = that.filtersList.validate() && isValid;
                 isValid = that.columnsList.validate() && isValid;
                 if (!isValid){
                     alert('Invalid report configuration. Please fix the issues and try again.');
+                    _.defer(function(el){
+                        $(el).find('.disable-on-submit').enableButton();
+                    }, formElement);
                 }
                 return isValid;
             }


### PR DESCRIPTION
Addresses http://manage.dimagi.com/default.asp?179730
Follows up on https://github.com/dimagi/commcare-hq/pull/7064

It seems that the event handler that disables the button is triggered after the knockout event handler, which is why the [`_.defer()`](http://underscorejs.org/#defer) wrapper is needed.

cc @orangejenny 
