### PR TITLE
adds field for justifying why not to invoice

### DIFF
--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -335,6 +335,9 @@ class SubscriptionForm(forms.Form):
     do_not_invoice = forms.BooleanField(
         label=ugettext_lazy("Do Not Invoice"), required=False
     )
+    no_invoice_reason = forms.CharField(
+        label=ugettext_lazy("Justify why \"Do Not Invoice\""), max_length=256, required=False
+    )
     auto_generate_credits = forms.BooleanField(
         label=ugettext_lazy("Auto-generate Plan Credits"), required=False
     )
@@ -431,6 +434,7 @@ class SubscriptionForm(forms.Form):
             self.fields['domain'].initial = subscription.subscriber.domain
             self.fields['salesforce_contract_id'].initial = subscription.salesforce_contract_id
             self.fields['do_not_invoice'].initial = subscription.do_not_invoice
+            self.fields['no_invoice_reason'].initial = subscription.no_invoice_reason
             self.fields['auto_generate_credits'].initial = subscription.auto_generate_credits
             self.fields['service_type'].initial = subscription.service_type
             self.fields['pro_bono_status'].initial = subscription.pro_bono_status
@@ -503,7 +507,8 @@ class SubscriptionForm(forms.Form):
                 plan_version_field,
                 domain_field,
                 'salesforce_contract_id',
-                'do_not_invoice',
+                crispy.Field('do_not_invoice', data_bind="checked: noInvoice"),
+                crispy.Div(crispy.Field('no_invoice_reason', data_bind="attr: {required: noInvoice}"), data_bind="visible: noInvoice"),
                 'auto_generate_credits',
                 'service_type',
                 'pro_bono_status'
@@ -571,6 +576,7 @@ class SubscriptionForm(forms.Form):
         date_delay_invoicing = self.cleaned_data['delay_invoice_until']
         salesforce_contract_id = self.cleaned_data['salesforce_contract_id']
         do_not_invoice = self.cleaned_data['do_not_invoice']
+        no_invoice_reason = self.cleaned_data['no_invoice_reason']
         auto_generate_credits = self.cleaned_data['auto_generate_credits']
         service_type = self.cleaned_data['service_type']
         pro_bono_status = self.cleaned_data['pro_bono_status']
@@ -581,6 +587,7 @@ class SubscriptionForm(forms.Form):
             date_delay_invoicing=date_delay_invoicing,
             salesforce_contract_id=salesforce_contract_id,
             do_not_invoice=do_not_invoice,
+            no_invoice_reason=no_invoice_reason,
             auto_generate_credits=auto_generate_credits,
             web_user=self.web_user,
             service_type=service_type,
@@ -602,6 +609,7 @@ class SubscriptionForm(forms.Form):
             date_end=self.cleaned_data['end_date'],
             date_delay_invoicing=self.cleaned_data['delay_invoice_until'],
             do_not_invoice=self.cleaned_data['do_not_invoice'],
+            no_invoice_reason=self.cleaned_data['no_invoice_reason'],
             auto_generate_credits=self.cleaned_data['auto_generate_credits'],
             salesforce_contract_id=self.cleaned_data['salesforce_contract_id'],
             web_user=self.web_user,

