### PR TITLE
Revert "Revert "don't fail hard on missing saved exports""

### DIFF
--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -54,6 +54,7 @@ from corehq.apps.users.permissions import FORM_EXPORT_PERMISSION, CASE_EXPORT_PE
     DEID_EXPORT_PERMISSION
 from corehq.couchapps.dbaccessors import \
     get_attachment_size_by_domain_app_id_xmlns
+from corehq.util import get_document_or_404
 from corehq.util.timezones.utils import get_timezone_for_user
 from couchexport.models import SavedExportSchema, ExportSchema
 from couchexport.schema import build_latest_schema
@@ -487,8 +488,8 @@ class BaseDownloadExportView(ExportsPermissionsMixin, JSONResponseMixin, BasePro
         raise NotImplementedError("You must implement download_export_form.")
 
     @staticmethod
-    def get_export_schema(export_id):
-        return SavedExportSchema.get(export_id)
+    def get_export_schema(domain, export_id):
+        return get_document_or_404(SavedExportSchema, domain, export_id)
 
     @property
     def export_id(self):
@@ -509,10 +510,10 @@ class BaseDownloadExportView(ExportsPermissionsMixin, JSONResponseMixin, BasePro
             and not self.request.is_ajax()
         ):
             raw_export_list = json.loads(self.request.POST['export_list'])
-            exports = map(lambda e: self.get_export_schema(e['id']),
+            exports = map(lambda e: self.get_export_schema(self.domain, e['id']),
                           raw_export_list)
         elif self.export_id:
-            exports = [self.get_export_schema(self.export_id)]
+            exports = [self.get_export_schema(self.domain, self.export_id)]
 
         if not self.has_view_permissions:
             if self.has_deid_view_permissions:
@@ -543,13 +544,6 @@ class BaseDownloadExportView(ExportsPermissionsMixin, JSONResponseMixin, BasePro
         """
         raise NotImplementedError(
             "Must return a SerializableFunction for get_filters."
-        )
-
-    def get_export_object(self, export_id):
-        """Must return either a FormExportSchema or CaseExportSchema object
-        """
-        raise NotImplementedError(
-            "Must implement get_export_object."
         )
 
     @allow_remote_invocation
@@ -608,7 +602,7 @@ class BaseDownloadExportView(ExportsPermissionsMixin, JSONResponseMixin, BasePro
     def _get_download_task(self, export_specs, export_filter, max_column_size=2000):
         try:
             export_data = export_specs[0]
-            export_object = self.get_export_object(export_data['export_id'])
+            export_object = self.get_export_schema(self.domain, export_data['export_id'])
         except (KeyError, IndexError):
             raise ExportAsyncException(
                 _("You need to pass a list of at least one export schema.")
@@ -702,8 +696,8 @@ class DownloadFormExportView(BaseDownloadExportView):
     form_or_case = 'form'
 
     @staticmethod
-    def get_export_schema(export_id):
-        return FormExportSchema.get(export_id)
+    def get_export_schema(domain, export_id):
+        return get_document_or_404(FormExportSchema, domain, export_id)
 
     @property
     def export_list_url(self):
@@ -742,16 +736,13 @@ class DownloadFormExportView(BaseDownloadExportView):
                                              filter=form_filter)
         return export_filter
 
-    def get_export_object(self, export_id):
-        return FormExportSchema.get(export_id)
-
     @allow_remote_invocation
     def has_multimedia(self, in_data):
         """Checks to see if this form export has multimedia available to export
         """
         try:
             size_hash = get_attachment_size_by_domain_app_id_xmlns(self.domain)
-            export_object = self.get_export_object(self.export_id)
+            export_object = self.get_export_schema(self.domain, self.export_id)
             hash_key = (export_object.app_id, export_object.xmlns
                         if hasattr(export_object, 'xmlns') else '')
             has_multimedia = hash_key in size_hash
@@ -777,7 +768,7 @@ class DownloadFormExportView(BaseDownloadExportView):
                     _("Please check that you've submitted all required filters.")
                 )
             download = DownloadBase()
-            export_object = self.get_export_schema(export_specs[0]['export_id'])
+            export_object = self.get_export_schema(self.domain, export_specs[0]['export_id'])
             task_kwargs = filter_form.get_multimedia_task_kwargs(
                 export_object, download.download_id
             )
@@ -810,8 +801,8 @@ class DownloadCaseExportView(BaseDownloadExportView):
     form_or_case = 'case'
 
     @staticmethod
-    def get_export_schema(export_id):
-        return CaseExportSchema.get(export_id)
+    def get_export_schema(domain, export_id):
+        return get_document_or_404(CaseExportSchema, domain, export_id)
 
     @property
     def export_list_url(self):
@@ -841,9 +832,6 @@ class DownloadCaseExportView(BaseDownloadExportView):
         if not filter_form.is_valid():
             raise ExportFormValidationException()
         return filter_form.get_case_filter()
-
-    def get_export_object(self, export_id):
-        return CaseExportSchema.get(export_id)
 
 
 class BaseExportListView(ExportsPermissionsMixin, JSONResponseMixin, BaseProjectDataView):

--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -54,7 +54,7 @@ from corehq.apps.users.permissions import FORM_EXPORT_PERMISSION, CASE_EXPORT_PE
     DEID_EXPORT_PERMISSION
 from corehq.couchapps.dbaccessors import \
     get_attachment_size_by_domain_app_id_xmlns
-from corehq.util import get_document_or_404
+from corehq.util.couch import get_document_or_404_lite
 from corehq.util.timezones.utils import get_timezone_for_user
 from couchexport.models import SavedExportSchema, ExportSchema
 from couchexport.schema import build_latest_schema
@@ -488,8 +488,8 @@ class BaseDownloadExportView(ExportsPermissionsMixin, JSONResponseMixin, BasePro
         raise NotImplementedError("You must implement download_export_form.")
 
     @staticmethod
-    def get_export_schema(domain, export_id):
-        return get_document_or_404(SavedExportSchema, domain, export_id)
+    def get_export_schema(export_id):
+        return get_document_or_404_lite(SavedExportSchema, export_id)
 
     @property
     def export_id(self):
@@ -510,10 +510,10 @@ class BaseDownloadExportView(ExportsPermissionsMixin, JSONResponseMixin, BasePro
             and not self.request.is_ajax()
         ):
             raw_export_list = json.loads(self.request.POST['export_list'])
-            exports = map(lambda e: self.get_export_schema(self.domain, e['id']),
+            exports = map(lambda e: self.get_export_schema(e['id']),
                           raw_export_list)
         elif self.export_id:
-            exports = [self.get_export_schema(self.domain, self.export_id)]
+            exports = [self.get_export_schema(self.export_id)]
 
         if not self.has_view_permissions:
             if self.has_deid_view_permissions:
@@ -602,7 +602,7 @@ class BaseDownloadExportView(ExportsPermissionsMixin, JSONResponseMixin, BasePro
     def _get_download_task(self, export_specs, export_filter, max_column_size=2000):
         try:
             export_data = export_specs[0]
-            export_object = self.get_export_schema(self.domain, export_data['export_id'])
+            export_object = self.get_export_schema(export_data['export_id'])
         except (KeyError, IndexError):
             raise ExportAsyncException(
                 _("You need to pass a list of at least one export schema.")
@@ -696,8 +696,8 @@ class DownloadFormExportView(BaseDownloadExportView):
     form_or_case = 'form'
 
     @staticmethod
-    def get_export_schema(domain, export_id):
-        return get_document_or_404(FormExportSchema, domain, export_id)
+    def get_export_schema(export_id):
+        return get_document_or_404_lite(FormExportSchema, export_id)
 
     @property
     def export_list_url(self):
@@ -742,7 +742,7 @@ class DownloadFormExportView(BaseDownloadExportView):
         """
         try:
             size_hash = get_attachment_size_by_domain_app_id_xmlns(self.domain)
-            export_object = self.get_export_schema(self.domain, self.export_id)
+            export_object = self.get_export_schema(self.export_id)
             hash_key = (export_object.app_id, export_object.xmlns
                         if hasattr(export_object, 'xmlns') else '')
             has_multimedia = hash_key in size_hash
@@ -768,7 +768,7 @@ class DownloadFormExportView(BaseDownloadExportView):
                     _("Please check that you've submitted all required filters.")
                 )
             download = DownloadBase()
-            export_object = self.get_export_schema(self.domain, export_specs[0]['export_id'])
+            export_object = self.get_export_schema(export_specs[0]['export_id'])
             task_kwargs = filter_form.get_multimedia_task_kwargs(
                 export_object, download.download_id
             )
@@ -801,8 +801,8 @@ class DownloadCaseExportView(BaseDownloadExportView):
     form_or_case = 'case'
 
     @staticmethod
-    def get_export_schema(domain, export_id):
-        return get_document_or_404(CaseExportSchema, domain, export_id)
+    def get_export_schema(export_id):
+        return get_document_or_404_lite(CaseExportSchema, export_id)
 
     @property
     def export_list_url(self):

--- a/corehq/util/tests/test_couch.py
+++ b/corehq/util/tests/test_couch.py
@@ -47,7 +47,7 @@ def mock_wrap_context():
         MockModel.wrap = func
 
 
-class GetDocMockTestCase(TestCase):
+class GetDocMockTestCase(SimpleTestCase):
     """
     Tests get_document_or_404 with mocking
     """

--- a/corehq/util/tests/test_couch.py
+++ b/corehq/util/tests/test_couch.py
@@ -9,7 +9,7 @@ from mock import Mock
 from corehq.util.exceptions import DocumentClassNotFound
 
 from ..couch import (get_document_or_404, IterDB, iter_update, IterUpdateError,
-        DocUpdate, get_document_class_by_doc_type)
+        DocUpdate, get_document_class_by_doc_type, get_document_or_404_lite)
 
 
 class MockDb(object):
@@ -80,6 +80,15 @@ class GetDocMockTestCase(SimpleTestCase):
         get_document_or_404 should return a wrapped model on success
         """
         doc = get_document_or_404(MockModel, 'ham', '123')
+        self.assertEqual(doc, {'wrapped': {'_id': '123', 'domain': 'ham', 'doc_type': 'MockModel'}})
+
+    def test_get_document_or_404_lite_not_found(self):
+        with mock_get_context():
+            with self.assertRaises(Http404):
+                get_document_or_404_lite(MockModel, '123')
+
+    def test_get_document_or_404_lite_success(self):
+        doc = get_document_or_404_lite(MockModel, '123')
         self.assertEqual(doc, {'wrapped': {'_id': '123', 'domain': 'ham', 'doc_type': 'MockModel'}})
 
 


### PR DESCRIPTION
Reverts dimagi/commcare-hq#10027

It turns out that even though `SavedExportSchema` objects have a `domain` property - it is always null.

Didn't look into how hard it would be to fix that yet so I just worked around it by making a new helper function.
