### PR TITLE
Usercase exchange

### DIFF
--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -483,6 +483,8 @@ def advanced_actions_use_usercase(actions):
 def enable_usercase(domain_name):
     with CriticalSection(['enable_usercase_' + domain_name]):
         domain = Domain.get_by_name(domain_name, strict=True)
+        if not domain: # copying domains passes in an id before name is saved
+            domain = Domain.get(domain_name)
         if not domain.usercase_enabled:
             domain.usercase_enabled = True
             domain.save()

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -483,7 +483,7 @@ def advanced_actions_use_usercase(actions):
 def enable_usercase(domain_name):
     with CriticalSection(['enable_usercase_' + domain_name]):
         domain = Domain.get_by_name(domain_name, strict=True)
-        if not domain: # copying domains passes in an id before name is saved
+        if not domain:  # copying domains passes in an id before name is saved
             domain = Domain.get(domain_name)
         if not domain.usercase_enabled:
             domain.usercase_enabled = True

--- a/corehq/apps/domain/tests/__init__.py
+++ b/corehq/apps/domain/tests/__init__.py
@@ -6,3 +6,4 @@ from .test_domain_name_generation import *
 from .test_domain_transfer import *
 from .test_delete_domain import *
 from .test_guess_phone_type import *
+from .test_domain_copy import *

--- a/corehq/apps/domain/tests/test_domain_copy.py
+++ b/corehq/apps/domain/tests/test_domain_copy.py
@@ -2,23 +2,23 @@ from __future__ import print_function, unicode_literals
 
 from django.test import TestCase
 
-from corehq.apps.domain.exceptions import NameUnavailableException
 from corehq.apps.domain.models import Domain
 
 from corehq.apps.app_manager.models import Application, Module
 from corehq.apps.app_manager.const import APP_V2
 
+
 class DomainCopyTest(TestCase):
     def setUp(self):
         self.domain = Domain(name='test')
-        self.domain.save();
+        self.domain.save()
         app = Application.new_app(
             'test', "Test Application", lang='en',
             application_version=APP_V2
         )
         module = Module.new_module("Untitled Module", 'en')
         app.add_module(module)
-        form = app.new_form(0, "Untitled Form", 'en')
+        app.new_form(0, "Untitled Form", 'en')
         app.save()
 
     def tearDown(self):

--- a/corehq/apps/domain/tests/test_domain_copy.py
+++ b/corehq/apps/domain/tests/test_domain_copy.py
@@ -1,0 +1,35 @@
+from __future__ import print_function, unicode_literals
+
+from django.test import TestCase
+
+from corehq.apps.domain.exceptions import NameUnavailableException
+from corehq.apps.domain.models import Domain
+
+from corehq.apps.app_manager.models import Application, Module
+from corehq.apps.app_manager.const import APP_V2
+
+class DomainCopyTest(TestCase):
+    def setUp(self):
+        self.domain = Domain(name='test')
+        self.domain.save();
+        app = Application.new_app(
+            'test', "Test Application", lang='en',
+            application_version=APP_V2
+        )
+        module = Module.new_module("Untitled Module", 'en')
+        app.add_module(module)
+        form = app.new_form(0, "Untitled Form", 'en')
+        app.save()
+
+    def tearDown(self):
+        self.domain.delete()
+
+    def test_base(self):
+        new_domain = self.domain.save_copy()
+        new_domain.delete()
+
+    def test_usercase_enabled(self):
+        self.domain.usercase_enabled = True
+        self.domain.save()
+        new_domain = self.domain.save_copy()
+        new_domain.delete()


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?180874#1006732

Not sure this is the best way to fix this, but when copying domains domains don't have names until after import_app happens

https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/domain/models.py#L703-L760

cc: @czue 
