### PR TITLE
Kill hqmedia tags

### DIFF
--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from itertools import imap
-import json
 import uuid
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
@@ -840,21 +839,6 @@ class Domain(Document, SnapshotMixin):
             return cls.view('domain/published_snapshots', startkey=[False, {}], include_docs=True, descending=True, limit=limit, skip=skip)
         else:
             return cls.view('domain/published_snapshots', endkey=[True], include_docs=True, descending=True, limit=limit, skip=skip)
-
-    @classmethod
-    def snapshot_search(cls, query, page=None, per_page=10):
-        skip = None
-        limit = None
-        if page:
-            skip = (page - 1) * per_page
-            limit = per_page
-        results = cls.get_db().search('domain/snapshot_search',
-            q=json.dumps(query),
-            limit=limit,
-            skip=skip,
-            #stale='ok',
-        )
-        return map(cls.get, [r['id'] for r in results]), results.total_rows
 
     def update_deployment(self, **kwargs):
         self.deployment.update(kwargs)

--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -229,15 +229,6 @@ class CommCareMultimedia(SafeSaveDocument):
         return cls.get_by_hash(file_hash)
 
     @classmethod
-    def search(cls, query, limit=10):
-        results = get_db().search(cls.Config.search_view,
-            q=query,
-            limit=limit,
-            #stale='ok',
-        )
-        return map(cls.get, [r['id'] for r in results])
-
-    @classmethod
     def get_doc_class(cls, doc_type):
         return {
             'CommCareImage': CommCareImage,

--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -229,10 +229,6 @@ class CommCareMultimedia(SafeSaveDocument):
         return cls.get_by_hash(file_hash)
 
     @classmethod
-    def all_tags(cls):
-        return [d['key'] for d in cls.view('hqmedia/tags', group=True).all()]
-
-    @classmethod
     def search(cls, query, limit=10):
         results = get_db().search(cls.Config.search_view,
             q=query,

--- a/corehq/apps/hqmedia/urls.py
+++ b/corehq/apps/hqmedia/urls.py
@@ -32,8 +32,6 @@ application_urls = patterns('corehq.apps.hqmedia.views',
         name=ProcessTextFileUploadView.name),
     url(r'^remove_logo/$', RemoveLogoView.as_view(), name=RemoveLogoView.name),
     url(r'^map/$', MultimediaReferencesView.as_view(), name=MultimediaReferencesView.name),
-    url(r'^search/$', 'search_for_media', name='hqmedia_search'),
-    url(r'^choose/$', 'choose_media', name='hqmedia_choose_media'),
 )
 
 download_urls = patterns('corehq.apps.hqmedia.views',


### PR DESCRIPTION
This is a few different pieces of random cleanup, but the first commit was my main goal: getting rid of the last usage of `hqmedia/tags`. For fun, I'd like to share the entire contents (reduced) of that view in production for the world to see:

| key | value |
| --- | --- |
| "speaker" | 1 |
| "analyze_think" | 1 |
| "analyze" | 1 |
| "" | 1950 |
