### PR TITLE
upgrade sqlagg to 0.3.1

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -56,7 +56,7 @@ socketpool==0.5.3
 markdown==2.2.1
 amqp==1.4.7
 amqplib==1.0.2
-sqlagg==0.3.0
+sqlagg==0.3.1
 django-redis==4.2
 redis==2.10.3
 unittest2


### PR DESCRIPTION
will need to restart tests after https://github.com/dimagi/sql-agg/pull/18 is merged and new version is distributed (DONE)

http://manage.dimagi.com/default.asp?pg=pgList
