### PR TITLE
uuids in UUID columns

### DIFF
--- a/corehq/apps/receiverwrapper/tests/data/form_with_case.xml
+++ b/corehq/apps/receiverwrapper/tests/data/form_with_case.xml
@@ -1,9 +1,9 @@
 <?xml version='1.0' ?>
 <form name="v2 create" version="1" uiVersion="1" xmlns:jrm="http://openrosa.org/jr/xforms" xmlns="http://commcarehq.org/test/submit">
     <meta>
-        <DeviceID>Chalimbana</DeviceID>
-        <TimeStart>2010-06-29T13:42:50.137</TimeStart>
-        <TimeEnd>2010-06-29T13:55:50.137</TimeEnd>
+        <deviceID>Chalimbana</deviceID>
+        <timeStart>2010-06-29T13:42:50.137</timeStart>
+        <timeEnd>2010-06-29T13:55:50.137</timeEnd>
         <username>someuser</username>
         <userID>ad38211be256653bceac8e2156475665</userID>
         <instanceID>ad38211be256653bceac8e2156475666</instanceID>

--- a/corehq/apps/receiverwrapper/tests/data/form_with_demo_case.xml
+++ b/corehq/apps/receiverwrapper/tests/data/form_with_demo_case.xml
@@ -1,9 +1,9 @@
 <?xml version='1.0' ?>
 <registration version="1" uiVersion="1" xmlns:jrm="http://openrosa.org/jr/xforms" xmlns="http://commcarehq.org/test/submit">
 <meta>
-    <DeviceID>Chalimbana</DeviceID>
-    <TimeStart>2010-06-29T13:42:50.137</TimeStart>
-    <TimeEnd>2010-06-29T13:55:50.137</TimeEnd>
+    <deviceID>Chalimbana</deviceID>
+    <timeStart>2010-06-29T13:42:50.137</timeStart>
+    <timeEnd>2010-06-29T13:55:50.137</timeEnd>
     <username>demo_user</username>
     <userID>demo_user</userID>
     <instanceID>{instanceID}</instanceID>

--- a/corehq/apps/receiverwrapper/tests/data/simple_form.xml
+++ b/corehq/apps/receiverwrapper/tests/data/simple_form.xml
@@ -1,12 +1,12 @@
 <?xml version='1.0' ?>
 <form version="1" uiVersion="1" xmlns:jrm="http://openrosa.org/jr/xforms" xmlns="http://commcarehq.org/test/submit">
 	<meta>
-	    <DeviceID>myphone</DeviceID>
-	    <TimeStart>2010-06-29T13:42:50.137</TimeStart>
-	    <TimeEnd>2010-06-29T13:55:50.137</TimeEnd>
+	    <deviceID>myphone</deviceID>
+	    <timeStart>2010-06-29T13:42:50.137</timeStart>
+	    <timeEnd>2010-06-29T13:55:50.137</timeEnd>
 	    <username>someuser</username>
-	    <userID>someuserid</userID>
-	    <uid>ad38211be256653bceac8e2156475664</uid>
+	    <userID>8b567820-4015-4e66-87ac-80c0f19ecad1</userID>
+	    <instanceID>ad38211be256653bceac8e2156475664</instanceID>
 	</meta>
 	<foo>bar</foo>
 	<baz>

--- a/corehq/apps/receiverwrapper/tests/data/user_registration.xml
+++ b/corehq/apps/receiverwrapper/tests/data/user_registration.xml
@@ -2,7 +2,7 @@
 <n0:registration xmlns:n0="http://openrosa.org/user/registration">
     <username>MEALZ</username>
     <password>123</password>
-    <uuid>HSPPFWGE9F6T94S6YU2JVLXOF</uuid>
+    <uuid>321856d5-4433-4863-b6bf-798c72a5da80</uuid>
     <date>2011-12-09</date>
     <registering_phone_id>1IAXXQA2PWO8EAFP5UCKJ1PG4</registering_phone_id>
     <user_data>

--- a/corehq/apps/receiverwrapper/tests/test_auth.py
+++ b/corehq/apps/receiverwrapper/tests/test_auth.py
@@ -164,7 +164,6 @@ class _AuthTest(TestCase):
             expected_status=403,
         )
 
