### PR TITLE
upgrade lxml

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -23,7 +23,7 @@ eulxml==0.18.0
 feedparser==5.1.3
 ghdiff==0.4
 gunicorn==18.0
-lxml==3.3.1
+lxml==3.4.4
 kafka-python==0.9.4
 mock==0.8.0
 mocker==1.1.1


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?185782

This version of lxml requires libxml2 2.7.0 or later and libxslt 1.1.23 or later. I've checked and all our machines meet those requirements (production and india and staging)

Also tests API's, restore, app building

@calellowitz 
