### PR TITLE
XFormBuilder for easy XForms

### DIFF
--- a/corehq/apps/app_manager/tests/__init__.py
+++ b/corehq/apps/app_manager/tests/__init__.py
@@ -48,10 +48,12 @@ except ImportError, e:
 from corehq.apps.app_manager.models import validate_property
 from corehq.apps.app_manager.util import is_valid_case_type, version_key
 from corehq.apps.app_manager.id_strings import _format_to_regex
+from corehq.apps.app_manager import xform_builder
 
 __test__ = {
     'is_valid_case_type': is_valid_case_type,
     'version_key': version_key,
     '_format_to_regex': _format_to_regex,
     'validate_property': validate_property,
+    'xform_builder': xform_builder,
 }

--- a/corehq/apps/app_manager/tests/__init__.py
+++ b/corehq/apps/app_manager/tests/__init__.py
@@ -38,6 +38,7 @@ try:
     from corehq.apps.app_manager.tests.test_child_module import *
     from corehq.apps.app_manager.tests.test_report_config import *
     from corehq.apps.app_manager.tests.test_grid_menus import *
+    from corehq.apps.app_manager.tests.test_xform_builder import *
 except ImportError, e:
     # for some reason the test harness squashes these so log them here for clarity
     # otherwise debugging is a pain

--- a/corehq/apps/app_manager/tests/data/xform_builder/data_types.xml
+++ b/corehq/apps/app_manager/tests/data/xform_builder/data_types.xml
@@ -1,0 +1,74 @@
+<?xml version='1.0' encoding='utf-8'?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa">
+  <h:head>
+    <h:title>Untitled Form</h:title>
+    <model>
+      <instance>
+        <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/2429276b-0aab-4379-8ed7-58df94e29358" uiVersion="1" version="3" name="Untitled Form">
+          <name/>
+          <dob/>
+          <with_mother/>
+          <height/>
+          <weight/>
+          <time/>
+          <now/>
+        </data>
+      </instance>
+      <itext>
+        <translation lang="en" default="">
+          <text id="name-label">
+            <value>Child name</value>
+          </text>
+          <text id="dob-label">
+            <value>Child date of birth</value>
+          </text>
+          <text id="with_mother-label">
+            <value>Does child live with mother?</value>
+          </text>
+          <text id="height-label">
+            <value>Child height (cm)</value>
+          </text>
+          <text id="weight-label">
+            <value>Child weight (metric tonnes)</value>
+          </text>
+          <text id="time-label">
+            <value>Arrival time</value>
+          </text>
+          <text id="now-label">
+            <value>Current timestamp</value>
+          </text>
+        </translation>
+      </itext>
+      <bind nodeset="/data/name" type="xsd:string"/>
+      <bind nodeset="/data/dob" type="xsd:date"/>
+      <bind nodeset="/data/with_mother" type="xsd:boolean"/>
+      <bind nodeset="/data/height" type="xsd:int"/>
+      <bind nodeset="/data/weight" type="xsd:decimal"/>
+      <bind nodeset="/data/time" type="xsd:time"/>
+      <bind nodeset="/data/now" type="xsd:dateTime"/>
+    </model>
+  </h:head>
+  <h:body>
+    <input ref="/data/name">
+      <label ref="jr:itext('name-label')"/>
+    </input>
+    <input ref="/data/dob">
+      <label ref="jr:itext('dob-label')"/>
+    </input>
+    <input ref="/data/with_mother">
+      <label ref="jr:itext('with_mother-label')"/>
+    </input>
+    <input ref="/data/height">
+      <label ref="jr:itext('height-label')"/>
+    </input>
+    <input ref="/data/weight">
+      <label ref="jr:itext('weight-label')"/>
+    </input>
+    <input ref="/data/time">
+      <label ref="jr:itext('time-label')"/>
+    </input>
+    <input ref="/data/now">
+      <label ref="jr:itext('now-label')"/>
+    </input>
+  </h:body>
+</h:html>

--- a/corehq/apps/app_manager/tests/data/xform_builder/group.xml
+++ b/corehq/apps/app_manager/tests/data/xform_builder/group.xml
@@ -1,0 +1,34 @@
+<?xml version='1.0' encoding='utf-8'?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa">
+  <h:head>
+    <h:title>Untitled Form</h:title>
+    <model>
+      <instance>
+        <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/0e4cb20f-2a04-4398-bd75-7806a9bcc302" uiVersion="1" version="3" name="Untitled Form">
+          <personal>
+            <name/>
+          </personal>
+        </data>
+      </instance>
+      <itext>
+        <translation lang="en" default="">
+          <text id="personal-label">
+            <value>Personal Questions</value>
+          </text>
+          <text id="personal/name-label">
+            <value>What is your name?</value>
+          </text>
+        </translation>
+      </itext>
+      <bind nodeset="/data/personal/name" type="xsd:string"/>
+    </model>
+  </h:head>
+  <h:body>
+    <group ref="/data/personal">
+      <label ref="jr:itext('personal-label')"/>
+      <input ref="/data/personal/name">
+        <label ref="jr:itext('personal/name-label')"/>
+      </input>
+    </group>
+  </h:body>
+</h:html>

--- a/corehq/apps/app_manager/tests/data/xform_builder/repeat_group.xml
+++ b/corehq/apps/app_manager/tests/data/xform_builder/repeat_group.xml
@@ -1,0 +1,44 @@
+<?xml version='1.0' encoding='utf-8'?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa">
+  <h:head>
+    <h:title>Untitled Form</h:title>
+    <model>
+      <instance>
+        <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/52628aa1-5fb2-4726-a917-653d50c965fd" uiVersion="1" version="3" name="Untitled Form">
+          <num_names/>
+          <personal>
+            <name/>
+          </personal>
+        </data>
+      </instance>
+      <itext>
+        <translation lang="en" default="">
+          <text id="num_names-label">
+            <value>How many names do you have?</value>
+          </text>
+          <text id="personal-label">
+            <value>Personal Questions</value>
+          </text>
+          <text id="personal/name-label">
+            <value>What is your <output value="ordinal(position(..) + 1)" /> name?</value>
+          </text>
+        </translation>
+      </itext>
+      <bind nodeset="/data/num_names" type="xsd:int"/>
+      <bind nodeset="/data/personal/name" type="xsd:string"/>
+    </model>
+  </h:head>
+  <h:body>
+    <input ref="/data/num_names">
+      <label ref="jr:itext('num_names-label')"/>
+    </input>
+    <group>
+      <label ref="jr:itext('personal-label')"/>
+      <repeat jr:count="/data/num_names" nodeset="/data/personal" jr:noAddRemove="true()">
+        <input ref="/data/personal/name">
+          <label ref="jr:itext('personal/name-label')"/>
+        </input>
+      </repeat>
+    </group>
+  </h:body>
+</h:html>

--- a/corehq/apps/app_manager/tests/data/xform_builder/select1_question.xml
+++ b/corehq/apps/app_manager/tests/data/xform_builder/select1_question.xml
@@ -1,0 +1,46 @@
+<?xml version='1.0' encoding='utf-8'?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa">
+  <h:head>
+    <h:title>Untitled Form</h:title>
+    <model>
+      <instance>
+        <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/6b870fef-2c47-438c-aa52-e55c29d61034" uiVersion="1" version="3" name="Untitled Form">
+          <you_aint_been_blue/>
+        </data>
+      </instance>
+      <itext>
+        <translation lang="en" default="">
+          <text id="you_aint_been_blue-label">
+            <value>What kind of blue are you?</value>
+          </text>
+          <text id="you_aint_been_blue-1-label">
+            <value>Blue</value>
+          </text>
+          <text id="you_aint_been_blue-2-label">
+            <value>Indigo</value>
+          </text>
+          <text id="you_aint_been_blue-3-label">
+            <value>Black</value>
+          </text>
+        </translation>
+      </itext>
+    </model>
+  </h:head>
+  <h:body>
+    <select1 ref="/data/you_aint_been_blue">
+      <label ref="jr:itext('you_aint_been_blue-label')"/>
+      <item>
+        <label ref="jr:itext('you_aint_been_blue-1-label')"/>
+        <value>1</value>
+      </item>
+      <item>
+        <label ref="jr:itext('you_aint_been_blue-2-label')"/>
+        <value>2</value>
+      </item>
+      <item>
+        <label ref="jr:itext('you_aint_been_blue-3-label')"/>
+        <value>3</value>
+      </item>
+    </select1>
+  </h:body>
+</h:html>

