### PR TITLE
Show deid-only exports only for deid-only users

### DIFF
--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -17,6 +17,7 @@ from corehq import privileges
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.app_manager.fields import ApplicationDataRMIHelper
 from corehq.apps.data_interfaces.dispatcher import require_can_edit_data
+from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.export.custom_export_helpers import make_custom_export_helper
 from corehq.apps.export.exceptions import (
     ExportNotFound,
@@ -86,6 +87,9 @@ class ExportsPermissionsMixin(object):
         users do not have the "view reports" permission, they should only be
         able to access deid reports.
     """
+    @property
+    def form_or_case(self):
+        raise NotImplementedError("Does this view operate on forms or cases?")
 
     @property
     def has_edit_permissions(self):
@@ -93,7 +97,15 @@ class ExportsPermissionsMixin(object):
 
     @property
     def has_view_permissions(self):
-        return self.request.couch_user.can_view_reports()
+        if self.form_or_case == 'form':
+            report_to_check = 'corehq.apps.reports.standard.export.ExcelExportReport'
+        elif self.form_or_case == 'case':
+            report_to_check = 'corehq.apps.reports.standard.export.CaseExportReport'
+        return (self.request.couch_user.can_view_reports()
+                or self.request.couch_user.has_permission(
+                    self.domain,
+                    get_permission_name(Permissions.view_report),
+                    data=report_to_check))
 
     @property
     def has_deid_view_permissions(self):
@@ -683,6 +695,7 @@ class DownloadFormExportView(BaseDownloadExportView):
     show_date_range = True
     page_title = ugettext_noop("Download Form Export")
     check_for_multimedia = True
+    form_or_case = 'form'
 
     @staticmethod
     def get_export_schema(export_id):
@@ -790,6 +803,7 @@ class DownloadCaseExportView(BaseDownloadExportView):
     """
     urlname = 'export_download_cases'
     page_title = ugettext_noop("Download Case Export")
+    form_or_case = 'case'
 
     @staticmethod
     def get_export_schema(export_id):
@@ -835,8 +849,10 @@ class BaseExportListView(ExportsPermissionsMixin, JSONResponseMixin, BaseProject
 
     @use_bootstrap3
     @use_select2
+    @method_decorator(login_and_domain_required)
     def dispatch(self, request, *args, **kwargs):
-        if not (self.has_edit_permissions or self.has_view_permissions):
+        if not (self.has_edit_permissions or self.has_view_permissions
+                or (self.is_deid and self.has_deid_view_permissions)):
             raise Http404()
         return super(BaseExportListView, self).dispatch(request, *args, **kwargs)
 
@@ -1026,6 +1042,7 @@ class BaseExportListView(ExportsPermissionsMixin, JSONResponseMixin, BaseProject
 class FormExportListView(BaseExportListView):
     urlname = 'list_form_exports'
     page_title = ugettext_noop("Export Forms")
+    form_or_case = 'form'
 
     @property
     def bulk_download_url(self):
@@ -1114,6 +1131,7 @@ class CaseExportListView(BaseExportListView):
     urlname = 'list_case_exports'
     page_title = ugettext_noop("Export Cases")
     allow_bulk_export = False
+    form_or_case = 'case'
 
     @property
     def page_name(self):

--- a/corehq/apps/hqwebapp/models.py
+++ b/corehq/apps/hqwebapp/models.py
@@ -34,6 +34,8 @@ from corehq.apps.indicators.utils import get_indicator_domains
 from corehq.apps.locations.analytics import users_have_locations
 from corehq.apps.smsbillables.dispatcher import SMSAdminInterfaceDispatcher
 from corehq.apps.userreports.util import has_report_builder_access
+from corehq.apps.users.decorators import get_permission_name
+from corehq.apps.users.models import Permissions
 from django_prbac.utils import has_privilege
 from corehq.util.markup import mark_up_urls
 
@@ -594,6 +596,18 @@ class ProjectDataTab(UITab):
 
     @property
     @memoized
+    def can_only_see_deid_exports(self):
+        from corehq.apps.export.views import user_can_view_deid_exports
+        return (not self.couch_user.can_view_reports()
+                and not self.couch_user.has_permission(
+                    self.domain,
+                    get_permission_name(Permissions.view_report),
+                    data='corehq.apps.reports.standard.export.ExcelExportReport'
+                )
+                and user_can_view_deid_exports(self.domain, self.couch_user))
+
+    @property
+    @memoized
     def can_use_lookup_tables(self):
         return domain_has_privilege(self.domain, privileges.LOOKUP_TABLES)
 
@@ -611,7 +625,20 @@ class ProjectDataTab(UITab):
         }
 
         export_data_views = []
-        if self.can_export_data:
+        if self.can_only_see_deid_exports:
+            from corehq.apps.export.views import DeIdFormExportListView, DownloadFormExportView
+            export_data_views.append({
+                'title': DeIdFormExportListView.page_title,
+                'url': reverse(DeIdFormExportListView.urlname,
+                               args=(self.domain,)),
+                'subpages': [
+                    {
+                        'title': DownloadFormExportView.page_title,
+                        'urlname': DownloadFormExportView.urlname,
+                    },
+                ]
+            })
+        elif self.can_export_data:
             from corehq.apps.export.views import (
                 FormExportListView,
                 CaseExportListView,
@@ -672,20 +699,6 @@ class ProjectDataTab(UITab):
                 },
             ])
 
-        from corehq.apps.export.views import user_can_view_deid_exports
-        if user_can_view_deid_exports(self.domain, self.couch_user):
-            from corehq.apps.export.views import DeIdFormExportListView, DownloadFormExportView
-            export_data_views.append({
-                'title': DeIdFormExportListView.page_title,
-                'url': reverse(DeIdFormExportListView.urlname,
-                               args=(self.domain,)),
-                'subpages': [
-                    {
-                        'title': DownloadFormExportView.page_title,
-                        'urlname': DownloadFormExportView.urlname,
-                    },
-                ]
-            })
         if export_data_views:
             items.append([_("Export Data"), export_data_views])
 
@@ -718,7 +731,7 @@ class ProjectDataTab(UITab):
 
     @property
     def dropdown_items(self):
-        if not self.can_export_data:
+        if self.can_only_see_deid_exports or not self.can_export_data:
             return []
         from corehq.apps.export.views import (
             FormExportListView,


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?188417
I tested this out locally with 4 categories of users:
- admin - can see all reports and edit interfaces
- read-only - can see all reports, but no edit interfaces
- specific report access - can see reports that they have access to - if that includes the forms export, then they don't see the deid-only exports page (as forms export supercedes it)
- deid-only - can only see deid-only report

@sravfeyn @biyeun
