### PR TITLE
Use bootstrap for bar code modal

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/odk_install.html
+++ b/corehq/apps/app_manager/templates/app_manager/odk_install.html
@@ -1,17 +1,28 @@
 {% load i18n %}
-<!DOCTYPE html>
-<html>
-<head>
-    <title>odk {% if media %}media {% endif %}install</title>
-</head>
-<body>
-    <div style="background-color:white; border:1px solid #555; padding:2em;">
-        <h3>{% trans "Install to Android by taking a picture of the image below on your phone." %}</h3>
-        <p style="text-align:center;">
-            <img src="{{ qr_code }}" width=250 alt="Download" >
-        </p>
-        <p>{% trans "You can also visit:" %} <code><a href="{{ profile_url }}">{{ profile_url }}</a></code> {% trans "in your mobile browser." %}</p>
-        <p>{% trans "For more about CommCare on Android, visit" %} <a href="https://confluence.dimagi.com/display/commcarepublic/Installing+CommCareODK+Android">{% trans "Installing CommCareODK Android" %}</a></p>
-    </div>
-</body>
-</html>
+<div class="modal-header">
+    <button type="button" class="close" data-dismiss="modal">
+        <span aria-hidden="true">&times;</span>
+    </button>
+    <h3>
+        {% trans "Install to Android by taking a picture of the image below on your phone." %}
+    </h3>
+</div>
+<div class="modal-body">
+    <p style="text-align:center;">
+        <img src="{{ qr_code }}" width=250 alt="Download" >
+    </p>
+    <p>
+        {% trans "You can also visit:" %}
+        <code><a href="{{ profile_url }}">{{ profile_url }}</a></code>
+        {% trans "in your mobile browser." %}
+    </p>
+    <p>
+        {% trans "For more about CommCare on Android, visit" %}
+        <a href="https://confluence.dimagi.com/display/commcarepublic/Installing+CommCareODK+Android">
+            {% trans "Installing CommCareODK Android" %}
+        </a>
+    </p>
+</div>
+<div class="modal-footer">
+    <a href="#" class="btn btn-default" data-dismiss="modal">Close</a>
+</div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases_deploy_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases_deploy_modal.html
@@ -73,7 +73,7 @@
                                     <p>
                                         {% trans "Or" %}
                                         <a href="#" data-bind="
-                                            openJqm: get_odk_install_url,
+                                            openRemoteModal: get_odk_install_url,
                                             click: function() { ga_track_event('App Manager', 'Show Bar Code', '-'); }
                                         ">
                                         {% trans "scan the bar code" %}

--- a/corehq/apps/style/static/style/ko/knockout_bindings.ko.js
+++ b/corehq/apps/style/static/style/ko/knockout_bindings.ko.js
@@ -324,18 +324,17 @@ ko.bindingHandlers.openModal = {
     }
 };
 
-ko.bindingHandlers.openJqm = {
+ko.bindingHandlers.openRemoteModal = {
     init: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
-        var modal = $('<div></div>').addClass('jqmWindow').appendTo('body'),
+        var modal = $('<div></div>').addClass('modal fade').css("width", "860px").css("margin-left", "-430px").appendTo('body'),
             newValueAccessor = function () {
                 var clickAction = function () {
-                    modal.jqm({ajax: $(element).data('ajaxSource')}).jqmShow();
+                    modal.load($(element).data('ajaxSource'));
+                    modal.modal('show');
                 };
                 return clickAction;
             };
         ko.bindingHandlers.click.init(element, newValueAccessor, allBindingsAccessor, viewModel, bindingContext);
-//            $('#odk-install-placeholder').jqm({ajax: '@href', trigger: 'a.odk_install',
-//            ajaxText: "Please wait while we load that for you..." });
     },
     update: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
         $(element).data('ajaxSource', ko.utils.unwrapObservable(valueAccessor()));


### PR DESCRIPTION
When cherry picking the jqModal removal from the app manager B3 branch (https://github.com/dimagi/commcare-hq/pull/9901), I missed the commit that converted the "scan bar code" modal. Thanks @NoahCarnahan for catching this.

code buddy @TylerSheffels 

old:
![screen shot 2016-01-15 at 10 26 14 am](https://cloud.githubusercontent.com/assets/1486591/12356906/0bebebb6-bb73-11e5-9406-a0fa4fcbab9e.png)

new:
![screen shot 2016-01-15 at 10 25 45 am](https://cloud.githubusercontent.com/assets/1486591/12356909/105571d6-bb73-11e5-8385-7b7b6094bc93.png)