--- a/corehq/apps/app_manager/tests/data/xform_builder/select_question.xml
+++ b/corehq/apps/app_manager/tests/data/xform_builder/select_question.xml
@@ -1,0 +1,74 @@
+<?xml version='1.0' encoding='utf-8'?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa">
+  <h:head>
+    <h:title>Untitled Form</h:title>
+    <model>
+      <instance>
+        <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/2c398446-d17d-4a97-8d7c-cefe169b4d95" uiVersion="1" version="3" name="Untitled Form">
+          <fav_colors/>
+        </data>
+      </instance>
+      <itext>
+        <translation lang="en" default="">
+          <text id="fav_colors-label">
+            <value>What are your favorite colors?</value>
+          </text>
+          <text id="fav_colors-b-label">
+            <value>Blue</value>
+          </text>
+          <text id="fav_colors-g-label">
+            <value>Green</value>
+          </text>
+          <text id="fav_colors-i-label">
+            <value>Indigo</value>
+          </text>
+          <text id="fav_colors-o-label">
+            <value>Orange</value>
+          </text>
+          <text id="fav_colors-r-label">
+            <value>Red</value>
+          </text>
+          <text id="fav_colors-v-label">
+            <value>Violet</value>
+          </text>
+          <text id="fav_colors-y-label">
+            <value>Yellow</value>
+          </text>
+        </translation>
+      </itext>
+    </model>
+  </h:head>
+  <h:body>
+    <select ref="/data/fav_colors">
+      <label ref="jr:itext('fav_colors-label')"/>
+      <item>
+        <label ref="jr:itext('fav_colors-b-label')"/>
+        <value>b</value>
+      </item>
+      <item>
+        <label ref="jr:itext('fav_colors-g-label')"/>
+        <value>g</value>
+      </item>
+      <item>
+        <label ref="jr:itext('fav_colors-i-label')"/>
+        <value>i</value>
+      </item>
+      <item>
+        <label ref="jr:itext('fav_colors-o-label')"/>
+        <value>o</value>
+      </item>
+      <item>
+        <label ref="jr:itext('fav_colors-r-label')"/>
+        <value>r</value>
+      </item>
+      <item>
+        <label ref="jr:itext('fav_colors-v-label')"/>
+        <value>v</value>
+      </item>
+      <item>
+        <label ref="jr:itext('fav_colors-y-label')"/>
+        <value>y</value>
+      </item>
+    </select>
+  </h:body>
+</h:html>

--- a/corehq/apps/app_manager/tests/data/xform_builder/unicode.xml
+++ b/corehq/apps/app_manager/tests/data/xform_builder/unicode.xml
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='utf-8'?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa">
+  <h:head>
+    <h:title>Untitled Form</h:title>
+    <model>
+      <instance>
+        <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/bafd213a-a20d-473e-a103-cd77dc20773e" uiVersion="1" version="3" name="Untitled Form">
+          <name/>
+        </data>
+      </instance>
+      <itext>
+        <translation lang="en" default="">
+          <text id="name-label">
+            <value>သင့်နာမည်ဘယ်လိုခေါ်လဲ?</value>
+          </text>
+        </translation>
+      </itext>
+      <bind nodeset="/data/name" type="xsd:string"/>
+    </model>
+  </h:head>
+  <h:body>
+    <input ref="/data/name">
+      <label ref="jr:itext('name-label')"/>
+    </input>
+  </h:body>
+</h:html>

--- a/corehq/apps/app_manager/tests/data/xform_builder/xform_title.xml
+++ b/corehq/apps/app_manager/tests/data/xform_builder/xform_title.xml
@@ -1,0 +1,51 @@
+<?xml version='1.0' encoding='utf-8'?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa">
+  <h:head>
+    <h:title>Built by XFormBuilder</h:title>
+    <model>
+      <instance>
+        <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/2fe65933-153c-4af0-9726-bc226971ab5f" name="Built by XFormBuilder" uiVersion="1" version="3">
+          <name/>
+          <personal>
+            <fav_color/>
+          </personal>
+        </data>
+      </instance>
+      <itext>
+        <translation default="" lang="en">
+          <text id="name-label">
+            <value>What is your name?</value>
+          </text>
+          <text id="personal-label">
+            <value>Personal Questions</value>
+          </text>
+          <text id="personal/fav_color-label">
+            <value>Quelle est ta couleur pr&#233;f&#233;r&#233;e?</value>
+          </text>
+          <text id="personal/fav_color-r-label">
+            <value>Rot</value>
+          </text>
+          <text id="personal/fav_color-b-label">
+            <value>Blau</value>
+          </text>
+          <text id="personal/fav_color-g-label">
+            <value>Gr&#252;n</value>
+          </text>
+        </translation>
+      </itext>
+      <bind nodeset="/data/name" type="xsd:string"/>
+      <bind nodeset="/data/personal/fav_color" type="xsd:string"/>
+    </model>
+  </h:head>
+  <h:body>
+    <input ref="/data/name">
+      <label ref="jr:itext('name-label')"/>
+    </input>
+    <group ref="/data/personal">
+      <label ref="jr:itext('personal-label')"/>
+      <input ref="/data/personal/fav_color">
+        <label ref="jr:itext('personal/fav_color-label')"/>
+      </input>
+    </group>
+  </h:body>
+</h:html>

--- a/corehq/apps/app_manager/tests/test_xform_builder.py
+++ b/corehq/apps/app_manager/tests/test_xform_builder.py
@@ -5,7 +5,7 @@ from corehq.apps.app_manager.tests import TestXmlMixin
 from corehq.apps.app_manager.xform_builder import XFormBuilder
 
 
-class XformBuilderTests(SimpleTestCase, TestXmlMixin):
+class XFormBuilderTests(SimpleTestCase, TestXmlMixin):
     file_path = ('data', 'xform_builder')
 
     def setUp(self):

--- a/corehq/apps/app_manager/tests/test_xform_builder.py
+++ b/corehq/apps/app_manager/tests/test_xform_builder.py
@@ -102,3 +102,14 @@ class XformBuilderTests(SimpleTestCase, TestXmlMixin):
             self.replace_xmlns(self.get_xml('data_types'), self.xform.xmlns),
             self.xform.tostring(pretty_print=True, encoding='utf-8', xml_declaration=True)
         )
+
+    def test_xform_title(self):
+        self.xform = XFormBuilder('Built by XFormBuilder')
+        self.xform.new_question('name', 'What is your name?')
+        group = self.xform.new_group('personal', 'Personal Questions')
+        group.new_question('fav_color', u'Quelle est ta couleur préférée?',
+                           choices={'r': 'Rot', 'g': u'Grün', 'b': 'Blau'})
+        self.assertXmlEqual(
+            self.replace_xmlns(self.get_xml('xform_title'), self.xform.xmlns),
+            self.xform.tostring(pretty_print=True, encoding='utf-8', xml_declaration=True)
+        )

