### PR TITLE
Add setting for "Persistent case context" tile

### DIFF
--- a/corehq/apps/app_manager/id_strings.py
+++ b/corehq/apps/app_manager/id_strings.py
@@ -262,6 +262,10 @@ def detail(module, detail_type):
     return u"m{module.id}_{detail_type}".format(module=module, detail_type=detail_type)
 
 
+def persistent_case_context_detail(module):
+    return detail(module, 'persistent_case_context')
+
+
 def fixture_detail(module):
     return detail(module, 'fixture_select')
 

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1671,9 +1671,16 @@ class Detail(IndexedSchema, CaseListLookupMixin):
 
     sort_elements = SchemaListProperty(SortElement)
     filter = StringProperty()
+
+    persist_case_context = BooleanProperty()
+    # If True, a small tile will display the case name after selection.
+
+    use_case_tiles = BooleanProperty()  # If True, use case tiles in the case list
+    # If given, use this string for the case tile markup instead of the default temaplte
     custom_xml = StringProperty()
-    use_case_tiles = BooleanProperty()
+
     persist_tile_on_forms = BooleanProperty()
+    # If True, the in form tile can be pulled down to reveal all the case details.
     pull_down_tile = BooleanProperty()
 
     def get_tab_spans(self):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1672,10 +1672,11 @@ class Detail(IndexedSchema, CaseListLookupMixin):
     sort_elements = SchemaListProperty(SortElement)
     filter = StringProperty()
 
-    persist_case_context = BooleanProperty()
     # If True, a small tile will display the case name after selection.
+    persist_case_context = BooleanProperty()
 
-    use_case_tiles = BooleanProperty()  # If True, use case tiles in the case list
+    # If True, use case tiles in the case list
+    use_case_tiles = BooleanProperty()
     # If given, use this string for the case tile markup instead of the default temaplte
     custom_xml = StringProperty()
 

