### PR TITLE
use different bind parameters for different date filters

### DIFF
--- a/corehq/apps/userreports/reports/filters.py
+++ b/corehq/apps/userreports/reports/filters.py
@@ -32,7 +32,11 @@ class DateFilterValue(FilterValue):
     def to_sql_filter(self):
         if self.value is None:
             return ""
-        return BetweenFilter(self.filter.field, 'startdate', 'enddate')
+        return BetweenFilter(
+            self.filter.field,
+            '%s_startdate' % self.filter.slug,
+            '%s_enddate' % self.filter.slug
+        )
 
     def to_sql_values(self):
         if self.value is None:
@@ -48,8 +52,8 @@ class DateFilterValue(FilterValue):
             enddate = str(enddate)
 
         return {
-            'startdate': startdate,
-            'enddate': enddate,
+            '%s_startdate' % self.filter.slug: startdate,
+            '%s_enddate' % self.filter.slug: enddate,
         }
 
 

--- a/corehq/apps/userreports/tests/test_report_filters.py
+++ b/corehq/apps/userreports/tests/test_report_filters.py
@@ -103,10 +103,10 @@ class DateFilterTestCase(SimpleTestCase):
             return filter.create_filter_value(reports_core_value).to_sql_values()
 
         val = get_query_value(compare_as_string=False)
-        self.assertEqual(type(val['startdate']), datetime)
+        self.assertEqual(type(val['my_slug_startdate']), datetime)
 
         val = get_query_value(compare_as_string=True)
-        self.assertEqual(type(val['startdate']), str)
+        self.assertEqual(type(val['my_slug_startdate']), str)
 
 
 class NumericFilterTestCase(SimpleTestCase):


### PR DESCRIPTION
... otherwise they overwritten each other.

(this happens elsewhere in the filters, but I'm fixing those as part of the security fixes)

@czue @NoahCarnahan cc: @calellowitz 
