### PR TITLE
Move simple test form creation to util

### DIFF
--- a/corehq/apps/repeaters/repeater_generators.py
+++ b/corehq/apps/repeaters/repeater_generators.py
@@ -15,8 +15,8 @@ from dimagi.utils.parsing import json_format_datetime
 
 
 def _get_test_form():
-    from corehq.form_processor.tests.utils import TestFormMetadata
-    from corehq.form_processor.tests.utils import get_simple_wrapped_form
+    from corehq.form_processor.utils import TestFormMetadata
+    from corehq.form_processor.utils import get_simple_wrapped_form
     metadata = TestFormMetadata(domain='demo-domain', xmlns=uuid4().hex, form_name='Demo Form')
     return get_simple_wrapped_form('test-form-' + uuid4().hex, metadata=metadata, save=False)
 

--- a/corehq/apps/reports/tests/test_analytics.py
+++ b/corehq/apps/reports/tests/test_analytics.py
@@ -5,7 +5,7 @@ from corehq.apps.reports.analytics.couchaccessors import guess_form_name_from_su
     update_reports_analytics_indexes, get_all_form_definitions_grouped_by_app_and_xmlns, SimpleFormInfo, \
     get_all_form_details, get_form_details_for_xmlns, get_form_details_for_app_and_module, \
     get_form_details_for_app_and_xmlns, get_form_details_for_app
-from corehq.form_processor.tests.utils import TestFormMetadata, get_simple_wrapped_form
+from corehq.form_processor.utils import TestFormMetadata, get_simple_wrapped_form
 
 
 class ReportsAnalyticsTest(TestCase):

--- a/corehq/apps/reports/tests/test_esaccessors.py
+++ b/corehq/apps/reports/tests/test_esaccessors.py
@@ -9,7 +9,7 @@ from elasticsearch.exceptions import ConnectionError
 from corehq.util.elastic import delete_es_index
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.groups.models import Group
-from corehq.form_processor.tests.utils import TestFormMetadata
+from corehq.form_processor.utils import TestFormMetadata
 from casexml.apps.case.models import CommCareCase, CommCareCaseAction
 from casexml.apps.case.const import CASE_ACTION_CREATE
 from corehq.pillows.xform import XFormPillow

--- a/corehq/form_processor/tests/test_form_dbaccessor.py
+++ b/corehq/form_processor/tests/test_form_dbaccessor.py
@@ -9,7 +9,8 @@ from corehq.form_processor.exceptions import XFormNotFound, AttachmentNotFound
 from corehq.form_processor.interfaces.processor import ProcessedForms
 from corehq.form_processor.models import XFormInstanceSQL, XFormOperationSQL, XFormAttachmentSQL
 from corehq.form_processor.parsers.form import apply_deprecation
-from corehq.form_processor.tests.utils import create_form_for_test, get_simple_form_xml, FormProcessorTestUtils
+from corehq.form_processor.tests.utils import create_form_for_test, FormProcessorTestUtils
+from corehq.form_processor.utils import get_simple_form_xml
 from corehq.sql_db.routers import db_for_read_write
 from crispy_forms.tests.utils import override_settings
 

