### PR TITLE
Basic working supply report

### DIFF
--- a/corehq/apps/reports/commtrack/__init__.py
+++ b/corehq/apps/reports/commtrack/__init__.py
@@ -1,1 +1,4 @@
 from .ledgers_by_location import LedgersByLocationDataSource, LedgersByLocationReport
+from .maps import StockStatusMapReport, ReportingStatusMapReport
+from .standard import (SimplifiedInventoryReport, InventoryReport,
+                       CurrentStockStatusReport, ReportingRatesReport)

--- a/corehq/apps/reports/commtrack/__init__.py
+++ b/corehq/apps/reports/commtrack/__init__.py
@@ -1,0 +1,1 @@
+from .ledgers_by_location import LedgersByLocationDataSource

--- a/corehq/apps/reports/commtrack/__init__.py
+++ b/corehq/apps/reports/commtrack/__init__.py
@@ -1,1 +1,1 @@
-from .ledgers_by_location import LedgersByLocationDataSource
+from .ledgers_by_location import LedgersByLocationDataSource, LedgersByLocationReport

--- a/corehq/apps/reports/commtrack/ledgers_by_location.py
+++ b/corehq/apps/reports/commtrack/ledgers_by_location.py
@@ -28,7 +28,7 @@ class LedgersByLocationDataSource(object):
         return self.params.get('section_id', STOCK_SECTION_TYPE)
 
     def _get_rows(self):
