### PR TITLE
preventing drilldown js when no filter

### DIFF
--- a/corehq/apps/reports/templates/reports/filters/bootstrap2/drilldown_options.html
+++ b/corehq/apps/reports/templates/reports/filters/bootstrap2/drilldown_options.html
@@ -35,6 +35,7 @@
 {% endblock %}
 {% block filter_js %}
 <script type="text/javascript" src="{% static 'reports/ko/report_filter.drilldown_options.js' %}"></script>
+{% if not is_empty %}
 <script type="text/javascript">
     $(function () {
        $('#{{ css_id }}').drilldownOptionFilter({
@@ -45,4 +46,5 @@
        });
     });
 </script>
+{%  endif %}
 {% endblock %}

--- a/corehq/apps/reports/templates/reports/filters/bootstrap3/drilldown_options.html
+++ b/corehq/apps/reports/templates/reports/filters/bootstrap3/drilldown_options.html
@@ -35,6 +35,7 @@
 {% endblock %}
 {% block filter_js %}
 <script type="text/javascript" src="{% new_static 'reports/ko/report_filter.drilldown_options.js' %}"></script>
+{% if not is_empty %}
 <script type="text/javascript">
     $(function () {
        $('#{{ css_id }}').drilldownOptionFilter({
@@ -45,4 +46,5 @@
        });
     });
 </script>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
@esoergel @benrudolph @kaapstorm cc: @millerdev 
http://manage.dimagi.com/default.asp?190609#1071055
The function call was creating a js error that was breaking all of the js on the page when this report was viewed in a domain without apps
