### PR TITLE
don't allow report to load more than 5000 rows from the DB

### DIFF
--- a/corehq/apps/reports/dont_use/fields.py
+++ b/corehq/apps/reports/dont_use/fields.py
@@ -172,12 +172,6 @@ class SelectProgramField(ReportSelectField):
         self.options = opts
 
 
-class GroupFieldMixin():
-    slug = "group"
-    name = ugettext_noop("Group")
-    cssId = "group_select"
-
-
 class ReportMultiSelectField(ReportSelectField):
     template = "reports/dont_use_fields/multiselect_generic.html"
     selected = []
@@ -190,7 +184,10 @@ class ReportMultiSelectField(ReportSelectField):
         self.selected = self.request.GET.getlist(self.slug) or self.default_option
 
 
-class MultiSelectGroupField(GroupFieldMixin, ReportMultiSelectField):
+class MultiSelectGroupField(ReportMultiSelectField):
+    slug = "group"
+    name = ugettext_noop("Group")
+    cssId = "group_select"
     default_option = ['_all']
     placeholder = 'Click to select groups'
     help_text = "Start typing to select one or more groups"

--- a/corehq/apps/reports/exceptions.py
+++ b/corehq/apps/reports/exceptions.py
@@ -22,3 +22,7 @@ class UnsupportedScheduledReportError(Exception):
 
 class InvalidDaterangeException(Exception):
     pass
+
+
+class TooMuchDataError(Exception):
+    pass

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -9,6 +9,7 @@ from corehq.apps.es import filters
 from corehq.apps.es import cases as case_es
 from corehq.apps.es.forms import FormES
 from corehq.apps.reports import util
+from corehq.apps.reports.exceptions import TooMuchDataError
 from corehq.apps.reports.filters.users import ExpandedMobileWorkerFilter as EMWF
 from corehq.apps.reports.standard import ProjectReportParametersMixin, \
     DatespanMixin, ProjectReport
@@ -785,6 +786,12 @@ class FormCompletionVsSubmissionTrendsReport(WorkerMonitoringFormReportTableBase
 
     @property
     def rows(self):
+        try:
+            return self._get_rows()
+        except TooMuchDataError as e:
+            return [['<span class="label label-important">{}</span>'.format(e)] + ['--'] * 5]
+
+    def _get_rows(self):
         rows = []
         total = 0
         total_seconds = 0
@@ -810,7 +817,10 @@ class FormCompletionVsSubmissionTrendsReport(WorkerMonitoringFormReportTableBase
                 .extra(
                     where=[where], params=params
                 )
-
+            if results.count() > 5000:
+                raise TooMuchDataError(
+                    _('The filters you selected include too much data. Please change your filters and try again')
+                )
             for row in results:
                 completion_time = (PhoneTime(row['time_end'], self.timezone)
                                    .server_time().done())

--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -109,7 +109,6 @@ class CompletionOrSubmissionTimeMixin(object):
 
 class CaseActivityReport(WorkerMonitoringCaseReportTableBase):
     """
-    todo move this to the cached version when ready
     User    Last 30 Days    Last 60 Days    Last 90 Days   Active Clients              Inactive Clients
     danny   5 (25%)         10 (50%)        20 (100%)       17                          6
     (name)  (modified_since(x)/[active + closed_since(x)])  (open & modified_since(120)) (open & !modified_since(120))


### PR DESCRIPTION
currently this does no pagination and you can very easily select 10,000+ rows (which seems like we should not allow)

also a couple small other bits of cleanup :blowfish: 

@benrudolph / anyone