--- a/corehq/apps/app_manager/tests/test_xform_builder.py
+++ b/corehq/apps/app_manager/tests/test_xform_builder.py
@@ -1,0 +1,104 @@
+# coding: utf-8
+from django.test import SimpleTestCase
+import re
+from corehq.apps.app_manager.tests import TestXmlMixin
+from corehq.apps.app_manager.xform_builder import XFormBuilder
+
+
+class XformBuilderTests(SimpleTestCase, TestXmlMixin):
+    file_path = ('data', 'xform_builder')
+
+    def setUp(self):
+        self.xform = XFormBuilder()
+
+    def replace_xmlns(self, xml, xmlns):
+        return re.sub(r'http://openrosa\.org/formdesigner/[\w-]{36}', xmlns, xml)
+
+    def test_new_question_group(self):
+        """
+        XFormBuilder.new_question should be able to add a group
+        """
+        self.xform.new_question('personal', 'Personal Questions', data_type='group')
+        self.xform.new_question('name', 'What is your name?', group='personal')
+        self.assertXmlEqual(
+            self.replace_xmlns(self.get_xml('group'), self.xform.xmlns),
+            self.xform.tostring(pretty_print=True, encoding='utf-8', xml_declaration=True)
+        )
+
+    def test_new_question_repeat_group(self):
+        num_names = self.xform.new_question('num_names', 'How many names do you have?', data_type='int')
+        self.xform.new_question('personal', 'Personal Questions', data_type='repeatGroup',
+                                repeat_count=num_names)
+        self.xform.new_question('name', 'What is your <output value="ordinal(position(..) + 1)" /> name?',
+                                group='personal', label_safe=True)
+        # Yes, that was plug for an ordinal function. cf. UserVoice:
+        # https://dimagi.uservoice.com/forums/176376-form-builder/suggestions/10610517--ordinal-function
+        self.assertXmlEqual(
+            self.replace_xmlns(self.get_xml('repeat_group'), self.xform.xmlns),
+            self.xform.tostring(pretty_print=True, encoding='utf-8', xml_declaration=True)
+        )
+
+    def test_new_group_group(self):
+        personal = self.xform.new_group('personal', 'Personal Questions')
+        personal.new_question('name', 'What is your name?')
+        self.assertXmlEqual(
+            self.replace_xmlns(self.get_xml('group'), self.xform.xmlns),
+            self.xform.tostring(pretty_print=True, encoding='utf-8', xml_declaration=True)
+        )
+
+    def test_new_group_repeat_group(self):
+        num_names = self.xform.new_question('num_names', 'How many names do you have?', data_type='int')
+        personal = self.xform.new_group('personal', 'Personal Questions', data_type='repeatGroup',
+                                        repeat_count=num_names)
+        personal.new_question('name', 'What is your <output value="ordinal(position(..) + 1)" /> name?',
+                              label_safe=True)
+        self.assertXmlEqual(
+            self.replace_xmlns(self.get_xml('repeat_group'), self.xform.xmlns),
+            self.xform.tostring(pretty_print=True, encoding='utf-8', xml_declaration=True)
+        )
+
+    def test_unicode(self):
+        self.xform.new_question('name', u'သင့်နာမည်ဘယ်လိုခေါ်လဲ?')  # ("What is your name?" in Myanmar/Burmese)
+        self.assertXmlEqual(
+            self.replace_xmlns(self.get_xml('unicode'), self.xform.xmlns),
+            self.xform.tostring(pretty_print=True, encoding='utf-8', xml_declaration=True)
+        )
+
+    def test_select_question(self):
+        self.xform.new_question('fav_colors', 'What are your favorite colors?', data_type='select', choices={
+            'r': 'Red',
+            'o': 'Orange',
+            'y': 'Yellow',
+            'g': 'Green',
+            'b': 'Blue',
+            'i': 'Indigo',
+            'v': 'Violet',
+        })
+        self.assertXmlEqual(
+            self.replace_xmlns(self.get_xml('select_question'), self.xform.xmlns),
+            self.xform.tostring(pretty_print=True, encoding='utf-8', xml_declaration=True)
+        )
+
+    def test_select1_question(self):
+        self.xform.new_question('you_aint_been_blue', 'What kind of blue are you?', data_type='select1', choices={
+            1: 'Blue',
+            2: 'Indigo',
+            3: 'Black',
+        })
+        self.assertXmlEqual(
+            self.replace_xmlns(self.get_xml('select1_question'), self.xform.xmlns),
+            self.xform.tostring(pretty_print=True, encoding='utf-8', xml_declaration=True)
+        )
+
+    def test_data_types(self):
+        self.xform.new_question('name', 'Child name')
+        self.xform.new_question('dob', 'Child date of birth', 'date')
+        self.xform.new_question('with_mother', 'Does child live with mother?', 'boolean')
+        self.xform.new_question('height', 'Child height (cm)', 'int')
+        self.xform.new_question('weight', 'Child weight (metric tonnes)', 'decimal')
+        self.xform.new_question('time', 'Arrival time', 'time')
+        self.xform.new_question('now', 'Current timestamp', 'dateTime')
+        self.assertXmlEqual(
+            self.replace_xmlns(self.get_xml('data_types'), self.xform.xmlns),
+            self.xform.tostring(pretty_print=True, encoding='utf-8', xml_declaration=True)
+        )

--- a/corehq/apps/app_manager/xform_builder.py
+++ b/corehq/apps/app_manager/xform_builder.py
@@ -48,17 +48,14 @@ EMPTY_XFORM = """<?xml version="1.0"?>
 </h:html>"""
 
 
-# The data types supported by the Open Data Kit XForm spec
-# cf. https://opendatakit.github.io/odk-xform-spec/#data-types
-ODK_TYPES = (
-    'string', 'int', 'boolean', 'decimal', 'date', 'time', 'dateTime', 'select', 'select1', 'geopoint', 'geotrace',
-    'geoshape', 'binary', 'barcode',
-)
-# CommCare question group types
-GROUP_TYPES = ('group', 'repeatGroup')  # TODO: Support 'questionList'
 # The subset of ODK data types that are XSD data types
 # cf. http://www.w3.org/TR/xmlschema-2/#built-in-datatypes
 XSD_TYPES = ('string', 'int', 'boolean', 'decimal', 'date', 'time', 'dateTime')
+# The data types supported by the Open Data Kit XForm spec
+# cf. https://opendatakit.github.io/odk-xform-spec/#data-types
+ODK_TYPES = XSD_TYPES + ('select', 'select1', 'geopoint', 'geotrace', 'geoshape', 'binary', 'barcode')
+# CommCare question group types
+GROUP_TYPES = ('group', 'repeatGroup')  # TODO: Support 'questionList'
 
 
 class XFormBuilder(object):

