### PR TITLE
cleanup aliased elastic pillows

### DIFF
--- a/corehq/apps/api/tests.py
+++ b/corehq/apps/api/tests.py
@@ -122,7 +122,6 @@ class TestXFormInstanceResource(APIResourceTest):
         """
         Any form in the appropriate domain should be in the list from the API.
         """
-
         # The actual infrastructure involves saving to CouchDB, having PillowTop
         # read the changes and write it to ElasticSearch.
 
@@ -136,10 +135,10 @@ class TestXFormInstanceResource(APIResourceTest):
         fake_xform_es = FakeXFormES()
         v0_4.MOCK_XFORM_ES = fake_xform_es
 
-        backend_form = XFormInstance(xmlns = 'fake-xmlns',
-                                     domain = self.domain.name,
-                                     received_on = datetime.utcnow(),
-                                     form = {
+        backend_form = XFormInstance(xmlns='fake-xmlns',
+                                     domain=self.domain.name,
+                                     received_on=datetime.utcnow(),
+                                     form={
                                          '#type': 'fake-type',
                                          '@xmlns': 'fake-xmlns'
                                      })

--- a/corehq/apps/hqcase/management/commands/__init__.py
+++ b/corehq/apps/hqcase/management/commands/__init__.py
@@ -43,7 +43,6 @@ class ReindexCommand(BaseCommand):
         pillow_instance.delete_index()
         print "Recreating index"
         pillow_instance.create_index()
-        pillow_instance.seen_types = {}
         print "Resetting %s Checkpoint" % self.pillow_name
 
         pillow_instance.reset_checkpoint()

--- a/corehq/apps/hqcase/management/commands/ptop_fast_reindexer.py
+++ b/corehq/apps/hqcase/management/commands/ptop_fast_reindexer.py
@@ -352,7 +352,6 @@ class ElasticReindexer(PtopReindexer):
             self.log("Recreating index")
             self.indexing_pillow.create_index()
             self.indexing_pillow.initialize_mapping_if_necessary()
-            self.indexing_pillow.seen_types = {}
 
     def post_load_hook(self):
         if not self.in_place:

--- a/corehq/apps/hqcase/management/commands/ptop_fast_reindexer.py
+++ b/corehq/apps/hqcase/management/commands/ptop_fast_reindexer.py
@@ -351,6 +351,7 @@ class ElasticReindexer(PtopReindexer):
             self.indexing_pillow.delete_index()
             self.log("Recreating index")
             self.indexing_pillow.create_index()
+            self.indexing_pillow.initialize_mapping_if_necessary()
             self.indexing_pillow.seen_types = {}
 
     def post_load_hook(self):

--- a/corehq/apps/reports/tests/test_pillows_cases.py
+++ b/corehq/apps/reports/tests/test_pillows_cases.py
@@ -449,16 +449,6 @@ EXAMPLE_CASE = {
 
 
 class testReportCaseProcessing(TestCase):
-    def testXFormMapping(self):
-        """
-        Verify that a simple case doc will yield the basic mapping
-        """
-
-        pillow = XFormPillow(create_index=False, online=False)
-        t1 = pillow.get_mapping_from_type(XFORM_SINGLE_CASE)
-        t2 = pillow.get_mapping_from_type(XFORM_MULTI_CASES)
-
-        self.assertEqual(t1, t2)
 
     def testXFormPillowSingleCaseProcess(self):
         """

--- a/corehq/pillows/application.py
+++ b/corehq/pillows/application.py
@@ -44,23 +44,5 @@ class AppPillow(AliasedElasticPillow):
         return self.calc_mapping_hash({"es_meta": self.es_meta,
                                        "mapping": self.default_mapping})
 
-    def get_mapping_from_type(self, doc_dict):
-        """
-        Define mapping uniquely to the user_type document.
-        See below on why date_detection is False
-
-        NOTE: DO NOT MODIFY THIS UNLESS ABSOLUTELY NECESSARY. A CHANGE BELOW WILL GENERATE A NEW
-        HASH FOR THE INDEX NAME REQUIRING A REINDEX+RE-ALIAS. THIS IS A SERIOUSLY RESOURCE
-        INTENSIVE OPERATION THAT REQUIRES SOME CAREFUL LOGISTICS TO MIGRATE
-        """
-        #the meta here is defined for when the case index + type is created for the FIRST time
-        #subsequent data added to it will be added automatically, but date_detection is necessary
-        # to be false to prevent indexes from not being created due to the way we store dates
-        #all are strings EXCEPT the core case properties which we need to explicitly define below.
-        #that way date sort and ranges will work with canonical date formats for queries.
-        return {
-            self.get_type_string(doc_dict): self.default_mapping
-        }
-
     def get_type_string(self, doc_dict):
         return self.es_type

--- a/corehq/pillows/application.py
+++ b/corehq/pillows/application.py
@@ -43,6 +43,3 @@ class AppPillow(AliasedElasticPillow):
         """
         return self.calc_mapping_hash({"es_meta": self.es_meta,
                                        "mapping": self.default_mapping})
-
-    def get_type_string(self, doc_dict):
-        return self.es_type

--- a/corehq/pillows/base.py
+++ b/corehq/pillows/base.py
@@ -95,6 +95,3 @@ class HQPillow(AliasedElasticPillow):
         """
 
         return doc_dict.get('domain', None)
-
-    def get_type_string(self, doc_dict):
-        return self.es_type

--- a/corehq/pillows/base.py
+++ b/corehq/pillows/base.py
@@ -82,9 +82,6 @@ class HQPillow(AliasedElasticPillow):
         }
     }
 
-    def __init__(self, **kwargs):
-        super(HQPillow, self).__init__(**kwargs)
-
     @memoized
     def calc_meta(self):
         """

--- a/corehq/pillows/base.py
+++ b/corehq/pillows/base.py
@@ -62,7 +62,6 @@ class HQPillow(AliasedElasticPillow):
     es_host = settings.ELASTICSEARCH_HOST
     es_port = settings.ELASTICSEARCH_PORT
     es_timeout = 60
-    default_mapping = None
     es_meta = {
         "settings": {
             "analysis": {
@@ -99,22 +98,3 @@ class HQPillow(AliasedElasticPillow):
 
     def get_type_string(self, doc_dict):
         return self.es_type
-
-    def get_mapping_from_type(self, doc_dict):
-        """
-        Define mapping uniquely to the domain_type document.
-        See below on why date_detection is False
-
-        NOTE: DO NOT MODIFY THIS UNLESS ABSOLUTELY NECESSARY. A CHANGE BELOW WILL GENERATE A NEW
-        HASH FOR THE INDEX NAME REQUIRING A REINDEX+RE-ALIAS. THIS IS A SERIOUSLY RESOURCE
-        INTENSIVE OPERATION THAT REQUIRES SOME CAREFUL LOGISTICS TO MIGRATE
-        """
-        #the meta here is defined for when the case index + type is created for the FIRST time
-        #subsequent data added to it will be added automatically, but date_detection is necessary
-        # to be false to prevent indexes from not being created due to the way we store dates
-        #all are strings EXCEPT the core case properties which we need to explicitly define below.
-        #that way date sort and ranges will work with canonical date formats for queries.
-        return {
-            self.get_type_string(doc_dict): self.default_mapping
-        }
-

--- a/corehq/pillows/case.py
+++ b/corehq/pillows/case.py
@@ -54,9 +54,6 @@ class CasePillow(HQPillow):
             'mapping': self.default_mapping,
         })
 
-    def get_type_string(self, doc_dict):
-        return self.es_type
-
     def change_transform(self, doc_dict):
         doc_ret = copy.deepcopy(doc_dict)
         if not doc_ret.get("owner_id"):

--- a/corehq/pillows/sms.py
+++ b/corehq/pillows/sms.py
@@ -45,23 +45,5 @@ class SMSPillow(AliasedElasticPillow):
         return self.calc_mapping_hash({"es_meta": self.es_meta,
                                        "mapping": self.default_mapping})
 
-    def get_mapping_from_type(self, doc_dict):
-        """
-        Define mapping uniquely to the user_type document.
-        See below on why date_detection is False
-
-        NOTE: DO NOT MODIFY THIS UNLESS ABSOLUTELY NECESSARY. A CHANGE BELOW WILL GENERATE A NEW
-        HASH FOR THE INDEX NAME REQUIRING A REINDEX+RE-ALIAS. THIS IS A SERIOUSLY RESOURCE
-        INTENSIVE OPERATION THAT REQUIRES SOME CAREFUL LOGISTICS TO MIGRATE
-        """
-        #the meta here is defined for when the case index + type is created for the FIRST time
-        #subsequent data added to it will be added automatically, but date_detection is necessary
-        # to be false to prevent indexes from not being created due to the way we store dates
-        #all are strings EXCEPT the core case properties which we need to explicitly define below.
-        #that way date sort and ranges will work with canonical date formats for queries.
-        return {
-            self.get_type_string(doc_dict): self.default_mapping
-        }
-
     def get_type_string(self, doc_dict):
         return self.es_type

--- a/corehq/pillows/sms.py
+++ b/corehq/pillows/sms.py
@@ -44,6 +44,3 @@ class SMSPillow(AliasedElasticPillow):
         """
         return self.calc_mapping_hash({"es_meta": self.es_meta,
                                        "mapping": self.default_mapping})
-
-    def get_type_string(self, doc_dict):
-        return self.es_type

--- a/corehq/pillows/user.py
+++ b/corehq/pillows/user.py
@@ -52,14 +52,6 @@ class UserPillow(AliasedElasticPillow):
     def get_unique_id(self):
         return USER_INDEX
 
-    def get_mapping_from_type(self, doc_dict):
-        """
-        Define mapping uniquely to the user_type document.
-        """
-        return {
-            self.get_type_string(doc_dict): self.default_mapping
-        }
-
     def get_type_string(self, doc_dict):
         return self.es_type
 

--- a/corehq/pillows/user.py
+++ b/corehq/pillows/user.py
@@ -55,17 +55,7 @@ class UserPillow(AliasedElasticPillow):
     def get_mapping_from_type(self, doc_dict):
         """
         Define mapping uniquely to the user_type document.
-        See below on why date_detection is False
-
-        NOTE: DO NOT MODIFY THIS UNLESS ABSOLUTELY NECESSARY. A CHANGE BELOW WILL GENERATE A NEW
-        HASH FOR THE INDEX NAME REQUIRING A REINDEX+RE-ALIAS. THIS IS A SERIOUSLY RESOURCE
-        INTENSIVE OPERATION THAT REQUIRES SOME CAREFUL LOGISTICS TO MIGRATE
         """
-        #the meta here is defined for when the case index + type is created for the FIRST time
-        #subsequent data added to it will be added automatically, but date_detection is necessary
-        # to be false to prevent indexes from not being created due to the way we store dates
-        #all are strings EXCEPT the core case properties which we need to explicitly define below.
-        #that way date sort and ranges will work with canonical date formats for queries.
         return {
             self.get_type_string(doc_dict): self.default_mapping
         }

--- a/corehq/pillows/user.py
+++ b/corehq/pillows/user.py
@@ -52,8 +52,6 @@ class UserPillow(AliasedElasticPillow):
     def get_unique_id(self):
         return USER_INDEX
 
-    def get_type_string(self, doc_dict):
-        return self.es_type
 
 class GroupToUserPillow(BulkPillow):
     couch_filter = "groups/all_groups"


### PR DESCRIPTION
codependent with https://github.com/dimagi/pillowtop/pull/128

probably easiest read commit by commit. this has no real functional changes and mostly just removes a bunch of legacy/duplicated code

@snopoke @dannyroberts cc @emord 
