### PR TITLE
OpenClinica updates for app and metadata changes

### DIFF
--- a/custom/openclinica/const.py
+++ b/custom/openclinica/const.py
@@ -98,3 +98,61 @@ SINGLE_EVENT_FORM_EVENT_INDEX = {
     # Unscheduled Visit 3: Vital Signs
     'http://openrosa.org/formdesigner/bfcc88f81fe74ac9c06a707981005477634aed8c': 2,
 }
+
+# Maps CommCare modules to OpenClinica events.
+MODULE_EVENTS = {
+    'Lab Tests': ('SE_VISIT1A', 'SE_VISIT1B', 'SE_VISIT2', 'SE_VISIT3', 'SE_ENDOFSTUDY', 'SE_UNSCHEDULEDVISIT'),
+    'Register Patient': ('SE_VISIT1A', ),
+    'Assign Screening Number': None,
+    'Visit 1: Screening': ('SE_VISIT1A', 'SE_VISIT1B'),
+    'Enrollment Call': (),
+    'Enroll Patient Into Study': (),
+    'Visit 2: Baseline Screening': ('SE_VISIT2', ),
+    'Visit 3: Dosing': ('SE_VISIT3', ),
+    'Discharge Patient from Ward': ('SE_ENDOFSTUDY', ),
+    '30 Days Follow Up Call': (),
+    'End of Study': ('SE_ENDOFSTUDY', ),
+    'Adverse Events Log': ('SE_AEANDCONCOMITANTMEDICATIONS', ),
+    'Concomitant Medication Log': ('SE_AEANDCONCOMITANTMEDICATIONS', ),
+    'Unscheduled Visits Log': ('SE_UNSCHEDULEDVISIT', ),
+    'Unscheduled Contact Log': ('SE_UNSCHEDULEDVISIT', ),
+
+    'Demographic and History': ('SE_VISIT1A', ),
+}
+
+# The Lab Tests module spans many events, and its forms each map to one event.
+FORM_EVENTS = {
+    # Lab Tests > Screening 1: Enter Lab Test results
+    "http://openrosa.org/formdesigner/7ce0af9273196c50fa1c7da4ce0ffe8efd95db89": ('SE_VISIT1A', 'SE_VISIT1B'),
+    # Lab Tests > Screening 2: Enter Lab Test results
+    "http://openrosa.org/formdesigner/bcc0e64bfca2ec49b23af088bd999ce6fa4519ca": ('SE_VISIT2', ),
+    # Lab Tests > Record Post Dose PK Sample Processing Time
+    "http://openrosa.org/formdesigner/E0ADA889-F6D7-45F9-A80F-D5558FEB12C3": ('SE_VISIT3', ),
+    # Lab Tests > Patient Discharge: Enter Lab Test results
+    "http://openrosa.org/formdesigner/B181B493-567F-4FF3-9C0A-684C306DCC84": ('SE_ENDOFSTUDY', ),
+    # Lab Tests > Unscheduled Visit: Enter Lab Results
+    "http://openrosa.org/formdesigner/11a29254a2df4a77a30608e97736c9f95aee7e2f": ('SE_UNSCHEDULEDVISIT', ),
+    # Unscheduled Visits Log > Screening & Lab Request Form
+    'http://openrosa.org/formdesigner/cdd2842cd1c8640fc2846f1b042dad06ac170d5': ('SE_UNSCHEDULEDVISIT', ),
+}
+
+# When MODULE_EVENTS is not narrow enough to determine a unique question-item match, map the CommCare form and
+# question to an OpenClinica Item OID, or None if it's a CommCare-only question
+FORM_QUESTION_ITEM = {
+    # Lab Tests > Patient Discharge: Enter Lab Test results
+    ('http://openrosa.org/formdesigner/B181B493-567F-4FF3-9C0A-684C306DCC84', 'dosh'): None,
+    ('http://openrosa.org/formdesigner/B181B493-567F-4FF3-9C0A-684C306DCC84', 'dosb'): None,
+    # Lab Tests > Unscheduled Visit: Enter Lab Results
+    ('http://openrosa.org/formdesigner/11a29254a2df4a77a30608e97736c9f95aee7e2f', 'dosh'): None,
+    ('http://openrosa.org/formdesigner/11a29254a2df4a77a30608e97736c9f95aee7e2f', 'dosb'): None,
+    ('http://openrosa.org/formdesigner/11a29254a2df4a77a30608e97736c9f95aee7e2f', 'pg_pf'): None,
+    ('http://openrosa.org/formdesigner/11a29254a2df4a77a30608e97736c9f95aee7e2f', 'dospg'): None,
+    ('http://openrosa.org/formdesigner/11a29254a2df4a77a30608e97736c9f95aee7e2f', 'pgt'): None,
+    # Unscheduled Visits Log > Screening & Lab Request Form
+    ('http://openrosa.org/formdesigner/cdd2842cd1c8640fc2846f1b042dad06ac170d5', 'smlcd'): None,
+    ('http://openrosa.org/formdesigner/cdd2842cd1c8640fc2846f1b042dad06ac170d5', 'psmk'): None,
+    ('http://openrosa.org/formdesigner/cdd2842cd1c8640fc2846f1b042dad06ac170d5', 'palc'): None,
+    ('http://openrosa.org/formdesigner/cdd2842cd1c8640fc2846f1b042dad06ac170d5', 'win'): None,
+    ('http://openrosa.org/formdesigner/cdd2842cd1c8640fc2846f1b042dad06ac170d5', 'bru'): None,
+    ('http://openrosa.org/formdesigner/cdd2842cd1c8640fc2846f1b042dad06ac170d5', 'sprt'): None,
+}

