### PR TITLE
App-aware sync

### DIFF
--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -32,11 +32,11 @@ class ReportFixturesProvider(object):
         if not toggles.MOBILE_UCR.enabled(user.domain):
             return []
 
+        apps = [app] if app else (a for a in get_apps_in_domain(user.domain, include_remote=False))
         report_configs = [
             report_config
-            for app in get_apps_in_domain(user.domain) if isinstance(app, Application)
-            # TODO: pass app_id to reduce size of fixture
-            for module in app.modules if isinstance(module, ReportModule)
+            for app_ in apps
+            for module in app_.modules if isinstance(module, ReportModule)
             for report_config in module.report_configs
         ]
         if not report_configs:

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -23,7 +23,7 @@ from corehq.apps.userreports.reports.util import (
 class ReportFixturesProvider(object):
     id = 'commcare:reports'
 
-    def __call__(self, user, version, last_sync=None):
+    def __call__(self, user, version, last_sync=None, app=None):
         """
         Generates a report fixture for mobile that can be used by a report module
         """

--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -18,6 +18,7 @@ from corehq.apps.userreports.reports.util import (
     get_expanded_columns,
     get_total_row,
 )
+from corehq.apps.app_manager.dbaccessors import get_apps_in_domain
 
 
 class ReportFixturesProvider(object):
@@ -27,8 +28,6 @@ class ReportFixturesProvider(object):
         """
         Generates a report fixture for mobile that can be used by a report module
         """
-        # delay import so that get_apps_in_domain is mockable
-        from corehq.apps.app_manager.dbaccessors import get_apps_in_domain
         if not toggles.MOBILE_UCR.enabled(user.domain):
             return []
 

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -82,6 +82,7 @@ from corehq.apps.app_manager.util import (
     actions_use_usercase,
     update_unique_ids,
     app_callout_templates,
+    use_app_aware_sync,
 )
 from corehq.apps.app_manager.xform import XForm, parse_xml as _parse_xml, \
     validate_xform
@@ -4047,7 +4048,9 @@ class ApplicationBase(VersionedDoc, SnapshotMixin,
 
     @absolute_url_property
     def ota_restore_url(self):
-        return reverse('corehq.apps.ota.views.restore', args=[self.domain])
+        if use_app_aware_sync(self):
+            return reverse('app_aware_restore', args=[self.domain, self._id])
+        return reverse('ota_restore', args=[self.domain])
 
     @absolute_url_property
     def form_record_url(self):

--- a/corehq/apps/app_manager/tests/test_report_config.py
+++ b/corehq/apps/app_manager/tests/test_report_config.py
@@ -130,8 +130,8 @@ class ReportFiltersSuiteTest(SimpleTestCase, TestXmlMixin):
         ]
         with mock_report_data(cls.data):
             with mock_report_configuration_get(cls.report_configs_by_id):
-                with mock.patch('corehq.apps.app_manager.dbaccessors.get_apps_in_domain',
-                                lambda domain: [cls.app]):
+                with mock.patch('corehq.apps.app_manager.fixtures.mobile_ucr.get_apps_in_domain',
+                                lambda domain, include_remote: [cls.app]):
                     fixture, = report_fixture_generator(cls.user, '2.0')
         cls.fixture = ElementTree.tostring(fixture)
 

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -6,6 +6,7 @@ import itertools
 import os
 import uuid
 import yaml
+from corehq import toggles
 from corehq.apps.app_manager.exceptions import SuiteError
 from corehq.apps.builds.models import CommCareBuildConfig
 from corehq.apps.app_manager.tasks import create_user_cases
@@ -604,3 +605,10 @@ def _app_callout_templates():
     while True:
         yield data
 app_callout_templates = _app_callout_templates()
+
+
+def use_app_aware_sync(app):
+    """
+    Determines whether OTA restore should sync only cases/ledgers/fixtures of the given app where possible
+    """
+    return toggles.APP_AWARE_SYNC.enabled(app.domain)

--- a/corehq/apps/callcenter/fixturegenerators.py
+++ b/corehq/apps/callcenter/fixturegenerators.py
@@ -45,7 +45,7 @@ def should_sync(domain, last_sync, utcnow=None):
 class IndicatorsFixturesProvider(object):
     id = 'indicators'
 
-    def __call__(self, user, version, last_sync=None):
+    def __call__(self, user, version, last_sync=None, app=None):
         assert isinstance(user, CommCareUser)
 
         domain = user.project

--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -48,7 +48,7 @@ def item_lists_by_domain(domain):
 class ItemListsProvider(object):
     id = 'item-list'
 
-    def __call__(self, user, version, last_sync=None):
+    def __call__(self, user, version, last_sync=None, app=None):
         assert isinstance(user, CommCareUser)
 
         all_types = dict([(t._id, t) for t in FixtureDataType.by_domain(user.domain)])

--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -59,7 +59,7 @@ def should_sync_locations(last_sync, location_db, user):
 class LocationFixtureProvider(object):
     id = 'commtrack:locations'
 
-    def __call__(self, user, version, last_sync=None):
+    def __call__(self, user, version, last_sync=None, app=None):
         """
         By default this will generate a fixture for the users
         location and it's "footprint", meaning the path

--- a/corehq/apps/ota/tests/__init__.py
+++ b/corehq/apps/ota/tests/__init__.py
@@ -1,1 +1,2 @@
 from .digest_restore import *
+from .app_aware_restore import *

--- a/corehq/apps/ota/tests/app_aware_restore.py
+++ b/corehq/apps/ota/tests/app_aware_restore.py
@@ -68,6 +68,9 @@ class AppAwareSyncTests(TestCase):
         module.report_configs = [ReportAppConfig.wrap(report_app_config)]
         cls.app2.save()
 
+        cls.app3 = Application.new_app(cls.domain, 'Test App 3', application_version=APP_V2)
+        cls.app3.save()
+
     @classmethod
     def tearDownClass(cls):
         toggles.MOBILE_UCR.set(cls.domain, False, toggles.NAMESPACE_DOMAIN)
@@ -103,3 +106,10 @@ class AppAwareSyncTests(TestCase):
         reports = fixtures[0].findall('.//report')
         self.assertEqual(len(reports), 1)
         self.assertEqual(reports[0].attrib.get('id'), '123456')
+
+    def test_report_fixtures_provider_with_app_that_doesnt_have_reports(self):
+        from corehq.apps.userreports.reports.data_source import ConfigurableReportDataSource
+        with patch.object(ConfigurableReportDataSource, 'get_data') as get_data_mock:
+            get_data_mock.return_value = self.rows
+            fixtures = report_fixture_generator(self.user, '2.0', None, app=self.app3)
+        self.assertEqual(len(fixtures), 0)

--- a/corehq/apps/ota/tests/app_aware_restore.py
+++ b/corehq/apps/ota/tests/app_aware_restore.py
@@ -11,6 +11,27 @@ from corehq.apps.userreports.tests import get_sample_report_config
 from corehq.apps.users.models import CommCareUser
 
 
+class OtaRestoreUrlTests(TestCase):
+    domain = 'test_domain'
+
+    @classmethod
+    def setUpClass(cls):
+        cls.app = Application.new_app(cls.domain, 'Test App', application_version=APP_V2)
+        cls.app.save()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.app.delete()
+
+    def test_app_aware_url(self):
+        toggles.APP_AWARE_SYNC.set(self.domain, True, toggles.NAMESPACE_DOMAIN)
+        self.assertIn(self.app._id, self.app.ota_restore_url)
+
+    def test_default_url(self):
+        toggles.APP_AWARE_SYNC.set(self.domain, False, toggles.NAMESPACE_DOMAIN)
+        self.assertNotIn(self.app._id, self.app.ota_restore_url)
+
+
 class AppAwareSyncTests(TestCase):
     domain = 'test_domain'
     rows = [{

--- a/corehq/apps/ota/tests/app_aware_restore.py
+++ b/corehq/apps/ota/tests/app_aware_restore.py
@@ -1,0 +1,84 @@
+from django.test import TestCase
+from mock import patch
+
+from corehq import toggles
+from corehq.apps.app_manager.const import APP_V2
+from corehq.apps.app_manager.fixtures.mobile_ucr import report_fixture_generator
+from corehq.apps.app_manager.models import Application, ReportModule, ReportAppConfig
+from corehq.apps.domain.models import Domain
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.apps.userreports.tests import get_sample_report_config
+from corehq.apps.users.models import CommCareUser
+
+
+class AppAwareSyncTests(TestCase):
+    domain = 'test_domain'
+    rows = [{
+        'owner': 'bob',
+        'count': 3,
+        'is_starred': True
+    }]
+
+    @classmethod
+    def setUpClass(cls):
+        create_domain(cls.domain)
+        toggles.MOBILE_UCR.set(cls.domain, True, toggles.NAMESPACE_DOMAIN)
+        cls.user = CommCareUser.create(cls.domain, 'john_doe', 's3cr3t')
+
+        cls.app1 = Application.new_app(cls.domain, 'Test App 1', application_version=APP_V2)
+        cls.report_config1 = get_sample_report_config()
+        cls.report_config1.save()
+        report_app_config = {
+            'report_id': cls.report_config1.get_id,
+            'uuid': '123456'
+        }
+        module = cls.app1.add_module(ReportModule.new_module('Reports', None))
+        module.report_configs = [ReportAppConfig.wrap(report_app_config)]
+        cls.app1.save()
+
+        cls.app2 = Application.new_app(cls.domain, 'Test App 2', application_version=APP_V2)
+        cls.report_config2 = get_sample_report_config()
+        cls.report_config2.save()
+        report_app_config = {
+            'report_id': cls.report_config2.get_id,
+            'uuid': 'abcdef'
+        }
+        module = cls.app2.add_module(ReportModule.new_module('Reports', None))
+        module.report_configs = [ReportAppConfig.wrap(report_app_config)]
+        cls.app2.save()
+
+    @classmethod
+    def tearDownClass(cls):
+        toggles.MOBILE_UCR.set(cls.domain, False, toggles.NAMESPACE_DOMAIN)
+        cls.app1.delete()
+        cls.report_config1.delete()
+        cls.app2.delete()
+        cls.report_config2.delete()
+        cls.user.delete()
+        domain = Domain.get_by_name(cls.domain)
+        domain.delete()
+
+    def test_report_fixtures_provider_without_app(self):
+        """
+        ReportFixturesProvider should iterate all apps if app not given
+        """
+        from corehq.apps.userreports.reports.data_source import ConfigurableReportDataSource
+        with patch.object(ConfigurableReportDataSource, 'get_data') as get_data_mock:
+            get_data_mock.return_value = self.rows
+            fixtures = report_fixture_generator(self.user, '2.0', None)
+        reports = fixtures[0].findall('.//report')
+        self.assertEqual(len(reports), 2)
+        report_ids = {r.attrib.get('id') for r in reports}
+        self.assertEqual(report_ids, {'123456', 'abcdef'})
+
+    def test_report_fixtures_provider_with_app(self):
+        """
+        ReportFixturesProvider should not iterate all apps if app given
+        """
+        from corehq.apps.userreports.reports.data_source import ConfigurableReportDataSource
+        with patch.object(ConfigurableReportDataSource, 'get_data') as get_data_mock:
+            get_data_mock.return_value = self.rows
+            fixtures = report_fixture_generator(self.user, '2.0', None, app=self.app1)
+        reports = fixtures[0].findall('.//report')
+        self.assertEqual(len(reports), 1)
+        self.assertEqual(reports[0].attrib.get('id'), '123456')

--- a/corehq/apps/ota/urls.py
+++ b/corehq/apps/ota/urls.py
@@ -3,6 +3,7 @@ from corehq.apps.ota.views import PrimeRestoreCacheView
 
 
 urlpatterns = patterns('corehq.apps.ota.views',
-    url(r'^restore/$', 'restore'),
+    url(r'^restore/$', 'restore', name='ota_restore'),
+    url(r'^restore/(?P<app_id>[\w-]+)/$', 'restore', name='app_aware_restore'),
     url(r'^prime_restore/$', PrimeRestoreCacheView.as_view(), name=PrimeRestoreCacheView.urlname),
 )

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -63,13 +63,13 @@ def get_restore_response(domain, couch_user, app_id=None, since=None, version='1
     restore_config = RestoreConfig(
         project=project,
         user=couch_user.to_casexml_user(),
-        app=app,
         params=RestoreParams(
             sync_log_id=since,
             version=version,
             state_hash=state,
             include_item_count=items,
             force_restore_mode=force_restore_mode,
+            app=app,
         ),
         cache_settings=RestoreCacheSettings(
             force_cache=force_cache,

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -4,6 +4,7 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext_noop
 from casexml.apps.case.xml import V2
 from corehq import toggles
+from corehq.apps.app_manager.models import Application
 from corehq.apps.domain.decorators import domain_admin_required, login_or_digest_or_basic_or_apikey
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.views import DomainViewMixin, EditMyProjectSettingsView
@@ -21,14 +22,14 @@ from soil import DownloadBase
 
 @json_error
 @login_or_digest_or_basic_or_apikey()
-def restore(request, domain):
+def restore(request, domain, app_id=None):
     """
     We override restore because we have to supply our own 
     user model (and have the domain in the url)
     """
     user = request.user
     couch_user = CouchUser.from_django_user(user)
-    return get_restore_response(domain, couch_user, **get_restore_params(request))
+    return get_restore_response(domain, couch_user, app_id, **get_restore_params(request))
 
 
 def get_restore_params(request):
@@ -41,11 +42,11 @@ def get_restore_params(request):
         'version': request.GET.get('version', "1.0"),
         'state': request.GET.get('state'),
         'items': request.GET.get('items') == 'true',
-        'force_restore_mode': request.GET.get('mode', None)
+        'force_restore_mode': request.GET.get('mode')
     }
 
 
-def get_restore_response(domain, couch_user, since=None, version='1.0',
+def get_restore_response(domain, couch_user, app_id=None, since=None, version='1.0',
                          state=None, items=False, force_cache=False,
                          cache_timeout=None, overwrite_cache=False,
                          force_restore_mode=None):
@@ -58,9 +59,11 @@ def get_restore_response(domain, couch_user, since=None, version='1.0',
                             status=401)
 
     project = Domain.get_by_name(domain)
+    app = Application.get_db().get(app_id) if app_id else None
     restore_config = RestoreConfig(
         project=project,
         user=couch_user.to_casexml_user(),
+        app=app,
         params=RestoreParams(
             sync_log_id=since,
             version=version,

--- a/corehq/apps/products/fixtures.py
+++ b/corehq/apps/products/fixtures.py
@@ -51,7 +51,7 @@ def product_fixture_generator_json(domain):
 class ProductFixturesProvider(object):
     id = 'commtrack:products'
 
-    def __call__(self, user, version, last_sync=None):
+    def __call__(self, user, version, last_sync=None, app=None):
 
         def get_products():
             return sorted(

--- a/corehq/apps/programs/fixtures.py
+++ b/corehq/apps/programs/fixtures.py
@@ -33,7 +33,7 @@ def program_fixture_generator_json(domain):
 class ProgramFixturesProvider(object):
     id = 'commtrack:programs'
 
-    def __call__(self, user, version, last_sync=None):
+    def __call__(self, user, version, last_sync=None, app=None):
         data_fn = lambda: Program.by_domain(user.domain)
         return _simple_fixture_generator(user, self.id, "program",
                                          PROGRAM_FIELDS, data_fn, last_sync)

--- a/corehq/apps/users/fixturegenerators.py
+++ b/corehq/apps/users/fixturegenerators.py
@@ -10,7 +10,7 @@ class UserGroupsFixtureProvider(object):
 
     id = 'user-groups'
 
-    def __call__(self, user, version, last_sync=None):
+    def __call__(self, user, version, last_sync=None, app=None):
         """
         For a given user, return a fixture containing all the groups
         they are a part of.

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/standard.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/standard.py
@@ -45,6 +45,7 @@ class FixtureElementProvider(RestoreDataProvider):
         for fixture in generator.get_fixtures(
             restore_state.user,
             restore_state.version,
-            restore_state.last_sync_log
+            restore_state.last_sync_log,
+            restore_state.app
         ):
             yield fixture

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/standard.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/standard.py
@@ -46,6 +46,6 @@ class FixtureElementProvider(RestoreDataProvider):
             restore_state.user,
             restore_state.version,
             restore_state.last_sync_log,
-            restore_state.app
+            restore_state.params.app
         ):
             yield fixture

