### PR TITLE
prevents invalid dates from being auto loaded in reports

### DIFF
--- a/corehq/apps/reports/static/reports/javascripts/reports.config.js
+++ b/corehq/apps/reports/static/reports/javascripts/reports.config.js
@@ -83,7 +83,8 @@ var HQReport = function (options) {
     };
 
     self.saveDatespanToCookie = function () {
-        if (self.datespan) {
+        var validDate = /^\d{4}-\d{2}-\d{2}$/;
+        if (self.datespan && validDate.test(self.datespan.startdate) && validDate.test(self.datespan.enddate)) {
             $.cookie(self.datespanCookie+'.startdate', self.datespan.startdate,
                 {path: self.urlRoot, expires: 1});
             $.cookie(self.datespanCookie+'.enddate', self.datespan.enddate,

--- a/corehq/apps/reports_core/templates/reports_core/filters/datespan_filter/datespan_filter.js
+++ b/corehq/apps/reports_core/templates/reports_core/filters/datespan_filter/datespan_filter.js
@@ -1,6 +1,6 @@
 var filter_id = "#{{ filter.css_id }}-input";
 $(filter_id).createDefaultDateRangePicker();
-$(filter_id).on('apply', function(ev, picker) {
+$(filter_id).on('apply change', function(ev, picker) {
     var separator = $().getDateRangeSeparator();
     var dates = $(this).val().split(separator);
     $('#{{ filter.css_id }}-start').val(dates[0]);


### PR DESCRIPTION
This addresses http://manage.dimagi.com/default.asp?183213#1020719
The bad state was caused by saving the last used date range in a cookie, these changes validate dates before saving them.
@nickpell 
