### PR TITLE
in progress flag for deploy

### DIFF
--- a/corehq/apps/hqadmin/management/commands/celery_deploy_in_progress.py
+++ b/corehq/apps/hqadmin/management/commands/celery_deploy_in_progress.py
@@ -1,0 +1,14 @@
+from dimagi.utils.couch.cache.cache_core import get_redis_default_cache
+from django.core.management.base import LabelCommand
+
+CELERY_DEPLOY_IN_PROGRESS_FLAG = 'celery_deploy_in_progress'
+
+
+class Command(LabelCommand):
+    help = """
+    Sets a celery_deploy_in_progress flag when we purposefully shut down celery during deploy
+    """
+
+    def handle(self, *args, **options):
+        cache = get_redis_default_cache()
+        cache.set(CELERY_DEPLOY_IN_PROGRESS_FLAG, True, timeout=5 * 60)


### PR DESCRIPTION
@gcapalbo ran threw this pretty quickly, but doesn't quite work as i expected. django-redis seems to be prefixing its keys with `:1:`. and then when i try to set a key via `redis-cli` like `:1:deploy_in_progress` django-redis throws an error when trying to read it if it hasn't originally set it:

```
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/home/cchq/www/staging/releases/2015-11-03_16.53/python_env/local/lib/python2.7/site-packages/django_redis/cache.py", line 25, in _decorator
    return method(self, *args, **kwargs)
  File "/home/cchq/www/staging/releases/2015-11-03_16.53/python_env/local/lib/python2.7/site-packages/django_redis/cache.py", line 73, in get
    client=client)
  File "/home/cchq/www/staging/releases/2015-11-03_16.53/python_env/local/lib/python2.7/site-packages/django_redis/client/default.py", line 205, in get
    return self.decode(value)
  File "/home/cchq/www/staging/releases/2015-11-03_16.53/python_env/local/lib/python2.7/site-packages/django_redis/client/default.py", line 303, in decode
    value = self._serializer.loads(value)
  File "/home/cchq/www/staging/releases/2015-11-03_16.53/python_env/local/lib/python2.7/site-packages/django_redis/serializers/pickle.py", line 43, in loads
    return pickle.loads(force_bytes(value))
UnpicklingError: could not find MARK
```

nothing came up via google and was wondering if you had any insight.

cc: @proteusvacuum 
