### PR TITLE
Always check celery on server.txt

### DIFF
--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -260,7 +260,7 @@ def server_up(req):
             "check_func": hb_check
         },
         "celery": {
-            "always_check": False,
+            "always_check": True,
             "message": "* celery is down",
             "check_func": celery_check
         },


### PR DESCRIPTION
@czue, realized that our main pingdom hits server.txt and our rabbitMQ one hits server.txt?celery=true. thinking this would be the way to consolidate unless we feel that's there a reason to not do this. maybe celery goes down more often so it caused too much noise for the main pingdom?

cc: @TylerSheffels 
