### PR TITLE
Report config uuids

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/report-module.js
+++ b/corehq/apps/app_manager/static/app_manager/js/report-module.js
@@ -2,8 +2,16 @@
 //       also defined corehq.apps.userreports.reports.filters.CHOICE_DELIMITER
 var select2Separator = "\u001F";
 
-var ReportModule = (function () {
+var makeUUID = function () {
+    var str = '';
+    // Composed of two 16-char strings
+    for(var i = 0; i < 2; i++) {
+        str += Math.random().toString(36).substring(2);
+    }
+    return str;
+};
 
+var ReportModule = (function () {
     function Config(dict) {
         var self = this;
 
@@ -207,7 +215,7 @@ var ReportModule = (function () {
         this.date_range_options = ['last7', 'last30', 'lastmonth', 'lastyear'];
     }
 
-    function ReportConfig(report_id, display, availableReportIds,
+    function ReportConfig(report_id, display, uuid, availableReportIds,
                           reportCharts, graph_configs,
                           filterValues, reportFilters,
                           language, changeSaveButton) {
@@ -216,6 +224,7 @@ var ReportModule = (function () {
         this.fullDisplay = display || {};
         this.availableReportIds = availableReportIds;
         this.display = ko.observable(this.fullDisplay[this.lang]);
+        this.uuid = uuid || makeUUID();
         this.reportId = ko.observable(report_id);
         this.graphConfig = new GraphConfig(report_id, this.reportId, availableReportIds, reportCharts, graph_configs, changeSaveButton);
         this.filterConfig = new FilterConfig(report_id, this.reportId, filterValues, reportFilters, changeSaveButton);
@@ -226,7 +235,8 @@ var ReportModule = (function () {
                 report_id: self.reportId(),
                 graph_configs: self.graphConfig.toJSON(),
                 filters: self.filterConfig.toJSON(),
-                header: self.fullDisplay
+                header: self.fullDisplay,
+                uuid: self.uuid
             };
         };
     }
@@ -291,6 +301,7 @@ var ReportModule = (function () {
             var report = new ReportConfig(
                 options.report_id,
                 options.header,
+                options.uuid,
                 self.availableReportIds,
                 self.reportCharts,
                 options.graph_configs,

--- a/corehq/apps/app_manager/tests/data/suite/reports_module_data_detail.xml
+++ b/corehq/apps/app_manager/tests/data/suite/reports_module_data_detail.xml
@@ -1,14 +1,14 @@
 <partial>
-  <detail id="reports.-1044519270389493083.data">
+  <detail id="reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.data">
     <title>
       <text>
-        <locale id="cchq.reports.-1044519270389493083.name"/>
+        <locale id="cchq.reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.name"/>
       </text>
     </title>
     <field>
       <header>
         <text>
-          <locale id="cchq.reports.-1044519270389493083.headers.owner"/>
+          <locale id="cchq.reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.headers.owner"/>
         </text>
       </header>
       <template>
@@ -20,7 +20,7 @@
     <field>
       <header>
         <text>
-          <locale id="cchq.reports.-1044519270389493083.headers.count"/>
+          <locale id="cchq.reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.headers.count"/>
         </text>
       </header>
       <template>
@@ -32,7 +32,7 @@
     <field>
       <header>
         <text>
-          <locale id="cchq.reports.-1044519270389493083.headers.is_starred"/>
+          <locale id="cchq.reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.headers.is_starred"/>
         </text>
       </header>
       <template>

--- a/corehq/apps/app_manager/tests/data/suite/reports_module_data_entry.xml
+++ b/corehq/apps/app_manager/tests/data/suite/reports_module_data_entry.xml
@@ -1,24 +1,24 @@
 <partial>
   <entry>
     <form>fixmeclayton</form>
-    <command id="reports.-1044519270389493083">
+    <command id="reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i">
       <text>
-        <locale id="cchq.reports.-1044519270389493083.name"/>
+        <locale id="cchq.reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.name"/>
       </text>
     </command>
     <instance id="reports" src="jr://fixture/commcare:reports"/>
     <session>
       <datum
-        id="report_id_-1044519270389493083"
-        nodeset="instance('reports')/reports/report[@id='-1044519270389493083']"
+        id="report_id_ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i"
+        nodeset="instance('reports')/reports/report[@id='ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i']"
         value="./@id"
-        detail-select="reports.-1044519270389493083.select"
-        detail-confirm="reports.-1044519270389493083.summary"/>
+        detail-select="reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.select"
+        detail-confirm="reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.summary"/>
       <datum
-        id="throwaway_-1044519270389493083"
-        nodeset="instance('reports')/reports/report[@id='-1044519270389493083']/rows/row"
+        id="throwaway_ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i"
+        nodeset="instance('reports')/reports/report[@id='ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i']/rows/row"
         value="''"
-        detail-select="reports.-1044519270389493083.data"/>
+        detail-select="reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.data"/>
     </session>
   </entry>
 </partial>

--- a/corehq/apps/app_manager/tests/data/suite/reports_module_menu.xml
+++ b/corehq/apps/app_manager/tests/data/suite/reports_module_menu.xml
@@ -3,6 +3,6 @@
     <text>
       <locale id="modules.m0"/>
     </text>
-    <command id="reports.-1044519270389493083"/>
+    <command id="reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i"/>
   </menu>
 </partial>

--- a/corehq/apps/app_manager/tests/data/suite/reports_module_select_detail.xml
+++ b/corehq/apps/app_manager/tests/data/suite/reports_module_select_detail.xml
@@ -1,5 +1,5 @@
 <partial>
-  <detail id="reports.-1044519270389493083.select">
+  <detail id="reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.select">
     <title>
       <text>
         <locale id="cchq.report_menu"/>

--- a/corehq/apps/app_manager/tests/data/suite/reports_module_summary_detail.xml
+++ b/corehq/apps/app_manager/tests/data/suite/reports_module_summary_detail.xml
@@ -1,5 +1,5 @@
 <partial>
-  <detail id="reports.-1044519270389493083.summary">
+  <detail id="reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.summary">
     <title>
       <text>
         <locale id="cchq.report_menu"/>
@@ -35,7 +35,7 @@
       </header>
       <template form="graph">
         <graph type="bar">
-          <series nodeset="instance('reports')/reports/report[@id='-1044519270389493083']/rows/row">
+          <series nodeset="instance('reports')/reports/report[@id='ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i']/rows/row">
             <configuration/>
             <x function="column[@id='owner']" />
             <y function="column[@id='tickets']" />

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -667,8 +667,11 @@ class SuiteTest(SimpleTestCase, TestFileMixin):
         report = get_sample_report_config()
         report._id = 'd3ff18cd83adf4550b35db8d391f6008'
 
-        report_app_config = ReportAppConfig(report_id=report._id,
-                                            header={'en': 'CommBugz'})
+        report_app_config = ReportAppConfig(
+            report_id=report._id,
+            header={'en': 'CommBugz'},
+            uuid='ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i',
+        )
         report_app_config._report = report
         report_module.report_configs = [report_app_config]
         report_module._loaded = True
@@ -680,17 +683,17 @@ class SuiteTest(SimpleTestCase, TestFileMixin):
         self.assertXmlPartialEqual(
             self.get_xml('reports_module_select_detail'),
             app.create_suite(),
-            "./detail[@id='reports.-1044519270389493083.select']",
+            "./detail[@id='reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.select']",
         )
         self.assertXmlPartialEqual(
             self.get_xml('reports_module_summary_detail'),
             app.create_suite(),
-            "./detail[@id='reports.-1044519270389493083.summary']",
+            "./detail[@id='reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.summary']",
         )
         self.assertXmlPartialEqual(
             self.get_xml('reports_module_data_detail'),
             app.create_suite(),
-            "./detail[@id='reports.-1044519270389493083.data']",
+            "./detail[@id='reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.data']",
         )
         self.assertXmlPartialEqual(
             self.get_xml('reports_module_data_entry'),
@@ -698,7 +701,7 @@ class SuiteTest(SimpleTestCase, TestFileMixin):
             "./entry",
         )
         self.assertIn(
-            'reports.-1044519270389493083=CommBugz',
+            'reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i=CommBugz',
             app.create_app_strings('default'),
         )
 


### PR DESCRIPTION
A better fix for http://manage.dimagi.com/default.asp?178654

Automatically assigns random UUIDs in JS when a report is added to an app.  If UUIDs are missing, they are added when the report module is resaved.

Would like to get in before deploy or in a hotfix deploy once merged.

@dannyroberts @czue @orangejenny 
