### PR TITLE
More csrf

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/import_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/import_app.html
@@ -38,6 +38,7 @@
 
 {% block main_column %}
     <form action="{% url "corehq.apps.app_manager.views.import_app" domain %}" id="app-import-form" method="post" data-bind="submit: save">
+        {% csrf_token %}
 {% if app %}
         <p>Import application <strong>{{ app.name }}</strong> from domain <strong>{{ app.domain }}</strong>?</p>
         <table {% if not is_superuser %}class="hide"{% endif %}>

--- a/corehq/apps/app_manager/templates/app_manager/module_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/module_view.html
@@ -214,6 +214,7 @@
     {% block tab-content %}
     <div class="tab-pane active" id="module-settings">
         <form class="form-horizontal save-button-form" action="{% url "corehq.apps.app_manager.views.edit_module_attr" domain app.id module.id 'all' %}">
+            {% csrf_token %}
             <div class="save-button-holder clearfix"></div>
             <fieldset>
                 <div class="control-group">
@@ -282,6 +283,7 @@
     </div>
     <div class="tab-pane" id="case-settings">
         <form class="form-horizontal save-button-form" action="{% url "corehq.apps.app_manager.views.edit_module_attr" domain app.id module.id 'all' %}">
+            {% csrf_token %}
             <div class="save-button-holder clearfix"></div>
             <fieldset>
                 <legend>{% trans "Basic" %}</legend>

--- a/corehq/apps/app_manager/templates/app_manager/partials/form_tab_advanced.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/form_tab_advanced.html
@@ -48,6 +48,7 @@
                 <div id="source-edit">
                     {% trans "You can edit your XForm here." %}<br />
                     <form action="{% url "corehq.apps.app_manager.views.edit_form_attr" domain app.id form.get_unique_id 'xform' %}" method="POST">
+                        {% csrf_token %}
                         <textarea name="xform" id="xform-source-edit" style="height:550px;width:90%;font-family:Monospace;">
                             {% trans "Loading..." %}
                         </textarea><br />
@@ -61,6 +62,7 @@
     </ul>
     {% if allow_form_copy%}
     <form class="form-inline" method='POST' action='{% url "copy_form" domain app.id module.id form.id %}'>
+        {% csrf_token %}
         <p>
         <i class="icon-share"></i> {% trans "Copy form to: " %}
         <select name='to_module_id'>{% for mod in app.get_modules %}

--- a/corehq/apps/app_manager/templates/app_manager/partials/form_tab_settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/form_tab_settings.html
@@ -3,6 +3,7 @@
 {% load hq_shared_tags %}
 <div class="tab-pane active" id="form-settings">
     <form class="form-horizontal save-button-form" action="{% url "corehq.apps.app_manager.views.edit_form_attr" domain app.id form.get_unique_id 'all' %}">
+        {% csrf_token %}
         <div class="save-button-holder clearfix"></div>
         <div class="control-group">
             <label class="control-label">{% trans "Form Name" %}</label>

--- a/corehq/apps/app_manager/templates/app_manager/partials/new_app_buttons.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/new_app_buttons.html
@@ -2,6 +2,7 @@
 
 <div class="row-fluid">
     <form action="{% url "new_app" domain %}" method="post">
+    {% csrf_token %}
         <input type="hidden" name="type" value="Application">
         <input type="hidden" name="application_version" value="2.0" />
         {% if request.couch_user.can_edit_apps %}

--- a/corehq/apps/appstore/templates/appstore/project_info.html
+++ b/corehq/apps/appstore/templates/appstore/project_info.html
@@ -293,6 +293,7 @@
     <div>
     {% if applications %}
         <form id="new-project-form" method="post" class="form-inline" action="{% url "domain_copy_snapshot" project %}">
+            {% csrf_token %}
             <fieldset>
                 <legend>{% trans "Download" %}</legend>
                 {% if request.couch_user %}
@@ -336,6 +337,7 @@
             </fieldset>
         </form>
         <form id="import-form" method="post" class="form-inline" action="{% url "import_app_from_snapshot" project %}">
+            {% csrf_token %}
             <div class="hide" id="import-app">
                 <select name="project" id="project_select">
                     {% for p in request.couch_user.projects %}

--- a/corehq/apps/commtrack/templates/commtrack/manage/default_consumption.html
+++ b/corehq/apps/commtrack/templates/commtrack/manage/default_consumption.html
@@ -16,6 +16,7 @@
         </div>
     </div>
     <form class="form-horizontal" method="post">
+        {% csrf_token %}
         <fieldset>
             <legend>{% trans 'Edit Default Monthly Consumption' %}</legend>
             {% crispy form %}

--- a/corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html
+++ b/corehq/apps/commtrack/templates/commtrack/manage/rebuild_stock_state.html
@@ -37,6 +37,7 @@
                 {% endblocktrans %}
                 {% if request.user.is_superuser and request|toggle_enabled:'SUPPORT' %}
                 <form method="post" action="" class="pull-right">
+                    {% csrf_token %}
                     <input type="hidden" name="case_id" value="{{ key.case_id }}">
                     <input type="hidden" name="section_id" value="{{ key.section_id }}">
                     <input type="hidden" name="product_id" value="{{ key.product_id }}">

