### PR TITLE
Multi select export fix

### DIFF
--- a/corehq/apps/export/models.py
+++ b/corehq/apps/export/models.py
@@ -136,7 +136,7 @@ class FormQuestionSchema(Document):
 
                     self.question_schema[question_path] = meta
                 else:
-                    # In the event that a question was previously a multi-select and not one any longer, 
+                    # In the event that a question was previously a multi-select and not one any longer,
                     # we need to clear the question schema
                     self.question_schema.pop(question_path, None)
 

--- a/corehq/apps/export/models.py
+++ b/corehq/apps/export/models.py
@@ -136,6 +136,8 @@ class FormQuestionSchema(Document):
 
                     self.question_schema[question_path] = meta
                 else:
+                    # In the event that a question was previously a multi-select and not one any longer, 
+                    # we need to clear the question schema
                     self.question_schema.pop(question_path, None)
 
         self.processed_apps.add(app.get_id)

--- a/corehq/apps/export/models.py
+++ b/corehq/apps/export/models.py
@@ -125,8 +125,8 @@ class FormQuestionSchema(Document):
                 return 'form.{}'.format(xml_path.replace('/', '.'))
 
             for question in xform.get_questions(app.langs):
+                question_path = to_json_path(question['value'])
                 if question['tag'] == 'select':
-                    question_path = to_json_path(question['value'])
                     meta = self.question_schema.get(question_path, QuestionMeta(
                         repeat_context=to_json_path(question['repeat'])
                     ))
@@ -135,6 +135,8 @@ class FormQuestionSchema(Document):
                             meta.options.append(opt['value'])
 
                     self.question_schema[question_path] = meta
+                else:
+                    self.question_schema.pop(question_path, None)
 
         self.processed_apps.add(app.get_id)
         self.last_processed_version = app.version

--- a/corehq/apps/export/tests/data/question_schema_no_multi.xml
+++ b/corehq/apps/export/tests/data/question_schema_no_multi.xml
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>Untitled Form</h:title>
+		<model>
+			<instance>
+				<custom_instance xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/284D3F7C-9C10-48E6-97AC-C37927CBA89A" uiVersion="1" version="1" name="Untitled Form">
+					<question1 />
+					<question2 />
+					<multi_root />
+					<new_multi />
+					<group1>
+						<multi_level1 />
+						<question6>
+							<multi_level_2 />
+						</question6>
+					</group1>
+					<repeat_1 jr:template="">
+						<multi_level_1_repeat />
+					</repeat_1>
+				</custom_instance>
+			</instance>
+			<bind nodeset="/custom_instance/question1" type="xsd:string" />
+			<bind nodeset="/custom_instance/question2" />
+			<bind nodeset="/custom_instance/multi_root" />
+			<bind nodeset="/custom_instance/new_multi" />
+			<bind nodeset="/custom_instance/group1" />
+			<bind nodeset="/custom_instance/group1/multi_level1" />
+			<bind nodeset="/custom_instance/group1/question6" />
+			<bind nodeset="/custom_instance/group1/question6/multi_level_2" />
+			<bind nodeset="/custom_instance/repeat_1" />
+			<bind nodeset="/custom_instance/repeat_1/multi_level_1_repeat" />
+			<itext>
+				<translation lang="en" default="">
+					<text id="question1-label">
+						<value>question1</value>
+					</text>
+					<text id="question2-label">
+						<value>question2</value>
+					</text>
+					<text id="question2-item1-label">
+						<value>item1</value>
+					</text>
+					<text id="question2-item2-label">
+						<value>item2</value>
+					</text>
+					<text id="multi_root-label">
+						<value>Multi in root</value>
+					</text>
+					<text id="new_multi-item1-label">
+						<value>new item1</value>
+					</text>
+					<text id="new_multi-item2-label">
+						<value>new item2</value>
+					</text>
+					<text id="group1-label">
+						<value>Group 1</value>
+					</text>
+					<text id="group1/multi_level1-label">
+						<value>Multi level 1</value>
+					</text>
+					<text id="group1/multi_level1-item1-label">
+						<value>item1</value>
+					</text>
+					<text id="group1/multi_level1-item2-label">
+						<value>item2</value>
+					</text>
+					<text id="group1/multi_level1-1_item-label">
+						<value>item3</value>
+					</text>
+					<text id="group1/question6-label">
+						<value>question6</value>
+					</text>
+					<text id="group1/question6/multi_level_2-label">
+						<value>Multi level 2</value>
+					</text>
+					<text id="group1/question6/multi_level_2-item1-label">
+						<value>item1</value>
+					</text>
+					<text id="group1/question6/multi_level_2-item2-label">
+						<value>item2</value>
+					</text>
+					<text id="repeat_1-label">
+						<value>Repeat 1</value>
+					</text>
+					<text id="repeat_1/multi_level_1_repeat-label">
+						<value>Multi level 1 repeat</value>
+					</text>
+					<text id="repeat_1/multi_level_1_repeat-item1-label">
+						<value>item1</value>
+					</text>
+					<text id="repeat_1/multi_level_1_repeat-item2-label">
+						<value>item2</value>
+					</text>
+				</translation>
+			</itext>
+		</model>
+	</h:head>
+	<h:body>
+		<input ref="/custom_instance/question1">
+			<label ref="jr:itext('question1-label')" />
+		</input>
+		<select1 ref="/custom_instance/question2">
+			<label ref="jr:itext('question2-label')" />
+			<item>
+				<label ref="jr:itext('question2-item1-label')" />
+				<value>item1</value>
+			</item>
+			<item>
+				<label ref="jr:itext('question2-item2-label')" />
+				<value>item2</value>
+			</item>
+		</select1>
+		<input ref="/custom_instance/multi_root">
+			<label ref="jr:itext('multi_root')" />
+		</input>
+		<select ref="/custom_instance/new_multi">
+			<item>
+				<label ref="jr:itext('new_multi-item1-label')" />
+				<value>z_first</value>
+			</item>
+			<item>
+				<label ref="jr:itext('new_multi-item2-label')" />
+				<value>a_last</value>
+			</item>
+		</select>
+		<group ref="/custom_instance/group1">
+			<label ref="jr:itext('group1-label')" />
+			<select ref="/custom_instance/group1/multi_level1">
+				<label ref="jr:itext('group1/multi_level1-label')" />
+				<item>
+					<label ref="jr:itext('group1/multi_level1-item1-label')" />
+					<value>item1</value>
+				</item>
+				<item>
+					<label ref="jr:itext('group1/multi_level1-item2-label')" />
+					<value>item2</value>
+				</item>
+				<item>
+					<label ref="jr:itext('group1/multi_level1-1_item-label')" />
+					<value>1_item</value>
+				</item>
+			</select>
+			<group ref="/custom_instance/group1/question6">
+				<label ref="jr:itext('group1/question6-label')" />
+				<select ref="/custom_instance/group1/question6/multi_level_2">
+					<label ref="jr:itext('group1/question6/multi_level_2-label')" />
+					<item>
+						<label ref="jr:itext('group1/question6/multi_level_2-item1-label')" />
+						<value>item1</value>
+					</item>
+					<item>
+						<label ref="jr:itext('group1/question6/multi_level_2-item2-label')" />
+						<value>item2</value>
+					</item>
+				</select>
+			</group>
+		</group>
+		<group>
+			<label ref="jr:itext('repeat_1-label')" />
+			<repeat nodeset="/custom_instance/repeat_1">
+				<select ref="/custom_instance/repeat_1/multi_level_1_repeat">
+					<label ref="jr:itext('repeat_1/multi_level_1_repeat-label')" />
+					<item>
+						<label ref="jr:itext('repeat_1/multi_level_1_repeat-item1-label')" />
+						<value>item1</value>
+					</item>
+					<item>
+						<label ref="jr:itext('repeat_1/multi_level_1_repeat-item2-label')" />
+						<value>item2</value>
+					</item>
+				</select>
+			</repeat>
+		</group>
+	</h:body>
+</h:html>

