### PR TITLE
clear caches on errors

### DIFF
--- a/corehq/apps/cachehq/mixins.py
+++ b/corehq/apps/cachehq/mixins.py
@@ -11,8 +11,10 @@ class _InvalidateCacheMixin(object):
         invalidate_document(self)
 
     def save(self, **params):
-        super(_InvalidateCacheMixin, self).save(**params)
-        self.clear_caches()
+        try:
+            super(_InvalidateCacheMixin, self).save(**params)
+        finally:
+            self.clear_caches()
 
     @classmethod
     def save_docs(cls, docs, use_uuids=True, all_or_nothing=False):


### PR DESCRIPTION
was thinking this would be a simple way to prevent repeated doc update conflicts.

up for grabs when tests pass
