### PR TITLE
drop @zindexNavBarMainMenu

### DIFF
--- a/corehq/apps/style/static/style/less/bootstrap3/includes/variables.less
+++ b/corehq/apps/style/static/style/less/bootstrap3/includes/variables.less
@@ -76,7 +76,6 @@
 // corehq/apps/style/static/style/lib/bootstrap-3.2.0/less/variables.less
 @zindexDashboardSpinner:              500;
 @zindexAccountingPricingTableHeader:  800;
-@zindexNavBarMainMenu:               1031;
 
 // Other Zindecies
 @zindex-report-loading:               100;

--- a/corehq/apps/style/static/style/less/bootstrap3/navbar.less
+++ b/corehq/apps/style/static/style/less/bootstrap3/navbar.less
@@ -1,7 +1,6 @@
 .navbar-hq-main-menu {
   border: 1px solid #d5d5d5;
   font-size: 13px;
-  z-index: @zindexNavBarMainMenu;
   #gradient > .vertical(#fdfdfd, #f4f4f4);
   margin-bottom: 0px;
 


### PR DESCRIPTION
@biyeun is this still necessary? I'm guessing it was used to override bootstrap's `@zindex-navbar-fixed`, which is 1030 and used by `.navbar-fixed-top` and `.navbar-fixed-top` which it doesn't look like HQ uses anymore.

It's interfering with full-screen mode for B3 vellum. I can work around it, but would rather remove it if it's no longer needed.

cc @TylerSheffels 
