### PR TITLE
usability fixes for report datepicker

### DIFF
--- a/corehq/apps/reports/static/reports/javascripts/daterangepicker.js
+++ b/corehq/apps/reports/static/reports/javascripts/daterangepicker.js
@@ -35,19 +35,16 @@ $(function() {
 
         //the custom range button is the 4th li, but has no other
         //defining class or id to select it
-        $('.ranges ul li:nth-child(4)').click(function() {
+        $('.ranges ul li:last').click(function() {
             $('.ranges .applyBtn').show();
             $('.ranges .cancelBtn').show();
         });
 
-        $('.ranges ul li:not(:nth-child(4))').click(function() {
+        $('.ranges ul li:not(:last)').click(function() {
             $('.ranges .applyBtn').hide();
             $('.ranges .cancelBtn').hide();
         });
 
-        $('#filter_range').change(function() {
-            $('.ranges .applyBtn').click();
-        });
     };
     $.fn.createDefaultDateRangePicker = function () {
         this.createDateRangePicker(

--- a/corehq/apps/reports/static/reports/javascripts/daterangepicker.js
+++ b/corehq/apps/reports/static/reports/javascripts/daterangepicker.js
@@ -26,6 +26,28 @@ $(function() {
             ranges: ranges,
             separator: separator
         });
+
+        $('.daterangepicker_start_input').hide();
+        $('.daterangepicker_end_input').hide();
+
+        $('.ranges .applyBtn').hide();
+        $('.ranges .cancelBtn').hide();
+
+        //the custom range button is the 4th li, but has no other
+        //defining class or id to select it
+        $('.ranges ul li:nth-child(4)').click(function() {
+            $('.ranges .applyBtn').show();
+            $('.ranges .cancelBtn').show();
+        });
+
+        $('.ranges ul li:not(:nth-child(4))').click(function() {
+            $('.ranges .applyBtn').hide();
+            $('.ranges .cancelBtn').hide();
+        });
+
+        $('#filter_range').change(function() {
+            $('.ranges .applyBtn').click();
+        });
     };
     $.fn.createDefaultDateRangePicker = function () {
         this.createDateRangePicker(

--- a/corehq/apps/reports/templates/reports/filters/datespan.html
+++ b/corehq/apps/reports/templates/reports/filters/datespan.html
@@ -34,7 +34,7 @@
             var report_labels = JSON.parse('{{ report_labels|safe }}');
 
             $('#filter_range').createDateRangePicker(report_labels, separator);
-            $('#filter_range').on('apply', function(ev, picker) {
+            $('#filter_range').on('change', function(ev, picker) {
                 var dates = $(this).val().split(separator);
                 $(standardHQReport.filterAccordion).trigger('hqreport.filter.datespan.startdate', dates[0]);
                 $('#report_filter_datespan_startdate').val(dates[0]);


### PR DESCRIPTION
@dimagi/product @nickpell 
This is some simple usability changes to the datepicker on reports pages, as outlined in http://manage.dimagi.com/default.asp?171582#1008961

When non-custom range is selected:
<img width="348" alt="datepickerscreenshot1" src="https://cloud.githubusercontent.com/assets/6844721/10057802/18d5d4c0-6210-11e5-88f5-3393b2dbbd32.png">

When a custom range is selected:
<img width="823" alt="datepickerscreenshot2" src="https://cloud.githubusercontent.com/assets/6844721/10057803/18d7014c-6210-11e5-914b-6e9684250ae8.png">
