### PR TITLE
Tweak "view source" page for latest version of of apps

### DIFF
--- a/corehq/apps/app_manager/views/download.py
+++ b/corehq/apps/app_manager/views/download.py
@@ -315,7 +315,7 @@ def download_index(request, domain, app_id, template="app_manager/download_index
     all the resource files that will end up zipped into the jar.
 
     """
-    files = None
+    files = []
     try:
         files = source_files(request.app)
     except Exception:
@@ -374,6 +374,7 @@ def download_index_files(app):
                  for path in app._attachments
                  if path.startswith('files/')]
     else:
+        app.set_media_versions(None)
         files = app.create_all_files().items()
 
     return sorted(files)


### PR DESCRIPTION
The "view source" page (`/a/<domain>/apps/download/<app_id>/`) can be used to view the files of the latest version of an app, not just builds. When doing so, the `media_suite.xml` file can be missing "version" attributes on its "resource" elements. This change ensures that those attributes will exist on the preview. This change is necessary for the commcare CLI tool.

@ctsims cc @kaapstorm 
