### PR TITLE
only initialize help if there is something to do

### DIFF
--- a/corehq/apps/hqwebapp/static/hqwebapp/js/main.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/main.js
@@ -197,7 +197,6 @@ var COMMCAREHQ = (function () {
             wrap = wrap === undefined ? true : wrap;
             var iconClass = "icon-question-sign";
             var containerStyle = '';
-
             if (opts.bootstrap3) {
                 iconClass = "fa fa-question-circle";
                 containerStyle = 'height: 0; width: auto;';
@@ -218,9 +217,11 @@ var COMMCAREHQ = (function () {
             return el;
         },
         transformHelpTemplate: function ($template, wrap) {
-            var $help = COMMCAREHQ.makeHqHelp($template.data(), wrap);
-            $help.insertAfter($template);
-            $template.remove();
+            if ($template.data()) {
+                var $help = COMMCAREHQ.makeHqHelp($template.data(), wrap);
+                $help.insertAfter($template);
+                $template.remove();
+            }
         },
         initBlock: function ($elem) {
             $('.submit_on_click', $elem).on("click", function (e) {


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?200794

This is a bit of a workaround - I'm not sure if there's a more surgical way to fix this. The issue is that the selector here: https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/translations/static/translations/js/translations.js#L239 is returning nothing useful which causes a js error that then causes the other js on the page to not run.

based on git blame it looks like @orangejenny and @dannyroberts may have the most context on this?

cc @benrudolph @esoergel 
