### PR TITLE
Report builder ko3.0

### DIFF
--- a/corehq/apps/style/decorators.py
+++ b/corehq/apps/style/decorators.py
@@ -52,3 +52,15 @@ def use_knockout_js():
             return fn(request, *args, **kwargs)
         return wrapped
     return decorate
+
+
+def upgrade_knockout_js():
+    def decorate(fn):
+        """
+        Decorator to Toggle on the use of knockout 3.0 in bootstrap2 pages
+        """
+        def wrapped(request, *args, **kwargs):
+            request.upgrade_knockout_js = True
+            return fn(request, *args, **kwargs)
+        return wrapped
+    return decorate

--- a/corehq/apps/style/templates/style/bootstrap2/base.html
+++ b/corehq/apps/style/templates/style/bootstrap2/base.html
@@ -30,7 +30,12 @@
         {% else %}
         <script src="{% static 'jquery-1.7.1-legacy/jquery.js' %}"></script>
         {% endif %}
+
+        {% if upgrade_knockout_js %}
+        <script type="text/javascript" src="{% new_static 'knockout/dist/knockout.js' %}"></script>
+        {% else %}
         <script type="text/javascript" src="{% static 'knockout-2.3.0-legacy/knockout.js' %}"></script>
+        {% endif %}
         <script type="text/javascript" src="{% static 'underscore-legacy/underscore-min.js' %}"></script>
         <script type="text/javascript" src="{% static 'style/ko/global_handlers.ko.js' %}"></script>
         <script type="text/javascript" src="{% new_static 'style/js/hq_extensions.jquery.js' %}"></script>

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -28,6 +28,7 @@ from corehq.apps.reports.dispatcher import cls_to_view_login_and_domain
 from corehq import privileges, toggles
 from corehq.apps.domain.decorators import login_and_domain_required, login_or_basic
 from corehq.apps.reports_core.filters import DynamicChoiceListFilter
+from corehq.apps.style.decorators import upgrade_knockout_js
 from corehq.apps.userreports.app_manager import get_case_data_source, get_form_data_source
 from corehq.apps.userreports.exceptions import (
     BadBuilderConfigError,
@@ -127,6 +128,7 @@ class ReportBuilderView(TemplateView):
     @cls_to_view_login_and_domain
     @method_decorator(toggles.REPORT_BUILDER.required_decorator())
     @method_decorator(requires_privilege_raise404(privileges.REPORT_BUILDER))
+    @method_decorator(upgrade_knockout_js)
     def dispatch(self, request, domain, **kwargs):
         self.domain = domain
         return super(ReportBuilderView, self).dispatch(request, domain, **kwargs)


### PR DESCRIPTION
@NoahCarnahan @orangejenny @benrudolph 

Although report builder is scheduled to be upgraded to bootstrap 3, this will finally fix http://manage.dimagi.com/default.asp?182553 in the meantime

Requires https://github.com/dimagi/commcare-hq/pull/8478
