### PR TITLE
WIP: pg listen

### DIFF
--- a/corehq/apps/change_feed/data_sources.py
+++ b/corehq/apps/change_feed/data_sources.py
@@ -5,9 +5,10 @@ from corehq.util.exceptions import DatabaseNotFound
 from pillowtop.dao.couch import CouchDocumentStore
 
 COUCH = 'couch'
+POSTGRES = 'postgres'
 
 
-def get_document_store(data_source_type, data_source_name):
+def get_document_store(data_source_type, data_source_name=None):
     if data_source_type == COUCH:
         try:
             return CouchDocumentStore(couch_config.get_db_for_db_name(data_source_name))
@@ -16,6 +17,14 @@ def get_document_store(data_source_type, data_source_name):
             if settings.DEBUG:
                 return None
             raise
+    elif data_source_type == POSTGRES:
+        conn = psycopg2.connect(
+            database='commcarehq',
+            user='commcarehq',
+            password='commcarehq',
+        )
+        conn.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
+        return conn
     else:
         raise UnknownDocumentStore(
             'getting document stores for backend {} is not supported!'.format(data_source_type)

--- a/corehq/apps/change_feed/pillow.py
+++ b/corehq/apps/change_feed/pillow.py
@@ -1,14 +1,12 @@
-import json
 from kafka import KeyedProducer
-from kafka.common import KafkaUnavailableError, LeaderNotAvailableError, FailedPayloadsError
-import time
+from kafka.common import KafkaUnavailableError
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.change_feed import data_sources
 from corehq.apps.change_feed.connection import get_kafka_client
 from corehq.apps.change_feed.topics import get_topic
+from corehq.apps.change_feed.utils import send_to_kafka
 from corehq.apps.users.models import CommCareUser
 from corehq.util.couchdb_management import couch_config
-from corehq.util.soft_assert import soft_assert
 from couchforms.models import all_known_formlike_doc_types
 import logging
 from pillowtop.checkpoints.manager import PillowCheckpoint, get_django_checkpoint_store, \
@@ -45,31 +43,7 @@ class KafkaProcessor(PillowProcessor):
                 is_deletion=change.deleted,
             )
 
-            def _send_to_kafka():
-                # closures
-                self._producer.send_messages(
-                    bytes(get_topic(document_type)),
-                    bytes(change_meta.domain.encode('utf-8') if change_meta.domain is not None else None),
-                    bytes(json.dumps(change_meta.to_json())),
-                )
-
-            try:
-                try:
-                    _send_to_kafka()
-                except FailedPayloadsError:
-                    # this typically an inactivity timeout - which can happen if the feed is low volume
-                    # just do a simple retry
-                    _send_to_kafka()
-            except LeaderNotAvailableError:
-                # kafka seems to be down. sleep a bit to avoid crazy amounts of error spam
-                time.sleep(15)
-                raise
-            except Exception as e:
-                _assert = soft_assert(to='@'.join(['czue', 'dimagi.com']))
-                _assert(False, u'Problem sending change to kafka {}: {} ({})'.format(
-                    change_meta.to_json(), e, type(e)
-                ))
-                raise
+            send_to_kafka(self._producer, get_topic(document_type), change_meta)
 
 
 class ChangeFeedPillow(PythonPillow):

