### PR TITLE
support specifying display names in UCR multibar charts

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/report-module.js
+++ b/corehq/apps/app_manager/static/app_manager/js/report-module.js
@@ -33,7 +33,7 @@ var ReportModule = (function () {
                 var series_configs = {};
                 var chart_series = [];
                 for(var k = 0; k < currentChart.y_axis_columns.length; k++) {
-                    var series = currentChart.y_axis_columns[k];
+                    var series = currentChart.y_axis_columns[k].column_id;
                     chart_series.push(series);
                     series_configs[series] = new Config(
                         currentReportId === report_id ? (graph_config.series_configs || {})[series] || {} : {}

--- a/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
+++ b/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
@@ -109,7 +109,7 @@ def _get_summary_details(config):
                         form='graph',
                         graph=Graph(
                             type=graph_config.graph_type,
-                            series=[_column_to_series(c) for c in chart_config.y_axis_columns],
+                            series=[_column_to_series(c.column_id) for c in chart_config.y_axis_columns],
                             configuration=ConfigurationGroup(configs=[
                                 ConfigurationItem(id=key, xpath_function=value)
                                 for key, value in graph_config.config.items()

--- a/corehq/apps/reports_core/static/reports_core/js/charts.js
+++ b/corehq/apps/reports_core/static/reports_core/js/charts.js
@@ -112,20 +112,20 @@ var charts = (function() {
             // initialize records
             for (i = 0; i < config.y_axis_columns.length; i++) {
                 record = {
-                    key: config.y_axis_columns[i]['display'],
+                    key: config.y_axis_columns[i].display,
                     values: []
                 };
-                valuesDict[config.y_axis_columns[i]['column_id']] = record;
+                valuesDict[config.y_axis_columns[i].column_id] = record;
                 chartData.push(record);
             }
 
             for (i = 0; i < data.length; i++) {
                 current = data[i];
                 for (j = 0; j < config.y_axis_columns.length; j++) {
-                    record = valuesDict[config.y_axis_columns[j]['column_id']];
+                    record = valuesDict[config.y_axis_columns[j].column_id];
                     record.values.push({
                         x: current[config.x_axis_column] || '',
-                        y: current[config.y_axis_columns[j]['column_id']]
+                        y: current[config.y_axis_columns[j].column_id]
                     });
                 }
             }

--- a/corehq/apps/reports_core/static/reports_core/js/charts.js
+++ b/corehq/apps/reports_core/static/reports_core/js/charts.js
@@ -112,19 +112,20 @@ var charts = (function() {
             // initialize records
             for (i = 0; i < config.y_axis_columns.length; i++) {
                 record = {
-                    key: config.y_axis_columns[i],
+                    key: config.y_axis_columns[i]['display'],
                     values: []
                 };
-                valuesDict[config.y_axis_columns[i]] = record;
+                valuesDict[config.y_axis_columns[i]['column_id']] = record;
                 chartData.push(record);
             }
+
             for (i = 0; i < data.length; i++) {
                 current = data[i];
                 for (j = 0; j < config.y_axis_columns.length; j++) {
-                    record = valuesDict[config.y_axis_columns[j]];
+                    record = valuesDict[config.y_axis_columns[j]['column_id']];
                     record.values.push({
                         x: current[config.x_axis_column] || '',
-                        y: current[config.y_axis_columns[j]]
+                        y: current[config.y_axis_columns[j]['column_id']]
                     });
                 }
             }

--- a/corehq/apps/userreports/README.md
+++ b/corehq/apps/userreports/README.md
@@ -1021,7 +1021,7 @@ A multibar chart takes a single x-axis column (typically a user, date, or select
 Field          | Description
 ---------------| -----------------------------------------------
 x_axis_column  | This will be the x-axis on the chart.
-y_axis_columns | These are the columns to use for the secondary axis. These will be the slices of the bar (or individual bars in "grouped" format)
+y_axis_columns | These are the columns to use for the secondary axis. These will be the slices of the bar (or individual bars in "grouped" format).
 
 Here's a sample spec:
 
@@ -1031,8 +1031,14 @@ Here's a sample spec:
     "title": "HIV Mismatch by Clinic",
     "x_axis_column": "clinic",
     "y_axis_columns": [
-        "diagnoses_match_no",
-        "diagnoses_match_yes"
+        {
+            "column_id": "diagnoses_match_no",
+            "display": "No match"
+        },
+        {
+            "column_id": "diagnoses_match_yes",
+            "display": "Match"
+        }
     ]
 }
 ```

--- a/corehq/apps/userreports/tests/test_report_charts.py
+++ b/corehq/apps/userreports/tests/test_report_charts.py
@@ -2,7 +2,8 @@ from django.test import SimpleTestCase
 from corehq.apps.userreports.models import ReportConfiguration
 from corehq.apps.userreports.exceptions import BadSpecError
 from corehq.apps.userreports.reports.factory import ChartFactory
-from corehq.apps.userreports.reports.specs import PieChartSpec, MultibarChartSpec, MultibarAggregateChartSpec
+from corehq.apps.userreports.reports.specs import PieChartSpec, MultibarChartSpec, MultibarAggregateChartSpec, \
+    GraphDisplayColumn
 
 
 class ChartTestCase(SimpleTestCase):
@@ -53,11 +54,46 @@ class MultibarTestCase(SimpleTestCase):
             "title": "Property Matches by clinic",
             "x_axis_column": "clinic",
             "y_axis_columns": [
-                "property_no",
-                "property_yes"
+                {
+                    "column_id": "property_no",
+                    "display": "No"
+                },
+                {
+                    "column_id": "property_yes",
+                    "display": "Yes"
+                }
             ],
         })
         self.assertEqual(MultibarChartSpec, type(chart))
+
+    def test_make_multibar_chart_legacy_columns(self):
+        chart = ChartFactory.from_spec({
+            "type": "multibar",
+            "title": "Property Matches by clinic",
+            "x_axis_column": "clinic",
+            "y_axis_columns": [
+                "property_no",
+                {"column_id": "property_yes"}
+            ],
+        })
+        self.assertEqual(MultibarChartSpec, type(chart))
+        col_0, col_1 = chart.y_axis_columns
+        self.assertTrue(isinstance(col_0, GraphDisplayColumn))
+        self.assertEqual('property_no', col_0.display)
+        self.assertEqual('property_no', col_0.column_id)
+        self.assertTrue(isinstance(col_1, GraphDisplayColumn))
+        self.assertEqual('property_yes', col_1.display)
+        self.assertEqual('property_yes', col_1.column_id)
+
+    def test_make_multibar_chart_bad_columns(self):
+        for test_case in [None, 5, [], {}, {"display": "missing column id"}]:
+            with self.assertRaises(BadSpecError):
+                ChartFactory.from_spec({
+                    "type": "multibar",
+                    "title": "Property Matches by clinic",
+                    "x_axis_column": "clinic",
+                    "y_axis_columns": [test_case],
+                })
 
     def test_missing_x_axis(self):
         with self.assertRaises(BadSpecError):


### PR DESCRIPTION
related to http://manage.dimagi.com/default.asp?185637

@NoahCarnahan https://github.com/dimagi/commcare-hq/commit/3adba33dc9d3d157cd527ec2cb753607c4867c30 caused all the expanded columns to change to `columnname-choiceindex` in the response json, which a) broke charts that depended on the name and not the index, and b) made it useless to fix since it would be totally opaque what choice the index referred to.

this makes it so you can specify both a column_id and a display (a backlog feature anyways).

cc @proteusvacuum 
