### PR TITLE
always return a response from importer poll

### DIFF
--- a/corehq/apps/importer/views.py
+++ b/corehq/apps/importer/views.py
@@ -320,7 +320,10 @@ def importer_job_poll(request, domain, download_id, template="importer/partials/
             messages.error(request, _('The session containing the file you '
                                       'uploaded has expired - please upload '
                                       'a new one.'))
-            return HttpResponseRedirect(base.ImportCases.get_url(domain=domain) + "?error=cache")
+        else:
+            messages.error(request, _('Sorry something went wrong with that import. Please try again. '
+                                      'Report an issue if you continue to have problems.'))
+        return HttpResponseRedirect(base.ImportCases.get_url(domain=domain) + "?error=cache")
     else:
         context = RequestContext(request)
         context.update(download_context)


### PR DESCRIPTION
should fix "ValueError: The view corehq.apps.importer.views.importer_job_poll didn't return an HttpResponse object. It returned None instead"

@snopoke I think this was introduced in https://github.com/dimagi/commcare-hq/pull/9023/. Wasn't really sure how to reproduce or if this was the right fix, but seemed reasonable enough.
