### PR TITLE
Support location descendants in mobile UCR filter

### DIFF
--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -67,7 +67,7 @@ class ReportFixturesProvider(object):
         data_source = ReportFactory.from_spec(report)
 
         all_filter_values = {
-            filter_slug: filter.get_filter_value(user)
+            filter_slug: filter.get_filter_value(user, report.get_ui_filter(filter_slug))
             for filter_slug, filter in report_config.filters.items()
         }
         filter_values = {

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -3280,11 +3280,11 @@ class ReportAppFilter(DocumentSchema):
         else:
             return super(ReportAppFilter, cls).wrap(data)
 
-    def get_filter_value(self, user):
+    def get_filter_value(self, user, ui_filter):
         raise NotImplementedError
 
 
-def _filter_by_case_sharing_group_id(user):
+def _filter_by_case_sharing_group_id(user, ui_filter):
     from corehq.apps.reports_core.filters import Choice
     return [
         Choice(value=group._id, display=None)
@@ -3292,17 +3292,16 @@ def _filter_by_case_sharing_group_id(user):
     ]
 
 
-def _filter_by_location_id(user):
-    from corehq.apps.reports_core.filters import Choice
-    return Choice(value=user.location_id, display=None)
+def _filter_by_location_id(user, ui_filter):
+    return ui_filter.value(**{ui_filter.name: user.location_id})
 
 
-def _filter_by_username(user):
+def _filter_by_username(user, ui_filter):
     from corehq.apps.reports_core.filters import Choice
     return Choice(value=user.username, display=None)
 
 
-def _filter_by_user_id(user):
+def _filter_by_user_id(user, ui_filter):
     from corehq.apps.reports_core.filters import Choice
     return Choice(value=user._id, display=None)
 
@@ -3318,14 +3317,14 @@ _filter_type_to_func = {
 class AutoFilter(ReportAppFilter):
     filter_type = StringProperty(choices=_filter_type_to_func.keys())
 
-    def get_filter_value(self, user):
-        return _filter_type_to_func[self.filter_type](user)
+    def get_filter_value(self, user, ui_filter):
+        return _filter_type_to_func[self.filter_type](user, ui_filter)
 
 
 class CustomDataAutoFilter(ReportAppFilter):
     custom_data_property = StringProperty()
 
-    def get_filter_value(self, user):
+    def get_filter_value(self, user, ui_filter):
         from corehq.apps.reports_core.filters import Choice
         return Choice(value=user.user_data[self.custom_data_property], display=None)
 
@@ -3333,7 +3332,7 @@ class CustomDataAutoFilter(ReportAppFilter):
 class StaticChoiceFilter(ReportAppFilter):
     select_value = StringProperty()
 
-    def get_filter_value(self, user):
+    def get_filter_value(self, user, ui_filter):
         from corehq.apps.reports_core.filters import Choice
         return [Choice(value=self.select_value, display=None)]
 
@@ -3341,7 +3340,7 @@ class StaticChoiceFilter(ReportAppFilter):
 class StaticChoiceListFilter(ReportAppFilter):
     value = StringListProperty()
 
-    def get_filter_value(self, user):
+    def get_filter_value(self, user, ui_filter):
         from corehq.apps.reports_core.filters import Choice
         return [Choice(value=string_value, display=None) for string_value in self.value]
 
@@ -3357,7 +3356,7 @@ class StaticDatespanFilter(ReportAppFilter):
         required=True,
     )
 
-    def get_filter_value(self, user):
+    def get_filter_value(self, user, ui_filter):
         start_date, end_date = get_daterange_start_end_dates(self.date_range)
         return DateSpan(startdate=start_date, enddate=end_date)
 
@@ -3377,7 +3376,7 @@ class CustomDatespanFilter(ReportAppFilter):
     date_number = StringProperty(required=True)
     date_number2 = StringProperty()
 
-    def get_filter_value(self, user):
+    def get_filter_value(self, user, ui_filter):
         today = datetime.date.today()
         start_date = end_date = None
         days = int(self.date_number)
@@ -3410,7 +3409,7 @@ class CustomDatespanFilter(ReportAppFilter):
 
 
 class MobileSelectFilter(ReportAppFilter):
-    def get_filter_value(self, user):
+    def get_filter_value(self, user, ui_filter):
         return None
 
 


### PR DESCRIPTION
Addresses ticket [#191500](http://manage.dimagi.com/default.asp?191500)

Mobile UCR were not respecting the `include_descendants` option for location filters when the `AutoFilter` type was used. Since `include_descendants` is configured in a `DynamicChoiceListFilter` and because the `AutoFilter` wasn't ever passed the corresponding `DynamicChoiceListFilter` instance, it didn't have any way of knowing the state of the `include_descendants` flag. This PR fixes the problem by adding a `ui_filter` argument to `ReportAppFilter.get_filter_value()`.

An alternative approach would be to store the `include_descendants` flag on the `AutoFilter` when it is created. This would help decouple the `ReportAppFilter`s and ui filters, but would probably mean that some `AutoFilter`s would have meaningless `include_descendants` flags (if they weren't being used for location_id), It also might be more difficult to propagate changes to the `include_descendants` flag in a report configuration to the the stored `AutoFilter` in the application configuration.

A third option might be to create a new `ReportAppFilter` type, called `DescendentLocationFilter` (or something like that), which would encode the desired behavior.

I think @czue or @dannyroberts designed this part of the code. Do either of you have suggestions about how this should work?

cc code budy @snopoke 
