### PR TITLE
cleanup performance_sms tests

### DIFF
--- a/corehq/apps/performance_sms/tests/test_dbaccessors.py
+++ b/corehq/apps/performance_sms/tests/test_dbaccessors.py
@@ -1,6 +1,7 @@
 import uuid
 from django.test import TestCase
 from corehq.apps.performance_sms import dbaccessors
+from corehq.apps.performance_sms.dbaccessors import delete_all_configs
 from corehq.apps.performance_sms.models import PerformanceConfiguration
 
 
@@ -9,16 +10,17 @@ class TestPerformanceDbaccessors(TestCase):
     def test_by_domain(self):
         domain = uuid.uuid4().hex
         config = _make_performance_config(domain)
-        try:
-            results = dbaccessors.by_domain(domain)
-            self.assertEqual(1, len(results))
-            self.assertEqual(config._id, results[0]._id)
 
-            # check no results for some other domain
-            no_results = dbaccessors.by_domain(uuid.uuid4().hex)
-            self.assertEqual(0, len(no_results))
-        finally:
-            config.delete()
+        results = dbaccessors.by_domain(domain)
+        self.assertEqual(1, len(results))
+        self.assertEqual(config._id, results[0]._id)
+
+        # check no results for some other domain
+        no_results = dbaccessors.by_domain(uuid.uuid4().hex)
+        self.assertEqual(0, len(no_results))
+
+    def tearDown(self):
+        delete_all_configs()
 
 
 def _make_performance_config(domain):

--- a/corehq/apps/performance_sms/tests/test_schedule.py
+++ b/corehq/apps/performance_sms/tests/test_schedule.py
@@ -16,84 +16,80 @@ class TestSchedule(TestCase):
     def setUpClass(cls):
         delete_all_configs()
 
+    def tearDown(self):
+        delete_all_configs()
+
     def test_daily_schedule(self):
         config = _make_performance_config(self.domain, DAILY, hour=4)
-        try:
-            as_of = datetime(2015, 1, 1, 4)
-            configs_at_4_hours = get_message_configs_at_this_hour(as_of=as_of)
-            self.assertEqual(1, len(configs_at_4_hours))
-            self.assertEqual(config._id, configs_at_4_hours[0]._id)
 
-            # check subfunctions
-            self.assertEqual(1, len(get_daily_messages(as_of)))
-            self.assertEqual(0, len(get_weekly_messages(as_of)))
-            self.assertEqual(0, len(get_monthly_messages(as_of)))
+        as_of = datetime(2015, 1, 1, 4)
+        configs_at_4_hours = get_message_configs_at_this_hour(as_of=as_of)
+        self.assertEqual(1, len(configs_at_4_hours))
+        self.assertEqual(config._id, configs_at_4_hours[0]._id)
 
-            # test wrong hour
-            wrong_hour = as_of.replace(hour=5)
-            self.assertEqual(0, len(get_daily_messages(wrong_hour)))
+        # check subfunctions
+        self.assertEqual(1, len(get_daily_messages(as_of)))
+        self.assertEqual(0, len(get_weekly_messages(as_of)))
+        self.assertEqual(0, len(get_monthly_messages(as_of)))
 
-            # test different day is fine
-            new_day = as_of + timedelta(days=5)
-            self.assertEqual(1, len(get_daily_messages(new_day)))
-        finally:
-            config.delete()
+        # test wrong hour
+        wrong_hour = as_of.replace(hour=5)
+        self.assertEqual(0, len(get_daily_messages(wrong_hour)))
+
+        # test different day is fine
+        new_day = as_of + timedelta(days=5)
+        self.assertEqual(1, len(get_daily_messages(new_day)))
 
     def test_weekly_schedule(self):
         config = _make_performance_config(self.domain, WEEKLY, day_of_week=4, hour=8)
-        try:
-            as_of = datetime(2015, 8, 14, 8)  # happens to be a friday (weekday 4)
-            configs_on_4th_day = get_message_configs_at_this_hour(as_of=as_of)
-            self.assertEqual(1, len(configs_on_4th_day))
-            self.assertEqual(config._id, configs_on_4th_day[0]._id)
 
