### PR TITLE
If it doesn't parse as JSON, let me re-edit it

### DIFF
--- a/corehq/apps/userreports/ui/widgets.py
+++ b/corehq/apps/userreports/ui/widgets.py
@@ -5,4 +5,8 @@ from django import forms
 class JsonWidget(forms.Textarea):
 
     def render(self, name, value, attrs=None):
+        if isinstance(value, basestring):
+            # It's probably invalid JSON
+            return super(JsonWidget, self).render(name, value, attrs)
+
         return super(JsonWidget, self).render(name, json.dumps(value, indent=2), attrs)


### PR DESCRIPTION
Currently if you leave in a trailing comma or whatever, when the page reloads, it'll display your field with a string representation of your previous entry, rather than the previous entry itself.
Something like `'\n{\n  "foo": "bar",\n}\n'`
@czue @benrudolph
