### PR TITLE
Stop flicker on source files page

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/source_files.html
+++ b/corehq/apps/app_manager/templates/app_manager/source_files.html
@@ -28,7 +28,7 @@
             </tr>
 
             {% if file.source %}
-                <tr>
+                <tr class="hide">
                     <td colspan="2">
                     {% block file_source %}{% endblock %}
                     </td>
@@ -46,8 +46,8 @@
     $(function(){
         $('.toggle-next').click(function(e){
             e.preventDefault();
-            $(this).parents('tr').next('tr').toggle();
-        }).trigger('click');
+            $(this).parents('tr').next('tr').toggleClass("hide");
+        });
     });
 </script>
 {% endblock js-inline %}


### PR DESCRIPTION
Source files page renders all source code visible, then hides it when js fires. On slow-ish connections, this makes for an annoying flicker.

@NoahCarnahan 
