### PR TITLE
Formplayer Java deploy

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,6 +73,6 @@
 [submodule "corehq/apps/prelogin"]
 	path = corehq/apps/prelogin
 	url = https://github.com/dimagi/commcarehq-prelogin.git
-[submodule "submodules/formsplayer"]
-	path = submodules/formsplayer
-	url = git@github.com:dimagi/formsplayer.git
+[submodule "submodules/formplayer"]
+	path = submodules/formplayer
+	url = https://github.com/dimagi/formplayer.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -73,3 +73,6 @@
 [submodule "corehq/apps/prelogin"]
 	path = corehq/apps/prelogin
 	url = https://github.com/dimagi/commcarehq-prelogin.git
+[submodule "submodules/formsplayer"]
+	path = submodules/formsplayer
+	url = git@github.com:dimagi/formsplayer.git

--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -699,7 +699,6 @@ def copy_tf_localsettings():
 def build_formplayer():
     spring_dir = '{}/{}'.format(env.code_root, 'submodules/formplayer')
     with cd(spring_dir):
-        sudo('gradle wrapper')
         sudo('./gradlew build')
 
 

--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -601,7 +601,7 @@ def _deploy_without_asking():
         _execute_with_timing(clear_services_dir)
         _set_supervisor_config()
 
-        _execute_with_timing(build_formsplayer)
+        _execute_with_timing(build_formplayer)
 
         do_migrate = env.should_migrate
         if do_migrate:

--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -1193,9 +1193,11 @@ def set_errand_boy_supervisorconf():
 def set_formsplayer_supervisorconf():
     _rebuild_supervisor_conf_file('make_supervisor_conf', 'supervisor_formsplayer.conf')
 
+
 @roles(ROLES_TOUCHFORMS)
 def set_formplayer_spring_supervisorconf():
     _rebuild_supervisor_conf_file('make_supervisor_conf', 'supervisor_formplayer_spring.conf')
+
 
 @roles(ROLES_SMS_QUEUE)
 def set_sms_queue_supervisorconf():

--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -699,6 +699,7 @@ def copy_tf_localsettings():
 def build_formplayer():
     spring_dir = '{}/{}'.format(env.code_root, 'submodules/formplayer')
     with cd(spring_dir):
+        sudo('gradle wrapper')
         sudo('./gradlew build')
 
 

--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -694,6 +694,16 @@ def copy_tf_localsettings():
         ))
 
 
+@parallel
+@roles(ROLES_TOUCHFORMS)
+def copy_formplayer_properties():
+    sudo(
+        'cp {}/submodules/formplayer/config/{}.properties '
+        '{}/submodules/formplayer/config'.format(
+            env.code_current, env.environment, env.code_root
+        ))
+
+
 @task
 @roles(ROLES_TOUCHFORMS)
 def build_formplayer():
@@ -714,6 +724,7 @@ def copy_components():
 def copy_release_files():
     execute(copy_localsettings)
     execute(copy_tf_localsettings)
+    execute(copy_formplayer_properties)
     execute(copy_components)
 
 

--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -696,8 +696,8 @@ def copy_tf_localsettings():
 
 @task
 @roles(ROLES_TOUCHFORMS)
-def build_formsplayer():
-    spring_dir = '{}/{}'.format(env.code_root, 'submodules/formsplayer')
+def build_formplayer():
+    spring_dir = '{}/{}'.format(env.code_root, 'submodules/formplayer')
     with cd(spring_dir):
         sudo('./gradlew build')
 
@@ -1193,6 +1193,10 @@ def set_errand_boy_supervisorconf():
 def set_formsplayer_supervisorconf():
     _rebuild_supervisor_conf_file('make_supervisor_conf', 'supervisor_formsplayer.conf')
 
+@roles(ROLES_TOUCHFORMS)
+def set_formplayer_spring_supervisorconf():
+    _rebuild_supervisor_conf_file('make_supervisor_conf', 'supervisor_formplayer_spring.conf')
+
 @roles(ROLES_SMS_QUEUE)
 def set_sms_queue_supervisorconf():
     if 'sms_queue' in get_celery_queues():
