### PR TITLE
Switch Submissions By Form Report to use FormData

### DIFF
--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -205,6 +205,11 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
         emws = request.GET.getlist(cls.slug)
         return [l[3:] for l in emws if l.startswith("l__")]
 
+    @classmethod
+    def show_all_mobile_workers(cls, request):
+        emws = request.GET.getlist(cls.slug)
+        return 't__0' in emws
+
     def get_default_selections(self):
         defaults = [('t__0', _("[All mobile workers]"))]
         if self.request.project.commtrack_enabled:

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -430,6 +430,7 @@ class SubmissionsByFormReport(WorkerMonitoringFormReportTableBase,
             startdate=self.datespan.startdate_utc.replace(tzinfo=pytz.UTC),
             enddate=self.datespan.enddate_utc.replace(tzinfo=pytz.UTC),
             user_ids=user_ids,
+            xmlnss=[f['xmlns'] for f in self.all_relevant_forms.values()],
             by_submission_time=self.by_submission_time,
         )
 

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -420,10 +420,16 @@ class SubmissionsByFormReport(WorkerMonitoringFormReportTableBase,
     @property
     @memoized
     def _form_counts(self):
+        if EMWF.show_all_mobile_workers(self.request):
+            user_ids = []
+        else:
+            # Don't query ALL mobile workers
+            user_ids = [u.user_id for u in self.selected_users]
         return get_form_counts_by_user_xmlns(
             domain=self.domain,
             startdate=self.datespan.startdate_utc.replace(tzinfo=pytz.UTC),
             enddate=self.datespan.enddate_utc.replace(tzinfo=pytz.UTC),
+            user_ids=user_ids,
             by_submission_time=self.by_submission_time,
         )
 

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -384,12 +384,16 @@ class SubmissionsByFormReport(WorkerMonitoringFormReportTableBase,
         return headers
 
     @property
+    @memoized
+    def selected_users(self):
+        users_data = EMWF.pull_users_and_groups(self.domain, self.request, True, True)
+        return users_data.combined_users
+
+    @property
     def rows(self):
         rows = []
         totals = [0] * (len(self.all_relevant_forms) + 1)
-        users_data = EMWF.pull_users_and_groups(
-            self.domain, self.request, True, True)
-        for user in users_data.combined_users:
+        for user in self.selected_users:
             row = []
             if self.all_relevant_forms:
                 for form in self.all_relevant_forms.values():

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -4,6 +4,7 @@ from urllib import urlencode
 import math
 from django.db.models.aggregates import Max, Min, Avg, StdDev, Count
 import operator
+import pytz
 from corehq.apps.es import filters
 from corehq.apps.es import cases as case_es
 from corehq.apps.es.forms import FormES
@@ -421,8 +422,8 @@ class SubmissionsByFormReport(WorkerMonitoringFormReportTableBase,
     def _form_counts(self):
         return get_form_counts_by_user_xmlns(
             domain=self.domain,
-            startdate=self.datespan.startdate_utc,
-            enddate=self.datespan.enddate_utc,
+            startdate=self.datespan.startdate_utc.replace(tzinfo=pytz.UTC),
+            enddate=self.datespan.enddate_utc.replace(tzinfo=pytz.UTC),
             by_submission_time=self.by_submission_time,
         )
 

--- a/corehq/apps/sofabed/dbaccessors.py
+++ b/corehq/apps/sofabed/dbaccessors.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from sqlalchemy import Table, MetaData, Column, types, func, sql
 from corehq.db import Session
 from .models import FormData
@@ -27,7 +28,7 @@ def get_form_counts_by_user_xmlns(domain, startdate, enddate, by_submission_time
              .where(startdate <= date_field)
              .where(date_field < enddate)
              .group_by(col.xmlns, col.user_id, col.app_id))
-    return {
+    return defaultdict(lambda: 0, {
         (user_id, xmlns, app_id): count
         for count, xmlns, user_id, app_id in Session.execute(query)
-    }
+    })

--- a/corehq/apps/sofabed/dbaccessors.py
+++ b/corehq/apps/sofabed/dbaccessors.py
@@ -20,7 +20,7 @@ SAFormData = Table(
 
 
 def get_form_counts_by_user_xmlns(domain, startdate, enddate, user_ids=None,
-                                  by_submission_time=True):
+                                  xmlnss=None, by_submission_time=True):
     # This kind of COUNT and GROUP BY query isn't possible with the Django ORM
     col = SAFormData.columns
     date_field = col.received_on if by_submission_time else col.time_end
@@ -29,8 +29,10 @@ def get_form_counts_by_user_xmlns(domain, startdate, enddate, user_ids=None,
              .where(startdate <= date_field)
              .where(date_field < enddate)
              .group_by(col.xmlns, col.user_id, col.app_id))
-    if user_ids:
+    if user_ids is not None:
         query = query.where(col.user_id.in_(user_ids))
+    if xmlnss is not None:
+        query = query.where(col.xmlns.in_(xmlnss))
     return defaultdict(lambda: 0, {
         (user_id, xmlns, app_id): count
         for count, xmlns, user_id, app_id in Session.execute(query)

--- a/corehq/apps/sofabed/dbaccessors.py
+++ b/corehq/apps/sofabed/dbaccessors.py
@@ -19,7 +19,8 @@ SAFormData = Table(
 )
 
 
-def get_form_counts_by_user_xmlns(domain, startdate, enddate, by_submission_time=True):
+def get_form_counts_by_user_xmlns(domain, startdate, enddate, user_ids=None,
+                                  by_submission_time=True):
     # This kind of COUNT and GROUP BY query isn't possible with the Django ORM
     col = SAFormData.columns
     date_field = col.received_on if by_submission_time else col.time_end
@@ -28,6 +29,8 @@ def get_form_counts_by_user_xmlns(domain, startdate, enddate, by_submission_time
              .where(startdate <= date_field)
              .where(date_field < enddate)
              .group_by(col.xmlns, col.user_id, col.app_id))
+    if user_ids:
+        query = query.where(col.user_id.in_(user_ids))
     return defaultdict(lambda: 0, {
         (user_id, xmlns, app_id): count
         for count, xmlns, user_id, app_id in Session.execute(query)

--- a/corehq/apps/sofabed/dbaccessors.py
+++ b/corehq/apps/sofabed/dbaccessors.py
@@ -29,9 +29,9 @@ def get_form_counts_by_user_xmlns(domain, startdate, enddate, user_ids=None,
              .where(startdate <= date_field)
              .where(date_field < enddate)
              .group_by(col.xmlns, col.user_id, col.app_id))
-    if user_ids is not None:
+    if user_ids:
         query = query.where(col.user_id.in_(user_ids))
-    if xmlnss is not None:
+    if xmlnss:
         query = query.where(col.xmlns.in_(xmlnss))
     return defaultdict(lambda: 0, {
         (user_id, xmlns, app_id): count

--- a/corehq/apps/sofabed/dbaccessors.py
+++ b/corehq/apps/sofabed/dbaccessors.py
@@ -1,0 +1,33 @@
+from sqlalchemy import Table, MetaData, Column, types, func, sql
+from corehq.db import Session
+from .models import FormData
+
+
+# A SQLAlchemy representation of the FormData table.
+# This skips the SQLAlchemy ORM and uses their SQL Expression Language
+# http://docs.sqlalchemy.org/en/rel_0_8/core/tutorial.html#selecting
+SAFormData = Table(
+    FormData._meta.db_table,
+    MetaData(),
+    Column('domain', types.String),
+    Column('received_on', types.DateTime),
+    Column('time_end', types.DateTime),
+    Column('xmlns', types.String),
+    Column('user_id', types.String),
+    Column('app_id', types.String),
+)
+
+
+def get_form_counts_by_user_xmlns(domain, startdate, enddate, by_submission_time=True):
+    # This kind of COUNT and GROUP BY query isn't possible with the Django ORM
+    col = SAFormData.columns
+    date_field = col.received_on if by_submission_time else col.time_end
+    query = (sql.select([func.count(), col.xmlns, col.user_id, col.app_id])
+             .where(col.domain == domain)
+             .where(startdate <= date_field)
+             .where(date_field < enddate)
+             .group_by(col.xmlns, col.user_id, col.app_id))
+    return {
+        (user_id, xmlns, app_id): count
+        for count, xmlns, user_id, app_id in Session.execute(query)
+    }

--- a/corehq/apps/sofabed/tests/test_formdata.py
+++ b/corehq/apps/sofabed/tests/test_formdata.py
@@ -111,6 +111,7 @@ class FormDataQueryTest(TestCase):
         self.assertEqual(counts[('user1', 'form1', 'app_id')], 2)
         self.assertEqual(counts[('user1', 'form2', 'app_id')], 1)
         self.assertEqual(counts[('user2', 'form1', 'app_id')], 2)
+        self.assertEqual(counts[('user2', 'form2', 'app_id')], 0)
 
     def test_form_counts_by_completion_time(self):
         start, end = utc_date(2015, 2, 1), utc_date(2015, 3, 1)
@@ -119,3 +120,18 @@ class FormDataQueryTest(TestCase):
         self.assertEqual(counts[('user1', 'form1', 'app_id')], 1)
         self.assertEqual(counts[('user1', 'form2', 'app_id')], 1)
         self.assertEqual(counts[('user2', 'form1', 'app_id')], 2)
+        self.assertEqual(counts[('user2', 'form2', 'app_id')], 0)
+
+    def test_specific_users(self):
+        start, end = utc_date(2015, 2, 1), utc_date(2015, 3, 1)
+        counts = get_form_counts_by_user_xmlns('test-domain', start, end,
+                                               user_ids=['user1'])
+        self.assertEqual(counts[('user1', 'form1', 'app_id')], 2)
+        self.assertEqual(counts[('user2', 'form1', 'app_id')], 0)
+
+    def test_specific_xmlnss(self):
+        start, end = utc_date(2015, 2, 1), utc_date(2015, 3, 1)
+        counts = get_form_counts_by_user_xmlns('test-domain', start, end,
+                                               xmlnss=['form1'])
+        self.assertEqual(counts[('user1', 'form1', 'app_id')], 2)
+        self.assertEqual(counts[('user1', 'form2', 'app_id')], 0)

--- a/corehq/apps/sofabed/tests/test_formdata.py
+++ b/corehq/apps/sofabed/tests/test_formdata.py
@@ -1,10 +1,13 @@
+from datetime import date, datetime
+import os
+import pytz
+import uuid
 from django.test import TestCase
 from corehq.apps.hqadmin.dbaccessors import get_all_forms_in_all_domains
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from couchforms.models import XFormInstance
-import os
+from corehq.apps.sofabed.dbaccessors import get_form_counts_by_user_xmlns
 from corehq.apps.sofabed.models import FormData
-from datetime import date, datetime
 
 
 class FormDataTestCase(TestCase):
@@ -68,3 +71,51 @@ class FormDataTestCase(TestCase):
         FormData.create_or_update_from_instance(self.instance)
         self.assertEqual(2, FormData.objects.count())
         self.assertTrue(FormData.objects.get(instance_id="UPDATED_INSTANCEID").matches_exact(self.instance))
+
+
+def utc_date(y, m, d):
+    return datetime(y, m, d, tzinfo=pytz.UTC)
+
+
+class FormDataQueryTest(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.form_data = []
+        for received_on, time_end, xmlns, user_id in [
+            (utc_date(2015, 2, 5), utc_date(2015, 1, 24), 'form1', 'user1'),
+            (utc_date(2015, 2, 8), utc_date(2015, 2, 7), 'form1', 'user1'),
+            (utc_date(2015, 2, 8), utc_date(2015, 2, 7), 'form2', 'user1'),
+            (utc_date(2015, 2, 8), utc_date(2015, 2, 7), 'form1', 'user2'),
+            (utc_date(2015, 2, 28), utc_date(2015, 2, 1), 'form1', 'user2'),
+        ]:
+            cls.form_data.append(FormData.objects.create(
+                domain='test-domain',
+                received_on=received_on,
+                time_end=time_end,
+                xmlns=xmlns,
+                user_id=user_id,
+                app_id='app_id',
+                time_start=time_end,
+                instance_id=uuid.uuid4().hex,
+                duration=3,
+            ))
+
+    @classmethod
+    def tearDownClass(cls):
+        for form_datum in cls.form_data:
+            form_datum.delete()
+
+    def test_form_counts_by_submission_time(self):
+        start, end = utc_date(2015, 2, 1), utc_date(2015, 3, 1)
+        counts = get_form_counts_by_user_xmlns('test-domain', start, end)
+        self.assertEqual(counts[('user1', 'form1', 'app_id')], 2)
+        self.assertEqual(counts[('user1', 'form2', 'app_id')], 1)
+        self.assertEqual(counts[('user2', 'form1', 'app_id')], 2)
+
+    def test_form_counts_by_completion_time(self):
+        start, end = utc_date(2015, 2, 1), utc_date(2015, 3, 1)
+        counts = get_form_counts_by_user_xmlns('test-domain', start, end,
+                                               by_submission_time=False)
+        self.assertEqual(counts[('user1', 'form1', 'app_id')], 1)
+        self.assertEqual(counts[('user1', 'form2', 'app_id')], 1)
+        self.assertEqual(counts[('user2', 'form1', 'app_id')], 2)


### PR DESCRIPTION
This removes one of our most egregious sources of couch queries.
Previously, this report was hitting the db for every `(user, xmlns, app_id)` combination.  On a domain I happened to have locally, this amounted to several minutes of load time and around 7000 db calls.

This is now one (big) postgres call:

``` SQL
SELECT count(*) AS count_1, sofabed_formdata.xmlns, sofabed_formdata.user_id,
    sofabed_formdata.app_id FROM sofabed_formdata
WHERE sofabed_formdata.domain = :domain_1
AND sofabed_formdata.received_on >= :received_on_1
AND sofabed_formdata.received_on < :received_on_2
AND sofabed_formdata.user_id IN (:user_id_1, :user_id_2)
AND sofabed_formdata.xmlns IN (:xmlns1, :xmlns2)
GROUP BY sofabed_formdata.xmlns, sofabed_formdata.user_id, sofabed_formdata.app_id
```

@nickpell

As far as assuring consistency, I wrote some tests on the query itself, and ran the report locally against a whole bunch of forms.  To compare, I put an `assert couch == sql` in there while testing, to catch any places where they disagreed.  That's how I found the timezones issue.
