### PR TITLE
Accounting logging

### DIFF
--- a/corehq/apps/accounting/payment_handlers.py
+++ b/corehq/apps/accounting/payment_handlers.py
@@ -1,5 +1,4 @@
 from decimal import Decimal
-import logging
 from django.db import transaction
 import stripe
 from django.conf import settings
@@ -17,13 +16,16 @@ from corehq.apps.accounting.models import (
     LastPayment
 )
 from corehq.apps.accounting.user_text import get_feature_name
-from corehq.apps.accounting.utils import fmt_dollar_amount
+from corehq.apps.accounting.utils import (
+    fmt_dollar_amount,
+    log_accounting_error,
+    log_accounting_info,
+)
 from corehq.apps.domain.models import Domain
 from corehq.const import USER_DATE_FORMAT
 from dimagi.utils.decorators.memoized import memoized
 
 stripe.api_key = settings.STRIPE_PRIVATE_KEY
-logger = logging.getLogger('accounting')
 
 
 class BaseStripePaymentHandler(object):
@@ -114,21 +116,22 @@ class BaseStripePaymentHandler(object):
             stripe.error.APIConnectionError,
             stripe.error.StripeError,
         ) as e:
-            logger.error(
-                "[BILLING] A payment for %(cost_item)s failed due "
+            log_accounting_error(
+                "A payment for %(cost_item)s failed due "
                 "to a Stripe %(error_class)s: %(error_msg)s" % {
                     'error_class': e.__class__.__name__,
                     'cost_item': self.cost_item_name,
                     'error_msg': e.json_body['error']
-                }, exc_info=True)
+                }
+            )
             return generic_error
         except Exception as e:
-            logger.error(
-                "[BILLING] A payment for %(cost_item)s failed due "
-                "to: %(error_msg)s" % {
+            log_accounting_error(
+                "A payment for %(cost_item)s failed due to: %(error_msg)s" % {
                     'cost_item': self.cost_item_name,
                     'error_msg': e,
-                }, exc_info=True)
+                }
+            )
             return generic_error
 
         with transaction.atomic():
@@ -140,11 +143,11 @@ class BaseStripePaymentHandler(object):
         try:
             self.send_email(payment_record)
         except Exception:
-            logger.error(
-                "[BILLING] Failed to send out an email receipt for "
+            log_accounting_error(
+                "Failed to send out an email receipt for "
                 "payment related to PaymentRecord No. %s. "
                 "Everything else succeeded."
-                % payment_record.id, exc_info=True
+                % payment_record.id
             )
 
         return {
@@ -362,9 +365,14 @@ class CreditStripePaymentHandler(BaseStripePaymentHandler):
                     payment_record=payment_record,
                 ))
             else:
-                logger.error("[BILLING] {account} tried to make a payment for {feature} for less than $0.5."
-                             "You should follow up with them.".format(account=self.account,
-                                                                      feature=feature['type']))
+                log_accounting_error(
+                    "{account} tried to make a payment for {feature} for less than $0.5."
+                    "You should follow up with them."
+                    .format(
+                        account=self.account,
+                        feature=feature['type']
+                    )
+                )
         for product in self.products:
             plan_amount = product['amount']
             if plan_amount >= 0.5:
@@ -376,9 +384,14 @@ class CreditStripePaymentHandler(BaseStripePaymentHandler):
                     payment_record=payment_record,
                 ))
             else:
-                logger.error("[BILLING] {account} tried to make a payment for {product} for less than $0.5."
-                             "You should follow up with them.".format(account=self.account,
-                                                                      product=product['type']))
+                log_accounting_error(
+                    "{account} tried to make a payment for {product} for less than $0.5."
+                    "You should follow up with them."
+                    .format(
+                        account=self.account,
+                        product=product['type']
+                    )
+                )
 
     def process_request(self, request):
         response = super(CreditStripePaymentHandler, self).process_request(request)
@@ -403,7 +416,7 @@ class AutoPayInvoicePaymentHandler(object):
         """ Pays the full balance of all autopayable invoices on date_due """
         autopayable_invoices = Invoice.autopayable_invoices(date_due)
         for invoice in autopayable_invoices:
-            logging.info("[Billing][Autopay] Autopaying invoice {}".format(invoice.id))
+            log_accounting_info("[Autopay] Autopaying invoice {}".format(invoice.id))
             amount = invoice.balance.quantize(Decimal(10) ** -2)
 
             auto_payer = invoice.subscription.account.auto_pay_user
@@ -450,15 +463,22 @@ class AutoPayInvoicePaymentHandler(object):
             self._handle_email_failure(payment_record)
 
     def _handle_card_declined(self, invoice):
-        logger.error("[Billing][Autopay] An automatic payment failed for invoice: {} "
-                     "because the card was declined. This invoice will not be automatically paid."
-                     .format(invoice.id))
+        log_accounting_error(
+            "[Autopay] An automatic payment failed for invoice: {} "
+            "because the card was declined. This invoice will not be automatically paid."
+            .format(invoice.id)
+        )
 
     def _handle_card_errors(self, invoice, e):