--- a/custom/openclinica/reports.py
+++ b/custom/openclinica/reports.py
@@ -126,9 +126,9 @@ class OdmExportReport(OdmExportReportView, CustomProjectReport, CaseListMixin):
         audit_log_id_ref = {'id': 0}  # To exclude audit logs, set `custom.openclinica.const.AUDIT_LOGS = False`
         for case in self.get_study_subject_cases():
             subject = Subject(getattr(case, CC_SUBJECT_KEY), getattr(case, CC_STUDY_SUBJECT_ID), self.domain)
-            subject.enrollment_date = getattr(case, CC_ENROLLMENT_DATE)
-            subject.sex = getattr(case, CC_SEX)
-            subject.dob = getattr(case, CC_DOB)
+            subject.enrollment_date = getattr(case, CC_ENROLLMENT_DATE, None)
+            subject.sex = getattr(case, CC_SEX, None)
+            subject.dob = getattr(case, CC_DOB, None)
             for form in originals_first(case.get_forms()):
                 # Pass audit log ID by reference to increment it for each audit log
                 subject.add_data(form.form, form, audit_log_id_ref)

--- a/custom/openclinica/study_metadata.xml
+++ b/custom/openclinica/study_metadata.xml
@@ -14311,6 +14311,174 @@
       <LastName>User</LastName>
       <Organization>Akaza Research</Organization>
     </User>
