### PR TITLE
install coveralls travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ install:
   - "curl -X PUT http://localhost:5984/commcarehq_test"  # this is an auth test
   - "scripts/uninstall-requirements.sh"
   - "time (pip install --exists-action w -r requirements/requirements.txt --timeout 60)"
+  - "pip install coveralls"
   - "cp .travis/localsettings.py localsettings.py"
   - ".travis/matrix-installs.sh"
 script: ".travis/matrix-runner.sh"


### PR DESCRIPTION
We are running `coveralls` at the end of our tests, but it is never installed so coveralls hasn't been updated in over a year. Was looking at coverage for some stuff today, and found it kind of useful/interesting.

I could also add this to requirements.txt, but we really only need it on travis. 

@benrudolph 
