### PR TITLE
Don't add options to caseid

### DIFF
--- a/corehq/apps/export/custom_export_helpers.py
+++ b/corehq/apps/export/custom_export_helpers.py
@@ -293,7 +293,6 @@ class FormCustomExportHelper(CustomExportHelper):
         if not requires_case:
             for col in case_cols:
                 col['tag'], col['show'] = 'deleted', col['selected']
-                col['allOptions'] = []
         elif not case_cols:
             column_conf.append({
                 'index': FORM_CASE_ID_PATH,


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?191055

so this was randomly adding `allOptions` to the caseid property which seems totally unnecessary. and when you do it add it, it causes this check to pass: https://github.com/dimagi/commcare-hq/blob/all-options-caseid/corehq/apps/export/static/export/js/customize_export.js#L307 which makes `caseid` a `SplitColumn` which is wrong. this never came up before because the question was never able to be selected (fixed in a different bug)
