### PR TITLE
removing demo and unknown users from case exports that do not specify…

### DIFF
--- a/corehq/apps/hqcase/export.py
+++ b/corehq/apps/hqcase/export.py
@@ -59,13 +59,11 @@ def export_cases(domain, cases, workbook, filter_group=None, users=None, all_gro
         else:
             return get_owner_id(case)
 
-    def might_be_relevant(case):
-        return get_owner_id(case) in owner_ids
 
     for i, case in enumerate(cases):
         if process:
             DownloadBase.set_progress(process, i, num_cases)
-        if might_be_relevant(case):
+        if get_owner_id(case) in owner_ids:
             matching_owner = get_matching_owner(case)
             case_row = {'dynamic_properties': {}}
             for key in case_static_keys:

--- a/corehq/apps/hqcase/export.py
+++ b/corehq/apps/hqcase/export.py
@@ -6,9 +6,13 @@ from soil import DownloadBase
 def export_cases(domain, cases, workbook, filter_group=None, users=None, all_groups=None, process=None):
     by_user_id = dict([(user.user_id, user) for user in users]) if users else {}
     by_group_id = dict([(g.get_id, g) for g in all_groups]) if all_groups else {}
+
+    owner_ids = set(by_user_id.keys())
     if filter_group:
-        owner_ids = set(by_user_id.keys())
         owner_ids.add(filter_group.get_id)
+    else:
+        # |= reassigns owner_ids to the union of the two sets
+        owner_ids |= set(by_group_id.keys())
 
     case_static_keys = (
         "case_id",
@@ -56,7 +60,7 @@ def export_cases(domain, cases, workbook, filter_group=None, users=None, all_gro
             return get_owner_id(case)
 
     def might_be_relevant(case):
-        return not filter_group or get_owner_id(case) in owner_ids
+        return get_owner_id(case) in owner_ids
 
     for i, case in enumerate(cases):
         if process:


### PR DESCRIPTION
… them

fixes http://manage.dimagi.com/default.asp?184784#1033477
@nickpell 
@kaapstorm this retouches the logic from https://github.com/dimagi/commcare-hq/pull/6887 so I want to make sure this seems ok to you

this fix makes mobile worker only, and mobile worker plus unknown worker exports do whats laid out in norman's comment here http://manage.dimagi.com/default.asp?166197 for full case exports
unknown worker only exports continue to export group owned cases as well so not ideal but not a regression
