### PR TITLE
properly handle FORM_CASE_ID_PATH when not required

### DIFF
--- a/corehq/apps/export/custom_export_helpers.py
+++ b/corehq/apps/export/custom_export_helpers.py
@@ -292,9 +292,8 @@ class FormCustomExportHelper(CustomExportHelper):
         case_cols = filter(lambda col: col["index"] == FORM_CASE_ID_PATH, column_conf)
         if not requires_case:
             for col in case_cols:
-                if col['index'] == FORM_CASE_ID_PATH:
-                    col['tag'], col['show'], col['selected'] = 'deleted', False, False
-                    col['allOptions'] = []
+                col['tag'], col['show'] = 'deleted', col['selected']
+                col['allOptions'] = []
         elif not case_cols:
             column_conf.append({
                 'index': FORM_CASE_ID_PATH,


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?189221

i've convinced myself this is the correct way to handle a caseid when it no longer requires a case. see comments for more explanation. i tested this out a couple different ways and was always able to select the `info.caseid` and it appeared in the exports

<img width="1552" alt="screen shot 2016-01-12 at 7 10 31 pm" src="https://cloud.githubusercontent.com/assets/918514/12281018/a02b0088-b960-11e5-8c99-42c1d56a44c8.png">

@kaapstorm @czue cc: @esoergel 
