### PR TITLE
Subentity detail configuration

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1525,14 +1525,16 @@ class GraphConfiguration(DocumentSchema):
 
 class DetailTab(IndexedSchema):
     """
-    Represents a tab in the case detail screen on the phone. Ex:
-        {
-            'name': 'Medical',
-            'starting_index': 3
-        }
+    Represents a tab in the case detail screen on the phone.
+    Each tab is itself a detail, nested inside the app's "main" detail.
     """
     header = DictProperty()
+
+    # The first index, of all fields in the parent detail, that belongs to this tab
     starting_index = IntegerProperty()
+
+    # A tab may be associated with a nodeset, resulting in a detail that
+    # iterates through sub-nodes of an entity rather than a single entity
     has_nodeset = BooleanProperty(default=False)
     nodeset = StringProperty()
 

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1533,6 +1533,8 @@ class DetailTab(IndexedSchema):
     """
     header = DictProperty()
     starting_index = IntegerProperty()
+    has_nodeset = BooleanProperty(default=False)
+    nodeset = StringProperty()
 
 
 class DetailColumn(IndexedSchema):

--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -493,7 +493,7 @@ var DetailScreenConfig = (function () {
                 isTab: false,
                 hasNodeset: false,
                 nodeset: "",
-            }
+            };
             _.defaults(this.original, tabDefaults);
             _.extend(this, _.pick(this.original, _.keys(tabDefaults)));
 

--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -515,12 +515,6 @@ var DetailScreenConfig = (function () {
                 that.field.observableVal(that.field.val());
             });
 
-            this.saveAttempted = ko.observable(false);
-            this.showWarning = ko.computed(function() {
-                // True if an invalid property name warning should be displayed.
-                return (this.field.observableVal() || this.saveAttempted()) && !DetailScreenConfig.field_val_re.test(this.field.observableVal());
-            }, this);
-
             (function () {
                 var i, lang, visibleVal = "", invisibleVal = "", nodesetVal;
                 if (that.original.header && that.original.header[that.lang]) {
@@ -544,8 +538,26 @@ var DetailScreenConfig = (function () {
                         that.header.ui.addClass('input-prepend').prepend($('<span class="add-on">Tab</span>'));
                         that.nodeset.ui.addClass('input-prepend').prepend($('<span class="add-on">Nodeset</span>'));
                     }, 0);
+
+                    // Observe nodeset values for the sake of validation
+                    if (that.hasNodeset) {
+                        that.nodeset.observableVal = ko.observable(that.original.nodeset);
+                        that.nodeset.on("change", function(){
+                            that.nodeset.observableVal(that.nodeset.val());
+                        });
+                    }
                 }
             }());
+
+            this.saveAttempted = ko.observable(false);
+            this.showWarning = ko.computed(function() {
+                if (this.isTab) {
+                    // Data tab missing its nodeset
+                    return this.hasNodeset && !this.nodeset.observableVal();
+                }
+                // Invalid property name
+                return (this.field.observableVal() || this.saveAttempted()) && !DetailScreenConfig.field_val_re.test(this.field.observableVal());
+            }, this);
 
             // Add the graphing option if this is a graph so that we can set the value to graph
             var menuOptions = DetailScreenConfig.MENU_OPTIONS;
@@ -875,6 +887,10 @@ var DetailScreenConfig = (function () {
                             return;
                         }
                     } else {
+                        if (column.showWarning()){
+                            alert("There are errors in your tabs");
+                            return;
+                        }
                         containsTab = true;
                     }
                 }

--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -491,6 +491,10 @@ var DetailScreenConfig = (function () {
             // Tab attributes
             this.original.isTab = this.original.isTab !== undefined ? this.original.isTab : false;
             this.isTab = this.original.isTab;
+            this.original.hasNodeset = this.original.hasNodeset !== undefined ? this.original.hasNodeset : false;
+            this.hasNodeset = this.original.hasNodeset;
+            this.original.nodeset = this.original.nodeset || "";
+            this.nodeset = this.original.nodeset;
 
             this.case_tile_field = ko.observable(this.original.case_tile_field);
 
@@ -537,10 +541,15 @@ var DetailScreenConfig = (function () {
                 }
                 that.header = uiElement.input().val(invisibleVal);
                 that.header.setVisibleValue(visibleVal);
+
+                visibleVal = invisibleVal = that.original.nodeset || "";
+                that.nodeset = uiElement.input().val(invisibleVal);
+                that.nodeset.setVisibleValue(visibleVal);
                 if (that.isTab) {
                     // hack to wait until the input's there to prepend the Tab: label.
                     setTimeout(function () {
-                        that.header.ui.addClass('input-prepend').prepend($('<span class="add-on">Tab:</span>'));
+                        that.header.ui.addClass('input-prepend').prepend($('<span class="add-on">Tab</span>'));
+                        that.nodeset.ui.addClass('input-prepend').prepend($('<span class="add-on">Nodeset</span>'));
                     }, 0);
                 }
             }());
@@ -604,6 +613,7 @@ var DetailScreenConfig = (function () {
                 'model',
                 'field',
                 'header',
+                'nodeset',
                 'format',
                 'enum_extra',
                 'graph_extra',
@@ -688,6 +698,7 @@ var DetailScreenConfig = (function () {
                 var column = this.original;
                 column.field = this.field.val();
                 column.header[this.lang] = this.header.val();
+                column.nodeset = this.nodeset.val();
                 column.format = this.format.val();
                 column.enum = this.enum_extra.getItems();
                 column.graph_configuration =
@@ -702,7 +713,9 @@ var DetailScreenConfig = (function () {
                     return {
                         starting_index: this.starting_index,
                         header: column.header,
-                        isTab: true
+                        isTab: true,
+                        has_nodeset: column.hasNodeset,
+                        nodeset: column.nodeset,
                     };
                 }
                 return column;
@@ -803,13 +816,16 @@ var DetailScreenConfig = (function () {
                 columns.splice(
                     tabs[i].starting_index + i,
                     0,
-                    {isTab: true, header: tabs[i].header}
+                    _.extend({
+                        hasNodeset: tabs[i].has_nodeset,
+                    }, _.pick(tabs[i], ["header", "nodeset", "has_nodeset", "isTab"]))
                 );
             }
             if (this.columnKey === 'long') {
-                this.addTab = function() {
+                this.addTab = function(hasNodeset) {
                     var col = that.initColumnAsColumn(Column.init({
                         isTab: true,
+                        hasNodeset: hasNodeset,
                         model: 'tab'
                     }, that));
                     that.columns.splice(0, 0, col);

--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -465,7 +465,7 @@ var DetailScreenConfig = (function () {
                 column properites: model, field, header, format
                 column extras: enum, late_flag
             */
-            var that = this, elements, i;
+            var that = this;
             eventize(this);
             this.original = JSON.parse(JSON.stringify(col));
 
@@ -522,7 +522,7 @@ var DetailScreenConfig = (function () {
             }, this);
 
             (function () {
-                var i, lang, visibleVal = "", invisibleVal = "";
+                var i, lang, visibleVal = "", invisibleVal = "", nodesetVal;
                 if (that.original.header && that.original.header[that.lang]) {
                     visibleVal = invisibleVal = that.original.header[that.lang];
                 } else {
@@ -537,9 +537,7 @@ var DetailScreenConfig = (function () {
                 that.header = uiElement.input().val(invisibleVal);
                 that.header.setVisibleValue(visibleVal);
 
-                visibleVal = invisibleVal = that.original.nodeset || "";
-                that.nodeset = uiElement.input().val(invisibleVal);
-                that.nodeset.setVisibleValue(visibleVal);
+                that.nodeset = uiElement.input().val(that.original.nodeset);
                 if (that.isTab) {
                     // hack to wait until the input's there to prepend the Tab: label.
                     setTimeout(function () {
@@ -603,7 +601,10 @@ var DetailScreenConfig = (function () {
             ]).val(this.original.time_ago_interval.toString());
             this.time_ago_extra.ui.prepend($('<div/>').text(DetailScreenConfig.message.TIME_AGO_EXTRA_LABEL));
 
-            elements = [
+            function fireChange() {
+                that.fire('change');
+            }
+            _.each([
                 'model',
                 'field',
                 'header',
@@ -615,15 +616,9 @@ var DetailScreenConfig = (function () {
                 'filter_xpath_extra',
                 'calc_xpath_extra',
                 'time_ago_extra'
-            ];
-
-            function fireChange() {
-                that.fire('change');
-            }
-
-            for (i = 0; i < elements.length; i += 1) {
-                this[elements[i]].on('change', fireChange);
-            }
+            ], function(element) {
+                that[element].on('change', fireChange);
+            });
             this.case_tile_field.subscribe(fireChange);
 
             this.$format = $('<div/>').append(this.format.ui);
@@ -704,13 +699,10 @@ var DetailScreenConfig = (function () {
                 column.case_tile_field = this.case_tile_field();
                 if (this.isTab) {
                     // Note: starting_index is added by Screen.serialize
-                    return {
+                    return _.extend({
                         starting_index: this.starting_index,
-                        header: column.header,
-                        isTab: true,
                         has_nodeset: column.hasNodeset,
-                        nodeset: column.nodeset,
-                    };
+                    }, _.pick(column, ['header', 'isTab', 'nodeset']));
                 }
                 return column;
             },
@@ -812,7 +804,7 @@ var DetailScreenConfig = (function () {
                     0,
                     _.extend({
                         hasNodeset: tabs[i].has_nodeset,
-                    }, _.pick(tabs[i], ["header", "nodeset", "has_nodeset", "isTab"]))
+                    }, _.pick(tabs[i], ["header", "nodeset", "isTab"]))
                 );
             }
             if (this.columnKey === 'long') {

--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -469,41 +469,36 @@ var DetailScreenConfig = (function () {
             eventize(this);
             this.original = JSON.parse(JSON.stringify(col));
 
-            function orDefault(value, d) {
-                if (value === undefined) {
-                    return d;
-                } else {
-                    return value;
-                }
-            }
-            this.original.model = this.original.model || screen.model;
-            this.original.field = this.original.field || "";
-            this.original.hasAutocomplete = orDefault(this.original.hasAutocomplete, true);
-            this.original.header = this.original.header || {};
-            this.original.format = this.original.format || "plain";
-            this.original['enum'] = this.original['enum'] || [];
+            // Set defaults for normal (non-tab) column attributes
+            var defaults = {
+                calc_xpath: ".",
+                enum: [],
+                field: "",
+                filter_xpath: "",
+                format: "plain",
+                graph_configuration: {},
+                hasAutocomplete: false,
+                header: {},
+                model: screen.model,
+                time_ago_interval: DetailScreenConfig.TIME_AGO.year,
+            };
+            _.defaults(this.original, defaults);
             this.original.late_flag = _.isNumber(this.original.late_flag) ? this.original.late_flag : 30;
-            this.original.filter_xpath = this.original.filter_xpath || "";
-            this.original.calc_xpath = this.original.calc_xpath || ".";
-            this.original.graph_configuration = this.original.graph_configuration || {};
+
             this.original.case_tile_field = ko.utils.unwrapObservable(this.original.case_tile_field) || "";
-
-            // Tab attributes
-            this.original.isTab = this.original.isTab !== undefined ? this.original.isTab : false;
-            this.isTab = this.original.isTab;
-            this.original.hasNodeset = this.original.hasNodeset !== undefined ? this.original.hasNodeset : false;
-            this.hasNodeset = this.original.hasNodeset;
-            this.original.nodeset = this.original.nodeset || "";
-            this.nodeset = this.original.nodeset;
-
             this.case_tile_field = ko.observable(this.original.case_tile_field);
 
-
-            this.original.time_ago_interval = this.original.time_ago_interval || DetailScreenConfig.TIME_AGO.year;
+            // Set up tab attributes
+            var tabDefaults = {
+                isTab: false,
+                hasNodeset: false,
+                nodeset: "",
+            }
+            _.defaults(this.original, tabDefaults);
+            _.extend(this, _.pick(this.original, _.keys(tabDefaults)));
 
             this.screen = screen;
             this.lang = screen.lang;
-
             this.model = uiElement.select([
                 {label: "Case", value: "case"}
             ]).val(this.original.model);
@@ -596,7 +591,6 @@ var DetailScreenConfig = (function () {
 
             this.calc_xpath_extra = uiElement.input().val(this.original.calc_xpath.toString());
             this.calc_xpath_extra.ui.prepend($('<div/>').text(DetailScreenConfig.message.CALC_XPATH_EXTRA_LABEL));
-
 
             this.time_ago_extra = uiElement.select([
                 {label: DetailScreenConfig.message.TIME_AGO_INTERVAL.YEARS, value: DetailScreenConfig.TIME_AGO.year},

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -67,7 +67,7 @@ class DetailContributor(SectionContributor):
         return r
 
     def build_detail(self, module, detail_type, detail, detail_column_infos,
-                     tabs=[], id=None, title=None, nodeset=None, start=0, end=None):
+                     tabs=None, id=None, title=None, nodeset=None, start=0, end=None):
         """
         Recursively builds the Detail object.
         (Details can contain other details for each of their tabs)

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -55,6 +55,7 @@ class DetailContributor(SectionContributor):
                                         Text(locale_id=id_strings.detail_title_locale(
                                             module, detail_type
                                         )),
