### PR TITLE
make location-based case sharing consistent with owner IDs

### DIFF
--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -309,6 +309,13 @@ class SQLLocation(MPTTModel):
 
         return g
 
+    def get_case_sharing_groups(self, for_user_id=None):
+        if self.location_type.shares_cases:
+            yield self.case_sharing_group_object(for_user_id)
+        if self.location_type.view_descendants:
+            for sql_loc in self.get_descendants().filter(location_type__shares_cases=True):
+                yield sql_loc.case_sharing_group_object(for_user_id)
+
     def case_sharing_group_object(self, user_id=None):
         """
         Returns a fake group object that cannot be saved.

--- a/corehq/apps/locations/tests/test_location_types.py
+++ b/corehq/apps/locations/tests/test_location_types.py
@@ -80,13 +80,15 @@ class TestLocationTypeOwnership(TestCase):
         no_case_sharing_type = make_loc_type('no-case-sharing', domain=self.domain)
         location = make_loc('loc', type=no_case_sharing_type.name, domain=self.domain)
         self.user.set_location(location)
-        self.assertEqual([], self.user.location_group_ids())
+        self.assertEqual([], self.user.get_case_sharing_groups())
 
     def test_sharing_no_descendants(self):
         case_sharing_type = make_loc_type('case-sharing', domain=self.domain, shares_cases=True)
         location = make_loc('loc', type=case_sharing_type.name, domain=self.domain)
         self.user.set_location(location)
-        self.assertEqual([_group_id(location._id)], self.user.location_group_ids())
+        location_groups = self.user.get_case_sharing_groups()
+        self.assertEqual(1, len(location_groups))
+        self.assertEqual(_group_id(location._id), location_groups[0]._id)
 
     def test_assigned_loc_included_with_descendants(self):
         parent_type = make_loc_type('parent', domain=self.domain, shares_cases=True, view_descendants=True)
@@ -96,7 +98,7 @@ class TestLocationTypeOwnership(TestCase):
         self.user.set_location(parent_loc)
         self.assertEqual(
             set(map(_group_id, [parent_loc._id, child_loc._id])),
-            set(self.user.location_group_ids())
+            set([g._id for g in self.user.get_case_sharing_groups()])
         )
 
     def test_only_case_sharing_descendents_included(self):
@@ -109,7 +111,7 @@ class TestLocationTypeOwnership(TestCase):
         self.user.set_location(parent_loc)
         self.assertEqual(
             set(map(_group_id, [parent_loc._id, grandchild_loc._id])),
-            set(self.user.location_group_ids())
+            set([g._id for g in self.user.get_case_sharing_groups()])
         )
 
 

--- a/corehq/apps/locations/tests/test_location_types.py
+++ b/corehq/apps/locations/tests/test_location_types.py
@@ -88,7 +88,7 @@ class TestLocationTypeOwnership(TestCase):
         self.user.set_location(location)
         location_groups = self.user.get_case_sharing_groups()
         self.assertEqual(1, len(location_groups))
-        self.assertEqual(_group_id(location._id), location_groups[0]._id)
+        self.assertEqual(location._id, location_groups[0]._id)
 
     def test_assigned_loc_included_with_descendants(self):
         parent_type = make_loc_type('parent', domain=self.domain, shares_cases=True, view_descendants=True)
@@ -97,7 +97,7 @@ class TestLocationTypeOwnership(TestCase):
         child_loc = make_loc('child', type=child_type.name, domain=self.domain, parent=parent_loc)
         self.user.set_location(parent_loc)
         self.assertEqual(
-            set(map(_group_id, [parent_loc._id, child_loc._id])),
+            set([parent_loc._id, child_loc._id]),
             set([g._id for g in self.user.get_case_sharing_groups()])
         )
 
@@ -110,7 +110,7 @@ class TestLocationTypeOwnership(TestCase):
         grandchild_loc = make_loc('grandchild', type=grandchild_type.name, domain=self.domain, parent=child_loc)
         self.user.set_location(parent_loc)
         self.assertEqual(
-            set(map(_group_id, [parent_loc._id, grandchild_loc._id])),
+            set([parent_loc._id, grandchild_loc._id]),
             set([g._id for g in self.user.get_case_sharing_groups()])
         )
 
@@ -125,7 +125,3 @@ def make_loc_type(name, parent_type=None, domain='locations-test',
         shares_cases=shares_cases,
         view_descendants=view_descendants
     )
-
-
-def _group_id(location_id):
-    return location_id

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1652,7 +1652,6 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
             return []
 
     def get_owner_ids(self):
-        from corehq.apps.groups.models import Group
         owner_ids = [self.user_id]
         owner_ids.extend([g._id for g in self.get_case_sharing_groups()])
         return owner_ids

--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1633,17 +1633,6 @@ class CommCareUser(CouchUser, SingleMembershipMixin, CommCareMobileContactMixin)
         """
         return CaseData.objects.filter(user_id=self._id).count()
 
-    def location_group_ids(self, for_user_id=None):
-        """
-        Return generated ID's that represent the virtual
-        groups used to send location data in the restore
-        payload.
-        """
-        if self.sql_location:
-            return [loc_group._id for loc_group in self.sql_location.get_case_sharing_groups(for_user_id)]
-        else:
-            return []
-
     def get_owner_ids(self):
         owner_ids = [self.user_id]
         owner_ids.extend([g._id for g in self.get_case_sharing_groups()])


### PR DESCRIPTION
This is like the ugly step child of https://github.com/dimagi/commcare-hq/pull/8485/

Fixes http://manage.dimagi.com/default.asp?183669 which that PR introduced.

This also explains the obscene number of sync log 412s in domains using commtrack-based location sharing.

@dannyroberts cc @esoergel 

commit-by-commit, wait for tests
