### PR TITLE
Move getCloudCareUrl to form_view_base

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/form_view_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view_base.html
@@ -99,7 +99,6 @@
         <script src="{% static 'app_manager/js/ejs.min.js' %}"></script>
         <script src="{% static 'app_manager/js/case-config-ui-1.js' %}"></script>
     {% endif %}
-    <script src="{% static 'cloudcare/js/util.js' %}"></script>
 {% endblock %}
 
 {% block js-inline %}{{ block.super }}
@@ -226,6 +225,22 @@
             {% if allow_cloudcare %}
                 // tag the 'preview in cloudcare' button with the right url
                 // unfortunately, has to be done in javascript
+                var getCloudCareUrl = function(urlRoot, appId, moduleId, formId, caseId) {
+                    var url = urlRoot;
+                    if (appId !== undefined) {
+                        url = url + "view/" + appId;
+                        if (moduleId !== undefined) {
+                            url = url + "/" + moduleId;
+                            if (formId !== undefined) {
+                                url = url + "/" + formId;
+                                if (caseId !== undefined) {
+                                    url = url + "/" + caseId;
+                                }
+                            }
+                        }
+                    }
+                    return url;
+                };
                 var cloudCareUrl = getCloudCareUrl("{% url "cloudcare_main" domain '' %}", "{{ app.id }}", "{{ module.id }}", "{{ nav_form.id }}") + "?preview=true";
                 $("#cloudcare-preview-url").attr("href", cloudCareUrl);
                 $('#cloudcare-preview-url').click(function(e) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/util.js
@@ -29,23 +29,6 @@ var localize = function(obj, language) {
 };
 localize.NOT_FOUND = '?';
 
-var getCloudCareUrl = function(urlRoot, appId, moduleId, formId, caseId) {
-    var url = urlRoot;
-    if (appId !== undefined) {
-        url = url + "view/" + appId;
-        if (moduleId !== undefined) {
-            url = url + "/" + moduleId;
-            if (formId !== undefined) {
-                url = url + "/" + formId;
-                if (caseId !== undefined) {
-                    url = url + "/" + caseId;
-                }
-            }
-        }  
-    }
-    return url;
-};
-
 var getFormUrl = function(urlRoot, appId, moduleId, formId, instanceId) {
     // TODO: make this cleaner
     var url = urlRoot + "view/" + appId + "/modules-" + moduleId + "/forms-" + formId + "/context/";


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?187892

JS was blocking because it couldn't find NProgress (new dependency in `util.js`) (https://github.com/dimagi/commcare-hq/commit/d4db6f9321807e17bcccb1f720418bac1a9f0819)
Moved the `getCloudCareUrl` out of that file (this is the only place it is used), so that we didn't need to include another JS file (`nprogress.js`) in `form_view_base.html`

cc: @millerdev 