+                                        None,   # HQ only supports nodesets on child details (tabs)
                                         0,
                                         len(detail_column_infos)
                                     )
@@ -69,13 +70,13 @@ class DetailContributor(SectionContributor):
         return r
 
     def build_detail(self, module, detail_type, detail, detail_column_infos,
-                     tabs, id, title, start, end):
+                     tabs, id, title, nodeset, start, end):
         """
         Recursively builds the Detail object.
         (Details can contain other details for each of their tabs)
         """
         from corehq.apps.app_manager.detail_screen import get_column_generator
-        d = Detail(id=id, title=title)
+        d = Detail(id=id, title=title, nodeset=nodeset)
         if tabs:
             tab_spans = detail.get_tab_spans()
             for tab in tabs:
@@ -89,6 +90,7 @@ class DetailContributor(SectionContributor):
                     Text(locale_id=id_strings.detail_tab_title_locale(
                         module, detail_type, tab
                     )),
+                    tab.nodeset if tab.has_nodeset else None,
                     tab_spans[tab.id][0],
                     tab_spans[tab.id][1]
                 )

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -50,14 +50,11 @@ class DetailContributor(SectionContributor):
                                         detail_type,
                                         detail,
                                         detail_column_infos,
-                                        list(detail.get_tabs()),
-                                        id_strings.detail(module, detail_type),
-                                        Text(locale_id=id_strings.detail_title_locale(
+                                        tabs=list(detail.get_tabs()),
+                                        id=id_strings.detail(module, detail_type),
+                                        title=Text(locale_id=id_strings.detail_title_locale(
                                             module, detail_type
                                         )),
-                                        None,   # HQ only supports nodesets on child details (tabs)
-                                        0,
-                                        len(detail_column_infos)
                                     )
                                     if d:
                                         r.append(d)
@@ -70,7 +67,7 @@ class DetailContributor(SectionContributor):
         return r
 
     def build_detail(self, module, detail_type, detail, detail_column_infos,
-                     tabs, id, title, nodeset, start, end):
+                     tabs=[], id=None, title=None, nodeset=None, start=0, end=None):
         """
         Recursively builds the Detail object.
         (Details can contain other details for each of their tabs)
@@ -85,14 +82,12 @@ class DetailContributor(SectionContributor):
                     detail_type,
                     detail,
                     detail_column_infos,
-                    [],
-                    None,
-                    Text(locale_id=id_strings.detail_tab_title_locale(
+                    title=Text(locale_id=id_strings.detail_tab_title_locale(
                         module, detail_type, tab
                     )),
-                    tab.nodeset if tab.has_nodeset else None,
-                    tab_spans[tab.id][0],
-                    tab_spans[tab.id][1]
+                    nodeset=tab.nodeset if tab.has_nodeset else None,
+                    start=tab_spans[tab.id][0],
+                    end=tab_spans[tab.id][1]
                 )
                 if sub_detail:
                     d.details.append(sub_detail)
@@ -115,6 +110,8 @@ class DetailContributor(SectionContributor):
                 d.variables.extend(variables)
 
             # Add fields
+            if end is None:
+                end = len(detail_column_infos)
             for column_info in detail_column_infos[start:end]:
                 fields = get_column_generator(
                     self.app, module, detail,

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_detail.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_detail.html
@@ -7,13 +7,17 @@
 <div data-bind="with: longScreen">
     {% include 'app_manager/partials/case_list_properties.html' %}
 </div>
+
 {% if request|toggle_enabled:"DETAIL_LIST_TABS" %}
     <button class="btn btn-default" data-bind="click: function() { longScreen.addTab(); }">
         <i class="icon-plus"></i>
         Add tab
     </button>
 {% endif %}
+
+{% if request|toggle_enabled:"DETAIL_LIST_TAB_NODESETS" %}
     <button class="btn btn-default" data-bind="click: function() { longScreen.addTab(true); }">
         <i class="icon-plus"></i>
         Add data tab
     </button>
+{% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_detail.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_detail.html
@@ -9,15 +9,15 @@
 </div>
 
 {% if request|toggle_enabled:"DETAIL_LIST_TABS" %}
-    <button class="btn btn-default" data-bind="click: function() { longScreen.addTab(); }">
+    <button class="btn btn-default" data-bind="click: function() { longScreen.addTab(false); }">
         <i class="icon-plus"></i>
-        Add tab
+        {% trans "Add tab" %}
     </button>
 {% endif %}
 
 {% if request|toggle_enabled:"DETAIL_LIST_TAB_NODESETS" %}
     <button class="btn btn-default" data-bind="click: function() { longScreen.addTab(true); }">
         <i class="icon-plus"></i>
-        Add data tab
+        {% trans "Add data tab" %}
     </button>
 {% endif %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_detail.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_detail.html
@@ -8,8 +8,12 @@
     {% include 'app_manager/partials/case_list_properties.html' %}
 </div>
 {% if request|toggle_enabled:"DETAIL_LIST_TABS" %}
-    <a href="#" data-bind="click: longScreen.addTab">
+    <button class="btn btn-default" data-bind="click: function() { longScreen.addTab(); }">
         <i class="icon-plus"></i>
-        Add a tab
-    </a>
+        Add tab
+    </button>
 {% endif %}
+    <button class="btn btn-default" data-bind="click: function() { longScreen.addTab(true); }">
+        <i class="icon-plus"></i>
+        Add data tab
+    </button>

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list_properties.html
@@ -53,15 +53,15 @@
                     <td data-bind="jqueryElement: $format"></td>
                 <!--/ko-->
                 <!--ko if: isTab -->
-                    <!--ko if: !$data.hasNodeset -->
-                        <td colspan="3" data-bind="jqueryElement: header.ui"></td>
-                    <!--/ko-->
                     <!--ko if: $data.hasNodeset -->
                         <td data-bind="jqueryElement: header.ui"></td>
                         <td class="control-group" colspan="2" data-bind="css: {error: showWarning}">
                             <div data-bind="jqueryElement: nodeset.ui"></div>
                             <span class="help-inline" data-bind="text: 'A nodeset must be specified.', visible: showWarning"></span>
                         </td>
+                    <!--/ko-->
+                    <!--ko ifnot: $data.hasNodeset -->
+                        <td colspan="3" data-bind="jqueryElement: header.ui"></td>
                     <!--/ko-->
                 <!--/ko-->
                 <!-- ko if: $parent.useCaseTiles() == "yes" && {{request|toggle_enabled:'CASE_LIST_TILE'|BOOL }}-->

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list_properties.html
@@ -53,7 +53,13 @@
                     <td data-bind="jqueryElement: $format"></td>
                 <!--/ko-->
                 <!--ko if: isTab -->
-                    <td colspan="3" data-bind="jqueryElement: header.ui"></td>
+                    <!--ko if: !$data.hasNodeset -->
+                        <td colspan="3" data-bind="jqueryElement: header.ui"></td>
+                    <!--/ko-->
+                    <!--ko if: $data.hasNodeset -->
+                        <td data-bind="jqueryElement: header.ui"></td>
+                        <td colspan="2" data-bind="jqueryElement: nodeset.ui"></td>
+                    <!--/ko-->
                 <!--/ko-->
                 <!-- ko if: $parent.useCaseTiles() == "yes" && {{request|toggle_enabled:'CASE_LIST_TILE'|BOOL }}-->
                 <td>

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list_properties.html
@@ -58,7 +58,13 @@
                     <!--/ko-->
                     <!--ko if: $data.hasNodeset -->
                         <td data-bind="jqueryElement: header.ui"></td>
-                        <td colspan="2" data-bind="jqueryElement: nodeset.ui"></td>
+                        <td class="control-group" colspan="2" data-bind="css: {error: showWarning}">
+                            <div data-bind="jqueryElement: nodeset.ui"></div>
+                            <div data-bind="visible: showWarning">
+                                <span class="help-inline" data-bind="text: 'A nodeset must be specified.'">
+                                </span>
+                            </div>
+                        </td>
                     <!--/ko-->
                 <!--/ko-->
                 <!-- ko if: $parent.useCaseTiles() == "yes" && {{request|toggle_enabled:'CASE_LIST_TILE'|BOOL }}-->

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list_properties.html
@@ -60,10 +60,7 @@
                         <td data-bind="jqueryElement: header.ui"></td>
                         <td class="control-group" colspan="2" data-bind="css: {error: showWarning}">
                             <div data-bind="jqueryElement: nodeset.ui"></div>
-                            <div data-bind="visible: showWarning">
-                                <span class="help-inline" data-bind="text: 'A nodeset must be specified.'">
-                                </span>
-                            </div>
+                            <span class="help-inline" data-bind="text: 'A nodeset must be specified.', visible: showWarning"></span>
                         </td>
                     <!--/ko-->
                 <!--/ko-->

--- a/corehq/apps/app_manager/tests/data/suite/app_case_detail_tabs.json
+++ b/corehq/apps/app_manager/tests/data/suite/app_case_detail_tabs.json
@@ -334,7 +334,9 @@
                         "en":""
                      },
                      "starting_index":1,
-                     "doc_type":"DetailTab"
+                     "doc_type":"DetailTab",
+                     "has_nodeset":true,
+                     "nodeset":"some/expression"
                   }
                ],
                "filter":null,

--- a/corehq/apps/app_manager/tests/data/suite/suite-case-detail-tabs.xml
+++ b/corehq/apps/app_manager/tests/data/suite/suite-case-detail-tabs.xml
@@ -67,7 +67,7 @@
         </template>
       </field>
     </detail>
-    <detail>
+    <detail nodeset="some/expression">
       <title>
         <text>
           <locale id="m0.case_long.tab.2.title"/>

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -236,6 +236,7 @@ DETAIL_LIST_TAB_NODESETS = StaticToggle(
     'Associate a nodeset with a case detail tab',
     TAG_PRODUCT_PATH,
     [NAMESPACE_DOMAIN],
+    help_link='https://confluence.dimagi.com/display/ccinternal/Case+Detail+Nodesets',
 )
 
 GRAPH_CREATION = StaticToggle(

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -231,6 +231,13 @@ DETAIL_LIST_TABS = StaticToggle(
     [NAMESPACE_DOMAIN, NAMESPACE_USER]
 )
 
+DETAIL_LIST_TAB_NODESETS = StaticToggle(
+    'detail-list-tab-nodesets',
+    'Associate a nodeset with a case detail tab',
+    TAG_PRODUCT_PATH,
+    [NAMESPACE_DOMAIN],
+)
+
 GRAPH_CREATION = StaticToggle(
     'graph-creation',
     'Case list/detail graph creation',


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?184689

HQ support for https://github.com/dimagi/commcare-odk/pull/554, which lets you specify an additional nodeset for any detail. That nodeset is applied to the current entity before applying the various field expressions.

Limited this to specifying a nodeset for details that are used as tabs because
a) that's the use case for ICDS and
b) this UI is awful enough, without adding even more inputs to support nodesets for non-tab details

![screen shot 2015-10-22 at 12 54 13 pm](https://cloud.githubusercontent.com/assets/1486591/10679137/882b7c36-78e4-11e5-9354-3b00220c3bc3.png)

@NoahCarnahan and fyi @ctsims 