--- a/corehq/apps/accounting/migrations/0004_subscription_no_invoice_reason.py
+++ b/corehq/apps/accounting/migrations/0004_subscription_no_invoice_reason.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounting', '0003_bootstrap'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='subscription',
+            name='no_invoice_reason',
+            field=models.CharField(max_length=256, null=True, blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -859,6 +859,7 @@ class Subscription(models.Model):
     date_created = models.DateTimeField(auto_now_add=True)
     is_active = models.BooleanField(default=False)
     do_not_invoice = models.BooleanField(default=False)
+    no_invoice_reason = models.CharField(blank=True, null=True, max_length=256)
     auto_generate_credits = models.BooleanField(default=False)
     is_trial = models.BooleanField(default=False)
     service_type = models.CharField(
@@ -915,7 +916,7 @@ class Subscription(models.Model):
         These are the attributes of a Subscription that can always be
         changed while the subscription is active (or reactivated)
         """
-        return ['do_not_invoice', 'salesforce_contract_id']
+        return ['do_not_invoice', 'no_invoice_reason', 'salesforce_contract_id']
 
     @property
     def is_renewed(self):
@@ -1028,6 +1029,7 @@ class Subscription(models.Model):
 
     def update_subscription(self, date_start=None, date_end=None,
                             date_delay_invoicing=None, do_not_invoice=False,
+                            no_invoice_reason=None,
                             salesforce_contract_id=None,
                             auto_generate_credits=False,
                             web_user=None, note=None, adjustment_method=None,
@@ -1060,6 +1062,7 @@ class Subscription(models.Model):
             self.date_delay_invoicing = date_delay_invoicing
 
         self.do_not_invoice = do_not_invoice
+        self.no_invoice_reason = no_invoice_reason
         self.auto_generate_credits = auto_generate_credits
         self.salesforce_contract_id = salesforce_contract_id
         if service_type is not None:
@@ -1078,7 +1081,7 @@ class Subscription(models.Model):
                     note=None, web_user=None, adjustment_method=None,
                     service_type=None, pro_bono_status=None,
                     transfer_credits=True, internal_change=False, account=None,
-                    do_not_invoice=None, **kwargs):
+                    do_not_invoice=None, no_invoice_reason=None, **kwargs):
         """
         Changing a plan TERMINATES the current subscription and
         creates a NEW SUBSCRIPTION where the old plan left off.
@@ -1111,6 +1114,7 @@ class Subscription(models.Model):
             date_delay_invoicing=self.date_delay_invoicing,
             is_active=is_active_subscription(new_start_date, date_end),
             do_not_invoice=do_not_invoice if do_not_invoice else self.do_not_invoice,
+            no_invoice_reason=no_invoice_reason if no_invoice_reason else self.no_invoice_reason,
             service_type=(service_type or SubscriptionType.NOT_SET),
             pro_bono_status=(pro_bono_status or ProBonoStatus.NOT_SET),
             **kwargs

--- a/corehq/apps/accounting/static/accounting/js/invoices.js
+++ b/corehq/apps/accounting/static/accounting/js/invoices.js
@@ -1,0 +1,9 @@
+var InvoiceModel = function () {
+    var self = this;
+    var invoice = $('#id_do_not_invoice').attr("checked");
+    self.noInvoice = ko.observable(invoice);
+};
+
+var invoiceModel = new InvoiceModel();
+ko.applyBindings(invoiceModel, $('fieldset').get(0));
+

--- a/corehq/apps/accounting/templates/accounting/subscriptions_base.html
+++ b/corehq/apps/accounting/templates/accounting/subscriptions_base.html
@@ -14,6 +14,7 @@
     <script src="{% static 'hqwebapp/js/lib/select2/select2.js' %}"></script>
     <script src="{% static 'accounting/js/accounting.billing_info_handler.js' %}"></script>
     <script src="{% static 'accounting/js/accounting.subscription_info_handler.js' %}"></script>
+    <script src="{% static 'accounting/js/invoices.js' %}"></script>
 {% endblock %}
 
 {% block js-inline %} {{ block.super }}

--- a/corehq/apps/accounting/templates/accounting/subscriptions_tab.html
+++ b/corehq/apps/accounting/templates/accounting/subscriptions_tab.html
@@ -21,6 +21,7 @@
                 <th>{% trans "Last Invoice Due Date" %}</th>
                 <th>{% trans "Delay Invoicing Until" %}</th>
                 <th>{% trans "Do Not Invoice" %}</th>
+                <th>{% trans "Why No Invoice" %}</th>
                 <th>{% trans "Edit" %}</th>
             </tr>
         </thead>
@@ -36,6 +37,7 @@
                     <td>{{ last_due_date }}</td>
                     <td>{{ subscription.date_delay_invoicing }}</td>
                     <td>{{ subscription.do_not_invoice }}</td>
+                    <td>{{ subscription.no_invoice_reason }}</td>
                     <td><a href="{% url 'edit_subscription' subscription.id %}" class="btn">Edit</a></td>
                 </tr>
             {% endfor %}


### PR DESCRIPTION
@nickpell 
addresses this fogbugz ticket
http://manage.dimagi.com/default.asp?175587#1017714

Screenshots:
When do not invoice is not selected:
<img width="472" alt="subscriptionscreenshot1" src="https://cloud.githubusercontent.com/assets/6844721/10148604/6504d49a-6602-11e5-8d11-9d127fbf6469.png">

When do not invoice is selected:
<img width="501" alt="subscriptionscreenshot2" src="https://cloud.githubusercontent.com/assets/6844721/10148605/65050852-6602-11e5-9d5d-6ea43e8607f9.png">

Where you can view the note:
<img width="1193" alt="subscriptionscreenshot3" src="https://cloud.githubusercontent.com/assets/6844721/10148606/6505baa4-6602-11e5-9260-3a5d70d90742.png">
