### PR TITLE
memoize indicators property

### DIFF
--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -140,6 +140,7 @@ class DataSourceConfiguration(UnicodeMixIn, CachedCouchDocumentMixin, Document):
                 for name, filter in self.named_filters.items()}
 
     @property
+    @memoized
     def indicators(self):
         default_indicators = [IndicatorFactory.from_spec({
             "column_id": "doc_id",


### PR DESCRIPTION
Seems to be the next big culprit in the memory leak here: http://manage.dimagi.com/default.asp?180806

UCR tests pass locally; would be nice to get into today's deploy

@orangejenny 
