### PR TITLE
ElasticSearch API fix

### DIFF
--- a/corehq/apps/hqadmin/reporting/reports.py
+++ b/corehq/apps/hqadmin/reporting/reports.py
@@ -143,8 +143,7 @@ def get_project_spaces(facets=None):
     )
     if facets:
         real_domain_query = add_params_to_query(real_domain_query, facets)
-    real_domain_query_results = real_domain_query.run().raw_hits
-    domain_names = [_['fields']['name'] for _ in real_domain_query_results]
+    domain_names = [hit['name'] for hit in real_domain_query.run().hits]
     if 'search' in facets:
         return list(set(domain_names) & set(facets['search']))
     return domain_names


### PR DESCRIPTION
@snopoke 
This addresses the ES 0.90 to ES 1.3 [fields api change](https://www.elastic.co/guide/en/elasticsearch/reference/1.3/_return_values.html), which is the cause behind [ticket #189284](http://manage.dimagi.com/default.asp?189284). This should fix most queries that use `ESQuery` classes, but not if they use the `ESQuerySet.raw_hits` property (instead of the `hits` property) to access the results. This happens in at least one place (which is addressed in 81f18ca), but I didn't attempt to find all instances. Regardless, this PR should be a strict improvement over the existing behavior.

There isn't any urgency to merge this PR. I made this branch to fix the aforementioned ticket on staging.
