### PR TITLE
allow Calculate fields in TdH case tiles

### DIFF
--- a/corehq/apps/app_manager/suite_xml/case_tile_templates/tdh.txt
+++ b/corehq/apps/app_manager/suite_xml/case_tile_templates/tdh.txt
@@ -18,10 +18,6 @@
       	</push>
       </stack>
     </action>
-
-    <variables>
-        <ageindays function="today() - date({date[prop_name]})"/>
-    </variables>
     <field>
       <style
           horz-align="center"
@@ -62,12 +58,12 @@
       </header>
       <template>
         <text>
-          &lt;b&gt;{header[prefix]} &lt;/b&gt; <xpath function="{header[prop_name]}"/>
+          &lt;b&gt;{header[prefix]} &lt;/b&gt; <xpath function="{header[xpath_function]}"/>
         </text>
       </template>
       <sort type="string" order="-2" direction="ascending">
         <text>
-          <xpath function="{header[prop_name]}"/>
+          <xpath function="{header[xpath_function]}"/>
         </text>
       </sort>
     </field>
@@ -88,11 +84,11 @@
         </text>
       </header>
       <template>
-        <text>&lt;b&gt;{top_left[prefix]} &lt;/b&gt; <xpath function="{top_left[prop_name]}"/></text>
+        <text>&lt;b&gt;{top_left[prefix]} &lt;/b&gt; <xpath function="{top_left[xpath_function]}"/></text>
       </template>
       <sort type="string" order="-2" direction="ascending">
         <text>
-          <xpath function="{top_left[prop_name]}"/>
+          <xpath function="{top_left[xpath_function]}"/>
         </text>
       </sort>
     </field>
@@ -113,7 +109,7 @@
         </text>
       </header>
       <template>
-        <text>&lt;b&gt;{sex[prefix]} &lt;/b&gt;<xpath function="if({sex[prop_name]} = 'male', $kmale, if({sex[prop_name]} = 'female', $kfemale, ''))">
+        <text>&lt;b&gt;{sex[prefix]} &lt;/b&gt;<xpath function="{sex[xpath_function]}">
             <variable name="kfemale">
               <locale id="{sex[enum_keys][female]}"/>
             </variable>
@@ -140,11 +136,11 @@
         </text>
       </header>
       <template>
-        <text>&lt;b&gt;{bottom_left[prefix]} &lt;/b&gt; <xpath function="{bottom_left[prop_name]}"/></text>
+        <text>&lt;b&gt;{bottom_left[prefix]} &lt;/b&gt; <xpath function="{bottom_left[xpath_function]}"/></text>
       </template>
       <sort type="string" order="-2" direction="ascending">
         <text>
-          <xpath function="{bottom_left[prop_name]}"/>
+          <xpath function="{bottom_left[xpath_function]}"/>
         </text>
       </sort>
     </field>
@@ -165,7 +161,7 @@
         </text>
       </header>
       <template>
