### PR TITLE
Riak CS backend for blob db

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ cache:
   directories:
     - $HOME/.cache/pip
     - $HOME/virtualenv/python$TRAVIS_PYTHON_VERSION.9
+    - $HOME/moto-s3
 python:
   - "2.7"
 env:

--- a/.travis/localsettings.py
+++ b/.travis/localsettings.py
@@ -26,6 +26,10 @@ COUCH_USERNAME = ''
 COUCH_PASSWORD = ''
 COUCH_DATABASE_NAME = 'commcarehq'
 
+####### S3 mock server config ######
+# See also utils.sh setup_moto_s3_server
+S3_BLOB_DB_SETTINGS = {"url": "http://localhost:5000"}
+
 ######## Email setup ########
 # email settings: these ones are the custom hq ones
 EMAIL_LOGIN = "notifications@dimagi.com"

--- a/.travis/matrix-installs.sh
+++ b/.travis/matrix-installs.sh
@@ -10,6 +10,7 @@ if [ "${MATRIX_TYPE}" = "python" ]; then
 
     setup_elasticsearch
     setup_kafka
+    setup_moto_s3_server
 elif [ "${MATRIX_TYPE}" = "javascript" ]; then
     npm install -g grunt
     npm install -g grunt-cli

--- a/.travis/utils.sh
+++ b/.travis/utils.sh
@@ -19,3 +19,14 @@ setup_kafka() {
     sleep 10
     kafka/bin/kafka-topics.sh --create --partitions 1 --replication-factor 1 --topic case --zookeeper localhost:2181
 }
+
+setup_moto_s3_server() {
+    mkdir -p moto-s3 && cd moto-s3
+    test -d moto-env || virtualenv ./moto-env
+    # todo: switch to https://github.com/spulec/moto.git when PR is merged
+    # https://github.com/spulec/moto/pull/518
+    test -d moto || git clone https://github.com/dimagi/moto.git
+    cd moto
+    ../moto-env/bin/pip install -e .
+    ../moto-env/bin/moto_server -H localhost -p 5000 s3 &
+}

