### PR TITLE
Fix default report builder filter

### DIFF
--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -655,9 +655,9 @@ class ConfigureNewReportBase(forms.Form):
                 # This will likely require implementing data source filters.
                 FilterViewModel(
                     exists_in_current_version=True,
-                    property='owner_id',
+                    property='computed/owner_name',
                     data_source_field=None,
-                    display_text='owner_id',
+                    display_text='owner name',
                     format='Choice',
                 ),
             ]


### PR DESCRIPTION
There was a default `owner_id` filter for new report builder reports. Now it's owner name, much more useful.

cc @gcapalbo 
