### PR TITLE
less celery workers

### DIFF
--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -214,25 +214,9 @@ swiss:
   celery_processes:
     '*':
       main:
-        concurrency: 4
-      background_queue:
-        concurrency: 2
-      periodic:
-        concurrency: 4
-      pillow_retry_queue:
         concurrency: 1
-      reminder_case_update_queue:
-        concurrency: 4
-      reminder_queue:
-        concurrency: 4
-      reminder_rule_queue:
-        concurrency: 4
-      saved_exports_queue:
-        concurrency: 3
-      sms_queue:
-        concurrency: 4
-      ucr_queue:
-        concurrency: 2
-      email_queue:
-        concurrency: 2
+      background_queue:
+        concurrency: 1
+      periodic:
+        concurrency: 1
       flower: {}


### PR DESCRIPTION
I had originally copied the celery settings from zambia, but the swiss server has less memory, so we need to reduce the memory footprint of running an HQ instance.

@emord 
