### PR TITLE
Show more of the app/module/form comment

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -717,19 +717,9 @@ class CommentMixin(DocumentSchema):
     @property
     def short_comment(self):
         """
-        Trim comment to 72 chars
-
-        >>> form = CommentMixin(
-        ...     comment=u"Twas bryllyg, and þe slythy toves "
-        ...             u"Did gyre and gymble in þe wabe: "
-        ...             u"All mimsy were þe borogoves; "
-        ...             u"And þe mome raths outgrabe."
-        ... )
-        >>> form.short_comment
-        u'Twas bryllyg, and \\xc3\\xbee slythy toves Did gyre and gymble in \\xc3\\xbee wabe: A...'
-
+        Trim comment to 500 chars (about 100 words)
         """
-        return self.comment if len(self.comment) <= 72 else self.comment[:69] + '...'
+        return self.comment if len(self.comment) <= 500 else self.comment[:497] + '...'
 
 
 class FormBase(DocumentSchema):


### PR DESCRIPTION
Small change. The app, module and form comments were being truncated at 72 chars at the top of the page and in the app summary, which looked too short. This increases that length to about 100 words.

e.g. Screenshots of a long module comment on the module page ... **Before**:
![comment_truncated](https://cloud.githubusercontent.com/assets/708421/12266086/ca7c961a-b949-11e5-9fa8-9e82177d026f.png)

**After**:
![comment_module_page](https://cloud.githubusercontent.com/assets/708421/12266070/a2edb476-b949-11e5-987f-8987abbfed79.png)
... and app summary ...
![comment_app_summary](https://cloud.githubusercontent.com/assets/708421/12266075/ae8066f8-b949-11e5-9721-cd1b12ac76b0.png)

(I have a nagging feeling that this now looks too long ... and that truncating from the model is half the work. The model should manage the payload size but not the presentation and we should use CSS for that. But then I think about how much time I could spend tweaking the app summary page and I wouldn't improve it significantly, so I tell the nagging feeling to shut up. @biyeun, if you have some tips on how to make the app summary page look nicer (a div with `overflow: hidden;` that sits to the right of the module/form name, maybe?) I'm open to suggestions. But I figured I'd go with as small a code change as possible, and assume that nobody has 100-word comments.)

@biyeun, cc @amsagoff 
