### PR TITLE
convert user supporting pillows to be a python pillow

### DIFF
--- a/corehq/apps/hqcase/management/commands/ptop_fast_reindexer.py
+++ b/corehq/apps/hqcase/management/commands/ptop_fast_reindexer.py
@@ -161,7 +161,6 @@ class PtopReindexer(NoArgsCommand):
 
         current_db_seq = self.pillow.couch_db.info()['update_seq']
 
-
         # Write sequence file to disk
         seq_filename = self.get_seq_filename()
         self.log('Writing sequence file to disk: {}'.format(seq_filename))
@@ -246,7 +245,8 @@ class PtopReindexer(NoArgsCommand):
             self.pillow.set_checkpoint({'seq': seq})
 
         self.post_load_hook()
-
+        self.pillow.couch_db = CachedCouchDB(self.pillow.document_class.get_db().uri,
+                                             readonly=True)
         if self.bulk:
             self.log("Preparing Bulk Payload")
             self.load_bulk()
@@ -290,9 +290,6 @@ class PtopReindexer(NoArgsCommand):
         json_iter = self.view_data_file_iter()
 
         bulk_slice = []
-        self.pillow.couch_db = CachedCouchDB(self.pillow.document_class.get_db().uri,
-                                             readonly=True)
-
         for curr_counter, json_doc in enumerate(json_iter):
             if curr_counter < start:
                 continue

