### PR TITLE
Set extension relationship when syncing

### DIFF
--- a/corehq/apps/app_manager/tests/data/form_preparation_v2_advanced/extension-case.xml
+++ b/corehq/apps/app_manager/tests/data/form_preparation_v2_advanced/extension-case.xml
@@ -1,0 +1,63 @@
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/jr/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+	<h:head>
+		<h:title>New Form</h:title>
+		<model>
+			<instance>
+				<data xmlns="http://openrosa.org/formdesigner/21683C30-2763-4659-B13F-2D4AF089EF7C" xmlns:jrm="http://dev.commcarehq.org/jr/xforms" name="New Form" uiVersion="1" version="3">
+					<mother_name/>
+					<child jr:template="">
+						<case xmlns="http://commcarehq.org/case/transaction/v2" case_id="" date_modified="" user_id=""><create><case_name/><owner_id/><case_type>child1</case_type></create><index><parent case_type="parent_test_case_type"/><host case_type="parent_test_case_type" relationship="extension"/></index></case><name/>
+                        <which_child/>
+					</child>
+				<orx:meta xmlns:cc="http://commcarehq.org/xforms"><orx:deviceID/><orx:timeStart/><orx:timeEnd/><orx:username/><orx:userID/><orx:instanceID/><cc:appVersion/></orx:meta></data>
+			</instance><instance id="commcaresession" src="jr://instance/session"/>
+			<bind nodeset="/data/mother_name" required="true()" type="xsd:string"/>
+			<bind nodeset="/data/child"/>
+			<bind nodeset="/data/child/name" required="true()" type="xsd:string"/>
+            <bind nodeset="/data/children/which_child"/>
+			<itext>
+				<translation default="" lang="en">
+					<text id="mother_name-label">
+						<value>Name</value>
+					</text>
+					<text id="child-label">
+						<value>Child</value>
+					</text>
+					<text id="which_child-label">
+						<value>which child</value>
+					</text>
+					<text id="which_child-1-label">
+						<value>one</value>
+					</text>
+					<text id="which_child-2-label">
+						<value>two</value>
+					</text>
+				</translation>
+			</itext>
+		<bind calculate="/data/meta/timeEnd" nodeset="/data/child/case/@date_modified" type="xsd:dateTime"/><bind calculate="/data/meta/userID" nodeset="/data/child/case/@user_id"/><bind nodeset="/data/child/case" relevant="false()"/><bind calculate="uuid()" nodeset="/data/child/case/@case_id"/><bind calculate="/data/mother_name" nodeset="/data/child/case/create/case_name"/><bind calculate="/data/meta/userID" nodeset="/data/child/case/create/owner_id"/><bind calculate="instance('commcaresession')/session/data/case_id_load_1" nodeset="/data/child/case/index/parent"/><bind calculate="instance('commcaresession')/session/data/case_id_load_1" nodeset="/data/child/case/index/host"/><setvalue event="xforms-ready" ref="/data/meta/deviceID" value="instance('commcaresession')/session/context/deviceid"/><setvalue event="xforms-ready" ref="/data/meta/timeStart" value="now()"/><bind nodeset="/data/meta/timeStart" type="xsd:dateTime"/><setvalue event="xforms-revalidate" ref="/data/meta/timeEnd" value="now()"/><bind nodeset="/data/meta/timeEnd" type="xsd:dateTime"/><setvalue event="xforms-ready" ref="/data/meta/username" value="instance('commcaresession')/session/context/username"/><setvalue event="xforms-ready" ref="/data/meta/userID" value="instance('commcaresession')/session/context/userid"/><setvalue event="xforms-ready" ref="/data/meta/instanceID" value="uuid()"/><setvalue event="xforms-ready" ref="/data/meta/appVersion" value="instance('commcaresession')/session/context/appversion"/></model>
+	</h:head>
+	<h:body>
+		<input ref="/data/mother_name">
+			<label ref="jr:itext('mother_name-label')"/>
+		</input>
+		<group>
+			<label ref="jr:itext('child-label')"/>
+			<repeat nodeset="/data/child">
+                <select1 ref="/data/children/which_child">
+					<label ref="jr:itext('which_child-label')"/>
+					<item>
+						<label ref="jr:itext('which_child-1-label')"/>
+						<value>1</value>
+					</item>
+					<item>
+						<label ref="jr:itext('which_child-2-label')"/>
+						<value>2</value>
+					</item>
+				</select1>
+				<input ref="/data/child/name">
+					<label ref="jr:itext('mother_name-label')"/>
+				</input>
+			</repeat>
+		</group>
+	</h:body>
+</h:html>

