### PR TITLE
Remove subentity connectors

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1563,10 +1563,6 @@ class DetailTab(IndexedSchema):
     has_nodeset = BooleanProperty(default=False)
     nodeset = StringProperty()
 
-    # Any instance connectors necessary for the nodeset,
-    # e.g., "reports" => "jr://fixture/reports"
-    connectors = DictProperty()
-
 
 class DetailColumn(IndexedSchema):
     """

--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -493,7 +493,6 @@ var DetailScreenConfig = (function () {
                 isTab: false,
                 hasNodeset: false,
                 nodeset: "",
-                connectors: {},
             };
             _.defaults(this.original, tabDefaults);
             _.extend(this, _.pick(this.original, _.keys(tabDefaults)));
@@ -533,19 +532,6 @@ var DetailScreenConfig = (function () {
                 that.header.setVisibleValue(visibleVal);
 
                 that.nodeset = uiElement.input().val(that.original.nodeset);
-                var o = {
-                    // Connectors are a simple string => string object, but key_value_mapping
-                    // expects an array of objects with "key" and "value" keys.
-                    items: _.reduce(_.keys(that.original.connectors), function(memo, key) {
-                        return memo.concat({
-                            key: key,
-                            value: that.original.connectors[key]
-                        });
-                    }, []),
-                    modalTitle: 'Editing connectors',
-                    buttonText: 'Connectors',
-                };
-                that.connectors = uiElement.key_value_mapping(o);
                 if (that.isTab) {
                     // hack to wait until the input's there to prepend the Tab: label.
                     setTimeout(function () {
@@ -635,7 +621,6 @@ var DetailScreenConfig = (function () {
                 'field',
                 'header',
                 'nodeset',
-                'connectors',
                 'format',
                 'enum_extra',
                 'graph_extra',
@@ -715,13 +700,6 @@ var DetailScreenConfig = (function () {
                 column.field = this.field.val();
                 column.header[this.lang] = this.header.val();
                 column.nodeset = this.nodeset.val();
-                // Reduce key_value_mapping's ordered list into the single dict stored on the server.
-                column.connectors = _.reduce(this.connectors.getItems(),
-                                             function(memo, value) {
-                                                memo[value.key] = value.value;
-                                                return memo;
-                                             },
-                                             {});
                 column.format = this.format.val();
                 column.enum = this.enum_extra.getItems();
                 column.graph_configuration =
@@ -736,7 +714,7 @@ var DetailScreenConfig = (function () {
                     return _.extend({
                         starting_index: this.starting_index,
                         has_nodeset: column.hasNodeset,
-                    }, _.pick(column, ['header', 'isTab', 'nodeset', 'connectors']));
+                    }, _.pick(column, ['header', 'isTab', 'nodeset']));
                 }
                 return column;
             },
@@ -838,7 +816,7 @@ var DetailScreenConfig = (function () {
                     0,
                     _.extend({
                         hasNodeset: tabs[i].has_nodeset,
-                    }, _.pick(tabs[i], ["header", "nodeset", "isTab", "connectors"]))
+                    }, _.pick(tabs[i], ["header", "nodeset", "isTab"]))
                 );
             }
             if (this.columnKey === 'long') {
@@ -847,7 +825,6 @@ var DetailScreenConfig = (function () {
                         isTab: true,
                         hasNodeset: hasNodeset,
                         model: 'tab',
-                        connectors: {},
                     }, that));
                     that.columns.splice(0, 0, col);
                 };

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -142,7 +142,6 @@ class EntriesHelper(object):
                 e.datums.append(datum)
                 e.assertions.extend(assertions)
 
-            self._add_extra_entry_connectors(e, module)
             results.append(e)
 
         if hasattr(module, 'case_list') and module.case_list.show:
@@ -184,24 +183,12 @@ class EntriesHelper(object):
                         value="./@id",
                         detail_select=self.details_helper.get_detail_id_safe(module, 'product_short')
                     ))
-            self._add_extra_entry_connectors(e, module)
             results.append(e)
 
         for entry in module.get_custom_entries():
             results.append(entry)
 
         return results
-
-    def _add_extra_entry_connectors(self, entry, module):
-        # Collect any extra connectors specified for details with nodesets
-        connectors = {}
-        detail_ids = [datum.detail_confirm for datum in entry.datums]
-        if hasattr(module, 'case_details'):
-            if self.details_helper.get_detail_id_safe(module, 'case_long') in detail_ids:
-                for tab in module.case_details.long.tabs:
-                    connectors.update(tab.connectors)
-        for id, src in connectors.iteritems():
-            entry.require_instances([Instance(id=id, src=src)])
 
     @staticmethod
     def get_assertion(test, locale_id, locale_arguments=None):

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list_properties.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list_properties.html
@@ -57,7 +57,6 @@
                         <td data-bind="jqueryElement: header.ui"></td>
                         <td class="control-group" colspan="2" data-bind="css: {error: showWarning}">
                             <div data-bind="jqueryElement: nodeset.ui"></div>
-                            <div data-bind="jqueryElement: connectors.ui"></div>
                             <span class="help-inline" data-bind="text: 'A nodeset must be specified.', visible: showWarning"></span>
                         </td>
                     <!--/ko-->

--- a/corehq/apps/app_manager/tests/data/suite/app_case_detail_tabs_with_nodesets.json
+++ b/corehq/apps/app_manager/tests/data/suite/app_case_detail_tabs_with_nodesets.json
@@ -631,13 +631,10 @@
                         {  
                             "doc_type":"DetailTab",
                             "has_nodeset":true,
-                            "nodeset":"instance('external')/some/data",
+                            "nodeset":"instance('commtrack:products')/some/data",
                             "isTab":true,
                             "header":{  
                                 "en":"External Data"
-                            },
-                            "connectors":{  
-                                "external": "jr://blahblah"
                             },
                             "starting_index":4
                         }

--- a/corehq/apps/app_manager/tests/data/suite/suite-case-detail-tabs-with-nodesets.xml
+++ b/corehq/apps/app_manager/tests/data/suite/suite-case-detail-tabs-with-nodesets.xml
@@ -118,7 +118,7 @@
         </template>
       </field>
     </detail>
-    <detail nodeset="instance('external')/some/data">
+    <detail nodeset="instance('commtrack:products')/some/data">
       <title>
         <text>
           <locale id="m0.case_long.tab.3.title"/>
@@ -160,7 +160,7 @@
       </text>
     </command>
     <instance id="casedb" src="jr://instance/casedb"/>
-    <instance id="external" src="jr://blahblah"/>
+    <instance id="commtrack:products" src="jr://fixture/commtrack:products"/>
     <session>
       <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='song'][@status='open']"
              value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>
@@ -173,7 +173,7 @@
       </text>
     </command>
     <instance id="casedb" src="jr://instance/casedb"/>
-    <instance id="external" src="jr://blahblah"/>
+    <instance id="commtrack:products" src="jr://fixture/commtrack:products"/>
     <session>
       <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='song'][@status='open']"
              value="./@case_id" detail-select="m0_case_short" detail-confirm="m0_case_long"/>

--- a/corehq/apps/hqwebapp/templatetags/menu_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/menu_tags.py
@@ -110,7 +110,7 @@ def format_sidebar(context):
             for nav in navs:
                 if (request.get_full_path().startswith(nav['url']) or
                    request.build_absolute_uri().startswith(nav['url'])):
-                    nav['is_active'] = True
+                    nav['is_active'] = False
                 else:
                     nav['is_active'] = False
 
@@ -121,7 +121,7 @@ def format_sidebar(context):
                                 actual_context = {}
                                 for d in context.dicts:
                                     actual_context.update(d)
-                                subpage['is_active'] = True
+                                subpage['is_active'] = False
                                 subpage['title'] = subpage['title'](**actual_context)
                             nav['subpage'] = subpage
                             break


### PR DESCRIPTION
The work done in https://github.com/dimagi/commcare-hq/pull/9340 makes most of https://github.com/dimagi/commcare-hq/pull/8848 no longer necessary.

Verified that ICDS, the only project using this, is only using the `commtrack:products` instance, which is already in the set we automatically detect.

@dannyroberts cc: @proteusvacuum 
