### PR TITLE
use argument instead of variable that happens to be in scope

### DIFF
--- a/corehq/apps/userreports/reports/data_source.py
+++ b/corehq/apps/userreports/reports/data_source.py
@@ -85,7 +85,7 @@ class ConfigurableReportDataSource(SqlData):
             # ask each column for its group_by contribution and combine to a single list
             # if the column isn't found just treat it as a normal field
             if column_id in self._column_configs:
-                return self._column_configs[col_id].get_group_by_columns()
+                return self._column_configs[column_id].get_group_by_columns()
             else:
                 return [column_id]
 


### PR DESCRIPTION
@czue @NoahCarnahan cc: @orangejenny 

shouldn't affect behavior, but reads much clearer / won't break if `col_id` in the for loop is renamed.  otherwise looks like the kind of code that "just happens to work"