--- a/.travis/utils.sh
+++ b/.travis/utils.sh
@@ -22,11 +22,11 @@ setup_kafka() {
 
 setup_moto_s3_server() {
     mkdir -p moto-s3 && cd moto-s3
-    test -d moto-env || virtualenv ./moto-env
+    test -d env || virtualenv env
     # todo: switch to https://github.com/spulec/moto.git when PR is merged
     # https://github.com/spulec/moto/pull/518
     test -d moto || git clone https://github.com/dimagi/moto.git
-    cd moto
-    ../moto-env/bin/pip install -e .
-    ../moto-env/bin/moto_server -H localhost -p 5000 s3 &
+    env/bin/pip install -e ./moto
+    env/bin/moto_server -H localhost -p 5000 s3 &
+    cd ..
 }

--- a/corehq/blobs/__init__.py
+++ b/corehq/blobs/__init__.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from functools import partial
 
 from .exceptions import Error
 
@@ -10,21 +11,16 @@ def get_blob_db():
         from .fsdb import FilesystemBlobDB
         from .s3db import S3BlobDB
         from django.conf import settings
-        s3_host = getattr(settings, "RIAK_CS_BLOB_DB_HOST", None)
-        if s3_host is None:
+        s3_settings = getattr(settings, "S3_BLOB_DB_SETTINGS", None)
+        if s3_settings is None:
             blob_dir = settings.SHARED_DRIVE_CONF.blob_dir
             if blob_dir is None:
                 reason = settings.SHARED_DRIVE_CONF.get_unset_reason("blob_dir")
                 raise Error("cannot initialize blob db: %s" % reason)
 
-            def db_factory():
-                return FilesystemBlobDB(blob_dir)
+            db_factory = partial(FilesystemBlobDB, blob_dir)
         else:
-            def db_factory():
-                return S3BlobDB(
-                    s3_host,
-                    getattr(settings, "S3_BLOB_DB_PORT", 8080)
-                )
+            db_factory = partial(S3BlobDB, s3_settings)
         _db.append(db_factory())
     return _db[-1]
 

--- a/corehq/blobs/__init__.py
+++ b/corehq/blobs/__init__.py
@@ -1,14 +1,32 @@
+from collections import namedtuple
+
 from .exceptions import Error
+
 _db = []  # singleton/global, stack for tests to push temporary dbs
 
 
 def get_blob_db():
     if not _db:
         from .fsdb import FilesystemBlobDB
+        from .s3db import S3BlobDB
         from django.conf import settings
-        blob_dir = settings.SHARED_DRIVE_CONF.blob_dir
-        if blob_dir is None:
-            reason = settings.SHARED_DRIVE_CONF.get_unset_reason("blob_dir")
-            raise Error("cannot initialize blob db: %s" % reason)
-        _db.append(FilesystemBlobDB(blob_dir))
+        s3_host = getattr(settings, "RIAK_CS_BLOB_DB_HOST", None)
+        if s3_host is None:
+            blob_dir = settings.SHARED_DRIVE_CONF.blob_dir
+            if blob_dir is None:
+                reason = settings.SHARED_DRIVE_CONF.get_unset_reason("blob_dir")
+                raise Error("cannot initialize blob db: %s" % reason)
+
+            def db_factory():
+                return FilesystemBlobDB(blob_dir)
+        else:
+            def db_factory():
+                return S3BlobDB(
+                    s3_host,
+                    getattr(settings, "S3_BLOB_DB_PORT", 8080)
+                )
+        _db.append(db_factory())
     return _db[-1]
+
+
+BlobInfo = namedtuple("BlobInfo", ["name", "length", "digest"])

--- a/corehq/blobs/fsdb.py
+++ b/corehq/blobs/fsdb.py
@@ -7,11 +7,11 @@ import os
 import re
 import shutil
 import sys
-from collections import namedtuple
 from hashlib import md5
 from os.path import commonprefix, exists, isabs, isdir, dirname, join, realpath, sep
 from uuid import uuid4
 
+from corehq.blobs import BlobInfo
 from corehq.blobs.exceptions import BadName, NotFound
 
 CHUNK_SIZE = 4096
@@ -109,9 +109,6 @@ class FilesystemBlobDB(object):
         if name is None:
             return bucket_path
         return safejoin(bucket_path, name)
-
-
-BlobInfo = namedtuple("BlobInfo", ["name", "length", "digest"])
 
 
 def safejoin(root, subpath):

--- a/corehq/blobs/mixin.py
+++ b/corehq/blobs/mixin.py
@@ -164,7 +164,6 @@ class BlobMixin(Document):
         def atomic_blobs_context():
             if self._id is None:
                 self._id = self.get_db().server.next_uuid()
-            non_atomic_blobs = dict(self.blobs)
             old_external_blobs = dict(self.external_blobs)
             if self.migrating_blobs_from_couch:
                 if self._attachments:

--- a/corehq/blobs/s3db.py
+++ b/corehq/blobs/s3db.py
@@ -18,14 +18,14 @@ SAFENAME = re.compile("^[a-z0-9_./-]+$", re.IGNORECASE)
 
 class S3BlobDB(object):
 
-    def __init__(self, settings):
+    def __init__(self, config):
         self.db = boto3.resource(
             's3',
-            endpoint_url=settings.get("url"),
-            aws_access_key_id=settings.get("access_key"),
-            aws_secret_access_key=settings.get("secret_key"),
+            endpoint_url=config.get("url"),
+            aws_access_key_id=config.get("access_key"),
+            aws_secret_access_key=config.get("secret_key"),
         )
-        self.s3_bucket_name = settings.get("s3_bucket", DEFAULT_S3_BUCKET)
+        self.s3_bucket_name = config.get("s3_bucket", DEFAULT_S3_BUCKET)
         self.s3_bucket_exists = False
         # https://github.com/boto/boto3/issues/259
         self.db.meta.client.meta.events.unregister('before-sign.s3', fix_s3_host)

--- a/corehq/blobs/s3db.py
+++ b/corehq/blobs/s3db.py
@@ -1,0 +1,143 @@
+from __future__ import absolute_import
+import base64
+import re
+import shutil
+import sys
+from contextlib import contextmanager, closing
+from hashlib import md5
+from os.path import sep
+from uuid import uuid4
+
+from corehq.blobs import BlobInfo
+from corehq.blobs.exceptions import BadName, NotFound
+
+import boto3
+from botocore.exceptions import ClientError
+from botocore.utils import fix_s3_host
+
+CHUNK_SIZE = 4096
+DEFAULT_S3_BUCKET = "blobdb"
+DEFAULT_BUCKET = "_default"
+SAFENAME = re.compile("^[a-z0-9_./-]+$", re.IGNORECASE)
+
+class S3BlobDB(object):
+
+    def __init__(self, settings):
+        self.db = boto3.resource(
+            's3',
+            endpoint_url=settings.get("url"),
+            aws_access_key_id=settings.get("access_key"),
+            aws_secret_access_key=settings.get("secret_key"),
+        )
+        self.s3_bucket_name = settings.get("s3_bucket", DEFAULT_S3_BUCKET)
+        self.s3_bucket_exists = False
+        # https://github.com/boto/boto3/issues/259
+        self.db.meta.client.meta.events.unregister('before-sign.s3', fix_s3_host)
+
+    def put(self, content, basename="", bucket=DEFAULT_BUCKET):
+        """Put a blob in persistent storage
+
+        :param content: A file-like object in binary read mode.
+        :param basename: Optional name from which the blob name will be
+        derived. This is used to make the unique blob name somewhat
+        recognizable.
+        :param bucket: Optional bucket name used to partition blob data
+        in the persistent storage medium. This may be delimited with
+        slashes (/). It must be a valid relative path.
+        :returns: A `BlobInfo` named tuple. The returned object has a
+        `name` member that must be used to get or delete the blob. It
+        should not be confused with the optional `basename` parameter.
+        """
+        name = self.get_unique_name(basename)
+        path = self.get_path(name, bucket)
+        length = 0
+        data = content.read()
+        digest = md5(data)
+        with self.s3_bucket(True) as s3_bucket:
+            s3_bucket.put_object(Key=path, Body=data)
+        b64digest = base64.b64encode(digest.digest())
+        return BlobInfo(name, length, "md5-" + b64digest)
+
+    def get(self, name, bucket=DEFAULT_BUCKET):
+        """Get a blob
+
+        :param name: The name of the object to get.
+        :param bucket: Optional bucket name. This must have the same
+        value that was passed to ``put``.
+        :raises: `NotFound` if the object does not exist.
+        :returns: A file-like object in binary read mode. The returned
+        object should be closed when finished reading.
+        """
+        path = self.get_path(name, bucket)
+        with self.s3_bucket() as s3_bucket:
+            try:
+                resp = s3_bucket.Object(path).get()
+            except ClientError as err:
+                if err.response["Error"]["Code"] == "NoSuchKey":
+                    raise NotFound(name, bucket)
+                raise
+            return closing(resp["Body"])  # body stream
+
+    def delete(self, name=None, bucket=DEFAULT_BUCKET):
+        """Delete a blob
+
+        :param name: The name of the object to be deleted. The entire
+        bucket will be deleted if this is not specified.
+        :param bucket: Optional bucket name. This must have the same
+        value that was passed to ``put``.
+        :returns: True if the blob was deleted else false.
+        """
+        path = self.get_path(name, bucket)
+        success = True
+        with self.s3_bucket() as s3_bucket:
+            if name is None:
+                summaries = s3_bucket.objects.filter(Prefix=path + "/")
+                pages = ([{"Key": o.key} for o in page]
+                         for page in summaries.pages())
+            else:
+                pages = [[{"Key": path}]]
+            for objects in pages:
+                resp = s3_bucket.delete_objects(Delete={"Objects": objects})
+                if success:
+                    deleted = set(d["Key"] for d in resp["Deleted"])
+                    success = all(o["Key"] in deleted for o in objects)
+        return success
+
+    @contextmanager
+    def s3_bucket(self, create=False):
+        if create and not self.s3_bucket_exists:
+            try:
+                self.db.meta.client.head_bucket(Bucket=self.s3_bucket_name)
+            except ClientError as err:
+                if err.response["Error"]["Code"] != "404":
+                    raise
+                self.db.create_bucket(Bucket=self.s3_bucket_name)
+            self.s3_bucket_exists = True
+        yield self.db.Bucket(self.s3_bucket_name)
+
+    @staticmethod
+    def get_unique_name(basename):
+        if not basename:
+            return uuid4().hex
+        if SAFENAME.match(basename) and "/" not in basename:
+            prefix = basename
+        else:
+            prefix = "unsafe"
+        return prefix + "." + uuid4().hex
+
+    def get_path(self, name=None, bucket=DEFAULT_BUCKET):
+        if name is None:
+            return safepath(bucket)
+        return safejoin(bucket, name)
+
+
+def safepath(path):
+    if not SAFENAME.match(path) or ".." in path or path.startswith(("/", ".")):
+        raise BadName(u"unsafe path name: %r" % path)
+    return path
+
+
+def safejoin(root, subpath):
+    """Join root to subpath ensuring that the result is actually inside root
+    """
+    return safepath(root) + "/" + safepath(subpath)

--- a/corehq/blobs/tests/__init__.py
+++ b/corehq/blobs/tests/__init__.py
@@ -7,6 +7,7 @@ if "django.conf" not in sys.modules:
         UNIT_TESTING=True,
         SECRET_KEY="secret",
         SHARED_DRIVE_CONF=None,
+        SKIP_TESTS_REQUIRING_EXTRA_SETUP=True,
     )
 else:
     from .test_fsdb import *

