### PR TITLE
lazy migrate apps prior to indexing

### DIFF
--- a/corehq/pillows/application.py
+++ b/corehq/pillows/application.py
@@ -36,3 +36,8 @@ class AppPillow(AliasedElasticPillow):
     @classmethod
     def get_unique_id(cls):
         return APP_INDEX
+
+    def change_transform(self, doc_dict):
+        # perform any lazy migrations
+        doc = self.document_class.wrap(doc_dict)
+        return doc.to_json()


### PR DESCRIPTION
ES errors on a bunch of old apps that have `built_with` as a string. Not too much of an issue since they just get excluded from the index except that it slows down the bulk indexing enough to cause `ReadTimeoutError` errors.

@NoahCarnahan 
