### PR TITLE
B3 js updates

### DIFF
--- a/corehq/apps/app_manager/views/app_summary.py
+++ b/corehq/apps/app_manager/views/app_summary.py
@@ -8,7 +8,7 @@ from corehq.apps.app_manager.xform import VELLUM_TYPES
 from corehq.apps.domain.views import LoginAndDomainMixin
 from corehq.apps.hqwebapp.views import BasePageView
 from corehq.apps.reports.formdetails.readable import FormQuestionResponse
-from corehq.apps.style.decorators import use_bootstrap3
+from corehq.apps.style.decorators import use_bootstrap3, use_angular_js
 
 
 class AppSummaryView(JSONResponseMixin, LoginAndDomainMixin, BasePageView, ApplicationViewMixin):
@@ -17,6 +17,7 @@ class AppSummaryView(JSONResponseMixin, LoginAndDomainMixin, BasePageView, Appli
     template_name = 'app_manager/summary.html'
 
     @use_bootstrap3
+    @use_angular_js
     def dispatch(self, request, *args, **kwargs):
         return super(AppSummaryView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -24,7 +24,7 @@ from corehq.apps.app_manager.exceptions import (
 from corehq.apps.domain.views import LoginAndDomainMixin, DomainViewMixin
 from corehq.apps.hqwebapp.views import BasePageView
 from corehq.apps.sms.views import get_sms_autocomplete_context
-from corehq.apps.style.decorators import use_bootstrap3
+from corehq.apps.style.decorators import use_bootstrap3, use_angular_js
 from dimagi.utils.web import json_response
 from corehq.util.timezones.utils import get_timezone_for_user
 from corehq.apps.domain.dbaccessors import get_doc_count_in_domain_by_class
@@ -304,6 +304,7 @@ class AppDiffView(LoginAndDomainMixin, BasePageView, DomainViewMixin):
     template_name = 'app_manager/app_diff.html'
 
     @use_bootstrap3
+    @use_angular_js
     def dispatch(self, request, *args, **kwargs):
         try:
             self.first_app_id = self.kwargs["first_app_id"]

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -50,7 +50,6 @@ from touchforms.formplayer.models import EntrySession
 from xml2json.lib import xml2json
 from corehq.apps.reports.formdetails import readable
 from corehq.apps.style.decorators import (
-    use_knockout_js,
     use_datatables,
     use_bootstrap3,
     use_jquery_ui,
@@ -72,7 +71,6 @@ def insufficient_privilege(request, domain, *args, **kwargs):
 
 class CloudcareMain(View):
 
-    @use_knockout_js
     @use_bootstrap3
     @use_datatables
     @use_jquery_ui
@@ -544,7 +542,6 @@ class EditCloudcareUserPermissionsView(BaseUserSettingsView):
     @method_decorator(domain_admin_required)
     @method_decorator(requires_privilege_with_fallback(privileges.CLOUDCARE))
     @use_bootstrap3
-    @use_knockout_js
     def dispatch(self, request, *args, **kwargs):
         return super(EditCloudcareUserPermissionsView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/commtrack/views.py
+++ b/corehq/apps/commtrack/views.py
@@ -12,7 +12,7 @@ from corehq.apps.commtrack.processing import plan_rebuild_stock_state, \
     rebuild_stock_state
 from corehq.apps.hqwebapp.doc_info import get_doc_info_by_id
 from corehq.apps.sofabed.models import FormData
-from corehq.apps.style.decorators import use_knockout_js, use_bootstrap3, use_jquery_ui
+from corehq.apps.style.decorators import use_bootstrap3, use_jquery_ui
 from corehq.util.timezones.conversions import ServerTime
 
 from dimagi.utils.decorators.memoized import memoized
@@ -151,7 +151,6 @@ class CommTrackSettingsView(BaseCommTrackManageView):
         return self.get(request, *args, **kwargs)
 
     @use_bootstrap3
-    @use_knockout_js
     def dispatch(self, request, *args, **kwargs):
         return super(BaseCommTrackManageView, self).dispatch(request, *args, **kwargs)
 
@@ -184,7 +183,6 @@ class DefaultConsumptionView(BaseCommTrackManageView):
         return self.get(request, *args, **kwargs)
 
     @use_bootstrap3
-    @use_knockout_js
     def dispatch(self, request, *args, **kwargs):
         return super(DefaultConsumptionView, self).dispatch(request, *args, **kwargs)
 
@@ -250,7 +248,6 @@ class SMSSettingsView(BaseCommTrackManageView):
         return self.get(request, *args, **kwargs)
 
     @use_bootstrap3
-    @use_knockout_js
     @use_jquery_ui
     def dispatch(self, request, *args, **kwargs):
         return super(SMSSettingsView, self).dispatch(request, *args, **kwargs)
@@ -316,7 +313,6 @@ class StockLevelsView(BaseCommTrackManageView):
         return self.get(request, *args, **kwargs)
 
     @use_bootstrap3
-    @use_knockout_js
     def dispatch(self, request, *args, **kwargs):
         return super(StockLevelsView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/dashboard/views.py
+++ b/corehq/apps/dashboard/views.py
@@ -17,7 +17,7 @@ from corehq.apps.domain.views import DomainViewMixin, LoginAndDomainMixin, \
 from corehq.apps.domain.utils import user_has_custom_top_menu
 from corehq.apps.hqwebapp.views import BasePageView
 from corehq.apps.users.views import DefaultProjectUserSettingsView
-from corehq.apps.style.decorators import use_bootstrap3
+from corehq.apps.style.decorators import use_bootstrap3, use_angular_js
 from django_prbac.utils import has_privilege
 from django.conf import settings
 
@@ -45,6 +45,7 @@ def default_dashboard_url(request, domain):
 class BaseDashboardView(LoginAndDomainMixin, BasePageView, DomainViewMixin):
 
     @use_bootstrap3
+    @use_angular_js
     def dispatch(self, request, *args, **kwargs):
         return super(BaseDashboardView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/data_interfaces/views.py
+++ b/corehq/apps/data_interfaces/views.py
@@ -32,7 +32,8 @@ from corehq.apps.hqcase.utils import get_case_by_identifier
 from corehq.apps.hqwebapp.views import CRUDPaginatedViewMixin, PaginatedItemException
 from corehq.apps.data_interfaces.dispatcher import (DataInterfaceDispatcher, EditDataInterfaceDispatcher,
                                                     require_can_edit_data)
-from corehq.apps.style.decorators import use_bootstrap3, use_typeahead
+from corehq.apps.style.decorators import use_bootstrap3, use_typeahead, \
+    use_angular_js
 from corehq.const import SERVER_DATETIME_FORMAT
 from .dispatcher import require_form_management_privilege
 from .interfaces import FormManagementMode, BulkFormManagementInterface, CaseReassignmentInterface
@@ -566,6 +567,7 @@ class AutomaticUpdateRuleListView(JSONResponseMixin, DataInterfaceSection):
         return get_timezone_for_user(None, self.domain)
 
     @use_bootstrap3
+    @use_angular_js
     @method_decorator(requires_privilege_with_fallback(privileges.DATA_CLEANUP))
     def dispatch(self, *args, **kwargs):
         return super(AutomaticUpdateRuleListView, self).dispatch(*args, **kwargs)
@@ -716,6 +718,7 @@ class AddAutomaticUpdateRuleView(JSONResponseMixin, DataInterfaceSection):
         }
 
     @use_bootstrap3
+    @use_angular_js
     @use_typeahead
     @method_decorator(requires_privilege_with_fallback(privileges.DATA_CLEANUP))
     def dispatch(self, *args, **kwargs):

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -38,7 +38,7 @@ from corehq.apps.accounting.decorators import (
 )
 from corehq.apps.hqwebapp.tasks import send_mail_async
 from corehq.apps.style.decorators import use_bootstrap3, use_jquery_ui, \
-    use_jquery_ui_multiselect, use_knockout_js, use_select2
+    use_jquery_ui_multiselect, use_select2
 from corehq.apps.accounting.exceptions import (
     NewSubscriptionError,
     PaymentRequestError,
@@ -448,7 +448,6 @@ class EditMyProjectSettingsView(BaseProjectSettingsView):
 
     @method_decorator(login_and_domain_required)
     @use_bootstrap3
-    @use_knockout_js
     def dispatch(self, *args, **kwargs):
         return super(LoginAndDomainMixin, self).dispatch(*args, **kwargs)
 
@@ -2021,7 +2020,6 @@ class ManageProjectMediaView(BaseAdminProjectSettingsView):
 
     @method_decorator(domain_admin_required)
     @use_bootstrap3
-    @use_knockout_js
     def dispatch(self, request, *args, **kwargs):
         return super(BaseProjectSettingsView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -45,7 +45,7 @@ from corehq.apps.style.decorators import (
     use_bootstrap3,
     use_select2,
     use_daterangepicker,
-)
+    use_angular_js)
 from corehq.apps.style.forms.widgets import DateRangePickerWidget
 from corehq.apps.style.utils import format_angular_error, format_angular_success
 from corehq.apps.users.decorators import get_permission_name
@@ -411,6 +411,7 @@ class BaseDownloadExportView(ExportsPermissionsMixin, JSONResponseMixin, BasePro
     @use_daterangepicker
     @use_bootstrap3
     @use_select2
+    @use_angular_js
     @method_decorator(login_and_domain_required)
     def dispatch(self, request, *args, **kwargs):
         if not (self.has_edit_permissions
@@ -852,6 +853,7 @@ class BaseExportListView(ExportsPermissionsMixin, JSONResponseMixin, BaseProject
 
     @use_bootstrap3
     @use_select2
+    @use_angular_js
     @method_decorator(login_and_domain_required)
     def dispatch(self, request, *args, **kwargs):
         if not (self.has_edit_permissions or self.has_view_permissions

--- a/corehq/apps/hqadmin/views.py
+++ b/corehq/apps/hqadmin/views.py
@@ -36,8 +36,7 @@ from couchdbkit import ResourceNotFound
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.callcenter.indicator_sets import CallCenterIndicators
 from corehq.apps.hqcase.utils import get_case_by_domain_hq_user_id
-from corehq.apps.style.decorators import use_datatables, use_knockout_js, \
-    use_jquery_ui
+from corehq.apps.style.decorators import use_datatables, use_jquery_ui
 from corehq.apps.style.views import BaseB3SectionPageView
 from corehq.toggles import any_toggle_enabled, SUPPORT
 from corehq.util.couchdb_management import couch_config
@@ -337,7 +336,6 @@ class SystemInfoView(BaseAdminSectionView):
     template_name = "hqadmin/system_info.html"
 
     @use_datatables
-    @use_knockout_js
     @use_jquery_ui
     @method_decorator(require_superuser_or_developer)
     def dispatch(self, request, *args, **kwargs):

--- a/corehq/apps/products/views.py
+++ b/corehq/apps/products/views.py
@@ -1,7 +1,7 @@
 import json
 from django.http.response import HttpResponseServerError
 from corehq.apps.commtrack.exceptions import DuplicateProductCodeException
-from corehq.apps.style.decorators import use_bootstrap3, use_knockout_js, use_jquery_ui
+from corehq.apps.style.decorators import use_bootstrap3, use_jquery_ui
 from corehq.util.files import file_extention_from_filename
 from couchexport.writers import Excel2007ExportWriter
 from couchexport.models import Format
@@ -130,7 +130,6 @@ class ProductListView(BaseCommTrackManageView):
         }
 
     @use_bootstrap3
-    @use_knockout_js
     def dispatch(self, request, *args, **kwargs):
         return super(ProductListView, self).dispatch(request, *args, **kwargs)
 
@@ -261,7 +260,6 @@ class NewProductView(BaseCommTrackManageView):
         return self.get(request, *args, **kwargs)
 
     @use_bootstrap3
-    @use_knockout_js
     def dispatch(self, request, *args, **kwargs):
         return super(NewProductView, self).dispatch(request, *args, **kwargs)
 
@@ -321,7 +319,6 @@ class UploadProductView(BaseCommTrackManageView):
         )
 
     @use_bootstrap3
-    @use_knockout_js
     def dispatch(self, request, *args, **kwargs):
         return super(UploadProductView, self).dispatch(request, *args, **kwargs)
 
@@ -490,7 +487,6 @@ class ProductFieldsView(CustomDataModelMixin, BaseCommTrackManageView):
     template_name = "custom_data_fields/bootstrap3/custom_data_fields.html"
 
     @use_bootstrap3
-    @use_knockout_js
     @use_jquery_ui
     def dispatch(self, request, *args, **kwargs):
         return super(ProductFieldsView, self).dispatch(request, *args, **kwargs)

--- a/corehq/apps/programs/views.py
+++ b/corehq/apps/programs/views.py
@@ -12,7 +12,7 @@ from corehq.apps.commtrack.views import BaseCommTrackManageView
 from corehq.apps.products.models import SQLProduct
 from corehq.apps.programs.models import Program
 from corehq.apps.programs.forms import ProgramForm
-from corehq.apps.style.decorators import use_knockout_js, use_bootstrap3
+from corehq.apps.style.decorators import use_bootstrap3
 
 
 @require_POST
@@ -34,7 +34,6 @@ class ProgramListView(BaseCommTrackManageView):
     page_title = ugettext_noop("Programs")
 
     @use_bootstrap3
-    @use_knockout_js
     def dispatch(self, request, *args, **kwargs):
         return super(ProgramListView, self).dispatch(request, *args, **kwargs)
 
@@ -100,7 +99,6 @@ class NewProgramView(BaseCommTrackManageView):
         return self.get(request, *args, **kwargs)
 
     @use_bootstrap3
-    @use_knockout_js
     def dispatch(self, request, *args, **kwargs):
         return super(NewProgramView, self).dispatch(request, *args, **kwargs)
 

--- a/corehq/apps/reminders/views.py
+++ b/corehq/apps/reminders/views.py
@@ -7,7 +7,7 @@ import pytz
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect, Http404, HttpResponse
 from django.shortcuts import render
-from corehq.apps.style.decorators import use_bootstrap3, use_datatables, use_knockout_js, use_jquery_ui, \
+from corehq.apps.style.decorators import use_bootstrap3, use_datatables, use_jquery_ui, \
     use_timepicker, use_select2
 from corehq.apps.translations.models import StandaloneTranslationDoc
 from corehq.const import SERVER_DATETIME_FORMAT
@@ -371,7 +371,6 @@ class CreateScheduledReminderView(BaseMessagingSectionView):
 
     @method_decorator(reminders_framework_permission)
     @use_bootstrap3
-    @use_knockout_js
     @use_jquery_ui
     @use_timepicker
     @use_select2
@@ -728,7 +727,6 @@ class AddStructuredKeywordView(BaseMessagingSectionView):
 
     @method_decorator(requires_privilege_with_fallback(privileges.OUTBOUND_SMS))
     @use_bootstrap3
-    @use_knockout_js
     def dispatch(self, *args, **kwargs):
         return super(BaseMessagingSectionView, self).dispatch(*args, **kwargs)
 
@@ -935,7 +933,6 @@ class CreateBroadcastView(BaseMessagingSectionView):
 
     @method_decorator(requires_privilege_with_fallback(privileges.OUTBOUND_SMS))
     @use_bootstrap3
-    @use_knockout_js
     @use_jquery_ui
     @use_timepicker
     def dispatch(self, *args, **kwargs):
@@ -1160,7 +1157,6 @@ class RemindersListView(BaseMessagingSectionView):
     @method_decorator(requires_privilege_with_fallback(privileges.OUTBOUND_SMS))
     @use_bootstrap3
     @use_datatables
-    @use_knockout_js
     def dispatch(self, *args, **kwargs):
         return super(BaseMessagingSectionView, self).dispatch(*args, **kwargs)
 
@@ -1354,7 +1350,6 @@ class KeywordsListView(BaseMessagingSectionView, CRUDPaginatedViewMixin):
 
     @method_decorator(requires_privilege_with_fallback(privileges.OUTBOUND_SMS))
     @use_bootstrap3
-    @use_knockout_js
     def dispatch(self, *args, **kwargs):
         return super(BaseMessagingSectionView, self).dispatch(*args, **kwargs)
 

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -137,7 +137,7 @@ from .models import (
 )
 
 from .standard import inspect, export, ProjectReport
-from corehq.apps.style.decorators import use_knockout_js, use_bootstrap3
+from corehq.apps.style.decorators import use_bootstrap3
 from .standard.cases.basic import CaseListReport
 from .tasks import (
     build_form_multimedia_zip,
@@ -1417,7 +1417,6 @@ def download_form(request, domain, instance_id):
 class EditFormInstance(View):
 
     @use_bootstrap3
-    @use_knockout_js
     @method_decorator(require_form_view_permission)
     @method_decorator(require_permission(Permissions.edit_data))
     def dispatch(self, request, *args, **kwargs):

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -2,7 +2,7 @@ import re
 from django.views.decorators.debug import sensitive_post_parameters
 from corehq.apps.hqwebapp.models import MySettingsTab
 from corehq.apps.settings.forms import HQPasswordChangeForm
-from corehq.apps.style.decorators import use_bootstrap3, use_select2, use_knockout_js
+from corehq.apps.style.decorators import use_bootstrap3, use_select2
 from corehq.apps.users.forms import AddPhoneNumberForm
 from dimagi.utils.couch.resource_conflict import retry_resource
 from django.contrib import messages
@@ -258,7 +258,6 @@ class ChangeMyPasswordView(BaseMyAccountView):
 
     @method_decorator(login_required)
     @use_bootstrap3
-    @use_knockout_js
     def dispatch(self, request, *args, **kwargs):
         # this is only here to add the login_required decorator
         return super(BaseMyAccountView, self).dispatch(request, *args, **kwargs)

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -32,7 +32,7 @@ from corehq.apps.sms.api import (
 from corehq.apps.domain.views import BaseDomainView, DomainViewMixin
 from corehq.apps.hqwebapp.views import CRUDPaginatedViewMixin
 from corehq.apps.sms.dbaccessors import get_forwarding_rules_for_domain
-from corehq.apps.style.decorators import use_bootstrap3, use_knockout_js, use_timepicker, use_typeahead, \
+from corehq.apps.style.decorators import use_bootstrap3, use_timepicker, use_typeahead, \
     use_select2
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import CouchUser, Permissions, CommCareUser
@@ -1041,7 +1041,6 @@ class DomainSmsGatewayListView(CRUDPaginatedViewMixin, BaseMessagingSectionView)
     strict_domain_fetching = True
 
     @use_bootstrap3
-    @use_knockout_js
     @method_decorator(domain_admin_required)
     def dispatch(self, request, *args, **kwargs):
         return super(DomainSmsGatewayListView, self).dispatch(request, *args, **kwargs)
@@ -1288,7 +1287,6 @@ class AddDomainGatewayView(BaseMessagingSectionView):
         return self.get(request, *args, **kwargs)
 
     @use_bootstrap3
-    @use_knockout_js
     @use_select2
     @method_decorator(domain_admin_required)
     @method_decorator(requires_privilege_with_fallback(privileges.OUTBOUND_SMS))
@@ -1695,7 +1693,6 @@ class SMSSettingsView(BaseMessagingSectionView):
     @method_decorator(domain_admin_required)
     @method_decorator(requires_privilege_with_fallback(privileges.OUTBOUND_SMS))
     @use_bootstrap3
-    @use_knockout_js
     @use_timepicker
     def dispatch(self, request, *args, **kwargs):
         return super(SMSSettingsView, self).dispatch(request, *args, **kwargs)

--- a/corehq/apps/style/decorators.py
+++ b/corehq/apps/style/decorators.py
@@ -59,24 +59,6 @@ def use_select2_v4(view_func):
     return _wrapped
 
 
-def use_knockout_js(view_func):
-    """Use this decorator on the dispatch method of a TemplateView subclass
-    to enable the inclusion of the knockout_js library at the base template
-    level.
-
-    Example:
-
-    @use_knockout_js
-    def dispatch(self, request, *args, **kwargs):
-        return super(MyView, self).dispatch(request, *args, **kwargs)
-    """
-    @wraps(view_func)
-    def _wrapped(class_based_view, request, *args, **kwargs):
-        request.use_knockout_js = True
-        return view_func(class_based_view, request, *args, **kwargs)
-    return _wrapped
-
-
 def use_angular_js(view_func):
     """Use this decorator on the dispatch method of a TemplateView subclass
     to enable the inclusion of the angularjs library at the base template

--- a/corehq/apps/style/decorators.py
+++ b/corehq/apps/style/decorators.py
@@ -77,6 +77,24 @@ def use_knockout_js(view_func):
     return _wrapped
 
 
+def use_angular_js(view_func):
+    """Use this decorator on the dispatch method of a TemplateView subclass
+    to enable the inclusion of the angularjs library at the base template
+    level.
+
+    Example:
+
+    @use_angular_js
+    def dispatch(self, request, *args, **kwargs):
+        return super(MyView, self).dispatch(request, *args, **kwargs)
+    """
+    @wraps(view_func)
+    def _wrapped(class_based_view, request, *args, **kwargs):
+        request.use_angular_js = True
+        return view_func(class_based_view, request, *args, **kwargs)
+    return _wrapped
+
+
 def upgrade_knockout_js(view_func):
     """Use this decorator on the dispatch method of a TemplateView subclass
     to enable the inclusion of the knockout_js 3.1 library at the base template

--- a/corehq/apps/style/templates/style/bootstrap3/base.html
+++ b/corehq/apps/style/templates/style/bootstrap3/base.html
@@ -353,14 +353,12 @@
         </script>
         {# JavaScript Display Logic Libaries #}
 
-        {% if request.use_knockout_js %}
         {% compress js %}
         <script type="text/javascript" src="{% new_static 'knockout/dist/knockout.js' %}"></script>
         <script type="text/javascript" src="{% new_static 'style/lib/knockout_plugins/knockout_mapping.ko.min.js' %}"></script>
         <script type="text/javascript" src="{% new_static 'style/ko/global_handlers.ko.js' %}"></script>
         <script type="text/javascript" src="{% new_static 'style/ko/knockout_bindings.ko.js' %}"></script>
         {% endcompress %}
-        {% endif %}
 
         {% if request.use_angular_js %}
         {% compress js %}

--- a/corehq/apps/style/templates/style/bootstrap3/base.html
+++ b/corehq/apps/style/templates/style/bootstrap3/base.html
@@ -353,7 +353,6 @@
         </script>
         {# JavaScript Display Logic Libaries #}
 
-        {# Use knockout explicitly, opt to move to angular js when possible. #}
         {% if request.use_knockout_js %}
         {% compress js %}
         <script type="text/javascript" src="{% new_static 'knockout/dist/knockout.js' %}"></script>
@@ -363,10 +362,11 @@
         {% endcompress %}
         {% endif %}
 
-        {# always use angular js by default, as this will be our core library #}
+        {% if request.use_angular_js %}
         {% compress js %}
         {% include "style/includes/bootstrap3/angular.html" %}
         {% endcompress %}
+        {% endif %}
 
         {% if request.use_select2 %}
         {% compress js %}

--- a/corehq/apps/toggle_ui/views.py
+++ b/corehq/apps/toggle_ui/views.py
@@ -9,7 +9,7 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.domain.decorators import require_superuser_or_developer
 from corehq.apps.hqwebapp.views import BasePageView
 from corehq.apps.users.models import CouchUser
-from corehq.apps.style.decorators import use_bootstrap3, use_knockout_js
+from corehq.apps.style.decorators import use_bootstrap3
 from corehq.toggles import all_toggles, ALL_TAGS, NAMESPACE_USER, NAMESPACE_DOMAIN
 from toggle.models import Toggle
 from toggle.shortcuts import clear_toggle_cache
@@ -85,7 +85,6 @@ class ToggleEditView(ToggleBaseView):
     template_name = 'toggle/edit_flag.html'
 
     @use_bootstrap3
-    @use_knockout_js
     @method_decorator(require_superuser_or_developer)
     def dispatch(self, request, *args, **kwargs):
         return super(ToggleEditView, self).dispatch(request, *args, **kwargs)

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -3,7 +3,7 @@ import os
 import tempfile
 from StringIO import StringIO
 from corehq.apps.domain.views import BaseDomainView
-from corehq.apps.style.decorators import use_bootstrap3, use_knockout_js, \
+from corehq.apps.style.decorators import use_bootstrap3, \
     use_select2, use_daterangepicker, use_jquery_ui, use_nvd3, use_datatables
 from dimagi.utils.modules import to_function
 from django.conf import settings
@@ -64,7 +64,6 @@ class ConfigurableReport(JSONResponseMixin, BaseDomainView):
         return super(ConfigurableReport, self).domain
 
     @use_bootstrap3
-    @use_knockout_js
     @use_select2
     @use_daterangepicker
     @use_jquery_ui

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -32,7 +32,6 @@ from corehq import toggles
 from corehq.apps.domain.decorators import login_and_domain_required, login_or_basic
 from corehq.apps.style.decorators import (
     use_bootstrap3,
-    use_knockout_js,
     use_select2,
     use_daterangepicker,
     use_datatables,
@@ -141,7 +140,6 @@ class ReportBuilderView(BaseDomainView):
 
     @cls_to_view_login_and_domain
     @use_bootstrap3
-    @use_knockout_js
     @use_select2
     @use_daterangepicker
     @use_datatables

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -37,7 +37,7 @@ from corehq.apps.style.decorators import (
     use_daterangepicker,
     use_datatables,
     use_jquery_ui,
-)
+    use_angular_js)
 from corehq.apps.userreports.app_manager import get_case_data_source, get_form_data_source
 from corehq.apps.userreports.exceptions import (
     BadBuilderConfigError,
@@ -164,6 +164,10 @@ class ReportBuilderTypeSelect(JSONResponseMixin, ReportBuilderView):
     template_name = "userreports/builder_report_type_select.html"
     urlname = 'report_builder_select_type'
     page_title = ugettext_lazy('Select Report Type')
+
+    @use_angular_js
+    def dispatch(self, request, *args, **kwargs):
+        return super(ReportBuilderTypeSelect, self).dispatch(request, *args, **kwargs)
 
     @property
     def page_url(self):

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -53,7 +53,7 @@ from corehq.apps.sms.verify import (
 from corehq.apps.style.decorators import (
     use_bootstrap3,
     use_knockout_js,
-)
+    use_angular_js)
 from corehq.apps.translations.models import StandaloneTranslationDoc
 from corehq.apps.users.decorators import require_can_edit_web_users, require_permission_to_edit_user
 from corehq.apps.users.forms import (BaseUserInfoForm, CommtrackUserForm, DomainRequestForm,
@@ -390,6 +390,7 @@ class ListWebUsersView(JSONResponseMixin, BaseUserSettingsView):
 
     @use_bootstrap3
     @use_knockout_js
+    @use_angular_js
     @method_decorator(require_can_edit_web_users)
     def dispatch(self, request, *args, **kwargs):
         return super(ListWebUsersView, self).dispatch(request, *args, **kwargs)

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -52,8 +52,8 @@ from corehq.apps.sms.verify import (
 )
 from corehq.apps.style.decorators import (
     use_bootstrap3,
-    use_knockout_js,
-    use_angular_js)
+    use_angular_js,
+)
 from corehq.apps.translations.models import StandaloneTranslationDoc
 from corehq.apps.users.decorators import require_can_edit_web_users, require_permission_to_edit_user
 from corehq.apps.users.forms import (BaseUserInfoForm, CommtrackUserForm, DomainRequestForm,
@@ -389,7 +389,6 @@ class ListWebUsersView(JSONResponseMixin, BaseUserSettingsView):
     urlname = 'web_users'
 
     @use_bootstrap3
-    @use_knockout_js
     @use_angular_js
     @method_decorator(require_can_edit_web_users)
     def dispatch(self, request, *args, **kwargs):

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -60,7 +60,8 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.domain.views import DomainViewMixin
 from corehq.apps.sms.models import SelfRegistrationInvitation
 from corehq.apps.sms.verify import initiate_sms_verification_workflow
-from corehq.apps.style.decorators import use_bootstrap3, use_select2
+from corehq.apps.style.decorators import use_bootstrap3, use_select2, \
+    use_angular_js
 from corehq.apps.users.bulkupload import check_headers, dump_users_and_groups, GroupNameError, UserUploadError
 from corehq.apps.users.tasks import bulk_upload_async
 from corehq.apps.users.decorators import require_can_edit_commcare_users
@@ -402,6 +403,7 @@ class MobileWorkerListView(JSONResponseMixin, BaseUserSettingsView):
 
     @use_bootstrap3
     @use_select2
+    @use_angular_js
     @method_decorator(require_can_edit_commcare_users)
     def dispatch(self, *args, **kwargs):
         return super(MobileWorkerListView, self).dispatch(*args, **kwargs)


### PR DESCRIPTION
explicitly specify use of angular js, make knockout default js library

@dimagi/team-commcare-hq 
note that this is getting rid of the `@use_knockout_js` decorator when migrating bootstrap 3 pages.
Knockout is always going to be used to support the messaging framework (coming in a different pr)

related: https://github.com/dimagi/commcarehq-prelogin/pull/56

@benrudolph 