-    @run_with_all_backends
     def test_case_noauth(self):
         self._test_post(
             file_path=self.form_with_demo_case,

--- a/corehq/apps/receiverwrapper/util.py
+++ b/corehq/apps/receiverwrapper/util.py
@@ -1,4 +1,6 @@
 import re
+from uuid import UUID
+
 from couchdbkit import ResourceNotFound
 from corehq.apps.app_manager.models import ApplicationBase
 from corehq.apps.domain.auth import determine_authtype_from_request
@@ -56,6 +58,8 @@ def get_version_from_build_id(domain, build_id):
     """
     if not build_id:
         return None
+    elif isinstance(build_id, UUID):
+        build_id = build_id.hex
 
     try:
         build = ApplicationBase.get(build_id)

--- a/corehq/ex-submodules/casexml/apps/case/signals.py
+++ b/corehq/ex-submodules/casexml/apps/case/signals.py
@@ -13,7 +13,7 @@ def rebuild_form_cases(sender, xform, *args, **kwargs):
     transactions = StockTransaction.objects.filter(report__form_id=xform.form_id)
     stock_case_ids = transactions.values_list('case_id', flat=True).distinct()
     case_ids.update(stock_case_ids)
-    detail = FormArchiveRebuild(form_id=xform.form_id, archived=xform.is_archived)
+    detail = FormArchiveRebuild(form_id=str(xform.form_id), archived=xform.is_archived)
     for case_id in case_ids:
         rebuild_case_from_forms(domain, case_id, detail)
 

--- a/corehq/ex-submodules/casexml/apps/case/tests/data/bugs/bugs_in_case_create_datatypes.xml
+++ b/corehq/ex-submodules/casexml/apps/case/tests/data/bugs/bugs_in_case_create_datatypes.xml
@@ -13,7 +13,7 @@
 		<timeStart>2011-11-16T10:06:54.055-05</timeStart>
 		<timeEnd>2011-11-16T10:08:46.093-05</timeEnd>
 		<username>admin</username>
-		<userID>5463YB9DV8CPCJHRJ6RO9PGJU</userID>
+		<userID>{user_id}</userID>
 		<instanceID>{form_id}</instanceID>
 	</meta>
 </data>

--- a/corehq/ex-submodules/casexml/apps/case/tests/data/bugs/bugs_in_case_update_datatypes.xml
+++ b/corehq/ex-submodules/casexml/apps/case/tests/data/bugs/bugs_in_case_update_datatypes.xml
@@ -13,7 +13,7 @@
 		<timeStart>2011-11-16T10:06:54.055-05</timeStart>
 		<timeEnd>2011-11-16T10:08:46.093-05</timeEnd>
 		<username>admin</username>
-		<userID>5463YB9DV8CPCJHRJ6RO9PGJU</userID>
+		<userID>{user_id}</userID>
 		<instanceID>{form_id}</instanceID>
 	</meta>
 </system>

--- a/corehq/ex-submodules/casexml/apps/case/tests/data/bugs/duplicate_case_properties_2.xml
+++ b/corehq/ex-submodules/casexml/apps/case/tests/data/bugs/duplicate_case_properties_2.xml
@@ -7,7 +7,7 @@
 		<n0:timeEnd>2012-04-25T14:05:45.250+05:30</n0:timeEnd>
 		<n0:username>mtest</n0:username>
 		<n0:userID>3ed205ad5d96199104c08eb5e0f5ae42</n0:userID>
-		<n0:instanceID>alsdkfjasdlk-785a-4159-8937-caf66c25ac4f</n0:instanceID>
+		<n0:instanceID>ea9571f2-785a-4159-8937-caf66c25ac4a</n0:instanceID>
 		<cc:appVersion>v2.0.0dev
 			(5fb368-980df7-unvers-2.1.0-Nokia/S40-native-input) #86 b:2012-Apr-23
 			r:2012-Apr-24</cc:appVersion>

--- a/corehq/ex-submodules/casexml/apps/case/tests/data/bugs/empty_id.xml
+++ b/corehq/ex-submodules/casexml/apps/case/tests/data/bugs/empty_id.xml
@@ -1,12 +1,12 @@
 <?xml version='1.0' ?>
 <anc version="8" uiVersion="2" xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://www.commcarehq.org/case/test/">
 	<Meta>
-		<DeviceID>6YE3THZNAVT40K5XGQSF09WL1</DeviceID>
+		<deviceID>6YE3THZNAVT40K5XGQSF09WL1</deviceID>
 		<timeStart>2011-02-15T22:00:52.312</timeStart>
 		<timeEnd>2011-02-15T22:01:18.957</timeEnd>
 		<username>user1</username>
-		<chw_id>82WS6S0JPCKFK82SPGF6W023L</chw_id>
-		<uid>3A6B9P0AYZD0OGC3U5XQ3HN45</uid>
+		<userID>f7f0c79e-8b79-11df-b7de-005056c00008</userID>
+		<instanceID>5d3d01561f584e85b53669a48bfc6039</instanceID>
 	</Meta>
 	<case>
 		<case_id></case_id>

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
@@ -10,7 +10,7 @@ from casexml.apps.case.tests.util import delete_all_cases
 from casexml.apps.case.util import post_case_blocks
 from casexml.apps.case.xml import V2, V1
 from corehq.apps.receiverwrapper import submit_form_locally
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import run_with_all_backends, UuidAssertMixin
 from corehq.util.test_utils import TestFileMixin
 
 
@@ -23,7 +23,7 @@ class SimpleCaseBugTests(SimpleTestCase):
 
 
 @override_settings(CASEXML_FORCE_DOMAIN_CHECK=False)
-class CaseBugTest(TestCase, TestFileMixin):
+class CaseBugTest(TestCase, TestFileMixin, UuidAssertMixin):
     """
     Tests bugs that come up in case processing
     """
@@ -72,7 +72,6 @@ class CaseBugTest(TestCase, TestFileMixin):
 
         _test({'case_name': value})
         _test({'case_type': value})
-        _test({'user_id': value})
 
     @run_with_all_backends
     def testDateInCasePropertyBug(self):
@@ -122,7 +121,7 @@ class CaseBugTest(TestCase, TestFileMixin):
 
         ids = case.xform_ids
         self.assertEqual(1, len(ids))
-        self.assertEqual(form.form_id, ids[0])
+        self.assertUuidEqual(form.form_id, ids[0])
 
     @run_with_all_backends
     def testLotsOfSubcases(self):

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_domains.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_domains.py
@@ -8,7 +8,7 @@ ALICE_XML = """<?xml version='1.0' ?>
 <data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/D95E58BD-A228-414F-83E6-EEE716F0B3AD">
     <name>Dinkle</name>
     <join_date>2010-08-28</join_date>
-    <n0:case case_id="ddb8e2b3-7ce0-43e4-ad45-d7a2eebe9169" user_id="user-xxx-alice" date_modified="2013-04-19T16:52:04.304-04" xmlns:n0="http://commcarehq.org/case/transaction/v2">
+    <n0:case case_id="ddb8e2b3-7ce0-43e4-ad45-d7a2eebe9169" user_id="da77a254-56dd-11e0-a55d-005056aa7fb5" date_modified="2013-04-19T16:52:04.304-04" xmlns:n0="http://commcarehq.org/case/transaction/v2">
         <n0:create>
             <n0:case_name>Dinkle</n0:case_name>
             <n0:owner_id>da77a254-56dd-11e0-a55d-005056aa7fb5</n0:owner_id>
@@ -32,7 +32,7 @@ ALICE_XML = """<?xml version='1.0' ?>
 EVE_XML = """<?xml version='1.0' ?>
 <data uiVersion="1" version="17" name="New Form" xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/1DFD8610-91E3-4409-BF8B-02D3B4FF3530">
     <plan_to_buy_gun>no</plan_to_buy_gun>
-    <n0:case case_id="ddb8e2b3-7ce0-43e4-ad45-d7a2eebe9169" user_id="user-xxx-eve" date_modified="2013-04-19T16:53:02.799-04" xmlns:n0="http://commcarehq.org/case/transaction/v2">
+    <n0:case case_id="ddb8e2b3-7ce0-43e4-ad45-d7a2eebe9169" user_id="da77a254-56dd-11e0-a55d-005056aa7fb6" date_modified="2013-04-19T16:53:02.799-04" xmlns:n0="http://commcarehq.org/case/transaction/v2">
         <n0:update>
             <n0:plan_to_buy_gun>no</n0:plan_to_buy_gun>
         </n0:update>
@@ -42,7 +42,7 @@ EVE_XML = """<?xml version='1.0' ?>
         <n1:timeStart>2013-04-19T16:52:41.000-04</n1:timeStart>
         <n1:timeEnd>2013-04-19T16:53:02.799-04</n1:timeEnd>
         <n1:username>eve</n1:username>
-        <n1:userID>user-xxx-eve</n1:userID>
+        <n1:userID>da77a254-56dd-11e0-a55d-005056aa7fb6</n1:userID>
         <n1:instanceID>b58df19c-efd5-4ecf-9581-65dda8b8787c</n1:instanceID>
         <n2:appVersion xmlns:n2="http://commcarehq.org/xforms">CommCare ODK, version "2.4.1"(10083). App v19. CommCare Version 2.4. Build 10083, built on: March-12-2013</n2:appVersion>
     </n1:meta>
@@ -51,7 +51,7 @@ EVE_XML = """<?xml version='1.0' ?>
 ALICE_UPDATE_XML = """<?xml version='1.0' ?>
 <data uiVersion="1" version="17" name="New Form" xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/1DFD8610-91E3-4409-BF8B-02D3B4FF3530">
     <plan_to_buy_gun>no</plan_to_buy_gun>
-    <n0:case case_id="ddb8e2b3-7ce0-43e4-ad45-d7a2eebe9169" user_id="user-xxx-alice" date_modified="2013-04-19T16:53:02.799-04" xmlns:n0="http://commcarehq.org/case/transaction/v2">
+    <n0:case case_id="ddb8e2b3-7ce0-43e4-ad45-d7a2eebe9169" user_id="da77a254-56dd-11e0-a55d-005056aa7fb5" date_modified="2013-04-19T16:53:02.799-04" xmlns:n0="http://commcarehq.org/case/transaction/v2">
         <n0:update>
             <n0:plan_to_buy_gun>no</n0:plan_to_buy_gun>
         </n0:update>
@@ -61,8 +61,8 @@ ALICE_UPDATE_XML = """<?xml version='1.0' ?>
         <n1:timeStart>2013-04-19T16:52:41.000-04</n1:timeStart>
         <n1:timeEnd>2013-04-19T16:53:02.799-04</n1:timeEnd>
         <n1:username>alice</n1:username>
-        <n1:userID>user-xxx-alice</n1:userID>
-        <n1:instanceID>b58df19c-efd5-4ecf-9581-65dda8b8787cXXX</n1:instanceID>
+        <n1:userID>da77a254-56dd-11e0-a55d-005056aa7fb5</n1:userID>
+        <n1:instanceID>b58df19c-efd5-4ecf-9581-65dda8b8787d</n1:instanceID>
         <n2:appVersion xmlns:n2="http://commcarehq.org/xforms">CommCare ODK, version "2.4.1"(10083). App v19. CommCare Version 2.4. Build 10083, built on: March-12-2013</n2:appVersion>
     </n1:meta>
 </data>"""

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -39,13 +39,13 @@ class CaseProcessingResult(object):
 
     def get_clean_owner_ids(self):
         dirty_flags = self.get_flags_to_save()
-        return {c.owner_id for c in self.cases if c.owner_id and c.owner_id not in dirty_flags}
+        return {str(c.owner_id) for c in self.cases if c.owner_id and str(c.owner_id) not in dirty_flags}
 
     def set_cases(self, cases):
         self.cases = cases
 
     def get_flags_to_save(self):
-        return {f.owner_id: f.case_id for f in self.dirtiness_flags}
+        return {str(f.owner_id): f.case_id for f in self.dirtiness_flags}
 
     def commit_dirtiness_flags(self):
         """

--- a/corehq/ex-submodules/couchforms/models.py
+++ b/corehq/ex-submodules/couchforms/models.py
@@ -349,6 +349,20 @@ class XFormInstance(SafeSaveDocument, UnicodeMixIn, ComputedDocumentMixin,
     def is_archived(self):
         return self.doc_type == "XFormArchived"
 
+    @memoized
+    def get_sync_token(self):
+        from casexml.apps.phone.models import get_properly_wrapped_sync_log
+        if self.last_sync_token:
+            from couchdbkit import ResourceNotFound
+            try:
+                return get_properly_wrapped_sync_log(self.last_sync_token)
+            except ResourceNotFound:
+                logging.exception('No sync token with ID {} found. Form is {} in domain {}'.format(
+                    self.last_sync_token, self.form_id, self.domain,
+                ))
+                raise
+        return None
+
 
 class XFormError(XFormInstance):
     """

--- a/corehq/ex-submodules/couchforms/tests/data/date_in_meta.xml
+++ b/corehq/ex-submodules/couchforms/tests/data/date_in_meta.xml
@@ -4,7 +4,7 @@
         <instanceID>c28f68a5-e920-4594-aea7-dbae3c3650b4</instanceID>
         <timeEnd>2014-07-11</timeEnd>
         <timeStart>2014-07-10</timeStart>
-        <userID>12345</userID>
+        <userID>c28f68a5-e920-4594-aea7-dbae3c3650b5</userID>
     </meta>
     <foo>bar</foo>
 </data>

--- a/corehq/ex-submodules/couchforms/tests/data/deprecation/edit.xml
+++ b/corehq/ex-submodules/couchforms/tests/data/deprecation/edit.xml
@@ -1,11 +1,11 @@
 <?xml version='1.0' ?>
 <general xmlns="http://openrosa.org/app/general">
 	<Meta>
-		<TimeStart>2010-07-22T13:54:27.971</TimeStart>
-		<TimeEnd>2010-07-24T13:55:11.648</TimeEnd>
+		<tmeStart>2010-07-22T13:54:27.971</tmeStart>
+		<timeEnd>2010-07-24T13:55:11.648</timeEnd>
 		<username>admin</username>
-		<uid>7H46J37FGH3</uid>
-        <user_id>f7f0c79e-8b79-11df-b7de-005056c00008</user_id>
+		<instanceID>7afa8ac1-3237-424e-8cd5-e437dd541232</instanceID>
+        <userID>f7f0c79e-8b79-11df-b7de-005056c00008</userID>
 	</Meta>
 	<encounter_date>2010-07-22</encounter_date>
     <vitals>

--- a/corehq/ex-submodules/couchforms/tests/data/deprecation/original.xml
+++ b/corehq/ex-submodules/couchforms/tests/data/deprecation/original.xml
@@ -1,11 +1,11 @@
 <?xml version='1.0' ?>
 <general xmlns="http://openrosa.org/app/general">
 	<Meta>
-		<TimeStart>2010-07-22T13:54:27.971</TimeStart>
-		<TimeEnd>2010-07-23T13:55:11.648</TimeEnd>
+		<timeStart>2010-07-22T13:54:27.971</timeStart>
+		<timeEnd>2010-07-23T13:55:11.648</timeEnd>
 		<username>admin</username>
-		<uid>7H46J37FGH3</uid>
-        <user_id>f7f0c79e-8b79-11df-b7de-005056c00008</user_id>
+		<instanceID>7afa8ac1-3237-424e-8cd5-e437dd541232</instanceID>
+        <userID>f7f0c79e-8b79-11df-b7de-005056c00008</userID>
 	</Meta>
 	<encounter_date>2010-07-22</encounter_date>
 	<vitals>

--- a/corehq/ex-submodules/couchforms/tests/data/missing_date_in_meta.xml
+++ b/corehq/ex-submodules/couchforms/tests/data/missing_date_in_meta.xml
@@ -3,7 +3,7 @@
     <meta xmlns="http://openrosa.org/jr/xforms">
         <instanceID>c28f68a5-e920-4594-aea7-dbae3c3650b4</instanceID>
         <timeStart>2014-07-10</timeStart>
-        <userID>12345</userID>
+        <userID>c28f68a5-e920-4594-aea7-dbae3c3650b5</userID>
     </meta>
     <foo>bar</foo>
 </data>

--- a/corehq/ex-submodules/couchforms/tests/data/posts/duplicate-sql.json
+++ b/corehq/ex-submodules/couchforms/tests/data/posts/duplicate-sql.json
@@ -1,14 +1,13 @@
 {
-    "form_id": "7H46J37FGH3",
+    "form_id": "f7f0c79e-8b79-11df-b7de-005056c00009",
     "form": {
         "#type": "general",
         "@xmlns": "http://openrosa.org/app/general",
-        "Meta": {
-            "TimeEnd": "2010-07-23T13:55:11.648000Z",
-            "TimeStart": "2010-07-22T13:54:27.971000Z",
-            "clinic_id": "5020280",
-            "uid": "7H46J37FGH3",
-            "user_id": "f7f0c79e-8b79-11df-b7de-005056c00008",
+        "meta": {
+            "timeEnd": "2010-07-23T13:55:11.648000Z",
+            "timeStart": "2010-07-22T13:54:27.971000Z",
+            "instanceID": "f7f0c79e-8b79-11df-b7de-005056c00009",
+            "userID": "f7f0c79e-8b79-11df-b7de-005056c00008",
             "username": "admin"
         },
         "assessment": {

--- a/corehq/ex-submodules/couchforms/tests/data/posts/duplicate.json
+++ b/corehq/ex-submodules/couchforms/tests/data/posts/duplicate.json
@@ -8,7 +8,7 @@
             "stub": true
         }
     },
-    "_id": "7H46J37FGH3",
+    "_id": "f7f0c79e-8b79-11df-b7de-005056c00009",
     "_rev": "1-ce4eda776ac0510cdaf4a8de4f71db21",
     "computed_": {},
     "computed_modified_on_": null,
@@ -16,12 +16,11 @@
     "form": {
         "#type": "general",
         "@xmlns": "http://openrosa.org/app/general",
-        "Meta": {
-            "TimeEnd": "2010-07-23T13:55:11.648000Z",
-            "TimeStart": "2010-07-22T13:54:27.971000Z",
-            "clinic_id": "5020280",
-            "uid": "7H46J37FGH3",
-            "user_id": "f7f0c79e-8b79-11df-b7de-005056c00008",
+        "meta": {
+            "timeEnd": "2010-07-23T13:55:11.648000Z",
+            "timeStart": "2010-07-22T13:54:27.971000Z",
+            "instanceID": "f7f0c79e-8b79-11df-b7de-005056c00009",
+            "userID": "f7f0c79e-8b79-11df-b7de-005056c00008",
             "username": "admin"
         },
         "assessment": {

--- a/corehq/ex-submodules/couchforms/tests/data/posts/duplicate.xml
+++ b/corehq/ex-submodules/couchforms/tests/data/posts/duplicate.xml
@@ -1,13 +1,12 @@
 <?xml version='1.0' ?>
 <general xmlns="http://openrosa.org/app/general">
-	<Meta>
-		<clinic_id>5020280</clinic_id>
-		<TimeStart>2010-07-22T13:54:27.971</TimeStart>
-		<TimeEnd>2010-07-23T13:55:11.648</TimeEnd>
+	<meta>
+		<timeStart>2010-07-22T13:54:27.971</timeStart>
+		<timeEnd>2010-07-23T13:55:11.648</timeEnd>
 		<username>admin</username>
-		<uid>7H46J37FGH3</uid>
-        <user_id>f7f0c79e-8b79-11df-b7de-005056c00008</user_id>
-	</Meta>
+		<instanceID>f7f0c79e-8b79-11df-b7de-005056c00009</instanceID>
+        <userID>f7f0c79e-8b79-11df-b7de-005056c00008</userID>
+	</meta>
 	<case>
 		<patient_id>6713c1c211b3af6832c8ad781e310d98</patient_id>
 		<case_type>malaria</case_type>

--- a/corehq/ex-submodules/couchforms/tests/data/posts/meta-sql.json
+++ b/corehq/ex-submodules/couchforms/tests/data/posts/meta-sql.json
@@ -1,5 +1,5 @@
 {
-    "form_id": "2591f063195bd3d107bfd20c71932faa",
+    "form_id": "2591f063-195b-d3d1-07bf-d20c-71932faa",
     "form": {
         "#type": "general",
         "@xmlns": "http://openrosa.org/app/general",

--- a/corehq/ex-submodules/couchforms/tests/data/posts/meta_bad_username-sql.json
+++ b/corehq/ex-submodules/couchforms/tests/data/posts/meta_bad_username-sql.json
@@ -1,5 +1,5 @@
 {
-    "form_id": "e8afaec3c66745ef80e48062d4b91b56",
+    "form_id": "e8afaec3-c667-45ef-80e4-8062d4b91b56",
     "form": {
         "#type": "data",
         "@uiVersion": "1",

--- a/corehq/ex-submodules/couchforms/tests/data/posts/meta_dict_appversion-sql.json
+++ b/corehq/ex-submodules/couchforms/tests/data/posts/meta_dict_appversion-sql.json
@@ -1,5 +1,5 @@
 {
-    "form_id": "5d3d01561f584e85b53669a48bfc6039",
+    "form_id": "5d3d0156-1f58-4e85-b536-69a48bfc6039",
     "form": {
         "#type": "data",
         "@uiVersion": "1",

--- a/corehq/ex-submodules/couchforms/tests/data/sample_xforms/basic.xml
+++ b/corehq/ex-submodules/couchforms/tests/data/sample_xforms/basic.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0' ?>
 <data uiVersion="1" version="17" name="New Form" xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/1DFD8610-91E3-4409-BF8B-02D3B4FF3530">
     <foo>bar</foo>
-    <n0:case case_id="ddb8e2b3-7ce0-43e4-ad45-d7a2eebe9169" user_id="user-xxx-eve" date_modified="2013-04-19T16:53:02.799-04" xmlns:n0="http://commcarehq.org/case/transaction/v2">
+    <n0:case case_id="ddb8e2b3-7ce0-43e4-ad45-d7a2eebe9169" user_id="c28f68a5-e920-4594-aea7-dbae3c3650b4" date_modified="2013-04-19T16:53:02.799-04" xmlns:n0="http://commcarehq.org/case/transaction/v2">
         <n0:create>
             <n0:case_name>bar</n0:case_name>
-            <n0:owner_id>user-xxx-eve</n0:owner_id>
+            <n0:owner_id>c28f68a5-e920-4594-aea7-dbae3c3650b4</n0:owner_id>
             <n0:case_type>member</n0:case_type>
         </n0:create>
     </n0:case>
@@ -13,7 +13,7 @@
         <n1:timeStart>2013-04-19T16:52:41.000-04</n1:timeStart>
         <n1:timeEnd>2013-04-19T16:53:02.799-04</n1:timeEnd>
         <n1:username>eve</n1:username>
-        <n1:userID>user-xxx-eve</n1:userID>
+        <n1:userID>c28f68a5-e920-4594-aea7-dbae3c3650b4</n1:userID>
         <n1:instanceID>b58df19c-efd5-4ecf-9581-65dda8b8787c</n1:instanceID>
         <n2:appVersion xmlns:n2="http://commcarehq.org/xforms">CommCare ODK, version "2.4.1"(10083). App v19. CommCare Version 2.4. Build 10083, built on: March-12-2013</n2:appVersion>
     </n1:meta>

--- a/corehq/ex-submodules/couchforms/tests/test_archive.py
+++ b/corehq/ex-submodules/couchforms/tests/test_archive.py
@@ -57,7 +57,7 @@ class TestFormArchiving(TestCase, TestFileMixin):
         self.assertTrue(xform.is_normal)
         case = self.casedb.get_case(case_id)
         self.assertFalse(case.is_deleted)
-        self.assertEqual(case.xform_ids, [xform.form_id])
+        self.assertEqual(case.xform_ids, [str(xform.form_id)])
 
         [archival, restoration] = xform.history
         self.assertTrue(lower_bound <= restoration.date <= upper_bound)

--- a/corehq/ex-submodules/couchforms/tests/test_duplicates.py
+++ b/corehq/ex-submodules/couchforms/tests/test_duplicates.py
@@ -3,12 +3,12 @@ from django.test import TestCase
 
 from corehq.apps.receiverwrapper import submit_form_locally
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends, post_xform
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends, post_xform, UuidAssertMixin
 from corehq.util.test_utils import TestFileMixin
 
 
-class DuplicateFormTest(TestCase, TestFileMixin):
-    ID = '7H46J37FGH3'
+class DuplicateFormTest(TestCase, TestFileMixin, UuidAssertMixin):
+    ID = 'f7f0c79e-8b79-11df-b7de-005056c00009'
     file_path = ('data', 'posts')
     root = os.path.dirname(__file__)
 
@@ -19,14 +19,14 @@ class DuplicateFormTest(TestCase, TestFileMixin):
     def test_basic_duplicate(self):
         xml_data = self.get_xml('duplicate')
         xform = post_xform(xml_data)
-        self.assertEqual(self.ID, xform.form_id)
+        self.assertUuidEqual(self.ID, xform.form_id)
         self.assertTrue(xform.is_normal)
         self.assertEqual("test-domain", xform.domain)
 
         xform = post_xform(xml_data, domain='test-domain')
-        self.assertNotEqual(self.ID, xform.form_id)
+        self.assertUuidNotEqual(self.ID, xform.form_id)
         self.assertTrue(xform.is_duplicate)
-        self.assertTrue(self.ID in xform.problem)
+        self.assertTrue(str(self.ID) in xform.problem)
 
     @run_with_all_backends
     def test_wrong_doc_type(self):

--- a/corehq/ex-submodules/couchforms/tests/test_edits.py
+++ b/corehq/ex-submodules/couchforms/tests/test_edits.py
@@ -15,12 +15,12 @@ from couchforms.models import (
 )
 
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends, post_xform
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends, post_xform, UuidAssertMixin
 from corehq.util.test_utils import TestFileMixin
 
 
-class EditFormTest(TestCase, TestFileMixin):
-    ID = '7H46J37FGH3'
+class EditFormTest(TestCase, TestFileMixin, UuidAssertMixin):
+    ID = '7afa8ac1-3237-424e-8cd5-e437dd541232'
     domain = 'test-form-edits'
 
     file_path = ('data', 'deprecation')
@@ -46,21 +46,21 @@ class EditFormTest(TestCase, TestFileMixin):
         xform.received_on = yesterday  # set this back in time to simulate an edit
         self.interface.save_xform(xform)
 
-        self.assertEqual(self.ID, xform.form_id)
+        self.assertUuidEqual(self.ID, xform.form_id)
         self.assertTrue(xform.is_normal)
         self.assertEqual("", xform.form_data['vitals']['height'])
         self.assertEqual("other", xform.form_data['assessment']['categories'])
 
         xform = post_xform(edit_xml, domain=self.domain)
-        self.assertEqual(self.ID, xform.form_id)
+        self.assertUuidEqual(self.ID, xform.form_id)
         self.assertTrue(xform.is_normal)
         self.assertEqual("100", xform.form_data['vitals']['height'])
         self.assertEqual("Edited Baby!", xform.form_data['assessment']['categories'])
 
         deprecated_xform = self.formdb.get_form(xform.deprecated_form_id)
 
-        self.assertEqual(self.ID, deprecated_xform.orig_id)
-        self.assertNotEqual(self.ID, deprecated_xform.form_id)
+        self.assertUuidEqual(self.ID, deprecated_xform.orig_id)
+        self.assertUuidNotEqual(self.ID, deprecated_xform.form_id)
         self.assertTrue(deprecated_xform.is_deprecated)
         self.assertEqual("", deprecated_xform.form_data['vitals']['height'])
         self.assertEqual("other", deprecated_xform.form_data['assessment']['categories'])
@@ -87,7 +87,7 @@ class EditFormTest(TestCase, TestFileMixin):
         edit_xml = self.get_xml('edit')
 
         _, xform, _ = submit_form_locally(original_xml, self.domain)
-        self.assertEqual(self.ID, xform.form_id)
+        self.assertUuidEqual(self.ID, xform.form_id)
         self.assertTrue(xform.is_normal)
         self.assertEqual(self.domain, xform.domain)
 
@@ -117,7 +117,7 @@ class EditFormTest(TestCase, TestFileMixin):
 
     @run_with_all_backends
     def test_case_management(self):
-        form_id = uuid.uuid4().hex
+        form_id = str(uuid.uuid4())
         case_id = uuid.uuid4().hex
         owner_id = uuid.uuid4().hex
         case_block = CaseBlock(
@@ -205,7 +205,7 @@ class EditFormTest(TestCase, TestFileMixin):
 
         # validate that worked
         case = self.casedb.get_case(case_id)
-        self.assertEqual([create_form_id], case.xform_ids)
+        self.assertUuidListEqual([create_form_id], case.xform_ids)
 
         if not settings.TESTS_SHOULD_USE_SQL_BACKEND:
             self.assertEqual([create_form_id], [a.xform_id for a in case.actions])
@@ -227,7 +227,7 @@ class EditFormTest(TestCase, TestFileMixin):
         # validate that worked
         case = self.casedb.get_case(case_id)
         self.assertEqual(case.dynamic_case_properties()['property'], 'first value')
-        self.assertEqual([create_form_id, edit_form_id], case.xform_ids)
+        self.assertUuidListEqual([create_form_id, edit_form_id], case.xform_ids)
 
         if not settings.TESTS_SHOULD_USE_SQL_BACKEND:
             self.assertEqual([create_form_id, edit_form_id], [a.xform_id for a in case.actions])
@@ -245,7 +245,7 @@ class EditFormTest(TestCase, TestFileMixin):
         # validate that worked
         case = self.casedb.get_case(case_id)
         self.assertEqual(case.dynamic_case_properties()['property'], 'final value')
-        self.assertEqual([create_form_id, edit_form_id, second_edit_form_id], case.xform_ids)
+        self.assertUuidListEqual([create_form_id, edit_form_id, second_edit_form_id], case.xform_ids)
 
         if not settings.TESTS_SHOULD_USE_SQL_BACKEND:
             self.assertEqual(
@@ -270,7 +270,7 @@ class EditFormTest(TestCase, TestFileMixin):
         case = self.casedb.get_case(case_id)
         self.assertEqual(case.dynamic_case_properties()['property'], 'final value')
         self.assertEqual(case.dynamic_case_properties()['added_property'], 'added value')
-        self.assertEqual([create_form_id, edit_form_id, second_edit_form_id], case.xform_ids)
+        self.assertUuidListEqual([create_form_id, edit_form_id, second_edit_form_id], case.xform_ids)
 
         if not settings.TESTS_SHOULD_USE_SQL_BACKEND:
             self.assertEqual(

--- a/corehq/ex-submodules/couchforms/tests/test_errors.py
+++ b/corehq/ex-submodules/couchforms/tests/test_errors.py
@@ -28,7 +28,7 @@ class CaseProcessingErrorsTest(TestCase):
         _, xform, _ = submit_form_locally(
             """<data xmlns="example.com/foo">
                 <meta>
-                    <instanceID>abc-easy-as-123</instanceID>
+                    <instanceID>e1f4ec50-a2f7-4b7a-b833-8a387924f976</instanceID>
                 </meta>
             <case case_id="" xmlns="http://commcarehq.org/case/transaction/v2">
                 <update><foo>bar</foo></update>
@@ -53,9 +53,9 @@ class CaseProcessingErrorsTest(TestCase):
         _, xform, _ = submit_form_locally(
             """<data xmlns="example.com/foo">
                 <meta>
-                    <instanceID>abc-easy-as-456</instanceID>
+                    <instanceID>e1f4ec50-a2f7-4b7a-b833-8a387924f977</instanceID>
                 </meta>
-            <case case_id="123" xmlns="http://commcarehq.org/case/transaction/v2">
+            <case case_id="e1f4ec50-a2f7-4b7a-b833-8a387924f978" xmlns="http://commcarehq.org/case/transaction/v2">
                 <referral>
                     <referral_id>456</referral_id>
                     <open>

--- a/corehq/form_processor/abstract_models.py
+++ b/corehq/form_processor/abstract_models.py
@@ -82,18 +82,8 @@ class AbstractXFormInstance(object):
     def get_with_attachments(self, xform_id):
         raise NotImplementedError()
 
-    @memoized
     def get_sync_token(self):
-        from casexml.apps.phone.models import get_properly_wrapped_sync_log
-        if self.last_sync_token:
-            try:
-                return get_properly_wrapped_sync_log(self.last_sync_token)
-            except ResourceNotFound:
-                logging.exception('No sync token with ID {} found. Form is {} in domain {}'.format(
-                    self.last_sync_token, self.form_id, self.domain,
-                ))
-                raise
-        return None
+        raise NotImplementedError
 
 
 class AbstractCommCareCase(object):

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -141,12 +141,12 @@ class CaseAccessorSQL(AbstractCaseAccessor):
 
     @staticmethod
     def get_case_xform_ids(case_id):
-        return list(CaseTransaction.objects.filter(
+        return [str(uuid) for uuid in CaseTransaction.objects.filter(
             case_id=case_id,
             revoked=False,
             form_uuid__isnull=False,
             type=CaseTransaction.TYPE_FORM
-        ).values_list('form_uuid', flat=True))
+        ).values_list('form_uuid', flat=True)]
 
     @staticmethod
     def get_indices(case_id):

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -37,13 +37,13 @@ class FormProcessorSQL(object):
     @classmethod
     def new_xform(cls, form_data):
         form_id = extract_meta_instance_id(form_data) or unicode(uuid.uuid4())
-
+        user_id = extract_meta_user_id(form_data)
         return XFormInstanceSQL(
             # other properties can be set post-wrap
             form_uuid=form_id,
             xmlns=form_data.get('@xmlns'),
             received_on=datetime.datetime.utcnow(),
-            user_id=extract_meta_user_id(form_data),
+            user_id=user_id,
         )
 
     @classmethod
@@ -208,7 +208,7 @@ class FormProcessorSQL(object):
                     deprecated_form = xform
                 affected_cases.update(case_update.id for case_update in get_case_updates(xform))
 
-            rebuild_detail = FormEditRebuild(deprecated_form_id=deprecated_form.form_id)
+            rebuild_detail = FormEditRebuild(deprecated_form_id=str(deprecated_form.form_id))
             for case_id in affected_cases:
                 case = case_db.get(case_id)
                 if not case:

--- a/corehq/form_processor/interfaces/processor.py
+++ b/corehq/form_processor/interfaces/processor.py
@@ -101,7 +101,7 @@ class FormProcessorInterface(object):
                           extra={'details': {'errors': e.errors}})
             raise
         except Exception as e:
-            xforms_being_saved = [xform.form_id for xform in xforms]
+            xforms_being_saved = [str(xform.form_id) for xform in xforms]
             error_message = u'Unexpected error bulk saving docs {}: {}, doc_ids: {}'.format(
                 type(e).__name__,
                 unicode(e),

--- a/corehq/form_processor/migrations/0035_remove_varchar_pattern_ops_indexes.py
+++ b/corehq/form_processor/migrations/0035_remove_varchar_pattern_ops_indexes.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import uuidfield.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('form_processor', '0034_location_id_index'),
+    ]
+
+    NOOP_REVERSE = 'SELECT 1'
+    operations = [
+        migrations.RunSQL(
+            'DROP INDEX IF EXISTS form_processor_xforminstancesql_form_uuid_12662b9ceadeeecc_like',
+            NOOP_REVERSE
+        ),
+        migrations.RunSQL(
+            'DROP INDEX IF EXISTS form_processor_xformattac_attachment_uuid_6d1d0a1eff4ada21_like',
+            NOOP_REVERSE
+        ),
+        migrations.RunSQL(
+            'DROP INDEX IF EXISTS form_processor_xformattachmentsql_name_4b9f1b0d840a70bc_like',
+            NOOP_REVERSE
+        ),
+        migrations.RunSQL(
+            'DROP INDEX IF EXISTS form_processor_xformoperationsql_xform_id_14e64e95f71c3764_like',
+            NOOP_REVERSE
+        ),
+    ]

--- a/corehq/form_processor/migrations/0036_convert_form_fields_to_uuids.py
+++ b/corehq/form_processor/migrations/0036_convert_form_fields_to_uuids.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import uuidfield.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('form_processor', '0035_remove_varchar_pattern_ops_indexes'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            'ALTER TABLE "form_processor_xforminstancesql" ALTER COLUMN "app_id" TYPE uuid USING app_id::uuid',
+            'ALTER TABLE "form_processor_xforminstancesql" ALTER COLUMN "app_id" TYPE varchar(255)',
+            state_operations=[migrations.AlterField(
+                model_name='xforminstancesql',
+                name='app_id',
+                field=uuidfield.fields.UUIDField(max_length=32, null=True),
+                preserve_default=True,
+            )]
+        ),
+        migrations.RunSQL(
+            'ALTER TABLE "form_processor_xforminstancesql" ALTER COLUMN "build_id" TYPE uuid USING build_id::uuid',
+            'ALTER TABLE "form_processor_xforminstancesql" ALTER COLUMN "build_id" TYPE varchar(255)',
+            state_operations=[migrations.AlterField(
+                model_name='xforminstancesql',
+                name='build_id',
+                field=uuidfield.fields.UUIDField(max_length=32, null=True),
+                preserve_default=True,
+            )]
+        ),
+        migrations.RunSQL(
+            'ALTER TABLE "form_processor_xforminstancesql" ALTER COLUMN "deprecated_form_id" TYPE uuid USING deprecated_form_id::uuid',
+            'ALTER TABLE "form_processor_xforminstancesql" ALTER COLUMN "deprecated_form_id" TYPE varchar(255)',
+            state_operations=[migrations.AlterField(
+                model_name='xforminstancesql',
+                name='deprecated_form_id',
+                field=uuidfield.fields.UUIDField(max_length=32, null=True),
+                preserve_default=True,
+            )]
+        ),
+        migrations.RunSQL(
+            '''
+            ALTER TABLE form_processor_xformattachmentsql DROP CONSTRAINT "D89b6a5bce7bb3669f0bc9fe50022b06";
+            ALTER TABLE form_processor_xformoperationsql DROP CONSTRAINT "b006f200335a0a74b529d3ef054b2ad9";
+            ALTER TABLE "form_processor_xformoperationsql" ALTER COLUMN "xform_id" TYPE uuid USING xform_id::uuid;
+            ALTER TABLE "form_processor_xformattachmentsql" ALTER COLUMN "form_uuid" TYPE uuid USING form_uuid::uuid;
+            ALTER TABLE "form_processor_xforminstancesql" ALTER COLUMN "form_uuid" TYPE uuid USING form_uuid::uuid;
+            ALTER TABLE "form_processor_xformattachmentsql" ADD CONSTRAINT "D89b6a5bce7bb3669f0bc9fe50022b06"
+                FOREIGN KEY (form_uuid) REFERENCES form_processor_xforminstancesql(form_uuid) DEFERRABLE INITIALLY DEFERRED;
+            ALTER TABLE "form_processor_xformoperationsql" ADD CONSTRAINT "b006f200335a0a74b529d3ef054b2ad9"
+                FOREIGN KEY (xform_id) REFERENCES form_processor_xforminstancesql(form_uuid) DEFERRABLE INITIALLY DEFERRED;
+            ''',
+            '''
+            ALTER TABLE form_processor_xformattachmentsql DROP CONSTRAINT "D89b6a5bce7bb3669f0bc9fe50022b06";
+            ALTER TABLE form_processor_xformoperationsql DROP CONSTRAINT "b006f200335a0a74b529d3ef054b2ad9";
+            ALTER TABLE "form_processor_xformoperationsql" ALTER COLUMN "xform_id" TYPE varchar(255);
+            ALTER TABLE "form_processor_xformattachmentsql" ALTER COLUMN "form_uuid" TYPE varchar(255);
+            ALTER TABLE "form_processor_xforminstancesql" ALTER COLUMN "form_uuid" TYPE varchar(255);
+            ALTER TABLE "form_processor_xformattachmentsql" ADD CONSTRAINT "D89b6a5bce7bb3669f0bc9fe50022b06"
+                FOREIGN KEY (form_uuid) REFERENCES form_processor_xforminstancesql(form_uuid) DEFERRABLE INITIALLY DEFERRED;
+            ALTER TABLE "form_processor_xformoperationsql" ADD CONSTRAINT "b006f200335a0a74b529d3ef054b2ad9"
+                FOREIGN KEY (xform_id) REFERENCES form_processor_xforminstancesql(form_uuid) DEFERRABLE INITIALLY DEFERRED;
+            ''',
+            state_operations=[migrations.AlterField(
+                model_name='xforminstancesql',
+                name='form_uuid',
+                field=uuidfield.fields.UUIDField(unique=True, max_length=32, db_index=True),
+                preserve_default=True,
+            )]
+        ),
+        migrations.RunSQL(
+            'ALTER TABLE "form_processor_xforminstancesql" ALTER COLUMN "last_sync_token" TYPE uuid USING last_sync_token::uuid',
+            'ALTER TABLE "form_processor_xforminstancesql" ALTER COLUMN "last_sync_token" TYPE varchar(255)',
+            state_operations=[migrations.AlterField(
+                model_name='xforminstancesql',
+                name='last_sync_token',
+                field=uuidfield.fields.UUIDField(max_length=32, null=True),
+                preserve_default=True,
+            )]
+        ),
+        migrations.RunSQL(
+            'ALTER TABLE "form_processor_xforminstancesql" ALTER COLUMN "orig_id" TYPE uuid USING orig_id::uuid',
+            'ALTER TABLE "form_processor_xforminstancesql" ALTER COLUMN "orig_id" TYPE varchar(255)',
+            state_operations=[migrations.AlterField(
+                model_name='xforminstancesql',
+                name='orig_id',
+                field=uuidfield.fields.UUIDField(max_length=32, null=True),
+                preserve_default=True,
+            )]
+        ),
+        migrations.RunSQL(
+            'ALTER TABLE "form_processor_xforminstancesql" ALTER COLUMN "user_id" TYPE uuid USING user_id::uuid',
+            'ALTER TABLE "form_processor_xforminstancesql" ALTER COLUMN "user_id" TYPE varchar(255)',
+            state_operations=[migrations.AlterField(
+                model_name='xforminstancesql',
+                name='user_id',
+                field=uuidfield.fields.UUIDField(max_length=32, null=True),
+                preserve_default=True,
+            )]
+        ),
+        migrations.RunSQL(
+            'ALTER TABLE "form_processor_casetransaction" ALTER COLUMN "form_uuid" TYPE uuid USING form_uuid::uuid',
+            'ALTER TABLE "form_processor_casetransaction" ALTER COLUMN "form_uuid" TYPE varchar(255)',
+            state_operations=[migrations.AlterField(
+                model_name='casetransaction',
+                name='form_uuid',
+                field=uuidfield.fields.UUIDField(max_length=32, null=True),
+                preserve_default=True,
+            )]
+        ),
+    ]

--- a/corehq/form_processor/migrations/0036_convert_form_fields_to_uuids.py
+++ b/corehq/form_processor/migrations/0036_convert_form_fields_to_uuids.py
@@ -4,6 +4,9 @@ from __future__ import unicode_literals
 from django.db import models, migrations
 import uuidfield.fields
 
+from corehq.form_processor.utils.migration import migrate_field_to_uuid, migrate_field_with_foreign_keys_to_uuid, \
+    ModelField, ForeignKeyField
+
 
 class Migration(migrations.Migration):
 
@@ -12,114 +15,20 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunSQL(
-            'ALTER TABLE "form_processor_xforminstancesql" ALTER COLUMN "app_id" TYPE uuid USING app_id::uuid',
-            'ALTER TABLE "form_processor_xforminstancesql" ALTER COLUMN "app_id" TYPE varchar(255)',
-            state_operations=[migrations.AlterField(
-                model_name='xforminstancesql',
-                name='app_id',
-                field=uuidfield.fields.UUIDField(max_length=32, null=True),
-                preserve_default=True,
-            )]
-        ),
-        migrations.RunSQL(
-            'ALTER TABLE "form_processor_xforminstancesql" ALTER COLUMN "build_id" TYPE uuid USING build_id::uuid',
-            'ALTER TABLE "form_processor_xforminstancesql" ALTER COLUMN "build_id" TYPE varchar(255)',
-            state_operations=[migrations.AlterField(
-                model_name='xforminstancesql',
-                name='build_id',
-                field=uuidfield.fields.UUIDField(max_length=32, null=True),
-                preserve_default=True,
-            )]
-        ),
-        migrations.RunSQL(
-            'ALTER TABLE "form_processor_xforminstancesql" ALTER COLUMN "deprecated_form_id" TYPE uuid USING deprecated_form_id::uuid',
-            'ALTER TABLE "form_processor_xforminstancesql" ALTER COLUMN "deprecated_form_id" TYPE varchar(255)',
-            state_operations=[migrations.AlterField(
-                model_name='xforminstancesql',
-                name='deprecated_form_id',
-                field=uuidfield.fields.UUIDField(max_length=32, null=True),
-                preserve_default=True,
-            )]
-        ),
-        migrations.RunSQL(
-            '''
-            ALTER TABLE form_processor_xformattachmentsql DROP CONSTRAINT "D89b6a5bce7bb3669f0bc9fe50022b06";
-            ALTER TABLE form_processor_xformoperationsql DROP CONSTRAINT "b006f200335a0a74b529d3ef054b2ad9";
-            ALTER TABLE "form_processor_xformoperationsql" ALTER COLUMN "xform_id" TYPE uuid USING xform_id::uuid;
-            ALTER TABLE "form_processor_xformattachmentsql" ALTER COLUMN "form_uuid" TYPE uuid USING form_uuid::uuid;
-            ALTER TABLE "form_processor_xforminstancesql" ALTER COLUMN "form_uuid" TYPE uuid USING form_uuid::uuid;
-            ALTER TABLE "form_processor_xformattachmentsql" ADD CONSTRAINT "D89b6a5bce7bb3669f0bc9fe50022b06"
-                FOREIGN KEY (form_uuid) REFERENCES form_processor_xforminstancesql(form_uuid) DEFERRABLE INITIALLY DEFERRED;
-            ALTER TABLE "form_processor_xformoperationsql" ADD CONSTRAINT "b006f200335a0a74b529d3ef054b2ad9"
-                FOREIGN KEY (xform_id) REFERENCES form_processor_xforminstancesql(form_uuid) DEFERRABLE INITIALLY DEFERRED;
-            ''',
-            '''
-            ALTER TABLE form_processor_xformattachmentsql DROP CONSTRAINT "D89b6a5bce7bb3669f0bc9fe50022b06";
-            ALTER TABLE form_processor_xformoperationsql DROP CONSTRAINT "b006f200335a0a74b529d3ef054b2ad9";
-            ALTER TABLE "form_processor_xformoperationsql" ALTER COLUMN "xform_id" TYPE varchar(255);
-            ALTER TABLE "form_processor_xformattachmentsql" ALTER COLUMN "form_uuid" TYPE varchar(255);
-            ALTER TABLE "form_processor_xforminstancesql" ALTER COLUMN "form_uuid" TYPE varchar(255);
-            ALTER TABLE "form_processor_xformattachmentsql" ADD CONSTRAINT "D89b6a5bce7bb3669f0bc9fe50022b06"
-                FOREIGN KEY (form_uuid) REFERENCES form_processor_xforminstancesql(form_uuid) DEFERRABLE INITIALLY DEFERRED;
-            ALTER TABLE "form_processor_xformoperationsql" ADD CONSTRAINT "b006f200335a0a74b529d3ef054b2ad9"
-                FOREIGN KEY (xform_id) REFERENCES form_processor_xforminstancesql(form_uuid) DEFERRABLE INITIALLY DEFERRED;
-            ''',
-            state_operations=[migrations.AlterField(
-                model_name='xforminstancesql',
-                name='form_uuid',
-                field=uuidfield.fields.UUIDField(unique=True, max_length=32, db_index=True),
-                preserve_default=True,
-            )]
-        ),
-        migrations.RunSQL(
-            'ALTER TABLE "form_processor_xforminstancesql" ALTER COLUMN "last_sync_token" TYPE uuid USING last_sync_token::uuid',
-            'ALTER TABLE "form_processor_xforminstancesql" ALTER COLUMN "last_sync_token" TYPE varchar(255)',
-            state_operations=[migrations.AlterField(
-                model_name='xforminstancesql',
-                name='last_sync_token',
-                field=uuidfield.fields.UUIDField(max_length=32, null=True),
-                preserve_default=True,
-            )]
-        ),
-        migrations.RunSQL(
-            'ALTER TABLE "form_processor_xforminstancesql" ALTER COLUMN "orig_id" TYPE uuid USING orig_id::uuid',
-            'ALTER TABLE "form_processor_xforminstancesql" ALTER COLUMN "orig_id" TYPE varchar(255)',
-            state_operations=[migrations.AlterField(
-                model_name='xforminstancesql',
-                name='orig_id',
-                field=uuidfield.fields.UUIDField(max_length=32, null=True),
-                preserve_default=True,
-            )]
-        ),
-        migrations.RunSQL(
-            'ALTER TABLE "form_processor_xforminstancesql" ALTER COLUMN "user_id" TYPE uuid USING user_id::uuid',
-            'ALTER TABLE "form_processor_xforminstancesql" ALTER COLUMN "user_id" TYPE varchar(255)',
-            state_operations=[migrations.AlterField(
-                model_name='xforminstancesql',
-                name='user_id',
-                field=uuidfield.fields.UUIDField(max_length=32, null=True),
-                preserve_default=True,
-            )]
-        ),
-        migrations.RunSQL(
-            'ALTER TABLE "form_processor_casetransaction" ALTER COLUMN "form_uuid" TYPE uuid USING form_uuid::uuid',
-            'ALTER TABLE "form_processor_casetransaction" ALTER COLUMN "form_uuid" TYPE varchar(255)',
-            state_operations=[migrations.AlterField(
-                model_name='casetransaction',
-                name='form_uuid',
-                field=uuidfield.fields.UUIDField(max_length=32, null=True),
-                preserve_default=True,
-            )]
-        ),
-        migrations.RunSQL(
-            'ALTER TABLE "form_processor_xformoperationsql" ALTER COLUMN "user" TYPE uuid USING user::uuid',
-            'ALTER TABLE "form_processor_xformoperationsql" ALTER COLUMN "user" TYPE varchar(255)',
-            state_operations=[migrations.AlterField(
-                model_name='xformoperationsql',
-                name='user',
-                field=uuidfield.fields.UUIDField(max_length=32, null=True),
-                preserve_default=True,
-            )]
+        migrate_field_to_uuid('xforminstancesql', 'app_id', null=True),
+        migrate_field_to_uuid('xforminstancesql', 'build_id', null=True),
+        migrate_field_to_uuid('xforminstancesql', 'deprecated_form_id', null=True),
+        migrate_field_to_uuid('xforminstancesql', 'deprecated_form_id', null=True),
+        migrate_field_to_uuid('xforminstancesql', 'last_sync_token', null=True),
+        migrate_field_to_uuid('xforminstancesql', 'orig_id', null=True),
+        migrate_field_to_uuid('xforminstancesql', 'user_id', null=True),
+        migrate_field_to_uuid('casetransaction', 'form_uuid', null=True),
+        migrate_field_to_uuid('xformoperationsql', 'user', null=True),
+        migrate_field_with_foreign_keys_to_uuid(
+            ModelField('xforminstancesql', 'form_uuid', unique=True, db_index=True),
+            [
+                ForeignKeyField('xformattachmentsql', 'form_uuid', constraint='D89b6a5bce7bb3669f0bc9fe50022b06'),
+                ForeignKeyField('xformoperationsql', 'xform_id', constraint='b006f200335a0a74b529d3ef054b2ad9'),
+            ]
         ),
     ]

--- a/corehq/form_processor/migrations/0036_convert_form_fields_to_uuids.py
+++ b/corehq/form_processor/migrations/0036_convert_form_fields_to_uuids.py
@@ -112,4 +112,14 @@ class Migration(migrations.Migration):
                 preserve_default=True,
             )]
         ),
+        migrations.RunSQL(
+            'ALTER TABLE "form_processor_xformoperationsql" ALTER COLUMN "user" TYPE uuid USING user::uuid',
+            'ALTER TABLE "form_processor_xformoperationsql" ALTER COLUMN "user" TYPE varchar(255)',
+            state_operations=[migrations.AlterField(
+                model_name='xformoperationsql',
+                name='user',
+                field=uuidfield.fields.UUIDField(max_length=32, null=True),
+                preserve_default=True,
+            )]
+        ),
     ]

--- a/corehq/form_processor/migrations/0037_convert_case_fields_to_uuids.py
+++ b/corehq/form_processor/migrations/0037_convert_case_fields_to_uuids.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+from corehq.form_processor.utils.migration import migrate_field_to_uuid, migrate_field_with_foreign_keys_to_uuid, \
+    ModelField, ForeignKeyField
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('form_processor', '0036_convert_form_fields_to_uuids'),
+    ]
+
+    operations = [
+        migrate_field_to_uuid('caseattachmentsql', 'attachment_uuid', unique=True, db_index=True),
+        migrate_field_to_uuid('commcarecaseindexsql', 'referenced_id', unique=False, db_index=False),
+        migrate_field_to_uuid('commcarecasesql', 'closed_by', null=True),
+        migrate_field_to_uuid('commcarecasesql', 'modified_by'),
+        migrate_field_to_uuid('commcarecasesql', 'opened_by', null=True),
+        migrate_field_to_uuid('commcarecasesql', 'owner_id'),
+        migrate_field_to_uuid('xformattachmentsql', 'attachment_uuid', unique=True, db_index=True),
+        migrate_field_with_foreign_keys_to_uuid(
+            ModelField('commcarecasesql', 'case_uuid', unique=True, db_index=True),
+            [
+                ForeignKeyField('casetransaction', 'case_uuid', constraint='ff0710f9213660f903847c891a5d5762'),
+                ForeignKeyField('commcarecaseindexsql', 'case_uuid', constraint='cfcdbfc04fcdbdaad9e930303c4ff2ef'),
+                ForeignKeyField('caseattachmentsql', 'case_uuid', constraint='D5884f36fb7907982691c5f0dc3e05fb'),
+            ]
+        ),
+    ]

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -304,7 +304,7 @@ class XFormOperationSQL(models.Model):
     ARCHIVE = 'archive'
     UNARCHIVE = 'unarchive'
 
-    user = models.CharField(max_length=255, null=True)
+    user = UUIDField(unique=False, null=True, hyphenate=True)
     operation = models.CharField(max_length=255)
     date = models.DateTimeField(auto_now_add=True)
     xform = models.ForeignKey(XFormInstanceSQL, to_field='form_uuid')

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -278,8 +278,8 @@ class AbstractAttachment(models.Model):
     @property
     def filepath(self):
         if getattr(settings, 'IS_TRAVIS', False):
-            return os.path.join('/home/travis/', self.attachment_uuid)
-        return os.path.join('/tmp/', self.attachment_uuid)
+            return os.path.join('/home/travis/', str(self.attachment_uuid))
+        return os.path.join('/tmp/', str(self.attachment_uuid))
 
     def write_content(self, content):
         with open(self.filepath, 'w+') as f:
@@ -394,7 +394,7 @@ class CommCareCaseSQL(PreSaveHashableMixin, models.Model, RedisLockableMixIn,
 
     @property
     def case_id(self):
-        return self.case_uuid
+        return str(self.case_uuid)
 
     @case_id.setter
     def case_id(self, _id):

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -268,8 +268,9 @@ class XFormInstanceSQL(PreSaveHashableMixin, models.Model, RedisLockableMixIn, A
                 raise
         return None
 
+
 class AbstractAttachment(models.Model):
-    attachment_uuid = models.CharField(max_length=255, unique=True, db_index=True)
+    attachment_uuid = UUIDField(unique=True, db_index=True, hyphenate=True)
     name = models.CharField(max_length=255, db_index=True)
     content_type = models.CharField(max_length=255)
     md5 = models.CharField(max_length=255)
@@ -366,28 +367,28 @@ class CommCareCaseSQL(PreSaveHashableMixin, models.Model, RedisLockableMixIn,
                       SupplyPointCaseMixin):
     hash_property = 'case_uuid'
 
-    case_uuid = models.CharField(max_length=255, unique=True, db_index=True)
+    case_uuid = UUIDField(unique=True, db_index=True, hyphenate=True)
     domain = models.CharField(max_length=255)
     type = models.CharField(max_length=255)
     name = models.CharField(max_length=255, null=True)
 
-    owner_id = models.CharField(max_length=255)
+    owner_id = UUIDField(unique=False, hyphenate=True)
 
     opened_on = models.DateTimeField(null=True)
-    opened_by = models.CharField(max_length=255, null=True)
+    opened_by = UUIDField(unique=False, null=True, hyphenate=True)
 
     modified_on = models.DateTimeField(null=False)
     server_modified_on = models.DateTimeField(null=False)
-    modified_by = models.CharField(max_length=255)
+    modified_by = UUIDField(unique=False, hyphenate=True)
 
     closed = models.BooleanField(default=False, null=False)
     closed_on = models.DateTimeField(null=True)
-    closed_by = models.CharField(max_length=255, null=True)
+    closed_by = UUIDField(unique=False, null=True, hyphenate=True)
 
     deleted = models.BooleanField(default=False, null=False)
 
     external_id = models.CharField(max_length=255)
-    location_uuid = UUIDField(null=True, unique=False)
+    location_uuid = UUIDField(null=True, unique=False, hyphenate=True)
 
     case_json = JSONField(lazy=True, default=dict)
 
@@ -545,7 +546,7 @@ class CommCareCaseIndexSQL(models.Model, SaveStateMixin):
     )
     domain = models.CharField(max_length=255)  # TODO SK 2015-11-05: is this necessary or should we join on case?
     identifier = models.CharField(max_length=255, null=False)
-    referenced_id = models.CharField(max_length=255, null=False)
+    referenced_id = UUIDField(unique=False, null=False, hyphenate=True)
     referenced_type = models.CharField(max_length=255, null=False)
     relationship_id = models.PositiveSmallIntegerField(choices=RELATIONSHIP_CHOICES)
 

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -99,7 +99,7 @@ class SubmissionPost(object):
 
     def _post_process_form(self, xform):
         self._set_submission_properties(xform)
-        if xform.is_submission_error_log:
+        if not xform.is_submission_error_log:
             found_old = scrub_meta(xform)
             legacy_notification_assert(not found_old, 'Form with old metadata submitted', xform.form_id)
 

--- a/corehq/form_processor/tests/test_basic_cases.py
+++ b/corehq/form_processor/tests/test_basic_cases.py
@@ -6,12 +6,12 @@ from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.util import post_case_blocks
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
-from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends, UuidAssertMixin
 
 DOMAIN = 'fundamentals'
 
 
-class FundamentalCaseTests(TestCase):
+class FundamentalCaseTests(TestCase, UuidAssertMixin):
 
     @classmethod
     def setUpClass(cls):
@@ -24,10 +24,12 @@ class FundamentalCaseTests(TestCase):
 
     @run_with_all_backends
     def test_create_case(self):
+        user = uuid.uuid4().hex
+        owner = uuid.uuid4().hex
         case_id = uuid.uuid4().hex
         modified_on = datetime.utcnow()
         _submit_case_block(
-            True, case_id, user_id='user1', owner_id='owner1', case_type='demo',
+            True, case_id, user_id=user, owner_id=owner, case_type='demo',
             case_name='create_case', date_modified=modified_on, update={
                 'dynamic': '123'
             }
@@ -35,14 +37,14 @@ class FundamentalCaseTests(TestCase):
 
         case = self.casedb.get_case(case_id)
         self.assertIsNotNone(case)
-        self.assertEqual(case.case_id, case_id)
-        self.assertEqual(case.owner_id, 'owner1')
+        self.assertUuidEqual(case.case_id, case_id)
+        self.assertUuidEqual(case.owner_id, owner)
         self.assertEqual(case.type, 'demo')
         self.assertEqual(case.name, 'create_case')
         self.assertEqual(case.opened_on, modified_on)
-        self.assertEqual(case.opened_by, 'user1')
+        self.assertUuidEqual(case.opened_by, user)
         self.assertEqual(case.modified_on, modified_on)
-        self.assertEqual(case.modified_by, 'user1')
+        self.assertUuidEqual(case.modified_by, user)
         self.assertTrue(case.server_modified_on > modified_on)
         self.assertFalse(case.closed)
         self.assertIsNone(case.closed_on)
@@ -57,30 +59,34 @@ class FundamentalCaseTests(TestCase):
 
     @run_with_all_backends
     def test_update_case(self):
+        user1 = uuid.uuid4().hex
+        owner1 = uuid.uuid4().hex
         case_id = uuid.uuid4().hex
         opened_on = datetime.utcnow()
         _submit_case_block(
-            True, case_id, user_id='user1', owner_id='owner1', case_type='demo',
+            True, case_id, user_id=user1, owner_id=owner1, case_type='demo',
             case_name='create_case', date_modified=opened_on, update={
                 'dynamic': '123'
             }
         )
 
         modified_on = datetime.utcnow()
+        user2 = uuid.uuid4().hex
+        owner2 = uuid.uuid4().hex
         _submit_case_block(
-            False, case_id, user_id='user2', owner_id='owner2',
+            False, case_id, user_id=user2, owner_id=owner2,
             case_name='update_case', date_modified=modified_on, update={
                 'dynamic': '1234'
             }
         )
 
         case = self.casedb.get_case(case_id)
-        self.assertEqual(case.owner_id, 'owner2')
+        self.assertUuidEqual(case.owner_id, owner2)
         self.assertEqual(case.name, 'update_case')
         self.assertEqual(case.opened_on, opened_on)
-        self.assertEqual(case.opened_by, 'user1')
+        self.assertUuidEqual(case.opened_by, user1)
         self.assertEqual(case.modified_on, modified_on)
-        self.assertEqual(case.modified_by, 'user2')
+        self.assertUuidEqual(case.modified_by, user2)
         self.assertTrue(case.server_modified_on > modified_on)
         self.assertFalse(case.closed)
         self.assertIsNone(case.closed_on)
@@ -91,37 +97,42 @@ class FundamentalCaseTests(TestCase):
         # same as update, closed, closed on, closed by
         case_id = uuid.uuid4().hex
         opened_on = datetime.utcnow()
+        user1 = uuid.uuid4().hex
+        owner1 = uuid.uuid4().hex
         _submit_case_block(
-            True, case_id, user_id='user1', owner_id='owner1', case_type='demo',
+            True, case_id, user_id=user1, owner_id=owner1, case_type='demo',
             case_name='create_case', date_modified=opened_on
         )
 
         modified_on = datetime.utcnow()
+        user2 = uuid.uuid4().hex
         _submit_case_block(
-            False, case_id, user_id='user2', date_modified=modified_on, close=True
+            False, case_id, user_id=user2, date_modified=modified_on, close=True
         )
 
         case = self.casedb.get_case(case_id)
-        self.assertEqual(case.owner_id, 'owner1')
+        self.assertUuidEqual(case.owner_id, owner1)
         self.assertEqual(case.modified_on, modified_on)
-        self.assertEqual(case.modified_by, 'user2')
+        self.assertUuidEqual(case.modified_by, user2)
         self.assertTrue(case.closed)
         self.assertEqual(case.closed_on, modified_on)
-        self.assertEqual(case.closed_by, 'user2')
+        self.assertUuidEqual(case.closed_by, user2)
         self.assertTrue(case.server_modified_on > modified_on)
 
     @run_with_all_backends
     def test_case_with_index(self):
         # same as update, indexes
         mother_case_id = uuid.uuid4().hex
+        user1 = uuid.uuid4().hex
+        owner1 = uuid.uuid4().hex
         _submit_case_block(
-            True, mother_case_id, user_id='user1', owner_id='owner1', case_type='mother',
+            True, mother_case_id, user_id=user1, owner_id=owner1, case_type='mother',
             case_name='mother', date_modified=datetime.utcnow()
         )
 
         child_case_id = uuid.uuid4().hex
         _submit_case_block(
-            True, child_case_id, user_id='user1', owner_id='owner1', case_type='child',
+            True, child_case_id, user_id=user1, owner_id=owner1, case_type='child',
             case_name='child', date_modified=datetime.utcnow(), index={
                 'mom': ('mother', mother_case_id)
             }
@@ -131,21 +142,23 @@ class FundamentalCaseTests(TestCase):
         self.assertEqual(len(case.indices), 1)
         index = case.indices[0]
         self.assertEqual(index.identifier, 'mom')
-        self.assertEqual(index.referenced_id, mother_case_id)
+        self.assertUuidEqual(index.referenced_id, mother_case_id)
         self.assertEqual(index.referenced_type, 'mother')
         self.assertEqual(index.relationship, 'child')
 
     @run_with_all_backends
     def test_update_index(self):
         mother_case_id = uuid.uuid4().hex
+        user1 = uuid.uuid4().hex
+        owner1 = uuid.uuid4().hex
         _submit_case_block(
-            True, mother_case_id, user_id='user1', owner_id='owner1', case_type='mother',
+            True, mother_case_id, user_id=user1, owner_id=owner1, case_type='mother',
             case_name='mother', date_modified=datetime.utcnow()
         )
 
         child_case_id = uuid.uuid4().hex
         _submit_case_block(
-            True, child_case_id, user_id='user1', owner_id='owner1', case_type='child',
+            True, child_case_id, user_id=user1, owner_id=owner1, case_type='child',
             case_name='child', date_modified=datetime.utcnow(), index={
                 'mom': ('mother', mother_case_id)
             }
@@ -155,7 +168,7 @@ class FundamentalCaseTests(TestCase):
         self.assertEqual(case.indices[0].identifier, 'mom')
 
         _submit_case_block(
-            False, child_case_id, user_id='user1', date_modified=datetime.utcnow(), index={
+            False, child_case_id, user_id=user1, date_modified=datetime.utcnow(), index={
                 'mom': ('other_mother', mother_case_id)
             }
         )
@@ -165,14 +178,16 @@ class FundamentalCaseTests(TestCase):
     @run_with_all_backends
     def test_delete_index(self):
         mother_case_id = uuid.uuid4().hex
+        user1 = uuid.uuid4().hex
+        owner1 = uuid.uuid4().hex
         _submit_case_block(
-            True, mother_case_id, user_id='user1', owner_id='owner1', case_type='mother',
+            True, mother_case_id, user_id=user1, owner_id=owner1, case_type='mother',
             case_name='mother', date_modified=datetime.utcnow()
         )
 
         child_case_id = uuid.uuid4().hex
         _submit_case_block(
-            True, child_case_id, user_id='user1', owner_id='owner1', case_type='child',
+            True, child_case_id, user_id=user1, owner_id=owner1, case_type='child',
             case_name='child', date_modified=datetime.utcnow(), index={
                 'mom': ('mother', mother_case_id)
             }
@@ -182,7 +197,7 @@ class FundamentalCaseTests(TestCase):
         self.assertEqual(len(case.indices), 1)
 
         _submit_case_block(
-            False, child_case_id, user_id='user1', date_modified=datetime.utcnow(), index={
+            False, child_case_id, user_id=user1, date_modified=datetime.utcnow(), index={
                 'mom': ('mother', '')
             }
         )

--- a/corehq/form_processor/tests/utils.py
+++ b/corehq/form_processor/tests/utils.py
@@ -1,4 +1,6 @@
 import functools
+from uuid import UUID
+
 from couchdbkit import ResourceNotFound
 from django.db.models.query_utils import Q
 
@@ -125,3 +127,24 @@ def post_xform(instance_xml, attachments=None, domain='test-domain'):
     with result.get_locked_forms() as xforms:
         FormProcessorInterface(domain).save_processed_models(xforms[0], xforms)
         return xforms[0]
+
+
+class UuidAssertMixin(object):
+    def to_uuid_safe(self, id_):
+        return id_ if id_ is None or isinstance(id_, UUID) else UUID(id_)
+
+    def assertUuidEqual(self, id1, id2):
+        return self.assertEqual(self.to_uuid_safe(id1), self.to_uuid_safe(id2))
+
+    def assertUuidNotEqual(self, id1, id2):
+        return self.assertNotEqual(self.to_uuid_safe(id1), self.to_uuid_safe(id2))
+
+    def assertUuidListEqual(self, list1, list2):
+        def to_uuids(alist):
+            if alist and isinstance(alist[0], UUID):
+                return alist
+
+            return [
+                UUID(id_) for id_ in alist
+            ]
+        return self.assertEqual(to_uuids(list1), to_uuids(list2))

--- a/corehq/form_processor/utils/migration.py
+++ b/corehq/form_processor/utils/migration.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from collections import namedtuple
+
+from django.db import models, migrations
+import uuidfield.fields
+
+
+class ModelField(object):
+    def __init__(self, model, name, unique=False, db_index=False, null=False):
+        self.name = name
+        self.model = model
+        self.unique = unique
+        self.db_index = db_index
+        self.null = null
+
+
+class ForeignKeyField(ModelField):
+    def __init__(self, model, field, constraint, unique=False, db_index=False, null=False):
+        self.constraint = constraint
+        super(ForeignKeyField, self).__init__(model, field, unique=unique, db_index=db_index, null=null)
+
+
+def migrate_field_to_uuid(model_name, field_name, unique=False, db_index=False, null=False):
+    return migrate_field_with_foreign_keys_to_uuid(ModelField(
+        model_name,
+        field_name,
+        unique=unique,
+        db_index=db_index,
+        null=False
+    ))
+
+
+def migrate_field_with_foreign_keys_to_uuid(primary_field, foreignkey_fields=None):
+    forward = []
+    reverse = []
+    foreignkey_fields = foreignkey_fields or []
+    for field in foreignkey_fields:
+        drop = _drop_constraint_sql(field)
+        forward.append(drop)
+        reverse.append(drop)
+
+    for field in [primary_field] + foreignkey_fields:
+        forward.append(_alter_to_uuid_sql_forawd(field))
+        reverse.append(_alter_to_uuid_sql_reverse(field))
+
+    for field in foreignkey_fields:
+        create = _create_constraint_sql(primary_field, field)
+        forward.append(create)
+        reverse.append(create)
+
+    return migrations.RunSQL(
+        '\n'.join(forward),
+        '\n'.join(reverse),
+        state_operations=[migrations.AlterField(
+            model_name=primary_field.model,
+            name=primary_field.name,
+            field=uuidfield.fields.UUIDField(
+                unique=primary_field.unique,
+                max_length=32,
+                db_index=primary_field.db_index,
+                null=primary_field.null),
+            preserve_default=True,
+        )]
+    )
+
+
+def _drop_constraint_sql(field):
+    return 'ALTER TABLE form_processor_{model} DROP CONSTRAINT "{constraint}";'.format(
+        model=field.model, constraint=field.constraint
+    )
+
+
+def _create_constraint_sql(primary, field):
+    return '''
+        ALTER TABLE "form_processor_{model}" ADD CONSTRAINT "{constraint}"
+        FOREIGN KEY ({field}) REFERENCES form_processor_{primary_model}({primary_field}) DEFERRABLE INITIALLY DEFERRED;
+        '''.format(
+            model=field.model,
+            constraint=field.constraint,
+            field=field.name,
+            primary_model=primary.model,
+            primary_field=primary.name
+    )
+
+
+def _alter_to_uuid_sql_forawd(field):
+    return 'ALTER TABLE "form_processor_{model}" ALTER COLUMN "{field}" TYPE uuid USING {field}::uuid;'.format(
+        model=field.model, field=field.name
+    )
+
+
+def _alter_to_uuid_sql_reverse(field):
+    return 'ALTER TABLE "form_processor_{model}" ALTER COLUMN "{field}" TYPE varchar(255);'.format(
+        model=field.model, field=field.name
+    )
+

--- a/corehq/util/quickcache.py
+++ b/corehq/util/quickcache.py
@@ -5,6 +5,8 @@ import hashlib
 import inspect
 from inspect import isfunction
 import logging
+from uuid import UUID
+
 from django.core.cache import caches as django_caches
 from corehq.util.soft_assert.api import soft_assert
 
@@ -135,6 +137,8 @@ class QuickCache(object):
         elif isinstance(value, set):
             return 'S' + self._hash(
                 ','.join(sorted(map(self._serialize_for_key, value))))
+        elif isinstance(value, UUID):
+            return '#' + value.hex
         elif value is None:
             return 'N'
         else:


### PR DESCRIPTION
@benrudolph @NoahCarnahan @czue @dannyroberts 
I started this today. There are a few complications that make it trickier than expected. I think in the long run (no more couch) this is worth it but it means that in the interim we're in a state that isn't great. I can't make up my mind whether its worth it or not and would appreciate opinions.

Details:
# comparing apples with apples

If we were able to use UUIDs everywhere there would be no issue but we need to support both which creates some issues 
- uuid's have multiple representations which are not equal when compared as strings

```
> uuid1 = uuid.uuid4()
> uuid1
UUID('82d17ade-1890-4518-9fe5-9c3e9ab28fc6')
> uuid1.hex
'82d17ade189045189fe59c3e9ab28fc6'
> str(uuid)
'82d17ade-1890-4518-9fe5-9c3e9ab28fc6'
> uuid1.hex == str(uuid)
False
```
- strings can't be directly compared to UUIDs

```
> case_id = uuid.uuid4().hex
> case = SqlDB.get_case(case_id)
> case.case_id == case_id
False
> case.case_id
UUID('82d17ade-1890-4518-9fe5-9c3e9ab28fc6')
> case_id
82d17ade189045189fe59c3e9ab28fc6
```

In test and SQL only code the solution to this is to normalise the UUIDS:

```
> UUID('82d17ade189045189fe59c3e9ab28fc6') == UUID('82d17ade-1890-4518-9fe5-9c3e9ab28fc6')
True
```

But in code that runs on both couch and sql we have to convert to string (as long as we're consistent with the string format):

```
> str(UUID('82d17ade-1890-4518-9fe5-9c3e9ab28fc6')) == '82d17ade-1890-4518-9fe5-9c3e9ab28fc6'
True
> str(UUID('82d17ade-1890-4518-9fe5-9c3e9ab28fc6')) == '82d17ade189045189fe5-9c3e9ab28fc6'
False
```
