### PR TITLE
Extract TestFileMixin

### DIFF
--- a/corehq/apps/app_manager/tests/test_bulk_app_translation.py
+++ b/corehq/apps/app_manager/tests/test_bulk_app_translation.py
@@ -9,13 +9,13 @@ from couchexport.export import export_raw
 from couchexport.models import Format
 from corehq.apps.app_manager.const import APP_V2
 from corehq.apps.app_manager.models import Application, Module
-from corehq.apps.app_manager.tests.util import TestFileMixin
+from corehq.apps.app_manager.tests.util import TestXmlMixin
 from corehq.apps.app_manager.translations import \
     process_bulk_app_translation_upload, expected_bulk_app_sheet_rows, \
     expected_bulk_app_sheet_headers
 
 
-class BulkAppTranslationTestBase(SimpleTestCase, TestFileMixin):
+class BulkAppTranslationTestBase(SimpleTestCase, TestXmlMixin):
 
     def setUp(self):
         """
@@ -272,7 +272,7 @@ class BulkAppTranslationFormTest(BulkAppTranslationTestBase):
         self.assertXmlEqual(self.get_xml("expected_form"), form.render_xform())
 
 
-class BulkAppTranslationDownloadTest(SimpleTestCase, TestFileMixin):
+class BulkAppTranslationDownloadTest(SimpleTestCase, TestXmlMixin):
 
     file_path = ('data', 'bulk_app_translation', 'download')
     maxDiff = None

--- a/corehq/apps/app_manager/tests/test_case_list_form.py
+++ b/corehq/apps/app_manager/tests/test_case_list_form.py
@@ -3,11 +3,11 @@ from corehq.apps.app_manager.const import APP_V2, AUTO_SELECT_USERCASE
 from corehq.apps.app_manager.models import Application, Module, OpenCaseAction, PreloadAction, \
     WORKFLOW_MODULE, AdvancedModule, AdvancedOpenCaseAction, LoadUpdateAction, AutoSelectCase
 from corehq.apps.app_manager.tests.app_factory import AppFactory
-from corehq.apps.app_manager.tests.util import TestFileMixin
+from corehq.apps.app_manager.tests.util import TestXmlMixin
 from mock import patch
 
 
-class CaseListFormSuiteTests(SimpleTestCase, TestFileMixin):
+class CaseListFormSuiteTests(SimpleTestCase, TestXmlMixin):
     file_path = ('data', 'case_list_form')
 
     def _prep_case_list_form_app(self):
@@ -314,7 +314,7 @@ class CaseListFormSuiteTests(SimpleTestCase, TestFileMixin):
         self.assertXmlEqual(self.get_xml('case-list-form-suite-parent-child-submodule-mixed'), factory.app.create_suite())
 
 
-class CaseListFormFormTests(SimpleTestCase, TestFileMixin):
+class CaseListFormFormTests(SimpleTestCase, TestXmlMixin):
     file_path = 'data', 'case_list_form'
 
     def setUp(self):

--- a/corehq/apps/app_manager/tests/test_child_module.py
+++ b/corehq/apps/app_manager/tests/test_child_module.py
@@ -13,7 +13,7 @@ from corehq.apps.app_manager.models import (
     PreloadAction,
     UpdateCaseAction,
 )
-from corehq.apps.app_manager.tests.util import TestFileMixin
+from corehq.apps.app_manager.tests.util import TestXmlMixin
 from corehq.feature_previews import MODULE_FILTER
 from corehq.toggles import NAMESPACE_DOMAIN
 from toggle.shortcuts import clear_toggle_cache, update_toggle_cache
@@ -21,7 +21,7 @@ from toggle.shortcuts import clear_toggle_cache, update_toggle_cache
 DOMAIN = 'domain'
 
 
-class ModuleAsChildTestBase(TestFileMixin):
+class ModuleAsChildTestBase(TestXmlMixin):
     file_path = ('data', 'suite')
     child_module_class = None
 
@@ -309,7 +309,7 @@ class UserCaseOnlyModuleAsChildTest(ModuleAsChildTestBase, SimpleTestCase):
         )
 
 
-class AdvancedSubModuleTests(SimpleTestCase, TestFileMixin):
+class AdvancedSubModuleTests(SimpleTestCase, TestXmlMixin):
     file_path = ('data', 'suite')
 
     def test_form_rename_session_vars(self):
@@ -350,7 +350,7 @@ class AdvancedSubModuleTests(SimpleTestCase, TestFileMixin):
         self.assertXmlEqual(self.get_xml('child-module-rename-session-vars'), upd_guppy_form.render_xform())
 
 
-class BasicSubModuleTests(SimpleTestCase, TestFileMixin):
+class BasicSubModuleTests(SimpleTestCase, TestXmlMixin):
     file_path = ('data', 'suite')
 
     def test_parent_preload(self):

--- a/corehq/apps/app_manager/tests/test_days_ago_migration.py
+++ b/corehq/apps/app_manager/tests/test_days_ago_migration.py
@@ -1,9 +1,9 @@
 from corehq.apps.app_manager.models import Application
-from corehq.apps.app_manager.tests.util import TestFileMixin
+from corehq.apps.app_manager.tests.util import TestXmlMixin
 from django.test import SimpleTestCase
 
 
-class DaysAgoMigrationTest(SimpleTestCase, TestFileMixin):
+class DaysAgoMigrationTest(SimpleTestCase, TestXmlMixin):
     file_path = ['data']
 
     def setUp(self):

--- a/corehq/apps/app_manager/tests/test_extension_case.py
+++ b/corehq/apps/app_manager/tests/test_extension_case.py
@@ -12,7 +12,7 @@ from corehq.apps.app_manager.models import (
     LoadUpdateAction,
     PreloadAction,
 )
-from corehq.apps.app_manager.tests import TestFileMixin
+from corehq.apps.app_manager.tests import TestXmlMixin
 from corehq.apps.app_manager.xform import CaseBlock, XForm, _make_elem
 from corehq.apps.app_manager.xpath import session_var
 from couchdbkit import BadValueError
@@ -20,7 +20,7 @@ from django.test import SimpleTestCase
 from mock import patch
 
 
-class ExtCasePropertiesTests(SimpleTestCase, TestFileMixin):
+class ExtCasePropertiesTests(SimpleTestCase, TestXmlMixin):
     file_path = 'data', 'extension_case'
 
     def setUp(self):
@@ -82,7 +82,7 @@ class ExtCasePropertiesTests(SimpleTestCase, TestFileMixin):
         self.skipTest('TODO: Write this test')
 
 
-class ExtCasePropertiesAdvancedTests(SimpleTestCase, TestFileMixin):
+class ExtCasePropertiesAdvancedTests(SimpleTestCase, TestXmlMixin):
     file_path = 'data', 'extension_case'
 
     def setUp(self):
@@ -133,7 +133,7 @@ class ExtCasePropertiesAdvancedTests(SimpleTestCase, TestFileMixin):
         self.skipTest('TODO: Write this test')
 
 
-class CaseBlockIndexRelationshipTest(SimpleTestCase, TestFileMixin):
+class CaseBlockIndexRelationshipTest(SimpleTestCase, TestXmlMixin):
     file_path = 'data', 'extension_case'
 
     def setUp(self):

--- a/corehq/apps/app_manager/tests/test_form_preparation_v2.py
+++ b/corehq/apps/app_manager/tests/test_form_preparation_v2.py
@@ -17,13 +17,13 @@ from corehq.apps.app_manager.models import (
     OpenSubCaseAction,
     CaseIndex)
 from django.test import SimpleTestCase
-from corehq.apps.app_manager.tests.util import TestFileMixin
+from corehq.apps.app_manager.tests.util import TestXmlMixin
 from corehq.apps.app_manager.util import new_careplan_module
 from corehq.apps.app_manager.xform import XForm
 from mock import patch
 
 
-class FormPreparationV2Test(SimpleTestCase, TestFileMixin):
+class FormPreparationV2Test(SimpleTestCase, TestXmlMixin):
     file_path = 'data', 'form_preparation_v2'
 
     def setUp(self):
@@ -103,7 +103,7 @@ class FormPreparationV2Test(SimpleTestCase, TestFileMixin):
             self.form.render_xform()
 
 
-class SubcaseRepeatTest(SimpleTestCase, TestFileMixin):
+class SubcaseRepeatTest(SimpleTestCase, TestXmlMixin):
     file_path = ('data', 'form_preparation_v2')
 
     def test_subcase_repeat(self):
@@ -159,7 +159,7 @@ class SubcaseRepeatTest(SimpleTestCase, TestFileMixin):
                             app.get_module(0).get_form(0).render_xform())
 
 
-class SubcaseParentRefTeset(SimpleTestCase, TestFileMixin):
+class SubcaseParentRefTeset(SimpleTestCase, TestXmlMixin):
     file_path = ('data', 'form_preparation_v2')
 
     def setUp(self):
@@ -175,7 +175,7 @@ class SubcaseParentRefTeset(SimpleTestCase, TestFileMixin):
                             self.get_xml('subcase-parent-ref'))
 
 
-class CaseSharingFormPrepTest(SimpleTestCase, TestFileMixin):
+class CaseSharingFormPrepTest(SimpleTestCase, TestXmlMixin):
     file_path = ('data', 'form_preparation_v2')
 
     def test_subcase_repeat(self):
@@ -184,7 +184,7 @@ class CaseSharingFormPrepTest(SimpleTestCase, TestFileMixin):
                             self.get_xml('complex-case-sharing'))
 
 
-class GPSFormPrepTest(SimpleTestCase, TestFileMixin):
+class GPSFormPrepTest(SimpleTestCase, TestXmlMixin):
     file_path = ('data', 'form_preparation_v2')
 
     def setUp(self):
@@ -209,7 +209,7 @@ class GPSFormPrepTest(SimpleTestCase, TestFileMixin):
                             self.get_xml('gps_no_question_auto'))
 
 
-class FormPreparationCareplanTest(SimpleTestCase, TestFileMixin):
+class FormPreparationCareplanTest(SimpleTestCase, TestXmlMixin):
     file_path = 'data', 'form_preparation_careplan'
 
     def setUp(self):
@@ -241,7 +241,7 @@ class FormPreparationCareplanTest(SimpleTestCase, TestFileMixin):
         self.assertXmlEqual(form.render_xform(), self.get_xml('update_task'))
 
 
-class FormPreparationV2TestAdvanced(SimpleTestCase, TestFileMixin):
+class FormPreparationV2TestAdvanced(SimpleTestCase, TestXmlMixin):
     file_path = 'data', 'form_preparation_v2_advanced'
 
     def setUp(self):
@@ -347,7 +347,7 @@ class FormPreparationV2TestAdvanced(SimpleTestCase, TestFileMixin):
         self.assertXmlEqual(self.get_xml('update_attachment_case'), self.form.render_xform())
 
 
-class FormPreparationChildModules(SimpleTestCase, TestFileMixin):
+class FormPreparationChildModules(SimpleTestCase, TestXmlMixin):
     file_path = 'data', 'form_preparation_v2_advanced'
 
     def setUp(self):
@@ -416,7 +416,7 @@ class FormPreparationChildModules(SimpleTestCase, TestFileMixin):
         self.assertXmlEqual(self.get_xml('child_module_adjusted_case_id_basic'), form.render_xform())
 
 
-class BaseIndexTest(SimpleTestCase, TestFileMixin):
+class BaseIndexTest(SimpleTestCase, TestXmlMixin):
     file_path = ('data', 'form_preparation_v2_advanced')
 
     def setUp(self):
@@ -560,7 +560,7 @@ class TestExtensionCase(BaseIndexTest):
         self.assertXmlEqual(self.get_xml('extension-case'), self.form.render_xform())
 
 
-class TestXForm(SimpleTestCase, TestFileMixin):
+class TestXForm(SimpleTestCase, TestXmlMixin):
     file_path = "data", "xform_test"
 
     def test_action_relevance(self):

--- a/corehq/apps/app_manager/tests/test_form_workflow.py
+++ b/corehq/apps/app_manager/tests/test_form_workflow.py
@@ -9,13 +9,13 @@ from corehq.apps.app_manager.models import (
     FormDatum)
 from corehq.apps.app_manager.const import AUTO_SELECT_RAW
 from corehq.apps.app_manager.tests.app_factory import AppFactory
-from corehq.apps.app_manager.tests.util import TestFileMixin
+from corehq.apps.app_manager.tests.util import TestXmlMixin
 from corehq.feature_previews import MODULE_FILTER
 from corehq.toggles import NAMESPACE_DOMAIN
 from toggle.shortcuts import update_toggle_cache, clear_toggle_cache
 
 
-class TestFormWorkflow(SimpleTestCase, TestFileMixin):
+class TestFormWorkflow(SimpleTestCase, TestXmlMixin):
     file_path = ('data', 'form_workflow')
 
     def setUp(self):

--- a/corehq/apps/app_manager/tests/test_media_suite.py
+++ b/corehq/apps/app_manager/tests/test_media_suite.py
@@ -7,14 +7,14 @@ from corehq.apps.app_manager import id_strings
 from corehq.apps.app_manager.const import APP_V2
 from corehq.apps.app_manager.models import Application, Module, ReportModule, ReportAppConfig
 from corehq.apps.app_manager.tests.app_factory import AppFactory
-from corehq.apps.app_manager.tests.util import TestFileMixin
+from corehq.apps.app_manager.tests.util import TestXmlMixin
 from corehq.apps.builds.models import BuildSpec
 from corehq.apps.hqmedia.models import CommCareImage, CommCareAudio
 
 import commcare_translations
 
 
-class MediaSuiteTest(SimpleTestCase, TestFileMixin):
+class MediaSuiteTest(SimpleTestCase, TestXmlMixin):
     file_path = ('data', 'suite')
 
     def test_all_media_paths(self):
@@ -108,7 +108,7 @@ class MediaSuiteTest(SimpleTestCase, TestFileMixin):
         self.assertEqual(len(app.all_media), 0)
 
 
-class LocalizedMediaSuiteTest(SimpleTestCase, TestFileMixin):
+class LocalizedMediaSuiteTest(SimpleTestCase, TestXmlMixin):
     """
         For CC >= 2.21
         Tests following for form, module, case_list_menu, case_list_form

