### PR TITLE
Graceful downgrade of user case

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -975,6 +975,9 @@ class FormBase(DocumentSchema):
          * registers a case of type 'case_type' if supplied
         """
         raise NotImplementedError()
+
+    def uses_usercase(self):
+        raise NotImplementedError()
     
     def update_app_case_meta(self, app_case_meta):
         pass
@@ -1346,6 +1349,9 @@ class Form(IndexedFormBase, NavMenuItemMediaMixin):
     def is_registration_form(self, case_type=None):
         reg_actions = self.get_registration_actions(case_type)
         return len(reg_actions) == 1
+
+    def uses_usercase(self):
+        return actions_use_usercase(self.active_actions())
 
     def extended_build_validation(self, error_meta, xml_valid, validate_module=True):
         errors = []
@@ -2188,7 +2194,7 @@ class Module(ModuleBase, ModuleDetailsMixin):
     def uses_usercase(self):
         """Return True if this module has any forms that use the usercase.
         """
-        return any(form for form in self.get_forms() if actions_use_usercase(form.active_actions()))
+        return any(form.uses_usercase() for form in self.get_forms())
 
 
 class AdvancedForm(IndexedFormBase, NavMenuItemMediaMixin):
@@ -2293,6 +2299,16 @@ class AdvancedForm(IndexedFormBase, NavMenuItemMediaMixin):
             registration_actions = [a for a in registration_actions if a.case_type == case_type]
 
         return registration_actions
+
+    def uses_case_type(self, case_type, invert_match=False):
+        def match(ct):
+            matches = ct == case_type
+            return not matches if invert_match else matches
+
+        return any(action for action in self.actions.load_update_cases if match(action.case_type))
+
+    def uses_usercase(self):
+        return self.uses_case_type(USERCASE_TYPE)
 
     def all_other_forms_require_a_case(self):
         m = self.get_module()
@@ -2833,15 +2849,7 @@ class AdvancedModule(ModuleBase):
         return errors
 
     def _uses_case_type(self, case_type, invert_match=False):
-        def match(ct):
-            matches = ct == case_type
-            return not matches if invert_match else matches
-
-        return any(
-            action for form in self.forms
-            for action in form.actions.load_update_cases
-            if match(action.case_type)
-        )
+        return any(form.uses_case_type(case_type, invert_match) for form in self.forms)
 
     def uses_usercase(self):
         """Return True if this module has any forms that use the usercase.

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4896,6 +4896,21 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
             return []
         return form.get_questions(self.langs)
 
+    def check_subscription(self):
+
+        def app_uses_usercase(app):
+            return any(m.uses_usercase() for m in app.get_modules())
+
+        errors = []
+        if app_uses_usercase(self) and not domain_has_privilege(self.domain, privileges.USER_CASE):
+            errors.append({
+                'type': 'subscription',
+                'message': _('Your application is using User Case functionality. You can remove User Case '
+                             'functionality by opening the User Case Management tab in a form that uses it, and '
+                             'clicking "Remove User Case Properties".')
+            })
+        return errors
+
     def validate_app(self):
         xmlns_count = defaultdict(int)
         errors = []
@@ -4930,6 +4945,7 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
             errors.append({'type': 'parent cycle'})
 
         errors.extend(self._child_module_errors(modules_dict))
+        errors.extend(self.check_subscription())
 
         if not errors:
             errors = super(Application, self).validate_app()

