### PR TITLE
Move Default Domain Backend to Postgres

### DIFF
--- a/corehq/apps/domain/deletion.py
+++ b/corehq/apps/domain/deletion.py
@@ -55,6 +55,16 @@ class ModelDeletion(BaseDeletion):
             model.objects.filter(**{self.domain_filter_kwarg: domain_name}).delete()
 
 
+def _delete_domain_backend_mappings(domain_name):
+    model = apps.get_model('sms', 'SQLMobileBackendMapping')
+    model.objects.filter(is_global=False, domain=domain_name).delete()
+
+
+def _delete_domain_backends(domain_name):
+    model = apps.get_model('sms', 'SQLMobileBackend')
+    model.objects.filter(is_global=False, domain=domain_name).delete()
+
+
 # We use raw queries instead of ORM because Django queryset delete needs to
 # fetch objects into memory to send signals and handle cascades. It makes deletion very slow
 # if we have a millions of rows in stock data tables.
@@ -86,9 +96,9 @@ DOMAIN_DELETE_OPERATIONS = [
     ModelDeletion('sms', 'MessagingSubEvent', 'parent__domain'),
     ModelDeletion('sms', 'MessagingEvent', 'domain'),
     ModelDeletion('sms', 'SelfRegistrationInvitation', 'domain'),
-    ModelDeletion('sms', 'SQLMobileBackendMapping', 'domain'),
+    CustomDeletion('sms', _delete_domain_backend_mappings),
     ModelDeletion('sms', 'MobileBackendInvitation', 'domain'),
-    ModelDeletion('sms', 'SQLMobileBackend', 'domain'),
+    CustomDeletion('sms', _delete_domain_backends),
 ]
 
 

--- a/corehq/apps/sms/management/commands/migrate_domain_default_backend.py
+++ b/corehq/apps/sms/management/commands/migrate_domain_default_backend.py
@@ -37,13 +37,26 @@ def migrate(balance_only=False):
                     print "ERROR: Backend %s for domain %s not found" % (backend_id, domain)
                     continue
 
-                SQLMobileBackendMapping(
+                mapping, created = SQLMobileBackendMapping.objects.get_or_create(
                     is_global=False,
                     domain=domain,
                     backend_type='SMS',
-                    prefix='*',
-                    backend=backend
-                ).save()
+                    prefix='*'
+                )
+                mapping.backend = backend
+                mapping.save()
+        elif not balance_only:
+            try:
+                mapping = SQLMobileBackendMapping.objects.get(
+                    is_global=False,
+                    domain=domain,
+                    backend_type='SMS',
+                    prefix='*'
+                )
+                mapping.delete()
+                print "Deleted mapping for domain %s" % domain
+            except SQLMobileBackendMapping.DoesNotExist:
+                pass
 
     balance(couch_count)
     if not balance_only:

--- a/corehq/apps/sms/management/commands/migrate_domain_default_backend.py
+++ b/corehq/apps/sms/management/commands/migrate_domain_default_backend.py
@@ -1,0 +1,65 @@
+from corehq.apps.domain.models import Domain
+from corehq.apps.sms.models import SQLMobileBackend, SQLMobileBackendMapping, MigrationStatus
+from dimagi.utils.couch.database import iter_docs
+from django.core.management.base import BaseCommand
+from optparse import make_option
+
+
+def balance(couch_count):
+    sql_count = SQLMobileBackendMapping.objects.filter(is_global=False).count()
+    print "%i / %i Total Domain Backend Mappings Migrated" % (sql_count, couch_count)
+
+    if couch_count != sql_count:
+        print "ERROR: Counts do not match. Please investigate before continuing."
+
+
+def migrate(balance_only=False):
+    if not MigrationStatus.has_migration_completed('backend'):
+        print ("ERROR: The backend migration (./manage.py migrate_backends_to_sql) "
+               "must be completed before doing the domain default backend migration")
+        return
+
+    couch_count = 0
+    result = Domain.view('domain/domains', include_docs=False, reduce=False).all()
+    ids = [row['id'] for row in result]
+
+    for doc in iter_docs(Domain.get_db(), ids):
+        backend_id = doc.get('default_sms_backend_id')
+        domain = doc.get('name')
+
+        if backend_id:
+            couch_count += 1
+
+            if not balance_only:
+                try:
+                    backend = SQLMobileBackend.objects.get(couch_id=backend_id)
+                except SQLMobileBackend.DoesNotExist:
+                    print "ERROR: Backend %s for domain %s not found" % (backend_id, domain)
+                    continue
+
+                SQLMobileBackendMapping(
+                    is_global=False,
+                    domain=domain,
+                    backend_type='SMS',
+                    prefix='*',
+                    backend=backend
+                ).save()
+
+    balance(couch_count)
+    if not balance_only:
+        MigrationStatus.set_migration_completed('domain_default_backend')
+
+
+class Command(BaseCommand):
+    args = ""
+    help = ("Migrates Domain.default_sms_backend_id to a SQLMobileBackendMapping entry")
+    option_list = BaseCommand.option_list + (
+        make_option("--balance-only",
+                    action="store_true",
+                    dest="balance_only",
+                    default=False,
+                    help="Include this option to only run the balancing step."),
+    )
+
+    def handle(self, *args, **options):
+        migrate(balance_only=options['balance_only'])

