### PR TITLE
Remove billing organization

### DIFF
--- a/corehq/apps/accounting/generator.py
+++ b/corehq/apps/accounting/generator.py
@@ -125,7 +125,7 @@ def generate_domain_subscription_from_date(date_start, billing_account, domain,
     # make sure that the last month is never a full month (for testing)
     date_end = datetime.date(date_end_year, date_end_month, min(date_end_last_day - 1, date_start.day + 1))
 
-    subscriber, _ = Subscriber.objects.get_or_create(domain=domain, organization=None)
+    subscriber, _ = Subscriber.objects.get_or_create(domain=domain)
     subscription = Subscription(
         account=billing_account,
         plan_version=plan_version or subscribable_plan(),

--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -344,10 +344,8 @@ class LineItemFactory(object):
     @property
     @memoized
     def subscribed_domains(self):
-        if self.subscription.subscriber.organization is None and self.subscription.subscriber.domain is None:
-            raise LineItemError("No domain or organization could be obtained as the subscriber.")
-        if self.subscription.subscriber.organization is not None:
-            return Domain.get_by_organization(self.subscription.subscriber.organization)
+        if self.subscription.subscriber.domain is None:
+            raise LineItemError("No domain could be obtained as the subscriber.")
         return [self.subscription.subscriber.domain]
 
     @property

--- a/corehq/apps/accounting/migrations/0006_remove_organization_field.py
+++ b/corehq/apps/accounting/migrations/0006_remove_organization_field.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def check_no_organizations(apps, schema_editor):
+    if apps.get_model('accounting', 'Subscriber').objects.exclude(organization=None):
+        raise Exception('There exists a Subscriber with an organization')
+
+
+def empty_func(*args):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounting', '0005_merge'),
+    ]
+
+    operations = [
+        migrations.RunPython(check_no_organizations, reverse_code=empty_func),
+        migrations.RemoveField(
+            model_name='subscriber',
+            name='organization',
+        ),
+    ]

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -808,7 +808,6 @@ class Subscriber(models.Model):
     The objects that can be subscribed to a Subscription.
     """
     domain = models.CharField(max_length=256, null=True, db_index=True)
-    organization = models.CharField(max_length=256, null=True, db_index=True)
     last_modified = models.DateTimeField(auto_now=True)
 
     objects = SubscriberManager()
@@ -817,8 +816,6 @@ class Subscriber(models.Model):
         app_label = 'accounting'
 
     def __unicode__(self):
-        if self.organization:
-            return u"ORGANIZATION %s" % self.organization
         return u"DOMAIN %s" % self.domain
 
     def create_subscription(self, new_plan_version, web_user, new_subscription, is_internal_change):
@@ -881,9 +878,6 @@ class Subscriber(models.Model):
         downgraded_privileges is the list of privileges that should be removed
         upgraded_privileges is the list of privileges that should be added
         """
-        if self.organization is not None:
-            raise SubscriptionChangeError("Only domain upgrades and downgrades are possible.")
-
         if new_plan_version is None:
             new_plan_version = DefaultProductPlan.get_default_plan_by_domain(self.domain)
 
@@ -1265,11 +1259,6 @@ class Subscription(models.Model):
         """
         adjustment_method = adjustment_method or SubscriptionAdjustmentMethod.INTERNAL
 
-        if self.subscriber.organization is not None:
-            raise SubscriptionRenewalError(
-                "Can't renew subscription because organizations are not "
-                "supported for this method."
-            )
         if self.date_end is None:
             raise SubscriptionRenewalError(
                 "Cannot renew a subscription with no date_end set."
@@ -1351,11 +1340,6 @@ class Subscription(models.Model):
         if self.date_end is None:
             raise SubscriptionReminderError(
                 "This subscription has no end date."
-            )
-        if self.subscriber.organization is not None:
-            raise SubscriptionReminderError(
-                "This reminder email does not yet handle organization "
-                "subscribers."
             )
         if self.is_renewed:
             # no need to send a reminder email if the subscription
@@ -1493,14 +1477,6 @@ class Subscription(models.Model):
         return current_subscription.plan_version, current_subscription
 
     @classmethod
-    def get_subscribed_plan_by_organization(cls, organization):
-        """
-        Returns SoftwarePlanVersion, Subscription for the given organization.
-        """
-        subscriber = Subscriber.objects.safe_get(organization=organization, domain=None)
-        return cls._get_plan_by_subscriber(subscriber) if subscriber else None, None
-
-    @classmethod
     def get_subscribed_plan_by_domain(cls, domain):
         """
         Returns SoftwarePlanVersion, Subscription for the given domain.
@@ -1516,9 +1492,8 @@ class Subscription(models.Model):
             except DefaultProductPlan.DoesNotExist:
                 raise ProductPlanNotFoundError
         domain = domain_obj
-        subscriber = Subscriber.objects.safe_get(domain=domain.name, organization=None)
-        plan_version, subscription = (cls._get_plan_by_subscriber(subscriber) if subscriber
-                                      else cls.get_subscribed_plan_by_organization(domain.organization))
+        subscriber = Subscriber.objects.safe_get(domain=domain.name)
+        plan_version, subscription = cls._get_plan_by_subscriber(subscriber) if subscriber else (None, None)
         if plan_version is None:
             plan_version = DefaultProductPlan.get_default_plan_by_domain(domain)
         return plan_version, subscription
@@ -1528,7 +1503,7 @@ class Subscription(models.Model):
                                 date_start=None, date_end=None, note=None,
                                 web_user=None, adjustment_method=None, internal_change=False,
                                 **kwargs):
-        subscriber = Subscriber.objects.get_or_create(domain=domain, organization=None)[0]
+        subscriber = Subscriber.objects.get_or_create(domain=domain)[0]
         today = datetime.date.today()
         date_start = date_start or today
 
@@ -1607,8 +1582,7 @@ class Subscription(models.Model):
     @classmethod
     def can_reactivate_domain_subscription(cls, account, domain, plan_version,
                                            date_start=None):
-        subscriber = Subscriber.objects.get_or_create(
-            domain=domain, organization=None)[0]
+        subscriber = Subscriber.objects.get_or_create(domain=domain)[0]
         date_start = date_start or datetime.date.today()
         last_subscription = Subscription.objects.filter(
             subscriber=subscriber, date_end=date_start


### PR DESCRIPTION
Once organizations are officially killed, remove the references to them in billing.

I added a check that no data is being lost (although I highly doubt that any data is in this column on any of the machines) and made the migration reversible.
