### PR TITLE
catch password-protected files in case importer

### DIFF
--- a/corehq/apps/importer/exceptions.py
+++ b/corehq/apps/importer/exceptions.py
@@ -1,0 +1,30 @@
+import xlrd
+
+
+class ImporterError(Exception):
+    """
+    Generic error raised for any problem to do with finding, opening, reading, etc.
+    the file being imported
+
+    When possible, a more specific subclass should be used
+    """
+
+
+class ImporterFileNotFound(ImporterError):
+    """Raised when a referenced file can't be found"""
+
+
+class ImporterRefError(ImporterError):
+    """Raised when a Soil download ref is None"""
+
+
+class ImporterExcelError(ImporterError, xlrd.XLRDError):
+    """
+    Generic error raised for any error parsing an Excel file
+
+    When possible, a more specific subclass should be used
+    """
+
+
+class ImporterExcelFileEncrypted(ImporterExcelError):
+    """Raised when a file cannot be open because it is encrypted (password-protected)"""

--- a/corehq/apps/importer/views.py
+++ b/corehq/apps/importer/views.py
@@ -345,8 +345,7 @@ def _get_importer_error_message(e):
         return _('The session containing the file you uploaded has expired '
                  '- please upload a new one.')
     elif isinstance(e, ImporterExcelFileEncrypted):
-        return _('The file you want to import is password-protected. '
-                 'In order to upload it correctly you will have to select a copy '
-                 'of the file that does not use password protection.')
+        return _('The file you want to import is password protected. '
+                 'Please choose a file that is not password protected.')
     elif isinstance(e, ImporterExcelError):
         return _("The file uploaded has the following error: ").format(unicode(e))

--- a/corehq/apps/importer/views.py
+++ b/corehq/apps/importer/views.py
@@ -13,7 +13,6 @@ from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
 from corehq.apps.app_manager.models import ApplicationBase
 from corehq.util.files import file_extention_from_filename
-from corehq.util.soft_assert import soft_assert
 from soil.exceptions import TaskFailedError
 from soil.util import expose_cached_download, get_download_context
 from soil import DownloadBase

--- a/corehq/apps/importer/views.py
+++ b/corehq/apps/importer/views.py
@@ -5,12 +5,15 @@ from corehq.apps.hqcase.dbaccessors import get_case_properties, \
     get_case_types_for_domain
 from corehq.apps.importer import base
 from corehq.apps.importer import util as importer_util
+from corehq.apps.importer.exceptions import ImporterExcelFileEncrypted, \
+    ImporterFileNotFound, ImporterExcelError, ImporterError, ImporterRefError
 from corehq.apps.importer.tasks import bulk_import_async
 from django.views.decorators.http import require_POST
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
 from corehq.apps.app_manager.models import ApplicationBase
 from corehq.util.files import file_extention_from_filename
+from corehq.util.soft_assert import soft_assert
 from soil.exceptions import TaskFailedError
 from soil.util import expose_cached_download, get_download_context
 from soil import DownloadBase
@@ -74,10 +77,10 @@ def excel_config(request, domain):
         file_extension=file_extention_from_filename(uploaded_file_handle.name),
     )
     request.session[EXCEL_SESSION_ID] = file_ref.download_id
-    spreadsheet = importer_util.get_spreadsheet(file_ref, named_columns)
-
-    if not spreadsheet:
-        return _spreadsheet_expired(request, domain)
+    try:
+        spreadsheet = importer_util.get_spreadsheet(file_ref, named_columns)
+    except ImporterError as e:
+        return render_error(request, domain, _get_importer_error_message(e))
 
     columns = spreadsheet.get_header_columns()
     row_count = spreadsheet.get_num_rows()
@@ -184,9 +187,10 @@ def excel_fields(request, domain):
 
     download_ref = DownloadBase.get(request.session.get(EXCEL_SESSION_ID))
 
-    spreadsheet = importer_util.get_spreadsheet(download_ref, named_columns)
-    if not spreadsheet:
-        return _spreadsheet_expired(request, domain)
+    try:
+        spreadsheet = importer_util.get_spreadsheet(download_ref, named_columns)
+    except ImporterError as e:
+        return render_error(request, domain, _get_importer_error_message(e))
 
     columns = spreadsheet.get_header_columns()
 
@@ -270,16 +274,10 @@ def excel_commit(request, domain):
     excel_id = request.session.get(EXCEL_SESSION_ID)
 
     excel_ref = DownloadBase.get(excel_id)
-    spreadsheet = importer_util.get_spreadsheet(excel_ref, config.named_columns)
-
-    if not spreadsheet:
-        return _spreadsheet_expired(request, domain)
-
-    if spreadsheet.has_errors:
-        messages.error(request, _('The session containing the file you '
-                                  'uploaded has expired - please upload '
-                                  'a new one.'))
-        return HttpResponseRedirect(base.ImportCases.get_url(domain=domain) + "?error=cache")
+    try:
+        importer_util.get_spreadsheet(excel_ref, config.named_columns)
+    except ImporterError as e:
+        return render_error(request, domain, _get_importer_error_message(e))
 
     download = DownloadBase()
     download.set_task(bulk_import_async.delay(
@@ -334,3 +332,21 @@ def importer_job_poll(request, domain, download_id, template="importer/partials/
 def _spreadsheet_expired(req, domain):
     messages.error(req, _('Sorry, your session has expired. Please start over and try again.'))
     return HttpResponseRedirect(base.ImportCases.get_url(domain))
+
+
+def _get_importer_error_message(e):
+    if isinstance(e, ImporterRefError):
+        # I'm not totally sure this is the right error, but it's what was being
+        # used before. (I think people were just calling _spreadsheet_expired
+        # or otherwise blaming expired sessions whenever anything unexpected
+        # happened though...)
+        return _('Sorry, your session has expired. Please start over and try again.')
+    elif isinstance(e, ImporterFileNotFound):
+        return _('The session containing the file you uploaded has expired '
+                 '- please upload a new one.')
+    elif isinstance(e, ImporterExcelFileEncrypted):
+        return _('The file you want to import is password-protected. '
+                 'In order to upload it correctly you will have to select a copy '
+                 'of the file that does not use password protection.')
+    elif isinstance(e, ImporterExcelError):
+        return _("The file uploaded has the following error: ").format(unicode(e))


### PR DESCRIPTION
and refactor the error handling

<img width="967" alt="screen shot 2015-12-15 at 3 55 10 pm" src="https://cloud.githubusercontent.com/assets/137212/11823857/6c51cb3e-a344-11e5-92c7-8e70daa78946.png">

It was previously catching all errors and ignoring them until the final page
at which point it was reporting them as an expired session
