### PR TITLE
Update case tile XML toggle to allow domains

### DIFF
--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -178,6 +178,7 @@ CASE_LIST_CUSTOM_XML = StaticToggle(
     'case_list_custom_xml',
     'Show text area for entering custom case list xml',
     TAG_EXPERIMENTAL,
+    [NAMESPACE_DOMAIN, NAMESPACE_USER]
 )
 
 CASE_LIST_TILE = StaticToggle(


### PR DESCRIPTION
Having this as a user-specific toggle isn't great. Planning to make the a domain-only toggle in another PR, after notifying the small number of people who have this flag turned on.

No test coverage.

@nickpell 