--- a/corehq/blobs/tests/test_init.py
+++ b/corehq/blobs/tests/test_init.py
@@ -29,6 +29,6 @@ def test_get_blobdb(self, msg, root=True, blob_dir=None):
             temp_dir=None,
             blob_dir=blob_dir,
         )
-        with override_settings(SHARED_DRIVE_CONF=conf):
+        with override_settings(SHARED_DRIVE_CONF=conf, S3_BLOB_DB_SETTINGS=None):
             with assert_raises(mod.Error, msg=re.compile(msg)):
                 mod.get_blob_db()

--- a/corehq/blobs/tests/test_mixin.py
+++ b/corehq/blobs/tests/test_mixin.py
@@ -4,11 +4,15 @@ import uuid
 from base64 import b64encode
 from hashlib import md5
 from os.path import join
-from unittest import TestCase
+from unittest import TestCase, SkipTest
 from StringIO import StringIO
 
+from botocore.exceptions import ClientError
+from django.conf import settings
+
 import corehq.blobs.mixin as mod
-from corehq.blobs.tests.util import TemporaryFilesystemBlobDB
+from corehq.blobs.s3db import ClosingContextProxy
+from corehq.blobs.tests.util import TemporaryFilesystemBlobDB, TemporaryS3BlobDB
 from dimagi.ext.couchdbkit import Document
 
 
@@ -89,19 +93,19 @@ class TestBlobMixin(BaseTestCase):
         content = StringIO(b"test_blob_directory content")
         self.obj.put_attachment(content, name)
         bucket = join("commcarehq_test", self.obj._id)
-        path = self.db.get_path(self.obj.blobs[name].id, bucket)
-        with open(path) as fh:
+        blob = self.get_blob(self.obj.blobs[name].id, bucket)
+        with blob.open() as fh:
             self.assertEqual(fh.read(), b"test_blob_directory content")
 
     def test_put_attachment_deletes_replaced_blob(self):
         name = "test.\u4500"
         bucket = self.obj._blobdb_bucket()
         self.obj.put_attachment("content 1", name)
-        path1 = self.db.get_path(self.obj.blobs[name].id, bucket)
+        blob1 = self.get_blob(self.obj.blobs[name].id, bucket)
         self.obj.put_attachment("content 2", name)
