### PR TITLE
fixing mobile worker pagination

### DIFF
--- a/corehq/apps/style/static/style/js/pagination.ng.js
+++ b/corehq/apps/style/static/style/js/pagination.ng.js
@@ -47,6 +47,7 @@
             storedLimit = 10;
         }
         $scope.limit = storedLimit;
+        $scope.maxSize = 8;
 
         $scope.total = 1;
         $scope.currentPage = 1;


### PR DESCRIPTION
Fixes http://manage.dimagi.com/default.asp?184017#1026605
I made it 8 instead of 5 pages at once to match the other bootstrap3 page selectors
Screenshot:
<img width="1182" alt="mobileworkerpagination" src="https://cloud.githubusercontent.com/assets/6844721/10406138/dc1e0702-6eab-11e5-8b4c-ea19733a1016.png">

@dimagi/product 
@biyeun 
