### PR TITLE
add case-type column in related cases view

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/models.py
+++ b/corehq/ex-submodules/casexml/apps/case/models.py
@@ -928,6 +928,10 @@ class CommCareCase(SafeSaveDocument, IndexHoldingMixIn, ComputedDocumentMixin,
                 'expr': "status"
             },
             {
+                'name': _('Case Type'),
+                'expr': "type",
+            },
+            {
                 'name': _('Date Opened'),
                 'expr': "opened_on",
                 'parse_date': True,


### PR DESCRIPTION
@benrudolph @proteusvacuum useful in projects with complicated case structure.
Would also be good to add relationship type since now we have3 types of relations 'extension', 'subcase' and 'indexed', but may be latter.
