### PR TITLE
Translate case list registration form label

### DIFF
--- a/corehq/apps/app_manager/tests/data/bulk_app_translation/basic/app.json
+++ b/corehq/apps/app_manager/tests/data/bulk_app_translation/basic/app.json
@@ -316,12 +316,12 @@
       "case_list_form": {
         "doc_type": "CaseListForm",
         "label": {
-          
+          "en": "Register Mother"
         },
         "media_audio": {
           
         },
-        "form_id": null,
+        "form_id": "6c6c6315b3c514c616b6c57d48f7cf7c963f1714",
         "media_image": {
           
         }

--- a/corehq/apps/app_manager/tests/test_bulk_app_translation.py
+++ b/corehq/apps/app_manager/tests/test_bulk_app_translation.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 import codecs
 import tempfile
 
@@ -142,6 +143,7 @@ class BulkAppTranslationBasicTest(BulkAppTranslationTestBase):
           ("Form", "module1_form1", "My more & awesome form", "", "", "", "", "", "", "", "93ea2a40df57d8f33b472f5b2b023882281722d4")
         )),
         ("module1", (
+          ("case_list_form_label", "list", "Register Mother", "Inscrivez-Mère"),
           ("name", "list", "Name", "Nom"),
           ("name", "detail", "", "Nom"),
           ("other-prop (ID Mapping Text)", "detail", "Other Prop", ""),

--- a/corehq/apps/app_manager/translations.py
+++ b/corehq/apps/app_manager/translations.py
@@ -711,6 +711,24 @@ def update_case_list_translations(sheet, rows, app):
         return msgs
 
     # Update the translations
+    def _update_translation(row, language_dict, require_translation=True):
+        ok_to_delete_translations = (
+            not require_translation or has_at_least_one_translation(
+                    row, 'default', app.langs
+            ))
+        if ok_to_delete_translations:
+            for lang in app.langs:
+                translation = row['default_%s' % lang]
+                if translation:
+                    language_dict[lang] = translation
+                else:
+                    language_dict.pop(lang, None)
+        else:
+            msgs.append((
+                messages.error,
+                "You must provide at least one translation" +
+                " of the case property '%s'" % row['case_property']
+            ))
 
     for row, detail in \
             zip(list_rows, short_details) + zip(detail_rows, long_details):
@@ -729,25 +747,6 @@ def update_case_list_translations(sheet, rows, app):
                 )
             ))
             continue
-
-        def _update_translation(row, language_dict, require_translation=True):
-            ok_to_delete_translations = (
-                not require_translation or has_at_least_one_translation(
-                    row, 'default', app.langs
-                ))
-            if ok_to_delete_translations:
-                for lang in app.langs:
-                    translation = row['default_%s' % lang]
-                    if translation:
-                        language_dict[lang] = translation
-                    else:
-                        language_dict.pop(lang, None)
-            else:
-                msgs.append((
-                    messages.error,
-                    "You must provide at least one translation" +
-                    " of the case property '%s'" % row['case_property']
-                ))
 
         # Update the translations for the row and all its child rows
         _update_translation(row, detail.header)

--- a/corehq/apps/app_manager/translations.py
+++ b/corehq/apps/app_manager/translations.py
@@ -258,6 +258,12 @@ def expected_bulk_app_sheet_rows(app):
         # Populate module sheet
         rows[module_string] = []
         if not isinstance(module, ReportModule):
+            if module.case_list_form.form_id:
+                # Add row for label of case list registration form
+                rows[module_string].append(
+                        ('case_list_form_label', 'list') +
+                        tuple(module.case_list_form.label.get(lang, '') for lang in app.langs)
+                )
             for list_or_detail, case_properties in [
                 ("list", module.case_details.short.get_columns()),
                 ("detail", module.case_details.long.get_columns())

--- a/corehq/apps/app_manager/translations.py
+++ b/corehq/apps/app_manager/translations.py
@@ -643,6 +643,7 @@ def update_case_list_translations(sheet, rows, app):
     # rows are nested under their respective DetailColumns.
 
     condensed_rows = []
+    case_list_form_label = None
     index_of_last_enum_in_condensed = -1
     index_of_last_graph_in_condensed = -1
     for i, row in enumerate(rows):
@@ -675,6 +676,10 @@ def update_case_list_translations(sheet, rows, app):
             row['id'] = int(row['case_property'].split(" ")[-1])
             parent = condensed_rows[index_of_last_graph_in_condensed]
             parent['annotations'] = parent.get('annotations', []) + [row]
+
+        # It's a case list registration form label. Don't add it to condensed rows
+        elif row['case_property'] == 'case_list_form_label':
+            case_list_form_label = row
 
         # It's a normal case property
         else:
@@ -765,6 +770,8 @@ def update_case_list_translations(sheet, rows, app):
                 detail['graph_configuration']['locale_specific_config'][config_key],
                 False
             )
+    if case_list_form_label:
+        _update_translation(case_list_form_label, module.case_list_form.label)
 
     return msgs
 


### PR DESCRIPTION
Bulk translate does not offer the case list registration form label to be translated. This change resolves that. cf. [FB 189956](http://manage.dimagi.com/default.asp?189956) for more context.

Probably easier to review per commit. @orangejenny, `git blame` makes me think you're the best person to eye-ball this. Buddy @dannyroberts 
