### PR TITLE
Expose case_tag for autoload in advanced case management

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/case_config_advanced.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_config_advanced.html
@@ -225,6 +225,9 @@
                 "></select>
                 <!-- ko template: {name: 'auto-select:' + mode()} --><!-- /ko -->
                 <!-- /ko -->
+                &nbsp;
+                {% trans "Case Tag:" %}
+                <input type="text" class="input-medium" data-bind="value: case_tag, disable: disable_tag" />
                 <span class="help-inline" data-bind="text: validate"></span>
                 <a href="#" data-bind="openModal: 'remove-action-modal-template', visible: true" class="pull-right">
                     <i class="icon-trash"></i>


### PR DESCRIPTION
[FB 180869](http://manage.dimagi.com/default.asp?180869)

Pretty small change, because case_tag is already a KnockOut Observable. This change just exposes it in the autoload form the same way it's exposed in the normal load/update case form.

@snopoke, cc @sheelio, @gcapalbo 

![autoload_case_tag_set](https://cloud.githubusercontent.com/assets/708421/9630983/1745e4e4-517e-11e5-982b-59c754950500.png)
