### PR TITLE
Pulling the trigger on csrf

### DIFF
--- a/corehq/apps/builds/templates/builds/edit_menu.html
+++ b/corehq/apps/builds/templates/builds/edit_menu.html
@@ -89,7 +89,7 @@
             <li>Click Submit</li>
             <li>Wait until the page loads. If successful click back and refresh to see your new build.</li>
         </ol>
-        <form action="{% url 'corehq.apps.builds.views.import_build' %}" method="post">% csrf_token %}
+        <form action="{% url 'corehq.apps.builds.views.import_build' %}" method="post">{% csrf_token %}
             <label for="import_build_name">Source for artifacts.zip</label>
             <input id="import_build_name" type="text" name="source"/>
             <br/>

--- a/corehq/apps/cloudcare/static/cloudcare/js/backbone/apps.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/backbone/apps.js
@@ -193,8 +193,14 @@ cloudCare.SessionView = Selectable.extend({
             e.stopPropagation();
             var dialog = confirm(translatedStrings.deleteSaved);
             if (dialog == true) {
-                self.model.destroy();
-                showSuccess(translatedStrings.deleteSuccess, $("#cloudcare-notifications"), 10000);
+                self.model.destroy({
+                    success: function(model, response) {
+                        showSuccess(translatedStrings.deleteSuccess, $("#cloudcare-notifications"), 10000);
+                    },
+                    error: function(model, response) {
+                        showError(translatedStrings.deleteError, $("#cloudcare-notifications"), 10000);
+                    }
+                });
             }
         });
         $("<a />").text(this.model.get('display')).appendTo($(this.el));

