### PR TITLE
connect to swiss server via ubuntu@185.12.7.167

### DIFF
--- a/fab/inventory/swiss
+++ b/fab/inventory/swiss
@@ -1,42 +1,42 @@
 [proxy]
-185.12.7.167
+ubuntu@185.12.7.167
 
 [webworkers]
-185.12.7.167
+ubuntu@185.12.7.167
 
 [couchdb]
-185.12.7.167
+ubuntu@185.12.7.167
 
 [postgresql]
-185.12.7.167
+ubuntu@185.12.7.167
 
 [rabbitmq]
-185.12.7.167
+ubuntu@185.12.7.167
 
 [zookeeper]
-185.12.7.167
+ubuntu@185.12.7.167
 
 [kafka]
-185.12.7.167 kafka_broker_id=0
+ubuntu@185.12.7.167 kafka_broker_id=0
 
 
 [celery]
 # ansible makes the first thing in this list the flower url
 # a little bit redundant with with more explicit settings in environments.yml
 # but ansible doesn't currently have access to that
-185.12.7.167
+ubuntu@185.12.7.167
 
 [pillowtop]
-185.12.7.167
+ubuntu@185.12.7.167
 
 [touchforms]
-185.12.7.167
+ubuntu@185.12.7.167
 
 [redis]
-185.12.7.167
+ubuntu@185.12.7.167
 
 [elasticsearch]
-185.12.7.167 elasticsearch_node_name=hqes1
+ubuntu@185.12.7.167 elasticsearch_node_name=hqes1
 
 [shared_dir_host]
-185.12.7.167
+ubuntu@185.12.7.167


### PR DESCRIPTION
I use `ssh ubuntu@185.12.7.167` to connect, so it seems that I need this prefix to deploy the stack via ansible.

@TylerSheffels @dannyroberts 
