### PR TITLE
Add form variables only for the last real action

### DIFF
--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -1553,14 +1553,14 @@ class XForm(WrappedNode):
                     form.default_name())
                 )
 
-        last_real_action = next(
-            (action for action in reversed(form.actions.load_update_cases) if not action.auto_select),
-            None
-        )
-
         module = form.get_module()
         has_schedule = (module.has_schedule and getattr(form, 'schedule', False) and form.schedule.enabled and
                         getattr(form.get_phase(), 'anchor', False))
+        last_real_action = next(
+            (action for action in reversed(form.actions.load_update_cases)
+             if not (action.auto_select) and action.case_type == module.case_type),
+            None
+        )
         adjusted_datums = {}
         if module.root_module:
             # for child modules the session variable for a case may have been
@@ -1605,7 +1605,7 @@ class XForm(WrappedNode):
                 if action.close_condition.type != 'never':
                     update_case_block.add_close_block(self.action_relevance(action.close_condition))
 
-                if has_schedule:
+                if has_schedule and action == last_real_action:
                     self.add_casedb()
                     configure_visit_schedule_updates(update_case_block.update_block, action, session_case_id)
 


### PR DESCRIPTION
Fixes http://manage.dimagi.com/default.asp?181585#1010745
@snopoke, I'm not sure if the `action.case_type == module.case_type` makes sense? I think if you have multiple load actions, you only want to pull out the last one that is of the same type as the module (i.e. ccs_record in the ICDS case). 
@biyeun 
