### PR TITLE
Add dummy cache setting so code can be loaded

### DIFF
--- a/dev_settings.py
+++ b/dev_settings.py
@@ -42,3 +42,5 @@ DATABASES = {
 }
 
 BOWER_PATH = os.popen('which bower').read().strip()
+
+CACHES = {'default': {'BACKEND': 'django.core.cache.backends.dummy.DummyCache'}}


### PR DESCRIPTION
I mimic what will happen on ReadTheDocs locally by doing the following:
- Don't start my hq environment (no couch, pillowtop, redis, etc)
- Enter my hq virtualenv
- move or rename `localsettings.py` to somewhere where it won't be found.
- `$ cd docs/`
- `$ make html`

Basically it needs to be able to import stuff without having a localsettings
(I just put the essentials in `dev_settings.py`) or db connection.

In the past we've had some singleton-type objects which are initialized on
import and require a db connection to init.  These need to either be lazily
initialized (you can then memoize it to keep it a singleton), or mocked out in
`docs/conf.py`.
@snopoke @gcapalbo
