### PR TITLE
refactor ReleaseMain and AsyncDownloader to prevent multiple download requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ celerybeat-schedule
 # compiled translations
 /locale/*/*/*.mo
 .grunt
+node_modules/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -28,7 +28,7 @@ module.exports = function(grunt) {
                 run: true,
                 log: true,
                 logErrors: true,
-                reporter: 'Nyan'
+                reporter: 'Spec'
             }
         };
         watchConfig[app] = {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,7 +25,10 @@ module.exports = function(grunt) {
         mochaConfig[app] = {
             options: {
                 urls: [BASE_URL + appName + '/' + (config ? config : '')],
-                run: true
+                run: true,
+                log: true,
+                logErrors: true,
+                reporter: 'Nyan'
             }
         };
         watchConfig[app] = {

--- a/corehq/apps/app_manager/static/app_manager/js/download_async_modal.js
+++ b/corehq/apps/app_manager/static/app_manager/js/download_async_modal.js
@@ -52,7 +52,7 @@ $(function(){
             return progress_response &&
                 progress_response.trim().length &&
                 _.any([ready_id, error_id], function(el_id) {
-                    return progress_response.indexOf(el_id) > 0;
+                    return progress_response.indexOf(el_id) >= 0;
                 });
         };
 

--- a/corehq/apps/app_manager/static/app_manager/js/download_async_modal.js
+++ b/corehq/apps/app_manager/static/app_manager/js/download_async_modal.js
@@ -12,8 +12,7 @@ $(function(){
         self.$download_progress = self.$el.find("#" + self.el_id + "-download-progress");
         self.$downloading = self.$el.find("#" + self.el_id + "-downloading");
 
-        self.init = function(download_url){
-            self.download_url = download_url;
+        self.init = function(){
             self.download_in_progress = false;
             self.download_poll_url = null;
             self.download_poll_id = null;
@@ -29,6 +28,8 @@ $(function(){
                         self.updateProgress(resp);
                         if (!self.isDone(resp)) {
                             setTimeout(self.pollDownloadStatus, self.POLL_FREQUENCY);
+                        } else {
+                            self.download_in_progress = false;
                         }
                     },
                     error: function (resp) {
@@ -55,12 +56,12 @@ $(function(){
                 });
         };
 
-        self.generateDownload = function(){
+        self.generateDownload = function(download_url){
             // prevent multiple calls
             if (!self.download_in_progress) {
                 self.download_in_progress = true;
                 $.ajax({
-                    url: self.download_url,
+                    url: download_url,
                     type: "GET",
                     dataType: "json",
                     success: function (data) {
@@ -76,13 +77,14 @@ $(function(){
         };
 
         self.downloadError = function(text){
-            self.init(null);
+            self.init();
             self.$download_progress.html(text);
         };
 
-        self.$el.on("show show.bs.modal", self.generateDownload);
         self.$el.on("hidden hidden.bs.modal", function(){
-            self.init(null);
+            self.init();
         });
+
+        self.init();
     };
 }());

--- a/corehq/apps/app_manager/static/app_manager/js/download_async_modal.js
+++ b/corehq/apps/app_manager/static/app_manager/js/download_async_modal.js
@@ -1,19 +1,19 @@
 $(function(){
     "use strict";
 
-    window.AsyncDownloader = function($el, download_url){
+    window.AsyncDownloader = function($el){
         var self = this;
         self.POLL_FREQUENCY = 1500; //ms
         self.ERROR_MESSAGE = "Sorry, something went wrong with the download. " +
                              "If you see this repeatedly please report an issue.";
-        self.download_url = download_url;
 
         self.$el = $el;
         self.el_id = $el.attr("id");
         self.$download_progress = self.$el.find("#" + self.el_id + "-download-progress");
         self.$downloading = self.$el.find("#" + self.el_id + "-downloading");
 
-        self.init = function(){
+        self.init = function(download_url){
+            self.download_url = download_url;
             self.download_in_progress = false;
             self.download_poll_url = null;
             self.download_poll_id = null;
@@ -57,7 +57,7 @@ $(function(){
 
         self.generateDownload = function(){
             // prevent multiple calls
-            if (!self.download_in_progress) {
+            if (!self.download_in_progress && self.download_url) {
                 self.download_in_progress = true;
                 $.ajax({
                     url: self.download_url,
@@ -76,14 +76,13 @@ $(function(){
         };
 
         self.downloadError = function(text){
-            self.init();
+            self.init(null);
             self.$download_progress.html(text);
         };
 
         self.$el.on("show show.bs.modal", self.generateDownload);
         self.$el.on("hidden hidden.bs.modal", function(){
-            self.init();
+            self.init(null);
         });
-        self.init();
     };
 }());

--- a/corehq/apps/app_manager/static/app_manager/js/download_async_modal.js
+++ b/corehq/apps/app_manager/static/app_manager/js/download_async_modal.js
@@ -57,7 +57,7 @@ $(function(){
 
         self.generateDownload = function(){
             // prevent multiple calls
-            if (!self.download_in_progress && self.download_url) {
+            if (!self.download_in_progress) {
                 self.download_in_progress = true;
                 $.ajax({
                     url: self.download_url,

--- a/corehq/apps/app_manager/static/app_manager/js/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases.js
@@ -1,5 +1,4 @@
-function SavedApp(o, r) {
-    var $root = r;
+function SavedApp(o, releasesMain) {
     var self = ko.mapping.fromJS(o);
     $.each(['comment_user_name', '_deleteState'], function (i, attr) {
         self[attr] = self[attr] || ko.observable();
@@ -68,7 +67,7 @@ function SavedApp(o, r) {
 
     self.get_odk_install_url = ko.computed(function() {
         var slug = self.include_media() ? 'odk_media' : 'odk';
-        return $root.url(slug, self.id());
+        return releasesMain.url(slug, self.id());
     });
 
     self.sms_url = function(index) {
@@ -91,7 +90,7 @@ function SavedApp(o, r) {
     self.submit_new_comment = function () {
         self.pending_comment_update(true);
         $.ajax({
-            url: r.options.urls.update_build_comment,
+            url: releasesMain.options.urls.update_build_comment,
             type: 'POST',
             dataType: 'JSON',
             data: {"build_id": self.id(), "comment": self.new_comment()},
@@ -109,14 +108,14 @@ function SavedApp(o, r) {
     };
 
     self.download_application_zip = function () {
-        $root.download_application_zip(self.id());
+        releasesMain.download_application_zip(self.id());
     };
 
     self.clickDeploy = function () {
         self.generate_short_url('short_odk_url');
         ga_track_event('App Manager', 'Deploy Button', self.id());
         analytics.workflow('Clicked Deploy');
-        $.post(r.options.urls.hubspot_click_deploy);
+        $.post(releasesMain.options.urls.hubspot_click_deploy);
     };
 
     return self;

--- a/corehq/apps/app_manager/static/app_manager/js/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases.js
@@ -108,15 +108,8 @@ function SavedApp(o, r) {
         });
     };
 
-    self.modal = $('#download-zip-modal');
-    self.async_downloader = new AsyncDownloader(self.modal);
-    self.download_application_zip = function (url) {
-        url = $root.url('download_zip', self.id());
-        self.async_downloader.init(url);
-        // Not so nice... Hide the open modal so we don't get bootstrap recursion errors
-        // http://stackoverflow.com/questions/13649459/twitter-bootstrap-multiple-modal-error
-        $('.modal.fade.in').modal('hide');
-        self.modal.modal({show: true});
+    self.download_application_zip = function () {
+        $root.download_application_zip(self.id());
     };
 
     self.clickDeploy = function () {
@@ -144,6 +137,19 @@ function ReleasesMain(o) {
     self.currentAppVersion = ko.observable(self.options.currentAppVersion);
     self.lastAppVersion = ko.observable();
     self.selectingVersion = ko.observable("");
+
+    self.download_modal = $(self.options.download_modal_id);
+    self.async_downloader = new AsyncDownloader(self.download_modal);
+
+    self.download_application_zip = function(appId) {
+        var url = self.url('download_zip', appId);
+        self.async_downloader.init(url);
+        // Not so nice... Hide the open modal so we don't get bootstrap recursion errors
+        // http://stackoverflow.com/questions/13649459/twitter-bootstrap-multiple-modal-error
+        $('.modal.fade.in').modal('hide');
+        self.download_modal.modal({show: true});
+    };
+
     self.buildButtonEnabled = ko.computed(function () {
         if (self.buildState() === 'pending' || self.fetchState() === 'pending') {
             return false;

--- a/corehq/apps/app_manager/static/app_manager/js/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases.js
@@ -111,7 +111,7 @@ function SavedApp(o, r) {
     self.modal = $('#download-zip-modal');
     self.async_downloader = new AsyncDownloader(self.modal);
     self.download_application_zip = function (url) {
-        url = url.replace('_____', self.id());
+        url = $root.url('download_zip', self.id());
         self.async_downloader.init(url);
         // Not so nice... Hide the open modal so we don't get bootstrap recursion errors
         // http://stackoverflow.com/questions/13649459/twitter-bootstrap-multiple-modal-error

--- a/corehq/apps/app_manager/static/app_manager/js/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases.js
@@ -143,7 +143,7 @@ function ReleasesMain(o) {
     self.download_application_zip = function(appId, multimedia_only) {
         var url_slug = multimedia_only ? 'download_multimedia' : 'download_zip';
         var url = self.url(url_slug, appId);
-        self.async_downloader.init(url);
+        self.async_downloader.generateDownload(url);
         // Not so nice... Hide the open modal so we don't get bootstrap recursion errors
         // http://stackoverflow.com/questions/13649459/twitter-bootstrap-multiple-modal-error
         $('.modal.fade.in').modal('hide');

--- a/corehq/apps/app_manager/static/app_manager/js/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases.js
@@ -314,8 +314,4 @@ function ReleasesMain(o) {
             self.buildState('error');
         });
     };
-    // init
-    setTimeout(function () {
-        self.getMoreSavedApps();
-    }, 0);
 }

--- a/corehq/apps/app_manager/static/app_manager/js/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases.js
@@ -1,5 +1,5 @@
-function SavedApp(o, releasesMain) {
-    var self = ko.mapping.fromJS(o);
+function SavedApp(app_data, releasesMain) {
+    var self = ko.mapping.fromJS(app_data);
     $.each(['comment_user_name', '_deleteState'], function (i, attr) {
         self[attr] = self[attr] || ko.observable();
     });

--- a/corehq/apps/app_manager/static/app_manager/js/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases.js
@@ -108,14 +108,15 @@ function SavedApp(o, r) {
         });
     };
 
+    self.modal = $('#download-zip-modal');
+    self.async_downloader = new AsyncDownloader(self.modal);
     self.download_application_zip = function (url) {
-        var modal = $('#download-zip-modal');
         url = url.replace('_____', self.id());
-        new AsyncDownloader(modal, url);
+        self.async_downloader.init(url);
         // Not so nice... Hide the open modal so we don't get bootstrap recursion errors
         // http://stackoverflow.com/questions/13649459/twitter-bootstrap-multiple-modal-error
         $('.modal.fade.in').modal('hide');
-        modal.modal({show: true});
+        self.modal.modal({show: true});
     };
 
     self.clickDeploy = function () {

--- a/corehq/apps/app_manager/static/app_manager/js/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases.js
@@ -107,8 +107,8 @@ function SavedApp(app_data, releasesMain) {
         });
     };
 
-    self.download_application_zip = function () {
-        releasesMain.download_application_zip(self.id());
+    self.download_application_zip = function (multimedia_only) {
+        releasesMain.download_application_zip(self.id(), multimedia_only);
     };
 
     self.clickDeploy = function () {
@@ -140,8 +140,9 @@ function ReleasesMain(o) {
     self.download_modal = $(self.options.download_modal_id);
     self.async_downloader = new AsyncDownloader(self.download_modal);
 
-    self.download_application_zip = function(appId) {
-        var url = self.url('download_zip', appId);
+    self.download_application_zip = function(appId, multimedia_only) {
+        var url_slug = multimedia_only ? 'download_multimedia' : 'download_zip';
+        var url = self.url(url_slug, appId);
         self.async_downloader.init(url);
         // Not so nice... Hide the open modal so we don't get bootstrap recursion errors
         // http://stackoverflow.com/questions/13649459/twitter-bootstrap-multiple-modal-error

--- a/corehq/apps/app_manager/static/app_manager/spec/download_async_modal_spec.js
+++ b/corehq/apps/app_manager/static/app_manager/spec/download_async_modal_spec.js
@@ -15,6 +15,7 @@ describe('Async Download Modal', function() {
 
         var test_done = [
             {input: 'progress ready_' + download_poll_id, expected: true},
+            {input: 'ready_' + download_poll_id, expected: true},
             {input: 'progress error_' + download_poll_id, expected: true}
 
         ];

--- a/corehq/apps/app_manager/static/app_manager/spec/download_async_modal_spec.js
+++ b/corehq/apps/app_manager/static/app_manager/spec/download_async_modal_spec.js
@@ -105,7 +105,6 @@ describe('Async Download Modal', function() {
 
         it('should handle multiple downloads correctly', function() {
             verify_download('ready_');
-            modal.modal('hide');
             downloader.init(url);
             verify_download('ready_');
         });

--- a/corehq/apps/app_manager/static/app_manager/spec/download_async_modal_spec.js
+++ b/corehq/apps/app_manager/static/app_manager/spec/download_async_modal_spec.js
@@ -74,7 +74,7 @@ describe('Async Download Modal', function() {
         function verify_download(state) {
             var pollUrl = 'ajax/temp/123',
                 downloadId = '123';
-            ajax_stub.reset()
+            ajax_stub.reset();
             ajax_stub.onFirstCall(0).yieldsTo("success", {
                 download_id: downloadId,
                 download_url: pollUrl

--- a/corehq/apps/app_manager/static/app_manager/spec/download_async_modal_spec.js
+++ b/corehq/apps/app_manager/static/app_manager/spec/download_async_modal_spec.js
@@ -10,7 +10,6 @@ describe('Async Download Modal', function() {
 
         beforeEach(function() {
             downloader = new AsyncDownloader(modal);
-            downloader.init(url);
             downloader.download_poll_id = download_poll_id;
         });
 
@@ -58,7 +57,7 @@ describe('Async Download Modal', function() {
 
         beforeEach(function() {
             ajax_stub = sinon.stub($, 'ajax');
-            downloader.init(url);
+            downloader.init();
         });
 
         afterEach(function() {
@@ -66,7 +65,7 @@ describe('Async Download Modal', function() {
         });
 
         it('should only make one download request', function(done) {
-            modal.modal({show: true});
+            downloader.generateDownload(url);
             assert.equal($.ajax.callCount, 1, 'Only expecting 1 ajax call');
             done();
         });
@@ -81,7 +80,7 @@ describe('Async Download Modal', function() {
             });
             ajax_stub.onSecondCall().yieldsTo("success", 'html progress content');
             ajax_stub.onThirdCall().yieldsTo("success", 'html read content ' + state + downloadId);
-            modal.modal({show: true});
+            downloader.generateDownload(url);
 
             assert.equal($.ajax.callCount, 2);
             assert.equal(ajax_stub.firstCall.args[0].url, url);
@@ -105,7 +104,6 @@ describe('Async Download Modal', function() {
 
         it('should handle multiple downloads correctly', function() {
             verify_download('ready_');
-            downloader.init(url);
             verify_download('ready_');
         });
     });

--- a/corehq/apps/app_manager/static/app_manager/spec/download_async_modal_spec.js
+++ b/corehq/apps/app_manager/static/app_manager/spec/download_async_modal_spec.js
@@ -9,7 +9,8 @@ describe('Async Download Modal', function() {
             download_poll_id = '12345';
 
         beforeEach(function() {
-            downloader = new AsyncDownloader(modal, url);
+            downloader = new AsyncDownloader(modal);
+            downloader.init(url);
             downloader.download_poll_id = download_poll_id;
         });
 
@@ -47,7 +48,8 @@ describe('Async Download Modal', function() {
             clock;
 
         before(function() {
-           clock = sinon.useFakeTimers();
+            clock = sinon.useFakeTimers();
+            downloader = new AsyncDownloader(modal);
         });
 
         after(function() {
@@ -56,11 +58,11 @@ describe('Async Download Modal', function() {
 
         beforeEach(function() {
             ajax_stub = sinon.stub($, 'ajax');
-            downloader = new AsyncDownloader(modal, url);
+            downloader.init(url);
         });
 
         afterEach(function() {
-          ajax_stub.restore();
+            ajax_stub.restore();
         });
 
         it('should only make one download request', function(done) {
@@ -72,6 +74,7 @@ describe('Async Download Modal', function() {
         function verify_download(state) {
             var pollUrl = 'ajax/temp/123',
                 downloadId = '123';
+            ajax_stub.reset()
             ajax_stub.onFirstCall(0).yieldsTo("success", {
                 download_id: downloadId,
                 download_url: pollUrl
@@ -98,6 +101,13 @@ describe('Async Download Modal', function() {
             it('should poll until ' + test.state, function() {
                 verify_download(test.state);
             });
+        });
+
+        it('should handle multiple downloads correctly', function() {
+            verify_download('ready_');
+            modal.modal('hide');
+            downloader.init(url);
+            verify_download('ready_');
         });
     });
 });

--- a/corehq/apps/app_manager/static/app_manager/spec/download_async_modal_spec.js
+++ b/corehq/apps/app_manager/static/app_manager/spec/download_async_modal_spec.js
@@ -29,7 +29,7 @@ describe('Async Download Modal', function() {
             {input: null, expected: false},
             {input: undefined, expected: false},
             {input: '', expected: false},
-            {input: 'progress', expected: false},
+            {input: 'progress', expected: false}
 
         ];
 

--- a/corehq/apps/app_manager/static/app_manager/spec/releases_spec.js
+++ b/corehq/apps/app_manager/static/app_manager/spec/releases_spec.js
@@ -1,0 +1,58 @@
+/* global $, sinon */
+
+describe('App Releases', function() {
+    describe('SavedApp', function() {
+        var releases = null,
+            urls = {
+                download_zip: 'download_zip_url',
+                fetch: 'fetch_url',
+                odk_media: 'odk_media'
+            },
+            options = {
+                urls: urls,
+                currentAppVersion: -1,
+                recipient_contacts: [],
+                download_modal_id: '#download-zip-modal-test'
+            },
+            ajax_stub,
+            clock;
+
+        before(function() {
+            clock = sinon.useFakeTimers();
+        });
+
+        after(function() {
+           clock.restore();
+        });
+
+        beforeEach(function() {
+            ajax_stub = sinon.stub($, 'ajax');
+            releases = new ReleasesMain(options);
+            releases.addSavedApps(get_saved_apps(releases.fetchLimit));
+        });
+
+        afterEach(function() {
+            ajax_stub.restore();
+        });
+
+        function get_saved_apps(num) {
+            return _.map(_.range(num), function (version) {
+                return {
+                    id: version,
+                    version: version,
+                    doc_type: 'Application',
+                    build_comment: '',
+                    build_broken: false,
+                    is_released: false
+                }
+            });
+        }
+
+        it('should have 5 saved apps', function() {
+            app = releases.savedApps()[0];
+            app.download_application_zip();
+            assert.equal($.ajax.callCount, 1);
+        });
+
+    });
+});

--- a/corehq/apps/app_manager/static/app_manager/spec/releases_spec.js
+++ b/corehq/apps/app_manager/static/app_manager/spec/releases_spec.js
@@ -48,7 +48,7 @@ describe('App Releases', function() {
             });
         }
 
-        it('should have 5 saved apps', function() {
+        it('should only make one request when downloading zip', function() {
             app = releases.savedApps()[0];
             app.download_application_zip();
             assert.equal($.ajax.callCount, 1);

--- a/corehq/apps/app_manager/static/app_manager/spec/releases_spec.js
+++ b/corehq/apps/app_manager/static/app_manager/spec/releases_spec.js
@@ -4,8 +4,8 @@ describe('App Releases', function() {
     describe('SavedApp', function() {
         var releases = null,
             urls = {
-                download_zip: 'download_zip_url',
-                download_multimedia: 'download_multimedia_url',
+                download_zip: 'download_zip_url ___',
+                download_multimedia: 'download_multimedia_url ___',
                 fetch: 'fetch_url',
                 odk_media: 'odk_media'
             },
@@ -50,14 +50,29 @@ describe('App Releases', function() {
             app = releases.savedApps()[0];
             app.download_application_zip();
             assert.equal($.ajax.callCount, 1);
-            assert.equal(ajax_stub.firstCall.args[0].url, urls['download_zip']);
+            assert.equal(ajax_stub.firstCall.args[0].url, releases.url('download_zip', app.id()));
         });
 
         it('should use the correct URL for downloading multimedia', function() {
             app = releases.savedApps()[0];
             app.download_application_zip(true);
             assert.equal($.ajax.callCount, 1);
-            assert.equal(ajax_stub.firstCall.args[0].url, urls['download_multimedia']);
+            assert.equal(ajax_stub.firstCall.args[0].url, releases.url('download_multimedia', app.id()));
+        });
+
+        it('should use the correct URL for different saved apps', function() {
+            _.each(releases.savedApps(), function (app) {
+                ajax_stub.reset();
+                ajax_stub.onFirstCall(0).yieldsTo("success", {
+                    download_id: '123' + app.id(),
+                    download_url: 'pollUrl'
+                });
+                ajax_stub.onSecondCall().yieldsTo("success", 'ready_123' + app.id());
+
+                app.download_application_zip();
+                assert.equal($.ajax.callCount, 2);
+                assert.equal(ajax_stub.firstCall.args[0].url, releases.url('download_zip', app.id()));
+            });
         });
     });
 });

--- a/corehq/apps/app_manager/static/app_manager/spec/releases_spec.js
+++ b/corehq/apps/app_manager/static/app_manager/spec/releases_spec.js
@@ -15,16 +15,7 @@ describe('App Releases', function() {
                 recipient_contacts: [],
                 download_modal_id: '#download-zip-modal-test'
             },
-            ajax_stub,
-            clock;
-
-        before(function() {
-            clock = sinon.useFakeTimers();
-        });
-
-        after(function() {
-           clock.restore();
-        });
+            ajax_stub;
 
         beforeEach(function() {
             ajax_stub = sinon.stub($, 'ajax');

--- a/corehq/apps/app_manager/static/app_manager/spec/releases_spec.js
+++ b/corehq/apps/app_manager/static/app_manager/spec/releases_spec.js
@@ -5,6 +5,7 @@ describe('App Releases', function() {
         var releases = null,
             urls = {
                 download_zip: 'download_zip_url',
+                download_multimedia: 'download_multimedia_url',
                 fetch: 'fetch_url',
                 odk_media: 'odk_media'
             },
@@ -54,5 +55,18 @@ describe('App Releases', function() {
             assert.equal($.ajax.callCount, 1);
         });
 
+        it('should use the correct URL for downloading ccz', function() {
+            app = releases.savedApps()[0];
+            app.download_application_zip();
+            assert.equal($.ajax.callCount, 1);
+            assert.equal(ajax_stub.firstCall.args[0].url, urls['download_zip']);
+        });
+
+        it('should use the correct URL for downloading multimedia', function() {
+            app = releases.savedApps()[0];
+            app.download_application_zip(true);
+            assert.equal($.ajax.callCount, 1);
+            assert.equal(ajax_stub.firstCall.args[0].url, urls['download_multimedia']);
+        });
     });
 });

--- a/corehq/apps/app_manager/static/app_manager/spec/releases_spec.js
+++ b/corehq/apps/app_manager/static/app_manager/spec/releases_spec.js
@@ -36,7 +36,7 @@ describe('App Releases', function() {
                     build_comment: '',
                     build_broken: false,
                     is_released: false
-                }
+                };
             });
         }
 

--- a/corehq/apps/app_manager/templates/app_manager/download_index.html
+++ b/corehq/apps/app_manager/templates/app_manager/download_index.html
@@ -50,7 +50,7 @@
 {% block modals %}
     {{ block.super }}
     {% url "download_ccz" app.domain app.id as ccz_url %}
-    {% include 'app_manager/partials/download_async_modal.html' with element_id="download_ccz" download_url=ccz_url %}
+    {% include 'app_manager/partials/download_async_modal.html' with element_id="download_ccz" %}
 {% endblock %}
 
 {% block js-inline %}

--- a/corehq/apps/app_manager/templates/app_manager/download_index.html
+++ b/corehq/apps/app_manager/templates/app_manager/download_index.html
@@ -23,7 +23,7 @@
         </tr>
         <tr>
             <td>
-                <a href="#download_ccz" data-toggle="modal">CommCare.ccz</a>
+                <a href="#download_ccz" data-toggle="modal" onclick="download_application_zip()">CommCare.ccz</a>
             </td>
         </tr>
     </table>

--- a/corehq/apps/app_manager/templates/app_manager/partials/download_async_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/download_async_modal.html
@@ -4,8 +4,8 @@
 
     Usage:
 
-    <a href="#{ID_OF_MODAL}" data-toggle="modal">Click me!</a>
-    {% include 'app_manager/partials/download_async_modal.html' with element_id={ID_OF_MODAL} download_url={URL_TO_DOWNLOAD} %}
+    <a href="#{ID_OF_MODAL}" data-toggle="modal" onclick="download_application_zip()">Click me!</a>
+    {% include 'app_manager/partials/download_async_modal.html' with element_id={ID_OF_MODAL} %}
 
     Also need to include associated JavaScript:
     {% include 'app_manager/partials/download_async_modal_inline.html' with element_id={ID_OF_MODAL} download_url={URL_TO_DOWNLOAD} %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/download_async_modal_inline.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/download_async_modal_inline.html
@@ -2,5 +2,10 @@
 
 <script src="{% static 'app_manager/js/download_async_modal.js' %}"></script>
 <script type="text/javascript">
-    new AsyncDownloader($("#{{element_id}}"), "{{download_url}}");
+    $(function() {
+        var downloader = new AsyncDownloader($("#{{element_id}}"));
+        window.download_application_zip = function() {
+            downloader.generateDownload("{{download_url}}");
+        };
+    });
 </script>

--- a/corehq/apps/app_manager/templates/app_manager/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/releases.html
@@ -44,7 +44,8 @@
         var o = {
             urls: urls,
             currentAppVersion: {% if app.version %}{{ app.version }}{% else %}-1{% endif %},
-            recipient_contacts: {{ sms_contacts|JSON }}
+            recipient_contacts: {{ sms_contacts|JSON }},
+            download_modal_id: '#download-zip-modal'
         };
         var el = $('#releases-table');
         var releasesMain = new ReleasesMain(o);

--- a/corehq/apps/app_manager/templates/app_manager/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/releases.html
@@ -39,7 +39,8 @@
             currentVersion: '{% url "corehq.apps.app_manager.views.current_app_version" domain app.id %}',
             update_build_comment: '{% url "update_build_comment" domain app.id %}',
             hubspot_click_deploy: '{% url "hubspot_click_deploy" %}',
-            download_zip: '{% url "download_ccz" app.domain '___' %}'
+            download_zip: '{% url "download_ccz" app.domain '___' %}',
+            download_multimedia: '{% url "download_multimedia_zip" app.domain '___' %}'
         };
         var o = {
             urls: urls,
@@ -421,7 +422,9 @@
                                                     <ol>
                                                         <li>
                                                             {% trans "Download" %}
-                                                            <a href="#" data-bind="click: download_application_zip">
+                                                            <a href="#" data-bind="click: function () {
+                                                                download_application_zip(false);
+                                                            }">
                                                                 CommCare.ccz
                                                             </a>
                                                         </li>

--- a/corehq/apps/app_manager/templates/app_manager/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/releases.html
@@ -50,9 +50,7 @@
         };
         var el = $('#releases-table');
         var releasesMain = new ReleasesMain(o);
-        setTimeout(function () {
-            releasesMain.getMoreSavedApps();
-        }, 0);
+        _.defer(function(){ releasesMain.getMoreSavedApps(); });
         ko.applyBindings(releasesMain, el.get(0));
         el.show();
     });

--- a/corehq/apps/app_manager/templates/app_manager/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/releases.html
@@ -47,7 +47,11 @@
             recipient_contacts: {{ sms_contacts|JSON }}
         };
         var el = $('#releases-table');
-        ko.applyBindings(new ReleasesMain(o), el.get(0));
+        var releasesMain = new ReleasesMain(o);
+        setTimeout(function () {
+            releasesMain.getMoreSavedApps();
+        }, 0);
+        ko.applyBindings(releasesMain, el.get(0));
         el.show();
     });
 

--- a/corehq/apps/app_manager/templates/app_manager/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/releases.html
@@ -39,6 +39,7 @@
             currentVersion: '{% url "corehq.apps.app_manager.views.current_app_version" domain app.id %}',
             update_build_comment: '{% url "update_build_comment" domain app.id %}',
             hubspot_click_deploy: '{% url "hubspot_click_deploy" %}',
+            download_zip: '{% url "download_ccz" app.domain '___' %}'
         };
         var o = {
             urls: urls,
@@ -415,9 +416,7 @@
                                                     <ol>
                                                         <li>
                                                             {% trans "Download" %}
-                                                            <a href="#" data-bind="click: function () {
-                                                                download_application_zip('{% url "download_ccz" app.domain '_____' %}');
-                                                            }">
+                                                            <a href="#" data-bind="click: download_application_zip">
                                                                 CommCare.ccz
                                                             </a>
                                                         </li>

--- a/corehq/apps/app_manager/templates/app_manager/spec/b3/mocha.html
+++ b/corehq/apps/app_manager/templates/app_manager/spec/b3/mocha.html
@@ -7,7 +7,6 @@
 {% endblock %}
 
 {% block dependencies %}
-{% include "style/includes/bootstrap3/angular.html" %}
 <script src="{% new_static 'app_manager/js/app_summary.ng.js' %}"></script>
 <script src="{% static 'app_manager/js/download_async_modal.js' %}"></script>
 {% endblock %}

--- a/corehq/apps/app_manager/templates/app_manager/spec/mocha.html
+++ b/corehq/apps/app_manager/templates/app_manager/spec/mocha.html
@@ -10,6 +10,7 @@
 
 {% block mocha_tests %}
 <script src="{% static 'app_manager/spec/form_workflow_spec.js' %}"></script>
+<script src="{% static 'app_manager/spec/download_async_modal_spec.js' %}"></script>
 <script src="{% static 'app_manager/spec/releases_spec.js' %}"></script>
 {% endblock %}
 

--- a/corehq/apps/app_manager/templates/app_manager/spec/mocha.html
+++ b/corehq/apps/app_manager/templates/app_manager/spec/mocha.html
@@ -4,11 +4,13 @@
 {% block dependencies %}
 <script src="{% static 'app_manager/js/form_workflow.js' %}"></script>
 <script src="{% static 'app_manager/js/download_async_modal.js' %}"></script>
+<script src="{% static 'app_manager/js/releases.js' %}"></script>
+<script src="{% static 'app_manager/js/app_manager_utils.js' %}"></script>
 {% endblock %}
 
 {% block mocha_tests %}
 <script src="{% static 'app_manager/spec/form_workflow_spec.js' %}"></script>
-<script src="{% static 'app_manager/spec/download_async_modal_spec.js' %}"></script>
+<script src="{% static 'app_manager/spec/releases_spec.js' %}"></script>
 {% endblock %}
 
 {% block fixtures %}

--- a/corehq/apps/hqmedia/templates/hqmedia/partials/multimedia_zip_notice.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/partials/multimedia_zip_notice.html
@@ -10,7 +10,7 @@
                 {# This happens when the template gets included in app_manager/releases.html #}
                 {# See app_manager/js/releases.js #}
                 data-bind="click: function () {
-                    download_application_zip('{% url "download_multimedia_zip" app.domain '_____' %}');
+                    download_application_zip(true);
                 }"
             {% endif %}
         >

--- a/corehq/apps/hqmedia/templates/hqmedia/partials/multimedia_zip_notice.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/partials/multimedia_zip_notice.html
@@ -4,7 +4,7 @@
     <p>
         <a class="btn btn-warning" style="color: #ffffff;"
             {% if include_modal %}
-                href="#multimedia-zip-modal" data-toggle="modal"
+                href="#multimedia-zip-modal" data-toggle="modal" onclick="download_application_zip()"
             }
             {% else %}
                 {# This happens when the template gets included in app_manager/releases.html #}

--- a/corehq/apps/hqmedia/templates/hqmedia/partials/multimedia_zip_notice.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/partials/multimedia_zip_notice.html
@@ -44,6 +44,6 @@
 
 {% if include_modal %}
     {% url "download_multimedia_zip" domain app.get_id as multimedia_url%}
-    {% include 'app_manager/partials/download_async_modal.html' with element_id='multimedia-zip-modal' download_url=multimedia_url%}
+    {% include 'app_manager/partials/download_async_modal.html' with element_id='multimedia-zip-modal' %}
     {% include 'app_manager/partials/download_async_modal_inline.html' with element_id='multimedia-zip-modal' download_url=multimedia_url%}
 {% endif %}

--- a/corehq/apps/hqmedia/templates/hqmedia/references.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/references.html
@@ -23,7 +23,7 @@
         $('.preview-media').tooltip();
     </script>
     {% url "download_multimedia_zip" domain app.get_id as media_url%}
-    {% include 'app_manager/partials/download_async_modal.html' with element_id='multimedia-zip-modal' download_url=media_url%}
+    {% include 'app_manager/partials/download_async_modal.html' with element_id='multimedia-zip-modal' %}
     {% include 'app_manager/partials/download_async_modal_inline.html' with element_id='multimedia-zip-modal' download_url=media_url%}
 {% endblock %}
 

--- a/corehq/apps/mocha/templates/mocha/bootstrap2/base.html
+++ b/corehq/apps/mocha/templates/mocha/bootstrap2/base.html
@@ -4,4 +4,5 @@
 {% block core_libraries %}
 {% include "style/includes/bootstrap2/core_libraries.html" %}
 <script src="{% static 'style/lib/bootstrap2/bootstrap.min.js' %}"></script>
+<script src="{% static 'style/lib/knockout_plugins/knockout_mapping.ko.min.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?185771
Turns out that every time you click download on the releases page a new JS object would be created and listen the 'show' event on the modal. After 3 downloads you'd have 3 download objects listening and sending off ajax requests for the download.

If the objects were created from different download URL's (ccz for v1, ccz for v2, multimedia zip for v3) then the actual file downloaded would be the request that finished last.

@benrudolph 
@sravfeyn 
