### PR TITLE
kill callcenter design doc

### DIFF
--- a/corehq/apps/callcenter/_design/views/config_by_domain/map.js
+++ b/corehq/apps/callcenter/_design/views/config_by_domain/map.js
@@ -1,5 +1,0 @@
-function (doc) {
-    if (doc.doc_type === 'CallCenterIndicatorConfig') {
-        emit(doc.domain, null);
-    }
-}


### PR DESCRIPTION
@dannyroberts cc: @NoahCarnahan 

Removes the only view in the design doc, so no preindexing required
