### PR TITLE
Bump up z-index of top-nav

### DIFF
--- a/corehq/apps/style/static/style/less/bootstrap3/navbar.less
+++ b/corehq/apps/style/static/style/less/bootstrap3/navbar.less
@@ -1,6 +1,7 @@
 .navbar-hq-main-menu {
   border: 1px solid #d5d5d5;
   font-size: 13px;
+  z-index: 1500;
   #gradient > .vertical(#fdfdfd, #f4f4f4);
   margin-bottom: 0px;
 


### PR DESCRIPTION
Places long tab-lists above footer, but now it get's truncated by the end of the browser window, not sure what the desired option is (need to scroll down either way...)
http://manage.dimagi.com/default.asp?187328#1047428
@biyeun I just randomly picked number above the footer's z-index. Not sure if there is a science to how that is done normally... 
cc: @millerdev 
