### PR TITLE
remove email opt-in

### DIFF
--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -81,8 +81,6 @@ def _link_account_with_cookie(form_id, webuser, cookies, meta):
             'lastname': webuser.last_name,
             'hs_context': json.dumps({"hutk": hubspot_cookie, "ipAddress": _get_client_ip(meta)}),
         }
-        if 'opt_into_emails' in meta:
-            data['opt_into_emails'] = meta['opt_into_emails']
 
         req = requests.post(
             url,

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -55,10 +55,6 @@ class NewWebUserRegistrationForm(DomainRegistrationForm):
     password = forms.CharField(label=_('Create Password'),
                                max_length=max_pwd,
                                widget=forms.PasswordInput(render_value=False))
-    email_opt_in = forms.BooleanField(required=False,
-                                      initial=True,
-                                      label="",
-                                      help_text=_("Opt into our monthly newsletter about new features and other CommCare updates."))
     create_domain = forms.BooleanField(widget=forms.HiddenInput(), required=False, initial=False)
     # Must be set to False to have the clean_*() routine called
     eula_confirmed = forms.BooleanField(required=False,

--- a/corehq/apps/registration/templates/registration/create_new_user.html
+++ b/corehq/apps/registration/templates/registration/create_new_user.html
@@ -21,7 +21,6 @@
             {% include "registration/partials/field.html" with field=form.email %}
             {% include "registration/partials/field.html" with field=form.password %}
             {% include "registration/partials/field.html" with field=form.hr_name %}
-            {% include "registration/partials/field.html" with field=form.email_opt_in %}
             {% include "registration/partials/field.html" with field=form.eula_confirmed %}
             {% for hidden in form.hidden_fields %}
                 {{ hidden }}

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -129,7 +129,6 @@ def activate_new_user(form, is_domain_admin=True, domain=None, ip=None):
     username = form.cleaned_data['email']
     password = form.cleaned_data['password']
     full_name = form.cleaned_data['full_name']
-    email_opt_in = form.cleaned_data['email_opt_in']
     now = datetime.utcnow()
 
     new_user = WebUser.create(domain, username, password, is_admin=is_domain_admin)
@@ -152,15 +151,14 @@ def activate_new_user(form, is_domain_admin=True, domain=None, ip=None):
         _log_mailchimp_error(e)
 
     new_user.subscribed_to_commcare_users = False
-    if email_opt_in:
-        try:
-            safe_subscribe_user_to_mailchimp_list(
-                new_user,
-                settings.MAILCHIMP_COMMCARE_USERS_ID
-            )
-            new_user.subscribed_to_commcare_users = True
-        except Exception as e:
-            _log_mailchimp_error(e)
+    try:
+        safe_subscribe_user_to_mailchimp_list(
+            new_user,
+            settings.MAILCHIMP_COMMCARE_USERS_ID
+        )
+        new_user.subscribed_to_commcare_users = True
+    except Exception as e:
+        _log_mailchimp_error(e)
 
     new_user.eula.signed = True
     new_user.eula.date = now

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -76,7 +76,6 @@ def register_user(request, domain_type=None):
                 meta = {
                     'HTTP_X_FORWARDED_FOR': request.META.get('HTTP_X_FORWARDED_FOR'),
                     'REMOTE_ADDR': request.META.get('REMOTE_ADDR'),
-                    'opt_into_emails': form.cleaned_data['email_opt_in'],
                 }
                 track_created_hq_account_on_hubspot.delay(new_user, request.COOKIES, meta)
                 requested_domain = form.cleaned_data['hr_name']

--- a/corehq/apps/users/templates/users/accept_invite_base.html
+++ b/corehq/apps/users/templates/users/accept_invite_base.html
@@ -68,7 +68,6 @@
                         {% include "users/partial/field.html" with field=form.email %}
                         {% include "users/partial/field.html" with field=form.password %}
                         {% include "users/partial/field.html" with field=form.hr_name %}
-                        {% include "users/partial/field.html" with field=form.email_opt_in %}
                         {% include "users/partial/field.html" with field=form.eula_confirmed %}
                     </fieldset>
                     <div class="form-actions">


### PR DESCRIPTION
people can still opt out later

http://manage.dimagi.com/default.asp?180631
@amsagoff @gjavetski is there an "opt_into_emails" field that you use for analytics? If there was, it now won't get sent.
