### PR TITLE
Use jsUglify and have source maps!

### DIFF
--- a/.travis/matrix-installs.sh
+++ b/.travis/matrix-installs.sh
@@ -20,6 +20,7 @@ else
 fi
 
 if [ "${BOWER:-no}" = "yes" ]; then
+    npm install -g uglify-js
     npm install -g bower
     bower install
 fi

--- a/corehq/apps/style/tests/test_compress_command.py
+++ b/corehq/apps/style/tests/test_compress_command.py
@@ -67,6 +67,7 @@ class TestDjangoCompressOffline(SimpleTestCase):
         return False
 
     def test_compress_offline(self):
+        call_command('collectstatic', verbosity=0, interactive=False)
         with patch('sys.stdout', new_callable=StringIO) as mock_stdout:
             call_command('compress', force=True)
 

--- a/corehq/apps/style/uglify.py
+++ b/corehq/apps/style/uglify.py
@@ -1,0 +1,91 @@
+import subprocess
+
+from compressor.exceptions import FilterError
+from compressor.filters import CompilerFilter
+from compressor.js import JsCompressor
+from compressor.utils.stringformat import FormattableString as fstr
+from django.conf import settings
+from django.utils.safestring import mark_safe
+
+
+# For use with node.js' uglifyjs minifier
+class UglifySourcemapFilter(CompilerFilter):
+    command = (
+        "uglifyjs {infiles} -o {outfile} --source-map {mapfile}"
+        " --source-map-url {mapurl} --source-map-root {maproot} -c -m")
+
+    def input(self, **kwargs):
+        return self.content
+
+    def output(self, **kwargs):
+        options = dict(self.options)
+        options['outfile'] = kwargs['outfile']
+
+        infiles = []
+        for infile in kwargs['content_meta']:
+            # type, full_filename, relative_filename
+            infiles.append(infile[1])
+
+        options['infiles'] = ' '.join(f for f in infiles)
+
+        options['mapfile'] = kwargs['outfile'].replace('.js', '.map.js')
+
+        options['mapurl'] = '{}{}'.format(
+            settings.STATIC_URL, options['mapfile'])
+
+        options['maproot'] = settings.STATIC_URL
+
+        self.cwd = kwargs['root_location']
+
+        try:
+            command = fstr(self.command).format(**options)
+
+            proc = subprocess.Popen(
+                command, shell=True, cwd=self.cwd, stdout=self.stdout,
+                stdin=self.stdin, stderr=self.stderr)
+            err = proc.communicate()
+        except (IOError, OSError), e:
+            raise FilterError('Unable to apply %s (%r): %s' %
+                              (self.__class__.__name__, self.command, e))
+        else:
+            # If the process doesn't return a 0 success code, throw an error
+            if proc.wait() != 0:
+                if not err:
+                    err = ('Unable to apply %s (%s)' %
+                           (self.__class__.__name__, self.command))
+                raise FilterError(err)
+            if self.verbose:
+                self.logger.debug(err)
+
+
+class JsUglifySourcemapCompressor(JsCompressor):
+
+    def output(self, mode='file', forced=False):
+        content = self.filter_input(forced)
+        if not content:
+            return ''
+
+        concatenated_content = '\n'.join(
+            c.encode(self.charset) for c in content)
+
+        if settings.COMPRESS_ENABLED or forced:
+            filepath = self.get_filepath(concatenated_content, basename=None)
+
+            # UglifySourcemapFilter writes the file directly, as it needs to
+            # output the sourcemap as well
+            UglifySourcemapFilter(content).output(
+                outfile=filepath,
+                content_meta=self.split_content,
+                root_location=self.storage.base_location)
+
+            return self.output_file(mode, filepath)
+        else:
+            return concatenated_content
+
+    def output_file(self, mode, new_filepath):
+        """
+        The output method that saves the content to a file and renders
+        the appropriate template with the file's URL.
+        """
+        url = mark_safe(self.storage.url(new_filepath))
+        return self.render_output(mode, {"url": url})

