### PR TITLE
cast user data to string for ES

### DIFF
--- a/corehq/apps/users/signals.py
+++ b/corehq/apps/users/signals.py
@@ -37,8 +37,10 @@ def update_user_in_es(sender, couch_user, **kwargs):
     """
     Automatically sync the user to elastic directly on save or delete
     """
-    send_to_elasticsearch("users", couch_user.to_json(),
-                          delete=couch_user.to_be_deleted())
+
+    from corehq.pillows.user import cast_user_data_to_string
+    doc = cast_user_data_to_string(couch_user.to_json())
+    send_to_elasticsearch("users", doc, delete=couch_user.to_be_deleted())
 
 
 def create_user_from_commcare_registration(sender, xform, **kwargs):


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?186943

Apply the same approach as in the pillow. I'm not sure if this will fix the issue without a reindex since I think ES already thinks that some fields are numeric.

Another option which I'm rather in favour of is to disable indexing of the `user_data` field altogether since I don't think we ever search on it: https://www.elastic.co/guide/en/elasticsearch/reference/0.90/mapping-object-type.html#_enabled_3

@czue @esoergel @emord thoughts?
buddy @NoahCarnahan 