--- a/corehq/apps/dashboard/templates/dashboard/dashboard_new_user.html
+++ b/corehq/apps/dashboard/templates/dashboard/dashboard_new_user.html
@@ -49,6 +49,7 @@
 
 {% if request|toggle_enabled:'REMOTE_APPS' %}
     <form class="pull-right form" action="{% url "new_app" domain %}" method="post">
+        {% csrf_token %}
         <input type="hidden" name="type" value="RemoteApp" />
         <button class="btn btn-default" href="#" type="submit">{% trans "Create a new RemoteApp (Advanced Users Only)" %}</button>
     </form>

--- a/corehq/apps/data_interfaces/templates/data_interfaces/interfaces/archive_forms.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/interfaces/archive_forms.html
@@ -96,6 +96,7 @@
         <form method="post"
               action="{% url 'xform_management' domain %}"
               enctype="multipart/form-data">
+                {% csrf_token %}
             {% if total_xForms > 0 %}
                 <div id ="form_options" class="well form-inline" style="marging: 1em">
                     <div>

--- a/corehq/apps/data_interfaces/templates/data_interfaces/list_automatic_update_rules.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/list_automatic_update_rules.html
@@ -172,6 +172,7 @@
                                     <form class="modal-content"
                                           method="post"
                                           ng-submit="deleteRule(rule, djangoRMI, paginationController);">
+                                        {% csrf_token %}
                                         <div class="modal-header">
                                             <button type="button"
                                                     class="close"

--- a/corehq/apps/domain/templates/domain/admin/feature_previews.html
+++ b/corehq/apps/domain/templates/domain/admin/feature_previews.html
@@ -24,6 +24,7 @@
     <div class="row">
         <div class="col-sm-10">
             <form action="" method="post">
+                {% csrf_token %}
                 <button type="submit" class="btn btn-primary">{% trans "Update previews" %}</button>
                 <table class="table table-striped">
                     <thead>

--- a/corehq/apps/domain/templates/domain/admin/media_manager.html
+++ b/corehq/apps/domain/templates/domain/admin/media_manager.html
@@ -23,6 +23,7 @@
 
 {% block page_content %}
 <form id="update-media-sharing-settings" class="disable-on-submit" method="post">
+    {% csrf_token %}
     <fieldset>
         <legend>{% trans 'Change Multimedia Sharing Settings' %}</legend>
         <p>

--- a/corehq/apps/domain/templates/domain/admin/repeater_row.html
+++ b/corehq/apps/domain/templates/domain/admin/repeater_row.html
@@ -14,6 +14,7 @@
                     </div>
                     <form name="drop_repeater" action="{% url 'drop_repeater' domain repeater.get_id %}"
                           method="post">
+                        {% csrf_token %}
                         <div class="modal-body">
                             <p>Are you sure you want to stop forwarding to: {{ repeater.url }}?</p>
                         </div>

--- a/corehq/apps/domain/templates/domain/admin/sms_settings.html
+++ b/corehq/apps/domain/templates/domain/admin/sms_settings.html
@@ -18,6 +18,7 @@
 
 {% block main_column %}
     <form id="settings" class="form form-horizontal" method="post">
+        {% csrf_token %}
         <fieldset>
             <legend>{% trans 'SMS Keywords' %}</legend>
             <div class="control-group" data-bind="css: { 'error': keyword_error }">

--- a/corehq/apps/domain/templates/domain/admin/transfer_domain_pending.html
+++ b/corehq/apps/domain/templates/domain/admin/transfer_domain_pending.html
@@ -25,6 +25,7 @@
         </div>
         <div class="span2">
             <form action="{{ transfer.deactivate_url }}" method="POST">
+                {% csrf_token %}
                 <input class="btn btn-danger" type="submit" value="{% trans "Cancel Transfer" %}" />
             </form>
         </div>

--- a/corehq/apps/domain/templates/domain/copy_snapshot.html
+++ b/corehq/apps/domain/templates/domain/copy_snapshot.html
@@ -10,6 +10,7 @@
 
 {% block user-view %}
 <form class="form-horizontal" method="post">
+    {% csrf_token %}
     <fieldset>
         <legend>Create new project from snapshot</legend>
         <div class="control-group{% if error_message %} error{% endif %}">

--- a/corehq/apps/domain/templates/domain/partials/payment_modal.html
+++ b/corehq/apps/domain/templates/domain/partials/payment_modal.html
@@ -15,6 +15,7 @@
               id: formId,
               action: submitURL,
           }">
+        {% csrf_token %}
         <div class="modal-body">
             <div data-bind="template: {
                 data: costItem,

--- a/corehq/apps/domain/templates/domain/partials/project_version_display.html
+++ b/corehq/apps/domain/templates/domain/partials/project_version_display.html
@@ -1,6 +1,7 @@
 {% load i18n %}
 {% if published %}
 <form class="form-horizontal" action="{% url "domain_clear_published" domain %}" method="POST">
+{% csrf_token %}
 <div class="row-fluid">
     <div class="span4"><h3>This project has been published</h3></div>
     <div class="span8">