-        for location in SQLLocation.objects.filter(domain=self.domain):
+        for location in SQLLocation.objects.filter(domain=self.domain).order_by('name'):
             # TODO pull out of loop
             stock = (StockState.objects
                      .filter(section_id=self.section_id,

--- a/corehq/apps/reports/commtrack/ledgers_by_location.py
+++ b/corehq/apps/reports/commtrack/ledgers_by_location.py
@@ -40,7 +40,7 @@ class LedgersByLocationDataSource(object):
         return list(SQLProduct.objects.filter(domain=self.domain).order_by('name'))
 
     def get_locations_queryset(self):
-        return (SQLLocation.objects
+        return (SQLLocation.active_objects
                 .filter(domain=self.domain)
                 .order_by('name'))
 

--- a/corehq/apps/reports/commtrack/ledgers_by_location.py
+++ b/corehq/apps/reports/commtrack/ledgers_by_location.py
@@ -1,0 +1,45 @@
+from collections import namedtuple
+from dimagi.utils.decorators.memoized import memoized
+
+from corehq.apps.commtrack.models import StockState
+from corehq.apps.locations.models import SQLLocation
+
+from .const import STOCK_SECTION_TYPE
+
+
+_Row = namedtuple('Row', "location stock")
+
+
+class LedgersByLocationDataSource(object):
+    """
+    Data source for a report showing ledger values at each location.
+
+                   | Product 1 | Product 2 |
+        Location 1 |        76 |        11 |
+        Location 2 |       132 |        49 |
+    """
+
+    def __init__(self, domain, params=None):
+        self.domain = domain
+        self.params = params
+
+    @property
+    def section_id(self):
+        return self.params.get('section_id', STOCK_SECTION_TYPE)
+
+    def _get_rows(self):
+        for location in SQLLocation.objects.filter(domain=self.domain):
+            # TODO pull out of loop
+            stock = (StockState.objects
+                     .filter(section_id=self.section_id,
+                             sql_location=location)
+                     .values_list('sql_product__product_id', 'stock_on_hand'))
+            yield _Row(
+                location,
+                {product_id: soh for product_id, soh in stock}
+            )
+
+    @property
+    @memoized
+    def rows(self):
+        return list(self._get_rows())

--- a/corehq/apps/reports/commtrack/ledgers_by_location.py
+++ b/corehq/apps/reports/commtrack/ledgers_by_location.py
@@ -7,11 +7,12 @@ from corehq.toggles import SUPPLY_REPORTS
 from corehq.apps.commtrack.models import StockState
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.products.models import SQLProduct
+
 from corehq.apps.reports.datatables import DataTablesHeader, DataTablesColumn
+from corehq.apps.reports.generic import GenericTabularReport
 
 from .const import STOCK_SECTION_TYPE
-from corehq.apps.reports.generic import GenericTabularReport
-from corehq.apps.reports.commtrack.standard import CommtrackReportMixin
+from .standard import CommtrackReportMixin
 
 LocationLedger = namedtuple('Row', "location stock")
 
@@ -101,7 +102,7 @@ class LedgersByLocationReport(GenericTabularReport, CommtrackReportMixin):
     @property
     def headers(self):
         return DataTablesHeader(
-            *[DataTablesColumn(header) for header in self.data.headers]
+            *[DataTablesColumn(header, sortable=False) for header in self.data.headers]
         )
 
     @property

--- a/corehq/apps/reports/commtrack/ledgers_by_location.py
+++ b/corehq/apps/reports/commtrack/ledgers_by_location.py
@@ -1,10 +1,15 @@
 from collections import namedtuple
 from dimagi.utils.decorators.memoized import memoized
+from django.utils.translation import ugettext as _, ugettext_lazy
+from django.utils.decorators import method_decorator
+from django.views.generic import TemplateView
 from no_exceptions.exceptions import Http400
 
+from corehq.toggles import SUPPLY_REPORTS
 from corehq.apps.commtrack.models import StockState
 from corehq.apps.locations.models import SQLLocation
 from corehq.apps.products.models import SQLProduct
+from corehq.apps.style.decorators import use_bootstrap3
 
 from .const import STOCK_SECTION_TYPE
 
@@ -51,3 +56,43 @@ class LedgersByLocationDataSource(object):
     @memoized
     def rows(self):
         return list(self._get_rows())
+
+
+class LedgersByLocationReport(TemplateView):
+    name = ugettext_lazy('Ledgers By Location')
+    urlname = 'ledgers_by_location'
+    template_name = 'style/bootstrap3/base_section.html'
+    asynchronous = True
+    fields = [
+        'corehq.apps.reports.filters.fixtures.AsyncLocationFilter',
+        'corehq.apps.reports.dont_use.fields.SelectProgramField',
+        'corehq.apps.reports.filters.dates.DatespanFilter',
+    ]
+    #  TODO?
+    #  exportable = True
+    #  emailable = True
+
+    @method_decorator(use_bootstrap3())
+    @method_decorator(SUPPLY_REPORTS.required_decorator())
+    def dispatch(self, request, domain, **kwargs):
+        self.domain = domain
+        return super(LedgersByLocationReport, self).dispatch(request, domain, **kwargs)
+
+    def get_context_data(self):
+        #  TODO accommodate `format_sidebar` context
+        return {
+            'domain': self.domain,
+            'section': {'url': '/path/to/page/', 'page_name': self.name},
+            'current_page': {
+                'url': '/path/',
+                'parents': [],
+                'page_name': self.name,  # the same...
+                'title': self.name,
+            },
+            'couch_user': self.request.couch_user,
+            'view': self,
+        }
+
+    @staticmethod
+    def show_in_navigation(domain, project, user=None):
+        return project.commtrack_enabled and SUPPLY_REPORTS.enabled(domain)

--- a/corehq/apps/reports/commtrack/ledgers_by_location.py
+++ b/corehq/apps/reports/commtrack/ledgers_by_location.py
@@ -1,7 +1,6 @@
 from collections import namedtuple
 from dimagi.utils.decorators.memoized import memoized
 from django.utils.translation import ugettext as _, ugettext_lazy
-from django.utils.decorators import method_decorator
 from no_exceptions.exceptions import Http400
 
 from corehq.toggles import SUPPLY_REPORTS
@@ -82,19 +81,12 @@ class LedgersByLocationReport(GenericTabularReport, CommtrackReportMixin):
     name = ugettext_lazy('Ledgers By Location')
     slug = 'ledgers_by_location'
     ajax_pagination = True
+    toggles = (SUPPLY_REPORTS,)
     # TODO actually filter by these
     fields = [
         'corehq.apps.reports.filters.fixtures.AsyncLocationFilter',
         'corehq.apps.reports.dont_use.fields.SelectProgramField',
     ]
-
-    @method_decorator(SUPPLY_REPORTS.required_decorator())
-    def dispatch(self, *args, **kwargs):
-        return super(LedgersByLocationReport, self).dispatch(*args, **kwargs)
-
-    @staticmethod
-    def show_in_navigation(domain, project, user=None):
-        return project.commtrack_enabled and SUPPLY_REPORTS.enabled(domain)
 
     @property
     @memoized

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -73,6 +73,7 @@ class GenericReportView(object):
     slug = None  # Name to be used in the URL (with lowercase and underscores)
     section_name = None  # string. ex: "Reports"
     dispatcher = None  # ReportDispatcher subclass
+    toggles = ()  # Optionally provide toggles to turn on/off the report
 
     is_cacheable = False  # whether to use caching on @request_cache methods
 

--- a/corehq/apps/reports/tests/__init__.py
+++ b/corehq/apps/reports/tests/__init__.py
@@ -7,6 +7,7 @@ try:
     from .test_form_export import *
     from .test_generic import *
     from .test_filters import *
+    from .test_ledgers_by_location import *
     from .test_pillows_cases import *
     from .test_pillows_xforms import *
     from .test_readable_formdata import *

--- a/corehq/apps/reports/tests/test_ledgers_by_location.py
+++ b/corehq/apps/reports/tests/test_ledgers_by_location.py
@@ -55,14 +55,14 @@ class TestLedgersByLocation(TestCase):
     def tearDownClass(cls):
         delete_all_locations()
 
-    def test_show_all_rows(self):
+    def test_show_all_rows_ordered(self):
         report = LedgersByLocationDataSource(
             'test',
             params={'ledger_section': 'stock'},
         )
-        self.assertItemsEqual(
+        self.assertEqual(
             [row.location.name for row in report.rows],
-            [self.boston.name, self.cambridge.name, self.allston.name]
+            [self.allston.name, self.boston.name, self.cambridge.name]
         )
 
     def test_one_row(self):
@@ -70,7 +70,6 @@ class TestLedgersByLocation(TestCase):
             'test',
             params={'ledger_section': 'stock'},
         )
-        print report.rows
         boston = [row for row in report.rows if row.location.name == "Boston"][0]
         self.assertEqual(boston.stock[self.aspirin.product_id], 135)
         self.assertEqual(boston.stock[self.bandaids.product_id], 43)

--- a/corehq/apps/reports/tests/test_ledgers_by_location.py
+++ b/corehq/apps/reports/tests/test_ledgers_by_location.py
@@ -1,0 +1,79 @@
+import datetime
+import mock
+from uuid import uuid4
+
+from django.db.models.signals import post_save
+from django.test import TestCase
+
+from corehq.apps.commtrack.models import StockState, update_domain_mapping
+from corehq.apps.commtrack.tests.util import make_loc
+from corehq.apps.locations.models import LocationType
+from corehq.apps.locations.tests.util import delete_all_locations
+from corehq.apps.products.models import SQLProduct
+
+from corehq.apps.reports.commtrack import LedgersByLocationDataSource
+
+
+class TestLedgersByLocation(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        def make_stock_state(location, product, soh):
+            return StockState.objects.create(
+                section_id='stock',
+                sql_location=location,
+                case_id=uuid4().hex,
+                sql_product=product,
+                product_id=product.product_id,
+                stock_on_hand=soh,
+                last_modified_date=datetime.datetime.now(),
+            )
+
+        def make_product(name):
+            return SQLProduct.objects.create(domain='test', name=name,
+                                             product_id=uuid4().hex)
+
+        def make_location(name):
+            return make_loc(name, domain='test').sql_location
+
+        # turn off the StockState post_save signal handler
+        post_save.disconnect(update_domain_mapping, StockState)
+
+        cls.aspirin = make_product(name="Aspirin")
+        cls.bandaids = make_product(name="Bandaids")
+
+        cls.boston = make_location("Boston")
+        make_stock_state(cls.boston, cls.aspirin, 135)
+        make_stock_state(cls.boston, cls.bandaids, 43)
+
+        cls.cambridge = make_location("Cambridge")
+        make_stock_state(cls.cambridge, cls.aspirin, 414)
+        make_stock_state(cls.cambridge, cls.bandaids, 107)
+
+        cls.allston = make_location(name="Allston")
+
+    @classmethod
+    def tearDownClass(cls):
+        delete_all_locations()
+
+    def test_show_all_rows(self):
+        report = LedgersByLocationDataSource(
+            'test',
+            params={'ledger_section': 'stock'},
+        )
+        self.assertItemsEqual(
+            [row.location.name for row in report.rows],
+            [self.boston.name, self.cambridge.name, self.allston.name]
+        )
+
+    def test_one_row(self):
+        report = LedgersByLocationDataSource(
+            'test',
+            params={'ledger_section': 'stock'},
+        )
+        print report.rows
+        boston = [row for row in report.rows if row.location.name == "Boston"][0]
+        self.assertEqual(boston.stock[self.aspirin.product_id], 135)
+        self.assertEqual(boston.stock[self.bandaids.product_id], 43)
+
+    def test_another_ledger_section(self):
+        self.fail()

--- a/corehq/apps/reports/tests/test_ledgers_by_location.py
+++ b/corehq/apps/reports/tests/test_ledgers_by_location.py
@@ -6,7 +6,7 @@ from django.test import TestCase
 
 from corehq.apps.commtrack.models import StockState, update_domain_mapping
 from corehq.apps.commtrack.tests.util import make_loc
-from corehq.apps.locations.tests.util import delete_all_locations
+from corehq.apps.domain.models import Domain
 from corehq.apps.products.models import SQLProduct
 
 from corehq.apps.reports.commtrack import LedgersByLocationDataSource
@@ -33,6 +33,9 @@ class TestLedgersByLocation(TestCase):
         def make_location(name):
             return make_loc(name, domain='test').sql_location
 
+        cls.domain_obj = Domain(name='test')
+        cls.domain_obj.save()
+
         # turn off the StockState post_save signal handler
         post_save.disconnect(update_domain_mapping, StockState)
 
@@ -52,7 +55,8 @@ class TestLedgersByLocation(TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        delete_all_locations()
+        cls.domain_obj.delete()
+        post_save.connect(update_domain_mapping, StockState)
 
     def test_show_all_rows_ordered(self):
         report = LedgersByLocationDataSource(

--- a/corehq/apps/reports/tests/test_ledgers_by_location.py
+++ b/corehq/apps/reports/tests/test_ledgers_by_location.py
@@ -57,29 +57,49 @@ class TestLedgersByLocation(TestCase):
     def test_show_all_rows_ordered(self):
         report = LedgersByLocationDataSource(
             domain='test',
-            section_id='stock'
+            section_id='stock',
+            page_start=0,
+            page_size=10000,
         )
         self.assertEqual(
-            [row.location.name for row in report.location_ledgers],
+            [row.location.name for row in report.location_rows],
             [self.allston.name, self.boston.name, self.cambridge.name]
         )
 
     def test_one_row(self):
         report = LedgersByLocationDataSource(
             domain='test',
-            section_id='stock'
+            section_id='stock',
+            page_start=0,
+            page_size=10000,
         )
-        boston = [row for row in report.location_ledgers if row.location.name == "Boston"][0]
+        boston = [row for row in report.location_rows if row.location.name == "Boston"][0]
         self.assertEqual(boston.stock[self.aspirin.product_id], 135)
         self.assertEqual(boston.stock[self.bandaids.product_id], 43)
 
     def test_another_ledger_section(self):
         report = LedgersByLocationDataSource(
             domain='test',
-            section_id='foo'
+            section_id='foo',
+            page_start=0,
+            page_size=10000,
         )
-        for row in report.location_ledgers:
+        for row in report.location_rows:
             if row.location.name == "Boston":
                 self.assertEqual(row.stock[self.aspirin.product_id], 82)
             else:
                 self.assertNotIn(self.aspirin.product_id, row.stock)
+
+    def test_pagination(self):
+        report = LedgersByLocationDataSource(
+            domain='test',
+            section_id='stock',
+            page_start=0,
+            page_size=2,
+        )
+        self.assertEqual(report.total_locations,
+                         len([self.allston, self.boston, self.cambridge]))
+        self.assertEqual(
+            [row.location.name for row in report.location_rows],
+            [self.allston.name, self.boston.name]
+        )

--- a/corehq/apps/reports/tests/test_ledgers_by_location.py
+++ b/corehq/apps/reports/tests/test_ledgers_by_location.py
@@ -1,5 +1,4 @@
 import datetime
-import mock
 from uuid import uuid4
 
 from django.db.models.signals import post_save
@@ -7,7 +6,6 @@ from django.test import TestCase
 
 from corehq.apps.commtrack.models import StockState, update_domain_mapping
 from corehq.apps.commtrack.tests.util import make_loc
-from corehq.apps.locations.models import LocationType
 from corehq.apps.locations.tests.util import delete_all_locations
 from corehq.apps.products.models import SQLProduct
 

--- a/corehq/apps/reports/tests/test_ledgers_by_location.py
+++ b/corehq/apps/reports/tests/test_ledgers_by_location.py
@@ -58,29 +58,29 @@ class TestLedgersByLocation(TestCase):
 
     def test_show_all_rows_ordered(self):
         report = LedgersByLocationDataSource(
-            'test',
-            params={'ledger_section': 'stock'},
+            domain='test',
+            section_id='stock'
         )
         self.assertEqual(
-            [row.location.name for row in report.rows],
+            [row.location.name for row in report.location_ledgers],
             [self.allston.name, self.boston.name, self.cambridge.name]
         )
 
     def test_one_row(self):
         report = LedgersByLocationDataSource(
-            'test',
-            params={'ledger_section': 'stock'},
+            domain='test',
+            section_id='stock'
         )
-        boston = [row for row in report.rows if row.location.name == "Boston"][0]
+        boston = [row for row in report.location_ledgers if row.location.name == "Boston"][0]
         self.assertEqual(boston.stock[self.aspirin.product_id], 135)
         self.assertEqual(boston.stock[self.bandaids.product_id], 43)
 
     def test_another_ledger_section(self):
         report = LedgersByLocationDataSource(
-            'test',
-            params={'ledger_section': 'foo'},
+            domain='test',
+            section_id='foo'
         )
-        for row in report.rows:
+        for row in report.location_ledgers:
             if row.location.name == "Boston":
                 self.assertEqual(row.stock[self.aspirin.product_id], 82)
             else:

--- a/corehq/reports.py
+++ b/corehq/reports.py
@@ -22,8 +22,7 @@ from corehq.apps.userreports.reports.view import (
     CustomConfigurableReportDispatcher,
 )
 import phonelog.reports as phonelog
-from corehq.apps.reports.commtrack import standard as commtrack_reports
-from corehq.apps.reports.commtrack import maps as commtrack_maps
+from corehq.apps.reports import commtrack
 from corehq.apps.reports.commconnect import system_overview
 from corehq.apps.fixtures.interface import FixtureViewInterface, FixtureEditInterface
 import hashlib
@@ -89,12 +88,13 @@ def REPORTS(project):
 
     if project.commtrack_enabled:
         reports.insert(0, (ugettext_lazy("CommCare Supply"), (
-            commtrack_reports.SimplifiedInventoryReport,
-            commtrack_reports.InventoryReport,
-            commtrack_reports.CurrentStockStatusReport,
-            commtrack_maps.StockStatusMapReport,
-            commtrack_reports.ReportingRatesReport,
-            commtrack_maps.ReportingStatusMapReport,
+            commtrack.SimplifiedInventoryReport,
+            commtrack.InventoryReport,
+            commtrack.CurrentStockStatusReport,
+            commtrack.StockStatusMapReport,
+            commtrack.ReportingRatesReport,
+            commtrack.ReportingStatusMapReport,
+            commtrack.LedgersByLocationReport,
         )))
 
     if project.has_careplan:

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -208,6 +208,13 @@ DEMO_REPORTS = StaticToggle(
     [NAMESPACE_DOMAIN, NAMESPACE_USER]
 )
 
+SUPPLY_REPORTS = StaticToggle(
+    'supply_reports',
+    "Early stages reports for CommCare Supply",
+    TAG_EXPERIMENTAL,
+    [NAMESPACE_DOMAIN],
+)
+
 DETAIL_LIST_TABS = StaticToggle(
     'detail-list-tabs',
     'Tabs in the case detail list',


### PR DESCRIPTION
This is incomplete and feature flagged.  This has the basic structure in-place though, so I'd like to throw it up for preliminary design review.

I wrote tests first, and split it out to a nice, strict DataSource and a view class for handling parameter reading and template rendering.

I tried splitting this out from the report framework altogether, but ended up backtracking on that.  My goal with that was to make the report view not inherit anything, and to map to it directly in a `urls.py`.  I did figure out a way to get the page to render appropriately with the sidebar and header, but got stuck on rendering filters and such appropriately.  This is something I'd like to revisit in the future at some point, but it was taking too much time, and is largely orthogonal to the rest of the work I'm doing, so I punted.

This is open for review, but we might as well merge it once the reviewers are satisfied (it's feature flagged, anyways).
