### PR TITLE
Custom scheduled subject

### DIFF
--- a/corehq/apps/reports/forms.py
+++ b/corehq/apps/reports/forms.py
@@ -8,6 +8,7 @@ from corehq.apps.userreports.reports.view import ConfigurableReport
 from crispy_forms import layout as crispy
 from crispy_forms.helper import FormHelper
 from .models import (
+    DEFAULT_REPORT_NOTIF_SUBJECT,
     ReportConfig,
     ReportNotification,
 )
@@ -124,6 +125,15 @@ class ScheduledReportForm(forms.Form):
         label='Other recipients',
         required=False)
 
+    use_custom_email_subject = forms.BooleanField(
+        required=False,
+    )
+
+    custom_email_subject = forms.CharField(
+        required=False,
+        help_text='Defaults to "%s".' % DEFAULT_REPORT_NOTIF_SUBJECT,
+    )
+
     language = forms.ChoiceField(
         label='Language',
         required=False,
@@ -145,6 +155,11 @@ class ScheduledReportForm(forms.Form):
                 'attach_excel',
                 'recipient_emails',
                 'language',
+                crispy.Field('use_custom_email_subject', data_bind="checked: useCustomEmailSubject"),
+                crispy.Div(
+                    crispy.Field('custom_email_subject'),
+                    data_bind="visible: useCustomEmailSubject",
+                ),
                 crispy.HTML(
                     render_to_string('reports/partials/privacy_disclaimer.html')
                 )

--- a/corehq/apps/reports/templates/reports/edit_scheduled_report.html
+++ b/corehq/apps/reports/templates/reports/edit_scheduled_report.html
@@ -79,6 +79,11 @@ $(function(){
         day_value: {{ day_value }}
     });
     scheduled_report_form_helper.init();
+
+    var scheduledReportFormModel = {
+        useCustomEmailSubject: ko.observable({{ use_custom_email_subject|yesno:"true,false" }})
+    };
+    ko.applyBindings(scheduledReportFormModel, $('#id-scheduledReportForm').get(0));
 </script>
 <script type="text/javascript">
     $('#id-scheduledReportForm').submit(function() {

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -805,6 +805,7 @@ def edit_scheduled_report(request, domain, scheduled_report_id=None,
     context['day_value'] = getattr(instance, "day", 1)
     context['weekly_day_options'] = ReportNotification.day_choices()
     context['monthly_day_options'] = [(i, i) for i in range(1, 32)]
+    context['use_custom_email_subject'] = instance.use_custom_email_subject
     if is_new:
         context['form_action'] = _("Create a new")
         context['report']['title'] = _("New Scheduled Report")


### PR DESCRIPTION
(For Abt) Allows specifying a custom subject line in the email sent by Scheduled Reports.

Screenshot 1)

<img width="473" alt="screen shot 2015-08-27 at 3 21 26 pm" src="https://cloud.githubusercontent.com/assets/1757035/9530754/b8173cbe-4ccf-11e5-9cb6-de85be5b7acb.png">

Screenshot 2)

<img width="487" alt="screen shot 2015-08-27 at 3 22 05 pm" src="https://cloud.githubusercontent.com/assets/1757035/9530758/b98108a0-4ccf-11e5-939a-477f23d37a42.png">

Holding off merge for feedback from @dimagi/product 

@dannyroberts 
