### PR TITLE
don't serialize DB during test setup

### DIFF
--- a/.travis/localsettings.py
+++ b/.travis/localsettings.py
@@ -12,7 +12,10 @@ DATABASES = {
         'USER': 'postgres',
         'PASSWORD': '',
         'HOST': 'localhost',
-        'PORT': '5432'
+        'PORT': '5432',
+        'TEST': {
+            'SERIALIZE': False,  # https://docs.djangoproject.com/en/1.8/ref/settings/#serialize
+        },
     }
 }
 


### PR DESCRIPTION
This should speed up our tests (if it works)

@NoahCarnahan 
