### PR TITLE
Credit line balances

### DIFF
--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -426,7 +426,7 @@ class SubscriptionForm(forms.Form):
                 'plan_name': subscription.plan_version,
             })
             try:
-                plan_product = subscription.plan_version.product_rates.all()[0].product.product_type
+                plan_product = subscription.plan_version.get_product_rate().product.product_type
                 self.fields['plan_product'].initial = plan_product
             except (IndexError, SoftwarePlanVersion.DoesNotExist):
                 plan_product = (

--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -26,6 +26,7 @@ from corehq.apps.accounting.models import (
     EntryPoint, WireInvoice, WireBillingRecord,
     SMALL_INVOICE_THRESHOLD, WirePrepaymentBillingRecord,
     WirePrepaymentInvoice,
+    UNLIMITED_FEATURE_USAGE,
 )
 from corehq.apps.smsbillables.models import SmsBillable
 from corehq.apps.users.models import CommCareUser
@@ -462,7 +463,7 @@ class UserLineItemFactory(FeatureLineItemFactory):
 
     @property
     def num_excess_users(self):
-        if self.rate.monthly_limit == -1:
+        if self.rate.monthly_limit == UNLIMITED_FEATURE_USAGE:
             return 0
         else:
             return max(self.num_users - self.rate.monthly_limit, 0)
@@ -513,7 +514,7 @@ class SmsLineItemFactory(FeatureLineItemFactory):
     @property
     @memoized
     def unit_description(self):
-        if self.rate.monthly_limit == -1:
+        if self.rate.monthly_limit == UNLIMITED_FEATURE_USAGE:
             return _("%(num_sms)d SMS Message%(plural)s") % {
                 'num_sms': self.num_sms,
                 'plural': '' if self.num_sms == 1 else 's',
@@ -526,7 +527,7 @@ class SmsLineItemFactory(FeatureLineItemFactory):
                 'monthly_limit': self.rate.monthly_limit,
             }
         else:
-            assert self.rate.monthly_limit != -1
+            assert self.rate.monthly_limit != UNLIMITED_FEATURE_USAGE
             assert self.rate.monthly_limit < self.num_sms
             num_extra = self.num_sms - self.rate.monthly_limit
             assert num_extra > 0
@@ -562,7 +563,7 @@ class SmsLineItemFactory(FeatureLineItemFactory):
     @property
     @memoized
     def is_within_monthly_limit(self):
-        if self.rate.monthly_limit == -1:
+        if self.rate.monthly_limit == UNLIMITED_FEATURE_USAGE:
             return True
         else:
             return self.num_sms <= self.rate.monthly_limit

--- a/corehq/apps/accounting/management/commands/cchq_software_plan_bootstrap.py
+++ b/corehq/apps/accounting/management/commands/cchq_software_plan_bootstrap.py
@@ -25,6 +25,7 @@ Subscription = apps.get_model('accounting', 'Subscription')
 
 from corehq.apps.accounting.models import (
     SoftwareProductType, SoftwarePlanEdition, SoftwarePlanVisibility, FeatureType,
+    UNLIMITED_FEATURE_USAGE,
 )
 
 
@@ -295,8 +296,8 @@ class Command(BaseCommand):
                 FeatureType.SMS: FeatureRate(monthly_limit=7 if self.for_tests else 1000),
             },
             SoftwarePlanEdition.ENTERPRISE: {
-                FeatureType.USER: FeatureRate(monthly_limit=-1, per_excess_fee=Decimal('0.00')),
-                FeatureType.SMS: FeatureRate(monthly_limit=-1),
+                FeatureType.USER: FeatureRate(monthly_limit=UNLIMITED_FEATURE_USAGE, per_excess_fee=Decimal('0.00')),
+                FeatureType.SMS: FeatureRate(monthly_limit=UNLIMITED_FEATURE_USAGE),
             },
         }
         for feature in features:

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -76,6 +76,8 @@ class FeatureType(object):
     USER = "User"
     SMS = "SMS"
     API = "API"
+    ANY = ""
+
     CHOICES = (
         (USER, USER),
         (SMS, SMS),
@@ -86,6 +88,8 @@ class SoftwareProductType(object):
     COMMCARE = "CommCare"
     COMMTRACK = "CommTrack"
     COMMCONNECT = "CommConnect"
+    ANY = ""
+
     CHOICES = (
         (COMMCARE, COMMCARE),
         (COMMTRACK, COMMTRACK),

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -2458,10 +2458,9 @@ class CreditLine(models.Model):
                                                  feature_type=None,
                                                  product_type=None):
         return cls.objects.filter(
-            models.Q(subscription=subscription) |
-            models.Q(account=subscription.account, subscription__exact=None)
-        ).filter(
-            product_type__exact=product_type, feature_type__exact=feature_type
+            subscription=subscription,
+            feature_type__exact=feature_type,
+            product_type__exact=product_type,
         ).all()
 
     @classmethod

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -780,6 +780,19 @@ class SoftwarePlanVersion(models.Model):
             'version_num': self.version,
         }
 
+    def get_product_rate(self):
+        product_rates = self.product_rates.all()
+        if len(product_rates) > 1:
+            # Models and UI are both written to support multiple products,
+            # but for now, each subscription can only have one product.
+            logger.error(
+                "[BILLING] "
+                "There are multiple product rates for plan version number %d. "
+                "Odd, right? Consider this an issue."
+                % self.id
+            )
+        return product_rates[0]
+
     @property
     def core_product(self):
         try:

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -3,6 +3,8 @@ import datetime
 import logging
 from tempfile import NamedTemporaryFile
 from decimal import Decimal
