### PR TITLE
Add switch expression to UCR

### DIFF
--- a/corehq/apps/userreports/README.md
+++ b/corehq/apps/userreports/README.md
@@ -78,6 +78,7 @@ constant        | A constant   | `"hello"`, `4`, `2014-12-20`
 property_name   | A reference to the property in a document |  `doc["name"]`
 property_path   | A nested reference to a property in a document | `doc["child"]["age"]`
 conditional     | An if/else expression | `"legal" if doc["age"] > 21 else "underage"`
+switch          | A switch statement | `if doc["age"] == 21: "legal"` `elif doc["age"] == 60: ...` `else: ...`
 iterator        | Combine multiple expressions into a list | `[doc.name, doc.age, doc.gender]`
 related_doc     | A way to reference something in another document | `form.case.owner_id`
 root_doc        | A way to reference the root document explicitly (only needed when making a data source from repeat/child data) | `repeat.parent.name`
@@ -145,6 +146,41 @@ This expression returns `"legal" if doc["age"] > 21 else "underage"`:
 Note that this expression contains other expressions inside it! This is why expressions are powerful. (It also contains a filter, but we haven't covered those yet - if you find the `"test"` section confusing, keep reading...)
 
 Note also that it's important to make sure that you are comparing values of the same type. In this example, the expression that retrieves the age property from the document also casts the value to an integer. If this datatype is not specified, the expression will compare a string to the `21` value, which will not produce the expected results!
+
+##### Switch Expression
+
+This expression returns the value of the expression for the case that matches the switch on expression. Note that case values may only be strings at this time.
+```json
+{
+    "type": "switch",
+    "switch_on": {
+        "type": "property_name",
+        "property_name": "district"
+    },
+    "cases": {
+        "north": {
+            "type: "constant",
+            "constant": 4000
+        },
+        "south": {
+            "type: "constant",
+            "constant": 2500
+        },
+        "east": {
+            "type: "constant",
+            "constant": 3300
+        },
+        "west": {
+            "type: "constant",
+            "constant": 65
+        },
+    },
+    "default": {
+        "type": "constant",
+        "constant": 0
+    }
+}
+```
 
 ##### Iterator Expression
 

--- a/corehq/apps/userreports/README.md
+++ b/corehq/apps/userreports/README.md
@@ -159,19 +159,19 @@ This expression returns the value of the expression for the case that matches th
     },
     "cases": {
         "north": {
-            "type: "constant",
+            "type": "constant",
             "constant": 4000
         },
         "south": {
-            "type: "constant",
+            "type": "constant",
             "constant": 2500
         },
         "east": {
-            "type: "constant",
+            "type": "constant",
             "constant": 3300
         },
         "west": {
-            "type: "constant",
+            "type": "constant",
             "constant": 65
         },
     },

--- a/corehq/apps/userreports/expressions/factory.py
+++ b/corehq/apps/userreports/expressions/factory.py
@@ -39,7 +39,7 @@ def _switch_expression(spec, context):
     wrapped = SwitchExpressionSpec.wrap(spec)
     wrapped.configure(
         ExpressionFactory.from_spec(wrapped.switch_on, context),
-        {k : ExpressionFactory.from_spec(v, context) for k, v in wrapped.cases.iteritems()},
+        {k: ExpressionFactory.from_spec(v, context) for k, v in wrapped.cases.iteritems()},
         ExpressionFactory.from_spec(wrapped.default, context),
     )
     return wrapped

--- a/corehq/apps/userreports/expressions/factory.py
+++ b/corehq/apps/userreports/expressions/factory.py
@@ -5,7 +5,7 @@ from jsonobject.exceptions import BadValueError
 from corehq.apps.userreports.exceptions import BadSpecError
 from corehq.apps.userreports.expressions.specs import PropertyNameGetterSpec, PropertyPathGetterSpec, \
     ConditionalExpressionSpec, ConstantGetterSpec, RootDocExpressionSpec, RelatedDocExpressionSpec, \
-    IdentityExpressionSpec, IteratorExpressionSpec
+    IdentityExpressionSpec, IteratorExpressionSpec, SwitchExpressionSpec
 
 
 def _make_filter(spec, context):
@@ -31,6 +31,16 @@ def _conditional_expression(spec, context):
         _make_filter(wrapped.test, context),
         ExpressionFactory.from_spec(wrapped.expression_if_true, context),
         ExpressionFactory.from_spec(wrapped.expression_if_false, context),
+    )
+    return wrapped
+
+
+def _switch_expression(spec, context):
+    wrapped = SwitchExpressionSpec.wrap(spec)
+    wrapped.configure(
+        ExpressionFactory.from_spec(wrapped.switch_on, context),
+        {k : ExpressionFactory.from_spec(v, context) for k, v in wrapped.cases.iteritems()},
+        ExpressionFactory.from_spec(wrapped.default, context),
     )
     return wrapped
 
@@ -70,6 +80,7 @@ class ExpressionFactory(object):
         'root_doc': _root_doc_expression,
         'related_doc': _related_doc_expression,
         'iterator': _iterator_expression,
+        'switch': _switch_expression,
     }
     # Additional items are added to the spec_map by use of the `register` method.
 

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -76,6 +76,25 @@ class ConditionalExpressionSpec(JsonObject):
             return self._false_expression(item, context)
 
 
+class SwitchExpressionSpec(JsonObject):
+    type = TypeProperty('switch')
+    switch_on = DictProperty(required=True)
+    cases = DictProperty(required=True)
+    default = DictProperty(required=True)
+
+    def configure(self, switch_on_expression, case_expressions, default_expression):
+        self._switch_on_expression = switch_on_expression
+        self._case_expressions = case_expressions
+        self._default_expression = default_expression
+
+    def __call__(self, item, context=None):
+        switch_value = self._switch_on_expression(item, context)
+        for c in self.cases:
+            if switch_value == c:
+                return self._case_expressions[c](item, context)
+        return self._default_expression(item, context)
+
+
 class IteratorExpressionSpec(JsonObject):
     type = TypeProperty('iterator')
     expressions = ListProperty(required=True)

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -208,6 +208,50 @@ class ConditionalExpressionTest(SimpleTestCase):
         }))
 
 
+class SwitchExpressionTest(SimpleTestCase):
+
+    def setUp(self):
+        spec = {
+            'type': 'switch',
+            'switch_on': {
+                'type': 'property_name',
+                'property_name': 'test',
+            },
+            'cases': {
+                'strawberry': {
+                    'type': 'constant',
+                    'constant': 'banana'
+                },
+                'apple': {
+                    'type': 'property_name',
+                    'property_name': 'apple'
+                }
+            },
+            'default': {
+                'type': 'constant',
+                'constant': 'orange'
+            },
+        }
+        self.expression = ExpressionFactory.from_spec(spec)
+
+    def testCases(self):
+        self.assertEqual('banana', self.expression({
+            'test': 'strawberry',
+        }))
+        self.assertEqual('foo', self.expression({
+            'test': 'apple',
+            'apple': 'foo'
+        }))
+        self.assertEqual(None, self.expression({
+            'test': 'apple',
+        }))
+
+    def testDefault(self):
+        self.assertEqual('orange', self.expression({
+            'test': 'value not in cases',
+        }))
+
+
 class IteratorExpressionTest(SimpleTestCase):
 
     def setUp(self):


### PR DESCRIPTION
Part of an effort to switch all the abt reports over to static configurations. This will make the data source configurations _much_ easier to maintain.

@czue cc: @snopoke 
