### PR TITLE
fix sync assertion when it falls back to user id

### DIFF
--- a/corehq/apps/users/cases.py
+++ b/corehq/apps/users/cases.py
@@ -8,8 +8,10 @@ from corehq.apps.hqcase.utils import assign_cases
 def user_db():
     return CouchUser.get_db()
 
+
 def get_owner_id(case):
-    return case.owner_id if case.owner_id is not None else case.user_id
+    return case.owner_id or case.user_id
+
 
 def get_wrapped_owner(owner_id):
     """

--- a/corehq/ex-submodules/casexml/apps/case/xml/generator.py
+++ b/corehq/ex-submodules/casexml/apps/case/xml/generator.py
@@ -139,9 +139,8 @@ class V2CaseXMLGenerator(CaseXMLGeneratorBase):
 
     def add_base_properties(self, element):
         super(V2CaseXMLGenerator, self).add_base_properties(element)
-        # owner id introduced in v2
-        # default to user_id for 1.3 compatibility
-        element.append(safe_element('owner_id', self.case.owner_id or self.case.user_id))
+        from corehq.apps.users.cases import get_owner_id
+        element.append(safe_element('owner_id', get_owner_id(self.case)))
 
     def add_custom_properties(self, element):
         if self.case.external_id:

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -565,6 +565,16 @@ class SyncTokenUpdateTest(SyncBaseTest):
         self.assertFalse(last_sync.phone_is_holding_case(case_id))
 
     @run_with_all_restore_configs
+    def test_sync_by_user_id(self):
+        # create a case with an empty owner but valid user id
+        case_id = self.factory.create_case(owner_id='', user_id=USER_ID)._id
+        restore_config = RestoreConfig(self.project, user=self.user)
+        payload = restore_config.get_payload().as_string()
+        self.assertTrue(case_id in payload)
+        sync_log = synclog_from_restore_payload(payload)
+        self.assertTrue(sync_log.phone_is_holding_case(case_id))
+
+    @run_with_all_restore_configs
     def test_create_irrelevant_owner_and_update_to_irrelevant_owner_in_same_form(self):
         # this tests an edge case that used to crash on submission which is why there are no asserts
         self.factory.create_case(owner_id='irrelevant_1', update={'owner_id': 'irrelevant_2'}, strict=False)


### PR DESCRIPTION
bugs are getting more and more obscure (hopefully?)