--- a/corehq/apps/app_manager/tests/test_form_preparation_v2.py
+++ b/corehq/apps/app_manager/tests/test_form_preparation_v2.py
@@ -416,7 +416,7 @@ class FormPreparationChildModules(SimpleTestCase, TestFileMixin):
         self.assertXmlEqual(self.get_xml('child_module_adjusted_case_id_basic'), form.render_xform())
 
 
-class SubcaseRepeatTestAdvanced(SimpleTestCase, TestFileMixin):
+class BaseIndexTest(SimpleTestCase, TestFileMixin):
     file_path = ('data', 'form_preparation_v2_advanced')
 
     def setUp(self):
@@ -445,6 +445,9 @@ class SubcaseRepeatTestAdvanced(SimpleTestCase, TestFileMixin):
 
     def tearDown(self):
         self.is_usercase_in_use_patch.stop()
+
+
+class SubcaseRepeatTestAdvanced(BaseIndexTest):
 
     def test_subcase(self):
         self.form.actions.load_update_cases.append(LoadUpdateAction(
@@ -536,6 +539,25 @@ class SubcaseRepeatTestAdvanced(SimpleTestCase, TestFileMixin):
         self.form.actions.open_cases[1].open_condition.question = '/data/child/which_child'
         self.form.actions.open_cases[1].open_condition.answer = '2'
         self.assertXmlEqual(self.get_xml('subcase-repeat-multiple'), self.form.render_xform())
+
+
+class TestExtensionCase(BaseIndexTest):
+
+    def test_relationship_added_to_form(self):
+        self.form.actions.load_update_cases.append(LoadUpdateAction(
+            case_type=self.parent_module.case_type,
+            case_tag='load_1',
+        ))
+        self.form.actions.open_cases.append(AdvancedOpenCaseAction(
+            case_type='child1',
+            case_tag='open_1',
+            name_path='/data/mother_name',
+            case_indices=[CaseIndex(tag='load_1'),
+                          CaseIndex(tag='load_1', reference_id='host', relationship='extension')],
+            repeat_context="/data/child",
+        ))
+
+        self.assertXmlEqual(self.get_xml('extension-case'), self.form.render_xform())
 
 
 class TestXForm(SimpleTestCase, TestFileMixin):

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -1668,6 +1668,7 @@ class XForm(WrappedNode):
                     reference_id,
                     parent_meta['action'].case_type,
                     ref,
+                    case_index.relationship,
                 )
 
             if action.close_condition.type != 'never':

--- a/corehq/ex-submodules/casexml/apps/case/models.py
+++ b/corehq/ex-submodules/casexml/apps/case/models.py
@@ -280,7 +280,8 @@ class CommCareCase(SafeSaveDocument, IndexHoldingMixIn, ComputedDocumentMixin,
         return dict([
             (index.identifier, {
                 "case_type": index.referenced_type,
-                "case_id": index.referenced_id
+                "case_id": index.referenced_id,
+                "relationship": index.relationship,
             }) for index in (self.indices if not reversed else self.reverse_indices)
         ])
 

--- a/corehq/ex-submodules/casexml/apps/case/sharedmodels.py
+++ b/corehq/ex-submodules/casexml/apps/case/sharedmodels.py
@@ -32,7 +32,8 @@ class CommCareCaseIndex(LooselyEqualDocumentSchema, UnicodeMixIn):
     def from_case_index_update(cls, index):
         return cls(identifier=index.identifier,
                    referenced_type=index.referenced_type,
-                   referenced_id=index.referenced_id)
+                   referenced_id=index.referenced_id,
+                   relationship=index.relationship,)
 
     def __unicode__(self):
         return "%(identifier)s ref: (type: %(ref_type)s, id: %(ref_id)s)" % \
@@ -134,12 +135,14 @@ class IndexHoldingMixIn(object):
                     index = self.get_index(index_update.identifier)
                     index.referenced_type = index_update.referenced_type
                     index.referenced_id = index_update.referenced_id
+                    index.relationship = index_update.relationship
             else:
                 # no id, no index
                 if index_update.referenced_id:
                     self.indices.append(CommCareCaseIndex(identifier=index_update.identifier,
                                                           referenced_type=index_update.referenced_type,
-                                                          referenced_id=index_update.referenced_id))
+                                                          referenced_id=index_update.referenced_id,
+                                                          relationship=index_update.relationship,))
 
     def remove_index_by_ref_id(self, doc_id):
         index = self.get_index_by_ref_id(doc_id)

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_indexes.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_indexes.py
@@ -165,6 +165,20 @@ class IndexTest(TestCase):
         self.assertIn('IllegalCaseId', xform.problem)
         self.assertIn('Bad case id', xform.problem)
 
