### PR TITLE
JS Datadog logger

### DIFF
--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -7,6 +7,7 @@ import re
 import sys
 import traceback
 import uuid
+import httpagentparser
 
 from django.conf import settings
 from django.contrib import messages
@@ -48,7 +49,9 @@ from corehq.apps.users.util import format_username
 from corehq.apps.hqwebapp.doc_info import get_doc_info
 from corehq.util.cache_utils import ExponentialBackoff
 from corehq.util.context_processors import get_domain_type
-from corehq.util.datadog.utils import create_datadog_event
+from corehq.util.datadog.utils import create_datadog_event, log_counter, sanitize_url
+from corehq.util.datadog.metrics import JSERROR_COUNT
+from corehq.util.datadog.const import DATADOG_UNKNOWN
 from dimagi.utils.couch.database import get_db
 from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.logging import notify_exception, notify_js_exception
@@ -481,27 +484,26 @@ def debug_notify(request):
 
 @require_POST
 def jserror(request):
-    stack = request.POST.get('stack', None)
-    message = request.POST.get('message', None)
-    if stack:
-        cache_key = ' '.join(map(lambda l: l.strip(), stack.split('\n'))[:3])
-    else:
-        cache_key = message
+    agent = request.META.get('HTTP_USER_AGENT', None)
+    if agent:
+        parsed_agent = httpagentparser.detect(agent)
+        os = browser_name = browser_version = DATADOG_UNKNOWN
+        bot = parsed_agent.get('bot', False)
+        if 'os' in parsed_agent:
+            os = parsed_agent['os'].get('name', DATADOG_UNKNOWN)
 
-    count = ExponentialBackoff.increment(cache_key)
-    if not ExponentialBackoff.should_backoff(cache_key):
-        notify_js_exception(
-            request,
-            message=message,
-            details={
-                'filename': request.POST.get('filename', None),
-                'line': request.POST.get('line', None),
-                'page': request.POST.get('page', None),
-                'agent': request.META.get('HTTP_USER_AGENT', None),
-                'js_stack': stack,
-                'count': count,
-            }
-        )
+        if 'browser' in parsed_agent:
+            browser_version = parsed_agent['browser'].get('version', DATADOG_UNKNOWN)
+            browser_name = parsed_agent['browser'].get('name', DATADOG_UNKNOWN)
+
+    log_counter(JSERROR_COUNT, {
+        'os': os,
+        'browser_version': browser_version,
+        'browser_name': browser_name,
+        'url': sanitize_url(request.POST.get('page', None)),
+        'file': request.POST.get('filename'),
+        'bot': bot,
+    })
 
     return HttpResponse('')
 

--- a/corehq/apps/style/static/style/js/hq.helpers.js
+++ b/corehq/apps/style/static/style/js/hq.helpers.js
@@ -40,6 +40,17 @@ $(function() {
         $.post(post_url, {note_id: note_id});
         $(this).parents('.alert').hide(150);
     });
+
+    window.onerror = function(message, file, line, col, error) {
+        $.post('/jserror/', {
+            message: message,
+            page: window.location.href,
+            file: file,
+            line: line,
+            stack: error ? error.stack : null
+        });
+        return false; // let default handler run
+    };
 });
 
 var oldHide = $.fn.popover.Constructor.prototype.hide;

--- a/corehq/apps/style/templates/style/bootstrap2/base.html
+++ b/corehq/apps/style/templates/style/bootstrap2/base.html
@@ -367,18 +367,6 @@
         {% endblock %}
         </div>
         <!--Begin javascript -->
-        <script>
-            window.onerror = function(message, file, line, col, error) {
-                $.post('/jserror/', {
-                    message: message,
-                    page: window.location.href,
-                    file: file,
-                    line: line,
-                    stack: error ? error.stack : null
-                });
-                return false; // let default handler run
-            }
-        </script>
         {% include 'style/bootstrap2/partials/bootstrap2_js.html' %}
         <script src="{% static 'hqstyle/js/jquery/plugins/jquery.form.js' %}"></script>
 

--- a/corehq/apps/style/templates/style/bootstrap2/base.html
+++ b/corehq/apps/style/templates/style/bootstrap2/base.html
@@ -367,6 +367,18 @@
         {% endblock %}
         </div>
         <!--Begin javascript -->
