### PR TITLE
Add named ucr expression

### DIFF
--- a/corehq/apps/userreports/README.md
+++ b/corehq/apps/userreports/README.md
@@ -84,6 +84,7 @@ iterator        | Combine multiple expressions into a list | `[doc.name, doc.age
 related_doc     | A way to reference something in another document | `form.case.owner_id`
 root_doc        | A way to reference the root document explicitly (only needed when making a data source from repeat/child data) | `repeat.parent.name`
 nested          | A way to chain any two expressions together | `f1(f2(doc))`
+named           | A way to emit an expresison with a name | `{"name": "test", "value": f(doc)}`
 
 
 ### JSON snippets for expressions
@@ -268,6 +269,28 @@ More examples can be found in the [practical examples](https://github.com/dimagi
     "value_expression": {
         "type": "property_name",
         "property_name": "inner"
+    }
+}
+```
+
+#### Named expressions
+
+These can be used to attach a name to an expression. This is only useful as an intermediate structure in another expression since the result of a named expession is a dictionary that cannot be saved to the database.
+
+See the [practical examples](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/userreports/examples/examples.md) for a way this can be used in a `base_item_expression` to emit multiple rows for a single form/case based on different properties.
+
+Here is a simple example that demonstrates the structure:
+
+```json
+{
+    "type": "named",
+    "name_expression": {
+        "type": "constant",
+        "constant": "the_name"
+    },
+    "value_expression": {
+        "type": "property_name",
+        "property_name": "prop"
     }
 }
 ```