+import itertools
+
 from couchdbkit import ResourceNotFound
 from django.db.models.manager import Manager
 
@@ -2451,17 +2453,33 @@ class CreditLine(models.Model):
 
     @classmethod
     def get_credits_for_line_item(cls, line_item):
-        return cls.get_credits_by_subscription_and_features(
-            line_item.invoice.subscription,
-            product_type=(line_item.product_rate.product.product_type
-                          if line_item.product_rate is not None else None),
-            feature_type=(line_item.feature_rate.feature.feature_type
-                          if line_item.feature_rate is not None else None),
+        product_type = (
+            line_item.product_rate.product.product_type
+            if line_item.product_rate is not None else None
+        )
+        feature_type = (
+            line_item.feature_rate.feature.feature_type
+            if line_item.feature_rate is not None else None
+        )
+        return itertools.chain(
+            cls.get_credits_by_subscription_and_features(
+                line_item.invoice.subscription,
+                product_type=product_type,
+                feature_type=feature_type,
+            ),
+            cls.get_credits_for_account(
+                line_item.invoice.subscription.account,
+                product_type=product_type,
+                feature_type=feature_type,
+            )
         )
 
     @classmethod
     def get_credits_for_invoice(cls, invoice):
-        return cls.get_credits_by_subscription_and_features(invoice.subscription)
+        return itertools.chain(
+            cls.get_credits_by_subscription_and_features(invoice.subscription),
+            cls.get_credits_for_account(invoice.subscription.account)
+        )
 
     @classmethod
     def get_credits_for_account(cls, account, feature_type=None, product_type=None):

--- a/corehq/apps/accounting/static/accounting/ko/accounting.credits.js
+++ b/corehq/apps/accounting/static/accounting/ko/accounting.credits.js
@@ -46,8 +46,10 @@ var CreditItem = function (category, data, paymentHandler, can_purchase_credits)
     self.usage = ko.observable(data.usage);
     self.remaining = ko.observable(data.remaining);
     self.monthlyFee = ko.observable(data.monthly_fee);
-    self.amount = ko.observable((data.credit) ? data.credit.amount : 0);
-    self.hasAmount = ko.observable(data.credit && data.credit.is_visible);
+    self.amount = ko.observable((data.subscription_credit) ? data.subscription_credit.amount : 0);
+    self.accountAmount = ko.observable((data.account_credit) ? data.account_credit.amount : 0);
+    self.hasAmount = ko.observable(data.subscription_credit && data.subscription_credit.is_visible);
+    self.hasAccountAmount = ko.observable(data.account_credit && data.account_credit.is_visible);
     self.canPurchaseCredits = ko.observable(can_purchase_credits);
     self.paymentHandler = paymentHandler;
     self.addAmount = ko.observable(0);
@@ -58,6 +60,10 @@ var CreditItem = function (category, data, paymentHandler, can_purchase_credits)
 
     self.isVisible = ko.computed(function () {
         return self.hasAmount() && self.canPurchaseCredits();
+    });
+
+    self.isAccountVisible = ko.computed(function () {
+        return self.hasAccountAmount() && self.canPurchaseCredits();
     });
 
     self.triggerPayment = function () {

--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -405,12 +405,12 @@ class DomainDowngradeStatusHandler(BaseModifySubscriptionHandler):
         """
         Get the allowed number of mobile workers based on plan version.
         """
-        from corehq.apps.accounting.models import FeatureType, FeatureRate
+        from corehq.apps.accounting.models import FeatureType, FeatureRate, UNLIMITED_FEATURE_USAGE
         num_users = CommCareUser.total_by_domain(self.domain.name, is_active=True)
         try:
             user_rate = self.new_plan_version.feature_rates.filter(
                 feature__feature_type=FeatureType.USER).latest('date_created')
-            if user_rate.monthly_limit == -1:
+            if user_rate.monthly_limit == UNLIMITED_FEATURE_USAGE:
                 return
             num_allowed = user_rate.monthly_limit
             num_extra = num_users - num_allowed

--- a/corehq/apps/domain/templates/domain/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/current_subscription.html
@@ -112,6 +112,38 @@
                             </div>
                         </div>
                     {% endif %}
+                    {% if plan.next_subscription.exists %}
+                        <div class="control-group">
+                            <label class="control-label">
+                                {% trans "Next Subscription Begins" %}
+                            </label>
+                            <div class="controls">
+                                <p class="control-group-text">
+                                    {{ plan.next_subscription.date_start }}
+                                </p>
+                            </div>
+                        </div>
+                        <div class="control-group">
+                            <label class="control-label">
+                                {% trans "Next Subscription Plan" %}
+                            </label>
+                            <div class="controls">
+                                <p class="control-group-text">
+                                    {{ plan.next_subscription.name }}
+                                </p>
+                            </div>
+                        </div>
+                        <div class="control-group">
+                            <label class="control-label">
+                                {% trans "Next Subscription Price" %}
+                            </label>
+                            <div class="controls">
+                                <p class="control-group-text">
+                                    {{ plan.next_subscription.price }}
+                                </p>
+                            </div>
+                        </div>
+                    {% endif %}
                     <div data-bind="foreach: products">
                         <div class="control-group">
                             <label class="control-label">{% trans 'Current Price' %}</label>
@@ -224,38 +256,6 @@
                             </label>
                             <div class="controls">
                                 <p class="control-group-text">{{ plan.account_feature_credit.amount }}</p>
-                            </div>
-                        </div>
-                    {% endif %}
-                    {% if plan.next_subscription.exists %}
-                        <div class="control-group">
-                            <label class="control-label">
-                                {% trans "Next Subscription Begins" %}
-                            </label>
-                            <div class="controls">
-                                <p class="control-group-text">
-                                    {{ plan.next_subscription.date_start }}
-                                </p>
-                            </div>
-                        </div>
-                        <div class="control-group">
-                            <label class="control-label">
-                                {% trans "Next Subscription Plan" %}
-                            </label>
-                            <div class="controls">
-                                <p class="control-group-text">
-                                    {{ plan.next_subscription.name }}
-                                </p>
-                            </div>
-                        </div>
-                        <div class="control-group">
-                            <label class="control-label">
-                                {% trans "Next Subscription Price" %}
-                            </label>
-                            <div class="controls">
-                                <p class="control-group-text">
-                                    {{ plan.next_subscription.price }}
-                                </p>
                             </div>
                         </div>
                     {% endif %}

--- a/corehq/apps/domain/templates/domain/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/current_subscription.html
@@ -156,7 +156,9 @@
                 {% endif %}
             </div>
             {% if not plan.is_trial %}
+                {% if plan.has_account_level_credit %}
                 <h2>{% trans 'Subscription Credit' %}</h2>
+                {% endif %}
                 <div class="form form-horizontal">
                     <div data-bind="foreach: products">
                         <div class="control-group">

--- a/corehq/apps/domain/templates/domain/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/current_subscription.html
@@ -156,6 +156,36 @@
                             </div>
                         </div>
                     {% endif %}
+                    {% if plan.feature_credit and plan.feature_credit.is_visible %}
+                        <div class="control-group">
+                            <label class="control-label">{% trans 'Feature Credit' %}</label>
+                            <div class="controls">
+                                <p class="control-group-text">{{ plan.feature_credit.amount }}</p>
+                                <p class="help-block">
+                                    <i class="icon-info-sign"></i>
+                                    {% blocktrans %}
+                                        This is credit that can be applied to the features below.
+                                        It's likely that someone from Dimagi added these credits for you.
+                                    {% endblocktrans %}
+                                </p>
+                            </div>
+                        </div>
+                    {% endif %}
+                    {% if plan.account_feature_credit and plan.account_feature_credit.is_visible %}
+                        <div class="control-group">
+                            <label class="control-label">{% trans 'Account Feature Credit' %}</label>
+                            <div class="controls">
+                                <p class="control-group-text">{{ plan.account_feature_credit.amount }}</p>
+                                <p class="help-block">
+                                    <i class="icon-info-sign"></i>
+                                    {% blocktrans %}
+                                        This is credit that can be applied to the features below.
+                                        It's likely that someone from Dimagi added these credits for you.
+                                    {% endblocktrans %}
+                                </p>
+                            </div>
+                        </div>
+                    {% endif %}
                     {% if plan.next_subscription.exists %}
                         <div class="control-group">
                             <label class="control-label">

--- a/corehq/apps/domain/templates/domain/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/current_subscription.html
@@ -140,6 +140,22 @@
                             </div>
                         </div>
                     {% endif %}
+                    {% if plan.account_general_credit and plan.account_general_credit.is_visible %}
+                        <div class="control-group">
+                            <label class="control-label">{% trans 'Account General Credit' %}</label>
+                            <div class="controls">
+                                <p class="control-group-text">{{ plan.account_general_credit.amount }}</p>
+                                <p class="help-block">
+                                    <i class="icon-info-sign"></i>
+                                    {% blocktrans %}
+                                        This is credit that can be applied to either your software plan
+                                        or the features below. It's likely that someone from Dimagi added these
+                                        credits for you.
+                                    {% endblocktrans %}
+                                </p>
+                            </div>
+                        </div>
+                    {% endif %}
                     {% if plan.next_subscription.exists %}
                         <div class="control-group">
                             <label class="control-label">

--- a/corehq/apps/domain/templates/domain/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/current_subscription.html
@@ -112,6 +112,15 @@
                             </div>
                         </div>
                     {% endif %}
+                    <div data-bind="foreach: products">
+                        <div class="control-group">
+                            <label class="control-label">{% trans 'Current Price' %}</label>
+                            <div class="controls">
+                                <p class="control-group-text"
+                                   data-bind="text: monthlyFee"></p>
+                            </div>
+                        </div>
+                    </div>
                     {% if plan.next_subscription.exists %}
                         <div class="control-group">
                             <label class="control-label">
@@ -144,20 +153,64 @@
                             </div>
                         </div>
                     {% endif %}
+                {% endif %}
+            </div>
+            {% if not plan.is_trial %}
+                <h2>{% trans 'Subscription Credit' %}</h2>
+                <div class="form form-horizontal">
                     <div data-bind="foreach: products">
-                        <div class="control-group">
-                            <label class="control-label">{% trans 'Current Price' %}</label>
-                            <div class="controls">
-                                <p class="control-group-text"
-                                   data-bind="text: monthlyFee"></p>
-                            </div>
-                        </div>
                         <div class="control-group">
                             <label class="control-label">{% trans 'Plan Credit' %}</label>
                             <div class="controls">
                                 <p class="control-group-text" data-bind="text: amount"></p>
                             </div>
                         </div>
+                    </div>
+                    {% if plan.feature_credit and plan.feature_credit.is_visible %}
+                    <div class="control-group">
+                        <label class="control-label">
+                            {% trans 'Feature Credit' %}
+                            <div class="hq-help">
+                                <a href="#"
+                                   data-content="This is credit that can be applied to the features below.
+                                    It's likely that someone from Dimagi added these credits for you."
+                                   data-title="Feature Credit"
+                                   data-original-title=""
+                                   title="">
+                                    <i class="icon-question-sign"></i>
+                                </a>
+                            </div>
+                        </label>
+                        <div class="controls">
+                            <p class="control-group-text">{{ plan.feature_credit.amount }}</p>
+                        </div>
+                    </div>
+                    {% endif %}
+                    {% if plan.general_credit and plan.general_credit.is_visible %}
+                    <div class="control-group">
+                        <label class="control-label">
+                            {% trans 'General Credit' %}
+                            <div class="hq-help">
+                                <a href="#"
+                                   data-content="This is credit that can be applied to either your software
+                                    plan or the features below. It's likely that someone from Dimagi added
+                                    these credits for you."
+                                   data-title="General Credit"
+                                   data-original-title=""
+                                   title="">
+                                    <i class="icon-question-sign"></i>
+                                </a>
+                            </div>
+                        </label>
+                        <div class="controls">
+                            <p class="control-group-text">{{ plan.general_credit.amount }}</p>
+                        </div>
+                    </div>
+                    {% endif %}
+                </div>
+                <h2>{% trans 'Account Credit' %}</h2>
+                <div class="form form-horizontal">
+                    <div data-bind="foreach: products">
                         <div class="control-group" data-bind="visible: isAccountVisible">
                             <label class="control-label">
                                 {% trans 'Account Plan Credit' %}
@@ -177,88 +230,49 @@
                             </div>
                         </div>
                     </div>
-                    {% if plan.general_credit and plan.general_credit.is_visible %}
-                        <div class="control-group">
-                            <label class="control-label">
-                                {% trans 'General Credit' %}
-                                <div class="hq-help">
-                                    <a href="#"
-                                       data-content="This is credit that can be applied to either your software
-                                        plan or the features below. It's likely that someone from Dimagi added
-                                        these credits for you."
-                                       data-title="General Credit"
-                                       data-original-title=""
-                                       title="">
-                                        <i class="icon-question-sign"></i>
-                                    </a>
-                                </div>
-                            </label>
-                            <div class="controls">
-                                <p class="control-group-text">{{ plan.general_credit.amount }}</p>
+                    {% if plan.account_feature_credit and plan.account_feature_credit.is_visible %}
+                    <div class="control-group">
+                        <label class="control-label">
+                            {% trans 'Account Feature Credit' %}
+                            <div class="hq-help">
+                                <a href="#"
+                                   data-content="This is credit that can be applied to the features below.
+                                    It's likely that someone from Dimagi added these credits for you."
+                                   data-title="Account Feature Credit"
+                                   data-original-title=""
+                                   title="">
+                                    <i class="icon-question-sign"></i>
+                                </a>
                             </div>
+                        </label>
+                        <div class="controls">
+                            <p class="control-group-text">{{ plan.account_feature_credit.amount }}</p>
                         </div>
+                    </div>
                     {% endif %}
                     {% if plan.account_general_credit and plan.account_general_credit.is_visible %}
-                        <div class="control-group">
-                            <label class="control-label">
-                                {% trans 'Account General Credit' %}
-                                <div class="hq-help">
-                                    <a href="#"
-                                       data-content="This is credit that can be applied to either your software
-                                        plan or the features below. It's likely that someone from Dimagi added
-                                        these credits for you."
-                                       data-title="Account General Credit"
-                                       data-original-title=""
-                                       title="">
-                                        <i class="icon-question-sign"></i>
-                                    </a>
-                                </div>
-                            </label>
-                            <div class="controls">
-                                <p class="control-group-text">{{ plan.account_general_credit.amount }}</p>
+                    <div class="control-group">
+                        <label class="control-label">
+                            {% trans 'Account General Credit' %}
+                            <div class="hq-help">
+                                <a href="#"
+                                   data-content="This is credit that can be applied to either your software
+                                    plan or the features below. It's likely that someone from Dimagi added
+                                    these credits for you."
+                                   data-title="Account General Credit"
+                                   data-original-title=""
+                                   title="">
+                                    <i class="icon-question-sign"></i>
+                                </a>
                             </div>
+                        </label>
+                        <div class="controls">
+                            <p class="control-group-text">{{ plan.account_general_credit.amount }}</p>
                         </div>
+                    </div>
                     {% endif %}
-                    {% if plan.feature_credit and plan.feature_credit.is_visible %}
-                        <div class="control-group">
-                            <label class="control-label">
-                                {% trans 'Feature Credit' %}
-                                <div class="hq-help">
-                                    <a href="#"
-                                       data-content="This is credit that can be applied to the features below.
-                                        It's likely that someone from Dimagi added these credits for you."
-                                       data-title="Feature Credit"
-                                       data-original-title=""
-                                       title="">
-                                        <i class="icon-question-sign"></i>
-                                    </a>
-                                </div>
-                            </label>
-                            <div class="controls">
-                                <p class="control-group-text">{{ plan.feature_credit.amount }}</p>
-                            </div>
-                        </div>
-                    {% endif %}
-                    {% if plan.account_feature_credit and plan.account_feature_credit.is_visible %}
-                        <div class="control-group">
-                            <label class="control-label">
-                                {% trans 'Account Feature Credit' %}
-                                <div class="hq-help">
-                                    <a href="#"
-                                       data-content="This is credit that can be applied to the features below.
-                                        It's likely that someone from Dimagi added these credits for you."
-                                       data-title="Account Feature Credit"
-                                       data-original-title=""
-                                       title="">
-                                        <i class="icon-question-sign"></i>
-                                    </a>
-                                </div>
-                            </label>
-                            <div class="controls">
-                                <p class="control-group-text">{{ plan.account_feature_credit.amount }}</p>
-                            </div>
-                        </div>
-                    {% endif %}
+                </div>
+                <div class="form form-horizontal">
                     <div data-bind="with: prepayments">
                         <div class="control-group">
                             <div class="controls">
@@ -288,8 +302,8 @@
                             </div>
                         </div>
                     </div>
-                {% endif %}
-            </div>
+                </div>
+            {% endif %}
             <h2>{% trans 'Usage Summary' %}</h2>
             <table class="table table-bordered table-striped">
                 <thead>

--- a/corehq/apps/domain/templates/domain/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/current_subscription.html
@@ -39,7 +39,12 @@
             creditsHandler.init();
         });
 