--- a/corehq/apps/app_manager/xform_builder.py
+++ b/corehq/apps/app_manager/xform_builder.py
@@ -1,0 +1,366 @@
+# coding: utf-8
+"""
+XFormBuilder is intended to be a simple way to create an XForm, and add
+questions to it.
+
+It was created for importing a CDISC ODM document as a CommCare app.
+Third-party solutions lacked important features like nested groups, and most
+required their input to come via an Excel spreadsheet or JSON, which did not
+seem to be a good fit.
+
+>>> from corehq.apps.app_manager.xform_builder import XFormBuilder
+>>> xform = XFormBuilder('Built by XFormBuilder')
+>>> xform.add_question('name', 'What is your name?')
+>>> xform.add_question('fav_color', u'Quelle est ta couleur préférée?',
+...                    choices={'r': 'Rot', 'g': u'Grün', 'b': 'Blau'})
+>>> xml = xform.tostring(pretty_print=True, encoding='utf-8')
+>>> xml.startswith(
+... '''<h:html xmlns:h="http://www.w3.org/1999/xhtml" '''
+...         '''xmlns:orx="http://openrosa.org/jr/xforms" '''
+...         '''xmlns="http://www.w3.org/2002/xforms" '''
+...         '''xmlns:xsd="http://www.w3.org/2001/XMLSchema" '''
+...         '''xmlns:jr="http://openrosa.org/javarosa">\\n'''
+... '''    <h:head>\\n'''
+... '''        <h:title>Built by XFormBuilder</h:title>\\n'''
+... '''        <model>\\n'''
+... '''            <instance>\\n'''
+... '''                <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" '''
+...                       '''xmlns="http://openrosa.org/formdesigner/''')  # Skip the random xmlns.
+True
+>>> xml.endswith('''" '''
+...                       '''uiVersion="1" '''
+...                       '''version="3" '''
+...                       '''name="Built by XFormBuilder">'''
+...                     '''<name/>'''
+...                     '''<fav_color/>'''
+...                 '''</data>\\n'''
+... '''            </instance>\\n'''
+... '''            <itext>\\n'''
+... '''                <translation lang="en" default="">'''
+...                     '''<text id="name-label">'''
+...                         '''<value>What is your name?</value>'''
+...                     '''</text>'''
+...                     '''<text id="fav_color-label">'''
+...                         '''<value>'''
+...                             '''Quelle est ta couleur pr\xc3\x83\xc2\xa9f\xc3\x83\xc2\xa9r\xc3\x83\xc2\xa9e?'''
+...                         '''</value>'''
+...                     '''</text>'''
+...                     '''<text id="fav_color-r-label">'''
+...                         '''<value>Rot</value>'''
+...                     '''</text>'''
+...                     '''<text id="fav_color-b-label">'''
+...                         '''<value>Blau</value>'''
+...                     '''</text>'''
+...                     '''<text id="fav_color-g-label">'''
+...                         '''<value>Gr\xc3\x83\xc2\xbcn</value>'''
+...                     '''</text>'''
+...                 '''</translation>\\n'''
+... '''            </itext>\\n'''
+...     '''        <bind nodeset="/data/name" type="xsd:string"/>'''
+...             '''<bind nodeset="/data/fav_color" type="xsd:string"/>'''
+...         '''</model>\\n'''
+... '''    </h:head>\\n'''
+... '''    <h:body>'''
+...         '''<input ref="/data/name"><label ref="jr:itext(\'name-label\')"/></input>'''
+...         '''<input ref="/data/fav_color"><label ref="jr:itext(\'fav_color-label\')"/></input>'''
+...     '''</h:body>\\n'''
+... '''</h:html>\\n'''
+... )
+True
+
+"""
+import uuid
+from lxml import etree
+from lxml.builder import E
+
+
+EMPTY_XFORM = """<?xml version="1.0"?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml"
+        xmlns:orx="http://openrosa.org/jr/xforms"
+        xmlns="http://www.w3.org/2002/xforms"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:jr="http://openrosa.org/javarosa">
+    <h:head>
+        <h:title>{name}</h:title>
+        <model>
+            <instance>
+                <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms"
+                      xmlns="{xmlns}"
+                      uiVersion="1"
+                      version="3"
+                      name="{name}"/>
+            </instance>
+            <itext>
+                <translation lang="en" default=""/>
+            </itext>
+        </model>
+    </h:head>
+    <h:body/>
+</h:html>"""
+
+
+class XFormBuilder(object):
+    """
+    A utility class for adding questions to an XForm
+    """
+    def __init__(self, name='Untitled Form', source=None):
+        """
+        Initialises an XFormBuilder instance
+
+        If source is not given, initialises an empty XForm, and sets
+        name/title to name parameter.
+
+        If source is given then initialises from source, ignores name
+        parameter. Assumes that source includes a data node.
+        """
+        self.ns = {
+            'h': "http://www.w3.org/1999/xhtml",
+            'orx': "http://openrosa.org/jr/xforms",
+            'x': "http://www.w3.org/2002/xforms",
+            'xsd': "http://www.w3.org/2001/XMLSchema",
+            'jr': "http://openrosa.org/javarosa",
+            'jrm': "http://dev.commcarehq.org/jr/xforms",
+        }
+        if source is None:
+            xmlns = 'http://openrosa.org/formdesigner/{}'.format(uuid.uuid4())
+            self._etree = etree.XML(EMPTY_XFORM.format(name=name, xmlns=xmlns))
+            self.ns['d'] = xmlns
+            self._data = self._etree.xpath('./h:head/x:model/x:instance/d:data', namespaces=self.ns)[0]
+        else:
+            self._etree = etree.fromstring(source)
+            # We don't know the data node's namespace, so we can't just fetch it with xpath.
+            instance = self._etree.xpath('./h:head/x:model/x:instance', namespaces=self.ns)[0]
+            self._data = [e for e in instance if e.tag == 'data'][0]
+            self.ns['d'] = self._data.nsmap[None]
+        self._translation1 = self._etree.xpath('./h:head/x:model/x:itext/x:translation', namespaces=self.ns)[0]
+        self._model = self._etree.xpath('./h:head/x:model', namespaces=self.ns)[0]
+        self._body = self._etree.xpath('./h:body', namespaces=self.ns)[0]
+
+    def tostring(self, **kwargs):
+        return etree.tostring(self._etree, **kwargs)
+
+    def add_question(self, name, label, data_type='string', group=None, choices=None):
+        """
+        Adds a question to the XForm.
+
+        Assumes that questions are added in a sane order. You can't add a
+        question to a group before you add the group.
+
+        :param name: Question name
+        :param label: Question label
+        :param data_type: The type of the question
+        :param group: The name of the question's group, or an iterable of names if nesting is deeper than one
+        :param choices: A dictionary of {name: label} pairs
+        """
+        if data_type not in ('string', 'int', 'double', 'date', 'time', 'dateTime', 'select', 'select1', 'group',
+                             'repeatGroup'):
+            raise TypeError('Unknown question data type "{}"'.format(data_type))
+        if group is not None and not isinstance(group, basestring) and not hasattr(group, '__iter__'):
+            raise TypeError('group parameter needs to be a string or iterable')
+        self._append_to_data(name, group)
+        self._append_to_translation(name, label, group, choices)
+        self._append_to_model(name, data_type, group)
+        self._append_to_body(name, data_type, group, choices)
+
+    @staticmethod
+    def groups_path(groups, ns=None):
+        """
+        Join groups with "/", and prefix with namespace if given.
+
+        >>> XFormBuilder.groups_path(('foo', 'bar', 'baz'), ns='x')
+        'x:foo/x:bar/x:baz'
+        >>> XFormBuilder.groups_path('foo', ns='x')
+        'x:foo'
+        >>> XFormBuilder.groups_path(('foo', 'bar', 'baz'))
+        'foo/bar/baz'
+
+        """
+        if isinstance(groups, basestring):
+            groups = [groups]
+        if ns is None:
+            return '/'.join(groups)
+        return '/'.join(['{}:{}'.format(ns, g) for g in groups])
+
+    @staticmethod
+    def get_text_id(name, group=None, choice_name=None):
+        """
+        Builds a text node "id" parameter
+
+        >>> XFormBuilder.get_text_id('foo')
+        'foo-label'
+        >>> XFormBuilder.get_text_id('foo', 'bar')
+        'bar/foo-label'
+        >>> XFormBuilder.get_text_id('foo', ('bar', 'baz'))
+        'bar/baz/foo-label'
+        >>> XFormBuilder.get_text_id('foo', ('bar', 'baz'), 'choice1')
+        'bar/baz/foo-choice1-label'
+
+        """
+        text_id = []
+        if group:
+            text_id.append(XFormBuilder.groups_path(group) + '/')
+        text_id.append(name)
+        if choice_name is not None:
+            text_id.append('-{}'.format(choice_name))
+        text_id.append('-label')
+        return ''.join(text_id)
+
+    @staticmethod
+    def get_data_ref(name, group=None):
+        """
+        Returns the reference to the data node of the given question
+
+        >>> XFormBuilder.get_data_ref('foo')
+        '/data/foo'
+        >>> XFormBuilder.get_text_id('foo', 'bar')
+        '/data/bar/foo'
+        >>> XFormBuilder.get_data_ref('foo', ('bar', 'baz'))
+        '/data/bar/baz/foo'
+
+        """
+        if group is None:
+            return '/data/' + name
+        return '/data/{}/{}'.format(XFormBuilder.groups_path(group), name)
+
+    def _append_to_data(self, name, group=None):
+        if group:
+            node = self._data.xpath('./' + self.groups_path(group))[0]
+        else:
+            node = self._data
+        node.append(etree.Element(name))
+
+    def _append_to_translation(self, name, label, group=None, choices=None):
+
+        def get_text_node(name_, label_, group_=None, choice_name_=None):
+            return E.text(
+                {'id': self.get_text_id(name_, group_, choice_name_)},
+                E.value(label_)
+            )
+
+        self._translation1.append(get_text_node(name, label, group))
+        if choices:
+            for choice_name, choice_label in choices.items():
+                self._translation1.append(get_text_node(name, choice_label, group, choice_name))
+
+    def _append_to_model(self, name, data_type, group=None):
+        if data_type in ('string', 'int', 'double', 'date', 'time', 'dateTime'):
+            bind = E.bind({'nodeset': self.get_data_ref(name, group),
+                           'type': 'xsd:' + data_type})
+        else:
+            bind = E.bind({'nodeset': self.get_data_ref(name, group)})
+        self._model.append(bind)
+
+    def _append_to_body(self, name, data_type, group=None, choices=None):
+
+        def walk_groups(node_, groups, data_ref='/data'):
+            """
+            The structure of repeating and non-repeating groups is different.
+            Walk a list of groups and return the node of the last one.
+            """
+            group_ = groups.pop(0)
+            data_ref = '{}/{}'.format(data_ref, group_)
+            try:
+                # Is it a repeat group?
+                group_node = node_.xpath('./group/repeat[@nodeset="{}"]'.format(data_ref))[0]
+            except IndexError:
+                # It must be a normal group
+                group_node = node_.xpath('./group[@ref="{}"]'.format(data_ref))[0]
+            if not groups:
+                return group_node
+            return walk_groups(group_node, groups, data_ref)
+
+        def get_group_question_node(name_, group_=None, choices_=None):
+            """
+            Returns a question node for a non-repeating group
+
+            >>> node = get_group_question_node('non-repeating_group')
+            >>> etree.tostring(node)
+            '<group ref="/data/non-repeating_group"><label ref="jr:itext('non-repeating_group-label')" /></group>'
+
+            """
+            return E.group(
+                {'ref': self.get_data_ref(name_, group_)},
+                E.label({'ref': "jr:itext('{}')".format(self.get_text_id(name_, group_))})
+            )
+
+        def get_repeat_group_question_node(name_, group_=None, choices_=None):
+            """
+            Returns a question node for a repeat group
+
+            >>> node = get_repeat_group_question_node('repeat_group')
+            >>> etree.tostring(node)
+            '<group><label ref="jr:itext(\'repeat_group-label\')"/><repeat nodeset="/data/repeat_group"/></group>'
+
+            """
+            return E.group(
+                E.label({'ref': "jr:itext('{}')".format(self.get_text_id(name_, group_))}),
+                E.repeat({'nodeset': self.get_data_ref(name_, group_)})
+            )
+
+        def _get_any_select_question_node(tag, name_, group_=None, choices_=None):
+            """
+            Return a question node for a single- or multiple-select multiple choice question
+
+            e.g.
+                <select ref="/data/multiple_answer_multichoice">
+                    <label ref="jr:itext('multiple_answer_multichoice-label')" />
+                    <item>
+                        <label ref="jr:itext('multiple_answer_multichoice-choice1-label')" />
+                        <value>choice1</value>
+                    </item>
+                    <item>
+                        <label ref="jr:itext('multiple_answer_multichoice-choice2-label')" />
+                        <value>choice2</value>
+                    </item>
+                </select>
+            """
+            node_ = etree.Element(tag, {'ref': self.get_data_ref(name_, group_)})
+            node_.append(E.label({'ref': "jr:itext('{}')".format(self.get_text_id(name_, group_))}))
+            for choice_name in choices_.keys():
+                node_.append(
+                    E.item(
+                        E.label({'ref': "jr:itext('{}')".format(self.get_text_id(name_, group_, choice_name))}),
+                        E.value(choice_name)
+                    )
+                )
+            return node_
+
+        def get_select_question_node(name_, group_=None, choices_=None):
+            """
+            Return a question node for a multiple-select multiple choice question
+            """
+            return _get_any_select_question_node('select', name_, group_=None, choices_=None)
+
+        def get_select1_question_node(name_, group_=None, choices_=None):
+            """
+            Return a question node for a single-select multiple choice question
+            """
+            return _get_any_select_question_node('select1', name_, group_=None, choices_=None)
+
+        def get_input_question_node(name_, group_=None, choices_=None):
+            """
+            Return a question node for a normal question
+
+            >>> node = get_input_question_node('text_question')
+            >>> etree.tostring(node)
+            '<input ref="/data/text_question"><label ref="jr:itext(\'text_question-label\')"/></input>'
+
+            """
+            node_ = etree.Element('input', {'ref': self.get_data_ref(name_, group_)})
+            node_.append(etree.Element('label', {'ref': "jr:itext('{}')".format(self.get_text_id(name_, group_))}))
+            return node_
+
+        if group:
+            if isinstance(group, basestring):
+                group = [group]
+            node = walk_groups(self._body, group)
+        else:
+            node = self._body
+        func = {
+            'group': get_group_question_node,
+            'repeatGroup': get_repeat_group_question_node,
+            'select': get_select_question_node,
+            'select1': get_select1_question_node,
+        }.get(data_type, get_input_question_node)
+        question_node = func(name, group, choices)
+        node.append(question_node)

