### PR TITLE
Bootstrap migrations

### DIFF
--- a/corehq/apps/accounting/migrations/0003_bootstrap.py
+++ b/corehq/apps/accounting/migrations/0003_bootstrap.py
@@ -1,0 +1,279 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+from collections import defaultdict
+from decimal import Decimal
+import logging
+
+from django.core.exceptions import ObjectDoesNotExist
+from django.db import models, migrations
+
+from corehq.apps.accounting.models import (
+    SoftwareProductType, SoftwarePlanEdition, SoftwarePlanVisibility, FeatureType,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def bootstrap_software_plans(apps, schema_editor):
+    BootstrapSoftwarePlans(apps).bootstrap()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounting', '0002_update_pricing_table'),
+    ]
+
+    operations = [
+        migrations.RunPython(bootstrap_software_plans),
+    ]
+
+
+class BootstrapSoftwarePlans(object):
+    """
+    This is a direct copy of the cchq_software_plan_bootstrap management command
+    so that orm can be used to reference the objects.
+    """
+    def __init__(self, apps):
+        self.apps = apps
+        self.verbose = False
+        self.for_tests = False
+
+    @property
+    def SoftwarePlanVersion(self):
+        return self.apps.get_model('accounting', 'SoftwarePlanVersion')
+
+    @property
+    def SoftwarePlan(self):
+        return self.apps.get_model('accounting', 'SoftwarePlan')
+
+    @property
+    def SoftwareProduct(self):
+        return self.apps.get_model('accounting', 'SoftwareProduct')
+
+    @property
+    def SoftwareProductRate(self):
+        return self.apps.get_model('accounting', 'SoftwareProductRate')
+
+    @property
+    def DefaultProductPlan(self):
+        return self.apps.get_model('accounting', 'DefaultProductPlan')
+
+    @property
+    def Feature(self):
+        return self.apps.get_model('accounting', 'Feature')
+
+    @property
+    def FeatureRate(self):
+        return self.apps.get_model('accounting', 'FeatureRate')
+
+    def bootstrap(self):
+        logger.info('Bootstrapping standard plans. Enterprise plans will have to be created via the admin UIs.')
+
+        self.product_types = [p[0] for p in SoftwareProductType.CHOICES]
+        self.editions = [
+            SoftwarePlanEdition.COMMUNITY,
+            SoftwarePlanEdition.STANDARD,
+            SoftwarePlanEdition.PRO,
+            SoftwarePlanEdition.ADVANCED,
+            SoftwarePlanEdition.ENTERPRISE,
+        ]
+        self.feature_types = [f[0] for f in FeatureType.CHOICES]
+        self.ensure_plans()
+
+    def ensure_plans(self, dry_run=False):
+        edition_to_features = self.ensure_features(dry_run=dry_run)
+        for product_type in self.product_types:
+            for edition in self.editions:
+                role_slug = self.BOOTSTRAP_EDITION_TO_ROLE[edition]
+                try:
+                    role = self.apps.get_model('django_prbac', 'Role').objects.get(slug=role_slug)
+                except ObjectDoesNotExist:
+                    logger.info("Could not find the role '%s'. Did you forget to run cchq_prbac_bootstrap?")
+                    logger.info("Aborting. You should figure this out.")
+                    return
+                software_plan_version = self.SoftwarePlanVersion(role=role)
+
+                product, product_rates = self.ensure_product_and_rate(product_type, edition, dry_run=dry_run)
+                feature_rates = self.ensure_feature_rates(edition_to_features[edition], edition, dry_run=dry_run)
+                software_plan = self.SoftwarePlan(
+                    name='%s Edition' % product.name, edition=edition, visibility=SoftwarePlanVisibility.PUBLIC
+                )
+                if dry_run:
+                    logger.info("[DRY RUN] Creating Software Plan: %s" % software_plan.name)
+                else:
+                    try:
+                        software_plan = self.SoftwarePlan.objects.get(name=software_plan.name)
+                        if self.verbose:
+                            logger.info("Plan '%s' already exists. Using existing plan to add version."
+                                        % software_plan.name)
+                    except self.SoftwarePlan.DoesNotExist:
+                        software_plan.save()
+                        if self.verbose:
+                            logger.info("Creating Software Plan: %s" % software_plan.name)
+
+                        software_plan_version.plan = software_plan
+                        software_plan_version.save()
+                        for product_rate in product_rates:
+                            product_rate.save()
+                            software_plan_version.product_rates.add(product_rate)
+                        for feature_rate in feature_rates:
+                            feature_rate.save()
+                            software_plan_version.feature_rates.add(feature_rate)
+                        software_plan_version.save()
+
+                default_product_plan = self.DefaultProductPlan(product_type=product.product_type, edition=edition)
+                if dry_run:
+                    logger.info("[DRY RUN] Setting plan as default for product '%s' and edition '%s'." %
+                                 (product.product_type, default_product_plan.edition))
+                else:
+                    try:
+                        default_product_plan = self.DefaultProductPlan.objects.get(
+                            product_type=product.product_type, edition=edition,
+                            is_trial=False
+                        )
+                        if self.verbose:
+                            logger.info("Default for product '%s' and edition "
+                                        "'%s' already exists." % (
+                                product.product_type, default_product_plan.edition
+                            ))
+                    except ObjectDoesNotExist:
+                        default_product_plan.plan = software_plan
+                        default_product_plan.save()
+                        if self.verbose:
+                            logger.info("Setting plan as default for product '%s' and edition '%s'." %
+                                        (product.product_type,
+                                         default_product_plan.edition))
+
+    def ensure_product_and_rate(self, product_type, edition, dry_run=False):
+        """
+        Ensures that all the necessary SoftwareProducts and SoftwareProductRates are created for the plan.
+        """
+        if self.verbose:
+            logger.info('Ensuring Products and Product Rates')
+
+        product = self.SoftwareProduct(name='%s %s' % (product_type, edition), product_type=product_type)
+        if edition == SoftwarePlanEdition.ENTERPRISE:
+            product.name = "Dimagi Only %s" % product.name
+
+        product_rates = []
+        BOOTSTRAP_PRODUCT_RATES = {
+            SoftwarePlanEdition.COMMUNITY: [
+                self.SoftwareProductRate(),  # use all the defaults
+            ],
+            SoftwarePlanEdition.STANDARD: [
+                self.SoftwareProductRate(monthly_fee=Decimal('100.00')),
+            ],
+            SoftwarePlanEdition.PRO: [
+                self.SoftwareProductRate(monthly_fee=Decimal('500.00')),
+            ],
+            SoftwarePlanEdition.ADVANCED: [
+                self.SoftwareProductRate(monthly_fee=Decimal('1000.00')),
+            ],
+            SoftwarePlanEdition.ENTERPRISE: [
+                self.SoftwareProductRate(monthly_fee=Decimal('0.00')),
+            ],
+        }
+
+        for product_rate in BOOTSTRAP_PRODUCT_RATES[edition]:
+            if dry_run:
+                logger.info("[DRY RUN] Creating Product: %s" % product)
+                logger.info("[DRY RUN] Corresponding product rate of $%d created." % product_rate.monthly_fee)
+            else:
+                try:
+                    product = self.SoftwareProduct.objects.get(name=product.name)
+                    if self.verbose:
+                        logger.info("Product '%s' already exists. Using "
+                                    "existing product to add rate."
+                                    % product.name)
+                except self.SoftwareProduct.DoesNotExist:
+                    product.save()
+                    if self.verbose:
+                        logger.info("Creating Product: %s" % product)
+                if self.verbose:
+                    logger.info("Corresponding product rate of $%d created."
+                                % product_rate.monthly_fee)
+            product_rate.product = product
+            product_rates.append(product_rate)
+        return product, product_rates
+
+    def ensure_features(self, dry_run=False):
+        """
+        Ensures that all the Features necessary for the plans are created.
+        """
+        if self.verbose:
+            logger.info('Ensuring Features')
+
+        edition_to_features = defaultdict(list)
+        for edition in self.editions:
+            for feature_type in self.feature_types:
+                feature = self.Feature(name='%s %s' % (feature_type, edition), feature_type=feature_type)
+                if edition == SoftwarePlanEdition.ENTERPRISE:
+                    feature.name = "Dimagi Only %s" % feature.name
+                if dry_run:
+                    logger.info("[DRY RUN] Creating Feature: %s" % feature)
+                else:
+                    try:
+                        feature = self.Feature.objects.get(name=feature.name)
+                        if self.verbose:
+                            logger.info("Feature '%s' already exists. Using "
+                                        "existing feature to add rate."
+                                        % feature.name)
+                    except ObjectDoesNotExist:
+                        feature.save()
+                        if self.verbose:
+                            logger.info("Creating Feature: %s" % feature)
+                edition_to_features[edition].append(feature)
+        return edition_to_features
+
+    def ensure_feature_rates(self, features, edition, dry_run=False):
+        """
+        Ensures that all the FeatureRates necessary for the plans are created.
+        """
+        if self.verbose:
+            logger.info('Ensuring Feature Rates')
+
+        feature_rates = []
+        BOOTSTRAP_FEATURE_RATES = {
+            SoftwarePlanEdition.COMMUNITY: {
+                FeatureType.USER: self.FeatureRate(monthly_limit=2 if self.for_tests else 50,
+                                              per_excess_fee=Decimal('1.00')),
+                FeatureType.SMS: self.FeatureRate(monthly_limit=0),  # use defaults here
+            },
+            SoftwarePlanEdition.STANDARD: {
+                FeatureType.USER: self.FeatureRate(monthly_limit=4 if self.for_tests else 100,
+                                              per_excess_fee=Decimal('1.00')),
+                FeatureType.SMS: self.FeatureRate(monthly_limit=3 if self.for_tests else 100),
+            },
+            SoftwarePlanEdition.PRO: {
+                FeatureType.USER: self.FeatureRate(monthly_limit=6 if self.for_tests else 500,
+                                              per_excess_fee=Decimal('1.00')),
+                FeatureType.SMS: self.FeatureRate(monthly_limit=5 if self.for_tests else 500),
+            },
+            SoftwarePlanEdition.ADVANCED: {
+                FeatureType.USER: self.FeatureRate(monthly_limit=8 if self.for_tests else 1000,
+                                              per_excess_fee=Decimal('1.00')),
+                FeatureType.SMS: self.FeatureRate(monthly_limit=7 if self.for_tests else 1000),
+            },
+            SoftwarePlanEdition.ENTERPRISE: {
+                FeatureType.USER: self.FeatureRate(monthly_limit=-1, per_excess_fee=Decimal('0.00')),
+                FeatureType.SMS: self.FeatureRate(monthly_limit=-1),
+            },
+        }
+        for feature in features:
+            feature_rate = BOOTSTRAP_FEATURE_RATES[edition][feature.feature_type]
+            feature_rate.feature = feature
+            if dry_run:
+                logger.info("[DRY RUN] Creating rate for feature '%s': %s" % (feature.name, feature_rate))
+            elif self.verbose:
+                logger.info("Creating rate for feature '%s': %s" % (feature.name, feature_rate))
+            feature_rates.append(feature_rate)
+        return feature_rates
+
+    BOOTSTRAP_EDITION_TO_ROLE = {
+        SoftwarePlanEdition.COMMUNITY: 'community_plan_v0',
+        SoftwarePlanEdition.STANDARD: 'standard_plan_v0',
+        SoftwarePlanEdition.PRO: 'pro_plan_v0',
+        SoftwarePlanEdition.ADVANCED: 'advanced_plan_v0',
+        SoftwarePlanEdition.ENTERPRISE: 'enterprise_plan_v0',
+    }