--- a/corehq/apps/userreports/examples/examples.md
+++ b/corehq/apps/userreports/examples/examples.md
@@ -370,7 +370,55 @@ In this example we take 3 case properties and save one row per property if it ex
 }
 ```
 
+## Emit multiple rows of named data
 
+In this example we take 3 case properties and emit the property name along with the value (only if non-empty).
+Note that the test must also change in this scenario.
+
+
+```json
+{
+    "type": "iterator",
+    "expressions": [
+        {
+            "type": "named",
+            "name_expression": "p1",
+            "value_expression": {
+                "type": "property_name",
+                "property_name": "p1"
+            },
+        },
+        {
+            "type": "named",
+            "name_expression": "p2",
+            "value_expression": {
+                "type": "property_name",
+                "property_name": "p2"
+            },
+        },
+        {
+            "type": "named",
+            "name_expression": "p3",
+            "value_expression": {
+                "type": "property_name",
+                "property_name": "p3"
+            }
+        }
+    ],
+    "test": {
+        "type": "not",
+        "filter": {
+            "type": "boolean_expression",
+            "expression": {
+                "type": "property_name",
+                "property_name": "value"
+            },
+            "operator": "in",
+            "property_value": ["", null],
+        }
+    }
+}
+```
 
 # Report examples
 

--- a/corehq/apps/userreports/expressions/factory.py
+++ b/corehq/apps/userreports/expressions/factory.py
@@ -6,7 +6,7 @@ from corehq.apps.userreports.exceptions import BadSpecError
 from corehq.apps.userreports.expressions.specs import PropertyNameGetterSpec, PropertyPathGetterSpec, \
     ConditionalExpressionSpec, ConstantGetterSpec, RootDocExpressionSpec, RelatedDocExpressionSpec, \
     IdentityExpressionSpec, IteratorExpressionSpec, SwitchExpressionSpec, ArrayIndexExpressionSpec, \
-    NestedExpressionSpec
+    NestedExpressionSpec, NamedExpressionSpec
 
 
 def _make_filter(spec, context):
@@ -88,6 +88,15 @@ def _nested_expression(spec, context):
     return wrapped
 
 
+def _named_expression(spec, context):
+    wrapped = NamedExpressionSpec.wrap(spec)
+    wrapped.configure(
+        name_expression=ExpressionFactory.from_spec(wrapped.name_expression),
+        value_expression=ExpressionFactory.from_spec(wrapped.value_expression),
+    )
+    return wrapped
+
+
 class ExpressionFactory(object):
     spec_map = {
         'identity': _identity_expression,
@@ -101,6 +110,7 @@ class ExpressionFactory(object):
         'iterator': _iterator_expression,
         'switch': _switch_expression,
         'nested': _nested_expression,
+        'named': _named_expression,
     }
     # Additional items are added to the spec_map by use of the `register` method.
 

--- a/corehq/apps/userreports/expressions/factory.py
+++ b/corehq/apps/userreports/expressions/factory.py
@@ -147,7 +147,7 @@ class ExpressionFactory(object):
 
 
 def _is_constant(value):
-    return value is None or isinstance(value, (basestring, int, bool, float))
+    return isinstance(value, (basestring, int, bool, float))
 
 
 def _convert_constant_to_expression_spec(value):

--- a/corehq/apps/userreports/expressions/factory.py
+++ b/corehq/apps/userreports/expressions/factory.py
@@ -130,6 +130,8 @@ class ExpressionFactory(object):
 
     @classmethod
     def from_spec(cls, spec, context=None):
+        if _is_constant(spec):
+            return cls.from_spec(_convert_constant_to_expression_spec(spec), context)
         try:
             return cls.spec_map[spec['type']](spec, context)
         except KeyError:
@@ -137,8 +139,16 @@ class ExpressionFactory(object):
                 spec.get('type', '[missing]'),
                 ', '.join(cls.spec_map.keys()),
             ))
-        except BadValueError as e:
+        except (TypeError, BadValueError) as e:
             raise BadSpecError(_('Problem creating getter: {}. Message is: {}').format(
                 json.dumps(spec, indent=2),
                 str(e),
             ))
+
+
+def _is_constant(value):
+    return value is None or isinstance(value, (basestring, int, bool, float))
+
+
+def _convert_constant_to_expression_spec(value):
+    return {'type': 'constant', 'constant': value}

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -202,3 +202,19 @@ class NestedExpressionSpec(JsonObject):
     def __call__(self, item, context=None):
         argument = self._argument_expression(item, context)
         return self._value_expression(argument, context)
+
+
+class NamedExpressionSpec(JsonObject):
+    type = TypeProperty('named')
+    name_expression = DictProperty(required=True)
+    value_expression = DictProperty(required=True)
+
+    def configure(self, name_expression, value_expression):
+        self._name_expression = name_expression
+        self._value_expression = value_expression
+
+    def __call__(self, item, context=None):
+        return {
+            'name': self._name_expression(item, context),
+            'value': self._value_expression(item, context),
+        }

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -23,7 +23,13 @@ class IdentityExpressionSpec(JsonObject):
 
 class ConstantGetterSpec(JsonObject):
     type = TypeProperty('constant')
-    constant = DefaultProperty(required=True)
+    constant = DefaultProperty()
+
+    @classmethod
+    def wrap(self, obj):
+        if 'constant' not in obj:
+            raise BadSpecError('"constant" property is required!')
+        return super(ConstantGetterSpec ,self).wrap(obj)
 
     def __call__(self, item, context=None):
         return self.constant

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -29,7 +29,7 @@ class ConstantGetterSpec(JsonObject):
     def wrap(self, obj):
         if 'constant' not in obj:
             raise BadSpecError('"constant" property is required!')
-        return super(ConstantGetterSpec ,self).wrap(obj)
+        return super(ConstantGetterSpec, self).wrap(obj)
 
     def __call__(self, item, context=None):
         return self.constant

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -50,7 +50,7 @@ class ConstantExpressionTest(SimpleTestCase):
             self.assertEqual(constant, getter({'some': 'random stuff'}))
 
     def test_constant_auto_detection(self):
-        for valid_constant in (7.2, 'hello world', 3, None, True):
+        for valid_constant in (7.2, 'hello world', 3, True):
             getter = ExpressionFactory.from_spec(valid_constant)
             self.assertEqual(valid_constant, getter({}))
             self.assertEqual(valid_constant, getter({'some': 'random stuff'}))

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -298,6 +298,29 @@ class ArrayIndexExpressionTest(SimpleTestCase):
         self.assertEqual(None, self.expression({'my_array': [], 'my_index': None}))
 
 
+class NamedExpressionTest(SimpleTestCase):
+
+    def setUp(self):
+        self.expression_spec = {
+            "type": "named",
+            "name_expression": {
+                "type": "constant",
+                "constant": "the_name"
+            },
+            "value_expression": {
+                "type": "property_name",
+                "property_name": "prop"
+            }
+        }
+        self.expression = ExpressionFactory.from_spec(self.expression_spec)
+
+    def test_basic(self):
+        value = self.expression({"prop": "p_value"})
+        self.assertTrue(isinstance(value, dict))
+        self.assertEqual('the_name', value['name'])
+        self.assertEqual('p_value', value['value'])
+
+
 class NestedExpressionTest(SimpleTestCase):
 
     def test_basic(self):

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -49,6 +49,17 @@ class ConstantExpressionTest(SimpleTestCase):
             self.assertEqual(constant, getter({}))
             self.assertEqual(constant, getter({'some': 'random stuff'}))
 
+    def test_constant_auto_detection(self):
+        for valid_constant in (7.2, 'hello world', 3, None, True):
+            getter = ExpressionFactory.from_spec(valid_constant)
+            self.assertEqual(valid_constant, getter({}))
+            self.assertEqual(valid_constant, getter({'some': 'random stuff'}))
+
+    def test_constant_auto_detection_invalid_types(self):
+        for invalid_constant in ([], {}):
+            with self.assertRaises(BadSpecError):
+                ExpressionFactory.from_spec(invalid_constant)
+
     def test_invalid_constant(self):
         with self.assertRaises(BadSpecError):
             ExpressionFactory.from_spec({

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -325,6 +325,20 @@ class NamedExpressionTest(SimpleTestCase):
         }
         self.expression = ExpressionFactory.from_spec(self.expression_spec)
 
+    def test_missing_name(self):
+        with self.assertRaises(BadSpecError):
+            ExpressionFactory.from_spec({
+                "type": "named",
+                "value_expression": "test",
+            })
+
+    def test_missing_value(self):
+        with self.assertRaises(BadSpecError):
+            ExpressionFactory.from_spec({
+                "type": "named",
+                "name_expression": "test",
+            })
+
     def test_basic(self):
         value = self.expression({"prop": "p_value"})
         self.assertTrue(isinstance(value, dict))

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -41,7 +41,7 @@ class IdentityExpressionTest(SimpleTestCase):
 class ConstantExpressionTest(SimpleTestCase):
 
     def test_constant_expression(self):
-        for constant in (7.2, 'hello world', ['a', 'list'], {'a': 'dict'}):
+        for constant in (None, 7.2, 'hello world', ['a', 'list'], {'a': 'dict'}):
             getter = ExpressionFactory.from_spec({
                 'type': 'constant',
                 'constant': constant,

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -9,7 +9,6 @@ from corehq.apps.userreports.expressions.factory import ExpressionFactory
 from corehq.apps.userreports.expressions.specs import (
     PropertyNameGetterSpec,
     PropertyPathGetterSpec,
-    RelatedDocExpressionSpec,
 )
 from corehq.apps.userreports.specs import EvaluationContext
 


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?184085

This also changes the spec to allow any string/integer/float/boolean constant in an expression to resolve to a constant expression, which should hopefully make specs a bit easier to read/write
