### PR TITLE
Multimedia test cleanup

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/tests/test_indexes.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_indexes.py
@@ -11,6 +11,7 @@ from casexml.apps.case.xml import V2
 from casexml.apps.phone.models import User
 from django.test import TestCase, SimpleTestCase
 from corehq.form_processor.interfaces import FormProcessorInterface
+from corehq.form_processor.test_utils import FormProcessorTestUtils
 from couchforms.models import XFormError
 
 USER_ID = 'test-index-user'
@@ -63,7 +64,7 @@ class IndexTest(TestCase):
     FATHER_CASE_ID = 'text-index-father-case'
 
     def tearDown(self):
-        FormProcessorInterface.delete_all_cases()
+        FormProcessorTestUtils.delete_all_cases()
 
     def testIndexes(self):
         user = User(user_id=USER_ID, username="", password="", date_joined="")

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_multimedia.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_multimedia.py
@@ -56,6 +56,12 @@ class BaseCaseMultimediaTest(TestCase, TestFileMixin):
         return final_xml
 
     def _prepAttachments(self, new_attachments, removes=[]):
+        """
+        Returns:
+            attachment_block - An XML representation of the attachment
+            dict_attachments - A key-value dict where the key is the name and the value is a Stream of the
+            attachment
+        """
         attachment_block = ''.join([self._singleAttachBlock(x) for x in new_attachments] + [self._singleAttachRemoveBlock(x) for x in removes])
         dict_attachments = dict((MEDIA_FILES[attach_name], self._attachmentFileStream(attach_name)) for attach_name in new_attachments)
         return attachment_block, dict_attachments

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_multimedia.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_multimedia.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-import time
 import uuid
 import os
 import hashlib
@@ -98,7 +97,6 @@ class BaseCaseMultimediaTest(TestCase):
                            sync_token=None, date=None):
         self._do_submit(xml_data, dict_attachments, sync_token, date=date)
 
-        time.sleep(2)
         form = XFormInstance.get(doc_id)
 
         self.assertEqual(len(dict_attachments), len(form.attachments))

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_multimedia.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_multimedia.py
@@ -10,13 +10,15 @@ from django.core.files.uploadedfile import UploadedFile
 from mock import patch
 
 from casexml.apps.case.models import CommCareCase
-from casexml.apps.case.tests.util import delete_all_cases, delete_all_xforms, TEST_DOMAIN_NAME
+from casexml.apps.case.tests.util import TEST_DOMAIN_NAME
 from casexml.apps.case.xml import V2
 from casexml.apps.phone.models import SyncLog
-from corehq.apps.receiverwrapper.util import submit_form_locally
-import couchforms
 from couchforms.models import XFormInstance
 from dimagi.utils.parsing import json_format_datetime
+from corehq.form_processor.interfaces import FormProcessorInterface, FormProcessorSyncLogInterface
+from corehq.form_processor.test_utils import FormProcessorTestUtils
+from corehq.form_processor.generic import GenericSyncLog
+from corehq.util.test_utils import TestFileMixin
 
 
 TEST_CASE_ID = "EOL9FIAKIQWOFXFOH0QAMWU64"
@@ -32,17 +34,14 @@ MEDIA_FILES = {
 }
 
 
+class BaseCaseMultimediaTest(TestCase, TestFileMixin):
 
-class BaseCaseMultimediaTest(TestCase):
+    file_path = ('data', 'multimedia')
+    root = os.path.dirname(__file__)
+
     def setUp(self):
-        delete_all_cases()
-        delete_all_xforms()
-
-    def _getXFormString(self, filename):
-        file_path = os.path.join(os.path.dirname(__file__), "data", "multimedia", filename)
-        with open(file_path, "rb") as f:
-            xml_data = f.read()
-        return xml_data
+        FormProcessorTestUtils.delete_all_cases()
+        FormProcessorTestUtils.delete_all_xforms()
 
     def _formatXForm(self, doc_id, raw_xml, attachment_block, date=None):
         if date is None:
@@ -81,38 +80,40 @@ class BaseCaseMultimediaTest(TestCase):
         """
         RequestFactory submitter - simulates direct submission to server directly (no need to call process case after fact)
         """
-        response, xform, cases = submit_form_locally(
+        response, form, cases = FormProcessorInterface.submit_form_locally(
             xml_data,
             TEST_DOMAIN_NAME,
             attachments=dict_attachments,
             last_sync_token=sync_token,
             received_on=date
         )
+        attachments = FormProcessorInterface.get_attachments(form.id)
         self.assertEqual(set(dict_attachments.keys()),
-                         set(xform.attachments.keys()))
+                         set(attachments.keys()))
         [case] = cases
         self.assertEqual(case.case_id, TEST_CASE_ID)
 
+        return response, form, cases
+
     def _submit_and_verify(self, doc_id, xml_data, dict_attachments,
                            sync_token=None, date=None):
-        self._do_submit(xml_data, dict_attachments, sync_token, date=date)
+        response, form, cases = self._do_submit(xml_data, dict_attachments, sync_token, date=date)
 
-        form = XFormInstance.get(doc_id)
-
-        self.assertEqual(len(dict_attachments), len(form.attachments))
+        attachments = FormProcessorInterface.get_attachments(form.id)
+        self.assertEqual(len(dict_attachments), len(attachments))
         for k, vstream in dict_attachments.items():
-            fileback = form.fetch_attachment(k)
+            fileback = FormProcessorInterface.get_attachment(form.id, k)
             # rewind the pointer before comparing
             orig_attachment = vstream
             orig_attachment.seek(0)
             self.assertEqual(hashlib.md5(fileback).hexdigest(), hashlib.md5(orig_attachment.read()).hexdigest())
-        return form
+        return response, form, cases
 
     def _doCreateCaseWithMultimedia(self, attachments=['fruity_file']):
-        xml_data = self._getXFormString('multimedia_create.xml')
+        xml_data = self.get_xml('multimedia_create')
         attachment_block, dict_attachments = self._prepAttachments(attachments)
         final_xml = self._formatXForm(CREATE_XFORM_ID, xml_data, attachment_block)
-        self._submit_and_verify(CREATE_XFORM_ID, final_xml, dict_attachments)
+        return self._submit_and_verify(CREATE_XFORM_ID, final_xml, dict_attachments)
 
     def _doSubmitUpdateWithMultimedia(self, new_attachments=None, removes=None,
                                       sync_token=None, date=None):
@@ -120,10 +121,10 @@ class BaseCaseMultimediaTest(TestCase):
             else ['commcare_logo_file', 'dimagi_logo_file']
         removes = removes if removes is not None else ['fruity_file']
         attachment_block, dict_attachments = self._prepAttachments(new_attachments, removes=removes)
-        raw_xform = self._getXFormString('multimedia_update.xml')
+        raw_xform = self.get_xml('multimedia_update')
         doc_id = uuid.uuid4().hex
         final_xform = self._formatXForm(doc_id, raw_xform, attachment_block, date)