@@ -15,6 +16,7 @@
         <dt><h4>Most Recent Version</h4></dt>
         <dd>
             <form method="get" action="{% url "domain_create_snapshot" domain %}">
+                {% csrf_token %}
                 <a class="btn btn-primary"
                    data-action="{% url "domain_set_published" domain version.name %}"
                    data-toggle="modal" data-target="#contentDistributionAgreement"

--- a/corehq/apps/domain/templates/domain/snapshot_settings.html
+++ b/corehq/apps/domain/templates/domain/snapshot_settings.html
@@ -110,6 +110,7 @@
             </td>
             <td>
                 <form action="{% url "domain_clear_published" domain %}" method="POST">
+                    {% csrf_token %}
                     <button class="btn btn-danger" type="submit">Unpublish</button>
                 </form>
             </td>

--- a/corehq/apps/export/templates/export/dialogs/delete_custom_export_dialog.html
+++ b/corehq/apps/export/templates/export/dialogs/delete_custom_export_dialog.html
@@ -5,6 +5,7 @@
         <h3>{% trans "Delete Export for" %} "{{ export.name }}"?</h3>
     </div>
     <form name="drop_report" action="{% url "delete_custom_export" domain export.get_id %}" method="post">
+        {% csrf_token %}
         <div class="modal-body">
             <p>{% trans "Are you sure you want to delete this export?" %}</p>
         </div>

--- a/corehq/apps/export/templates/export/partial/export_bulk_notice.html
+++ b/corehq/apps/export/templates/export/partial/export_bulk_notice.html
@@ -4,6 +4,7 @@
     <form class="form form-inline"
           method="post"
           action="{{ bulk_download_url }}">
+          {% csrf_token %}
         <div class="row">
             <div class="col-sm-3 col-lg-2">
                 <input name="export_list"

--- a/corehq/apps/export/templates/export/partial/export_download_progress.html
+++ b/corehq/apps/export/templates/export/partial/export_download_progress.html
@@ -32,6 +32,7 @@
                     <form class="form-inline download-form"
                           method="POST"
                           action="{{ dropboxUrl }}">
+                        {% csrf_token %}
                         <a href="{{ downloadUrl }}"
                            class="btn btn-success btn-full-width"
                            ng-show="!!isDownloadReady"

--- a/corehq/apps/fixtures/templates/fixtures/manage_tables.html
+++ b/corehq/apps/fixtures/templates/fixtures/manage_tables.html
@@ -134,7 +134,7 @@
         </div>
 </div>
 <div class="row-fluid" id="fixture-upload">
-        <form class="form form-horizontal span10" id="uploadForm" action="{% url "upload_fixtures" domain %}" method="post" enctype="multipart/form-data">
+        <form class="form form-horizontal span10" id="uploadForm" action="{% url "upload_fixtures" domain %}" method="post" enctype="multipart/form-data">{% csrf_token %}
             <div class="form-actions" style="padding-left: 1em;">
                 <fieldset class="modal-body">
                     <label for="bulk_upload_file" class="control-label">{% trans "Lookup Tables File" %}</label>

--- a/corehq/apps/groups/templates/groups/group_members.html
+++ b/corehq/apps/groups/templates/groups/group_members.html
@@ -146,6 +146,7 @@
 {% if group.is_deleted %}
     <div class="alert alert-info">{% trans "Whoa, how did you get here? This group has been deleted already. If you would like to undelete it you can do so below."%}</div>
     <form name="restore_group" action="{% url "restore_group" domain group.get_id %}" method="post">
+        {% csrf_token %}
         <button class="btn btn-primary disable-on-submit" type="submit">
             {% blocktrans with group.name as group_name %}
                 Restore Group "{{group_name}}"
@@ -166,6 +167,7 @@
             </a>
             {% if bulk_sms_verification_enabled %}
             <form id="initiate-verification-workflow" class="form form-horizontal" method="post" action="{% url "bulk_sms_verification" domain group.get_id %}">
+                {% csrf_token %}
                 <button id="submit-verification" type="submit" class="btn">
                     <i class="icon icon-signal"></i> {% trans 'Initiate Phone Verification for All Members' %}
                 </button>
@@ -266,6 +268,7 @@
             </h3>
         </div>
         <form name="delete_group" action="{% url "delete_group" domain group.get_id %}" method="post">
+            {% csrf_token %}
             <div class="modal-body">
                 <p>
                 {% blocktrans with group.name as group_name %}

--- a/corehq/apps/hqadmin/templates/hqadmin/mass_email.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/mass_email.html
@@ -31,6 +31,7 @@
         </p>
     </div>
     <form name="form" method="post" action="">
+        {% csrf_token %}
         <fieldset>
             <legend>Email</legend>
             <div class="form-group">

--- a/corehq/apps/hqcase/templates/hqcase/explode_cases.html
+++ b/corehq/apps/hqcase/templates/hqcase/explode_cases.html
@@ -20,6 +20,7 @@
                 <p><strong>Warning!</strong> The Exploder will multiply all cases you have by the explode factor your write in, so, for example, if you're exploding a test user with 20 cases, and write the factor to be 200, it will actually give you 4,000 cases, NOT 200. Be careful! For this reason, it's best to create a new test user with only one case to explode.</p>
             </div>
             <form class="form" action="" method="POST">
