### PR TITLE
Drop absolute position and put form data inside container

### DIFF
--- a/corehq/apps/reports/templates/reports/form/partials/readable_form.html
+++ b/corehq/apps/reports/templates/reports/form/partials/readable_form.html
@@ -55,35 +55,37 @@ $(function () {
 });
 </script>
 
-{% if question_list_not_found %}
-<div class="row-fluid">
-    <div class="alert alert-warning clear-fix span6">
-        <strong>{{ question_list_not_found.message }}</strong>
-        <br/>
-        {% trans "All data is listed as Unrecognized Data." %}
+<div class="container">
+    {% if question_list_not_found %}
+    <div class="row-fluid">
+        <div class="alert alert-warning clear-fix span6">
+            <strong>{{ question_list_not_found.message }}</strong>
+            <br/>
+            {% trans "All data is listed as Unrecognized Data." %}
+        </div>
     </div>
+    {% else %}
+    <ul class="nav nav-pills formDisplayToggle">
+        <li class="active"><a href="#" class="showReadable">{% trans "Labels" %}</a></li>
+        <li><a href="#" class="showRaw">{% trans "Question IDs" %}</a></li>
+    </ul>
+    <label class="checkbox">
+        <input type="checkbox" class="showSkippedToggle"/>
+        {% trans "Show questions in form that were not shown to the user" %}
+        <span class="hq-help-template"
+            data-title="{% trans "Questions not shown to the user" %}"
+            data-content="{% trans "These questions were not shown to the user because their display conditions were not met." %}"
+        ></span>
+    </label>
+    {% endif %}
+    <table class="table table-bordered form-data-table">
+        <tr>
+            <th class="span6">
+                <span class="form-data-readable">{% trans "Question" %}</span>
+                <span class="form-data-raw">{% trans "Question ID" %}</span>
+            </th>
+            <th class="span6">{% trans "Response" %}</th>
+        </tr>
+        {% include 'reports/form/partials/single_form_tree.html' %}
+    </table>
 </div>
-{% else %}
-<ul class="nav nav-pills formDisplayToggle">
-    <li class="active"><a href="#" class="showReadable">{% trans "Labels" %}</a></li>
-    <li><a href="#" class="showRaw">{% trans "Question IDs" %}</a></li>
-</ul>
-<label class="checkbox">
-    <input type="checkbox" class="showSkippedToggle"/>
-    {% trans "Show questions in form that were not shown to the user" %}
-    <span class="hq-help-template"
-        data-title="{% trans "Questions not shown to the user" %}"
-        data-content="{% trans "These questions were not shown to the user because their display conditions were not met." %}"
-    ></span>
-</label>
-{% endif %}
-<table class="table table-bordered form-data-table">
-    <tr>
-        <th class="span6">
-            <span class="form-data-readable">{% trans "Question" %}</span>
-            <span class="form-data-raw">{% trans "Question ID" %}</span>
-        </th>
-        <th class="span6">{% trans "Response" %}</th>
-    </tr>
-    {% include 'reports/form/partials/single_form_tree.html' %}
-</table>

--- a/corehq/apps/reports/templates/reports/form/partials/single_form.html
+++ b/corehq/apps/reports/templates/reports/form/partials/single_form.html
@@ -202,8 +202,8 @@ requires imports/proptable.html to be included in the main template
     </li>
 </ul>
 <div class="tab-content form-details" style="overflow:visible">
-    <div class="tab-pane active" id="form-data" style="position:relative">
-        <div class="btn-toolbar" id='form-actions-toolbar' style="position: absolute; right: 0; top: 0">
+    <div class="tab-pane active" id="form-data">
+        <div class="btn-toolbar row" id='form-actions-toolbar'>
             {% if context_case_id %}
                 <a class="btn"
                     href="{% url "render_form_data" instance.domain instance.get_id %}">


### PR DESCRIPTION
Buttons overlapped because layout used absolute positioning instead of Bootstrap. 

This change drops the absolute position, and wraps the inner content in a standard Bootstrap `container`. Layout now scales properly: 
![form_properties](https://cloud.githubusercontent.com/assets/708421/10488494/36964730-7299-11e5-8da6-eac0fa678eed.png)

For more context and a "before" picture, see [case 183533](http://manage.dimagi.com/default.asp?183533).

@biyeun, @NoahCarnahan 
