### PR TITLE
shorten table_id to avoid error

### DIFF
--- a/custom/abt/reports/data_sources/supervisory.json
+++ b/custom/abt/reports/data_sources/supervisory.json
@@ -313,6 +313,6 @@
         "display_name": "Supervisory Indicators",
         "named_filters": {},
         "referenced_doc_type": "XFormInstance",
-        "table_id": "static-supervisory-indicators"
+        "table_id": "supervisory"
     }
 }

--- a/custom/abt/reports/incident_report.json
+++ b/custom/abt/reports/incident_report.json
@@ -5,7 +5,7 @@
         "airsmadagascar",
         "airsethiopia"
     ],
-   "data_source_table":"static-supervisory-indicators",
+   "data_source_table":"supervisory",
    "report_id":"incident-report",
    "config":{
       "domain":"abtmali",


### PR DESCRIPTION
@NoahCarnahan 

fixes local issue that will happen on prod:

```
CustomDataSourcePillow().bootstrap()
...
IdentifierError: Identifier 'config_report_airsmadagascar_static-supervisory-indicators_71388103' exceeds maximum length of 63 characters
```

I'll also add some validation later (http://manage.dimagi.com/default.asp?181046) but this quick fix should make it into the deploy.  (no test coverage)
