### PR TITLE
Advanced module persitent case tiles

### DIFF
--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -219,12 +219,15 @@ class EntriesHelper(object):
                 for datum_meta in self.get_datum_meta_module(module, use_filter=False):
                     e.datums.append(datum_meta.datum)
             elif isinstance(module, AdvancedModule):
+                detail_persistent, detail_inline = self.get_case_tile_datum_attrs(module, module)
                 e.datums.append(SessionDatum(
                     id='case_id_case_%s' % module.case_type,
                     nodeset=(EntriesHelper.get_nodeset_xpath(module.case_type)),
                     value="./@case_id",
                     detail_select=self.details_helper.get_detail_id_safe(module, 'case_short'),
-                    detail_confirm=self.details_helper.get_detail_id_safe(module, 'case_long')
+                    detail_confirm=self.details_helper.get_detail_id_safe(module, 'case_long'),
+                    detail_persistent=detail_persistent,
+                    detail_inline=detail_inline,
                 ))
                 if self.app.commtrack_enabled:
                     e.datums.append(SessionDatum(

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -538,6 +538,8 @@ class EntriesHelper(object):
             target_module_ = get_target_module(action_.case_type, action_.details_module)
             referenced_by = form.actions.actions_meta_by_parent_tag.get(action_.case_tag)
             filter_xpath = EntriesHelper.get_filter_xpath(target_module_)
+            detail_persistent, detail_inline = self.get_case_tile_datum_attrs(target_module_, target_module_)
+
             return SessionDatum(
                 id=action_.case_session_var,
                 nodeset=(EntriesHelper.get_nodeset_xpath(action_.case_type, filter_xpath=filter_xpath)
@@ -547,7 +549,9 @@ class EntriesHelper(object):
                 detail_confirm=(
                     self.details_helper.get_detail_id_safe(target_module_, 'case_long')
                     if not referenced_by or referenced_by['type'] != 'load' else None
-                )
+                ),
+                detail_persistent=detail_persistent,
+                detail_inline=detail_inline,
             )
 
         datums = []

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -373,17 +373,9 @@ class EntriesHelper(object):
                 parent_filter = ''
 
             detail_module = module if module.module_type == 'shadow' else datum['module']
-            detail_persistent = None
-            detail_inline = False
-            for detail_type, detail, enabled in datum['module'].get_details():
-                if (
-                    detail.persist_tile_on_forms
-                    and (detail.use_case_tiles or detail.custom_xml)
-                    and enabled
-                ):
-                    detail_persistent = id_strings.detail(detail_module, detail_type)
-                    detail_inline = bool(detail.pull_down_tile)
-                    break
+            detail_persistent, detail_inline = self.get_case_tile_datum_attrs(
+                datum['module'], detail_module
+            )
 
             fixture_select_filter = ''
             if datum['module'].fixture_select.active:
@@ -819,3 +811,14 @@ class EntriesHelper(object):
             elif form.mode == 'update':
                 e.datums.append(session_datum('case_id_goal', CAREPLAN_GOAL, 'parent', 'case_id'))
                 e.datums.append(session_datum('case_id_task', CAREPLAN_TASK, 'goal', 'case_id_goal'))
+
+    @staticmethod
+    def get_case_tile_datum_attrs(module, detail_module):
+        detail_persistent = None
+        detail_inline = False
+        for detail_type, detail, enabled in module.get_details():
+            if (detail.persist_tile_on_forms and (detail.use_case_tiles or detail.custom_xml) and enabled):
+                detail_persistent = id_strings.detail(detail_module, detail_type)
+                detail_inline = bool(detail.pull_down_tile)
+                break
+        return detail_persistent, detail_inline

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -412,10 +412,7 @@ class EntriesHelper(object):
                         if datum['index'] == 0 and not detail_inline else None
                     ),
                     detail_persistent=detail_persistent,
-                    detail_inline=(
-                        self.details_helper.get_detail_id_safe(detail_module, 'case_long')
-                        if detail_inline else None
-                    )
+                    detail_inline=detail_inline,
                 ),
                 case_type=datum['case_type'],
                 requires_selection=True,
@@ -819,13 +816,12 @@ class EntriesHelper(object):
                 e.datums.append(session_datum('case_id_goal', CAREPLAN_GOAL, 'parent', 'case_id'))
                 e.datums.append(session_datum('case_id_task', CAREPLAN_TASK, 'goal', 'case_id_goal'))
 
