### PR TITLE
changes format of report post data to allow multiple properties with …

### DIFF
--- a/corehq/apps/reports/static/reports/javascripts/reports.config.js
+++ b/corehq/apps/reports/static/reports/javascripts/reports.config.js
@@ -44,7 +44,7 @@ var HQReport = function (options) {
                         if (self.isExportAll) {
                             $.ajax({
                                 url: getReportBaseUrl("export"),
-                                data: getReportParams(undefined, true),
+                                data: getReportParams(undefined),
                                 type: "POST",
                                 success: function() {
                                     alert_user("Your requested excel report will be sent to the email address " +
@@ -157,7 +157,7 @@ var HQReport = function (options) {
         });
     };
 
-    function getReportParams(additionalParams, asObject) {
+    function getReportParams(additionalParams) {
         var params = window.location.search.substr(1);
         if (params.length <= 1) {
             if (self.loadDatespanFromCookie()) {
@@ -166,16 +166,6 @@ var HQReport = function (options) {
             }
         }
         params += (additionalParams ? "&" + additionalParams : "");
-        if (asObject) {
-            // http://stackoverflow.com/a/8649003/835696
-            return JSON.parse('{"' +
-                decodeURI(params)
-                    .replace(/"/g, '\\"')
-                    .replace(/&/g, '","')
-                    .replace(/=/g,'":"') +
-                '"}');
-
-        }
         return params;
 
     }


### PR DESCRIPTION
... same name

this addresses http://manage.dimagi.com/default.asp?183836#1025484

when multiple groups are selected for a report, they have the same query string attribute. JSON.parse was overwriting the same property when it converted the query string to JSON. this changes the POST so it sends data in query string format instead of JSON

@benrudolph this reverses a lot of the work you did in https://github.com/dimagi/commcare-hq/pull/5788
i tested dates to make sure they were handled correctly, but i want to make sure there were not other reasons for choosing JSON as the format before this gets merged
