### PR TITLE
Better compress test

### DIFF
--- a/corehq/apps/export/templates/export/export_list.html
+++ b/corehq/apps/export/templates/export/export_list.html
@@ -6,14 +6,14 @@
 {% load djangular_tags %}
 
 {% block stylesheets %}{{ block.super }}
-    <script type="text/css">
+    <style>
         .bulk-checkbox {
             margin-top: 8px;
             vertical-align: top;
             line-height: 20px;
             display: inline-block;
         }
-    </script>
+    </style>
 {% endblock %}
 
 {% block js %}

--- a/corehq/apps/style/tests/test_compress_command.py
+++ b/corehq/apps/style/tests/test_compress_command.py
@@ -11,10 +11,16 @@ BLOCK_JS = ' block js '
 BLOCK_CSS = ' block css '
 ENDBLOCK = ' endblock '
 
+DISALLOWED_TAGS = [
+    '{% if',
+]
+
 
 class TestDjangoCompressOffline(SimpleTestCase):
 
     def _assert_valid_import(self, line):
+        for tag in DISALLOWED_TAGS:
+            self.assertNotIn(tag, line)
         if 'src' not in line and 'href' not in line:
             return
         self.assertIn('new_static', line)

--- a/corehq/apps/style/tests/test_compress_command.py
+++ b/corehq/apps/style/tests/test_compress_command.py
@@ -8,7 +8,7 @@ from django.core.management import call_command
 from django.test import SimpleTestCase
 
 BLOCK_JS = ' block js '
-BLOCK_CSS = ' block css '
+BLOCK_CSS = ' block stylesheets '
 ENDBLOCK = ' endblock '
 
 DISALLOWED_TAGS = [

--- a/corehq/apps/style/tests/test_compress_command.py
+++ b/corehq/apps/style/tests/test_compress_command.py
@@ -1,4 +1,3 @@
-import re
 from StringIO import StringIO
 from mock import patch, MagicMock
 

--- a/corehq/apps/style/tests/test_compress_command.py
+++ b/corehq/apps/style/tests/test_compress_command.py
@@ -1,8 +1,64 @@
+from StringIO import StringIO
+from mock import patch, MagicMock
+
+from compressor.offline.django import DjangoParser
+from django.conf import settings
+from django.template.loader_tags import ExtendsNode
 from django.core.management import call_command
 from django.test import SimpleTestCase
+
+BLOCK_JS = ' block js '
+BLOCK_CSS = ' block css '
+ENDBLOCK = ' endblock '
 
 
 class TestDjangoCompressOffline(SimpleTestCase):
 
+    def _assert_valid_import(self, line):
+        if 'src' not in line and 'href' not in line:
+            return
+        self.assertIn('new_static', line)
+
+    def _is_b3(self, filename):
+        parser = DjangoParser(charset=settings.FILE_CHARSET)
+        template = parser.parse(filename)
+
+        return self._is_b3_base_template(template)
+
+    def _is_b3_base_template(self, template):
+        if template.name == 'style/bootstrap3/base.html':
+            return True
+
+        nodes = list(template.nodelist)
+        for node in nodes:
+            if isinstance(node, ExtendsNode):
+                # Get parent requires a context variable, just pass in mock to make it work
+                return self._is_b3_base_template(node.get_parent(MagicMock()))
+
+        return False
+
     def test_compress_offline(self):
-        call_command('compress', force=True)
+        with patch('sys.stdout', new_callable=StringIO) as mock_stdout:
+            call_command('compress', force=True)
+
+            mock_stdout.seek(0)
+            filenames = mock_stdout.readlines()
+
+        in_compress_block = False
+
+        # Filter lines that are not html and strip whitespace
+        filenames = filter(lambda name: name.endswith('.html'), map(lambda name: name.strip(), filenames))
+
+        for filename in filenames:
+            if self._is_b3(filename):
+                with open(filename, 'r+') as f:
+                    for line in f.readlines():
+                        if (BLOCK_JS in line or BLOCK_CSS in line) and ENDBLOCK not in line:
+                            in_compress_block = True
+                            continue
+
+                        if ENDBLOCK in line:
+                            in_compress_block = False
+
+                        if in_compress_block:
+                            self._assert_valid_import(line)

--- a/corehq/apps/style/tests/test_compress_command.py
+++ b/corehq/apps/style/tests/test_compress_command.py
@@ -1,3 +1,4 @@
+import re
 from StringIO import StringIO
 from mock import patch, MagicMock
 
@@ -12,15 +13,18 @@ BLOCK_CSS = ' block stylesheets '
 ENDBLOCK = ' endblock '
 
 DISALLOWED_TAGS = [
-    '{% if',
+    ('{% if', 'You cannot use "if" tags in a compress block'),
+    ('^</script>$', 'You cannot use inline JS in a compress block'),
 ]
 
 
 class TestDjangoCompressOffline(SimpleTestCase):
 
     def _assert_valid_import(self, line):
+        if not line.strip():
+            return
         for tag in DISALLOWED_TAGS:
-            self.assertNotIn(tag, line)
+            self.assertNotRegexpMatches(tag[0], line.strip(), tag[1])
         if 'src' not in line and 'href' not in line:
             return
         self.assertIn('new_static', line)


### PR DESCRIPTION
@czue @proteusvacuum so this should catch most b3 static vs. new_static errors. the code is a bit gross, but it wasn't trivial to get working. very little documentation on it. i did check locally for the negative case. i.e. leave a new_static out and it will fail, and add an if statement to the compress block and it will also fail

fyi: @biyeun 

cc: @emord 
