### PR TITLE
make message more vague

### DIFF
--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -228,7 +228,7 @@ class EditCommCareUserView(BaseFullEditUserView):
         if request.POST['form_type'] == "commtrack":
             if self.update_commtrack_form.is_valid():
                 self.update_commtrack_form.save(self.editable_user)
-                messages.success(request, _("CommCare Supply information updated!"))
+                messages.success(request, _("Information updated!"))
         return super(EditCommCareUserView, self).post(request, *args, **kwargs)
 
     def custom_user_is_valid(self):


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?187898

I intentionally didn't bother changing the message to depend on whether supply was enabled since it seemed unnecessarily complicated for the ROI (you stay on the tab when the page reloads so it should be obvious what information we're talking about)