--- a/corehq/apps/app_manager/xform_builder.py
+++ b/corehq/apps/app_manager/xform_builder.py
@@ -11,76 +11,12 @@ seem to be a good fit.
 
 >>> from corehq.apps.app_manager.xform_builder import XFormBuilder
 >>> xform = XFormBuilder('Built by XFormBuilder')
->>> xform.new_question('name', 'What is your name?')
+>>> _ = xform.new_question('name', 'What is your name?')
 >>> group = xform.new_group('personal', 'Personal Questions')
->>> group.new_question('fav_color', u'Quelle est ta couleur préférée?',
-...                    choices={'r': 'Rot', 'g': u'Grün', 'b': 'Blau'})
+>>> _ = group.new_question('fav_color', u'Quelle est ta couleur préférée?',
+...                        choices={'r': 'Rot', 'g': u'Grün', 'b': 'Blau'})
 >>> xml = xform.tostring(pretty_print=True, encoding='utf-8', xml_declaration=True)
->>> # Skip the random xmlns when checking the result:
->>> xml.startswith(
-... '''<?xml version=\'1.0\' encoding=\'utf-8\'?>\\n'''
-... '''<h:html xmlns:h="http://www.w3.org/1999/xhtml" '''
-...         '''xmlns:orx="http://openrosa.org/jr/xforms" '''
-...         '''xmlns="http://www.w3.org/2002/xforms" '''
-...         '''xmlns:xsd="http://www.w3.org/2001/XMLSchema" '''
-...         '''xmlns:jr="http://openrosa.org/javarosa">\\n'''
-... '''  <h:head>\\n'''
-... '''    <h:title>Built by XFormBuilder</h:title>\\n'''
-... '''    <model>\\n'''
-... '''      <instance>\\n'''
-... '''        <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" '''
-...               '''xmlns="http://openrosa.org/formdesigner/''') and xml.endswith('''" '''
-...               '''uiVersion="1" '''
-...               '''version="3" '''
-...               '''name="Built by XFormBuilder">\\n'''
-... '''          <name/>\\n'''
-... '''          <personal>\\n'''
-... '''            <fav_color/>\\n'''
-... '''          </personal>\\n'''
-... '''        </data>\\n'''
-... '''      </instance>\\n'''
-... '''      <itext>\\n'''
-... '''        <translation lang="en" default="">\\n'''
-... '''          <text id="name-label">\\n'''
-... '''            <value>What is your name?</value>\\n'''
-... '''          </text>\\n'''
-... '''          <text id="personal-label">\\n'''
-... '''            <value>Personal Questions</value>\\n'''
-... '''          </text>\\n'''
-... '''          <text id="personal/fav_color-label">\\n'''
-... '''            <value>'''
-...               '''Quelle est ta couleur pr\xc3\x83\xc2\xa9f\xc3\x83\xc2\xa9r\xc3\x83\xc2\xa9e?'''
-...             '''</value>\\n'''
-... '''          </text>\\n'''
-... '''          <text id="personal/fav_color-r-label">\\n'''
-... '''            <value>Rot</value>\\n'''
-... '''          </text>\\n'''
-... '''          <text id="personal/fav_color-b-label">\\n'''
-... '''            <value>Blau</value>\\n'''
-... '''          </text>\\n'''
-... '''          <text id="personal/fav_color-g-label">\\n'''
-... '''            <value>Gr\xc3\x83\xc2\xbcn</value>\\n'''
-... '''          </text>\\n'''
-... '''        </translation>\\n'''
-... '''      </itext>\\n'''
-... '''      <bind nodeset="/data/name" type="xsd:string"/>\\n'''
-... '''      <bind nodeset="/data/personal"/>\\n'''
-... '''      <bind nodeset="/data/personal/fav_color" type="xsd:string"/>\\n'''
-... '''    </model>\\n'''
-... '''  </h:head>\\n'''
-... '''  <h:body>\\n'''
-... '''    <input ref="/data/name">\\n'''
-... '''      <label ref="jr:itext(\'name-label\')"/>\\n'''
-... '''    </input>\\n'''
-... '''    <group ref="/data/personal">\\n'''
-... '''      <label ref="jr:itext(\'personal-label\')"/>\\n'''
-... '''      <input ref="/data/personal/fav_color">\\n'''
-... '''        <label ref="jr:itext(\'personal/fav_color-label\')"/>\\n'''
-... '''      </input>\\n'''
-... '''    </group>\\n'''
-... '''  </h:body>\\n'''
-... '''</h:html>\\n''')
-True
+
 
 """
 import uuid

--- a/corehq/apps/app_manager/xform_builder.py
+++ b/corehq/apps/app_manager/xform_builder.py
@@ -113,6 +113,14 @@ EMPTY_XFORM = """<?xml version="1.0"?>
 </h:html>"""
 
 
+# cf. https://opendatakit.github.io/odk-xform-spec/#data-types
+ODK_DATA_TYPES = (
+    'string', 'int', 'boolean', 'decimal', 'date', 'time', 'dateTime', 'select', 'select1', 'geopoint', 'geotrace',
+    'geoshape', 'binary', 'barcode',
+)
+GROUP_TYPES = ('group', 'repeatGroup')  # TODO: Support 'questionList'
+
+
 class XFormBuilder(object):
     """
     A utility class for adding questions to an XForm