-        <text>&lt;b&gt;{date[prefix]} &lt;/b&gt; <xpath function="if($ageindays &gt; 30, concat(int($ageindays div 30.25), ' Mois'), concat(int($ageindays), ' Jours'))"/></text>
+        <text>&lt;b&gt;{date[prefix]} &lt;/b&gt; <xpath function="{date[xpath_function]}"/></text>
       </template>
     </field>
   </detail>

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -427,8 +427,9 @@ class CaseTileHelper(object):
     def _get_column_context(self, column):
         from corehq.apps.app_manager.detail_screen import get_column_generator
         context = {
-            "xpath_function": get_column_generator(
+            "xpath_function": escape(get_column_generator(
                 self.app, self.module, self.detail, column).xpath_function,
+                {'"': '&quot;'}),
             "locale_id": id_strings.detail_column_header_locale(
                 self.module, self.detail_type, column,
             ),

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -425,11 +425,10 @@ class CaseTileHelper(object):
         }
 
     def _get_column_context(self, column):
-        from corehq.apps.app_manager.detail_screen import get_column_xpath_generator
+        from corehq.apps.app_manager.detail_screen import get_column_generator
         context = {
-            "prop_name": get_column_xpath_generator(
-                self.app, self.module, self.detail, column
-            ).xpath,
+            "xpath_function": get_column_generator(
+                self.app, self.module, self.detail, column).xpath_function,
             "locale_id": id_strings.detail_column_header_locale(
                 self.module, self.detail_type, column,
             ),

--- a/corehq/apps/app_manager/tests/data/suite/app_case_tiles.json
+++ b/corehq/apps/app_manager/tests/data/suite/app_case_tiles.json
@@ -297,7 +297,7 @@
             {
               "case_tile_field": "header",
               "filter_xpath": "",
-              "format": "plain",
+              "format": "calculate",
               "isTab": false,
               "enum": [
                 
@@ -308,7 +308,7 @@
                 "en": ""
               },
               "doc_type": "DetailColumn",
-              "calc_xpath": ".",
+              "calc_xpath": "if(today() - date(dob) &gt; 30, concat(name, ' (', int((today() - date(dob)) div 30.25), ' Mois)'), concat(name, ' (',int(today() - date(dob)), ' Jours)'))",
               "field": "name",
               "model": "case",
               "hasAutocomplete": true,
@@ -395,7 +395,7 @@
               "case_tile_field": "date",
               "doc_type": "DetailColumn",
               "filter_xpath": "",
-              "format": "date",
+              "format": "calculate",
               "late_flag": 30,
               "enum": [
                 
@@ -406,7 +406,7 @@
               "time_ago_interval": 365.25,
               "field": "dob",
               "isTab": false,
-              "calc_xpath": ".",
+              "calc_xpath": "format-date(date(dob), '%e/%n/%Y')",
               "model": "case",
               "hasAutocomplete": true,
               "graph_configuration": null,

--- a/corehq/apps/app_manager/tests/data/suite/app_case_tiles.json
+++ b/corehq/apps/app_manager/tests/data/suite/app_case_tiles.json
@@ -308,7 +308,7 @@
                 "en": ""
               },
               "doc_type": "DetailColumn",
-              "calc_xpath": "if(today() - date(dob) &gt; 30, concat(name, ' (', int((today() - date(dob)) div 30.25), ' Mois)'), concat(name, ' (',int(today() - date(dob)), ' Jours)'))",
+              "calc_xpath": "if(today() - date(dob) > 30, concat(name, ' (', int((today() - date(dob)) div 30.25), ' Mois)'), concat(name, ' (',int(today() - date(dob)), ' Jours)'))",
               "field": "name",
               "model": "case",
               "hasAutocomplete": true,
@@ -406,7 +406,7 @@
               "time_ago_interval": 365.25,
               "field": "dob",
               "isTab": false,
-              "calc_xpath": "format-date(date(dob), '%e/%n/%Y')",
+              "calc_xpath": "format-date(date(dob), \"%e/%n/%Y\")",
               "model": "case",
               "hasAutocomplete": true,
               "graph_configuration": null,

--- a/corehq/apps/app_manager/tests/data/suite/suite-case-tiles.xml
+++ b/corehq/apps/app_manager/tests/data/suite/suite-case-tiles.xml
@@ -45,9 +45,6 @@
       </stack>
     </action>
 
-    <variables>
-        <ageindays function="today() - date(dob)"/>
-    </variables>
     <field>
       <style horz-align="center" vert-align="center" font-size="medium">
       	<grid grid-height="3" grid-width="2" grid-x="0" grid-y="0"/>
@@ -74,12 +71,12 @@
       </header>
       <template>
         <text>
-          &lt;b&gt; &lt;/b&gt; <xpath function="case_name"/>
+          &lt;b&gt; &lt;/b&gt; <xpath function="if(today() - date(dob) &gt; 30, concat(name, ' (', int((today() - date(dob)) div 30.25), ' Mois)'), concat(name, ' (',int(today() - date(dob)), ' Jours)'))"/>
         </text>
       </template>
       <sort type="string" order="-2" direction="ascending">
         <text>
-          <xpath function="case_name"/>
+          <xpath function="if(today() - date(dob) &gt; 30, concat(name, ' (', int((today() - date(dob)) div 30.25), ' Mois)'), concat(name, ' (',int(today() - date(dob)), ' Jours)'))"/>
         </text>
       </sort>
     </field>
@@ -149,7 +146,7 @@
         </text>
       </header>
       <template>
-        <text>&lt;b&gt; &lt;/b&gt; <xpath function="if($ageindays &gt; 30, concat(int($ageindays div 30.25), ' Mois'), concat(int($ageindays), ' Jours'))"/></text>
+        <text>&lt;b&gt; &lt;/b&gt; <xpath function="format-date(date(dob), '%e/%n/%Y')"/></text>
       </template>
     </field>
   </detail>

--- a/corehq/apps/app_manager/tests/data/suite/suite-case-tiles.xml
+++ b/corehq/apps/app_manager/tests/data/suite/suite-case-tiles.xml
@@ -146,7 +146,7 @@
         </text>
       </header>
       <template>
-        <text>&lt;b&gt; &lt;/b&gt; <xpath function="format-date(date(dob), '%e/%n/%Y')"/></text>
+        <text>&lt;b&gt; &lt;/b&gt; <xpath function="format-date(date(dob), &quot;%e/%n/%Y&quot;)"/></text>
       </template>
     </field>
   </detail>


### PR DESCRIPTION
@NoahCarnahan 

I took the approach of using the xpath_function method (taking advantage of whatever the default is for the Enum / Calculate / etc.). (I also renamed `prop_name` to `xpath_function`, accordingly.)

In terms of tests:
- `app_case_tiles.json` shows the changes that ismaila was proposing (making the "header" and the "date" tile blocks Calculate fields; "header" with the name + age, "date" with a formatted date)
- `suite-case-tiles.xml` shows the total changes to the suite.xml output, which should now correspond to the changes is `app_case_tiles.json` the way we want them to.
