### PR TITLE
rename the ESQuerySet used in the api module to ElasticAPIQuerySet

### DIFF
--- a/corehq/apps/api/es.py
+++ b/corehq/apps/api/es.py
@@ -499,7 +499,7 @@ class ReportXFormES(XFormES):
         return query
 
 
-class ESQuerySet(object):
+class ElasticAPIQuerySet(object):
     """
     An abstract representation of an elastic search query,
     modeled somewhat after Django's QuerySet but with
@@ -538,7 +538,7 @@ class ESQuerySet(object):
 
     def with_fields(self, es_client=None, payload=None, model=None):
         "Clones this queryset, optionally changing some fields"
-        return ESQuerySet(es_client=es_client or self.es_client,
+        return ElasticAPIQuerySet(es_client=es_client or self.es_client,
                           payload=payload or self.payload,
                           model=model or self.model)
         

--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -26,7 +26,7 @@ from corehq.apps.users.models import CouchUser, Permissions
 
 from corehq.apps.api.resources import v0_1, v0_3, HqBaseResource, DomainSpecificResourceMixin, \
     SimpleSortableResourceMixin
-from corehq.apps.api.es import XFormES, CaseES, ESQuerySet, es_search
+from corehq.apps.api.es import XFormES, CaseES, ElasticAPIQuerySet, es_search
 from corehq.apps.api.fields import ToManyDocumentsField, UseIfRequested, ToManyDictField, ToManyListDictField
 from corehq.apps.api.serializers import CommCareCaseSerializer
 
@@ -96,9 +96,11 @@ class XFormInstanceResource(SimpleSortableResourceMixin, v0_3.XFormInstanceResou
                 return doc
 
         # Note that XFormES is used only as an ES client, for `run_query` against the proper index
-        return ESQuerySet(payload=es_query,
-                          model=wrapper,
-                          es_client=self.xform_es(domain)).order_by('-received_on')
+        return ElasticAPIQuerySet(
+            payload=es_query,
+            model=wrapper,
+            es_client=self.xform_es(domain)).order_by('-received_on'
+        )
 
     class Meta(v0_3.XFormInstanceResource.Meta):
         ordering = ['received_on']
@@ -218,9 +220,11 @@ class CommCareCaseResource(SimpleSortableResourceMixin, v0_3.CommCareCaseResourc
             del query['size']
 
         # Note that CaseES is used only as an ES client, for `run_query` against the proper index
-        return ESQuerySet(payload=query,
-                          model=CommCareCase,
-                          es_client=self.case_es(domain)).order_by('server_modified_on')
+        return ElasticAPIQuerySet(
+            payload=query,
+            model=CommCareCase,
+            es_client=self.case_es(domain)
+        ).order_by('server_modified_on')
 
     class Meta(v0_3.CommCareCaseResource.Meta):
         max_limit = 100 # Today, takes ~25 seconds for some domains
@@ -426,9 +430,11 @@ class HOPECaseResource(CommCareCaseResource):
             del query['size']
 
         # Note that CaseES is used only as an ES client, for `run_query` against the proper index
-        return ESQuerySet(payload=query,
-                          model=HOPECase,
-                          es_client=self.case_es(domain)).order_by('server_modified_on')
+        return ElasticAPIQuerySet(
+            payload=query,
+            model=HOPECase,
+            es_client=self.case_es(domain)).order_by('server_modified_on',
+        )
 
     def alter_list_data_to_serialize(self, request, data):
 

--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -99,8 +99,8 @@ class XFormInstanceResource(SimpleSortableResourceMixin, v0_3.XFormInstanceResou
         return ElasticAPIQuerySet(
             payload=es_query,
             model=wrapper,
-            es_client=self.xform_es(domain)).order_by('-received_on'
-        )
+            es_client=self.xform_es(domain)
+        ).order_by('-received_on')
 
     class Meta(v0_3.XFormInstanceResource.Meta):
         ordering = ['received_on']
@@ -433,8 +433,8 @@ class HOPECaseResource(CommCareCaseResource):
         return ElasticAPIQuerySet(
             payload=query,
             model=HOPECase,
-            es_client=self.case_es(domain)).order_by('server_modified_on',
-        )
+            es_client=self.case_es(domain),
+        ).order_by('server_modified_on')
 
     def alter_list_data_to_serialize(self, request, data):
 

--- a/corehq/apps/api/tests.py
+++ b/corehq/apps/api/tests.py
@@ -29,10 +29,9 @@ from corehq.pillows.case import CasePillow
 from corehq.apps.users.models import CommCareUser, WebUser
 from corehq.apps.domain.models import Domain
 from corehq.apps.repeaters.models import FormRepeater, CaseRepeater, ShortFormRepeater
-from corehq.apps.api.resources import v0_1, v0_4, v0_5
+from corehq.apps.api.resources import v0_4, v0_5
 from corehq.apps.api.fields import ToManyDocumentsField, ToOneDocumentField, UseIfRequested, ToManyDictField
-from corehq.apps.api import es
-from corehq.apps.api.es import ElasticAPIQuerySet, ESUserError
+from corehq.apps.api.es import ElasticAPIQuerySet
 from corehq.apps.users.analytics import update_analytics_indexes
 from django.conf import settings
 from custom.hope.models import CC_BIHAR_PREGNANCY

--- a/corehq/apps/api/tests.py
+++ b/corehq/apps/api/tests.py
@@ -32,7 +32,7 @@ from corehq.apps.repeaters.models import FormRepeater, CaseRepeater, ShortFormRe
 from corehq.apps.api.resources import v0_1, v0_4, v0_5
 from corehq.apps.api.fields import ToManyDocumentsField, ToOneDocumentField, UseIfRequested, ToManyDictField
 from corehq.apps.api import es
-from corehq.apps.api.es import ESQuerySet, ESUserError
+from corehq.apps.api.es import ElasticAPIQuerySet, ESUserError
 from corehq.apps.users.analytics import update_analytics_indexes
 from django.conf import settings
 from custom.hope.models import CC_BIHAR_PREGNANCY
@@ -762,9 +762,9 @@ class TestReportPillow(TestCase):
             self.assertTrue(cleaned['form']['meta']['appVersion'], "CCODK:\"2.5.1\"(11126). v236 CC2.5b[11126] on April-15-2013")
 
 
-class TestESQuerySet(TestCase):
+class TestElasticAPIQuerySet(TestCase):
     '''
-    Tests the ESQuerySet for appropriate slicing, etc
+    Tests the ElasticAPIQuerySet for appropriate slicing, etc
     '''
 
     def test_slice(self):
@@ -772,21 +772,21 @@ class TestESQuerySet(TestCase):
         for i in xrange(0, 1300):
             es.add_doc(i, {'i': i})
         
-        queryset = ESQuerySet(es_client=es, payload={})
+        queryset = ElasticAPIQuerySet(es_client=es, payload={})
         qs_slice = list(queryset[3:7])
 
         self.assertEqual(es.queries[0]['from'], 3)
         self.assertEqual(es.queries[0]['size'], 4)
         self.assertEqual(len(qs_slice), 4)
 
-        queryset = ESQuerySet(es_client=es, payload={})
+        queryset = ElasticAPIQuerySet(es_client=es, payload={})
         qs_slice = list(queryset[10:20])
 
         self.assertEqual(es.queries[1]['from'], 10)
         self.assertEqual(es.queries[1]['size'], 10)
         self.assertEqual(len(qs_slice), 10)
 
-        queryset = ESQuerySet(es_client=es, payload={})
+        queryset = ElasticAPIQuerySet(es_client=es, payload={})
         qs_slice = list(queryset[500:1000])
         
         self.assertEqual(es.queries[2]['from'], 500)
@@ -798,7 +798,7 @@ class TestESQuerySet(TestCase):
         for i in xrange(0, 1300):
             es.add_doc(i, {'i': i})
         
-        queryset = ESQuerySet(es_client=es, payload={})
+        queryset = ElasticAPIQuerySet(es_client=es, payload={})
         qs_asc = list(queryset.order_by('foo'))
         self.assertEqual(es.queries[0]['sort'], [{'foo': 'asc'}])
 


### PR DESCRIPTION
this was pretty confusing since there's also [this `ESQuerySet`](https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/es/es_query.py#L331)

@esoergel @snopoke @benrudolph 

wait for tests
