### PR TITLE
cleaning up release version information

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/releases.html
@@ -198,7 +198,6 @@
                     <td class="nowrap" data-bind="text: built_on_time"></td>
                     <td class="nowrap">
                         <span data-bind="if: build_label(), text: build_label()"></span>
-                        <p data-bind="text: jar_path"></p>
                         <h6 data-bind="if: !built_with.signed()">{% trans "Unsigned Jar" %}</h6>
                     </td>
                     <td class="nowrap">

--- a/corehq/apps/builds/models.py
+++ b/corehq/apps/builds/models.py
@@ -147,8 +147,7 @@ class BuildSpec(DocumentSchema):
 
     def get_label(self):
         if not self.is_null():
-            fmt = "{self.version} "
-            fmt += "(latest)" if self.latest else "({self.build_number})"
+            fmt = "{self.version}"
             return fmt.format(self=self)
         else:
             return None


### PR DESCRIPTION
addresses http://manage.dimagi.com/default.asp?184351#1029757
@dimagi/product 
@biyeun 
Screenshot:
<img width="1047" alt="screen shot 2015-10-16 at 2 30 19 pm" src="https://cloud.githubusercontent.com/assets/6844721/10550063/97b49c7c-7412-11e5-92eb-29ccab608691.png">
