### PR TITLE
Fix bootstrap 3 scheduled reports

### DIFF
--- a/corehq/apps/reports/models.py
+++ b/corehq/apps/reports/models.py
@@ -487,7 +487,7 @@ class ReportConfig(CachedCouchDocumentMixin, Document):
         CCHQPRBACMiddleware.apply_prbac(mock_request)
 
         try:
-            dispatch_func = functools.partial(self._dispatcher.dispatch, mock_request, **self.view_kwargs)
+            dispatch_func = functools.partial(self._dispatcher.__class__.as_view(), mock_request, **self.view_kwargs)
             email_response = dispatch_func(render_as='email')
             if email_response.status_code == 302:
                 return ReportContent(


### PR DESCRIPTION
This change fixes a bug revealed by the UCR bootstrap 3 conversion (https://github.com/dimagi/commcare-hq/pull/8701). I'm putting this in its own PR because it's not dependent and it should make testing easier if it's on its own branch.

Here's the problem:
The change [here](https://github.com/dimagi/commcare-hq/commit/1d21df9173d390f58244cf4490eae5eff53e6df5#diff-783410c84f07dfc780a4e0e3a8e6dfa9R64) results in [this line](https://github.com/dimagi/commcare-hq/blob/559e05ef74411e2d7db648a5948b1bf99f26a25e/corehq/apps/domain/views.py#L182) being executed. `self.args` (referenced in that line) is set in the `View.as_view()` method, which was never being called because `dispatch()` was being invoked directly.
Calling `as_view()` here solves the problem, and I also think it is more semantically correct.
