### PR TITLE
Include the supply_point_id with location fixture

### DIFF
--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -181,6 +181,7 @@ def _location_to_fixture(location_db, location, type):
         'latitude',
         'longitude',
         'location_type',
+        'supply_point_id',
     ]
     for field in fixture_fields:
         field_node = Element(field)


### PR DESCRIPTION
This will appear in the location fixture in the restore, simplifying stuff like parent lookups for transfers.

``` xml
<town id="f9d54b1d254eadf454caaa0818e8e86e">
   <name>Jacksonville</name>
   <site_code>jacksonville</site_code>
   <external_id/>
   <latitude>42.3652000000</latitude>
   <longitude>-71.1039000000</longitude>
   <location_type>town</location_type>
   <supply_point_id>f96ec198a137487bb87763b05a8f8a3c</supply_point_id>
   <location_data>
       <color>vermilion</color>
       <stuff/>
   </location_data>
</town>
```

It will show up as an empty node if not applicable:

``` xml
<city id="2e661b53e068b0fb2ac01982d76d7f6b">
   <name>Boston</name>
   <site_code>boston1</site_code>
   <external_id/>
   <latitude/>
   <longitude/>
   <location_type>city</location_type>
   <supply_point_id/>
   <location_data/>
</city>
```

@snopoke @sheelio
Can you think of any reason why this isn't a good idea?  For instance, it will potentially give access to supply-point case ids that users might not otherwise have access to (albeit via complicated xpath expressions).  That puts a bit more discretion on the app builder.
