### PR TITLE
Add hq helpers to edit menu

### DIFF
--- a/corehq/apps/builds/templates/builds/edit_menu.html
+++ b/corehq/apps/builds/templates/builds/edit_menu.html
@@ -111,6 +111,7 @@
     <script type="text/javascript" src="{% static 'knockout-2.3.0-legacy/knockout.js' %}"></script>
     <script type="text/javascript" src="{% static 'underscore-legacy/underscore-min.js' %}"></script>
     <script type="text/javascript" src="{% static 'style/ko/knockout_bindings.ko.js' %}"></script>
+    <script type="text/javascript" src="{% static 'style/js/hq.helpers.js' %}"></script>
     <script>
         var doc = {{ doc|JSON }};
         var pretty_doc = JSON.stringify(doc, undefined, 2)


### PR DESCRIPTION
js error was: Uncaught TypeError: $(...).koApplyBindings is not a function

@phillipm reported this on slack

cc: @esoergel 