--- a/corehq/apps/sms/management/commands/migrate_domain_default_backend.py
+++ b/corehq/apps/sms/management/commands/migrate_domain_default_backend.py
@@ -14,7 +14,7 @@ def balance(couch_count):
 
 
 def migrate(balance_only=False):
-    if not MigrationStatus.has_migration_completed('backend'):
+    if not MigrationStatus.has_migration_completed(MigrationStatus.MIGRATION_BACKEND):
         print ("ERROR: The backend migration (./manage.py migrate_backends_to_sql) "
                "must be completed before doing the domain default backend migration")
         return
@@ -47,7 +47,7 @@ def migrate(balance_only=False):
 
     balance(couch_count)
     if not balance_only:
-        MigrationStatus.set_migration_completed('domain_default_backend')
+        MigrationStatus.set_migration_completed(MigrationStatus.MIGRATION_DOMAIN_DEFAULT_BACKEND)
 
 
 class Command(BaseCommand):

--- a/corehq/apps/sms/management/commands/migrate_domain_default_backend.py
+++ b/corehq/apps/sms/management/commands/migrate_domain_default_backend.py
@@ -25,7 +25,11 @@ def migrate(balance_only=False):
             couch_count += 1
 
         if not balance_only:
-            _sync_default_backend_mapping(domain)
+            try:
+                _sync_default_backend_mapping(domain)
+            except Exception as e:
+                print ("Error while syncing domain %s, backend %s: %s" %
+                       (domain.name, domain.default_sms_backend_id, e))
 
     balance(couch_count)
     if not balance_only:

--- a/corehq/apps/sms/migrations/0008_add_backend_mapping_unique_constraint.py
+++ b/corehq/apps/sms/migrations/0008_add_backend_mapping_unique_constraint.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sms', '0007_check_for_backend_migration'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='sqlmobilebackendmapping',
+            unique_together=set([('domain', 'backend_type', 'prefix')]),
+        ),
+    ]

--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -1653,6 +1653,7 @@ class MigrationStatus(models.Model):
 
     MIGRATION_BACKEND = 'backend'
     MIGRATION_BACKEND_MAP = 'backend_map'
+    MIGRATION_DOMAIN_DEFAULT_BACKEND = 'domain_default_backend'
 
     class Meta:
         db_table = 'messaging_migrationstatus'

--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -1677,3 +1677,7 @@ class MigrationStatus(models.Model):
             return True
         except cls.DoesNotExist:
             return False
+
+
+# Import signal receiver so that it gets registered
+from corehq.apps.sms.signals import sync_default_backend_mapping

--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -1600,6 +1600,7 @@ class SQLMobileBackendMapping(SyncSQLToCouchMixin, models.Model):
     """
     class Meta:
         db_table = 'messaging_mobilebackendmapping'
+        unique_together = ('domain', 'backend_type', 'prefix')
 
     couch_id = models.CharField(max_length=126, null=True, db_index=True)
 

--- a/corehq/apps/sms/signals.py
+++ b/corehq/apps/sms/signals.py
@@ -1,0 +1,41 @@
+from django.dispatch import receiver
+from corehq.apps.domain.signals import commcare_domain_post_save
+from corehq.apps.sms.models import (SQLMobileBackend, SQLMobileBackendMapping,
+    MigrationStatus)
+from dimagi.utils.logging import notify_exception
+
+
+@receiver(commcare_domain_post_save)
+def sync_default_backend_mapping(sender, domain, **kwargs):
+    try:
+        if not MigrationStatus.has_migration_completed(MigrationStatus.MIGRATION_BACKEND):
+            return
+        _sync_default_backend_mapping(domain)
+    except Exception:
+        notify_exception(None, message="Error syncing default backend mapping"
+                         "for domain" % domain.name)
+
+
+def _sync_default_backend_mapping(domain):
+    mapping_attrs = {
+        'is_global': False,
+        'domain': domain.name,
+        'backend_type': 'SMS',
+        'prefix': '*',
+    }
+
+    try:
+        mapping = SQLMobileBackendMapping.objects.get(**mapping_attrs)
+    except SQLMobileBackendMapping.DoesNotExist:
+        mapping = None
+
+    if domain.default_sms_backend_id:
+        if not mapping:
+            mapping = SQLMobileBackendMapping(**mapping_attrs)
+
+        backend = SQLMobileBackend.objects.get(couch_id=domain.default_sms_backend_id)
+        mapping.backend = backend
+        mapping.save()
+    else:
+        if mapping:
+            mapping.delete()


### PR DESCRIPTION
Adds a migration for moving the default SMS backend setting for a domain to the Postgres model for backend mappings. Probably easiest to review all at once rather than each commit separately.

@NoahCarnahan @snopoke code review buddies
