### PR TITLE
Fix report builder form warning

### DIFF
--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -384,12 +384,18 @@ class DataSourceForm(forms.Form):
             else:
                 report_source_crispy_fields.append(k)
 
+        top_fields = [
+            FieldWithHelpBubble(
+                'report_name',
+                help_bubble_text=_('Web users will see this name in the "Reports" section of CommCareHQ and can click to view the report'))
+        ]
+        if chart_type_crispy_field:
+            top_fields.append(chart_type_crispy_field)
 
         self.helper.layout = crispy.Layout(
             crispy.Fieldset(
                 _('{} Report'.format(self.report_type.capitalize())),
-                FieldWithHelpBubble('report_name', help_bubble_text=_('Web users will see this name in the "Reports" section of CommCareHQ and can click to view the report')),
-                chart_type_crispy_field
+                *top_fields
             ),
             crispy.Fieldset(
                 _('Data'), *report_source_crispy_fields


### PR DESCRIPTION
`chart_type_crispy_field` is `None` if the report type being built isn't "chart". The page renders fine, but crispy forms logs a warning. This change excludes `chart_type_crispy_field` from its fieldset if it is `None`, thereby fixing the warning.

cc @snopoke @biyeun 
