### PR TITLE
add setproctitle

### DIFF
--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -2,3 +2,4 @@ flower==0.7.0
 newrelic
 errand-boy==0.3.8
 datadog==0.9.0
+setproctitle==1.1.9


### PR DESCRIPTION
This allows gunicorn to set its process title which is required for datadog to pick it up.

@millerdev 
