### PR TITLE
DailyFormStatsReport errors on date range too big

### DIFF
--- a/corehq/apps/reports/standard/__init__.py
+++ b/corehq/apps/reports/standard/__init__.py
@@ -292,6 +292,7 @@ class DatespanMixin(object):
     """
     datespan_field = 'corehq.apps.reports.filters.dates.DatespanFilter'
     datespan_default_days = 7
+    datespan_max_days = -1
     inclusive = True
 
     _datespan = None
@@ -314,6 +315,7 @@ class DatespanMixin(object):
     @property
     def default_datespan(self):
         datespan = DateSpan.since(self.datespan_default_days, timezone=self.timezone, inclusive=self.inclusive)
+        datespan.max_days = self.datespan_max_days
         datespan.is_default = True
         return datespan
 

--- a/corehq/apps/reports/standard/__init__.py
+++ b/corehq/apps/reports/standard/__init__.py
@@ -292,7 +292,7 @@ class DatespanMixin(object):
     """
     datespan_field = 'corehq.apps.reports.filters.dates.DatespanFilter'
     datespan_default_days = 7
-    datespan_max_days = -1
+    datespan_max_days = None
     inclusive = True
 
     _datespan = None


### PR DESCRIPTION
This builds on dimagi-utils [#329](https://github.com/dimagi/dimagi-utils/pull/329). This is to avoid errors caused by massive DataTable async request headers.

Context: [FB 185304](http://manage.dimagi.com/default.asp?185304)

I chose a limit of 90 days because the error starts at a datespan of somewhere between 90 and 120 days.

Example error message:
![datespan](https://cloud.githubusercontent.com/assets/708421/10788189/979e744a-7d7e-11e5-94a6-de67de58da20.png)

@snopoke, @czue, @TylerSheffels, cc @millerdev 
