### PR TITLE
Fixtures db prep

### DIFF
--- a/corehq/apps/domain/__init__.py
+++ b/corehq/apps/domain/__init__.py
@@ -1,4 +1,5 @@
 from corehq.preindex import ExtraPreindexPlugin
 from django.conf import settings
 
-ExtraPreindexPlugin.register('domain', __file__, settings.NEW_USERS_GROUPS_DB)
+ExtraPreindexPlugin.register('domain', __file__, (
+    settings.NEW_USERS_GROUPS_DB, settings.NEW_FIXTURES_DB))

--- a/corehq/apps/fixtures/__init__.py
+++ b/corehq/apps/fixtures/__init__.py
@@ -1,0 +1,4 @@
+from corehq.preindex import ExtraPreindexPlugin
+from django.conf import settings
+
+ExtraPreindexPlugin.register('fixtures', __file__, settings.NEW_FIXTURES_DB)

--- a/corehq/couchapps/__init__.py
+++ b/corehq/couchapps/__init__.py
@@ -5,5 +5,5 @@ CouchAppsPreindexPlugin.register('couchapps', __file__, {
     'form_question_schema': 'meta',
     'users_extra': (settings.USERS_GROUPS_DB, settings.NEW_USERS_GROUPS_DB),
     'noneulized_users': (settings.USERS_GROUPS_DB, settings.NEW_USERS_GROUPS_DB),
-    'all_docs': (None, settings.NEW_USERS_GROUPS_DB),
+    'all_docs': (None, settings.NEW_USERS_GROUPS_DB, settings.NEW_FIXTURES_DB),
 })

--- a/corehq/couchapps/tests/test_all_docs.py
+++ b/corehq/couchapps/tests/test_all_docs.py
@@ -30,7 +30,8 @@ class AllDocsTest(TestCase):
             {key.uri: list(value) for key, value in
              get_all_doc_ids_for_domain_grouped_by_db(self.domain)},
             {get_db(None).uri: ['main_db_doc'],
-             get_db('users').uri: ['users_db_doc']}
+             get_db('users').uri: ['users_db_doc'],
+             get_db('fixtures').uri: []}
         )
 
     def test_get_doc_count_by_type(self):

--- a/corehq/doctypemigrations/migrator_instances.py
+++ b/corehq/doctypemigrations/migrator_instances.py
@@ -19,6 +19,17 @@ users_migration = Migrator(
     )
 )
 
+fixtures_migration = Migrator(
+    slug='fixtures',
+    source_db_name=None,
+    target_db_name=settings.NEW_FIXTURES_DB,
+    doc_types=(
+        'FixtureDataType',
+        'FixtureDataItem',
+        'FixtureOwnership',
+    )
+)
+
 
 def get_migrator_by_slug(slug):
     return Migrator.instances[slug]

--- a/settings.py
+++ b/settings.py
@@ -1188,7 +1188,7 @@ COUCHDB_APPS += LOCAL_COUCHDB_APPS
 
 COUCHDB_DATABASES = make_couchdb_tuples(COUCHDB_APPS, COUCH_DATABASE)
 EXTRA_COUCHDB_DATABASES = get_extra_couchdbs(COUCHDB_APPS, COUCH_DATABASE,
-                                             [NEW_USERS_GROUPS_DB])
+                                             [NEW_USERS_GROUPS_DB, NEW_FIXTURES_DB])
 
 INSTALLED_APPS += LOCAL_APPS
 

--- a/settings.py
+++ b/settings.py
@@ -1086,6 +1086,8 @@ COUCH_DATABASE = _dynamic_db_settings["COUCH_DATABASE"]
 NEW_USERS_GROUPS_DB = 'users'
 USERS_GROUPS_DB = NEW_USERS_GROUPS_DB
 
+NEW_FIXTURES_DB = 'fixtures'
+FIXTURES_DB = None
 
 COUCHDB_APPS = [
     'api',
@@ -1112,7 +1114,6 @@ COUCHDB_APPS = [
     'ext',
     'facilities',
     'fluff_filter',
-    'fixtures',
     'hqcase',
     'hqmedia',
     'hope',
@@ -1178,6 +1179,9 @@ COUCHDB_APPS = [
     # users and groups
     ('groups', USERS_GROUPS_DB),
     ('users', USERS_GROUPS_DB),
+
+    # fixtures
+    ('fixtures', FIXTURES_DB),
 ]
 
 COUCHDB_APPS += LOCAL_COUCHDB_APPS


### PR DESCRIPTION
This is seeming really simple because (we knew this before, but I rechecked):
- `fixtures` views don't reference any other doc types
- no other views reference fixtures doc types

The process to complete the migration is something like
1. merge and deploy this PR
2. run initial and continuous migrations ([docs](https://github.com/dimagi/commcare-hq/blob/master/corehq/doctypemigrations/README.md#run-the-doctype-migration))
3. Make another PR flipping the db and deploy that
4. kill continuous and eventually delete docs form old db (also in the docs above)
