### PR TITLE
remove syncdb during deploy

### DIFF
--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -944,7 +944,6 @@ def _migrate():
     _require_target()
     with cd(env.code_root):
         sudo('%(virtualenv_root)s/bin/python manage.py sync_finish_couchdb_hq' % env)
-        sudo('%(virtualenv_root)s/bin/python manage.py syncdb --noinput' % env)
         sudo('%(virtualenv_root)s/bin/python manage.py migrate --noinput' % env)
 
 


### PR DESCRIPTION
syncdb has been replace by `migrate`
@benrudolph 

cc @millerdev 
