### PR TITLE
don't fail hard if XML can't be found

### DIFF
--- a/corehq/apps/reports/templatetags/xform_tags.py
+++ b/corehq/apps/reports/templatetags/xform_tags.py
@@ -34,9 +34,10 @@ register = template.Library()
 
 @register.simple_tag
 def render_form_xml(form):
-    xml = form.get_xml() or ''
+    xml = form.get_xml()
+    formatted_xml = indent_xml(xml) if xml else ''
     return '<pre class="fancy-code prettyprint linenums"><code class="language-xml">%s</code></pre>' \
-           % escape(indent_xml(xml))
+           % escape(formatted_xml)
 
 
 


### PR DESCRIPTION
@benrudolph noticed this locally when I had just copied over a form json.