-    @staticmethod
-    def get_case_tile_datum_attrs(module, detail_module):
+    def get_case_tile_datum_attrs(self, module, detail_module):
         detail_persistent = None
-        detail_inline = False
+        detail_inline = None
         for detail_type, detail, enabled in module.get_details():
             if (detail.persist_tile_on_forms and (detail.use_case_tiles or detail.custom_xml) and enabled):
                 detail_persistent = id_strings.detail(detail_module, detail_type)
-                detail_inline = bool(detail.pull_down_tile)
+                detail_inline = self.details_helper.get_detail_id_safe(detail_module, 'case_long')
                 break
         return detail_persistent, detail_inline

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -822,6 +822,7 @@ class EntriesHelper(object):
         for detail_type, detail, enabled in module.get_details():
             if (detail.persist_tile_on_forms and (detail.use_case_tiles or detail.custom_xml) and enabled):
                 detail_persistent = id_strings.detail(detail_module, detail_type)
-                detail_inline = self.details_helper.get_detail_id_safe(detail_module, 'case_long')
+                if detail.pull_down_tile:
+                    detail_inline = self.details_helper.get_detail_id_safe(detail_module, 'case_long')
                 break
         return detail_persistent, detail_inline

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -401,6 +401,71 @@ class SuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
             "./entry/session"
         )
 
+    def test_persistent_case_tiles_in_advanced_forms(self):
+        """
+        Test that the detail-persistent attributes is set correctly when persistent
+        case tiles are used on advanced forms.
+        """
+        factory = AppFactory()
+        module, form = factory.new_advanced_module("my_module", "person")
+        factory.form_requires_case(form, "person")
+        module.case_details.short.custom_xml = '<detail id="m0_case_short"></detail>'
+        module.case_details.short.persist_tile_on_forms = True
+        suite = factory.app.create_suite()
+
+        # The relevant check is really that detail-persistent="m0_case_short"
+        # but assertXmlPartialEqual xpath implementation doesn't currently
+        # support selecting attributes
+        self.assertXmlPartialEqual(
+            """
+            <partial>
+                <datum
+                    detail-confirm="m0_case_long"
+                    detail-persistent="m0_case_short"
+                    detail-select="m0_case_short"
+                    id="case_id_load_person_0"
+                    nodeset="instance('casedb')/casedb/case[@case_type='person'][@status='open']"
+                    value="./@case_id"
+                />
+            </partial>
+            """,
+            suite,
+            "entry/session/datum"
+        )
+
+    def test_persistent_case_tiles_in_advanced_module_case_lists(self):
+        """
+        Test that the detail-persistent attributes is set correctly when persistent
+        case tiles are used on advanced module case lists
+        """
+        factory = AppFactory()
+        module, form = factory.new_advanced_module("my_module", "person")
+        factory.form_requires_case(form, "person")
+        module.case_list.show = True
+        module.case_details.short.custom_xml = '<detail id="m0_case_short"></detail>'
+        module.case_details.short.persist_tile_on_forms = True
+        suite = factory.app.create_suite()
+
+        # The relevant check is really that detail-persistent="m0_case_short"
+        # but assertXmlPartialEqual xpath implementation doesn't currently
+        # support selecting attributes
+        self.assertXmlPartialEqual(
+            """
+            <partial>
+                <datum
+                    detail-confirm="m0_case_long"
+                    detail-persistent="m0_case_short"
+                    detail-select="m0_case_short"
+                    id="case_id_case_person"
+                    nodeset="instance('casedb')/casedb/case[@case_type='person'][@status='open']"
+                    value="./@case_id"
+                />
+            </partial>
+            """,
+            suite,
+            'entry/command[@id="m0-case-list"]/../session/datum',
+        )
+
     def test_subcase_repeat_mixed(self):
         app = Application.new_app(None, "Untitled Application", application_version=APP_V2)
         module_0 = app.add_module(Module.new_module('parent', None))


### PR DESCRIPTION
Fixes [#184423](http://manage.dimagi.com/default.asp?184423).

There are two places that the `detail-persistent` attribute wasn't being set on datums:
- Datums for advanced module forms
- Datums for advanced module case list menu items

@snopoke @dannyroberts @benrudolph cc @kaapstorm 
Best reviewed commit-by-commit