-        logger.error("[Billing][Autopay] An automatic payment failed for invoice: {invoice} "
-                     "because the of {error}. This invoice will not be automatically paid."
-                     .format(invoice=invoice.id, error=e))
+        log_accounting_error(
+            "[Autopay] An automatic payment failed for invoice: {invoice} "
+            "because the of {error}. This invoice will not be automatically paid."
+            .format(invoice=invoice.id, error=e)
+        )
 
     def _handle_email_failure(self, payment_record):
-        logger.error("[Billing][Autopay] During an automatic payment, sending a payment receipt failed"
-                     " for Payment Record: {}. Everything else succeeded".format(payment_record.id))
+        log_accounting_error(
+            "[Autopay] During an automatic payment, sending a payment receipt failed"
+            " for Payment Record: {}. Everything else succeeded"
+            .format(payment_record.id)
+        )

--- a/corehq/apps/accounting/utils.py
+++ b/corehq/apps/accounting/utils.py
@@ -2,6 +2,8 @@ import calendar
 from collections import namedtuple
 import datetime
 from decimal import Decimal
+import logging
+
 from django.conf import settings
 from django.template.loader import render_to_string
 from corehq.util.view_utils import absolute_reverse
@@ -18,8 +20,17 @@ from dimagi.utils.couch.database import iter_docs
 from dimagi.utils.dates import add_months
 from django_prbac.models import Role, UserRole
 
+logger = logging.getLogger('accounting')
 
 EXCHANGE_RATE_DECIMAL_PLACES = 9
+
+
+def log_accounting_error(message):
+    logger.error("[BILLING] %s" % message, exc_info=True)
+
+
+def log_accounting_info(message):
+    logger.info("[BILLING] %s" % message)
 
 
 def get_first_last_days(year, month):

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -1,6 +1,5 @@
 from datetime import date
 import json
-import logging
 
 from django.conf import settings
 from django.contrib import messages
@@ -63,17 +62,14 @@ from corehq.apps.accounting.models import (
 from corehq.apps.accounting.user_text import PricingTable
 from corehq.apps.accounting.utils import (
     fmt_feature_rate_dict, fmt_product_rate_dict,
-    has_subscription_already_ended
-)
+    has_subscription_already_ended,
+    log_accounting_error)
 from corehq.apps.hqwebapp.views import BaseSectionPageView, CRUDPaginatedViewMixin
 from corehq import privileges, toggles
 from django_prbac.decorators import requires_privilege_raise404
 from django_prbac.models import Role, Grant
 
 from urllib import urlencode
-
-
-logger = logging.getLogger('accounting')
 
 
 @requires_privilege_raise404(privileges.ACCOUNTING_ADMIN)
@@ -211,8 +207,8 @@ class ManageBillingAccountView(BillingAccountsSectionView, AsyncHandlerMixin):
                     messages.success(request, "Successfully adjusted credit.")
                     return HttpResponseRedirect(self.page_url)
             except CreditLineError as e:
-                logger.error(
-                    "[BILLING] failed to add credit in admin UI due to: %s"
+                log_accounting_error(
+                    "failed to add credit in admin UI due to: %s"
                     % e
                 )
                 messages.error(request, "Issue adding credit: %s" % e)

--- a/corehq/apps/smsbillables/async_handlers.py
+++ b/corehq/apps/smsbillables/async_handlers.py
@@ -1,8 +1,7 @@
 import json
-import logging
 from couchdbkit import ResourceNotFound
 from django.utils.translation import ugettext_lazy as _
-from corehq.apps.accounting.utils import fmt_dollar_amount
+from corehq.apps.accounting.utils import fmt_dollar_amount, log_accounting_error
 from corehq.apps.hqwebapp.async_handler import BaseAsyncHandler
 from corehq.apps.hqwebapp.encoders import LazyEncoder
 from corehq.apps.sms.mixin import SMSBackend
@@ -15,7 +14,6 @@ from corehq.util.quickcache import quickcache
 
 
 NONMATCHING_COUNTRY = 'nonmatching'
-logger = logging.getLogger('accounting')
 
 
 class SMSRatesAsyncHandler(BaseAsyncHandler):
@@ -31,8 +29,10 @@ class SMSRatesAsyncHandler(BaseAsyncHandler):
             backend = SMSBackend.get(gateway)
             backend_api_id = get_backend_by_class_name(backend.doc_type).get_api_id()
         except Exception as e:
-            logger.error("Failed to get backend for calculating an sms rate "
-                         "due to: %s" % e)
+            log_accounting_error(
+                "Failed to get backend for calculating an sms rate due to: %s"
+                % e
+            )
             raise SMSRateCalculatorError("Could not obtain connection information.")
 
         country_code = self.data.get('country_code')


### PR DESCRIPTION
Billing errors are weird because some are prefixed with "[BILLING]", some with "[Billing]", others with no prefix; and errors are sometimes logged to accounting logs, other times are logged to the regular hq logs.  This standardizes billing logging by introducing helper functions for error and info logs.
