### PR TITLE
Action menu always needs Display element

### DIFF
--- a/corehq/apps/app_manager/suite_xml.py
+++ b/corehq/apps/app_manager/suite_xml.py
@@ -259,7 +259,7 @@ class TextOrDisplay(XmlObject):
 
     def __init__(self, node=None, context=None,
                  menu_locale_id=None, image_locale_id=None, audio_locale_id=None,
-                 media_image=None, media_audio=None, **kwargs):
+                 media_image=None, media_audio=None, for_action_menu=False, **kwargs):
         super(TextOrDisplay, self).__init__(node, context, **kwargs)
         text = Text(locale_id=menu_locale_id) if menu_locale_id else None
 
@@ -278,6 +278,10 @@ class TextOrDisplay(XmlObject):
         if media_text:
             self.display = LocalizedMediaDisplay(
                 media_text=[text] + media_text if text else media_text
+            )
+        elif for_action_menu and text:
+            self.display = LocalizedMediaDisplay(
+                media_text=[text]
             )
         elif text:
             self.text = text
@@ -1405,7 +1409,8 @@ class SuiteGenerator(SuiteGeneratorBase):
                 media_audio=bool(len(case_list_form.all_audio_paths())),
                 image_locale_id=id_strings.case_list_form_icon_locale(module),
                 audio_locale_id=id_strings.case_list_form_audio_locale(module),
-                stack=Stack()
+                stack=Stack(),
+                for_action_menu=True,
             )
         else:
             detail.action = Action(

--- a/corehq/apps/app_manager/tests/test_media_suite.py
+++ b/corehq/apps/app_manager/tests/test_media_suite.py
@@ -151,17 +151,34 @@ class LocalizedMediaSuiteTest(SimpleTestCase, TestFileMixin):
             audio_locale_id=audio_locale_id,
         )
 
-    def test_no_media(self):
-        XML = """
-        <partial>
-            <text>
-                <locale id="forms.m0f0"/>
-            </text>
-        </partial>
-        """
-        self.assertXmlPartialEqual(XML, self.app.create_suite(), "./entry/command[@id='m0-f0']/")
+    def XML_without_media(self, menu_locale_id, for_action_menu=False):
+        if for_action_menu:
+            XML_template = """
+            <partial>
+                <display>
+                    <text>
+                        <locale id="{menu_locale_id}"/>
+                    </text>
+                </display>
+            </partial>
+            """
+        else:
+            XML_template = """
+            <partial>
+                <text>
+                    <locale id="{menu_locale_id}"/>
+                </text>
+            </partial>
+            """
+
+        return XML_template.format(
+            menu_locale_id=menu_locale_id,
+        )
 
     def test_form_suite(self):
+        no_media_xml = self.XML_without_media("forms.m0f0")
+        self.assertXmlPartialEqual(no_media_xml, self.app.create_suite(), "./entry/command[@id='m0-f0']/text")
+
         self.form.set_icon('en', self.image_path)
         self.form.set_audio('en', self.audio_path)
 
@@ -176,6 +193,9 @@ class LocalizedMediaSuiteTest(SimpleTestCase, TestFileMixin):
         self._test_correct_audio_translations(self.app, self.form, audio_locale)
 
     def test_module_suite(self):
+        no_media_xml = self.XML_without_media("modules.m0")
+        self.assertXmlPartialEqual(no_media_xml, self.app.create_suite(), "././menu[@id='m0']/text")
+
         self.module.set_icon('en', self.image_path)
         self.module.set_audio('en', self.audio_path)
 
@@ -193,6 +213,13 @@ class LocalizedMediaSuiteTest(SimpleTestCase, TestFileMixin):
         app = AppFactory.case_list_form_app_factory().app
         app.build_spec = self.min_spec
 
+        no_media_xml = self.XML_without_media("case_list_form.m0", for_action_menu=True)
+        self.assertXmlPartialEqual(
+            no_media_xml,
+            app.create_suite(),
+            "./detail[@id='m0_case_short']/action/display"
+        )
+
         app.get_module(0).case_list_form.set_icon('en', self.image_path)
         app.get_module(0).case_list_form.set_audio('en', self.audio_path)
 
@@ -207,6 +234,10 @@ class LocalizedMediaSuiteTest(SimpleTestCase, TestFileMixin):
 
     def test_case_list_menu_media(self):
         self.module.case_list.show = True
+
+        no_media_xml = self.XML_without_media("case_lists.m0")
+        self.assertXmlPartialEqual(no_media_xml, self.app.create_suite(), "./entry/command[@id='m0-case-list']/")
+
         self.module.case_list.set_icon('en', self.image_path)
         self.module.case_list.set_audio('en', self.audio_path)
 


### PR DESCRIPTION
Localized-media sets one of `text` or `display` elements for all menus that can display a text or multimedia. But the case-list-form which uses `action` tag only expects `display`.

http://manage.dimagi.com/default.asp?181213#1008043
