### PR TITLE
Avoid duplicate menu item IDs

### DIFF
--- a/corehq/apps/app_manager/id_strings.py
+++ b/corehq/apps/app_manager/id_strings.py
@@ -285,14 +285,17 @@ def fixture_session_var(module):
 
 
 def menu_id(module, suffix=""):
+    menu_id_ = u'm{}.{}'.format(module.id, suffix) if suffix else u'm{}'.format(module.id)
     put_in_root = getattr(module, 'put_in_root', False)
     if put_in_root:
         # handle circular calls, if bad module workflow setup
-        return menu_id(module.root_module) if getattr(module, 'root_module', False) else ROOT
-    else:
-        if suffix:
-            suffix = ".{}".format(suffix)
-        return u"m{module.id}{suffix}".format(module=module, suffix=suffix)
+        root_id = menu_id(module.root_module) if getattr(module, 'root_module', False) else ROOT
+        # Suffix root module ID with module ID to avoid duplicates when more
+        # than one module has the same root module. (FB 188908)
+        # Don't nest if module.root_module is not set; workflow,
+        # navigation and grid style look for ROOT.
+        menu_id_ = root_id if root_id == ROOT else u'{}-{}'.format(menu_id(module.root_module), menu_id_)
+    return menu_id_
 
 
 def form_command(form, module=None):

--- a/corehq/apps/app_manager/tests/__init__.py
+++ b/corehq/apps/app_manager/tests/__init__.py
@@ -23,6 +23,7 @@ try:
     from corehq.apps.app_manager.tests.test_form_versioning import *
     from corehq.apps.app_manager.tests.test_form_workflow import *
     from corehq.apps.app_manager.tests.test_grid_menus import *
+    from corehq.apps.app_manager.tests.test_id_strings import *
     from corehq.apps.app_manager.tests.test_media_suite import *
     from corehq.apps.app_manager.tests.test_models import *
     from corehq.apps.app_manager.tests.test_profile import *

--- a/corehq/apps/app_manager/tests/test_child_module.py
+++ b/corehq/apps/app_manager/tests/test_child_module.py
@@ -68,7 +68,7 @@ class ModuleAsChildTestBase(TestXmlMixin):
             </text>
             <command id="m0-f0"/>
           </menu>
-          <menu id="m0">
+          <menu id="m0-m1">
             <text>
               <locale id="modules.m1"/>
             </text>

--- a/corehq/apps/app_manager/tests/test_id_strings.py
+++ b/corehq/apps/app_manager/tests/test_id_strings.py
@@ -1,0 +1,67 @@
+from __future__ import unicode_literals
+from django.test import SimpleTestCase
+from mock import Mock
+from corehq.apps.app_manager import id_strings
+
+
+class MenuIdTests(SimpleTestCase):
+
+    def test_normal_module(self):
+        module = Mock()
+        module.id = 1
+        module.put_in_root = False
+        self.assertEqual(id_strings.menu_id(module), 'm1')
+
+    def test_normal_module_suffixed(self):
+        module = Mock()
+        module.id = 1
+        module.put_in_root = False
+        self.assertEqual(id_strings.menu_id(module, suffix='foo'), 'm1.foo')
+
+    def test_put_in_root_without_root_module(self):
+        module = Mock()
+        module.id = 1
+        module.put_in_root = True
+        module.root_module = None
+        self.assertEqual(id_strings.menu_id(module), 'root')
+
+    def test_put_in_root_with_root_module(self):
+        root_module = Mock()
+        root_module.id = 1
+        root_module.put_in_root = False
+
+        module = Mock()
+        module.id = 2
+        module.put_in_root = True
+        module.root_module = root_module
+
+        self.assertEqual(id_strings.menu_id(module), 'm1-m2')
+
+    def test_put_in_root_with_root_module_suffixed(self):
+        root_module = Mock()
+        root_module.id = 1
+        root_module.put_in_root = False
+
+        module = Mock()
+        module.id = 2
+        module.put_in_root = True
+        module.root_module = root_module
+
+        self.assertEqual(id_strings.menu_id(module, suffix='foo'), 'm1-m2.foo')
+
+    def test_put_in_root_nested_suffixed(self):
+        root_root_module = Mock()
+        root_root_module.id = 1
+        root_root_module.put_in_root = False
+
+        root_module = Mock()
+        root_module.id = 2
+        root_module.put_in_root = True
+        root_module.root_module = root_root_module
+
+        module = Mock()
+        module.id = 3
+        module.put_in_root = True
+        module.root_module = root_module
+
+        self.assertEqual(id_strings.menu_id(module, suffix='foo'), 'm1-m2-m3.foo')


### PR DESCRIPTION
Child modules can result in duplicate menu IDs when "Menu mode" is set to "Display only forms". 

[FB 188908](http://manage.dimagi.com/default.asp?188908)

This resolves the problem when `module.root_module` is set, by appending the child module ID to the root module ID. 

Current behaviour is preserved when `module.root_module` is not set (because the menu ID is set to a constant which is checked for elsewhere) -- if this is going to be an issue, we can check `.startswith` instead of equality. 

@benrudolph @calellowitz cc @biyeun 

Labelling "Hold off" in case there's something I'm not considering, @snopoke @ctsims 