--- a/corehq/apps/export/tests/test_form_schema.py
+++ b/corehq/apps/export/tests/test_form_schema.py
@@ -42,6 +42,29 @@ class FormQuestionSchemaTest(SimpleTestCase, TestXmlMixin):
         self.assertEqual(schema.question_schema['form.new_multi'].options, ['z_first', 'a_last'])
         self.assertEqual(schema.question_schema['form.group1.multi_level1'].options, ['item1', 'item2', '1_item'])
 
+    def test_change_multi_select(self):
+        """
+        This test ensures that when you update a multi select question to not be a multi select question, the
+        FormQuestionSchema reflects that change
+        """
+        app = Application.wrap(self.get_json('question_schema_test_app'))
+        app._id = '123'
+        app.version = 1
+
+        xmlns = 'http://openrosa.org/formdesigner/284D3F7C-9C10-48E6-97AC-C37927CBA89A'
+        schema = FormQuestionSchema(xmlns=xmlns)
+
+        schema.update_for_app(app)
+        self.assertEqual(schema.question_schema['form.multi_root'].options, ['item1', 'item2', 'item3'])
+
+        # Change the question to a different type
+        updated_form_xml = self.get_xml('question_schema_no_multi')
+        app.get_form_by_xmlns(xmlns).source = updated_form_xml
+        app.version = 2
+
+        schema.update_for_app(app)
+        self.assertNotIn('form.multi_root', schema.question_schema)
+
 
 class TestGetOrCreateSchema(SimpleTestCase):
     def setUp(self):


### PR DESCRIPTION
When you create an export with a multi select and then change it to a different question type but keep the same ID, exports still thinks it's a multi select because it doesn't clear the formschema:

<img width="1039" alt="screen shot 2016-01-12 at 5 22 03 pm" src="https://cloud.githubusercontent.com/assets/918514/12279567/e1174e68-b955-11e5-9e5a-b088256398a2.png">

http://manage.dimagi.com/default.asp?190434

@calellowitz cc: @czue @esoergel 
