### PR TITLE
Handle missing earlier revisions

### DIFF
--- a/corehq/apps/cleanup/management/commands/undelete_docs.py
+++ b/corehq/apps/cleanup/management/commands/undelete_docs.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from collections import namedtuple
+from couchdbkit import ResourceNotFound
 from django.core.management.base import LabelCommand
 from dimagi.utils.chunked import chunked
 from corehq.util.couch import send_keys_to_couch, IterDB
@@ -13,7 +14,12 @@ def get_deleted_doc(db, doc_id, rev):
     start = res['_revisions']['start']
     ids = res['_revisions']['ids']
     prev_revision = "{}-{}".format(start-1, ids[1])
-    doc = db.get(doc_id, rev=prev_revision)
+    try:
+        doc = db.get(doc_id, rev=prev_revision)
+    except ResourceNotFound:
+        res.pop('_deleted')
+        res.pop('_revisions')
+        doc = res
     doc.pop('_rev')
     return doc
 


### PR DESCRIPTION
Some docs on prod don't return ResourceNotFound when you try tog et the previous revision, I assume 'cause of compaction, but it looks like that can be restored via a less preferable mechanism
