### PR TITLE
Properly wrap exports so MM DL works

### DIFF
--- a/corehq/apps/reports/dbaccessors.py
+++ b/corehq/apps/reports/dbaccessors.py
@@ -1,5 +1,5 @@
 import json
-import settings
+from django.conf import settings
 from corehq.apps.reports.models import HQExportSchema
 
 

--- a/corehq/apps/reports/standard/export.py
+++ b/corehq/apps/reports/standard/export.py
@@ -63,8 +63,7 @@ class FormExportReportBase(ExportReport, DatespanMixin):
 
     @memoized
     def get_saved_exports(self):
-        exports = stale_get_exports(self.domain)
-        exports = filter(lambda x: x.type == "form", exports)
+        exports = FormExportSchema.get_stale_exports(self.domain)
         if not self.can_view_deid:
             exports = filter(lambda x: not x.is_safe, exports)
         return sorted(exports, key=lambda x: x.name)
@@ -316,8 +315,7 @@ class CaseExportReport(ExportReport):
         return self.request.GET.copy()
 
     def get_saved_exports(self):
-        exports = stale_get_exports(self.domain).all()
-        exports = filter(lambda x: x.type == "case", exports)
+        exports = CaseExportSchema.get_stale_exports(self.domain)
         return sorted(exports, key=lambda x: x.name)
 
     @property
@@ -401,10 +399,7 @@ class DataExportInterface(GenericReportView):
     @property
     @memoized
     def saved_exports(self):
-        exports = [
-            self.export_schema.wrap(doc.to_json())
-            for doc in filter(lambda x: x.type == self.export_type, stale_get_exports(self.domain))
-        ]
+        exports = self.export_schema.get_stale_exports(self.domain)
         for export in exports:
             export.download_url = (
                 self.download_page_url_root + '?export_id=' + export._id

--- a/corehq/apps/reports/standard/export.py
+++ b/corehq/apps/reports/standard/export.py
@@ -9,7 +9,7 @@ from django.utils.translation import ugettext_noop, ugettext_lazy
 from django.http import Http404
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.hqcase.dbaccessors import get_case_types_for_domain
-from corehq.apps.reports.dbaccessors import stale_get_exports
+from corehq.apps.reports.dbaccessors import stale_get_export_count
 from dimagi.utils.decorators.memoized import memoized
 from django_prbac.utils import has_privilege
 from corehq import privileges
@@ -356,7 +356,7 @@ class DeidExportReport(FormExportReportBase):
 
     @classmethod
     def show_in_navigation(cls, domain=None, project=None, user=None):
-        return stale_get_exports(domain, include_docs=False, limit=1).count() > 0
+        return stale_get_export_count(domain) > 0
 
     def get_saved_exports(self):
         return filter(lambda export: export.is_safe, super(DeidExportReport, self).get_saved_exports())


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?181096
FormExportSchema has a pointer to xmlns, whereas HQExportSchema doesn't - this made it so the export task would try to make an export of an empty list of xmlnss.  There was some weird stuff about wrapping the docs appropriately, so I made a classmethod that does the job.