-
+        $(function () {
+            $('.hq-help-template').each(function () {
+                COMMCAREHQ.transformHelpTemplate($(this), true);
+            });
+            $('.hq-help').hqHelp();
+        });
     </script>
 {% endblock %}
 
@@ -122,78 +127,103 @@
                             </div>
                         </div>
                         <div class="control-group" data-bind="visible: isAccountVisible">
-                            <label class="control-label">{% trans 'Account Plan Credit' %}</label>
+                            <label class="control-label">
+                                {% trans 'Account Plan Credit' %}
+                                <div class="hq-help">
+                                    <a href="#"
+                                       data-content="This is credit that can be applied to your software plan.
+                                        It's likely that someone from Dimagi added these credits for you."
+                                       data-title="Account Plan Credit"
+                                       data-original-title=""
+                                       title="">
+                                        <i class="icon-question-sign"></i>
+                                    </a>
+                                </div>
+                            </label>
                             <div class="controls">
                                 <p class="control-group-text" data-bind="text: accountAmount"></p>
-                                <p class="help-block">
-                                    <i class="icon-info-sign"></i>
-                                    {% blocktrans %}
-                                        This is credit that can be applied to your software plan.
-                                        It's likely that someone from Dimagi added these credits for you.
-                                    {% endblocktrans %}
-                                </p>
                             </div>
                         </div>
                     </div>
                     {% if plan.general_credit and plan.general_credit.is_visible %}
                         <div class="control-group">
