### PR TITLE
Allow to filter locations by parents.

### DIFF
--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -136,6 +136,17 @@ class LocationQueriesMixin(object):
             return itertools.imap(Location.wrap, locations)
         return locations
 
+    def include_children(self):
+        """
+        Returns a new queryset including all children of the current queryset.
+        This means "Middlesex" will match:
+            Massachusetts/Middlesex
+            Massachusetts/Middlesex/Boston
+            Massachusetts/Middlesex/Cambridge
+        """
+        return (SQLLocation.objects
+                .get_queryset_descendants(self, include_self=True))
+
 
 class LocationQuerySet(LocationQueriesMixin, models.query.QuerySet):
     pass

--- a/corehq/apps/locations/tests/__init__.py
+++ b/corehq/apps/locations/tests/__init__.py
@@ -1,6 +1,7 @@
 from .test_dbaccessors import *
 from .test_location_fixtures import *
 from .test_location_import import *
+from .test_location_queries import *
 from .test_location_set import *
 from .test_location_types import *
 from .test_location_utils import *

--- a/corehq/apps/locations/tests/test_location_queries.py
+++ b/corehq/apps/locations/tests/test_location_queries.py
@@ -16,11 +16,25 @@ class TestLocationQuerysetMethods(LocationHierarchyTestCase):
         ])
     ]
 
