### PR TITLE
bump django

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,7 +7,7 @@ jsonobject-couchdbkit==0.7.1.0
 celery==3.1.18
 # required by django-digest
 decorator==4.0.4
-django==1.7.10
+django==1.7.11
 django-braces==1.8.1
 django-celery==3.1.16
 django-json-field==0.5.7


### PR DESCRIPTION
https://www.djangoproject.com/weblog/2015/nov/24/security-releases-issued/

Don't think this actually affects us. All date filters I found were hardcoded.

also noted: 

> This is likely to be the last release of the 1.7 series as it will be end-of-life upon the release of Django 1.9, scheduled for December 1.

cc: @benrudolph 
