### PR TITLE
Icds extension case structure

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -722,7 +722,7 @@ class SimplifiedSyncLog(AbstractSyncLog):
         incoming_extensions = _reverse_index_map(self.extension_index_tree.indices)
         available = {case for case in relevant
                      if case not in self.closed_cases
-                     and not self.extension_index_tree.indices.get(case) or self.index_tree.indices.get(case)}
+                     and (not self.extension_index_tree.indices.get(case) or self.index_tree.indices.get(case))}
         new_available = set() | available
         while new_available:
             case_to_check = new_available.pop()

--- a/corehq/ex-submodules/casexml/apps/phone/tests/data/case_relationship_tests.json
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/data/case_relationship_tests.json
@@ -722,5 +722,39 @@
             "d",
             "e"
         ]
+    },
+    {
+        "name": "icds_structure_closed_person",
+        "owned": [
+            "a",
+            "b",
+            "c"
+        ],
+        "closed": [
+            "b"
+        ],
+        "extensions": [
+            [
+                "c",
+                "b"
+            ],
+            [
+                "d",
+                "b"
+            ],
+            [
+                "b",
+                "a"
+            ]
+        ],
+        "subcases": [
+            [
+                "b",
+                "a"
+            ]
+        ],
+        "outcome": [
+            "a"
+        ]
     }
 ]

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_sync_mode.py
@@ -715,6 +715,7 @@ class SyncTokenUpdateTest(SyncBaseTest):
         next_sync_log = synclog_from_restore_payload(payload)
         self.assertFalse(next_sync_log.phone_is_holding_case(case.case_id))
 
+    @run_with_all_backends
     def test_cousins(self):
         """http://manage.dimagi.com/default.asp?189528
         """


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?191085

Nice edge case. Dumb mistake. 

Basically, because the closed case was a child, it was getting added as an "available" case and adding _all_ of the cases that were dependents of it to the sync. 

Wait for tests... 
@gcapalbo 
@czue 
