### PR TITLE
whitelist DomainInvitations

### DIFF
--- a/corehq/apps/domain/dbaccessors.py
+++ b/corehq/apps/domain/dbaccessors.py
@@ -33,6 +33,7 @@ def get_docs_in_domain_by_class(domain, doc_class):
         'CallCenterIndicatorConfig',
         'CommtrackConfig',
         'Invitation',
+        'DomainInvitation',
     ]
     doc_type = doc_class.__name__
     assert doc_type in whitelist


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?187558

introduced in https://github.com/dimagi/commcare-hq/pull/9213, fyi @nickpell 

seems this code could use some tests.

Also I think the `Invitation` base class is now completely useless since orgs are dead. I didn't bother removing it though since I was worried something else might break.