+    <User OID="USR_2">
+      <FullName>Alice Nyasimi</FullName>
+      <FirstName>Alice</FirstName>
+      <LastName>Nyasimi</LastName>
+      <Organization>KEMRI</Organization>
+    </User>
+    <User OID="USR_3">
+      <FullName>Alfred Muia</FullName>
+      <FirstName>Alfred</FirstName>
+      <LastName>Muia</LastName>
+      <Organization>KEMRI</Organization>
+    </User>
+    <User OID="USR_4">
+      <FullName>Anne Mwenje</FullName>
+      <FirstName>Anne</FirstName>
+      <LastName>Mwenje</LastName>
+      <Organization>KEMRI</Organization>
+    </User>
+    <User OID="USR_5">
+      <FullName>Beatrice Injugu</FullName>
+      <FirstName>Beatrice</FirstName>
+      <LastName>Injugu</LastName>
+      <Organization>KEMRI</Organization>
+    </User>
+    <User OID="USR_6">
+      <FullName>Charles Magiri</FullName>
+      <FirstName>Charles</FirstName>
+      <LastName>Magiri</LastName>
+      <Organization>KEMRI</Organization>
+    </User>
+    <User OID="USR_7">
+      <FullName>Daniel Njenga</FullName>
+      <FirstName>Daniel</FirstName>
+      <LastName>Njenga</LastName>
+      <Organization>KEMRI</Organization>
+    </User>
+    <User OID="USR_8">
+      <FullName>Elizabeth Juma</FullName>
+      <FirstName>Elizabeth</FirstName>
+      <LastName>Juma</LastName>
+      <Organization>KEMRI</Organization>
+    </User>
+    <User OID="USR_9">
+      <FullName>Emily Mulongo</FullName>
+      <FirstName>Emily</FirstName>
+      <LastName>Mulongo</LastName>
+      <Organization>KEMRI</Organization>
+    </User>
+    <User OID="USR_10">
+      <FullName>Edith Mwangi</FullName>
+      <FirstName>Edith</FirstName>
+      <LastName>Mwangi</LastName>
+      <Organization>KEMRI</Organization>
+    </User>
+    <User OID="USR_11">
+      <FullName>Elizabeth Ndegwa</FullName>
+      <FirstName>Elizabeth</FirstName>
+      <LastName>Ndegwa</LastName>
+      <Organization>KEMRI</Organization>
+    </User>
+    <User OID="USR_12">
+      <FullName>Finnley Osuna</FullName>
+      <FirstName>Finnley</FirstName>
+      <LastName>Osuna</LastName>
+      <Organization>KEMRI</Organization>
+    </User>
+    <User OID="USR_13">
+      <FullName>Irene Thuo</FullName>
+      <FirstName>Irene</FirstName>
+      <LastName>Thuo</LastName>
+      <Organization>KEMRI</Organization>
+    </User>
+    <User OID="USR_14">
+      <FullName>Joseph Muita</FullName>
+      <FirstName>Joseph</FirstName>
+      <LastName>Muita</LastName>
+      <Organization>KEMRI</Organization>
+    </User>
+    <User OID="USR_15">
+      <FullName>Kevin Omondi</FullName>
+      <FirstName>Kevin</FirstName>
+      <LastName>Omondi</LastName>
+      <Organization>KEMRI</Organization>
+    </User>
+    <User OID="USR_16">
+      <FullName>Lukas Agura</FullName>
+      <FirstName>Lukas</FirstName>
+      <LastName>Agura</LastName>
+      <Organization>KEMRI</Organization>
+    </User>
+    <User OID="USR_17">
+      <FullName>Mary Wambui Kamau</FullName>
+      <FirstName>Mary</FirstName>
+      <LastName>Wambui Kamau</LastName>
+      <Organization>KEMRI</Organization>
+    </User>
+    <User OID="USR_18">
+      <FullName>Mary Muriu</FullName>
+      <FirstName>Mary</FirstName>
+      <LastName>Muriu</LastName>
+      <Organization>KEMRI</Organization>
+    </User>
+    <User OID="USR_19">
+      <FullName>Pauline Mueni</FullName>
+      <FirstName>Pauline</FirstName>
+      <LastName>Mueni</LastName>
+      <Organization>KEMRI</Organization>
+    </User>
+    <User OID="USR_20">
+      <FullName>Rose Nzioki</FullName>
+      <FirstName>Rose</FirstName>
+      <LastName>Nzioki</LastName>
+      <Organization>KEMRI</Organization>
+    </User>
+    <User OID="USR_21">
+      <FullName>Rehema Mwachuo</FullName>
+      <FirstName>Rehema</FirstName>
+      <LastName>Mwachuo</LastName>
+      <Organization>KEMRI</Organization>
+    </User>
+    <User OID="USR_22">
+      <FullName>Rose Kiage</FullName>
+      <FirstName>Rose</FirstName>
+      <LastName>Kiage</LastName>
+      <Organization>KEMRI</Organization>
+    </User>
+    <User OID="USR_23">
+      <FullName>Sahara Hussein</FullName>
+      <FirstName>Sahara</FirstName>
+      <LastName>Hussein</LastName>
+      <Organization>KEMRI</Organization>
+    </User>
+    <User OID="USR_24">
+      <FullName>Zipporah Amdany</FullName>
+      <FirstName>Zipporah</FirstName>
+      <LastName>Amdany</LastName>
+      <Organization>KEMRI</Organization>
+    </User>
+    <User OID="USR_25">
+      <FullName>Nele Groosman</FullName>
+      <FirstName>Nele</FirstName>
+      <LastName>Groosman</LastName>
+      <Organization>KEMRI</Organization>
+    </User>
+    <User OID="USR_26">
+      <FullName>Test McTest</FullName>
+      <FirstName>Test</FirstName>
+      <LastName>McTest</LastName>
+      <Organization>KEMRI</Organization>
+    </User>
+    <User OID="USR_27">
+      <FullName>Betty Sizemore</FullName>
+      <FirstName>Betty</FirstName>
+      <LastName>Sizemore</LastName>
+      <Organization>KEMRI</Organization>
+    </User>
+    <User OID="USR_28">
+      <FullName>Florence Nightingale</FullName>
+      <FirstName>Florence</FirstName>
+      <LastName>Nightingale</LastName>
+      <Organization>KEMRI</Organization>
+    </User>
+    <User OID="USR_29">
+      <FullName>Justin Nurse</FullName>
+      <FirstName>Justin</FirstName>
+      <LastName>Nurse</LastName>
+      <Organization>KEMRI</Organization>
+    </User>
   </AdminData>
 </ODM>
 

