### PR TITLE
Decorator cleanup

### DIFF
--- a/corehq/apps/app_manager/views/app_summary.py
+++ b/corehq/apps/app_manager/views/app_summary.py
@@ -16,7 +16,7 @@ class AppSummaryView(JSONResponseMixin, LoginAndDomainMixin, BasePageView, Appli
     page_title = ugettext_noop("Summary")
     template_name = 'app_manager/summary.html'
 
-    @method_decorator(use_bootstrap3())
+    @use_bootstrap3
     def dispatch(self, request, *args, **kwargs):
         return super(AppSummaryView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -312,7 +312,7 @@ class AppDiffView(LoginAndDomainMixin, BasePageView, DomainViewMixin):
     page_title = ugettext_lazy("App diff")
     template_name = 'app_manager/app_diff.html'
 
-    @method_decorator(use_bootstrap3())
+    @use_bootstrap3
     def dispatch(self, request, *args, **kwargs):
         try:
             self.first_app_id = self.kwargs["first_app_id"]

--- a/corehq/apps/dashboard/views.py
+++ b/corehq/apps/dashboard/views.py
@@ -41,7 +41,7 @@ def default_dashboard_url(request, domain):
 
 class BaseDashboardView(LoginAndDomainMixin, BasePageView, DomainViewMixin):
 
-    @method_decorator(use_bootstrap3())
+    @use_bootstrap3
     def dispatch(self, request, *args, **kwargs):
         return super(BaseDashboardView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/indicators/views.py
+++ b/corehq/apps/indicators/views.py
@@ -136,7 +136,7 @@ class BulkImportIndicatorsView(BaseSectionPageView, DomainViewMixin):
 
     @method_decorator(login_and_domain_required)
     @method_decorator(require_edit_indicators)
-    @method_decorator(use_bootstrap3())
+    @use_bootstrap3
     def dispatch(self, request, *args, **kwargs):
         return super(BulkImportIndicatorsView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/style/decorators.py
+++ b/corehq/apps/style/decorators.py
@@ -15,12 +15,12 @@ def use_bootstrap3(view_func):
         return super(MyView, self).dispatch(request, *args, **kwargs)
     """
     @wraps(view_func)
-    def _wrapped(request, *args, **kwargs):
+    def _wrapped(class_based_view, request, *args, **kwargs):
         # set bootstrap version in thread local
         set_bootstrap_version3()
         # set crispy forms template in thread local
         set_template_pack('bootstrap3')
-        return view_func(request, *args, **kwargs)
+        return view_func(class_based_view, request, *args, **kwargs)
     return _wrapped
 
 
@@ -35,9 +35,9 @@ def use_select2(view_func):
         return super(MyView, self).dispatch(request, *args, **kwargs)
     """
     @wraps(view_func)
-    def _wrapped(request, *args, **kwargs):
+    def _wrapped(class_based_view, request, *args, **kwargs):
         request.use_select2 = True
-        return view_func(request, *args, **kwargs)
+        return view_func(class_based_view, request, *args, **kwargs)
     return _wrapped
 
 
@@ -53,9 +53,9 @@ def use_select2_v4(view_func):
         return super(MyView, self).dispatch(request, *args, **kwargs)
     """
     @wraps(view_func)
-    def _wrapped(request, *args, **kwargs):
+    def _wrapped(class_based_view, request, *args, **kwargs):
         request.use_select2_v4 = True
-        return view_func(request, *args, **kwargs)
+        return view_func(class_based_view, request, *args, **kwargs)
     return _wrapped
 
 
@@ -66,12 +66,12 @@ def use_knockout_js(view_func):
 
     Example:
 
-    @use_select2_v4
+    @use_knockout_js
     def dispatch(request, *args, **kwargs):
         return super(MyView, self).dispatch(request, *args, **kwargs)
     """
     @wraps(view_func)
-    def _wrapped(request, *args, **kwargs):
+    def _wrapped(class_based_view, request, *args, **kwargs):
         request.use_knockout_js = True
-        return view_func(request, *args, **kwargs)
+        return view_func(class_based_view, request, *args, **kwargs)
     return _wrapped

--- a/corehq/apps/style/decorators.py
+++ b/corehq/apps/style/decorators.py
@@ -4,8 +4,15 @@ from crispy_forms.utils import set_template_pack
 
 
 def use_bootstrap3(view_func):
-    """
-    Decorator to Toggle on the use of bootstrap 3.
+    """Use this decorator on the dispatch method of a TemplateView subclass
+    to enable Bootstrap3 features for the included template. This makes sure
+    that all crispy forms are in Boostrap3 mode, for instance.
+
+    Example:
+
+    @use_bootstrap3
+    def dispatch(request, *args, **kwargs):
+        return super(MyView, self).dispatch(request, *args, **kwargs)
     """
     @wraps(view_func)
     def _wrapped(request, *args, **kwargs):

--- a/corehq/apps/style/decorators.py
+++ b/corehq/apps/style/decorators.py
@@ -34,16 +34,22 @@ def use_select2(view_func):
     return _wrapped
 
 
-def use_select2_v4():
-    def decorate(fn):
-        """
-        Use the 4.0 Version of select2 (still in testing phase)
-        """
-        def wrapped(request, *args, **kwargs):
-            request.use_select2_v4 = True
-            return fn(request, *args, **kwargs)
-        return wrapped
-    return decorate
+def use_select2_v4(view_func):
+    """Use this decorator on the dispatch method of a TemplateView subclass
+    to enable the inclusion of the 4.0 Version of select2 js library at
+    the base template. (4.0 is still in testing phase)
+
+    Example:
+
+    @use_select2_v4
+    def dispatch(request, *args, **kwargs):
+        return super(MyView, self).dispatch(request, *args, **kwargs)
+    """
+    @wraps(view_func)
+    def _wrapped(request, *args, **kwargs):
+        request.use_select2_v4 = True
+        return view_func(request, *args, **kwargs)
+    return _wrapped
 
 
 def use_knockout_js():

--- a/corehq/apps/style/decorators.py
+++ b/corehq/apps/style/decorators.py
@@ -59,13 +59,19 @@ def use_select2_v4(view_func):
     return _wrapped
 
 
-def use_knockout_js():
-    def decorate(fn):
-        """
-        Decorator to Toggle on the use of bootstrap 3.
-        """
-        def wrapped(request, *args, **kwargs):
-            request.use_knockout_js = True
-            return fn(request, *args, **kwargs)
-        return wrapped
-    return decorate
+def use_knockout_js(view_func):
+    """Use this decorator on the dispatch method of a TemplateView subclass
+    to enable the inclusion of the knockout_js library at the base template
+    level.
+
+    Example:
+
+    @use_select2_v4
+    def dispatch(request, *args, **kwargs):
+        return super(MyView, self).dispatch(request, *args, **kwargs)
+    """
+    @wraps(view_func)
+    def _wrapped(request, *args, **kwargs):
+        request.use_knockout_js = True
+        return view_func(request, *args, **kwargs)
+    return _wrapped

--- a/corehq/apps/style/decorators.py
+++ b/corehq/apps/style/decorators.py
@@ -17,16 +17,21 @@ def use_bootstrap3(view_func):
     return _wrapped
 
 
-def use_select2():
-    def decorate(fn):
-        """
-        Decorator to Toggle on the use of bootstrap 3.
-        """
-        def wrapped(request, *args, **kwargs):
-            request.use_select2 = True
-            return fn(request, *args, **kwargs)
-        return wrapped
-    return decorate
+def use_select2(view_func):
+    """Use this decorator on the dispatch method of a TemplateView subclass
+    to enable the inclusion of the select2 js library at the base template.
+
+    Example:
+
+    @use_select2
+    def dispatch(request, *args, **kwargs):
+        return super(MyView, self).dispatch(request, *args, **kwargs)
+    """
+    @wraps(view_func)
+    def _wrapped(request, *args, **kwargs):
+        request.use_select2 = True
+        return view_func(request, *args, **kwargs)
+    return _wrapped
 
 
 def use_select2_v4():

--- a/corehq/apps/style/decorators.py
+++ b/corehq/apps/style/decorators.py
@@ -1,21 +1,20 @@
-from corehq import toggles
+from functools import wraps
 from corehq.apps.style.utils import set_bootstrap_version3
 from crispy_forms.utils import set_template_pack
 
 
-def use_bootstrap3():
-    def decorate(fn):
-        """
-        Decorator to Toggle on the use of bootstrap 3.
-        """
-        def wrapped(request, *args, **kwargs):
-            # set bootstrap version in thread local
-            set_bootstrap_version3()
-            # set crispy forms template in thread local
-            set_template_pack('bootstrap3')
-            return fn(request, *args, **kwargs)
-        return wrapped
-    return decorate
+def use_bootstrap3(view_func):
+    """
+    Decorator to Toggle on the use of bootstrap 3.
+    """
+    @wraps(view_func)
+    def _wrapped(request, *args, **kwargs):
+        # set bootstrap version in thread local
+        set_bootstrap_version3()
+        # set crispy forms template in thread local
+        set_template_pack('bootstrap3')
+        return view_func(request, *args, **kwargs)
+    return _wrapped
 
 
 def use_select2():

--- a/corehq/apps/style/views.py
+++ b/corehq/apps/style/views.py
@@ -7,6 +7,6 @@ class BaseB3SectionPageView(BaseSectionPageView):
     """Subclass of BaseSectionPageView to immediately support Bootstrap3.
     """
 
-    @method_decorator(use_bootstrap3())
+    @use_bootstrap3
     def dispatch(self, request, *args, **kwargs):
         return super(BaseB3SectionPageView, self).dispatch(request, *args, **kwargs)

--- a/corehq/apps/styleguide/examples/controls_demo/views.py
+++ b/corehq/apps/styleguide/examples/controls_demo/views.py
@@ -42,7 +42,7 @@ class SelectControlDemoView(BaseControlDemoFormsView):
     urlname = 'ex_controls_demo'
     template_name = 'styleguide/examples/controls_demo/selects.html'
 
-    @method_decorator(use_select2())
+    @use_select2
     def dispatch(self, request, *args, **kwargs):
         return super(SelectControlDemoView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/styleguide/templates/styleguide/docs/controls_demo/views.html
+++ b/corehq/apps/styleguide/templates/styleguide/docs/controls_demo/views.html
@@ -58,7 +58,7 @@
     </div>
     <div class="row">
         <div class="col-lg-4"></div>
-        <div class="col-lg-8"><div class="highlight"><pre>    <span class="nd">@method_decorator</span><span class="p">(</span><span class="n">use_select2</span><span class="p">())</span>
+        <div class="col-lg-8"><div class="highlight"><pre>    <span class="nd">@use_select2</span>
     <span class="k">def</span> <span class="nf">dispatch</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">request</span><span class="p">,</span> <span class="o">*</span><span class="n">args</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">):</span>
         <span class="k">return</span> <span class="nb">super</span><span class="p">(</span><span class="n">SelectControlDemoView</span><span class="p">,</span> <span class="bp">self</span><span class="p">)</span><span class="o">.</span><span class="n">dispatch</span><span class="p">(</span><span class="n">request</span><span class="p">,</span> <span class="o">*</span><span class="n">args</span><span class="p">,</span> <span class="o">**</span><span class="n">kwargs</span><span class="p">)</span>
 

--- a/corehq/apps/styleguide/views/__init__.py
+++ b/corehq/apps/styleguide/views/__init__.py
@@ -22,7 +22,7 @@ class MainStyleGuideView(TemplateView):
 class BaseStyleGuideArticleView(TemplateView):
     template_name = 'styleguide/base_section.html'
 
-    @method_decorator(use_bootstrap3())
+    @use_bootstrap3
     def dispatch(self, request, *args, **kwargs):
         return super(BaseStyleGuideArticleView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -390,7 +390,7 @@ class ListWebUsersView(JSONResponseMixin, BaseUserSettingsView):
     urlname = 'web_users'
 
     @use_bootstrap3
-    @method_decorator(use_knockout_js())
+    @use_knockout_js
     @method_decorator(require_can_edit_web_users)
     def dispatch(self, request, *args, **kwargs):
         return super(ListWebUsersView, self).dispatch(request, *args, **kwargs)

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -389,7 +389,7 @@ class ListWebUsersView(JSONResponseMixin, BaseUserSettingsView):
     page_title = ugettext_lazy("Web Users & Roles")
     urlname = 'web_users'
 
-    @method_decorator(use_bootstrap3())
+    @use_bootstrap3
     @method_decorator(use_knockout_js())
     @method_decorator(require_can_edit_web_users)
     def dispatch(self, request, *args, **kwargs):


### PR DESCRIPTION
Cleanup decorator syntax so that you don't have to call them, they immediately wrap the view functions.
Also adds better doc strings

@NoahCarnahan @benrudolph 
