### PR TITLE
Exports Case Name Issues

### DIFF
--- a/corehq/apps/export/custom_export_helpers.py
+++ b/corehq/apps/export/custom_export_helpers.py
@@ -234,8 +234,11 @@ class FormCustomExportHelper(CustomExportHelper):
 
         def generate_additional_columns(requires_case):
             ret = []
+            # the default of the case_name_col MUST have selected = false, because
+            # there is no way to store selected = false in the current export schema
+            # as it only stores selected columns, not the selected states for all columns
             case_name_col = CustomColumn(slug='case_name', index=FORM_CASE_ID_PATH, display='info.case_name',
-                                         transform=CASENAME_TRANSFORM, show=True, selected=True)
+                                         transform=CASENAME_TRANSFORM, show=True, selected=False)
             if not requires_case:
                 case_name_col.show, case_name_col.selected, case_name_col.tag = False, False, 'deleted'
             matches = filter(case_name_col.match, column_conf)

--- a/corehq/apps/export/templates/export/customize_export.html
+++ b/corehq/apps/export/templates/export/customize_export.html
@@ -312,9 +312,7 @@
                                         index: column.index,
                                         display: column.display,
                                         transform: column.transform() || null, // it doesn't save '' well
-                                        is_sensitive: Boolean(is_sensitive),
-                                        show: ko.utils.unwrapObservable(column.selected),
-                                        selected: ko.utils.unwrapObservable(column.selected)
+                                        is_sensitive: Boolean(is_sensitive)
                                 };
                                 if (self.export_type() === 'form') {
                                     if (self.custom_export.split_multiselects() && column.allOptions()) {

--- a/corehq/apps/export/templates/export/customize_export.html
+++ b/corehq/apps/export/templates/export/customize_export.html
@@ -305,9 +305,9 @@
                             display: table.display,
                             index: table.index,
                             columns: _(table.column_configuration()).filter(function (column) {
-                                return column.selected();
+                                return column.selected() && !(column.isCaseName() && self.custom_export.is_safe());
                             }).map(function (column) {
-                                var is_sensitive = column.transform() && (column.is_sensitive() || !ko.utils.unwrapObservable(column.special)),
+                                var is_sensitive = column.transform() && (column.is_sensitive() || !ko.utils.unwrapObservable(column.special )),
                                     col = {
                                         index: column.index,
                                         display: column.display,
@@ -623,7 +623,18 @@
                                         <td class="sortable-handle">
                                             <i class="icon-resize-vertical"></i>
                                         </td>
-                                        <td><input type="checkbox" class="field-include" data-bind="checked: selected" /></td>
+                                        <td>
+                                            <!--ko if: ($root.custom_export.is_safe() && isCaseName()) -->
+                                            <input type="checkbox"
+                                                   class="field-include"
+                                                   disabled="disabled" />
+                                            <!--/ko-->
+                                            <!--ko ifnot: ($root.custom_export.is_safe() && isCaseName()) -->
+                                            <input type="checkbox"
+                                                   class="field-include"
+                                                   data-bind="checked: selected" />
+                                            <!--/ko-->
+                                        </td>
                                         <td>
                                             <span data-bind="foreach: _niceField.tags">
                                                 <span data-bind="text: $data, visible: $data, attr: { 'class': $root.row_label_classes($data)}"></span>
@@ -669,6 +680,11 @@
                                             ">
                                                 <option data-bind="value: value, text: label"></option>
                                             </select>
+
+                                            <span class="label label-info"
+                                                  data-bind="visible: $root.custom_export.is_safe() && isCaseName()">
+                                                {% trans "Cannot be published in De-Identified Export." %}
+                                            </span>
                                         </td>
                                         {% endif %}
                                     </tr>

--- a/corehq/apps/export/templates/export/customize_export.html
+++ b/corehq/apps/export/templates/export/customize_export.html
@@ -235,6 +235,9 @@
                             niceField['field'] = special;
                         }
                         column._niceField = niceField;
+                        column.isCaseName = ko.computed(function () {
+                            return ko.utils.unwrapObservable(column.special) === 'case_name';
+                        });
                         column.showOptions = ko.observable(false);
                         column.newOption = ko.observable("");
                         column.addOption = function(e) {
@@ -309,7 +312,9 @@
                                         index: column.index,
                                         display: column.display,
                                         transform: column.transform() || null, // it doesn't save '' well
-                                        is_sensitive: Boolean(is_sensitive)
+                                        is_sensitive: Boolean(is_sensitive),
+                                        show: ko.utils.unwrapObservable(column.selected),
+                                        selected: ko.utils.unwrapObservable(column.selected)
                                 };
                                 if (self.export_type() === 'form') {
                                     if (self.custom_export.split_multiselects() && column.allOptions()) {
@@ -660,7 +665,7 @@
                                             <select data-bind="
                                                 value: transform || '',
                                                 foreach: $root.deid_options,
-                                                visible: index() !== 'id' || transform()
+                                                visible: (index() !== 'id' || transform()) && !isCaseName()
                                             ">
                                                 <option data-bind="value: value, text: label"></option>
                                             </select>

--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -13,7 +13,6 @@ from corehq.apps.app_manager.templatetags.xforms_extras import trans
 from corehq.apps.export.custom_export_helpers import make_custom_export_helper
 from corehq.apps.export.exceptions import ExportNotFound, ExportAppException
 from corehq.apps.export.forms import CreateFormExportForm, CreateCaseExportForm
-from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_enabled
 from corehq.apps.reports.dbaccessors import touch_exports
 from corehq.apps.reports.display import xmlns_to_name
 from corehq.apps.reports.standard.export import (

--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -13,12 +13,11 @@ from corehq.apps.app_manager.templatetags.xforms_extras import trans
 from corehq.apps.export.custom_export_helpers import make_custom_export_helper
 from corehq.apps.export.exceptions import ExportNotFound, ExportAppException
 from corehq.apps.export.forms import CreateFormExportForm, CreateCaseExportForm
+from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_enabled
 from corehq.apps.reports.dbaccessors import touch_exports
 from corehq.apps.reports.display import xmlns_to_name
 from corehq.apps.reports.standard.export import (
-    CaseExportInterface,
     CaseExportReport,
-    FormExportInterface,
     ExcelExportReport,
 )
 from corehq.apps.settings.views import BaseProjectDataView
@@ -31,7 +30,6 @@ from django.utils.translation import ugettext as _, ugettext_noop, ugettext_lazy
 from dimagi.utils.logging import notify_exception
 from dimagi.utils.parsing import json_format_date
 from dimagi.utils.web import json_response
-from toggle import toggle_enabled
 
 require_form_export_permission = require_permission(
     Permissions.view_report,
@@ -80,11 +78,6 @@ class BaseExportView(BaseProjectDataView):
     @memoized
     def report_class(self):
         try:
-            if toggle_enabled(self.request, toggles.REVAMPED_EXPORTS):
-                return {
-                    'form': FormExportInterface,
-                    'case': CaseExportInterface,
-                }[self.export_type]
             return {
                 'form': ExcelExportReport,
                 'case': CaseExportReport

--- a/corehq/apps/reports/models.py
+++ b/corehq/apps/reports/models.py
@@ -13,6 +13,7 @@ from corehq.apps.app_manager.models import Form, RemoteApp
 from corehq.apps.app_manager.util import get_case_properties
 from corehq.apps.cachehq.mixins import CachedCouchDocumentMixin
 from corehq.apps.domain.middleware import CCHQPRBACMiddleware
+from couchforms.filters import instances
 from .exceptions import UnsupportedSavedReportError, UnsupportedScheduledReportError
 from corehq.apps.export.models import FormQuestionSchema
 from corehq.apps.reports.daterange import get_daterange_start_end_dates, get_all_daterange_slugs
@@ -835,9 +836,10 @@ class FormExportSchema(HQExportSchema):
 
         f = SerializableFunction(_top_level_filter)
         if self.app_id is not None:
-            f.add(reports.util.app_export_filter, app_id=self.app_id)
+            from corehq.apps.reports import util as reports_util
+            f.add(reports_util.app_export_filter, app_id=self.app_id)
         if not self.include_errors:
-            f.add(couchforms.filters.instances)
+            f.add(instances)
         actual = SerializableFunction(default_form_filter, filter=f)
         return actual
 


### PR DESCRIPTION
- defaults to the case_name added to the report to have selected=false (there is no way to EASILY store a previous select=false decision, as exports schema ONLY stores selected=true values in the first place, so on a reload a new, defaulted to selected=true case_name Custom Column was always being added. Gross.)
- makes sure that the transform cannot be overridden, thus not allowing case_name to be marked as sensitive data
- prevents case_name from being published in an export explicitly marked as de-identified because the nature of the way it's created via a transform prevents it from being de-identified in the first place. Also gross.

TL;DR exports sucks. We need to rewrite the backend entirely.

@czue @TylerSheffels @esoergel 
