### PR TITLE
Move ewsghana into the other group of travis tests

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -1601,7 +1601,7 @@ TRAVIS_TEST_GROUPS = (
         'auditcare', 'bihar', 'builds', 'cachehq', 'callcenter', 'care_benin',
         'case', 'casegroups', 'cleanup', 'cloudcare', 'commtrack', 'consumption',
         'couchapps', 'couchlog', 'crud', 'cvsu', 'django_digest',
-        'domain', 'domainsync', 'export',
+        'domain', 'domainsync', 'export', 'sms',
         'facilities', 'fixtures', 'fluff_filter', 'formplayer',
         'formtranslate', 'fri', 'grapevine', 'groups', 'gsid', 'hope',
         'hqadmin', 'hqcase', 'hqcouchlog', 'hqmedia',


### PR DESCRIPTION
Looks like that's a particularly time-consuming test module, and this group
consistently takes less time to complete than the other group of tests.
@emord (wise to wait for build on this one, also so we can check the test times)
