### PR TITLE
Add CouchConfig for coordinating multiple couchdbs

### DIFF
--- a/corehq/util/couchdb_management.py
+++ b/corehq/util/couchdb_management.py
@@ -1,0 +1,37 @@
+from couchdbkit.client import Database
+from dimagi.utils.decorators.memoized import memoized
+from django.conf import settings
+
+
+class CouchConfig(object):
+    def __init__(self, db_uri=None):
+        if db_uri:
+            self._settings_helper = (
+                settings.COUCH_SETTINGS_HELPER._replace(couch_database_url=db_uri))
+        else:
+            self._settings_helper = settings.COUCH_SETTINGS_HELPER
+
+    @property
+    def db_uri(self):
+        return self._settings_helper.couch_database_url
+
+    def get_db(self, postfix):
+        """
+        Get the couch database.
+        """
+        if postfix:
+            db_uri = settings.EXTRA_COUCHDB_DATABASES[postfix]
+        else:
+            db_uri = self.db_uri
+        return Database(db_uri, create=True)
+
+    @property
+    @memoized
+    def app_label_to_db_slug(self):
+        return dict(self._settings_helper.make_couchdb_tuples())
+
+    def get_db_for_class(self, klass):
+        return self.app_label_to_db_slug[klass.Meta.app_label]
+
+
+couch_config = CouchConfig()

--- a/corehq/util/couchdb_management.py
+++ b/corehq/util/couchdb_management.py
@@ -1,5 +1,5 @@
 from couchdbkit.client import Database
-from dimagi.ext.couchdbkit import Document
+from corehq.util.couch import get_document_class_by_doc_type
 from dimagi.utils.decorators.memoized import memoized
 from django.conf import settings
 
@@ -51,26 +51,13 @@ class CouchConfig(object):
         return self.app_label_to_db_uri[getattr(klass._meta, "app_label")]
 
     def get_db_uri_for_doc_type(self, doc_type):
-        return self.get_db_for_class(class_by_doc_type()[doc_type])
+        return self.get_db_for_class(get_document_class_by_doc_type(doc_type))
 
     def get_db_for_class(self, klass):
         return Database(self.get_db_uri_for_class(klass))
 
     def get_db_for_doc_type(self, doc_type):
         return Database(self.get_db_uri_for_doc_type(doc_type))
-
-
-@memoized
-def class_by_doc_type():
-    queue = [Document]
-    m = {}
-    while queue:
-        klass = queue.pop()
-        app_label = getattr(klass._meta, "app_label", None)
-        if app_label:
-            m[klass._doc_type] = klass
-        queue.extend(klass.__subclasses__())
-    return m
 
 
 couch_config = CouchConfig()

--- a/corehq/util/couchdb_management.py
+++ b/corehq/util/couchdb_management.py
@@ -51,7 +51,7 @@ class CouchConfig(object):
         return self.app_label_to_db_uri[getattr(klass._meta, "app_label")]
 
     def get_db_uri_for_doc_type(self, doc_type):
-        return self.get_db_for_class(get_document_class_by_doc_type(doc_type))
+        return self.get_db_uri_for_class(get_document_class_by_doc_type(doc_type))
 
     def get_db_for_class(self, klass):
         return Database(self.get_db_uri_for_class(klass))

--- a/corehq/util/couchdb_management.py
+++ b/corehq/util/couchdb_management.py
@@ -5,6 +5,13 @@ from django.conf import settings
 
 
 class CouchConfig(object):
+    """
+    Interface for accessing the couch-related settings
+
+    You can use db_uri pass in a different couch instance
+    from the one specified by COUCH_DATABASE
+
+    """
     def __init__(self, db_uri=None):
         if db_uri:
             self._settings_helper = (

--- a/corehq/util/couchdb_management.py
+++ b/corehq/util/couchdb_management.py
@@ -18,16 +18,22 @@ class CouchConfig(object):
 
     @property
     @memoized
-    def all_dbs_by_slug(self):
+    def all_db_uris_by_slug(self):
         dbs = self._settings_helper.get_extra_couchdbs()
         dbs[None] = self.db_uri
         return dbs
+
+    @property
+    @memoized
+    def all_dbs_by_slug(self):
+        return {slug: Database(db_uri)
+                for slug, db_uri in self.all_db_uris_by_slug.items()}
 
     def get_db(self, postfix):
         """
         Get the couch database by slug
         """
-        return Database(self.all_dbs_by_slug[postfix], create=True)
+        return Database(self.all_db_uris_by_slug[postfix], create=True)
 
     @property
     @memoized

--- a/corehq/util/couchdb_management.py
+++ b/corehq/util/couchdb_management.py
@@ -37,14 +37,20 @@ class CouchConfig(object):
 
     @property
     @memoized
-    def app_label_to_db_slug(self):
+    def app_label_to_db_uri(self):
         return dict(self._settings_helper.make_couchdb_tuples())
 
+    def get_db_uri_for_class(self, klass):
+        return self.app_label_to_db_uri[getattr(klass._meta, "app_label")]
+
+    def get_db_uri_for_doc_type(self, doc_type):
+        return self.get_db_for_class(class_by_doc_type()[doc_type])
+
     def get_db_for_class(self, klass):
-        return self.app_label_to_db_slug[getattr(klass._meta, "app_label")]
+        return Database(self.get_db_uri_for_class(klass))
 
     def get_db_for_doc_type(self, doc_type):
-        return self.get_db_for_class(class_by_doc_type()[doc_type])
+        return Database(self.get_db_uri_for_doc_type(doc_type))
 
 
 @memoized

--- a/corehq/util/tests/__init__.py
+++ b/corehq/util/tests/__init__.py
@@ -1,17 +1,17 @@
-from corehq.util.spreadsheets.excel import IteratorJSONReader
-from test_couch import *
-from test_log import *
-from test_toggle import *
-from test_quickcache import *
-from test_timezone_conversions import *
-from test_soft_assert import *
 from test_cache_util import *
-from test_override_db import *
-from test_spreadsheets import *
-from test_jsonobject import *
-from test_xml import *
+from test_couch import *
 from test_couchdb_management import *
+from test_jsonobject import *
+from test_log import *
+from test_override_db import *
+from test_quickcache import *
+from test_soft_assert import *
+from test_spreadsheets import *
+from test_timezone_conversions import *
+from test_toggle import *
+from test_xml import *
 
+from corehq.util.spreadsheets.excel import IteratorJSONReader
 from corehq.util.dates import iso_string_to_datetime, iso_string_to_date
 
 __test__ = {

--- a/corehq/util/tests/__init__.py
+++ b/corehq/util/tests/__init__.py
@@ -10,6 +10,7 @@ from test_override_db import *
 from test_spreadsheets import *
 from test_jsonobject import *
 from test_xml import *
+from test_couchdb_management import *
 
 from corehq.util.dates import iso_string_to_datetime, iso_string_to_date
 

--- a/corehq/util/tests/test_couch.py
+++ b/corehq/util/tests/test_couch.py
@@ -9,7 +9,7 @@ from mock import Mock
 from corehq.util.exceptions import DocumentClassNotFound
 
 from ..couch import (get_document_or_404, IterDB, iter_update, IterUpdateError,
-        DocUpdate, get_document_class_by_name)
+        DocUpdate, get_document_class_by_doc_type)
 
 
 class MockDb(object):
@@ -253,10 +253,10 @@ class DocumentClassLookupTest(SimpleTestCase):
             ('FixtureDataType', FixtureDataType),
         ]
         for model_name, model_class in test_cases:
