### PR TITLE
fix for UCR deleted filter

### DIFF
--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -94,15 +94,15 @@ class DataSourceConfiguration(UnicodeMixIn, CachedCouchDocumentMixin, Document):
 
     @memoized
     def _get_deleted_filter(self):
-        return self._get_filter(get_deleted_doc_types(self.referenced_doc_type))
+        return self._get_filter(get_deleted_doc_types(self.referenced_doc_type), include_configured=False)
 
-    def _get_filter(self, doc_types):
+    def _get_filter(self, doc_types, include_configured=True):
         if not doc_types:
             return None
 
         extras = (
             [self.configured_filter]
-            if self.configured_filter else []
+            if include_configured and self.configured_filter else []
         )
         built_in_filters = [
             self._get_domain_filter_spec(),

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -107,8 +107,6 @@ class IndicatorConfigFilterTest(SimpleTestCase):
 
     def setUp(self):
         self.config = get_sample_data_source()
-        self.pillow = ConfigurableIndicatorPillow()
-        self.pillow.bootstrap(configs=[self.config])
 
     def test_filter(self):
         not_matching = [
@@ -117,9 +115,9 @@ class IndicatorConfigFilterTest(SimpleTestCase):
             dict(doc_type="CommCareCase", domain='user-reports', type='not-ticket'),
         ]
         for document in not_matching:
-            self.assertFalse(self.pillow.python_filter(document)), 'Failing dog: %s' % document
+            self.assertFalse(self.config.filter(document)), 'Failing dog: %s' % document
 
-        self.assertTrue(self.pillow.python_filter(
+        self.assertTrue(self.config.filter(
             dict(doc_type="CommCareCase", domain='user-reports', type='ticket')
         ))
 

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -1,7 +1,7 @@
 from copy import copy
 import decimal
 import uuid
-from django.test import TestCase
+from django.test import TestCase, SimpleTestCase
 from mock import patch
 from datetime import datetime, timedelta
 from casexml.apps.case.models import CommCareCase
@@ -52,20 +52,6 @@ class IndicatorPillowTest(TestCase):
         self.config.delete()
         self.adapter.drop_table()
 
-    def test_filter(self):
-        # note: this is a silly test now that python_filter always returns true
-        not_matching = [
-            dict(doc_type="NotCommCareCase", domain='user-reports', type='ticket'),
-            dict(doc_type="CommCareCase", domain='not-user-reports', type='ticket'),
-            dict(doc_type="CommCareCase", domain='user-reports', type='not-ticket'),
-        ]
-        for document in not_matching:
-            self.assertTrue(self.pillow.python_filter(document))
-
-        self.assertTrue(self.pillow.python_filter(
-            dict(doc_type="CommCareCase", domain='user-reports', type='ticket')
-        ))
-
     def test_stale_rebuild(self):
         later_config = copy(self.config)
         later_config.save()
@@ -115,3 +101,25 @@ class IndicatorPillowTest(TestCase):
                 self.assertAlmostEqual(expected_indicators[k], v)
             else:
                 self.assertEqual(expected_indicators[k], v)
+
+
+class IndicatorConfigFilterTest(SimpleTestCase):
+
+    def setUp(self):
+        self.config = get_sample_data_source()
+        self.pillow = ConfigurableIndicatorPillow()
+        self.pillow.bootstrap(configs=[self.config])
+
+    def test_filter(self):
+        not_matching = [
+            dict(doc_type="NotCommCareCase", domain='user-reports', type='ticket'),
+            dict(doc_type="CommCareCase", domain='not-user-reports', type='ticket'),
+            dict(doc_type="CommCareCase", domain='user-reports', type='not-ticket'),
+        ]
+        for document in not_matching:
+            self.assertFalse(self.pillow.python_filter(document)), 'Failing dog: %s' % document
+
+        self.assertTrue(self.pillow.python_filter(
+            dict(doc_type="CommCareCase", domain='user-reports', type='ticket')
+        ))
+

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -121,3 +121,18 @@ class IndicatorConfigFilterTest(SimpleTestCase):
             dict(doc_type="CommCareCase", domain='user-reports', type='ticket')
         ))
 
+    def test_deleted_filter(self):
+        not_matching = [
+            dict(doc_type="CommCareCase", domain='user-reports', type='ticket'),
+            dict(doc_type="CommCareCase-Deleted", domain='not-user-reports', type='ticket'),
+        ]
+        for document in not_matching:
+            self.assertFalse(self.config.deleted_filter(document), 'Failing dog: %s' % document)
+
+        matching = [
+            dict(doc_type="CommCareCase-Deleted", domain='user-reports', type='ticket'),
+            dict(doc_type="CommCareCase-Deleted", domain='user-reports', type='bot-ticket'),
+            dict(doc_type="CommCareCase-Deleted", domain='user-reports'),
+        ]
+        for document in matching:
+            self.assertTrue(self.config.deleted_filter(document), 'Failing dog: %s' % document)


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?183427
@czue 

cc @sravfeyn 

The issue here is that when a case is deleted by archiving its only form then the `type` property gets removed.
