### PR TITLE
Suggest doc conflict deletion in doctype migration

### DIFF
--- a/corehq/doctypemigrations/README.md
+++ b/corehq/doctypemigrations/README.md
@@ -209,10 +209,22 @@ Once deploy is complete, kill the `--continuous` command with `^C`.
 ## Cleanup
 
 After you're confident in the change and stability of the site,
-it's time to delete the old documents still in the source db. To do this run,
+it's time to delete the old documents still in the source db.
+
+First you should clean up any doc conflicts, as that can get in the way of
+deleting stuff.
+
+```bash
+$ ./manage.py delete_doc_conflicts
+```
+
+Now you can actually delete the documents:
 
 ```bash
 $ ./manage.py run_doctype_migration user_db_migration --cleanup
 ```
 
 Keep in mind that this will likely incur some reindexing overhead in the source db.
+
+If you run `$ ./manage.py run_doctype_migration user_db_migration --stats`, you
+should see that only the target database has these doc types in it now.

--- a/corehq/doctypemigrations/management/commands/run_doctype_migration.py
+++ b/corehq/doctypemigrations/management/commands/run_doctype_migration.py
@@ -117,6 +117,8 @@ class Command(BaseCommand):
         if cleanup:
             confirmation = raw_input(
                 "Cleanup will remove doc_types ({}) from db {}\n"
+                "I recommend running './manage.py delete_doc_conflicts' "
+                "first or some docs might not actually be deleted.\n"
                 "Are you sure you want to proceed? [y/n]"
                 .format(', '.join(migrator.doc_types), migrator.source_db))
             if confirmation == 'y':


### PR DESCRIPTION
@dannyroberts
the doc_conflicts view emits `[domain, doc_type]` keys which makes it tough to do a targetted delete.  I figure just running the delete conflicts command before doing the cleanup is sufficient.
