### PR TITLE
redirect to xlsx export when there are too many rows for xls

### DIFF
--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -699,6 +699,18 @@ def export_data_source(request, domain, config_id):
     for sql_filter in params.sql_filters:
         q = q.filter(sql_filter)
 
+    # xls format has limit of 65536 rows
+    # First row is taken up by headers
+    if params.format == 'xls' and q.count() >= 65535:
+        keyword_params = dict(**request.GET)
+        keyword_params.update(format='xlsx')
+        return HttpResponseRedirect(
+            '%s?%s' % (
+                reverse('export_configurable_data_source', args=[domain, config._id]),
+                urlencode(keyword_params)
+            )
+        )
+
     # build export
     def get_table(q):
         yield table.columns.keys()


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?189139

@czue @esoergel cc: @kaapstorm 

It would be nice if there was an alert to the user that the export format was changed (it's not clear what page would even be appropriate for that warning since not all users can see the data source config editor), but this covers a good 80% of the use case with 20% of the effort.
