### PR TITLE
add dialog encouraging upgrade

### DIFF
--- a/corehq/apps/users/templates/users/mobile_workers.html
+++ b/corehq/apps/users/templates/users/mobile_workers.html
@@ -199,14 +199,6 @@ $(function () {
                                        There will be an additional charge of {{ u }} per month per additional Mobile Worker over this limit.
                                        {% endblocktrans %}
                                     </p>
-                                    {% if show_inactive %}
-                                    <p>
-                                       {% blocktrans %}
-                                       You may not Reactivate any Mobile Workers until you Deactivate or delete existing Mobile Workers or
-                                       confirm your project's billing information.
-                                       {% endblocktrans %}
-                                    </p>
-                                    {% endif %}
                                     <p>
                                     {% if not can_edit_billing_info %}
                                        {% blocktrans %}

--- a/corehq/apps/users/templates/users/mobile_workers.html
+++ b/corehq/apps/users/templates/users/mobile_workers.html
@@ -208,11 +208,9 @@ $(function () {
                                     </p>
                                     {% endif %}
                                     <p>
-                                    {% if can_edit_billing_info %}
-                                       <a href="{% url 'extra_users_confirm_billing' domain %}" class="btn btn-primary">{% trans 'Confirm Billing Information' %}</a>
-                                    {% else %}
+                                    {% if not can_edit_billing_info %}
                                        {% blocktrans %}
-                                           Note: You must be a Billing Admin to confirm your Billing Information.
+                                           Note: You must be an admin web user to confirm your Billing Information.
                                        {% endblocktrans %}
                                     {% endif %}
                                     </p>
@@ -220,7 +218,7 @@ $(function () {
                             </div>
                             <div class="modal-footer">
                                 <button type="button" class="btn btn-default" data-dismiss="modal">{% trans 'Cancel' %}</button>
-                                <a href="{% url 'domain_subscription_view' domain %}" class="btn btn-primary">{% trans "Update Subscription" %}</a>
+                                <a href="{% url 'extra_users_confirm_billing' domain %}" class="btn btn-primary {% if not can_edit_billing_info %}disabled{% endif %}">{% trans 'Confirm Billing Information' %}</a>
                             </div>
                         </div>
                     </div>

--- a/corehq/apps/users/templates/users/mobile_workers.html
+++ b/corehq/apps/users/templates/users/mobile_workers.html
@@ -116,15 +116,14 @@ $(function () {
                         {% endblocktrans %}
                     </p>
                     <div class="btn-toolbar" style="margin-bottom: 20px;">
-                        {% if can_add_extra_users %}
-                            <button type="button"
-                                    class="btn btn-success"
-                                    data-toggle="modal"
-                                    data-target="#newMobileWorkerModal"
-                                    ng-click="initializeMobileWorker()">
-                                <i class="fa fa-plus"></i> {% trans "Create Mobile Worker" %}
-                            </button>
-                        {% endif %}
+
+                        <button type="button"
+                                class="btn btn-success"
+                                data-toggle="modal"
+                                data-target="#newMobileWorkerModal"
+                                ng-click="initializeMobileWorker()">
+                            <i class="fa fa-plus"></i> {% trans "Create Mobile Worker" %}
+                        </button>
                         {% if can_bulk_edit_users %}
                             <a id="bulk_download" class="btn btn-info" href="{% url "download_commcare_users" domain %}">
                                 <i class="icon-download-alt"></i> {% trans "Download Mobile Workers" %}
@@ -142,11 +141,41 @@ $(function () {
                 </div>
             </div>
             <div class="modal fade" id="newMobileWorkerModal">
-                <div class="modal-dialog">
-                    <form id="newMobileWorkerForm"
-                          name="mobileWorkerForm"
-                          novalidate
-                          ng-submit="submitNewMobileWorker()">
+                {% if can_add_extra_users %}
+                    <div class="modal-dialog">
+                        <form id="newMobileWorkerForm"
+                              name="mobileWorkerForm"
+                              novalidate
+                              ng-submit="submitNewMobileWorker()">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <button type="button" class="close" data-dismiss="modal">
+                                        <span aria-hidden="true">&times;</span>
+                                        <span class="sr-only">{% trans 'Close' %}</span>
+                                    </button>
+                                    <h3 class="modal-title">{% trans "Create New Mobile Worker" %}</h3>
+                                </div>
+                                <div class="modal-body">
+                                    <div class="form-horizontal">
+                                        {% crispy new_mobile_worker_form %}
+                                        {% if custom_fields_form.fields %}
+                                            {% crispy custom_fields_form %}
+                                        {% endif %}
+                                    </div>
+                                </div>
+                                <div class="modal-footer">
+                                    <button type="button" class="btn btn-default" data-dismiss="modal">{% trans 'Cancel' %}</button>
+                                    <button type="submit"
+                                            ng-disabled="mobileWorkerForm.$invalid || usernameAvailabilityStatus !== 'available'"
+                                            class="btn btn-primary">
+                                        {% trans "Create" %}
+                                    </button>
+                                </div>
+                            </div>
+                        </form>
+                    </div>
+                {% else %}
+                    <div class="modal-dialog">
                         <div class="modal-content">
                             <div class="modal-header">
                                 <button type="button" class="close" data-dismiss="modal">
@@ -156,24 +185,46 @@ $(function () {
                                 <h3 class="modal-title">{% trans "Create New Mobile Worker" %}</h3>
                             </div>
                             <div class="modal-body">
-                                <div class="form-horizontal">
-                                    {% crispy new_mobile_worker_form %}
-                                    {% if custom_fields_form.fields %}
-                                        {% crispy custom_fields_form %}
+                                <div class="alert">
+                                    {% url 'domain_select_plan' domain as change_plan_url %}
+                                    <p>
+                                    {% blocktrans with request.plan.user_limit as u %}
+                                       <strong>Mobile Worker Limit Reached:</strong> You have reached the limit of {{ u }}
+                                       Mobile Workers included with your plan. You may no longer add new Mobile Workers until you
+                                       confirm your project's billing information.
+                                    {% endblocktrans %}
+                                    </p>
+                                    <p>
+                                       {% blocktrans with request.plan.user_fee as u %}
+                                       There will be an additional charge of {{ u }} per month per additional Mobile Worker over this limit.
+                                       {% endblocktrans %}
+                                    </p>
+                                    {% if show_inactive %}
+                                    <p>
+                                       {% blocktrans %}
+                                       You may not Reactivate any Mobile Workers until you Deactivate or delete existing Mobile Workers or
+                                       confirm your project's billing information.
+                                       {% endblocktrans %}
+                                    </p>
                                     {% endif %}
+                                    <p>
+                                    {% if can_edit_billing_info %}
+                                       <a href="{% url 'extra_users_confirm_billing' domain %}" class="btn btn-primary">{% trans 'Confirm Billing Information' %}</a>
+                                    {% else %}
+                                       {% blocktrans %}
+                                           Note: You must be a Billing Admin to confirm your Billing Information.
+                                       {% endblocktrans %}
+                                    {% endif %}
+                                    </p>
                                 </div>
                             </div>
                             <div class="modal-footer">
                                 <button type="button" class="btn btn-default" data-dismiss="modal">{% trans 'Cancel' %}</button>
-                                <button type="submit"
-                                        ng-disabled="mobileWorkerForm.$invalid || usernameAvailabilityStatus !== 'available'"
-                                        class="btn btn-primary">
-                                    {% trans "Create" %}
-                                </button>
+                                <a href="{% url 'domain_subscription_view' domain %}" class="btn btn-primary">{% trans "Update Subscription" %}</a>
                             </div>
                         </div>
-                    </form>
-                </div>
+                    </div>
+                {% endif %}
             </div>
             {% angularjs %}
 

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -441,9 +441,9 @@ class MobileWorkerListView(JSONResponseMixin, BaseUserSettingsView):
             'custom_field_names': [f.label for f in self.custom_data.fields],
             'can_bulk_edit_users': self.can_bulk_edit_users,
             'can_add_extra_users': self.can_add_extra_users,
-            'pagination_limit_cookie_name': ('hq.pagination.limit'
-                                             '.mobile_workers_list.%s'
-                                             % self.domain)
+            'pagination_limit_cookie_name': (
+                'hq.pagination.limit.mobile_workers_list.%s' % self.domain),
+            'can_edit_billing_info': self.request.couch_user.is_domain_admin(self.domain)
         }
 
     @property


### PR DESCRIPTION
when a project cannot add more mobile workers

~~Screenshot:~~
<img width="649" alt="screen shot 2015-12-17 at 1 47 19 pm" src="https://cloud.githubusercontent.com/assets/137212/11878586/bf6adc3a-a4c4-11e5-9d20-6d724a35a80e.png">

(The “-1” and “USD 0” are an artifact of how I was triggering this screen to show up locally without jumping through the hoops of actually setting up a community project with 50 users; those numbers will show something sensical in any real production situation.)

~~Update Subscription button takes you to Current Subscription.~~

Screenshot:
<img width="612" alt="screen shot 2015-12-17 at 4 21 09 pm" src="https://cloud.githubusercontent.com/assets/137212/11882448/71a889be-a4da-11e5-974e-a3bb31acdecf.png">

When you are an admin, you won't see the “Note: ...” at the bottom, and the “Confirm Billing Information” button will be enabled and lead to the “Confirm Billing Information” page (/a/<domain>/settings/users/commcare/confirm_charges/).