-        path2 = self.db.get_path(self.obj.blobs[name].id, bucket)
-        self.assertNotEqual(path1, path2)
-        self.assertFalse(os.path.exists(path1), "found unexpected file: " + path1)
+        blob2 = self.get_blob(self.obj.blobs[name].id, bucket)
+        self.assertNotEqual(blob1.path, blob2.path)
+        self.assertFalse(blob1.exists(), "found unexpected file: " + blob1.path)
         self.assertEqual(self.obj.fetch_attachment(name), "content 2")
 
     def test_put_attachment_failed_save_does_not_delete_replaced_blob(self):
@@ -112,9 +116,9 @@ class TestBlobMixin(BaseTestCase):
         old_blob = doc.blobs[name]
         with self.assertRaises(BlowUp):
             doc.put_attachment("content 2", name)
-        old_path = self.db.get_path(old_blob.id, bucket)
+        blob = self.get_blob(old_blob.id, bucket)
         doc.blobs[name] = old_blob  # simulate get from couch
-        self.assertTrue(os.path.exists(old_path), "not found: " + old_path)
+        self.assertTrue(blob.exists(), "not found: " + blob.path)
         self.assertEqual(doc.fetch_attachment(name), "content 1")
 
     def test_put_attachment_deletes_couch_attachment(self):
@@ -188,12 +192,12 @@ class TestBlobMixin(BaseTestCase):
         bucket = self.obj._blobdb_bucket()
         with self.obj.atomic_blobs():
             self.obj.put_attachment("content 1", name)
-        path1 = self.db.get_path(self.obj.blobs[name].id, bucket)
+        blob1 = self.get_blob(self.obj.blobs[name].id, bucket)
         with self.obj.atomic_blobs():
             self.obj.put_attachment("content 2", name)
-        path2 = self.db.get_path(self.obj.blobs[name].id, bucket)
-        self.assertNotEqual(path1, path2)
-        self.assertFalse(os.path.exists(path1), "found unexpected file: " + path1)
+        blob2 = self.get_blob(self.obj.blobs[name].id, bucket)
+        self.assertNotEqual(blob1.path, blob2.path)
+        self.assertFalse(blob1.exists(), "found unexpected blob: " + blob1.path)
         self.assertEqual(self.obj.fetch_attachment(name), "content 2")
 
     def test_atomic_blobs_deletes_replaced_blob_in_same_context(self):
@@ -201,11 +205,11 @@ class TestBlobMixin(BaseTestCase):
         bucket = self.obj._blobdb_bucket()
         with self.obj.atomic_blobs():
             self.obj.put_attachment("content 1", name)
-            path1 = self.db.get_path(self.obj.blobs[name].id, bucket)
+            blob1 = self.get_blob(self.obj.blobs[name].id, bucket)
             self.obj.put_attachment("content 2", name)
-        path2 = self.db.get_path(self.obj.blobs[name].id, bucket)
-        self.assertNotEqual(path1, path2)
-        self.assertFalse(os.path.exists(path1), "found unexpected file: " + path1)
+        blob2 = self.get_blob(self.obj.blobs[name].id, bucket)
+        self.assertNotEqual(blob1.path, blob2.path)
+        self.assertFalse(blob1.exists(), "found unexpected blob: " + blob1.path)
         self.assertEqual(self.obj.fetch_attachment(name), "content 2")
 
     def test_atomic_blobs_deletes_replaced_blob_in_nested_context(self):
@@ -213,12 +217,12 @@ class TestBlobMixin(BaseTestCase):
         bucket = self.obj._blobdb_bucket()
         with self.obj.atomic_blobs():
             self.obj.put_attachment("content 1", name)
-            path1 = self.db.get_path(self.obj.blobs[name].id, bucket)
+            blob1 = self.get_blob(self.obj.blobs[name].id, bucket)
             with self.obj.atomic_blobs():
                 self.obj.put_attachment("content 2", name)
-        path2 = self.db.get_path(self.obj.blobs[name].id, bucket)
-        self.assertNotEqual(path1, path2)
-        self.assertFalse(os.path.exists(path1), "found unexpected file: " + path1)
+        blob2 = self.get_blob(self.obj.blobs[name].id, bucket)
+        self.assertNotEqual(blob1.path, blob2.path)
+        self.assertFalse(blob1.exists(), "found unexpected blob: " + blob1.path)
         self.assertEqual(self.obj.fetch_attachment(name), "content 2")
 
     def test_atomic_blobs_preserves_blob_replaced_in_failed_nested_context(self):
@@ -226,14 +230,14 @@ class TestBlobMixin(BaseTestCase):
         bucket = self.obj._blobdb_bucket()
         with self.obj.atomic_blobs():
             self.obj.put_attachment("content 1", name)
-            path1 = self.db.get_path(self.obj.blobs[name].id, bucket)
+            blob1 = self.get_blob(self.obj.blobs[name].id, bucket)
             with self.assertRaises(BlowUp):
                 with self.obj.atomic_blobs():
                     self.obj.put_attachment("content 2", name)
-                    path2 = self.db.get_path(self.obj.blobs[name].id, bucket)
+                    blob2 = self.get_blob(self.obj.blobs[name].id, bucket)
                     raise BlowUp("fail")