@@ -1227,6 +1231,7 @@ def _set_supervisor_config():
     _execute_with_timing(set_djangoapp_supervisorconf)
     _execute_with_timing(set_errand_boy_supervisorconf)
     _execute_with_timing(set_formsplayer_supervisorconf)
+    _execute_with_timing(set_formplayer_spring_supervisorconf)
     _execute_with_timing(set_pillowtop_supervisorconf)
     _execute_with_timing(set_sms_queue_supervisorconf)
     _execute_with_timing(set_reminder_queue_supervisorconf)

--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -601,7 +601,7 @@ def _deploy_without_asking():
         _execute_with_timing(clear_services_dir)
         _set_supervisor_config()
 
-        _execute_with_timing(build_tf)
+        _execute_with_timing(build_formsplayer)
 
         do_migrate = env.should_migrate
         if do_migrate:
@@ -696,7 +696,7 @@ def copy_tf_localsettings():
 
 @task
 @roles(ROLES_TOUCHFORMS)
-def build_tf():
+def build_formsplayer():
     spring_dir = '{}/{}'.format(env.code_root, 'submodules/formsplayer')
     with cd(spring_dir):
         sudo('./gradlew build')

--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -601,6 +601,8 @@ def _deploy_without_asking():
         _execute_with_timing(clear_services_dir)
         _set_supervisor_config()
 
+        _execute_with_timing(build_tf)
+
         do_migrate = env.should_migrate
         if do_migrate:
 
@@ -690,6 +692,14 @@ def copy_tf_localsettings():
         '{}/submodules/touchforms-src/touchforms/backend/localsettings.py'.format(
             env.code_current, env.code_root
         ))
+
+
+@task
+@roles(ROLES_TOUCHFORMS)
+def build_tf():
+    spring_dir = '{}/{}'.format(env.code_root, 'submodules/formsplayer')
+    with cd(spring_dir):
+        sudo('./gradlew build')
 
 
 @parallel

--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -697,11 +697,12 @@ def copy_tf_localsettings():
 @parallel
 @roles(ROLES_TOUCHFORMS)
 def copy_formplayer_properties():
-    sudo(
-        'cp {}/submodules/formplayer/config/{}.properties '
-        '{}/submodules/formplayer/config'.format(
-            env.code_current, env.environment, env.code_root
-        ))
+    with settings(warn_only=True):
+        sudo(
+            'cp {}/submodules/formplayer/config/{}.properties '
+            '{}/submodules/formplayer/config'.format(
+                env.code_current, env.environment, env.code_root
+            ))
 
 
 @task

--- a/fab/services/templates/supervisor_formplayer_spring.conf
+++ b/fab/services/templates/supervisor_formplayer_spring.conf
@@ -1,5 +1,5 @@
 [program:{{ project }}-{{ environment }}-formsplayer-spring]
-command=java -jar -Xmx3584 -Xss1024k {{ code_current}}/submodules/formplayer/build/libs/formplayer.jar --spring.config.name={{ environment }}
+command=java -jar -Xmx3584m -Xss1024k {{ code_current}}/submodules/formplayer/build/libs/formplayer.jar --spring.config.name={{ environment }}
 user={{ sudo_user }}
 autostart=true
 autorestart=true

--- a/fab/services/templates/supervisor_formplayer_spring.conf
+++ b/fab/services/templates/supervisor_formplayer_spring.conf
@@ -1,9 +1,9 @@
 [program:{{ project }}-{{ environment }}-formsplayer-spring]
-command=java -jar {{ code_current}}/submodules/formsplayer/build/libs/formsplayer.jar
+command=java -jar {{ code_current}}/submodules/formplayer/build/libs/formplayer.jar
 user={{ sudo_user }}
 autostart=true
 autorestart=true
-stdout_logfile={{ log_dir }}/formsplayer-spring.log
+stdout_logfile={{ log_dir }}/formplayer-spring.log
 redirect_stderr=true
-stderr_logfile={{ log_dir }}/formsplayer-spring.error.log
+stderr_logfile={{ log_dir }}/formplayer-spring.error.log
 startsecs=10

--- a/fab/services/templates/supervisor_formplayer_spring.conf
+++ b/fab/services/templates/supervisor_formplayer_spring.conf
@@ -6,4 +6,5 @@ autorestart=true
 stdout_logfile={{ log_dir }}/formplayer-spring.log
 redirect_stderr=true
 stderr_logfile={{ log_dir }}/formplayer-spring.error.log