+    def testRelationshipGetsSet(self):
+        user = User(user_id=USER_ID, username="", password="", date_joined="")
+        create_index = CaseBlock(
+            create=True,
+            case_id=self.CASE_ID,
+            user_id=USER_ID,
+            owner_id=USER_ID,
+            index={'mom': ('mother-case', self.MOTHER_CASE_ID, 'extension')},
+            version=V2
+        ).as_xml()
+
+        post_case_blocks([create_index])
+        check_user_has_case(self, user, create_index, version=V2)
+
 
 class CaseBlockIndexRelationshipTests(SimpleTestCase):
 

--- a/corehq/ex-submodules/casexml/apps/case/xml/generator.py
+++ b/corehq/ex-submodules/casexml/apps/case/xml/generator.py
@@ -62,6 +62,8 @@ class CaseXMLGeneratorBase(object):
     def get_index_element(self, index):
         elem = safe_element(index.identifier, index.referenced_id)
         elem.attrib = {"case_type": index.referenced_type}
+        if getattr(index, 'relationship') and index.relationship == "extension":
+            elem.attrib.update({"relationship": index.relationship})
         return elem
 
     def get_case_type_element(self):

--- a/corehq/ex-submodules/casexml/apps/case/xml/parser.py
+++ b/corehq/ex-submodules/casexml/apps/case/xml/parser.py
@@ -196,10 +196,11 @@ class CaseIndex(object):
     """
     A class that holds an index to a case.
     """
-    def __init__(self, identifier, referenced_type, referenced_id):
+    def __init__(self, identifier, referenced_type, referenced_id, relationship='child'):
         self.identifier = identifier
         self.referenced_type = referenced_type
         self.referenced_id = referenced_id
+        self.relationship = relationship
     
 class CaseIndexAction(CaseActionBase):
     """
@@ -225,7 +226,8 @@ class CaseIndexAction(CaseActionBase):
         for id, data in block.items():
             if "@case_type" not in data:
                 raise CaseGenerationException("Invalid index, must have a case type attribute.")
-            indices.append(CaseIndex(id, data["@case_type"], data.get("#text", "")))
+            indices.append(CaseIndex(id, data["@case_type"], data.get("#text", ""),
+                                     data.get("@relationship", 'child')))
         return cls(block, indices)
     
 


### PR DESCRIPTION
- Index relationship was not getting set correctly in the `<index>` block
- When newly created extension cases were sent back to HQ, their relationship status was not getting set correctly. Now it should be. :two_men_holding_hands:

@kaapstorm 
code bud: @biyeun 
