### PR TITLE
enabling email for sync history reports

### DIFF
--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -164,6 +164,7 @@ class SyncHistoryReport(DeploymentsReport):
     MAX_LIMIT = 1000
     name = ugettext_noop("User Sync History")
     slug = "sync_history"
+    emailable = True
     fields = ['corehq.apps.reports.filters.users.AltPlaceholderMobileWorkerFilter']
 
     @property


### PR DESCRIPTION
fixes http://manage.dimagi.com/default.asp?179149#1028269
note: the worker whose history is being sent is only identifiable if the description or subject are modified by the user to include the name of the worker, but otherwise this has been tested on staging and is working as expected
@nickpell 