-        self.assertNotEqual(path1, path2)
-        self.assertFalse(os.path.exists(path2), "found unexpected file: " + path1)
+        self.assertNotEqual(blob1.path, blob2.path)
+        self.assertFalse(blob2.exists(), "found unexpected blob: " + blob2.path)
         self.assertEqual(self.obj.fetch_attachment(name), "content 1")
 
     def test_atomic_blobs_fail(self):
@@ -267,8 +271,8 @@ class TestBlobMixin(BaseTestCase):
         self.assertEqual(self.obj.blobs[name].content_length, 7)
         self.assertEqual(self.obj.fetch_attachment(name), "content")
         # verify cleanup
-        path = self.db.get_path(bucket=self.obj._blobdb_bucket())
-        self.assertEqual(len(os.listdir(path)), len(self.obj.blobs))
+        blob = self.get_blob(bucket=self.obj._blobdb_bucket())
+        self.assertEqual(len(blob.listdir()), len(self.obj.blobs))
 
     def test_atomic_blobs_fail_restores_couch_attachments(self):
         couch_digest = "md5-" + b64encode(md5(b"content").digest())
@@ -286,8 +290,8 @@ class TestBlobMixin(BaseTestCase):
         self.assertEqual(doc.blobs["att"].content_length, 13)
         self.assertEqual(doc.fetch_attachment("att"), "couch content")
         # verify cleanup
-        path = self.db.get_path(bucket=doc._blobdb_bucket())
-        self.assertEqual(len(os.listdir(path)), 0)
+        blob = self.get_blob(bucket=doc._blobdb_bucket())
+        self.assertEqual(len(blob.listdir()), 0)
 
     def test_atomic_blobs_fail_restores_deleted_blob(self):
         name = "delete-fail"
@@ -299,8 +303,8 @@ class TestBlobMixin(BaseTestCase):
         self.assertEqual(self.obj.blobs[name].content_length, 7)
         self.assertEqual(self.obj.fetch_attachment(name), "content")
         # verify cleanup
-        path = self.db.get_path(bucket=self.obj._blobdb_bucket())
-        self.assertEqual(len(os.listdir(path)), len(self.obj.blobs))
+        blob = self.get_blob(bucket=self.obj._blobdb_bucket())
+        self.assertEqual(len(blob.listdir()), len(self.obj.blobs))
 
     def test_atomic_blobs_fail_restores_deleted_couch_attachment(self):
         couch_digest = "md5-" + b64encode(md5(b"content").digest())
@@ -318,8 +322,63 @@ class TestBlobMixin(BaseTestCase):
         self.assertEqual(doc.blobs["att"].content_length, 13)
         self.assertEqual(doc.fetch_attachment("att"), "couch content")
         # verify cleanup
-        path = self.db.get_path(bucket=doc._blobdb_bucket())
-        self.assertTrue(not os.path.exists(path) or len(os.listdir(path)) == 0)
+        blob = self.get_blob(bucket=doc._blobdb_bucket())
+        self.assertTrue(not blob.exists() or len(blob.listdir()) == 0)
+
+    def get_blob(self, name=None, bucket=None):
+        return self.TestBlob(self.db, name, bucket)
+
+    class TestBlob(object):
+
+        def __init__(self, db, name, bucket):
+            self.db = db
+            self.path = db.get_path(name, bucket)
+
+        def exists(self):
+            return os.path.exists(self.path)
+
+        def open(self):
+            return open(self.path)
+
+        def listdir(self):
+            return os.listdir(self.path)
+
+
+class TestBlobMixinWithS3Backend(TestBlobMixin):
+
+    @classmethod
+    def setUpClass(cls):
+        s3_settings = getattr(settings, "S3_BLOB_DB_SETTINGS", None)
+        if s3_settings is None:
+            raise SkipTest("S3_BLOB_DB_SETTINGS not configured")
+        cls.db = TemporaryS3BlobDB(s3_settings)
+
+    class TestBlob(object):
+
+        def __init__(self, db, name, bucket):
+            self.db = db
+            self.path = db.get_path(name, bucket)
+
+        @property
+        def s3_bucket(self):
+            return self.db.db.Bucket(self.db.s3_bucket_name)
+
+        def exists(self):
+            try:
+                self.s3_bucket.Object(self.path).load()
+            except ClientError as err:
+                if err.response["Error"]["Code"] != "404":
+                    raise
+                return False
+            return True
+
+        def open(self):
+            obj = self.s3_bucket.Object(self.path).get()
+            return ClosingContextProxy(obj["Body"])
+
+        def listdir(self):
+            summaries = self.s3_bucket.objects.filter(Prefix=self.path + "/")
+            return [o.key for o in summaries]
 
 
 class FakeCouchDocument(mod.BlobMixin, Document):

--- a/corehq/blobs/tests/test_mixin.py
+++ b/corehq/blobs/tests/test_mixin.py
@@ -4,7 +4,7 @@ import uuid
 from base64 import b64encode
 from hashlib import md5
 from os.path import join
-from unittest import TestCase, SkipTest
+from unittest import TestCase
 from StringIO import StringIO
 
 from botocore.exceptions import ClientError
@@ -13,6 +13,7 @@ from django.conf import settings
 import corehq.blobs.mixin as mod
 from corehq.blobs.s3db import ClosingContextProxy
 from corehq.blobs.tests.util import TemporaryFilesystemBlobDB, TemporaryS3BlobDB
+from corehq.util.test_utils import trap_extra_setup
 from dimagi.ext.couchdbkit import Document
 
 
