### PR TITLE
Move some J2ME settings to J2ME section

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/json/commcare-settings-layout.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-settings-layout.yaml
@@ -22,9 +22,6 @@
     - hq.build_spec  # CommCare Version
     - properties.cc-autoup-freq  # Auto Update Frequency
     - properties.unsent-number-limit  # Unsent Form Limit
-    - properties.server-tether  # Sync Mode
-    - properties.cc-autosync-freq  # Auto-Sync Frequency
-    - properties.unsent-time-limit  # Unsynced Time Limit
     - properties.cc-content-valid  # Multimedia Validation
     
 
@@ -36,6 +33,9 @@
     - hq.admin_password  # Admin Password
     - hq.show_user_registration  # Allow User Registration from Phone
     - properties.cc-send-procedure  # Send Data
+    - properties.server-tether  # Sync Mode
+    - properties.cc-autosync-freq  # Auto-Sync Frequency
+    - properties.unsent-time-limit  # Unsynced Time Limit
     - properties.password_format  # Password Format
 
 - title: 'Java Phone User Interface Settings'


### PR DESCRIPTION
Jenny Schweers [9:56 AM] 
@ctsims: can you confirm that the "Sync Mode (Push Only / Two Way Sync)" is ignored by android? I'd like to move it into one of the Java sections and out of the General section (on HQ's app settings page) if that's the case.

Clayton Sims [11:04 AM] 
It is ignored entirely on android

Also moved cc-autosync-freq and unsent-time-limit, which depend on server-tether

@czue fyi @ctsims 
