### PR TITLE
retry once on FailedPayloadsError

### DIFF
--- a/corehq/apps/change_feed/pillow.py
+++ b/corehq/apps/change_feed/pillow.py
@@ -1,6 +1,6 @@
 import json
 from kafka import KeyedProducer
-from kafka.common import KafkaUnavailableError, LeaderNotAvailableError
+from kafka.common import KafkaUnavailableError, LeaderNotAvailableError, FailedPayloadsError
 import time
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.change_feed import data_sources
@@ -44,20 +44,30 @@ class KafkaProcessor(PillowProcessor):
                 domain=change.document.get('domain', None),
                 is_deletion=change.deleted,
             )
-            try:
+
+            def _send_to_kafka():
+                # closures
                 self._producer.send_messages(
                     bytes(get_topic(document_type)),
                     bytes(change_meta.domain.encode('utf-8') if change_meta.domain is not None else None),
                     bytes(json.dumps(change_meta.to_json())),
                 )
+
+            try:
+                try:
+                    _send_to_kafka()
+                except FailedPayloadsError:
+                    # this typically an inactivity timeout - which can happen if the feed is low volume
+                    # just do a simple retry
+                    _send_to_kafka()
             except LeaderNotAvailableError:
                 # kafka seems to be down. sleep a bit to avoid crazy amounts of error spam
                 time.sleep(15)
                 raise
             except Exception as e:
                 _assert = soft_assert(to='@'.join(['czue', 'dimagi.com']))
-                _assert(False, u'Problem sending change to kafka {}: {}'.format(
-                    change_meta.to_json(), e
+                _assert(False, u'Problem sending change to kafka {}: {} ({})'.format(
+                    change_meta.to_json(), e, type(e)
                 ))
                 raise
 


### PR DESCRIPTION
Think I finally figured out what's going on with [this ticket](http://manage.dimagi.com/default.asp?190629)

Since the user/groups DB is much lower volume than the prod DB, sometimes kafka times out waiting for new requests from the pillow. I believe (though had trouble reproducing) that just trying again in this scenario will fix it.
