### PR TITLE
Allow user location parents to be used as call center case owners

### DIFF
--- a/corehq/apps/callcenter/tests/test_location_owners.py
+++ b/corehq/apps/callcenter/tests/test_location_owners.py
@@ -74,6 +74,25 @@ class CallCenterLocationOwnerTest(TestCase):
         self.user.save()
         self.assertCallCenterCaseOwner(self.child_location._id)
 
+    def test_ancestor_location_sync(self):
+        # Alter config
+        original_setting = self.domain.call_center_config.user_location_ancestor_level
+        self.domain.call_center_config.user_location_ancestor_level = 2
+        self.domain.save()
+
+        self.user.set_location(self.grandchild_location)
+        self.user.save()
+        self.assertCallCenterCaseOwner(self.root_location._id)
+
+        self.user.set_location(self.child_location)
+        self.user.save()
+        # owner should be the highest ancestor if there aren't any further ancestors
+        self.assertCallCenterCaseOwner(self.root_location._id)
+
+        # Reset config
+        self.domain.call_center_config.user_location_ancestor_level = original_setting
+        self.domain.save()
+
     def assertCallCenterCaseOwner(self, owner_id):
         case = get_case_by_domain_hq_user_id(TEST_DOMAIN, self.user._id, CASE_TYPE)
         self.assertEqual(case.owner_id, owner_id)

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -549,23 +549,23 @@ class DomainGlobalSettingsForm(forms.Form):
                 domain.delete_attachment(LOGO_ATTACHMENT)
 
     def _save_call_center_configuration(self, domain):
-        domain.call_center_config.enabled = self.cleaned_data.get('call_center_enabled', False)
-        if domain.call_center_config.enabled:
+        cc_config = domain.call_center_config
+        cc_config.enabled = self.cleaned_data.get('call_center_enabled', False)
+        if cc_config.enabled:
 
             domain.internal.using_call_center = True
-            domain.call_center_config.use_fixtures = \
-                self.cleaned_data['call_center_type'] == self.CASES_AND_FIXTURES_CHOICE
+            cc_config.use_fixtures = self.cleaned_data['call_center_type'] == self.CASES_AND_FIXTURES_CHOICE
 
             owner = self.cleaned_data.get('call_center_case_owner', None)
             if owner in self.LOCATION_CHOICES:
-                domain.call_center_config.call_center_case_owner = None
-                domain.call_center_config.use_user_location_as_owner = True
-                domain.call_center_config.user_location_ancestor_level = 1 if owner == self.USE_PARENT_LOCATION_CHOICE else 0
+                cc_config.call_center_case_owner = None
+                cc_config.use_user_location_as_owner = True
+                cc_config.user_location_ancestor_level = 1 if owner == self.USE_PARENT_LOCATION_CHOICE else 0
             else:
-                domain.call_center_config.case_owner_id = owner
-                domain.call_center_config.use_user_location_as_owner = False
+                cc_config.case_owner_id = owner
+                cc_config.use_user_location_as_owner = False
 
-            domain.call_center_config.case_type = self.cleaned_data.get('call_center_case_type', None)
+            cc_config.case_type = self.cleaned_data.get('call_center_case_type', None)
 
     def _save_timezone_configuration(self, domain):
         global_tz = self.cleaned_data['default_timezone']

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -412,7 +412,9 @@ class SubAreaMixin():
 
 
 class DomainGlobalSettingsForm(forms.Form):
-    USE_LOCATIONS_CHOICE = "user_location"
+    USE_LOCATION_CHOICE = "user_location"
+    USE_PARENT_LOCATION_CHOICE = 'user_parent_location'
+    LOCATION_CHOICES = [USE_LOCATION_CHOICE, USE_PARENT_LOCATION_CHOICE]
     CASES_AND_FIXTURES_CHOICE = "cases_and_fixtures"
     CASES_ONLY_CHOICE = "cases_only"
 
@@ -500,7 +502,8 @@ class DomainGlobalSettingsForm(forms.Form):
                 call_center_location_choices = []
                 if CALL_CENTER_LOCATION_OWNERS.enabled(domain):
                     call_center_location_choices = [
-                        (self.USE_LOCATIONS_CHOICE, ugettext_lazy("user's location [location]"))
+                        (self.USE_LOCATION_CHOICE, ugettext_lazy("user's location [location]")),
+                        (self.USE_PARENT_LOCATION_CHOICE, ugettext_lazy("user's location's parent [location]")),
                     ]
 
                 self.fields["call_center_case_owner"].choices = \
@@ -554,9 +557,10 @@ class DomainGlobalSettingsForm(forms.Form):
                 self.cleaned_data['call_center_type'] == self.CASES_AND_FIXTURES_CHOICE
 
             owner = self.cleaned_data.get('call_center_case_owner', None)
-            if owner == self.USE_LOCATIONS_CHOICE:
+            if owner in self.LOCATION_CHOICES:
                 domain.call_center_config.call_center_case_owner = None
                 domain.call_center_config.use_user_location_as_owner = True
+                domain.call_center_config.user_location_ancestor_level = 1 if owner == self.USE_PARENT_LOCATION_CHOICE else 0
             else:
                 domain.call_center_config.case_owner_id = owner
                 domain.call_center_config.use_user_location_as_owner = False

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -110,8 +110,11 @@ class Deployment(DocumentSchema, UpdatableSchema):
 class CallCenterProperties(DocumentSchema):
     enabled = BooleanProperty(default=False)
     use_fixtures = BooleanProperty(default=True)
-    use_user_location_as_owner = BooleanProperty(default=False)
+
     case_owner_id = StringProperty()
+    use_user_location_as_owner = BooleanProperty(default=False)
+    user_location_ancestor_level = IntegerProperty(default=0)
+
     case_type = StringProperty()
 
     def fixtures_are_active(self):

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -405,7 +405,9 @@ class EditBasicProjectInfoView(BaseEditProjectInfoView):
     def initial_call_center_case_owner(self):
         config = self.domain_object.call_center_config
         if config.use_user_location_as_owner:
-            return DomainGlobalSettingsForm.USE_LOCATIONS_CHOICE
+            if config.user_location_ancestor_level == 1:
+                return DomainGlobalSettingsForm.USE_PARENT_LOCATION_CHOICE
+            return DomainGlobalSettingsForm.USE_LOCATION_CHOICE
         return self.domain_object.call_center_config.case_owner_id
 
     @property


### PR DESCRIPTION
Extension of this PR: https://github.com/dimagi/commcare-hq/pull/8635/
Adds a "user's location's parent" option to the "Call Center Case Owner" select on the project settings page.

fyi @czue cc @orangejenny 
(best reviewed commit-by-commit)
