### PR TITLE
add celery settings to dev_settings.py

### DIFF
--- a/dev_settings.py
+++ b/dev_settings.py
@@ -48,3 +48,8 @@ CACHES = {'default': {'BACKEND': 'django.core.cache.backends.dummy.DummyCache'}}
 
 
 PILLOWTOP_MACHINE_ID = 'testhq'  # for tests
+
+#  make celery synchronous
+CELERY_ALWAYS_EAGER = True
+# Fail hard in tasks so you get a traceback
+CELERY_EAGER_PROPAGATES_EXCEPTIONS = True


### PR DESCRIPTION
@dimagi/team-commcare-hq FYI.
If you use `dev_settings.py`, this will make your celery tasks synchronous, and make them fail hard.  I find this helpful, but if you like, they're easy to disable in your `localsettings.py`.  (Or if you really think this is a bad thing, let me know why, and we can remove this default).
http://docs.celeryproject.org/en/latest/configuration.html#celery-eager-propagates-exceptions
