### PR TITLE
Extra logging utils (and couch request logging)

### DIFF
--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -78,6 +78,6 @@ class TimingMiddleware(object):
 
     def process_response(self, request, response):
         if hasattr(request, '_profile_starttime'):
-            end = datetime.datetime.utcnow() - request._profile_starttime
-            profile_logger.info('{} time {}'.format(request.path, end))
+            duration = datetime.datetime.utcnow() - request._profile_starttime
+            profile_logger.info('{} time {}'.format(request.path, duration), extras={'duration': duration})
         return response

--- a/corehq/util/log.py
+++ b/corehq/util/log.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from itertools import islice
-from logging import Handler, Filter, LoggerAdapter
+from logging import Filter
 import traceback
 from datetime import timedelta
 

--- a/corehq/util/log.py
+++ b/corehq/util/log.py
@@ -1,6 +1,8 @@
 from collections import defaultdict
 from itertools import islice
+from logging import Handler, Filter, LoggerAdapter
 import traceback
+from datetime import timedelta
 
 from pygments import highlight
 from pygments.lexers import PythonLexer
@@ -11,6 +13,7 @@ from django.core import mail
 from django.utils.log import AdminEmailHandler
 from django.views.debug import SafeExceptionReporterFilter, get_exception_reporter_filter
 from django.template.loader import render_to_string
+from corehq.util.view_utils import get_request
 
 
 def clean_exception(exception):
@@ -161,3 +164,45 @@ class SensitiveErrorMail(ErrorMail):
         context['args'] = self.replacement
         context['kwargs'] = self.replacement
         return self.body.strip() % context
+
+
+class HQRequestFilter(Filter):
+    """
+    Filter that adds custom context to log records for HQ domain, username, and path.
+
+    This lets you add custom log formatters to include this information. For example,
+    the following format:
+
+    [%(username)s:%(domain)s] %(hq_url)s %(message)s
+
+    Will log:
+
+    [user@example.com:my-domain] /a/my-domain/apps/ [original message]
+    """
+
+    def filter(self, record):
+        request = get_request()
+        if request is not None:
+            record.domain = getattr(request, 'domain', '')
+            record.username = request.couch_user.username if getattr(request, 'couch_user', None) else ''
+            record.hq_url = request.path
+        else:
+            record.domain = record.username = record.hq_url = None
+        return True
+
+
+class SlowRequestFilter(Filter):
+    """
+    Filter that can be used to log a slow request or action.
+    Expects that LogRecords passed in will have a .duration property that is a timedelta.
+    Intended to be used primarily with the couchdbkit request_logger
+    """
+    def __init__(self, name='', duration=5):
+        self.duration_cutoff = timedelta(seconds=duration)
+        super(SlowRequestFilter, self).__init__(name)
+
+    def filter(self, record):
+        try:
+            return record.duration > self.duration_cutoff
+        except (TypeError, AttributeError):
+            return False


### PR DESCRIPTION
This allows you to define a log config with the following minimal setup to log all requests to couch that take longer than 10 seconds (with username, domain, and HQ url).

Goes with https://github.com/dimagi/couchdbkit/pull/10

``` python
LOGGING = {
    'version': 1,
    'disable_existing_loggers': True,
    'formatters': {
        'couch-request-formatter': {
            'format': '[%(username)s:%(domain)s] %(hq_url)s %(method)s %(path)s %(duration)s'
        }
    },
    'filters': {
        'hqcontext': {
            '()': 'corehq.util.log.HQRequestFilter',
        },
        'slow': {
            '()': 'corehq.util.log.SlowRequestFilter',
            'duration': 10,
        }
    },
    'handlers': {
        'couch-request-handler': {
            'level': 'DEBUG',
            'class': 'logging.StreamHandler',
            'formatter': 'couch-request-formatter',
            'filters': ['slow', 'hqcontext'],

        },
    },
    'loggers': {
        'couchdbkit.request': {
            'handlers': ['couch-request-handler'],
            'level': 'DEBUG',
            'propagate': False,
        },
    }
}
```