+                {% csrf_token %}
                 <label for="explode-user_id">User</label>
                 <select id="explode-user_id" name="user_id" data-bind="value: user_id">
                     <option>Select a CHW...</option>

--- a/corehq/apps/hqpillow_retry/templates/hqpillow_retry/pillow_errors.html
+++ b/corehq/apps/hqpillow_retry/templates/hqpillow_retry/pillow_errors.html
@@ -18,6 +18,7 @@
 {% block reporttable %}
 {% if not report.needs_filters %}
     <form class="form-inline" action="{% url "pillow_errors" %}" method="post">
+    {% csrf_token %}
     <div style="text-align:right;">
         <select name="action">
             <option value="">{% trans "Select Action..." %}</option>

--- a/corehq/apps/hqpillow_retry/templates/hqpillow_retry/single.html
+++ b/corehq/apps/hqpillow_retry/templates/hqpillow_retry/single.html
@@ -57,6 +57,7 @@
             </div>
             <div>
                 <form id="actionform" class="form-inline" action="{% url "pillow_errors" %}" method="post">
+                    {% csrf_token %}
                     <input type="hidden" name="source" value="single" />
                     <input type="hidden" name="PillowError_{{ error.id }}" value="1" />
                     <input type="hidden" name="action" value="" />

--- a/corehq/apps/hqwebapp/templates/500.html
+++ b/corehq/apps/hqwebapp/templates/500.html
@@ -40,6 +40,7 @@
                 </form>
             </div>
             <form class="well form form-horizontal" style="padding-bottom: 0;" action="{% url "bug_report" %}" method="post">
+                {% csrf_token %}
                 <input type="hidden" id="bug-report-500-url" name="url" value="{{ request.build_absolute_uri }}"/>
                 <input type="hidden" id="bug-report-500-username" name="username" value="{{ user.username }}"/>
                 <input type="hidden" id="bug-report-500-domain" name="domain" value="{{ domain }}"/>

--- a/corehq/apps/hqwebapp/templates/password_change.html
+++ b/corehq/apps/hqwebapp/templates/password_change.html
@@ -3,6 +3,7 @@
 {% block content %}
 <h2>Change Password for {{user.username}}</h2>
 <form method="POST">
+	{% csrf_token %}
     <table>
         {{ form.as_table}}
     </table>

--- a/corehq/apps/hqwebapp/utils.py
+++ b/corehq/apps/hqwebapp/utils.py
@@ -198,3 +198,15 @@ def submenu_dropdown_dict(title, url, menu):
 def divider_and_more_menu(url):
     return [dropdown_dict('placeholder', is_divider=True),
             dropdown_dict(_('View All'), url=url)]
+
+
+def csrf_inline(request):
+    """
+    Returns "<input type='hidden' name='csrfmiddlewaretoken' value='<csrf-token-value>' />",
+    same as csrf_token template tag, but a shortcut without needing a Template or Context explicitly.
+
+    Useful for adding inline forms in messages for e.g. while showing an "'undo' Archive Form" message
+    """
+    from django.template import Template, RequestContext
+    node = "{% csrf_token %}"
+    return Template(node).render(RequestContext(request))

--- a/corehq/apps/importer/templates/importer/excel_config.html
+++ b/corehq/apps/importer/templates/importer/excel_config.html
@@ -40,6 +40,7 @@
     <form class="form-horizontal form-report"
           action="{% url "corehq.apps.importer.views.excel_fields" domain %}"
           method="post">
+        {% csrf_token %}
         <input type="hidden" name="named_columns" value="{{named_columns}}" />
 
         <fieldset>

--- a/corehq/apps/importer/templates/importer/import_cases.html
+++ b/corehq/apps/importer/templates/importer/import_cases.html
@@ -9,6 +9,7 @@
           action="{% url "corehq.apps.importer.views.excel_config" domain %}"
           method="post"
           enctype="multipart/form-data">
+        {% csrf_token %}
         <fieldset>
             <legend>
                 {% trans "Upload an Excel File From Your Computer to Import From" %}

--- a/corehq/apps/locations/templates/locations/downgrade_locations.html
+++ b/corehq/apps/locations/templates/locations/downgrade_locations.html
@@ -24,6 +24,7 @@
 
     <p>
         <form action="{% url "unassign_users" request.domain %}" method="POST">
+            {% csrf_token %}
             <input type="hidden" name="redirect" value="{{ request.path }}">
             <input value="{% trans "Remove Mobile Workers From Locations" %}"
                    type="submit" class="btn btn-danger"></input>

--- a/corehq/apps/locations/templates/locations/location_types.html
+++ b/corehq/apps/locations/templates/locations/location_types.html
@@ -70,6 +70,7 @@
         </div>
     </div>
     <form id="settings" class="form form-horizontal" method="post">
+        {% csrf_token %}
         <fieldset>
             <div class="control-group">
                 <button type="button" class="btn btn-success" data-bind="click: new_loctype">

