### PR TITLE
dont reject csrf fail on login urls; till the weird bug is resolved

### DIFF
--- a/corehq/apps/hqwebapp/middleware.py
+++ b/corehq/apps/hqwebapp/middleware.py
@@ -12,17 +12,22 @@ logger = logging.getLogger('')
 class HQCsrfViewMiddleWare(CsrfViewMiddleware):
 
     def _reject(self, request, reason):
+        request_url = request.path
         referring_url = request.META.get('HTTP_REFERER', 'Unknown URL')
         warning = "Request at {url} doesn't contain a csrf token. "\
                   "Referring url is {referer}. Letting the request pass through for now. "\
                   "Check if we are sending csrf_token in the corresponding POST form, if not fix it. "\
                   "Read more here https://github.com/dimagi/commcare-hq/pull/9227".format(
-                      url=request.path,
+                      url=request_url,
                       referer=referring_url,
                   )
         logger.error(warning)  # send it couchlog for log-analysis
         _assert = soft_assert('{}@{}'.format('sreddy+logs', 'dimagi.com'), exponential_backoff=False)
         _assert(False, warning)
+
+        if request_url.find('login'):
+            # exempt login URLs from csrf, but still get failure logs
+            self._accept(request)
 
         if settings.CSRF_SOFT_MODE and reason in [REASON_NO_CSRF_COOKIE, REASON_BAD_TOKEN]:
             return self._accept(request)


### PR DESCRIPTION
Few login attempts are CSRF failing, not all of them are failing (Around 7 users in past two days). In spite of spending good amount of time (including Tyler's), we were not able to reproduce or reason about this bug. Since we do need to turn on CSRF for the Audit, we decided to exempt login from CSRF, till we nail down the bug.

This PR exempts login URLs via our custom middleware so that we still get logs for future analysis.

@TylerSheffels @czue 
