### PR TITLE
Don't set owner_id when creating extension cases

### DIFF
--- a/corehq/apps/app_manager/tests/data/extension_case/open_subcase.xml
+++ b/corehq/apps/app_manager/tests/data/extension_case/open_subcase.xml
@@ -10,7 +10,7 @@
             <case xmlns="http://commcarehq.org/case/transaction/v2" case_id="" date_modified="" user_id="">
               <create>
                 <case_name/>
-                <owner_id/>
+                <owner_id>-</owner_id>
                 <case_type>freshwater</case_type>
               </create>
               <update>
@@ -39,7 +39,6 @@
       <bind calculate="/data/meta/userID" nodeset="/data/subcase_0/case/@user_id"/>
       <setvalue event="xforms-ready" ref="/data/subcase_0/case/@case_id" value="instance('commcaresession')/session/data/case_id_new_freshwater_0"/>
       <bind calculate="/data/Wanda" nodeset="/data/subcase_0/case/create/case_name"/>
-      <bind calculate="/data/meta/userID" nodeset="/data/subcase_0/case/create/owner_id"/>
       <bind nodeset="/data/Wanda" required="true()"/>
       <bind calculate="/data/question1" nodeset="/data/subcase_0/case/update/case_name" relevant="count(/data/question1) &gt; 0"/>
       <bind calculate="/data/case/@case_id" nodeset="/data/subcase_0/case/index/host"/>

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -1419,17 +1419,12 @@ class XForm(WrappedNode):
                     subcase_block.add_close_block(self.action_relevance(subcase.close_condition))
 
                 if case_block is not None and subcase.case_type != form.get_case_type():
-                    if subcase.reference_id:
-                        reference_id = subcase.reference_id
-                    elif subcase.relationship == 'extension':
-                        reference_id = 'host'
-                    else:
-                        reference_id = 'parent'
+                    reference_id = subcase.reference_id or 'parent'
+
                     subcase_block.add_index_ref(
                         reference_id,
                         form.get_case_type(),
                         self.resolve_path("case/@case_id"),
-                        subcase.relationship,
                     )
 
         case = self.case_node

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -500,6 +500,28 @@ def autoset_owner_id_for_subcase(subcase):
     return 'owner_id' not in subcase.case_properties
 
 
+def autoset_owner_id_for_advanced_action(action):
+    """
+    The owner_id should be set if any indices are not 'extension'.
+    If it was explicitly_set, never autoset it.
+    """
+
+    explicitly_set = ('owner_id' in action.case_properties)
+
+    if explicitly_set:
+        return False
+
+    if not len(action.case_indices):
+        return True
+
+    for index in action.case_indices:
+        if index.relationship == 'child':
+            # if there is a child relationship, autoset
+            return True
+    # if there are only extension indices, don't autoset
+    return False
+
+
 def validate_xform(source, version='1.0'):
     if isinstance(source, unicode):
         source = source.encode("utf-8")
@@ -1654,7 +1676,7 @@ class XForm(WrappedNode):
                 case_name=action.name_path,
                 case_type=action.case_type,
                 delay_case_id=bool(action.repeat_context),
-                autoset_owner_id=('owner_id' not in action.case_properties),
+                autoset_owner_id=autoset_owner_id_for_advanced_action(action),
                 has_case_sharing=form.get_app().case_sharing,
                 case_id=case_id
             )


### PR DESCRIPTION
When creating extension cases, we set the owner_id to '-'.

We haven't enabled extension cases for non-Advanced modules, so I removed some code and updated tests that was making things a little obscure when I was reading this. 

Code buddy @sravfeyn 
FYI @kaapstorm, what we talked about this afternoon is in the last 3 commits
FYI @dannyroberts @czue, this is 'step 1' from my email this morning.
