### PR TITLE
Explicitly remove </script> from anything we serialize as JSON

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/form_designer.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_designer.html
@@ -29,7 +29,7 @@
                         endpoint: '{% url 'fixture_metadata' domain=domain %}'
                     }
                 ],
-                form: {{ form.source|to_javascript_string }},
+                form: {{ form.source|JSON }},
                 formId: '{{ form.get_unique_id }}',
                 formName: "{{ form.name|trans:app.langs|escapejs }}",
                 saveType: 'patch',

--- a/corehq/apps/domain/templates/domain/admin/add_form_repeater.html
+++ b/corehq/apps/domain/templates/domain/admin/add_form_repeater.html
@@ -50,7 +50,7 @@
                 var data = {
                     url: $('#id_url').val(),
                     format: $('#id_format').val(),
-                    repeater_type: {{ repeater_type|to_javascript_string }}
+                    repeater_type: {{ repeater_type|JSON }}
                 };
                 $testLinkButton.disableButton();
 

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -25,7 +25,7 @@ def JSON(obj):
     if isinstance(obj, QueryDict):
         obj = dict(obj)
     try:
-        return mark_safe(json.dumps(obj, default=json_handler))
+        return mark_safe(escape_script_tags(json.dumps(obj, default=json_handler)))
     except TypeError as e:
         msg = ("Unserializable data was sent to the `|JSON` template tag.  "
                "If DEBUG is off, Django will silently swallow this error.  "
@@ -34,10 +34,9 @@ def JSON(obj):
         raise e
 
 
-@register.filter
-def to_javascript_string(obj):
+def escape_script_tags(unsafe_str):
     # seriously: http://stackoverflow.com/a/1068548/8207
-    return mark_safe(JSON(obj).replace('</script>', '<" + "/script>'))
+    return unsafe_str.replace('</script>', '<" + "/script>')
 
 
 @register.filter


### PR DESCRIPTION
@benrudolph @czue This is a second pass at this PR that got reverted: https://github.com/dimagi/commcare-hq/pull/9793

This should be a safer method as all we need to do is remove the end script tag from the text.