@@ -167,8 +175,7 @@ class XFormBuilder(object):
         :param group: The name of the question's group, or an iterable of names if nesting is deeper than one
         :param choices: A dictionary of {name: label} pairs
         """
-        if data_type not in ('string', 'int', 'double', 'date', 'time', 'dateTime', 'select', 'select1', 'group',
-                             'repeatGroup'):
+        if data_type not in ODK_DATA_TYPES + GROUP_TYPES:
             raise TypeError('Unknown question data type "{}"'.format(data_type))
         if group is not None and not isinstance(group, basestring) and not hasattr(group, '__iter__'):
             raise TypeError('group parameter needs to be a string or iterable')
@@ -187,7 +194,7 @@ class XFormBuilder(object):
         :param data_type: The type of the group ("group" or "repeatGroup")
         :param group: The name or names of the group(s) that this group is inside
         """
-        if data_type not in ('group', 'repeatGroup'):
+        if data_type not in GROUP_TYPES:
             raise TypeError('Unknown question group type "{}"'.format(data_type))
         self.add_question(name, label, data_type, group)
         parents = [group] if isinstance(group, basestring) else group

--- a/corehq/apps/app_manager/xform_builder.py
+++ b/corehq/apps/app_manager/xform_builder.py
@@ -163,6 +163,13 @@ class XFormBuilder(object):
         self._model = self._etree.xpath('./h:head/x:model', namespaces=self.ns)[0]
         self._body = self._etree.xpath('./h:body', namespaces=self.ns)[0]
 
+    @property
+    def xmlns(self):
+        """
+        Unique XMLNS
+        """
+        return self.ns['d']
+
     def tostring(self, **kwargs):
         return etree.tostring(self._etree, **kwargs)
 
@@ -360,7 +367,7 @@ class XFormBuilder(object):
                 node_.append(
                     E.item(
                         E.label({'ref': "jr:itext('{}')".format(self.get_text_id(name_, groups_, choice_name))}),
-                        E.value(choice_name)
+                        E.value(choice_name if isinstance(choice_name, basestring) else str(choice_name))
                     )
                 )
             return node_

--- a/corehq/apps/app_manager/xform_builder.py
+++ b/corehq/apps/app_manager/xform_builder.py
@@ -113,12 +113,17 @@ EMPTY_XFORM = """<?xml version="1.0"?>
 </h:html>"""
 
 
+# The data types supported by the Open Data Kit XForm spec
 # cf. https://opendatakit.github.io/odk-xform-spec/#data-types
-ODK_DATA_TYPES = (
+ODK_TYPES = (
     'string', 'int', 'boolean', 'decimal', 'date', 'time', 'dateTime', 'select', 'select1', 'geopoint', 'geotrace',
     'geoshape', 'binary', 'barcode',
 )
+# CommCare question group types
 GROUP_TYPES = ('group', 'repeatGroup')  # TODO: Support 'questionList'
+# The subset of ODK data types that are XSD data types
+# cf. http://www.w3.org/TR/xmlschema-2/#built-in-datatypes
+XSD_TYPES = ('string', 'int', 'boolean', 'decimal', 'date', 'time', 'dateTime')
 
 
 class XFormBuilder(object):
@@ -175,7 +180,7 @@ class XFormBuilder(object):
         :param group: The name of the question's group, or an iterable of names if nesting is deeper than one
         :param choices: A dictionary of {name: label} pairs
         """
-        if data_type not in ODK_DATA_TYPES + GROUP_TYPES:
+        if data_type not in ODK_TYPES + GROUP_TYPES:
             raise TypeError('Unknown question data type "{}"'.format(data_type))
         if group is not None and not isinstance(group, basestring) and not hasattr(group, '__iter__'):
             raise TypeError('group parameter needs to be a string or iterable')
@@ -262,12 +267,8 @@ class XFormBuilder(object):
                 self._translation1.append(get_text_node(name, choice_label, group, choice_name))
 
     def _append_to_model(self, name, data_type, group=None):
-        if data_type in ('string', 'int', 'double', 'date', 'time', 'dateTime'):
-            bind = E.bind({'nodeset': self.get_data_ref(name, group),
-                           'type': 'xsd:' + data_type})
-        else:
-            bind = E.bind({'nodeset': self.get_data_ref(name, group)})
-        self._model.append(bind)
+        if data_type in XSD_TYPES:
+            self._model.append(E.bind({'nodeset': self.get_data_ref(name, group), 'type': 'xsd:' + data_type}))
 
     def _append_to_body(self, name, data_type, groups=None, choices=None):
 

--- a/corehq/apps/app_manager/xform_builder.py
+++ b/corehq/apps/app_manager/xform_builder.py
@@ -8,64 +8,78 @@ Third-party solutions lacked important features like nested groups, and most
 required their input to come via an Excel spreadsheet or JSON, which did not
 seem to be a good fit.
 
+
 >>> from corehq.apps.app_manager.xform_builder import XFormBuilder
 >>> xform = XFormBuilder('Built by XFormBuilder')
 >>> xform.add_question('name', 'What is your name?')
->>> xform.add_question('fav_color', u'Quelle est ta couleur préférée?',
+>>> group = xform.new_group('personal', 'Personal Questions')
+>>> group.add_question('fav_color', u'Quelle est ta couleur préférée?',
 ...                    choices={'r': 'Rot', 'g': u'Grün', 'b': 'Blau'})
->>> xml = xform.tostring(pretty_print=True, encoding='utf-8')
+>>> xml = xform.tostring(pretty_print=True, encoding='utf-8', xml_declaration=True)
+>>> # Skip the random xmlns when checking the result:
 >>> xml.startswith(
+... '''<?xml version=\'1.0\' encoding=\'utf-8\'?>\\n'''
 ... '''<h:html xmlns:h="http://www.w3.org/1999/xhtml" '''
 ...         '''xmlns:orx="http://openrosa.org/jr/xforms" '''
 ...         '''xmlns="http://www.w3.org/2002/xforms" '''
 ...         '''xmlns:xsd="http://www.w3.org/2001/XMLSchema" '''
 ...         '''xmlns:jr="http://openrosa.org/javarosa">\\n'''
-... '''    <h:head>\\n'''
-... '''        <h:title>Built by XFormBuilder</h:title>\\n'''
-... '''        <model>\\n'''
-... '''            <instance>\\n'''
-... '''                <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" '''
-...                       '''xmlns="http://openrosa.org/formdesigner/''')  # Skip the random xmlns.
-True
->>> xml.endswith('''" '''
-...                       '''uiVersion="1" '''
-...                       '''version="3" '''
-...                       '''name="Built by XFormBuilder">'''
-...                     '''<name/>'''
-...                     '''<fav_color/>'''
-...                 '''</data>\\n'''
-... '''            </instance>\\n'''
-... '''            <itext>\\n'''
-... '''                <translation lang="en" default="">'''
-...                     '''<text id="name-label">'''
-...                         '''<value>What is your name?</value>'''
-...                     '''</text>'''
-...                     '''<text id="fav_color-label">'''
-...                         '''<value>'''
-...                             '''Quelle est ta couleur pr\xc3\x83\xc2\xa9f\xc3\x83\xc2\xa9r\xc3\x83\xc2\xa9e?'''
-...                         '''</value>'''
-...                     '''</text>'''
-...                     '''<text id="fav_color-r-label">'''
-...                         '''<value>Rot</value>'''
-...                     '''</text>'''
-...                     '''<text id="fav_color-b-label">'''
-...                         '''<value>Blau</value>'''
-...                     '''</text>'''
-...                     '''<text id="fav_color-g-label">'''
-...                         '''<value>Gr\xc3\x83\xc2\xbcn</value>'''
-...                     '''</text>'''
-...                 '''</translation>\\n'''
-... '''            </itext>\\n'''
-...     '''        <bind nodeset="/data/name" type="xsd:string"/>'''
-...             '''<bind nodeset="/data/fav_color" type="xsd:string"/>'''
-...         '''</model>\\n'''
-... '''    </h:head>\\n'''
-... '''    <h:body>'''
-...         '''<input ref="/data/name"><label ref="jr:itext(\'name-label\')"/></input>'''
-...         '''<input ref="/data/fav_color"><label ref="jr:itext(\'fav_color-label\')"/></input>'''
-...     '''</h:body>\\n'''
-... '''</h:html>\\n'''
-... )
+... '''  <h:head>\\n'''
+... '''    <h:title>Built by XFormBuilder</h:title>\\n'''
+... '''    <model>\\n'''
+... '''      <instance>\\n'''
+... '''        <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" '''
+...               '''xmlns="http://openrosa.org/formdesigner/''') and xml.endswith('''" '''
+...               '''uiVersion="1" '''
+...               '''version="3" '''
+...               '''name="Built by XFormBuilder">\\n'''
+... '''          <name/>\\n'''
+... '''          <personal>\\n'''
+... '''            <fav_color/>\\n'''
+... '''          </personal>\\n'''
+... '''        </data>\\n'''
+... '''      </instance>\\n'''
+... '''      <itext>\\n'''
+... '''        <translation lang="en" default="">\\n'''
+... '''          <text id="name-label">\\n'''
+... '''            <value>What is your name?</value>\\n'''
+... '''          </text>\\n'''
+... '''          <text id="personal-label">\\n'''
+... '''            <value>Personal Questions</value>\\n'''
+... '''          </text>\\n'''
+... '''          <text id="personal/fav_color-label">\\n'''
+... '''            <value>'''
+...               '''Quelle est ta couleur pr\xc3\x83\xc2\xa9f\xc3\x83\xc2\xa9r\xc3\x83\xc2\xa9e?'''
+...             '''</value>\\n'''
+... '''          </text>\\n'''
+... '''          <text id="personal/fav_color-r-label">\\n'''
+... '''            <value>Rot</value>\\n'''
+... '''          </text>\\n'''
+... '''          <text id="personal/fav_color-b-label">\\n'''
+... '''            <value>Blau</value>\\n'''
+... '''          </text>\\n'''
+... '''          <text id="personal/fav_color-g-label">\\n'''
+... '''            <value>Gr\xc3\x83\xc2\xbcn</value>\\n'''
+... '''          </text>\\n'''
+... '''        </translation>\\n'''
+... '''      </itext>\\n'''
+... '''      <bind nodeset="/data/name" type="xsd:string"/>\\n'''
+... '''      <bind nodeset="/data/personal"/>\\n'''
+... '''      <bind nodeset="/data/personal/fav_color" type="xsd:string"/>\\n'''
+... '''    </model>\\n'''
+... '''  </h:head>\\n'''
+... '''  <h:body>\\n'''
+... '''    <input ref="/data/name">\\n'''
+... '''      <label ref="jr:itext(\'name-label\')"/>\\n'''
+... '''    </input>\\n'''
+... '''    <group ref="/data/personal">\\n'''
+... '''      <label ref="jr:itext(\'personal-label\')"/>\\n'''
+... '''      <input ref="/data/personal/fav_color">\\n'''
+... '''        <label ref="jr:itext(\'personal/fav_color-label\')"/>\\n'''
+... '''      </input>\\n'''
+... '''    </group>\\n'''
+... '''  </h:body>\\n'''
+... '''</h:html>\\n''')
 True
 
 """
@@ -121,13 +135,14 @@ class XFormBuilder(object):
             'jr': "http://openrosa.org/javarosa",
             'jrm': "http://dev.commcarehq.org/jr/xforms",
         }