--- a/corehq/apps/locations/templates/locations/manage/location.html
+++ b/corehq/apps/locations/templates/locations/manage/location.html
@@ -190,6 +190,7 @@
     <h3>{% trans 'Move Location?' %}</h3>
   </div>
   <form class="form form-horizontal hq-form" name="verify_move_location" action="" method="post">
+    {% csrf_token %}
     <div class="modal-body">
       <p>{% blocktrans %}You've changed this location's parent.{% endblocktrans %}</p>
       <p>{% blocktrans %}If you move this location, all the data submitted for this location must be updated as well.

--- a/corehq/apps/performance_sms/templates/performance_sms/list_performance_configs.html
+++ b/corehq/apps/performance_sms/templates/performance_sms/list_performance_configs.html
@@ -49,6 +49,7 @@ g{% load i18n %}
                         <li><a class="send-message" href="#" data-config="{{ performance_config.get_id }}">{% trans "Send Real Messages Now" %}</a></li>
                     </ul>
                     <form id="{{ performance_config.get_id }}" action="{% url "performance_sms.send_performance_messages" domain performance_config.get_id %}" method="POST" class="hidden" >
+                    {% csrf_token %}
                     </form>
                 </td>
             </tr>

--- a/corehq/apps/products/templates/products/manage/product.html
+++ b/corehq/apps/products/templates/products/manage/product.html
@@ -11,6 +11,7 @@
 
 {% block main_column %}
     <form class="form form-horizontal" name="product" method="post">
+        {% csrf_token %}
         {% bootstrap_form_errors form %}
         {% bootstrap_fieldset form "Product Information" %}
 

--- a/corehq/apps/registration/templates/registration/confirmation_resend.html
+++ b/corehq/apps/registration/templates/registration/confirmation_resend.html
@@ -7,6 +7,7 @@
 
 {% block registration-content %}
 <form method="post" action="{% url "registration_resend_domain_confirmation" %}" class="form-horizontal">
+    {% csrf_token %}
     <fieldset>
         <div class="control-group">
             <label class="control-label">Username / Email:</label>

--- a/corehq/apps/reminders/templates/reminders/list_broadcasts.html
+++ b/corehq/apps/reminders/templates/reminders/list_broadcasts.html
@@ -76,6 +76,7 @@
                                 <h3>{% trans 'Delete Broadcast Message?' %}</h3>
                             </div>
                             <form class="form form-horizontal" name="delete_handler" action="{% url "delete_reminder" domain handler.handler.get_id %}" method="post">
+                                {% csrf_token %}
                                 <div class="modal-body">
                                     <p>{% trans 'Are you sure you want to delete this broadcast message?' %}</p>
                                 </div>

--- a/corehq/apps/reminders/templates/reminders/partial/add_one_time_reminder.html
+++ b/corehq/apps/reminders/templates/reminders/partial/add_one_time_reminder.html
@@ -84,6 +84,7 @@
 {% include "style/bootstrap2/partials/time_notice.html" %}
 <h4>{% trans 'Broadcast Message' %}</h4>
 <form id="one_time_reminder_form" action="{% if handler_id %}{% url "edit_one_time_reminder" domain handler_id %}{% else %}{% url "add_one_time_reminder" domain %}{% endif %}" method="post">
+    {% csrf_token %}
     <div class="form-block">
         <table id="main_table">
             <tbody>

--- a/corehq/apps/reports/templates/reports/form/partials/single_form.html
+++ b/corehq/apps/reports/templates/reports/form/partials/single_form.html
@@ -217,7 +217,7 @@ requires imports/proptable.html to be included in the main template
                         </a>
                 {% endif %}
                 {% if not is_archived and not edit_info.was_edited %}
-                <form action="{% url "archive_form" domain instance.get_id %}" method="POST" id="archive-form">
+                <form action="{% url "archive_form" domain instance.get_id %}" method="POST" id="archive-form">{% csrf_token %}
                     <span class="hq-help-template"
                         data-title="{% trans "Archiving Forms" %}"
                         data-content="{% trans "Archived forms will no longer show up in reports and they will be removed from any relevant case histories. " %}"
@@ -229,7 +229,7 @@ requires imports/proptable.html to be included in the main template
                     </button>
                 </form>
                 {% elif edit_info.was_edited %}
-                <form action="{% url "restore_edit" domain instance.get_id %}" method="POST" id="archive-form">
+                <form action="{% url "restore_edit" domain instance.get_id %}" method="POST" id="archive-form">{% csrf_token %}
                     <span class="hq-help-template"
                         data-title="{% trans "Restoring Edited Forms" %}"
                         data-content="{% trans "Restoring an edited form will undo any later edits made. This operation is reversible." %}"
@@ -243,7 +243,7 @@ requires imports/proptable.html to be included in the main template
                 {% endif %}
                 {% if is_archived %}
                 <form action="{% url "unarchive_form" domain instance.get_id %}" method="POST"
-                      id="unarchive-form">
+                      id="unarchive-form">{% csrf_token %}
                     <span class="hq-help-template"
                         data-title="{% trans "Restoring Forms" %}"
                         data-content="{% trans "Restoring this form will cause it to show up in reports again." %}"
