### PR TITLE
inline js in its own block

### DIFF
--- a/corehq/apps/domain/templates/domain/admin/media_manager.html
+++ b/corehq/apps/domain/templates/domain/admin/media_manager.html
@@ -5,6 +5,9 @@
 
 {% block js %} {{ block.super }}
 <script type="text/javascript" src="{% static 'domain/js/media_manager.js' %}"></script>
+{% endblock %}
+
+{% block js-inline %}{{ block.super }}
 <script type="text/javascript">
     ko.applyBindings(new MediaManager({{ media|JSON }}, {{ licenses|JSON }}));
 </script>


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?187381#1047568
moving to bootstrap3 compresses js by default. inline js needs to be in  `{% block js-inline %}` block 

FYI @biyeun @kkrampa 

cc @millerdev 
