### PR TITLE
Stable report config uuids

### DIFF
--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -68,14 +68,14 @@ def _create_custom_app_strings(app, lang):
         yield id_strings.module_locale(module), maybe_add_index(trans(module.name))
         if hasattr(module, 'report_configs'):
             for config in module.report_configs:
-                yield id_strings.report_command(config.uuid), trans(config.header)
-                yield id_strings.report_name(config.uuid), config.report.title
+                yield id_strings.report_command(config.config_id), trans(config.header)
+                yield id_strings.report_name(config.config_id), config.report.title
                 yield id_strings.report_menu(), 'Reports'
                 yield id_strings.report_name_header(), 'Report Name'
                 yield id_strings.report_description_header(), 'Report Description'
                 for column in config.report.report_columns:
                     yield (
-                        id_strings.report_column_header(config.uuid, column.column_id),
+                        id_strings.report_column_header(config.config_id, column.column_id),
                         column.get_header(lang)
                     )
 

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2924,20 +2924,20 @@ class ReportAppConfig(DocumentSchema):
         return self._report
 
     @property
-    def uuid(self):
+    def config_id(self):
         return "{}-{}".format(self.report_id, str(self._index))
 
     @property
     def select_detail_id(self):
-        return 'reports.{}.select'.format(self.uuid)
+        return 'reports.{}.select'.format(self.config_id)
 
     @property
     def summary_detail_id(self):
-        return 'reports.{}.summary'.format(self.uuid)
+        return 'reports.{}.summary'.format(self.config_id)
 
     @property
     def data_detail_id(self):
-        return 'reports.{}.data'.format(self.uuid)
+        return 'reports.{}.data'.format(self.config_id)
 
     def get_details(self):
         yield (self.select_detail_id, self.select_details(), True)
