### PR TITLE
B3 web user deletion not deleting expected user

### DIFF
--- a/corehq/apps/users/static/users/js/web_users_list.ng.js
+++ b/corehq/apps/users/static/users/js/web_users_list.ng.js
@@ -11,6 +11,7 @@
 
     var WebUser = function (data) {
         var self = this;
+        self.id = data.id;
         self.email = data.email;
         self.name = data.name;
         self.role = data.role;


### PR DESCRIPTION
On the bootstrap 3 version of web user settings, clicking any **Remove Membership** button removes the first user in the list.

@proteusvacuum / @biyeun 
