### PR TITLE
Don't autoload report, removed required option

### DIFF
--- a/corehq/apps/example_reports/testreport.py
+++ b/corehq/apps/example_reports/testreport.py
@@ -23,7 +23,7 @@ class TestReportData(ReportDataSource):
     title = "Test Report"
     slug = "test_report"
     filters = [
-        DatespanFilter(name='datespan', required=False),
+        DatespanFilter(name='datespan'),
     ]
 
     def columns(self):

--- a/corehq/apps/reports_core/filters.py
+++ b/corehq/apps/reports_core/filters.py
@@ -19,19 +19,12 @@ class BaseFilter(object):
     Base object for filters.
     """
 
-    def __init__(self, name, required=False, params=None):
+    def __init__(self, name, params=None):
         self.name = name
-        self.required = required
         self.params = params or []
 
     def get_value(self, context):
-        context_ok = self.check_context(context)
-        if self.required and not context_ok:
-            required_slugs = ', '.join([slug.name for slug in self.params if slug.required])
-            raise MissingParamException("Missing filter parameters. "
-                                        "Required parameters are: {}".format(required_slugs))
-
-        if context_ok:
+        if self.check_context(context):
             kwargs = {param.name: context[param.name] for param in self.params if param.name in context}
             return self.value(**kwargs)
         else:
@@ -82,7 +75,7 @@ class DatespanFilter(BaseFilter):
     template = 'reports_core/filters/datespan_filter/datespan_filter.html'
     javascript_template = 'reports_core/filters/datespan_filter/datespan_filter.js'
 
-    def __init__(self, name, required=True, label='Datespan Filter',
+    def __init__(self, name, label='Datespan Filter',
                  css_id=None):
         self.label = label
         self.css_id = css_id or name
@@ -91,8 +84,7 @@ class DatespanFilter(BaseFilter):
             FilterParam(self.enddate_param_name, True),
             FilterParam('date_range_inclusive', False),
         ]
-        super(DatespanFilter, self).__init__(required=required, name=name, params=params)
-
+        super(DatespanFilter, self).__init__(name=name, params=params)
 
     @property
     def startdate_param_name(self):
@@ -135,14 +127,14 @@ class DatespanFilter(BaseFilter):
 class NumericFilter(BaseFilter):
     template = "reports_core/filters/numeric_filter.html"
 
-    def __init__(self, name, required=True, label=_('Numeric Filter'), css_id=None):
+    def __init__(self, name, label=_('Numeric Filter'), css_id=None):
         self.label = label
         self.css_id = css_id or name
         params = [
             FilterParam(self.operator_param_name, True),
             FilterParam(self.operand_param_name, True),
         ]
-        super(NumericFilter, self).__init__(required=required, name=name, params=params)
+        super(NumericFilter, self).__init__(name=name, params=params)
 
     @property
     def operator_param_name(self):
@@ -178,13 +170,13 @@ class ChoiceListFilter(BaseFilter):
     Filter for a list of choices. Each choice should be a Choice object as per above.
     """
 
