### PR TITLE
Datespan Filter in Saved Reports not updating default text correctly

### DIFF
--- a/corehq/apps/reports_core/templates/reports_core/filters/datespan_filter/datespan_filter.js
+++ b/corehq/apps/reports_core/templates/reports_core/filters/datespan_filter/datespan_filter.js
@@ -1,11 +1,20 @@
-var filter_id = "#{{ filter.css_id }}-input";
-$(filter_id).createBootstrap3DefaultDateRangePicker();
-$(filter_id).on('apply change', function(ev, picker) {
-    var separator = $().getDateRangeSeparator();
-    var dates = $(this).val().split(separator);
-    $('#{{ filter.css_id }}-start').val(dates[0]);
-    $('#{{ filter.css_id }}-end').val(dates[1]);
-});
-if(!$(filter_id).val()) {
-    $(filter_id).val("Show All Dates");
-}
+(function ($, gettext) {
+    var filter_id = "#{{ filter.css_id }}-input";
+    var filter_id_start = '#{{ filter.css_id }}-start';
+    var filter_id_end = '#{{ filter.css_id }}-end';
+
+    $(filter_id).createBootstrap3DefaultDateRangePicker();
+    $(filter_id).on('apply change', function (ev, picker) {
+        var separator = $().getDateRangeSeparator();
+        var dates = $(this).val().split(separator);
+        $(filter_id_start).val(dates[0]);
+        $(filter_id_end).val(dates[1]);
+    });
+
+    if (!$(filter_id).val() && $(filter_id_start).val() && $(filter_id_end).val()) {
+        var text = $(filter_id_start).val() + $().getDateRangeSeparator() + $(filter_id_end).val();
+        $(filter_id).val(text);
+    } else if (!$(filter_id).val()) {
+        $(filter_id).val(gettext("Show All Dates"));
+    }
+})($, gettext);


### PR DESCRIPTION
With a saved report datespan defaulting to 7 days, the datespan filter still reads 'Show All Dates' as the value in the input when the saved report is loaded (the widget is configured correcly, but the user doesn't immediately see that).

Ticket: http://manage.dimagi.com/default.asp?189447
This pr:
- updates to the correct behavior
- surrounds the offending code in a closure
- adds a translation

@dannyroberts @sravfeyn 
