### PR TITLE
Don't fail hard when there are no args in message

### DIFF
--- a/custom/ilsgateway/tanzania/handlers/keyword.py
+++ b/custom/ilsgateway/tanzania/handlers/keyword.py
@@ -27,6 +27,9 @@ class KeywordHandler(object):
         if location:
             return location.sql_location
 
+        if not self.args:
+            return
+
         try:
             return SQLLocation.objects.get(domain=self.domain, site_code=self.args[0])
         except SQLLocation.DoesNotExist:


### PR DESCRIPTION
@gcapalbo http://manage.dimagi.com/default.asp?187839#1050434
All EWS handlers extend KeywordHandler from ILS module that's why change is in ILS module. In the future it should be moved to logistics module.
