### PR TITLE
Restrict api access

### DIFF
--- a/corehq/apps/accounting/decorators.py
+++ b/corehq/apps/accounting/decorators.py
@@ -83,7 +83,7 @@ def requires_privilege_json_response(slug, http_status_code=None,
                                      get_response=None, **assignment):
     """
     A version of the requires privilege decorator which returns an
-    HttpResponse object with an HTTP Status Code of 405 by default
+    HttpResponse object with an HTTP Status Code of 401 by default
     and content_type application/json if the privilege is not found.
 
     `get_response` is an optional parameter where you can specify the
@@ -97,7 +97,7 @@ def requires_privilege_json_response(slug, http_status_code=None,
     ```
     todo accounting for API requests
     """
-    http_status_code = http_status_code or 405
+    http_status_code = http_status_code or 401
     if get_response is None:
         get_response = lambda msg, code: {'code': code, 'message': msg}
 
@@ -111,7 +111,7 @@ def requires_privilege_json_response(slug, http_status_code=None,
                 error_message = "You have lost access to this feature."
                 response = get_response(error_message, http_status_code)
                 return HttpResponse(json.dumps(response),
-                                    content_type="application/json")
+                                    content_type="application/json", status=401)
         return wrapped
     return decorate
 

--- a/corehq/apps/api/resources/__init__.py
+++ b/corehq/apps/api/resources/__init__.py
@@ -90,12 +90,12 @@ class HqBaseResource(CorsResourceMixin, JsonResourceMixin, Resource):
     Convenience class to allow easy adjustment of API resource base classes.
     """
     def dispatch(self, request_type, request, **kwargs):
-        if  request.user.is_superuser or domain_has_privilege(request.domain, privileges.API_ACCESS):
+        if request.user.is_superuser or domain_has_privilege(request.domain, privileges.API_ACCESS):
             return super(HqBaseResource, self).dispatch(request_type, request, **kwargs)
         else:
             raise ImmediateHttpResponse(HttpResponse(json.dumps({"error": "not authorized"}),
-                                                        content_type="application/json",
-                                                        status=401))
+                                            content_type="application/json",
+                                            status=401))
 
 
 class SimpleSortableResourceMixin(object):

--- a/corehq/apps/api/resources/__init__.py
+++ b/corehq/apps/api/resources/__init__.py
@@ -1,9 +1,13 @@
+import json
+
 from django.core.urlresolvers import NoReverseMatch
 from django.http import HttpResponse
 from tastypie import http
 from tastypie.resources import Resource
 from tastypie.exceptions import InvalidSortError, ImmediateHttpResponse
 
+from corehq import privileges
+from corehq.apps.accounting.utils import domain_has_privilege
 
 class dict_object(object):
     def __init__(self, dict):
@@ -85,7 +89,13 @@ class HqBaseResource(CorsResourceMixin, JsonResourceMixin, Resource):
     """
     Convenience class to allow easy adjustment of API resource base classes.
     """
-    pass
+    def dispatch(self, request_type, request, **kwargs):
+        if  request.user.is_superuser or domain_has_privilege(request.domain, privileges.API_ACCESS):
+            return super(HqBaseResource, self).dispatch(request_type, request, **kwargs)
+        else:
+            raise ImmediateHttpResponse(HttpResponse(json.dumps({"error": "not authorized"}),
+                                                        content_type="application/json",
+                                                        status=401))
 
 
 class SimpleSortableResourceMixin(object):

--- a/corehq/apps/api/tests.py
+++ b/corehq/apps/api/tests.py
@@ -64,19 +64,11 @@ class FakeXFormES(object):
             }
         }
 
+
 def set_up_subscription(cls):
-    cls.account = BillingAccount.get_or_create_account_by_domain(
-                    cls.domain.name,
-                    created_by="automated-test",
-                    )[0]
-    plan = DefaultProductPlan.get_default_plan_by_domain(
-                cls.domain.name, edition=SoftwarePlanEdition.ADVANCED
-                )
-    cls.subscription = Subscription.new_domain_subscription(
-                        cls.account,
-                        cls.domain.name,
-                        plan
-                        )
+    cls.account = BillingAccount.get_or_create_account_by_domain(cls.domain.name, created_by="automated-test")[0]
+    plan = DefaultProductPlan.get_default_plan_by_domain(cls.domain.name, edition=SoftwarePlanEdition.ADVANCED)
+    cls.subscription = Subscription.new_domain_subscription(cls.account, cls.domain.name, plan)
     cls.subscription.is_active = True
     cls.subscription.save()
 
@@ -1087,18 +1079,9 @@ class TestSingleSignOnResource(APIResourceTest):
         wrong_domain = Domain.get_or_create_with_name('dvorak', is_active=True)
 
         # have to set up subscription for the bad domain or it will fail on authorization
-        new_account = BillingAccount.get_or_create_account_by_domain(
-                        wrong_domain.name,
-                        created_by="automated-test",
-                        )[0]
-        plan = DefaultProductPlan.get_default_plan_by_domain(
-                wrong_domain.name, edition=SoftwarePlanEdition.ADVANCED
-                )
-        new_subscription = Subscription.new_domain_subscription(
-                        new_account,
-                        wrong_domain.name,
-                        plan
-                        )
+        new_account = BillingAccount.get_or_create_account_by_domain(wrong_domain.name, created_by="automated-test")[0]
+        plan = DefaultProductPlan.get_default_plan_by_domain(wrong_domain.name, edition=SoftwarePlanEdition.ADVANCED)
+        new_subscription = Subscription.new_domain_subscription(new_account, wrong_domain.name, plan)
         new_subscription.is_active = True
         new_subscription.save()
         wrong_list_endpoint = reverse('api_dispatch_list', kwargs=dict(domain=wrong_domain.name,

--- a/corehq/apps/api/tests.py
+++ b/corehq/apps/api/tests.py
@@ -6,6 +6,7 @@ import dateutil.parser
 from django.utils.http import urlencode
 from django.test import TestCase
 from django.core.urlresolvers import reverse
+from django_prbac.models import Role
 from tastypie.models import ApiKey
 from tastypie.resources import Resource
 from tastypie import fields
@@ -15,6 +16,14 @@ from corehq.pillows.reportxform import ReportXFormPillow
 from couchforms.models import XFormInstance
 from casexml.apps.case.models import CommCareCase
 
+from corehq.apps.accounting import generator
+from corehq.apps.accounting.models import (
+    BillingAccount,
+    DefaultProductPlan,
+    SoftwarePlanEdition,
+    Subscription,
+    SubscriptionAdjustment
+)
 from corehq.pillows.xform import XFormPillow
 from corehq.pillows.case import CasePillow
 from corehq.apps.users.models import CommCareUser, WebUser
@@ -55,6 +64,21 @@ class FakeXFormES(object):
             }
         }
 
+def set_up_subscription(cls):
+    cls.account = BillingAccount.get_or_create_account_by_domain(
+                    cls.domain.name,
+                    created_by="automated-test",
+                    )[0]
+    plan = DefaultProductPlan.get_default_plan_by_domain(
+                cls.domain.name, edition=SoftwarePlanEdition.ADVANCED
+                )
+    cls.subscription = Subscription.new_domain_subscription(
+                        cls.account,
+                        cls.domain.name,
+                        plan
+                        )
+    cls.subscription.is_active = True
+    cls.subscription.save()
 
 class APIResourceTest(TestCase):
     """
