### PR TITLE
limit select2 to .hq-content

### DIFF
--- a/corehq/apps/accounting/static/accounting/js/accounting.billing_info_handler.js
+++ b/corehq/apps/accounting/static/accounting/js/accounting.billing_info_handler.js
@@ -29,7 +29,7 @@ var AsyncSelect2Handler = function (field, multiple) {
 
     self.init = function () {
         $(function () {
-            var $field = $('[name="' + self.fieldName + '"]');
+            var $field = $('.hq-content [name="' + self.fieldName + '"]');
             if ($field.attr('type') !== 'hidden') {
                 $field.select2({
                     minimumInputLength: 0,
@@ -44,7 +44,7 @@ var AsyncSelect2Handler = function (field, multiple) {
                                 handler: 'select2_billing',
                                 action: self.fieldName,
                                 searchString: term,
-                                existing: $('[name="' + self.fieldName + '"]').val().split(','),
+                                existing: $('.hq-content [name="' + self.fieldName + '"]').val().split(','),
                                 additionalData: self.getAdditionalData()
                             };
                         },
@@ -80,7 +80,7 @@ var EmailSelect2Handler = function (field, valid_email_text) {
 
     self.init = function () {
         $(function () {
-            $('[name="' + self.fieldName + '"]').select2({
+            $('.hq-content [name="' + self.fieldName + '"]').select2({
                 createSearchChoice: function (term, data) {
                     var matchedData = $(data).filter(function() {
                         return this.text.localeCompare(term) === 0;


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?188536

AsyncSelect2Handler uses a rather generic `name=['foo']` selector which was turning the report an issue modal's hidden domain input into a select2. I played with passing a DOM/jQuery object instead of just a field name, ended up undoing that in favor of a more minimal code change.

@dannyroberts / @proteusvacuum 