@@ -2946,7 +2946,7 @@ class ReportAppConfig(DocumentSchema):
 
     def select_details(self):
         return Detail(custom_xml=suite_xml.Detail(
-            id='reports.{}.select'.format(self.uuid),
+            id='reports.{}.select'.format(self.config_id),
             title=suite_xml.Text(
                 locale=suite_xml.Locale(id=id_strings.report_menu()),
             ),
@@ -2975,7 +2975,7 @@ class ReportAppConfig(DocumentSchema):
 
                     def _column_to_series(column):
                         return suite_xml.Series(
-                            nodeset="instance('reports')/reports/report[@id='{}']/rows/row".format(self.uuid),
+                            nodeset="instance('reports')/reports/report[@id='{}']/rows/row".format(self.config_id),
                             x_function="column[@id='{}']".format(chart_config.x_axis_column),
                             y_function="column[@id='{}']".format(column),
                             configuration=suite_xml.ConfigurationGroup(configs=[
@@ -2999,7 +2999,7 @@ class ReportAppConfig(DocumentSchema):
                     )
 
         return Detail(custom_xml=suite_xml.Detail(
-            id='reports.{}.summary'.format(self.uuid),
+            id='reports.{}.summary'.format(self.config_id),
             title=suite_xml.Text(
                 locale=suite_xml.Locale(id=id_strings.report_menu()),
             ),
@@ -3035,7 +3035,7 @@ class ReportAppConfig(DocumentSchema):
                 header=suite_xml.Header(
                     text=suite_xml.Text(
                         locale=suite_xml.Locale(
-                            id=id_strings.report_column_header(self.uuid, column.column_id)
+                            id=id_strings.report_column_header(self.config_id, column.column_id)
                         ),
                     )
                 ),
@@ -3046,9 +3046,9 @@ class ReportAppConfig(DocumentSchema):
             )
 
         return Detail(custom_xml=suite_xml.Detail(
-            id='reports.{}.data'.format(self.uuid),
+            id='reports.{}.data'.format(self.config_id),
             title=suite_xml.Text(
-                locale=suite_xml.Locale(id=id_strings.report_name(self.uuid)),
+                locale=suite_xml.Locale(id=id_strings.report_name(self.config_id)),
             ),
             fields=[_column_to_field(c) for c in self.report.report_columns]
         ).serialize())
@@ -3057,24 +3057,24 @@ class ReportAppConfig(DocumentSchema):
         return suite_xml.Entry(
             form='fixmeclayton',
             command=suite_xml.Command(
-                id='reports.{}'.format(self.uuid),
+                id='reports.{}'.format(self.config_id),
                 text=suite_xml.Text(
-                    locale=suite_xml.Locale(id=id_strings.report_name(self.uuid)),
+                    locale=suite_xml.Locale(id=id_strings.report_name(self.config_id)),
                 ),
             ),
             datums=[
                 suite_xml.SessionDatum(
                     detail_confirm=self.summary_detail_id,
                     detail_select=self.select_detail_id,
-                    id='report_id_{}'.format(self.uuid),
-                    nodeset="instance('reports')/reports/report[@id='{}']".format(self.uuid),
+                    id='report_id_{}'.format(self.config_id),
+                    nodeset="instance('reports')/reports/report[@id='{}']".format(self.config_id),
                     value='./@id',
                 ),
                 # you are required to select something - even if you don't use it
                 suite_xml.SessionDatum(
                     detail_select=self.data_detail_id,
-                    id='throwaway_{}'.format(self.uuid),
-                    nodeset="instance('reports')/reports/report[@id='{}']/rows/row".format(self.uuid),
+                    id='throwaway_{}'.format(self.config_id),
+                    nodeset="instance('reports')/reports/report[@id='{}']/rows/row".format(self.config_id),
                     value="''",
                 )
 
@@ -3136,7 +3136,7 @@ class ReportModule(ModuleBase):
                 locale=suite_xml.Locale(id=id_strings.module_locale(self))
             ),
             commands=[
-                suite_xml.Command(id=id_strings.report_command(config.uuid))
+                suite_xml.Command(id=id_strings.report_command(config.config_id))
                 for config in self.report_configs
             ]
         )

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2914,6 +2914,7 @@ class ReportAppConfig(DocumentSchema):
     filters = SchemaDictProperty(ReportAppFilter)
 
     _report = None
+    _index = None
 
     @property
     def report(self):
@@ -2924,7 +2925,7 @@ class ReportAppConfig(DocumentSchema):
 
     @property
     def uuid(self):
-        return str(hash(json.dumps(self.to_json(), sort_keys=True)))
+        return "{}-{}".format(self.report_id, str(self._index))
 
     @property
     def select_detail_id(self):

--- a/corehq/apps/app_manager/tests/data/suite/reports_module_data_detail.xml
+++ b/corehq/apps/app_manager/tests/data/suite/reports_module_data_detail.xml
@@ -1,14 +1,14 @@
 <partial>
-  <detail id="reports.-1044519270389493083.data">
+  <detail id="reports.d3ff18cd83adf4550b35db8d391f6008-None.data">
     <title>
       <text>
-        <locale id="cchq.reports.-1044519270389493083.name"/>
+        <locale id="cchq.reports.d3ff18cd83adf4550b35db8d391f6008-None.name"/>
       </text>
     </title>
     <field>
       <header>
         <text>
-          <locale id="cchq.reports.-1044519270389493083.headers.owner"/>
+          <locale id="cchq.reports.d3ff18cd83adf4550b35db8d391f6008-None.headers.owner"/>
         </text>
       </header>
       <template>
@@ -20,7 +20,7 @@
     <field>
       <header>
         <text>
-          <locale id="cchq.reports.-1044519270389493083.headers.count"/>
+          <locale id="cchq.reports.d3ff18cd83adf4550b35db8d391f6008-None.headers.count"/>
         </text>
       </header>
       <template>
@@ -32,7 +32,7 @@
     <field>
       <header>
         <text>
-          <locale id="cchq.reports.-1044519270389493083.headers.is_starred"/>
+          <locale id="cchq.reports.d3ff18cd83adf4550b35db8d391f6008-None.headers.is_starred"/>
         </text>
       </header>
       <template>

--- a/corehq/apps/app_manager/tests/data/suite/reports_module_data_entry.xml
+++ b/corehq/apps/app_manager/tests/data/suite/reports_module_data_entry.xml
@@ -1,24 +1,24 @@
 <partial>
   <entry>
     <form>fixmeclayton</form>
-    <command id="reports.-1044519270389493083">
+    <command id="reports.d3ff18cd83adf4550b35db8d391f6008-None">
       <text>
-        <locale id="cchq.reports.-1044519270389493083.name"/>
+        <locale id="cchq.reports.d3ff18cd83adf4550b35db8d391f6008-None.name"/>
       </text>
     </command>
     <instance id="reports" src="jr://fixture/commcare:reports"/>
     <session>
       <datum
-        id="report_id_-1044519270389493083"
-        nodeset="instance('reports')/reports/report[@id='-1044519270389493083']"
+        id="report_id_d3ff18cd83adf4550b35db8d391f6008-None"
+        nodeset="instance('reports')/reports/report[@id='d3ff18cd83adf4550b35db8d391f6008-None']"
         value="./@id"
-        detail-select="reports.-1044519270389493083.select"
-        detail-confirm="reports.-1044519270389493083.summary"/>
+        detail-select="reports.d3ff18cd83adf4550b35db8d391f6008-None.select"
+        detail-confirm="reports.d3ff18cd83adf4550b35db8d391f6008-None.summary"/>
       <datum
-        id="throwaway_-1044519270389493083"
-        nodeset="instance('reports')/reports/report[@id='-1044519270389493083']/rows/row"
+        id="throwaway_d3ff18cd83adf4550b35db8d391f6008-None"
+        nodeset="instance('reports')/reports/report[@id='d3ff18cd83adf4550b35db8d391f6008-None']/rows/row"
         value="''"
-        detail-select="reports.-1044519270389493083.data"/>
+        detail-select="reports.d3ff18cd83adf4550b35db8d391f6008-None.data"/>
     </session>
   </entry>
 </partial>

--- a/corehq/apps/app_manager/tests/data/suite/reports_module_menu.xml
+++ b/corehq/apps/app_manager/tests/data/suite/reports_module_menu.xml
@@ -3,6 +3,6 @@
     <text>
       <locale id="modules.m0"/>
     </text>
-    <command id="reports.-1044519270389493083"/>
+    <command id="reports.d3ff18cd83adf4550b35db8d391f6008-None"/>
   </menu>
 </partial>

--- a/corehq/apps/app_manager/tests/data/suite/reports_module_select_detail.xml
+++ b/corehq/apps/app_manager/tests/data/suite/reports_module_select_detail.xml
@@ -1,5 +1,5 @@
 <partial>
-  <detail id="reports.-1044519270389493083.select">
+  <detail id="reports.d3ff18cd83adf4550b35db8d391f6008-None.select">
     <title>
       <text>
         <locale id="cchq.report_menu"/>

--- a/corehq/apps/app_manager/tests/data/suite/reports_module_summary_detail.xml
+++ b/corehq/apps/app_manager/tests/data/suite/reports_module_summary_detail.xml
@@ -1,5 +1,5 @@
 <partial>
-  <detail id="reports.-1044519270389493083.summary">
+  <detail id="reports.d3ff18cd83adf4550b35db8d391f6008-None.summary">
     <title>
       <text>
         <locale id="cchq.report_menu"/>
@@ -35,7 +35,7 @@
       </header>
       <template form="graph">
         <graph type="bar">
-          <series nodeset="instance('reports')/reports/report[@id='-1044519270389493083']/rows/row">
+          <series nodeset="instance('reports')/reports/report[@id='d3ff18cd83adf4550b35db8d391f6008-None']/rows/row">
             <configuration/>
             <x function="column[@id='owner']" />
             <y function="column[@id='tickets']" />

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -643,17 +643,17 @@ class SuiteTest(SimpleTestCase, TestFileMixin):
         self.assertXmlPartialEqual(
             self.get_xml('reports_module_select_detail'),
             app.create_suite(),
-            "./detail[@id='reports.-1044519270389493083.select']",
+            "./detail[@id='reports.d3ff18cd83adf4550b35db8d391f6008-None.select']",
         )
         self.assertXmlPartialEqual(
             self.get_xml('reports_module_summary_detail'),
             app.create_suite(),
-            "./detail[@id='reports.-1044519270389493083.summary']",
+            "./detail[@id='reports.d3ff18cd83adf4550b35db8d391f6008-None.summary']",
         )
         self.assertXmlPartialEqual(
             self.get_xml('reports_module_data_detail'),
             app.create_suite(),
-            "./detail[@id='reports.-1044519270389493083.data']",
+            "./detail[@id='reports.d3ff18cd83adf4550b35db8d391f6008-None.data']",
         )
         self.assertXmlPartialEqual(
             self.get_xml('reports_module_data_entry'),
@@ -661,7 +661,7 @@ class SuiteTest(SimpleTestCase, TestFileMixin):
             "./entry",
         )
         self.assertIn(
-            'reports.-1044519270389493083=CommBugz',
+            'reports.d3ff18cd83adf4550b35db8d391f6008-None=CommBugz',
             app.create_app_strings('default'),
         )
 

--- a/corehq/apps/userreports/fixtures.py
+++ b/corehq/apps/userreports/fixtures.py
@@ -66,7 +66,7 @@ class ReportFixturesProvider(object):
         return [root]
 
     def _report_config_to_fixture(self, report_config, user):
-        report_elem = ElementTree.Element('report', attrib={'id': report_config.uuid})
+        report_elem = ElementTree.Element('report', attrib={'id': report_config.config_id})
         report = ReportConfiguration.get(report_config.report_id)
         report_elem.append(self._element('name', report.title))
         report_elem.append(self._element('description', report.description))

--- a/corehq/apps/userreports/fixtures.py
+++ b/corehq/apps/userreports/fixtures.py
@@ -51,9 +51,15 @@ class ReportFixturesProvider(object):
 
         root = ElementTree.Element('fixture', attrib={'id': self.id})
         reports_elem = ElementTree.Element('reports')
+        used_report_configs = []
         for report_config in report_configs:
             try:
+                report_config._index = len(filter(
+                    lambda used_report_config: report_config.report_id == used_report_config.report_id,
+                    used_report_configs
+                ))
                 reports_elem.append(self._report_config_to_fixture(report_config, user))
+                used_report_configs.append(report_config)
             except UserReportsError:
                 pass
         root.append(reports_elem)


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/pull/8000 makes it difficult to reference the fixture in forms, because the uuids can change when filters/graph configs change.
worse, it makes it impossible to refer to one's on report fixture in a graph config, since adding the uuid to the graph config ends up changing the config.

instead, go with a scheme that only depends on the report's order in the fixture and id.

@czue @dannyroberts @orangejenny 
