### PR TITLE
Improve bower deploy steps

### DIFF
--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -1000,7 +1000,8 @@ def _do_collectstatic(use_current_release=False):
 @roles(ROLES_STATIC)
 def _bower_install(use_current_release=False):
     with cd(env.code_root if not use_current_release else env.code_current):
-        sudo('bower install --production')
+        sudo('bower prune --production')
+        sudo('bower update --production')
 
 
 @roles(ROLES_DJANGO)


### PR DESCRIPTION
Previously, the deploy could hang if old components are installed that aren't in the current dependencies that conflict with the current dependencies. The new steps make sure such packages are deleted first.

@benrudolph @czue cc @nickpell 
