### PR TITLE
move restriction on column count to get_ajax

### DIFF
--- a/corehq/apps/userreports/reports/data_source.py
+++ b/corehq/apps/userreports/reports/data_source.py
@@ -108,8 +108,6 @@ class ConfigurableReportDataSource(SqlData):
 
     @memoized
     def get_data(self, slugs=None):
-        if len(self.columns) > 50:
-            raise UserReportsError(_("This report has too many columns to be displayed"))
         try:
             ret = super(ConfigurableReportDataSource, self).get_data(slugs)
             for report_column in self.column_configs:

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -219,6 +219,8 @@ class ConfigurableReport(JSONResponseMixin, TemplateView):
     def get_ajax(self, request):
         try:
             data_source = self.data_source
+            if len(data_source.columns) > 50:
+                raise UserReportsError(_("This report has too many columns to be displayed"))
             data_source.set_filter_values(self.filter_values)
             data_source.set_order_by([(o['field'], o['order']) for o in self.spec.sort_expression])
             total_records = data_source.get_total_records()


### PR DESCRIPTION
permits rendering reports in emails, but still limits the number of columns that can be rendered in web reports.  Needed to email some of the Abt reports, including https://www.commcarehq.org/a/airsmadagascar/reports/custom_configurable/custom-airsmadagascar-incident-report/

@czue @NoahCarnahan cc: @dannyroberts 

Related: https://github.com/dimagi/commcare-hq/pull/8008
