### PR TITLE
Move subscription change time

### DIFF
--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -47,9 +47,12 @@ def activate_subscriptions(based_on_date=None):
     Activates all subscriptions starting today (or, for testing, based on the date specified)
     """
     starting_date = based_on_date or datetime.date.today()
-    starting_subscriptions = Subscription.objects.filter(date_start=starting_date)
+    starting_subscriptions = Subscription.objects.filter(
+        date_start=starting_date,
+        is_active=False,
+    )
     for subscription in starting_subscriptions:
-        if not has_subscription_already_ended(subscription) and not subscription.is_active:
+        if not has_subscription_already_ended(subscription):
             with transaction.atomic():
                 subscription.is_active = True
                 subscription.save()

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -91,7 +91,7 @@ def deactivate_subscriptions(based_on_date=None):
             )
 
 
-@periodic_task(run_every=crontab(minute=0, hour=0))
+@periodic_task(run_every=crontab(minute=0, hour=5))
 def update_subscriptions():
     deactivate_subscriptions()
     activate_subscriptions()

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -65,7 +65,10 @@ def deactivate_subscriptions(based_on_date=None):
     Deactivates all subscriptions ending today (or, for testing, based on the date specified)
     """
     ending_date = based_on_date or datetime.date.today()
-    ending_subscriptions = Subscription.objects.filter(date_end=ending_date)
+    ending_subscriptions = Subscription.objects.filter(
+        date_end=ending_date,
+        is_active=True,
+    )
     for subscription in ending_subscriptions:
         with transaction.atomic():
             subscription.is_active = False


### PR DESCRIPTION
Ops requested to move the time subscriptions are activated/deactivated from 00:00 UTC to 05:00 UTC.

Also ensures that subscriptions canceled between 00:00 UTC and 05:00 UTC on the end date don't get deactivated a second time.

@emord 
