### PR TITLE
adding detail_uri_name to location resource meta

### DIFF
--- a/corehq/apps/locations/resources/v0_5.py
+++ b/corehq/apps/locations/resources/v0_5.py
@@ -56,6 +56,7 @@ class LocationResource(SQLResourceURIMixin, ModelResource, HqBaseResource):
 
     class Meta:
         resource_name = 'location'
+        detail_uri_name = 'location_id'
         queryset = SQLLocation.objects.filter(is_archived=False).all()
         authentication = DomainAdminAuthentication()
         allowed_methods = ['get']


### PR DESCRIPTION
fixes
http://manage.dimagi.com/default.asp?189290#1066830

It was trying to filter the sql results using the couch id as the sql primary key

@esoergel cc: @proteusvacuum 
