### PR TITLE
CloudCare Debugger UX Revamp

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/backbone/apps.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/backbone/apps.js
@@ -695,7 +695,10 @@ cloudCare.AppView = Backbone.View.extend({
                     url: self.options.renderFormRoot,
                     data: {'session_id': sessionId},
                     success: function (data) {
-                        var codeMirror = CodeMirror(function(el) {
+                        var $instanceTab = $('#debugger-xml-instance-tab'),
+                            codeMirror;
+
+                        codeMirror = CodeMirror(function(el) {
                             $('#xml-viewer-pretty').html(el);
                         }, {
                             value: data.instance_xml,
@@ -703,6 +706,12 @@ cloudCare.AppView = Backbone.View.extend({
                             viewportMargin: Infinity,
                             readOnly: true,
                             lineNumbers: true,
+                        });
+$('#debugger-xml-instance-tab')
+
+                        $instanceTab.off();
+                        $instanceTab.on('shown.bs.tab', function() {
+                            codeMirror.refresh();
                         });
 
                         $("#question-viewer-pretty").html(data.form_data || 'Could not render form');

--- a/corehq/apps/cloudcare/static/cloudcare/js/backbone/apps.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/backbone/apps.js
@@ -707,7 +707,6 @@ cloudCare.AppView = Backbone.View.extend({
                             readOnly: true,
                             lineNumbers: true,
                         });
-$('#debugger-xml-instance-tab')
 
                         $instanceTab.off();
                         $instanceTab.on('shown.bs.tab', function() {


### PR DESCRIPTION
@czue @wpride this revamps the cc debugger to be more user friendly (imo). ux peeps: @biyeun @orangejenny @dimagi/product 

screenshots:
<img width="1552" alt="screen shot 2015-11-26 at 8 40 30 pm" src="https://cloud.githubusercontent.com/assets/918514/11433090/3bdae6fe-947e-11e5-9bd6-0228181f0b9c.png">
<img width="1552" alt="screen shot 2015-11-26 at 8 40 11 pm" src="https://cloud.githubusercontent.com/assets/918514/11433091/3bf0287a-947e-11e5-99d7-c49b114ddeae.png">
<img width="1552" alt="screen shot 2015-11-26 at 8 40 24 pm" src="https://cloud.githubusercontent.com/assets/918514/11433092/3c0750cc-947e-11e5-9993-6cfbbe9ec8a0.png">
<img width="1552" alt="screen shot 2015-11-26 at 8 40 21 pm" src="https://cloud.githubusercontent.com/assets/918514/11433093/3c1f1568-947e-11e5-8cfd-a5375f93c7bf.png">
<img width="1552" alt="screen shot 2015-11-26 at 8 40 17 pm" src="https://cloud.githubusercontent.com/assets/918514/11433094/3c374aac-947e-11e5-9ed9-174fec81894c.png">
