### PR TITLE
Add `match_all` filter if all filters are removed.

### DIFF
--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -301,6 +301,8 @@ class ESQuery(object):
         query = deepcopy(self)
         if default in query._default_filters:
             query._default_filters.pop(default)
+        if len(query._default_filters) == 0:
+            query._default_filters = {"match_all": filters.match_all()}
         return query
 
     def values(self, *fields):

--- a/corehq/apps/es/tests.py
+++ b/corehq/apps/es/tests.py
@@ -120,6 +120,14 @@ class TestESQuery(ElasticTestMixin, TestCase):
                 .xmlns('banana')
         self.checkQuery(query, json_output)
 
+    def test_remove_all_defaults(self):
+        # Elasticsearch fails if you pass it an empty list of filters
+        query = (users.UserES()
+                 .remove_default_filter('not_deleted')
+                 .remove_default_filter('active'))
+        filters = query.raw_query['query']['filtered']['filter']['and']
+        self.assertTrue(len(filters) > 0)
+
 
 class TestESQuerySet(TestCase):
     example_response = {


### PR DESCRIPTION
If you try to send a query to elasticsearch with no filters, it will throw an exception.  ESQuery normally has the `"match_all"` noop filter to prevent this, but you could still trigger this condition by removing the default filters directly.
https://github.com/dimagi/commcare-hq/commit/b3afe204082c222b918bbb0e077f722047cb2e59#commitcomment-15082505