+        strip_spaces = etree.XMLParser(remove_blank_text=True)
         if source is None:
             xmlns = 'http://openrosa.org/formdesigner/{}'.format(uuid.uuid4())
-            self._etree = etree.XML(EMPTY_XFORM.format(name=name, xmlns=xmlns))
+            self._etree = etree.XML(EMPTY_XFORM.format(name=name, xmlns=xmlns), parser=strip_spaces)
             self.ns['d'] = xmlns
             self._data = self._etree.xpath('./h:head/x:model/x:instance/d:data', namespaces=self.ns)[0]
         else:
-            self._etree = etree.fromstring(source)
+            self._etree = etree.fromstring(source, parser=strip_spaces)
             # We don't know the data node's namespace, so we can't just fetch it with xpath.
             instance = self._etree.xpath('./h:head/x:model/x:instance', namespaces=self.ns)[0]
             self._data = [e for e in instance if e.tag == 'data'][0]
@@ -157,48 +172,45 @@ class XFormBuilder(object):
             raise TypeError('Unknown question data type "{}"'.format(data_type))
         if group is not None and not isinstance(group, basestring) and not hasattr(group, '__iter__'):
             raise TypeError('group parameter needs to be a string or iterable')
-        self._append_to_data(name, group)
-        self._append_to_translation(name, label, group, choices)
-        self._append_to_model(name, data_type, group)
-        self._append_to_body(name, data_type, group, choices)
+        groups = [group] if isinstance(group, basestring) else group
+        self._append_to_data(name, groups)
+        self._append_to_translation(name, label, groups, choices)
+        self._append_to_model(name, data_type, groups)
+        self._append_to_body(name, data_type, groups, choices)
+
+    def new_group(self, name, label, data_type='group', group=None):
+        """
+        Adds and returns a question group to the XForm.
+
+        :param name: Group name
+        :param label: Group label
+        :param data_type: The type of the group ("group" or "repeatGroup")
+        :param group: The name or names of the group(s) that this group is inside
+        """
+        if data_type not in ('group', 'repeatGroup'):
+            raise TypeError('Unknown question group type "{}"'.format(data_type))
+        self.add_question(name, label, data_type, group)
+        parents = [group] if isinstance(group, basestring) else group
+        return QuestionGroup(name, self, parents)
 
     @staticmethod
-    def groups_path(groups, ns=None):
-        """
-        Join groups with "/", and prefix with namespace if given.
-
-        >>> XFormBuilder.groups_path(('foo', 'bar', 'baz'), ns='x')
-        'x:foo/x:bar/x:baz'
-        >>> XFormBuilder.groups_path('foo', ns='x')
-        'x:foo'
-        >>> XFormBuilder.groups_path(('foo', 'bar', 'baz'))
-        'foo/bar/baz'
-
-        """
-        if isinstance(groups, basestring):
-            groups = [groups]
-        if ns is None:
-            return '/'.join(groups)
-        return '/'.join(['{}:{}'.format(ns, g) for g in groups])
-
-    @staticmethod
-    def get_text_id(name, group=None, choice_name=None):
+    def get_text_id(name, groups=None, choice_name=None):
         """
         Builds a text node "id" parameter
 
         >>> XFormBuilder.get_text_id('foo')
         'foo-label'
-        >>> XFormBuilder.get_text_id('foo', 'bar')
+        >>> XFormBuilder.get_text_id('foo', ['bar'])
         'bar/foo-label'
-        >>> XFormBuilder.get_text_id('foo', ('bar', 'baz'))
+        >>> XFormBuilder.get_text_id('foo', ['bar', 'baz'])
         'bar/baz/foo-label'
-        >>> XFormBuilder.get_text_id('foo', ('bar', 'baz'), 'choice1')
+        >>> XFormBuilder.get_text_id('foo', ['bar', 'baz'], 'choice1')
         'bar/baz/foo-choice1-label'
 
         """
         text_id = []
-        if group:
-            text_id.append(XFormBuilder.groups_path(group) + '/')
+        if groups:
+            text_id.append('/'.join(groups) + '/')
         text_id.append(name)
         if choice_name is not None:
             text_id.append('-{}'.format(choice_name))
@@ -206,25 +218,25 @@ class XFormBuilder(object):
         return ''.join(text_id)
 
     @staticmethod
