### PR TITLE
Fix form name in report

### DIFF
--- a/corehq/apps/reports/display.py
+++ b/corehq/apps/reports/display.py
@@ -139,8 +139,8 @@ class FormType(object):
         if form_json:
             form = json.loads(form_json)
         else:
-            form_info = get_form_analytics_metadata(domain, app_id, xmlns)
-            cache.set(cache_key, json.dumps(form_info), 30)
+            form = get_form_analytics_metadata(domain, app_id, xmlns)
+            cache.set(cache_key, json.dumps(form), 30)
         return form
 
 


### PR DESCRIPTION
@czue @TylerSheffels how about this one? sorry about that previous red herring. also how do we feel about remove this ["catch all errors bit"](https://github.com/dimagi/commcare-hq/blob/fix-form-name-forreal/corehq/apps/reports/display.py#L89) it made it much harder to track down. here's the error from running on prod:
<img width="699" alt="screen shot 2015-10-07 at 11 31 22 am" src="https://cloud.githubusercontent.com/assets/918514/10342591/bbd3fa8a-6ce7-11e5-9176-59d975767381.png">
