### PR TITLE
add retry_on_conflict ES param

### DIFF
--- a/corehq/elastic.py
+++ b/corehq/elastic.py
@@ -36,7 +36,8 @@ def get_es(timeout=30):
     """
     return rawes.Elastic('%s:%s' % (settings.ELASTICSEARCH_HOST,
                                     settings.ELASTICSEARCH_PORT),
-                         timeout=timeout)
+                         timeout=timeout,
+                         retry_on_conflict=2)
 
 
 def doc_exists_in_es(index, doc_id):


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?186218
https://www.elastic.co/guide/en/elasticsearch/reference/0.90/docs-update.html
@czue 

I think these were always happening but we weren't aware of them. With the rawes upgrade it now raises Exceptions for return codes >= 400.
