### PR TITLE
update tests to accommodate for 15 minute reporting intervals

### DIFF
--- a/corehq/apps/reports/tests/test_scheduled_reports.py
+++ b/corehq/apps/reports/tests/test_scheduled_reports.py
@@ -52,7 +52,7 @@ class ScheduledReportTest(TestCase):
     def testDefaultValue(self):
         now = datetime.utcnow()
         ReportNotification(hour=now.hour, minute=(now.minute / 30) * 30, interval='daily').save()
-        if now.minute % 30 <= 5:
+        if now.minute % 15 <= 5:
             self._check('daily', None, 1)
         else:
             self.assertRaises(


### PR DESCRIPTION
introduced in https://github.com/dimagi/commcare-hq/pull/8720 but it would only fail if the test ran between minutes 15-20 or 45-50 of the hour...
