### PR TITLE
Set a default SHARED_DRIVE_ROOT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ celerybeat-schedule
 /locale/*/*/*.mo
 .grunt
 node_modules/
+/sharedfiles/

--- a/dev_settings.py
+++ b/dev_settings.py
@@ -67,3 +67,10 @@ CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
 INACTIVITY_TIMEOUT = 60 * 24 * 365
 
 CACHE_REPORTS = False
+
+# Make a dir to use for storing attachments as blobs on the filesystem
+shared_dirname = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                              'sharedfiles')
+if not os.path.exists(shared_dirname):
+    os.mkdir(shared_dirname)
+SHARED_DRIVE_ROOT = shared_dirname


### PR DESCRIPTION
Because otherwise you get failures running certain commands.
@millerdev @czue @benrudolph
