### PR TITLE
Multi test cleanup refactor

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/tests/test_multimedia.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_multimedia.py
@@ -56,6 +56,12 @@ class BaseCaseMultimediaTest(TestCase, TestFileMixin):
         return final_xml
 
     def _prepAttachments(self, new_attachments, removes=[]):
+        """
+        Returns:
+            attachment_block - An XML representation of the attachment
+            dict_attachments - A key-value dict where the key is the name and the value is a Stream of the
+            attachment
+        """
         attachment_block = ''.join([self._singleAttachBlock(x) for x in new_attachments] + [self._singleAttachRemoveBlock(x) for x in removes])
         dict_attachments = dict((MEDIA_FILES[attach_name], self._attachmentFileStream(attach_name)) for attach_name in new_attachments)
         return attachment_block, dict_attachments

--- a/corehq/ex-submodules/couchforms/attachments.py
+++ b/corehq/ex-submodules/couchforms/attachments.py
@@ -1,0 +1,18 @@
+from corehq.util.couch_helpers import CouchAttachmentsBuilder
+
+
+class AttachmentsManager(object):
+
+    def __init__(self, xform):
+        self.xform = xform
+        self.builder = CouchAttachmentsBuilder()
+
+    def store_attachment(self, name, content, content_type=None):
+        self.builder.add(
+            content=content,
+            name=name,
+            content_type=content_type,
+        )
+
+    def commit(self):
+        self.xform._attachments = self.builder.to_json()


### PR DESCRIPTION
@snopoke super wimpy refactor, but think we'll need to split out attachments since right now they're very coupled with the xform. obviously suggestions are welcome on how to better do this. note this is a PR into `multi-test-cleanup`. I'm not in love with the `commit` function, but thought it could be useful for how we're going to store attachments in the future

cc: @esoergel 