-            # check subfunctions
-            self.assertEqual(0, len(get_daily_messages(as_of)))
-            self.assertEqual(1, len(get_weekly_messages(as_of)))
-            self.assertEqual(0, len(get_monthly_messages(as_of)))
+        as_of = datetime(2015, 8, 14, 8)  # happens to be a friday (weekday 4)
+        configs_on_4th_day = get_message_configs_at_this_hour(as_of=as_of)
+        self.assertEqual(1, len(configs_on_4th_day))
+        self.assertEqual(config._id, configs_on_4th_day[0]._id)
 
-            # any weekday that's not 4th
-            wrong_day = as_of.replace(day=15)
-            self.assertEqual(0, len(get_weekly_messages(wrong_day)))
+        # check subfunctions
+        self.assertEqual(0, len(get_daily_messages(as_of)))
+        self.assertEqual(1, len(get_weekly_messages(as_of)))
+        self.assertEqual(0, len(get_monthly_messages(as_of)))
 
-            # wrong hour
-            wrong_hour = as_of.replace(hour=7)
-            self.assertEqual(0, len(get_weekly_messages(wrong_hour)))
+        # any weekday that's not 4th
+        wrong_day = as_of.replace(day=15)
+        self.assertEqual(0, len(get_weekly_messages(wrong_day)))
 
-            # one week later should be ok
-            next_week = as_of + timedelta(days=7)
-            self.assertEqual(1, len(get_weekly_messages(next_week)))
+        # wrong hour
+        wrong_hour = as_of.replace(hour=7)
+        self.assertEqual(0, len(get_weekly_messages(wrong_hour)))
 
-        finally:
-            config.delete()
+        # one week later should be ok
+        next_week = as_of + timedelta(days=7)
+        self.assertEqual(1, len(get_weekly_messages(next_week)))
 
     def test_monthly_schedule(self):
         # Todo, doesn't handle last-day-of-month
         config = _make_performance_config(self.domain, MONTHLY, hour=8, day_of_month=4)
-        try:
-            as_of = datetime(2015, 1, 4, 8)
-            configs_on_4th_day = get_message_configs_at_this_hour(as_of=as_of)
-            self.assertEqual(1, len(configs_on_4th_day))
-            self.assertEqual(config._id, configs_on_4th_day[0]._id)
 
-            # check subfunctions
-            self.assertEqual(0, len(get_daily_messages(as_of)))
-            self.assertEqual(0, len(get_weekly_messages(as_of)))
-            self.assertEqual(1, len(get_monthly_messages(as_of)))
+        as_of = datetime(2015, 1, 4, 8)
+        configs_on_4th_day = get_message_configs_at_this_hour(as_of=as_of)
+        self.assertEqual(1, len(configs_on_4th_day))
+        self.assertEqual(config._id, configs_on_4th_day[0]._id)
 
-            # check wrong day
-            wrong_day = as_of.replace(day=5)
-            self.assertEqual(0, len(get_monthly_messages(as_of=wrong_day)))
+        # check subfunctions
+        self.assertEqual(0, len(get_daily_messages(as_of)))
+        self.assertEqual(0, len(get_weekly_messages(as_of)))
+        self.assertEqual(1, len(get_monthly_messages(as_of)))
 
-            # check wrong hour
-            wrong_hour = as_of.replace(hour=5)
-            self.assertEqual(0, len(get_monthly_messages(as_of=wrong_hour)))
+        # check wrong day
+        wrong_day = as_of.replace(day=5)
+        self.assertEqual(0, len(get_monthly_messages(as_of=wrong_day)))
 
-            # next month ok
-            next_month = as_of.replace(month=2)
-            self.assertEqual(1, len(get_monthly_messages(as_of=next_month)))
-        finally:
-            config.delete()
+        # check wrong hour
+        wrong_hour = as_of.replace(hour=5)
+        self.assertEqual(0, len(get_monthly_messages(as_of=wrong_hour)))
+
+        # next month ok
+        next_month = as_of.replace(month=2)
+        self.assertEqual(1, len(get_monthly_messages(as_of=next_month)))
 
 
 def _make_performance_config(domain, interval, hour=DEFAULT_HOUR, day_of_week=DEFAULT_WEEK_DAY,


### PR DESCRIPTION
use tearDown instead of complicating test logic with try...finally blocks

@NoahCarnahan 