-        self._submit_and_verify(doc_id, final_xform, dict_attachments,
+        return self._submit_and_verify(doc_id, final_xform, dict_attachments,
                                 sync_token, date=date)
 
 
@@ -132,76 +133,71 @@ class CaseMultimediaTest(BaseCaseMultimediaTest):
     Tests new attachments for cases and case properties
     Spec: https://github.com/dimagi/commcare/wiki/CaseAttachmentAPI
     """
-    def tearDown(self):
-        delete_all_xforms()
-
     def testAttachInCreate(self):
         single_attach = 'fruity_file'
-        self._doCreateCaseWithMultimedia(attachments=[single_attach])
+        _, _, [case] = self._doCreateCaseWithMultimedia(attachments=[single_attach])
 
-        case = CommCareCase.get(TEST_CASE_ID)
         self.assertEqual(1, len(case.case_attachments))
         self.assertTrue(single_attach in case.case_attachments)
         self.assertEqual(1, len(filter(lambda x: x['action_type'] == 'attachment', case.actions)))
-        self.assertEqual(self._calc_file_hash(single_attach), hashlib.md5(case.get_attachment(single_attach)).hexdigest())
+        self.assertEqual(
+            self._calc_file_hash(single_attach),
+            hashlib.md5(FormProcessorInterface.get_attachment(case.id, single_attach)).hexdigest()
+        )
 
     def testArchiveAfterAttach(self):
         single_attach = 'fruity_file'
-        self._doCreateCaseWithMultimedia(attachments=[single_attach])
+        _, _, [case] = self._doCreateCaseWithMultimedia(attachments=[single_attach])
 
-        case = CommCareCase.get(TEST_CASE_ID)
+        for xform_id in case.xform_ids:
+            form = FormProcessorInterface.get_xform(xform_id)
 
-        for xform in case.xform_ids:
-            form = XFormInstance.get(xform)
-            form.archive()
-            self.assertEqual('XFormArchived', form.doc_type)
-            form.unarchive()
-            self.assertEqual('XFormInstance', form.doc_type)
+            FormProcessorInterface.archive_xform(form)
+            form = FormProcessorInterface.get_xform(xform_id)
+            self.assertTrue(form.is_archived)
+
+            FormProcessorInterface.unarchive_xform(form)
+            form = FormProcessorInterface.get_xform(xform_id)
+            self.assertFalse(form.is_archived)
 
     def testAttachRemoveSingle(self):
-        self.testAttachInCreate()
+        _, _, [case] = self._doCreateCaseWithMultimedia()
         new_attachments = []
         removes = ['fruity_file']
-        self._doSubmitUpdateWithMultimedia(new_attachments=new_attachments, removes=removes)
-        case = CommCareCase.get(TEST_CASE_ID)
+        _, _, [case] = self._doSubmitUpdateWithMultimedia(new_attachments=new_attachments, removes=removes)
 
-        #1 plus the 2 we had
         self.assertEqual(0, len(case.case_attachments))
-        self.assertIsNone(case._attachments)
         attach_actions = filter(lambda x: x['action_type'] == 'attachment', case.actions)
         self.assertEqual(2, len(attach_actions))
         last_action = attach_actions[-1]
         self.assertEqual(sorted(removes), sorted(last_action['attachments'].keys()))
 
     def testAttachRemoveMultiple(self):
-        self.testAttachInCreate()
+        _, _, [case] = self._doCreateCaseWithMultimedia()
 
         new_attachments = ['commcare_logo_file', 'dimagi_logo_file']
         removes = ['fruity_file']
-        self._doSubmitUpdateWithMultimedia(new_attachments=new_attachments, removes=removes)
+        _, _, [case] = self._doSubmitUpdateWithMultimedia(new_attachments=new_attachments, removes=removes)
 
-        case = CommCareCase.get(TEST_CASE_ID)
-        #1 plus the 2 we had
-        self.assertEqual(2, len(case.case_attachments))
-        self.assertEqual(2, len(case._attachments))
+        self.assertEqual(sorted(new_attachments), sorted(case.case_attachments.keys()))
         attach_actions = filter(lambda x: x['action_type'] == 'attachment', case.actions)
         self.assertEqual(2, len(attach_actions))
-        last_action = attach_actions[-1]
-        self.assertEqual(sorted(new_attachments), sorted(case._attachments.keys()))
 
     def testOTARestoreSingle(self):
-        self.testAttachInCreate()
+        _, _, [case] = self._doCreateCaseWithMultimedia()
         restore_attachments = ['fruity_file']
-        self._validateOTARestore(TEST_CASE_ID, restore_attachments)
+        self._validateOTARestore(case.id, restore_attachments)
 
     def testOTARestoreMultiple(self):
-        self.testAttachRemoveMultiple()
+        _, _, [case] = self._doCreateCaseWithMultimedia()
         restore_attachments = ['commcare_logo_file', 'dimagi_logo_file']
-        self._validateOTARestore(TEST_CASE_ID, restore_attachments)
+        removes = ['fruity_file']
+        _, _, [case] = self._doSubmitUpdateWithMultimedia(new_attachments=restore_attachments, removes=removes)
+
+        self._validateOTARestore(case.id, restore_attachments)
 
     def _validateOTARestore(self, case_id, restore_attachments):
-        case = CommCareCase.get(TEST_CASE_ID)
-        case_xml = case.to_xml(V2)
+        case_xml = FormProcessorInterface.case_to_xml(case_id, V2)
         root_node = lxml.etree.fromstring(case_xml)
         attaches = root_node.find('{http://commcarehq.org/case/transaction/v2}attachment')
         self.assertEqual(len(restore_attachments), len(attaches))
@@ -219,13 +215,14 @@ class CaseMultimediaTest(BaseCaseMultimediaTest):
 
         self.assertEqual(0, len(restore_attachments))
 
-    def testAttachInUpdate(self, new_attachments=['commcare_logo_file', 'dimagi_logo_file']):
-        self.testAttachInCreate()
-        self._doSubmitUpdateWithMultimedia(new_attachments=new_attachments, removes=[])
+    def testAttachInUpdate(self):
+        new_attachments = ['commcare_logo_file', 'dimagi_logo_file']
 
-        case = CommCareCase.get(TEST_CASE_ID)
-        #1 plus the 2 we had
-        self.assertEqual(len(new_attachments)+1, len(case.case_attachments))
+        _, _, _ = self._doCreateCaseWithMultimedia()
+        _, _, [case] = self._doSubmitUpdateWithMultimedia(new_attachments=new_attachments, removes=[])
+
+        # 1 plus the 2 we had
+        self.assertEqual(len(new_attachments) + 1, len(case.case_attachments))
         attach_actions = filter(lambda x: x['action_type'] == 'attachment', case.actions)
         self.assertEqual(2, len(attach_actions))
         last_action = attach_actions[-1]
@@ -233,10 +230,13 @@ class CaseMultimediaTest(BaseCaseMultimediaTest):
 
         for attach_name in new_attachments:
             self.assertTrue(attach_name in case.case_attachments)
-            self.assertEqual(self._calc_file_hash(attach_name), hashlib.md5(case.get_attachment(attach_name)).hexdigest())
+            self.assertEqual(
+                self._calc_file_hash(attach_name),
+                hashlib.md5(FormProcessorInterface.get_case_attachment(case.id, attach_name)).hexdigest()
+            )
 
     def testUpdateWithNoNewAttachment(self):
-        self.testAttachInCreate()
+        _, _, [case] = self._doCreateCaseWithMultimedia()
         bulk_save = XFormInstance.get_db().bulk_save
         bulk_save_attachments = []
 
@@ -264,10 +264,12 @@ class CaseMultimediaTest(BaseCaseMultimediaTest):
              if value.get('data')], [])
 
     def test_sync_log_invalidation_bug(self):
-        sync_log = SyncLog(user_id='6dac4940-913e-11e0-9d4b-005056aa7fb5')
-        sync_log.save()
-        self.testAttachInCreate()
+        sync_log = FormProcessorSyncLogInterface.create_from_generic(
+            GenericSyncLog(user_id='6dac4940-913e-11e0-9d4b-005056aa7fb5')
+        )
+        _, _, [case] = self._doCreateCaseWithMultimedia()
+
         # this used to fail before we fixed http://manage.dimagi.com/default.asp?158373
         self._doSubmitUpdateWithMultimedia(new_attachments=['commcare_logo_file'], removes=[],
-                                           sync_token=sync_log._id)
-        sync_log.delete()
+                                           sync_token=sync_log.id)
+        FormProcessorTestUtils.delete_all_sync_logs()

--- a/corehq/ex-submodules/casexml/apps/case/tests/util.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/util.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from xml.etree import ElementTree
 from corehq.apps.domain.models import Domain
 from corehq.form_processor.interfaces import FormProcessorInterface
+from corehq.form_processor.test_utils import FormProcessorTestUtils
 from corehq.util.test_utils import unit_testing_only
 
 from dimagi.utils.dates import utcnow_sans_milliseconds
@@ -194,14 +195,14 @@ def check_user_has_case(testcase, user, case_blocks, should_have=True,
 
 @unit_testing_only
 def delete_all_cases():
-    FormProcessorInterface.delete_all_cases()
+    FormProcessorTestUtils.delete_all_cases()
 
 
 @unit_testing_only
 def delete_all_xforms():
-    FormProcessorInterface.delete_all_xforms()
+    FormProcessorTestUtils.delete_all_xforms()
 
 
 @unit_testing_only
 def delete_all_sync_logs():
-    FormProcessorInterface.delete_all_sync_logs()
+    FormProcessorTestUtils.delete_all_sync_logs()

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -5,6 +5,7 @@ import json
 from couchdbkit.exceptions import ResourceConflict, ResourceNotFound
 from casexml.apps.phone.exceptions import IncompatibleSyncLogType
 from corehq.toggles import LEGACY_SYNC_SUPPORT
+from corehq.form_processor.utils import ToFromGeneric
 from corehq.util.global_request import get_request
 from corehq.util.soft_assert import soft_assert
 from dimagi.ext.couchdbkit import *
@@ -108,7 +109,7 @@ LOG_FORMAT_LEGACY = 'legacy'
 LOG_FORMAT_SIMPLIFIED = 'simplified'
 
 
-class AbstractSyncLog(SafeSaveDocument, UnicodeMixIn):
+class AbstractSyncLog(SafeSaveDocument, UnicodeMixIn, ToFromGeneric):
     date = DateTimeProperty()
     # domain = StringProperty()
     user_id = StringProperty()
@@ -149,6 +150,13 @@ class AbstractSyncLog(SafeSaveDocument, UnicodeMixIn):
         if hasattr(ret, 'has_assert_errors'):
             ret.strict = False
         return ret
+
+    @classmethod
+    def from_generic(cls, generic_sync_log):
+        sync_log = cls.wrap(generic_sync_log.to_json())
+        if generic_sync_log.id:
+            sync_log['_id'] = generic_sync_log.id
+        return sync_log
 
     def case_count(self):
         """
@@ -248,6 +256,13 @@ class SyncLog(AbstractSyncLog):
         from casexml.apps.phone.dbaccessors.sync_logs_by_user import get_last_synclog_for_user
 
         return get_last_synclog_for_user(user_id)
+
+    def to_generic(self):
+        from corehq.form_processor.generic import GenericSyncLog
+        generic = GenericSyncLog(self.to_json())
+        if '_id' in self:
+            generic.id = self['_id']
+        return generic
 
     def case_count(self):
         return len(self.cases_on_phone)

--- a/corehq/ex-submodules/couchforms/attachments.py
+++ b/corehq/ex-submodules/couchforms/attachments.py
@@ -1,0 +1,18 @@
+from corehq.util.couch_helpers import CouchAttachmentsBuilder
+
+
+class AttachmentsManager(object):
+
+    def __init__(self, xform):
+        self.xform = xform
+        self.builder = CouchAttachmentsBuilder()
+
+    def store_attachment(self, name, content, content_type=None):
+        self.builder.add(
+            content=content,
+            name=name,
+            content_type=content_type,
+        )
+
+    def commit(self):
+        self.xform._attachments = self.builder.to_json()

--- a/corehq/ex-submodules/couchforms/tests/test_duplicates.py
+++ b/corehq/ex-submodules/couchforms/tests/test_duplicates.py
@@ -2,6 +2,7 @@ import os
 from django.test import TestCase
 
 from corehq.form_processor.interfaces import FormProcessorInterface
+from corehq.form_processor.test_utils import FormProcessorTestUtils
 from corehq.form_processor.generic import GenericXFormInstance
 from couchforms.models import XFormInstance
 
@@ -10,7 +11,7 @@ class DuplicateFormTest(TestCase):
     ID = '7H46J37FGH3'
 
     def tearDown(self):
-        FormProcessorInterface.delete_all_xforms()
+        FormProcessorTestUtils.delete_all_xforms()
 
     def _get_file(self):
         file_path = os.path.join(os.path.dirname(__file__), "data", "duplicate.xml")

--- a/corehq/ex-submodules/couchforms/tests/test_edits.py
+++ b/corehq/ex-submodules/couchforms/tests/test_edits.py
@@ -12,6 +12,7 @@ from couchforms.models import XFormInstance, \
     UnfinishedSubmissionStub
 
 from corehq.form_processor.interfaces import FormProcessorInterface
+from corehq.form_processor.test_utils import FormProcessorTestUtils
 
 
 class EditFormTest(TestCase):
@@ -19,7 +20,7 @@ class EditFormTest(TestCase):
     domain = 'test-form-edits'
 
     def tearDown(self):
-        FormProcessorInterface.delete_all_xforms()
+        FormProcessorTestUtils.delete_all_xforms()
 
     def _get_files(self):
         first_file = os.path.join(os.path.dirname(__file__), "data", "deprecation", "original.xml")

--- a/corehq/ex-submodules/couchforms/tests/test_post.py
+++ b/corehq/ex-submodules/couchforms/tests/test_post.py
@@ -6,6 +6,7 @@ from corehq.apps.tzmigration.test_utils import \
     run_pre_and_post_timezone_migration
 
 from corehq.form_processor.interfaces import FormProcessorInterface
+from corehq.form_processor.test_utils import FormProcessorTestUtils
 
 
 class PostTest(TestCase):
@@ -13,7 +14,7 @@ class PostTest(TestCase):
     maxDiff = None
 
     def tearDown(self):
-        FormProcessorInterface.delete_all_xforms()
+        FormProcessorTestUtils.delete_all_xforms()
 
     def _test(self, name, any_id_ok=False, tz_differs=False):
         with open(os.path.join(os.path.dirname(__file__), 'data', '{name}.xml'.format(name=name))) as f:
@@ -46,7 +47,7 @@ class PostTest(TestCase):
     @run_pre_and_post_timezone_migration
     def test_cloudant_template(self):
         self._test('cloudant-template', tz_differs=True)
-        FormProcessorInterface.delete_all_xforms()
+        FormProcessorTestUtils.delete_all_xforms()
 
     def test_decimalmeta(self):
         self._test('decimalmeta', any_id_ok=True)

--- a/corehq/form_processor/generic.py
+++ b/corehq/form_processor/generic.py
@@ -12,6 +12,7 @@ from dimagi.ext.jsonobject import (
 from jsonobject.base import DefaultProperty
 
 from casexml.apps.case import const
+from casexml.apps.phone.models import LOG_FORMAT_LEGACY
 from couchforms.jsonobject_extensions import GeoPointProperty
 from dimagi.utils.decorators.memoized import memoized
 
@@ -224,3 +225,57 @@ class GenericCommCareCase(JsonObject):
             (key, json[key]) for key in get_dynamic_properties(wrapped_case)
             if re.search(r'^[a-zA-Z]', key) and key not in exclude
         ])