-            self.assertEqual(model_class, get_document_class_by_name(model_name))
+            self.assertEqual(model_class, get_document_class_by_doc_type(model_name))
 
     def test_missing(self):
         test_cases = [None, 'FooDocument']
         for bad_model in test_cases:
             with self.assertRaises(DocumentClassNotFound):
-                get_document_class_by_name(bad_model)
+                get_document_class_by_doc_type(bad_model)

--- a/corehq/util/tests/test_couchdb_management.py
+++ b/corehq/util/tests/test_couchdb_management.py
@@ -1,0 +1,36 @@
+from django.conf import settings
+from django.test import SimpleTestCase
+from corehq.util.couchdb_management import CouchConfig, couch_config
+
+
+class CouchConfigTest(SimpleTestCase):
+    remote_db_uri = 'https://mycouch.com/cchq'
+
+    def test_default_db_uri(self):
+        config = CouchConfig()
+        self.assertEqual(config.db_uri, settings.COUCH_DATABASE)
+
+    def test_default_couch_config_db_uri(self):
+        self.assertEqual(couch_config.db_uri, settings.COUCH_DATABASE)
+
+    def test_remote_db_uri(self):
+        config = CouchConfig(db_uri=self.remote_db_uri)
+        self.assertEqual(config.db_uri, self.remote_db_uri)
+
+    def test_all_db_uris_by_slug(self):
+        config = CouchConfig(db_uri=self.remote_db_uri)
+        self.assertDictContainsSubset(
+            {
+                None: self.remote_db_uri,
+                'users': '{}__users'.format(self.remote_db_uri),
+                'fixtures': '{}__fixtures'.format(self.remote_db_uri),
+                'meta': '{}__meta'.format(self.remote_db_uri),
+            },
+            config.all_db_uris_by_slug
+        )
+
+    def test_get_db_for_doc_type(self):
+        config = CouchConfig(db_uri=self.remote_db_uri)
+        self.assertEqual(config.get_db_for_doc_type('CommCareCase').uri, self.remote_db_uri)
+        self.assertEqual(config.get_db_for_doc_type('CommCareUser').uri,
+                         '{}__users'.format(self.remote_db_uri))

--- a/settings.py
+++ b/settings.py
@@ -1036,8 +1036,7 @@ INDICATOR_CONFIG = {
 ####### Couch Forms & Couch DB Kit Settings #######
 from settingshelper import (
     get_dynamic_db_settings,
-    make_couchdb_tuples,
-    get_extra_couchdbs,
+    CouchSettingsHelper,
     SharedDriveConfiguration
 )
 
@@ -1153,9 +1152,10 @@ COUCHDB_APPS = [
 
 COUCHDB_APPS += LOCAL_COUCHDB_APPS
 
-COUCHDB_DATABASES = make_couchdb_tuples(COUCHDB_APPS, COUCH_DATABASE)
-EXTRA_COUCHDB_DATABASES = get_extra_couchdbs(COUCHDB_APPS, COUCH_DATABASE,
-                                             [NEW_USERS_GROUPS_DB, NEW_FIXTURES_DB])
+COUCH_SETTINGS_HELPER = CouchSettingsHelper(COUCH_DATABASE, COUCHDB_APPS,
+                                            [NEW_USERS_GROUPS_DB, NEW_FIXTURES_DB])
+COUCHDB_DATABASES = COUCH_SETTINGS_HELPER.make_couchdb_tuples()
+EXTRA_COUCHDB_DATABASES = COUCH_SETTINGS_HELPER.get_extra_couchdbs()
 
 INSTALLED_APPS += LOCAL_APPS
 


### PR DESCRIPTION
This PR
- refactors settings helpers for couch into a class
- adds `CouchConfig` as an interface for accessing couch settings in more intuitive ways,
  as well as figuring out what the equivalent dbs on a remote setup would be
- fixes (and future-proofs) the `copy_domain` bug preventing docs in non-main dbs from being copied