--- a/custom/openclinica/utils.py
+++ b/custom/openclinica/utils.py
@@ -11,8 +11,6 @@ from corehq.util.quickcache import quickcache
 from couchforms.models import XFormDeprecated
 from custom.openclinica.const import MODULE_EVENTS, FORM_QUESTION_ITEM, FORM_EVENTS
 
-logger = logging.Logger(__name__)
-
 
 class OpenClinicaIntegrationError(Exception):
     pass
@@ -154,7 +152,7 @@ def get_question_item(domain, form_xmlns, question):
         return Item(se_oid, form_oid, ig_oid, item_oid)
     except KeyError:
         # Did an old form set the value of a question that no longer exists? Best to check that out.
-        logger.error('Unknown CommCare question "{}" found in form "{}"'.format(question, form_xmlns))
+        logging.error('Unknown CommCare question "{}" found in form "{}"'.format(question, form_xmlns))
         return None
     except TypeError:
         # CommCare question does not match an OpenClinica item. This is a CommCare-only question.

--- a/custom/openclinica/utils.py
+++ b/custom/openclinica/utils.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from corehq.apps.app_manager.util import all_apps_by_domain
 from corehq.util.quickcache import quickcache
 from couchforms.models import XFormDeprecated
-
+from custom.openclinica.const import MODULE_EVENTS, FORM_QUESTION_ITEM, FORM_EVENTS
 
 logger = logging.Logger(__name__)
 
@@ -38,11 +38,57 @@ def get_question_items(domain):
     Return a map of CommCare form questions to OpenClinica form items
     """
 
-    def read_question_item_map(odm):
+    def get_item_prefix(form_oid, ig_oid):
+        """
+        OpenClinica item OIDs are prefixed with "I_<prefix>_" where <prefix> is derived from the item's form
+        OID. Dropping "I_<prefix>_" will give us the CommCare question name in upper case for human-built apps
+        (i.e. the KEMRI app)
+        """
+        form_name = form_oid[2:]  # Drop "F_"
+        ig_name = ig_oid[3:]  # Drop "IG_"
+        prefix = os.path.commonprefix((form_name, ig_name))
+        if prefix.endswith('_'):
+            prefix = prefix[:-1]
+        return prefix
+
+    def filter_items(items, module, form, question):
+        if not items:
+            return None  # This is a CommCare-only question
+        if len(items) == 1:
+            return items[0]
+        # Match module to event
+        events = MODULE_EVENTS[module]
+        if events is None:
+            # CommCare-only module (e.g. subject registration)
+            return None
+        matches = [i for i in items if Item(*i).study_event_oid in events]
+        if len(matches) == 1:
+            return matches[0]
+        # Match form to event
+        events = FORM_EVENTS[form]
+        matches = [i for i in items if Item(*i).study_event_oid in events]
+        if len(matches) == 1:
+            return matches[0]
+        # Match form and question to an item
+        try:
+            return FORM_QUESTION_ITEM[(form, question)]
+        except KeyError:
+            raise OpenClinicaIntegrationError(
+                'Unable to match CommCare question "{} > {} > {}" to an OpenClinica item. '
+                'I got {}.'.format(module, form, question, [Item(*i).item_oid for i in items])
+            )
+
+    def read_question_item_map(odm, imported=True):
         """
         Return a dictionary of {question: (study_event_oid, form_oid, item_group_oid, item_oid)}
