### PR TITLE
Add usage metrics to feature flags list

### DIFF
--- a/corehq/apps/toggle_ui/templates/toggle/flags.html
+++ b/corehq/apps/toggle_ui/templates/toggle/flags.html
@@ -56,6 +56,8 @@
         <thead>
             <th>{% trans "Tag" %}</th>
             <th>{% trans "Name" %}</th>
+            <th>{% trans "Domains" %}</th>
+            <th>{% trans "Users" %}</th>
             <th></th>
         </thead>
         <tbody>
@@ -63,6 +65,8 @@
             <tr>
                 <td><span class="label label-{{ toggle.tag.css_class }}">{{ toggle.tag.name }}</span></td>
                 <td>{{ toggle.label }}{% if toggle.help_link %} (<a href="{{ toggle.help_link }}" target="_blank">docs</a>){% endif %}</td>
+                <td>{{ domain_counts|dict_lookup:toggle.slug }}</td>
+                <td>{{ user_counts|dict_lookup:toggle.slug }}</td>
                 <td>
                     <a href="{% url "edit_toggle" toggle.slug %}" role="button" data-toggle="modal" class="btn btn-primary">{% trans "Edit" %}</a>
                 </td>

--- a/corehq/apps/toggle_ui/templates/toggle/flags.html
+++ b/corehq/apps/toggle_ui/templates/toggle/flags.html
@@ -52,12 +52,20 @@
             <button class="btn" data-bind="click: function (){ tagFilter('{{ tag.name }}') }">{{ tag.name }}</button>
         {% endfor %}
     </div>
+    {% if not show_usage %}
+        <a href="{{ page_url }}?show_usage=true" class="btn btn-info">
+            <i class="icon-white icon-info-sign"></i>
+            {% trans "Show usage metrics" %}
+        </a>
+    {% endif %}
     <table class="table table-striped datatable">
         <thead>
             <th>{% trans "Tag" %}</th>
             <th>{% trans "Name" %}</th>
-            <th>{% trans "Domains" %}</th>
-            <th>{% trans "Users" %}</th>
+            {% if show_usage %}
+                <th>{% trans "Domains" %}</th>
+                <th>{% trans "Users" %}</th>
+            {% endif %}
             <th></th>
         </thead>
         <tbody>
@@ -65,8 +73,10 @@
             <tr>
                 <td><span class="label label-{{ toggle.tag.css_class }}">{{ toggle.tag.name }}</span></td>
                 <td>{{ toggle.label }}{% if toggle.help_link %} (<a href="{{ toggle.help_link }}" target="_blank">docs</a>){% endif %}</td>
-                <td>{{ domain_counts|dict_lookup:toggle.slug }}</td>
-                <td>{{ user_counts|dict_lookup:toggle.slug }}</td>
+                {% if show_usage %}
+                    <td>{{ domain_counts|dict_lookup:toggle.slug }}</td>
+                    <td>{{ user_counts|dict_lookup:toggle.slug }}</td>
+                {% endif %}
                 <td>
                     <a href="{% url "edit_toggle" toggle.slug %}" role="button" data-toggle="modal" class="btn btn-primary">{% trans "Edit" %}</a>
                 </td>

--- a/corehq/apps/toggle_ui/templates/toggle/flags.html
+++ b/corehq/apps/toggle_ui/templates/toggle/flags.html
@@ -72,7 +72,13 @@
             {% for toggle in toggles %}
             <tr>
                 <td><span class="label label-{{ toggle.tag.css_class }}">{{ toggle.tag.name }}</span></td>
-                <td>{{ toggle.label }}{% if toggle.help_link %} (<a href="{{ toggle.help_link }}" target="_blank">docs</a>){% endif %}</td>
+                <td>
+                    {% if toggle.randomness %}
+                        <i class="icon icon-random" title="Also applied randomly under certain conditions"></i>
+                    {% endif %}
+                    {{ toggle.label }}
+                    {% if toggle.help_link %} (<a href="{{ toggle.help_link }}" target="_blank">docs</a>){% endif %}
+                </td>
                 {% if show_usage %}
                     <td>{{ domain_counts|dict_lookup:toggle.slug }}</td>
                     <td>{{ user_counts|dict_lookup:toggle.slug }}</td>

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -31,28 +31,35 @@ class ToggleListView(ToggleBaseView):
         return reverse(self.urlname)
 
     @property
+    def show_usage(self):
+        return self.request.GET.get('show_usage') == 'true'
+
+    @property
     def page_context(self):
         toggles = list(all_toggles())
         domain_counts = {}
         user_counts = {}
-        for t in toggles:
-            counter = Counter()
-            try:
-                usage = Toggle.get(t.slug)
-            except ResourceNotFound:
-                domain_counts[t.slug] = 0
-                user_counts[t.slug] = 0
-                continue
-            for u in usage.enabled_users:
-                namespace = u.split(":", 1)[0] if u.find(":") != -1 else NAMESPACE_USER
-                counter[namespace] += 1
-            domain_counts[t.slug] = counter.get(NAMESPACE_DOMAIN, 0)
-            user_counts[t.slug] = counter.get(NAMESPACE_USER, 0)
+        if self.show_usage:
+            for t in toggles:
+                counter = Counter()
+                try:
+                    usage = Toggle.get(t.slug)
+                except ResourceNotFound:
+                    domain_counts[t.slug] = 0
+                    user_counts[t.slug] = 0
+                else:
+                    for u in usage.enabled_users:
+                        namespace = u.split(":", 1)[0] if u.find(":") != -1 else NAMESPACE_USER
+                        counter[namespace] += 1
+                    domain_counts[t.slug] = counter.get(NAMESPACE_DOMAIN, 0)
+                    user_counts[t.slug] = counter.get(NAMESPACE_USER, 0)
 
         return {
+            'domain_counts': domain_counts,
+            'page_url': self.page_url,
+            'show_usage': self.show_usage,
             'toggles': toggles,
             'tags': ALL_TAGS,
-            'domain_counts': domain_counts,
             'user_counts': user_counts,
         }
 


### PR DESCRIPTION
Summit followup: make it quicker to see how heavily individual feature flags are used, to help identify good candidates for productizing/killing.

This is quick and dirty (read: not performant).

![screen shot 2015-10-08 at 3 58 39 pm](https://cloud.githubusercontent.com/assets/1486591/10378181/7adb16a0-6dd5-11e5-857d-56c3d71f04f0.png)

code buddy @nickpell 
fyi @dimagi/product 
