### PR TITLE
replace jqModal with bootstrap modal

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/commcaresettings.js
+++ b/corehq/apps/app_manager/static/app_manager/js/commcaresettings.js
@@ -428,7 +428,7 @@ $(function () {
     ko.bindingHandlers.passwordSetter = {
         init: function (element, valueAccessor) {
             var observableValue = valueAccessor();
-            $(element).password_setter({title: ''});
+            $(element).password_setter();
             $(element).on('textchange change', function () {
                 observableValue($(element).val());
             });

--- a/corehq/apps/app_manager/templates/app_manager/app_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/app_view.html
@@ -133,7 +133,7 @@
                 randID = Math.floor(Math.random() * 1000),
                 password1ID = 'password-' + randID + '-1',
                 password2ID = 'password-' + randID + '-2',
-                $popupLink = $('<a/>').attr({href: '#'}).text("Reset"),
+                $popupLink = $('<a/>').attr({href: '#'}).text("{% trans "Reset" %}"),
                 $modal = $("#password-setter"),
                 $passwordRow = $modal.find(".password"),
                 $passwordInput = $passwordRow.find("input"),
@@ -312,21 +312,21 @@
             {% trans "Please enter a password or cancel." %}
         </div>
         <div class="control-group password">
-            <label class="control-label">Password</label>
+            <label class="control-label">{% trans "Password" %}</label>
             <div class="controls">
                 <input type="password" class="form-control" />
             </div>
         </div>
         <div class="control-group repeat-password">
-            <label class="control-label">Repeat Password</label>
+            <label class="control-label">{% trans "Repeat Password" %}</label>
             <div class="controls">
                 <input type="password" class="form-control" />
             </div>
         </div>
     </div>
     <div class="modal-footer">
-        <button class="btn btn-default" data-dismiss="modal">Cancel</button>
-        <button class="btn btn-primary save">Save</button>
+        <button class="btn btn-default" data-dismiss="modal">{% trans "Cancel" %}</button>
+        <button class="btn btn-primary save">{% trans "Save" %}</button>
     </div>
 </div>
 {% endblock %}

--- a/corehq/apps/app_manager/templates/app_manager/app_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/app_view.html
@@ -128,85 +128,43 @@
     </script>
     {% endif %}
     <script>
-        $.fn.password_setter = function (options) {
+        $.fn.password_setter = function () {
             var that = this,
-                options = options || {},
-                title = options.title || "Set Password",
                 randID = Math.floor(Math.random() * 1000),
                 password1ID = 'password-' + randID + '-1',
                 password2ID = 'password-' + randID + '-2',
-                message = {
-                    RESET: "Reset",
-                    LABEL1: "Password",
-                    LABEL2: "Repeat Password",
-                    OK: "OK",
-                    CANCEL: "Cancel",
-                    PASSWORD_EMPTY: "You must enter a password.",
-                    PASSWORD_MISMATCH: "Try again. The passwords don't match"
-                },
-                label1 = $('<label/>').attr({'for': password1ID}).text(message.LABEL1),
-                label2 = $('<label/>').attr({'for': password2ID}).text(message.LABEL2),
-                password1 = $('<input/>').attr({type: 'password', id: password1ID}),
-                password2 = $('<input/>').attr({type: 'password', id: password2ID}),
-                popupLink = $('<a/>').attr({href: '#'}).text(message.RESET),
-                popup = $('<section/>').addClass('password-setter-popup'),
-                popupOK = $('<input/>').attr({type: 'submit'}).val(message.OK).button(),
-                popupCancel = $('<a/>').attr({href: '#'}).text(message.CANCEL).button(),
-                passwordMismatch = $('<p/>').text(message.PASSWORD_MISMATCH),
-                passwordEmpty = $('<p/>').text(message.PASSWORD_EMPTY),
-                form = $('<form/>').attr({action: ''}),
-                undefined = undefined;
-            this.hide();
-            this.after(popupLink);
-            popup.append(
-                $('<h1/>').text(title),
-                form.append(
-                    passwordMismatch,
-                    $('<table/>').append(
-                        $('<tr/>').append(
-                            $('<td/>').append(label1),
-                            $('<td/>').append(passwordEmpty, password1)
-                        ),
-                        $('<tr/>').append(
-                            $('<td/>').append(label2),
-                            $('<td/>').append(password2)
-                        )
-                    ),
-                    popupOK,
-                    popupCancel
-                )
-            );
-            passwordEmpty.hide();
-            passwordMismatch.hide();
-            popupLink.click(function (e) {
-                var position = popupLink.offset();
-                e.preventDefault();
-                popup.css({
-                    display: 'block',
-                    position: 'absolute',
-                    top: position.top,
-                    left: position.left,
-                }).addClass('ui-corner-tr ui-corner-br ui-corner-bl shadow');
-                $('body').append(popup);
-                password1.focus();
+                $popupLink = $('<a/>').attr({href: '#'}).text("Reset"),
+                $modal = $("#password-setter"),
+                $passwordRow = $modal.find(".password"),
+                $passwordInput = $passwordRow.find("input"),
+                $repeatRow = $modal.find(".repeat-password"),
+                $repeatInput = $repeatRow.find("input"),
+                $errorMismatch = $modal.find(".password-mismatch"),
+                $errorEmpty = $modal.find(".password-empty");
+
+            that.hide();
+            that.after($popupLink);
+            $popupLink.click(function() {
+                $modal.modal('show');
+                $passwordRow.find("input").focus();
             });
 
-            popupCancel.click(function (e) {
-                e.preventDefault();
-                popup.detach();
-            });
-
-            form.submit(function (e) {
-                e.preventDefault();
-                passwordEmpty.hide();
-                passwordMismatch.hide();
-                if (password1.val() && password1.val() === password2.val()) {
-                    popup.detach();
-                    that.val(password1.val()).trigger('textchange');
-                } else if (!password1.val()) {
-                    passwordEmpty.show();
-                } else {
-                    passwordMismatch.show();
+            $passwordRow.find("label").attr("for", password1ID);
+            $passwordInput.attr("id", password1ID);
+            $repeatRow.find("label").attr("for", password2ID);
+            $repeatInput.find("input").attr("id", password2ID);
+            
+            $modal.find("button.save").click(function (e) {
+                $errorMismatch.addClass("hide");
+                $errorEmpty.addClass("hide");
+                if ($passwordInput.val() !== $repeatInput.val()) {
+                    $errorMismatch.removeClass("hide");
+                } else if (!$passwordInput.val()) {
+                    $errorEmpty.removeClass("hide");
+                }
+                else {
+                    $modal.modal('hide');
+                    that.val($passwordInput.val()).trigger('textchange');
                 }
             });
         };
@@ -294,25 +252,6 @@
             background-color: #FFF;
             border-radius: 40px;
         }
-        .password-setter-popup {
-            background-color: white;
-            border: 1px solid #CCC;
-            padding: 1em;
-        }
-        .password-setter-popup h1 {
-            text-align: center;
-            font-size: 1.2em;
-        }
-        .password-setter-popup table {
-            margin: 0;
-        }
-        .password-setter-popup .ui-button {
-            float: right;
-            margin: 5px;
-        }
-        .password-setter-popup input[type='password'] {
-            width: 40px;
-        }
     </style>
 {% endblock %}
 {% block form-view %}
@@ -358,4 +297,36 @@
 {% for uploader in uploaders %}
 {% include 'hqmedia/bootstrap2/partials/multimedia_uploader.html' %}
 {% endfor %}
+<div class="modal hide fade" id="password-setter">
+    <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal">
+            <span aria-hidden="true">&times;</span>
+        </button>
+        <h3>{% trans "Set Password" %}</h3>
+    </div>
+    <div class="modal-body form-horizontal">
+        <div class="alert alert-danger password-mismatch hide">
+            {% trans "The passwords don't match. Please try again." %}
+        </div>
+        <div class="alert alert-danger password-empty hide">
+            {% trans "Please enter a password or cancel." %}
+        </div>
+        <div class="control-group password">
+            <label class="control-label">Password</label>
+            <div class="controls">
+                <input type="password" class="form-control" />
+            </div>
+        </div>
+        <div class="control-group repeat-password">
+            <label class="control-label">Repeat Password</label>
+            <div class="controls">
+                <input type="password" class="form-control" />
+            </div>
+        </div>
+    </div>
+    <div class="modal-footer">
+        <button class="btn btn-default" data-dismiss="modal">Cancel</button>
+        <button class="btn btn-primary save">Save</button>
+    </div>
+</div>
 {% endblock %}

--- a/corehq/apps/app_manager/templates/app_manager/apps_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/apps_base.html
@@ -24,10 +24,6 @@
     {% endcompress %}
 {% endblock %}
 
-{% block head %}{{ block.super }}
-    {% include "imports/jqmodal.html" %}
-{% endblock %}
-
 {% block js %}{{ block.super }}
     <script src="{% static 'hqwebapp/js/ui-element.js' %}"></script>
     <script src="{% static 'langcodes/js/langcodes.js' %}"></script>


### PR DESCRIPTION
cherry-picked from B3 app manager migration

before:
![screen shot 2016-01-14 at 6 10 20 pm](https://cloud.githubusercontent.com/assets/1486591/12340662/3a0eb020-baea-11e5-83e7-bd56321de6d3.png)

after:
![screen shot 2016-01-14 at 6 10 43 pm](https://cloud.githubusercontent.com/assets/1486591/12340667/3e983260-baea-11e5-98b9-32c1838a2255.png)

I'd like to get rid of jqModal altogether, but it's still used in couchlog, and adding bootstrap there requires upgrading jquery (from 1.4), which causes an error in datatables. Not going to dig into that today.

@TylerSheffels 
