### PR TITLE
Archive/Restore logos based on subscription privileges

### DIFF
--- a/corehq/apps/accounting/tests/__init__.py
+++ b/corehq/apps/accounting/tests/__init__.py
@@ -10,3 +10,4 @@ from .test_new_domain_subscription import *
 from .test_renew_subscription import *
 from .test_forms import *
 from .test_autopay import *
+from .test_subscription_permissions_changes import *

--- a/corehq/apps/accounting/tests/data/app-commcare-icon-build.json
+++ b/corehq/apps/accounting/tests/data/app-commcare-icon-build.json
@@ -1,0 +1,1198 @@
+{
+   "_id": "c9ef81db4836c4eb5037ac49253880ec",
+   "comment": "",
+   "multimedia_map": {
+       "jr://file/commcare/logo/data/hq_logo_android_login.png": {
+           "doc_type": "HQMediaMapItem",
+           "output_size": {
+           },
+           "version": 7,
+           "multimedia_id": "c9ef81db4836c4eb5037ac4925193db7",
+           "media_type": "CommCareImage",
+           "unique_id": "65a3afc128a74c7e38fac23aeb92f64e"
+       },
+       "jr://file/commcare/logo/data/hq_logo_android_home.png": {
+           "doc_type": "HQMediaMapItem",
+           "output_size": {
+           },
+           "version": 7,
+           "multimedia_id": "c9ef81db4836c4eb5037ac4925193db7",
+           "media_type": "CommCareImage",
+           "unique_id": "1e89448f48bfdae8b2c0d8396a51de37"
+       }
+   },
+   "domain": "test-sub-changes",
+   "build_langs": [
+       "en"
+   ],
+   "auto_gps_capture": false,
+   "short_url": null,
+   "deployment_date": null,
+   "user_type": null,
+   "text_input": "roman",
+   "secure_submissions": true,
+   "build_broken": false,
+   "minimum_use_threshold": "15",
+   "custom_base_url": null,
+   "copy_of": "455f5cc9cfe7cb6e69093f143bf97fe1",
+   "phone_model": null,
+   "build_signed": true,
+   "recipients": "",
+   "copy_history": [
+   ],
+   "platform": "nokia/s40",
+   "media_form_errors": false,
+   "application_version": "2.0",
+   "is_released": false,
+   "version": 7,
+   "admin_password": null,
+   "build_spec": {
+       "doc_type": "BuildSpec",
+       "version": "2.16.0",
+       "build_number": null,
+       "latest": true
+   },
+   "admin_password_charset": "n",
+   "logo_refs": {
+       "hq_logo_android_home": {
+           "updated": false,
+           "m_id": "c9ef81db4836c4eb5037ac4925193db7",
+           "icon_class": "icon-picture",
+           "uid": "2a02b1e09ee78daee18b5244dc76eba9",
+           "url": "/hq/multimedia/file/CommCareImage/c9ef81db4836c4eb5037ac4925193db7/",
+           "original_path": null,
+           "path": "jr://file/commcare/logo/data/hq_logo_android_home.png",
+           "media_type": "Image"
+       },
+       "hq_logo_android_login": {
+           "updated": false,
+           "m_id": "c9ef81db4836c4eb5037ac4925193db7",
+           "icon_class": "icon-picture",
+           "uid": "2a02b1e09ee78daee18b5244dc76eba9",
+           "url": "/hq/multimedia/file/CommCareImage/c9ef81db4836c4eb5037ac4925193db7/",
+           "original_path": null,
+           "media_type": "Image",
+           "path": "jr://file/commcare/logo/data/hq_logo_android_login.png"
+       }
+   },
+   "short_odk_media_url": null,
+   "short_odk_url": null,
+   "amplifies_workers": "not_set",
+   "comment_from": "99d62cda964b23d3f2b0e18ca67c1011",
+   "cloudcare_enabled": true,
+   "description": null,
+   "user_registration": {
+       "doc_type": "UserRegistrationForm",
+       "xmlns": null,
+       "name": {
+       },
+       "password_path": "password",
+       "auto_gps_capture": false,
+       "schedule_form_id": null,
+       "show_count": false,
+       "version": null,
+       "no_vellum": false,
+       "form_links": [
+       ],
+       "post_form_workflow": "default",
+       "form_type": "user_registration",
+       "username_path": "username",
+       "unique_id": "6d95add353e24c67357393a7bad39c30e5422a47",
+       "data_paths": {
+       }
+   },
+   "use_grid_menus": false,
+   "translations": {
+   },
+   "built_on": "2015-12-23T21:12:41.168885Z",
+   "built_with": {
+       "doc_type": "BuildRecord",
+       "build_number": 339716,
+       "signed": true,
+       "datetime": "2015-12-23T21:12:41.168885Z",
+       "version": "2.16.0",
+       "latest": null
+   },
+   "profile": {
+       "features": {
+           "users": "true",
+           "sense": "false"
+       },
+       "properties": {
+           "cc-user-mode": "cc-u-normal",
+           "cc-show-saved": "yes",
+           "restore-tolerance": "loose",
+           "cc-days-form-retain": "-1",
+           "cc-fuzzy-search-enabled": "yes",
+           "cc-autoup-freq": "freq-never",
+           "purge-freq": "0",
+           "server-tether": "push-only",
+           "user_reg_server": "required",
+           "extra_key_action": "audio",
+           "log_prop_daily": "log_never",
+           "ViewStyle": "v_chatterbox",
+           "cc-login-duration-seconds": "86400",
+           "cc-resize-images": "none",
+           "cc-entry-mode": "cc-entry-quick",
+           "cc-send-procedure": "cc-send-http",
+           "cc-login-images": "No",
+           "log_prop_weekly": "log_short",
+           "cc-show-incomplete": "yes",
+           "cc-send-unsent": "cc-su-auto",
+           "loose_media": "no",
+           "password_format": "n",
+           "unsent-number-limit": "5",
+           "cc-content-valid": "no",
+           "logenabled": "Enabled"
+       }
+   },
+   "case_sharing": false,
+   "langs": [
+       "en"
+   ],
+   "use_custom_suite": false,
+   "build_comment": "asdfa",
+   "build_broken_reason": null,
+   "doc_type": "Application",
+   "cached_properties": {
+   },
+   "name": "Surveys",
+   "amplifies_project": "not_set",
+   "modules": [
+       {
+           "comment": "",
+           "referral_label": {
+               "en": "Referrals"
+           },
+           "case_list": {
+               "doc_type": "CaseList",
+               "label": {
+               },
+               "media_audio": null,
+               "media_image": null,
+               "show": false
+           },
+           "auto_select_case": false,
+           "put_in_root": false,
+           "root_module_id": null,
+           "ref_details": {
+               "doc_type": "DetailPair",
+               "short": {
+                   "doc_type": "Detail",
+                   "persist_case_context": null,
+                   "pull_down_tile": null,
+                   "sort_elements": [
+                   ],
+                   "tabs": [
+                   ],
+                   "lookup_responses": [
+                   ],
+                   "lookup_image": null,
+                   "filter": null,
+                   "persist_tile_on_forms": null,
+                   "custom_xml": null,
+                   "lookup_name": null,
+                   "use_case_tiles": null,
+                   "lookup_extras": [
+                   ],
+                   "columns": [
+                   ],
+                   "lookup_action": null,
+                   "display": "short",
+                   "lookup_enabled": false
+               },
+               "long": {
+                   "doc_type": "Detail",
+                   "persist_case_context": null,
+                   "pull_down_tile": null,
+                   "sort_elements": [
+                   ],
+                   "tabs": [
+                   ],
+                   "lookup_responses": [
+                   ],
+                   "lookup_image": null,
+                   "filter": null,
+                   "persist_tile_on_forms": null,
+                   "custom_xml": null,
+                   "lookup_name": null,
+                   "use_case_tiles": null,
+                   "lookup_extras": [
+                   ],
+                   "columns": [
+                   ],
+                   "lookup_action": null,
+                   "display": "long",
+                   "lookup_enabled": false
+               }
+           },
+           "case_label": {
+               "en": "Cases"
+           },
+           "referral_list": {
+               "doc_type": "CaseList",
+               "label": {
+               },
+               "media_audio": null,
+               "media_image": null,
+               "show": false
+           },
+           "media_image": null,
+           "parent_select": {
+               "active": false,
+               "module_id": null,
+               "relationship": "parent",
+               "doc_type": "ParentSelect"
+           },
+           "forms": [
+               {
+                   "comment": "",
+                   "doc_type": "Form",
+                   "xmlns": "http://openrosa.org/formdesigner/E2E07B3C-9665-4247-B2E9-D0162C4B0D6C",
+                   "form_filter": "",
+                   "name": {
+                       "en": "Survey 1"
+                   },
+                   "auto_gps_capture": false,
+                   "schedule_form_id": null,
+                   "show_count": false,
+                   "requires": "none",
+                   "actions": {
+                       "doc_type": "FormActions",
+                       "subcases": [
+                       ],
+                       "usercase_preload": {
+                           "preload": {
+                           },
+                           "doc_type": "PreloadAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "update_case": {
+                           "doc_type": "UpdateCaseAction",
+                           "update": {
+                           },
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "close_referral": {
+                           "doc_type": "FormAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "open_referral": {
+                           "name_path": null,
+                           "doc_type": "OpenReferralAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           },
+                           "followup_date": null
+                       },
+                       "open_case": {
+                           "name_path": null,
+                           "doc_type": "OpenCaseAction",
+                           "external_id": null,
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "usercase_update": {
+                           "doc_type": "UpdateCaseAction",
+                           "update": {
+                           },
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "update_referral": {
+                           "doc_type": "UpdateReferralAction",
+                           "followup_date": null,
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "referral_preload": {
+                           "preload": {
+                           },
+                           "doc_type": "PreloadAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "case_preload": {
+                           "preload": {
+                           },
+                           "doc_type": "PreloadAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "close_case": {
+                           "doc_type": "FormAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       }
+                   },
+                   "version": null,
+                   "no_vellum": false,
+                   "media_image": null,
+                   "form_links": [
+                   ],
+                   "post_form_workflow": "default",
+                   "form_type": "module_form",
+                   "media_audio": null,
+                   "unique_id": "ed360a947c07a6f95cf87fe08a774580f4835381"
+               },
+               {
+                   "comment": "",
+                   "doc_type": "Form",
+                   "xmlns": "http://openrosa.org/formdesigner/5E654925-C1FA-4D1A-A172-E21BA89F01AC",
+                   "form_filter": "",
+                   "name": {
+                       "en": "Survey 2"
+                   },
+                   "auto_gps_capture": false,
+                   "schedule_form_id": null,
+                   "show_count": false,
+                   "requires": "none",
+                   "actions": {
+                       "doc_type": "FormActions",
+                       "subcases": [
+                       ],
+                       "usercase_preload": {
+                           "preload": {
+                           },
+                           "doc_type": "PreloadAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "update_case": {
+                           "doc_type": "UpdateCaseAction",
+                           "update": {
+                           },
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "close_referral": {
+                           "doc_type": "FormAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "open_referral": {
+                           "name_path": null,
+                           "doc_type": "OpenReferralAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           },
+                           "followup_date": null
+                       },
+                       "open_case": {
+                           "name_path": null,
+                           "doc_type": "OpenCaseAction",
+                           "external_id": null,
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "usercase_update": {
+                           "doc_type": "UpdateCaseAction",
+                           "update": {
+                           },
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "update_referral": {
+                           "doc_type": "UpdateReferralAction",
+                           "followup_date": null,
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "referral_preload": {
+                           "preload": {
+                           },
+                           "doc_type": "PreloadAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "case_preload": {
+                           "preload": {
+                           },
+                           "doc_type": "PreloadAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "close_case": {
+                           "doc_type": "FormAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       }
+                   },
+                   "version": null,
+                   "no_vellum": false,
+                   "media_image": null,
+                   "form_links": [
+                   ],
+                   "post_form_workflow": "default",
+                   "form_type": "module_form",
+                   "media_audio": null,
+                   "unique_id": "a96387b87a7c60bb585ecbcb5b068a46a052ca44"
+               }
+           ],
+           "module_filter": null,
+           "module_type": "basic",
+           "case_list_form": {
+               "doc_type": "CaseListForm",
+               "label": {
+               },
+               "media_audio": null,
+               "form_id": null,
+               "media_image": null
+           },
+           "case_details": {
+               "doc_type": "DetailPair",
+               "short": {
+                   "doc_type": "Detail",
+                   "lookup_name": null,
+                   "sort_elements": [
+                   ],
+                   "tabs": [
+                   ],
+                   "persist_case_context": null,
+                   "lookup_image": null,
+                   "filter": null,
+                   "persist_tile_on_forms": null,
+                   "custom_xml": null,
+                   "lookup_extras": [
+                   ],
+                   "use_case_tiles": null,
+                   "pull_down_tile": null,
+                   "columns": [
+                       {
+                           "case_tile_field": null,
+                           "filter_xpath": "",
+                           "format": "plain",
+                           "late_flag": 30,
+                           "enum": [
+                           ],
+                           "time_ago_interval": 365.25,
+                           "header": {
+                               "en": "Name"
+                           },
+                           "doc_type": "DetailColumn",
+                           "calc_xpath": ".",
+                           "field": "name",
+                           "model": "case",
+                           "graph_configuration": {
+                               "doc_type": "GraphConfiguration",
+                               "series": [
+                               ],
+                               "locale_specific_config": {
+                               },
+                               "graph_type": null,
+                               "config": {
+                               },
+                               "annotations": [
+                               ]
+                           },
+                           "advanced": ""
+                       }
+                   ],
+                   "lookup_action": null,
+                   "display": "short",
+                   "lookup_enabled": false,
+                   "lookup_responses": [
+                   ]
+               },
+               "long": {
+                   "doc_type": "Detail",
+                   "lookup_name": null,
+                   "sort_elements": [
+                   ],
+                   "tabs": [
+                   ],
+                   "persist_case_context": null,
+                   "lookup_image": null,
+                   "filter": null,
+                   "persist_tile_on_forms": null,
+                   "custom_xml": null,
+                   "lookup_extras": [
+                   ],
+                   "use_case_tiles": null,
+                   "pull_down_tile": null,
+                   "columns": [
+                       {
+                           "case_tile_field": null,
+                           "filter_xpath": "",
+                           "format": "plain",
+                           "late_flag": 30,
+                           "enum": [
+                           ],
+                           "time_ago_interval": 365.25,
+                           "header": {
+                               "en": "Name"
+                           },
+                           "doc_type": "DetailColumn",
+                           "calc_xpath": ".",
+                           "field": "name",
+                           "model": "case",
+                           "graph_configuration": {
+                               "doc_type": "GraphConfiguration",
+                               "series": [
+                               ],
+                               "locale_specific_config": {
+                               },
+                               "graph_type": null,
+                               "config": {
+                               },
+                               "annotations": [
+                               ]
+                           },
+                           "advanced": ""
+                       }
+                   ],
+                   "lookup_action": null,
+                   "display": "long",
+                   "lookup_enabled": false,
+                   "lookup_responses": [
+                   ]
+               }
+           },
+           "doc_type": "Module",
+           "name": {
+               "en": "Survey Category 1 (Ex. Household)"
+           },
+           "case_type": "",
+           "task_list": {
+               "doc_type": "CaseList",
+               "label": {
+               },
+               "media_audio": null,
+               "media_image": null,
+               "show": false
+           },
+           "fixture_select": {
+               "xpath": "",
+               "doc_type": "FixtureSelect",
+               "variable_column": null,
+               "fixture_type": null,
+               "active": false,
+               "localize": false,
+               "display_column": null
+           },
+           "media_audio": null,
+           "unique_id": "aee8ee02a1ee84ba22b1d39fb0be7f9c1fc92c92"
+       },
+       {
+           "comment": "",
+           "referral_label": {
+               "en": "Referrals"
+           },
+           "case_list": {
+               "doc_type": "CaseList",
+               "label": {
+               },
+               "media_audio": null,
+               "media_image": null,
+               "show": false
+           },
+           "auto_select_case": false,
+           "put_in_root": false,
+           "root_module_id": null,
+           "ref_details": {
+               "doc_type": "DetailPair",
+               "short": {
+                   "doc_type": "Detail",
+                   "persist_case_context": null,
+                   "pull_down_tile": null,
+                   "sort_elements": [
+                   ],
+                   "tabs": [
+                   ],
+                   "lookup_responses": [
+                   ],
+                   "lookup_image": null,
+                   "filter": null,
+                   "persist_tile_on_forms": null,
+                   "custom_xml": null,
+                   "lookup_name": null,
+                   "use_case_tiles": null,
+                   "lookup_extras": [
+                   ],
+                   "columns": [
+                   ],
+                   "lookup_action": null,
+                   "display": "short",
+                   "lookup_enabled": false
+               },
+               "long": {
+                   "doc_type": "Detail",
+                   "persist_case_context": null,
+                   "pull_down_tile": null,
+                   "sort_elements": [
+                   ],
+                   "tabs": [
+                   ],
+                   "lookup_responses": [
+                   ],
+                   "lookup_image": null,
+                   "filter": null,
+                   "persist_tile_on_forms": null,
+                   "custom_xml": null,
+                   "lookup_name": null,
+                   "use_case_tiles": null,
+                   "lookup_extras": [
+                   ],
+                   "columns": [
+                   ],
+                   "lookup_action": null,
+                   "display": "long",
+                   "lookup_enabled": false
+               }
+           },
+           "case_label": {
+               "en": "Cases"
+           },
+           "referral_list": {
+               "doc_type": "CaseList",
+               "label": {
+               },
+               "media_audio": null,
+               "media_image": null,
+               "show": false
+           },
+           "media_image": null,
+           "parent_select": {
+               "active": false,
+               "module_id": null,
+               "relationship": "parent",
+               "doc_type": "ParentSelect"
+           },
+           "forms": [
+               {
+                   "comment": "",
+                   "doc_type": "Form",
+                   "xmlns": "http://openrosa.org/formdesigner/7F88A227-567E-4B5E-9747-FB3818EE1A44",
+                   "form_filter": "",
+                   "name": {
+                       "en": "Survey 1"
+                   },
+                   "auto_gps_capture": false,
+                   "schedule_form_id": null,
+                   "show_count": false,
+                   "requires": "none",
+                   "actions": {
+                       "doc_type": "FormActions",
+                       "subcases": [
+                       ],
+                       "usercase_preload": {
+                           "preload": {
+                           },
+                           "doc_type": "PreloadAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "update_case": {
+                           "doc_type": "UpdateCaseAction",
+                           "update": {
+                           },
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "close_referral": {
+                           "doc_type": "FormAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "open_referral": {
+                           "name_path": null,
+                           "doc_type": "OpenReferralAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           },
+                           "followup_date": null
+                       },
+                       "open_case": {
+                           "name_path": null,
+                           "doc_type": "OpenCaseAction",
+                           "external_id": null,
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "usercase_update": {
+                           "doc_type": "UpdateCaseAction",
+                           "update": {
+                           },
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "update_referral": {
+                           "doc_type": "UpdateReferralAction",
+                           "followup_date": null,
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "referral_preload": {
+                           "preload": {
+                           },
+                           "doc_type": "PreloadAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "case_preload": {
+                           "preload": {
+                           },
+                           "doc_type": "PreloadAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "close_case": {
+                           "doc_type": "FormAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       }
+                   },
+                   "version": null,
+                   "no_vellum": false,
+                   "media_image": null,
+                   "form_links": [
+                   ],
+                   "post_form_workflow": "default",
+                   "form_type": "module_form",
+                   "media_audio": null,
+                   "unique_id": "6fd47bb6bbd754b9a1ea60f139a0191778d90ad6"
+               },
+               {
+                   "comment": "",
+                   "doc_type": "Form",
+                   "xmlns": "http://openrosa.org/formdesigner/A6567651-4C52-4038-8F12-D31E61A64F60",
+                   "form_filter": "",
+                   "name": {
+                       "en": "Survey 2"
+                   },
+                   "auto_gps_capture": false,
+                   "schedule_form_id": null,
+                   "show_count": false,
+                   "requires": "none",
+                   "actions": {
+                       "doc_type": "FormActions",
+                       "subcases": [
+                       ],
+                       "usercase_preload": {
+                           "preload": {
+                           },
+                           "doc_type": "PreloadAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "update_case": {
+                           "doc_type": "UpdateCaseAction",
+                           "update": {
+                           },
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "close_referral": {
+                           "doc_type": "FormAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "open_referral": {
+                           "name_path": null,
+                           "doc_type": "OpenReferralAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           },
+                           "followup_date": null
+                       },
+                       "open_case": {
+                           "name_path": null,
+                           "doc_type": "OpenCaseAction",
+                           "external_id": null,
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "usercase_update": {
+                           "doc_type": "UpdateCaseAction",
+                           "update": {
+                           },
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "update_referral": {
+                           "doc_type": "UpdateReferralAction",
+                           "followup_date": null,
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "referral_preload": {
+                           "preload": {
+                           },
+                           "doc_type": "PreloadAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "case_preload": {
+                           "preload": {
+                           },
+                           "doc_type": "PreloadAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "close_case": {
+                           "doc_type": "FormAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       }
+                   },
+                   "version": null,
+                   "no_vellum": false,
+                   "media_image": null,
+                   "form_links": [
+                   ],
+                   "post_form_workflow": "default",
+                   "form_type": "module_form",
+                   "media_audio": null,
+                   "unique_id": "2ee2c28f5ed7a97f94b49cfc08d368be3644a94f"
+               }
+           ],
+           "module_filter": null,
+           "module_type": "basic",
+           "case_list_form": {
+               "doc_type": "CaseListForm",
+               "label": {
+               },
+               "media_audio": null,
+               "form_id": null,
+               "media_image": null
+           },
+           "case_details": {
+               "doc_type": "DetailPair",
+               "short": {
+                   "doc_type": "Detail",
+                   "lookup_name": null,
+                   "sort_elements": [
+                   ],
+                   "tabs": [
+                   ],
+                   "persist_case_context": null,
+                   "lookup_image": null,
+                   "filter": null,
+                   "persist_tile_on_forms": null,
+                   "custom_xml": null,
+                   "lookup_extras": [
+                   ],
+                   "use_case_tiles": null,
+                   "pull_down_tile": null,
+                   "columns": [
+                       {
+                           "case_tile_field": null,
+                           "filter_xpath": "",
+                           "format": "plain",
+                           "late_flag": 30,
+                           "enum": [
+                           ],
+                           "time_ago_interval": 365.25,
+                           "header": {
+                               "en": "Name"
+                           },
+                           "doc_type": "DetailColumn",
+                           "calc_xpath": ".",
+                           "field": "name",
+                           "model": "case",
+                           "graph_configuration": {
+                               "doc_type": "GraphConfiguration",
+                               "series": [
+                               ],
+                               "locale_specific_config": {
+                               },
+                               "graph_type": null,
+                               "config": {
+                               },
+                               "annotations": [
+                               ]
+                           },
+                           "advanced": ""
+                       }
+                   ],
+                   "lookup_action": null,
+                   "display": "short",
+                   "lookup_enabled": false,
+                   "lookup_responses": [
+                   ]
+               },
+               "long": {
+                   "doc_type": "Detail",
+                   "lookup_name": null,
+                   "sort_elements": [
+                   ],
+                   "tabs": [
+                   ],
+                   "persist_case_context": null,
+                   "lookup_image": null,
+                   "filter": null,
+                   "persist_tile_on_forms": null,
+                   "custom_xml": null,
+                   "lookup_extras": [
+                   ],
+                   "use_case_tiles": null,
+                   "pull_down_tile": null,
+                   "columns": [
+                       {
+                           "case_tile_field": null,
+                           "filter_xpath": "",
+                           "format": "plain",
+                           "late_flag": 30,
+                           "enum": [
+                           ],
+                           "time_ago_interval": 365.25,
+                           "header": {
+                               "en": "Name"
+                           },
+                           "doc_type": "DetailColumn",
+                           "calc_xpath": ".",
+                           "field": "name",
+                           "model": "case",
+                           "graph_configuration": {
+                               "doc_type": "GraphConfiguration",
+                               "series": [
+                               ],
+                               "locale_specific_config": {
+                               },
+                               "graph_type": null,
+                               "config": {
+                               },
+                               "annotations": [
+                               ]
+                           },
+                           "advanced": ""
+                       }
+                   ],
+                   "lookup_action": null,
+                   "display": "long",
+                   "lookup_enabled": false,
+                   "lookup_responses": [
+                   ]
+               }
+           },
+           "doc_type": "Module",
+           "name": {
+               "en": "Survey Category 2 (Ex. Village)"
+           },
+           "case_type": "",
+           "task_list": {
+               "doc_type": "CaseList",
+               "label": {
+               },
+               "media_audio": null,
+               "media_image": null,
+               "show": false
+           },
+           "fixture_select": {
+               "xpath": "",
+               "doc_type": "FixtureSelect",
+               "variable_column": null,
+               "fixture_type": null,
+               "active": false,
+               "localize": false,
+               "display_column": null
+           },
+           "media_audio": null,
+           "unique_id": "e4d6b2ce4e822ed401f3daaa03fe894887d4bbbf"
+       }
+   ],
+   "created_from_template": "survey",
+   "attribution_notes": null,
+   "commtrack_requisition_mode": null,
+   "translation_strategy": "select-known",
+   "show_user_registration": false
+}

--- a/corehq/apps/accounting/tests/data/app-commcare-icon-standard.json
+++ b/corehq/apps/accounting/tests/data/app-commcare-icon-standard.json
@@ -1,0 +1,1197 @@
+{
+   "_id": "455f5cc9cfe7cb6e69093f143bf97fe1",
+   "comment": "",
+   "multimedia_map": {
+       "jr://file/commcare/logo/data/hq_logo_android_login.png": {
+           "doc_type": "HQMediaMapItem",
+           "output_size": {
+           },
+           "version": null,
+           "multimedia_id": "c9ef81db4836c4eb5037ac4925193db7",
+           "media_type": "CommCareImage",
+           "unique_id": "65a3afc128a74c7e38fac23aeb92f64e"
+       },
+       "jr://file/commcare/logo/data/hq_logo_android_home.png": {
+           "doc_type": "HQMediaMapItem",
+           "output_size": {
+           },
+           "version": null,
+           "multimedia_id": "c9ef81db4836c4eb5037ac4925193db7",
+           "media_type": "CommCareImage",
+           "unique_id": "1e89448f48bfdae8b2c0d8396a51de37"
+       }
+   },
+   "domain": "test-sub-changes",
+   "build_langs": [
+       "en"
+   ],
+   "auto_gps_capture": false,
+   "short_url": null,
+   "deployment_date": null,
+   "user_type": null,
+   "text_input": "roman",
+   "secure_submissions": true,
+   "build_broken": false,
+   "minimum_use_threshold": "15",
+   "custom_base_url": null,
+   "copy_of": null,
+   "phone_model": null,
+   "build_signed": true,
+   "recipients": "",
+   "copy_history": [
+   ],
+   "is_released": false,
+   "application_version": "2.0",
+   "platform": "nokia/s40",
+   "version": 9,
+   "admin_password": null,
+   "build_spec": {
+       "doc_type": "BuildSpec",
+       "version": "2.16.0",
+       "build_number": null,
+       "latest": true
+   },
+   "admin_password_charset": "n",
+   "logo_refs": {
+       "hq_logo_android_home": {
+           "updated": false,
+           "m_id": "c9ef81db4836c4eb5037ac4925193db7",
+           "icon_class": "icon-picture",
+           "uid": "2a02b1e09ee78daee18b5244dc76eba9",
+           "url": "/hq/multimedia/file/CommCareImage/c9ef81db4836c4eb5037ac4925193db7/",
+           "original_path": null,
+           "path": "jr://file/commcare/logo/data/hq_logo_android_home.png",
+           "media_type": "Image"
+       },
+       "hq_logo_android_login": {
+           "updated": false,
+           "m_id": "c9ef81db4836c4eb5037ac4925193db7",
+           "icon_class": "icon-picture",
+           "uid": "2a02b1e09ee78daee18b5244dc76eba9",
+           "url": "/hq/multimedia/file/CommCareImage/c9ef81db4836c4eb5037ac4925193db7/",
+           "original_path": null,
+           "media_type": "Image",
+           "path": "jr://file/commcare/logo/data/hq_logo_android_login.png"
+       }
+   },
+   "short_odk_media_url": null,
+   "short_odk_url": null,
+   "amplifies_workers": "not_set",
+   "comment_from": null,
+   "cloudcare_enabled": true,
+   "description": null,
+   "user_registration": {
+       "doc_type": "UserRegistrationForm",
+       "xmlns": null,
+       "name": {
+       },
+       "password_path": "password",
+       "auto_gps_capture": false,
+       "schedule_form_id": null,
+       "show_count": false,
+       "version": null,
+       "no_vellum": false,
+       "form_links": [
+       ],
+       "post_form_workflow": "default",
+       "form_type": "user_registration",
+       "username_path": "username",
+       "unique_id": "6d95add353e24c67357393a7bad39c30e5422a47",
+       "data_paths": {
+       }
+   },
+   "use_grid_menus": false,
+   "translations": {
+   },
+   "built_on": null,
+   "built_with": {
+       "doc_type": "BuildRecord",
+       "build_number": null,
+       "signed": true,
+       "datetime": null,
+       "version": null,
+       "latest": null
+   },
+   "profile": {
+       "features": {
+           "users": "true",
+           "sense": "false"
+       },
+       "properties": {
+           "cc-user-mode": "cc-u-normal",
+           "cc-show-saved": "yes",
+           "restore-tolerance": "loose",
+           "cc-days-form-retain": "-1",
+           "cc-fuzzy-search-enabled": "yes",
+           "cc-autoup-freq": "freq-never",
+           "purge-freq": "0",
+           "server-tether": "push-only",
+           "user_reg_server": "required",
+           "extra_key_action": "audio",
+           "log_prop_daily": "log_never",
+           "ViewStyle": "v_chatterbox",
+           "cc-login-duration-seconds": "86400",
+           "cc-resize-images": "none",
+           "cc-entry-mode": "cc-entry-quick",
+           "cc-send-procedure": "cc-send-http",
+           "cc-login-images": "No",
+           "log_prop_weekly": "log_short",
+           "cc-show-incomplete": "yes",
+           "cc-send-unsent": "cc-su-auto",
+           "loose_media": "no",
+           "password_format": "n",
+           "unsent-number-limit": "5",
+           "cc-content-valid": "no",
+           "logenabled": "Enabled"
+       }
+   },
+   "case_sharing": false,
+   "langs": [
+       "en"
+   ],
+   "use_custom_suite": false,
+   "build_comment": null,
+   "build_broken_reason": null,
+   "doc_type": "Application",
+   "cached_properties": {
+   },
+   "name": "Surveys",
+   "amplifies_project": "not_set",
+   "modules": [
+       {
+           "comment": "",
+           "referral_label": {
+               "en": "Referrals"
+           },
+           "case_list": {
+               "doc_type": "CaseList",
+               "label": {
+               },
+               "media_audio": null,
+               "media_image": null,
+               "show": false
+           },
+           "auto_select_case": false,
+           "put_in_root": false,
+           "root_module_id": null,
+           "ref_details": {
+               "doc_type": "DetailPair",
+               "short": {
+                   "doc_type": "Detail",
+                   "persist_case_context": null,
+                   "pull_down_tile": null,
+                   "sort_elements": [
+                   ],
+                   "tabs": [
+                   ],
+                   "lookup_responses": [
+                   ],
+                   "lookup_image": null,
+                   "filter": null,
+                   "persist_tile_on_forms": null,
+                   "custom_xml": null,
+                   "lookup_name": null,
+                   "use_case_tiles": null,
+                   "lookup_extras": [
+                   ],
+                   "columns": [
+                   ],
+                   "lookup_action": null,
+                   "display": "short",
+                   "lookup_enabled": false
+               },
+               "long": {
+                   "doc_type": "Detail",
+                   "persist_case_context": null,
+                   "pull_down_tile": null,
+                   "sort_elements": [
+                   ],
+                   "tabs": [
+                   ],
+                   "lookup_responses": [
+                   ],
+                   "lookup_image": null,
+                   "filter": null,
+                   "persist_tile_on_forms": null,
+                   "custom_xml": null,
+                   "lookup_name": null,
+                   "use_case_tiles": null,
+                   "lookup_extras": [
+                   ],
+                   "columns": [
+                   ],
+                   "lookup_action": null,
+                   "display": "long",
+                   "lookup_enabled": false
+               }
+           },
+           "case_label": {
+               "en": "Cases"
+           },
+           "referral_list": {
+               "doc_type": "CaseList",
+               "label": {
+               },
+               "media_audio": null,
+               "media_image": null,
+               "show": false
+           },
+           "media_image": null,
+           "parent_select": {
+               "active": false,
+               "module_id": null,
+               "relationship": "parent",
+               "doc_type": "ParentSelect"
+           },
+           "forms": [
+               {
+                   "comment": "",
+                   "doc_type": "Form",
+                   "xmlns": "http://openrosa.org/formdesigner/E2E07B3C-9665-4247-B2E9-D0162C4B0D6C",
+                   "form_filter": "",
+                   "name": {
+                       "en": "Survey 1"
+                   },
+                   "auto_gps_capture": false,
+                   "schedule_form_id": null,
+                   "show_count": false,
+                   "requires": "none",
+                   "actions": {
+                       "doc_type": "FormActions",
+                       "subcases": [
+                       ],
+                       "usercase_preload": {
+                           "preload": {
+                           },
+                           "doc_type": "PreloadAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "update_case": {
+                           "doc_type": "UpdateCaseAction",
+                           "update": {
+                           },
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "close_referral": {
+                           "doc_type": "FormAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "open_referral": {
+                           "name_path": null,
+                           "doc_type": "OpenReferralAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           },
+                           "followup_date": null
+                       },
+                       "open_case": {
+                           "name_path": null,
+                           "doc_type": "OpenCaseAction",
+                           "external_id": null,
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "usercase_update": {
+                           "doc_type": "UpdateCaseAction",
+                           "update": {
+                           },
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "update_referral": {
+                           "doc_type": "UpdateReferralAction",
+                           "followup_date": null,
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "referral_preload": {
+                           "preload": {
+                           },
+                           "doc_type": "PreloadAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "case_preload": {
+                           "preload": {
+                           },
+                           "doc_type": "PreloadAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "close_case": {
+                           "doc_type": "FormAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       }
+                   },
+                   "version": null,
+                   "no_vellum": false,
+                   "media_image": null,
+                   "form_links": [
+                   ],
+                   "post_form_workflow": "default",
+                   "form_type": "module_form",
+                   "media_audio": null,
+                   "unique_id": "ed360a947c07a6f95cf87fe08a774580f4835381"
+               },
+               {
+                   "comment": "",
+                   "doc_type": "Form",
+                   "xmlns": "http://openrosa.org/formdesigner/5E654925-C1FA-4D1A-A172-E21BA89F01AC",
+                   "form_filter": "",
+                   "name": {
+                       "en": "Survey 2"
+                   },
+                   "auto_gps_capture": false,
+                   "schedule_form_id": null,
+                   "show_count": false,
+                   "requires": "none",
+                   "actions": {
+                       "doc_type": "FormActions",
+                       "subcases": [
+                       ],
+                       "usercase_preload": {
+                           "preload": {
+                           },
+                           "doc_type": "PreloadAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "update_case": {
+                           "doc_type": "UpdateCaseAction",
+                           "update": {
+                           },
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "close_referral": {
+                           "doc_type": "FormAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "open_referral": {
+                           "name_path": null,
+                           "doc_type": "OpenReferralAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           },
+                           "followup_date": null
+                       },
+                       "open_case": {
+                           "name_path": null,
+                           "doc_type": "OpenCaseAction",
+                           "external_id": null,
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "usercase_update": {
+                           "doc_type": "UpdateCaseAction",
+                           "update": {
+                           },
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "update_referral": {
+                           "doc_type": "UpdateReferralAction",
+                           "followup_date": null,
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "referral_preload": {
+                           "preload": {
+                           },
+                           "doc_type": "PreloadAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "case_preload": {
+                           "preload": {
+                           },
+                           "doc_type": "PreloadAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "close_case": {
+                           "doc_type": "FormAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       }
+                   },
+                   "version": null,
+                   "no_vellum": false,
+                   "media_image": null,
+                   "form_links": [
+                   ],
+                   "post_form_workflow": "default",
+                   "form_type": "module_form",
+                   "media_audio": null,
+                   "unique_id": "a96387b87a7c60bb585ecbcb5b068a46a052ca44"
+               }
+           ],
+           "module_filter": null,
+           "module_type": "basic",
+           "case_list_form": {
+               "doc_type": "CaseListForm",
+               "label": {
+               },
+               "media_audio": null,
+               "form_id": null,
+               "media_image": null
+           },
+           "case_details": {
+               "doc_type": "DetailPair",
+               "short": {
+                   "doc_type": "Detail",
+                   "lookup_name": null,
+                   "sort_elements": [
+                   ],
+                   "tabs": [
+                   ],
+                   "persist_case_context": null,
+                   "lookup_image": null,
+                   "filter": null,
+                   "persist_tile_on_forms": null,
+                   "custom_xml": null,
+                   "lookup_extras": [
+                   ],
+                   "use_case_tiles": null,
+                   "pull_down_tile": null,
+                   "columns": [
+                       {
+                           "case_tile_field": null,
+                           "filter_xpath": "",
+                           "format": "plain",
+                           "late_flag": 30,
+                           "enum": [
+                           ],
+                           "time_ago_interval": 365.25,
+                           "header": {
+                               "en": "Name"
+                           },
+                           "doc_type": "DetailColumn",
+                           "calc_xpath": ".",
+                           "field": "name",
+                           "model": "case",
+                           "graph_configuration": {
+                               "doc_type": "GraphConfiguration",
+                               "series": [
+                               ],
+                               "locale_specific_config": {
+                               },
+                               "graph_type": null,
+                               "config": {
+                               },
+                               "annotations": [
+                               ]
+                           },
+                           "advanced": ""
+                       }
+                   ],
+                   "lookup_action": null,
+                   "display": "short",
+                   "lookup_enabled": false,
+                   "lookup_responses": [
+                   ]
+               },
+               "long": {
+                   "doc_type": "Detail",
+                   "lookup_name": null,
+                   "sort_elements": [
+                   ],
+                   "tabs": [
+                   ],
+                   "persist_case_context": null,
+                   "lookup_image": null,
+                   "filter": null,
+                   "persist_tile_on_forms": null,
+                   "custom_xml": null,
+                   "lookup_extras": [
+                   ],
+                   "use_case_tiles": null,
+                   "pull_down_tile": null,
+                   "columns": [
+                       {
+                           "case_tile_field": null,
+                           "filter_xpath": "",
+                           "format": "plain",
+                           "late_flag": 30,
+                           "enum": [
+                           ],
+                           "time_ago_interval": 365.25,
+                           "header": {
+                               "en": "Name"
+                           },
+                           "doc_type": "DetailColumn",
+                           "calc_xpath": ".",
+                           "field": "name",
+                           "model": "case",
+                           "graph_configuration": {
+                               "doc_type": "GraphConfiguration",
+                               "series": [
+                               ],
+                               "locale_specific_config": {
+                               },
+                               "graph_type": null,
+                               "config": {
+                               },
+                               "annotations": [
+                               ]
+                           },
+                           "advanced": ""
+                       }
+                   ],
+                   "lookup_action": null,
+                   "display": "long",
+                   "lookup_enabled": false,
+                   "lookup_responses": [
+                   ]
+               }
+           },
+           "doc_type": "Module",
+           "name": {
+               "en": "Survey Category 1 (Ex. Household)"
+           },
+           "case_type": "",
+           "task_list": {
+               "doc_type": "CaseList",
+               "label": {
+               },
+               "media_audio": null,
+               "media_image": null,
+               "show": false
+           },
+           "fixture_select": {
+               "xpath": "",
+               "doc_type": "FixtureSelect",
+               "variable_column": null,
+               "fixture_type": null,
+               "active": false,
+               "localize": false,
+               "display_column": null
+           },
+           "media_audio": null,
+           "unique_id": "aee8ee02a1ee84ba22b1d39fb0be7f9c1fc92c92"
+       },
+       {
+           "comment": "",
+           "referral_label": {
+               "en": "Referrals"
+           },
+           "case_list": {
+               "doc_type": "CaseList",
+               "label": {
+               },
+               "media_audio": null,
+               "media_image": null,
+               "show": false
+           },
+           "auto_select_case": false,
+           "put_in_root": false,
+           "root_module_id": null,
+           "ref_details": {
+               "doc_type": "DetailPair",
+               "short": {
+                   "doc_type": "Detail",
+                   "persist_case_context": null,
+                   "pull_down_tile": null,
+                   "sort_elements": [
+                   ],
+                   "tabs": [
+                   ],
+                   "lookup_responses": [
+                   ],
+                   "lookup_image": null,
+                   "filter": null,
+                   "persist_tile_on_forms": null,
+                   "custom_xml": null,
+                   "lookup_name": null,
+                   "use_case_tiles": null,
+                   "lookup_extras": [
+                   ],
+                   "columns": [
+                   ],
+                   "lookup_action": null,
+                   "display": "short",
+                   "lookup_enabled": false
+               },
+               "long": {
+                   "doc_type": "Detail",
+                   "persist_case_context": null,
+                   "pull_down_tile": null,
+                   "sort_elements": [
+                   ],
+                   "tabs": [
+                   ],
+                   "lookup_responses": [
+                   ],
+                   "lookup_image": null,
+                   "filter": null,
+                   "persist_tile_on_forms": null,
+                   "custom_xml": null,
+                   "lookup_name": null,
+                   "use_case_tiles": null,
+                   "lookup_extras": [
+                   ],
+                   "columns": [
+                   ],
+                   "lookup_action": null,
+                   "display": "long",
+                   "lookup_enabled": false
+               }
+           },
+           "case_label": {
+               "en": "Cases"
+           },
+           "referral_list": {
+               "doc_type": "CaseList",
+               "label": {
+               },
+               "media_audio": null,
+               "media_image": null,
+               "show": false
+           },
+           "media_image": null,
+           "parent_select": {
+               "active": false,
+               "module_id": null,
+               "relationship": "parent",
+               "doc_type": "ParentSelect"
+           },
+           "forms": [
+               {
+                   "comment": "",
+                   "doc_type": "Form",
+                   "xmlns": "http://openrosa.org/formdesigner/7F88A227-567E-4B5E-9747-FB3818EE1A44",
+                   "form_filter": "",
+                   "name": {
+                       "en": "Survey 1"
+                   },
+                   "auto_gps_capture": false,
+                   "schedule_form_id": null,
+                   "show_count": false,
+                   "requires": "none",
+                   "actions": {
+                       "doc_type": "FormActions",
+                       "subcases": [
+                       ],
+                       "usercase_preload": {
+                           "preload": {
+                           },
+                           "doc_type": "PreloadAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "update_case": {
+                           "doc_type": "UpdateCaseAction",
+                           "update": {
+                           },
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "close_referral": {
+                           "doc_type": "FormAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "open_referral": {
+                           "name_path": null,
+                           "doc_type": "OpenReferralAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           },
+                           "followup_date": null
+                       },
+                       "open_case": {
+                           "name_path": null,
+                           "doc_type": "OpenCaseAction",
+                           "external_id": null,
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "usercase_update": {
+                           "doc_type": "UpdateCaseAction",
+                           "update": {
+                           },
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "update_referral": {
+                           "doc_type": "UpdateReferralAction",
+                           "followup_date": null,
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "referral_preload": {
+                           "preload": {
+                           },
+                           "doc_type": "PreloadAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "case_preload": {
+                           "preload": {
+                           },
+                           "doc_type": "PreloadAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "close_case": {
+                           "doc_type": "FormAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       }
+                   },
+                   "version": null,
+                   "no_vellum": false,
+                   "media_image": null,
+                   "form_links": [
+                   ],
+                   "post_form_workflow": "default",
+                   "form_type": "module_form",
+                   "media_audio": null,
+                   "unique_id": "6fd47bb6bbd754b9a1ea60f139a0191778d90ad6"
+               },
+               {
+                   "comment": "",
+                   "doc_type": "Form",
+                   "xmlns": "http://openrosa.org/formdesigner/A6567651-4C52-4038-8F12-D31E61A64F60",
+                   "form_filter": "",
+                   "name": {
+                       "en": "Survey 2"
+                   },
+                   "auto_gps_capture": false,
+                   "schedule_form_id": null,
+                   "show_count": false,
+                   "requires": "none",
+                   "actions": {
+                       "doc_type": "FormActions",
+                       "subcases": [
+                       ],
+                       "usercase_preload": {
+                           "preload": {
+                           },
+                           "doc_type": "PreloadAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "update_case": {
+                           "doc_type": "UpdateCaseAction",
+                           "update": {
+                           },
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "close_referral": {
+                           "doc_type": "FormAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "open_referral": {
+                           "name_path": null,
+                           "doc_type": "OpenReferralAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           },
+                           "followup_date": null
+                       },
+                       "open_case": {
+                           "name_path": null,
+                           "doc_type": "OpenCaseAction",
+                           "external_id": null,
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "usercase_update": {
+                           "doc_type": "UpdateCaseAction",
+                           "update": {
+                           },
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "update_referral": {
+                           "doc_type": "UpdateReferralAction",
+                           "followup_date": null,
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "referral_preload": {
+                           "preload": {
+                           },
+                           "doc_type": "PreloadAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "case_preload": {
+                           "preload": {
+                           },
+                           "doc_type": "PreloadAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "close_case": {
+                           "doc_type": "FormAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       }
+                   },
+                   "version": null,
+                   "no_vellum": false,
+                   "media_image": null,
+                   "form_links": [
+                   ],
+                   "post_form_workflow": "default",
+                   "form_type": "module_form",
+                   "media_audio": null,
+                   "unique_id": "2ee2c28f5ed7a97f94b49cfc08d368be3644a94f"
+               }
+           ],
+           "module_filter": null,
+           "module_type": "basic",
+           "case_list_form": {
+               "doc_type": "CaseListForm",
+               "label": {
+               },
+               "media_audio": null,
+               "form_id": null,
+               "media_image": null
+           },
+           "case_details": {
+               "doc_type": "DetailPair",
+               "short": {
+                   "doc_type": "Detail",
+                   "lookup_name": null,
+                   "sort_elements": [
+                   ],
+                   "tabs": [
+                   ],
+                   "persist_case_context": null,
+                   "lookup_image": null,
+                   "filter": null,
+                   "persist_tile_on_forms": null,
+                   "custom_xml": null,
+                   "lookup_extras": [
+                   ],
+                   "use_case_tiles": null,
+                   "pull_down_tile": null,
+                   "columns": [
+                       {
+                           "case_tile_field": null,
+                           "filter_xpath": "",
+                           "format": "plain",
+                           "late_flag": 30,
+                           "enum": [
+                           ],
+                           "time_ago_interval": 365.25,
+                           "header": {
+                               "en": "Name"
+                           },
+                           "doc_type": "DetailColumn",
+                           "calc_xpath": ".",
+                           "field": "name",
+                           "model": "case",
+                           "graph_configuration": {
+                               "doc_type": "GraphConfiguration",
+                               "series": [
+                               ],
+                               "locale_specific_config": {
+                               },
+                               "graph_type": null,
+                               "config": {
+                               },
+                               "annotations": [
+                               ]
+                           },
+                           "advanced": ""
+                       }
+                   ],
+                   "lookup_action": null,
+                   "display": "short",
+                   "lookup_enabled": false,
+                   "lookup_responses": [
+                   ]
+               },
+               "long": {
+                   "doc_type": "Detail",
+                   "lookup_name": null,
+                   "sort_elements": [
+                   ],
+                   "tabs": [
+                   ],
+                   "persist_case_context": null,
+                   "lookup_image": null,
+                   "filter": null,
+                   "persist_tile_on_forms": null,
+                   "custom_xml": null,
+                   "lookup_extras": [
+                   ],
+                   "use_case_tiles": null,
+                   "pull_down_tile": null,
+                   "columns": [
+                       {
+                           "case_tile_field": null,
+                           "filter_xpath": "",
+                           "format": "plain",
+                           "late_flag": 30,
+                           "enum": [
+                           ],
+                           "time_ago_interval": 365.25,
+                           "header": {
+                               "en": "Name"
+                           },
+                           "doc_type": "DetailColumn",
+                           "calc_xpath": ".",
+                           "field": "name",
+                           "model": "case",
+                           "graph_configuration": {
+                               "doc_type": "GraphConfiguration",
+                               "series": [
+                               ],
+                               "locale_specific_config": {
+                               },
+                               "graph_type": null,
+                               "config": {
+                               },
+                               "annotations": [
+                               ]
+                           },
+                           "advanced": ""
+                       }
+                   ],
+                   "lookup_action": null,
+                   "display": "long",
+                   "lookup_enabled": false,
+                   "lookup_responses": [
+                   ]
+               }
+           },
+           "doc_type": "Module",
+           "name": {
+               "en": "Survey Category 2 (Ex. Village)"
+           },
+           "case_type": "",
+           "task_list": {
+               "doc_type": "CaseList",
+               "label": {
+               },
+               "media_audio": null,
+               "media_image": null,
+               "show": false
+           },
+           "fixture_select": {
+               "xpath": "",
+               "doc_type": "FixtureSelect",
+               "variable_column": null,
+               "fixture_type": null,
+               "active": false,
+               "localize": false,
+               "display_column": null
+           },
+           "media_audio": null,
+           "unique_id": "e4d6b2ce4e822ed401f3daaa03fe894887d4bbbf"
+       }
+   ],
+   "created_from_template": "survey",
+   "attribution_notes": null,
+   "commtrack_requisition_mode": null,
+   "translation_strategy": "select-known",
+   "show_user_registration": false
+}

--- a/corehq/apps/accounting/tests/test_subscription_permissions_changes.py
+++ b/corehq/apps/accounting/tests/test_subscription_permissions_changes.py
@@ -1,12 +1,10 @@
-import datetime
 import os
-from pandas import json
+import json
 from corehq.apps.accounting import generator
 from corehq.apps.accounting.models import BillingAccount, DefaultProductPlan, \
     SoftwarePlanEdition, Subscription
 from corehq.apps.accounting.tests import BaseAccountingTest
-from corehq.apps.app_manager.const import APP_V2
-from corehq.apps.app_manager.models import Application, Module
+from corehq.apps.app_manager.models import Application
 from corehq.apps.domain.models import Domain
 
 

--- a/corehq/apps/accounting/tests/test_subscription_permissions_changes.py
+++ b/corehq/apps/accounting/tests/test_subscription_permissions_changes.py
@@ -1,0 +1,87 @@
+import datetime
+import os
+from pandas import json
+from corehq.apps.accounting import generator
+from corehq.apps.accounting.models import BillingAccount, DefaultProductPlan, \
+    SoftwarePlanEdition, Subscription
+from corehq.apps.accounting.tests import BaseAccountingTest
+from corehq.apps.app_manager.const import APP_V2
+from corehq.apps.app_manager.models import Application, Module
+from corehq.apps.domain.models import Domain
+
+
+
+class TestSubscriptionPermissionsChanges(BaseAccountingTest):
+
+    def setUp(self):
+        super(TestSubscriptionPermissionsChanges, self).setUp()
+        self.domain = Domain(
+            name="test-sub-changes",
+            is_active=True,
+        )
+        self.domain.save()
+
+        self.admin_user = generator.arbitrary_web_user()
+        self.admin_user.add_domain_membership(self.domain.name, is_admin=True)
+        self.admin_user.save()
+
+        self.account = BillingAccount.get_or_create_account_by_domain(
+            self.domain.name, created_by=self.admin_user.username)[0]
+        self.advanced_plan = DefaultProductPlan.get_default_plan_by_domain(
+            self.domain.name, edition=SoftwarePlanEdition.ADVANCED)
+
+    def test_app_icon_permissions(self):
+        LOGO_HOME = u'hq_logo_android_home'
+        LOGO_LOGIN = u'hq_logo_android_login'
+
+        advanced_sub = Subscription.new_domain_subscription(
+            self.account, self.domain.name, self.advanced_plan,
+            web_user=self.admin_user.username
+        )
+        with open(os.path.join(os.path.dirname(__file__), 'data', 'app-commcare-icon-standard.json')) as f:
+            standard_source = json.load(f)
+        with open(os.path.join(os.path.dirname(__file__), 'data', 'app-commcare-icon-build.json')) as f:
+            build_source = json.load(f)
+
+        app_standard = Application.wrap(standard_source)
+        app_standard.save()
+        self.assertEqual(self.domain.name, app_standard.domain)
+
+        app_build = Application.wrap(build_source)
+        app_build.save()
+        self.assertEqual(self.domain.name, app_build.domain)
+
+        self.assertTrue(LOGO_HOME in app_standard.logo_refs.keys())
+        self.assertTrue(LOGO_LOGIN in app_standard.logo_refs.keys())
+        self.assertTrue(LOGO_HOME in app_build.logo_refs.keys())
+        self.assertTrue(LOGO_LOGIN in app_build.logo_refs.keys())
+
+        advanced_sub.cancel_subscription(web_user=self.admin_user.username)
+
+        app_standard = Application.get(app_standard._id)
+        app_build = Application.get(app_build._id)
+
+        self.assertFalse(LOGO_HOME in app_standard.logo_refs.keys())
+        self.assertFalse(LOGO_LOGIN in app_standard.logo_refs.keys())
+        self.assertFalse(LOGO_HOME in app_build.logo_refs.keys())
+        self.assertFalse(LOGO_LOGIN in app_build.logo_refs.keys())
+
+        Subscription.new_domain_subscription(
+            self.account, self.domain.name, self.advanced_plan,
+            web_user=self.admin_user.username
+        )
+
+        app_standard = Application.get(app_standard._id)
+        app_build = Application.get(app_build._id)
+
+        self.assertTrue(LOGO_HOME in app_standard.logo_refs.keys())
+        self.assertTrue(LOGO_LOGIN in app_standard.logo_refs.keys())
+        self.assertTrue(LOGO_HOME in app_build.logo_refs.keys())
+        self.assertTrue(LOGO_LOGIN in app_build.logo_refs.keys())
+
+    def tearDown(self):
+        self.domain.delete()
+        self.admin_user.delete()
+        generator.delete_all_subscriptions()
+        generator.delete_all_accounts()
+        super(TestSubscriptionPermissionsChanges, self).tearDown()

--- a/corehq/apps/app_manager/dbaccessors.py
+++ b/corehq/apps/app_manager/dbaccessors.py
@@ -133,3 +133,21 @@ def get_exports_by_application(domain):
         reduce=False,
         stale=settings.COUCH_STALE_QUERY,
     )
+
+
+def get_all_apps(domain):
+    """
+    Returns a list of all the apps ever built and current Applications.
+    Used for subscription management when apps use subscription only features
+    that shouldn't be present in built apps as well as app definitions.
+    """
+    from .models import Application
+    saved_apps = Application.get_db().view(
+        'app_manager/saved_app',
+        startkey=[domain],
+        endkey=[domain, {}],
+        include_docs=True,
+    )
+    all_apps = [get_correct_app_class(row['doc']).wrap(row['doc']) for row in saved_apps]
+    all_apps.extend(get_apps_in_domain(domain))
+    return all_apps


### PR DESCRIPTION
addresses future issues related to: http://manage.dimagi.com/default.asp?189744

on loss of `COMMCARE_LOGO_UPLOADER` privilege on subscription change, remove logos from `logo_refs` and store in `archived_media`.

on gaining the `COMMCARE_LOGO_UPLOADER` privilege, restore any logos that do exist in `archived_media`