--- a/corehq/ex-submodules/casexml/apps/phone/fixtures.py
+++ b/corehq/ex-submodules/casexml/apps/phone/fixtures.py
@@ -45,7 +45,7 @@ class FixtureGenerator(object):
                     to_function(func_path) for func_path in func_paths
                 ])
 
-    def _get_fixtures(self, group, fixture_id, user, version, last_sync):
+    def _get_fixtures(self, group, fixture_id, user, version, last_sync, app):
         if version == V1:
             return []  # V1 phones will never use or want fixtures
 
@@ -71,23 +71,23 @@ class FixtureGenerator(object):
 
             providers = [provider for provider in providers if provider_matches(provider)]
 
-        return itertools.chain(*[provider(user, version, last_sync)
+        return itertools.chain(*[provider(user, version, last_sync, app)
                                  for provider in providers])
 
     def get_fixture_by_id(self, fixture_id, user, version, last_sync=None):
         """
         Only get fixtures with the specified ID.
         """
-        fixtures = self._get_fixtures(None, fixture_id, user, version, last_sync)
+        fixtures = self._get_fixtures(None, fixture_id, user, version, last_sync, None)
         for fixture in fixtures:
             if fixture.attrib.get("id") == fixture_id:
                 return fixture
 
-    def get_fixtures(self, user, version, last_sync=None, group=None):
+    def get_fixtures(self, user, version, last_sync=None, group=None, app=None):
         """
         Gets all fixtures associated with an OTA restore operation
         """
-        return self._get_fixtures(group, None, user, version, last_sync)
+        return self._get_fixtures(group, None, user, version, last_sync, app)
 
 
 generator = FixtureGenerator()

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -298,13 +298,14 @@ class RestoreState(object):
     """
     restore_class = FileRestoreResponse
 
-    def __init__(self, project, user, params):
+    def __init__(self, project, user, app, params):
         self.project = project
         self.domain = project.name if project else ''
         _assert = soft_assert(to=['czue' + '@' + 'dimagi.com'], fail_if_debug=True)
         _assert(self.domain, 'Restore for {} missing a domain!'.format(user.username))
 
         self.user = user
+        self.app = app
         self.params = params
         self.provider_log = {}  # individual data providers can log stuff here
         # get set in the start_sync() function
@@ -441,15 +442,16 @@ class RestoreConfig(object):
     :param cache_settings:  The RestoreCacheSettings associated with this (see above).
     """
 
-    def __init__(self, project=None, user=None, params=None, cache_settings=None):
+    def __init__(self, project=None, user=None, app=None, params=None, cache_settings=None):
         self.project = project
         self.domain = project.name if project else ''
         self.user = user
+        self.app = app
         self.params = params or RestoreParams()
         self.cache_settings = cache_settings or RestoreCacheSettings()
 
         self.version = self.params.version
-        self.restore_state = RestoreState(self.project, self.user, self.params)
+        self.restore_state = RestoreState(self.project, self.user, self.app, self.params)
 
         self.force_cache = self.cache_settings.force_cache
         self.cache_timeout = self.cache_settings.cache_timeout

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -265,12 +265,13 @@ class RestoreParams(object):
     """
 
     def __init__(self, sync_log_id='', version=V1, state_hash='', include_item_count=False,
-                 force_restore_mode=None):
+                 force_restore_mode=None, app=None):
         self.sync_log_id = sync_log_id
         self.version = version
         self.state_hash = state_hash
         self.include_item_count = include_item_count
         self.force_restore_mode = force_restore_mode
+        self.app = app
 
 
 class RestoreCacheSettings(object):
@@ -298,14 +299,13 @@ class RestoreState(object):
     """
     restore_class = FileRestoreResponse
 
-    def __init__(self, project, user, app, params):
+    def __init__(self, project, user, params):
         self.project = project
         self.domain = project.name if project else ''
         _assert = soft_assert(to=['czue' + '@' + 'dimagi.com'], fail_if_debug=True)
         _assert(self.domain, 'Restore for {} missing a domain!'.format(user.username))
 
         self.user = user
-        self.app = app
         self.params = params
         self.provider_log = {}  # individual data providers can log stuff here
         # get set in the start_sync() function
@@ -442,16 +442,15 @@ class RestoreConfig(object):
     :param cache_settings:  The RestoreCacheSettings associated with this (see above).
     """
 
-    def __init__(self, project=None, user=None, app=None, params=None, cache_settings=None):
+    def __init__(self, project=None, user=None, params=None, cache_settings=None):
         self.project = project
         self.domain = project.name if project else ''
         self.user = user
-        self.app = app
         self.params = params or RestoreParams()
         self.cache_settings = cache_settings or RestoreCacheSettings()
 
         self.version = self.params.version
-        self.restore_state = RestoreState(self.project, self.user, self.app, self.params)
+        self.restore_state = RestoreState(self.project, self.user, self.params)
 
         self.force_cache = self.cache_settings.force_cache
         self.cache_timeout = self.cache_settings.cache_timeout

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -169,6 +169,13 @@ APP_BUILDER_SHADOW_MODULES = StaticToggle(
     help_link='https://confluence.dimagi.com/display/ccinternal/Shadow+Modules',
 )
 
+APP_AWARE_SYNC = StaticToggle(
+    'app_aware_sync',
+    'App-aware Sync',
+    TAG_PRODUCT_PATH,
+    [NAMESPACE_DOMAIN]
+)
+
 BOOTSTRAP3_PREVIEW = StaticToggle(
     'bootstrap3_preview',
     'Bootstrap 3 Preview',

--- a/custom/bihar/reports/indicators/fixtures.py
+++ b/custom/bihar/reports/indicators/fixtures.py
@@ -15,7 +15,7 @@ hard_coded_fixture_id = 'indicators:bihar-supervisor'
 class IndicatorFixtureProvider(object):
     id = hard_coded_fixture_id
 
-    def __call__(self, user, version, last_sync=None):
+    def __call__(self, user, version, last_sync=None, app=None):
         if user.domain in hard_coded_domains:
             groups = filter(hard_coded_group_filter, Group.by_user(user))
             if len(groups) == 1:

--- a/custom/m4change/fixtures/location_fixtures.py
+++ b/custom/m4change/fixtures/location_fixtures.py
@@ -8,7 +8,7 @@ from lxml import etree as ElementTree
 class LocationFixtureProvider(object):
     id = 'user-locations'
 
-    def __call__(self, user, version, last_sync=None):
+    def __call__(self, user, version, last_sync=None, app=None):
         if user.domain in M4CHANGE_DOMAINS:
             domain = Domain.get_by_name(user.domain)
             location_id = get_commtrack_location_id(user, domain)

--- a/custom/m4change/fixtures/report_fixtures.py
+++ b/custom/m4change/fixtures/report_fixtures.py
@@ -36,7 +36,7 @@ def get_last_day_of_month(month_start, today):
 class ReportFixtureProvider(object):
     id = 'reports:m4change-mobile'
 
-    def __call__(self, user, version, last_sync=None):
+    def __call__(self, user, version, last_sync=None, app=None):
         if user.domain in M4CHANGE_DOMAINS:
             domain = Domain.get_by_name(user.domain)
             location_id = get_commtrack_location_id(user, domain)


### PR DESCRIPTION
This is just what's required for app-aware sync of UCR fixtures, so, the bare minimum at this stage. (cf. [Spec](https://docs.google.com/document/d/1RzoiFX4GE7tOndhWIPtTI_BBwSBWc9ueGiCl50EOpH0/edit#)) 

Still to be done:
- tests
- auto-detect whether fixtures/ledgers/cases are only used in one app instead of using a toggle
- support for more kinds of data than just UCR fixtures

Might be easier to review per commit.

@czue @snopoke cc @nickpell 
