### PR TITLE
use correct case block version

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/tests/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/util.py
@@ -119,7 +119,7 @@ def assert_user_doesnt_have_case(testcase, user, case_id, **kwargs):
 
 
 def assert_user_doesnt_have_cases(testcase, user, case_ids, **kwargs):
-    case_blocks = [CaseBlock(case_id=case_id).as_xml() for case_id in case_ids]
+    case_blocks = [CaseBlock(case_id=case_id, version=V2).as_xml() for case_id in case_ids]
     return check_user_has_case(testcase, user, case_blocks,
                                should_have=False, version=V2, **kwargs)
 

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -1199,12 +1199,7 @@ class MultiUserSyncTest(SyncBaseTest):
         self.assertTrue(main_sync_log.phone_is_holding_case(case_id))
         self.assertTrue(main_sync_log.phone_is_holding_case(parent_id))
         
-        # original user syncs again
-        # make sure there are no new changes
-        assert_user_doesnt_have_case(self, self.user, parent_id, restore_id=self.sync_log.get_id,
-                                     purge_restore_cache=True)
-        assert_user_doesnt_have_case(self, self.user, case_id, restore_id=self.sync_log.get_id)
-
+        # make sure the other user gets the reassigned case
         assert_user_has_case(self, self.other_user, parent_id, restore_id=self.other_sync_log.get_id,
                              purge_restore_cache=True)
         # update the parent case from another user

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -1132,7 +1132,7 @@ class MultiUserSyncTest(SyncBaseTest):
         # create a parent and child case (with index) from one user
         parent_id = "indexes_sync_parent"
         case_id = "indexes_sync"
-        self._createCaseStubs([parent_id])
+        self._createCaseStubs([parent_id], owner_id=USER_ID)
         child = CaseBlock(
             create=True,
             case_id=case_id,


### PR DESCRIPTION
@czue this is a bug with the tests. 3 tests failed after fixing it. I've fixed the one but not 100% sure about the other 2:

```
======================================================================
FAIL: testOtherUserUpdatesIndex (casexml.apps.phone.tests.test_sync_mode.MultiUserSyncTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "./corehq/ex-submodules/casexml/apps/phone/tests/restore_test_utils.py", line 45, in inner
    return helper(*args, **kwargs)
  File "./corehq/ex-submodules/casexml/apps/phone/tests/restore_test_utils.py", line 32, in __call__
    call_with_settings(fn_with_pre_and_post, run_config.settings, args, kwargs)
  File "/home/skelly/src/cchq/corehq/apps/tzmigration/test_utils.py", line 28, in call_with_settings
    fn(*args, **kwargs)
  File "./corehq/ex-submodules/casexml/apps/phone/tests/restore_test_utils.py", line 28, in fn_with_pre_and_post
    self.fn(*args, **kwargs)
  File "./corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py", line 1205, in testOtherUserUpdatesIndex
    purge_restore_cache=True)
  File "./corehq/ex-submodules/casexml/apps/case/tests/util.py", line 118, in assert_user_doesnt_have_case
    return assert_user_doesnt_have_cases(testcase, user, [case_id], return_single=True, **kwargs)
  File "./corehq/ex-submodules/casexml/apps/case/tests/util.py", line 124, in assert_user_doesnt_have_cases
    should_have=False, version=V2, **kwargs)
  File "./corehq/ex-submodules/casexml/apps/case/tests/util.py", line 193, in check_user_has_case
    matches = [check_block(case_block) for case_block in case_blocks]
  File "./corehq/ex-submodules/casexml/apps/case/tests/util.py", line 185, in check_block
    "but shouldn't:%s" % (user.username, case_id, extra_info())
AssertionError: User 'syncguy' gets case 'other_updates_index_parent' but shouldn't:
<ns0:case xmlns:ns0="http://commcarehq.org/case/transaction/v2" case_id="other_updates_index_parent" date_modified="2015-10-16T10:28:14.573993Z" />
['<ns0:case xmlns:ns0="http://commcarehq.org/case/transaction/v2" case_id="other_updates_index_parent" date_modified="2015-10-16T10:28:14.012450Z" user_id="main_user"><ns0:update><ns0:case_type>mother</ns0:case_type><ns0:case_name /><ns0:owner_id>someone_else</ns0:owner_id><ns0:greeting>hello</ns0:greeting></ns0:update></ns0:case>']

======================================================================
FAIL: test_create_closed_child_case_and_close_parent_in_same_form (casexml.apps.phone.tests.test_sync_mode.SyncTokenUpdateTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "./corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py", line 659, in test_create_closed_child_case_and_close_parent_in_same_form
    self._testUpdate(self.sync_log._id, {}, {})
  File "./corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py", line 123, in _testUpdate
    self.assertEqual(len(dependent_case_id_map), len(sync_log.dependent_cases_on_phone))
AssertionError: 0 != 1
```
