### PR TITLE
Quickcache UserRole.get and memoize User.role

### DIFF
--- a/corehq/apps/users/tests/create.py
+++ b/corehq/apps/users/tests/create.py
@@ -210,6 +210,9 @@ class TestDomainMemberships(TestCase):
     def testNewRole(self):
         self.webuser.set_role(self.domain, "field-implementer")
         self.ccuser.set_role(self.domain, "field-implementer")
+        self.webuser.save()
+        self.ccuser.save()
+        self.setUp()  # reload users to clear CouchUser.role
 
         self.assertEquals(self.webuser.get_domain_membership(self.domain).role_id,
                           self.ccuser.get_domain_membership(self.domain).role_id)

--- a/corehq/util/quickcache.py
+++ b/corehq/util/quickcache.py
@@ -290,7 +290,7 @@ def quickcache(vary_on, timeout=None, memoize_timeout=None, cache=None,
             CacheWithTimeout(
                 django_caches['locmem'],
                 timeout=memoize_timeout)]
-        if timeout != 0:
+        if timeout > 0:
             caches.append(
                 CacheWithTimeout(
                     django_caches['default'], timeout=timeout))


### PR DESCRIPTION
@gcapalbo @dannyroberts @czue 
`UserRole.get` is called only for non-admin users, so we devs didn't really
feel the pain of that.  On the dashboard page, I saw it get called 68 times
for one page load, and for the base reports page, 144 times.

Turns out memoizing `User.role` was really all that was necessary.  I figure
slapping a `QuickCacheDocumentMixin` in here is super easy too and doesn't
hurt anything, so I did that too (it'll span multiple requests, and I
really can't imagine roles changing much).
