### PR TITLE
Make current language available for suite file calculations

### DIFF
--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -30,11 +30,12 @@ def _create_custom_app_strings(app, lang, for_default=False):
     yield 'cchq.case', "Case"
     yield 'cchq.referral', "Referral"
 
-    # include language code names
+    # include language code names and current language
     for lc in app.langs:
         name = langcodes.get_name(lc) or lc
         if name:
             yield lc, name
+    yield id_strings.current_language(), lang
 
     for module in app.get_modules():
         for detail_type, detail, _ in module.get_details():

--- a/corehq/apps/app_manager/detail_screen.py
+++ b/corehq/apps/app_manager/detail_screen.py
@@ -114,7 +114,7 @@ class FormattedDetailColumn(object):
         )
         return header
 
-    variables = {}
+    variables = None
 
     @property
     def template(self):
@@ -318,7 +318,7 @@ class Enum(FormattedDetailColumn):
 
     @property
     def variables(self):
-        variables = super(Enum, self).variables
+        variables = {}
         for item in self.column.enum:
             v_key = item.key_as_variable
             v_val = self.id_strings.detail_column_enum_variable(

--- a/corehq/apps/app_manager/detail_screen.py
+++ b/corehq/apps/app_manager/detail_screen.py
@@ -12,6 +12,7 @@ from corehq.apps.app_manager.xpath import (
     dot_interpolate,
     UserCaseXPath)
 from corehq.apps.hqmedia.models import CommCareMultimedia
+import re
 
 CASE_PROPERTY_MAP = {
     # IMPORTANT: if you edit this you probably want to also edit
@@ -113,11 +114,7 @@ class FormattedDetailColumn(object):
         )
         return header
 
-    @property
-    def variables(self):
-        variables = {}
-        variables['lang'] = self.id_strings.current_language()
-        return variables
+    variables = {}
 
     @property
     def template(self):
@@ -380,6 +377,13 @@ class Filter(HideShortColumn):
 
 @register_format_type('calculate')
 class Calculate(FormattedDetailColumn):
+
+    @property
+    def variables(self):
+        variables = {}
+        if re.search(r'\$lang', self.column.calc_xpath):
+            variables['lang'] = self.id_strings.current_language()
+        return variables
 
     @property
     def xpath_function(self):

--- a/corehq/apps/app_manager/detail_screen.py
+++ b/corehq/apps/app_manager/detail_screen.py
@@ -113,7 +113,11 @@ class FormattedDetailColumn(object):
         )
         return header
 
-    variables = None
+    @property
+    def variables(self):
+        variables = {}
+        variables['lang'] = self.id_strings.current_language()
+        return variables
 
     @property
     def template(self):
@@ -317,7 +321,7 @@ class Enum(FormattedDetailColumn):
 
     @property
     def variables(self):
-        variables = {}
+        variables = super(Enum, self).variables
         for item in self.column.enum:
             v_key = item.key_as_variable
             v_val = self.id_strings.detail_column_enum_variable(

--- a/corehq/apps/app_manager/id_strings.py
+++ b/corehq/apps/app_manager/id_strings.py
@@ -58,6 +58,11 @@ def app_display_name():
     return "app.display.name"
 
 
+@pattern('lang.current')
+def current_language():
+    return "lang.current"
+
+
 @pattern('m%d.%s.title')
 def detail_title_locale(module, detail_type):
     return u"m{module.id}.{detail_type}.title".format(module=module,

--- a/corehq/apps/app_manager/tests/data/suite/app.json
+++ b/corehq/apps/app_manager/tests/data/suite/app.json
@@ -321,7 +321,51 @@
                             "late_flag": 30,
                             "model": "case",
                             "time_ago_interval": 365.25
-                        }
+                        },
+                        {
+                            "advanced": "",
+                            "calc_xpath": "concat(., .)",
+                            "case_tile_field": "",
+                            "doc_type": "DetailColumn",
+                            "enum": [],
+                            "field": "plain",
+                            "filter_xpath": "",
+                            "format": "calculate",
+                            "graph_configuration": null,
+                            "hasAutocomplete": true,
+                            "hasNodeset": false,
+                            "header": {
+                                "en": "Calculation"
+                            },
+                            "isTab": false,
+                            "late_flag": 30,
+                            "model": "case",
+                            "nodeset": "",
+                            "time_ago_interval": 365.25
+                        },
+                        {
+                            "advanced": "",
+                            "calc_xpath": "if($lang = 'en', ., 'nope')",
+                            "case_tile_field": "",
+                            "doc_type": "DetailColumn",
+                            "enum": [],
+                            "field": "plain",
+                            "filter_xpath": "",
+                            "format": "calculate",
+                            "graph_configuration": null,
+                            "hasAutocomplete": true,
+                            "hasNodeset": false,
+                            "header": {
+                                "en": "Calculation with Language"
+                            },
+                            "isTab": false,
+                            "late_flag": 30,
+                            "model": "case",
+                            "nodeset": "",
+                            "late_flag": 30,
+                            "model": "case",
+                            "time_ago_interval": 365.25
+                         }
                     ],
                     "doc_type": "Detail",
                     "type": "case_long"

--- a/corehq/apps/app_manager/tests/data/suite/normal-suite.xml
+++ b/corehq/apps/app_manager/tests/data/suite/normal-suite.xml
@@ -284,6 +284,34 @@
             </text>
         </template>
     </field>
+    <field>
+        <header>
+            <text>
+                <locale id="m0.case_long.case_plain_10.header"/>
+            </text>
+        </header>
+        <template>
+            <text>
+                <xpath function="concat(plain, plain)"/>
+            </text>
+        </template>
+    </field>
+    <field>
+        <header>
+            <text>
+                <locale id="m0.case_long.case_plain_11.header"/>
+            </text>
+        </header>
+        <template>
+            <text>
+                <xpath function="if($lang = 'en', plain, 'nope')">
+                    <variable name="lang">
+                        <locale id="lang.current"/>
+                    </variable>
+                </xpath>
+            </text>
+        </template>
+    </field>
 </detail>
 <entry>
     <form>http://openrosa.org/formdesigner/0260EE34-0345-490B-A1ED-B32361750D36</form>


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?188421

Adds `lang.current` locale id to each app_strings file (value "en", "fra", etc.) and makes this available as variable `$lang` to calculation properties in case list/detail.

@dannyroberts / @proteusvacuum 