--- a/corehq/apps/change_feed/producer/postgres.py
+++ b/corehq/apps/change_feed/producer/postgres.py
@@ -14,7 +14,7 @@ CHANNELS = {
 
 class PostgresProducer(object):
     """
-    Abstract class. Producer that pushes changes to Kafka
+    Producer that pushes changes to Kafka
     """
 
     def __init__(self, kafka, data_source_type, data_source_name):

--- a/corehq/apps/change_feed/producer/postgres.py
+++ b/corehq/apps/change_feed/producer/postgres.py
@@ -1,0 +1,61 @@
+import select
+import json
+import psycopg2.extensions
+from kafka import KeyedProducer
+from pillowtop.feed.interface import ChangeMeta
+
+from ..data_sources import get_document_store, POSTGRES
+from ..utils import send_to_kafka
+
+CHANNELS = {
+    XFormChannel.name: XFormChannel
+}
+
+
+class PostgresProducer(object):
+    """
+    Abstract class. Producer that pushes changes to Kafka
+    """
+
+    def __init__(self, kafka, data_source_type, data_source_name):
+        self._kafka = kafka
+        self._producer = KeyedProducer(self._kafka)
+        self._conn = get_document_store(POSTGRES)
+        self._conn.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
+        self._data_source_type = data_source_type
+        self._channel = CHANNELS[data_source_name]()
+
+    def listen(self):
+        # Each instance of PostgresProducer will take up one connection to the master database. Keep these to
+        # a minimum
+        curs = self._conn.cursor()
+        curs.execute("LISTEN {};".format(self._channel.name))
+
+        while True:
+            #  http://initd.org/psycopg/docs/advanced.html#asynchronous-notifications
+            result = select.select([self._conn], [], [], 5)
+            if result == ([], [], []):
+                print "Timeout"
+            else:
+                self._conn.poll()
+                while self._conn.notifies:
+                    notify = self._conn.notifies.pop(0)
+                    payload = json.loads(notify.payload)  # Have channel wrap this?
+
+                    change_meta = ChangeMeta(
+                        document_id=payload.id,
+                        data_source_type=self._data_source_type,
+                        data_source_name=self._data_source_name,
+                        document_type=None,
+                        document_subtype=None,
+                        domain=payload.get('domain', None),
+                        is_deletion=payload.deleted,
+                    )
+
+                    send_to_kafka(
+                        self._producer,
+                        self._channel.name,
+                        change_meta,
+                    )
+
+                    print "Got NOTIFY:", notify.pid, notify.channel, notify.payload

--- a/corehq/apps/change_feed/utils.py
+++ b/corehq/apps/change_feed/utils.py
@@ -1,0 +1,32 @@
+import json
+import time
+
+from corehq.util.soft_assert import soft_assert
+from kafka.common import LeaderNotAvailableError, FailedPayloadsError
+
+
+def send_to_kafka(producer, topic, change_meta):
+    def _send_to_kafka():
+        producer.send_messages(
+            bytes(topic),
+            bytes(change_meta.domain.encode('utf-8') if change_meta.domain is not None else None),
+            bytes(json.dumps(change_meta.to_json())),
+        )
+
+    try:
+        try:
+            _send_to_kafka()
+        except FailedPayloadsError:
+            # this typically an inactivity timeout - which can happen if the feed is low volume
+            # just do a simple retry
+            _send_to_kafka()
+    except LeaderNotAvailableError:
+        # kafka seems to be down. sleep a bit to avoid crazy amounts of error spam
+        time.sleep(15)
+        raise
+    except Exception as e:
+        _assert = soft_assert(to='@'.join(['czue', 'dimagi.com']))
+        _assert(False, u'Problem sending change to kafka {}: {} ({})'.format(
+            change_meta.to_json(), e, type(e)
+        ))
+        raise

--- a/corehq/sql_proxy_accessors/sql_templates/create_case_notify_trigger.sql
+++ b/corehq/sql_proxy_accessors/sql_templates/create_case_notify_trigger.sql
@@ -1,0 +1,9 @@
+CREATE OR REPLACE FUNCTION case_notify() RETURNS trigger AS $$
+DECLARE
+BEGIN
+  PERFORM pg_notify('{{ channel.name }}', row_to_json(NEW));
+  RETURN NEW;
+END;
+$$ LANGUAGE plproxy;
+
+CREATE TRIGGER case_insert_notify AFTER UPDATE ON {{ case_table }} FOR EACH ROW EXECUTE PROCEDURE case_notify();


### PR DESCRIPTION
@czue @snopoke i played around with `NOTIFY <channel>, <payload>` and `LISTEN <channel>` (works exactly like it sounds) today and I think i have a strategy but wanted to run a high level overview by you guys first before diving in. it involves touching a lot of the `changes_feed` code and the sharded db.

`PostgresProducer (corehq/apps/changes_feed/producer/postgres.py)` - This class is instantiated for each channel that we have (xform, cases, etc) and is responsible for listening to postgres for and notify events and then forwarding that data to kafka with minimal transformation.

`PostgresConsumer (corehq/apps/changes_feed/consumer/postgres.py)` - This class is instantiated once for each channel that we have and is responsible for listening to _kafka_. I'm little hazy on the details of this one. haven't written it yet, but I'm imagining it has a `process_change` function that gets called by Kafka. @czue it seems like this functionality is tied to the current pillowtop infrastructure

`<channel_name>Channel` - Each channel is responsible for being able to do the transform/process the change. It's called from the `PostgresConsumer`

Postgres setup is just to create triggers that `NOTIFY` on update for each postgres table that we want. The details I have to hash out such as how triggers work with plproxy etc.

The below is kind of pseudo code to give you an idea of the direction i'm headed. none of the code has been run expect for very basic testing for postgres' notify and listen commands. I think one of my bigger questions is how do `PostgresConsumers` relate to pillows? Are they completely divorced or do we want to try and mimic the pillow setup?

cc: @esoergel 
