### PR TITLE
Fix report builder filter format selection

### DIFF
--- a/corehq/apps/userreports/reports/builder/__init__.py
+++ b/corehq/apps/userreports/reports/builder/__init__.py
@@ -188,3 +188,15 @@ def get_form_indicator_data_type(question_type):
         "Text": "string",
         "string": "string",
     }.get(question_type, "string")
+
+
+def get_filter_format_from_question_type(question_type):
+    return {
+        "Date": 'date',
+        "DateTime": "date",
+        "date": "date",  # Actually a meta property type
+        "dateime": "date",  # Actually a meta property type
+        "Text": "dynamic_choice_list",
+        "Int": "numeric",
+        "Double": "numeric",
+    }.get(question_type, "dynamic_choice_list")

--- a/corehq/apps/userreports/reports/builder/__init__.py
+++ b/corehq/apps/userreports/reports/builder/__init__.py
@@ -12,11 +12,11 @@ FORM_QUESTION_DATATYPE_MAP = {
 }
 
 FORM_METADATA_PROPERTIES = [
-    ('username', 'string'),
-    ('userID', 'string'),
-    ('timeStart', 'datetime'),
-    ('timeEnd', 'datetime'),
-    ('deviceID', 'string'),
+    ('username', 'Text'),
+    ('userID', 'Text'),
+    ('timeStart', 'DateTime'),
+    ('timeEnd', 'DateTime'),
+    ('deviceID', 'Text'),
 ]
 
 
@@ -194,8 +194,6 @@ def get_filter_format_from_question_type(question_type):
     return {
         "Date": 'date',
         "DateTime": "date",
-        "date": "date",  # Actually a meta property type
-        "dateime": "date",  # Actually a meta property type
         "Text": "dynamic_choice_list",
         "Int": "numeric",
         "Double": "numeric",

--- a/corehq/apps/userreports/reports/builder/__init__.py
+++ b/corehq/apps/userreports/reports/builder/__init__.py
@@ -154,8 +154,8 @@ def make_form_question_indicator(question, column_id=None):
         "column_id": column_id or question['value'],
         'property_path': ['form'] + path[2:],
         "display_name": path[-1],
+        "datatype": get_form_indicator_data_type(data_type),
     }
-    ret.update(_get_form_indicator_data_type(data_type))
     return ret
 
 
@@ -172,12 +172,19 @@ def make_form_meta_block_indicator(spec, column_id=None):
         "column_id": column_id,
         "property_path": ['form', 'meta'] + [field_name],
         "display_name": field_name,
+        "datatype": get_form_indicator_data_type(data_type),
     }
-    ret.update(_get_form_indicator_data_type(data_type))
     return ret
 
 
-def _get_form_indicator_data_type(data_type):
-    if data_type in ["date", "datetime"]:
-        return {"datatype": data_type}
-    return {"datatype": "string"}
+def get_form_indicator_data_type(question_type):
+    return {
+        "date": "date",
+        "datetime": "datetime",
+        "Date": "date",
+        "DateTime": "datetime",
+        "Int": "integer",
+        "Double": "decimal",
+        "Text": "string",
+        "string": "string",
+    }.get(question_type, "string")

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -41,6 +41,7 @@ from corehq.apps.userreports.reports.builder import (
     make_form_meta_block_indicator,
     make_form_question_indicator,
     make_owner_name_indicator,
+    get_filter_format_from_question_type
 )
 from corehq.apps.userreports.exceptions import BadBuilderConfigError
 from corehq.apps.userreports.sql import get_column_name
@@ -56,7 +57,7 @@ class FilterField(JsonField):
     def validate(self, value):
         super(FilterField, self).validate(value)
         for filter_conf in value:
-            if filter_conf.get('format', None) not in ['Choice', 'Date', 'Numeric']:
+            if filter_conf.get('format', None) not in ['', 'Choice', 'Date', 'Numeric']:
                 raise forms.ValidationError("Invalid filter format!")
 
 
