### PR TITLE
PoC Mobile worker auth as web user in CC

### DIFF
--- a/corehq/apps/cloudcare/forms.py
+++ b/corehq/apps/cloudcare/forms.py
@@ -1,0 +1,9 @@
+from django import forms
+
+
+class CloudCareControlsForm(forms.Form):
+
+    mobile_username = forms.CharField(required=False)
+    mobile_password = forms.CharField(widget=forms.PasswordInput(), required=False)
+
+    preview_mode = forms.BooleanField(required=False)

--- a/corehq/apps/cloudcare/static/cloudcare/js/backbone/apps.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/backbone/apps.js
@@ -652,6 +652,10 @@ cloudCare.AppView = Backbone.View.extend({
         data.formContext = {
             case_model: caseModel ? caseModel.toJSON() : null
         };
+        data.mobileAuth = {
+            username: $('#id_mobile_username').val(),
+            password: $('#id_mobile_password').val()
+        }
         data.onsubmit = function (xml) {
             window.mainView.router.view.dirty = false;
             // post to receiver

--- a/corehq/apps/cloudcare/templates/cloudcare/cloudcare_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/cloudcare_home.html
@@ -1,6 +1,7 @@
 {% extends "cloudcare/base.html" %}
 {% load i18n %}
 {% load hq_shared_tags %}
+{% load crispy_forms_tags %}
 
 {% block title %}
     {% if request.couch_user.is_web_user %}
@@ -182,7 +183,12 @@
                     More information can be found at the <a href="https://help.commcarehq.org/display/commcarepublic/CloudCare+-+Web+Data+Entry">CommCare Help Site</a>.
                 {% endblocktrans %}
         </div>
+
     {% endif %}
+    <div class="cloudcare-controls">
+        {% crispy cloudcare_controls_form %}
+    </div>
+    <hr />
     <div id="offline-prompt" class="alert fade in alert-block alert-full alert-danger" style="display: none;">
         {% blocktrans %}
             Offline CloudCare is not running!

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -56,6 +56,8 @@ from corehq.apps.style.decorators import (
 )
 from django.shortcuts import get_object_or_404
 
+from .forms import CloudCareControlsForm
+
 
 @require_cloudcare_access
 def default(request, domain):
@@ -188,6 +190,7 @@ class CloudcareMain(View):
             "offline_enabled": toggles.OFFLINE_CLOUDCARE.enabled(request.user.username),
             "sessions_enabled": request.couch_user.is_commcare_user(),
             "use_cloudcare_releases": request.project.use_cloudcare_releases,
+            "cloudcare_controls_form": CloudCareControlsForm(),
         }
         context.update(_url_context())
         return render(request, "cloudcare/cloudcare_home.html", context)


### PR DESCRIPTION
@czue @wpride how bout this PoC? there's significant amount of cleanup I'd like to do, but this is a basic working version of allowing web users log in as mobile workers. This will obviate the whole incognito tab workflow. was curious if you guys see any potential blockers for adding this feature
<img width="1552" alt="screen shot 2015-12-05 at 12 50 37 pm" src="https://cloud.githubusercontent.com/assets/918514/11607438/eeda93e0-9b4e-11e5-8886-0279e21ccadc.png">
