### PR TITLE
do not error when trying to sort a boolean column

### DIFF
--- a/corehq/apps/userreports/reports/data_source.py
+++ b/corehq/apps/userreports/reports/data_source.py
@@ -174,7 +174,7 @@ class ConfigurableReportDataSource(SqlData):
                                     'num_matching': len(matching_indicators),
                                 }
                             )
-                        return matching_indicators[0]['datatype']
+                        return matching_indicators[0].get('datatype')
 
                     datatype = get_datatype(matching_report_column)
 


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?189220

@esoergel @czue 

Defaults an empty boolean field to sort as if it were `None`

```
>>> sorted([True, False, None])
[None, False, True]
```
