### PR TITLE
Make accounting db actions atomic

### DIFF
--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -9,6 +9,7 @@ from django.core.exceptions import ValidationError
 from django.core.validators import MinLengthValidator, validate_slug
 from django import forms
 from django.core.urlresolvers import reverse
+from django.db import transaction
 from django.db.models import ProtectedError
 from django.forms.util import ErrorList
 from django.template.loader import render_to_string
@@ -201,6 +202,7 @@ class BillingAccountBasicForm(forms.Form):
             )
         return transfer_subs
 
+    @transaction.atomic
     def create_account(self):
         name = self.cleaned_data['name']
         salesforce_account_id = self.cleaned_data['salesforce_account_id']
@@ -223,6 +225,7 @@ class BillingAccountBasicForm(forms.Form):
 
         return account
 
+    @transaction.atomic
     def update_basic_info(self, account):
         account.name = self.cleaned_data['name']
         account.is_active = self.cleaned_data['is_active']
@@ -570,6 +573,7 @@ class SubscriptionForm(forms.Form):
 
         return self.cleaned_data
 
+    @transaction.atomic
     def create_subscription(self):
         account = BillingAccount.objects.get(id=self.cleaned_data['account'])
         domain = self.cleaned_data['domain']
@@ -606,6 +610,7 @@ class SubscriptionForm(forms.Form):
                                     "current account to transfer to."))
         return transfer_account
 
+    @transaction.atomic
     def update_subscription(self):
         self.subscription.update_subscription(
             date_start=self.cleaned_data['start_date'],
@@ -688,6 +693,7 @@ class ChangeSubscriptionForm(forms.Form):
             ),
         )
 
+    @transaction.atomic
     def change_subscription(self):
         new_plan_version = SoftwarePlanVersion.objects.get(id=self.cleaned_data['new_plan_version'])
         return self.subscription.change_plan(
@@ -757,6 +763,7 @@ class CreditForm(forms.Form):
             )))
         return amount
 
+    @transaction.atomic
     def adjust_credit(self, web_user=None):
         amount = self.cleaned_data['amount']
         note = self.cleaned_data['note']
@@ -1309,6 +1316,7 @@ class SoftwarePlanVersionForm(forms.Form):
             raise ValidationError(_("A name is required for this new role."))
         return val
 
+    @transaction.atomic
     def save(self, request):
         if not self.is_update:
             messages.info(request, "No changes to rates and roles were present, so the current version was kept.")
@@ -1533,6 +1541,7 @@ class TriggerInvoiceForm(forms.Form):
             )
         )
 
+    @transaction.atomic
     def trigger_invoice(self):
         year = int(self.cleaned_data['year'])
         month = int(self.cleaned_data['month'])
@@ -1759,6 +1768,7 @@ class AdjustBalanceForm(forms.Form):
             raise ValidationError(_("Received invalid adjustment type: %s")
                                   % adjustment_type)
 
+    @transaction.atomic
     def adjust_balance(self, web_user=None):
         method = self.cleaned_data['method']
         kwargs = {
@@ -1977,6 +1987,7 @@ class CreateAdminForm(forms.Form):
             )
         )
 
+    @transaction.atomic
     def add_admin_user(self):
         # create UserRole for user
         username = self.cleaned_data['username']

--- a/corehq/apps/accounting/payment_handlers.py
+++ b/corehq/apps/accounting/payment_handlers.py
@@ -1,5 +1,6 @@
 from decimal import Decimal
 import logging
+from django.db import transaction
 import stripe
 from django.conf import settings
 from django.utils.translation import ugettext as _
@@ -404,7 +405,8 @@ class AutoPayInvoicePaymentHandler(object):
                 self._handle_card_errors(invoice, payment_method, e)
                 continue
             else:
-                invoice.pay_invoice(payment_record)
+                with transaction.atomic():
+                    invoice.pay_invoice(payment_record)
                 self._send_payment_receipt(invoice, payment_record)
 
     def _send_payment_receipt(self, invoice, payment_record):

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -6,6 +6,7 @@ from celery.utils.log import get_task_logger
 import datetime
 from couchdbkit import ResourceNotFound
 from django.conf import settings
