### PR TITLE
changing api unauthorized message

### DIFF
--- a/corehq/apps/api/resources/__init__.py
+++ b/corehq/apps/api/resources/__init__.py
@@ -93,9 +93,10 @@ class HqBaseResource(CorsResourceMixin, JsonResourceMixin, Resource):
         if request.user.is_superuser or domain_has_privilege(request.domain, privileges.API_ACCESS):
             return super(HqBaseResource, self).dispatch(request_type, request, **kwargs)
         else:
-            raise ImmediateHttpResponse(HttpResponse(json.dumps({"error": "You have lost access to this feature"}),
-                                            content_type="application/json",
-                                            status=401))
+            raise ImmediateHttpResponse(HttpResponse(
+                json.dumps({"error": "Your current plan does not have access to this feature"}),
+                content_type="application/json",
+                status=401))
 
 
 class SimpleSortableResourceMixin(object):

--- a/corehq/apps/api/resources/__init__.py
+++ b/corehq/apps/api/resources/__init__.py
@@ -93,7 +93,7 @@ class HqBaseResource(CorsResourceMixin, JsonResourceMixin, Resource):
         if request.user.is_superuser or domain_has_privilege(request.domain, privileges.API_ACCESS):
             return super(HqBaseResource, self).dispatch(request_type, request, **kwargs)
         else:
-            raise ImmediateHttpResponse(HttpResponse(json.dumps({"error": "not authorized"}),
+            raise ImmediateHttpResponse(HttpResponse(json.dumps({"error": "You have lost access to this feature"}),
                                             content_type="application/json",
                                             status=401))
 


### PR DESCRIPTION
@czue 
This is in response to your comment on the ticket last week about vecna losing api access. The language is now in line with the accounting decorators we use for permission checks elsewhere in the code, and makes it clear what happened. Open to changing if you have other ideas, just wanted to get something out quickly before this slipped my mind.
cc: @sravfeyn @kaapstorm 