+
+        :param odm: An ElementTree of the CISC ODM study metadata document
+        :param imported: Whether the CommCare app was originally imported from the ODM doc. (Question names of
+                         imported apps will match OpenClinica item OIDs exactly.)
         """
-        question_item_map = {}  # A dictionary of question: (study_event_oid, form_oid, item_group_oid, item_oid)
+        # TODO: Post-KEMRI, remove `imported` parameter and code for when `imported` is False.
+        # A dictionary of {question: [(study_event_oid, form_oid, item_group_oid, item_oid)]}
+        question_item_map = defaultdict(list)
 
         meta_e = odm.xpath('./odm:Study/odm:MetaDataVersion', namespaces=odm_nsmap)[0]
 
@@ -54,32 +100,46 @@ def get_question_items(domain):
                 for ig_ref in meta_e.xpath('./odm:FormDef[@OID="{}"]/odm:ItemGroupRef'.format(form_oid),
                                            namespaces=odm_nsmap):
                     ig_oid = ig_ref.get('ItemGroupOID')
+                    if not imported:
+                        prefix = get_item_prefix(form_oid, ig_oid)
+                        prefix_len = len(prefix) + 3  # len of "I_<prefix>_"
                     for item_ref in meta_e.xpath('./odm:ItemGroupDef[@OID="{}"]/odm:ItemRef'.format(ig_oid),
                                                  namespaces=odm_nsmap):
                         item_oid = item_ref.get('ItemOID')
-                        question = item_oid.lower()
-                        question_item_map[question] = (se_oid, form_oid, ig_oid, item_oid)
+                        if imported:
+                            question = item_oid.lower()
+                        else:
+                            question = item_oid[prefix_len:].lower()  # Drop prefix
+                            question = re.sub(r'^(.*?)_\d+$', r'\1', question)  # Drop OpenClinica-added ID
+                        question_item_map[question].append((se_oid, form_oid, ig_oid, item_oid))
         return question_item_map
 
     def read_forms(question_item_map):
         data = defaultdict(dict)
-        for domain_, pymodule in settings.DOMAIN_MODULE_MAP.iteritems():
-            if pymodule == 'custom.openclinica':
-                for app in all_apps_by_domain(domain_):
-                    for ccmodule in app.get_modules():
-                        for ccform in ccmodule.get_forms():
-                            form = data[ccform.xmlns]
-                            form['app'] = app.name
-                            form['module'] = ccmodule.name['en']
-                            form['name'] = ccform.name['en']
-                            form['questions'] = {}
-                            for question in ccform.get_questions(['en']):
-                                name = question['value'].split('/')[-1]
-                                form['questions'][name] = question_item_map.get(name)
+        openclinica_domains = (d for d, m in settings.DOMAIN_MODULE_MAP.iteritems() if m == 'custom.openclinica')
+        for domain_ in openclinica_domains:
+            for app in all_apps_by_domain(domain_):
+                for ccmodule in app.get_modules():
+                    for ccform in ccmodule.get_forms():
+                        form = data[ccform.xmlns]
+                        form['app'] = app.name
+                        form['module'] = ccmodule.name['en']
+                        form['name'] = ccform.name['en']
+                        form['questions'] = {}
+                        for question in ccform.get_questions(['en']):
+                            name = question['value'].split('/')[-1]
+                            # `question_item_map.get(name)` will return a list containing a single item in the
+                            # case of imported apps, or list of possible items in the case of the KEMRI app.
+                            # Determine which item this question maps to by filtering on module. A CommCare module
+                            # maps (kinda) one-to-one to an OpenClinica event, and should narrow possible item
+                            # matches to 1.
+                            item = filter_items(question_item_map.get(name), form['module'], ccform.xmlns, name)
+                            form['questions'][name] = item
         return data
 
     metadata_xml = get_study_metadata(domain)
-    map_ = read_question_item_map(metadata_xml)
+    # The KEMRI app was not imported. Future apps will be.
+    map_ = read_question_item_map(metadata_xml, imported=False)
     question_items = read_forms(map_)
     return question_items
 
@@ -97,7 +157,7 @@ def get_question_item(domain, form_xmlns, question):
         logger.error('Unknown CommCare question "{}" found in form "{}"'.format(question, form_xmlns))
         return None
     except TypeError:
-        # CommCare question does not match an OpenClinica item. This happens with CommCare-only forms
+        # CommCare question does not match an OpenClinica item. This is a CommCare-only question.
         return None
 
 


### PR DESCRIPTION
CommCare questions no longer need to be exact matches to OpenClinica items. They are matched using their modules and forms to figure out what OpenClinica item they correspond to. 

(In future, when CommCare apps are built using OpenClinica metadata and question names _are_ OpenClinica item IDs then this won't be necessary, and these changes can be deleted. But for the KEMRI project sadly we need this.)

A temporary metadata file with made-up users for testing is also included in this PR. When the KEMRI data manager creates CommCare users on OpenClinica we will need to update the metadata file again with the official version.

Easier to review per commit, although, frankly, only a0f1cf4 is interesting.

buddy @orangejenny although @snopoke might have more context.