-                            <label class="control-label">{% trans 'General Credit' %}</label>
+                            <label class="control-label">
+                                {% trans 'General Credit' %}
+                                <div class="hq-help">
+                                    <a href="#"
+                                       data-content="This is credit that can be applied to either your software
+                                        plan or the features below. It's likely that someone from Dimagi added
+                                        these credits for you."
+                                       data-title="General Credit"
+                                       data-original-title=""
+                                       title="">
+                                        <i class="icon-question-sign"></i>
+                                    </a>
+                                </div>
+                            </label>
                             <div class="controls">
                                 <p class="control-group-text">{{ plan.general_credit.amount }}</p>
-                                <p class="help-block">
-                                    <i class="icon-info-sign"></i>
-                                    {% blocktrans %}
-                                        This is credit that can be applied to either your software plan
-                                        or the features below. It's likely that someone from Dimagi added these
-                                        credits for you.
-                                    {% endblocktrans %}
-                                </p>
                             </div>
                         </div>
                     {% endif %}
                     {% if plan.account_general_credit and plan.account_general_credit.is_visible %}
                         <div class="control-group">
-                            <label class="control-label">{% trans 'Account General Credit' %}</label>
+                            <label class="control-label">
+                                {% trans 'Account General Credit' %}
+                                <div class="hq-help">
+                                    <a href="#"
+                                       data-content="This is credit that can be applied to either your software
+                                        plan or the features below. It's likely that someone from Dimagi added
+                                        these credits for you."
+                                       data-title="Account General Credit"
+                                       data-original-title=""
+                                       title="">
+                                        <i class="icon-question-sign"></i>
+                                    </a>
+                                </div>
+                            </label>
                             <div class="controls">
                                 <p class="control-group-text">{{ plan.account_general_credit.amount }}</p>
