### PR TITLE
Fix backbone version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
         "knockout": "~3.1.0",
         "select2-3.4.5-legacy": "select2#~3.4.5",
         "less": "~1.7.3",
-        "backbone": "~0.9.1",
+        "backbone": "0.9.1",
         "bootstrap-daterangepicker": "~2.1.13",
         "datatables": "~1.10.9",
         "datatables-bootstrap3": "0.1",


### PR DESCRIPTION
cc @nickpell 
There was a [bug](http://manage.dimagi.com/default.asp?187129#1046374) in cloudcare. A bisect revealed that it was introduced here: https://github.com/dimagi/commcare-hq/commit/45c8bcf238ded8407e395d07c3c1a4466a1948e7. It looks like the bower conf changed from version `0.9.1` to `~0.9.1` (meaning the latest version in the `0.9` range, which for the backbone package resolves to `0.9.10`). However, it looks like backbone [doesn't use](https://github.com/jashkenas/backbone/issues/2888) semantic versioning, so there were breaking changes introduced between `0.9.1` and `0.9.10`

@benrudolph, I noticed that you switched all our packages to use version ranges with `~`. I think we should revert all of those unless we confirm that the packages conform to semantic versioning. Any objection?
