### PR TITLE
add regression tests for strange dimagi.ext.jsonobject bug

### DIFF
--- a/corehq/util/tests/__init__.py
+++ b/corehq/util/tests/__init__.py
@@ -8,6 +8,7 @@ from test_soft_assert import *
 from test_cache_util import *
 from test_override_db import *
 from test_spreadsheets import *
+from test_jsonobject import *
 
 from corehq.util.dates import iso_string_to_datetime, iso_string_to_date
 

--- a/corehq/util/tests/test_jsonobject.py
+++ b/corehq/util/tests/test_jsonobject.py
@@ -1,0 +1,32 @@
+import datetime
+from django.test import SimpleTestCase
+from jsonobject import JsonObject as TheirJsonObject
+from dimagi.ext.jsonobject import JsonObject as OurJsonObject
+from jsonobject.exceptions import BadValueError
+
+
+class JsonObjectTest(SimpleTestCase):
+
+    JsonObject = TheirJsonObject
+
+    def test_ms(self):
+        class Foo(self.JsonObject):
+            pass
+        foo = Foo({'date': '2015-10-01T14:05:45.087434Z'})
+        self.assertEqual(foo.date, datetime.datetime(2015, 10, 1, 14, 5, 45))
+
+    def test_no_ms(self):
+        class Foo(self.JsonObject):
+            pass
+        foo = Foo({'date': '2015-10-01T14:05:45Z'})
+        self.assertEqual(foo.date, datetime.datetime(2015, 10, 1, 14, 5, 45))
+
+    def test_dt(self):
+        class Foo(self.JsonObject):
+            pass
+        with self.assertRaises(BadValueError):
+            Foo({'date': datetime.datetime(2015, 10, 1, 14, 5, 45, 87434)})
+
+
+class OurJsonObjectTest(JsonObjectTest):
+    JsonObject = OurJsonObject

--- a/corehq/util/tests/test_jsonobject.py
+++ b/corehq/util/tests/test_jsonobject.py
@@ -1,7 +1,7 @@
 import datetime
 from django.test import SimpleTestCase
 from jsonobject import JsonObject as TheirJsonObject
-from dimagi.ext.jsonobject import JsonObject as OurJsonObject
+from dimagi.ext.jsonobject import JsonObject as OurJsonObject, re_trans_datetime
 from jsonobject.exceptions import BadValueError
 
 
@@ -30,3 +30,12 @@ class JsonObjectTest(SimpleTestCase):
 
 class OurJsonObjectTest(JsonObjectTest):
     JsonObject = OurJsonObject
+
+    def test_match(self):
+        self.assertTrue(re_trans_datetime.match('2015-10-01T14:05:45.087434Z'), True)
+
+    def test_ms(self):
+        class Foo(self.JsonObject):
+            pass
+        foo = Foo({'date': '2015-10-01T14:05:45.087434Z'})
+        self.assertEqual(foo.date, datetime.datetime(2015, 10, 1, 14, 5, 45, 87434))


### PR DESCRIPTION
`SimpleTestCase`s for dimagi.ext.jsonobject bug

```
======================================================================
FAIL: test_ms (corehq.util.tests.test_jsonobject.OurJsonObjectTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/droberts/dimagi/commcare-hq/corehq/util/tests/test_jsonobject.py", line 16, in test_ms
    self.assertEqual(foo.date, datetime.datetime(2015, 10, 1, 14, 5, 45))
AssertionError: u'2015-10-01T14:05:45.087434Z' != datetime.datetime(2015, 10, 1, 14, 5, 45)

======================================================================
FAIL: test_no_ms (corehq.util.tests.test_jsonobject.OurJsonObjectTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/droberts/dimagi/commcare-hq/corehq/util/tests/test_jsonobject.py", line 22, in test_no_ms
    self.assertEqual(foo.date, datetime.datetime(2015, 10, 1, 14, 5, 45))
AssertionError: u'2015-10-01T14:05:45Z' != datetime.datetime(2015, 10, 1, 14, 5, 45)

----------------------------------------------------------------------
Ran 6 tests in 0.005s
```

https://github.com/dimagi/dimagi-utils/pull/321 fixes tests
