### PR TITLE
Exports Refactor Outline

### DIFF
--- a/corehq/apps/export/models.py
+++ b/corehq/apps/export/models.py
@@ -1,5 +1,8 @@
 import hashlib
+from couchdbkit import SchemaListProperty, SchemaProperty
 from couchdbkit.exceptions import ResourceNotFound
+
+from corehq.apps.userreports.expressions.getters import NestedDictGetter
 from dimagi.ext.couchdbkit import (
     Document, DocumentSchema, ListProperty, StringProperty,
     IntegerProperty, SetProperty, SchemaDictProperty
@@ -7,6 +10,144 @@ from dimagi.ext.couchdbkit import (
 from corehq.apps.app_manager.exceptions import AppManagerException
 from corehq.apps.app_manager.models import Application
 from dimagi.utils.couch.database import iter_docs
+
+from corehq.apps.userreports import models
+from dimagi.utils.decorators.memoized import memoized
+
+
+class ExportItem(DocumentSchema):
+    """
+    An item for export.
+    path is a question path like ["my_group", "q1"] or a case property name
+    like ["date_of_birth"].
+    """
+    path = SchemaListProperty(StringProperty)
+    label = StringProperty()
+    last_occurrence = IntegerProperty()
+
+
+class ExportColumn(DocumentSchema):
+    item = SchemaProperty(ExportItem)
+    display = StringProperty()
+
+    def get_value(self, doc, base_path):
+        """
+        Get the value of self.item of the given doc.
+        When base_path is [], doc is a form submission or case,
+        when base_path is non empty, doc is a repeat group from a form submission.
+        :param doc: A form submission or instance of a repeat group in a submission or case
+        :param base_path:
+        :return:
+        """
+        # Confirm the ExportItem's path starts with the base_path
+        assert base_path == self.item.path[:len(base_path)]
+        # Get the path from the doc root to the desired ExportItem
+        path = self.item.path[len(base_path):]
+        return NestedDictGetter(path)(doc)
+
+
+class SplitExportColumn(ExportColumn):
+    pass
+
+
+class TableConfiguration(DocumentSchema):
+
+    table_name = StringProperty()
+    repeat_path = ListProperty(StringProperty)
+    columns = ListProperty(ExportColumn)
+
+    def get_rows(self, document):
+        """
+        Return a list of ExportRows generated for the given document.
+        :param document: dictionary representation of a form submission or case
+        :return: List of ExportRows
+        """
+        # Note that sub_documents will be [document] if self.repeat_path is []
+        sub_documents = self._get_sub_documents(self.repeat_path, [document])
+        rows = []
+        for sub_doc in sub_documents:
+            row = ExportRow(data=[
+                col.get_value(sub_doc, self.repeat_path) for col in self.columns
+            ])
+            rows.append(row)
+        return rows
+
+    def _get_sub_documents(self, path, docs):
+        """
+        Return each instance of a repeat group at the path from the given docs.
+        If path is [], just return the docs
+
+        >>> TableConfiguration()._get_sub_documents(['foo'], [{'foo': {'bar': 'a'}}, {'foo': {'bar': 'b'}}])
+        [{'bar': 'a'}, {'bar': 'b'}]
+        >>> TableConfiguration()._get_sub_documents(['foo', 'bar'], [{'foo': [{'bar': {'baz': 'a'}}, {'bar': {'baz': 'b'}},]}]
+        [{'baz': 'a'}, {'baz': 'b'}]
+
+        :param path: A list of a strings
+        :param docs: A list of dicts representing form submissions
+        :return:
+        """
+        if len(path) == 0:
+            return docs
+
+        new_docs = []
+        for doc in docs:
+            next_doc = doc.get(path[0], {})
+            if type(next_doc) == list:
+                new_docs.extend(next_doc)
+            else:
+                new_docs.append(next_doc)
+        return self._get_sub_documents(path[1:], new_docs)
+
+
+class ExportRow(object):
+    def __init__(self, data):
+        self.data = data
+
+
+class RepeatGroup(DocumentSchema):
+    path = SchemaListProperty(StringProperty)
+    last_occurrence = IntegerProperty()
+    items = SchemaListProperty(ExportItem)
+
+
+class ExportableItems(DocumentSchema):
+    """
+    An object representing the things that can be exported for a particular
+    form xmlns or case type.
+    Each item in the list is uniquely identified by its path and doc_type.
+    repeats is a list of RepeatGroups, present at any level of the question hierarchy
+    """
+    items = SchemaListProperty(ExportItem)
+    repeats = SchemaListProperty(RepeatGroup)
+
+
+class ScalarItem(ExportItem):
+    """
+    A text, numeric, date, etc. question or case property
+    """
+    data_type = StringProperty()
+
+
+class Option(DocumentSchema):
+    """
+    This object represents a multiple choice question option.
+
+    last_occurrence is an app build number representing the last version of the app in
+    which this option was present.
+    """
+    last_occurrence = IntegerProperty()
+    value = StringProperty()
+
+
+class MultipleChoiceItem(ExportItem):
+    """
+    A multiple choice question or case property
+    Choices is the union of choices for the question in each of the builds with
+    this question.
+    """
+    choices = SchemaListProperty(Option)
+
+
 
 
 class QuestionMeta(DocumentSchema):

--- a/corehq/apps/export/tests/__init__.py
+++ b/corehq/apps/export/tests/__init__.py
@@ -1,1 +1,2 @@
 from corehq.apps.export.tests.test_form_schema import *
+from corehq.apps.export.tests.test_table_configuration import *

--- a/corehq/apps/export/tests/test_form_schema.py
+++ b/corehq/apps/export/tests/test_form_schema.py
@@ -7,7 +7,7 @@ from jsonobject.exceptions import BadValueError
 
 from corehq.apps.app_manager.models import Application
 from corehq.apps.app_manager.tests.util import TestXmlMixin
-from corehq.apps.reports.models import FormQuestionSchema
+from corehq.apps.export.models import FormQuestionSchema
 
 
 class FormQuestionSchemaTest(SimpleTestCase, TestXmlMixin):

--- a/corehq/apps/export/tests/test_table_configuration.py
+++ b/corehq/apps/export/tests/test_table_configuration.py
@@ -1,0 +1,86 @@
+from django.test import SimpleTestCase
+
+from corehq.apps.export.models import TableConfiguration, ExportColumn, \
+    ScalarItem, ExportRow
+
+
+class TableConfigurationGetRowsTest(SimpleTestCase):
+
+    def test_simple(self):
+        table_configuration = TableConfiguration(
+            columns=[
+                ExportColumn(
+                    item=ScalarItem(
+                        path=['form', 'q3'],
+                    )
+                ),
+                ExportColumn(
+                    item=ScalarItem(
+                        path=['form', 'q1'],
+                    )
+                ),
+            ]
+        )
+        submission = {
+            "form": {
+                "q1": "foo",
+                "q2": "bar",
+                "q3": "baz"
+            }
+        }
+        self.assertEqual(
+            [row.data for row in table_configuration.get_rows(submission)],
+            [ExportRow(['baz', 'foo']).data]
+        )
+
+    def test_repeats(self):
+        table_configuration = TableConfiguration(
+            repeat_path=['form', 'repeat1'],
+            columns=[
+                ExportColumn(
+                    item=ScalarItem(
+                        path=['form', 'repeat1', 'q1'],
+                    )
+                ),
+            ]
+        )
+        submission = {
+            'form': {
+                'repeat1': [
+                    {'q1', 'foo'},
+                    {'q1', 'bar'}
+                ]
+            }
+        }
+        self.assertEqual(
+            table_configuration.get_rows(submission),
+            [ExportRow(['foo']), ExportRow(['bar'])]
+        )
+
+    def test_split_columns(self):
+        # TODO: It probably makes more sense to test columns independently...
+        # I'm assuming they will have some sort of get_value(document) property
+        table_configuration = TableConfiguration(
+            repeat_path=['form'],
+            columns=[
+                SplitExportColumn(
+                    item=MultipleChoiceItem(
+                        path=['form', 'q1'],
+                        options=['a', 'c']
+                    ),
+                    ignore_extras=False
+                ),
+                SplitExportColumn(
+                    item=MultipleChoiceItem(
+                        path=['form', 'q1'],
+                        options=['a', 'c']
+                    ),
+                    ignore_extras=True
+                ),
+            ]
+        )
+        submission = {"form": {"q1": "a b d"}}
+        self.assertEqual(
+            [row.data for row in table_configuration.get_rows(submission)],
+            [ExportRow([1, "", 1, "", "b d"]).data]
+        )

--- a/corehq/apps/reports/models.py
+++ b/corehq/apps/reports/models.py
@@ -25,7 +25,6 @@ from corehq.apps.cachehq.mixins import (
 )
 from corehq.apps.domain.middleware import CCHQPRBACMiddleware
 from corehq.apps.domain.models import Domain
-from corehq.apps.export.models import FormQuestionSchema
 from corehq.apps.hqwebapp.tasks import send_html_email_async
 from corehq.apps.reports.daterange import get_daterange_start_end_dates, get_all_daterange_slugs
 from corehq.apps.reports.dbaccessors import (
@@ -844,6 +843,7 @@ class FormExportSchema(HQExportSchema):
 
     @property
     def question_schema(self):
+        from corehq.apps.export.models import FormQuestionSchema
         return FormQuestionSchema.get_or_create(self.domain, self.app_id, self.xmlns)
 
     @property


### PR DESCRIPTION
@benrudolph here's the outline I've been playing around with, with a few tests demonstrating how I've been thinking the `TableConfiguration` will behave. I'm imagining that each `TableConfiguration` is configured by a user selecting some subset of the items in an `ExportableItems`.
So, the part I was thinking might be good for you to work on now is constructing `ExportableItems`s from apps.