+
+
+class GenericCaseState(JsonObject):
+    """
+    Represents the state of a case on a phone.
+    """
+
+    case_id = StringProperty()
+    type = StringProperty()
+    indices = ListProperty(GenericCommCareCaseIndex)
+
+
+class GenericAbstractSyncLog(JsonObject):
+    id = StringProperty()
+    date = DateTimeProperty()
+    # domain = StringProperty()
+    user_id = StringProperty()
+    previous_log_id = StringProperty()  # previous sync log, forming a chain
+    duration = IntegerProperty()  # in seconds
+    log_format = StringProperty()
+
+    # owner_ids_on_phone stores the ids the phone thinks it's the owner of.
+    # This typically includes the user id,
+    # as well as all groups that that user is a member of.
+    owner_ids_on_phone = ListProperty()
+
+    # for debugging / logging
+    previous_log_rev = StringProperty()  # rev of the previous log at the time of creation
+    last_submitted = DateTimeProperty()  # last time a submission caused this to be modified
+    rev_before_last_submitted = StringProperty()  # rev when the last submission was saved
+    last_cached = DateTimeProperty()  # last time this generated a cached response
+    hash_at_last_cached = StringProperty()  # the state hash of this when it was last cached
+
+    # save state errors and hashes here
+    had_state_error = BooleanProperty(default=False)
+    error_date = DateTimeProperty()
+    error_hash = StringProperty()
+
+
+class GenericSyncLog(GenericAbstractSyncLog):
+    log_format = StringProperty(default=LOG_FORMAT_LEGACY)
+    last_seq = StringProperty()  # the last_seq of couch during this sync
+
+    # we need to store a mapping of cases to indices for generating the footprint
+    # cases_on_phone represents the state of all cases the server
+    # thinks the phone has on it and cares about.
+    cases_on_phone = ListProperty(GenericCaseState)
+
+    # dependant_cases_on_phone represents the possible list of cases
+    # also on the phone because they are referenced by a real case's index
+    # (or a dependent case's index).
+    # This list is not necessarily a perfect reflection
+    # of what's on the phone, but is guaranteed to be after pruning
+    dependent_cases_on_phone = ListProperty(GenericCaseState)