@@ -730,12 +731,27 @@ class ConfigureNewReportBase(forms.Form):
         }
 
         def _make_report_filter(conf, index):
-            col_id = self.data_source_properties[conf["property"]]['column_id']
+            property = self.data_source_properties[conf["property"]]
+            col_id = property['column_id']
+
+            selected_filter_type = conf['format']
+            if not selected_filter_type:
+                if property['type'] == 'question':
+                    filter_format = get_filter_format_from_question_type(
+                        property['source']['type']
+                    )
+                else:  #property['type'] == 'meta':
+                    filter_format = get_filter_format_from_question_type(
+                        property['source'][1]
+                    )
+            else:
+                filter_format = filter_type_map[selected_filter_type]
+
             ret = {
                 "field": col_id,
                 "slug": "{}-{}".format(col_id, index),
                 "display": conf["display_text"],
-                "type": filter_type_map[conf['format']]
+                "type": filter_format
             }
             if conf['format'] == 'Date':
                 ret.update({'compare_as_string': True})

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -740,7 +740,8 @@ class ConfigureNewReportBase(forms.Form):
                     filter_format = get_filter_format_from_question_type(
                         property['source']['type']
                     )
-                else:  #property['type'] == 'meta':
+                else:
+                    assert property['type'] == 'meta'
                     filter_format = get_filter_format_from_question_type(
                         property['source'][1]
                     )

--- a/corehq/apps/userreports/templates/userreports/partials/report_builder_configure_report.html
+++ b/corehq/apps/userreports/templates/userreports/partials/report_builder_configure_report.html
@@ -154,7 +154,7 @@
             });
             // TODO: Pass help texts from template so that they can be translated.
             this.filtersList = new propertyList({
-                hasFormatCol: true,
+                hasFormatCol: {% if form.source_type == "case" %}true{% else %}false{% endif %},
                 initialCols: initialFilters,
                 buttonText: 'Add Filter',
                 propertyHelpText: '{{ filter_property_help_text|escapejs}}',

--- a/corehq/apps/userreports/templates/userreports/partials/report_builder_configure_report.html
+++ b/corehq/apps/userreports/templates/userreports/partials/report_builder_configure_report.html
@@ -106,7 +106,7 @@
             this.formatHelpText = options.formatHelpText !== undefined ? options.formatHelpText : null;
 
             this.hasFormatCol = ko.observable(options.hasFormatCol !== undefined ? options.hasFormatCol : true);
-            this.formatOptions = ko.observableArray(["Choice", "Date", "Numeric"]);
+            this.formatOptions = ko.observableArray(["Choice", "Date"]);
             this.propertyOptions = ko.observableArray({{ property_options|JSON }});
             var rawOptions = {{ property_options|JSON }};
             this.optionsContainQuestions = _.any(rawOptions, function (o) {

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -248,7 +248,7 @@ class ConfigureChartReport(ReportBuilderView):
             ],
             'filter_property_help_text': _('Choose the property you would like to add as a filter to this report.'),
             'filter_display_help_text': _('Web users viewing the report will see this display text instead of the property name. Name your filter something easy for users to understand.'),
-            'filter_format_help_text': _('What type of property is this filter?<br/><br/><strong>Date</strong>: select this if the property is a date.<br/><strong>Choice</strong>: select this if the property is text or multiple choice.<br/><strong>Numeric</strong>: select this if the property is a number.'),
+            'filter_format_help_text': _('What type of property is this filter?<br/><br/><strong>Date</strong>: select this if the property is a date.<br/><strong>Choice</strong>: select this if the property is text or multiple choice.'),
         }
         return context
 


### PR DESCRIPTION
This PR makes the following changes to the report builder:
- Form based reports/data sources use the form question type to decide the data source indicator data type.
- Users no longer select a format for filter on form based reports. The format matching the indicator data type is used instead.
- Remove the "Numeric" filter type option from case based reports (because all indicators have a data type of string in case based reports)

Can be reviewed commit-by-commit.

cc @snopoke FYI @czue 
Addresses http://manage.dimagi.com/default.asp?179783
