### PR TITLE
Get rid of some naked `get_db`s

### DIFF
--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -24,7 +24,7 @@ from corehq.util.quickcache import skippable_quickcache
 from dimagi.utils.couch import CriticalSection
 from dimagi.utils.couch.cache import cache_core
 from dimagi.utils.couch.database import (
-    iter_docs, get_db, get_safe_write_kwargs, apply_update, iter_bulk_delete
+    iter_docs, get_safe_write_kwargs, apply_update, iter_bulk_delete
 )
 from dimagi.utils.decorators.memoized import memoized
 from corehq.apps.hqwebapp.tasks import send_html_email_async
@@ -878,7 +878,7 @@ class Domain(Document, SnapshotMixin):
         if page:
             skip = (page - 1) * per_page
             limit = per_page
-        results = get_db().search('domain/snapshot_search',
+        results = cls.get_db().search('domain/snapshot_search',
             q=json.dumps(query),
             limit=limit,
             skip=skip,

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -1081,8 +1081,7 @@ class Domain(Document, SnapshotMixin):
         """
             Returns the total number of downloads from every snapshot created from this domain
         """
-        from corehq.apps.app_manager.models import Application
-        return Application.get_db().view("domain/snapshots",
+        return self.get_db().view("domain/snapshots",
             startkey=[self.get_id],
             endkey=[self.get_id, {}],
             reduce=True,

--- a/corehq/apps/reports/filters/forms.py
+++ b/corehq/apps/reports/filters/forms.py
@@ -6,8 +6,8 @@ import re
 from corehq.apps.app_manager.models import RemoteApp, Application
 from corehq.apps.reports.filters.base import BaseDrilldownOptionFilter, BaseSingleOptionFilter, BaseMultipleOptionFilter, BaseTagsFilter
 from couchforms.analytics import get_all_xmlns_app_id_pairs_submitted_to_in_domain
+from couchforms.models import XFormInstance
 from dimagi.utils.couch.cache import cache_core
-from dimagi.utils.couch.database import get_db
 from dimagi.utils.decorators.memoized import memoized
 
 # For translations
@@ -450,7 +450,7 @@ class FormsByApplicationFilter(BaseDrilldownOptionFilter):
     def get_unknown_form_name(self, xmlns, app_id=None, none_if_not_found=False):
         if app_id is not None and app_id != '_MISSING_APP_ID':
             try:
-                app = get_db().get(app_id)
+                app = Application.get_db().get(app_id)
             except ResourceNotFound:
                 # must have been a weird app id, don't fail hard
                 pass
@@ -463,7 +463,7 @@ class FormsByApplicationFilter(BaseDrilldownOptionFilter):
 
         key = ["xmlns", self.domain, xmlns]
         results = cache_core.cached_view(
-            get_db(),
+            XFormInstance.get_db(),
             'reports_forms/name_by_xmlns',
             reduce=False,
             startkey=key,

--- a/corehq/apps/translations/models.py
+++ b/corehq/apps/translations/models.py
@@ -2,7 +2,6 @@ from collections import defaultdict
 from dimagi.ext.couchdbkit import (Document, DictProperty,
     StringProperty, ListProperty)
 import commcare_translations
-from dimagi.utils.couch.database import get_db
 from dimagi.utils.couch import CouchDocLockableMixIn
 
 class TranslationMixin(Document):
@@ -93,7 +92,7 @@ class Translation(object):
             return translations
         else:
             translations = defaultdict(list)
-            r = get_db().view('translations/popularity',
+            r = TranslationDoc.get_db().view('translations/popularity',
                 startkey=[lang],
                 endkey=[lang, {}],
                 group=True

--- a/custom/_legacy/pathindia/reports.py
+++ b/custom/_legacy/pathindia/reports.py
@@ -1,6 +1,7 @@
+from casexml.apps.case.models import CommCareCase
 from corehq.apps.reports.standard import CustomProjectReport, ProjectReportParametersMixin, DatespanMixin
 from corehq.const import USER_DATE_FORMAT, USER_MONTH_FORMAT
-from dimagi.utils.couch.database import get_db
+from couchforms.models import XFormInstance
 
 class PathIndiaKrantiReport(CustomProjectReport, ProjectReportParametersMixin, DatespanMixin):
     name = "Key Indicators"
@@ -16,7 +17,7 @@ class PathIndiaKrantiReport(CustomProjectReport, ProjectReportParametersMixin, D
         report_data = dict()
         for user in self.users:
             key = [user.user_id]
-            data = get_db().view("pathindia/kranti_report",
+            data = XFormInstance.get_db().view("pathindia/kranti_report",
                 reduce=True,
                 startkey = key+[self.datespan.startdate_param_utc],
                 endkey = key+[self.datespan.enddate_param_utc]
@@ -113,7 +114,7 @@ class PathIndiaKrantiReport(CustomProjectReport, ProjectReportParametersMixin, D
                 total_link_workers=len(self.users),
                 month_of_reporting=month_reporting_range,
                 date_of_sending_report=self.datespan.enddate.strftime(USER_DATE_FORMAT),
-                total_preg_women_monitored=get_db().view("pathindia/kranti_cases",
+                total_preg_women_monitored=CommCareCase.get_db().view("pathindia/kranti_cases",
                     reduce=True
                 ).first().get('value', 0),
                 uhp=self.group.name if self.group else "All UHPs"

--- a/custom/apps/crs_reports/fields.py
+++ b/custom/apps/crs_reports/fields.py
@@ -1,8 +1,8 @@
+from casexml.apps.case.models import CommCareCase
 from corehq.apps.reports.dont_use.fields import ReportSelectField
 from corehq.apps.reports.filters.users import SelectCaseOwnerFilter
 from django.utils.translation import ugettext_noop
 from corehq.apps.groups.models import Group
-from dimagi.utils.couch.database import get_db
 from django.utils.translation import ugettext as _
 
 
@@ -23,7 +23,7 @@ class SelectBlockField(ReportSelectField):
     @classmethod
     def get_blocks(cls, domain):
         key = [domain]
-        for r in get_db().view('crs_reports/field_block',
+        for r in CommCareCase.get_db().view('crs_reports/field_block',
                       startkey=key,
                       endkey=key + [{}],
                       group_level=3).all():

--- a/custom/uth/utils.py
+++ b/custom/uth/utils.py
@@ -1,7 +1,6 @@
 from casexml.apps.case.xform import get_case_updates
 from corehq.apps.receiverwrapper import submit_form_locally
 from corehq.form_processor.utils import convert_xform_to_json
-from dimagi.utils.couch.database import get_db
 from casexml.apps.case.models import CommCareCase
 from lxml import etree
 import os
@@ -25,7 +24,7 @@ def scan_case(scanner_serial, scan_id):
     # but has them on the file itself
     scan_id = scan_id.lstrip('0')
 
-    return get_db().view(
+    return CommCareCase.get_db().view(
         'uth/uth_lookup',
         startkey=[UTH_DOMAIN, scanner_serial, scan_id],
         endkey=[UTH_DOMAIN, scanner_serial, scan_id, {}],

--- a/custom/uth/views.py
+++ b/custom/uth/views.py
@@ -1,3 +1,4 @@
+from casexml.apps.case.models import CommCareCase
 from corehq.apps.domain.decorators import login_or_basic
 from django.views.decorators.http import require_POST, require_GET
 import json
@@ -10,7 +11,6 @@ from custom.uth.utils import (
 from custom.uth.models import SonositeUpload, VscanUpload
 from custom.uth.tasks import async_create_case, async_find_and_attach
 from custom.uth.decorators import require_uth_domain
-from dimagi.utils.couch.database import get_db
 from custom.uth.const import UTH_DOMAIN
 
 
@@ -72,7 +72,7 @@ def pending_exams(request, domain, scanner_serial, **kwargs):
         response_data['message'] = 'Missing scanner serial'
         return HttpResponse(json.dumps(response_data), content_type="application/json")
 
-    results = get_db().view(
+    results = CommCareCase.get_db().view(
         'uth/uth_lookup',
         startkey=[UTH_DOMAIN, scanner_serial],
         endkey=[UTH_DOMAIN, scanner_serial, {}],


### PR DESCRIPTION
Misc cleanup I came across while looking in to the domains migration.
We still have a bunch of `get_db`s left in the codebase, but these ones I was able to figure out no problem.
It seems like there are three categories of `get_db`s:
1. I have an id and I don't know what kind of doc it corresponds to
2. `get_db().get('HARDCODED_DOC_ID')` - standalone metadata documents
3. Things that should immediately be converted to a `Document.get_db()`

The first of those will become more problematic as we continue to split up the dbs.  There are already some that I think can refer to users, but only check the "main" db.  I don't know of a good solution to this other than to simply abstract "look up this id in all of these databases".

@nickpell @dannyroberts FYI