--- a/corehq/apps/smsbillables/management/commands/add_moz_zero_charge.py
+++ b/corehq/apps/smsbillables/management/commands/add_moz_zero_charge.py
@@ -13,10 +13,10 @@ from corehq.apps.smsbillables.models import SmsGatewayFee, SmsGatewayFeeCriteria
 logger = logging.getLogger('accounting')
 
 
-def add_moz_zero_charge(orm):
-    mzn, _ = (orm['accounting.Currency'] if orm else Currency).objects.get_or_create(code='MZN')
-    sms_gateway_fee_class = orm['smsbillables.SmsGatewayFee'] if orm else SmsGatewayFee
-    sms_gateway_fee_criteria_class = orm['smsbillables.SmsGatewayFeeCriteria'] if orm else SmsGatewayFeeCriteria
+def add_moz_zero_charge(apps):
+    mzn, _ = (apps.get_model('accounting', 'Currency') if apps else Currency).objects.get_or_create(code='MZN')
+    sms_gateway_fee_class = apps.get_model('smsbillables', 'SmsGatewayFee') if apps else SmsGatewayFee
+    sms_gateway_fee_criteria_class = apps.get_model('smsbillables', 'SmsGatewayFeeCriteria') if apps else SmsGatewayFeeCriteria
 
     SmsGatewayFee.create_new(
         'SISLOG',

--- a/corehq/apps/smsbillables/management/commands/bootstrap_grapevine_gateway.py
+++ b/corehq/apps/smsbillables/management/commands/bootstrap_grapevine_gateway.py
@@ -11,10 +11,10 @@ from corehq.apps.smsbillables.utils import get_global_backends_by_class
 logger = logging.getLogger('accounting')
 
 
-def bootstrap_grapevine_gateway(orm):
-    currency_class = orm['accounting.Currency'] if orm else Currency
-    sms_gateway_fee_class = orm['smsbillables.SmsGatewayFee'] if orm else SmsGatewayFee
-    sms_gateway_fee_criteria_class = orm['smsbillables.SmsGatewayFeeCriteria'] if orm else SmsGatewayFeeCriteria
+def bootstrap_grapevine_gateway(apps):
+    currency_class = apps.get_model('accounting', 'Currency') if apps else Currency
+    sms_gateway_fee_class = apps.get_model('smsbillables', 'SmsGatewayFee') if apps else SmsGatewayFee
+    sms_gateway_fee_criteria_class = apps.get_model('smsbillables', 'SmsGatewayFeeCriteria') if apps else SmsGatewayFeeCriteria
 
     relevant_backends = get_global_backends_by_class(GrapevineBackend)
     currency = currency_class.objects.get_or_create(code="ZAR")[0]

--- a/corehq/apps/smsbillables/management/commands/bootstrap_grapevine_gateway_update.py
+++ b/corehq/apps/smsbillables/management/commands/bootstrap_grapevine_gateway_update.py
@@ -10,10 +10,10 @@ from corehq.apps.smsbillables.models import SmsGatewayFee, SmsGatewayFeeCriteria
 logger = logging.getLogger('accounting')
 
 
-def bootstrap_grapevine_gateway_update(orm):
-    currency_class = orm['accounting.Currency'] if orm else Currency
-    sms_gateway_fee_class = orm['smsbillables.SmsGatewayFee'] if orm else SmsGatewayFee
-    sms_gateway_fee_criteria_class = orm['smsbillables.SmsGatewayFeeCriteria'] if orm else SmsGatewayFeeCriteria
+def bootstrap_grapevine_gateway_update(apps):
+    currency_class = apps.get_model('accounting', 'Currency') if apps else Currency
+    sms_gateway_fee_class = apps.get_model('smsbillables', 'SmsGatewayFee') if apps else SmsGatewayFee
+    sms_gateway_fee_criteria_class = apps.get_model('smsbillables', 'SmsGatewayFeeCriteria') if apps else SmsGatewayFeeCriteria
 
     currency = currency_class.objects.get_or_create(code="ZAR")[0]
 

--- a/corehq/apps/smsbillables/management/commands/bootstrap_mach_gateway.py
+++ b/corehq/apps/smsbillables/management/commands/bootstrap_mach_gateway.py
@@ -11,10 +11,10 @@ from corehq.apps.smsbillables.models import SmsGatewayFee, SmsGatewayFeeCriteria
 logger = logging.getLogger('accounting')
 
 
-def bootstrap_mach_gateway(orm):
-    currency_class = orm['accounting.Currency'] if orm else Currency
-    sms_gateway_fee_class = orm['smsbillables.SmsGatewayFee'] if orm else SmsGatewayFee
-    sms_gateway_fee_criteria_class = orm['smsbillables.SmsGatewayFeeCriteria'] if orm else SmsGatewayFeeCriteria
+def bootstrap_mach_gateway(apps):
+    currency_class = apps.get_model('accounting', 'Currency') if apps else Currency
+    sms_gateway_fee_class = apps.get_model('smsbillables', 'SmsGatewayFee') if apps else SmsGatewayFee
+    sms_gateway_fee_criteria_class = apps.get_model('smsbillables', 'SmsGatewayFeeCriteria') if apps else SmsGatewayFeeCriteria
 
     workbook = xlrd.open_workbook('corehq/apps/smsbillables/management/'
                                   'commands/pricing_data/Syniverse_coverage_list_DIAMONDplus.xls')

--- a/corehq/apps/smsbillables/management/commands/bootstrap_moz_gateway.py
+++ b/corehq/apps/smsbillables/management/commands/bootstrap_moz_gateway.py
@@ -13,10 +13,10 @@ from corehq.apps.smsbillables.models import SmsGatewayFee, SmsGatewayFeeCriteria
 logger = logging.getLogger('accounting')
 
 
-def bootstrap_moz_gateway(orm):
-    mzn, _ = (orm['accounting.Currency'] if orm else Currency).objects.get_or_create(code='MZN')
-    sms_gateway_fee_class = orm['smsbillables.SmsGatewayFee'] if orm else SmsGatewayFee
-    sms_gateway_fee_criteria_class = orm['smsbillables.SmsGatewayFeeCriteria'] if orm else SmsGatewayFeeCriteria
+def bootstrap_moz_gateway(apps):
+    mzn, _ = (apps.get_model('accounting', 'Currency') if apps else Currency).objects.get_or_create(code='MZN')
+    sms_gateway_fee_class = apps.get_model('smsbillables', 'SmsGatewayFee') if apps else SmsGatewayFee
+    sms_gateway_fee_criteria_class = apps.get_model('smsbillables', 'SmsGatewayFeeCriteria') if apps else SmsGatewayFeeCriteria
 
     SmsGatewayFee.create_new(
         'SISLOG',

--- a/corehq/apps/smsbillables/management/commands/bootstrap_telerivet_gateway.py
+++ b/corehq/apps/smsbillables/management/commands/bootstrap_telerivet_gateway.py
@@ -1,6 +1,7 @@
 from decimal import Decimal
 import logging
 
+from django.conf import settings
 from django.core.management.base import LabelCommand
 
 from corehq.apps.accounting.models import Currency
@@ -12,10 +13,10 @@ from corehq.apps.telerivet.models import TelerivetBackend
 logger = logging.getLogger('accounting')
 
 
-def bootstrap_telerivet_gateway(orm):
-    default_currency = (orm['accounting.Currency'] if orm else Currency).get_default()
-    sms_gateway_fee_class = orm['smsbillables.SmsGatewayFee'] if orm else SmsGatewayFee
-    sms_gateway_fee_criteria_class = orm['smsbillables.SmsGatewayFeeCriteria'] if orm else SmsGatewayFeeCriteria
+def bootstrap_telerivet_gateway(apps):
+    default_currency, _  = (apps.get_model('accounting', 'Currency') if apps else Currency).objects.get_or_create(code=settings.DEFAULT_CURRENCY)
+    sms_gateway_fee_class = apps.get_model('smsbillables', 'SmsGatewayFee') if apps else SmsGatewayFee
+    sms_gateway_fee_criteria_class = apps.get_model('smsbillables', 'SmsGatewayFeeCriteria') if apps else SmsGatewayFeeCriteria
 
     SmsGatewayFee.create_new(
         TelerivetBackend.get_api_id(),

--- a/corehq/apps/smsbillables/management/commands/bootstrap_test_gateway.py
+++ b/corehq/apps/smsbillables/management/commands/bootstrap_test_gateway.py
@@ -1,6 +1,7 @@
 from decimal import Decimal
 import logging
 
+from django.conf import settings
 from django.core.management.base import LabelCommand
 
 from corehq.apps.accounting.models import Currency
@@ -12,10 +13,10 @@ from corehq.apps.smsbillables.models import SmsGatewayFee, SmsGatewayFeeCriteria
 logger = logging.getLogger('accounting')
 
 
-def bootstrap_test_gateway(orm):
-    default_currency = (orm['accounting.Currency'] if orm else Currency).get_default()
-    sms_gateway_fee_class = orm['smsbillables.SmsGatewayFee'] if orm else SmsGatewayFee
-    sms_gateway_fee_criteria_class = orm['smsbillables.SmsGatewayFeeCriteria'] if orm else SmsGatewayFeeCriteria
+def bootstrap_test_gateway(apps):
+    default_currency, _ = (apps.get_model('accounting', 'Currency') if apps else Currency).objects.get_or_create(code=settings.DEFAULT_CURRENCY)
+    sms_gateway_fee_class = apps.get_model('smsbillables', 'SmsGatewayFee') if apps else SmsGatewayFee
+    sms_gateway_fee_criteria_class = apps.get_model('smsbillables', 'SmsGatewayFeeCriteria') if apps else SmsGatewayFeeCriteria
 
     SmsGatewayFee.create_new(
         TestSMSBackend.get_api_id(),

--- a/corehq/apps/smsbillables/management/commands/bootstrap_tropo_gateway.py
+++ b/corehq/apps/smsbillables/management/commands/bootstrap_tropo_gateway.py
@@ -9,10 +9,10 @@ from corehq.apps.smsbillables.models import SmsGatewayFee, SmsGatewayFeeCriteria
 logger = logging.getLogger('accounting')
 
 
-def bootstrap_tropo_gateway(orm):
-    currency = (orm['accounting.Currency'] if orm else Currency).objects.get(code="USD")
-    sms_gateway_fee_class = orm['smsbillables.SmsGatewayFee'] if orm else SmsGatewayFee
-    sms_gateway_fee_criteria_class = orm['smsbillables.SmsGatewayFeeCriteria'] if orm else SmsGatewayFeeCriteria
+def bootstrap_tropo_gateway(apps):
+    currency = (apps.get_model('accounting', 'Currency') if apps else Currency).objects.get(code="USD")
+    sms_gateway_fee_class = apps.get_model('smsbillables', 'SmsGatewayFee') if apps else SmsGatewayFee
+    sms_gateway_fee_criteria_class = apps.get_model('smsbillables', 'SmsGatewayFeeCriteria') if apps else SmsGatewayFeeCriteria
 
     SmsGatewayFee.create_new(
         TropoBackend.get_api_id(),

--- a/corehq/apps/smsbillables/management/commands/bootstrap_twilio_gateway.py
+++ b/corehq/apps/smsbillables/management/commands/bootstrap_twilio_gateway.py
@@ -12,10 +12,10 @@ from corehq.apps.smsbillables.models import SmsGatewayFee, SmsGatewayFeeCriteria
 logger = logging.getLogger('accounting')
 
 
-def bootstrap_twilio_gateway(orm):
-    currency_class = orm['accounting.Currency'] if orm else Currency
-    sms_gateway_fee_class = orm['smsbillables.SmsGatewayFee'] if orm else SmsGatewayFee
-    sms_gateway_fee_criteria_class = orm['smsbillables.SmsGatewayFeeCriteria'] if orm else SmsGatewayFeeCriteria
+def bootstrap_twilio_gateway(apps):
+    currency_class = apps.get_model('accounting', 'Currency') if apps else Currency
+    sms_gateway_fee_class = apps.get_model('smsbillables', 'SmsGatewayFee') if apps else SmsGatewayFee
+    sms_gateway_fee_criteria_class = apps.get_model('smsbillables', 'SmsGatewayFeeCriteria') if apps else SmsGatewayFeeCriteria
 
     # iso -> provider -> rate
     def get_twilio_data():

--- a/corehq/apps/smsbillables/management/commands/bootstrap_twilio_gateway_incoming.py
+++ b/corehq/apps/smsbillables/management/commands/bootstrap_twilio_gateway_incoming.py
@@ -10,10 +10,10 @@ from corehq.apps.smsbillables.models import SmsGatewayFee, SmsGatewayFeeCriteria
 logger = logging.getLogger('accounting')
 
 
-def bootstrap_twilio_gateway_incoming(orm):
-    currency_class = orm['accounting.Currency'] if orm else Currency
-    sms_gateway_fee_class = orm['smsbillables.SmsGatewayFee'] if orm else SmsGatewayFee
-    sms_gateway_fee_criteria_class = orm['smsbillables.SmsGatewayFeeCriteria'] if orm else SmsGatewayFeeCriteria
+def bootstrap_twilio_gateway_incoming(apps):
+    currency_class = apps.get_model('accounting', 'Currency') if apps else Currency
+    sms_gateway_fee_class = apps.get_model('smsbillables', 'SmsGatewayFee') if apps else SmsGatewayFee
+    sms_gateway_fee_criteria_class = apps.get_model('smsbillables', 'SmsGatewayFeeCriteria') if apps else SmsGatewayFeeCriteria
 
     # https://www.twilio.com/sms/pricing/us
     SmsGatewayFee.create_new(

--- a/corehq/apps/smsbillables/management/commands/bootstrap_unicel_gateway.py
+++ b/corehq/apps/smsbillables/management/commands/bootstrap_unicel_gateway.py
@@ -9,10 +9,10 @@ from corehq.apps.unicel.api import UnicelBackend
 logger = logging.getLogger('accounting')
 
 
-def bootstrap_unicel_gateway(orm):
-    currency = (orm['accounting.Currency'] if orm else Currency).objects.get(code="INR")
-    sms_gateway_fee_class = orm['smsbillables.SmsGatewayFee'] if orm else SmsGatewayFee
-    sms_gateway_fee_criteria_class = orm['smsbillables.SmsGatewayFeeCriteria'] if orm else SmsGatewayFeeCriteria
+def bootstrap_unicel_gateway(apps):
+    currency = (apps.get_model('accounting.Currency') if apps else Currency).objects.get(code="INR")
+    sms_gateway_fee_class = apps.get_model('smsbillables.SmsGatewayFee') if apps else SmsGatewayFee
+    sms_gateway_fee_criteria_class = apps.get_model('smsbillables.SmsGatewayFeeCriteria') if apps else SmsGatewayFeeCriteria
 
     SmsGatewayFee.create_new(UnicelBackend.get_api_id(), INCOMING, 0.50,
                              currency=currency,

--- a/corehq/apps/smsbillables/management/commands/bootstrap_yo_gateway.py
+++ b/corehq/apps/smsbillables/management/commands/bootstrap_yo_gateway.py
@@ -11,10 +11,10 @@ from corehq.apps.smsbillables.models import SmsGatewayFee, SmsGatewayFeeCriteria
 logger = logging.getLogger('accounting')
 
 
-def bootstrap_yo_gateway(orm):
-    ugx, _ = (orm['accounting.Currency'] if orm else Currency).objects.get_or_create(code='UGX')
-    sms_gateway_fee_class = orm['smsbillables.SmsGatewayFee'] if orm else SmsGatewayFee
-    sms_gateway_fee_criteria_class = orm['smsbillables.SmsGatewayFeeCriteria'] if orm else SmsGatewayFeeCriteria
+def bootstrap_yo_gateway(apps):
+    ugx, _ = (apps.get_model('accounting', 'Currency') if apps else Currency).objects.get_or_create(code='UGX')
+    sms_gateway_fee_class = apps.get_model('smsbillables', 'SmsGatewayFee') if apps else SmsGatewayFee
+    sms_gateway_fee_criteria_class = apps.get_model('smsbillables', 'SmsGatewayFeeCriteria') if apps else SmsGatewayFeeCriteria
 
     SmsGatewayFee.create_new(
         'YO',

--- a/corehq/apps/smsbillables/migrations/0002_bootstrap.py
+++ b/corehq/apps/smsbillables/migrations/0002_bootstrap.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+from django.core.management import call_command
+
+from dimagi.utils.couch import sync_docs
+
+import corehq.apps.sms.models as sms_models
+from corehq.apps.smsbillables.management.commands.bootstrap_grapevine_gateway import \
+    bootstrap_grapevine_gateway
+from corehq.apps.smsbillables.management.commands.bootstrap_mach_gateway import \
+    bootstrap_mach_gateway
+from corehq.apps.smsbillables.management.commands.bootstrap_tropo_gateway import \
+    bootstrap_tropo_gateway
+from corehq.apps.smsbillables.management.commands.bootstrap_twilio_gateway import \
+    bootstrap_twilio_gateway
+from corehq.apps.smsbillables.management.commands.bootstrap_unicel_gateway import \
+    bootstrap_unicel_gateway
+
+
+def sync_sms_docs(apps, schema_editor):
+    # hack: manually force sync SMS design docs before
+    # we try to load from them. the bootstrap commands are dependent on these.
+    # import ipdb; ipdb.set_trace()
+    sync_docs.sync(apps.get_app_config('sms').get_models(), verbosity=2)
+
+
+def bootstrap_currency(apps, schema_editor):
+    Currency = apps.get_model("accounting", "Currency")
+    Currency.objects.get_or_create(code=settings.DEFAULT_CURRENCY)
+    Currency.objects.get_or_create(code='EUR')
+    Currency.objects.get_or_create(code='INR')
+
+
+def bootstrap_sms(apps, schema_editor):
+    bootstrap_grapevine_gateway(apps)
+    bootstrap_mach_gateway(apps)
+    bootstrap_tropo_gateway(apps)
+    bootstrap_twilio_gateway(apps)
+    bootstrap_unicel_gateway(apps)
+    call_command('bootstrap_usage_fees')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('smsbillables', '0001_initial'),
+        ('sms', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(sync_sms_docs),
+        migrations.RunPython(bootstrap_currency),
+        migrations.RunPython(bootstrap_sms),
+    ]

--- a/corehq/apps/smsbillables/migrations/0002_bootstrap.py
+++ b/corehq/apps/smsbillables/migrations/0002_bootstrap.py
@@ -38,7 +38,7 @@ def sync_sms_docs(apps, schema_editor):
     # hack: manually force sync SMS design docs before
     # we try to load from them. the bootstrap commands are dependent on these.
     # import ipdb; ipdb.set_trace()
-    sync_docs.sync(apps.get_app_config('sms').get_models(), verbosity=2)
+    pass
 
 
 def bootstrap_currency(apps, schema_editor):
@@ -49,6 +49,7 @@ def bootstrap_currency(apps, schema_editor):
 
 
 def bootstrap_sms(apps, schema_editor):
+    sync_docs.sync(apps.get_app_config('sms').get_models(), verbosity=2)
     bootstrap_grapevine_gateway(apps)
     bootstrap_mach_gateway(apps)
     bootstrap_tropo_gateway(apps)

--- a/corehq/apps/smsbillables/migrations/0002_bootstrap.py
+++ b/corehq/apps/smsbillables/migrations/0002_bootstrap.py
@@ -49,7 +49,7 @@ def bootstrap_currency(apps, schema_editor):
 
 
 def bootstrap_sms(apps, schema_editor):
-    sync_docs.sync(apps.get_app_config('sms').get_models(), verbosity=2)
+    sync_docs.sync(sms_models, verbosity=2)
     bootstrap_grapevine_gateway(apps)
     bootstrap_mach_gateway(apps)
     bootstrap_tropo_gateway(apps)

--- a/corehq/apps/smsbillables/migrations/0002_bootstrap.py
+++ b/corehq/apps/smsbillables/migrations/0002_bootstrap.py
@@ -18,6 +18,20 @@ from corehq.apps.smsbillables.management.commands.bootstrap_twilio_gateway impor
     bootstrap_twilio_gateway
 from corehq.apps.smsbillables.management.commands.bootstrap_unicel_gateway import \
     bootstrap_unicel_gateway
+from corehq.apps.smsbillables.management.commands.bootstrap_moz_gateway import \
+    bootstrap_moz_gateway
+from corehq.apps.smsbillables.management.commands.bootstrap_test_gateway import \
+    bootstrap_test_gateway
+from corehq.apps.smsbillables.management.commands.bootstrap_telerivet_gateway import \
+    bootstrap_telerivet_gateway
+from corehq.apps.smsbillables.management.commands.bootstrap_twilio_gateway_incoming import \
+    bootstrap_twilio_gateway_incoming
+from corehq.apps.smsbillables.management.commands.bootstrap_yo_gateway import \
+    bootstrap_yo_gateway
+from corehq.apps.smsbillables.management.commands.add_moz_zero_charge import \
+    add_moz_zero_charge
+from corehq.apps.smsbillables.management.commands.bootstrap_grapevine_gateway_update import \
+    bootstrap_grapevine_gateway_update
 
 
 def sync_sms_docs(apps, schema_editor):
@@ -41,6 +55,13 @@ def bootstrap_sms(apps, schema_editor):
     bootstrap_twilio_gateway(apps)
     bootstrap_unicel_gateway(apps)
     call_command('bootstrap_usage_fees')
+    bootstrap_moz_gateway(apps)
+    bootstrap_test_gateway(apps)
+    bootstrap_telerivet_gateway(apps)
+    bootstrap_twilio_gateway_incoming(apps)
+    bootstrap_yo_gateway(apps)
+    add_moz_zero_charge(apps)
+    bootstrap_grapevine_gateway_update(apps)
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/pull/8113#issuecomment-138335121

smsbillables should be the same

accounting is different though: https://gist.github.com/emord/357065f321ffdf72112a/revisions (left is the old south_migrations, right is new django migration)

the deleted code: https://gist.github.com/emord/357065f321ffdf72112a/revisions#diff-671811f11318cfeb2257a5ef5c20b500L26 looked like it was only migrating from old accounting models the new ones (it also references some fields that are no longer here)

@nickpell 

cc: @czue 
