### PR TITLE
Remove stale ok

### DIFF
--- a/corehq/ex-submodules/couchforms/analytics.py
+++ b/corehq/ex-submodules/couchforms/analytics.py
@@ -217,7 +217,6 @@ def get_form_analytics_metadata(domain, app_id, xmlns):
     view_results = XFormInstance.get_db().view(
         'exports_forms/by_xmlns',
         key=[domain, app_id, xmlns],
-        stale=stale_ok(),
         group=True
     ).one()
     if view_results:


### PR DESCRIPTION
@czue this seemed to be causing the issues for: http://manage.dimagi.com/default.asp?183691

essentially the view wasn't getting updated and then there was no metadata when the report loaded. seems odd that the stale thing persists for a long time, but i was able to reproduce it locally pretty easily.
