### PR TITLE
ILS: Recalculate data after location parent/group change

### DIFF
--- a/custom/ilsgateway/migrations/0004_auto_20160121_1049.py
+++ b/custom/ilsgateway/migrations/0004_auto_20160121_1049.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import datetime
+import json_field.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('locations', '0001_initial'),
+        ('ilsgateway', '0003_auto_20160104_1012'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='PendingReportingDataRecalculation',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('domain', models.CharField(max_length=128)),
+                ('type', models.CharField(max_length=128)),
+                ('data', json_field.fields.JSONField(default='null', help_text='Enter a valid JSON object')),
+                ('sql_location', models.ForeignKey(to='locations.SQLLocation')),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        )
+    ]

--- a/custom/ilsgateway/models.py
+++ b/custom/ilsgateway/models.py
@@ -1,6 +1,6 @@
-from collections import defaultdict
 from datetime import datetime
 
+import json_field
 from django.core.urlresolvers import reverse
 from django.dispatch.dispatcher import receiver
 from corehq.apps.domain.signals import commcare_domain_pre_delete
@@ -561,6 +561,13 @@ class ILSGatewayWebUser(models.Model):
     email = models.CharField(max_length=128)
 
 
+class PendingReportingDataRecalculation(models.Model):
+    domain = models.CharField(max_length=128)
+    sql_location = models.ForeignKey(SQLLocation)
+    type = models.CharField(max_length=128)
+    data = json_field.JSONField()
+
+
 @receiver(commcare_domain_pre_delete)
 def domain_pre_delete_receiver(domain, **kwargs):
     from corehq.apps.domain.deletion import ModelDeletion, CustomDeletion
@@ -614,28 +621,28 @@ def domain_pre_delete_receiver(domain, **kwargs):
 
 @receiver(location_edited)
 def location_edited_receiver(sender, loc, moved, **kwargs):
-    from custom.ilsgateway.tanzania.warehouse.updater import default_start_date, \
-        process_non_facility_warehouse_data
-
+    from custom.ilsgateway.utils import last_location_group
     config = ILSGatewayConfig.for_domain(loc.domain)
-    if not config or not config.enabled or not moved or not loc.previous_parents:
+    if not config or not config.enabled:
         return
 
     last_run = ReportRun.last_success(loc.domain)
     if not last_run:
         return
 
-    previous_parent = SQLLocation.objects.get(location_id=loc.previous_parents[-1])
-    type_location_map = defaultdict(set)
+    if moved:
+        PendingReportingDataRecalculation.objects.create(
+            domain=loc.domain,
+            type='parent_change',
+            sql_location=loc.sql_location,
+            data={'previous_parent': loc.previous_parents[-1], 'current_parent': loc.parent_id}
+        )
 
-    previous_ancestors = list(previous_parent.get_ancestors(include_self=True))
-    actual_ancestors = list(loc.sql_location.get_ancestors())
-
-    for sql_location in previous_ancestors + actual_ancestors:
-        type_location_map[sql_location.location_type.name].add(sql_location)
-
-    for location_type in ["DISTRICT", "REGION", "MSDZONE"]:
-        for sql_location in type_location_map[location_type]:
-            process_non_facility_warehouse_data.delay(
-                sql_location.couch_location, default_start_date(), last_run.end, last_run, strict=False
-            )
+    group = last_location_group(loc)
+    if group != loc.metadata['group']:
+        PendingReportingDataRecalculation.objects.create(
+            domain=loc.domain,
+            type='group_change',
+            sql_location=loc.sql_location,
+            data={'previous_group': group, 'current_group': loc.metadata['group']}
+        )

--- a/custom/ilsgateway/tasks.py
+++ b/custom/ilsgateway/tasks.py
@@ -1,10 +1,10 @@
+from collections import defaultdict
 from datetime import datetime, timedelta
 from functools import partial
 import logging
 from celery.schedules import crontab
 
 from celery.task import task, periodic_task
-from django.conf import settings
 from django.db import transaction
 from psycopg2._psycopg import DatabaseError
 
@@ -18,12 +18,14 @@ from custom.ilsgateway.tanzania.reminders.delivery import DeliveryReminder
 from custom.ilsgateway.tanzania.reminders.randr import RandrReminder
 from custom.ilsgateway.tanzania.reminders.stockonhand import SOHReminder
 from custom.ilsgateway.tanzania.reminders.supervision import SupervisionReminder
