### PR TITLE
Get rid of DomainMigrations

### DIFF
--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -1,9 +1,7 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 from itertools import imap
 import json
-import logging
 import uuid
-from couchdbkit.exceptions import ResourceConflict
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.template.loader import render_to_string
@@ -23,7 +21,6 @@ from django.db import models, connection
 from django.utils.translation import ugettext_lazy as _
 from corehq.apps.appstore.models import SnapshotMixin
 from corehq.util.quickcache import skippable_quickcache
-from corehq.util.dates import iso_string_to_datetime
 from dimagi.utils.couch import CriticalSection
 from dimagi.utils.couch.cache import cache_core
 from dimagi.utils.couch.database import (
@@ -66,24 +63,6 @@ for lang in all_langs:
     if lang['two'] != '':
         lang_lookup[lang['two']] = lang['names'][0]
 
-
-class DomainMigrations(DocumentSchema):
-    has_migrated_permissions = BooleanProperty(default=False)
-
-    def apply(self, domain):
-        if not self.has_migrated_permissions:
-            logging.info("Applying permissions migration to domain %s" % domain.name)
-            from corehq.apps.users.models import UserRole, WebUser
-            UserRole.init_domain_with_presets(domain.name)
-            for web_user in WebUser.by_domain(domain.name):
-                try:
-                    web_user.save()
-                except ResourceConflict:
-                    # web_user has already been saved by another thread in the last few seconds
-                    pass
-
-            self.has_migrated_permissions = True
-            domain.save()
 
 LICENSES = {
     'cc': 'Creative Commons Attribution (CC BY)',
@@ -328,8 +307,6 @@ class Domain(Document, SnapshotMixin):
     image_path = StringProperty()
     image_type = StringProperty()
 
-    migrations = SchemaProperty(DomainMigrations)
-
     cached_properties = DictProperty()
 
     internal = SchemaProperty(InternalProperties)
@@ -396,8 +373,6 @@ class Domain(Document, SnapshotMixin):
         self = super(Domain, cls).wrap(data)
         if self.deployment is None:
             self.deployment = Deployment()
-        if self.get_id:
-            self.apply_migrations()
         if should_save:
             self.save()
         return self
@@ -439,9 +414,9 @@ class Domain(Document, SnapshotMixin):
     def field_by_prefix(cls, field, prefix='', is_approved=True):
         # unichr(0xfff8) is something close to the highest character available
         res = cls.view("domain/fields_by_prefix",
-                                    group=True,
-                                    startkey=[field, is_approved, prefix],
-                                    endkey=[field, is_approved, "%s%c" % (prefix, unichr(0xfff8)), {}])
+                       group=True,
+                       startkey=[field, is_approved, prefix],
+                       endkey=[field, is_approved, "%s%c" % (prefix, unichr(0xfff8)), {}])
         vals = [(d['value'], d['key'][2]) for d in res]
         vals.sort(reverse=True)
         return [(v[1], v[0]) for v in vals]
@@ -449,9 +424,6 @@ class Domain(Document, SnapshotMixin):
     @classmethod
     def get_by_field(cls, field, value, is_approved=True):
         return cls.view('domain/fields_by_prefix', key=[field, is_approved, value], reduce=False, include_docs=True).all()
-
-    def apply_migrations(self):
-        self.migrations.apply(self)
 
     def add(self, model_instance, is_active=True):
         """
@@ -608,7 +580,6 @@ class Domain(Document, SnapshotMixin):
                 date_created=datetime.utcnow(),
                 secure_submissions=secure_submissions,
             )
-            new_domain.migrations = DomainMigrations(has_migrated_permissions=True)
             new_domain.save(**get_safe_write_kwargs())
             return new_domain
 

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -16,7 +16,7 @@ from dimagi.utils.web import get_ip, get_url_base, get_site_domain
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from corehq.apps.domain.models import Domain
-from corehq.apps.users.models import WebUser, CouchUser
+from corehq.apps.users.models import WebUser, CouchUser, UserRole
 from corehq.apps.hqwebapp.tasks import send_html_email_async
 from dimagi.utils.couch.database import get_safe_write_kwargs
 from corehq.apps.hqwebapp.tasks import send_mail_async
@@ -92,6 +92,7 @@ def request_new_domain(request, form, org, domain_type=None, new_user=True):
         new_domain.save() # we need to get the name from the _id
 
     create_30_day_trial(new_domain)
+    UserRole.init_domain_with_presets(new_domain.name)
 
     dom_req.domain = new_domain.name
 


### PR DESCRIPTION
When users are saved:
1) This sends out a signal, picked up by `user_save_callback`
2) that attempts to `update_subscription_properties_by_user`
3) in turn, that `get[s]_subscribed_plan_by_domain`
4) which of course calls something which calls `Domain.get_by_name`
5) on a successful get, the domain document is `wrap`ped
6) In the process of wrapping it, `Domain.apply_migrations` is called.
  `DomainMigrations` is a lazy migration (only performing the migration   when the domain is first accessed after the migration was written), but this also happens any time a new domain is created, unless you use `get_or_create_with_name`.  (You might've seen "Applying permissions migration to domain %s" during test setup)
7) Anyways, the migration makes sure that a UserRole exists on the domain, and then saves all `WebUser`s on the domain, I assume to pick up the `UserRole`.
8) Each call to `WebUser.save` sends out a signal... [GOTO 1]

Once the recursion limit is reached, this exception is caught by Django's `send_robust()` function, and we `notify_exception` - "Error occured while syncing user %s: %s"

This was really slowing down some tests.  I checked in elasticsearch, and of all 12499 domains, none have that migration unapplied, so I'm removing it.

@gcapalbo
