### PR TITLE
CC table styling

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/backbone/cases.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/backbone/cases.js
@@ -284,8 +284,11 @@ cloudCare.CaseListView = Backbone.View.extend({
 
     },
     appendAll: function () {
+        var $table;
         this.caseList.each(this.appendItem);
-        $('table', this.el).dataTable({
+        $table = $('table', this.el);
+        $table.css('width', '100%');
+        $table.dataTable({
             bFilter: true,
             bPaginate: false,
             bSort: true,


### PR DESCRIPTION
@emord found this when poking around on HQ.
before:
<img width="1552" alt="screen shot 2015-11-17 at 7 52 49 pm" src="https://cloud.githubusercontent.com/assets/918514/11229643/828e8062-8d65-11e5-9412-2ca9340dece4.png">
after:
<img width="1552" alt="screen shot 2015-11-17 at 7 57 09 pm" src="https://cloud.githubusercontent.com/assets/918514/11229645/88395e56-8d65-11e5-8219-7b23cb00d831.png">
i'm still not totally sure why this works. i was looking at this page: https://datatables.net/examples/basic_init/flexible_width.html
