### PR TITLE
Exclude archived locations from location fixture

### DIFF
--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -69,7 +69,7 @@ class LocationFixtureProvider(object):
         a fixture with ALL locations for the domain.
         """
         if toggles.SYNC_ALL_LOCATIONS.enabled(user.domain):
-            locations = SQLLocation.objects.filter(domain=user.domain)
+            locations = SQLLocation.active_objects.filter(domain=user.domain)
         else:
             locations = []
             user_location = user.sql_location
@@ -78,12 +78,13 @@ class LocationFixtureProvider(object):
                 locations.append(user_location)
 
                 # add all descendants as well
-                locations += user_location.get_descendants()
+                locations += (user_location.get_descendants()
+                                           .filter(is_archived=False))
 
             if user.project.supports_multiple_locations_per_user:
                 # this might add duplicate locations but we filter that out later
                 location_ids = [loc._id for loc in user.locations]
-                locations += SQLLocation.objects.filter(
+                locations += SQLLocation.active_objects.filter(
                     location_id__in=location_ids
                 )
 

--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -183,6 +183,12 @@ class LocationManager(LocationQueriesMixin, TreeManager):
         return self.get_queryset_descendants(direct_matches, include_self=True)
 
 
+class OnlyUnarchivedLocationManager(LocationManager):
+    def get_queryset(self):
+        return (super(OnlyUnarchivedLocationManager, self).get_query_set()
+                .filter(is_archived=False))
+
+
 class SQLLocation(MPTTModel):
     domain = models.CharField(max_length=255, db_index=True)
     name = models.CharField(max_length=100, null=True)
@@ -208,6 +214,8 @@ class SQLLocation(MPTTModel):
     supply_point_id = models.CharField(max_length=255, db_index=True, unique=True, null=True)
 
     objects = LocationManager()
+    # This should really be the default location manager
+    active_objects = OnlyUnarchivedLocationManager()
 
     @property
     def get_id(self):


### PR DESCRIPTION
I know I could easily just add `.filter(is_archived=False)` to the specific instances here, but I'm doing this as a foot-in-the-door thing.  The way "archived locations" should have been implemented in the first place is by modifying the default queryset, so archived locations are always excluded.  My plan with this is to make a second manager and switch stuff over piecemeal as it's identified, then eventually make it the default.