+from custom.ilsgateway.tanzania.warehouse.updater import populate_report_data, default_start_date, \
+    process_facility_warehouse_data, process_non_facility_warehouse_data
 from custom.ilsgateway.temporary import fix_stock_data
 from custom.ilsgateway.utils import send_for_day, send_for_all_domains
 from custom.logistics.commtrack import bootstrap_domain as ils_bootstrap_domain, save_stock_data_checkpoint
 from custom.ilsgateway.models import ILSGatewayConfig, SupplyPointStatus, DeliveryGroupReport, ReportRun, \
-    GroupSummary, OrganizationSummary, ProductAvailabilityData, Alert, SupplyPointWarehouseRecord
-from custom.ilsgateway.tanzania.warehouse.updater import populate_report_data
+    GroupSummary, OrganizationSummary, ProductAvailabilityData, Alert, SupplyPointWarehouseRecord, \
+    PendingReportingDataRecalculation
 from custom.logistics.models import StockDataCheckpoint
 from custom.logistics.tasks import stock_data_task
 from dimagi.utils.dates import get_business_day_of_month
@@ -197,6 +199,8 @@ def fix_stock_data_task(domain):
 @task(queue='logistics_background_queue', ignore_result=True)
 def report_run(domain, locations=None, strict=True):
     last_successful_run = ReportRun.last_success(domain)
+    recalculation_on_location_change(domain, last_successful_run)
+
     last_run = ReportRun.last_run(domain)
     start_date = (datetime.min if not last_successful_run else last_successful_run.end)
 
@@ -364,3 +368,67 @@ def third_soh_task():
     last_month_last_day, fifth_business_day = get_last_and_nth_business_day(now, 5)
     if now.day == fifth_business_day.day:
         send_for_all_domains(last_month_last_day, SOHReminder)
+
+
+def recalculate_on_group_change(location, last_run):
+    OrganizationSummary.objects.filter(location_id=location.get_id).delete()
+    process_facility_warehouse_data(location, default_start_date(), last_run.end)
+
+    for parent in location.sql_location.get_ancestors(ascending=True):
+        process_non_facility_warehouse_data(parent.couch_location,
+                                            default_start_date(), last_run.end, strict=False)
+
+
+def recalculate_on_parent_change(location, previous_parent_id, last_run):
+    previous_parent = SQLLocation.objects.get(location_id=previous_parent_id)
+    type_location_map = defaultdict(set)
+
+    previous_ancestors = list(previous_parent.get_ancestors(include_self=True, ascending=True))
+    actual_ancestors = list(location.sql_location.get_ancestors(ascending=True))
+
+    locations_to_recalculate = set()
+
+    i = 0
+    while previous_ancestors[i] != actual_ancestors[i] and i < len(previous_ancestors):
+        locations_to_recalculate.add(previous_ancestors[i])
+        locations_to_recalculate.add(actual_ancestors[i])
+        i += 1
+
+    for sql_location in locations_to_recalculate:
+        type_location_map[sql_location.location_type.name].add(sql_location)
+
+    for location_type in ["DISTRICT", "REGION", "MSDZONE"]:
+        for sql_location in type_location_map[location_type]:
+            process_non_facility_warehouse_data(
+                sql_location.couch_location, default_start_date(), last_run.end, strict=False
+            )
+
+
+def recalculation_on_location_change(domain, last_run):
+    if not last_run:
+        PendingReportingDataRecalculation.objects.filter(domain=domain).delete()
+        return
+
+    pending_recalculations = PendingReportingDataRecalculation.objects.filter(domain=domain).order_by('pk')
+    recalcs_dict = defaultdict(list)
+
+    for pending_recalculation in pending_recalculations:
+        key = (pending_recalculation.sql_location, pending_recalculation.type)
+        recalcs_dict[key].append(pending_recalculation.data)
+
+    for (sql_location, recalculation_type), data_list in recalcs_dict.iteritems():
+        # If there are more changes, consider earliest and latest change.
+        # Thanks to this we avoid recalculations when in fact group/parent wasn't changed.
+        # E.g Group is changed from A -> B and later from B -> A.
+        # In this situation there is no need to recalculate data.
+        if recalculation_type == 'group_change'\
+                and data_list[0]['previous_group'] != data_list[-1]['current_group']:
+            recalculate_on_group_change(sql_location.couch_location, last_run)
+        elif recalculation_type == 'parent_change' \
+                and data_list[0]['previous_parent'] != data_list[-1]['current_parent']:
+            recalculate_on_parent_change(
+                sql_location.couch_location, data_list[0]['previous_parent'], last_run
+            )
+        PendingReportingDataRecalculation.objects.filter(
+            sql_location=sql_location, type=recalculation_type, domain=domain
+        ).delete()