--- a/corehq/form_processor/interfaces.py
+++ b/corehq/form_processor/interfaces.py
@@ -1,12 +1,11 @@
 from couchdbkit import ResourceNotFound
 from casexml.apps.case.dbaccessors import get_reverse_indices_for_case_id
 from casexml.apps.case.util import get_case_xform_ids, post_case_blocks
-from casexml.apps.phone.models import SyncLog
 from corehq.apps.hqcase.dbaccessors import get_case_ids_in_domain
 from corehq.util.test_utils import unit_testing_only
 
 from dimagi.utils.couch.undo import DELETED_SUFFIX
-from dimagi.utils.couch.database import iter_docs, safe_delete
+from dimagi.utils.couch.database import iter_docs
 from casexml.apps.case.models import CommCareCase
 from couchforms.util import process_xform
 from couchforms.models import doc_types, XFormInstance, XFormError
@@ -185,30 +184,3 @@ class FormProcessorInterface(object):
         from casexml.apps.case.cleanup import safe_hard_delete
         case = cls._get_case(case_generic.id)
         safe_hard_delete(case)
-
-    @classmethod
-    @unit_testing_only
-    def delete_all_cases(cls):
-        cls._delete_all(CommCareCase.get_db(), 'case/get_lite')
-
-    @classmethod
-    @unit_testing_only
-    def delete_all_xforms(cls):
-        cls._delete_all(XFormInstance.get_db(), 'couchforms/all_submissions_by_domain')
-
-    @classmethod
-    @unit_testing_only
-    def delete_all_sync_logs(cls):
-        cls._delete_all(SyncLog.get_db(), 'phone/sync_logs_by_user')
-
-    @staticmethod
-    def _delete_all(db, viewname):
-        deleted = set()
-        for row in db.view(viewname, reduce=False):
-            doc_id = row['id']
-            if id not in deleted:
-                try:
-                    safe_delete(db, doc_id)
-                    deleted.add(doc_id)
-                except ResourceNotFound:
-                    pass

