### PR TITLE
[ci skip] add domain to app dependencies

### DIFF
--- a/corehq/tests/app_test_db_dependencies.yml
+++ b/corehq/tests/app_test_db_dependencies.yml
@@ -8,6 +8,7 @@
 pillowtop: []
 testapps.test_elasticsearch: []
 testapps.test_pillowtop:
+  - corehq.apps.domain
   - corehq.apps.users
   - couchforms
 casexml.apps.phone:


### PR DESCRIPTION
this seems to be required when we have any pillows that point at a model with its own db

@dannyroberts @esoergel cc @benrudolph / anyone (no tests)