--- a/corehq/apps/app_manager/tests/test_profile.py
+++ b/corehq/apps/app_manager/tests/test_profile.py
@@ -2,7 +2,7 @@
 from django.test import SimpleTestCase
 from corehq.apps.app_manager.commcare_settings import get_commcare_settings_lookup, get_custom_commcare_settings
 from corehq.apps.app_manager.models import Application
-from corehq.apps.app_manager.tests.util import TestFileMixin
+from corehq.apps.app_manager.tests.util import TestXmlMixin
 import xml.etree.ElementTree as ET
 
 from corehq.apps.builds.models import BuildSpec
@@ -10,7 +10,7 @@ from corehq import toggles
 from toggle.shortcuts import update_toggle_cache, clear_toggle_cache
 
 
-class ProfileTest(SimpleTestCase, TestFileMixin):
+class ProfileTest(SimpleTestCase, TestXmlMixin):
     file_path = ('data',)
 
     def setUp(self):

--- a/corehq/apps/app_manager/tests/test_schedule.py
+++ b/corehq/apps/app_manager/tests/test_schedule.py
@@ -13,10 +13,10 @@ from corehq.apps.app_manager.models import (
     FormActionCondition,
 )
 from corehq.apps.app_manager.exceptions import ScheduleError
-from corehq.apps.app_manager.tests.util import TestFileMixin
+from corehq.apps.app_manager.tests.util import TestXmlMixin
 
 
-class ScheduleTest(SimpleTestCase, TestFileMixin):
+class ScheduleTest(SimpleTestCase, TestXmlMixin):
     file_path = ('data', 'suite')
 
     def setUp(self):

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -28,7 +28,7 @@ from corehq.apps.app_manager.models import (
     UpdateCaseAction,
 )
 from corehq.apps.app_manager.tests.app_factory import AppFactory