-    def test_filter_by_ancestry(self):
+    def test_filter_by_user_input(self):
         middlesex_locs = (SQLLocation.objects
-                          .filter(domain=self.domain,
-                                  name="Middlesex")
-                          .include_children())
+                          .filter_by_user_input(self.domain, "Middlesex"))
+        self.assertItemsEqual(
+            ['Middlesex'],
+            [loc.name for loc in middlesex_locs]
+        )
+
+    def test_filter_path_by_user_input(self):
+        middlesex_locs = (SQLLocation.objects
+                          .filter_path_by_user_input(self.domain, "Middlesex"))
+        self.assertItemsEqual(
+            ['Middlesex', 'Cambridge', 'Somerville'],
+            [loc.name for loc in middlesex_locs]
+        )
+
+    def test_filter_by_partial_match(self):
+        middlesex_locs = (SQLLocation.objects
+                          .filter_path_by_user_input(self.domain, "Middle"))
         self.assertItemsEqual(
             ['Middlesex', 'Cambridge', 'Somerville'],
             [loc.name for loc in middlesex_locs]

--- a/corehq/apps/locations/tests/test_location_queries.py
+++ b/corehq/apps/locations/tests/test_location_queries.py
@@ -1,0 +1,27 @@
+from ..models import SQLLocation
+from .util import LocationHierarchyTestCase
+
+
+class TestLocationQuerysetMethods(LocationHierarchyTestCase):
+    location_type_names = ['state', 'county', 'city']
+    location_structure = [
+        ('Massachusetts', [
+            ('Middlesex', [
+                ('Cambridge', []),
+                ('Somerville', []),
+            ]),
+            ('Suffolk', [
+                ('Boston', []),
+            ])
+        ])
+    ]
+
+    def test_filter_by_ancestry(self):
+        middlesex_locs = (SQLLocation.objects
+                          .filter(domain=self.domain,
+                                  name="Middlesex")
+                          .include_children())
+        self.assertItemsEqual(
+            ['Middlesex', 'Cambridge', 'Somerville'],
+            [loc.name for loc in middlesex_locs]
+        )

--- a/corehq/apps/locations/tests/test_location_utils.py
+++ b/corehq/apps/locations/tests/test_location_utils.py
@@ -1,38 +1,21 @@
-from django.test import TestCase
-
-from corehq.apps.commtrack.tests.util import bootstrap_domain
-
 from ..models import LocationType
 from ..util import get_locations_and_children
-from .util import delete_all_locations, setup_locations_and_types
+from .util import LocationHierarchyTestCase
 
 
-class MassachusettsTestCase(TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.domain = 'test-domain'
-        cls.domain_obj = bootstrap_domain(cls.domain)
-
-        cls.location_type_names = ['state', 'county', 'city']
-        cls.location_structure = [
-            ('Massachusetts', [
-                ('Middlesex', [
-                    ('Cambridge', []),
-                    ('Somerville', []),
-                ]),
-                ('Suffolk', [
-                    ('Boston', []),
-                ])
+class MassachusettsTestCase(LocationHierarchyTestCase):
+    location_type_names = ['state', 'county', 'city']
+    location_structure = [
+        ('Massachusetts', [
+            ('Middlesex', [
+                ('Cambridge', []),
+                ('Somerville', []),
+            ]),
+            ('Suffolk', [
+                ('Boston', []),
             ])
-        ]
-        cls.location_types, cls.locations = setup_locations_and_types(
-            cls.domain, cls.location_type_names, cls.location_structure
-        )
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.domain_obj.delete()
-        delete_all_locations()
+        ])
+    ]
 
 
 class TestLocationsSetup(MassachusettsTestCase):

--- a/corehq/apps/locations/tests/util.py
+++ b/corehq/apps/locations/tests/util.py
@@ -1,6 +1,8 @@
+from django.test import TestCase
 from dimagi.utils.couch.database import iter_bulk_delete
 from corehq.util.test_utils import unit_testing_only
 from corehq.apps.commtrack.models import SupplyPointCase
+from corehq.apps.commtrack.tests.util import bootstrap_domain
 from corehq.apps.locations.models import Location, SQLLocation, LocationType
 
 TEST_DOMAIN = 'locations-test'
@@ -70,3 +72,24 @@ def setup_locations_and_types(domain, location_types, locations):
         _setup_location_types(domain, location_types),
         _setup_locations(domain, locations, location_types)
     )
+
+
+class LocationHierarchyTestCase(TestCase):
+    """
+    Sets up and tears down a hierarchy for you based on the two class attrs
+    """
+    location_type_names = []
+    location_structure = []
+
+    @classmethod
+    def setUpClass(cls):
+        cls.domain = 'test-domain'
+        cls.domain_obj = bootstrap_domain(cls.domain)
+        cls.location_types, cls.locations = setup_locations_and_types(
+            cls.domain, cls.location_type_names, cls.location_structure
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.domain_obj.delete()
+        delete_all_locations()

--- a/corehq/apps/reports/filters/api.py
+++ b/corehq/apps/reports/filters/api.py
@@ -56,10 +56,7 @@ class EmwfOptionsView(LoginAndDomainMixin, JSONResponseMixin, View):
         })
 
     def get_locations_query(self, query):
-        return SQLLocation.objects.filter(
-            name__icontains=query.lower(),
-            domain=self.domain,
-        )
+        return SQLLocation.objects.filter_path_by_user_input(self.domain, query)
 
     def get_locations(self, query, start, size):
         return map(self.utils.location_tuple,


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?176003

Match locations in User/Group filter by path.  Note that this will still match against only one element of the path, given:

```
    Massachusetts
    Massachusetts/Suffolk
    Massachusetts/Suffolk/Boston
    Massachusetts/Middlesex
    Massachusetts/Middlesex/Cambridge
    Massachusetts/Middlesex/Somerville
```

The string "Middlesex" will match the last 3 results.  "MiddlesexCambridge" will not match anything, nor will "Middlesex/Cambridge" (that'd be nice, but it sounds unnecessarily complex).
This filter is only available on the manager - this would be confusing as a queryset method, as filters applied prior to this one would not be true of the result.
For instance, in

``` python
    qs = (SQLLocation.objects
          .filter(location_type__name="district")
          .filter_path_by_user_input("blah"))
```

The results will not all be districts (just descendants of matching districts).  I stuck it on the manager directly to avoid this confusion.
The changes here are mostly tests.

@emord @proteusvacuum 
