### PR TITLE
Allow user locations to be used as call center case owners

### DIFF
--- a/corehq/apps/callcenter/tests/__init__.py
+++ b/corehq/apps/callcenter/tests/__init__.py
@@ -4,6 +4,7 @@ try:
     from corehq.apps.callcenter.tests.test_utils import *
     from corehq.apps.callcenter.tests.test_models import *
     from corehq.apps.callcenter.tests.test_use_fixtures_configuration import *
+    from corehq.apps.callcenter.tests.test_location_owners import *
 except ImportError, e:
     # for some reason the test harness squashes these so log them here for clarity
     # otherwise debugging is a pain

--- a/corehq/apps/callcenter/tests/test_location_owners.py
+++ b/corehq/apps/callcenter/tests/test_location_owners.py
@@ -1,0 +1,73 @@
+from django.test import TestCase
+from casexml.apps.case.tests import delete_all_cases
+from corehq.apps.callcenter.utils import sync_call_center_user_case
+from corehq.apps.domain.models import CallCenterProperties
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.hqcase.utils import get_case_by_domain_hq_user_id
+from corehq.apps.locations.models import LocationType
+from corehq.apps.locations.tests import make_loc
+from corehq.apps.users.models import CommCareUser
+
+TEST_DOMAIN = "cc-location-owner-test-domain"
+CASE_TYPE = "cc-case-type"
+LOCATION_TYPE = "my-location"
+
+
+class CallCenterLocationOwnerTest(TestCase):
+
+    @classmethod
+    def get_call_center_config(cls):
+        return CallCenterProperties(
+            enabled=True,
+            use_user_location_as_owner=True,
+            case_owner_id=None,
+            case_type=CASE_TYPE
+        )
+
+    @classmethod
+    def setUpClass(cls):
+        cls.domain = create_domain(TEST_DOMAIN)
+        user = CommCareUser.create(TEST_DOMAIN, 'user1', '***')
+        cls.user_id = user.user_id
+        cls.domain.call_center_config = cls.get_call_center_config()
+        cls.domain.save()
+
+        LocationType.objects.get_or_create(
+            domain=cls.domain.name,
+            name=LOCATION_TYPE,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.domain.delete()
+
+    def setUp(self):
+        self.user = CommCareUser.get(self.user_id)
+
+    def tearDown(self):
+        delete_all_cases()
+
+    def test_no_location_sync(self):
+        self.user.unset_location()
+        self.user.save()
+        sync_call_center_user_case(self.user)
+        case = get_case_by_domain_hq_user_id(TEST_DOMAIN, self.user._id, CASE_TYPE)
+        self.assertEqual(case.owner_id, "")
+
+    def test_location_sync(self):
+        location = make_loc('loc', type=LOCATION_TYPE, domain=TEST_DOMAIN)
+        self.user.set_location(location)
+        self.user.save()
+        case = get_case_by_domain_hq_user_id(TEST_DOMAIN, self.user._id, CASE_TYPE)
+        self.assertEqual(case.owner_id, location._id)
+
+    def test_location_change_sync(self):
+        location = make_loc('loc', type=LOCATION_TYPE, domain=TEST_DOMAIN)
+        self.user.set_location(location)
+        self.user.save()
+        location_2 = make_loc('loc2', type=LOCATION_TYPE, domain=TEST_DOMAIN)
+        self.user.set_location(location_2)
+        self.user.save()
+
+        case = get_case_by_domain_hq_user_id(TEST_DOMAIN, self.user._id, CASE_TYPE)
+        self.assertEqual(case.owner_id, location_2._id)

--- a/corehq/apps/callcenter/utils.py
+++ b/corehq/apps/callcenter/utils.py
@@ -82,6 +82,7 @@ def sync_user_case(commcare_user, case_type, owner_id):
             changed = close != case.closed
             changed = changed or case.type != case_type
             changed = changed or case.name != fields['name']
+            changed = changed or case.owner_id != owner_id
 
             if not changed:
                 for field, value in fields.items():
@@ -93,6 +94,7 @@ def sync_user_case(commcare_user, case_type, owner_id):
                 caseblock = CaseBlock(
                     create=False,
                     case_id=case._id,
+                    owner_id=owner_id,
                     version=V2,
                     case_type=case_type,
                     close=close,
@@ -118,10 +120,14 @@ def sync_user_case(commcare_user, case_type, owner_id):
 def sync_call_center_user_case(user):
     domain = user.project
     if domain and domain.call_center_config.enabled:
+        owner_id = domain.call_center_config.case_owner_id
+        if domain.call_center_config.use_user_location_as_owner:
+            owner_id = user.location_id
+
         sync_user_case(
             user,
             domain.call_center_config.case_type,
-            domain.call_center_config.case_owner_id
+            owner_id
         )
 
 

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -414,6 +414,7 @@ class SubAreaMixin():
 class DomainGlobalSettingsForm(forms.Form):
     USE_LOCATIONS_CHOICE = "user_location"
     CASES_AND_FIXTURES_CHOICE = "cases_and_fixtures"
+    CASES_ONLY_CHOICE = "cases_only"
 
     hr_name = forms.CharField(
         label=ugettext_lazy("Project Name"),
@@ -446,7 +447,7 @@ class DomainGlobalSettingsForm(forms.Form):
     call_center_type = ChoiceField(
         label=ugettext_lazy("Call Center Type"),
         initial=CASES_AND_FIXTURES_CHOICE,
-        choices=[(CASES_AND_FIXTURES_CHOICE, "Create cases and indicators"), ('cases_only', "Create just cases")],
+        choices=[(CASES_AND_FIXTURES_CHOICE, "Create cases and indicators"), (CASES_ONLY_CHOICE, "Create just cases")],
         help_text=ugettext_lazy(
             """
             If "Create cases and indicators" is selected, each user will have a case associated with it,

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -447,7 +447,10 @@ class DomainGlobalSettingsForm(forms.Form):
     call_center_type = ChoiceField(
         label=ugettext_lazy("Call Center Type"),
         initial=CASES_AND_FIXTURES_CHOICE,
-        choices=[(CASES_AND_FIXTURES_CHOICE, "Create cases and indicators"), (CASES_ONLY_CHOICE, "Create just cases")],
+        choices=[
+            (CASES_AND_FIXTURES_CHOICE, "Create cases and indicators"),
+            (CASES_ONLY_CHOICE, "Create just cases"),
+        ],
         help_text=ugettext_lazy(
             """
             If "Create cases and indicators" is selected, each user will have a case associated with it,
@@ -547,7 +550,8 @@ class DomainGlobalSettingsForm(forms.Form):
         if domain.call_center_config.enabled:
 
             domain.internal.using_call_center = True
-            domain.call_center_config.use_fixtures = self.cleaned_data['call_center_type'] == self.CASES_AND_FIXTURES_CHOICE
+            domain.call_center_config.use_fixtures = \
+                self.cleaned_data['call_center_type'] == self.CASES_AND_FIXTURES_CHOICE
 
             owner = self.cleaned_data.get('call_center_case_owner', None)
             if owner == self.USE_LOCATIONS_CHOICE:

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -411,6 +411,8 @@ class SubAreaMixin():
 
 
 class DomainGlobalSettingsForm(forms.Form):
+    CASES_AND_FIXTURES_CHOICE = "cases_and_fixtures"
+
     hr_name = forms.CharField(
         label=ugettext_lazy("Project Name"),
         help_text=ugettext_lazy("This name will appear in the upper right corner "
@@ -441,8 +443,8 @@ class DomainGlobalSettingsForm(forms.Form):
     )
     call_center_type = ChoiceField(
         label=ugettext_lazy("Call Center Type"),
-        initial='cases_and_fixtures',
-        choices=[('cases_and_fixtures', "Create cases and indicators"), ('cases_only', "Create just cases")],
+        initial=CASES_AND_FIXTURES_CHOICE,
+        choices=[(CASES_AND_FIXTURES_CHOICE, "Create cases and indicators"), ('cases_only', "Create just cases")],
         help_text=ugettext_lazy(
             """
             If "Create cases and indicators" is selected, each user will have a case associated with it,
@@ -536,8 +538,8 @@ class DomainGlobalSettingsForm(forms.Form):
         domain.call_center_config.enabled = self.cleaned_data.get('call_center_enabled', False)
         if domain.call_center_config.enabled:
             domain.internal.using_call_center = True
-            domain.call_center_config.use_fixtures = self.cleaned_data['call_center_type'] == "cases_and_fixtures"
             domain.call_center_config.case_owner_id = self.cleaned_data.get('call_center_case_owner', None)
+            domain.call_center_config.use_fixtures = self.cleaned_data['call_center_type'] == self.CASES_AND_FIXTURES_CHOICE
             domain.call_center_config.case_type = self.cleaned_data.get('call_center_case_type', None)
 
         global_tz = self.cleaned_data['default_timezone']

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -131,6 +131,7 @@ class Deployment(DocumentSchema, UpdatableSchema):
 class CallCenterProperties(DocumentSchema):
     enabled = BooleanProperty(default=False)
     use_fixtures = BooleanProperty(default=True)
+    use_user_location_as_owner = BooleanProperty(default=False)
     case_owner_id = StringProperty()
     case_type = StringProperty()
 

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -360,8 +360,7 @@ class EditBasicProjectInfoView(BaseEditProjectInfoView):
             'default_timezone': self.domain_object.default_timezone,
             'case_sharing': json.dumps(self.domain_object.case_sharing),
             'call_center_enabled': self.domain_object.call_center_config.enabled,
-            'call_center_type':
-                'cases_and_fixtures' if self.domain_object.call_center_config.use_fixtures else 'cases_only',
+            'call_center_type': self.initial_call_center_type,
             'call_center_case_owner': self.initial_call_center_case_owner,
             'call_center_case_type': self.domain_object.call_center_config.case_type,
             'commtrack_enabled': self.domain_object.commtrack_enabled,
@@ -407,6 +406,13 @@ class EditBasicProjectInfoView(BaseEditProjectInfoView):
         if config.use_user_location_as_owner:
             return DomainGlobalSettingsForm.USE_LOCATIONS_CHOICE
         return self.domain_object.call_center_config.case_owner_id
+
+    @property
+    @memoized
+    def initial_call_center_type(self):
+        if self.domain_object.call_center_config.use_fixtures:
+            return DomainGlobalSettingsForm.CASES_AND_FIXTURES_CHOICE
+        return DomainGlobalSettingsForm.CASES_ONLY_CHOICE
 
     @property
     def page_context(self):

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -362,7 +362,7 @@ class EditBasicProjectInfoView(BaseEditProjectInfoView):
             'call_center_enabled': self.domain_object.call_center_config.enabled,
             'call_center_type':
                 'cases_and_fixtures' if self.domain_object.call_center_config.use_fixtures else 'cases_only',
-            'call_center_case_owner': self.domain_object.call_center_config.case_owner_id,
+            'call_center_case_owner': self.initial_call_center_case_owner,
             'call_center_case_type': self.domain_object.call_center_config.case_type,
             'commtrack_enabled': self.domain_object.commtrack_enabled,
         }
@@ -399,6 +399,14 @@ class EditBasicProjectInfoView(BaseEditProjectInfoView):
             domain=self.domain_object.name,
             can_use_custom_logo=self.can_use_custom_logo
         )
+
+    @property
+    @memoized
+    def initial_call_center_case_owner(self):
+        config = self.domain_object.call_center_config
+        if config.use_user_location_as_owner:
+            return DomainGlobalSettingsForm.USE_LOCATIONS_CHOICE
+        return self.domain_object.call_center_config.case_owner_id
 
     @property
     def page_context(self):

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -683,3 +683,10 @@ EWS_WEB_USER_EXTENSION = StaticToggle(
     TAG_ONE_OFF,
     [NAMESPACE_DOMAIN]
 )
+
+CALL_CENTER_LOCATION_OWNERS = StaticToggle(
+    'call_center_location_owners',
+    'Enable the use of locations as owners of call center cases',
+    TAG_PRODUCT_PATH,
+    [NAMESPACE_DOMAIN]
+)


### PR DESCRIPTION
This PR introduces the ability to configure the call center to assign user cases to the users location. Show this option with the "Enable the use of locations as owners of call center cases" feature flag. Enable it by selecting "user's location [location]" from the call center case owner drop down.
<img width="765" alt="screen shot 2015-10-14 at 11 44 29 am" src="https://cloud.githubusercontent.com/assets/2117127/10476188/2608d688-7269-11e5-9717-ff7bf2fc5806.png">

Best reviewed commit-by-commit
@czue cc @kaapstorm 
