### PR TITLE
Fix web role delete modal

### DIFF
--- a/corehq/apps/users/templates/users/web_users.html
+++ b/corehq/apps/users/templates/users/web_users.html
@@ -5,7 +5,6 @@
 {% load djangular_tags %}
 
 {% block js %}{{ block.super }}
-    <script src="{% new_static 'hqwebapp/js/main.js' %}"></script>
     <script src="{% new_static 'users/js/roles.js' %}"></script>
     <script src="{% new_static 'users/js/web_users_list.ng.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
Addresses [Ticket #187330](http://manage.dimagi.com/default.asp?187330).

The modal required `COMMCAREHQ.DeleteButton` to be defined on the page. This button is defined in the base template [here](https://github.com/dimagi/commcare-hq/blob/ec9325a8e377579c2ab10467bee63a1019d419ac/corehq/apps/style/templates/style/bootstrap3/base.html#L308). However, this page also included `hqwebapp/js/main.js`, which overwrites `COMMCAREHQ`. `hqwebapp/js/main.js` was originally included on the page to gain access to the `postGo()` function, which has [since been moved](https://github.com/dimagi/commcare-hq/commit/5f6cc25038c075cf5872aed6892a1099cb4d7a13) to `style/js/hq_extensions.jquery.js`, which is already being included in the base template. Therefore we can just remove `hqwebapp/js/main.js` from the page.

cc @nickpell 
fyi @orangejenny 
