### PR TITLE
Create user in hubspot before sign in

### DIFF
--- a/corehq/apps/analytics/signals.py
+++ b/corehq/apps/analytics/signals.py
@@ -132,4 +132,4 @@ def track_user_login(sender, request, user, **kwargs):
             return
 
         meta = get_meta(request)
-        track_user_sign_in_on_hubspot.delay(couch_user, request.COOKIES, meta)
+        track_user_sign_in_on_hubspot(couch_user, request.COOKIES, meta, request.path)

--- a/corehq/apps/analytics/signals.py
+++ b/corehq/apps/analytics/signals.py
@@ -132,4 +132,4 @@ def track_user_login(sender, request, user, **kwargs):
             return
 
         meta = get_meta(request)
-        track_user_sign_in_on_hubspot(couch_user, request.COOKIES, meta, request.path)
+        track_user_sign_in_on_hubspot.delay(couch_user, request.COOKIES, meta, request.path)

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -17,6 +17,7 @@ import KISSmetrics
 import logging
 
 from django.conf import settings
+from django.core.urlresolvers import reverse
 from corehq.util.soft_assert import soft_assert
 from corehq.apps.accounting.models import SoftwarePlanEdition
 
@@ -156,16 +157,13 @@ def update_hubspot_properties(webuser, properties):
 
 
 @task(queue='background_queue', acks_late=True, ignore_result=True)
-def track_created_hq_account_on_hubspot(webuser, cookies, meta):
-    _track_on_hubspot(webuser, {
-        'created_account_in_hq': True,
-        'is_a_commcare_user': True,
-    })
-    _send_form_to_hubspot(HUBSPOT_SIGNUP_FORM_ID, webuser, cookies, meta)
-
-
-@task(queue='background_queue', acks_late=True, ignore_result=True)
-def track_user_sign_in_on_hubspot(webuser, cookies, meta):
+def track_user_sign_in_on_hubspot(webuser, cookies, meta, path):
+    if path.startswith(reverse("register_user")):
+        _track_on_hubspot(webuser, {
+            'created_account_in_hq': True,
+            'is_a_commcare_user': True,
+        })
+        _send_form_to_hubspot(HUBSPOT_SIGNUP_FORM_ID, webuser, cookies, meta)
     _send_form_to_hubspot(HUBSPOT_SIGNIN_FORM_ID, webuser, cookies, meta)
 
 

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -11,7 +11,6 @@ from django.utils.translation import ugettext as _
 import sys
 
 from corehq.apps.analytics.tasks import (
-    track_created_hq_account_on_hubspot,
     track_workflow,
     track_confirmed_account_on_hubspot,
 )
@@ -70,15 +69,6 @@ def register_user(request, domain_type=None):
                 new_user = authenticate(username=form.cleaned_data['email'],
                                         password=form.cleaned_data['password'])
 
-                meta = {
-                    'HTTP_X_FORWARDED_FOR': request.META.get('HTTP_X_FORWARDED_FOR'),
-                    'REMOTE_ADDR': request.META.get('REMOTE_ADDR'),
-                }  # request.META can't be pickled for use by the task, so we copy the pertinent properties
-                track_created_hq_account_on_hubspot.delay(
-                    CouchUser.get_by_username(new_user.username),
-                    request.COOKIES,
-                    meta
-                )
                 track_workflow(new_user.email, "Requested new account")
 
                 login(request, new_user)


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?188760

@proteusvacuum not sure this is the best way to do this. since the login comes from a signal, but the register user did not, there'd need to be a larger refactor to use celery chaining. Or I could just be missing something obvious

cc: @esoergel 
