### PR TITLE
Permit hyphens in UCR filter slugs

### DIFF
--- a/corehq/apps/userreports/reports/filters/specs.py
+++ b/corehq/apps/userreports/reports/filters/specs.py
@@ -45,16 +45,6 @@ class FilterChoice(JsonObject):
         return self.display or self.value
 
 
-def _validate_filter_slug(s):
-    if "-" in s:
-        raise Exception(_(
-            """
-            Filter slugs must be legal sqlalchemy bind parameter names.
-            '-' and other special character are prohibited
-            """
-        ))
-
-
 class FilterSpec(JsonObject):
     """
     This is the spec for a report filter - a thing that should show up as a UI filter element
@@ -62,7 +52,7 @@ class FilterSpec(JsonObject):
     """
     type = StringProperty(required=True, choices=['date', 'numeric', 'choice_list', 'dynamic_choice_list'])
     # this shows up as the ID in the filter HTML.
-    slug = StringProperty(required=True, validators=_validate_filter_slug)
+    slug = StringProperty(required=True)
     field = StringProperty(required=True)  # this is the actual column that is queried
     display = DefaultProperty()
     datatype = DataTypeProperty(default='string')

--- a/corehq/apps/userreports/tests/test_filters.py
+++ b/corehq/apps/userreports/tests/test_filters.py
@@ -5,18 +5,6 @@ from corehq.apps.userreports.filters.factory import FilterFactory
 from corehq.apps.userreports.specs import FactoryContext
 
 
-class BasicFilterTest(SimpleTestCase):
-
-    def test_invalid_slug(self):
-        with self.assertRaises(BadSpecError):
-            FilterFactory.from_spec({
-                'type': 'property_match',
-                'property_name': 'foo',
-                'property_value': 'bar',
-                'slug': 'this-is-bad',
-            })
-
-
 class PropertyMatchFilterTest(SimpleTestCase):
 
     def get_filter(self):


### PR DESCRIPTION
reverts https://github.com/dimagi/commcare-hq/pull/8474

The validation being removed is no longer needed since we use the function `bindparam` now in sqlagg (see https://github.com/dimagi/commcare-hq/pull/8474#issue-109564104)

@NoahCarnahan @snopoke 