(here is sample output for the dashboard with no caching and a threshold of `0`)

```
[user@dimagi.com:cory] /a/cory/dashboard/project/ HEAD /hqdev/ 0:00:00.001148
[user@dimagi.com:cory] /a/cory/dashboard/project/ GET _design/domain/_view/domains 0:00:00.003493
[user@dimagi.com:cory] /a/cory/dashboard/project/ GET DOMAIN_MODULE_CONFIG 0:00:00.001166
[user@dimagi.com:cory] /a/cory/dashboard/project/ HEAD /hqdev/ 0:00:00.000706
[user@dimagi.com:cory] /a/cory/dashboard/project/ GET hqFeatureToggle-custom_menu_bar 0:00:00.001087
[user@dimagi.com:cory] /a/cory/dashboard/project/ HEAD /hqdev/ 0:00:00.000723
[user@dimagi.com:cory] /a/cory/dashboard/project/ GET _design/app_manager/_view/applications_brief 0:00:00.001693
[user@dimagi.com:cory] /a/cory/dashboard/project/ GET _design/app_manager/_view/applications_brief 0:00:00.002293
[user@dimagi.com:cory] /a/cory/dashboard/project/ HEAD /hqdev/ 0:00:00.001052
[user@dimagi.com:cory] /a/cory/dashboard/project/ GET _design/reportconfig/_view/configs_by_domain 0:00:00.002584
[user@dimagi.com:cory] /a/cory/dashboard/project/ HEAD /hqdev__meta/ 0:00:00.001205
[user@dimagi.com:cory] /a/cory/dashboard/project/ GET _design/userreports/_view/report_configs_by_domain 0:00:00.001775
[user@dimagi.com:cory] /a/cory/dashboard/project/ GET hqFeatureToggle-messaging_status 0:00:00.040394
[user@dimagi.com:cory] /a/cory/dashboard/project/ GET hqFeatureToggle-demo-reports 0:00:00.001620
[user@dimagi.com:cory] /a/cory/dashboard/project/ GET hqFeatureToggle-demo-reports 0:00:00.037239
[user@dimagi.com:cory] /a/cory/dashboard/project/ GET hqFeatureToggle-demo-reports 0:00:00.039264
[user@dimagi.com:cory] /a/cory/dashboard/project/ GET hqFeatureToggle-demo-reports 0:00:00.039329
[user@dimagi.com:cory] /a/cory/dashboard/project/ GET _design/couchexport/_view/saved_export_schemas 0:00:00.001941
[user@dimagi.com:cory] /a/cory/dashboard/project/ GET hqFeatureToggle-bulk_archive_forms 0:00:00.040189
[user@dimagi.com:cory] /a/cory/dashboard/project/ GET hqFeatureToggle-revamped_exports 0:00:00.038589
[user@dimagi.com:cory] /a/cory/dashboard/project/ GET hqFeatureToggle-revamped_exports 0:00:00.039336
[user@dimagi.com:cory] /a/cory/dashboard/project/ GET hqFeatureToggle-locations 0:00:00.001783
[user@dimagi.com:cory] /a/cory/dashboard/project/ GET _design/app_manager/_view/applications_brief 0:00:00.002812
[user@dimagi.com:cory] /a/cory/dashboard/project/ GET hqFeatureToggle-sms_performance_feedback 0:00:00.001243
[user@dimagi.com:cory] /a/cory/dashboard/project/ POST _design/domain/_view/by_status 0:00:00.002613
[user@dimagi.com:cory] /a/cory/dashboard/project/ GET 8f9756be9b1c7f28057d707b405cf6fa 0:00:00.001444
[user@dimagi.com:cory] /a/cory/dashboard/project/ GET 8f9756be9b1c7f28057d707b405cf6fa 0:00:00.001601
[user@dimagi.com:cory] /a/cory/dashboard/project/ GET 8f9756be9b1c7f28057d707b405cf6fa 0:00:00.002020
[user@dimagi.com:cory] /a/cory/dashboard/project/ GET 8f9756be9b1c7f28057d707b405cf6fa 0:00:00.001379
```
