### PR TITLE
fallback to column_id if no display name specified

### DIFF
--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -86,7 +86,7 @@ class ReportColumn(JsonObject):
         raise NotImplementedError(_("You can't group by columns of type {}".format(self.type)))
 
     def get_header(self, lang):
-        return localize(self.display, lang)
+        return localize(self.display, lang) if self.display else self.column_id
 
     def get_column_ids(self):
         """


### PR DESCRIPTION
Does this seem like an acceptable thing to fallback?  Right now if you don't specify `"display"`, the column header will be `"None"`.

Sorry about all these tiny PRs, I'm getting aqcuainted with UCR and fixing small stuff I notice as I go through.  I just `cherry-pick`ed these out to new branches 'cause I figured it'd be easier to review/merge as a series of discrete changes.

@czue @benrudolph
