### PR TITLE
Mark password

### DIFF
--- a/corehq/apps/domain/middleware.py
+++ b/corehq/apps/domain/middleware.py
@@ -24,7 +24,6 @@ class CCHQPRBACMiddleware(object):
     Neither domains nor users currently have roles in the PRBAC tables.
     """
 
-    @method_decorator(sensitive_post_parameters('password'))
     def process_view(self, request, view_func, view_args, view_kwargs):
         self.apply_prbac(request)
         return None

--- a/corehq/util/global_request/middleware.py
+++ b/corehq/util/global_request/middleware.py
@@ -1,8 +1,12 @@
+from django.utils.decorators import method_decorator
+from django.views.decorators.debug import sensitive_post_parameters
+
 from .api import set_request
 
 
 class GlobalRequestMiddleware(object):
 
+    @method_decorator(sensitive_post_parameters('password'))
     def process_request(self, request):
         set_request(request)
 

--- a/corehq/util/log.py
+++ b/corehq/util/log.py
@@ -43,7 +43,8 @@ def clean_exception(exception):
 
 def get_sanitized_request_repr(request):
     """
-    Santizes sensitive data inside request object
+    Santizes sensitive data inside request object, if request has been marked sensitive
+    via Django decorator, django.views.decorators.debug.sensitive_post_parameters
     """
     if isinstance(request, HttpRequest):
         filter = get_exception_reporter_filter(request)


### PR DESCRIPTION
Soft-assert still was leaking passwords (at least in `HQCsrfMiddleware`) because
1. Django's inbuilt cleaning works only if request is marked as sensitive explicitly via `sensitive_post_parameters` decorator
2. Currently we mark request as sensitive in `CCHQPRBACMiddleware.process_view` instead of `process_request` and it comes after `HQCsrfMiddleware`

I changed this behaviour by marking request as sensitive on `GlobalRequestMiddleware` which is high up in the middleware order and on `process_request`
@czue 
