### PR TITLE
Fix syntax error

### DIFF
--- a/corehq/apps/commtrack/static/commtrack/ko/location_bulk_upload_file.js
+++ b/corehq/apps/commtrack/static/commtrack/ko/location_bulk_upload_file.js
@@ -23,6 +23,6 @@ $(function () {
     }
 
     $("#download_block").koApplyBindings(
-        new ConsumptionOptionsViewModel($("#download_link").get(0).href),
+        new ConsumptionOptionsViewModel($("#download_link").get(0).href)
     );
 });


### PR DESCRIPTION
@orangejenny
http://manage.dimagi.com/default.asp?189978
There was a superfluous comma, which caused a syntax error.  This meant that the javascript used to append kwargs to the download URL didn't get executed.