-from corehq.apps.app_manager.tests.util import TestFileMixin, commtrack_enabled
+from corehq.apps.app_manager.tests.util import TestXmlMixin, commtrack_enabled
 from corehq.apps.app_manager.xpath import (
     dot_interpolate,
     UserCaseXPath,
@@ -44,7 +44,7 @@ import commcare_translations
 from mock import patch
 
 
-class SuiteTest(SimpleTestCase, TestFileMixin):
+class SuiteTest(SimpleTestCase, TestXmlMixin):
     file_path = ('data', 'suite')
 
     def setUp(self):
@@ -733,7 +733,7 @@ class RegexTest(SimpleTestCase):
                 interpolate_xpath(case, None),
 
 
-class FormFilterErrorTests(SimpleTestCase, TestFileMixin):
+class FormFilterErrorTests(SimpleTestCase, TestXmlMixin):
     file_path = ('data', 'suite')
 
     def setUp(self):

--- a/corehq/apps/app_manager/tests/test_xform_parsing.py
+++ b/corehq/apps/app_manager/tests/test_xform_parsing.py
@@ -1,11 +1,11 @@
 # coding=utf-8
 from django.test import SimpleTestCase
-from corehq.apps.app_manager.tests.util import TestFileMixin
+from corehq.apps.app_manager.tests.util import TestXmlMixin
 from corehq.apps.app_manager.xform import XForm, XFormException, ItextValue, \
     WrappedNode
 
 
-class XFormParsingTest(SimpleTestCase, TestFileMixin):
+class XFormParsingTest(SimpleTestCase, TestXmlMixin):
     file_path = ('data',)
 
     def setUp(self):

--- a/corehq/apps/app_manager/tests/util.py
+++ b/corehq/apps/app_manager/tests/util.py
@@ -1,4 +1,3 @@
-import json
 import os
 import lxml
 from lxml.doctestcompare import LXMLOutputChecker, LHTMLOutputChecker
@@ -6,9 +5,12 @@ import mock
 from corehq.apps.builds.models import CommCareBuild, CommCareBuildConfig, \
     BuildSpec
 import difflib
+from corehq.util.test_utils import TestFileMixin
 
 
-class TestXmlMixin(object):
+class TestXmlMixin(TestFileMixin):
+    root = os.path.dirname(__file__)
+
     def assertXmlPartialEqual(self, expected, actual, xpath):
         """
         Extracts a section of XML using the xpath and compares it to the expected
@@ -36,43 +38,6 @@ class TestXmlMixin(object):
             expected = parse_normalize(expected, is_html=True)
             actual = parse_normalize(actual, is_html=True)
         _check_shared(expected, actual, LHTMLOutputChecker(), "html")
-
-
-class TestFileMixin(TestXmlMixin):
-
-    file_path = ''
-    root = os.path.dirname(__file__)
-
-    @property
-    def base(self):
-        return self.get_base()
-
-    @classmethod
-    def get_base(cls, override_path=None):
-        path = override_path or cls.file_path
-        return os.path.join(cls.root, *path)
-
-    @classmethod
-    def get_path(cls, name, ext, override_path=None):
-        return os.path.join(cls.get_base(override_path), '%s.%s' % (name, ext))
-
-    @classmethod
-    def get_file(cls, name, ext, override_path=None):
-        with open(cls.get_path(name, ext, override_path)) as f:
-            return f.read()
-
-    @classmethod
-    def write_xml(cls, name, xml, override_path=None):
-        with open(cls.get_path(name, 'xml', override_path), 'w') as f:
-            return f.write(xml)
-
-    @classmethod
-    def get_json(cls, name, override_path=None):
-        return json.loads(cls.get_file(name, 'json', override_path))
-
-    @classmethod
-    def get_xml(cls, name, override_path=None):
-        return cls.get_file(name, 'xml', override_path)
 
 
 def normalize_attributes(xml):

--- a/corehq/apps/commtrack/tests/test_fixture.py
+++ b/corehq/apps/commtrack/tests/test_fixture.py
@@ -4,7 +4,7 @@ from xml.etree import ElementTree
 
 from casexml.apps.case.xml import V1
 from casexml.apps.phone.tests.utils import generate_restore_payload
-from corehq.apps.app_manager.tests.util import TestFileMixin
+from corehq.apps.app_manager.tests.util import TestXmlMixin
 from corehq.apps.programs.fixtures import program_fixture_generator
 from corehq.apps.products.fixtures import product_fixture_generator
 from corehq.apps.products.models import Product
@@ -15,7 +15,7 @@ from casexml.apps.phone.models import SyncLog
 import datetime
 
 
-class FixtureTest(CommTrackTest, TestFileMixin):
+class FixtureTest(CommTrackTest, TestXmlMixin):
 
     def _random_string(self, length):
         return ''.join(random.choice(string.ascii_lowercase)

--- a/corehq/apps/export/tests/test_form_schema.py
+++ b/corehq/apps/export/tests/test_form_schema.py
@@ -6,11 +6,11 @@ from fakecouch import FakeCouchDb
 from jsonobject.exceptions import BadValueError
 
 from corehq.apps.app_manager.models import Application
-from corehq.apps.app_manager.tests.util import TestFileMixin
+from corehq.apps.app_manager.tests.util import TestXmlMixin
 from corehq.apps.reports.models import FormQuestionSchema
 
 
-class FormQuestionSchemaTest(SimpleTestCase, TestFileMixin):
+class FormQuestionSchemaTest(SimpleTestCase, TestXmlMixin):
     file_path = ['data']
     root = os.path.dirname(__file__)
 

--- a/corehq/apps/hqcase/tests/test_explode_cases.py
+++ b/corehq/apps/hqcase/tests/test_explode_cases.py
@@ -7,7 +7,7 @@ from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.sharedmodels import CommCareCaseAttachment
 from casexml.apps.case.tests import delete_all_cases
 from casexml.apps.case.xml import V2
-from corehq.apps.app_manager.tests import TestFileMixin
+from corehq.apps.app_manager.tests import TestXmlMixin
 from corehq.apps.hqcase.dbaccessors import get_case_ids_in_domain, \
     get_cases_in_domain
 from corehq.apps.hqcase.tasks import explode_cases
@@ -90,7 +90,7 @@ class mock_fetch_case_attachment(object):
         CommCareCase.fetch_case_attachment = self.old_fetch_case_attachment
 
 
-class ExplodeCasesTest(SimpleTestCase, TestFileMixin):
+class ExplodeCasesTest(SimpleTestCase, TestXmlMixin):
     maxDiff = 1000000
 
     def test_make_creating_casexml(self):

--- a/corehq/apps/tzmigration/tests/test_timezonemigration.py
+++ b/corehq/apps/tzmigration/tests/test_timezonemigration.py
@@ -3,7 +3,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.tests import delete_all_xforms, delete_all_cases
-from corehq.apps.app_manager.tests import TestFileMixin
+from corehq.util.test_utils import TestFileMixin
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.hqcase.dbaccessors import get_cases_in_domain
 from corehq.apps.receiverwrapper.exceptions import LocalSubmissionError

--- a/corehq/apps/userreports/tests/test_static_data_sources.py
+++ b/corehq/apps/userreports/tests/test_static_data_sources.py
@@ -1,7 +1,7 @@
 import os
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
-from corehq.apps.app_manager.tests import TestFileMixin
+from corehq.util.test_utils import TestFileMixin
 from corehq.apps.userreports.models import StaticDataSourceConfiguration
 
 

--- a/corehq/apps/userreports/tests/test_static_reports.py
+++ b/corehq/apps/userreports/tests/test_static_reports.py
@@ -1,7 +1,7 @@
 import os
 from django.test import SimpleTestCase
 from django.test.utils import override_settings
-from corehq.apps.app_manager.tests import TestFileMixin
+from corehq.util.test_utils import TestFileMixin
 from corehq.apps.userreports.models import StaticDataSourceConfiguration, StaticReportConfiguration
 
 

--- a/corehq/util/test_utils.py
+++ b/corehq/util/test_utils.py
@@ -1,3 +1,6 @@
+import json
+import os
+
 from functools import wraps
 from django.conf import settings
 
@@ -14,3 +17,40 @@ def unit_testing_only(fn):
                 'You may only call {} during unit testing'.format(fn.__name__))
         return fn(*args, **kwargs)
     return inner
+
+
+class TestFileMixin(object):
+
+    file_path = ''
+    root = ''
+
+    @property
+    def base(self):
+        return self.get_base()
+
+    @classmethod
+    def get_base(cls, override_path=None):
+        path = override_path or cls.file_path
+        return os.path.join(cls.root, *path)
+
+    @classmethod
+    def get_path(cls, name, ext, override_path=None):
+        return os.path.join(cls.get_base(override_path), '%s.%s' % (name, ext))
+
+    @classmethod
+    def get_file(cls, name, ext, override_path=None):
+        with open(cls.get_path(name, ext, override_path)) as f:
+            return f.read()
+
+    @classmethod
+    def write_xml(cls, name, xml, override_path=None):
+        with open(cls.get_path(name, 'xml', override_path), 'w') as f:
+            return f.write(xml)
+
+    @classmethod
+    def get_json(cls, name, override_path=None):
+        return json.loads(cls.get_file(name, 'json', override_path))
+
+    @classmethod
+    def get_xml(cls, name, override_path=None):
+        return cls.get_file(name, 'xml', override_path)


### PR DESCRIPTION
switch the inheritance of `TestFileMixin` and `TestXmlMixin`, since
`TestFileMixin` is generic and useful elsewhere
