### PR TITLE
add comment about importer_job_poll error handling

### DIFF
--- a/corehq/apps/importer/views.py
+++ b/corehq/apps/importer/views.py
@@ -310,6 +310,8 @@ def importer_job_poll(request, domain, download_id, template="importer/partials/
     try:
         download_context = get_download_context(download_id, check_state=True)
     except TaskFailedError as e:
+        # todo: this is async, so it's totally inappropriate to be using messages.error
+        # todo: and HttpResponseRedirect
         error = e.errors
         if error == 'EXPIRED':
             return _spreadsheet_expired(request, domain)


### PR DESCRIPTION
something else i noticed when reproducing the error. When you get an error in the importer, it loads the entire CommCareHQ page into a div in the screen creating a very bizarre visual. Not fixing now, but thought I'd at least leave a note.
