### PR TITLE
Add feature flag for report builder beta group

### DIFF
--- a/corehq/apps/hqwebapp/models.py
+++ b/corehq/apps/hqwebapp/models.py
@@ -295,8 +295,11 @@ class ProjectReportsTab(UITab):
         ])]
 
         user_reports = []
-        if (toggle_enabled(self._request, toggles.REPORT_BUILDER)
-                and has_privilege(self._request, privileges.REPORT_BUILDER)):
+
+        builder_enabled = toggle_enabled(self._request, toggles.REPORT_BUILDER)
+        builder_privileges = has_privilege(self._request, privileges.REPORT_BUILDER)
+        beta_group_enabled = toggle_enabled(self._request, toggles.REPORT_BUILDER_BETA_GROUP)
+        if ((builder_enabled and builder_privileges) or beta_group_enabled):
             user_reports = [(
                 _("Create Reports"),
                 [{

--- a/corehq/apps/hqwebapp/models.py
+++ b/corehq/apps/hqwebapp/models.py
@@ -33,6 +33,7 @@ from corehq.apps.indicators.dispatcher import IndicatorAdminInterfaceDispatcher
 from corehq.apps.indicators.utils import get_indicator_domains
 from corehq.apps.locations.analytics import users_have_locations
 from corehq.apps.smsbillables.dispatcher import SMSAdminInterfaceDispatcher
+from corehq.apps.userreports.util import has_report_builder_access
 from django_prbac.utils import has_privilege
 from corehq.util.markup import mark_up_urls
 
@@ -296,10 +297,7 @@ class ProjectReportsTab(UITab):
 
         user_reports = []
 
-        builder_enabled = toggle_enabled(self._request, toggles.REPORT_BUILDER)
-        builder_privileges = has_privilege(self._request, privileges.REPORT_BUILDER)
-        beta_group_enabled = toggle_enabled(self._request, toggles.REPORT_BUILDER_BETA_GROUP)
-        if ((builder_enabled and builder_privileges) or beta_group_enabled):
+        if has_report_builder_access(self._request):
             user_reports = [(
                 _("Create Reports"),
                 [{

--- a/corehq/apps/userreports/util.py
+++ b/corehq/apps/userreports/util.py
@@ -1,4 +1,7 @@
 import collections
+from corehq import privileges, toggles
+from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_enabled
+from django_prbac.utils import has_privilege
 
 
 def localize(value, lang):
@@ -22,3 +25,11 @@ def localize(value, lang):
 
 def default_language():
     return "en"
+
+
+def has_report_builder_access(request):
+    builder_enabled = toggle_enabled(request, toggles.REPORT_BUILDER)
+    builder_privileges = has_privilege(request, privileges.REPORT_BUILDER)
+    beta_group_enabled = toggle_enabled(request, toggles.REPORT_BUILDER_BETA_GROUP)
+
+    return (builder_enabled and builder_privileges) or beta_group_enabled

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -73,6 +73,7 @@ from corehq.apps.userreports.ui.forms import (
     ConfigurableDataSourceEditForm,
     ConfigurableDataSourceFromAppForm,
 )
+from corehq.apps.userreports.util import has_report_builder_access
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
 from corehq.util.couch import get_document_or_404
@@ -147,10 +148,7 @@ class ReportBuilderView(BaseDomainView):
     @use_daterangepicker
     @use_datatables
     def dispatch(self, request, *args, **kwargs):
-        builder_enabled = toggle_enabled(request, toggles.REPORT_BUILDER)
-        builder_privileges = has_privilege(request, privileges.REPORT_BUILDER)
-        beta_group_enabled = toggle_enabled(request, toggles.REPORT_BUILDER_BETA_GROUP)
-        if ((builder_enabled and builder_privileges) or beta_group_enabled):
+        if has_report_builder_access(request):
             return super(ReportBuilderView, self).dispatch(request, *args, **kwargs)
         else:
             raise Http404

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -11,11 +11,10 @@ from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect, HttpResponse
 from django.http.response import Http404
 from django.shortcuts import render
-from django.utils.decorators import method_decorator
 from django.utils.http import urlencode
 from django.utils.translation import ugettext as _, ugettext_noop, ugettext_lazy
 from django.views.decorators.http import require_POST
-from django.views.generic import TemplateView, View
+from django.views.generic import View
 from corehq.apps.analytics.tasks import track_workflow
 from djangular.views.mixins import JSONResponseMixin, allow_remote_invocation
 
@@ -27,11 +26,9 @@ from sqlalchemy.exc import ProgrammingError
 
 from corehq.apps.dashboard.models import IconContext, TileConfiguration, Tile
 from corehq.apps.domain.views import BaseDomainView
-from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_enabled
 from corehq.apps.reports.dispatcher import cls_to_view_login_and_domain
-from corehq import privileges, toggles
+from corehq import toggles
 from corehq.apps.domain.decorators import login_and_domain_required, login_or_basic
-from corehq.apps.reports_core.filters import DynamicChoiceListFilter
 from corehq.apps.style.decorators import (
     use_bootstrap3,
     use_knockout_js,
@@ -82,11 +79,9 @@ from couchexport.export import export_from_tables
 from couchexport.files import Temp
 from couchexport.models import Format
 from couchexport.shortcuts import export_response
-from django_prbac.decorators import requires_privilege_raise404
 
 from dimagi.utils.web import json_response
 from dimagi.utils.decorators.memoized import memoized
-from django_prbac.utils import has_privilege
 
 
 def get_datasource_config_or_404(config_id, domain):

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -294,6 +294,13 @@ REPORT_BUILDER = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
+REPORT_BUILDER_BETA_GROUP = StaticToggle(
+    'report_builder_beta_group',
+    'RB beta group',
+    TAG_ONE_OFF,
+    [NAMESPACE_DOMAIN],
+)
+
 STOCK_TRANSACTION_EXPORT = StaticToggle(
     'ledger_export',
     'Show "export transactions" link on case details page',


### PR DESCRIPTION
The report builder beta group needs a feature flag separate from the standard report builder feature flag because domains in the beta group should be able to access the report builder even if they aren't on a subscription that grants report builder privileges.

cc @nickpell 
