### PR TITLE
B3 help icons

### DIFF
--- a/corehq/apps/style/static/style/js/commcarehq.js
+++ b/corehq/apps/style/static/style/js/commcarehq.js
@@ -36,11 +36,11 @@ COMMCAREHQ.makeHqHelp = function (opts, wrap) {
     var el = $(
         '<div class="hq-help">' + 
             '<a href="#">' +
-                '<i class="icon-question-sign"></i></a></div>'
+                '<i class="fa fa-question-circle icon-question-sign"></i></a></div>'
     );
-    for (var attr in ['content', 'title', 'html']) {
+    _.each(['content', 'title', 'html'], function(attr) {
         $('a', el).data(attr, opts[attr]);
-    }
+    });
     if (wrap) {
         el.hqHelp();
     }

--- a/corehq/apps/style/static/style/less/bootstrap3/icons.less
+++ b/corehq/apps/style/static/style/less/bootstrap3/icons.less
@@ -3,7 +3,6 @@
     vertical-align: top;
     position: relative;
     overflow: visible;
-    width: 0px;
     line-height: 25px;
     margin: 0 3px;
     i {

--- a/corehq/apps/style/templates/style/bootstrap3/base.html
+++ b/corehq/apps/style/templates/style/bootstrap3/base.html
@@ -350,6 +350,11 @@
                 RETRY: '{% trans "Try Again"|escapejs %}',
                 ERROR_SAVING: '{% trans "There was an error deleting"|escapejs %}'
             }, 'btn btn-danger');
+
+            $('.hq-help-template').each(function () {
+                COMMCAREHQ.makeHqHelp($(this).data()).insertAfter(this);
+                $(this).remove();
+            });
         </script>
         {# JavaScript Display Logic Libaries #}
 


### PR DESCRIPTION
Help hasn't been displaying on bootstrap 3 pages because
- B3 icon wasn't included
- B3's base template includes commcarehq.js instead of main.js, and the commcarehq.js version of `makeHqHelp` (let's not talk about why we have multiple versions of `makeHqHelp`) had a bug

I'm also moving the help icon creation javascript snippet into the base template, since we currently have it in ~25 different places. It ought to be removed from those places as the B3 migration completes, but there's no ill effect from that code running twice.

@TylerSheffels 
