### PR TITLE
update doc on conflict

### DIFF
--- a/corehq/ex-submodules/pillowtop/listener.py
+++ b/corehq/ex-submodules/pillowtop/listener.py
@@ -2,7 +2,7 @@ from functools import wraps
 import logging
 from couchdbkit.exceptions import ResourceNotFound
 from elasticsearch import Elasticsearch
-from elasticsearch.exceptions import RequestError, ConnectionError, NotFoundError
+from elasticsearch.exceptions import RequestError, ConnectionError, NotFoundError, ConflictError
 from psycopg2._psycopg import InterfaceError
 from datetime import datetime, timedelta
 import hashlib
@@ -399,6 +399,8 @@ def send_to_elasticsearch(index, doc_type, doc_id, es_getter, name, data=None, r
             else:
                 pillow_logging.error(error_message)
             break
+        except ConflictError:
+            break  # ignore the error if a doc already exists when trying to create it in the index
         except NotFoundError:
             break
 

--- a/corehq/ex-submodules/pillowtop/tests/test_elasticsearch.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_elasticsearch.py
@@ -293,3 +293,10 @@ class TestSendToElasticsearch(SimpleTestCase):
         doc = {'_id': uuid.uuid4().hex, 'doc_type': 'MyCoolDoc', 'property': 'bar'}
 
         self._send_to_es_and_check(doc, delete=True)
+
+    def test_conflict(self):
+        doc = {'_id': uuid.uuid4().hex, 'doc_type': 'MyCoolDoc', 'property': 'foo'}
+        self._send_to_es_and_check(doc)
+
+        # attempt to create the same doc twice shouldn't fail
+        self._send_to_es_and_check(doc)


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?190792

Seeing quite a few of these errors since the ES client change. I'm not able to reproduce locally so not really clear on the cause but I think it must be a race condition.

The previous functionality was just to ignore the error (only response code 400 was checked: https://github.com/dimagi/commcare-hq/blob/5452f862e81d9794fa86eab10230c0489c0e594d/corehq/ex-submodules/pillowtop/listener.py#L394) so I've just stuck with that approach.

An alternative would be to update the doc but since this only happens on doc creation I think its safe to ignore (open to other opinions though)

@NoahCarnahan 
cc @czue @gcapalbo 