--- a/custom/ilsgateway/tests/handlers/utils.py
+++ b/custom/ilsgateway/tests/handlers/utils.py
@@ -1,6 +1,8 @@
 from corehq.apps.accounting import generator
 from corehq.apps.accounting.models import BillingAccount, DefaultProductPlan, SoftwarePlanEdition, Subscription
 from corehq.apps.commtrack.models import CommtrackActionConfig
+from corehq.apps.custom_data_fields import CustomDataFieldsDefinition
+from corehq.apps.custom_data_fields.models import CustomDataField
 from corehq.apps.domain.models import Domain
 from corehq.apps.locations.models import Location, SQLLocation, LocationType
 from corehq.apps.products.models import Product, SQLProduct
@@ -148,6 +150,15 @@ def prepare_domain(domain_name):
     subscription.save()
     ils_config = ILSGatewayConfig(enabled=True, domain=domain.name, all_stock_data=True)
     ils_config.save()
+    fields_definition = CustomDataFieldsDefinition.get_or_create(domain.name, 'LocationFields')
+    fields_definition.fields.append(CustomDataField(
+        slug='group',
+        label='Group',
+        is_required=False,
+        choices=['A', 'B', 'C'],
+        is_multiple_choice=False
+    ))
+    fields_definition.save()
     return domain
 
 

--- a/custom/ilsgateway/utils.py
+++ b/custom/ilsgateway/utils.py
@@ -7,7 +7,8 @@ from corehq.apps.products.models import SQLProduct
 from corehq.apps.sms.api import send_sms_to_verified_number
 from corehq.form_processor.interfaces.supply import SupplyInterface
 from corehq.util.translation import localize
-from custom.ilsgateway.models import SupplyPointStatus, ILSGatewayConfig
+from custom.ilsgateway.models import SupplyPointStatus, ILSGatewayConfig, GroupSummary, SupplyPointStatusTypes, \
+    DeliveryGroups
 from dimagi.utils.dates import get_business_day_of_month_before
 from django.db.models.aggregates import Max
 
@@ -67,7 +68,7 @@ def send_translated_message(user, message, **kwargs):
 
 def make_loc(code, name, domain, type, metadata=None, parent=None):
     name = name or code
-    location_type, _ = LocationType.objects.get_or_create(domain=domain, name=type)
+    location_type = LocationType.objects.get(domain=domain, name=type)
     loc = Location(site_code=code, name=name, domain=domain, location_type=type, parent=parent)
     loc.metadata = metadata or {}
     loc.save()
@@ -94,3 +95,15 @@ def create_stock_report(location, products_quantities, date=datetime.utcnow()):
             case_id=sql_location.supply_point_id,
             product_id=SQLProduct.objects.get(domain=sql_location.domain, code=product_code).product_id
         ).save()
+
+
+def last_location_group(location):
+    try:
+        gs = GroupSummary.objects.filter(
+            total=1, org_summary__location_id=location.get_id, title=SupplyPointStatusTypes.DELIVERY_FACILITY
+        ).latest('org_summary__date')
+    except GroupSummary.DoesNotExist:
+        return
+
+    delivery_groups = DeliveryGroups(gs.org_summary.date.month)
+    return delivery_groups.current_delivering_group()


### PR DESCRIPTION
@gcapalbo 
http://manage.dimagi.com/default.asp?188509
http://manage.dimagi.com/default.asp?190548#1076366

My idea is to add record about change to DB on location edited signal (https://github.com/dimagi/commcare-hq/pull/9998/files#diff-0e4344fca7ea6c1ae255c1e97a6545c4L616)
and then recalculate data for those changes in daily report run task (https://github.com/dimagi/commcare-hq/pull/9998/files#diff-c38fa7a0ccb68dea7554cfa81582801bR202)