@@ -257,7 +257,7 @@ requires imports/proptable.html to be included in the main template
                 {% endif %}
                 {% if show_resave %}
                 <form action="{% url "resave_form" domain instance.get_id %}" method="POST"
-                      id="resave-form">
+                      id="resave-form">{% csrf_token %}
                     <span class="hq-help-template"
                         data-title="{% trans "Resaving Forms" %}"
                         data-content="{% trans "Resaving a form can manually cause it to be reincluded in reports if something went wrong during initial processing." %}"

--- a/corehq/apps/reports/templates/reports/reportdata/case_details.html
+++ b/corehq/apps/reports/templates/reports/reportdata/case_details.html
@@ -81,18 +81,18 @@
     {% render_case case case_display_options %}
     <section id="case-actions" >
     {% if show_case_rebuild %}
-        <form action="{% url 'resave_case' domain case_id %}" method="post" >
+        <form action="{% url 'resave_case' domain case_id %}" method="post" >{% csrf_token %}
              <button type="submit" class="btn btn-info disable-on-submit" >{% trans 'Resave Case' %}</button>
         </form>
-        <form action="{% url 'rebuild_case' domain case_id %}" method="post" >
+        <form action="{% url 'rebuild_case' domain case_id %}" method="post" >{% csrf_token %}
              <button type="submit" class="btn btn-primary disable-on-submit" >{% trans 'Rebuild Case' %}</button>
         </form>
-        <form action="{% url 'bootstrap_ledgers' domain case_id %}" method="post" >
+        <form action="{% url 'bootstrap_ledgers' domain case_id %}" method="post" >{% csrf_token %}
              <button type="submit" class="btn btn-primary disable-on-submit" >{% trans 'Bootstrap Empty Ledgers' %}</button>
         </form>
     {% endif %}
     {% if not case.closed and not is_usercase %}
-        <form action="{% url 'close_case' domain case_id %}" method="post" id="close_case">
+        <form action="{% url 'close_case' domain case_id %}" method="post" id="close_case">{% csrf_token %}
              <button type="submit" class="btn btn-danger disable-on-submit" >{% trans 'Close Case' %}</button>
         </form>
     {% endif %}

--- a/corehq/apps/reports/templates/reports/reports_home.html
+++ b/corehq/apps/reports/templates/reports/reports_home.html
@@ -149,6 +149,7 @@ $(function() {
                                         <h3>{% trans "Stop sending report?" %}</h3>
                                     </div>
                                     <form class="form form-horizontal" action="{% url "delete_scheduled_report" domain report.get_id %}" method="post">
+                                        {% csrf_token %}
                                         <div class="modal-body">
                                             <p>{% trans "Are you sure you want to stop sending this report?" %}</p>
                                         </div>

--- a/corehq/apps/reports/templatetags/xform_tags.py
+++ b/corehq/apps/reports/templatetags/xform_tags.py
@@ -1,5 +1,6 @@
 from functools import partial
 
+from django.template import RequestContext
 from django.template.loader import render_to_string
 from django.core.urlresolvers import reverse
 from django import template
@@ -222,4 +223,4 @@ def render_form(form, domain, options):
         "show_edit_options": show_edit_options,
         "show_edit_submission": show_edit_submission,
         "show_resave": show_resave,
-    })
+    }, RequestContext(request))

--- a/corehq/apps/settings/templates/settings/my_projects.html
+++ b/corehq/apps/settings/templates/settings/my_projects.html
@@ -40,6 +40,7 @@
                                         <form class="form form-horizontal"
                                               name="delete_domain_membership"
                                               method="post">
+                                            {% csrf_token %}
                                             <input type="hidden" value="{{ domain.name }}" name="domain"/>
 
                                             <div class="modal-body">

--- a/corehq/apps/sms/templates/sms/add_backend.html
+++ b/corehq/apps/sms/templates/sms/add_backend.html
@@ -85,6 +85,7 @@
 {% block main_column %}
     <div class="page-header"><h3>{{ backend_generic_name }} {% trans "Connection" %}</h3></div>
     <form id="settings_form" action="" method="post">
+        {% csrf_token %}
         <h4>{% trans "General Settings" %}</h4>
         <div class="form-block">
             <table>

--- a/corehq/apps/sms/templates/sms/add_forwarding_rule.html
+++ b/corehq/apps/sms/templates/sms/add_forwarding_rule.html
@@ -45,6 +45,7 @@
 
 {% block main_column %}
     <form action="" method="post">
+        {% csrf_token %}
         <table>
             <tr>
                 <th><label for="id_forward_type">{% trans "Forward type" %}</label></th>

--- a/corehq/apps/sms/templates/sms/list_backends.html
+++ b/corehq/apps/sms/templates/sms/list_backends.html
@@ -103,6 +103,7 @@
                             <h3>{% trans "Delete SMS Connection?" %}</h3>
                         </div>
                         <form class="form form-horizontal" name="delete_backend" action="{% if show_global %}{% url "delete_backend" backend.get_id %}{% else %}{% url "delete_domain_backend" domain backend.get_id %}{% endif %}" method="post">
