### PR TITLE
Fix UCR data source Session usage

### DIFF
--- a/corehq/apps/userreports/sql/columns.py
+++ b/corehq/apps/userreports/sql/columns.py
@@ -2,7 +2,6 @@ import sqlalchemy
 from sqlagg import SumWhen
 from django.utils.translation import ugettext as _
 from corehq.apps.userreports.exceptions import ColumnNotFoundError
-from corehq.db import Session
 from corehq.apps.reports.sqlreport import DatabaseColumn
 from fluff import TYPE_STRING
 from fluff.util import get_column_type
@@ -80,15 +79,13 @@ def _get_distinct_values(data_source_configuration, column_config, expansion_lim
     :param expansion_limit:
     :return:
     """
-    from corehq.apps.userreports.sql.adapter import get_indicator_table
-
+    from corehq.apps.userreports.sql import IndicatorSqlAdapter
+    adapter = IndicatorSqlAdapter(data_source_configuration)
     too_many_values = False
 
-    session = Session()
     try:
-        connection = session.connection()
-        table = get_indicator_table(data_source_configuration)
-        if not table.exists(bind=connection):
+        table = adapter.get_table()
+        if not table.exists(bind=adapter.engine):
             return [], False
 
         if column_config.field not in table.c:
@@ -98,8 +95,8 @@ def _get_distinct_values(data_source_configuration, column_config, expansion_lim
             )
         column = table.c[column_config.field]
 
-        query = sqlalchemy.select([column], limit=expansion_limit + 1).distinct()
-        result = connection.execute(query).fetchall()
+        query = adapter.session_helper.Session.query(column).limit(expansion_limit + 1).distinct()
+        result = query.all()
         distinct_values = [x[0] for x in result]
         if len(distinct_values) > expansion_limit:
             distinct_values = distinct_values[:expansion_limit]

--- a/corehq/apps/userreports/sql/columns.py
+++ b/corehq/apps/userreports/sql/columns.py
@@ -83,29 +83,23 @@ def _get_distinct_values(data_source_configuration, column_config, expansion_lim
     adapter = IndicatorSqlAdapter(data_source_configuration)
     too_many_values = False
 
-    try:
-        table = adapter.get_table()
-        if not table.exists(bind=adapter.engine):
-            return [], False
+    table = adapter.get_table()
+    if not table.exists(bind=adapter.engine):
+        return [], False
 
-        if column_config.field not in table.c:
-            raise ColumnNotFoundError(_(
-                'The column "{}" does not exist in the report source! '
-                'Please double check your report configuration.').format(column_config.field)
-            )
-        column = table.c[column_config.field]
+    if column_config.field not in table.c:
+        raise ColumnNotFoundError(_(
+            'The column "{}" does not exist in the report source! '
+            'Please double check your report configuration.').format(column_config.field)
+        )
+    column = table.c[column_config.field]
 
-        query = adapter.session_helper.Session.query(column).limit(expansion_limit + 1).distinct()
-        result = query.all()
-        distinct_values = [x[0] for x in result]
-        if len(distinct_values) > expansion_limit:
-            distinct_values = distinct_values[:expansion_limit]
-            too_many_values = True
-    except:
-        session.rollback()
-        raise
-    finally:
-        session.close()
+    query = adapter.session_helper.Session.query(column).limit(expansion_limit + 1).distinct()
+    result = query.all()
+    distinct_values = [x[0] for x in result]
+    if len(distinct_values) > expansion_limit:
+        distinct_values = distinct_values[:expansion_limit]
+        too_many_values = True
 
     return distinct_values, too_many_values
 

--- a/corehq/apps/userreports/tests/test_columns.py
+++ b/corehq/apps/userreports/tests/test_columns.py
@@ -3,7 +3,6 @@ import uuid
 from jsonobject.exceptions import BadValueError
 from sqlagg import SumWhen
 from django.test import SimpleTestCase, TestCase
-from corehq.db import Session
 
 from corehq.apps.userreports import tasks
 from corehq.apps.userreports.app_manager import _clean_table_name
@@ -111,7 +110,7 @@ class ChoiceListColumnDbTest(TestCase):
             'long_column': 'duplicate_choice_1',
         })
         # and query it back
-        q = Session.query(adapter.get_table())
+        q = adapter.get_query_object()
         self.assertEqual(1, q.count())
 
 

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -659,9 +659,10 @@ def choice_list_api(request, domain, report_id, filter_id):
         if not isinstance(filter, DynamicChoiceListFilter):
             return []
 
-        table = get_indicator_table(data_source)
+        adapter = IndicatorSqlAdapter(data_source)
+        table = adapter.get_table()
         sql_column = table.c[filter.field]
-        query = Session.query(sql_column)
+        query = adapter.session_helper.Session.query(sql_column)
         if search_term:
             query = query.filter(sql_column.contains(search_term))
 


### PR DESCRIPTION
There are two places where the default engine id was being used to retrieve a database session instead of getting the engine id from the data source itself. This was happening in the code that queries the data source to figure out the expanded column columns, and the code that queries the data source to get the choices for a filter. In both cases, `corehq.db.Session()` was being used (which uses the `DEFAULT_ENGINE_ID`). This PR replaces those and instead accesses the session through `IndicatorSqlAdapter`.

I'm pretty sure this will solve [Ticket #182856](http://manage.dimagi.com/default.asp?182856), [Ticket #183489](http://manage.dimagi.com/default.asp?183489), and [Ticket #182951](http://manage.dimagi.com/default.asp?182951).

@czue @nickpell 
cc @kaapstorm 
best reviewed commit-by-commit
