### PR TITLE
Add a setting for image inflation

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/json/commcare-profile-settings.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-profile-settings.yaml
@@ -302,3 +302,12 @@
   default: "86400"
   values_txt: "This will set the amount of time you will remain logged in before automatically being logged out."
   since: "2.21"
+  
+- name: "Smart Image Inflation"
+  description: "When a value is selected, this feature controls the display size of any user-provided image such that it will be consistent with the size of the original image file, and consistent across devices. Follow the instructions here to determine which value you should use: https://confluence.dimagi.com/display/commcarepublic/Images+in+CommCare#ImagesinCommCare-ImageSizes"
+  id: "cc-inflation-target-density"
+  values: ["120", "160", "240", "280", "320", "400", "480", "none"]
+  value_names: ["Low Density", "Medium Density", "High Density", "Density 280", "XHigh Density", "Density 400", "XXHigh Density", "None"]
+  default: "none"
+  since: "2.24"
+  force: true

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-settings-layout.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-settings-layout.yaml
@@ -63,6 +63,7 @@
     - hq.auto_gps_capture
     - properties.cc-login-duration-seconds
     - properties.cc-log-entity-detail-enabled
+    - properties.cc-inflation-target-density
     - hq.use_grid_menus
 
 - title: 'Advanced'


### PR DESCRIPTION
Add dropdown for enabling new image inflation technique.

The confluence page that is referred to in the message hasn't actually been updated yet; will updated it  concurrently with this getting merged
