### PR TITLE
link to domain that triggered the autopay change

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -356,19 +356,19 @@ class BillingAccount(models.Model):
 
         return StripePaymentMethod.objects.get(web_user=self.auto_pay_user).get_autopay_card(self)
 
-    def update_autopay_user(self, new_user):
+    def update_autopay_user(self, new_user, domain):
         if self.auto_pay_enabled and new_user != self.auto_pay_user:
-            self._send_autopay_card_removed_email(new_user=new_user)
+            self._send_autopay_card_removed_email(new_user=new_user, domain=domain)
 
         self.auto_pay_user = new_user
         self.save()
-        self._send_autopay_card_added_email()
+        self._send_autopay_card_added_email(domain)
 
     def remove_autopay_user(self):
         self.auto_pay_user = None
         self.save()
 
-    def _send_autopay_card_removed_email(self, new_user):
+    def _send_autopay_card_removed_email(self, new_user, domain):
         """Sends an email to the old autopayer for this account telling them {new_user} is now the autopayer"""
         from corehq.apps.domain.views import EditExistingBillingAccountView
         old_user = self.auto_pay_user
@@ -384,7 +384,7 @@ class BillingAccount(models.Model):
             'old_user_name': old_user_name,
             'billing_account_name': self.name,
             'billing_info_url': absolute_reverse(EditExistingBillingAccountView.urlname,
-                                                 args=[self.created_by_domain])
+                                                 args=[domain])
         }
 
         send_html_email_async(
@@ -394,7 +394,7 @@ class BillingAccount(models.Model):
             text_content=strip_tags(render_to_string('accounting/autopay_card_removed.html', context)),
         )
 
-    def _send_autopay_card_added_email(self):
+    def _send_autopay_card_added_email(self, domain):
         """Sends an email to the new autopayer for this account telling them they are now the autopayer"""
         from corehq.apps.domain.views import EditExistingBillingAccountView
         subject = _("Your card is being used to auto-pay for {billing_account}").format(
@@ -411,11 +411,11 @@ class BillingAccount(models.Model):
         context = {
             'name': new_user_name,
             'email': self.auto_pay_user,
-            'domain': self.created_by_domain,
+            'domain': domain,
             'last_4': last_4,
             'billing_account_name': self.name,
             'billing_info_url': absolute_reverse(EditExistingBillingAccountView.urlname,
-                                                 args=[self.created_by_domain])
+                                                 args=[domain])
         }
 
         send_html_email_async(
@@ -2559,12 +2559,12 @@ class StripePaymentMethod(PaymentMethod):
             if account.autopay_card == card:
                 account.remove_autopay_user()
 
-    def create_card(self, stripe_token, billing_account, autopay=False):
+    def create_card(self, stripe_token, billing_account, domain, autopay=False):
         customer = self.customer
         card = customer.cards.create(card=stripe_token)
         self.set_default_card(card)
         if autopay:
-            self.set_autopay(card, billing_account)
+            self.set_autopay(card, billing_account, domain)
         return card
 
     def set_default_card(self, card):
@@ -2572,7 +2572,7 @@ class StripePaymentMethod(PaymentMethod):
         self.customer.save()
         return card
 
-    def set_autopay(self, card, billing_account):
+    def set_autopay(self, card, billing_account, domain):
         """
         Sets the auto_pay status on the card for a billing account
 
@@ -2582,7 +2582,7 @@ class StripePaymentMethod(PaymentMethod):
             self._remove_other_auto_pay_cards(billing_account)
 
         self._update_autopay_status(card, billing_account, autopay=True)
-        billing_account.update_autopay_user(self.web_user)
+        billing_account.update_autopay_user(self.web_user, domain)
 
     def unset_autopay(self, card, billing_account):
         """

--- a/corehq/apps/accounting/payment_handlers.py
+++ b/corehq/apps/accounting/payment_handlers.py
@@ -89,7 +89,7 @@ class BaseStripePaymentHandler(object):
                 self.payment_method.remove_card(card)
                 return {'success': True, 'removedCard': card, }
             if save_card:
-                card = self.payment_method.create_card(card, billing_account, autopay=autopay)
+                card = self.payment_method.create_card(card, billing_account, self.domain, autopay=autopay)
             if save_card or is_saved_card:
                 customer = self.payment_method.customer
 

--- a/corehq/apps/accounting/tests/test_autopay.py
+++ b/corehq/apps/accounting/tests/test_autopay.py
@@ -24,7 +24,7 @@ class TestBillingAutoPay(BaseInvoiceTestCase):
         self.fake_card = FakeStripeCard()
         self.fake_stripe_customer = FakeStripeCustomer(cards=[self.fake_card])
 
-        self.account.update_autopay_user(self.web_user.username)
+        self.account.update_autopay_user(self.web_user.username, self.domain)
         self.invoice_date = utils.months_from_date(self.subscription.date_start,
                                                    random.randint(2, self.subscription_length))
 
@@ -43,7 +43,7 @@ class TestBillingAutoPay(BaseInvoiceTestCase):
         fake_customer.__get__ = mock.Mock(return_value=self.fake_stripe_customer)
         self.payment_method = StripePaymentMethod(web_user=self.web_user.username,
                                                   customer_id=self.fake_stripe_customer.id)
-        self.payment_method.set_autopay(self.fake_card, self.account)
+        self.payment_method.set_autopay(self.fake_card, self.account, self.domain)
         self.payment_method.save()
         autopayable_invoice = Invoice.objects.filter(subscription=self.subscription)
         date_due = autopayable_invoice.first().date_due
@@ -58,7 +58,7 @@ class TestBillingAutoPay(BaseInvoiceTestCase):
         fake_customer.__get__ = mock.Mock(return_value=self.fake_stripe_customer)
         self.payment_method = StripePaymentMethod(web_user=self.web_user.username,
                                                   customer_id=self.fake_stripe_customer.id)
-        self.payment_method.set_autopay(self.fake_card, self.account)
+        self.payment_method.set_autopay(self.fake_card, self.account, self.domain)
         self.payment_method.save()
         original_outbox_length = len(mail.outbox)
 

--- a/corehq/apps/accounting/tests/test_invoicing.py
+++ b/corehq/apps/accounting/tests/test_invoicing.py
@@ -197,7 +197,7 @@ class TestInvoice(BaseInvoiceTestCase):
             plan_version=plan
         )
 
