### PR TITLE
EWS: Delete all models objects during domain deletion

### DIFF
--- a/custom/ewsghana/models.py
+++ b/custom/ewsghana/models.py
@@ -148,3 +148,6 @@ class EWSMigrationProblem(models.Model):
 @receiver(commcare_domain_pre_delete)
 def domain_pre_delete_receiver(domain, **kwargs):
     FacilityInCharge.objects.filter(location__in=SQLLocation.objects.filter(domain=domain)).delete()
+    EWSExtension.objects.filter(domain=domain).delete()
+    EWSMigrationStats.objects.filter(domain=domain).delete()
+    EWSMigrationProblem.objects.filter(domain=domain).delete()


### PR DESCRIPTION
@gcapalbo Previously I forgot to add this in pre delete.
