### PR TITLE
Add editable codes in organization levels

### DIFF
--- a/corehq/apps/commtrack/static/commtrack/ko/locations.js
+++ b/corehq/apps/commtrack/static/commtrack/ko/locations.js
@@ -7,6 +7,7 @@ function LocationSettingsViewModel(loc_types, commtrack_enabled) {
     this.json_payload = ko.observable();
 
     this.loc_types_error = ko.observable(false);
+    this.advanced_mode = ko.observable(false);
 
     this.loc_type_options = function(loc_type) {
         return this.loc_types().filter(function(type) {
@@ -120,13 +121,20 @@ function LocationTypeModel(loc_type, commtrack_enabled) {
     this.tracks_stock = ko.observable(!loc_type.administrative);
     this.shares_cases = ko.observable(loc_type.shares_cases);
     this.view_descendants = ko.observable(loc_type.view_descendants);
+    this.code = ko.observable(loc_type.code);
 
     this.name_error = ko.observable(false);
+    this.code_error = ko.observable(false);
 
     this.validate = function() {
         this.name_error(false);
         if (!this.name()) {
             this.name_error(true);
+            return false;
+        }
+        this.code_error(false);
+        if (!this.code()) {
+            this.code_error(true);
             return false;
         }
         return true;
@@ -139,7 +147,8 @@ function LocationTypeModel(loc_type, commtrack_enabled) {
             parent_type: this.parent_type() || null,
             administrative: commtrack_enabled ? !this.tracks_stock() : true,
             shares_cases: this.shares_cases() === true,
-            view_descendants: this.view_descendants() === true
+            view_descendants: this.view_descendants() === true,
+            code: this.code()
         };
     };
 }

--- a/corehq/apps/locations/templates/locations/settings.html
+++ b/corehq/apps/locations/templates/locations/settings.html
@@ -77,6 +77,12 @@
                     <i class="icon-plus"></i> {% trans "New Organization Level" %}
                 </button>
                 <hr />
+                <div class="pull-right">
+                    <label>
+                        <input type="checkbox" data-bind="checked:advanced_mode"/>
+                        {% trans "Advanced mode" %}
+                    </label>
+                </div>
                 <div class="alert alert-error" style="display: none"
                      data-bind="visible: loc_types_error">
                     {% trans "Organization Levels cannot be their own ancestors." %}
@@ -96,6 +102,11 @@
                                       {% endblocktrans %}">
                                 </span>
                             </th>
+                            <!-- ko if:advanced_mode -->
+                            <th>
+                                {% trans "Type Code"%}
+                            </th>
+                            <!-- /ko -->
                             {% if commtrack_enabled %}
                             <th>{% trans "Tracks Stock" %}</th>
                             {% endif %}
@@ -140,6 +151,14 @@
                                                optionsCaption: '\u2013top level\u2013'">
                             </select>
                         </td>
+                        <!-- ko if:$parent.advanced_mode() -->
+                        <td class="control-group" data-bind="css: { 'error': code_error }">
+                            <input class="typecode" data-bind="value: code" type="text" />
+                            <div class="help-inline" data-bind="visible: code_error">
+                                {% trans "Required" %}
+                            </div>
+                        </td>
+                        <!-- /ko -->
                         {% if commtrack_enabled %}
                         <td>
                             <input data-bind="checked: tracks_stock" type="checkbox" />

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -22,6 +22,7 @@ from soil.util import expose_cached_download, get_download_context
 from corehq import toggles
 from corehq.apps.commtrack.exceptions import MultipleSupplyPointException
 from corehq.apps.commtrack.tasks import import_locations_async
+from corehq.apps.commtrack.util import unicode_slug
 from corehq.apps.consumption.shortcuts import get_default_monthly_consumption
 from corehq.apps.custom_data_fields import CustomDataModelMixin
 from corehq.apps.domain.decorators import domain_admin_required
@@ -135,7 +136,8 @@ class LocationTypesView(BaseLocationView):
                             if loc_type.parent_type else None),
             'administrative': loc_type.administrative,
             'shares_cases': loc_type.shares_cases,
-            'view_descendants': loc_type.view_descendants
+            'view_descendants': loc_type.view_descendants,
+            'code': loc_type.code,
         } for loc_type in LocationType.objects.by_domain(self.domain)]
 
     def post(self, request, *args, **kwargs):
@@ -146,7 +148,7 @@ class LocationTypesView(BaseLocationView):
             return isinstance(pk, basestring) and pk.startswith("fake-pk-")
 
         def mk_loctype(name, parent_type, administrative,
-                       shares_cases, view_descendants, pk):
+                       shares_cases, view_descendants, pk, code):
             parent = sql_loc_types[parent_type] if parent_type else None
 
             loc_type = None
@@ -162,6 +164,7 @@ class LocationTypesView(BaseLocationView):
             loc_type.parent_type = parent
             loc_type.shares_cases = shares_cases
             loc_type.view_descendants = view_descendants
+            loc_type.code = unicode_slug(code)
             loc_type.save()
             sql_loc_types[pk] = loc_type
 


### PR DESCRIPTION
<img width="1191" alt="screen shot 2015-11-18 at 3 54 07 pm" src="https://cloud.githubusercontent.com/assets/146896/11238697/7b4c3102-8e0d-11e5-945d-09610a82e8be.png">
http://manage.dimagi.com/default.asp?186409#1046824

Not sure if the "advanced mode" toggle (top right of table) is the best way. I could also potentially put a big red warning message if this is toggled that changing codes could break the app?
@esoergel @sheelio 

Code buddy: @millerdev 
