### PR TITLE
Hook app diff to deploy page

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases.js
@@ -135,6 +135,7 @@ function ReleasesMain(o) {
     self.deployAnyway = {};
     self.currentAppVersion = ko.observable(self.options.currentAppVersion);
     self.lastAppVersion = ko.observable();
+    self.selectingVersion = ko.observable("");
     self.buildButtonEnabled = ko.computed(function () {
         if (self.buildState() === 'pending' || self.fetchState() === 'pending') {
             return false;

--- a/corehq/apps/app_manager/templates/app_manager/download_index.html
+++ b/corehq/apps/app_manager/templates/app_manager/download_index.html
@@ -1,11 +1,14 @@
 {% extends base_template %}
+{% load i18n %}
+
 {% block head %}{{ block.super }}
     {% include "imports/bootstrap.google-prettify.html" %}
 {% endblock %}
+{% block title %}{% trans 'Build' %} #{{ app.version }}: {{ app.name }}{% endblock %}
 {% block content %}
 <div class="container-fluid">
     <h1>Build #{{ app.version }}: {{ app.name }}</h1>
-    <p>See <a href="{% url "view_app" app.domain app.copy_of|default_if_none:app.get_id %}">original app</a> for the latest work in progress.</p>
+    <p>See <a href="{% url "view_app" app.domain app.copy_of|default_if_none:app.get_id %}">current app</a> for the latest work in progress.</p>
     <h2>Downloads</h2>
     <table class="table table-condensed">
         <tr>

--- a/corehq/apps/app_manager/templates/app_manager/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/releases.html
@@ -25,7 +25,7 @@
             fetch: '{% url "paginate_releases" domain app.id %}',
             delete: '{% url "corehq.apps.app_manager.views.delete_copy" domain app.id %}',
             cloudcare: '{% url "cloudcare_get_app" domain '___' %}',
-            compare: 'diff/___/and/___',
+            compare: 'diff/___/___',
             jad: '{% url "corehq.apps.app_manager.views.download_jad" domain '___' %}',
             jar: '{% url "corehq.apps.app_manager.views.download_jar" domain '___' %}',
             ccz: '{% url "download_ccz" domain '___' %}',
@@ -271,9 +271,7 @@
                                     </a>
                                     <a href="#" class="btn btn-mini btn-success"
                                        data-bind="
-                                            click: function() {
-                                                window.alert($root.url('compare', $root.selectingVersion(), id()));
-                                            },
+                                            attr: {href: $root.url('compare', $root.selectingVersion(), id())},
                                             visible: $root.selectingVersion() && $root.selectingVersion() != id()">
                                         Compare
                                     </a>

--- a/corehq/apps/app_manager/templates/app_manager/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/releases.html
@@ -53,6 +53,7 @@
     function track_deploy_type(type) {
         ga_track_event('App Manager', 'Deploy Type', type);
     }
+    // TODO: update analytics?
     $(function () {
         gaTrackLink('a.view-source-files-link', 'App Manager', 'Deploy Type', 'View Source Files');
     });
@@ -69,13 +70,19 @@
     .build.build-unreleased {
         color: #888;
     }
-    .build.build-released {
-    }
     .build.build-latest-release {
         background-color: #EFEFFF;
     }
     .build.build-latest-release .build-is-released:after{
         content: "Latest";
+    }
+    .build .edit-comment-pencil {
+        display: none;
+        margin-left: 5px;
+        position: absolute;
+    }
+    .build:hover .edit-comment-pencil {
+        display: inline;
     }
     .nowrap {
         white-space: nowrap;
@@ -96,14 +103,6 @@
     .released {
         color: #ffff00;
         text-shadow: 1px 0px #ffa500, -1px 0px #ffa500, 0px 1px #ffa500, 0px -1px #ffa500;
-    }
-    .build .edit-comment-pencil {
-        display: none;
-        margin-left: 5px;
-        position: absolute;
-    }
-    .build:hover .edit-comment-pencil {
-        display: inline;
     }
 </style>
 {% endblock %}
@@ -523,11 +522,19 @@
                     {% if request.user.is_superuser %}
                         <div class="accordion-group">
                             <div class="accordion-heading">
-                                <a class="accordion-toggle view-source-files-link" data-bind="
-                                    attr: {href: $root.url('source', id)},
-                                ">
-                                    {% trans "View Source Files" %}
+                                <a class="accordion-toggle" data-toggle="collapse">
+                                    {% trans "Summary & Source" %}
                                 </a>
+                            </div>
+                            <div class="accordion-body collapse">
+                                <div class="accordion-inner">
+                                    <p><a href="{% url "app_summary" domain app.id %}">App Summary</a></p>
+                                    <p>
+                                        <a href="{% url "app_source" domain app.id %}" class="view-source-files-link" href="">
+                                            Source Files
+                                        </a>
+                                    </p>
+                                </div>
                             </div>
                         </div>
                     {% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/releases.html
@@ -25,7 +25,7 @@
             fetch: '{% url "paginate_releases" domain app.id %}',
             delete: '{% url "corehq.apps.app_manager.views.delete_copy" domain app.id %}',
             cloudcare: '{% url "cloudcare_get_app" domain '___' %}',
-            compare: 'diff/___/___',
+            compare: '{% url "diff" domain '___' '___' %}',
             jad: '{% url "corehq.apps.app_manager.views.download_jad" domain '___' %}',
             jar: '{% url "corehq.apps.app_manager.views.download_jar" domain '___' %}',
             ccz: '{% url "download_ccz" domain '___' %}',
@@ -55,7 +55,6 @@
     function track_deploy_type(type) {
         ga_track_event('App Manager', 'Deploy Type', type);
     }
-    // TODO: update analytics?
     $(function () {
         gaTrackLink('a.view-source-files-link', 'App Manager', 'Deploy Type', 'View Source Files');
     });

--- a/corehq/apps/app_manager/templates/app_manager/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/releases.html
@@ -31,6 +31,7 @@
             odk: '{% url "odk_install" domain '___' %}',
             odk_media: '{% url "odk_media_install" domain '___' %}',
             source: '{% url "download_index" domain '___' %}',
+            summary: '{% url "app_summary" domain '___' %}',
             release: '{% url "release_build" domain app.id '___' %}',
             newBuild: '{% url "corehq.apps.app_manager.views.save_copy" domain app.id %}',
             revertBuild: '{% url "corehq.apps.app_manager.views.revert_to_copy" domain app.id %}',
@@ -141,7 +142,7 @@
                 <th>{% trans "CommCare Version" %}</th>
                 <th></th>
                 <th></th>
-                <th>{% trans "Comment" %}</th>
+                <th>{% trans "Changes" %}</th>
                 <th>
                     {% trans "Released" %}
                     <span class="hq-help-template"
@@ -250,6 +251,16 @@
                         <div data-bind="visible: comment_update_error()" class="alert alert-error">
                             {% trans "Error updating comment.  Please try again" %}
                         </div>
+                        {% if request.user.is_superuser %}
+                            <h6>
+                                {% blocktrans %}
+                                    View
+                                    <a data-bind="attr: {href: $root.url('summary', id)}">app summary</a>
+                                    or
+                                    <a data-bind="attr: {href: $root.url('source', id)}" class="view-source-files-link">source files</a>
+                                {% endblocktrans %}
+                            </h6>
+                        {% endif %}
                     </td>
                     <td class="build-is-released">
                         <div data-bind="starred: is_released, click: $root.toggleRelease"></div>
@@ -515,25 +526,6 @@
                             <div class="accordion-body collapse" data-bind="attr: {id: id() + '_multimedia'}">
                                 <div class="accordion-inner">
                                     {% include 'hqmedia/partials/multimedia_zip_notice.html' with include_modal=False %}
-                                </div>
-                            </div>
-                        </div>
-                    {% endif %}
-                    {% if request.user.is_superuser %}
-                        <div class="accordion-group">
-                            <div class="accordion-heading">
-                                <a class="accordion-toggle" data-toggle="collapse">
-                                    {% trans "Summary & Source" %}
-                                </a>
-                            </div>
-                            <div class="accordion-body collapse">
-                                <div class="accordion-inner">
-                                    <p><a href="{% url "app_summary" domain app.id %}">App Summary</a></p>
-                                    <p>
-                                        <a href="{% url "app_source" domain app.id %}" class="view-source-files-link" href="">
-                                            Source Files
-                                        </a>
-                                    </p>
                                 </div>
                             </div>
                         </div>

--- a/corehq/apps/app_manager/templates/app_manager/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/releases.html
@@ -251,7 +251,7 @@
                         <div data-bind="visible: comment_update_error()" class="alert alert-error">
                             {% trans "Error updating comment.  Please try again" %}
                         </div>
-                        {% if request.user.is_superuser %}
+                        {% if request|toggle_enabled:"VIEW_BUILD_SOURCE" %}
                             <h6>
                                 {% blocktrans %}
                                     View

--- a/corehq/apps/app_manager/templates/app_manager/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/releases.html
@@ -25,6 +25,7 @@
             fetch: '{% url "paginate_releases" domain app.id %}',
             delete: '{% url "corehq.apps.app_manager.views.delete_copy" domain app.id %}',
             cloudcare: '{% url "cloudcare_get_app" domain '___' %}',
+            compare: 'diff/___/and/___',
             jad: '{% url "corehq.apps.app_manager.views.download_jad" domain '___' %}',
             jar: '{% url "corehq.apps.app_manager.views.download_jar" domain '___' %}',
             ccz: '{% url "download_ccz" domain '___' %}',
@@ -258,6 +259,24 @@
                                     <a data-bind="attr: {href: $root.url('summary', id)}">app summary</a>
                                     or
                                     <a data-bind="attr: {href: $root.url('source', id)}" class="view-source-files-link">source files</a>
+                                    <br />
+                                    <a href="#" data-bind="click: function() {
+                                            $root.selectingVersion(id());
+                                        }, visible: !$root.selectingVersion()">
+                                        Compare with another version
+                                    </a>
+                                    <a href="#"
+                                       data-bind="visible: $root.selectingVersion() === id(), click: function() {$root.selectingVersion('')}">
+                                        Cancel
+                                    </a>
+                                    <a href="#" class="btn btn-mini btn-success"
+                                       data-bind="
+                                            click: function() {
+                                                window.alert($root.url('compare', $root.selectingVersion(), id()));
+                                            },
+                                            visible: $root.selectingVersion() && $root.selectingVersion() != id()">
+                                        Compare
+                                    </a>
                                 {% endblocktrans %}
                             </h6>
                         {% endif %}

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -654,3 +654,10 @@ LEGACY_SYNC_SUPPORT = StaticToggle(
     TAG_EXPERIMENTAL,
     [NAMESPACE_DOMAIN]
 )
+
+VIEW_BUILD_SOURCE = StaticToggle(
+    'diff_builds',
+    'Allow users to view and diff build source files',
+    TAG_EXPERIMENTAL,
+    [NAMESPACE_DOMAIN, NAMESPACE_USER]
+)


### PR DESCRIPTION
Dependent on https://github.com/dimagi/commcare-hq/pull/8290

@NoahCarnahan / @nickpell 

I moved the "View Source Files" link from the deploy modal onto the main page, into the comments column, making that column a more general place for info about changes made in that build. Added a link to the build's app summary and a link to diff with another build.
![screen shot 2015-09-22 at 12 23 43 pm](https://cloud.githubusercontent.com/assets/1486591/10024398/0cddb3d6-6125-11e5-90b2-008d5c1ddb6f.png)

When you click the link to compare, you get an option for each build, and a link to cancel the comparison so all the buttons go away.
![screen shot 2015-09-22 at 12 25 12 pm](https://cloud.githubusercontent.com/assets/1486591/10024402/11872714-6125-11e5-9865-48e88955fda1.png)

@dimagi/product Feedback welcome. I experimented with making the new controls part of the "View Source Files" area in the deploy modal, but that makes it harder to have a good experience for selecting the version to diff.
