### PR TITLE
Minor repeater cleanup

### DIFF
--- a/corehq/apps/domain/templates/domain/admin/add_form_repeater.html
+++ b/corehq/apps/domain/templates/domain/admin/add_form_repeater.html
@@ -18,23 +18,23 @@
 
                 $.post("{% url "test_repeater" domain %}", data, function(resp) {
                     var jsonResp = JSON.parse(response);
-                    $testLabel.removeClass("hide label-danger label-success");
+                    $testResult.removeClass("hide label-danger label-success");
                     if (jsonResp.status) {
                         msg = jsonResp.status + ": " + jsonResp.response;
                     } else {
                         msg = jsonResp.response;
                     }
                     if (jsonResp.success) {
-                        $testLabel.addClass("label-success");
-                        $testLabel.text("{% trans 'Success! Response is' %}: " + msg);
+                        $testResult.addClass("label-success");
+                        $testResult.text("{% trans 'Success! Response is' %}: " + msg);
                     } else {
-                        $testLabel.addClass("label-danger");
-                        $testLabel.text("{% trans 'Failed! Response is' %}: " + msg);
+                        $testResult.addClass("label-danger");
+                        $testResult.text("{% trans 'Failed! Response is' %}: " + msg);
                     }
                 });
             });
             $('#id_url').after($testLinkButton);
