### PR TITLE
JavaScript Translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Populate your database:
     $ ./manage.py sync_couch_views
     $ ./manage.py migrate --noinput
     $ ./manage.py collectstatic --noinput
+    $ ./manage.py compilejsi18n
 
 Create a project. The following command will do some basic setup, create a superuser, and create a project. The 
 project-name, email, and password given here are specific to your local development environment. Ignore warnings 
@@ -370,6 +371,7 @@ Notice that `COMPRESS_MINT_DELAY`, `COMPRESS_MTIME_DELAY`, and
 For all STATICFILES changes, run:
 
     $ manage.py collectstatic
+    $ manage.py compilejsi18n
     $ manage.py fix_less_imports_collectstatic
     $ manage.py compress
 

--- a/corehq/apps/app_manager/static/app_manager/js/app_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager.js
@@ -75,7 +75,7 @@
                 var $form = $(this),
                     $buttonHolder = $form.find('.save-button-holder'),
                     button = COMMCAREHQ.SaveButton.initForm($form, {
-                        unsavedMessage: "You have unsaved changes",
+                        unsavedMessage: gettext("You have unsaved changes"),
                         success: function (data) {
                             var key;
                             COMMCAREHQ.app_manager.updateDOM(data.update);

--- a/corehq/apps/app_manager/static/app_manager/js/commcaresettings.js
+++ b/corehq/apps/app_manager/static/app_manager/js/commcaresettings.js
@@ -146,11 +146,13 @@ function CommcareSettings(options) {
             var optionOK = setting.optionOK();
             if (!setting.enabled() || !optionOK) {
                 if (!optionOK) {
+                    var upgrade_text;
                     if (setting.versionOK()) {
-                        return 'Upgrade to CommCare ' + setting.requiredVersion().option + ' for this option!';
+                        upgrade_text = gettext('Upgrade to CommCare %s for this option!');
                     } else {
-                        return 'Upgrade to CommCare ' + setting.requiredVersion().option + '!';
+                        upgrade_text = gettext('Upgrade to CommCare %s!');
                     }
+                    return interpolate(upgrade_text, [setting.requiredVersion().option]);
                 } else {
                     var condition = setting.parsedCondition();
                     var names = _(condition.settings).map(function (setting) {

--- a/corehq/apps/app_manager/static/app_manager/js/commcaresettings.js
+++ b/corehq/apps/app_manager/static/app_manager/js/commcaresettings.js
@@ -161,7 +161,7 @@ function CommcareSettings(options) {
                     uniqueNames = names.filter(function(elem, pos) {
                         return names.indexOf(elem) == pos;
                     })
-                    return 'Auto-set by ' + uniqueNames.join(', ')
+                    return gettext('Auto-set by ') + uniqueNames.join(', ')
                 }
             } else {
                 return '';

--- a/corehq/apps/style/templates/style/bootstrap2/base.html
+++ b/corehq/apps/style/templates/style/bootstrap2/base.html
@@ -1,4 +1,4 @@
-{% load menu_tags %}{% load i18n %}{% load hq_shared_tags %}{% load cache %}{% load compress %}<!DOCTYPE html>
+{% load menu_tags %}{% load i18n %}{% load hq_shared_tags %}{% load cache %}{% load compress %}{% load statici18n %}<!DOCTYPE html>
 {% get_current_language as LANGUAGE_CODE %}
 <html lang="{{ LANGUAGE_CODE }}">
     <head>
@@ -27,6 +27,7 @@
         {% endcompress %}
         {% block stylesheets %}{% endblock %}
 
+        <script src="{% statici18n LANGUAGE_CODE %}"></script> {# DO NOT COMPRESS #}
         {% include "style/includes/bootstrap2/core_libraries.html" %}
 
         {% if request.guided_tour %}

--- a/corehq/apps/style/templates/style/bootstrap3/base.html
+++ b/corehq/apps/style/templates/style/bootstrap3/base.html
@@ -1,4 +1,4 @@
-{% load menu_tags %}{% load i18n %}{% load hq_shared_tags %}{% load cache %}{% load compress %}<!DOCTYPE html>
+{% load menu_tags %}{% load i18n %}{% load hq_shared_tags %}{% load cache %}{% load compress %}{% load statici18n %}<!DOCTYPE html>
 {% get_current_language as LANGUAGE_CODE %}
 <html lang="{{ LANGUAGE_CODE }}">
     <head>
@@ -305,6 +305,7 @@
         </script>
 
         {# HQ Specific Libraries #}
+        <script src="{% statici18n LANGUAGE_CODE %}"></script> {# DO NOT COMPRESS #}
         {% compress js %}
         <script type="text/javascript" src="{% new_static 'style/js/hq-bug-report.js' %}"></script>
         <script type="text/javascript" src="{% new_static 'style/js/layout.js' %}"></script>

--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -1018,6 +1018,7 @@ def _do_collectstatic(use_current_release=False):
     with cd(env.code_root if not use_current_release else env.code_current):
         sudo('{}/bin/python manage.py collectstatic --noinput -v 0'.format(venv))
         sudo('{}/bin/python manage.py fix_less_imports_collectstatic'.format(venv))
+        sudo('{}/bin/python manage.py compilejsi18n'.format(venv))
 
 
 @parallel

--- a/locale/en/LC_MESSAGES/djangojs.po
+++ b/locale/en/LC_MESSAGES/djangojs.po
@@ -1,0 +1,36 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-12-15 01:09+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: corehq/apps/app_manager/static/app_manager/js/app_manager.js:78
+msgid "You have unsaved changes"
+msgstr ""
+
+#: corehq/apps/app_manager/static/app_manager/js/commcaresettings.js:151
+#, c-format
+msgid "Upgrade to CommCare %s for this option!"
+msgstr ""
+
+#: corehq/apps/app_manager/static/app_manager/js/commcaresettings.js:153
+#, c-format
+msgid "Upgrade to CommCare %s!"
+msgstr ""
+
+#: corehq/apps/app_manager/static/app_manager/js/commcaresettings.js:164
+msgid "Auto-set by "
+msgstr ""

--- a/locale/es/LC_MESSAGES/djangojs.po
+++ b/locale/es/LC_MESSAGES/djangojs.po
@@ -1,0 +1,37 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-12-15 01:09+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: corehq/apps/app_manager/static/app_manager/js/app_manager.js:78
+msgid "You have unsaved changes"
+msgstr ""
+
+#: corehq/apps/app_manager/static/app_manager/js/commcaresettings.js:151
+#, c-format
+msgid "Upgrade to CommCare %s for this option!"
+msgstr ""
+
+#: corehq/apps/app_manager/static/app_manager/js/commcaresettings.js:153
+#, c-format
+msgid "Upgrade to CommCare %s!"
+msgstr ""
+
+#: corehq/apps/app_manager/static/app_manager/js/commcaresettings.js:164
+msgid "Auto-set by "
+msgstr ""

--- a/locale/fr/LC_MESSAGES/djangojs.po
+++ b/locale/fr/LC_MESSAGES/djangojs.po
@@ -1,0 +1,37 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-12-15 01:09+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: corehq/apps/app_manager/static/app_manager/js/app_manager.js:78
+msgid "You have unsaved changes"
+msgstr ""
+
+#: corehq/apps/app_manager/static/app_manager/js/commcaresettings.js:151
+#, c-format
+msgid "Upgrade to CommCare %s for this option!"
+msgstr ""
+
+#: corehq/apps/app_manager/static/app_manager/js/commcaresettings.js:153
+#, c-format
+msgid "Upgrade to CommCare %s!"
+msgstr ""
+
+#: corehq/apps/app_manager/static/app_manager/js/commcaresettings.js:164
+msgid "Auto-set by "
+msgstr ""

--- a/locale/fra/LC_MESSAGES/djangojs.po
+++ b/locale/fra/LC_MESSAGES/djangojs.po
@@ -1,0 +1,36 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-12-15 01:09+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: corehq/apps/app_manager/static/app_manager/js/app_manager.js:78
+msgid "You have unsaved changes"
+msgstr ""
+
+#: corehq/apps/app_manager/static/app_manager/js/commcaresettings.js:151
+#, c-format
+msgid "Upgrade to CommCare %s for this option!"
+msgstr ""
+
+#: corehq/apps/app_manager/static/app_manager/js/commcaresettings.js:153
+#, c-format
+msgid "Upgrade to CommCare %s!"
+msgstr ""
+
+#: corehq/apps/app_manager/static/app_manager/js/commcaresettings.js:164
+msgid "Auto-set by "
+msgstr ""

--- a/locale/hin/LC_MESSAGES/djangojs.po
+++ b/locale/hin/LC_MESSAGES/djangojs.po
@@ -1,0 +1,36 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-12-15 01:09+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: corehq/apps/app_manager/static/app_manager/js/app_manager.js:78
+msgid "You have unsaved changes"
+msgstr ""
+
+#: corehq/apps/app_manager/static/app_manager/js/commcaresettings.js:151
+#, c-format
+msgid "Upgrade to CommCare %s for this option!"
+msgstr ""
+
+#: corehq/apps/app_manager/static/app_manager/js/commcaresettings.js:153
+#, c-format
+msgid "Upgrade to CommCare %s!"
+msgstr ""
+
+#: corehq/apps/app_manager/static/app_manager/js/commcaresettings.js:164
+msgid "Auto-set by "
+msgstr ""

--- a/locale/por/LC_MESSAGES/djangojs.po
+++ b/locale/por/LC_MESSAGES/djangojs.po
@@ -1,0 +1,36 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-12-15 01:09+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: corehq/apps/app_manager/static/app_manager/js/app_manager.js:78
+msgid "You have unsaved changes"
+msgstr ""
+
+#: corehq/apps/app_manager/static/app_manager/js/commcaresettings.js:151
+#, c-format
+msgid "Upgrade to CommCare %s for this option!"
+msgstr ""
+
+#: corehq/apps/app_manager/static/app_manager/js/commcaresettings.js:153
+#, c-format
+msgid "Upgrade to CommCare %s!"
+msgstr ""
+
+#: corehq/apps/app_manager/static/app_manager/js/commcaresettings.js:164
+msgid "Auto-set by "
+msgstr ""

--- a/locale/sw/LC_MESSAGES/djangojs.po
+++ b/locale/sw/LC_MESSAGES/djangojs.po
@@ -1,0 +1,37 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-12-15 01:09+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: corehq/apps/app_manager/static/app_manager/js/app_manager.js:78
+msgid "You have unsaved changes"
+msgstr ""
+
+#: corehq/apps/app_manager/static/app_manager/js/commcaresettings.js:151
+#, c-format
+msgid "Upgrade to CommCare %s for this option!"
+msgstr ""
+
+#: corehq/apps/app_manager/static/app_manager/js/commcaresettings.js:153
+#, c-format
+msgid "Upgrade to CommCare %s!"
+msgstr ""
+
+#: corehq/apps/app_manager/static/app_manager/js/commcaresettings.js:164
+msgid "Auto-set by "
+msgstr ""

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -82,3 +82,4 @@ django-uuidfield==0.5.0
 # required by ctable
 SQLAlchemy==1.0.9
 alembic==0.6.4
+django-statici18n==1.1.5

--- a/settings.py
+++ b/settings.py
@@ -181,6 +181,7 @@ TEMPLATE_CONTEXT_PROCESSORS = [
     "corehq.util.context_processors.base_template",
     "corehq.util.context_processors.analytics_js",
     'corehq.util.context_processors.websockets_override',
+    'django.core.context_processors.i18n',
 ]
 
 TEMPLATE_DIRS = []
@@ -205,6 +206,7 @@ DEFAULT_APPS = (
     'mptt',
     'tastypie',
     'ws4redis',
+    'statici18n',
 )
 
 CRISPY_TEMPLATE_PACK = 'bootstrap'


### PR DESCRIPTION
@dimagi/js-team Added ability to translate javascript files. In order for django to pick up on changes, 
`./manage.py makemessages -d djangojs --all` will need to be run in addition to the standard `makemessages` command. `compilemessages` should be run as normal.

In addition to this, you'll need to run `./manage.py compilejsi18n` to make the translation utilities available in all js files.