@@ -348,10 +349,9 @@ class TestBlobMixinWithS3Backend(TestBlobMixin):
 
     @classmethod
     def setUpClass(cls):
-        s3_settings = getattr(settings, "S3_BLOB_DB_SETTINGS", None)
-        if s3_settings is None:
-            raise SkipTest("S3_BLOB_DB_SETTINGS not configured")
-        cls.db = TemporaryS3BlobDB(s3_settings)
+        with trap_extra_setup(AttributeError, msg="S3_BLOB_DB_SETTINGS not configured"):
+            config = settings.S3_BLOB_DB_SETTINGS
+        cls.db = TemporaryS3BlobDB(config)
 
     class TestBlob(object):
 

--- a/corehq/blobs/tests/test_s3db.py
+++ b/corehq/blobs/tests/test_s3db.py
@@ -56,11 +56,10 @@ Finally, add the following to `localsettings.py`:
 ## Alternate/easier/faster testing setup using moto (probably not as robust)
 
     mkdir moto-s3 && cd moto-s3
-    virtualenv moto-env
+    virtualenv env
     git clone https://github.com/dimagi/moto.git
-    cd moto
-    ../moto-env/bin/pip install -e .
-    ../moto-env/bin/moto_server -p 5000 &
+    env/bin/pip install -e ./moto
+    env/bin/moto_server -p 5000
 
 Add the following to localsettings.py
 

--- a/corehq/blobs/tests/test_s3db.py
+++ b/corehq/blobs/tests/test_s3db.py
@@ -57,7 +57,7 @@ Finally, add the following to `localsettings.py`:
 
     mkdir moto-s3 && cd moto-s3
     virtualenv moto-env
-    git clone -b fix-s3-server https://github.com/millerdev/moto.git
+    git clone https://github.com/dimagi/moto.git
     cd moto
     ../moto-env/bin/pip install -e .
     ../moto-env/bin/moto_server -p 5000 &

--- a/corehq/blobs/tests/test_s3db.py
+++ b/corehq/blobs/tests/test_s3db.py
@@ -1,3 +1,58 @@
+"""Test S3 Blob DB
+
+Commands to setup Docker with Riak CS for development/testing
+
+First, [install Docker](https://docs.docker.com/mac/#h_installation). Then
+initialize a docker machine for Riak CS:
+
+    git clone https://github.com/hectcastro/docker-riak-cs
+    cd docker-riak-cs
+    docker-machine create --driver virtualbox riakcs
+    eval "$(docker-machine env riakcs)"
+    # recommended 5-node cluster is slow and resource hungry; use 1 node
+    DOCKER_RIAK_CS_CLUSTER_SIZE=1 make start-cluster
+
+Test Riak CS connection:
+
+    DOCKER_RIAKCS_HOST=$(echo $DOCKER_HOST | cut -d/ -f3 | cut -d: -f1)
+    DOCKER_RIAKCS_PORT=$(docker port riak-cs01 8080 | cut -d: -f2)
+    curl -i http://$DOCKER_RIAKCS_HOST:$DOCKER_RIAKCS_PORT; echo ""
+    # expected output:
+    # HTTP/1.1 403 Forbidden
+    # Server: Riak CS ...
+
+Get admin-key and admin-secret from riak-cs01 container:
+
+    RIAKCS_SSH_PORT=$(docker port riak-cs01 22 | cut -d: -f2)
+    ssh -i .insecure_key -p $RIAKCS_SSH_PORT root@$DOCKER_RIAKCS_HOST \
+        'egrep "admin_key|admin_secret" /etc/riak-cs/app.config'
+    # copy key values into localsettings.py S3_BLOB_DB_SETTINGS (see below)
+
+Finally, add the following to `localsettings.py`:
+
+    def _get_riak_params():
+        # these can change depending on host state
+        import os, re, subprocess
+        def run(command, pattern=None, group=1):
+            out = subprocess.check_output(command.split())
+            return re.search(pattern, out).group(group) if pattern else out
+        try:
+            evars = run("docker-machine env riakcs")
+            for match in re.finditer(r'export (.*?)="(.*?)"', evars):
+                os.environ[match.group(1)] = match.group(2)
+            host = re.search(r'DOCKER_HOST="tcp://(.*?):', evars).group(1)
+            port = run("docker port riak-cs01 8080", r':(\d+)')
+            return {"host": host, "port": port}
+        except Exception:
+            return None  # docker host is not running
+    _riak_params = _get_riak_params()
+    if _riak_params:
+        S3_BLOB_DB_SETTINGS = {
+            "url": "http://{host}:{port}".format(**_riak_params),
+            "access_key": "admin key value",
+            "secret_key": "admin secret value",
+        }
+"""
 from __future__ import unicode_literals
 from os.path import join
 from unittest import TestCase, SkipTest
@@ -14,6 +69,10 @@ class TestS3BlobDB(TestCase):
 
     @classmethod
     def setUpClass(cls):
+        # use trap_extra_setup when Riak CS is setup on travis (or maybe
+        # use something more lightweight like the options mentioned on
+        # http://stackoverflow.com/questions/6615988)
+        #with trap_extra_setup(AttributeError, msg="S3_BLOB_DB_SETTINGS not configured"):
         s3_settings = getattr(settings, "S3_BLOB_DB_SETTINGS", None)
         if s3_settings is None:
             raise SkipTest("S3_BLOB_DB_SETTINGS not configured")

