### PR TITLE
Use typeahead for project space when copying app

### DIFF
--- a/corehq/apps/app_manager/forms.py
+++ b/corehq/apps/app_manager/forms.py
@@ -7,7 +7,9 @@ from corehq.apps.domain.models import Domain
 
 
 class CopyApplicationForm(forms.Form):
-    domain = forms.CharField(label=_("Copy this app to project:"))
+    domain = forms.CharField(
+        label=_("Copy this app to project"),
+        widget=forms.TextInput(attrs={"data-bind":"typeahead: domain_names"}))
     name = forms.CharField(required=False, label=_('Name'))
 
     def __init__(self, app_id, *args, **kwargs):

--- a/corehq/apps/app_manager/forms.py
+++ b/corehq/apps/app_manager/forms.py
@@ -9,7 +9,7 @@ from corehq.apps.domain.models import Domain
 class CopyApplicationForm(forms.Form):
     domain = forms.CharField(
         label=_("Copy this app to project"),
-        widget=forms.TextInput(attrs={"data-bind":"typeahead: domain_names"}))
+        widget=forms.TextInput(attrs={"data-bind": "typeahead: domain_names"}))
     name = forms.CharField(required=False, label=_('Name'))
 
     def __init__(self, app_id, *args, **kwargs):

--- a/corehq/apps/app_manager/templates/app_manager/app_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/app_view.html
@@ -235,6 +235,14 @@
             ga_track_event('App Builder', 'Download Multimedia');
         });
     </script>
+    <script>
+        // Set up typeahead for domain names
+        $(function(){
+            $("#id_domain").koApplyBindings({
+                domain_names: {{ domain_names|JSON }},
+            });
+        });
+    </script>
 {% endblock %}
 
 {% block title %}

--- a/corehq/apps/app_manager/views/view_generic.py
+++ b/corehq/apps/app_manager/views/view_generic.py
@@ -16,6 +16,7 @@ from corehq.apps.hqmedia.controller import (
     MultimediaImageUploadController,
     MultimediaAudioUploadController,
 )
+from corehq.apps.domain.models import Domain
 from corehq.apps.hqmedia.models import (
     ApplicationMediaReference,
     CommCareImage,
@@ -194,9 +195,12 @@ def view_generic(request, domain, app_id=None, module_id=None, form_id=None,
         'app': app,
     })
 
-    # Pass form for Copy Application to template:
+    # Pass form for Copy Application to template
+    domain_names = [d.name for d in Domain.active_for_user(request.user)]
+    domain_names.sort()
     context.update({
-        'copy_app_form': copy_app_form if copy_app_form is not None else CopyApplicationForm(app_id)
+        'copy_app_form': copy_app_form if copy_app_form is not None else CopyApplicationForm(app_id),
+        'domain_names': domain_names,
     })
 
     context['latest_commcare_version'] = get_commcare_versions(request.user)[-1]


### PR DESCRIPTION
Inspired by Claire, in commcare-users:

> Make sure when CommCare HQ prompts you to copy over the application to your new space that you use only lowercase letters (even if the new project space name in the orange dropdown menu has a capitalized letter in it). Additionally if there is a space in the original name of the project space where you want the app to go, make sure to use a dash "-" instead. 

This would be a bit easier to use if we suggested project spaces you might want to copy to. Added autocomplete that will suggest the user's active project spaces but also allow free text entry. Ideally users would only deal with domain human-readable names, but that makes it harder to support free text.

![screen shot 2015-12-17 at 5 17 27 pm](https://cloud.githubusercontent.com/assets/1486591/11883634/5ea3742a-a4e2-11e5-91ff-37f9359b2cec.png)

code buddy @nickpell 
pinging @dimagi/product for approval
