### PR TITLE
[FIX] Removing case properties / preloads did not activate save button

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/careplan-config-ui.js
+++ b/corehq/apps/app_manager/static/app_manager/js/careplan-config-ui.js
@@ -259,6 +259,7 @@ var CareplanConfig = (function () {
 
             self.removeProperty = function (property) {
                 self.case_properties.remove(property);
+                self.careplanConfig.saveButton.fire('change');
             };
 
             self.addPreload = function () {
@@ -272,6 +273,7 @@ var CareplanConfig = (function () {
 
             self.removePreload = function (property) {
                 self.case_preload.remove(property);
+                self.careplanConfig.saveButton.fire('change');
             };
 
             self.repeat_context = function () {

--- a/corehq/apps/app_manager/static/app_manager/js/case-config-ui-2.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case-config-ui-2.js
@@ -312,6 +312,7 @@ var CaseConfig = (function () {
 
             self.removeProperty = function (property) {
                 self.case_properties.remove(property);
+                self.caseConfig.saveButton.fire('change');
             };
 
             self.propertyCounts = ko.computed(function () {
@@ -339,6 +340,7 @@ var CaseConfig = (function () {
 
                 self.removePreload = function (property) {
                     self.case_preload.remove(property);
+                    self.caseConfig.saveButton.fire('change');
                 };
 
                 self.preloadCounts = ko.computed(function () {
@@ -494,6 +496,7 @@ var CaseConfig = (function () {
 
             self.removeProperty = function (property) {
                 self.case_properties.remove(property);
+                self.caseConfig.saveUsercaseButton.fire('change');
             };
 
             self.propertyCounts = ko.computed(function () {
@@ -521,6 +524,7 @@ var CaseConfig = (function () {
 
                 self.removePreload = function (property) {
                     self.case_preload.remove(property);
+                    self.caseConfig.saveUsercaseButton.fire('change');
                 };
 
                 self.preloadCounts = ko.computed(function () {

--- a/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
@@ -717,6 +717,7 @@ var AdvancedCase = (function () {
 
             self.removeProperty = function (property) {
                 self.case_properties.remove(property);
+                self.config.saveButton.fire('change');
             };
 
             self.addPreload = function () {
@@ -729,6 +730,7 @@ var AdvancedCase = (function () {
 
             self.removePreload = function (property) {
                 self.preload.remove(property);
+                self.config.saveButton.fire('change');
             };
 
             self.hasPreload = function() {
@@ -950,6 +952,7 @@ var AdvancedCase = (function () {
 
             self.removeProperty = function (property) {
                 self.case_properties.remove(property);
+                self.config.saveButton.fire('change');
             };
 
             self.relationshipTypes = ActionBase.relationshipTypes;


### PR DESCRIPTION
Resolves the bug described in this ticket:
http://manage.dimagi.com/default.asp?189170#1062318

This bug is correlated with the jquery upgrade. I couldn't quite boil it down to the root cause. Perhaps we were relying on something bad that old jquery was doing which got fixed in the new version. Perhaps it's unrelated to jquery. After spending some time trying to figure out why, I just decided on this fix, which fires the `change` event on the appropriate save button for the `removeProperty` and `removePreload` actions. Note: don't confuse our implementation of `removeProperty` with the jquery `removeProperty`. Two different things.

@sravfeyn @nickpell @emord 
