### PR TITLE
Allow searching for single strings

### DIFF
--- a/corehq/apps/es/domains.py
+++ b/corehq/apps/es/domains.py
@@ -79,7 +79,9 @@ def last_modified(gt=None, gte=None, lt=None, lte=None):
 
 
 def in_domains(domains):
-    return filters.term('name', list(domains))
+    if type(domains) is not list:
+        domains = [domains]
+    return filters.term('name', domains)
 
 
 def is_active(is_active=True):

--- a/corehq/apps/es/domains.py
+++ b/corehq/apps/es/domains.py
@@ -79,8 +79,6 @@ def last_modified(gt=None, gte=None, lt=None, lte=None):
 
 
 def in_domains(domains):
-    if type(domains) is not list:
-        domains = [domains]
     return filters.term('name', domains)
 
 


### PR DESCRIPTION
@esoergel 

previously:

``` py
>>> DomainES().in_domains('foo').filters
[{'match_all': {}}, {'terms': {'name': ['f', 'o', 'o']}}]
```

now:

``` py
>>> DomainES().in_domains('foo').filters
[{'match_all': {}}, {'terms': {'name': ['foo']}}]
```

code buddy: @orangejenny, 
code troll: @dannyroberts 
