### PR TITLE
Rename enabled_domains -> all_domains and add docstrings to tests

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/cleanliness.py
+++ b/corehq/ex-submodules/casexml/apps/phone/cleanliness.py
@@ -44,9 +44,9 @@ def should_create_flags_on_submission(domain):
     return False
 
 
-def set_cleanliness_flags_for_enabled_domains(force_full=False):
+def set_cleanliness_flags_for_all_domains(force_full=False):
     """
-    Updates cleanliness for all domains that have the toggle enabled
+    Updates cleanliness for all domains
     """
     for domain in Domain.get_all_names():
         try:

--- a/corehq/ex-submodules/casexml/apps/phone/management/commands/set_cleanliness_flags.py
+++ b/corehq/ex-submodules/casexml/apps/phone/management/commands/set_cleanliness_flags.py
@@ -16,11 +16,11 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         from casexml.apps.phone.cleanliness import (
-            set_cleanliness_flags_for_domain, set_cleanliness_flags_for_enabled_domains)
+            set_cleanliness_flags_for_domain, set_cleanliness_flags_for_all_domains)
         force_full = options['force']
         if len(args) == 1:
             domain = args[0]
             set_cleanliness_flags_for_domain(domain, force_full=force_full)
         else:
             assert len(args) == 0
-            set_cleanliness_flags_for_enabled_domains(force_full=force_full)
+            set_cleanliness_flags_for_all_domains(force_full=force_full)

--- a/corehq/ex-submodules/casexml/apps/phone/tasks.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tasks.py
@@ -1,6 +1,6 @@
 from celery.schedules import crontab
 from celery.task import periodic_task
-from casexml.apps.phone.cleanliness import set_cleanliness_flags_for_enabled_domains
+from casexml.apps.phone.cleanliness import set_cleanliness_flags_for_all_domains
 
 
 @periodic_task(run_every=crontab(hour="2", minute="0", day_of_week="1"),
@@ -9,7 +9,7 @@ def update_cleanliness_flags():
     """
     Once a week go through all cleanliness flags and see if any dirty ones have become clean
     """
-    set_cleanliness_flags_for_enabled_domains(force_full=False)
+    set_cleanliness_flags_for_all_domains(force_full=False)
 
 
 @periodic_task(run_every=crontab(hour="4", minute="0", day_of_month="5"),
@@ -21,4 +21,4 @@ def force_update_cleanliness_flags():
     # the only reason this task is run is to use the soft_assert to validate
     # that there are no bugs in the weekly task.
     # If we haven't seen any issues by the end of 2015 (so 6 runs) we should remove this.
-    set_cleanliness_flags_for_enabled_domains(force_full=True)
+    set_cleanliness_flags_for_all_domains(force_full=True)

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_cleanliness.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_cleanliness.py
@@ -77,34 +77,35 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self.assertEqual(owner_id, case.owner_id)
 
     def test_add_normal_case_stays_clean(self):
-        # change the owner ID of a normal case, should remain clean
+        """Owned case with no indices remains clean"""
         self.factory.create_case()
         self.assert_owner_clean()
         self._verify_set_cleanliness_flags()
 
     def test_change_owner_stays_clean(self):
-        # change the owner ID of a normal case, should remain clean
+        """change the owner ID of a normal case, should remain clean"""
         new_owner = uuid.uuid4().hex
         self._set_owner(self.sample_case.case_id, new_owner)
         self.assert_owner_clean()
         self._verify_set_cleanliness_flags()
 
     def test_change_owner_child_case_stays_clean(self):
-        # change the owner ID of a child case, should remain clean
+        """change the owner ID of a child case, should remain clean"""
         new_owner = uuid.uuid4().hex
         self._set_owner(self.child.case_id, new_owner)
         self.assert_owner_clean()
         self._verify_set_cleanliness_flags()
 
     def test_add_clean_parent_stays_clean(self):
-        # add a parent with the same owner, should remain clean
+        """add a parent with the same owner, should remain clean"""
         self.factory.create_or_update_case(CaseStructure(indices=[CaseIndex()]))
         self.assert_owner_clean()
         self._verify_set_cleanliness_flags()
 
     def test_create_dirty_makes_dirty(self):
-        # create a case and a parent case with a different owner at the same time
-        # make sure the owner becomes dirty.
+        """create a case and a parent case with a different owner at the same time
+        make sure the owner becomes dirty.
+        """
         new_owner = uuid.uuid4().hex
         [child, parent] = self.factory.create_or_update_case(
             CaseStructure(
@@ -118,7 +119,7 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self._verify_set_cleanliness_flags()
 
     def test_add_dirty_parent_makes_dirty(self):
-        # add parent with a different owner and make sure the owner becomes dirty
+        """add parent with a different owner and make sure the owner becomes dirty"""
         new_owner = uuid.uuid4().hex
         [child, parent] = self.factory.create_or_update_case(
             CaseStructure(
@@ -133,7 +134,7 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self._verify_set_cleanliness_flags()
 
     def test_change_parent_owner_makes_dirty(self):
-        # change the owner id of a parent case and make sure the owner becomes dirty
+        """change the owner id of a parent case and make sure the owner becomes dirty"""
         new_owner = uuid.uuid4().hex
         self._set_owner(self.parent.case_id, new_owner)
         self.assert_owner_dirty()
@@ -159,8 +160,8 @@ class OwnerCleanlinessTest(SyncBaseTest):
         self.assertEqual(None, self.owner_cleanliness.hint)
 
     def test_cross_domain_on_submission(self):
-        # create a form that makes a dirty owner with the same ID but in a different domain
-        # make sure the original owner stays clean
+        """create a form that makes a dirty owner with the same ID but in a different domain
+        make sure the original owner stays clean"""
         new_domain = uuid.uuid4().hex
         # initialize the new cleanliness flag
         OwnershipCleanlinessFlag.objects.create(domain=new_domain, owner_id=self.owner_id, is_clean=True)


### PR DESCRIPTION
Was confused by `set_cleanliness_flags_for_enabled_domains` since it was actually being run on all domains. 

Also, cleaned up a misleading docstring in a test, and made those comments into docstrings so they show up when tests fail. 
@czue 