@@ -67,6 +91,8 @@ class APIResourceTest(TestCase):
 
     @classmethod
     def setUpClass(cls):
+        Role.get_cache().clear()
+        generator.instantiate_accounting_for_tests()
         cls.domain = Domain.get_or_create_with_name('qwerty', is_active=True)
         cls.list_endpoint = reverse('api_dispatch_list',
                 kwargs=dict(domain=cls.domain.name,
@@ -77,11 +103,23 @@ class APIResourceTest(TestCase):
         cls.user = WebUser.create(cls.domain.name, cls.username, cls.password)
         cls.user.set_role(cls.domain.name, 'admin')
         cls.user.save()
+        set_up_subscription(cls)
+        cls.domain = Domain.get(cls.domain._id)
 
     @classmethod
     def tearDownClass(cls):
         cls.user.delete()
-        cls.domain.delete()
+
+        SubscriptionAdjustment.objects.all().delete()
+
+        if cls.subscription:
+            cls.subscription.delete()
+
+        if cls.account:
+            cls.account.delete()
+
+        for domain in Domain.get_all():
+            domain.delete()
 
     def single_endpoint(self, id):
         return reverse('api_dispatch_detail', kwargs=dict(domain=self.domain.name,
@@ -274,6 +312,21 @@ class TestCommCareCaseResource(APIResourceTest):
 
         backend_case.delete()
 
+    def test_no_subscription(self):
+        """
+        Tests authorization function properly blocks domains without proper subscription
+        :return:
+        """
+        community_domain = Domain.get_or_create_with_name('dvorak', is_active=True)
+        new_user = WebUser.create(community_domain.name, 'test', 'testpass')
+        new_user.save()
+        self.client.login(username='test', password='testpass')
+        response = self.client.get(self.list_endpoint)
+        self.assertEqual(response.status_code, 401)
+
+        community_domain.delete()
+        new_user.delete()
+
 class TestHOPECaseResource(APIResourceTest):
     """
     Tests the HOPECaseREsource, currently only v0_4, just to make sure
@@ -337,7 +390,7 @@ class TestCommCareUserResource(APIResourceTest):
 
         api_users = json.loads(response.content)['objects']
         self.assertEqual(len(api_users), 1)
-        self.assertEqual(api_users[0]['id'], backend_id)    
+        self.assertEqual(api_users[0]['id'], backend_id)
 
         commcare_user.delete()
 
@@ -1017,12 +1070,28 @@ class TestSingleSignOnResource(APIResourceTest):
         If correct credentials for a user in a different domain are submitted, the response is forbidden
         '''
         wrong_domain = Domain.get_or_create_with_name('dvorak', is_active=True)
+
+        # have to set up subscription for the bad domain or it will fail on authorization
+        new_account = BillingAccount.get_or_create_account_by_domain(
+                        wrong_domain.name,
+                        created_by="automated-test",
+                        )[0]
+        plan = DefaultProductPlan.get_default_plan_by_domain(
+                wrong_domain.name, edition=SoftwarePlanEdition.ADVANCED
+                )
+        new_subscription = Subscription.new_domain_subscription(
+                        new_account,
+                        wrong_domain.name,
+                        plan
+                        )
+        new_subscription.is_active = True
+        new_subscription.save()
         wrong_list_endpoint = reverse('api_dispatch_list', kwargs=dict(domain=wrong_domain.name,
                                                                        api_name=self.api_name,
                                                                        resource_name=self.resource.Meta.resource_name))
         response = self.client.post(wrong_list_endpoint, {'username': self.username, 'password': self.password})
         self.assertEqual(response.status_code, 403)
-        wrong_domain.delete() 
+        wrong_domain.delete()
 
     def test_wrong_credentials(self):
         '''
@@ -1154,6 +1223,8 @@ class TestBulkUserAPI(APIResourceTest):
 
     @classmethod
     def setUpClass(cls):
+        Role.get_cache().clear()
+        generator.instantiate_accounting_for_tests()
         cls.domain = Domain.get_or_create_with_name('qwerty', is_active=True)
         cls.username = 'rudolph@qwerty.commcarehq.org'
         cls.password = '***'
@@ -1164,11 +1235,22 @@ class TestBulkUserAPI(APIResourceTest):
         cls.fake_user_es = FakeUserES()
         v0_5.MOCK_BULK_USER_ES = cls.mock_es_wrapper
         cls.make_users()
+        set_up_subscription(cls)
+        cls.domain = Domain.get(cls.domain._id)
 
     @classmethod
     def tearDownClass(cls):
         cls.admin_user.delete()
-        cls.domain.delete()
+        SubscriptionAdjustment.objects.all().delete()
+
+        if cls.subscription:
+            cls.subscription.delete()
+
+        if cls.account:
+            cls.account.delete()
+
+        for domain in Domain.get_all():
+            domain.delete()
         v0_5.MOCK_BULK_USER_ES = None
 
     @classmethod

--- a/corehq/apps/api/tests.py
+++ b/corehq/apps/api/tests.py
@@ -1079,8 +1079,10 @@ class TestSingleSignOnResource(APIResourceTest):
         wrong_domain = Domain.get_or_create_with_name('dvorak', is_active=True)
 
         # have to set up subscription for the bad domain or it will fail on authorization
-        new_account = BillingAccount.get_or_create_account_by_domain(wrong_domain.name, created_by="automated-test")[0]
-        plan = DefaultProductPlan.get_default_plan_by_domain(wrong_domain.name, edition=SoftwarePlanEdition.ADVANCED)
+        new_account = BillingAccount.get_or_create_account_by_domain(wrong_domain.name,
+                                                                     created_by="automated-test")[0]
+        plan = DefaultProductPlan.get_default_plan_by_domain(wrong_domain.name,
+                                                             edition=SoftwarePlanEdition.ADVANCED)
         new_subscription = Subscription.new_domain_subscription(new_account, wrong_domain.name, plan)
         new_subscription.is_active = True
         new_subscription.save()

--- a/corehq/apps/api/tests.py
+++ b/corehq/apps/api/tests.py
@@ -327,6 +327,21 @@ class TestCommCareCaseResource(APIResourceTest):
         community_domain.delete()
         new_user.delete()
 
+    def test_superuser(self):
+        """
+        Tests superuser overrides authorization
+        :return:
+        """
+        community_domain = Domain.get_or_create_with_name('dvorak', is_active=True)
+        new_user = WebUser.create(community_domain.name, 'test', 'testpass', is_superuser=True)
+        new_user.save()
+        self.client.login(username='test', password='testpass')
+        response = self.client.get(self.list_endpoint)
+        self.assertEqual(response.status_code, 200)
+
+        community_domain.delete()
+        new_user.delete()
+
 class TestHOPECaseResource(APIResourceTest):
     """
     Tests the HOPECaseREsource, currently only v0_4, just to make sure

--- a/corehq/apps/api/urls.py
+++ b/corehq/apps/api/urls.py
@@ -6,7 +6,7 @@ from corehq.apps.api.domainapi import DomainAPI
 from corehq.apps.api.redis_assets import RedisAssetsAPI
 from corehq.apps.api.resources import v0_1, v0_2, v0_3, v0_4, v0_5
 from corehq.apps.commtrack.resources.v0_1 import ProductResource
-from corehq.apps.fixtures.resources.v0_1 import FixtureResource
+from corehq.apps.fixtures.resources.v0_1 import FixtureResource, InternalFixtureResource
 from corehq.apps.locations import resources as locations
 from corehq.apps.reports.resources.v0_1 import ReportResource
 from django.conf.urls import *
@@ -40,9 +40,11 @@ API_LIST = (
         v0_3.CommCareCaseResource,
         v0_3.XFormInstanceResource,
         FixtureResource,
+        InternalFixtureResource,
         ReportResource,
         DomainMetadataResource,
         locations.v0_1.LocationResource,
+        locations.v0_1.InternalLocationResource,
         ProductResource,
     )),
     ((0, 4), (

--- a/corehq/apps/fixtures/resources/v0_1.py
+++ b/corehq/apps/fixtures/resources/v0_1.py
@@ -30,7 +30,6 @@ class FixtureResource(HqBaseResource):
     id = tp_f.CharField(attribute='_id', readonly=True, unique=True)
 
     def obj_get(self, bundle, **kwargs):
-        import ipdb; ipdb.set_trace()
         return convert_fdt(get_object_or_not_exist(
             FixtureDataItem, kwargs['pk'], kwargs['domain']))
 
@@ -64,6 +63,7 @@ class FixtureResource(HqBaseResource):
         object_class = FixtureDataItem
         resource_name = 'fixture'
         limit = 0
+
 
 class InternalFixtureResource(FixtureResource):
 

--- a/corehq/apps/fixtures/resources/v0_1.py
+++ b/corehq/apps/fixtures/resources/v0_1.py
@@ -1,5 +1,6 @@
 from couchdbkit import ResourceNotFound
 from tastypie import fields as tp_f
+from tastypie.resources import Resource
 from corehq.apps.api.resources import HqBaseResource
 from corehq.apps.api.resources.v0_1 import (
     CustomResourceMeta,
@@ -29,6 +30,7 @@ class FixtureResource(HqBaseResource):
     id = tp_f.CharField(attribute='_id', readonly=True, unique=True)
 
     def obj_get(self, bundle, **kwargs):
+        import ipdb; ipdb.set_trace()
         return convert_fdt(get_object_or_not_exist(
             FixtureDataItem, kwargs['pk'], kwargs['domain']))
 
@@ -61,4 +63,16 @@ class FixtureResource(HqBaseResource):
         authentication = RequirePermissionAuthentication(Permissions.edit_apps)
         object_class = FixtureDataItem
         resource_name = 'fixture'
+        limit = 0
+
+class InternalFixtureResource(FixtureResource):
+
+    # using the default resource dispatch function to bypass our authorization for internal use
+    def dispatch(self, request_type, request, **kwargs):
+        return Resource.dispatch(self, request_type, request, **kwargs)
+
+    class Meta(CustomResourceMeta):
+        authentication = RequirePermissionAuthentication(Permissions.edit_apps)
+        object_class = FixtureDataItem
+        resource_name = 'fixture_internal'
         limit = 0

--- a/corehq/apps/locations/resources/v0_1.py
+++ b/corehq/apps/locations/resources/v0_1.py
@@ -1,5 +1,6 @@
 import json
 from tastypie import fields
+from tastypie.resources import Resource
 
 from corehq.apps.api.resources.v0_1 import CustomResourceMeta, LoginAndDomainAuthentication
 from corehq.apps.api.util import get_object_or_not_exist
@@ -74,4 +75,16 @@ class LocationResource(HqBaseResource):
         authentication = LoginAndDomainAuthentication()
         object_class = Location
         resource_name = 'location'
+        limit = 0
+
+class InternalLocationResource(LocationResource):
+
+    # using the default resource dispatch function to bypass our authorization for internal use
+    def dispatch(self, request_type, request, **kwargs):
+        return Resource.dispatch(self, request_type, request, **kwargs)
+
+    class Meta(CustomResourceMeta):
+        authentication = LoginAndDomainAuthentication()
+        object_class = Location
+        resource_name = 'location_internal'
         limit = 0

--- a/corehq/apps/locations/resources/v0_1.py
+++ b/corehq/apps/locations/resources/v0_1.py
@@ -77,6 +77,7 @@ class LocationResource(HqBaseResource):
         resource_name = 'location'
         limit = 0
 
+
 class InternalLocationResource(LocationResource):
 
     # using the default resource dispatch function to bypass our authorization for internal use

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -68,7 +68,7 @@ class BaseLocationView(BaseDomainView):
         context.update({
             'hierarchy': location_hierarchy_config(self.domain),
             'api_root': reverse('api_dispatch_list', kwargs={'domain': self.domain,
-                                                             'resource_name': 'location',
+                                                             'resource_name': 'location_internal',
                                                              'api_name': 'v0.3'}),
         })
         return context

--- a/corehq/apps/reports/filters/fixtures.py
+++ b/corehq/apps/reports/filters/fixtures.py
@@ -35,8 +35,8 @@ class AsyncDrillableFilter(BaseReportFilter):
     @property
     def api_root(self):
         return reverse('api_dispatch_list', kwargs={'domain': self.domain,
-                                                        'resource_name': 'fixture_internal',
-                                                        'api_name': 'v0.1'})
+                                                    'resource_name': 'fixture_internal',
+                                                    'api_name': 'v0.1'})
 
     @property
     def full_hierarchy(self):

--- a/corehq/apps/reports/filters/fixtures.py
+++ b/corehq/apps/reports/filters/fixtures.py
@@ -35,7 +35,7 @@ class AsyncDrillableFilter(BaseReportFilter):
     @property
     def api_root(self):
         return reverse('api_dispatch_list', kwargs={'domain': self.domain,
-                                                        'resource_name': 'fixture',
+                                                        'resource_name': 'fixture_internal',
                                                         'api_name': 'v0.1'})
 
     @property
@@ -107,7 +107,7 @@ class AsyncLocationFilter(BaseReportFilter):
     @property
     def filter_context(self):
         api_root = reverse('api_dispatch_list', kwargs={'domain': self.domain,
-                                                        'resource_name': 'location',
+                                                        'resource_name': 'location_internal',
                                                         'api_name': 'v0.3'})
         user = self.request.couch_user
         loc_id = self.request.GET.get('location_id')

--- a/corehq/apps/reports/templates/reports/partials/download_case_export.html
+++ b/corehq/apps/reports/templates/reports/partials/download_case_export.html
@@ -16,7 +16,7 @@
         var caseExportManager = new ExportManager({
             domain: '{{ domain }}',
             exportFilters: '{{ get_filter_params.urlencode|safe }}',
-            downloadUrl: '{% url "download_cases" domain %}',
+            downloadUrl: '{% url "download_cases_internal" domain %}',
             is_new_exporter: true,
             export_type: "case"
         } );

--- a/corehq/apps/reports/templates/reports/reportdata/case_export_data.html
+++ b/corehq/apps/reports/templates/reports/reportdata/case_export_data.html
@@ -15,7 +15,7 @@
         var exportManager = new ExportManager( {
             domain: '{{ domain }}',
             exportFilters: '{{ get_filter_params.urlencode|safe }}',
-            downloadUrl: '{% url "download_cases" domain %}',
+            downloadUrl: '{% url "download_cases_internal" domain %}',
             export_type: "case"
         } );
         $('#full-case-export').one().each(function () {

--- a/corehq/apps/reports/tests/test_export_api.py
+++ b/corehq/apps/reports/tests/test_export_api.py
@@ -71,18 +71,9 @@ class ExportTest(BaseAccountingTest):
     def setUp(self):
         self._clear_docs()
         self.domain = create_domain(DOMAIN)
-        self.account = BillingAccount.get_or_create_account_by_domain(
-                    DOMAIN,
-                    created_by="automated-test",
-                    )[0]
-        plan = DefaultProductPlan.get_default_plan_by_domain(
-                DOMAIN, edition=SoftwarePlanEdition.ADVANCED
-                )
-        self.subscription = Subscription.new_domain_subscription(
-                        self.account,
-                        DOMAIN,
-                        plan
-                        )
+        self.account = BillingAccount.get_or_create_account_by_domain(DOMAIN, created_by="automated-test")[0]
+        plan = DefaultProductPlan.get_default_plan_by_domain(DOMAIN, edition=SoftwarePlanEdition.ADVANCED)
+        self.subscription = Subscription.new_domain_subscription(self.account, DOMAIN, plan)
         self.subscription.is_active = True
         self.subscription.save()
         self.couch_user = WebUser.create(None, "test", "foobar")

--- a/corehq/apps/reports/tests/test_export_api.py
+++ b/corehq/apps/reports/tests/test_export_api.py
@@ -1,5 +1,4 @@
 from django.test.client import Client
-from django.test import TestCase
 from couchforms.util import spoof_submission
 import uuid
 from corehq.apps.receiverwrapper.util import get_submit_url
@@ -10,6 +9,16 @@ from couchforms.models import XFormInstance
 from couchexport.export import ExportConfiguration
 import time
 from couchexport.models import ExportSchema
+
+from corehq.apps.accounting.tests import BaseAccountingTest
+from corehq.apps.accounting.models import (
+    BillingAccount,
+    DefaultProductPlan,
+    SoftwarePlanEdition,
+    Subscription,
+    SubscriptionAdjustment,
+)
+from corehq.apps.domain.models import Domain
 
 FORM_TEMPLATE = """<?xml version='1.0' ?>
 <foo xmlns:jrm="http://openrosa.org/jr/xforms" xmlns="http://www.commcarehq.org/export/test">
@@ -33,10 +42,10 @@ def submit_form(f=None, domain=DOMAIN):
     return spoof_submission(url, f, hqsubmission=False)
 
 
-def get_export_response(client, previous="", include_errors=False):
+def get_export_response(client, previous="", include_errors=False, domain=DOMAIN):
     # e.g. /a/wvtest/reports/export/?export_tag=%22http://openrosa.org/formdesigner/0B5AEAF6-0394-4E4B-B2FD-6CDDE1BCBC8D%22
     return client.get(
-        reverse("corehq.apps.reports.views.export_data", args=[DOMAIN]),
+        reverse("corehq.apps.reports.views.export_data", args=[domain]),
         {
             "export_tag": '"http://www.commcarehq.org/export/test"',
             "previous_export": previous,
@@ -51,7 +60,7 @@ def _content(streaming_response):
     return ''.join(streaming_response.streaming_content)
 
 
-class ExportTest(TestCase):
+class ExportTest(BaseAccountingTest):
     
     def _clear_docs(self):
         config = ExportConfiguration(XFormInstance.get_db(),
@@ -61,7 +70,21 @@ class ExportTest(TestCase):
 
     def setUp(self):
         self._clear_docs()
-        create_domain(DOMAIN)
+        self.domain = create_domain(DOMAIN)
+        self.account = BillingAccount.get_or_create_account_by_domain(
+                    DOMAIN,
+                    created_by="automated-test",
+                    )[0]
+        plan = DefaultProductPlan.get_default_plan_by_domain(
+                DOMAIN, edition=SoftwarePlanEdition.ADVANCED
+                )
+        self.subscription = Subscription.new_domain_subscription(
+                        self.account,
+                        DOMAIN,
+                        plan
+                        )
+        self.subscription.is_active = True
+        self.subscription.save()
         self.couch_user = WebUser.create(None, "test", "foobar")
         self.couch_user.add_domain_membership(DOMAIN, is_admin=True)
         self.couch_user.save()
@@ -69,6 +92,16 @@ class ExportTest(TestCase):
     def tearDown(self):
         self.couch_user.delete()
         self._clear_docs()
+
+        SubscriptionAdjustment.objects.all().delete()
+
+        if self.subscription:
+            self.subscription.delete()
+
+        if self.account:
+            self.account.delete()
+
+        super(ExportTest, self).tearDown()
 
     def testExportTokenMigration(self):
         c = Client()
@@ -145,3 +178,21 @@ class ExportTest(TestCase):
         resp = get_export_response(c, include_errors=True)
         self.assertEqual(200, resp.status_code)
         self.assertTrue(len(_content(resp)) > len(initial_content))
+
+    def test_no_subscription(self):
+        """
+        Tests authorization function properly blocks domains without proper subscription
+        :return:
+        """
+        community_domain = Domain.get_or_create_with_name('dvorak', is_active=True)
+        new_user = WebUser.create(community_domain.name, 'test2', 'testpass')
+        new_user.save()
+        c = Client()
+        c.login(**{'username': 'test2', 'password': 'testpass'})
+        f = get_form()
+        submit_form(f, community_domain.name)
+        resp = get_export_response(c, domain=community_domain.name)
+        self.assertEqual(401, resp.status_code)
+
+        community_domain.delete()
+        new_user.delete()

--- a/corehq/apps/reports/urls.py
+++ b/corehq/apps/reports/urls.py
@@ -114,6 +114,7 @@ urlpatterns = patterns('corehq.apps.reports.views',
     url(r"^export/forms/all/$", 'export_all_form_metadata', name="export_all_form_metadata"),
     url(r"^export/forms/all/async/$", 'export_all_form_metadata_async', name="export_all_form_metadata_async"),
     url(r'^download/cases/$', 'download_cases', name='download_cases'),
+    url(r'^download/internal/cases/$', 'download_cases_internal', name='download_cases_internal'),
 
     url(r'^custom/', include(custom_report_urls)),
     url(r'^filters/', include(filter_urls)),

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -233,6 +233,7 @@ def saved_reports(request, domain, template="reports/reports_home.html"):
 
     return render(request, template, context)
 
+
 @requires_privilege_json_response(privileges.API_ACCESS)
 @login_or_digest
 @require_form_export_permission
@@ -1263,9 +1264,11 @@ def generate_case_export_payload(domain, include_closed, format, group, user_fil
         workbook.close()
     return FileWrapper(open(path))
 
+
 @requires_privilege_json_response(privileges.API_ACCESS)
 def download_cases(request, domain):
     return download_cases_internal(request, domain)
+
 
 @login_or_digest
 @require_case_export_permission

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -79,6 +79,7 @@ from soil import DownloadBase
 from soil.tasks import prepare_download
 
 from corehq import privileges, toggles
+from corehq.apps.accounting.decorators import requires_privilege_json_response
 from corehq.apps.app_manager.const import USERCASE_TYPE
 from corehq.apps.app_manager.models import Application
 from corehq.apps.cloudcare.touchforms_api import get_user_contributions_to_touchforms_session
@@ -232,7 +233,7 @@ def saved_reports(request, domain, template="reports/reports_home.html"):
 
     return render(request, template, context)
 
-
+@requires_privilege_json_response(privileges.API_ACCESS)
 @login_or_digest
 @require_form_export_permission
 @datespan_default
@@ -1262,10 +1263,17 @@ def generate_case_export_payload(domain, include_closed, format, group, user_fil
         workbook.close()
     return FileWrapper(open(path))
 
+@requires_privilege_json_response(privileges.API_ACCESS)
+def download_cases(request, domain):
+    return download_cases_internal(request, domain)
+
 @login_or_digest
 @require_case_export_permission
 @require_GET
-def download_cases(request, domain):
+def download_cases_internal(request, domain):
+    """
+    bypass api access checks to allow internal use
+    """
     include_closed = json.loads(request.GET.get('include_closed', 'false'))
     try:
         format = Format.from_format(request.GET.get('format') or Format.XLS_2007)

--- a/custom/intrahealth/filters.py
+++ b/custom/intrahealth/filters.py
@@ -18,7 +18,7 @@ class LocationFilter(AsyncLocationFilter):
     @property
     def ctx(self):
         api_root = reverse('api_dispatch_list', kwargs={'domain': self.domain,
-                                                        'resource_name': 'location',
+                                                        'resource_name': 'location_internal',
                                                         'api_name': 'v0.3'})
         selected_loc_id = self.request.GET.get('location_id')
 


### PR DESCRIPTION
This restricts all of our APIs (except those used by mobile apps) to only domains on a standard plan or higher. Tastypie APIs also allow superuser access for our analytics. APIs that were used internally now also have new internal endpoints to override the checks.

Reviewing commit by commit may be easier, but changes to each file are pretty self explanatory so it may not be necessary.

@nickpell @czue 