+from django.db import transaction
 from django.http import HttpRequest, QueryDict
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext
@@ -50,13 +51,14 @@ def activate_subscriptions(based_on_date=None):
     starting_subscriptions = Subscription.objects.filter(date_start=starting_date)
     for subscription in starting_subscriptions:
         if not has_subscription_already_ended(subscription) and not subscription.is_active:
-            subscription.is_active = True
-            subscription.save()
-            upgraded_privs = get_change_status(None, subscription.plan_version).upgraded_privs
-            subscription.subscriber.activate_subscription(
-                upgraded_privileges=upgraded_privs,
-                subscription=subscription,
-            )
+            with transaction.atomic():
+                subscription.is_active = True
+                subscription.save()
+                upgraded_privs = get_change_status(None, subscription.plan_version).upgraded_privs
+                subscription.subscriber.activate_subscription(
+                    upgraded_privileges=upgraded_privs,
+                    subscription=subscription,
+                )
 
 
 def deactivate_subscriptions(based_on_date=None):
@@ -66,22 +68,23 @@ def deactivate_subscriptions(based_on_date=None):
     ending_date = based_on_date or datetime.date.today()
     ending_subscriptions = Subscription.objects.filter(date_end=ending_date)
     for subscription in ending_subscriptions:
-        subscription.is_active = False
-        subscription.save()
-        next_subscription = subscription.next_subscription
-        if next_subscription and next_subscription.date_start == ending_date:
-            new_plan_version = next_subscription.plan_version
-            next_subscription.is_active = True
-            next_subscription.save()
-        else:
-            new_plan_version = None
-        _, downgraded_privs, upgraded_privs = get_change_status(subscription.plan_version, new_plan_version)
-        subscription.subscriber.deactivate_subscription(
-            downgraded_privileges=downgraded_privs,
-            upgraded_privileges=upgraded_privs,
-            old_subscription=subscription,
-            new_subscription=next_subscription,
-        )
+        with transaction.atomic():
+            subscription.is_active = False
+            subscription.save()
+            next_subscription = subscription.next_subscription
+            if next_subscription and next_subscription.date_start == ending_date:
+                new_plan_version = next_subscription.plan_version
+                next_subscription.is_active = True
+                next_subscription.save()
+            else:
+                new_plan_version = None
+            _, downgraded_privs, upgraded_privs = get_change_status(subscription.plan_version, new_plan_version)
+            subscription.subscriber.deactivate_subscription(
+                downgraded_privileges=downgraded_privs,
+                upgraded_privileges=upgraded_privs,
+                old_subscription=subscription,
+                new_subscription=next_subscription,
+            )
 
 
 @periodic_task(run_every=crontab(minute=0, hour=0))

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1168,7 +1168,7 @@ class ConfirmNewSubscriptionForm(EditBillingAccountInfoForm):
     def save(self, commit=True):
         try:
             with transaction.atomic():
-                account_save_success = super(ConfirmNewSubscriptionForm, self).save(commit=False)
+                account_save_success = super(ConfirmNewSubscriptionForm, self).save()
                 if not account_save_success:
                     return False
 
@@ -1270,7 +1270,7 @@ class ConfirmSubscriptionRenewalForm(EditBillingAccountInfoForm):
     def save(self, commit=True):
         try:
             with transaction.atomic():
-                account_save_success = super(ConfirmSubscriptionRenewalForm, self).save(commit=False)
+                account_save_success = super(ConfirmSubscriptionRenewalForm, self).save()
                 if not account_save_success:
                     return False
                 self.current_subscription.renew_subscription(

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1109,6 +1109,8 @@ class EditBillingAccountInfoForm(forms.ModelForm):
                                               "Did you forget the country code?"))
             return "+%s%s" % (parsed_number.country_code, parsed_number.national_number)
 
+    # Does not use the commit kwarg.
+    # TODO - Should support it or otherwise change the function name
     @transaction.atomic
     def save(self, commit=True):
         billing_contact_info = super(EditBillingAccountInfoForm, self).save(commit=False)


### PR DESCRIPTION
Motivated by http://manage.dimagi.com/default.asp?187886, where an exception raised during a series of db operations left accounting in an inconsistent state, requiring tedious work to clean up.  Goal here is to make accounting operations initiated by Ops, periodic events, and users wrapped in transactions.

May be easiest to follow commit by commit.
