### PR TITLE
always load codemirror even if toggle isn't on

### DIFF
--- a/corehq/apps/cloudcare/templates/cloudcare/cloudcare_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/cloudcare_home.html
@@ -27,9 +27,7 @@
           href="{% new_static 'datatables/media/css/jquery.dataTables.min.css ' %}" />
     <link rel="stylesheet" href="{% new_static 'formplayer/style/webforms.css' %}">
     <link rel="stylesheet" href="{% new_static 'cloudcare/css/cloudcare.css' %}">
-    {% if request|toggle_enabled:"INSTANCE_VIEWER" %}
     <link rel="stylesheet" href="{% new_static 'codemirror/lib/codemirror.css' %}" />
-    {% endif %}
 {% endblock %}
 
 {% block js %} {{ block.super }}
@@ -54,10 +52,8 @@
     <script src="{% new_static 'formplayer/script/entrycontrols_full.js' %}"></script>
     <script src="{% new_static 'formplayer/script/fullform-ui.js' %}"></script>
 
-    {% if request|toggle_enabled:"INSTANCE_VIEWER" %}
     <script src="{% new_static 'codemirror/lib/codemirror.js' %}"></script>
     <script src="{% new_static 'codemirror/mode/xml/xml.js' %}"></script>
-    {% endif %}
 {% endblock %}
 
 {% block js-inline %} {{ block.super }}


### PR DESCRIPTION
I believe this should fix http://manage.dimagi.com/default.asp?187691 (though I didn't repro locally)

I recall something about not allowing any page-specific changes to anything inside a compress block because the whole thing gets hashed at static compile-time as well as again at runtime. I'm a little fuzzy on the details, but I think the general rule is that we can't include something like this toggle inside a compress block. @biyeun probably has the full explanation.

@benrudolph fyi, cc @orangejenny / anyone
