### PR TITLE
add ability to get dbs by db name

### DIFF
--- a/corehq/util/couchdb_management.py
+++ b/corehq/util/couchdb_management.py
@@ -36,6 +36,12 @@ class CouchConfig(object):
         return {slug: Database(db_uri)
                 for slug, db_uri in self.all_db_uris_by_slug.items()}
 
+    @property
+    @memoized
+    def all_dbs_by_name(self):
+        return {Database(db_uri).dbname: Database(db_uri)
+                for db_uri in self.all_db_uris_by_slug.values()}
+
     def get_db(self, postfix):
         """
         Get the couch database by slug
@@ -58,6 +64,12 @@ class CouchConfig(object):
 
     def get_db_for_doc_type(self, doc_type):
         return Database(self.get_db_uri_for_doc_type(doc_type))
+
+    def get_db_for_postfix(self, postfix):
+        return Database(self.all_db_uris_by_slug[postfix])
+
+    def get_db_for_db_name(self, db_name):
+        return self.all_dbs_by_name[db_name]
 
 
 couch_config = CouchConfig()

--- a/corehq/util/couchdb_management.py
+++ b/corehq/util/couchdb_management.py
@@ -38,7 +38,7 @@ class CouchConfig(object):
 
     @property
     @memoized
-    def all_dbs_by_name(self):
+    def all_dbs_by_db_name(self):
         return {Database(db_uri).dbname: Database(db_uri)
                 for db_uri in self.all_db_uris_by_slug.values()}
 
@@ -65,11 +65,8 @@ class CouchConfig(object):
     def get_db_for_doc_type(self, doc_type):
         return Database(self.get_db_uri_for_doc_type(doc_type))
 
-    def get_db_for_postfix(self, postfix):
-        return Database(self.all_db_uris_by_slug[postfix])
-
     def get_db_for_db_name(self, db_name):
-        return self.all_dbs_by_name[db_name]
+        return self.all_dbs_by_db_name[db_name]
 
 
 couch_config = CouchConfig()

--- a/corehq/util/tests/test_couchdb_management.py
+++ b/corehq/util/tests/test_couchdb_management.py
@@ -32,5 +32,15 @@ class CouchConfigTest(SimpleTestCase):
     def test_get_db_for_doc_type(self):
         config = CouchConfig(db_uri=self.remote_db_uri)
         self.assertEqual(config.get_db_for_doc_type('CommCareCase').uri, self.remote_db_uri)
+
         self.assertEqual(config.get_db_for_doc_type('CommCareUser').uri,
                          '{}__users'.format(self.remote_db_uri))
+
+    def test_get_db_for_postfix(self):
+        config = CouchConfig(db_uri=self.remote_db_uri)
+        self.assertEqual('{}__users'.format(self.remote_db_uri), config.get_db_for_postfix('users').uri)
+
+    def test_get_db_for_db_name(self):
+        config = CouchConfig(db_uri=self.remote_db_uri)
+        self.assertEqual(self.remote_db_uri, config.get_db_for_db_name('cchq').uri)
+        self.assertEqual('{}__users'.format(self.remote_db_uri), config.get_db_for_db_name('cchq__users').uri)

--- a/corehq/util/tests/test_couchdb_management.py
+++ b/corehq/util/tests/test_couchdb_management.py
@@ -32,13 +32,8 @@ class CouchConfigTest(SimpleTestCase):
     def test_get_db_for_doc_type(self):
         config = CouchConfig(db_uri=self.remote_db_uri)
         self.assertEqual(config.get_db_for_doc_type('CommCareCase').uri, self.remote_db_uri)
-
         self.assertEqual(config.get_db_for_doc_type('CommCareUser').uri,
                          '{}__users'.format(self.remote_db_uri))
-
-    def test_get_db_for_postfix(self):
-        config = CouchConfig(db_uri=self.remote_db_uri)
-        self.assertEqual('{}__users'.format(self.remote_db_uri), config.get_db_for_postfix('users').uri)
 
     def test_get_db_for_db_name(self):
         config = CouchConfig(db_uri=self.remote_db_uri)


### PR DESCRIPTION
@dannyroberts the new pillow infrastructure needs to be able to pull these out by name (still useful to keep auth and what not isolated to this class).

cc @esoergel @benrudolph 
