### PR TITLE
Fix race condition

### DIFF
--- a/corehq/ex-submodules/couchexport/groupexports.py
+++ b/corehq/ex-submodules/couchexport/groupexports.py
@@ -57,6 +57,7 @@ def rebuild_export(config, schema, output_dir, last_access_cutoff=None, filter=N
             try:
                 saved.save()
             except ResourceConflict:
+                # task was executed concurrently, so let first to finish win and abort the rest
                 return
             saved.set_payload(payload)
         else:

--- a/corehq/ex-submodules/couchexport/groupexports.py
+++ b/corehq/ex-submodules/couchexport/groupexports.py
@@ -1,6 +1,6 @@
 from couchexport.exceptions import SchemaMismatchException, ExportRebuildError
 from couchexport.models import GroupExportConfiguration, SavedBasicExport
-from couchdbkit.exceptions import ResourceNotFound
+from couchdbkit.exceptions import ResourceConflict, ResourceNotFound
 from datetime import datetime
 import os
 import json
@@ -54,7 +54,10 @@ def rebuild_export(config, schema, output_dir, last_access_cutoff=None, filter=N
             if saved.last_accessed is None:
                 saved.last_accessed = datetime.utcnow()
             saved.last_updated = datetime.utcnow()
-            saved.save()
+            try:
+                saved.save()
+            except ResourceConflict:
+                return
             saved.set_payload(payload)
         else:
             with open(os.path.join(output_dir, config.filename), "wb") as f:

--- a/corehq/ex-submodules/couchexport/groupexports.py
+++ b/corehq/ex-submodules/couchexport/groupexports.py
@@ -58,8 +58,9 @@ def rebuild_export(config, schema, output_dir, last_access_cutoff=None, filter=N
                 saved.save()
             except ResourceConflict:
                 # task was executed concurrently, so let first to finish win and abort the rest
-                return
-            saved.set_payload(payload)
+                pass
+            else:
+                saved.set_payload(payload)
         else:
             with open(os.path.join(output_dir, config.filename), "wb") as f:
                 f.write(payload)


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?189979 is reproducible by running multiple `rebuild_export_task` concurrently.

Cleanly aborts losing tasks.

@czue @orangejenny @TylerSheffels 
