### PR TITLE
Add named expressions to UCR data sources

### DIFF
--- a/corehq/apps/userreports/README.md
+++ b/corehq/apps/userreports/README.md
@@ -308,7 +308,7 @@ Here is a simple example that demonstrates the structure. The keys of `propertie
 
 Last, but certainly not least, are named expressions.
 These are special expressions that can be defined once in a data source and then used throughout other filters and indicators in that data source.
-This allows you to write out a very complicated expression a single time, but restill use it in multiple places with a simple syntax.
+This allows you to write out a very complicated expression a single time, but still use it in multiple places with a simple syntax.
 
 Named expressions are defined in a special section of the data source. To reference a named expression, you just specify the type of `"named"` and the name as folllows:
 

--- a/corehq/apps/userreports/README.md
+++ b/corehq/apps/userreports/README.md
@@ -27,6 +27,7 @@ indicators           | List of indicators to save
 table_id             | A unique ID for the table
 display_name         | A display name for the table that shows up in UIs
 base_item_expression | Used for making tables off of repeat or list data
+named_expressions    | A list of named expressions that can be referenced in other filters and indicators
 named_filters        | A list of named filters that can be referenced in other filters and indicators
 
 
@@ -302,6 +303,34 @@ Here is a simple example that demonstrates the structure. The keys of `propertie
     }
 }
 ```
+
+#### Named Expressions
+
+Last, but certainly not least, are named expressions.
+These are special expressions that can be defined once in a data source and then used throughout other filters and indicators in that data source.
+This allows you to write out a very complicated expression a single time, but restill use it in multiple places with a simple syntax.
+
+Named expressions are defined in a special section of the data source. To reference a named expression, you just specify the type of `"named"` and the name as folllows:
+
+```json
+{
+    "type": "named",
+    "name": "my_expression"
+}
+```
+
+This assumes that your named expression section of your data source includes a snippet like the following:
+
+```json
+{
+    "my_expression": {
+        "type": "property_name",
+        "property_name": "test"
+    }
+}
+```
+
+This is just a simple example - the value that `"my_expression"` takes on can be as complicated as you want _as long as it doesn't reference any other named expressions_.
 
 ### Boolean Expression Filters
 

--- a/corehq/apps/userreports/expressions/factory.py
+++ b/corehq/apps/userreports/expressions/factory.py
@@ -6,7 +6,7 @@ from corehq.apps.userreports.exceptions import BadSpecError
 from corehq.apps.userreports.expressions.specs import PropertyNameGetterSpec, PropertyPathGetterSpec, \
     ConditionalExpressionSpec, ConstantGetterSpec, RootDocExpressionSpec, RelatedDocExpressionSpec, \
     IdentityExpressionSpec, IteratorExpressionSpec, SwitchExpressionSpec, ArrayIndexExpressionSpec, \
-    NestedExpressionSpec, DictExpressionSpec
+    NestedExpressionSpec, DictExpressionSpec, NamedExpressionSpec
 
 
 def _make_filter(spec, context):
@@ -24,6 +24,12 @@ _identity_expression = functools.partial(_simple_expression_generator, IdentityE
 _constant_expression = functools.partial(_simple_expression_generator, ConstantGetterSpec)
 _property_name_expression = functools.partial(_simple_expression_generator, PropertyNameGetterSpec)
 _property_path_expression = functools.partial(_simple_expression_generator, PropertyPathGetterSpec)
+
+
+def _named_expression(spec, context):
+    expression = NamedExpressionSpec.wrap(spec)
+    expression.configure(context=context)
+    return expression
 
 
 def _conditional_expression(spec, context):
@@ -103,6 +109,7 @@ class ExpressionFactory(object):
         'constant': _constant_expression,
         'property_name': _property_name_expression,
         'property_path': _property_path_expression,
+        'named': _named_expression,
         'conditional': _conditional_expression,
         'array_index': _array_index_expression,
         'root_doc': _root_doc_expression,

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -65,6 +65,19 @@ class PropertyPathGetterSpec(JsonObject):
         return self.expression(item, context)
 
 
+class NamedExpressionSpec(JsonObject):
+    type = TypeProperty('named')
+    name = StringProperty(required=True)
+
+    def configure(self, context):
+        if self.name not in context.named_expressions:
+            raise BadSpecError(u'Name {} not found in list of named expressions!'.format(self.name))
+        self._context = context
+
+    def __call__(self, item, context=None):
+        return self._context.named_expressions[self.name](item, context)
+
+
 class ConditionalExpressionSpec(JsonObject):
     type = TypeProperty('conditional')
     test = DictProperty(required=True)

--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -68,8 +68,8 @@ class PropertyPathGetterSpec(JsonObject):
 class ConditionalExpressionSpec(JsonObject):
     type = TypeProperty('conditional')
     test = DictProperty(required=True)
-    expression_if_true = DictProperty(required=True)
-    expression_if_false = DictProperty(required=True)
+    expression_if_true = DefaultProperty(required=True)
+    expression_if_false = DefaultProperty(required=True)
 
     def configure(self, test_function, true_expression, false_expression):
         self._test_function = test_function

--- a/corehq/apps/userreports/filters/factory.py
+++ b/corehq/apps/userreports/filters/factory.py
@@ -56,7 +56,7 @@ def _build_boolean_expression_filter(spec, context):
 
 def _build_named_filter(spec, context):
     wrapped = NamedFilterSpec.wrap(spec)
-    return context[wrapped.name]
+    return context.named_filters[wrapped.name]
 
 
 class FilterFactory(object):

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -143,7 +143,7 @@ class DataSourceConfiguration(UnicodeMixIn, CachedCouchDocumentMixin, Document):
     @property
     @memoized
     def named_filter_objects(self):
-        return {name: FilterFactory.from_spec(filter, None)
+        return {name: FilterFactory.from_spec(filter, FactoryContext.empty())
                 for name, filter in self.named_filters.items()}
 
     def _get_factory_context(self):

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -27,7 +27,7 @@ from corehq.apps.userreports.reports.factory import ReportFactory, ChartFactory,
     ReportColumnFactory, ReportOrderByFactory
 from corehq.apps.userreports.reports.specs import FilterSpec
 from django.utils.translation import ugettext as _
-from corehq.apps.userreports.specs import EvaluationContext
+from corehq.apps.userreports.specs import EvaluationContext, FactoryContext
 from corehq.pillows.utils import get_deleted_doc_types
 from corehq.util.couch import get_document_or_not_found, DocumentNotFound
 from dimagi.utils.couch.database import iter_docs
@@ -70,6 +70,7 @@ class DataSourceConfiguration(UnicodeMixIn, CachedCouchDocumentMixin, Document):
     base_item_expression = DictProperty()
     configured_filter = DictProperty()
     configured_indicators = ListProperty()
+    named_expressions = DictProperty()
     named_filters = DictProperty()
     meta = SchemaProperty(DataSourceMeta)
 
@@ -123,7 +124,7 @@ class DataSourceConfiguration(UnicodeMixIn, CachedCouchDocumentMixin, Document):
                 'type': 'and',
                 'filters': built_in_filters + extras,
             },
-            context=self.named_filter_objects,
+            context=self._get_factory_context(),
         )
 
     def _get_domain_filter_spec(self):
@@ -135,9 +136,18 @@ class DataSourceConfiguration(UnicodeMixIn, CachedCouchDocumentMixin, Document):
 
     @property
     @memoized
+    def named_expression_objects(self):
+        return {name: ExpressionFactory.from_spec(expression, FactoryContext.empty())
+                for name, expression in self.named_expressions.items()}
+
+    @property
+    @memoized
     def named_filter_objects(self):
-        return {name: FilterFactory.from_spec(filter, {})
+        return {name: FilterFactory.from_spec(filter, None)
                 for name, filter in self.named_filters.items()}
+
+    def _get_factory_context(self):
+        return FactoryContext(self.named_expression_objects, self.named_filter_objects)
 
     @property
     @memoized
@@ -156,20 +166,20 @@ class DataSourceConfiguration(UnicodeMixIn, CachedCouchDocumentMixin, Document):
                     "property_name": "_id"
                 }
             }
-        }, self.named_filter_objects)]
+        }, self._get_factory_context())]
 
         default_indicators.append(IndicatorFactory.from_spec({
             "type": "inserted_at",
-        }, self.named_filter_objects))
+        }, self._get_factory_context()))
 
         if self.base_item_expression:
             default_indicators.append(IndicatorFactory.from_spec({
                 "type": "repeat_iteration",
-            }, self.named_filter_objects))
+            }, self._get_factory_context()))
         return CompoundIndicator(
             self.display_name,
             default_indicators + [
-                IndicatorFactory.from_spec(indicator, self.named_filter_objects)
+                IndicatorFactory.from_spec(indicator, self._get_factory_context())
                 for indicator in self.configured_indicators
             ]
         )
@@ -178,7 +188,7 @@ class DataSourceConfiguration(UnicodeMixIn, CachedCouchDocumentMixin, Document):
     @memoized
     def parsed_expression(self):
         if self.base_item_expression:
-            return ExpressionFactory.from_spec(self.base_item_expression, context=self.named_filter_objects)
+            return ExpressionFactory.from_spec(self.base_item_expression, context=self._get_factory_context())
         return None
 
     def get_columns(self):

--- a/corehq/apps/userreports/specs.py
+++ b/corehq/apps/userreports/specs.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 from dimagi.ext.jsonobject import StringProperty
 from datetime import datetime
 
@@ -9,6 +10,13 @@ def TypeProperty(value):
     according to the type.
     """
     return StringProperty(required=True, choices=[value])
+
+
+class FactoryContext(namedtuple('FactoryContext', ('named_expressions', 'named_filters'))):
+
+    @staticmethod
+    def empty():
+        return FactoryContext({}, {})
 
 
 class EvaluationContext(object):

--- a/corehq/apps/userreports/tests/test_data_source_config.py
+++ b/corehq/apps/userreports/tests/test_data_source_config.py
@@ -2,6 +2,7 @@ import datetime
 from mock import patch
 from django.test import SimpleTestCase, TestCase
 from jsonobject.exceptions import BadValueError
+from corehq.apps.userreports.exceptions import BadSpecError
 from corehq.apps.userreports.models import DataSourceConfiguration
 from corehq.apps.userreports.tests.utils import get_sample_data_source, get_sample_doc_and_indicators
 from corehq.db import UCR_ENGINE_ID
@@ -127,6 +128,143 @@ class DataSourceConfigurationDbTest(TestCase):
     def test_doc_type_is_required(self):
         with self.assertRaises(BadValueError):
             DataSourceConfiguration(domain='domain', table_id='table').save()
+
+
+class IndicatorNamedExpressionTest(SimpleTestCase):
+    def setUp(self):
+        self.indicator_configuration = DataSourceConfiguration.wrap({
+            'display_name': 'Mother Indicators',
+            'doc_type': 'DataSourceConfiguration',
+            'domain': 'test',
+            'referenced_doc_type': 'CommCareCase',
+            'table_id': 'mother_indicators',
+            'named_expressions': {
+                'pregnant': {
+                    'type': 'property_name',
+                    'property_name': 'pregnant',
+                },
+                'is_evil': {
+                    'type': 'property_name',
+                    'property_name': 'is_evil',
+                },
+                'laugh_sound': {
+                    'type': 'conditional',
+                    'test': {
+                        'type': 'boolean_expression',
+                        'expression': {
+                            'type': 'property_name',
+                            'property_name': 'is_evil',
+                        },
+                        'operator': 'eq',
+                        'property_value': True,
+                    },
+                    'expression_if_true': "mwa-ha-ha",
+                    'expression_if_false': "hehe",
+                }
+            },
+            'named_filters': {},
+            'configured_filter': {
+                'type': 'boolean_expression',
+                'expression': {
+                    'type': 'named',
+                    'name': 'pregnant'
+                },
+                'operator': 'eq',
+                'property_value': 'yes',
+            },
+            'configured_indicators': [
+                {
+                    "type": "expression",
+                    "column_id": "laugh_sound",
+                    "datatype": "string",
+                    "expression": {
+                        'type': 'named',
+                        'name': 'laugh_sound'
+                    }
+                },
+                {
+                    "type": "expression",
+                    "column_id": "characterization",
+                    "datatype": "string",
+                    "expression": {
+                        'type': 'conditional',
+                        'test': {
+                            'type': 'boolean_expression',
+                            'expression': {
+                                'type': 'named',
+                                'name': 'is_evil',
+                            },
+                            'operator': 'eq',
+                            'property_value': True,
+                        },
+                        'expression_if_true': "evil!",
+                        'expression_if_false': "okay",
+                    }
+                },
+
+            ]
+        })
+
+    def test_filter_match(self):
+        self.assertTrue(self.indicator_configuration.filter({
+            'doc_type': 'CommCareCase',
+            'domain': 'test',
+            'pregnant': 'yes'
+        }))
+
+    def test_filter_nomatch(self):
+        self.assertFalse(self.indicator_configuration.filter({
+            'doc_type': 'CommCareCase',
+            'domain': 'test',
+            'pregnant': 'no'
+        }))
+
+    def test_indicator(self):
+        for evil_status, laugh in ((True, 'mwa-ha-ha'), (False, 'hehe')):
+            [values] = self.indicator_configuration.get_all_values({
+                'doc_type': 'CommCareCase',
+                'domain': 'test',
+                'pregnant': 'yes',
+                'is_evil': evil_status
+            })
+            i = 2
+            self.assertEqual('laugh_sound', values[i].column.id)
+            self.assertEqual(laugh, values[i].value)
+
+    def test_nested_indicator(self):
+        for evil_status, characterization in ((True, 'evil!'), (False, 'okay')):
+            [values] = self.indicator_configuration.get_all_values({
+                'doc_type': 'CommCareCase',
+                'domain': 'test',
+                'pregnant': 'yes',
+                'is_evil': evil_status
+            })
+            i = 3
+            self.assertEqual('characterization', values[i].column.id)
+            self.assertEqual(characterization, values[i].value)
+
+    def test_missing_reference(self):
+        bad_config = DataSourceConfiguration.wrap(self.indicator_configuration.to_json())
+        bad_config.configured_indicators.append({
+            "type": "expression",
+            "column_id": "missing",
+            "datatype": "string",
+            "expression": {
+                'type': 'named',
+                'name': 'missing'
+            }
+        })
+        with self.assertRaises(BadSpecError):
+            bad_config.validate()
+
+    def test_missing_no_named_in_named(self):
+        bad_config = DataSourceConfiguration.wrap(self.indicator_configuration.to_json())
+        bad_config.named_expressions['broken'] = {
+            "type": "named",
+            "name": "pregnant",
+        }
+        with self.assertRaises(BadSpecError):
+            bad_config.validate()
 
 
 class IndicatorNamedFilterTest(SimpleTestCase):

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -177,7 +177,7 @@ class ConditionalExpressionTest(SimpleTestCase):
     def setUp(self):
         # this expression is the equivalent to:
         #   doc.true_value if doc.test == 'match' else doc.false_value
-        spec = {
+        self.spec = {
             'type': 'conditional',
             'test': {
                 # any valid filter can go here
@@ -198,7 +198,7 @@ class ConditionalExpressionTest(SimpleTestCase):
                 'property_name': 'false_value',
             },
         }
-        self.expression = ExpressionFactory.from_spec(spec)
+        self.expression = ExpressionFactory.from_spec(self.spec)
 
     def testConditionIsTrue(self):
         self.assertEqual('correct', self.expression({
@@ -224,6 +224,18 @@ class ConditionalExpressionTest(SimpleTestCase):
         self.assertEqual(None, self.expression({
             'test': 'match',
             'false_value': 'incorrect',
+        }))
+
+    def test_literals(self):
+        spec = copy.copy(self.spec)
+        spec['expression_if_true'] = 'true literal'
+        spec['expression_if_false'] = 'false literal'
+        expression_with_literals = ExpressionFactory.from_spec(spec)
+        self.assertEqual('true literal', expression_with_literals({
+            'test': 'match',
+        }))
+        self.assertEqual('false literal', expression_with_literals({
+            'test': 'non-match',
         }))
 
 

--- a/corehq/apps/userreports/tests/test_filters.py
+++ b/corehq/apps/userreports/tests/test_filters.py
@@ -2,6 +2,7 @@ from django.test import SimpleTestCase
 from corehq.apps.userreports.exceptions import BadSpecError
 from corehq.apps.userreports.filters import ANDFilter, ORFilter, NOTFilter
 from corehq.apps.userreports.filters.factory import FilterFactory
+from corehq.apps.userreports.specs import FactoryContext
 
 
 class BasicFilterTest(SimpleTestCase):
@@ -359,7 +360,7 @@ class ConfigurableNamedFilterTest(SimpleTestCase):
     def setUp(self):
         self.filter = FilterFactory.from_spec(
             {'type': 'named', 'name': 'foo'},
-            {
+            FactoryContext({}, {
                 'foo': FilterFactory.from_spec({
                     "type": "not",
                     "filter": {
@@ -368,11 +369,11 @@ class ConfigurableNamedFilterTest(SimpleTestCase):
                         "property_value": "bar"
                     }
                 })
-            }
+            })
         )
         self.assertTrue(isinstance(self.filter, NOTFilter))
 
-    def test_filter_atch(self):
+    def test_filter_match(self):
         self.assertTrue(self.filter(dict(foo='not bar')))
 
     def test_filter_no_match(self):

--- a/corehq/apps/userreports/ui/forms.py
+++ b/corehq/apps/userreports/ui/forms.py
@@ -100,6 +100,9 @@ class ConfigurableDataSourceEditForm(DocumentFormBase):
                                   help_text=help_text.CONFIGURED_FILTER)
     configured_indicators = JsonField(
         expected_type=list, help_text=help_text.CONFIGURED_INDICATORS)
+    named_expressions = JsonField(required=False, expected_type=dict,
+                              label=_("Named expressions (optional)"),
+                              help_text=help_text.NAMED_EXPRESSIONS)
     named_filters = JsonField(required=False, expected_type=dict,
                               label=_("Named filters (optional)"),
                               help_text=help_text.NAMED_FILTER)

--- a/corehq/apps/userreports/ui/help_text.py
+++ b/corehq/apps/userreports/ui/help_text.py
@@ -28,9 +28,10 @@ CONFIGURED_INDICATORS = _(
     '<a target="_blank" href="'
     'https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/userreports/README.md#indicators'
     '">these docs</a>')
-NAMED_FILTER = _(
+NAMED_EXPRESSIONS = _(
     'For this advanced and useful feature, '
     'give a dict where the keys are the variable names you choose '
-    'and the values are filters according to the syntax of '
-    'Configured Filters above. You can then reference these from '
-    'Configured Filters as {"type": "named", "name": "myvarname"}')
+    'and the values are any valid expressions. You can then reference these from filters and indicators '
+    'wherever an expression goes using: <code>{"type": "named", "name": "myvarname"}</code>')
+NAMED_FILTER = _('These behave exactly like named expressions (see above), except the values '
+                 'should be a valid filter, and they can be used wherever filters are used above.')


### PR DESCRIPTION
This was inspired by @dannyroberts's implementation of named filters, and getting overwhelmed by the amount of repetition in some of the ICDS data sources and thinking this would be a very simple and useful thing to add.

@NoahCarnahan @nickpell @sravfeyn @esoergel and @sheelio might be interested. cc @proteusvacuum 
