### PR TITLE
Wire invoice recipients

### DIFF
--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -241,6 +241,7 @@ class DomainWireInvoiceFactory(object):
         if self.domain is None:
             raise InvoiceError("Domain '{}' is not a valid domain on HQ!".format(self.domain))
 
+    @transaction.atomic()
     def create_wire_invoice(self, balance):
 
         # Gather relevant invoices

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1811,12 +1811,15 @@ class Invoice(InvoiceBase):
 
     @property
     def contact_emails(self):
-        billing_contact_info = BillingContactInfo.objects.filter(account=self.account)
-        contact_email_str = billing_contact_info[0].emails if billing_contact_info else None
-        contact_emails = contact_email_str.split(',') if contact_email_str else []
+        try:
+            billing_contact_info = BillingContactInfo.objects.get(account=self.account)
+            contact_emails = billing_contact_info.emails.split(',') if billing_contact_info.emails else []
+        except BillingContactInfo.DoesNotExist:
+            contact_emails = []
+
         if not contact_emails:
             admins = WebUser.get_admins_by_domain(self.get_domain())
-            contact_emails = [a.email if a.email else a.username for a in admins]
+            contact_emails = [admin.email if admin.email else admin.username for admin in admins]
             logger.error(
                 "[BILLING] "
                 "Could not find an email to send the invoice "

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1780,6 +1780,21 @@ class WireInvoice(InvoiceBase):
     def get_total(self):
         return self.balance
 
+    @property
+    def email_recipients(self):
+        try:
+            original_record = WireBillingRecord.objects.filter(invoice=self).order_by('-date_created')[0]
+            return original_record.emailed_to.split(',') if original_record.emailed_to else []
+        except IndexError:
+            logger.error(
+                "[BILLING] "
+                "Strange that WireInvoice %d has no associated WireBillingRecord. "
+                "Should investigate."
+                % self.id
+            )
+            return []
+
+
 
 class WirePrepaymentInvoice(WireInvoice):
     class Meta:

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1732,23 +1732,6 @@ class InvoiceBase(models.Model):
     def email_recipients(self):
         raise NotImplementedError
 
-    @property
-    def contact_emails(self):
-        billing_contact_info = BillingContactInfo.objects.filter(account=self.account)
-        contact_email_str = billing_contact_info[0].emails if billing_contact_info else None
-        contact_emails = contact_email_str.split(',') if contact_email_str else []
-        if not contact_emails:
-            admins = WebUser.get_admins_by_domain(self.get_domain())
-            contact_emails = [a.email if a.email else a.username for a in admins]
-            logger.error(
-                "[BILLING] "
-                "Could not find an email to send the invoice "
-                "email to for the domain %s. Sending to domain admins instead: "
-                "%s." %
-                (self.get_domain(), ', '.join(contact_emails))
-            )
-        return contact_emails
-
 
 class WireInvoice(InvoiceBase):
     # WireInvoice is tied to a domain, rather than a subscription
@@ -1825,6 +1808,23 @@ class Invoice(InvoiceBase):
             return [settings.FINANCE_EMAIL]
         else:
             return self.contact_emails
+
+    @property
+    def contact_emails(self):
+        billing_contact_info = BillingContactInfo.objects.filter(account=self.account)
+        contact_email_str = billing_contact_info[0].emails if billing_contact_info else None
+        contact_emails = contact_email_str.split(',') if contact_email_str else []
+        if not contact_emails:
+            admins = WebUser.get_admins_by_domain(self.get_domain())
+            contact_emails = [a.email if a.email else a.username for a in admins]
+            logger.error(
+                "[BILLING] "
+                "Could not find an email to send the invoice "
+                "email to for the domain %s. Sending to domain admins instead: "
+                "%s." %
+                (self.get_domain(), ', '.join(contact_emails))
+            )
+        return contact_emails
 
     @property
     def subtotal(self):

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1730,7 +1730,7 @@ class InvoiceBase(models.Model):
 
     @property
     def email_recipients(self):
-        return self.contact_emails
+        raise NotImplementedError
 
     @property
     def contact_emails(self):

--- a/corehq/apps/accounting/tests/test_wire_invoice.py
+++ b/corehq/apps/accounting/tests/test_wire_invoice.py
@@ -24,7 +24,10 @@ class TestWireInvoice(BaseInvoiceTestCase):
         super(TestWireInvoice, self).tearDown()
 
     def test_factory(self):
-        factory = DomainWireInvoiceFactory(self.domain_name)
+        factory = DomainWireInvoiceFactory(
+            self.domain_name,
+            contact_emails=[self.dimagi_user.username],
+        )
         balance = Decimal(100)
 
         mail.outbox = []


### PR DESCRIPTION
addresses http://manage.dimagi.com/default.asp?190017, where an error email was incorrectly being sent every time an Ops user visited the page of a wire invoice.  Also cleans up some code.

@benrudolph cc: @orangejenny @TylerSheffels 
