### PR TITLE
fix bad wrapping of change as dict

### DIFF
--- a/corehq/apps/hqcase/management/commands/ptop_fast_reindexer.py
+++ b/corehq/apps/hqcase/management/commands/ptop_fast_reindexer.py
@@ -7,6 +7,8 @@ from django.core.management.base import NoArgsCommand
 import json
 from corehq.util.couch_helpers import paginate_view
 from pillowtop.couchdb import CachedCouchDB
+from pillowtop.feed.couch import change_from_couch_row
+from pillowtop.feed.interface import Change
 from pillowtop.listener import AliasedElasticPillow, PythonPillow
 from pillowtop.pillow.interface import PillowRuntimeContext
 
@@ -267,6 +269,9 @@ class PtopReindexer(NoArgsCommand):
                 try:
                     if not self.custom_filter(row):
                         break
+                    if not isinstance(row, Change):
+                        assert isinstance(row, dict)
+                        row = change_from_couch_row(row)
                     self.pillow.processor(row, PillowRuntimeContext(do_set_checkpoint=False))
                     break
                 except Exception, ex:

--- a/corehq/apps/users/management/commands/ptop_fast_reindex_unknownusers.py
+++ b/corehq/apps/users/management/commands/ptop_fast_reindex_unknownusers.py
@@ -1,6 +1,7 @@
 from corehq.apps.hqcase.management.commands.ptop_fast_reindexer import ElasticReindexer
 from corehq.pillows.user import UserPillow, UnknownUsersPillow
 from couchforms.models import XFormInstance
+from pillowtop.feed.interface import Change
 
 
 class Command(ElasticReindexer):
@@ -17,7 +18,8 @@ class Command(ElasticReindexer):
 
     def process_row(self, row, count):
         doc = _make_view_dict_look_like_xform_doc(row)
-        super(Command, self).process_row({'id': doc['_id'], 'doc': doc}, count)
+        change = Change(id=doc['_id'], sequence_id=None, document=doc)
+        super(Command, self).process_row(change, count)
 
 
 def _make_view_dict_look_like_xform_doc(emitted_dict):


### PR DESCRIPTION
should fix http://manage.dimagi.com/default.asp?186992 :blowfish: 

there were a couple things going wrong:
1. bad conversion of dicts to `Change` objects
2. python pillows weren't properly sending the last chunk over ever (long standing bug and what prevented me from seeing 1 locally)

@esoergel @emord 