-    def __init__(self, name, datatype, required=True, label='Choice List Filter',
+    def __init__(self, name, datatype, label='Choice List Filter',
                  template='reports_core/filters/choice_list_filter.html',
                  css_id=None, choices=None):
         params = [
             FilterParam(name, True),
         ]
-        super(ChoiceListFilter, self).__init__(required=required, name=name, params=params)
+        super(ChoiceListFilter, self).__init__(name=name, params=params)
         self.datatype = datatype
         self.label = label
         self.template = template
@@ -214,7 +206,7 @@ class DynamicChoiceListFilter(BaseFilter):
     template = 'reports_core/filters/dynamic_choice_list_filter/dynamic_choice_list.html'
     javascript_template = 'reports_core/filters/dynamic_choice_list_filter/dynamic_choice_list.js'
 
-    def __init__(self, name, field, required, datatype, label, show_all, url_generator, css_id=None):
+    def __init__(self, name, field, datatype, label, show_all, url_generator, css_id=None):
         """
         url_generator should be a callable that takes a domain, report, and filter and returns a url.
         see userreports.reports.filters.dynamic_choice_list_url for an example.
@@ -222,7 +214,7 @@ class DynamicChoiceListFilter(BaseFilter):
         params = [
             FilterParam(name, True),
         ]
-        super(DynamicChoiceListFilter, self).__init__(required=required, name=name, params=params)
+        super(DynamicChoiceListFilter, self).__init__(name=name, params=params)
         self.datatype = datatype
         self.field = field
         self.label = label

--- a/corehq/apps/reports_core/templates/reports_core/base_template_new.html
+++ b/corehq/apps/reports_core/templates/reports_core/base_template_new.html
@@ -57,6 +57,8 @@
             extraCallbacks: [updateCharts]
         });
         $('#report-filters').submit(function(event) {
+            $('#reportHint').remove();
+            $('#reportContent').removeClass('hide');
             var postData = $(this).serialize();
             $.ajax({
                 url: $(this).attr("action"),
@@ -181,20 +183,27 @@
         {% endif %}
     </div>
 </div>
-{% block reportcharts %}
-<section id="chart-container" style="display: none;">
-</section>
-{% endblock %}
-{% block reporttable %}
-<div>
-    <table id="report_table_{{ report.slug }}" class="table table-striped datatable">
-        <thead>
-        {{ headers.render_html|safe }}
-        </thead>
-        <tbody>
-        </tbody>
-    </table>
+<div id="reportHint" class="well">
+    <h4>Why can't I see any data?</h4>
+    <p>Please choose your filters above and click <strong>Apply</strong> to see report data.</p>
 </div>
-{% endblock reporttable %}
+<div id="reportContent" class="hide">
+    {% block reportcharts %}
+    <section id="chart-container" style="display: none;">
+    </section>
+    {% endblock %}
+    {% block reporttable %}
+    <div>
+        <table id="report_table_{{ report.slug }}" class="table table-striped datatable">
+            <thead>
+            {{ headers.render_html|safe }}
+            </thead>
+            <tbody>
+            </tbody>
+        </table>
+    </div>
+    {% endblock reporttable %}
+</div>
+
 {% endblock main_column_content %}
 {% endblock main_column %}

--- a/corehq/apps/reports_core/templates/reports_core/base_template_new.html
+++ b/corehq/apps/reports_core/templates/reports_core/base_template_new.html
@@ -184,8 +184,8 @@
     </div>
 </div>
 <div id="reportHint" class="well">
-    <h4>Why can't I see any data?</h4>
-    <p>Please choose your filters above and click <strong>Apply</strong> to see report data.</p>
+    <h4>{% blocktrans %}Why can't I see any data?{% endblocktrans %}</h4>
+    <p>{% blocktrans %}Please choose your filters above and click <strong>Apply</strong> to see report data.{% endblocktrans %}</p>
 </div>
 <div id="reportContent" class="hide">
     {% block reportcharts %}

--- a/corehq/apps/userreports/reports/factory.py
+++ b/corehq/apps/userreports/reports/factory.py
@@ -20,7 +20,6 @@ def _build_date_filter(spec):
     return DatespanFilter(
         name=wrapped.slug,
         label=wrapped.get_display(),
-        required=wrapped.required,
     )
 
 
@@ -29,7 +28,6 @@ def _build_numeric_filter(spec):
     return NumericFilter(
         name=wrapped.slug,
         label=wrapped.get_display(),
-        required=wrapped.required,
     )
 
 
@@ -45,7 +43,6 @@ def _build_choice_list_filter(spec):
         name=wrapped.slug,
         datatype=wrapped.datatype,
         label=wrapped.display,
-        required=wrapped.required,
         choices=choices,
     )
 
@@ -57,7 +54,6 @@ def _build_dynamic_choice_list_filter(spec):
         datatype=wrapped.datatype,
         field=wrapped.field,
         label=wrapped.display,
-        required=wrapped.required,
         show_all=wrapped.show_all,
         url_generator=dynamic_choice_list_url,
     )

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -305,7 +305,6 @@ class FilterSpec(JsonObject):
     slug = StringProperty(required=True)  # this shows up as the ID in the filter HTML
     field = StringProperty(required=True)  # this is the actual column that is queried
     display = DefaultProperty()
-    required = BooleanProperty(default=False)
     datatype = DataTypeProperty(default='string')
 
     def get_display(self):

--- a/corehq/apps/userreports/templates/userreports/configurable_report.html
+++ b/corehq/apps/userreports/templates/userreports/configurable_report.html
@@ -30,6 +30,8 @@
                             $('#built-warning').addClass('hide');
                             if (retrying){
                                 location.reload();
+                            } else if ($('#report-filters').find('.control-label').length === 0) {
+                                $('#report-filters').submit();
                             }
                         } else {
                             retrying = true;

--- a/corehq/apps/userreports/templates/userreports/configurable_report.html
+++ b/corehq/apps/userreports/templates/userreports/configurable_report.html
@@ -30,8 +30,6 @@
                             $('#built-warning').addClass('hide');
                             if (retrying){
                                 location.reload();
-                            } else {
-                                $('#report-filters').submit();
                             }
                         } else {
                             retrying = true;


### PR DESCRIPTION
@czue @NoahCarnahan 
Since required option allowed to load report with blank filters (it just checked if proper params were send in request) I think we can drop required option. At the initial load user is informed that he needs to click apply button.

![](http://i.imgur.com/CqscEZH.png)