+        <script>
+            window.onerror = function(message, file, line, col, error) {
+                $.post('/jserror/', {
+                    message: message,
+                    page: window.location.href,
+                    file: file,
+                    line: line,
+                    stack: error ? error.stack : null
+                });
+                return false; // let default handler run
+            }
+        </script>
         {% include 'style/bootstrap2/partials/bootstrap2_js.html' %}
         <script src="{% static 'hqstyle/js/jquery/plugins/jquery.form.js' %}"></script>
 

--- a/corehq/apps/style/templates/style/bootstrap3/base.html
+++ b/corehq/apps/style/templates/style/bootstrap3/base.html
@@ -332,6 +332,18 @@
                 ERROR_SAVING: '{% trans "There was an error deleting"|escapejs %}'
             }, 'btn btn-danger');
         </script>
+        <script>
+            window.onerror = function(message, file, line, col, error) {
+                $.post('/jserror/', {
+                    message: message,
+                    page: window.location.href,
+                    file: file,
+                    line: line,
+                    stack: error ? error.stack : null
+                });
+                return false; // let default handler run
+            }
+        </script>
 
         {# JavaScript Display Logic Libaries #}
 

--- a/corehq/apps/style/templates/style/bootstrap3/base.html
+++ b/corehq/apps/style/templates/style/bootstrap3/base.html
@@ -332,19 +332,6 @@
                 ERROR_SAVING: '{% trans "There was an error deleting"|escapejs %}'
             }, 'btn btn-danger');
         </script>
