### PR TITLE
make new sync logs when serving cached initial restores

### DIFF
--- a/corehq/apps/commtrack/tests/test_xml.py
+++ b/corehq/apps/commtrack/tests/test_xml.py
@@ -9,7 +9,7 @@ from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.xml import V2
 from casexml.apps.phone.restore import RestoreConfig, RestoreParams
 from casexml.apps.phone.tests import run_with_all_restore_configs
-from casexml.apps.phone.tests.utils import synclog_id_from_restore_payload
+from casexml.apps.phone.xml import synclog_id_from_restore_payload
 from corehq.apps.commtrack.models import ConsumptionConfig, StockRestoreConfig, StockState
 from corehq.apps.domain.models import Domain
 from corehq.apps.consumption.shortcuts import set_default_monthly_consumption_for_domain

--- a/corehq/ex-submodules/casexml/apps/phone/cache_utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/cache_utils.py
@@ -1,0 +1,67 @@
+from collections import namedtuple
+import os
+import shutil
+import tempfile
+import uuid
+import re
+from casexml.apps.phone.exceptions import SyncLogCachingError
+from casexml.apps.phone.models import get_properly_wrapped_sync_log
+
+
+FileReference = namedtuple('FileReference', ['file', 'path'])
+
+
+def copy_payload_and_synclog_and_get_new_file(filelike_payload):
+    """
+    Given a restore payload, extracts the sync log id and sync log from the payload,
+    makes a copy of the sync log, and then returns a new FileReference with the same contents
+    except using the new sync log ID.
+    """
+    synclog_id, end_position = extract_synclog_id_from_filelike_payload(filelike_payload)
+    old_sync_log = get_properly_wrapped_sync_log(synclog_id)
+    new_sync_log_doc = old_sync_log.to_json()
+    new_sync_log_id = uuid.uuid4().hex
+    new_sync_log_doc['_id'] = new_sync_log_id
+    del new_sync_log_doc['_rev']
+    old_sync_log.get_db().save_doc(new_sync_log_doc)
+    return replace_sync_log_id_in_filelike_payload(
+        filelike_payload, old_sync_log._id, new_sync_log_id, end_position
+    )
+
+
+def extract_synclog_id_from_filelike_payload(filelike_payload):
+    filelike_payload.seek(0)
+    try:
+        beginning_of_log = filelike_payload.read(500)
+        # i know, regex parsing xml is bad. not sure what to do since this is arbitrarily truncated
+        match = re.search('<restore_id>([\w_-]+)</restore_id>', beginning_of_log)
+        if not match:
+            raise SyncLogCachingError("Couldn't find synclog ID from beginning of restore!")
+        groups = match.groups()
+        if len(groups) != 1:
+            raise SyncLogCachingError("Found more than one synclog ID from beginning of restore! {}".format(
+                ', '.join(groups))
+            )
+        return groups[0], beginning_of_log.index(groups[0])
+    finally:
+        filelike_payload.seek(0)
+
+
+def replace_sync_log_id_in_filelike_payload(filelike_payload, old_id, new_id, position):
+    filelike_payload.seek(0)
+    try:
+        beginning = filelike_payload.read(position)
+        extracted_id = filelike_payload.read(len(old_id))
+        if extracted_id != old_id:
+            raise SyncLogCachingError('Error putting sync log back together. Expected ID {} but was {}'.format(
+                old_id, extracted_id,
+            ))
+        # write the result to a new file
+        fd, path = tempfile.mkstemp()
+        with os.fdopen(fd, 'wb') as outfile:
+            outfile.write(beginning)
+            outfile.write(new_id)
+            shutil.copyfileobj(filelike_payload, outfile)
+        return FileReference(open(path, 'r'), path)
+    finally:
+        filelike_payload.seek(0)

--- a/corehq/ex-submodules/casexml/apps/phone/exceptions.py
+++ b/corehq/ex-submodules/casexml/apps/phone/exceptions.py
@@ -62,3 +62,7 @@ class InvalidOwnerIdError(OwnershipCleanlinessError):
 
 class SimplifiedSyncAssertionError(Exception):
     pass
+
+
+class SyncLogCachingError(Exception):
+    pass

--- a/corehq/ex-submodules/casexml/apps/phone/tests/__init__.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/__init__.py
@@ -1,5 +1,6 @@
 import logging
 try:
+    from .test_caching_utils import *
     from .test_cleanliness import *
     from .test_new_sync import *
     from .test_index_tree import *

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_caching_utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_caching_utils.py
@@ -1,0 +1,78 @@
+import os
+import tempfile
+import uuid
+from StringIO import StringIO
+from django.test import SimpleTestCase, TestCase
+from casexml.apps.phone.cache_utils import extract_synclog_id_from_filelike_payload, \
+    replace_sync_log_id_in_filelike_payload, copy_payload_and_synclog_and_get_new_file
+from casexml.apps.phone.exceptions import SyncLogCachingError
+from casexml.apps.phone.models import SimplifiedSyncLog, get_properly_wrapped_sync_log
+from casexml.apps.phone.tests.dummy import dummy_restore_xml
+from casexml.apps.phone.xml import synclog_id_from_restore_payload
+
+
+class CacheUtilsTest(SimpleTestCase):
+
+    def test_extract_restore_id_basic(self):
+        restore_id = uuid.uuid4().hex
+        fd, path = tempfile.mkstemp()
+        restore_payload = dummy_restore_xml(restore_id).strip()
+        with os.fdopen(fd, 'wb') as f:
+            f.write(restore_payload)
+
+        with open(path, 'r') as f:
+            extracted, position = extract_synclog_id_from_filelike_payload(f)
+            self.assertEqual(restore_id, extracted)
+            self.assertEqual(restore_payload.index(restore_id), position)
+            # also make sure we reset the file pointer
+            self.assertEqual('<OpenRosaResponse', f.read(17))
+
+    def test_extract_restore_id_not_found(self):
+        f = StringIO('not much here')
+        with self.assertRaises(SyncLogCachingError):
+            extract_synclog_id_from_filelike_payload(f)
+
+    def test_replace_synclog_id(self):
+        initial_id = uuid.uuid4().hex
+        fd, path = tempfile.mkstemp()
+        restore_payload = dummy_restore_xml(initial_id).strip()
+        self.assertTrue(_restore_id_block(initial_id) in restore_payload)
+        with os.fdopen(fd, 'wb') as f:
+            f.write(restore_payload)
+
+        new_id = uuid.uuid4().hex
+        with open(path, 'r') as f:
+            position = restore_payload.index(initial_id)
+            file_reference = replace_sync_log_id_in_filelike_payload(f, initial_id, new_id, position)
+
+        updated_payload = file_reference.file.read()
+        self.assertTrue(_restore_id_block(new_id) in updated_payload)
+        self.assertFalse(initial_id in updated_payload)
+        self.assertEqual(restore_payload, updated_payload.replace(new_id, initial_id))
+        self.assertEqual(updated_payload, restore_payload.replace(initial_id, new_id))
+
+
+class CacheUtilsDbTest(TestCase):
+
+    def test_copy_payload(self):
+        sync_log = SimplifiedSyncLog(case_ids_on_phone=set(['case-1', 'case-2']))
+        sync_log.save()
+        payload = dummy_restore_xml(sync_log._id).strip()
+        fd, path = tempfile.mkstemp()
+        with os.fdopen(fd, 'wb') as f:
+            f.write(payload)
+
+        with open(path, 'r') as f:
+            updated_fileref = copy_payload_and_synclog_and_get_new_file(f)
+
+        updated_payload = updated_fileref.file.read()
+        updated_id = synclog_id_from_restore_payload(updated_payload)
+        self.assertNotEqual(sync_log._id, updated_id)
+        self.assertTrue(_restore_id_block(updated_id) in updated_payload)
+        self.assertFalse(sync_log._id in updated_payload)
+        updated_log = get_properly_wrapped_sync_log(updated_id)
+        self.assertEqual(updated_log.case_ids_on_phone, sync_log.case_ids_on_phone)
+
+
+def _restore_id_block(sync_id):
+    return '<restore_id>{}</restore_id>'.format(sync_id)

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -664,8 +664,6 @@ class SyncTokenCachingTest(SyncBaseTest):
         cached_payload = restore_config.get_payload()
         self.assertIsInstance(cached_payload, CachedResponse)
 
-        self.assertEqual(original_payload.as_string(), cached_payload.as_string())
-
     @run_with_all_restore_configs
     def testCacheInvalidation(self):
         original_payload = RestoreConfig(

--- a/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
@@ -28,7 +28,14 @@ def generate_restore_payload(project, user, restore_id="", version=V1, state_has
 
         returns: the xml payload of the sync operation
     """
-    config = RestoreConfig(
+    return get_restore_config(
+        project, user, restore_id, version, state_hash, items, overwrite_cache, force_cache
+    ).get_payload().as_string()
+
+
+def get_restore_config(project, user, restore_id="", version=V1, state_hash="",
+                       items=False, overwrite_cache=False, force_cache=False):
+    return RestoreConfig(
         project=project,
         user=user,
         params=RestoreParams(
@@ -42,7 +49,6 @@ def generate_restore_payload(project, user, restore_id="", version=V1, state_has
             force_cache=force_cache,
         )
     )
-    return config.get_payload().as_string()
 
 
 def generate_restore_response(project, user, restore_id="", version=V1, state_hash="", items=False):

--- a/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/utils.py
@@ -1,14 +1,8 @@
-from xml.etree import ElementTree
 from casexml.apps.case.xml import V1
 from casexml.apps.phone.dbaccessors.sync_logs_by_user import get_all_sync_logs_docs
 from casexml.apps.phone.models import get_properly_wrapped_sync_log, get_sync_log_class_by_format
 from casexml.apps.phone.restore import RestoreConfig, RestoreParams, RestoreCacheSettings
-from casexml.apps.phone.xml import SYNC_XMLNS
-
-
-def synclog_id_from_restore_payload(restore_payload):
-    element = ElementTree.fromstring(restore_payload)
-    return element.findall('{%s}Sync' % SYNC_XMLNS)[0].findall('{%s}restore_id' % SYNC_XMLNS)[0].text
+from casexml.apps.phone.xml import synclog_id_from_restore_payload
 
 
 def synclog_from_restore_payload(restore_payload):

--- a/corehq/ex-submodules/casexml/apps/phone/xml.py
+++ b/corehq/ex-submodules/casexml/apps/phone/xml.py
@@ -107,3 +107,8 @@ def get_data_element(name, dict):
         sub_el.attrib = {"key": k}
         elem.append(sub_el)
     return elem
+
+
+def synclog_id_from_restore_payload(restore_payload):
+    element = ElementTree.fromstring(restore_payload)
+    return element.findall('{%s}Sync' % SYNC_XMLNS)[0].findall('{%s}restore_id' % SYNC_XMLNS)[0].text


### PR DESCRIPTION
addresses the root cause of http://manage.dimagi.com/default.asp?181443

basically two phones got the same cached initial sync, which completely screws up the server's ability to detect what's on either phone.

this change makes it so that whenever you get a cached initial sync you make a copy of the log, inject the ID in the response, and then serve that. the code is pretty ugly because of having to deal with streaming everything and open to feedback on how to improve.

@benrudolph cc @snopoke 

wait for tests
