### PR TITLE
Expand hubspot error handling

### DIFF
--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -144,6 +144,8 @@ def _send_form_to_hubspot(form_id, webuser, cookies, meta):
             url,
             data=data
         )
+        logger.debug('Sent this data to HS: %s \nreceived: %s'
+                     .format(data, json.dumps(json.loads(req.json), indent=2, sort_keys=True)))
         req.raise_for_status()
 
 


### PR DESCRIPTION
@czue This is the only other place that we hit hubspot in the python code, might be helpful to log this as well.

Note to self, kissmetrics stores a log in /tmp/kissmetrics_error.log