--- a/corehq/form_processor/utils/__init__.py
+++ b/corehq/form_processor/utils/__init__.py
@@ -7,6 +7,9 @@ from .xform import (
     extract_meta_user_id,
     convert_xform_to_json,
     adjust_datetimes,
+    get_simple_form_xml,
+    get_simple_wrapped_form,
+    TestFormMetadata,
 )
 
 from .metadata import (

--- a/corehq/form_processor/utils/xform.py
+++ b/corehq/form_processor/utils/xform.py
@@ -1,11 +1,68 @@
 import iso8601
 import pytz
 import xml2json
+from datetime import datetime
 
-from dimagi.ext.jsonobject import re_loose_datetime
+from dimagi.ext import jsonobject
 from dimagi.utils.parsing import json_format_datetime
 
 from corehq.apps.tzmigration import phone_timezones_should_be_processed
+from corehq.form_processor.models import Attachment
+
+
+# The functionality below to create a simple wrapped XForm is used in production code (repeaters) and so is
+# not in the test utils
+SIMPLE_FORM = """<?xml version='1.0' ?>
+<data uiVersion="1" version="17" name="{form_name}" xmlns:jrm="http://dev.commcarehq.org/jr/xforms"
+    xmlns="{xmlns}">
+    <dalmation_count>yes</dalmation_count>
+    <n1:meta xmlns:n1="http://openrosa.org/jr/xforms">
+        <n1:deviceID>DEV IL</n1:deviceID>
+        <n1:timeStart>2013-04-19T16:52:41.000-04</n1:timeStart>
+        <n1:timeEnd>{time_end}</n1:timeEnd>
+        <n1:username>eve</n1:username>
+        <n1:userID>{user_id}</n1:userID>
+        <n1:instanceID>{uuid}</n1:instanceID>
+        <n2:appVersion xmlns:n2="http://commcarehq.org/xforms"></n2:appVersion>
+    </n1:meta>
+    {case_block}
+</data>"""
+
+
+class TestFormMetadata(jsonobject.JsonObject):
+    domain = jsonobject.StringProperty(required=False)
+    xmlns = jsonobject.StringProperty(default='http://openrosa.org/formdesigner/form-processor')
+    form_name = jsonobject.StringProperty(default='New Form')
+    user_id = jsonobject.StringProperty(default='cruella_deville')
+    time_end = jsonobject.DateTimeProperty(default=datetime(2013, 4, 19, 16, 53, 2))
+    # Set this property to fake the submission time
+    received_on = jsonobject.DateTimeProperty(default=datetime.utcnow())
+
+
+def get_simple_form_xml(form_id, case_id=None, metadata=None):
+    from casexml.apps.case.mock import CaseBlock
+
+    metadata = metadata or TestFormMetadata()
+    case_block = ''
+    if case_id:
+        case_block = CaseBlock(create=True, case_id=case_id).as_string()
+    form_xml = SIMPLE_FORM.format(uuid=form_id, case_block=case_block, **metadata.to_json())
+    return form_xml
+
+
+def get_simple_wrapped_form(form_id, case_id=None, metadata=None, save=True):
+    from corehq.form_processor.interfaces.processor import FormProcessorInterface
+
+    xml = get_simple_form_xml(form_id=form_id, metadata=metadata)
+    form_json = convert_xform_to_json(xml)
+    interface = FormProcessorInterface(domain=metadata.domain)
+    wrapped_form = interface.new_xform(form_json)
+    wrapped_form.domain = metadata.domain
+    interface.store_attachments(wrapped_form, [Attachment('form.xml', xml, 'text/xml')])
+    if save:
+        interface.save_processed_models([wrapped_form])
+
+    return wrapped_form
 
 
 def extract_meta_instance_id(form):
@@ -62,7 +119,7 @@ def adjust_datetimes(data, parent=None, key=None):
     """
     # this strips the timezone like we've always done
     # todo: in the future this will convert to UTC
-    if isinstance(data, basestring) and re_loose_datetime.match(data):
+    if isinstance(data, basestring) and jsonobject.re_loose_datetime.match(data):
         try:
             matching_datetime = iso8601.parse_date(data)
         except iso8601.ParseError:

--- a/corehq/util/test_utils.py
+++ b/corehq/util/test_utils.py
@@ -285,7 +285,7 @@ def make_es_ready_form(metadata):
     # this is rather complicated due to form processor abstractions and ES restrictions
     # on what data needs to be in the index and is allowed in the index
     from corehq.form_processor.interfaces.processor import FormProcessorInterface
-    from corehq.form_processor.tests.utils import get_simple_form_xml
+    from corehq.form_processor.utils import get_simple_form_xml
     from corehq.form_processor.utils import convert_xform_to_json
 
     assert metadata is not None

--- a/testapps/test_elasticsearch/tests/test_xform_es.py
+++ b/testapps/test_elasticsearch/tests/test_xform_es.py
@@ -5,7 +5,7 @@ from django.test import SimpleTestCase
 from elasticsearch.exceptions import ConnectionError
 
 from corehq.apps.es import FormES
-from corehq.form_processor.tests.utils import TestFormMetadata
+from corehq.form_processor.utils import TestFormMetadata
 from corehq.pillows.xform import XFormPillow
 from corehq.util.test_utils import make_es_ready_form, trap_extra_setup
 from pillowtop.tests import require_explicit_elasticsearch_testing

--- a/testapps/test_pillowtop/tests/test_reindexer.py
+++ b/testapps/test_pillowtop/tests/test_reindexer.py
@@ -6,7 +6,8 @@ from casexml.apps.case.signals import case_post_save
 from corehq.apps.es import UserES, CaseES, FormES, ESQuery
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 from corehq.apps.users.models import CommCareUser
-from corehq.form_processor.tests.utils import TestFormMetadata, FormProcessorTestUtils
+from corehq.form_processor.utils import TestFormMetadata
+from corehq.form_processor.tests.utils import FormProcessorTestUtils
 from corehq.pillows.mappings.user_mapping import USER_INDEX
 from corehq.util.context_managers import drop_connected_signals
 from corehq.util.elastic import delete_es_index, ensure_index_deleted


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?191054

we were getting a nose import error since we don't download it in production and we were relying on a test util in the repeater code. I moved that code to an actual util since it's being used in production code. The other option is to make nose a required package for prod (but wouldn't stop this from happening again)

@czue @esoergel 

wait for tests
