### PR TITLE
Replace group views

### DIFF
--- a/corehq/apps/cachehq/cachemodels.py
+++ b/corehq/apps/cachehq/cachemodels.py
@@ -42,9 +42,7 @@ class GroupGenerationCache(GenerationCache):
         "groups/by_user",
         "groups/by_hierarchy_type",
         "groups/by_user_type",
-        "groups/by_name",
         "groups/all_groups",
-        "groups/by_domain",
         "users/by_group",
     ]
 

--- a/corehq/apps/domain/dbaccessors.py
+++ b/corehq/apps/domain/dbaccessors.py
@@ -32,6 +32,7 @@ def get_docs_in_domain_by_class(domain, doc_class):
     whitelist = [
         'CallCenterIndicatorConfig',
         'CommtrackConfig',
+        'Group',
         'Invitation',
         'PerformanceConfiguration',
     ]

--- a/corehq/apps/groups/dbaccessors.py
+++ b/corehq/apps/groups/dbaccessors.py
@@ -1,64 +1,21 @@
-from django.conf import settings
+from corehq.apps.domain.dbaccessors import (
+    get_docs_in_domain_by_class,
+    get_doc_ids_in_domain_by_class,
+)
 
 
-def _group_by_domain(domain, **kwargs):
+def group_by_domain(domain):
     from corehq.apps.groups.models import Group
-    return list(Group.view(
-        'groups/by_domain',
-        key=domain,
-        **kwargs
-    ))
-
-
-def group_by_domain(domain, include_docs=True):
-    return _group_by_domain(
-        domain,
-        include_docs=include_docs,
-    )
-
-
-def stale_group_by_domain(domain, include_docs=True):
-    return _group_by_domain(
-        domain,
-        include_docs=include_docs,
-        stale=settings.COUCH_STALE_QUERY,
-    )
-
-
-def _group_by_name(domain, name, **kwargs):
-    from corehq.apps.groups.models import Group
-    return list(Group.view(
-        'groups/by_name',
-        key=[domain, name],
-        **kwargs
-    ))
+    return get_docs_in_domain_by_class(domain, Group)
 
 
 def group_by_name(domain, name, include_docs=True):
-    return _group_by_name(
-        domain,
-        name,
-        include_docs=include_docs,
+    return filter(
+        lambda group: group.name == name,
+        group_by_domain(domain)
     )
 
 
-def stale_group_by_name(domain, name, include_docs=True):
-    return _group_by_name(
-        domain,
-        name,
-        include_docs=include_docs,
-        stale=settings.COUCH_STALE_QUERY,
-    )
-
-
-def refresh_group_views():
+def get_group_ids_by_domain(domain):
     from corehq.apps.groups.models import Group
-    for view_name in [
-        'groups/by_domain',
-        'groups/by_name',
-    ]:
-        Group.view(
-            view_name,
-            include_docs=False,
-            limit=1,
-        ).fetch()
+    return get_doc_ids_in_domain_by_class(domain, Group)

--- a/corehq/util/tests/test_couch.py
+++ b/corehq/util/tests/test_couch.py
@@ -2,7 +2,6 @@ from contextlib import contextmanager
 from couchdbkit import ResourceNotFound
 from django.http import Http404
 from django.test import TestCase, SimpleTestCase
-from corehq.apps.groups.dbaccessors import refresh_group_views
 from corehq.apps.groups.models import Group
 from jsonobject.exceptions import WrappingAttributeError
 from mock import Mock
@@ -165,7 +164,6 @@ class IterDBTest(TestCase):
             for group in self.groups[4:]:
                 saved_groups.add(group._id)
                 iter_db.save(group)
-        refresh_group_views()
 
         self.assertEqual(deleted_groups, iter_db.deleted_ids)
         self.assertEqual(saved_groups, iter_db.saved_ids)
@@ -192,7 +190,6 @@ class IterDBTest(TestCase):
 
         ids = [g._id for g in self.groups] + ['NOT_REAL_ID']
         res = iter_update(self.db, mark_cool, ids)
-        refresh_group_views()
         self.assertEqual(res.not_found_ids, {'NOT_REAL_ID'})
         for result_ids, action in [
             (res.ignored_ids, 'IGNORE'),


### PR DESCRIPTION
This came up in the perf meeting, but just wanted to check my understanding.

Replacing `groups/by_name` with a call to by_domain and filtering in python is a bad idea because domains may contain a huge number of groups. (see changes for details)

It's less clear to me whether or not replacing `groups/by_domain` is a good idea, because either way you have a view that will have to return a large number of objects.  Not sure if utilizing `get_docs_in_domain_by_class` makes this worse.  @dannyroberts Thoughts?

(PRing code I had written for reference)
