### PR TITLE
Accept any version of pip >= 6.1.1

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -75,7 +75,7 @@ django-angular==0.7.8
 Pycco==0.3.0
 django-mptt==0.7.4
 jsonpath-rw==1.3.0
-pip==6.1.1
+pip>=6.1.1
 git+git://github.com/smartfile/django-transfer.git@6e0dc94c3341c358fca8eb2bf74e23aee3983ec4
 Pygments==2.0.2
 


### PR DESCRIPTION
This way you can upgrade pip locally to silence that deprecation warning. Note
that this will not force an upgrade on any environments, so if that's
something we need/want, we should also bump the version number.

@snopoke, you added the dependency, do you know if it's important we stay
up-to-date?
@sravfeyn code buddy ping
