### PR TITLE
make Subscriber.domain required

### DIFF
--- a/corehq/apps/accounting/migrations/0007_make_subscriber_domain_required.py
+++ b/corehq/apps/accounting/migrations/0007_make_subscriber_domain_required.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.db.models import Q
+
+
+def check_for_subscriber_domain(apps, schema_editor):
+    if apps.get_model('accounting', 'Subscriber').objects.filter(
+        Q(domain=None) | Q(domain='')
+    ):
+        raise Exception("There exists a subscriber with no domain.")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounting', '0006_remove_organization_field'),
+    ]
+
+    operations = [
+        migrations.RunPython(check_for_subscriber_domain, reverse_code=lambda: None),
+        migrations.AlterField(
+            model_name='subscriber',
+            name='domain',
+            field=models.CharField(max_length=256, db_index=True),
+            preserve_default=True,
+        ),
+    ]

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -807,7 +807,7 @@ class Subscriber(models.Model):
     """
     The objects that can be subscribed to a Subscription.
     """
-    domain = models.CharField(max_length=256, null=True, db_index=True)
+    domain = models.CharField(max_length=256, db_index=True)
     last_modified = models.DateTimeField(auto_now=True)
 
     objects = SubscriberManager()


### PR DESCRIPTION
we tacitly assume that the `domain` field of `Subscriber` is nonempty, so let's enforce this constraint.

@proteusvacuum @benrudolph cc: @esoergel 
