### PR TITLE
Turn on CSRF

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -126,7 +126,7 @@ TEMPLATE_LOADERS = (
 )
 
 # Add this to localsettings and set it to False, so that CSRF protection is enabled on localhost
-CSRF_SOFT_MODE = True
+CSRF_SOFT_MODE = False
 
 MIDDLEWARE_CLASSES = [
     'django.middleware.common.CommonMiddleware',


### PR DESCRIPTION
The CSRF bugs rate has been within 20 per day since past 2 rounds. Here is another round https://github.com/dimagi/commcare-hq/pull/9989

We need to turn on CSRF for doing the audit (and release, of course). I will keep monitoring the logs and do fixes. There are two bugs that we couldn't resolve
1. For login forms - PR to not fail on logins https://github.com/dimagi/commcare-hq/pull/9990
2. Very few of /jserror (around 2 of them) - plan is to let them fail and get more logs

This should be merge after all parent PRs and submodule PRS #9989 #9990 @TylerSheffels @czue 
