### PR TITLE
Use container-fluid instead of container

### DIFF
--- a/corehq/apps/reports/templates/reports/form/partials/readable_form.html
+++ b/corehq/apps/reports/templates/reports/form/partials/readable_form.html
@@ -55,7 +55,7 @@ $(function () {
 });
 </script>
 
-<div class="container">
+<div class="container-fluid">
     {% if question_list_not_found %}
     <div class="row-fluid">
         <div class="alert alert-warning clear-fix span6">


### PR DESCRIPTION
Context: [FB 184707](http://manage.dimagi.com/default.asp?184707)

The "container-fluid" class uses full width, and avoids the stupid 1px border and centering on the Submit History page.

Submit History page now:
![submit_history](https://cloud.githubusercontent.com/assets/708421/10677722/bb3ec952-7916-11e5-8e9a-bed40842f54f.png)

And the Case History tab:
![case_history](https://cloud.githubusercontent.com/assets/708421/10677826/59066dfc-7917-11e5-9152-43d7aa431f94.png)

@biyeun, cc @millerdev 
