### PR TITLE
Add commtrack settings to copied domains

### DIFF
--- a/corehq/apps/appstore/views.py
+++ b/corehq/apps/appstore/views.py
@@ -262,6 +262,9 @@ def copy_snapshot(request, domain):
                     new_domain = dom.save_copy(new_domain_name,
                                                new_hr_name=form.cleaned_data['hr_name'],
                                                user=user)
+                    if new_domain.commtrack_enabled:
+                        new_domain.convert_to_commtrack()
+
                 except NameUnavailableException:
                     messages.error(request, _("A project by that name already exists"))
                     return project_info(request, domain)

--- a/corehq/apps/commtrack/views.py
+++ b/corehq/apps/commtrack/views.py
@@ -178,6 +178,11 @@ class SMSSettingsView(BaseCommTrackManageView):
     page_title = ugettext_noop("SMS")
     template_name = 'domain/admin/sms_settings.html'
 
+    def get(self, *args, **kwargs):
+        if self.domain_object.commtrack_settings is None:
+            raise Http404()
+        return super(SMSSettingsView, self).get(*args, **kwargs)
+
     @property
     def page_context(self):
         return {

--- a/corehq/apps/commtrack/views.py
+++ b/corehq/apps/commtrack/views.py
@@ -47,6 +47,11 @@ class BaseCommTrackManageView(BaseDomainView):
     def section_url(self):
         return reverse('default_commtrack_setup', args=[self.domain])
 
+    def get(self, *args, **kwargs):
+        if self.domain_object.commtrack_settings is None:
+            raise Http404()
+        return super(BaseCommTrackManageView, self).get(*args, **kwargs)
+
     @method_decorator(domain_admin_required)  # TODO: will probably want less restrictive permission?
     def dispatch(self, request, *args, **kwargs):
         return super(BaseCommTrackManageView, self).dispatch(request, *args, **kwargs)
@@ -177,11 +182,6 @@ class SMSSettingsView(BaseCommTrackManageView):
     urlname = 'commtrack_sms_settings'
     page_title = ugettext_noop("SMS")
     template_name = 'domain/admin/sms_settings.html'
-
-    def get(self, *args, **kwargs):
-        if self.domain_object.commtrack_settings is None:
-            raise Http404()
-        return super(SMSSettingsView, self).get(*args, **kwargs)
 
     @property
     def page_context(self):


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?186397#1046813

I think raising a 404 makes sense here - domains without commtrack settings shouldn't really be going to that page... (unless I misunderstood the ticket). 

@millerdev 
