### PR TITLE
Make app-level test dependencies for locations

### DIFF
--- a/corehq/apps/locations/tests/test_locations.py
+++ b/corehq/apps/locations/tests/test_locations.py
@@ -71,35 +71,6 @@ class LocationProducts(TestCase):
 
 
 class LocationTestBase(TestCase):
-    dependent_apps = [
-        'auditcare',
-        'casexml.apps.case',
-        'casexml.apps.phone',
-        'casexml.apps.stock',
-        'corehq.apps.accounting',
-        'corehq.apps.commtrack',
-        'corehq.apps.domain',
-        'corehq.apps.dropbox',
-        'corehq.apps.fixtures',
-        'corehq.apps.hqcase',
-        'corehq.apps.products',
-        'corehq.apps.reminders',
-        'corehq.apps.sms',
-        'corehq.apps.smsforms',
-        'corehq.apps.tzmigration',
-        'corehq.apps.users',
-        'corehq.couchapps',
-        'couchforms',
-        'custom.logistics',
-        'custom.ilsgateway',
-        'custom.ewsghana',
-        'django.contrib.admin',
-        'django_digest',
-        'django_prbac',
-        'tastypie',
-        'touchforms.formplayer',
-    ]
-
     def setUp(self):
         self.domain = create_domain('locations-test')
         self.domain.convert_to_commtrack()

--- a/corehq/tests/app_test_db_dependencies.yml
+++ b/corehq/tests/app_test_db_dependencies.yml
@@ -159,6 +159,41 @@ corehq.apps.commtrack:
   - corehq.apps.dropbox
   - touchforms.formplayer
   - corehq.apps.tour
+corehq.apps.locations:
+  - auditcare
+  - couchforms
+  - phonelog
+  - django_digest
+  - casexml.apps.case
+  - casexml.apps.phone
+  - casexml.apps.stock
+  - corehq.couchapps
+  - corehq.form_processor
+  - corehq.sql_accessors
+  - corehq.sql_proxy_accessors
+  - corehq.apps.commtrack
+  - corehq.apps.consumption
+  - corehq.apps.custom_data_fields
+  - corehq.apps.domain
+  - corehq.apps.hqcase
+  - corehq.apps.fixtures
+  - corehq.apps.groups
+  - corehq.apps.products
+  - corehq.apps.reminders
+  - corehq.apps.sms
+  - corehq.apps.smsforms
+  - corehq.apps.tzmigration
+  - corehq.apps.users
+  - custom.logistics
+  - custom.ilsgateway
+  - custom.ewsghana
+  - django_prbac
+  - django.contrib.admin
+  - tastypie
+  - corehq.apps.accounting
+  - corehq.apps.dropbox
+  - touchforms.formplayer
+  - corehq.apps.tour
 corehq.apps.userreports:
   - casexml.apps.case
   - casexml.apps.stock


### PR DESCRIPTION
The dependencies in the test class were out of date.  I've confirmed that the full locations test suite passes locally.
