### PR TITLE
Catch ResourceNotFound in paginate_view

### DIFF
--- a/corehq/util/couch_helpers.py
+++ b/corehq/util/couch_helpers.py
@@ -4,6 +4,7 @@ import hashlib
 from mimetypes import guess_type
 import datetime
 import threading
+from couchdbkit import ResourceNotFound
 
 
 class CouchAttachmentsBuilder(object):
@@ -143,7 +144,11 @@ def paginate_view(db, view_name, chunk_size,
         log_handler.view_starting(db, view_name, view_kwargs, total_emitted)
         start_time = datetime.datetime.utcnow()
         results = db.view(view_name, **view_kwargs)
-        len_results = len(results)
+        try:
+            len_results = len(results)
+        except ResourceNotFound:
+            results = []
+            len_results = 0
 
         for result in results:
             yield result


### PR DESCRIPTION
This resolves my "missing" error when migrating user db from a clean install (i.e. nothing to migrate).

@dannyroberts I don't know why I was getting the error though, nor whether this change is a good idea.
cc @NoahCarnahan 
