### PR TITLE
extract attachments view access to dbaccessor with cache

### DIFF
--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -6,7 +6,6 @@ from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect, HttpResponseBadRequest, Http404
 from django.utils.decorators import method_decorator
 import json
-from corehq import toggles
 from corehq.apps.app_manager.dbaccessors import get_apps_in_domain
 from corehq.apps.app_manager.models import Application
 from corehq.apps.app_manager.templatetags.xforms_extras import trans

--- a/corehq/apps/reports/standard/export.py
+++ b/corehq/apps/reports/standard/export.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-import json
 import logging
 from datetime import timedelta, datetime
 from django.conf import settings
@@ -7,7 +6,6 @@ from django.conf import settings
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_noop, ugettext_lazy
 from django.http import Http404
-from casexml.apps.case.models import CommCareCase
 from corehq.apps.hqcase.dbaccessors import get_case_types_for_domain
 from corehq.apps.reports.dbaccessors import stale_get_export_count
 from dimagi.utils.decorators.memoized import memoized

--- a/corehq/couchapps/dbaccessors.py
+++ b/corehq/couchapps/dbaccessors.py
@@ -1,0 +1,39 @@
+from corehq.apps.app_manager.models import Application
+from corehq.util.quickcache import quickcache
+
+
+def _sizeof_fmt(num):
+    for x in ['bytes', 'KB', 'MB', 'GB', 'TB']:
+        if num < 1024.0:
+            return "%3.1f %s" % (num, x)
+        num /= 1024.0
+
+
+def get_attachment_size_by_domain(domain):
+    return get_attachment_size_by_domain_app_id_xmlns(domain)
+
+
+@quickcache(['domain', 'app_id', 'xmlns'], timeout=30)
+def get_attachment_size_by_domain_app_id_xmlns(domain, app_id=None, xmlns=None):
+    """
+    :return: dict {
+        (app_id, xmlns): size_of_attachments,
+    }
+    """
+    startkey = [domain]
+    if app_id:
+        startkey += [app_id]
+    if xmlns:
+        startkey += [xmlns]
+
+    view = Application.get_db().view(
+        'attachments/attachments',
+        startkey=startkey,
+        endkey=startkey + [{}],
+        group_level=3,
+        reduce=True,
+        group=True
+    )
+    # grouped key = [domain, app_id, xmlns]
+    available_attachments = {(a['key'][1], a['key'][2]): _sizeof_fmt(a['value']) for a in view}
+    return available_attachments

--- a/corehq/couchapps/tests/__init__.py
+++ b/corehq/couchapps/tests/__init__.py
@@ -1,1 +1,2 @@
 from test_all_docs import *
+from test_dbaccessors import *

--- a/corehq/couchapps/tests/test_dbaccessors.py
+++ b/corehq/couchapps/tests/test_dbaccessors.py
@@ -1,0 +1,77 @@
+from django.core.files.uploadedfile import UploadedFile
+from corehq.couchapps.dbaccessors import get_attachment_size_by_domain, get_attachment_size_by_domain_app_id_xmlns
+from corehq.form_processor.interfaces.processor import FormProcessorInterface
+from corehq.form_processor.test_utils import FormProcessorTestUtils
+from django.test import TestCase
+from dimagi.utils.make_uuid import random_hex
+
+DOMAIN = 'test-attachments'
+FORM_XML = """<?xml version='1.0' ?>
+<data uiVersion="1" version="1" name="Form with attachment"
+    xmlns:jrm="http://dev.commcarehq.org/jr/xforms"
+    xmlns:cc="http://commcarehq.org/xforms"
+    xmlns="{xmlns}">
+    <attachment>fgg</attachment>
+    <n1:meta xmlns:n1="http://openrosa.org/jr/xforms">
+        <n1:deviceID>321</n1:deviceID>
+        <n1:timeStart>2015-04-08T12:00:01.000000Z</n1:timeStart>
+        <n1:timeEnd>2015-04-08T12:05:01.000000Z</n1:timeEnd>
+        <n1:username>demo</n1:username>
+        <n1:userID>123</n1:userID>
+        <n1:instanceID>{doc_id}</n1:instanceID>
+    </n1:meta>
+</data>
+"""
+APP_ID_1 = '123'
+APP_ID_2 = '456'
+XMLNS_1 = 'http://openrosa.org/formdesigner/abc'
+XMLNS_2 = 'http://openrosa.org/formdesigner/def'
+COMBOS = [
+    (APP_ID_1, XMLNS_1, True),
+    (APP_ID_1, XMLNS_1, False),
+    (APP_ID_1, XMLNS_2, False),
+    (APP_ID_2, XMLNS_2, True),
+]
+
+
+class AttachmentsTest(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        for app_id, xmlns, with_attachments in COMBOS:
+            AttachmentsTest._create_form(app_id, xmlns, with_attachments)
+
+    @staticmethod
+    def _create_form(app_id, xmlns, with_attachment):
+        xml = FORM_XML.format(doc_id=random_hex(), xmlns=xmlns)
+        attachments = {}
+        if with_attachment:
+            attachment = open('./corehq/ex-submodules/casexml/apps/case/tests/data/attachments/fruity.jpg', 'rb')
+            attachments = {
+                'pic.jpg': UploadedFile(attachment, 'pic.jpg')
+            }
+        FormProcessorInterface().submit_form_locally(xml, domain=DOMAIN, app_id=app_id, attachments=attachments)
+
+    @classmethod
+    def tearDownClass(cls):
+        FormProcessorTestUtils.delete_all_xforms(DOMAIN)
+
+    def test_get_attachment_size_by_domain(self):
+        atts = get_attachment_size_by_domain(DOMAIN)
+        self.assertIn((APP_ID_1, XMLNS_1), atts)
+        self.assertIn((APP_ID_2, XMLNS_2), atts)
+        self.assertNotIn((APP_ID_1, XMLNS_2), atts)
+        self.assertNotIn((APP_ID_2, XMLNS_1), atts)
+
+    def test_get_attachment_size_by_domain_app_id_xmlns_app_id(self):
+        atts = get_attachment_size_by_domain_app_id_xmlns(DOMAIN, APP_ID_1)
+        self.assertEqual(len(atts), 1)
+        self.assertIn((APP_ID_1, XMLNS_1), atts)
+
+    def test_get_attachment_size_by_domain_app_id_xmlns_xmlns_1(self):
+        atts = get_attachment_size_by_domain_app_id_xmlns(DOMAIN, APP_ID_1, xmlns=XMLNS_1)
+        self.assertEqual(len(atts), 1)
+        self.assertIn((APP_ID_1, XMLNS_1), atts)
+
+    def test_get_attachment_size_by_domain_app_id_xmlns_xmlns_2(self):
+        atts = get_attachment_size_by_domain_app_id_xmlns(DOMAIN, APP_ID_1, xmlns=XMLNS_2)
+        self.assertEqual(atts, {})


### PR DESCRIPTION
Surprisingly this view is one of the most accessed according to data from our couch logs. It is also one that has a non-trivial reduce function. This use doesn't require up to the minute data so I added caching.

@biyeun 
