### PR TITLE
Force CommCare to update its image resizing

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/json/commcare-profile-settings.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-profile-settings.yaml
@@ -274,6 +274,7 @@
   default: "none"
   values_txt: "This will determine how images you select for your questions will be resized to fit the screen. Horizontal will stretch/compress the image to fit perfectly horizontally while scaling to height to maintain the aspect ratio. Full Resize will try to be clever and find the ideal vertical/horizontal scaling for the screen. Half Resize will do the same but with half the area."
   since: "2.11"
+  force: true
 
 - name: "Fuzzy Search"
   description: "Whether searches on the phone will match similar strings. IE: 'Jhon' will match 'John'"


### PR DESCRIPTION
Method when this is changed on HQ

I think this is causing some confusion in QA, and can't think of a reason why we wouldn't force CommCare to use the most recent settings when this is changed
