### PR TITLE
remove compression at base level template for js

### DIFF
--- a/corehq/apps/style/templates/style/bootstrap3/base.html
+++ b/corehq/apps/style/templates/style/bootstrap3/base.html
@@ -414,9 +414,7 @@
         {% endcompress %}
         {% endif %}
 
-        {% compress js %}
         {% block js %}{% endblock js %}
-        {% endcompress %}
 
         {# Report Issue #}
         {% include 'style/includes/modal_report_issue.html' %}


### PR DESCRIPTION
unfortunately it seems calling `{{ block.super }}` does indeed confuse compressor :(
