### PR TITLE
Don't retire unsaved CC user

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -7,6 +7,7 @@ from tastypie.utils import dict_strip_unicode_keys
 
 from collections import namedtuple
 
+from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 
 from tastypie import fields
@@ -159,6 +160,12 @@ class CommCareUserResource(v0_1.CommCareUserResource):
         except Exception:
             if bundle.obj._id:
                 bundle.obj.retire()
+            try:
+                django_user = bundle.obj.get_django_user()
+            except User.DoesNotExist:
+                pass
+            else:
+                django_user.delete()
         return bundle
 
     def obj_update(self, bundle, **kwargs):

--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -157,7 +157,8 @@ class CommCareUserResource(v0_1.CommCareUserResource):
             self._update(bundle)
             bundle.obj.save()
         except Exception:
-            bundle.obj.retire()
+            if bundle.obj._id:
+                bundle.obj.retire()
         return bundle
 
     def obj_update(self, bundle, **kwargs):


### PR DESCRIPTION
fixes http://manage.dimagi.com/default.asp?189985

Most of the `retire` method requires `_id`, except for the django user.  I checked for the django user because it gets saved before the couch user, so it might exist even if the couch user has not yet been written to the db before an exception is thrown.

@TylerSheffels @orangejenny 
