### PR TITLE
Revert "Bump up z-index of top-nav"

### DIFF
--- a/corehq/apps/style/static/style/less/bootstrap3/navbar.less
+++ b/corehq/apps/style/static/style/less/bootstrap3/navbar.less
@@ -1,7 +1,6 @@
 .navbar-hq-main-menu {
   border: 1px solid #d5d5d5;
   font-size: 13px;
-  z-index: 1500;
   #gradient > .vertical(#fdfdfd, #f4f4f4);
   margin-bottom: 0px;
 


### PR DESCRIPTION
Reverts dimagi/commcare-hq#9182

This interferes with rendering modals. I think we'll have to poke at this issue a little more to make sure that the top bar doesn't go over the modal
