### PR TITLE
Fix travis

### DIFF
--- a/corehq/apps/accounting/tests/test_invoicing.py
+++ b/corehq/apps/accounting/tests/test_invoicing.py
@@ -16,7 +16,7 @@ from corehq.apps.accounting.models import (
     Invoice, FeatureType, LineItem, Subscriber, DefaultProductPlan,
     CreditAdjustment, CreditLine, SubscriptionAdjustment, SoftwareProductType,
     SoftwarePlanEdition, BillingRecord, BillingAccount, SubscriptionType,
-    InvoiceBaseManager, SMALL_INVOICE_THRESHOLD,
+    InvoiceBaseManager, SMALL_INVOICE_THRESHOLD, Subscription
 )
 
 
@@ -134,6 +134,7 @@ class TestInvoice(BaseInvoiceTestCase):
 
     def test_date_due_not_set_small_invoice(self):
         """Date Due doesn't get set if the invoice is small"""
+        Subscription.objects.all().delete()
         subscription_length = 5  # months
         plan = DefaultProductPlan.objects.get(
             edition=SoftwarePlanEdition.STANDARD,
@@ -157,6 +158,7 @@ class TestInvoice(BaseInvoiceTestCase):
 
     def test_date_due_set_large_invoice(self):
         """Date Due only gets set for a large invoice (> $100)"""
+        Subscription.objects.all().delete()
         subscription_length = 5  # months
         plan = DefaultProductPlan.objects.get(
             edition=SoftwarePlanEdition.ADVANCED,
@@ -180,6 +182,7 @@ class TestInvoice(BaseInvoiceTestCase):
 
     def test_date_due_gets_set_autopay(self):
         """Date due always gets set for autopay """
+        Subscription.objects.all().delete()
         subscription_length = 4
         plan = DefaultProductPlan.objects.get(
             edition=SoftwarePlanEdition.STANDARD,


### PR DESCRIPTION
ok, @proteusvacuum, i think i got to the bottom of this bad boy. can you check my logic?

in each of these tests two subscriptions are being created one in the `setUp` and one in the actual test. when it comes time to calculate the [total_balance](https://github.com/dimagi/commcare-hq/blob/fix-invoice-test/corehq/apps/accounting/invoicing.py#L193-196) for the small invoice it almost always works because when we [create_invoice_for_subscription](https://github.com/dimagi/commcare-hq/blob/fix-invoice-test/corehq/apps/accounting/invoicing.py#L149) for subscription we call the `get_subscriptions` method which orders the subscriptions by [date](https://github.com/dimagi/commcare-hq/blob/fix-invoice-test/corehq/apps/accounting/invoicing.py#L68). Since the first subscription is generated with a random start date and random plan, this sometimes means if the subscription that was created in the `setUp` block gets computed first and has a sufficiently high balance, the total_balance for the next subscription would get its date_due set. this explains why it would get by the first check of lower than the `SMALL_BALANCE_THRESHOLD` but fail on the date due. i don't know what the proper action is to fix it, deleting the subscriptions will for sure work, but don't know if that's "right."

this bug killed a little part of my soul today

cc: @TylerSheffels 
http://manage.dimagi.com/default.asp?183922#1026027
