### PR TITLE
Do not specify channel and emoji for deploy bot

### DIFF
--- a/corehq/apps/hqadmin/management/commands/record_deploy_success.py
+++ b/corehq/apps/hqadmin/management/commands/record_deploy_success.py
@@ -62,10 +62,8 @@ class Command(BaseCommand):
         if hasattr(settings, 'MIA_THE_DEPLOY_BOT_API'):
             link = diff_link(STYLE_SLACK, git_snapshot['diff_url'])
             requests.post(settings.MIA_THE_DEPLOY_BOT_API, data=json.dumps({
-                "channel": "#hq-ops",
-                "username": "Mia the Deploy Bot",
+                "username": "Igor the Iguana",
                 "text": deploy_notification_text.format(diff_link=link),
-                "icon_emoji": ":see_no_evil:"
             }))
 
         if settings.DATADOG_API_KEY:


### PR DESCRIPTION
Gonna let the defaults on the integration handle this. before it was trying to post to `hq-ops` which doesn't exist in alldimagi.

@calellowitz @millerdev 
