### PR TITLE
Fix report builder filter slugs

### DIFF
--- a/corehq/apps/userreports/filters/factory.py
+++ b/corehq/apps/userreports/filters/factory.py
@@ -1,7 +1,7 @@
 import json
 import warnings
 from django.utils.translation import ugettext as _
-from jsonobject.exceptions import BadValueError
+from jsonobject.exceptions import BadValueError, WrappingAttributeError
 from corehq.apps.userreports.expressions.factory import ExpressionFactory
 from corehq.apps.userreports.filters.specs import (PropertyMatchFilterSpec, NotFilterSpec, NamedFilterSpec,
     BooleanExpressionFilterSpec)
@@ -74,7 +74,7 @@ class FilterFactory(object):
         cls.validate_spec(spec)
         try:
             return cls.constructor_map[spec['type']](spec, context)
-        except (AssertionError, BadValueError) as e:
+        except (AssertionError, BadValueError, WrappingAttributeError) as e:
             raise BadSpecError(_('Problem creating filter from spec: {}, message is {}').format(
                 json.dumps(spec, indent=2),
                 str(e),

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -757,7 +757,7 @@ class ConfigureNewReportBase(forms.Form):
 
             ret = {
                 "field": col_id,
-                "slug": "{}-{}".format(col_id, index),
+                "slug": "{}_{}".format(col_id, index),
                 "display": conf["display_text"],
                 "type": filter_format
             }

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -297,13 +297,23 @@ class FilterChoice(JsonObject):
         return self.display or self.value
 
 
+def _validate_filter_slug(s):
+    if "-" in s:
+        raise Exception(_(
+            """
+            Filter slugs must be legal sqlalchemy bind parameter names.
+            '-' and other special character are prohibited
+            """
+        ))
+
+
 class FilterSpec(JsonObject):
     """
     This is the spec for a report filter - a thing that should show up as a UI filter element
     in a report (like a date picker or a select list).
     """
     type = StringProperty(required=True, choices=['date', 'numeric', 'choice_list', 'dynamic_choice_list'])
-    slug = StringProperty(required=True)  # this shows up as the ID in the filter HTML
+    slug = StringProperty(required=True, validators=_validate_filter_slug)  # this shows up as the ID in the filter HTML.
     field = StringProperty(required=True)  # this is the actual column that is queried
     display = DefaultProperty()
     datatype = DataTypeProperty(default='string')

--- a/corehq/apps/userreports/tests/test_filters.py
+++ b/corehq/apps/userreports/tests/test_filters.py
@@ -4,6 +4,17 @@ from corehq.apps.userreports.filters import ANDFilter, ORFilter, NOTFilter
 from corehq.apps.userreports.filters.factory import FilterFactory
 
 
+class BasicFilterTest(SimpleTestCase):
+
+    def test_invalid_slug(self):
+        with self.assertRaises(BadSpecError):
+            FilterFactory.from_spec({
+                'type': 'property_match',
+                'property_name': 'foo',
+                'property_value': 'bar',
+                'slug': 'this-is-bad',
+            })
+
 
 class PropertyMatchFilterTest(SimpleTestCase):
 


### PR DESCRIPTION
Fixes a bug that causes UCR query execution errors. http://manage.dimagi.com/default.asp?183456#1022893

The filter slug is eventually used as the name of a sqlalchemy bind param [in sqlagg](https://github.com/dimagi/sql-agg/blob/bb2f076e060ce438170831bdf0a945582324eca6/sqlagg/filters.py#L30). But, when this string is eventually converted into an action query for postgres, the bind parameter isn't properly delineated. e.g.
If your slug is `name-1`, the query ends up looking something like

```
SELECT ... FROM ... WHERE "name_column" = %(name)s-1 GROUP BY ...
```

The best place to solve this is probably in sqlagg (it should likely be using functions like [`bindparam()`](http://docs.sqlalchemy.org/en/rel_0_9/core/sqlelement.html#sqlalchemy.sql.expression.bindparam) instead of building the strings manually), but I didn't attempt to implement that given time constraints.

cc @kaapstorm 
FYI @snopoke who I think knows the most about sqlagg