-                                <p class="help-block">
-                                    <i class="icon-info-sign"></i>
-                                    {% blocktrans %}
-                                        This is credit that can be applied to either your software plan
-                                        or the features below. It's likely that someone from Dimagi added these
-                                        credits for you.
-                                    {% endblocktrans %}
-                                </p>
                             </div>
                         </div>
                     {% endif %}
                     {% if plan.feature_credit and plan.feature_credit.is_visible %}
                         <div class="control-group">
-                            <label class="control-label">{% trans 'Feature Credit' %}</label>
+                            <label class="control-label">
+                                {% trans 'Feature Credit' %}
+                                <div class="hq-help">
+                                    <a href="#"
+                                       data-content="This is credit that can be applied to the features below.
+                                        It's likely that someone from Dimagi added these credits for you."
+                                       data-title="Feature Credit"
+                                       data-original-title=""
+                                       title="">
+                                        <i class="icon-question-sign"></i>
+                                    </a>
+                                </div>
+                            </label>
                             <div class="controls">
                                 <p class="control-group-text">{{ plan.feature_credit.amount }}</p>
-                                <p class="help-block">
-                                    <i class="icon-info-sign"></i>
-                                    {% blocktrans %}
-                                        This is credit that can be applied to the features below.
-                                        It's likely that someone from Dimagi added these credits for you.
-                                    {% endblocktrans %}
-                                </p>
                             </div>
                         </div>
                     {% endif %}
                     {% if plan.account_feature_credit and plan.account_feature_credit.is_visible %}
                         <div class="control-group">
