### PR TITLE
show date range for each individual emailed report

### DIFF
--- a/corehq/apps/reports/templates/reports/report_email.html
+++ b/corehq/apps/reports/templates/reports/report_email.html
@@ -23,11 +23,6 @@ td.null-entry {
         This is a {{ report_type }} from <a href="{{ DNS_name }}">CommCareHQ</a> for the project '{{ domain }}'.
         {% endblocktrans %}
     </p>
-    <p>
-        {% if startdate %}
-            {% trans "Date range" %}: {{ startdate }} - {{ enddate }}
-        {% endif %}
-    </p>
     {% endif %}
 
     {% if notes %}
@@ -43,6 +38,11 @@ td.null-entry {
         {% if report.description %}
         <p>
             {{ report.description }}
+        </p>
+        {% endif %}
+        {% if report.startdate %}
+        <p>
+            {% trans "Date range" %}: {{ report.startdate }} - {{ report.enddate }}
         </p>
         {% endif %}
         {{ report.content|safe }}

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -963,14 +963,16 @@ def _render_report_configs(request, configs, domain, owner_id, couch_user, email
                 'file_obj': excel_file,
                 'mimetype': format.mimetype
             })
+        date_range = config.get_date_range()
         report_outputs.append({
             'title': config.full_name,
             'url': config.url,
             'content': content,
             'description': config.description,
+            "startdate": date_range.get("startdate") if date_range else "",
+            "enddate": date_range.get("enddate") if date_range else "",
         })
 
-    date_range = config.get_date_range()
     return render(request, "reports/report_email.html", {
         "reports": report_outputs,
         "domain": domain,
@@ -979,8 +981,6 @@ def _render_report_configs(request, configs, domain, owner_id, couch_user, email
         "owner_name": couch_user.full_name or couch_user.get_email(),
         "email": email,
         "notes": notes,
-        "startdate": date_range.get("startdate") if date_range else "",
-        "enddate": date_range.get("enddate") if date_range else "",
         "report_type": _("once off report") if once else _("scheduled report"),
     }), excel_attachments
 


### PR DESCRIPTION
Otherwise, misleading suggests that all reports in the email have the same date range

**Before:**
<img width="467" alt="screen shot 2015-10-28 at 1 23 12 pm" src="https://cloud.githubusercontent.com/assets/1757035/10797047/2a201fd8-7d77-11e5-9ee3-7f52bf19d0e2.png">

**After:**
<img width="432" alt="screen shot 2015-10-28 at 1 23 23 pm" src="https://cloud.githubusercontent.com/assets/1757035/10797048/2d3b2b72-7d77-11e5-808c-4169e82f4e58.png">

@calellowitz 