--- a/corehq/form_processor/interfaces.py
+++ b/corehq/form_processor/interfaces.py
@@ -7,6 +7,7 @@ from corehq.util.test_utils import unit_testing_only
 from dimagi.utils.couch.undo import DELETED_SUFFIX
 from dimagi.utils.couch.database import iter_docs
 from casexml.apps.case.models import CommCareCase
+from casexml.apps.phone.models import SyncLog
 from couchforms.util import process_xform
 from couchforms.models import doc_types, XFormInstance, XFormError
 from couchforms.exceptions import UnexpectedDeletedXForm
@@ -40,6 +41,16 @@ class FormProcessorInterface(object):
     @staticmethod
     def get_attachment(xform_id, attachment_name):
         return XFormInstance.get_db().fetch_attachment(xform_id, attachment_name)
+
+    @classmethod
+    def get_attachments(cls, xform_id):
+        xform = cls._get_xform(xform_id)
+        return xform.attachments
+
+    @classmethod
+    def get_case_attachment(cls, case_id, attachment_name):
+        case = cls._get_case(case_id)
+        return case.get_attachment(attachment_name)
 
     @classmethod
     def archive_xform(cls, xform_generic, user=None):
@@ -81,6 +92,11 @@ class FormProcessorInterface(object):
             return cls._get_case(case_id)
         except ResourceNotFound:
             raise CaseNotFound
