### PR TITLE
use new style meta

### DIFF
--- a/corehq/apps/hqcase/templates/hqcase/xml/case_block.xml
+++ b/corehq/apps/hqcase/templates/hqcase/xml/case_block.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' ?>
-<system version="1" uiVersion="1" xmlns="http://commcarehq.org/case" xmlns:orx="http://openrosa.org/jr/xforms">
+<system version="1" uiVersion="1" xmlns="{{ xmlns }}" xmlns:orx="http://openrosa.org/jr/xforms">
     <orx:meta xmlns:cc="http://commcarehq.org/xforms">
         <orx:deviceID />
         <orx:timeStart>{{ time }}</orx:timeStart>

--- a/corehq/apps/hqcase/templates/hqcase/xml/case_block.xml
+++ b/corehq/apps/hqcase/templates/hqcase/xml/case_block.xml
@@ -1,12 +1,13 @@
 <?xml version='1.0' ?>
-<system version="1" uiVersion="1" xmlns="{{ xmlns }}">
-    <meta xmlns="http://openrosa.org/jr/xforms">
-        <deviceID />
-        <timeStart>{{ time }}</timeStart>
-        <timeEnd>{{ time }}</timeEnd>
-        <username>{{ username }}</username>
-        <userID>{{ user_id }}</userID>
-        <uid>{{ uid }}</uid>
-    </meta>
+<system version="1" uiVersion="1" xmlns="http://commcarehq.org/case" xmlns:orx="http://openrosa.org/jr/xforms">
+    <orx:meta xmlns:cc="http://commcarehq.org/xforms">
+        <orx:deviceID />
+        <orx:timeStart>{{ time }}</orx:timeStart>
+        <orx:timeEnd>{{ time }}</orx:timeEnd>
+        <orx:username>{{ username }}</orx:username>
+        <orx:userID>{{ user_id }}</orx:userID>
+        <orx:instanceID>{{ uid }}</orx:instanceID>
+        <cc:appVersion />
+    </orx:meta>
     {{ case_block|safe }}
 </system>

--- a/corehq/apps/hqcase/utils.py
+++ b/corehq/apps/hqcase/utils.py
@@ -26,8 +26,7 @@ ALLOWED_CASE_IDENTIFIER_TYPES = [
 
 
 def submit_case_blocks(case_blocks, domain, username="system", user_id="",
-                       xmlns='http://commcarehq.org/case', attachments=None,
-                       form_id=None):
+                       attachments=None, form_id=None):
     """
     Submits casexml in a manner similar to how they would be submitted from a phone.
 
@@ -39,7 +38,6 @@ def submit_case_blocks(case_blocks, domain, username="system", user_id="",
         case_blocks = ''.join(case_blocks)
     form_id = form_id or uuid.uuid4().hex
     form_xml = render_to_string('hqcase/xml/case_block.xml', {
-        'xmlns': xmlns,
         'case_block': case_blocks,
         'time': now,
         'uid': form_id,

--- a/corehq/apps/hqcase/utils.py
+++ b/corehq/apps/hqcase/utils.py
@@ -26,7 +26,8 @@ ALLOWED_CASE_IDENTIFIER_TYPES = [
 
 
 def submit_case_blocks(case_blocks, domain, username="system", user_id="",
-                       attachments=None, form_id=None):
+                       xmlns='http://commcarehq.org/case', attachments=None,
+                       form_id=None):
     """
     Submits casexml in a manner similar to how they would be submitted from a phone.
 
@@ -38,6 +39,7 @@ def submit_case_blocks(case_blocks, domain, username="system", user_id="",
         case_blocks = ''.join(case_blocks)
     form_id = form_id or uuid.uuid4().hex
     form_xml = render_to_string('hqcase/xml/case_block.xml', {
+        'xmlns': xmlns,
         'case_block': case_blocks,
         'time': now,
         'uid': form_id,


### PR DESCRIPTION
Based on findings from [this soft assert](https://github.com/dimagi/commcare-hq/blob/master/corehq/ex-submodules/couchforms/util.py#L463-463) we're using old style meta for system forms.

@millerdev

cc @czue
