### PR TITLE
remove duplicated page title

### DIFF
--- a/corehq/apps/style/templates/style/bootstrap3/base_section.html
+++ b/corehq/apps/style/templates/style/bootstrap3/base_section.html
@@ -3,13 +3,6 @@
 
 {% block title %}{% if current_page.title %}{{ current_page.title }} : {% endif %}{{ section.page_name }} :: {% endblock %}
 
-{% block page_title %}
-    {{ current_page.page_name }}
-    {% if current_page.page_subtitle %}
-    <small>{{ current_page.page_subtitle }}</small>
-    {% endif %}
-{% endblock %}
-
 {% block page_breadcrumbs %}
 {% captureas page_actions_block %}{% block page_actions %}{% endblock page_actions %}{% endcaptureas %}
 {% if page_actions_block %}


### PR DESCRIPTION
the page title element (unless specifically declared) is currently duplicating information provided by the breadcrumbs

remove this until we actually revisit a layout redesign

@snopoke @NoahCarnahan 
