### PR TITLE
adding http method to email mock requests

### DIFF
--- a/corehq/apps/reports/models.py
+++ b/corehq/apps/reports/models.py
@@ -466,6 +466,7 @@ class ReportConfig(CachedCouchDocumentMixin, Document):
         mock_request.domain = self.domain
         mock_request.couch_user.current_domain = self.domain
         mock_request.couch_user.language = lang
+        mock_request.method = 'GET'
 
         mock_query_string_parts = [self.query_string, 'filterSet=true']
         if self.is_configurable_report:


### PR DESCRIPTION
addresses http://manage.dimagi.com/default.asp?184648#1031947
it was failing to pull in the query parameters because the mock request was treated as post at
https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/reports/generic.py#L132 so it was looking for the parameters in the post attribute of the request instead of the get attribute
@nickpell 