--- a/corehq/apps/style/uglify.py
+++ b/corehq/apps/style/uglify.py
@@ -25,14 +25,15 @@ class UglifySourcemapFilter(CompilerFilter):
         infiles = []
         for infile in kwargs['content_meta']:
             # type, full_filename, relative_filename
-            infiles.append(infile[1])
+            infiles.append(infile[2])
 
         options['infiles'] = ' '.join(f for f in infiles)
 
         options['mapfile'] = kwargs['outfile'].replace('.js', '.map.js')
 
         options['mapurl'] = '{}{}'.format(
-            settings.STATIC_URL, options['mapfile'])
+            settings.STATIC_URL, options['mapfile']
+        )
 
         options['maproot'] = settings.STATIC_URL
 

--- a/corehq/apps/style/uglify.py
+++ b/corehq/apps/style/uglify.py
@@ -10,6 +10,7 @@ from django.utils.safestring import mark_safe
 
 
 # For use with node.js' uglifyjs minifier
+# Code taken from: https://roverdotcom.github.io/blog/2014/05/28/javascript-error-reporting-with-source-maps-in-django/
 class UglifySourcemapFilter(CompilerFilter):
     command = (
         "uglifyjs {infiles} -o {outfile} --source-map {mapfile}"

--- a/corehq/apps/style/uglify.py
+++ b/corehq/apps/style/uglify.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 
 from compressor.exceptions import FilterError
@@ -69,6 +70,11 @@ class JsUglifySourcemapCompressor(JsCompressor):
             c.encode(self.charset) for c in content)
 
         if settings.COMPRESS_ENABLED or forced:
+            js_compress_dir = os.path.join(
+                settings.STATIC_ROOT, self.output_dir, self.output_prefix
+            )
+            if not os.path.exists(js_compress_dir):
+                os.makedirs(js_compress_dir, 0775)
             filepath = self.get_filepath(concatenated_content, basename=None)
 
             # UglifySourcemapFilter writes the file directly, as it needs to

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "dependencies": {
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
-    "grunt-mocha": "^0.4.13",
     "grunt-contrib-watch": "^0.6.1",
-    "mocha": "^2.3.3"
+    "grunt-mocha": "^0.4.13",
+    "mocha": "^2.3.3",
+    "uglifyjs": "^2.4.10"
   }
 }

--- a/settings.py
+++ b/settings.py
@@ -1625,6 +1625,7 @@ COMPRESS_OFFLINE_CONTEXT = {
 }
 
 COMPRESS_CSS_HASHING_METHOD = 'content'
+COMPRESS_JS_COMPRESSOR = 'corehq.apps.style.uglify.JsUglifySourcemapCompressor'
 
 
 if 'locmem' not in CACHES:


### PR DESCRIPTION
@biyeun this switches compressor to use uglifyjs as the compressor. i imagine there might be some path issues on deploy with uglifier which shouldn't be too hard to figure out once i give it a go on staging. this should "just work". here's the output of the `staticfiles` dir:
<img width="722" alt="screen shot 2015-12-18 at 5 01 45 pm" src="https://cloud.githubusercontent.com/assets/918514/11899630/1211aefc-a5a9-11e5-9c71-1c2e83aeaebd.png">

one step closer to better javascript error reporting!! :runner: 

edit (more context): the original JS compressor didn't provide source maps. this is useful so we can get real numbers of where things broke in the javascript. this change uses a custom filter that basically just calls uglify on each of the concatenated content. uglify comes with options to add source maps. this also gives us more control of how we do our compression in general. though i'm still skeptical that this'll work completely because we concat all the files first so the lines are still messed up :disappointed: one thing we could do is save the uncompressed version along side the compressed version as like `[hex].uncompressed.js`. that way if we ever do error reporting and want to have "code context" we can pull from that. open to ideas
