### PR TITLE
Travis cache virtualenv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,6 @@ addons:
     - libblas-dev
     - liblapack-dev
 install:
-  - "git clone https://github.com/dimagi/commcarehq-venv.git"
-  - "cp -r commcarehq-venv/hq_env/* ~/virtualenv/"
   - "source ~/virtualenv/bin/activate"
   - "bash -e scripts/uninstall-requirements.sh"
   # set env variables for couch username/password, used by install.sh, to blank

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: python
 sudo: false
-cache: pip
+cache:
+  directories:
+    - $HOME/.cache/pip
+    - $HOME/virtualenv
 python:
   - "2.7"
 env:


### PR DESCRIPTION
I noticed before when working on this that even just downloading the `commcarehq-venv` repo takes a while, so this could theoretically speed things up significantly
