### PR TITLE
fixing broken toggles in admin report

### DIFF
--- a/corehq/apps/appstore/static/appstore/js/facet_sidebar.js
+++ b/corehq/apps/appstore/static/appstore/js/facet_sidebar.js
@@ -20,6 +20,7 @@ function chevron_toggle(show, $toggling, $chevron, $holds_toggle_state, after_fn
         $holds_toggle_state.data("show", false);
     } else {
         $toggling.show();
+        $toggling.removeClass('hide');
         $chevron
             .removeClass(chev + "right")
             .addClass(chev + "down")


### PR DESCRIPTION
@benrudolph @kaapstorm cc: @millerdev 
http://manage.dimagi.com/default.asp?190737#1069905
the hide css class had a !important tag that was overriding our show functionality
