### PR TITLE
Return missing datatbles args when UCR errors

### DIFF
--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -232,6 +232,8 @@ class ConfigurableReport(JSONResponseMixin, TemplateView):
             return self.render_json_response({
                 'error': e.message,
                 'aaData': [],
+                'iTotalRecords': 0,
+                'iTotalDisplayRecords': 0,
             })
         except TableNotFoundWarning:
             if self.spec.report_meta.created_by_builder:


### PR DESCRIPTION
Fixes pagination (no pages will be displayed) when error returned.
cc @biyeun @snopoke 
