### PR TITLE
add last_sync datetime to reports fixture

### DIFF
--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -81,6 +81,7 @@ def _create_custom_app_strings(app, lang, for_default=False):
                 yield id_strings.report_menu(), 'Reports'
                 yield id_strings.report_name_header(), 'Report Name'
                 yield id_strings.report_description_header(), 'Report Description'
+                yield id_strings.report_last_sync(), 'Last Sync'
                 for column in config.report.report_columns:
                     yield (
                         id_strings.report_column_header(config.uuid, column.column_id),

--- a/corehq/apps/app_manager/id_strings.py
+++ b/corehq/apps/app_manager/id_strings.py
@@ -181,6 +181,11 @@ def report_name(report_id):
     return u'cchq.reports.{report_id}.name'.format(report_id=report_id)
 
 
+@pattern('cchq.report_last_sync')
+def report_last_sync():
+    return u'cchq.report_last_sync'
+
+
 CUSTOM_APP_STRINGS_RE = _regex_union(REGEXES)
 
 

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -3399,7 +3399,22 @@ class ReportAppConfig(DocumentSchema):
                             xpath=suite_xml.Xpath(function='description'))
                     ),
                 ),
-            ] + list(_get_graph_fields())
+            ] + list(_get_graph_fields()) + [
+                suite_xml.Field(
+                    header=suite_xml.Header(
+                        text=suite_xml.Text(
+                            locale=suite_xml.Locale(id=id_strings.report_last_sync())
+                        )
+                    ),
+                    template=suite_xml.Template(
+                        text=suite_xml.Text(
+                            xpath=suite_xml.Xpath(
+                                function="format-date(date(instance('reports')/reports/@last_sync), '%Y-%m-%d %H:%M')"
+                            )
+                        )
+                    )
+                ),
+            ]
         ).serialize())
 
     def data_details(self):

--- a/corehq/apps/app_manager/tests/data/suite/reports_module_summary_detail.xml
+++ b/corehq/apps/app_manager/tests/data/suite/reports_module_summary_detail.xml
@@ -44,5 +44,17 @@
         </graph>
       </template>
     </field>
+    <field>
+      <header>
+        <text>
+          <locale id="cchq.report_last_sync"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="format-date(date(instance('reports')/reports/@last_sync), '%Y-%m-%d %H:%M')"/>
+        </text>
+      </template>
+    </field>
   </detail>
 </partial>

--- a/corehq/apps/userreports/fixtures.py
+++ b/corehq/apps/userreports/fixtures.py
@@ -1,4 +1,6 @@
+from datetime import datetime
 from xml.etree import ElementTree
+
 from corehq import toggles
 from corehq.apps.app_manager.dbaccessors import get_apps_in_domain
 from corehq.apps.app_manager.models import (
@@ -50,7 +52,12 @@ class ReportFixturesProvider(object):
             return []
 
         root = ElementTree.Element('fixture', attrib={'id': self.id})
-        reports_elem = ElementTree.Element('reports')
+        reports_elem = ElementTree.Element(
+            'reports',
+            attrib={
+                'last_sync': datetime.utcnow().isoformat(),
+            },
+        )
         for report_config in report_configs:
             try:
                 reports_elem.append(self._report_config_to_fixture(report_config, user))


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?180137

@orangejenny Does this format work for you:

```
<fixture id="commcare:reports">
    <reports last_sync="2015-09-03T18:08:37.280823Z">
    <report id="7n7chrmwvhqqto6roe5wjgbqvxcg14iuw0lta8h07fogvi">
            ....
```

![img_0768](https://cloud.githubusercontent.com/assets/1757035/9770066/e63911f4-56fb-11e5-87a6-a22ed53b9a52.JPG)