+directory={{ code_current }}/submodules/formplayer
 startsecs=10

--- a/fab/services/templates/supervisor_formplayer_spring.conf
+++ b/fab/services/templates/supervisor_formplayer_spring.conf
@@ -6,3 +6,4 @@ autorestart=true
 stdout_logfile={{ log_dir }}/formsplayer-spring.log
 redirect_stderr=true
 stderr_logfile={{ log_dir }}/formsplayer-spring.error.log
+startsecs=10

--- a/fab/services/templates/supervisor_formplayer_spring.conf
+++ b/fab/services/templates/supervisor_formplayer_spring.conf
@@ -1,5 +1,5 @@
 [program:{{ project }}-{{ environment }}-formsplayer-spring]
-command=java -jar {{ code_current}}/submodules/formplayer/build/libs/formplayer.jar --spring.config.name={{ environment }}
+command=java -jar -Xmx3584 -Xss1024k {{ code_current}}/submodules/formplayer/build/libs/formplayer.jar --spring.config.name={{ environment }}
 user={{ sudo_user }}
 autostart=true
 autorestart=true

--- a/fab/services/templates/supervisor_formplayer_spring.conf
+++ b/fab/services/templates/supervisor_formplayer_spring.conf
@@ -1,5 +1,5 @@
 [program:{{ project }}-{{ environment }}-formsplayer-spring]
-command=java -jar {{ code_current}}/submodules/formplayer/build/libs/formplayer.jar --spring.config.name={{ environment }}.properties
+command=java -jar {{ code_current}}/submodules/formplayer/build/libs/formplayer.jar --spring.config.name={{ environment }}
 user={{ sudo_user }}
 autostart=true
 autorestart=true

--- a/fab/services/templates/supervisor_formplayer_spring.conf
+++ b/fab/services/templates/supervisor_formplayer_spring.conf
@@ -1,5 +1,5 @@
 [program:{{ project }}-{{ environment }}-formsplayer-spring]
-command=java -jar {{ code_current}}/submodules/formplayer/build/libs/formplayer.jar
+command=java -jar {{ code_current}}/submodules/formplayer/build/libs/formplayer.jar --spring.config.name={{ environment }}.properties
 user={{ sudo_user }}
 autostart=true
 autorestart=true

--- a/fab/services/templates/supervisor_formsplayer_spring.conf
+++ b/fab/services/templates/supervisor_formsplayer_spring.conf
@@ -6,4 +6,3 @@ autorestart=true
 stdout_logfile={{ log_dir }}/formsplayer-spring.log
 redirect_stderr=true
 stderr_logfile={{ log_dir }}/formsplayer-spring.error.log
-

--- a/fab/services/templates/supervisor_formsplayer_spring.conf
+++ b/fab/services/templates/supervisor_formsplayer_spring.conf
@@ -1,4 +1,4 @@
-[program:{{ project }}-{{ environment }}-formsplayer]
+[program:{{ project }}-{{ environment }}-formsplayer-spring]
 command=java -jar {{ code_current}}/submodules/formsplayer/build/libs/formsplayer.jar
 user={{ sudo_user }}
 autostart=true

--- a/fab/services/templates/supervisor_formsplayer_spring.conf
+++ b/fab/services/templates/supervisor_formsplayer_spring.conf
@@ -1,0 +1,9 @@
+[program:{{ project }}-{{ environment }}-formsplayer]
+command=java -jar {{ code_current}}/submodules/formsplayer/build/libs/formsplayer.jar
+user={{ sudo_user }}
+autostart=true
+autorestart=true
+stdout_logfile={{ log_dir }}/formsplayer-spring.log
+redirect_stderr=true
+stderr_logfile={{ log_dir }}/formsplayer-spring.error.log
+


### PR DESCRIPTION
@snopoke, sat down with @wpride today to work out a deploy plan. i think what we have here is the simplest way to do a deploy. requires a couple more things on ansible side. gonna need to test it out on staging of course. i hate the naming for touchforms (cloudcare, formsplayer). i went with formsplayer since it's what we call the jython server and it makes more sense than touchforms. let me know if you have any better ideas

cc: @czue @esoergel
