### PR TITLE
Log UCR fixture errors instead of crashing

### DIFF
--- a/corehq/apps/userreports/fixtures.py
+++ b/corehq/apps/userreports/fixtures.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import logging
 from xml.etree import ElementTree
 
 from corehq import toggles
@@ -65,6 +66,8 @@ class ReportFixturesProvider(object):
                 reports_elem.append(self._report_config_to_fixture(report_config, user))
             except UserReportsError:
                 pass
+            except Exception as err:
+                logging.exception('Error generating report fixture: {}'.format(err))
         root.append(reports_elem)
         return [root]
 


### PR DESCRIPTION
This is to address [FB 185846](http://manage.dimagi.com/default.asp?185846): Mobile UCR fixture exceptions break syncing for all users.

I haven't managed to reproduce locally, but that probably has something to do with dodgy state of my local DB. 

I intend to add a test that uses the Django test client, mocks the `_report_config_to_fixture()` method call to raise an exception, and checks it returns an `<OpenRosaResponse>`.

@snopoke, cc @millerdev 
