### PR TITLE
Send receipt for correct domain

### DIFF
--- a/corehq/apps/accounting/payment_handlers.py
+++ b/corehq/apps/accounting/payment_handlers.py
@@ -152,7 +152,7 @@ class BaseStripePaymentHandler(object):
         additional_context = self.get_email_context()
         from corehq.apps.accounting.tasks import send_purchase_receipt
         send_purchase_receipt.delay(
-            payment_record, self.core_product, self.receipt_email_template,
+            payment_record, self.core_product, self.domain, self.receipt_email_template,
             self.receipt_email_template_plaintext, additional_context
         )
 
@@ -423,7 +423,7 @@ class AutoPayInvoicePaymentHandler(object):
                 'invoice_num': invoice.invoice_number,
             }
             send_purchase_receipt.delay(
-                payment_record, product, receipt_email_template, receipt_email_template_plaintext, context,
+                payment_record, product, domain, receipt_email_template, receipt_email_template_plaintext, context,
             )
         except:
             self._handle_email_failure(invoice, payment_record)

--- a/corehq/apps/accounting/payment_handlers.py
+++ b/corehq/apps/accounting/payment_handlers.py
@@ -412,7 +412,7 @@ class AutoPayInvoicePaymentHandler(object):
         receipt_email_template = 'accounting/invoice_receipt_email.html'
         receipt_email_template_plaintext = 'accounting/invoice_receipt_email_plaintext.txt'
         try:
-            domain = invoice.subscription.account.created_by_domain
+            domain = invoice.subscription.subscriber.domain
             product = SoftwareProductType.get_type_by_domain(Domain.get_by_name(domain))
 
             context = {

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -278,7 +278,7 @@ def create_wire_credits_invoice(domain_name,
 
 
 @task(ignore_result=True)
-def send_purchase_receipt(payment_record, core_product,
+def send_purchase_receipt(payment_record, core_product, domain,
                           template_html, template_plaintext,
                           additional_context):
     email = payment_record.payment_method.web_user
@@ -296,7 +296,7 @@ def send_purchase_receipt(payment_record, core_product,
     context = {
         'name': name,
         'amount': fmt_dollar_amount(payment_record.amount),
-        'project': payment_record.creditadjustment_set.last().credit_line.account.created_by_domain,
+        'project': domain,
         'date_paid': payment_record.date_created.strftime(USER_DATE_FORMAT),
         'product': core_product,
         'transaction_id': payment_record.public_transaction_id,


### PR DESCRIPTION
When I make a payment to an invoice, make sure that the receipt contains the invoice's domain, not the original domain of the billing account that the subscription currently belongs too.

@benrudolph @proteusvacuum cc: @esoergel 
