### PR TITLE
Remove SavedBasicExport.migrating_blobs_from_couch

### DIFF
--- a/corehq/blobs/migrate.py
+++ b/corehq/blobs/migrate.py
@@ -51,11 +51,14 @@ models' attachments to the blob database:
    Then modify the new migration, adding an operation:
    ```
    operations = [
-       migrations.RunPython(*assert_migration_complete("<your_slug>"))
+       HqRunPython(*assert_migration_complete("<your_slug>"))
    ]
    ```
    Don't forget to put
-   `from corehq.blobs.migrate import assert_migration_complete`
+   ```
+   from corehq.blobs.migrate import assert_migration_complete
+   from corehq.sql_db.operations import HqRunPython
+   ```
    at the top of the file.
 
 7. Deploy.
@@ -87,7 +90,9 @@ Run these commands to procede with migrations:
 ./manage.py migrate
 
 Note: --file=FILE is optional and can be omitted if you do not want to
-keep a copy of the pre-migrated couch documents.
+keep a copy of the couch documents that were migrated. Also note that
+the copy of the couch documents will not include attachment content
+because `get_all_docs_with_doc_types()` does not support that.
 
 See also:
 https://github.com/dimagi/commcare-hq/blob/master/corehq/blobs/migrate.py

--- a/corehq/blobs/migrations/0002_auto_20151221_1623.py
+++ b/corehq/blobs/migrations/0002_auto_20151221_1623.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+from corehq.blobs.migrate import assert_migration_complete
+from corehq.sql_db.operations import HqRunPython
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('blobs', '0001_initial'),
+    ]
+
+    operations = [
+       HqRunPython(*assert_migration_complete("saved_exports"))
+    ]

--- a/corehq/ex-submodules/couchexport/models.py
+++ b/corehq/ex-submodules/couchexport/models.py
@@ -935,7 +935,6 @@ class SavedBasicExport(BlobMixin, Document):
     A cache of an export that lives in couch.
     Doesn't do anything smart, just works off an index
     """
-    migrating_blobs_from_couch = True
     configuration = SchemaProperty(ExportConfiguration)
     last_updated = DateTimeProperty()
     last_accessed = DateTimeProperty()


### PR DESCRIPTION
The migration has already been run on prod and staging, so this should not create an issue during deploys there. We will need to run the management command on india and switzerland, any others? zambia? prior to deploying this.

Dev environments should upgrade seamlessly if there are less than 500 docs with attachments in your local couchdb. If there more, it will stop the migration and require a manual management command before commencing with `./manage.py migrate`.

@dannyroberts cc @snopoke 