-                            <label class="control-label">{% trans 'Account Feature Credit' %}</label>
+                            <label class="control-label">
+                                {% trans 'Account Feature Credit' %}
+                                <div class="hq-help">
+                                    <a href="#"
+                                       data-content="This is credit that can be applied to the features below.
+                                        It's likely that someone from Dimagi added these credits for you."
+                                       data-title="Account Feature Credit"
+                                       data-original-title=""
+                                       title="">
+                                        <i class="icon-question-sign"></i>
+                                    </a>
+                                </div>
+                            </label>
                             <div class="controls">
                                 <p class="control-group-text">{{ plan.account_feature_credit.amount }}</p>
-                                <p class="help-block">
-                                    <i class="icon-info-sign"></i>
-                                    {% blocktrans %}
-                                        This is credit that can be applied to the features below.
-                                        It's likely that someone from Dimagi added these credits for you.
-                                    {% endblocktrans %}
-                                </p>
                             </div>
                         </div>
                     {% endif %}

--- a/corehq/apps/domain/templates/domain/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/current_subscription.html
@@ -269,6 +269,9 @@
                         <th>{% trans "Remaining" %}</th>
                         {% if not plan.is_trial %}
                         <th>{% trans "Credits Available" %}</th>
+                        {% if show_account_credits %}
+                        <th>{% trans "Account Credits Available" %}</th>
+                        {% endif %}
                         {% endif %}
                     </tr>
                 </thead>
@@ -279,6 +282,9 @@
                         <td data-bind="text: remaining"></td>
                         {% if not plan.is_trial %}
                         <td data-bind="text: amount"></td>
+                        {% if show_account_credits %}
+                        <td data-bind="text: accountAmount"></td>
+                        {% endif %}
                         {% endif %}
                     </tr>
                 </tbody>

--- a/corehq/apps/domain/templates/domain/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/current_subscription.html
@@ -118,9 +118,20 @@
                         <div class="control-group">
                             <label class="control-label">{% trans 'Plan Credit' %}</label>
                             <div class="controls">
-                                <span class="help-inline"
-                                      style="margin-right: 10px;"
-                                      data-bind="text: amount"></span>
+                                <p class="control-group-text" data-bind="text: amount"></p>
+                            </div>
+                        </div>
+                        <div class="control-group" data-bind="visible: isAccountVisible">
+                            <label class="control-label">{% trans 'Account Plan Credit' %}</label>
+                            <div class="controls">
+                                <p class="control-group-text" data-bind="text: accountAmount"></p>
+                                <p class="help-block">
+                                    <i class="icon-info-sign"></i>
+                                    {% blocktrans %}
+                                        This is credit that can be applied to your software plan.
+                                        It's likely that someone from Dimagi added these credits for you.
+                                    {% endblocktrans %}
+                                </p>
                             </div>
                         </div>
                     </div>

--- a/corehq/apps/domain/templates/domain/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/current_subscription.html
@@ -52,7 +52,7 @@
 <div class="row">
     <div class="span12">
         <article id="subscriptionSummary">
-            <h2>{% trans 'Current Subscription' %}</h2>
+            <legend>{% trans 'Current Subscription' %}</legend>
             <div class="form form-horizontal">
                 <div class="control-group">
                     <label class="control-label">{% trans 'Plan' %}</label>
@@ -157,7 +157,7 @@
             </div>
             {% if not plan.is_trial %}
                 {% if plan.has_account_level_credit %}
-                <h2>{% trans 'Subscription Credit' %}</h2>
+                <legend>{% trans 'Subscription Credit' %}</legend>
                 {% endif %}
                 <div class="form form-horizontal">
                     <div data-bind="foreach: products">
@@ -211,7 +211,7 @@
                     {% endif %}
                 </div>
                 {% if plan.has_account_level_credit %}
-                <h2>{% trans 'Account Credit' %}</h2>
+                <legend>{% trans 'Account Credit' %}</legend>
                 <div class="form form-horizontal">
                     <div data-bind="foreach: products">
                         <div class="control-group" data-bind="visible: isAccountVisible">
@@ -308,7 +308,7 @@
                     </div>
                 </div>
             {% endif %}