--- a/corehq/apps/app_manager/static/app_manager/js/case-config-ui-2.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case-config-ui-2.js
@@ -28,6 +28,7 @@ var CaseConfig = (function () {
         self.caseType = params.caseType;
         self.reserved_words = params.reserved_words;
         self.moduleCaseTypes = params.moduleCaseTypes;
+        self.allowUsercase = params.allowUsercase;
 
         self.setPropertiesMap = function (propertiesMap) {
             self.propertiesMap = ko.mapping.fromJS(propertiesMap);
@@ -166,9 +167,15 @@ var CaseConfig = (function () {
                 self.forceRefreshTextchangeBinding($home);
 
                 ko.applyBindings(self, $usercaseMgmt.get(0));
-                $usercaseMgmt.on('textchange', 'input', self.usercaseChange)
-                             .on('change', 'select, input[type="hidden"]', self.usercaseChange)
-                             .on('click', 'a', self.usercaseChange);
+                if (self.allowUsercase) {
+                    $usercaseMgmt.on('textchange', 'input', self.usercaseChange)
+                                 .on('change', 'select, input[type="hidden"]', self.usercaseChange)
+                                 .on('click', 'a', self.usercaseChange);
+                } else {
+                    $usercaseMgmt.find('input').prop('disabled', true);
+                    $usercaseMgmt.find('select').prop('disabled', true);
+                    $usercaseMgmt.find('a').off('click');
+                }
                 self.caseConfigViewModel.usercase_transaction.ensureBlankProperties();
                 self.forceRefreshTextchangeBinding($usercaseMgmt);
             });

--- a/corehq/apps/app_manager/static/app_manager/js/case-config-ui-2.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case-config-ui-2.js
@@ -171,12 +171,14 @@ var CaseConfig = (function () {
                     $usercaseMgmt.on('textchange', 'input', self.usercaseChange)
                                  .on('change', 'select, input[type="hidden"]', self.usercaseChange)
                                  .on('click', 'a', self.usercaseChange);
+                    self.caseConfigViewModel.usercase_transaction.ensureBlankProperties();
                 } else {
                     $usercaseMgmt.find('input').prop('disabled', true);
                     $usercaseMgmt.find('select').prop('disabled', true);
                     $usercaseMgmt.find('a').off('click');
+                    // Remove "Load properties" / "Save properties" link
+                    _.each($usercaseMgmt.find('.firstProperty'), function (elem) { elem.remove(); });
                 }
-                self.caseConfigViewModel.usercase_transaction.ensureBlankProperties();
                 self.forceRefreshTextchangeBinding($usercaseMgmt);
             });
 

--- a/corehq/apps/app_manager/templates/app_manager/form_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view.html
@@ -101,6 +101,7 @@
         reserved_words: {{ case_reserved_words_json|JSON }},
         moduleCaseTypes: {{ module_case_types|JSON }},
         caseType: {{ form.get_case_type|JSON }},
+        allowUsercase: {{ allow_usercase|JSON }},
         propertiesMap: {{ case_properties|JSON }},
         usercasePropertiesMap: {{ usercase_properties|JSON }}
         {% if app.application_version == '1.0' %}

--- a/corehq/apps/app_manager/templates/app_manager/form_view_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view_base.html
@@ -303,7 +303,7 @@
                     {% trans "Case Management" %}
                 </a>
             </li>
-            {%  if allow_usercase or is_usercase_in_use and form.form_type == 'module_form' %}
+            {%  if allow_usercase or form.uses_usercase and form.form_type == 'module_form' %}
             <li>
                 <a id="usercase-configuration-tab" href="#usercase-configuration" data-toggle="tab">
                     {% trans "User Case Management" %}

--- a/corehq/apps/app_manager/templates/app_manager/form_view_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view_base.html
@@ -303,7 +303,7 @@
                     {% trans "Case Management" %}
                 </a>
             </li>
-            {%  if allow_usercase and form.form_type == 'module_form' %}
+            {%  if allow_usercase or is_usercase_in_use and form.form_type == 'module_form' %}
             <li>
                 <a id="usercase-configuration-tab" href="#usercase-configuration" data-toggle="tab">
                     {% trans "User Case Management" %}

--- a/corehq/apps/app_manager/templates/app_manager/form_view_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view_base.html
@@ -378,6 +378,32 @@
                     </header>
                     <div class="casexml" id="usercasexml_home">
                         {% block usercase_management_content %}
+                            {%  if form.uses_usercase and not allow_usercase %}
+                                <div class="container-fluid span6">
+                                <p>{% blocktrans %}
+                                    The User Case feature is no longer available because of the change in your
+                                    CommCare subscription. Although currently-deployed applications will still
+                                    function properly, it will not be possible to update or redeploy them unless
+                                    the User Case functionality is removed, or you upgrade your CommCare
+                                    subscription.
+                                {% endblocktrans %}</p>
+
+                                <p class="alert alert-danger">{% blocktrans %}
+                                    WARNING: By clicking "Remove User Case Properties" you will lose User Case
+                                    functionality if you redeploy your application. However, you will still be
+                                    able to see all previously collected data.
+                                {% endblocktrans %}</p>
+
+                                <p>
+                                    <a href="{% url 'domain_select_plan' domain %}" class="btn btn-primary span6">
+                                        {% trans "Change your subscription" %}
+                                    </a>
+                                    <a href="{% url 'drop_user_case' domain app.id %}" class="btn btn-danger span6">
+                                        {% trans "Remove User Case Properties" %}
+                                    </a>
+                                </p>
+                                </div>
+                            {% endif %}
                             {% include 'app_manager/partials/usercase_config.html' %}
                         {% endblock %}
                     </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -240,6 +240,10 @@
                             {% if not not_actual_build %}in form {% include "app_manager/partials/form_error_message.html" %}{% endif %}.
                         {% case "error" %}
                             <p>Details: {{ error.message }}</p>
+                        {% case "subscription" %}
+                            Your application uses a feature that is not available in your current subscription. You
+                            can <a href="{% url 'domain_select_plan' domain %}">change your subscription</a>, or
+                            remove the feature as follows.
                         {% else %}
                             Unknown error: {{ error.type }}
                             <p>Details: {{ error }}</p>

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_config_shared.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_config_shared.html
@@ -105,7 +105,7 @@
             </tr>
         </tbody>
     </table>
-    <a href="#" data-bind="click: addPreload, visible: !case_preload().length">
+    <a href="#" class="firstProperty" data-bind="click: addPreload, visible: !case_preload().length">
         <i class="icon-plus"></i>
         {% trans "Load properties" %}
     </a>
@@ -152,7 +152,7 @@
             </tr>
         </tbody>
     </table>
-    <a href="#" data-bind="click: addProperty, visible: !case_properties().length">
+    <a href="#" class="firstProperty" data-bind="click: addProperty, visible: !case_properties().length">
         <i class="icon-plus"></i>
         {% trans "Save properties" %}
     </a>

--- a/corehq/apps/app_manager/templates/app_manager/partials/usercase_config.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/usercase_config.html
@@ -14,11 +14,12 @@
 <div id="usercase-config-ko">
     <div class="row-fluid">
         <div class="span12">
+            {% if allow_usercase %}
             <div data-bind="saveButton: saveUsercaseButton"></div>
+            {% endif %}
         </div>
     </div>
     <div data-bind="with: caseConfigViewModel">
         <div data-bind="template: {name: 'usercase-config:case-transaction', data: usercase_transaction }"></div>
-        {% comment %} subcases removed for now {% endcomment %}
     </div>
 </div>

--- a/corehq/apps/app_manager/urls.py
+++ b/corehq/apps/app_manager/urls.py
@@ -57,6 +57,7 @@ urlpatterns = patterns('corehq.apps.app_manager.views',
     url(r'^new_app/$', 'new_app', name='new_app'),
     url(r'^default_new_app/$', 'default_new_app', name='default_new_app'),
     url(r'^new_form/(?P<app_id>[\w-]+)/(?P<module_id>[\w-]+)/$', 'new_form'),
+    url(r'^drop_user_case/(?P<app_id>[\w-]+)/$', 'drop_user_case', name='drop_user_case'),
 
     url(r'^delete_app/(?P<app_id>[\w-]+)/$', 'delete_app'),
     url(r'^delete_module/(?P<app_id>[\w-]+)/(?P<module_unique_id>[\w-]+)/$',

--- a/corehq/apps/app_manager/views/__init__.py
+++ b/corehq/apps/app_manager/views/__init__.py
@@ -31,6 +31,7 @@ from corehq.apps.app_manager.views.apps import (
     default_new_app,
     delete_app,
     delete_app_lang,
+    drop_user_case,
     edit_app_attr,
     edit_app_langs,
     edit_app_translations,

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -30,6 +30,7 @@ from corehq.apps.app_manager.const import (
     APP_V1,
     APP_V2,
     MAJOR_RELEASE_TO_VERSION,
+    AUTO_SELECT_USERCASE,
 )
 from corehq.apps.app_manager.util import (
     get_settings_values,
@@ -743,3 +744,26 @@ def formdefs(request, domain, app_id):
         return response
     else:
         return json_response(formdefs)
+
+
+@require_GET
+@require_can_edit_apps
+def drop_user_case(request, domain, app_id):
+    app = get_app(domain, app_id)
+    for module in app.get_modules():
+        for form in module.get_forms():
+            if form.form_type == 'module_form':
+                if 'usercase_update' in form.actions and form.actions['usercase_update'].update:
+                    form.actions['usercase_update'].update = {}
+                if 'usercase_preload' in form.actions and form.actions['usercase_preload'].preload:
+                    form.actions['usercase_preload'].preload = {}
+            else:
+                for action in list(form.actions.load_update_cases):
+                    if action.auto_select and action.auto_select.mode == AUTO_SELECT_USERCASE:
+                        form.actions.load_update_cases.remove(action)
+            app.save()
+            messages.success(
+                request,
+                _('You have successfully removed User Case properties from this application.')
+            )
+    return back_to_main(request, domain, app_id=app_id)


### PR DESCRIPTION
If user case is in use when a domain's pricing plan is downgraded, then show the user case management, but don't allow it to be edited or saved.

(For any more context, please chat to @amsagoff or Kevin. (I can't find your GitHub username Kevin. You out there?))

@NoahCarnahan, @snopoke 
