### PR TITLE
Fix UCR date filter `compare_as_string` option

### DIFF
--- a/corehq/apps/userreports/reports/filters/values.py
+++ b/corehq/apps/userreports/reports/filters/values.py
@@ -72,12 +72,12 @@ class DateFilterValue(FilterValue):
         startdate = self.value.startdate
         enddate = self.value.enddate
 
+        if self.value.inclusive and enddate:
+            enddate = enddate + timedelta(days=1) - timedelta.resolution
+
         if self.filter.compare_as_string:
             startdate = str(startdate) if startdate is not None else None
             enddate = str(enddate) if enddate is not None else None
-
-        if self.value.inclusive and enddate:
-                enddate = self.value.enddate + timedelta(days=1) - timedelta.resolution
 
         sql_values = {}
         if startdate is not None:

--- a/corehq/apps/userreports/tests/test_report_filters.py
+++ b/corehq/apps/userreports/tests/test_report_filters.py
@@ -97,6 +97,7 @@ class DateFilterTestCase(SimpleTestCase):
             reports_core_value = reports_core_filter.get_value({
                 "my_slug-start": "2015-06-07",
                 "my_slug-end": "2015-06-08",
+                "date_range_inclusive": True,
             })
 
             filter = ReportFilter.wrap(spec)
@@ -104,9 +105,11 @@ class DateFilterTestCase(SimpleTestCase):
 
         val = get_query_value(compare_as_string=False)
         self.assertEqual(type(val['my_slug_startdate']), datetime)
+        self.assertEqual(type(val['my_slug_enddate']), datetime)
 
         val = get_query_value(compare_as_string=True)
         self.assertEqual(type(val['my_slug_startdate']), str)
+        self.assertEqual(type(val['my_slug_enddate']), str)
 
 
 class NumericFilterTestCase(SimpleTestCase):


### PR DESCRIPTION
Ticket [#188131](http://manage.dimagi.com/default.asp?188131)

Looks like the `self.value.inclusive` check was mistakenly moved after the part that casts the dates to strings, which in turn would overwrite the string value with a datetime if the check passed. That happened here: https://github.com/dimagi/commcare-hq/commit/a79344eab05ee777cec1cb4d8bd12df49807a541#diff-96e8a1d51cd7514d901bf02511cc5cd3L64

Also made the test a little more robust.

cc @nickpell
