### PR TITLE
Don't fail hard when no format exists for form repeater

### DIFF
--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -529,7 +529,7 @@ def drop_repeater(request, domain, repeater_id):
 def test_repeater(request, domain):
     url = request.POST["url"]
     repeater_type = request.POST['repeater_type']
-    format = request.POST['format']
+    format = request.POST.get('format', None)
     form = GenericRepeaterForm(
         {"url": url, "format": format},
         domain=domain,


### PR DESCRIPTION
@czue http://manage.dimagi.com/default.asp?188429 somehow format was no longer being submitted, but this is fine to leave as `None` since the `Repeater` just uses the default format if multiple don't exist
