### PR TITLE
Make the device report sort properly

### DIFF
--- a/corehq/apps/reports/templates/reports/async/partials/tabular_cell.html
+++ b/corehq/apps/reports/templates/reports/async/partials/tabular_cell.html
@@ -1,4 +1,4 @@
 {% if not col.unwrap %}<td{% if not col or col.html != None and not col.html %} class="null-entry"{% endif %}>{% endif %}
-    {% if col.html != None %}{{ col.html|safe }}{% else %}{{ col|safe }}{% endif %}
     <span title="{% if col.sort_key != "" %}{{ col.sort_key }}{% else %}{{ col }}{% endif %}"></span>
+    {% if col.html != None %}{{ col.html|safe }}{% else %}{{ col|safe }}{% endif %}
 {% if not col.unwrap %}</td>{% endif %}


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?182247
If you have a column with title elements in it, it screws with the sorting logic, which appears to take the first title attr in the `<td/>` and use that as the sort key.  I figured this out basically by trial and error -_-
@snopoke
