### PR TITLE
Data forward layout tweak

### DIFF
--- a/corehq/apps/repeaters/forms.py
+++ b/corehq/apps/repeaters/forms.py
@@ -56,15 +56,15 @@ class GenericRepeaterForm(forms.Form):
             'url',
             crispy.Div(
                 crispy.Div(
-                    crispy.Div(
-                        css_id='test-forward-result',
-                        css_class='text-success hide',
-                    ),
                     twbscrispy.StrictButton(
                         _('Test Link'),
                         type='button',
                         css_id='test-forward-link',
                         css_class='btn btn-info disabled',
+                    ),
+                    crispy.Div(
+                        css_id='test-forward-result',
+                        css_class='text-success hide',
                     ),
                     css_class='{} {}'.format(self.helper.field_class, self.helper.offset_class),
                 ),

--- a/corehq/apps/repeaters/forms.py
+++ b/corehq/apps/repeaters/forms.py
@@ -50,11 +50,11 @@ class GenericRepeaterForm(forms.Form):
         self.helper.form_class = 'form-horizontal'
         self.helper.label_class = 'col-sm-3 col-md-2'
         self.helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
+        self.helper.offset_class = 'col-sm-offset-3 col-md-offset-2'
 
         self.form_fields.extend([
             'url',
             crispy.Div(
-                crispy.Div('', css_class=self.helper.label_class),
                 crispy.Div(
                     crispy.Div(
                         css_id='test-forward-result',
@@ -66,7 +66,7 @@ class GenericRepeaterForm(forms.Form):
                         css_id='test-forward-link',
                         css_class='btn btn-info disabled',
                     ),
-                    css_class=self.helper.field_class,
+                    css_class='{} {}'.format(self.helper.field_class, self.helper.offset_class),
                 ),
                 css_class='form-group'
             ),


### PR DESCRIPTION
@biyeun i decided not to use the crispy template because this seemed simple enough. i moved the button above the result and also used offsets instead of an empty div

cc: @czue 