--- a/corehq/apps/hqcase/management/commands/ptop_fast_reindexer.py
+++ b/corehq/apps/hqcase/management/commands/ptop_fast_reindexer.py
@@ -279,9 +279,7 @@ class PtopReindexer(NoArgsCommand):
         Iterative view indexing - use --bulk for faster reindex.
         :return:
         """
-        # todo: should this use self.view_data_file_iter() instead?
-        # currently some reindexers run full_couch_view_iter twice
-        for ix, item in enumerate(self.full_couch_view_iter()):
+        for ix, item in enumerate(self.view_data_file_iter()):
             self.log("\tProcessing item %s (%d)" % (item['id'], ix))
             self.process_row(item, ix)
 

--- a/corehq/apps/users/management/commands/ptop_fast_reindex_unknownusers.py
+++ b/corehq/apps/users/management/commands/ptop_fast_reindex_unknownusers.py
@@ -14,3 +14,28 @@ class Command(ElasticReindexer):
 
     def get_extra_view_kwargs(self):
         return {'startkey': ['submission'], 'endkey': ['submission', {}]}
+
+    def process_row(self, row, count):
+        doc = _make_view_dict_look_like_xform_doc(row)
+        super(Command, self).process_row({'id': doc['_id'], 'doc': doc}, count)
+
+
+def _make_view_dict_look_like_xform_doc(emitted_dict):
+    # this is an optimization hack for preindexing - in order to avoid getting the
+    # full xform docs out of couch we just transform the view key/values into what
+    # the pillow would expect to get from the doc
+    domain = emitted_dict['key'][1]
+    user_id = emitted_dict['value'].get('user_id')
+    username = emitted_dict['value'].get('username')
+    xform_id = emitted_dict['id']
+    return {
+        '_id': xform_id,
+        'doc_type': 'XFormInstance',
+        'domain': domain,
+        'form': {
+            'meta': {
+                'userID': user_id,
+                'username': username,
+            }
+        }
+    }

--- a/corehq/ex-submodules/couchforms/models.py
+++ b/corehq/ex-submodules/couchforms/models.py
@@ -45,6 +45,11 @@ def doc_types():
     }
 
 
+def all_known_formlike_doc_types():
+    # also pulls in extra doc types from filters/xforms.js
+    return set(doc_types().keys()) | set(['XFormInstance-Deleted', 'HQSubmission'])
+
+
 def get(doc_id):
     import warnings
     warnings.warn(

--- a/corehq/ex-submodules/couchforms/tests/__init__.py
+++ b/corehq/ex-submodules/couchforms/tests/__init__.py
@@ -4,6 +4,7 @@ from couchforms.jsonobject_extensions import GeoPointProperty
 try:
     from .test_archive import *
     from .test_meta import *
+    from .test_doc_types import *
     from .test_duplicates import *
     from .test_edits import *
     from .test_namespaces import *

--- a/corehq/ex-submodules/couchforms/tests/test_doc_types.py
+++ b/corehq/ex-submodules/couchforms/tests/test_doc_types.py
@@ -1,0 +1,13 @@
+from django.test import SimpleTestCase
+from couchforms import models as couchforms_models
+
+
+class FormlikeDocTypeTest(SimpleTestCase):
+
+    def test_wrappable(self):
+        types = couchforms_models.all_known_formlike_doc_types()
+        for key in couchforms_models.doc_types().keys():
+            self.assertTrue(key in types)
+
+    def test_deleted(self):
+        self.assertTrue('XFormInstance-Deleted' in couchforms_models.all_known_formlike_doc_types())

--- a/corehq/pillows/user.py
+++ b/corehq/pillows/user.py
@@ -1,11 +1,12 @@
+from casexml.apps.case.xform import is_device_report
 from corehq.apps.groups.models import Group
 from corehq.apps.users.models import CommCareUser, CouchUser
 from corehq.apps.users.util import WEIRD_USER_IDS
 from corehq.elastic import ES_URLS, stream_es_query, get_es
 from corehq.pillows.mappings.user_mapping import USER_MAPPING, USER_INDEX
-from couchforms.models import XFormInstance
+from couchforms.models import XFormInstance, all_known_formlike_doc_types
 from dimagi.utils.decorators.memoized import memoized
-from pillowtop.listener import AliasedElasticPillow, BasicPillow, PythonPillow
+from pillowtop.listener import AliasedElasticPillow, PythonPillow
 from django.conf import settings
 
 
@@ -80,12 +81,11 @@ class GroupToUserPillow(PythonPillow):
         pass
 
 
-class UnknownUsersPillow(BasicPillow):
+class UnknownUsersPillow(PythonPillow):
     """
     This pillow adds users from xform submissions that come in to the User Index if they don't exist in HQ
     """
     document_class = XFormInstance
-    couch_filter = "couchforms/xforms"
     include_docs_when_preindexing = False
 
     def __init__(self, **kwargs):
@@ -94,12 +94,9 @@ class UnknownUsersPillow(BasicPillow):
         self.user_db = CouchUser.get_db()
         self.es = get_es()
 
-    def get_fields_from_emitted_dict(self, emitted_dict):
-        domain = emitted_dict['key'][1]
-        user_id = emitted_dict['value'].get('user_id')
-        username = emitted_dict['value'].get('username')
-        xform_id = emitted_dict['id']
-        return user_id, username, domain, xform_id
+    def python_filter(self, doc):
+        # designed to exactly mimic the behavior of couchforms/filters/xforms.js
+        return doc.get('doc_type', None) in all_known_formlike_doc_types() and not is_device_report(doc)
 
     def get_fields_from_doc(self, doc):
         form_meta = doc.get('form', {}).get('meta', {})
@@ -114,11 +111,8 @@ class UnknownUsersPillow(BasicPillow):
         return self.user_db.doc_exist(user_id)
 
     def change_trigger(self, changes_dict):
-        if 'key' in changes_dict:
-            user_id, username, domain, xform_id = self.get_fields_from_emitted_dict(changes_dict)
-        else:
-            doc = changes_dict['doc'] if 'doc' in changes_dict else self.couch_db.open_doc(changes_dict['id'])
-            user_id, username, domain, xform_id = self.get_fields_from_doc(doc)
+        doc = changes_dict['doc'] if 'doc' in changes_dict else self.couch_db.open_doc(changes_dict['id'])
+        user_id, username, domain, xform_id = self.get_fields_from_doc(doc)
 
         if user_id in WEIRD_USER_IDS:
             user_id = None

--- a/corehq/pillows/user.py
+++ b/corehq/pillows/user.py
@@ -1,11 +1,11 @@
 from corehq.apps.groups.models import Group
 from corehq.apps.users.models import CommCareUser, CouchUser
 from corehq.apps.users.util import WEIRD_USER_IDS
-from corehq.elastic import es_query, ES_URLS, stream_es_query, get_es
+from corehq.elastic import ES_URLS, stream_es_query, get_es
 from corehq.pillows.mappings.user_mapping import USER_MAPPING, USER_INDEX
 from couchforms.models import XFormInstance
 from dimagi.utils.decorators.memoized import memoized
-from pillowtop.listener import AliasedElasticPillow, BulkPillow
+from pillowtop.listener import AliasedElasticPillow, BasicPillow
 from django.conf import settings
 
 
@@ -53,7 +53,7 @@ class UserPillow(AliasedElasticPillow):
         return USER_INDEX
 
 
-class GroupToUserPillow(BulkPillow):
+class GroupToUserPillow(BasicPillow):
     couch_filter = "groups/all_groups"
     document_class = CommCareUser
 
@@ -77,13 +77,10 @@ class GroupToUserPillow(BulkPillow):
     def change_transport(self, doc_dict):
         pass
 
-    def send_bulk(self, payload):
-        pass
 
-
-class UnknownUsersPillow(BulkPillow):
+class UnknownUsersPillow(BasicPillow):
     """
-        This pillow adds users from xform submissions that come in to the User Index if they don't exist in HQ
+    This pillow adds users from xform submissions that come in to the User Index if they don't exist in HQ
     """
     document_class = XFormInstance
     couch_filter = "couchforms/xforms"
@@ -140,9 +137,6 @@ class UnknownUsersPillow(BulkPillow):
             self.es.put(es_path + user_id, data=doc)
 
     def change_transport(self, doc_dict):
-        pass
-
-    def send_bulk(self, payload):
         pass
 
 


### PR DESCRIPTION
and misc cleanup. read commit by commit 

the two pillows touched are the one that saves unknown users from xforms and the one that maps users to groups.

@dannyroberts @benrudolph cc @emord 
