### PR TITLE
Remove dropbox toggle

### DIFF
--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -620,13 +620,6 @@ HSPH_HACK = StaticToggle(
     [NAMESPACE_DOMAIN],
 )
 
-DROPBOX_SYNC = StaticToggle(
-    'dropbox_sync',
-    'Allows users to sync their file downloads to Dropbox',
-    TAG_PRODUCT_PATH,
-    [NAMESPACE_DOMAIN, NAMESPACE_USER],
-)
-
 EMAIL_IN_REMINDERS = StaticToggle(
     'email_in_reminders',
     'Send emails from reminders',


### PR DESCRIPTION
@dimagi/product Dropbox toggle removed and added a bit more HTML formatting to message:
<img width="597" alt="screen shot 2015-08-27 at 10 27 53 am" src="https://cloud.githubusercontent.com/assets/918514/9523229/ee27a9b6-4ca6-11e5-977c-c408d26aea8d.png">

corresponding PR: https://github.com/dimagi/django-soil/pull/31
buddy: @biyeun 