-        autopay_subscription.account.update_autopay_user(self.billing_contact.username)
+        autopay_subscription.account.update_autopay_user(self.billing_contact.username, self.domain)
         invoice_date_autopay = utils.months_from_date(autopay_subscription.date_start, 1)
         tasks.generate_invoices(invoice_date_autopay)
 

--- a/corehq/apps/accounting/tests/test_models.py
+++ b/corehq/apps/accounting/tests/test_models.py
@@ -41,14 +41,14 @@ class TestBillingAccount(BaseAccountingTest):
 
         mail.outbox = []
         autopay_user = generator.arbitrary_web_user()
-        self.billing_account.update_autopay_user(autopay_user.username)
+        self.billing_account.update_autopay_user(autopay_user.username, None)
         self.assertEqual(len(mail.outbox), 1)
         self.assertTrue(self.billing_account.auto_pay_enabled)
         self.assertEqual(self.billing_account.auto_pay_user, autopay_user.username)
 
         mail.outbox = []
         other_autopay_user = generator.arbitrary_web_user()
-        self.billing_account.update_autopay_user(other_autopay_user.username)
+        self.billing_account.update_autopay_user(other_autopay_user.username, None)
         self.assertEqual(len(mail.outbox), 2)
         self.assertEqual(self.billing_account.auto_pay_user, other_autopay_user.username)
 
@@ -186,12 +186,12 @@ class TestStripePaymentMethod(BaseAccountingTest):
         self.assertEqual(self.billing_account.auto_pay_user, None)
         self.assertFalse(self.billing_account.auto_pay_enabled)
 
-        self.payment_method.set_autopay(self.fake_card, self.billing_account)
+        self.payment_method.set_autopay(self.fake_card, self.billing_account, None)
         self.assertEqual(self.fake_card.metadata, {"auto_pay_{}".format(self.billing_account.id): 'True'})
         self.assertEqual(self.billing_account.auto_pay_user, self.web_user.username)
         self.assertTrue(self.billing_account.auto_pay_enabled)
 
-        self.payment_method.set_autopay(self.fake_card, self.billing_account_2)
+        self.payment_method.set_autopay(self.fake_card, self.billing_account_2, None)
         self.assertEqual(self.fake_card.metadata, {"auto_pay_{}".format(self.billing_account.id): 'True',
                                                    "auto_pay_{}".format(self.billing_account_2.id): 'True'})
 
@@ -199,14 +199,14 @@ class TestStripePaymentMethod(BaseAccountingTest):
         other_payment_method = StripePaymentMethod(web_user=other_web_user.username)
         different_fake_card = FakeStripeCard()
 
-        other_payment_method.set_autopay(different_fake_card, self.billing_account)
+        other_payment_method.set_autopay(different_fake_card, self.billing_account, None)
         self.assertEqual(self.billing_account.auto_pay_user, other_web_user.username)
         self.assertTrue(different_fake_card.metadata["auto_pay_{}".format(self.billing_account.id)])
         self.assertFalse(self.fake_card.metadata["auto_pay_{}".format(self.billing_account.id)] == 'True')
 
     def test_unset_autopay(self, fake_customer):
         fake_customer.__get__ = mock.Mock(return_value=self.fake_stripe_customer)
-        self.payment_method.set_autopay(self.fake_card, self.billing_account)
+        self.payment_method.set_autopay(self.fake_card, self.billing_account, None)
         self.assertEqual(self.fake_card.metadata, {"auto_pay_{}".format(self.billing_account.id): 'True'})
 
         self.payment_method.unset_autopay(self.fake_card, self.billing_account)

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -2697,7 +2697,7 @@ class CardView(BaseCardView):
         try:
             card = self.payment_method.get_card(card_token)
             if request.POST.get("is_autopay") == 'true':
-                self.payment_method.set_autopay(card, self.account)
+                self.payment_method.set_autopay(card, self.account, domain)
             elif request.POST.get("is_autopay") == 'false':
                 self.payment_method.unset_autopay(card, self.account)
         except self.payment_method.STRIPE_GENERIC_ERROR as e:
@@ -2727,7 +2727,7 @@ class CardsView(BaseCardView):
         stripe_token = request.POST.get('token')
         autopay = request.POST.get('autopay') == 'true'
         try:
-            self.payment_method.create_card(stripe_token, self.account, autopay)
+            self.payment_method.create_card(stripe_token, self.account, domain, autopay)
         except self.payment_method.STRIPE_GENERIC_ERROR as e:
             return self._stripe_error(e)
         except Exception as e:


### PR DESCRIPTION
If I'm on domain X and I add my card as the autopayer, and the billing account was created by domain Y, then both me and the owner of the old autopay card receive an email with a link to Billing Info of domain Y.  This changes the link to domain X.

@proteusvacuum @benrudolph cc: @esoergel 
