### PR TITLE
Add grid menu configuration

### DIFF
--- a/corehq/apps/app_manager/commcaresettings-README.md
+++ b/corehq/apps/app_manager/commcaresettings-README.md
@@ -34,6 +34,7 @@ with each element containing the following properties:
 * `group` - Presentational; defines how the properties get grouped on HQ 
 * `disabled` - Set to `true` for deprecated values we don't want to show up in the UI anymore
 * `force` - Set to `true` to have the `force` attribute of the setting set when building the profile. Only applies when type='properties' (default).
+* `toggle` - If specified, the property will only be shown if the given toggle is enabled. The value should be an identifier for a toggle in `corehq/toggles.py`, e.g. "GRID_MENUS"
 
 ## Example
 ```yaml

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4263,6 +4263,7 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
     commtrack_requisition_mode = StringProperty(choices=CT_REQUISITION_MODES)
     auto_gps_capture = BooleanProperty(default=False)
     created_from_template = StringProperty()
+    use_grid_menus = BooleanProperty(default=False)
 
     @property
     @memoized

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yaml
@@ -166,3 +166,10 @@
    - 'Not Set'
   default: 'not_set'
   preview: true
+
+- id: use_grid_menus
+  name: Use Menu Grids
+  description: Display forms and modules in grids instead of lists.
+  widget: bool
+  default: false
+  since: "2.24"

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yaml
@@ -173,3 +173,4 @@
   widget: bool
   default: false
   since: "2.24"
+  toggle: GRID_MENUS

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-settings-layout.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-settings-layout.yaml
@@ -63,6 +63,7 @@
     - hq.auto_gps_capture
     - properties.cc-login-duration-seconds
     - properties.cc-log-entity-detail-enabled
+    - hq.use_grid_menus
 
 - title: 'Advanced'
   id: app-settings-advanced

--- a/corehq/apps/app_manager/suite_xml/generator.py
+++ b/corehq/apps/app_manager/suite_xml/generator.py
@@ -3,6 +3,7 @@ import urllib
 from django.core.urlresolvers import reverse
 
 from corehq.apps.app_manager.exceptions import MediaResourceError
+from corehq.apps.app_manager.suite_xml.post_process.menu import GridMenuHelper
 from corehq.apps.app_manager.suite_xml.sections.details import DetailContributor
 from corehq.apps.app_manager.suite_xml.sections.entries import EntriesContributor
 from corehq.apps.app_manager.suite_xml.features.careplan import CareplanMenuContributor
@@ -65,6 +66,8 @@ class SuiteGenerator(object):
         # post process
         if self.app.enable_post_form_workflow:
             WorkflowHelper(self.suite, self.app, self.modules).update_suite()
+        if self.app.use_grid_menus:
+            GridMenuHelper(self.suite, self.app, self.modules).update_suite()
 
         EntryInstances(self.suite, self.app, self.modules).update_suite()
         return self.suite.serializeDocument(pretty=True)

--- a/corehq/apps/app_manager/suite_xml/post_process/menu.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/menu.py
@@ -1,0 +1,20 @@
+from corehq.apps.app_manager import id_strings
+from corehq.apps.app_manager.suite_xml.contributors import PostProcessor
+from corehq.apps.app_manager.suite_xml.xml_models import Menu, Text
+
+
+class GridMenuHelper(PostProcessor):
+
+    def update_suite(self):
+        """
+        Ensure that there exists at least one menu where id="root".
+        """
+        if not self._contains_root_menu(self.suite.menus):
+            self.suite.menus.append(Menu(id=id_strings.ROOT, text=Text(), style="grid"))
+
+    @staticmethod
+    def _contains_root_menu(menus):
+        for menu in menus:
+            if menu.id == id_strings.ROOT:
+                return True
+        return False

--- a/corehq/apps/app_manager/suite_xml/sections/menus.py
+++ b/corehq/apps/app_manager/suite_xml/sections/menus.py
@@ -84,6 +84,9 @@ class MenuContributor(SuiteContributorByModule):
 
             menus.append(menu)
 
+        if self.app.use_grid_menus:
+            self._give_root_menus_grid_style(menus)
+
         return menus
 
     @staticmethod
@@ -95,3 +98,9 @@ class MenuContributor(SuiteContributorByModule):
         except ScheduleError:
             relevant = None
         return relevant
+
+    @staticmethod
+    def _give_root_menus_grid_style(menus):
+        for menu in menus:
+            if menu.id == id_strings.ROOT:
+                menu.style = "grid"

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -400,6 +400,7 @@ class MenuMixin(XmlObject):
 
     root = StringField('@root')
     relevant = XPathField('@relevant')
+    style = StringField('@style')
     commands = NodeListField('command', Command)
 
 

--- a/corehq/apps/app_manager/tests/__init__.py
+++ b/corehq/apps/app_manager/tests/__init__.py
@@ -36,6 +36,7 @@ try:
     from corehq.apps.app_manager.tests.test_case_list_lookup import *
     from corehq.apps.app_manager.tests.test_child_module import *
     from corehq.apps.app_manager.tests.test_report_config import *
+    from corehq.apps.app_manager.tests.test_grid_menus import *
 except ImportError, e:
     # for some reason the test harness squashes these so log them here for clarity
     # otherwise debugging is a pain

--- a/corehq/apps/app_manager/tests/test_grid_menus.py
+++ b/corehq/apps/app_manager/tests/test_grid_menus.py
@@ -10,8 +10,10 @@ class GridMenuSuiteTests(SimpleTestCase, TestXmlMixin):
         """
         factory = AppFactory(build_version='2.24')
         factory.app.use_grid_menus = True
-        factory.new_basic_module('registration', 'patient')
+        factory.new_basic_module('registration', 'patient registration')
         factory.app.get_module(0).put_in_root = True
+        factory.new_basic_module('visit', 'patient visit')
+        factory.app.get_module(1).put_in_root = True
 
         suite = factory.app.create_suite()
         root_xpath = './menu[@id="root"]'
@@ -22,6 +24,10 @@ class GridMenuSuiteTests(SimpleTestCase, TestXmlMixin):
                 <menu id="root" style="grid">
                     <text><locale id="modules.m0"/></text>
                     <command id="m0-f0"/>
+                </menu>
+                <menu id="root" style="grid">
+                    <text><locale id="modules.m1"/></text>
+                    <command id="m1-f0"/>
                 </menu>
             </partial>
             """,

--- a/corehq/apps/app_manager/tests/test_grid_menus.py
+++ b/corehq/apps/app_manager/tests/test_grid_menus.py
@@ -1,0 +1,60 @@
+from django.test import SimpleTestCase
+from corehq.apps.app_manager.tests import AppFactory, TestXmlMixin
+
+
+class GridMenuSuiteTests(SimpleTestCase, TestXmlMixin):
+
+    def test_that_grid_style_is_added(self):
+        """
+        Confirms that style="grid" is added to the root menu
+        """
+        factory = AppFactory(build_version='2.24')
+        factory.app.use_grid_menus = True
+        factory.new_basic_module('registration', 'patient')
+        factory.app.get_module(0).put_in_root = True
+
+        suite = factory.app.create_suite()
+        root_xpath = './menu[@id="root"]'
+        self.assertXmlHasXpath(suite, root_xpath)
+        self.assertXmlPartialEqual(
+            """
+            <partial>
+                <menu id="root" style="grid">
+                    <text><locale id="modules.m0"/></text>
+                    <command id="m0-f0"/>
+                </menu>
+            </partial>
+            """,
+            suite,
+            root_xpath
+        )
+
+    def test_that_root_menu_added(self):
+        """
+        Confirms that a menu is added with id="root" and style="grid"
+        when the app normally wouldn't have a menu with id="root".
+        """
+        factory = AppFactory(build_version='2.24')
+        factory.app.use_grid_menus = True
+        factory.new_basic_module('registration', 'patient')
+
+        suite = factory.app.create_suite()
+        root_xpath = './menu[@id="root"]'
+        self.assertXmlHasXpath(suite, root_xpath)
+        self.assertXmlPartialEqual(
+            '<partial><menu id="root" style="grid"><text/></menu></partial>',
+            suite,
+            root_xpath
+        )
+
+    def test_use_grid_menus_is_false(self):
+        """
+        Confirms that style="grid" is not added to any menus when use_grid_menus is False.
+        """
+        factory = AppFactory(build_version='2.24')
+        factory.app.use_grid_menus = False
+        factory.new_basic_module('registration', 'patient')
+
+        suite = factory.app.create_suite()
+        style_xpath = './menu[@style="grid"]'
+        self.assertXmlDoesNotHaveXpath(suite, style_xpath)

--- a/corehq/apps/app_manager/tests/util.py
+++ b/corehq/apps/app_manager/tests/util.py
@@ -33,8 +33,15 @@ class TestXmlMixin(TestFileMixin):
 
     def assertXmlHasXpath(self, element, xpath):
         message = "Could not find xpath expression '{}' in below XML\n".format(xpath)
+        self._assertXpathHelper(element, xpath, message, should_not_exist=False)
+
+    def assertXmlDoesNotHaveXpath(self, element, xpath):
+        message = "Found xpath expression '{}' in below XML\n".format(xpath)
+        self._assertXpathHelper(element, xpath, message, should_not_exist=True)
+
+    def _assertXpathHelper(self, element, xpath, message, should_not_exist):
         element = parse_normalize(element, to_string=False)
-        if not bool(element.xpath(xpath)):
+        if bool(element.xpath(xpath)) == should_not_exist:
             raise AssertionError(message + lxml.etree.tostring(element, pretty_print=True))
 
     def assertHtmlEqual(self, expected, actual, normalize=True):

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -571,6 +571,7 @@ def edit_app_attr(request, domain, app_id, attr):
         ('auto_gps_capture', None),
         ('amplifies_workers', None),
         ('amplifies_project', None),
+        ('use_grid_menus', None),
     )
     for attribute, transformation in easy_attrs:
         if should_edit(attribute):

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -698,3 +698,10 @@ CALL_CENTER_LOCATION_OWNERS = StaticToggle(
     TAG_PRODUCT_PATH,
     [NAMESPACE_DOMAIN]
 )
+
+GRID_MENUS = StaticToggle(
+    'grid_menus',
+    'Allow using grid menus on Android',
+    TAG_ONE_OFF,
+    [NAMESPACE_DOMAIN]
+)


### PR DESCRIPTION
Adds an option (behind a feature flag) to the applications setting page for enabling grid menus.

cc @kaapstorm FYI @ctsims, @snopoke 
Best reviewed commit-by-commit.
Looking to get this deployed before weekend, so quick review would be much appreciated.
