### PR TITLE
exclude 'case' from query form query props

### DIFF
--- a/corehq/pillows/xform.py
+++ b/corehq/pillows/xform.py
@@ -19,14 +19,12 @@ def is_valid_date(txt):
         pass
     return False
 
-RESERVED = RESERVED_WORDS[:]
-RESERVED.remove('case')
 
 # modified from: http://stackoverflow.com/questions/6027558/flatten-nested-python-dictionaries-compressing-keys
 def flatten(d, parent_key='', delimiter='/'):
     items = []
     for k, v in d.items():
-        if k in RESERVED:
+        if k in RESERVED_WORDS:
             continue
         new_key = parent_key + delimiter + k if parent_key else k
         if isinstance(v, collections.MutableMapping):


### PR DESCRIPTION
Lucene has a max length for fields of 32766 bytes. This gets exceeded by some forms (mostly case import forms) for the [__props_for_querying](https://github.com/dimagi/commcare-hq/blob/609fbca3b6697edea8452112edf39bab6df98a53/corehq/pillows/xform.py#L91-L91) field. 

This field is only used in the SubmitHistory report and only if the `SUBMIT_HISTORY_FILTERS` feature flag is enabled.

Removing the 'case' field from the queriable props means that you won't be able to filter the list of forms based on any case properties in the form but to me that doesn't seems like it should be the main use case.
@NoahCarnahan 

cc @czue 
