### PR TITLE
delete property if it doesn't exist in calc_fns

### DIFF
--- a/corehq/apps/domain/calculations.py
+++ b/corehq/apps/domain/calculations.py
@@ -166,16 +166,16 @@ def first_form_submission(domain, display=True):
     try:
         submission_time = get_first_form_submission_received(domain)
     except ValueError:
-        return "Unable to parse time of first form"
-    return display_time(submission_time, display) if submission_time else "No forms"
+        return None
+    return display_time(submission_time, display) if submission_time else None
 
 
 def last_form_submission(domain, display=True):
     try:
         submission_time = get_last_form_submission_received(domain)
     except ValueError:
-        return "Unable to parse time of last form"
-    return display_time(submission_time, display) if submission_time else "No forms"
+        return None
+    return display_time(submission_time, display) if submission_time else None
 
 
 def has_app(domain, *args):

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -766,6 +766,10 @@ class AdminDomainStatsReport(AdminFacetedReport, DomainStatsReport):
 
         for dom in domains:
             if dom.has_key('name'):  # for some reason when using the statistical facet, ES adds an empty dict to hits
+                first_form_default_message = _("No Forms")
+                if dom.get("cp_last_form", None):
+                    first_form_default_message = _("Unable to parse date")
+
                 yield [
                     self.get_name_or_link(dom, internal_settings=True),
                     format_date((dom.get("date_created")), _('No date')),
@@ -780,7 +784,7 @@ class AdminDomainStatsReport(AdminFacetedReport, DomainStatsReport):
                     dom.get("cp_n_inactive_cases", _("Not yet calculated")),
                     dom.get("cp_n_cases", _("Not yet calculated")),
                     dom.get("cp_n_forms", _("Not yet calculated")),
-                    format_date(dom.get("cp_first_form"), _("No forms")),
+                    format_date(dom.get("cp_first_form"), first_form_default_message),
                     format_date(dom.get("cp_last_form"), _("No forms")),
                     dom.get("cp_n_web_users", _("Not yet calculated")),
                     dom.get('internal', {}).get('notes') or _('No notes'),

--- a/corehq/apps/reports/standard/domains.py
+++ b/corehq/apps/reports/standard/domains.py
@@ -77,6 +77,10 @@ class DomainStatsReport(GenericTabularReport):
 
         for dom in domains:
             if dom.has_key('name'): # for some reason when using the statistical facet, ES adds an empty dict to hits
+                first_form_default_message = _("No Forms")
+                if dom.get("cp_last_form", None):
+                    first_form_default_message = _("Unable to parse date")
+
                 yield [
                     self.get_name_or_link(dom),
                     numcell(dom.get("cp_n_active_cc_users", _("Not yet calculated"))),
@@ -84,7 +88,7 @@ class DomainStatsReport(GenericTabularReport):
                     numcell(dom.get("cp_n_active_cases", _("Not yet calculated"))),
                     numcell(dom.get("cp_n_cases", _("Not yet calculated"))),
                     numcell(dom.get("cp_n_forms", _("Not yet calculated"))),
-                    format_date(dom.get("cp_first_form"), _("No forms")),
+                    format_date(dom.get("cp_first_form"), first_form_default_message),
                     format_date(dom.get("cp_last_form"), _("No forms")),
                     numcell(dom.get("cp_n_web_users", _("Not yet calculated")))
                 ]

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -235,8 +235,9 @@ def update_calculated_properties():
                 "cp_n_sms_in_30_d": int(CALC_FNS["sms_in_in_last"](dom, 30)),
                 "cp_n_sms_out_30_d": int(CALC_FNS["sms_out_in_last"](dom, 30)),
             }
-            if calced_props['cp_first_form'] == 'No forms':
+            if calced_props['cp_first_form'] is None:
                 del calced_props['cp_first_form']
+            if calced_props['cp_last_form'] is None:
                 del calced_props['cp_last_form']
             send_to_elasticsearch("domains", calced_props)
         except Exception, e:


### PR DESCRIPTION
@TylerSheffels third time's the charm. returning "No Forms" was a misnomer here and is not actually sent to elastic. the reports that use this property default to ["No Forms"](https://github.com/dimagi/commcare-hq/blob/fix-again-calc-fns/corehq/apps/hqadmin/reports.py#L783) if that property doesn't exist, so that is why i decided to just return None on error or empty. this can lead to some confusion if first form says "No Forms" because it can't parse the date and the last form has a parseable date and thus leads to the column showing a form. (i.e. there exists a last form but not a first form makes no sense).

maybe as a halfway, in the reports we could check and if it last_form is not none but first_form is, we can return a different string like "Unable to parse date". not foolproof, but this is only happening to like 10 domains in our entire database