+                            {% csrf_token %}
                             <div class="modal-body">
                                 <p>{% trans "Are you sure you want to delete SMS Connection" %} '{{ backend.name }}'?</p>
                             </div>

--- a/corehq/apps/sms/templates/sms/list_forwarding_rules.html
+++ b/corehq/apps/sms/templates/sms/list_forwarding_rules.html
@@ -38,6 +38,7 @@
                             <h3>{% trans "Delete Forwarding Rule?" %}</h3>
                         </div>
                         <form class="form form-horizontal" name="delete_forwarding_rule" action="{% url "delete_forwarding_rule" domain rule.get_id %}" method="post">
+                            {% csrf_token %}
                             <div class="modal-body">
                                 <p>{% trans "Are you sure you want to delete this forwarding rule?" %}</p>
                             </div>

--- a/corehq/apps/sms/templates/sms/message_tester.html
+++ b/corehq/apps/sms/templates/sms/message_tester.html
@@ -3,6 +3,7 @@
 
 {% block main_column %}
     <form class="form form-horizontal" action="{% url "corehq.apps.sms.views.message_test" domain phone_number %}" method="post">
+        {% csrf_token %}
         <fieldset>
             <legend>{% trans "Simulate Inbound Message from" %} +{{ phone_number }}</legend>
             <div class="control-group">

--- a/corehq/apps/style/templates/style/bootstrap2/base.html
+++ b/corehq/apps/style/templates/style/bootstrap2/base.html
@@ -166,6 +166,7 @@
                     <h3>{% trans "Report an Issue with CommCare HQ" %}</h3>
                 </div>
                 <form id="hqwebapp-bugReportForm" class="form-horizontal" action="{% url "bug_report" %}" method="post" enctype="multipart/form-data">
+                    {% csrf_token %}
                     <input type="hidden" id="bug-report-url" name="url"/>
                     <input type="hidden" id="bug-report-username" name="username" value="{{ user.username }}"/>
                     <input type="hidden" id="bug-report-domain" name="domain" value="{{ domain }}"/>
@@ -254,6 +255,7 @@
                             {% trans "To continue using Commcare HQ, please agree to our new End User License Agreement" %}
                         </div>
                         <form id="eula-agree" action="{% url "agree_to_eula" %}" method="POST">
+                            {% csrf_token %}
                             <input name="next" type="hidden" value="{{ request.path }}" />
                             <button type="submit" class="btn btn-primary">Agree</button>
                             <a href="#" data-dismiss="modal" class="btn">Disagree</a>
@@ -268,6 +270,7 @@
                 </div>
                 <div class="modal-body">
                     <form id="keyboard-shortcuts-config-form" method="POST" action="{% url "keyboard_config" %}?next={{ request.get_full_path|urlencode }}">
+                        {% csrf_token %}
                         <div class="control-group">
                             <div class="controls">
                                 <label class="checkbox">