--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -747,7 +747,7 @@ var DetailScreenConfig = (function () {
             this.properties = options.properties;
             this.childCaseTypes = options.childCaseTypes;
             this.fixtures = options.fixtures;
-            // The column key is used to retreive the columns from the spec and
+            // The column key is used to retrieve the columns from the spec and
             // as the name of the key in the data object that is sent to the
             // server on save.
             this.columnKey = options.columnKey;
@@ -764,6 +764,7 @@ var DetailScreenConfig = (function () {
             this.containsCustomXMLConfiguration = options.containsCustomXMLConfiguration;
             this.allowsTabs = options.allowsTabs;
             this.useCaseTiles = ko.observable(spec[this.columnKey].use_case_tiles ? "yes" : "no");
+            this.persistCaseContext = ko.observable(spec[this.columnKey].persist_case_context || false);
             this.persistTileOnForms = ko.observable(spec[this.columnKey].persist_tile_on_forms || false);
             this.enableTilePullDown = ko.observable(spec[this.columnKey].pull_down_tile || false);
             this.allowsEmptyColumns = options.allowsEmptyColumns;
@@ -837,6 +838,9 @@ var DetailScreenConfig = (function () {
                 this.saveButton.fire('change');
             });
             this.useCaseTiles.subscribe(function(){
+                that.saveButton.fire('change');
+            });
+            this.persistCaseContext.subscribe(function(){
                 that.saveButton.fire('change');
             });
             this.persistTileOnForms.subscribe(function(){
@@ -935,6 +939,7 @@ var DetailScreenConfig = (function () {
                 ));
 
                 data.useCaseTiles = this.useCaseTiles() == "yes" ? true : false;
+                data.persistCaseContext = this.persistCaseContext();
                 data.persistTileOnForms = this.persistTileOnForms();
                 data.enableTilePullDown = this.persistTileOnForms() ? this.enableTilePullDown() : false;
 

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -61,20 +61,7 @@ class DetailContributor(SectionContributor):
                                     if d:
                                         r.append(d)
                 if module.fixture_select.active:
-                    d = Detail(
-                        id=id_strings.fixture_detail(module),
-                        title=Text(),
-                    )
-                    xpath = Xpath(function=module.fixture_select.display_column)
-                    if module.fixture_select.localize:
-                        template_text = Text(locale=Locale(child_id=Id(xpath=xpath)))
-                    else:
-                        template_text = Text(xpath_function=module.fixture_select.display_column)
-                    fields = [Field(header=Header(text=Text()),
-                                    template=Template(text=template_text),
-                                    sort_node='')]
-
-                    d.fields = fields
+                    d = self._get_fixture_detail(module)
                     r.append(d)
         return r
 
@@ -267,6 +254,23 @@ class DetailContributor(SectionContributor):
                 os.path.dirname(os.path.dirname(__file__)), "case_tile_templates", "tdh.txt"
         )) as f:
             return f.read().decode('utf-8')
+
+    def _get_fixture_detail(self, module):
+        d = Detail(
+            id=id_strings.fixture_detail(module),
+            title=Text(),
+        )
+        xpath = Xpath(function=module.fixture_select.display_column)
+        if module.fixture_select.localize:
+            template_text = Text(locale=Locale(child_id=Id(xpath=xpath)))
+        else:
+            template_text = Text(
+                xpath_function=module.fixture_select.display_column)
+        fields = [Field(header=Header(text=Text()),
+                        template=Template(text=template_text),
+                        sort_node='')]
+        d.fields = fields
+        return d
 
 
 class DetailsHelper(object):

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -10,7 +10,8 @@ from corehq.apps.app_manager.suite_xml.const import FIELD_TYPE_LEDGER
 from corehq.apps.app_manager.suite_xml.contributors import SectionContributor
 from corehq.apps.app_manager.suite_xml.post_process.instances import EntryInstances
 from corehq.apps.app_manager.suite_xml.xml_models import Text, Xpath, Locale, Id, Header, Template, Field, Lookup, Extra, \
-    Response, Detail, LocalizedAction, Stack, Action, Display, PushFrame, StackDatum
+    Response, Detail, LocalizedAction, Stack, Action, Display, PushFrame, StackDatum, \
+    Style
 from corehq.apps.app_manager.suite_xml.features.scheduler import schedule_detail_variables
 from corehq.apps.app_manager.util import create_temp_sort_column
 from corehq.apps.app_manager import id_strings
@@ -59,6 +60,9 @@ class DetailContributor(SectionContributor):
                                     )
                                     if d:
                                         r.append(d)
+                        if detail.persist_case_context and not detail.persist_tile_on_forms:
+                            d = self._get_persistent_case_context_detail(module)
+                            r.append(d)
                 if module.fixture_select.active:
                     d = self._get_fixture_detail(module)
                     r.append(d)
@@ -194,9 +198,27 @@ class DetailContributor(SectionContributor):
         frame.add_datum(StackDatum(id=RETURN_TO, value=XPath.string(id_strings.menu_id(module))))
         detail.action.stack.add_frame(frame)
 
+    @staticmethod
+    def _get_persistent_case_context_detail(module):
+        return Detail(
+            id=id_strings.persistent_case_context_detail(module),
+            title=Text(),
+            fields=[Field(
+                style=Style(
+                    horz_align="center",
+                    font_size="large",
+                    grid_height=2,
+                    grid_width=12,
+                    grid_x=0,
+                    grid_y=0,
+                ),
+                header=Header(text=Text()),
+                template=Template(text=Text(xpath_function="case_name")),
+            )]
+        )
 
-
-    def _get_fixture_detail(self, module):
+    @staticmethod
+    def _get_fixture_detail(module):
         d = Detail(
             id=id_strings.fixture_detail(module),
             title=Text(),

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -100,13 +100,7 @@ class DetailContributor(SectionContributor):
         else:
             # Add lookup
             if detail.lookup_enabled and detail.lookup_action:
-                d.lookup = Lookup(
-                    name=detail.lookup_name or None,
-                    action=detail.lookup_action,
-                    image=detail.lookup_image or None,
-                )
-                d.lookup.extras = [Extra(**e) for e in detail.lookup_extras]
-                d.lookup.responses = [Response(**r) for r in detail.lookup_responses]
+                d.lookup = self._get_lookup_element(detail)
 
             # Add variables
             variables = list(
@@ -138,6 +132,15 @@ class DetailContributor(SectionContributor):
             else:
                 # only yield the Detail if it has Fields
                 return d
+
+    def _get_lookup_element(self, detail):
+        return Lookup(
+            name=detail.lookup_name or None,
+            action=detail.lookup_action,
+            image=detail.lookup_image or None,
+            extras=[Extra(**e) for e in detail.lookup_extras],
+            responses=[Response(**r) for r in detail.lookup_responses],
+        )
 
     def _add_action_to_detail(self, detail, module):
         # add form action to detail

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -166,15 +166,14 @@ class EntriesHelper(object):
                 for datum_meta in self.get_datum_meta_module(module, use_filter=False):
                     e.datums.append(datum_meta.datum)
             elif isinstance(module, AdvancedModule):
-                detail_persistent, detail_inline = self.get_case_tile_datum_attrs(module, module)
                 e.datums.append(SessionDatum(
                     id='case_id_case_%s' % module.case_type,
                     nodeset=(EntriesHelper.get_nodeset_xpath(module.case_type)),
                     value="./@case_id",
                     detail_select=self.details_helper.get_detail_id_safe(module, 'case_short'),
                     detail_confirm=self.details_helper.get_detail_id_safe(module, 'case_long'),
-                    detail_persistent=detail_persistent,
-                    detail_inline=detail_inline,
+                    detail_persistent=self.get_detail_persistent_attr(module, module, "case_short"),
+                    detail_inline=self.get_detail_inline_attr(module, module, "case_short")
                 ))
                 if self.app.commtrack_enabled:
                     e.datums.append(SessionDatum(
@@ -323,9 +322,8 @@ class EntriesHelper(object):
                 parent_filter = ''
 
             detail_module = module if module.module_type == 'shadow' else datum['module']
-            detail_persistent, detail_inline = self.get_case_tile_datum_attrs(
-                datum['module'], detail_module
-            )
+            detail_persistent = self.get_detail_persistent_attr(datum['module'], detail_module, "case_short")
+            detail_inline = self.get_detail_inline_attr(datum['module'], detail_module, "case_short")
 
             fixture_select_filter = ''
             if datum['module'].fixture_select.active:
@@ -485,7 +483,6 @@ class EntriesHelper(object):
             target_module_ = get_target_module(action_.case_type, action_.details_module)
             referenced_by = form.actions.actions_meta_by_parent_tag.get(action_.case_tag)
             filter_xpath = EntriesHelper.get_filter_xpath(target_module_)
-            detail_persistent, detail_inline = self.get_case_tile_datum_attrs(target_module_, target_module_)
 
             return SessionDatum(
                 id=action_.case_session_var,
@@ -497,8 +494,8 @@ class EntriesHelper(object):
                     self.details_helper.get_detail_id_safe(target_module_, 'case_long')
                     if not referenced_by or referenced_by['type'] != 'load' else None
                 ),
-                detail_persistent=detail_persistent,
-                detail_inline=detail_inline,
+                detail_persistent=self.get_detail_persistent_attr(target_module_, target_module_, "case_short"),
+                detail_inline=self.get_detail_inline_attr(target_module_, target_module_, "case_short"),
             )
 
         datums = []
@@ -544,7 +541,13 @@ class EntriesHelper(object):
                             id='product_id',
                             nodeset=nodeset,
                             value="./@id",
-                            detail_select=self.details_helper.get_detail_id_safe(target_module, 'product_short')
+                            detail_select=self.details_helper.get_detail_id_safe(target_module, 'product_short'),
+                            detail_persistent=self.get_detail_persistent_attr(
+                                target_module, target_module, "product_short"
+                            ),
+                            detail_inline=self.get_detail_inline_attr(
+                                target_module, target_module, "product_short"
+                            ),
                         ),
                         case_type=None,
                         requires_selection=True,
@@ -763,13 +766,30 @@ class EntriesHelper(object):
                 e.datums.append(session_datum('case_id_goal', CAREPLAN_GOAL, 'parent', 'case_id'))
                 e.datums.append(session_datum('case_id_task', CAREPLAN_TASK, 'goal', 'case_id_goal'))
 
-    def get_case_tile_datum_attrs(self, module, detail_module):
-        detail_persistent = None
-        detail_inline = None
-        for detail_type, detail, enabled in module.get_details():
-            if (detail.persist_tile_on_forms and (detail.use_case_tiles or detail.custom_xml) and enabled):
-                detail_persistent = id_strings.detail(detail_module, detail_type)
-                if detail.pull_down_tile:
-                    detail_inline = self.details_helper.get_detail_id_safe(detail_module, 'case_long')
-                break
-        return detail_persistent, detail_inline
+    def get_detail_persistent_attr(self, module, detail_module, detail_type="case_short"):
+        detail, detail_enabled = self._get_detail_from_module(module, detail_type)
+        if detail_enabled and self._has_persistent_tile(detail):
+            return id_strings.detail(detail_module, detail_type)
+        return None
+
+    def get_detail_inline_attr(self, module, detail_module, detail_type="case_short"):
+        assert detail_type in ["case_short", "product_short"]
+        detail, detail_enabled = self._get_detail_from_module(module, detail_type)
+        if detail_enabled and self._has_persistent_tile(detail) and detail.pull_down_tile:
+            list_type = "case_long" if detail_type == "case_short" else "product_long"
+            return self.details_helper.get_detail_id_safe(detail_module, list_type)
+        return None
+
+    def _get_detail_from_module(self, module, detail_type):
+        """
+        Return the Detail object of the given type from the given module
+        """
+        details = {d[0]: d for d in module.get_details()}
+        _, detail, detail_enabled = details[detail_type]
+        return detail, detail_enabled
+
+    def _has_persistent_tile(self, detail):
+        """
+        Return True if the given Detail is configured to persist a case tile on forms
+        """
+        return detail.persist_tile_on_forms and (detail.use_case_tiles or detail.custom_xml)

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -768,8 +768,12 @@ class EntriesHelper(object):
 
     def get_detail_persistent_attr(self, module, detail_module, detail_type="case_short"):
         detail, detail_enabled = self._get_detail_from_module(module, detail_type)
-        if detail_enabled and self._has_persistent_tile(detail):
-            return id_strings.detail(detail_module, detail_type)
+        if detail_enabled:
+            if self._has_persistent_tile(detail):
+                return id_strings.detail(detail_module, detail_type)
+            if detail.persist_case_context and detail_type == "case_short":
+                # persistent_case_context will not work on product lists.
+                return id_strings.persistent_case_context_detail(detail_module)
         return None
 
     def get_detail_inline_attr(self, module, detail_module, detail_type="case_short"):

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list.html
@@ -44,7 +44,7 @@
     <div data-bind="visible: useCaseTiles() == 'no'">
         <label class="checkbox">
             <input type="checkbox" data-bind="checked: persistCaseContext">
-            Persist case name at top of forms
+            {% trans "Show the case name at the top of the screen when filling out forms" %}
         </label>
     </div>
     {% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list.html
@@ -39,6 +39,16 @@
         <option value="yes">Use Case Tiles</option>
     </select>
     {% endif %}
+
+    {% if request|toggle_enabled:'SHOW_PERSIST_CASE_CONTEXT_SETTING' %}
+    <div data-bind="visible: useCaseTiles() == 'no'">
+        <label class="checkbox">
+            <input type="checkbox" data-bind="checked: persistCaseContext">
+            Persist case name at top of forms
+        </label>
+    </div>
+    {% endif %}
+
     <div data-bind="visible: useCaseTiles() == 'yes' || window.toggles.CASE_LIST_CUSTOM_XML">
         <label class="checkbox">
             <input type="checkbox" data-bind="checked: persistTileOnForms">

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -466,6 +466,95 @@ class SuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
             'entry/command[@id="m0-case-list"]/../session/datum',
         )
 
+    def test_persistent_case_name_in_forms(self):
+        """
+        Test that the detail-persistent attributes are set correctly when the
+        module is configured to persist the case name at the top of the form.
+        Also confirm that the appropriate <detail> element is added to the suite.
+        """
+        factory = AppFactory()
+        module, form = factory.new_basic_module("my_module", "person")
+        factory.form_requires_case(form, "person")
+        module.case_details.short.persist_case_context = True
+        suite = factory.app.create_suite()
+
+        self.assertXmlPartialEqual(
+            """
+            <partial>
+                <detail id="m0_persistent_case_context">
+                    <title>
+                        <text/>
+                    </title>
+                    <field>
+                        <style font-size="large" horz-align="center">
+                            <grid grid-height="2" grid-width="12" grid-x="0" grid-y="0"/>
+                        </style>
+                        <header>
+                            <text/>
+                        </header>
+                        <template>
+                            <text>
+                                <xpath function="case_name"/>
+                            </text>
+                        </template>
+                    </field>
+                </detail>
+            </partial>
+            """,
+            suite,
+            "detail[@id='m0_persistent_case_context']"
+        )
+
+        # The attribute we care about here is detail-persistent="m0_persistent_case_context"
+        self.assertXmlPartialEqual(
+            """
+            <partial>
+                <datum
+                    detail-confirm="m0_case_long"
+                    detail-persistent="m0_persistent_case_context"
+                    detail-select="m0_case_short"
+                    id="case_id"
+                    nodeset="instance('casedb')/casedb/case[@case_type='person'][@status='open']"
+                    value="./@case_id"
+                />
+            </partial>
+            """,
+            suite,
+            "entry/session/datum"
+        )
+
+    def test_persistent_case_name_when_tiles_enabled(self):
+        """
+        Confirm that the persistent case name context is not added when case tiles
+        are configured to persist in forms
+        """
+        factory = AppFactory()
+        module, form = factory.new_advanced_module("my_module", "person")
+        factory.form_requires_case(form, "person")
+        module.case_details.short.custom_xml = '<detail id="m0_case_short"></detail>'
+        module.case_details.short.persist_tile_on_forms = True
+        module.case_details.short.persist_case_context = True
+        suite = factory.app.create_suite()
+
+        self.assertXmlDoesNotHaveXpath(suite, "detail[@id='m0_persistent_case_context']")
+        self.assertXmlPartialEqual(
+            """
+            <partial>
+                <datum
+                    detail-confirm="m0_case_long"
+                    detail-persistent="m0_case_short"
+                    detail-select="m0_case_short"
+                    id="case_id_load_person_0"
+                    nodeset="instance('casedb')/casedb/case[@case_type='person'][@status='open']"
+                    value="./@case_id"
+                />
+            </partial>
+            """,
+            suite,
+            "entry/session/datum"
+        )
+
+
     def test_subcase_repeat_mixed(self):
         app = Application.new_app(None, "Untitled Application", application_version=APP_V2)
         module_0 = app.add_module(Module.new_module('parent', None))

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -551,6 +551,7 @@ def edit_module_detail_screens(request, domain, app_id, module_id):
     parent_select = params.get('parent_select', None)
     fixture_select = params.get('fixture_select', None)
     sort_elements = params.get('sort_elements', None)
+    persist_case_context = params.get('persistCaseContext', None)
     use_case_tiles = params.get('useCaseTiles', None)
     persist_tile_on_forms = params.get("persistTileOnForms", None)
     pull_down_tile = params.get("enableTilePullDown", None)
@@ -573,6 +574,8 @@ def edit_module_detail_screens(request, domain, app_id, module_id):
 
     if short is not None:
         detail.short.columns = map(DetailColumn.wrap, short)
+        if persist_case_context is not None:
+            detail.short.persist_case_context = persist_case_context
         if use_case_tiles is not None:
             detail.short.use_case_tiles = use_case_tiles
         if persist_tile_on_forms is not None:

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -189,6 +189,13 @@ CASE_LIST_TILE = StaticToggle(
     [NAMESPACE_DOMAIN, NAMESPACE_USER]
 )
 
+SHOW_PERSIST_CASE_CONTEXT_SETTING = StaticToggle(
+    'show_persist_case_context_setting',
+    'Allow toggling the persistent case context tile',
+    TAG_PRODUCT_PATH,
+    [NAMESPACE_DOMAIN],
+)
+
 CASE_LIST_LOOKUP = StaticToggle(
     'case_list_lookup',
     'Allow external android callouts to search the caselist',


### PR DESCRIPTION
Adds the ability to toggle "persistent case context". If this setting is enabled, a small amount of case context (the case name), will be displayed at the top of the screen while filling out forms (like a mini case tile). At present, the case context always shows the case name, but in the future it could be configured to show a user specified case property. This feature is being implemented for ICDS. The setting is behind a feature flag called "Allow toggling the persistent case context tile".

This PR also includes a minor refactor or `app_manager/suite_xml/sections/details.py` and a fix for some faulty `suite.xml` building logic regarding case tiles on product lists.

FYI @ctsims @snopoke 
cc @orangejenny 
Best reviewed commit-by-commit

The persistent case context looks like this:
![screenshot_2015-10-21-14-50-17](https://cloud.githubusercontent.com/assets/2117127/10632693/a940f61c-7803-11e5-8e94-fbcc03778c1f.png)

Configuration looks like this:
<img width="1185" alt="screen shot 2015-10-21 at 4 55 08 pm" src="https://cloud.githubusercontent.com/assets/2117127/10635191/8f4da906-7814-11e5-9a82-0687f34ed239.png">
