### PR TITLE
Add get_menu_item_label() method

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4412,6 +4412,7 @@ class SavedAppBuild(ApplicationBase):
             'built_on_date': built_on_user_time.ui_string(USER_DATE_FORMAT),
             'built_on_time': built_on_user_time.ui_string(USER_TIME_FORMAT),
             'build_label': self.built_with.get_label(),
+            'menu_item_label': self.built_with.get_menu_item_label(),
             'jar_path': self.get_jar_path(),
             'short_name': self.short_name,
             'enable_offline_install': self.enable_offline_install,

--- a/corehq/apps/app_manager/templates/app_manager/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/releases.html
@@ -203,7 +203,7 @@
                     <td class="nowrap" data-bind="text: built_on_date"></td>
                     <td class="nowrap" data-bind="text: built_on_time"></td>
                     <td class="nowrap">
-                        <span data-bind="if: build_label(), text: build_label()"></span>
+                        <span data-bind="if: menu_item_label(), text: menu_item_label()"></span>
                         <h6 data-bind="if: !built_with.signed()">{% trans "Unsigned Jar" %}</h6>
                     </td>
                     <td class="nowrap">

--- a/corehq/apps/builds/models.py
+++ b/corehq/apps/builds/models.py
@@ -152,6 +152,13 @@ class BuildSpec(DocumentSchema):
         else:
             return None
 
+    def get_menu_item_label(self):
+        build_config = CommCareBuildConfig.fetch()
+        for item in build_config.menu:
+            if item.build.version == self.version:
+                return item.label or self.get_label()
+        return self.get_label()
+
     def __str__(self):
         fmt = "{self.version}/"
         fmt += "latest" if self.latest else "{self.build_number}"


### PR DESCRIPTION
Mimics [ApplicationBase.get_build_label()](https://github.com/dimagi/commcare-hq/blob/93fa15b31970f543de8ed6746bf320c3d39b03d5/corehq/apps/app_manager/models.py#L4038-L4038) but allows it to be used by SavedAppBuild.built_with (which is a BuildRecord).

![version_label](https://cloud.githubusercontent.com/assets/708421/12173970/9fbf421e-b562-11e5-99cc-0fd26a1a7e79.png)

If a matching build label is not found, it falls back to the version number.

[FB 190324](http://manage.dimagi.com/default.asp?190324)

@benrudolph cc @dannyroberts 