+
+    @classmethod
+    def case_to_xml(cls, case_id, version):
+        case = cls._get_case(case_id)
+        return case.to_xml(version)
 
     @staticmethod
     def _get_case(case_id):
@@ -184,3 +200,13 @@ class FormProcessorInterface(object):
         from casexml.apps.case.cleanup import safe_hard_delete
         case = cls._get_case(case_generic.id)
         safe_hard_delete(case)
+
+
+class FormProcessorSyncLogInterface(object):
+
+    @staticmethod
+    @to_generic
+    def create_from_generic(generic_sync_log, generic_attachment=None):
+        sync_log = SyncLog.from_generic(generic_sync_log)
+        sync_log.save()
+        return sync_log

--- a/corehq/form_processor/test_utils.py
+++ b/corehq/form_processor/test_utils.py
@@ -1,0 +1,38 @@
+from couchdbkit import ResourceNotFound
+
+from casexml.apps.case.models import CommCareCase
+from casexml.apps.phone.models import SyncLog
+from couchforms.models import XFormInstance
+from dimagi.utils.couch.database import safe_delete
+from corehq.util.test_utils import unit_testing_only
+
+
+class FormProcessorTestUtils(object):
+
+    @classmethod
+    @unit_testing_only
+    def delete_all_cases(cls):
+        cls._delete_all(CommCareCase.get_db(), 'case/get_lite')
+
+    @classmethod
+    @unit_testing_only
+    def delete_all_xforms(cls):
+        cls._delete_all(XFormInstance.get_db(), 'couchforms/all_submissions_by_domain')
+
+    @classmethod
+    @unit_testing_only
+    def delete_all_sync_logs(cls):
+        cls._delete_all(SyncLog.get_db(), 'phone/sync_logs_by_user')
+
+    @staticmethod
+    @unit_testing_only
+    def _delete_all(db, viewname):
+        deleted = set()
+        for row in db.view(viewname, reduce=False):
+            doc_id = row['id']
+            if id not in deleted:
+                try:
+                    safe_delete(db, doc_id)
+                    deleted.add(doc_id)
+                except ResourceNotFound:
+                    pass


### PR DESCRIPTION
@snopoke reworking some of these tests to use the interface. also feel like the `interface.py` file is outliving its usefulness. also i realize this is just working on the tests in isolation, but i just need to read more of the code and understand it before i can feel comfortable correctly refactoring the data access points in the current form processing. will be trying to refactor soon. how do you feel about this sort of structure

```
form_processor/interfaces/xform.py
form_processor/interfaces/case.py
form_processor/interfaces/sync_log.py
form_processor/interfaces/__init__.py   # inherits the 3 different interfaces
```

only saying this cause i find myself writing `get_case_from_generic`, `get_form_from_generic`, and `get_sync_log_from_generic`, so it seems like they should be split out.

buddy: @esoergel 

probably best read commit-by-commit
