### PR TITLE
Fix multimedia_suite.xml in CLI ccz download

### DIFF
--- a/corehq/apps/app_manager/views/cli.py
+++ b/corehq/apps/app_manager/views/cli.py
@@ -33,6 +33,7 @@ def list_apps(request, domain):
 def direct_ccz(request, domain):
     if 'app_id' in request.GET:
         app = get_app(domain, request.GET['app_id'])
+        app.set_media_versions(None)
         download = DownloadBase()
         build_application_zip(
             include_multimedia_files=False,

--- a/corehq/apps/app_manager/views/download.py
+++ b/corehq/apps/app_manager/views/download.py
@@ -315,7 +315,7 @@ def download_index(request, domain, app_id, template="app_manager/download_index
     all the resource files that will end up zipped into the jar.
 
     """
-    files = None
+    files = []
     try:
         files = source_files(request.app)
     except Exception:

--- a/corehq/apps/app_manager/views/download.py
+++ b/corehq/apps/app_manager/views/download.py
@@ -374,7 +374,6 @@ def download_index_files(app):
                  for path in app._attachments
                  if path.startswith('files/')]
     else:
-        app.set_media_versions(None)
         files = app.create_all_files().items()
 
     return sorted(files)
@@ -386,6 +385,8 @@ def source_files(app):
     Return format is a list of tuples where the first item in the tuple is a
     file name and the second is the file contents.
     """
+    if not app.copy_of:
+        app.set_media_versions(None)
     files = download_index_files(app)
     files.append(
         ("app.json", json.dumps(


### PR DESCRIPTION
The "view source" page (/a/<domain>/apps/download/<app_id>/) can be used to view the files of the latest version of an app, not just builds. When doing so, the media_suite.xml file can be missing "version" attributes on its "resource" elements. This change ensures that those attributes will exist on the preview. 

More importantly, this does the same thing to the url that the CLI tool uses to get the latest ccz of an app. This fixes the issue the CLI tool has with apps that contain multimedia.

@ctsims cc @kaapstorm, @orangejenny 
