### PR TITLE
Uniquify menu ids for shadow module's children

### DIFF
--- a/corehq/apps/app_manager/id_strings.py
+++ b/corehq/apps/app_manager/id_strings.py
@@ -284,13 +284,15 @@ def fixture_session_var(module):
     return u'fixture_value_m{module.id}'.format(module=module)
 
 
-def menu_id(module):
+def menu_id(module, suffix=""):
     put_in_root = getattr(module, 'put_in_root', False)
     if put_in_root:
         # handle circular calls, if bad module workflow setup
         return menu_id(module.root_module) if getattr(module, 'root_module', False) else ROOT
     else:
-        return u"m{module.id}".format(module=module)
+        if suffix:
+            suffix = ".{}".format(suffix)
+        return u"m{module.id}{suffix}".format(module=module, suffix=suffix)
 
 
 def form_command(form, module=None):

--- a/corehq/apps/app_manager/suite_xml/sections/menus.py
+++ b/corehq/apps/app_manager/suite_xml/sections/menus.py
@@ -77,10 +77,12 @@ class MenuContributor(SuiteContributorByModule):
 
             for id_module in id_modules:
                 for root_module in root_modules:
-                    menu_kwargs = {
-                        'id': id_strings.menu_id(id_module),
-                        'root': id_strings.menu_id(root_module) if root_module else None,
-                    }
+                    menu_kwargs = {}
+                    suffix = ""
+                    if root_module:
+                        menu_kwargs.update({'root': id_strings.menu_id(root_module)})
+                        suffix = id_strings.menu_id(root_module) if root_module.doc_type == 'ShadowModule' else ""
+                    menu_kwargs.update({'id': id_strings.menu_id(id_module, suffix)})
 
                     if supports_module_filter:
                         menu_kwargs['relevant'] = interpolate_xpath(module.module_filter)

--- a/corehq/apps/app_manager/tests/data/suite/shadow_module_families_source_parent.xml
+++ b/corehq/apps/app_manager/tests/data/suite/shadow_module_families_source_parent.xml
@@ -11,7 +11,7 @@
     </text>
     <command id="m1-f0"/>
   </menu>
-  <menu root="m2" id="m1">
+  <menu root="m2" id="m1.m2">
     <text>
       <locale id="modules.m1"/>
     </text>


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?184603

Duplicate menu entries are being shown when a shadow module's source is a parent module.

Shadow modules duplicate their source's command & menu structure, so a scenario with three modules, m1 (normal module), m2 (shadow module, source is m1), and m3 (child module, parent is m1) results in this menu:

```
<menu root="m1" id="m3">
    <command id="m3-f0">
</menu>
<menu root="m2" id="m3">
    <command id="m3-f0">
</menu>
```

...so the child module's form, `m3-f0`, is displayed twice.

Dealing with this by adjusting the id of the shadow's copy of the child module.

```
<menu root="m1" id="m3">
    <command id="m3-f0">
</menu>
<menu root="m2" id="m3.m2">
    <command id="m3-f0">
</menu>
```

@snopoke 
cc @nickpell 
