### PR TITLE
one call to sort report

### DIFF
--- a/corehq/apps/reports/static/reports/javascripts/config.dataTables.bootstrap.js
+++ b/corehq/apps/reports/static/reports/javascripts/config.dataTables.bootstrap.js
@@ -11,7 +11,7 @@ function HQReportDataTables(options) {
     self.aoColumns = options.aoColumns;
     self.autoWidth = (options.autoWidth != undefined) ? options.autoWidth : true;
     self.defaultSort = (options.defaultSort != undefined) ? options.defaultSort : true;
-    self.customSort = options.customSort;
+    self.customSort = options.customSort || null;
     self.ajaxParams = options.ajaxParams || new Object();
     self.ajaxSource = options.ajaxSource;
     self.loadingText = options.loadingText || "Loading <img src='/static/hqwebapp/img/ajax-loader.gif' alt='loading indicator' />";
@@ -85,8 +85,8 @@ function HQReportDataTables(options) {
                 sScrollX: "100%",
                 bSort: self.defaultSort
             };
-            if (self.aaSorting !== null) {
-                params.aaSorting = self.aaSorting;
+            if (self.aaSorting !== null || self.customSort !== null) {
+                params.aaSorting = self.aaSorting || self.customSort;
             }
 
             if(self.ajaxSource) {
@@ -171,9 +171,7 @@ function HQReportDataTables(options) {
             var datatable = $(this).dataTable(params);
             if (!self.datatable)
                 self.datatable = datatable;
-            if(self.customSort) {
-                datatable.fnSort( self.customSort );
-            }
+
             if(self.fixColumns)
                 new FixedColumns( datatable, {
                     iLeftColumns: self.fixColsNumLeft,


### PR DESCRIPTION
@esoergel you might be interested in this. got side tracked when refactoring and ran into an oddity where the call to reports was being made twice. (i know we had seen this behavior before). found out that the call to `fnSort` would recall for all the data after it had just got all the data. an initialization of datatables makes an implicit call to grab data. this sets the sort parameter before initialization so we don't have that issue. datatables is a monster

buddy: @czue 