-    def get_data_ref(name, group=None):
+    def get_data_ref(name, groups=None):
         """
         Returns the reference to the data node of the given question
 
         >>> XFormBuilder.get_data_ref('foo')
         '/data/foo'
-        >>> XFormBuilder.get_text_id('foo', 'bar')
+        >>> XFormBuilder.get_text_id('foo', ['bar'])
         '/data/bar/foo'
-        >>> XFormBuilder.get_data_ref('foo', ('bar', 'baz'))
+        >>> XFormBuilder.get_data_ref('foo', ['bar', 'baz'])
         '/data/bar/baz/foo'
 
         """
-        if group is None:
+        if groups is None:
             return '/data/' + name
-        return '/data/{}/{}'.format(XFormBuilder.groups_path(group), name)
+        return '/data/{}/{}'.format('/'.join(groups), name)
 
-    def _append_to_data(self, name, group=None):
-        if group:
-            node = self._data.xpath('./' + self.groups_path(group))[0]
+    def _append_to_data(self, name, groups=None):
+        if groups:
+            node = self._data.xpath('./' + '/'.join(groups))[0]
         else:
             node = self._data
         node.append(etree.Element(name))
@@ -250,14 +262,15 @@ class XFormBuilder(object):
             bind = E.bind({'nodeset': self.get_data_ref(name, group)})
         self._model.append(bind)
 
-    def _append_to_body(self, name, data_type, group=None, choices=None):
+    def _append_to_body(self, name, data_type, groups=None, choices=None):
 
-        def walk_groups(node_, groups, data_ref='/data'):
+        def walk_groups(node_, groups_, data_ref='/data'):
             """
             The structure of repeating and non-repeating groups is different.
             Walk a list of groups and return the node of the last one.
             """
-            group_ = groups.pop(0)
+            groups_ = list(groups_)  # groups_ is passed by ref. Don't modify original.
+            group_ = groups_.pop(0)
             data_ref = '{}/{}'.format(data_ref, group_)
             try:
                 # Is it a repeat group?
@@ -265,11 +278,11 @@ class XFormBuilder(object):
             except IndexError:
                 # It must be a normal group
                 group_node = node_.xpath('./group[@ref="{}"]'.format(data_ref))[0]
-            if not groups:
+            if not groups_:
                 return group_node
-            return walk_groups(group_node, groups, data_ref)
+            return walk_groups(group_node, groups_, data_ref)
 
-        def get_group_question_node(name_, group_=None, choices_=None):
+        def get_group_question_node(name_, groups_=None, choices_=None):
             """
             Returns a question node for a non-repeating group
 
@@ -279,11 +292,11 @@ class XFormBuilder(object):
 
             """
             return E.group(
-                {'ref': self.get_data_ref(name_, group_)},
-                E.label({'ref': "jr:itext('{}')".format(self.get_text_id(name_, group_))})
+                {'ref': self.get_data_ref(name_, groups_)},
+                E.label({'ref': "jr:itext('{}')".format(self.get_text_id(name_, groups_))})
             )
 
-        def get_repeat_group_question_node(name_, group_=None, choices_=None):
+        def get_repeat_group_question_node(name_, groups_=None, choices_=None):
             """
             Returns a question node for a repeat group
 
@@ -293,11 +306,11 @@ class XFormBuilder(object):
 
             """
             return E.group(
-                E.label({'ref': "jr:itext('{}')".format(self.get_text_id(name_, group_))}),
-                E.repeat({'nodeset': self.get_data_ref(name_, group_)})
+                E.label({'ref': "jr:itext('{}')".format(self.get_text_id(name_, groups_))}),
+                E.repeat({'nodeset': self.get_data_ref(name_, groups_)})
             )
 
-        def _get_any_select_question_node(tag, name_, group_=None, choices_=None):
+        def _get_any_select_question_node(tag, name_, groups_=None, choices_=None):
             """
             Return a question node for a single- or multiple-select multiple choice question
 
@@ -314,30 +327,30 @@ class XFormBuilder(object):
                     </item>
                 </select>
             """
-            node_ = etree.Element(tag, {'ref': self.get_data_ref(name_, group_)})
-            node_.append(E.label({'ref': "jr:itext('{}')".format(self.get_text_id(name_, group_))}))
+            node_ = etree.Element(tag, {'ref': self.get_data_ref(name_, groups_)})
+            node_.append(E.label({'ref': "jr:itext('{}')".format(self.get_text_id(name_, groups_))}))
             for choice_name in choices_.keys():
                 node_.append(
                     E.item(
-                        E.label({'ref': "jr:itext('{}')".format(self.get_text_id(name_, group_, choice_name))}),
+                        E.label({'ref': "jr:itext('{}')".format(self.get_text_id(name_, groups_, choice_name))}),
                         E.value(choice_name)
                     )
                 )
             return node_
 
-        def get_select_question_node(name_, group_=None, choices_=None):
+        def get_select_question_node(name_, groups_=None, choices_=None):
             """
             Return a question node for a multiple-select multiple choice question
             """
-            return _get_any_select_question_node('select', name_, group_=None, choices_=None)
+            return _get_any_select_question_node('select', name_, groups_, choices_)
 
-        def get_select1_question_node(name_, group_=None, choices_=None):
+        def get_select1_question_node(name_, groups_=None, choices_=None):
             """
             Return a question node for a single-select multiple choice question
             """
-            return _get_any_select_question_node('select1', name_, group_=None, choices_=None)
+            return _get_any_select_question_node('select1', name_, groups_, choices_)
 
-        def get_input_question_node(name_, group_=None, choices_=None):
+        def get_input_question_node(name_, groups_=None, choices_=None):
             """
             Return a question node for a normal question
 
@@ -346,14 +359,13 @@ class XFormBuilder(object):
             '<input ref="/data/text_question"><label ref="jr:itext(\'text_question-label\')"/></input>'
 
             """
-            node_ = etree.Element('input', {'ref': self.get_data_ref(name_, group_)})
-            node_.append(etree.Element('label', {'ref': "jr:itext('{}')".format(self.get_text_id(name_, group_))}))
-            return node_
+            return E.input(
+                {'ref': self.get_data_ref(name_, groups_)},
+                E.label({'ref': "jr:itext('{}')".format(self.get_text_id(name_, groups_))})
+            )
 
-        if group:
-            if isinstance(group, basestring):
-                group = [group]
-            node = walk_groups(self._body, group)
+        if groups:
+            node = walk_groups(self._body, groups)
         else:
             node = self._body
         func = {
@@ -362,5 +374,18 @@ class XFormBuilder(object):
             'select': get_select_question_node,
             'select1': get_select1_question_node,
         }.get(data_type, get_input_question_node)
-        question_node = func(name, group, choices)
+        question_node = func(name, groups, choices)
         node.append(question_node)
+
+
+class QuestionGroup(object):
+    def __init__(self, name, xform, parents=None):
+        self.name = name
+        self.xform = xform
+        self.groups = [name] if parents is None else list(parents) + [name]
+
+    def add_question(self, name, label, data_type='string', choices=None):
+        self.xform.add_question(name, label, data_type, self.groups, choices)
+
+    def new_group(self, name, label, data_type='group'):
+        return self.xform.new_group(name, label, data_type, self.groups)


### PR DESCRIPTION
XFormBuilder is intended to be a simple way to create an XForm, and add questions to it.

It was created for importing a CDISC ODM document as a CommCare app. Third-party solutions lacked important features like nested groups, and most required their input to come via an Excel spreadsheet or JSON, which did not seem to be a good fit. I also took a look at [app_manager.xform.XForm](https://github.com/dimagi/commcare-hq/blob/xform_builder/corehq/apps/app_manager/xform.py#L539-539) but it seemed aimed at getting data from xfoms already built by Vellum. So I thought XFormBuilder might be a useful tool to add. Usage is as simple as

``` python
xform = XFormBuilder('Built by XFormBuilder')
xform.add_question('personal', 'Personal Questions', data_type='group')
xform.add_question('name', 'What is your name?', group='personal')
xform.add_question('fav_color', 'What is your favorite color?',
                   group='personal',
                   choices={'r': 'Red', 'g': 'Green', 'b': 'Blue'})
xml = xform.tostring(pretty_print=True, encoding='utf-8')
```

(Please excuse the ugly XML formatting in the doctest. I can't see why `pretty_print=True` is so not pretty.)

@millerdev @snopoke cc @orangejenny @czue
