### PR TITLE
Consistent localization of report description

### DIFF
--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -83,6 +83,7 @@ def _create_custom_app_strings(app, lang, for_default=False):
             for config in module.report_configs:
                 yield id_strings.report_command(config.uuid), trans(config.header)
                 yield id_strings.report_name(config.uuid), trans(config.header)
+                yield id_strings.report_description(config.uuid), trans(config.localized_description)
                 for column in config.report.report_columns:
                     yield (
                         id_strings.report_column_header(config.uuid, column.column_id),

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -60,9 +60,6 @@ class ReportFixturesProvider(object):
     def _report_config_to_fixture(self, report_config, user):
         report_elem = ElementTree.Element('report', attrib={'id': report_config.uuid})
         report = ReportConfiguration.get(report_config.report_id)
-        report_elem.append(self._element('name', localize(report_config.header, user.language)))
-        if not report_config.use_xpath_description:
-            report_elem.append(self._element('description', localize(report_config.localized_description, user.language)))
         data_source = ReportFactory.from_spec(report)
 
         data_source.set_filter_values({

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -13,7 +13,6 @@ from corehq.util.xml_utils import serialize
 from corehq.apps.userreports.exceptions import UserReportsError
 from corehq.apps.userreports.models import ReportConfiguration
 from corehq.apps.userreports.reports.factory import ReportFactory
-from corehq.apps.userreports.util import localize
 
 
 class ReportFixturesProvider(object):

--- a/corehq/apps/app_manager/id_strings.py
+++ b/corehq/apps/app_manager/id_strings.py
@@ -186,6 +186,11 @@ def report_name(report_id):
     return u'cchq.reports.{report_id}.name'.format(report_id=report_id)
 
 
+@pattern('cchq.reports.%s.description')
+def report_description(report_id):
+    return u'cchq.reports.{report_id}.description'.format(report_id=report_id)
+
+
 @pattern('cchq.report_last_sync')
 def report_last_sync():
     return u'cchq.report_last_sync'

--- a/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
+++ b/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
@@ -132,6 +132,16 @@ def _get_summary_details(config):
                     )
                 )
 
+    def _get_description_text(report_config):
+        if report_config.use_xpath_description:
+            return Text(
+                xpath=Xpath(function=config.xpath_description)
+            )
+        else:
+            return Text(
+                locale=Locale(id=id_strings.report_description(report_config.uuid))
+            )
+
     return models.Detail(custom_xml=Detail(
         id='reports.{}.summary'.format(config.uuid),
         title=Text(
@@ -162,9 +172,7 @@ def _get_summary_details(config):
                             )
                         ),
                         template=Template(
-                            text=Text(
-                                xpath=Xpath(function=config.xpath_description if config.use_xpath_description else 'description')
-                            )
+                            text=_get_description_text(config)
                         ),
                     ),
                 ] + [

--- a/corehq/apps/app_manager/tests/data/suite/reports_module_summary_detail_use_localized_description.xml
+++ b/corehq/apps/app_manager/tests/data/suite/reports_module_summary_detail_use_localized_description.xml
@@ -31,7 +31,7 @@
         </header>
         <template>
           <text>
-            <xpath function='description'/>
+            <locale id="cchq.reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.description"/>
           </text>
         </template>
       </field>


### PR DESCRIPTION
Make report description dependent on the localization settings on the phone, not the language of the user.

https://trello.com/c/tqWMP6er/88-ui-for-reporting-to-match-other-existing-modules

@orangejenny cc: @NoahCarnahan 
