### PR TITLE
Better support for setting empty owner_ids in sync

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -660,7 +660,7 @@ class SimplifiedSyncLog(AbstractSyncLog):
             # "latest" just means as this forms actions are played through
             if action is not None:
                 owner_id_from_action = action.updated_known_properties.get("owner_id")
-                if owner_id_from_action:
+                if owner_id_from_action is not None:
                     owner_id_map[case_id] = owner_id_from_action
             return owner_id_map.get(case_id, None)
 
@@ -675,7 +675,7 @@ class SimplifiedSyncLog(AbstractSyncLog):
             for action in actions:
                 logger.debug('{}: {}'.format(case._id, action.action_type))
                 owner_id = get_latest_owner_id(case._id, action)
-                case_update.is_live = not owner_id or owner_id in self.owner_ids_on_phone
+                case_update.is_live = owner_id is None or owner_id in self.owner_ids_on_phone
                 if action.action_type == const.CASE_ACTION_INDEX:
                     for index in action.indices:
                         if index.referenced_id:

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -595,7 +595,8 @@ class SyncTokenUpdateTest(SyncBaseTest):
     def test_create_relevant_owner_and_update_to_empty_owner_in_same_form(self):
         case = self.factory.create_case(owner_id=USER_ID, update={'owner_id': ''}, strict=False)
         sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
-        self.assertFalse(sync_log.phone_is_holding_case(case._id))
+        if isinstance(sync_log, SimplifiedSyncLog):
+            self.assertFalse(sync_log.phone_is_holding_case(case._id))
 
     @run_with_all_restore_configs
     def test_create_irrelevant_owner_and_update_to_empty_owner_in_same_form(self):

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -592,6 +592,18 @@ class SyncTokenUpdateTest(SyncBaseTest):
             self.assertTrue(sync_log.phone_is_holding_case(case._id))
 
     @run_with_all_restore_configs
+    def test_create_relevant_owner_and_update_to_empty_owner_in_same_form(self):
+        case = self.factory.create_case(owner_id=USER_ID, update={'owner_id': ''}, strict=False)
+        sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
+        self.assertFalse(sync_log.phone_is_holding_case(case._id))
+
+    @run_with_all_restore_configs
+    def test_create_irrelevant_owner_and_update_to_empty_owner_in_same_form(self):
+        case = self.factory.create_case(owner_id='irrelevant_1', update={'owner_id': ''}, strict=False)
+        sync_log = get_properly_wrapped_sync_log(self.sync_log._id)
+        self.assertFalse(sync_log.phone_is_holding_case(case._id))
+
+    @run_with_all_restore_configs
     def test_create_irrelevant_child_case_and_close_parent_in_same_form(self):
         # create the parent
         parent_id = self.factory.create_case()._id


### PR DESCRIPTION
confirmed with @ctsims that the phone will purge things if explicitly set to empty.

wait for tests.

@snopoke cc @benrudolph 
