### PR TITLE
Fix Abt data source target numbers

### DIFF
--- a/custom/abt/reports/data_sources/sms.json
+++ b/custom/abt/reports/data_sources/sms.json
@@ -435,7 +435,7 @@
                     "value_expression": {
                       "datatype": null,
                       "type": "property_name",
-                      "property_name": "level_1_name"
+                      "property_name": "level_1_data"
                     },
                     "type": "related_doc",
                     "related_doc_type": "CommCareCase",
@@ -731,7 +731,7 @@
                     "value_expression": {
                       "datatype": null,
                       "type": "property_name",
-                      "property_name": "level_2_name"
+                      "property_name": "level_2_data"
                     },
                     "type": "related_doc",
                     "related_doc_type": "CommCareCase",


### PR DESCRIPTION
@nickpell 
Target numbers for Zambia were given by region ID, not "name". This fixes missing targets.
