### PR TITLE
Fix `django.forms.util` name deprecation

### DIFF
--- a/corehq/apps/style/forms/widgets.py
+++ b/corehq/apps/style/forms/widgets.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.forms.fields import MultiValueField, CharField
-from django.forms.util import flatatt
+from django.forms.utils import flatatt
 from django.forms.widgets import CheckboxInput, HiddenInput, Input, RadioSelect, RadioFieldRenderer, RadioInput, TextInput, MultiWidget
 from django.utils.encoding import force_unicode
 from django.utils.html import conditional_escape


### PR DESCRIPTION
"The django.forms.util module has been renamed. Use django.forms.utils
instead."
@anyone @gcapalbo