-            <h2>{% trans 'Usage Summary' %}</h2>
+            <legend>{% trans 'Usage Summary' %}</legend>
             <table class="table table-bordered table-striped">
                 <thead>
                     <tr>

--- a/corehq/apps/domain/templates/domain/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/current_subscription.html
@@ -208,6 +208,7 @@
                     </div>
                     {% endif %}
                 </div>
+                {% if plan.has_account_level_credit %}
                 <h2>{% trans 'Account Credit' %}</h2>
                 <div class="form form-horizontal">
                     <div data-bind="foreach: products">
@@ -272,6 +273,7 @@
                     </div>
                     {% endif %}
                 </div>
+                {% endif %}
                 <div class="form form-horizontal">
                     <div data-bind="with: prepayments">
                         <div class="control-group">

--- a/corehq/apps/domain/templates/domain/current_subscription.html
+++ b/corehq/apps/domain/templates/domain/current_subscription.html
@@ -213,7 +213,7 @@
                     <div data-bind="foreach: products">
                         <div class="control-group" data-bind="visible: isAccountVisible">
                             <label class="control-label">
-                                {% trans 'Account Plan Credit' %}
+                                {% trans 'Plan Credit' %}
                                 <div class="hq-help">
                                     <a href="#"
                                        data-content="This is credit that can be applied to your software plan.
@@ -233,7 +233,7 @@
                     {% if plan.account_feature_credit and plan.account_feature_credit.is_visible %}
                     <div class="control-group">
                         <label class="control-label">
-                            {% trans 'Account Feature Credit' %}
+                            {% trans 'Feature Credit' %}
                             <div class="hq-help">
                                 <a href="#"
                                    data-content="This is credit that can be applied to the features below.
@@ -253,7 +253,7 @@
                     {% if plan.account_general_credit and plan.account_general_credit.is_visible %}
                     <div class="control-group">
                         <label class="control-label">
-                            {% trans 'Account General Credit' %}
+                            {% trans 'General Credit' %}
                             <div class="hq-help">
                                 <a href="#"
                                    data-content="This is credit that can be applied to either your software

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -678,6 +678,14 @@ class DomainSubscriptionView(DomainAccountingSettings):
             'cards': cards,
             'next_subscription': next_subscription,
         }
+        info['has_account_level_credit'] = (
+            any(
+                product_info['account_credit'] and product_info['account_credit']['is_visible']
+                for product_info in info['products']
+            )
+            or info['account_feature_credit'] and info['account_feature_credit']['is_visible']
+            or info['account_general_credit'] and info['account_general_credit']['is_visible']
+        )
         info.update(plan_version.user_facing_description)
 
         return info

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -652,9 +652,19 @@ class DomainSubscriptionView(DomainAccountingSettings):
                     subscription
                 ) if subscription else None
             )),
+            'feature_credit': self._fmt_credit(self._credit_grand_total(
+                CreditLine.get_credits_by_subscription_and_features(
+                    subscription, feature_type=FeatureType.ANY
+                ) if subscription else None
+            )),
             'account_general_credit': self._fmt_credit(self._credit_grand_total(
                 CreditLine.get_credits_for_account(
                     self.account
+                ) if self.account else None
+            )),
+            'account_feature_credit': self._fmt_credit(self._credit_grand_total(
+                CreditLine.get_credits_for_account(
+                    self.account, feature_type=FeatureType.ANY
                 ) if self.account else None
             )),
             'css_class': "label-plan %s" % plan_version.plan.edition.lower(),

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -707,18 +707,19 @@ class DomainSubscriptionView(DomainAccountingSettings):
                 % self.account
             )
         product_rate = product_rates[0]
+        product_type = product_rate.product.product_type
         return {
-            'name': product_rate.product.product_type,
+            'name': product_type,
             'monthly_fee': _("USD %s /month") % product_rate.monthly_fee,
-            'type': product_rate.product.product_type,
+            'type': product_type,
             'subscription_credit': self._fmt_credit(self._credit_grand_total(
                 CreditLine.get_credits_by_subscription_and_features(
-                    subscription, product_type=product_rate.product.product_type
+                    subscription, product_type=product_type
                 ) if subscription else None
             )),
             'account_credit': self._fmt_credit(self._credit_grand_total(
                 CreditLine.get_credits_for_account(
-                    account, product_type=product_rate.product.product_type
+                    account, product_type=product_type
                 ) if account else None
             )),
         }
@@ -726,24 +727,25 @@ class DomainSubscriptionView(DomainAccountingSettings):
     def get_feature_summary(self, plan_version, account, subscription):
         def _get_feature_info(feature_rate):
             usage = FeatureUsageCalculator(feature_rate, self.domain).get_usage()
