### PR TITLE
tracking new project space creation on hubspot

### DIFF
--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -206,6 +206,7 @@ def track_app_from_template_on_hubspot(webuser, cookies, meta):
 def track_clicked_deploy_on_hubspot(webuser, cookies, meta):
     _send_form_to_hubspot(HUBSPOT_CLICKED_DEPLOY_FORM_ID, webuser, cookies, meta)
 
+
 @task(queue="background_queue", acks_late=True, ignore_result=True)
 def track_created_new_project_space_on_hubspot(webuser, cookies, meta):
     _send_form_to_hubspot(HUBSPOT_CREATED_NEW_PROJECT_SPACE_FORM_ID, webuser, cookies, meta)

--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -29,6 +29,7 @@ HUBSPOT_SIGNIN_FORM_ID = "a2aa2df0-e4ec-469e-9769-0940924510ef"
 HUBSPOT_FORM_BUILDER_FORM_ID = "4f118cda-3c73-41d9-a5d1-e371b23b1fb5"
 HUBSPOT_APP_TEMPLATE_FORM_ID = "91f9b1d2-934d-4e7a-997e-e21e93d36662"
 HUBSPOT_CLICKED_DEPLOY_FORM_ID = "c363c637-d0b1-44f3-9d73-f34c85559f03"
+HUBSPOT_CREATED_NEW_PROJECT_SPACE_FORM_ID = "619daf02-e043-4617-8947-a23e4589935a"
 HUBSPOT_COOKIE = 'hubspotutk'
 
 
@@ -204,6 +205,10 @@ def track_app_from_template_on_hubspot(webuser, cookies, meta):
 @task(queue="background_queue", acks_late=True, ignore_result=True)
 def track_clicked_deploy_on_hubspot(webuser, cookies, meta):
     _send_form_to_hubspot(HUBSPOT_CLICKED_DEPLOY_FORM_ID, webuser, cookies, meta)
+
+@task(queue="background_queue", acks_late=True, ignore_result=True)
+def track_created_new_project_space_on_hubspot(webuser, cookies, meta):
+    _send_form_to_hubspot(HUBSPOT_CREATED_NEW_PROJECT_SPACE_FORM_ID, webuser, cookies, meta)
 
 
 def track_workflow(email, event, properties=None):

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -21,6 +21,8 @@ from corehq.apps.users.models import WebUser, CouchUser, UserRole
 from corehq.apps.hqwebapp.tasks import send_html_email_async
 from dimagi.utils.couch.database import get_safe_write_kwargs
 from corehq.apps.hqwebapp.tasks import send_mail_async
+from corehq.apps.analytics.tasks import track_created_new_project_space_on_hubspot
+from corehq.apps.analytics.utils import get_meta
 
 
 def activate_new_user(form, is_domain_admin=True, domain=None, ip=None):
@@ -118,6 +120,8 @@ def request_new_domain(request, form, domain_type=None, new_user=True):
         send_global_domain_registration_email(request.user, new_domain.name)
     send_new_request_update_email(request.user, get_ip(request), new_domain.name, is_new_user=new_user)
 
+    meta = get_meta(request)
+    track_created_new_project_space_on_hubspot(current_user, request.COOKIES, meta)
     return new_domain.name
 
 

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -121,7 +121,7 @@ def request_new_domain(request, form, domain_type=None, new_user=True):
     send_new_request_update_email(request.user, get_ip(request), new_domain.name, is_new_user=new_user)
 
     meta = get_meta(request)
-    track_created_new_project_space_on_hubspot(current_user, request.COOKIES, meta)
+    track_created_new_project_space_on_hubspot.delay(current_user, request.COOKIES, meta)
     return new_domain.name
 
 


### PR DESCRIPTION
@benrudolph @kaapstorm cc: @millerdev 
http://manage.dimagi.com/default.asp?191028#1071803
I adding the tracking at the end of the creation function instead of in the view, because new users and current users get to the creation function from different views. Unsuccessful creations throw an exception so we can be pretty certain the domain has been created when it gets to the return statement.
