### PR TITLE
Save form before attempting to put_attachment

### DIFF
--- a/corehq/ex-submodules/couchforms/models.py
+++ b/corehq/ex-submodules/couchforms/models.py
@@ -309,6 +309,7 @@ class XFormInstance(SafeSaveDocument, UnicodeMixIn, ComputedDocumentMixin,
             element = _to_xml_element(decoded_payload)
 
             # in this scenario resave the attachment properly in case future calls circumvent this method
+            self.save()
             self.put_attachment(decoded_payload, ATTACHMENT_NAME)
             return element
 

--- a/corehq/ex-submodules/couchforms/models.py
+++ b/corehq/ex-submodules/couchforms/models.py
@@ -14,6 +14,7 @@ from lxml import etree
 from django.utils.datastructures import SortedDict
 from couchdbkit.exceptions import PreconditionFailed, BadValueError
 from corehq.util.dates import iso_string_to_datetime
+from corehq.util.soft_assert import soft_assert
 from dimagi.ext.couchdbkit import *
 from couchdbkit import ResourceNotFound
 from lxml.etree import XMLSyntaxError
@@ -29,6 +30,9 @@ from dimagi.utils.mixins import UnicodeMixIn
 from couchforms.signals import xform_archived, xform_unarchived
 from couchforms.const import ATTACHMENT_NAME
 from couchforms import const
+
+
+_soft_assert = soft_assert(notify_admins=True)
 
 
 def doc_types():
@@ -303,6 +307,8 @@ class XFormInstance(SafeSaveDocument, UnicodeMixIn, ComputedDocumentMixin,
         try:
             return _to_xml_element(xml_string)
         except XMLSyntaxError:
+            _soft_assert(False, "Form {} has invalid xml, assuming it's b64 "
+                                "encoded and retrying.".format(self._id))
             # there is a bug at least in pact code that double
             # saves a submission in a way that the attachments get saved in a base64-encoded format
             decoded_payload = base64.b64decode(xml_string)


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?182634

There's a lot of weird interactions happening here - but I think this missing _rev issue is related to a race condition between here and the other handlers of the signal that gets called in the save form process.

I'm not crazy about double-saving the doc, but this is an edge case which shouldn't occur under normal operation.  I'm open to alternate suggestions.

At any rate, this was consistently reproducible locally, and this change fixes it.

@snopoke
