### PR TITLE
Test bower_install with -F

### DIFF
--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -996,7 +996,7 @@ def _do_collectstatic(use_current_release=False):
 def _bower_install(use_current_release=False):
     venv = env.virtualenv_root if not use_current_release else env.virtualenv_current
     with cd(env.code_root if not use_current_release else env.code_current):
-        sudo('{venv}/bin/python manage.py bower install'.format(venv=venv), user=env.sudo_user)
+        sudo('{venv}/bin/python manage.py bower_install -F'.format(venv=venv), user=env.sudo_user)
 
 
 @roles(ROLES_DJANGO)


### PR DESCRIPTION
I discussed this a bit with @benrudolph, but am not 100% sure on this change yet.  For context, today when deploying staging bower_install hit two conflicting versions of D3.js, and waited for input to resolve that situation.  Adding -F chooses to automagically pick the newer version, but it doesn't record this conflict anywhere.  More frightening, I was unable to reproduce the conflict locally, using the autostaging branch (or any branch).

CC: @gcapalbo 
