### PR TITLE
Report description xpath

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -3318,7 +3318,7 @@ class ReportAppConfig(DocumentSchema):
     """
     report_id = StringProperty(required=True)
     header = DictProperty()
-    description = DictProperty()
+    description = StringProperty()
     graph_configs = DictProperty(ReportGraphConfig)
     filters = SchemaDictProperty(ReportAppFilter)
     uuid = StringProperty(required=True)
@@ -3329,6 +3329,17 @@ class ReportAppConfig(DocumentSchema):
         super(ReportAppConfig, self).__init__(*args, **kwargs)
         if not self.uuid:
             self.uuid = random_hex()
+
+    @classmethod
+    def wrap(cls, doc):
+        from corehq.apps.userreports.util import default_language, localize
+        if isinstance(doc.get('description'), dict):
+            if doc['description']:
+                doc['description'] = localize(doc['description'], default_language())
+            else:
+                doc['description'] = ''
+
+        return super(ReportAppConfig, cls).wrap(doc)
 
     @property
     def report(self):

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -3332,6 +3332,7 @@ class ReportAppConfig(DocumentSchema):
 
     @classmethod
     def wrap(cls, doc):
+        # for backwards compatibility with apps that have localized descriptions
         from corehq.apps.userreports.util import default_language, localize
         if isinstance(doc.get('description'), dict):
             if doc['description']:

--- a/corehq/apps/app_manager/static/app_manager/js/report-module.js
+++ b/corehq/apps/app_manager/static/app_manager/js/report-module.js
@@ -213,10 +213,9 @@ var ReportModule = (function () {
         var self = this;
         this.lang = language;
         this.fullDisplay = display || {};
-        this.fullDescription = description || {};
         this.availableReportIds = availableReportIds;
         this.display = ko.observable(this.fullDisplay[this.lang]);
-        this.description = ko.observable(this.fullDescription[this.lang]);
+        this.description = ko.observable(description);
         this.uuid = uuid;
         this.reportId = ko.observable(report_id);
         this.graphConfig = new GraphConfig(report_id, this.reportId, availableReportIds, reportCharts, graph_configs, changeSaveButton);
@@ -224,13 +223,12 @@ var ReportModule = (function () {
 
         this.toJSON = function () {
             self.fullDisplay[self.lang] = self.display();
-            self.fullDescription[self.lang] = self.description();
             return {
                 report_id: self.reportId(),
                 graph_configs: self.graphConfig.toJSON(),
                 filters: self.filterConfig.toJSON(),
                 header: self.fullDisplay,
-                description: self.fullDescription,
+                description: self.description(),
                 uuid: self.uuid
             };
         };

--- a/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
+++ b/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
@@ -149,7 +149,7 @@ def _get_summary_details(config):
                         ),
                         template=Template(
                             text=Text(
-                                xpath=Xpath(function='description')
+                                xpath=Xpath(function=config.description)
                             )
                         ),
                     ),

--- a/corehq/apps/app_manager/templates/app_manager/module_view_report.html
+++ b/corehq/apps/app_manager/templates/app_manager/module_view_report.html
@@ -78,7 +78,7 @@
                         <th></th>
                         <th>{% trans "Report" %}</th>
                         <th>{% trans "Display" %}</th>
-                        <th>{% trans "Description" %}</th>
+                        <th>{% trans "Description (requires valid Xpath expression)" %}</th>
                         <th></th>
                     </tr>
                 </thead>

--- a/corehq/apps/app_manager/tests/data/suite/reports_module_summary_detail.xml
+++ b/corehq/apps/app_manager/tests/data/suite/reports_module_summary_detail.xml
@@ -31,7 +31,7 @@
         </header>
         <template>
           <text>
-            <xpath function="description"/>
+            <xpath function="report description"/>
           </text>
         </template>
       </field>

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -614,6 +614,7 @@ class SuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
             report_id=report._id,
             header={'en': 'CommBugz'},
             uuid='ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i',
+            description='report description',
         )
         report_app_config._report = report
         report_module.report_configs = [report_app_config]

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -491,7 +491,7 @@ def _new_report_module(request, domain, app, name, lang):
         ReportAppConfig(
             report_id=report._id,
             header={lang: report.title},
-            description={lang: report.description},
+            description=report.description,
         )
         for report in ReportConfiguration.by_domain(domain)
     ]

--- a/corehq/apps/userreports/fixtures.py
+++ b/corehq/apps/userreports/fixtures.py
@@ -13,11 +13,12 @@ from corehq.apps.app_manager.models import (
     StaticChoiceListFilter,
     StaticDatespanFilter,
 )
-from corehq.apps.userreports.exceptions import UserReportsError
-from corehq.apps.userreports.reports.factory import ReportFactory
-from corehq.apps.userreports.util import localize
 from corehq.util.xml import serialize
+
+from .exceptions import UserReportsError
 from .models import ReportConfiguration
+from .reports.factory import ReportFactory
+from .util import localize
 
 
 def wrap_by_filter_type(report_app_filter):

--- a/corehq/apps/userreports/fixtures.py
+++ b/corehq/apps/userreports/fixtures.py
@@ -76,7 +76,6 @@ class ReportFixturesProvider(object):
         report_elem = ElementTree.Element('report', attrib={'id': report_config.uuid})
         report = ReportConfiguration.get(report_config.report_id)
         report_elem.append(self._element('name', localize(report_config.header, user.language)))
-        report_elem.append(self._element('description', localize(report_config.description, user.language)))
         data_source = ReportFactory.from_spec(report)
 
         data_source.set_filter_values({


### PR DESCRIPTION
Allows xpath expressions to be included in the report description.  Removes ability to do translations.

https://trello.com/c/4Li7iOpU/442-ucr-mobile-ucr