--- a/corehq/apps/cloudcare/static/cloudcare/js/post.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/post.js
@@ -1,3 +1,6 @@
+// Note: This file should probably be deleted, this function is not being used anywhere,
+// using this function would result in a csrf error
+
 // hat tip: http://stackoverflow.com/questions/133925/javascript-post-request-like-a-form-submit
 var postToUrl = function (path, params, method) {
     method = method || "post"; // Set method to post by default, if not specified.

--- a/corehq/apps/cloudcare/templates/cloudcare/cloudcare_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/cloudcare_home.html
@@ -74,6 +74,7 @@
         newWindow: "{% trans "Open in New Window" %}",
         deleteSaved: "{% trans "Permanently delete this form? You will not be able to return to it later." %}",
         deleteSuccess: "{% trans "Form was deleted." %}",
+        deleteError:  "{% trans "Error deleting form. Please try again and report an issue if this problem persists." %}",
         caseListError: "{% trans "Unable to load the case list. If you are using a filter expression please double check the syntax and try again. Please report an issue if this problem persists." %}",
         navigateDirty: "{% trans "You have not submitted this form. Click ‘Stay on this Page’ to continue working on this form. If you click 'Leave this Page' you can resume work on this form later." %}",
         sidebarDirty: "{% trans "You have not submitted this form. Click ‘Cancel’ to continue working on this form. If you click 'OK' you can resume work on this form later." %}"

--- a/corehq/apps/data_interfaces/templates/data_interfaces/add_automatic_update_rule.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/add_automatic_update_rule.html
@@ -11,6 +11,7 @@
     var autoUpdateRuleApp = angular.module('addUpdateRuleApp', ['ng.django.rmi']);
 
     autoUpdateRuleApp.config(['$httpProvider', function($httpProvider) {
+        $httpProvider.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
         $httpProvider.defaults.xsrfCookieName = 'csrftoken';
         $httpProvider.defaults.xsrfHeaderName = 'X-CSRFToken';
     }]);

--- a/corehq/apps/data_interfaces/templates/data_interfaces/list_automatic_update_rules.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/list_automatic_update_rules.html
@@ -12,6 +12,12 @@
 (function (angular, undefined) {
     'use strict';
     var autoUpdateRuleApp = angular.module('autoUpdateRuleApp', ['hq.pagination']);
+    autoUpdateRuleApp.config(['$httpProvider', function($httpProvider) {
+        $httpProvider.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
+        $httpProvider.defaults.xsrfCookieName = 'csrftoken';
+        $httpProvider.defaults.xsrfHeaderName = 'X-CSRFToken';
+    }]);
+
     autoUpdateRuleApp.config(["djangoRMIProvider", function(djangoRMIProvider) {
         djangoRMIProvider.configure({% djng_current_rmi %});
     }]);

--- a/corehq/apps/hqmedia/views.py
+++ b/corehq/apps/hqmedia/views.py
@@ -10,6 +10,7 @@ import itertools
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View, TemplateView
 
 from couchdbkit.exceptions import ResourceNotFound
@@ -167,6 +168,12 @@ class BaseProcessUploadedView(BaseMultimediaView):
             return CommCareMultimedia.get_mime_type(data, filename=self.uploaded_file.name)
         except Exception as e:
             raise BadMediaFileException("There was an error fetching the MIME type of your file. Error: %s" % e)
+
+    @method_decorator(require_permission(Permissions.edit_apps, login_decorator=login_with_permission_from_post()))
+    # YUI js uploader library doesn't support csrf
+    @csrf_exempt
+    def dispatch(self, request, *args, **kwargs):
+        return super(BaseMultimediaView, self).dispatch(request, *args, **kwargs)
 
     def get(self, request, *args, **kwargs):
         return HttpResponseBadRequest("You may only post to this URL.")

--- a/corehq/apps/hqwebapp/middleware.py
+++ b/corehq/apps/hqwebapp/middleware.py
@@ -20,4 +20,8 @@ class HQCsrfViewMiddleWare(CsrfViewMiddleware):
             logger.error(warning)
             return self._accept(request)
         else:
+            warning = "The request at {url} doesn't contain a csrf token. This has been rejected".format(
+                          url=request.path
+                      )
+            logger.error(warning)
             return super(HQCsrfViewMiddleWare, self)._reject(request, reason)

--- a/corehq/apps/style/static/style/js/hq_extensions.jquery.js
+++ b/corehq/apps/style/static/style/js/hq_extensions.jquery.js
@@ -6,6 +6,7 @@
             document.location = url + '?' + $.param(params);
         },
         postGo: function (url, params) {
+            params.csrfmiddlewaretoken = $.cookie('csrftoken');
             var $form = $("<form>")
                 .attr("method", "post")
                 .attr("action", url);

--- a/corehq/apps/style/templates/style/bootstrap3/base.html
+++ b/corehq/apps/style/templates/style/bootstrap3/base.html
@@ -312,6 +312,7 @@
         {# HQ Specific Libraries #}
         <script src="{% statici18n LANGUAGE_CODE %}"></script> {# DO NOT COMPRESS #}
         {% compress js %}
+        <script src="{% static 'hqwebapp/js/ajax_csrf_setup.js' %}"></script>
         <script type="text/javascript" src="{% new_static 'style/js/hq-bug-report.js' %}"></script>
         <script type="text/javascript" src="{% new_static 'style/js/layout.js' %}"></script>
         <script type="text/javascript" src="{% new_static 'style/js/form_tools.js' %}"></script>

--- a/corehq/apps/users/templates/users/partial/basic_info_modals.html
+++ b/corehq/apps/users/templates/users/partial/basic_info_modals.html
@@ -14,7 +14,7 @@
               action="{% url "delete_phone_number" domain couch_user.couch_id %}"
               {% endif %}
               method="POST">
-
+            {% csrf_token %}
             <input type="hidden" name="form_type" value="delete-phone-number"/>
             <input type="hidden" name="phone_number" value="{{ phone_number.number }}"/>
 

--- a/corehq/apps/users/templates/users/partial/manage_phone_numbers.b3.html
+++ b/corehq/apps/users/templates/users/partial/manage_phone_numbers.b3.html
@@ -37,6 +37,7 @@
                         <form method="post"
                               action="{% url "verify_phone_number" domain couch_user.couch_id %}?phone_number={{phone.number|urlencode}}"
                               style="display: inline;">
+                              {% csrf_token %}
                             <button type="submit"
                                     data-title="{% trans 'Send a verification SMS to this phone. When the user replies to this SMS, the phone number will be verified.' %}"
                                     class="btn btn-primary verify-button"><i class="fa fa-signal"></i> {% trans 'Verify' %}
@@ -73,6 +74,7 @@
                               action="{% url "make_phone_number_default" domain couch_user.couch_id %}"
                               {% endif %}
                               method="POST">
+                            {% csrf_token %}
                             <input type="hidden" name="form_type" value="make-phone-number-default"/>
                             <input type="hidden" name="phone_number" value="{{ phone.number }}"/>
                             <button type="submit" class="btn btn-default">

--- a/corehq/apps/users/templates/users/partial/manage_phone_numbers.html
+++ b/corehq/apps/users/templates/users/partial/manage_phone_numbers.html
@@ -36,6 +36,7 @@
                         <form method="post"
                               action="{% url "verify_phone_number" domain couch_user.couch_id %}?phone_number={{phone.number|urlencode}}"
                               style="display: inline;">
+                            {% csrf_token %}
                             <button type="submit"
                                     data-title="{% trans 'Send a verification SMS to this phone. When the user replies to this SMS, the phone number will be verified.' %}"
                                     class="btn btn-primary verify-button"><i class="icon-signal"></i> {% trans 'Verify' %}
@@ -72,6 +73,7 @@
                               action="{% url "make_phone_number_default" domain couch_user.couch_id %}"
                               {% endif %}
                               method="POST">
+                            {% csrf_token %}
                             <input type="hidden" name="form_type" value="make-phone-number-default"/>
                             <input type="hidden" name="phone_number" value="{{ phone.number }}"/>
                             <button type="submit" class="btn">

--- a/settings.py
+++ b/settings.py
@@ -129,7 +129,7 @@ TEMPLATE_LOADERS = (
     'django.template.loaders.eggs.Loader',
 )
 
-CSRF_ALWAYS_OFF = True
+CSRF_ALWAYS_OFF = False
 
 MIDDLEWARE_CLASSES = [
     'django.middleware.common.CommonMiddleware',


### PR DESCRIPTION
This PR adds fixes for most of remaining errors and turns CSRF protection actively on, meaning, from now on all requests that don't contain csrf token will 403. I have done a simple analysis of csrf failure logs to confidently say that we are good to go on this now.

We have logged csrf-failures in Couchlog, so I was able to write simple functions to calculate number of csrf-failures per day (for last month). Here is what I found

``` python
 datetime.date(2015, 12, 4): 0,
 datetime.date(2015, 12, 5): 0,
 datetime.date(2015, 12, 6): 0,
 datetime.date(2015, 12, 7): 302,
 datetime.date(2015, 12, 8): 1474,
 datetime.date(2015, 12, 9): 1428,
 datetime.date(2015, 12, 10): 312,
 datetime.date(2015, 12, 11): 221,
 datetime.date(2015, 12, 12): 152,
 datetime.date(2015, 12, 13): 65,
 datetime.date(2015, 12, 14): 475,
 datetime.date(2015, 12, 15): 326,
 datetime.date(2015, 12, 16): 440,
 datetime.date(2015, 12, 17): 167,
 datetime.date(2015, 12, 18): 139,
 datetime.date(2015, 12, 19): 43,
 datetime.date(2015, 12, 20): 29,
 datetime.date(2015, 12, 21): 143,
 datetime.date(2015, 12, 22): 115,
 datetime.date(2015, 12, 23): 107,
 datetime.date(2015, 12, 24): 1230,
 datetime.date(2015, 12, 25): 48,
 datetime.date(2015, 12, 26): 82,
 datetime.date(2015, 12, 27): 23}
```

CSRF has been deployed on 7th Dec. From 7th to 16th number of perday errors are at least 150. By 16th we have done 2 or 3 rounds of fixes. So the number of failure dropped to below 150 (around half of them below 80). I have manually looked at the error logs since 16th (as opposed to looking at the buggy `/couchlog` (couldn't sort by date)). Most of the big number of 24th are errors at `/jserror` and the other errors or in some pages of cloudcare. I have fixed almost all of these in this PR. I am confident that number of failures after this will be a manageable number, so I don't see any issues in switching on CSRF. All the rejected requests will be logged, so we can still fix the ones we haven't caught.

@czue cc @TylerSheffels, buddies @kaapstorm @calellowitz 

**A comment on analysing logs** `/couchlog` on prod seems to be broken, i.e. sorting and lucene search are not working. I didn't look too deep into the issue as that interface is not too useful for the aggregate analysis I wanted to do. I looked at raw log files, but my shell commands are not advanced enough for aggregations. I remembered ES/Logstash/Kibana (ELK), I have set it up on my local machine and I was able to do the analysis in few seconds (and with a pretty graph as well). Then I found how it is not straightforward to replicate prod couchlog db to my local machine, I suppressed my urge of installing Logstash/Kibana on prod machines. Then I speculated writing a UCR for couchlog, but most of the existing UCR framework seems to be centered around domain specific docs, so it is a considerable lift before I can setup a couchlog UCR (but if we do the lift, we can probably do lot of admin reports and data-analytics stuff using UCRs). I  also thought about writing a ES pillow or SQL pillow for couchlog so that I can write a custom report for it. Instead, I finally wrote simple script to iterate couchlog docs, filtering by date, using raw `find` and raw aggregations to do my simple analysis. That took few minutes but I got the results! But ELK took few seconds! Can we install a ELK on one of machines, it is super helpful in analysing logs. I remember we tried and removed it for memory reasons, but we were probably doing a live feed to Logstash, instead we can do a periodic indexing and it shouldn't be as memory intensive. Just a thought.