+            feature_type = feature_rate.feature.feature_type
             return {
-                'name': get_feature_name(feature_rate.feature.feature_type, self.product),
+                'name': get_feature_name(feature_type, self.product),
                 'usage': usage,
                 'remaining': (
                     feature_rate.monthly_limit - usage
                     if feature_rate.monthly_limit != UNLIMITED_FEATURE_USAGE
                     else _('Unlimited')
                 ),
-                'type': feature_rate.feature.feature_type,
-                'recurring_interval': get_feature_recurring_interval(feature_rate.feature.feature_type),
+                'type': feature_type,
+                'recurring_interval': get_feature_recurring_interval(feature_type),
                 'subscription_credit': self._fmt_credit(self._credit_grand_total(
                     CreditLine.get_credits_by_subscription_and_features(
-                        subscription, feature_type=feature_rate.feature.feature_type
+                        subscription, feature_type=feature_type
                     ) if subscription else None
                 )),
                 'account_credit': self._fmt_credit(self._credit_grand_total(
                     CreditLine.get_credits_for_account(
-                        account, feature_type=feature_rate.feature.feature_type
+                        account, feature_type=feature_type
                     ) if account else None
                 )),
             }

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -696,17 +696,7 @@ class DomainSubscriptionView(DomainAccountingSettings):
         return sum([c.balance for c in credit_lines]) if credit_lines else Decimal('0.00')
 
     def get_product_summary(self, plan_version, account, subscription):
-        product_rates = plan_version.product_rates.all()
-        if len(product_rates) > 1:
-            # Models and UI are both written to support multiple products,
-            # but for now, each subscription can only have one product.
-            accounting_logger.error(
-                "[BILLING] "
-                "There seem to be multiple ACTIVE NEXT subscriptions for the subscriber %s. "
-                "Odd, right? The latest one by date_created was used, but consider this an issue."
-                % self.account
-            )
-        product_rate = product_rates[0]
+        product_rate = plan_version.get_product_rate()
         product_type = product_rate.product.product_type
         return {
             'name': product_type,

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -724,10 +724,9 @@ class DomainSubscriptionView(DomainAccountingSettings):
         }
 
     def get_feature_summary(self, plan_version, account, subscription):
-        feature_summary = []
-        for feature_rate in plan_version.feature_rates.all():
+        def _get_feature_info(feature_rate):
             usage = FeatureUsageCalculator(feature_rate, self.domain).get_usage()
-            feature_info = {
+            return {
                 'name': get_feature_name(feature_rate.feature.feature_type, self.product),
                 'usage': usage,
                 'remaining': (
@@ -749,8 +748,7 @@ class DomainSubscriptionView(DomainAccountingSettings):
                 )),
             }
 
-            feature_summary.append(feature_info)
-        return feature_summary
+        return map(_get_feature_info, plan_version.feature_rates.all())
 
     @property
     def page_context(self):

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -67,7 +67,8 @@ from corehq.apps.accounting.models import (
     BillingAccountType,
     Invoice, BillingRecord, InvoicePdf, PaymentMethodType,
     PaymentMethod, EntryPoint, WireInvoice, SoftwarePlanVisibility, FeatureType,
-    StripePaymentMethod, LastPayment
+    StripePaymentMethod, LastPayment,
+    UNLIMITED_FEATURE_USAGE,
 )
 from corehq.apps.accounting.usage import FeatureUsageCalculator
 from corehq.apps.accounting.user_text import (
@@ -731,7 +732,7 @@ class DomainSubscriptionView(DomainAccountingSettings):
                 'usage': usage,
                 'remaining': (
                     feature_rate.monthly_limit - usage
-                    if feature_rate.monthly_limit != -1
+                    if feature_rate.monthly_limit != UNLIMITED_FEATURE_USAGE
                     else _('Unlimited')
                 ),
                 'type': feature_rate.feature.feature_type,

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -705,24 +705,21 @@ class DomainSubscriptionView(DomainAccountingSettings):
                 % self.account
             )
         product_rate = product_rates[0]
-        product_info = {
+        return {
             'name': product_rate.product.product_type,
             'monthly_fee': _("USD %s /month") % product_rate.monthly_fee,
-            'credit': None,
             'type': product_rate.product.product_type,
+            'subscription_credit': self._fmt_credit(self._credit_grand_total(
+                CreditLine.get_credits_by_subscription_and_features(
+                    subscription, product_type=product_rate.product.product_type
+                ) if subscription else None
+            )),
+            'account_credit': self._fmt_credit(self._credit_grand_total(
+                CreditLine.get_credits_for_account(
+                    account, product_type=product_rate.product.product_type
+                ) if account else None
+            )),
         }
-        credit_lines = None
-        if subscription is not None:
-            credit_lines = CreditLine.get_credits_by_subscription_and_features(
-                subscription, product_type=product_rate.product.product_type
-            )
-        elif account is not None:
-            credit_lines = CreditLine.get_credits_for_account(
-                account, product_type=product_rate.product.product_type
-            )
-        if credit_lines:
-            product_info['credit'] = self._fmt_credit(self._credit_grand_total(credit_lines))
-        return product_info
 
     def get_feature_summary(self, plan_version, account, subscription):
         feature_summary = []


### PR DESCRIPTION
Specify in the user facing UI which credits belong to the subscription, and which belong to the account.  In most cases the UI will be unchanged, since account level credits only exist in special cases and those UI elements are not shown if there are no account credits. Also solves http://manage.dimagi.com/default.asp?189803

(best read commit by commit.  a lot of the changes are just refactors)

Before:

<img width="1394" alt="screen shot 2015-12-28 at 11 23 14 am" src="https://cloud.githubusercontent.com/assets/1757035/12021572/c3d46270-ad55-11e5-8e42-844b7424ee82.png">

After (shows all possible UI changes that might appear to the user):

<img width="1394" alt="screen shot 2015-12-28 at 11 22 52 am" src="https://cloud.githubusercontent.com/assets/1757035/12021586/d4e85670-ad55-11e5-8797-c45dd9b5a1e8.png">