--- a/corehq/apps/style/templates/style/bootstrap2/maintenance_alerts.html
+++ b/corehq/apps/style/templates/style/bootstrap2/maintenance_alerts.html
@@ -17,6 +17,7 @@ $(function () {
             shown at a time, and the most recently modified alert will be displayed.
         </p>
         <form method="post" action="{% url 'create_alert' %}" id="alertForm">
+            {% csrf_token %}
             <textarea name="alert_text" placeholder="Alert text..." form="alertForm"></textarea>
             <button type="submit" class="btn btn-primary">Preview Alert</button>
         </form>
@@ -38,12 +39,14 @@ $(function () {
                 <td data-bind="text: active"></td>
                 <td>
                     <form method="post" action="{% url 'activate_alert' %}">
+                        {% csrf_token %}
                         <input name="alert_id" type="hidden" data-bind="value: id">
                         <button type="submit" class="btn btn-primary">Activate Alert</button>
                     </form>
                 </td>
                 <td>
                     <form method="post" action="{% url 'deactivate_alert' %}">
+                        {% csrf_token %}
                         <input name="alert_id" type="hidden" data-bind="value: id">
                         <button type="submit" class="btn btn-error">De-activate Alert</button>
                     </form>

--- a/corehq/apps/style/templates/style/includes/modal_eula.html
+++ b/corehq/apps/style/templates/style/includes/modal_eula.html
@@ -5,6 +5,7 @@
             <form id="eula-agree"
                   action="{% url "agree_to_eula" %}"
                   method="POST">
+                {% csrf_token %}
                 <input name="next" type="hidden" value="{{ request.path }}" />
                 <div class="modal-content">
                     <div class="modal-header">

--- a/corehq/apps/style/templates/style/includes/modal_report_issue.html
+++ b/corehq/apps/style/templates/style/includes/modal_report_issue.html
@@ -7,6 +7,7 @@
                   method="post"
                   enctype="multipart/form-data"
                   role="form">
+                {% csrf_token %}
                 <input type="hidden" id="bug-report-url" name="url"/>
                 <input type="hidden" id="bug-report-username" name="username" value="{{ user.username }}"/>
                 <input type="hidden" id="bug-report-domain" name="domain" value="{{ domain }}"/>

--- a/corehq/apps/users/templates/users/edit_commcare_user.html
+++ b/corehq/apps/users/templates/users/edit_commcare_user.html
@@ -167,6 +167,7 @@
             <form class="form form-horizontal reset-password-form"
                   action="{% url "change_password" domain couch_user.user_id %}"
                   method="post">
+                {% csrf_token %}
                 <fieldset>
                     <legend>{% trans 'Reset Password' %}</legend>
                     <div class="reset-password-body">
@@ -213,6 +214,7 @@
               action="{% url "delete_commcare_user" domain couch_user.user_id %}"
               method="post"
               data-bind="submit: submit">
+            {% csrf_token %}
             <div class="modal-body">
                 <p class="alert">
                     <i class="icon-white icon-warning-sign"></i>

--- a/corehq/apps/users/templates/users/edit_web_user.html
+++ b/corehq/apps/users/templates/users/edit_web_user.html
@@ -32,6 +32,7 @@
         </fieldset>
     </div>
     <form class="form form-horizontal" name="user_role" method="post">
+        {% csrf_token %}
         <input type="hidden" name="form_type" value="update-user" />
         <fieldset>
             <legend>{% blocktrans with couch_user.human_friendly_name as friendly_name %}Change {{ friendly_name }}'s Role{% endblocktrans %}</legend>
@@ -45,6 +46,7 @@
 
     {% if update_permissions %}
         <form class="form form-horizontal" name="user_permissions" method="post">
+            {% csrf_token %}
             <input type="hidden" name="form_type" value="update-user-permissions" />
             <fieldset>
 
@@ -60,6 +62,7 @@
 
     {% if update_form %}
         <form id="commtrack_form" class="form form-horizontal" name="" method="post">
+            {% csrf_token %}
             <input type="hidden" name="form_type" value="commtrack" />
             <fieldset>
                 {% if commtrack_enabled %}

--- a/corehq/apps/users/templates/users/partial/basic_info_modals.b3.html
+++ b/corehq/apps/users/templates/users/partial/basic_info_modals.b3.html
@@ -17,7 +17,7 @@
                       action="{% url "delete_phone_number" domain couch_user.couch_id %}"
                       {% endif %}
                       method="POST">
-
+                    {% csrf_token %}
                     <input type="hidden" name="form_type" value="delete-phone-number"/>
                     <input type="hidden" name="phone_number" value="{{ phone_number.number }}"/>
 

--- a/corehq/apps/users/templates/users/partial/manage_phone_numbers.html
+++ b/corehq/apps/users/templates/users/partial/manage_phone_numbers.html
@@ -88,6 +88,7 @@
 {% endif %}
 
 <form id="add_phone_number" class="form form-horizontal" name="add_phone_number" method="post">
+    {% csrf_token %}
     <input type="hidden" name="form_type" value="add-phonenumber" />
     <fieldset>
         <legend>{% trans 'Add a Phone Number' %}</legend>

--- a/custom/ewsghana/templates/ewsghana/user_extension.html
+++ b/custom/ewsghana/templates/ewsghana/user_extension.html
@@ -3,6 +3,7 @@
 {% block main_column %}
     <a class="btn btn-primary" href="{% url 'user_account' domain=domain couch_user_id=couch_user.get_id %}">Back to user account settings</a>
     <form id="commtrack_form" class="form form-horizontal" name="" method="post">
+    {% csrf_token %}
         <fieldset>
             <legend>{{ couch_user.username }} - {% trans 'EWS Settings' %}</legend>
             {% include 'hqstyle/forms/basic_fieldset.html' with form=form %}

--- a/custom/fri/templates/fri/message_bank.html
+++ b/custom/fri/templates/fri/message_bank.html
@@ -16,6 +16,7 @@
 {{ block.super }}
 {% if is_previewer %}
     <form action="{% url "fri_upload_message_bank" domain %}" method="post" enctype="multipart/form-data" style="padding: 10px;">
+        {% csrf_token %}
         <h4>Upload Additional Messages</h4>
         <div style="border-bottom: 1px solid #CCC; padding: 10px;">
             <input type="file" name="message_bank_file" /> <input type="submit" class="btn btn-primary" value="Upload" />

--- a/custom/ilsgateway/templates/ilsgateway/ilsconfig.html
+++ b/custom/ilsgateway/templates/ilsgateway/ilsconfig.html
@@ -104,7 +104,7 @@
                 </td>
                 <td>
                     <form action="{% url 'end_report_run' domain %}" method="POST">
-
+                        {% csrf_token %}
                         <button type="submit" class="btn">Mark as finished</button>
                     </form>
                 </td>


### PR DESCRIPTION
Best viewed commit by commit. First 3 commits are added by looking at csrf-failures from logs.

For the 4th commit, I did a find for all post HTML forms and tried to add `csrf_token`. I have tested at least around 70% of these. I have added csrf to HTML post forms those that I was confident have the right template-context (so that rendered is aware of csrf_token value) and that target internal URLs. There are still some forms to go, but would like to get these in and see if #of csrf failure go down for complete release of csrf.

@esoergel 
