### PR TITLE
Make OPM CMR exportable for @dimagi.com users

### DIFF
--- a/custom/opm/reports.py
+++ b/custom/opm/reports.py
@@ -521,10 +521,13 @@ class MetReport(CaseReportMixin, BaseReport):
     report_template_path = "opm/met_report.html"
     slug = "met_report"
     model = ConditionsMet
-    exportable = False
     default_rows = 5
     cache_key = 'opm-report'
     show_total = True
+
+    @property
+    def exportable(self):
+        return self.request.couch_user.is_dimagi
 
     @property
     def row_objects(self):


### PR DESCRIPTION
This works fine locally (right number of rows, and the columns I checked look good).  The only reason I'm restricting it to @dimagi.com users is because I think the partner doesn't want this report exported to pdf, as it loses the multimedia.
@czue @benrudolph
