### PR TITLE
more configurable support for multiple rows per document

### DIFF
--- a/corehq/apps/userreports/README.md
+++ b/corehq/apps/userreports/README.md
@@ -73,10 +73,12 @@ In user configurable reports the following expression types are currently suppor
 
 Expression Type | Description  | Example
 --------------- | ------------ | ------
+identity        | Just returns whatever is passed in | `doc`
 constant        | A constant   | `"hello"`, `4`, `2014-12-20`
 property_name   | A reference to the property in a document |  `doc["name"]`
 property_path   | A nested reference to a property in a document | `doc["child"]["age"]`
 conditional     | An if/else expression | `"legal" if doc["age"] > 21 else "underage"`
+iterator        | Combine multiple expressions into a list | `[doc.name, doc.age, doc.gender]`
 related_doc     | A way to reference something in another document | `form.case.owner_id`
 root_doc        | A way to reference the root document explicitly (only needed when making a data source from repeat/child data) | `repeat.parent.name`
 
@@ -113,6 +115,7 @@ This expression returns `doc["child"]["age"]`:
 }
 ```
 An optional `"datatype"` attribute may be specified, which will attempt to cast the property to the given data type. The options are "date", "datetime", "string", "integer", and "decimal". If no datatype is specified, "string" will be used.
+
 ##### Conditional Expression
 
 This expression returns `"legal" if doc["age"] > 21 else "underage"`:
@@ -142,6 +145,34 @@ This expression returns `"legal" if doc["age"] > 21 else "underage"`:
 Note that this expression contains other expressions inside it! This is why expressions are powerful. (It also contains a filter, but we haven't covered those yet - if you find the `"test"` section confusing, keep reading...)
 
 Note also that it's important to make sure that you are comparing values of the same type. In this example, the expression that retrieves the age property from the document also casts the value to an integer. If this datatype is not specified, the expression will compare a string to the `21` value, which will not produce the expected results!
+
+##### Iterator Expression
+
+```json
+{
+    "type": "iterator",
+    "expressions": [
+        {
+            "type": "property_name",
+            "property_name": "p1"
+        },
+        {
+            "type": "property_name",
+            "property_name": "p2"
+        },
+        {
+            "type": "property_name",
+            "property_name": "p3"
+        },
+    ],
+    "test": {}
+}
+```
+
+This will emit `[doc.p1, doc.p2, doc.p3]`.
+You can add a `test` attribute to filter rows from what is emitted - if you don't specify this then the iterator will include one row per expression it contains regardless of what is passed in.
+This can be used/combined with the `base_item_expression` to emit multiple rows per document.
+
 
 #### Related document expressions
 
@@ -393,9 +424,13 @@ These are some practical notes for how to choose what indicators to create.
 
 All indicators output single values. Though fractional indicators are common, these should be modeled as two separate indicators (for numerator and denominator) and the relationship should be handled in the report UI config layer.
 
-## Saving Repeat Data
+## Saving Multiple Rows per Case/Form
 
-You can save data from a repeatable or child element in a form by specifying a root level `base_item_expression` that describes how to get the repeat data from the main document. You can also use the `root_doc` expression type to reference parent properties. This is not described in detail, but the following sample (which creates a table off of a repeat element called "time_logs" can be used as a guide):
+You can save multiple rows per case/form by specifying a root level `base_item_expression` that describes how to get the repeat data from the main document.
+You can also use the `root_doc` expression type to reference parent properties.
+This can be combined with the `iterator` expression type to do complex data source transforms.
+This is not described in detail, but the following sample (which creates a table off of a repeat element called "time_logs" can be used as a guide).
+There are also additional examples in the [examples](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/userreports/examples/examples.md):
 
 ```
 {

--- a/corehq/apps/userreports/examples/examples.md
+++ b/corehq/apps/userreports/examples/examples.md
@@ -160,7 +160,7 @@ If you want to include the time change the datatypes to `"datetime"`.
 This is the same type of indicator that should be used for typical Impact 123 indicators.
 In the example below, the indicator is inside a form group question called "impact123".
 
-```
+```json
 {
     "type": "expression",
     "expression": {
@@ -290,6 +290,44 @@ In the example below, the indicator is inside a form group question called "impa
     }
 }
 ```
+
+# Base Item Expressions
+
+## Emit multiple rows (one per non-empty case property)
+
+In this example we take 3 case properties and save one row per property if it exists.
+
+```json
+{
+    "type": "iterator",
+    "expressions": [
+        {
+            "type": "property_name",
+            "property_name": "p1"
+        },
+        {
+            "type": "property_name",
+            "property_name": "p2"
+        },
+        {
+            "type": "property_name",
+            "property_name": "p3"
+        },
+    ],
+    "test": {
+        "type": "not",
+        "filter": {
+            'type': 'boolean_expression',
+            'expression': {
+                'type': 'identity',
+            },
+            'operator': 'in',
+            'property_value': ['', None],
+        }
+    }
+}
+```
+
 
 
 # Report examples

--- a/corehq/apps/userreports/examples/examples.md
+++ b/corehq/apps/userreports/examples/examples.md
@@ -317,12 +317,12 @@ In this example we take 3 case properties and save one row per property if it ex
     "test": {
         "type": "not",
         "filter": {
-            'type': 'boolean_expression',
-            'expression': {
-                'type': 'identity',
+            "type": "boolean_expression",
+            "expression": {
+                "type": "identity",
             },
-            'operator': 'in',
-            'property_value': ['', None],
+            "operator": "in",
+            "property_value": ["", null],
         }
     }
 }

--- a/corehq/apps/userreports/expressions/factory.py
+++ b/corehq/apps/userreports/expressions/factory.py
@@ -4,12 +4,15 @@ from django.utils.translation import ugettext as _
 from jsonobject.exceptions import BadValueError
 from corehq.apps.userreports.exceptions import BadSpecError
 from corehq.apps.userreports.expressions.specs import PropertyNameGetterSpec, PropertyPathGetterSpec, \
-    ConditionalExpressionSpec, ConstantGetterSpec, RootDocExpressionSpec, RelatedDocExpressionSpec
+    ConditionalExpressionSpec, ConstantGetterSpec, RootDocExpressionSpec, RelatedDocExpressionSpec, \
+    IdentityExpressionSpec
 
 
 def _simple_expression_generator(wrapper_class, spec, context):
     return wrapper_class.wrap(spec)
 
+
+_identity_expression = functools.partial(_simple_expression_generator, IdentityExpressionSpec)
 _constant_expression = functools.partial(_simple_expression_generator, ConstantGetterSpec)
 _property_name_expression = functools.partial(_simple_expression_generator, PropertyNameGetterSpec)
 _property_path_expression = functools.partial(_simple_expression_generator, PropertyPathGetterSpec)
@@ -45,6 +48,7 @@ def _related_doc_expression(spec, context):
 
 class ExpressionFactory(object):
     spec_map = {
+        'identity': _identity_expression,
         'constant': _constant_expression,
         'property_name': _property_name_expression,
         'property_path': _property_path_expression,

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -76,6 +76,29 @@ class ConditionalExpressionSpec(JsonObject):
             return self._false_expression(item, context)
 
 
+class IteratorExpressionSpec(JsonObject):
+    type = TypeProperty('iterator')
+    expressions = ListProperty(required=True)
+    # an optional filter to test the values on - if they don't match they won't be included in the iteration
+    test = DictProperty()
+
+    def configure(self, expressions, test):
+        self._expression_fns = expressions
+        if test:
+            self._test = test
+        else:
+            # if not defined then all values should be returned
+            self._test = lambda *args, **kwargs: True
+
+    def __call__(self, item, context=None):
+        values = []
+        for expression in self._expression_fns:
+            value = expression(item, context)
+            if self._test(value):
+                values.append(value)
+        return values
+
+
 class RootDocExpressionSpec(JsonObject):
     type = TypeProperty('root_doc')
     expression = DictProperty(required=True)

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -13,6 +13,13 @@ from corehq.util.quickcache import quickcache
 from dimagi.utils.couch.database import get_db
 
 
+class IdentityExpressionSpec(JsonObject):
+    type = TypeProperty('identity')
+
+    def __call__(self, item, context=None):
+        return item
+
+
 class ConstantGetterSpec(JsonObject):
     type = TypeProperty('constant')
     constant = DefaultProperty(required=True)

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -26,6 +26,16 @@ class ExpressionPluginTest(SimpleTestCase):
             ExpressionFactory.register("foo", lambda x: x * 2)
 
 
+class IdentityExpressionTest(SimpleTestCase):
+
+    def setUp(self):
+        self.expression = ExpressionFactory.from_spec({'type': 'identity'})
+
+    def test_identity(self):
+        for obj in (7.2, 'hello world', ['a', 'list'], {'a': 'dict'}):
+            self.assertEqual(obj, self.expression(obj))
+
+
 class ConstantExpressionTest(SimpleTestCase):
 
     def test_constant_expression(self):


### PR DESCRIPTION
introduces two new expression types for this - the important one being one that can contain multiple expressions and emits a list of all of them (which can be used to save multiple rows for a single case/form without the need for a repeat)

also adds tests and docs.

@nickpell has some context on why this is needed. cc @NoahCarnahan @emord 
