### PR TITLE
remove ownership cleanliness submission toggle and related code/tests

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/tests/restore_test_utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/restore_test_utils.py
@@ -58,15 +58,6 @@ run_with_all_restore_configs = functools.partial(
             },
             post_run=lambda *args, **kwargs: args[0].tearDown()
         ),
-        # clean restore code but without cleanliness flags
-        RunConfig(
-            settings={
-                'TESTS_SHOULD_USE_CLEAN_RESTORE': True,
-                'TESTS_SHOULD_TRACK_CLEANLINESS': False,
-            },
-            pre_run=lambda *args, **kwargs: args[0].setUp(),
-            post_run=lambda *args, **kwargs: args[0].tearDown()
-        ),
         # clean restore code with cleanliness flags
         RunConfig(
             settings={

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_cleanliness.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_cleanliness.py
@@ -11,7 +11,6 @@ from casexml.apps.phone.restore import RestoreState, RestoreParams
 from casexml.apps.phone.tests.test_sync_mode import SyncBaseTest
 from corehq.apps.domain.models import Domain
 from corehq.apps.users.models import CommCareUser
-from corehq.toggles import OWNERSHIP_CLEANLINESS
 
 
 @override_settings(TESTS_SHOULD_TRACK_CLEANLINESS=None)
@@ -19,8 +18,6 @@ class OwnerCleanlinessTest(SyncBaseTest):
 
     def setUp(self):
         super(OwnerCleanlinessTest, self).setUp()
-        # ensure that randomization is on
-        OWNERSHIP_CLEANLINESS.randomness = 1
         self.owner_id = uuid.uuid4().hex
         self.synclog_id = uuid.uuid4().hex
         self.domain = uuid.uuid4().hex
@@ -142,13 +139,6 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self.assert_owner_dirty()
         self.assertEqual(self.child._id, self.owner_cleanliness.hint)
         self._verify_set_cleanliness_flags()
-
-    def test_toggle(self):
-        # make sure the flag gets removed
-        OWNERSHIP_CLEANLINESS.randomness = 0
-        # and any test that normally expects a flag to be set to fail
-        with self.assertRaises(AssertionError):
-            self.test_create_dirty_makes_dirty()
 
     def test_set_flag_clean_no_data(self):
         unused_owner_id = uuid.uuid4().hex

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -463,15 +463,6 @@ ENABLE_LOADTEST_USERS = StaticToggle(
     help_link='https://confluence.dimagi.com/display/ccinternal/Loadtest+Users',
 )
 
-OWNERSHIP_CLEANLINESS = PredictablyRandomToggle(
-    'enable_owner_cleanliness_flags',
-    'Enable tracking ownership cleanliness on submission',
-    TAG_EXPERIMENTAL,
-    randomness=.20,
-    namespaces=[NAMESPACE_DOMAIN],
-    help_link='https://docs.google.com/a/dimagi.com/document/d/12WfZLerFL832LZbMwqRAvXt82scdjDL51WZVNa31f28/edit#heading=h.gu9sjekp0u2p',
-)
-
 OWNERSHIP_CLEANLINESS_RESTORE = StaticToggle(
     'enable_owner_cleanliness_restore',
     'Enable restoring with updated owner cleanliness logic.',


### PR DESCRIPTION
@snopoke @dannyroberts 

this is just the flag that starts tracking it on submission. new restore is still only enabled for a small subset of domains.
