### PR TITLE
Make active_cases a strict subset of total_cases

### DIFF
--- a/corehq/apps/es/cases.py
+++ b/corehq/apps/es/cases.py
@@ -30,6 +30,7 @@ class CaseES(HQESQuery):
             is_closed,
             case_type,
             owner,
+            active_in_range,
         ] + super(CaseES, self).builtin_filters
 
 
@@ -51,3 +52,11 @@ def case_type(type_):
 
 def owner(owner_id):
     return filters.term('owner_id', owner_id)
+
+
+def active_in_range(gt=None, gte=None, lt=None, lte=None):
+    """Restricts cases returned to those with actions during the range"""
+    return filters.nested(
+        "actions",
+        filters.date_range("actions.date", gt, gte, lt, lte)
+    )

--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -158,6 +158,7 @@ class ESQuery(object):
             filters.exists,
             filters.empty,
             filters.doc_id,
+            filters.nested,
         ]
 
     def __getattr__(self, attr):

--- a/corehq/apps/es/filters.py
+++ b/corehq/apps/es/filters.py
@@ -102,3 +102,13 @@ def empty(field):
     """Only return docs with a missing or null value for ``field``"""
     return OR(missing(field, exist=True, null=True),
               term(field, ''))
+
+
+def nested(path, filter_):
+    """Query nested documents which normally can't be queried directly"""
+    return {
+        "nested": {
+            "path": path,
+            "filter": filter_
+        }
+    }


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?176041
There have been reports recently of active_cases being greater than total_cases, which is kinda confusing.  This PR makes the two indicators share filtering constraints.

This also adds support for nested filtering in ESQuery, and introduces a `CaseES().active_in_range()` filter.

@snopoke
