### PR TITLE
Ability to rollback in deploys

### DIFF
--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -687,7 +687,8 @@ def copy_tf_localsettings():
 @task
 def rollback():
     """
-    Rolls back the servers to the previous release if it exists and is same across servers
+    Rolls back the servers to the previous release if it exists and is same across servers. Note this will not
+    rollback the supervisor services.
     """
     number_of_releases = execute(get_number_of_releases)
     if not all(map(lambda n: n > 1, number_of_releases)):


### PR DESCRIPTION
@dannyroberts this implements a rollback to a previous release. One major caveat about this is that it doesn't redeploy the fab services templates. That's pretty much our only global state and hard to rollback unless we do some fiddling with git (or decide to keep the services templates in the release). I decided that in 99% of the cases this rollback works fine since we rarely change those files anyways. Let me know if you think I'm overlooking something. Going to test out on staging (have tested all the commands but the actual rollback), but pretty sure this is harmless to merge. Would love to figure out some sort of testing scheme for fabric too.

buddy: @czue 
