### PR TITLE
Remove duplicate location ids before query

### DIFF
--- a/corehq/apps/reports/standard/cases/basic.py
+++ b/corehq/apps/reports/standard/cases/basic.py
@@ -124,8 +124,8 @@ class CaseListMixin(ElasticProjectInspectionReport, ProjectReportParametersMixin
         selected_sharing_group_ids = EMWF.selected_sharing_group_ids(self.request)
 
         # Show cases owned by any selected locations, user locations, or their children
-        loc_ids = (EMWF.selected_location_ids(self.request) +
-                   get_users_location_ids(self.domain, selected_user_ids))
+        loc_ids = set(EMWF.selected_location_ids(self.request) +
+                      get_users_location_ids(self.domain, selected_user_ids))
         location_owner_ids = get_locations_and_children(loc_ids).location_ids()
 
         # Get user ids for each user in specified reporting groups


### PR DESCRIPTION
This just gets immediately passed to
`python SQLLocation.objects.filter(location_id__in=location_ids)
` which I hope does some optimization, but coercing to a `set` here 
certainly couldn't hurt.

@nickpell
from https://github.com/dimagi/commcare-hq/pull/8898/files#r43719343
