### PR TITLE
Clear daterangepicker if no start and end date given

### DIFF
--- a/corehq/apps/style/static/style/js/daterangepicker.config.js
+++ b/corehq/apps/style/static/style/js/daterangepicker.config.js
@@ -28,11 +28,17 @@ $(function () {
                 separator: separator
             }
         };
-        if (!_.isEmpty(startdate) && !_.isEmpty(enddate)) {
+        var hasStartAndEndDate = !_.isEmpty(startdate) && !_.isEmpty(enddate);
+        if (hasStartAndEndDate) {
             config.startDate = new Date(startdate);
             config.endDate = new Date(enddate);
         }
+
         $(this).daterangepicker(config);
+
+        if (! hasStartAndEndDate){
+            $(this).val("");
+        }
     };
     $.fn.createBootstrap3DefaultDateRangePicker = function () {
         this.createBootstrap3DateRangePicker(


### PR DESCRIPTION
Seems like the version of daterangepicker that bootstrap3 pages use behaves a little differently than the version that other pages use (can't tell which version it is because it's minified :( ). The latest version requires manual clearing. See note below list of events here: http://www.daterangepicker.com/#events

@biyeun 
