### PR TITLE
Fix `CustomConfigurableReportDispatcher` bug

### DIFF
--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -426,7 +426,7 @@ class CustomConfigurableReportDispatcher(ReportDispatcher):
             report_class = self._report_class(domain, report_config_id)
         except BadSpecError:
             raise Http404
-        return report_class().dispatch(request, domain, report_config_id, **kwargs)
+        return report_class.as_view()(request, domain=domain, subreport_slug=report_config_id, **kwargs)
 
     def get_report(self, domain, slug, config_id):
         try:


### PR DESCRIPTION
Use `as_view()` instead of `dispatch()` so that `self.args` exists when this is executed: https://github.com/dimagi/commcare-hq/blob/6f4e2438c3db7fa8594134f000e31ae1bc60e83a/corehq/apps/domain/views.py#L182

@nickpell 
Fixes [Ticket #187008](http://manage.dimagi.com/default.asp?187008)
