### PR TITLE
Trim case config dropdown

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/add_property_button.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/add_property_button.html
@@ -2,15 +2,12 @@
 {% load hq_shared_tags %}
 <div class="btn-group">
     <button class="btn" data-bind="click: addProperty">{% trans "Add Property" %}</button>
-    {% if request|feature_preview_enabled:'CALC_XPATHS' or request|toggle_enabled:'GRAPH_CREATION' %}
+    {% if request|toggle_enabled:'GRAPH_CREATION' %}
     <button class="btn dropdown-toggle" data-toggle="dropdown">
         <span class="caret"></span>
     </button>
     <ul class="dropdown-menu">
         <li data-bind="click: addProperty"><a>{% trans "Property" %}</a></li>
-        {% if request|feature_preview_enabled:'CALC_XPATHS' %}
-        <li data-bind="click: addCalculation"><a>{% trans "Calculation" %}</a></li>
-        {% endif %}
         {% if request|toggle_enabled:'GRAPH_CREATION' %}
         <!-- ko if: COMMCAREHQ.app_manager.checkCommcareVersion("2.17") -->
         <li data-bind="click: addGraph"><a>{% trans "Graph" %}</a></li>

--- a/corehq/apps/app_manager/templates/app_manager/partials/add_property_button.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/add_property_button.html
@@ -1,7 +1,10 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 <div class="btn-group">
-    <button class="btn" data-bind="click: addProperty">{% trans "Add Property" %}</button>
+    <button class="btn" data-bind="click: addProperty">
+        <i class="icon icon-plus"></i>
+        {% trans "Add Property" %}
+    </button>
     {% if request|toggle_enabled:'GRAPH_CREATION' %}
     <button class="btn dropdown-toggle" data-toggle="dropdown">
         <span class="caret"></span>


### PR DESCRIPTION
Killing the "Add Calculation" option from the "Add Property" dropdown on case list/detail, since the same action is available by selecting "calculation" from the format dropdown.

Chatted with @amsagoff about this.

@TylerSheffels 