-            $testLinkButton.after($testLabel.addClass('hide'));
+            $testLinkButton.after($testResult.addClass('hide'));
             $('#id_url').change(function () {
                 if ($(this).val()) {
                     $testLinkButton.removeClass('hide');

--- a/corehq/apps/domain/templates/domain/admin/add_form_repeater.html
+++ b/corehq/apps/domain/templates/domain/admin/add_form_repeater.html
@@ -7,9 +7,8 @@
 {% block js-inline %} {{ block.super }}
     <script type="text/javascript">
         $(function() {
-            var $testLinkButton = $('<a style="margin-left: 5px;" class="btn btn-info hide" href="#" />'),
-                     $testLabel = $('<span style="margin-left: 5px;" class="label" />');
-            $testLinkButton.text("{% trans 'Test Link' %}");
+            var $testLinkButton = $('#test-forward-link'),
+                $testResult = $('#test-forward-result');
             $testLinkButton.click(function () {
                 var url = $("#id_url").val(),
                     format = $("#id_format").val(),

--- a/corehq/apps/domain/templates/domain/admin/add_form_repeater.html
+++ b/corehq/apps/domain/templates/domain/admin/add_form_repeater.html
@@ -18,17 +18,17 @@
 
                 $.post("{% url "test_repeater" domain %}", data, function(resp) {
                     var jsonResp = JSON.parse(response);
-                    $testResult.removeClass("hide label-danger label-success");
+                    $testResult.removeClass("hide bg-danger bg-success");
                     if (jsonResp.status) {
                         msg = jsonResp.status + ": " + jsonResp.response;
                     } else {
                         msg = jsonResp.response;
                     }
                     if (jsonResp.success) {
-                        $testResult.addClass("label-success");
+                        $testResult.addClass("bg-success");
                         $testResult.text("{% trans 'Success! Response is' %}: " + msg);
                     } else {
-                        $testResult.addClass("label-danger");
+                        $testResult.addClass("bg-danger");
                         $testResult.text("{% trans 'Failed! Response is' %}: " + msg);
                     }
                 });

--- a/corehq/apps/domain/templates/domain/admin/add_form_repeater.html
+++ b/corehq/apps/domain/templates/domain/admin/add_form_repeater.html
@@ -34,8 +34,6 @@
                     }
                 });
             });
-            $('#id_url').after($testLinkButton);
-            $testLinkButton.after($testResult.addClass('hide'));
             $('#id_url').change(function () {
                 if ($(this).val()) {
                     $testLinkButton.removeClass('hide');

--- a/corehq/apps/domain/templates/domain/admin/add_form_repeater.html
+++ b/corehq/apps/domain/templates/domain/admin/add_form_repeater.html
@@ -6,39 +6,56 @@
 
 {% block js-inline %} {{ block.super }}
     <script type="text/javascript">
-        $(function() {
+        $(document).ready(function() {
             var $testLinkButton = $('#test-forward-link'),
                 $testResult = $('#test-forward-result');
+
+            var handleSuccess = function(resp) {
+                var jsonResp = JSON.parse(resp),
+                    message;
+                $testResult.removeClass("hide text-danger text-success");
+                $testLinkButton.enableButton();
+
+                if (jsonResp.status) {
+                    message = jsonResp.status + ": " + jsonResp.response;
+                } else {
+                    message = jsonResp.response;
+                }
+
+                if (jsonResp.success) {
+                    $testResult.addClass("text-success");
+                    $testResult.text("{% trans 'Success! Response is' %}: " + message);
+                } else {
+                    $testResult.addClass("text-danger");
+                    $testResult.text("{% trans 'Failed! Response is' %}: " + message);
+                }
+            };
+
+            var handleFailure = function(resp) {
+                $testLinkButton.enableButton();
+                $testResult
+                    .removeClass("hide text-success")
+                    .addClass("text-danger");
+                $testResult.text("{% trans 'HQ was unable to make the request' %}: " + resp.statusText);
+            };
+
             $testLinkButton.click(function () {
                 var data = {
                     url: $('#id_url').val(),
                     format: $('#id_format').val(),
-                    type: {{ repeater_type|to_javascript_string }}
+                    repeater_type: {{ repeater_type|to_javascript_string }}
                 };
+                $testLinkButton.disableButton();
 
-                $.post("{% url "test_repeater" domain %}", data, function(resp) {
-                    var jsonResp = JSON.parse(response),
-                        message;
-                    $testResult.removeClass("hide bg-danger bg-success");
-                    if (jsonResp.status) {
-                        message = jsonResp.status + ": " + jsonResp.response;
-                    } else {
-                        message = jsonResp.response;
-                    }
-                    if (jsonResp.success) {
-                        $testResult.addClass("bg-success");
-                        $testResult.text("{% trans 'Success! Response is' %}: " + message);
-                    } else {
-                        $testResult.addClass("bg-danger");
-                        $testResult.text("{% trans 'Failed! Response is' %}: " + message);
-                    }
-                });
+                $.post("{% url "test_repeater" domain %}", data)
+                    .success(handleSuccess)
+                    .fail(handleFailure);
             });
             $('#id_url').change(function () {
                 if ($(this).val()) {
-                    $testLinkButton.removeClass('hide');
+                    $testLinkButton.removeClass('disabled');
                 } else {
-                    $testLinkButton.addClass('hide');
+                    $testLinkButton.addClass('disabled');
                 }
             });
         });

--- a/corehq/apps/domain/templates/domain/admin/add_form_repeater.html
+++ b/corehq/apps/domain/templates/domain/admin/add_form_repeater.html
@@ -11,6 +11,10 @@
                 $testResult = $('#test-forward-result');
 
             var handleSuccess = function(resp) {
+                /*
+                 * Handles a successful attempt to test the link. Note, just gets run when HQ returns
+                 * successful not if the link being tested returns successful
+                 */
                 var jsonResp = JSON.parse(resp),
                     message;
                 $testResult.removeClass("hide text-danger text-success");
@@ -32,6 +36,9 @@
             };
 
             var handleFailure = function(resp) {
+                /*
+                 * Handles an HQ failure to test the URL
+                 */
                 $testLinkButton.enableButton();
                 $testResult
                     .removeClass("hide text-success")

--- a/corehq/apps/domain/templates/domain/admin/add_form_repeater.html
+++ b/corehq/apps/domain/templates/domain/admin/add_form_repeater.html
@@ -10,19 +10,21 @@
             var $testLinkButton = $('#test-forward-link'),
                 $testResult = $('#test-forward-result');
             $testLinkButton.click(function () {
-                var url = $("#id_url").val(),
-                    format = $("#id_format").val(),
-                    type = {{ repeater_type|to_javascript_string }},
-                    data = {url: url, repeater_type: type, format: format};
-                jQuery.post("{% url "test_repeater" domain %}", data, function(data) {
-                    json_res = JSON.parse(data);
+                var data = {
+                    url: $('#id_url').val(),
+                    format: $('#id_format').val(),
+                    type: {{ repeater_type|to_javascript_string }}
+                };
+
+                $.post("{% url "test_repeater" domain %}", data, function(resp) {
+                    var jsonResp = JSON.parse(response);
                     $testLabel.removeClass("hide label-danger label-success");
-                    if (json_res.status) {
-                        msg = json_res.status + ": " + json_res.response;
+                    if (jsonResp.status) {
+                        msg = jsonResp.status + ": " + jsonResp.response;
                     } else {
-                        msg = json_res.response;
+                        msg = jsonResp.response;
                     }
-                    if (json_res.success) {
+                    if (jsonResp.success) {
                         $testLabel.addClass("label-success");
                         $testLabel.text("{% trans 'Success! Response is' %}: " + msg);
                     } else {

--- a/corehq/apps/domain/templates/domain/admin/add_form_repeater.html
+++ b/corehq/apps/domain/templates/domain/admin/add_form_repeater.html
@@ -17,19 +17,20 @@
                 };
 
                 $.post("{% url "test_repeater" domain %}", data, function(resp) {
-                    var jsonResp = JSON.parse(response);
+                    var jsonResp = JSON.parse(response),
+                        message;
                     $testResult.removeClass("hide bg-danger bg-success");
                     if (jsonResp.status) {
-                        msg = jsonResp.status + ": " + jsonResp.response;
+                        message = jsonResp.status + ": " + jsonResp.response;
                     } else {
-                        msg = jsonResp.response;
+                        message = jsonResp.response;
                     }
                     if (jsonResp.success) {
                         $testResult.addClass("bg-success");
-                        $testResult.text("{% trans 'Success! Response is' %}: " + msg);
+                        $testResult.text("{% trans 'Success! Response is' %}: " + message);
                     } else {
                         $testResult.addClass("bg-danger");
-                        $testResult.text("{% trans 'Failed! Response is' %}: " + msg);
+                        $testResult.text("{% trans 'Failed! Response is' %}: " + message);
                     }
                 });
             });

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -2160,7 +2160,6 @@ class AddRepeaterView(BaseAdminProjectSettingsView, RepeaterMixin):
         return repeater
 
     def post(self, request, *args, **kwargs):
-        print self.add_repeater_form.errors
         if self.add_repeater_form.is_valid():
             repeater = self.make_repeater()
             repeater.save()

--- a/corehq/apps/repeaters/forms.py
+++ b/corehq/apps/repeaters/forms.py
@@ -58,12 +58,13 @@ class GenericRepeaterForm(forms.Form):
                 crispy.Div(
                     crispy.Div(
                         css_id='test-forward-result',
-                        css_class='bg-success hide',
+                        css_class='text-success hide',
                     ),
                     twbscrispy.StrictButton(
                         _('Test Link'),
                         type='button',
-                        css_class='btn btn-info test-forward-link hide',
+                        css_id='test-forward-link',
+                        css_class='btn btn-info disabled',
                     ),
                     css_class=self.helper.field_class,
                 ),

--- a/corehq/apps/repeaters/forms.py
+++ b/corehq/apps/repeaters/forms.py
@@ -11,6 +11,26 @@ from corehq.apps.style import crispy as hqcrispy
 
 class GenericRepeaterForm(forms.Form):
 
+    url = forms.URLField(
+        required=True,
+        label='URL to forward to',
+        help_text='Please enter the full url, like http://www.example.com/forwarding/',
+        widget=forms.TextInput(attrs={"class": "url"})
+    )
+    use_basic_auth = forms.BooleanField(
+        required=False,
+        label='Use basic authentication?',
+    )
+    username = forms.CharField(
+        required=False,
+        label='Username',
+    )
+    password = forms.CharField(
+        required=False,
+        label='Password',
+        widget=forms.PasswordInput()
+    )
+
     def __init__(self, *args, **kwargs):
         self.domain = kwargs.pop('domain')
         self.repeater_class = kwargs.pop('repeater_class')
@@ -52,26 +72,6 @@ class GenericRepeaterForm(forms.Form):
             cleaned_data['format'] = self.formats[0][0]
 
         return cleaned_data
-
-    url = forms.URLField(
-        required=True,
-        label='URL to forward to',
-        help_text='Please enter the full url, like http://www.example.com/forwarding/',
-        widget=forms.TextInput(attrs={"class": "url"})
-    )
-    use_basic_auth = forms.BooleanField(
-        required=False,
-        label='Use basic authentication?',
-    )
-    username = forms.CharField(
-        required=False,
-        label='Username',
-    )
-    password = forms.CharField(
-        required=False,
-        label='Password',
-        widget=forms.PasswordInput()
-    )
 
 
 class FormRepeaterForm(GenericRepeaterForm):

--- a/corehq/apps/repeaters/forms.py
+++ b/corehq/apps/repeaters/forms.py
@@ -58,7 +58,7 @@ class GenericRepeaterForm(forms.Form):
                 crispy.Div(
                     crispy.Div(
                         css_id='test-forward-result',
-                        css_class='bg-success',
+                        css_class='bg-success hide',
                     ),
                     twbscrispy.StrictButton(
                         _('Test Link'),

--- a/corehq/apps/repeaters/forms.py
+++ b/corehq/apps/repeaters/forms.py
@@ -46,12 +46,33 @@ class GenericRepeaterForm(forms.Form):
                 choices=self.formats,
             )
 
-        self.form_fields.extend(['url', twbscrispy.PrependedText('use_basic_auth', ''), 'username', 'password'])
-
         self.helper = FormHelper(self)
         self.helper.form_class = 'form-horizontal'
         self.helper.label_class = 'col-sm-3 col-md-2'
         self.helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
+
+        self.form_fields.extend([
+            'url',
+            crispy.Div(
+                crispy.Div('', css_class=self.helper.label_class),
+                crispy.Div(
+                    crispy.Div(
+                        css_id='test-forward-result',
+                        css_class='bg-success',
+                    ),
+                    twbscrispy.StrictButton(
+                        _('Test Link'),
+                        type='button',
+                        css_class='btn btn-info test-forward-link hide',
+                    ),
+                    css_class=self.helper.field_class,
+                ),
+                css_class='form-group'
+            ),
+            twbscrispy.PrependedText('use_basic_auth', ''),
+            'username',
+            'password'
+        ])
         self.helper.layout = crispy.Layout(
             crispy.Fieldset(
                 'Forwarding Settings',

--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -394,6 +394,7 @@ class RepeatRecord(Document, LockableMixIn):
     last_checked = DateTimeProperty()
     next_check = DateTimeProperty()
     succeeded = BooleanProperty(default=False)
+    failure_reason = StringProperty()
 
     payload_id = StringProperty()
 
@@ -431,8 +432,8 @@ class RepeatRecord(Document, LockableMixIn):
         self.last_checked = datetime.utcnow()
         self.next_check = None
         self.succeeded = True
-    
-    def update_failure(self):
+
+    def update_failure(self, reason):
         # we use an exponential back-off to avoid submitting to bad urls
         # too frequently.
         assert self.succeeded is False
@@ -441,12 +442,13 @@ class RepeatRecord(Document, LockableMixIn):
         window = timedelta(minutes=0)
         if self.last_checked:
             window = self.next_check - self.last_checked
-            window += (window // 2) # window *= 1.5
+            window += (window // 2)  # window *= 1.5
         if window < timedelta(minutes=60):
             window = timedelta(minutes=60)
 
         self.last_checked = now
         self.next_check = self.last_checked + window
+        self.failure_reason = reason
 
     def try_now(self):
         # try when we haven't succeeded and either we've
@@ -480,17 +482,19 @@ class RepeatRecord(Document, LockableMixIn):
             if self.try_now():
                 # we don't use celery's version of retry because
                 # we want to override the success/fail each try
+                failure_reason = None
                 for i in range(max_tries):
                     try:
                         resp = post_fn(payload, self.url, headers=headers)
                         if 200 <= resp.status < 300:
                             self.update_success()
                             break
-                    except Exception:
-                        pass  # some other connection issue probably
+                    except Exception, e:
+                        failure_reason = unicode(e)
+
                 if not self.succeeded:
                     # mark it failed for later and give up
-                    self.update_failure()
+                    self.update_failure(failure_reason)
 
 # import signals
 from corehq.apps.repeaters import signals

--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -433,7 +433,7 @@ class RepeatRecord(Document, LockableMixIn):
         self.next_check = None
         self.succeeded = True
 
-    def update_failure(self, reason):
+    def update_failure(self, reason=None):
         # we use an exponential back-off to avoid submitting to bad urls
         # too frequently.
         assert self.succeeded is False

--- a/corehq/apps/repeaters/tests/test_repeater.py
+++ b/corehq/apps/repeaters/tests/test_repeater.py
@@ -246,22 +246,29 @@ class CaseRepeaterTest(BaseRepeaterTest, TestXmlMixin):
 class RepeaterFailureTest(BaseRepeaterTest):
 
     def setUp(self):
-        self.domain = "test-domain"
-        create_domain(self.domain)
+        self.domain_name = "test-domain"
+        self.domain = create_domain(self.domain_name)
 
         self.repeater = CaseRepeater(
-            domain=self.domain,
+            domain=self.domain_name,
             url='case-repeater-url',
             version=V1,
-            format='new_format'
+            format='other_format'
         )
         self.repeater.save()
         self.post_xml(xform_xml, self.domain)
 
+    def tearDown(self):
+        self.domain.delete()
+        self.repeater.delete()
+        repeat_records = RepeatRecord.all()
+        for repeat_record in repeat_records:
+            repeat_record.delete()
+
     def test_failure(self):
         payload = "some random case"
 
-        @RegisterGenerator(CaseRepeater, 'new_format', 'XML')
+        @RegisterGenerator(CaseRepeater, 'other_format', 'XML')
         class NewCaseGenerator(BasePayloadGenerator):
             def get_payload(self, repeat_record, payload_doc):
                 return payload

--- a/corehq/tests/app_test_db_dependencies.yml
+++ b/corehq/tests/app_test_db_dependencies.yml
@@ -165,3 +165,22 @@ corehq.form_processor:
 corehq.apps.toggle_ui: []
 corehq.doctypemigrations:
   - corehq.couchapps
+corehq.apps.repeaters:
+  - casexml.apps.case
+  - casexml.apps.stock
+  - corehq.apps.commtrack
+  - corehq.apps.locations
+  - corehq.apps.products
+  - corehq.apps.domain
+  - corehq.apps.tzmigration
+  - corehq.apps.users
+  - corehq.couchapps
+  - couchforms
+  - django_prbac
+  # unfortunately domain.delete() needs all of these - otherwise they could be removed
+  - custom.logistics
+  - custom.ilsgateway
+  - custom.ewsghana
+  - django_prbac
+  - corehq.apps.accounting
+  - corehq.apps.smsforms


### PR DESCRIPTION
This does a bit of cleanup around the UI and starts recording the failure reason for a repeat record. Making that failure reason available in the UI is going to take a bit more work

Here are some screenshots:

Failure when link fails:
<img width="1552" alt="screen shot 2015-12-05 at 11 45 51 am" src="https://cloud.githubusercontent.com/assets/918514/11607206/4f76e644-9b46-11e5-9575-2d97be75a7ff.png">
When link succeeds:
<img width="1552" alt="screen shot 2015-12-05 at 11 45 36 am" src="https://cloud.githubusercontent.com/assets/918514/11607208/5a5b8cae-9b46-11e5-812d-33cfc9a180fc.png">
When HQ chokes:
<img width="1552" alt="screen shot 2015-12-05 at 11 52 21 am" src="https://cloud.githubusercontent.com/assets/918514/11607224/b18ea6fa-9b46-11e5-8882-028061ba09ec.png">

cc: @czue :blowfish: if you want
