### PR TITLE
encoding all forms as utf-8 to handle non-ascii api submissions

### DIFF
--- a/corehq/apps/reports/templatetags/xform_tags.py
+++ b/corehq/apps/reports/templatetags/xform_tags.py
@@ -35,7 +35,9 @@ register = template.Library()
 
 @register.simple_tag
 def render_form_xml(form):
-    xml = form.get_xml().encode('utf-8')
+    xml = form.get_xml()
+    if isinstance(xml, unicode):
+        xml.encode('utf-8', errors='replace')
     formatted_xml = indent_xml(xml) if xml else ''
     return '<pre class="fancy-code prettyprint linenums"><code class="language-xml">%s</code></pre>' \
            % escape(formatted_xml)

--- a/corehq/apps/reports/templatetags/xform_tags.py
+++ b/corehq/apps/reports/templatetags/xform_tags.py
@@ -35,7 +35,7 @@ register = template.Library()
 
 @register.simple_tag
 def render_form_xml(form):
-    xml = form.get_xml()
+    xml = form.get_xml().encode('utf-8')
     formatted_xml = indent_xml(xml) if xml else ''
     return '<pre class="fancy-code prettyprint linenums"><code class="language-xml">%s</code></pre>' \
            % escape(formatted_xml)


### PR DESCRIPTION
@benrudolph @kaapstorm @millerdev 
This encodes all form xml strings as utf-8 when display raw xml on the site. Doesnt affect how the forms are stored.
http://manage.dimagi.com/default.asp?190926#1071149