-        <script>
-            window.onerror = function(message, file, line, col, error) {
-                $.post('/jserror/', {
-                    message: message,
-                    page: window.location.href,
-                    file: file,
-                    line: line,
-                    stack: error ? error.stack : null
-                });
-                return false; // let default handler run
-            }
-        </script>
-
         {# JavaScript Display Logic Libaries #}
 
         {# Use knockout explicitly, opt to move to angular js when possible. #}

--- a/corehq/util/datadog/const.py
+++ b/corehq/util/datadog/const.py
@@ -2,3 +2,5 @@ ALERT_ERROR = 'error'
 ALERT_WARNING = 'warning'
 ALERT_INFO = 'info'
 ALERT_SUCCESS = 'success'
+
+DATADOG_UNKNOWN = '<unknown>'

--- a/corehq/util/datadog/metrics.py
+++ b/corehq/util/datadog/metrics.py
@@ -1,0 +1,1 @@
+JSERROR_COUNT = 'jserror.count'

--- a/corehq/util/datadog/utils.py
+++ b/corehq/util/datadog/utils.py
@@ -1,3 +1,5 @@
+import re
+import logging
 from functools import wraps
 
 from datadog.api.exceptions import DatadogException
@@ -7,6 +9,10 @@ from datadog import api
 
 
 from corehq.util.datadog.const import ALERT_INFO
+
+datadog_metric_logger = logging.getLogger('datadog-metrics')
+
+WILDCARD = '*'
 
 
 def count_by_response_code(metric_prefix):
@@ -43,3 +49,32 @@ def create_datadog_event(title, text, alert_type=ALERT_INFO, tags=None, aggregat
             datadog_logger.exception('Error creating Datadog event')
     else:
         datadog_logger.debug('Datadog event: (%s) %s\n%s', alert_type, title, text)
+
+
+def log_counter(metric, details=None):
+    details = details or {}
+    message = ' '.join(['{}={}'.format(key, value) for key, value in details.iteritems()])
+    datadog_metric_logger.info(
+        message,
+        extra={
+            'value': 1,
+            'metric_type': 'counter',
+            'metric': metric,
+        },
+    )
+
+
+def sanitize_url(url):
+    # Normalize all domain names
+    url = re.sub(r'/a/[0-9a-z-]+', '/a/{}'.format(WILDCARD), url)
+
+    # Normalize all urls with indexes or ids
+    url = re.sub(r'/modules-[0-9]+', '/modules-{}'.format(WILDCARD), url)
+    url = re.sub(r'/forms-[0-9]+', '/forms-{}'.format(WILDCARD), url)
+    url = re.sub(r'/form_data/[a-z0-9-]+', '/form_data/{}'.format(WILDCARD), url)
+    url = re.sub(r'/uuid:[a-z0-9-]+', '/uuid:{}'.format(WILDCARD), url)
+    url = re.sub(r'[-0-9a-f]{10,}', '{}'.format(WILDCARD), url)
+
+    # Remove URL params
+    url = re.sub(r'\?[^ ]*', '', url)
+    return url

--- a/corehq/util/tests/__init__.py
+++ b/corehq/util/tests/__init__.py
@@ -1,6 +1,7 @@
 from test_cache_util import *
 from test_couch import *
 from test_couchdb_management import *
+from test_datadog_utils import *
 from test_jsonobject import *
 from test_log import *
 from test_override_db import *

--- a/corehq/util/tests/test_datadog_utils.py
+++ b/corehq/util/tests/test_datadog_utils.py
@@ -1,0 +1,19 @@
+from django.test import SimpleTestCase
+
+from corehq.util.test_utils import generate_cases
+from corehq.util.datadog.utils import sanitize_url
+
+
+class DatadogUtilsTest(SimpleTestCase):
+    """Tests datadog utility functions"""
+
+
+@generate_cases([
+    (
+        '/a/uth-rhd/api/a26f2e21-5f24-48b6-b283-200a21f79bb6/20150922T034026.MP4',
+        '/a/*/api/*/20150922T034026.MP4'
+    ),
+    ('/a/ben/modules-1/forms-2/uuid:abc123/', '/a/*/modules-*/forms-*/uuid:*/')
+], DatadogUtilsTest)
+def test_sanitize_url(self, url, sanitized):
+    self.assertEqual(sanitize_url(url), sanitized)

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -83,3 +83,4 @@ django-uuidfield==0.5.0
 SQLAlchemy==1.0.9
 alembic==0.6.4
 django-statici18n==1.1.5
+httpagentparser==1.7.8

--- a/settings.py
+++ b/settings.py
@@ -111,6 +111,8 @@ del _formdesigner_path
 DJANGO_LOG_FILE = "%s/%s" % (FILEPATH, "commcarehq.django.log")
 ACCOUNTING_LOG_FILE = "%s/%s" % (FILEPATH, "commcarehq.accounting.log")
 ANALYTICS_LOG_FILE = "%s/%s" % (FILEPATH, "commcarehq.analytics.log")
+DATADOG_LOG_FILE = "%s/%s" % (FILEPATH, "commcarehq.datadog.log")
+
 
 # URL prefix for admin media -- CSS, JavaScript and images. Make sure to use a
 # trailing slash.
@@ -808,6 +810,9 @@ LOGGING = {
         'pillowtop': {
             'format': '%(asctime)s %(levelname)s %(module)s %(message)s'
         },
+        'datadog': {
+            'format': '%(metric)s %(created)s %(value)s metric_type=%(metric_type)s %(message)s'
+        }
     },
     'filters': {
         'require_debug_false': {
@@ -842,6 +847,12 @@ LOGGING = {
             'class': 'logging.FileHandler',
             'formatter': 'simple',
             'filename': ANALYTICS_LOG_FILE
+        },
+        'datadog': {
+            'level': 'INFO',
+            'class': 'logging.FileHandler',
+            'formatter': 'datadog',
+            'filename': DATADOG_LOG_FILE
         },
         'couchlog': {
             'level': 'WARNING',
@@ -910,6 +921,11 @@ LOGGING = {
             'handlers': ['analytics'],
             'level': 'DEBUG',
             'propagate': True,
+        },
+        'datadog-metrics': {
+            'handler': ['datadog'],
+            'level': 'INFO',
+            'propogate': False,
         },
     }
 }


### PR DESCRIPTION
@dimagi/js-team  this should get our feet wet in terms of JS error tracking. curious to see what kind of volume we get on this. and this won't blow up our emails like last time @czue :smile: this'll output this log format when your logging config is setup correctly (requires an ansible bit):

```
jserror.count 1450303032.07 1 metric_type=counter url=http://localhost:8000/a/*/dashboard/project/ bot=False browser_name=Chrome browser_version=46.0.2490.86 file=None os=Macintosh
```

which datadog should be able to parse correctly