--- a/corehq/blobs/tests/test_s3db.py
+++ b/corehq/blobs/tests/test_s3db.py
@@ -1,0 +1,89 @@
+from __future__ import unicode_literals
+from os.path import join
+from unittest import TestCase, SkipTest
+from StringIO import StringIO
+
+from django.conf import settings
+
+import corehq.blobs.s3db as mod
+from corehq.blobs.tests.util import TemporaryS3BlobDB
+from corehq.util.test_utils import generate_cases
+
+
+class TestS3BlobDB(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        s3_settings = getattr(settings, "S3_BLOB_DB_SETTINGS", None)
+        if s3_settings is None:
+            raise SkipTest("S3_BLOB_DB_SETTINGS not configured")
+        cls.db = TemporaryS3BlobDB(s3_settings)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.db.close()
+
+    def test_put_and_get(self):
+        name = "test.1"
+        info = self.db.put(StringIO(b"content"), name)
+        with self.db.get(info.name) as fh:
+            self.assertEqual(fh.read(), b"content")
+
+    def test_put_and_get_with_unicode_names(self):
+        name = "test.\u4500"
+        bucket = "doc.4500"
+        info = self.db.put(StringIO(b"content"), name, bucket)
+        with self.db.get(info.name, bucket) as fh:
+            self.assertEqual(fh.read(), b"content")
+
+    def test_put_and_get_with_bucket(self):
+        name = "test.2"
+        bucket = "doc.2"
+        info = self.db.put(StringIO(b"content"), name, bucket)
+        with self.db.get(info.name, bucket) as fh:
+            self.assertEqual(fh.read(), b"content")
+
+    def test_put_with_bucket_and_get_without_bucket(self):
+        name = "test.3"
+        bucket = "doc.3"
+        info = self.db.put(StringIO(b"content"), name, bucket)
+        with self.assertRaises(mod.NotFound):
+            self.db.get(info.name)
+
+    def test_delete(self):
+        name = "test.4"
+        bucket = "doc.4"
+        info = self.db.put(StringIO(b"content"), name, bucket)
+
+        self.assertTrue(self.db.delete(info.name, bucket), 'delete failed')
+
+        with self.assertRaises(mod.NotFound):
+            self.db.get(info.name, bucket)
+
+        # boto3 client reports that the object was deleted even if there was
+        # no object to delete
+        #self.assertFalse(self.db.delete(info.name, bucket), 'delete should fail')
+
+    def test_delete_bucket(self):
+        bucket = join("doctype", "ys7v136b")
+        info = self.db.put(StringIO(b"content"), bucket=bucket)
+        self.assertTrue(self.db.delete(bucket=bucket))
+
+        self.assertTrue(info.name)
+        with self.assertRaises(mod.NotFound):
+            self.db.get(info.name, bucket=bucket)
+
+
+@generate_cases([
+    ("test.1", "\u4500.1"),
+    ("test.1", "/tmp/notallowed"),
+    ("test.1", "."),
+    ("test.1", ".."),
+    ("test.1", "../notallowed"),
+    ("test.1", "notallowed/.."),
+    ("/test.1",),
+    ("../test.1",),
+], TestS3BlobDB)
+def test_bad_name(self, name, bucket=mod.DEFAULT_BUCKET):
+    with self.assertRaises(mod.BadName):
+        self.db.get(name, bucket)

--- a/corehq/blobs/tests/util.py
+++ b/corehq/blobs/tests/util.py
@@ -54,7 +54,8 @@ class TemporaryS3BlobDB(TemporaryBlobDBMixin, S3BlobDB):
 
     def __init__(self, settings):
         settings = dict(settings)
-        settings["s3_bucket"] = "test-blobdb"
+        settings.setdefault("s3_bucket", "test-blobdb")
+        assert settings["s3_bucket"].startswith("test-"), settings["s3_bucket"]
         super(TemporaryS3BlobDB, self).__init__(settings)
 
     def clean_db(self):

--- a/corehq/blobs/tests/util.py
+++ b/corehq/blobs/tests/util.py
@@ -59,10 +59,10 @@ class TemporaryS3BlobDB(TemporaryBlobDBMixin, S3BlobDB):
         super(TemporaryS3BlobDB, self).__init__(settings)
 
     def clean_db(self):
-        if not self.s3_bucket_exists:
+        if not self._s3_bucket_exists:
             return
         assert self.s3_bucket_name.startswith("test-"), self.s3_bucket_name
-        s3_bucket = self.s3_bucket()
+        s3_bucket = self._s3_bucket()
         summaries = s3_bucket.objects.all()
         for page in summaries.pages():
             objects = [{"Key": o.key} for o in page]

--- a/corehq/blobs/tests/util.py
+++ b/corehq/blobs/tests/util.py
@@ -62,9 +62,9 @@ class TemporaryS3BlobDB(TemporaryBlobDBMixin, S3BlobDB):
         if not self.s3_bucket_exists:
             return
         assert self.s3_bucket_name.startswith("test-"), self.s3_bucket_name
-        with self.s3_bucket() as s3_bucket:
-            summaries = s3_bucket.objects.all()
-            for page in summaries.pages():
-                objects = [{"Key": o.key} for o in page]
-                s3_bucket.delete_objects(Delete={"Objects": objects})
-            s3_bucket.delete()
+        s3_bucket = self.s3_bucket()
+        summaries = s3_bucket.objects.all()
+        for page in summaries.pages():
+            objects = [{"Key": o.key} for o in page]
+            s3_bucket.delete_objects(Delete={"Objects": objects})
+        s3_bucket.delete()

--- a/corehq/blobs/tests/util.py
+++ b/corehq/blobs/tests/util.py
@@ -3,17 +3,17 @@ from tempfile import mkdtemp
 
 import corehq.blobs as blobs
 from corehq.blobs.fsdb import FilesystemBlobDB
+from corehq.blobs.s3db import S3BlobDB
 
 
-class TemporaryFilesystemBlobDB(FilesystemBlobDB):
+class TemporaryBlobDBMixin(object):
     """Create temporary blob db and install as global blob db
 
     Global blob DB can be retrieved with `corehq.blobs.get_blob_db()`
     """
 
-    def __init__(self):
-        rootdir = mkdtemp(prefix="blobdb")
-        super(TemporaryFilesystemBlobDB, self).__init__(rootdir)
+    def __init__(self, *args, **kw):
+        super(TemporaryBlobDBMixin, self).__init__(*args, **kw)
 
         blobs._db.append(self)
         try:
@@ -27,11 +27,43 @@ class TemporaryFilesystemBlobDB(FilesystemBlobDB):
         try:
             blobs._db.remove(self)
         finally:
-            rmtree(self.rootdir)
-            self.rootdir = None
+            self.clean_db()
+
+    def clean_db(self):
+        raise NotImplementedError("abstract method")
 
     def __enter__(self):
         return self
 
     def __exit__(self, *exc_info):
         self.close()
+
+
+class TemporaryFilesystemBlobDB(TemporaryBlobDBMixin, FilesystemBlobDB):
+
+    def __init__(self):
+        rootdir = mkdtemp(prefix="blobdb")
+        super(TemporaryFilesystemBlobDB, self).__init__(rootdir)
+
+    def clean_db(self):
+        rmtree(self.rootdir)
+        self.rootdir = None
+
+
+class TemporaryS3BlobDB(TemporaryBlobDBMixin, S3BlobDB):
+
+    def __init__(self, settings):
+        settings = dict(settings)
+        settings["s3_bucket"] = "test-blobdb"
+        super(TemporaryS3BlobDB, self).__init__(settings)
+
+    def clean_db(self):
+        if not self.s3_bucket_exists:
+            return
+        assert self.s3_bucket_name.startswith("test-"), self.s3_bucket_name
+        with self.s3_bucket() as s3_bucket:
+            summaries = s3_bucket.objects.all()
+            for page in summaries.pages():
+                objects = [{"Key": o.key} for o in page]
+                s3_bucket.delete_objects(Delete={"Objects": objects})
+            s3_bucket.delete()

--- a/corehq/tests/nose.py
+++ b/corehq/tests/nose.py
@@ -113,15 +113,19 @@ class ErrorOnDbAccessContext(object):
         mock_couch = Mock(side_effect=error, spec=[])
 
         # register our dbs with the extension document classes
+        self.real_couch_dbs = dbs = []
         old_handler = loading.couchdbkit_handler
         for app, value in old_handler.app_schema.items():
             for name, cls in value.items():
+                dbs.append((cls, cls.get_db()))
                 cls.set_db(mock_couch)
 
     def teardown(self):
         """Enable database access"""
         from django.conf import settings
         settings.DB_ENABLED = self.original_db_enabled
+        for cls, db in self.real_couch_dbs:
+            cls.set_db(db)
         self.db_patch.stop()
 
 

--- a/corehq/util/test_utils.py
+++ b/corehq/util/test_utils.py
@@ -5,11 +5,9 @@ import json
 import logging
 import mock
 import os
-from unittest import TestCase
+from unittest import TestCase, SkipTest
 from collections import namedtuple
 from contextlib import contextmanager
-
-from unittest.case import SkipTest
 
 from fakecouch import FakeCouchDb
 from functools import wraps
@@ -37,7 +35,7 @@ unit_testing_only.__test__ = False
 
 
 @contextmanager
-def trap_extra_setup(*exceptions):
+def trap_extra_setup(*exceptions, **kw):
     """Conditioinally skip test on error
 
     Use this context manager to skip tests that would otherwise fail in
@@ -50,12 +48,16 @@ def trap_extra_setup(*exceptions):
     false there.
     """
     assert exceptions, "at least one argument is required"
+    msg = kw.pop("msg", "")
+    assert not kw, "unknown keyword args: {}".format(kw)
     skip = getattr(settings, "SKIP_TESTS_REQUIRING_EXTRA_SETUP", False)
     try:
         yield
     except exceptions as err:
         if skip:
-            raise SkipTest("{}: {}".format(type(err).__name__, err))
+            if msg:
+                msg += ": "
+            raise SkipTest("{}{}: {}".format(msg, type(err).__name__, err))
         raise
 
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -81,3 +81,4 @@ alembic==0.6.4
 pyzxcvbn==0.5.0
 django-statici18n==1.1.5
 httpagentparser==1.7.8
+boto3==1.2.3


### PR DESCRIPTION
This change has no effect if `S3_BLOB_DB_SETTINGS` is not found in django settings. Before we can use this in production we'll need a migration script to move blobs from fsdb to s3db (to be done in a separate PR).

`test_s3db.py` contains instructions for setting up Riak CS for testing/development.

@dannyroberts @benrudolph cc @czue @snopoke @calellowitz 
