### PR TITLE
add testrunner that only syncs a a subset of apps' models

### DIFF
--- a/corehq/apps/reports/tests/test_scheduled_reports.py
+++ b/corehq/apps/reports/tests/test_scheduled_reports.py
@@ -37,6 +37,7 @@ class GuessReportingMinuteTest(SimpleTestCase):
 
 
 class ScheduledReportTest(TestCase):
+    dependent_apps = ['corehq.apps.reports', 'corehq.couchapps']
 
     def setUp(self):
         for report in ReportNotification.view(

--- a/corehq/apps/reports/tests/test_scheduled_reports.py
+++ b/corehq/apps/reports/tests/test_scheduled_reports.py
@@ -37,7 +37,7 @@ class GuessReportingMinuteTest(SimpleTestCase):
 
 
 class ScheduledReportTest(TestCase):
-    dependent_apps = ['corehq.apps.reports', 'corehq.couchapps']
+    dependent_apps = ['corehq.couchapps']
 
     def setUp(self):
         for report in ReportNotification.view(

--- a/corehq/apps/userreports/tests/test_data_source_config.py
+++ b/corehq/apps/userreports/tests/test_data_source_config.py
@@ -97,7 +97,7 @@ class DataSourceConfigurationTest(SimpleTestCase):
 
 
 class DataSourceConfigurationDbTest(TestCase):
-    dependent_apps = ['corehq.apps.userreports']
+    dependent_apps = []
 
     @classmethod
     def setUpClass(cls):

--- a/corehq/apps/userreports/tests/test_data_source_config.py
+++ b/corehq/apps/userreports/tests/test_data_source_config.py
@@ -97,6 +97,7 @@ class DataSourceConfigurationTest(SimpleTestCase):
 
 
 class DataSourceConfigurationDbTest(TestCase):
+    dependent_apps = ['corehq.apps.userreports']
 
     @classmethod
     def setUpClass(cls):

--- a/corehq/form_processor/test_utils.py
+++ b/corehq/form_processor/test_utils.py
@@ -17,8 +17,8 @@ class FormProcessorTestUtils(object):
     @classmethod
     @unit_testing_only
     def delete_all_cases(cls, domain=None):
+        assert CommCareCase.get_db().dbname.endswith('test')
         view_kwargs = {}
-
         if domain:
             view_kwargs = {
                 'startkey': [domain],

--- a/corehq/tests/app_test_db_dependencies.yml
+++ b/corehq/tests/app_test_db_dependencies.yml
@@ -1,0 +1,42 @@
+
+pillowtop: []
+testapps.test_pillowtop:
+  - corehq.apps.users
+  - couchforms
+casexml.apps.case:
+  - casexml.apps.phone
+  - casexml.apps.stock
+  - corehq.couchapps
+  - corehq.form_processor
+  - corehq.apps.hqcase
+  - corehq.apps.products
+  - corehq.apps.receiverwrapper
+  - corehq.apps.reminders
+  - corehq.apps.sms
+  - corehq.apps.tzmigration
+  - couchforms
+  - phonelog
+corehq.apps.userreports:
+  - casexml.apps.case
+  - casexml.apps.stock
+  - corehq.couchapps
+  - corehq.form_processor
+  - corehq.apps.app_manager
+  - corehq.apps.commtrack
+  - corehq.apps.domain
+  - corehq.apps.locations
+  - corehq.apps.products
+  - corehq.apps.receiverwrapper
+  - corehq.apps.reminders
+  - corehq.apps.sms
+  - corehq.apps.tzmigration
+  - corehq.apps.users
+  - couchforms
+  # unfortunately domain.delete() needs all of these - otherwise they could be removed
+  - custom.logistics
+  - custom.ilsgateway
+  - custom.ewsghana
+  - custom.ewsghana
+  - django_prbac
+  - corehq.apps.accounting
+  - corehq.apps.smsforms

--- a/corehq/tests/optimizer.py
+++ b/corehq/tests/optimizer.py
@@ -41,8 +41,8 @@ class OptimizedTestRunnerMixin(object):
     class MyTestCase(TestCase):
         dependent_apps = ['myapp.dependentapp1', 'myapp.dependentapp2']
 
-    This will override the app-level setting. Note that when declaring explicit test dependencies
-    you _must_ explicitly specify the test's own fully-qualified app path (if necessary).
+    This will override the app-level setting. Like apps, tests are always assumed to be dependent
+    on the apps they live in.
 
     Updating:
 
@@ -95,7 +95,7 @@ class AppAndTestMap(object):
         return self._dependencies[app]
 
     def get_test_dependencies(self, app, test):
-        dependencies = set()
+        dependencies = set([apps.get_app_config(app).name])
 
         def _extract_tests(test_suite_or_test):
             if isinstance(test_suite_or_test, unittest.TestCase):

--- a/corehq/tests/optimizer.py
+++ b/corehq/tests/optimizer.py
@@ -54,7 +54,7 @@ class OptimizedTestRunnerMixin(object):
     def run_tests(self, test_labels, extra_tests=None, **kwargs):
         test_labels = test_labels or self.get_test_labels()
         with optimize_apps_for_test_labels(test_labels):
-            super(OptimizedTestRunnerMixin, self).run_tests(test_labels, extra_tests, **kwargs)
+            return super(OptimizedTestRunnerMixin, self).run_tests(test_labels, extra_tests, **kwargs)
 
 
 class AppAndTestMap(object):

--- a/dev_settings.py
+++ b/dev_settings.py
@@ -11,6 +11,8 @@ LOCAL_APPS = (
     'django_extensions',
 )
 
+TEST_RUNNER = 'testrunner.DevTestRunner'
+
 ####### Django Extensions #######
 # These things will be imported when you run ./manage.py shell_plus
 SHELL_PLUS_POST_IMPORTS = (

--- a/testrunner.py
+++ b/testrunner.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.test import TransactionTestCase
 from django.utils import unittest
 from mock import patch, Mock
+from corehq.tests.optimizer import OptimizedTestRunnerMixin
 
 import settingshelper
 
@@ -73,7 +74,6 @@ class HqTestSuiteRunner(CouchDbKitTestSuiteRunner):
             db_name: self.get_test_db_name(url)
             for db_name, url in settings.EXTRA_COUCHDB_DATABASES.items()
         }
-
         return super(HqTestSuiteRunner, self).setup_databases(**kwargs)
 
     def teardown_databases(self, old_config, **kwargs):
@@ -304,6 +304,12 @@ class TwoStageTestRunner(HqTestSuiteRunner):
             percent,
         )
 
+
+class DevTestRunner(OptimizedTestRunnerMixin, TwoStageTestRunner):
+    """
+    See OptimizedTestRunner.
+    """
+    pass
 
 class NonDbOnlyTestRunner(TwoStageTestRunner):
     """


### PR DESCRIPTION
@proteusvacuum thought this would be useful after discussing how to speed up tests. it'd be amazing if it somehow auto-detected dependencies, but I think doing it this way is still super helpful. This makes running declared subsets of the tests waaaay faster.

cc @snopoke since we discussed this, @orangejenny buddy

(pasted from docstring)

```
    You can have any TestRunner mixin this class to add db optimizations to it.
    What this does is allow you to explicitly declare test app dependencies and then
    using this test runner will only bootstrap those apps. If an app needs the database
    but has very few dependencies this can drastically improve speedup times.

    There are two ways to optimize tests, by app and by test class.

    By app:

    To optimize tests by app, you should add the app as an entry to `app_test_db_dependencies.yml`.
    Then you declare all other dependencies the app has by following the format of other apps.
    You _must_ use the fully qualified app from settings.py.
    The app is always assumed to be dependent on itself.

    App dependencies will be picked up and used by any of the following formats:

     - ./manage.py test appname
     - ./manage.py test appname.TestCase
     - ./manage.py test appname.TestCase.test_method

    By test:

    Some tests may require far fewer dependencies than the entire app. In this case you can further
    optimize by adding a `dependent_apps` property to the test itself. For example:

    class MyTestCase(TestCase):
        dependent_apps = ['myapp.dependentapp1', 'myapp.dependentapp2']

    This will override the app-level setting. Like apps, tests are always assumed to be dependent
    on the apps they live in.
    Updating:

    The easiest way to determine an app/test's dependencies is to mark them empty and then run the tests.
    The tests will fail on various django/couch access. You can then iteratively add those apps to the
    list of dependencies until tests pass again.
```
