### PR TITLE
Case schema generation

### DIFF
--- a/corehq/apps/export/const.py
+++ b/corehq/apps/export/const.py
@@ -8,3 +8,4 @@ CASE_HISTORY_PROPERTIES = [
     'xform_name',
     'sync_log_id',
 ]
+CASE_HISTORY_GROUP_NAME = 'history'

--- a/corehq/apps/export/const.py
+++ b/corehq/apps/export/const.py
@@ -1,0 +1,10 @@
+CASE_HISTORY_PROPERTIES = [
+    'action_type',
+    'user_id',
+    'date',
+    'server_date',
+    'xform_id',
+    'xform_xmlns',
+    'xform_name',
+    'sync_log_id',
+]

--- a/corehq/apps/export/models/__init__.py
+++ b/corehq/apps/export/models/__init__.py
@@ -5,6 +5,7 @@ from .new import (
     ExportRow,
     ExportInstance,
     ExportDataSchema,
+    FormExportDataSchema,
     ExportGroupSchema,
     TableConfiguration,
     ScalarItem,

--- a/corehq/apps/export/models/__init__.py
+++ b/corehq/apps/export/models/__init__.py
@@ -6,6 +6,7 @@ from .new import (
     ExportInstance,
     ExportDataSchema,
     FormExportDataSchema,
+    CaseExportDataSchema,
     ExportGroupSchema,
     TableConfiguration,
     ScalarItem,

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -13,7 +13,10 @@ from dimagi.ext.couchdbkit import (
     StringProperty,
     IntegerProperty,
 )
-from corehq.apps.export.const import CASE_HISTORY_PROPERTIES
+from corehq.apps.export.const import (
+    CASE_HISTORY_PROPERTIES,
+    CASE_HISTORY_GROUP_NAME,
+)
 
 
 class ExportItem(DocumentSchema):
@@ -329,7 +332,7 @@ class CaseExportDataSchema(ExportDataSchema):
     def _generate_schema_for_case_history(appVersion):
         schema = CaseExportDataSchema()
         group_schema = ExportGroupSchema(
-            path=['history'],
+            path=[CASE_HISTORY_GROUP_NAME],
             last_occurrence=appVersion,
         )
         for prop in CASE_HISTORY_PROPERTIES:

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -220,16 +220,16 @@ class ExportDataSchema(DocumentSchema):
             group_schema.items = items
             return group_schema
 
-        previous_schema = schemas[0]
+        previous_group_schemas = schemas[0].group_schemas
         for current_schema in schemas[1:]:
             group_schemas = _merge_lists(
-                previous_schema.group_schemas,
+                previous_group_schemas,
                 current_schema.group_schemas,
                 keyfn=lambda group_schema: _list_path_to_string(group_schema.path),
                 resolvefn=resolvefn,
                 copyfn=lambda group_schema: ExportGroupSchema(group_schema.to_json())
             )
-            previous_schema = current_schema
+            previous_group_schemas = group_schemas
 
         schema.group_schemas = group_schemas
 

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -195,7 +195,7 @@ class ExportDataSchema(DocumentSchema):
     })
 
     @staticmethod
-    def _merge_schema(schema1, schema2):
+    def _merge_schema(*schemas):
         """Merges two ExportDataSchemas together
 
         :param schema1: The first ExportDataSchema
@@ -220,13 +220,16 @@ class ExportDataSchema(DocumentSchema):
             group_schema.items = items
             return group_schema
 
-        group_schemas = _merge_lists(
-            schema1.group_schemas,
-            schema2.group_schemas,
-            keyfn=lambda group_schema: _list_path_to_string(group_schema.path),
-            resolvefn=resolvefn,
-            copyfn=lambda group_schema: ExportGroupSchema(group_schema.to_json())
-        )
+        previous_schema = schemas[0]
+        for current_schema in schemas[1:]:
+            group_schemas = _merge_lists(
+                previous_schema.group_schemas,
+                current_schema.group_schemas,
+                keyfn=lambda group_schema: _list_path_to_string(group_schema.path),
+                resolvefn=resolvefn,
+                copyfn=lambda group_schema: ExportGroupSchema(group_schema.to_json())
+            )
+            previous_schema = current_schema
 
         schema.group_schemas = group_schemas
 
@@ -294,8 +297,11 @@ class CaseExportDataSchema(ExportDataSchema):
                 app.version,
             )
 
-            all_case_schema = CaseExportDataSchema._merge_schema(all_case_schema, case_schema)
-            all_case_schema = CaseExportDataSchema._merge_schema(all_case_schema, case_history_schema)
+            all_case_schema = CaseExportDataSchema._merge_schema(
+                all_case_schema,
+                case_schema,
+                case_history_schema
+            )
 
         return all_case_schema
 

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -238,6 +238,17 @@ class ExportDataSchema(DocumentSchema):
 
         return schema
 
+    @staticmethod
+    def generate_schema_from_builds(domain, app_id, identifier):
+        """Builds a schema from Application builds for a given identifier (either form_id or case type)
+
+        :param domain: The domain that the export belongs to
+        :param app_id: The app_id that the export belongs to
+        :param identifier: The unique identifier of the item being exported
+        :returns: Returns a ExportDataSchema instance
+        """
+        raise NotImplementedError()
+
 
 class FormExportDataSchema(ExportDataSchema):
 

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -13,6 +13,7 @@ from dimagi.ext.couchdbkit import (
     StringProperty,
     IntegerProperty,
 )
+from corehq.apps.export.const import CASE_HISTORY_PROPERTIES
 
 
 class ExportItem(DocumentSchema):
@@ -242,15 +243,15 @@ class FormExportDataSchema(ExportDataSchema):
         for app_doc in iter_docs(Application.get_db(), app_build_ids):
             app = Application.wrap(app_doc)
             xform = app.get_form(unique_form_id).wrapped_xform()
-            xform_conf = ExportDataSchema._generate_schema_from_xform(xform, app.langs, app.version)
-            all_xform_conf = ExportDataSchema._merge_schema(all_xform_conf, xform_conf)
+            xform_conf = FormExportDataSchema._generate_schema_from_xform(xform, app.langs, app.version)
+            all_xform_conf = FormExportDataSchema._merge_schema(all_xform_conf, xform_conf)
 
         return all_xform_conf
 
     @staticmethod
     def _generate_schema_from_xform(xform, langs, appVersion):
         questions = xform.get_questions(langs)
-        schema = ExportDataSchema()
+        schema = FormExportDataSchema()
 
         for group_path, group_questions in groupby(questions, lambda q: q['repeat']):
             # If group_path is None, that means the questions are part of the form and not a repeat group
@@ -261,7 +262,7 @@ class FormExportDataSchema(ExportDataSchema):
             )
             for question in group_questions:
                 # Create ExportItem based on the question type
-                item = ExportDataSchema.datatype_mapping[question['type']].create_from_question(
+                item = FormExportDataSchema.datatype_mapping[question['type']].create_from_question(
                     question,
                     appVersion,
                 )
@@ -269,6 +270,69 @@ class FormExportDataSchema(ExportDataSchema):
 
             schema.group_schemas.append(group_schema)
 
+        return schema
+
+
+class CaseExportDataSchema(ExportDataSchema):
+
+    @staticmethod
+    def generate_schema_from_builds(domain, app_id, case_type):
+        app_build_ids = get_built_app_ids_for_app_id(domain, app_id)
+        all_case_schema = CaseExportDataSchema()
+
+        for app_doc in iter_docs(Application.get_db(), app_build_ids):
+            app = Application.wrap(app_doc)
+            case_type_metadata = filter(
+                lambda case_type_meta: case_type_meta.name == case_type,
+                app.get_case_metadata().case_types
+            )[0]
+            case_schema = CaseExportDataSchema._generate_schema_from_case_meta(
+                case_type_metadata,
+                app.version,
+            )
+            case_history_schema = CaseExportDataSchema._generate_schema_from_case_history(
+                app.version,
+            )
+
+            all_case_schema = CaseExportDataSchema._merge_schema(all_case_schema, case_schema)
+            all_case_schema = CaseExportDataSchema._merge_schema(all_case_schema, case_history_schema)
+
+        return all_case_schema
+
+    @staticmethod
+    def _generate_schema_from_case_meta(case_type_metadata, appVersion):
+        properties = case_type_metadata.properties
+        schema = CaseExportDataSchema()
+
+        group_schema = ExportGroupSchema(
+            path=[case_type_metadata.name],
+            last_occurrence=appVersion,
+        )
+
+        for prop in properties:
+            group_schema.items.append(ScalarItem(
+                path=[prop.name],
+                label=prop.name,
+                last_occurrence=appVersion,
+            ))
+
+        schema.group_schemas.append(group_schema)
+        return schema
+
+    @staticmethod
+    def _generate_schema_for_case_history(appVersion):
+        schema = CaseExportDataSchema()
+        group_schema = ExportGroupSchema(
+            path=['history'],
+            last_occurrence=appVersion,
+        )
+        for prop in CASE_HISTORY_PROPERTIES:
+            group_schema.items.append(ScalarItem(
+                path=[prop],
+                label=prop,
+                last_occurrence=appVersion,
+            ))
+        schema.group_schemas.append(group_schema)
         return schema
 
 

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -194,43 +194,6 @@ class ExportDataSchema(DocumentSchema):
     })
 
     @staticmethod
-    def generate_schema_from_builds(domain, app_id, unique_form_id):
-        app_build_ids = get_built_app_ids_for_app_id(domain, app_id)
-        all_xform_conf = ExportDataSchema()
-
-        for app_doc in iter_docs(Application.get_db(), app_build_ids):
-            app = Application.wrap(app_doc)
-            xform = app.get_form(unique_form_id).wrapped_xform()
-            xform_conf = ExportDataSchema._generate_schema_from_xform(xform, app.langs, app.version)
-            all_xform_conf = ExportDataSchema._merge_schema(all_xform_conf, xform_conf)
-
-        return all_xform_conf
-
-    @staticmethod
-    def _generate_schema_from_xform(xform, langs, appVersion):
-        questions = xform.get_questions(langs)
-        schema = ExportDataSchema()
-
-        for group_path, group_questions in groupby(questions, lambda q: q['repeat']):
-            # If group_path is None, that means the questions are part of the form and not a repeat group
-            # inside of the form
-            group_schema = ExportGroupSchema(
-                path=_string_path_to_list(group_path),
-                last_occurrence=appVersion,
-            )
-            for question in group_questions:
-                # Create ExportItem based on the question type
-                item = ExportDataSchema.datatype_mapping[question['type']].create_from_question(
-                    question,
-                    appVersion,
-                )
-                group_schema.items.append(item)
-
-            schema.group_schemas.append(group_schema)
-
-        return schema
-
-    @staticmethod
     def _merge_schema(schema1, schema2):
         """Merges two ExportDataSchemas together
 
@@ -265,6 +228,46 @@ class ExportDataSchema(DocumentSchema):
         )
 
         schema.group_schemas = group_schemas
+
+        return schema
+
+
+class FormExportDataSchema(ExportDataSchema):
+
+    @staticmethod
+    def generate_schema_from_builds(domain, app_id, unique_form_id):
+        app_build_ids = get_built_app_ids_for_app_id(domain, app_id)
+        all_xform_conf = ExportDataSchema()
+
+        for app_doc in iter_docs(Application.get_db(), app_build_ids):
+            app = Application.wrap(app_doc)
+            xform = app.get_form(unique_form_id).wrapped_xform()
+            xform_conf = ExportDataSchema._generate_schema_from_xform(xform, app.langs, app.version)
+            all_xform_conf = ExportDataSchema._merge_schema(all_xform_conf, xform_conf)
+
+        return all_xform_conf
+
+    @staticmethod
+    def _generate_schema_from_xform(xform, langs, appVersion):
+        questions = xform.get_questions(langs)
+        schema = ExportDataSchema()
+
+        for group_path, group_questions in groupby(questions, lambda q: q['repeat']):
+            # If group_path is None, that means the questions are part of the form and not a repeat group
+            # inside of the form
+            group_schema = ExportGroupSchema(
+                path=_string_path_to_list(group_path),
+                last_occurrence=appVersion,
+            )
+            for question in group_questions:
+                # Create ExportItem based on the question type
+                item = ExportDataSchema.datatype_mapping[question['type']].create_from_question(
+                    question,
+                    appVersion,
+                )
+                group_schema.items.append(item)
+
+            schema.group_schemas.append(group_schema)
 
         return schema
 

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -195,7 +195,7 @@ class ExportDataSchema(DocumentSchema):
     })
 
     @staticmethod
-    def _merge_schema(*schemas):
+    def _merge_schemas(*schemas):
         """Merges two ExportDataSchemas together
 
         :param schema1: The first ExportDataSchema
@@ -247,7 +247,7 @@ class FormExportDataSchema(ExportDataSchema):
             app = Application.wrap(app_doc)
             xform = app.get_form(unique_form_id).wrapped_xform()
             xform_conf = FormExportDataSchema._generate_schema_from_xform(xform, app.langs, app.version)
-            all_xform_conf = FormExportDataSchema._merge_schema(all_xform_conf, xform_conf)
+            all_xform_conf = FormExportDataSchema._merge_schemas(all_xform_conf, xform_conf)
 
         return all_xform_conf
 
@@ -297,7 +297,7 @@ class CaseExportDataSchema(ExportDataSchema):
                 app.version,
             )
 
-            all_case_schema = CaseExportDataSchema._merge_schema(
+            all_case_schema = CaseExportDataSchema._merge_schemas(
                 all_case_schema,
                 case_schema,
                 case_history_schema

--- a/corehq/apps/export/tests/data/basic_case_application.json
+++ b/corehq/apps/export/tests/data/basic_case_application.json
@@ -1,0 +1,531 @@
+{
+   "_id": "58b0156dc3a8420669efb286bc81e048",
+   "comment": "",
+   "short_odk_url": null,
+   "domain": "aspace",
+   "build_langs": [
+       "en"
+   ],
+   "auto_gps_capture": false,
+   "short_url": null,
+   "deployment_date": null,
+   "user_type": null,
+   "text_input": "roman",
+   "secure_submissions": true,
+   "build_broken": false,
+   "minimum_use_threshold": "15",
+   "custom_base_url": null,
+   "copy_of": null,
+   "show_user_registration": false,
+   "phone_model": null,
+   "build_signed": true,
+   "recipients": "",
+   "copy_history": [
+   ],
+   "is_released": false,
+   "application_version": "2.0",
+   "platform": "nokia/s40",
+   "version": 12,
+   "admin_password": null,
+   "build_spec": {
+       "doc_type": "BuildSpec",
+       "version": "2.19.0",
+       "build_number": null,
+       "latest": true
+   },
+   "admin_password_charset": "n",
+   "logo_refs": {
+   },
+   "short_odk_media_url": null,
+   "profile": {
+       "custom_properties": {
+       },
+       "features": {
+           "users": "true",
+           "sense": "false"
+       },
+       "properties": {
+           "cc-days-form-retain": "-1",
+           "cc-show-saved": "yes",
+           "restore-tolerance": "loose",
+           "cc-user-mode": "cc-u-normal",
+           "cc-fuzzy-search-enabled": "yes",
+           "cc-autoup-freq": "freq-never",
+           "purge-freq": "0",
+           "server-tether": "push-only",
+           "user_reg_server": "required",
+           "extra_key_action": "audio",
+           "log_prop_daily": "log_never",
+           "ViewStyle": "v_chatterbox",
+           "cc-resize-images": "none",
+           "cc-entry-mode": "cc-entry-quick",
+           "cc-send-procedure": "cc-send-http",
+           "cc-login-images": "No",
+           "log_prop_weekly": "log_short",
+           "cc-show-incomplete": "yes",
+           "cc-send-unsent": "cc-su-auto",
+           "loose_media": "no",
+           "password_format": "n",
+           "unsent-number-limit": "5",
+           "cc-content-valid": "no",
+           "logenabled": "Enabled"
+       }
+   },
+   "amplifies_workers": "not_set",
+   "comment_from": null,
+   "cloudcare_enabled": false,
+   "description": null,
+   "user_registration": {
+       "doc_type": "UserRegistrationForm",
+       "xmlns": null,
+       "name": {
+       },
+       "password_path": "password",
+       "auto_gps_capture": false,
+       "schedule_form_id": null,
+       "show_count": false,
+       "version": null,
+       "no_vellum": false,
+       "form_links": [
+       ],
+       "post_form_workflow": "default",
+       "form_type": "user_registration",
+       "data_paths": {
+       },
+       "unique_id": null,
+       "username_path": "username"
+   },
+   "use_grid_menus": false,
+   "translations": {
+   },
+   "built_on": null,
+   "built_with": {
+       "doc_type": "BuildRecord",
+       "build_number": null,
+       "signed": true,
+       "datetime": null,
+       "version": null,
+       "latest": null
+   },
+   "multimedia_map": {
+   },
+   "archived_media": {
+   },
+   "langs": [
+       "en"
+   ],
+   "use_custom_suite": false,
+   "build_comment": null,
+   "build_broken_reason": null,
+   "doc_type": "Application",
+   "cached_properties": {
+   },
+   "name": "Candy",
+   "amplifies_project": "not_set",
+   "modules": [
+       {
+           "comment": "",
+           "referral_label": {
+               "en": "Referrals"
+           },
+           "case_list": {
+               "doc_type": "CaseList",
+               "show": false,
+               "media_audio": {
+                   "en": ""
+               },
+               "media_image": {
+                   "en": ""
+               },
+               "label": {
+               }
+           },
+           "auto_select_case": false,
+           "put_in_root": false,
+           "root_module_id": null,
+           "ref_details": {
+               "doc_type": "DetailPair",
+               "short": {
+                   "doc_type": "Detail",
+                   "lookup_name": null,
+                   "sort_elements": [
+                   ],
+                   "tabs": [
+                   ],
+                   "persist_case_context": null,
+                   "lookup_image": null,
+                   "filter": null,
+                   "persist_tile_on_forms": null,
+                   "custom_xml": null,
+                   "lookup_enabled": false,
+                   "lookup_extras": [
+                   ],
+                   "use_case_tiles": null,
+                   "pull_down_tile": null,
+                   "lookup_action": null,
+                   "display": "short",
+                   "columns": [
+                   ],
+                   "lookup_responses": [
+                   ]
+               },
+               "long": {
+                   "doc_type": "Detail",
+                   "lookup_name": null,
+                   "sort_elements": [
+                   ],
+                   "tabs": [
+                   ],
+                   "persist_case_context": null,
+                   "lookup_image": null,
+                   "filter": null,
+                   "persist_tile_on_forms": null,
+                   "custom_xml": null,
+                   "lookup_enabled": false,
+                   "lookup_extras": [
+                   ],
+                   "use_case_tiles": null,
+                   "pull_down_tile": null,
+                   "lookup_action": null,
+                   "display": "long",
+                   "columns": [
+                   ],
+                   "lookup_responses": [
+                   ]
+               }
+           },
+           "case_label": {
+               "en": "Cases"
+           },
+           "referral_list": {
+               "doc_type": "CaseList",
+               "show": false,
+               "media_audio": {
+               },
+               "media_image": {
+               },
+               "label": {
+               }
+           },
+           "media_image": {
+               "en": ""
+           },
+           "parent_select": {
+               "active": false,
+               "module_id": null,
+               "relationship": "parent",
+               "doc_type": "ParentSelect"
+           },
+           "forms": [
+               {
+                   "comment": "",
+                   "doc_type": "Form",
+                   "xmlns": "undefined",
+                   "name": {
+                       "en": "Buy Candy Corn"
+                   },
+                   "auto_gps_capture": false,
+                   "schedule_form_id": null,
+                   "requires": "none",
+                   "media_audio": {
+                       "en": ""
+                   },
+                   "post_form_workflow": "default",
+                   "actions": {
+                       "doc_type": "FormActions",
+                       "subcases": [
+                       ],
+                       "usercase_preload": {
+                           "preload": {
+                           },
+                           "doc_type": "PreloadAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "update_case": {
+                           "doc_type": "UpdateCaseAction",
+                           "update": {
+                               "question3": "/data/question3",
+                               "question2": "/data/question2"
+                           },
+                           "condition": {
+                               "answer": null,
+                               "type": "always",
+                               "question": null,
+                               "operator": null,
+                               "doc_type": "FormActionCondition"
+                           }
+                       },
+                       "close_referral": {
+                           "doc_type": "FormAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "open_referral": {
+                           "name_path": null,
+                           "doc_type": "OpenReferralAction",
+                           "followup_date": null,
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "open_case": {
+                           "name_path": "/data/question1",
+                           "doc_type": "OpenCaseAction",
+                           "external_id": null,
+                           "condition": {
+                               "operator": null,
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "always"
+                           }
+                       },
+                       "usercase_update": {
+                           "doc_type": "UpdateCaseAction",
+                           "update": {
+                           },
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "update_referral": {
+                           "doc_type": "UpdateReferralAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           },
+                           "followup_date": null
+                       },
+                       "referral_preload": {
+                           "preload": {
+                           },
+                           "doc_type": "PreloadAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "case_preload": {
+                           "preload": {
+                           },
+                           "doc_type": "PreloadAction",
+                           "condition": {
+                               "answer": null,
+                               "type": "always",
+                               "question": null,
+                               "operator": null,
+                               "doc_type": "FormActionCondition"
+                           }
+                       },
+                       "close_case": {
+                           "doc_type": "FormAction",
+                           "condition": {
+                               "operator": null,
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       }
+                   },
+                   "version": null,
+                   "no_vellum": false,
+                   "media_image": {
+                       "en": ""
+                   },
+                   "form_links": [
+                   ],
+                   "show_count": false,
+                   "form_type": "module_form",
+                   "form_filter": "",
+                   "unique_id": "b68a311749a6f45bdfda015b895d607012c91613"
+               }
+           ],
+           "module_filter": null,
+           "module_type": "basic",
+           "case_list_form": {
+               "doc_type": "CaseListForm",
+               "media_image": {
+                   "en": ""
+               },
+               "media_audio": {
+                   "en": ""
+               },
+               "form_id": "",
+               "label": {
+                   "en": ""
+               }
+           },
+           "case_details": {
+               "doc_type": "DetailPair",
+               "short": {
+                   "doc_type": "Detail",
+                   "persist_case_context": null,
+                   "sort_elements": [
+                   ],
+                   "tabs": [
+                   ],
+                   "lookup_name": null,
+                   "lookup_image": null,
+                   "filter": null,
+                   "persist_tile_on_forms": null,
+                   "custom_xml": null,
+                   "lookup_enabled": false,
+                   "pull_down_tile": null,
+                   "use_case_tiles": null,
+                   "lookup_extras": [
+                   ],
+                   "lookup_action": null,
+                   "display": "short",
+                   "columns": [
+                       {
+                           "case_tile_field": null,
+                           "doc_type": "DetailColumn",
+                           "filter_xpath": "",
+                           "format": "plain",
+                           "late_flag": 30,
+                           "enum": [
+                           ],
+                           "header": {
+                               "en": "Name"
+                           },
+                           "time_ago_interval": 365.25,
+                           "field": "name",
+                           "calc_xpath": ".",
+                           "model": "case",
+                           "graph_configuration": {
+                               "doc_type": "GraphConfiguration",
+                               "series": [
+                               ],
+                               "locale_specific_config": {
+                               },
+                               "graph_type": null,
+                               "config": {
+                               },
+                               "annotations": [
+                               ]
+                           },
+                           "advanced": ""
+                       }
+                   ],
+                   "lookup_responses": [
+                   ]
+               },
+               "long": {
+                   "doc_type": "Detail",
+                   "persist_case_context": null,
+                   "sort_elements": [
+                   ],
+                   "tabs": [
+                   ],
+                   "lookup_name": null,
+                   "lookup_image": null,
+                   "filter": null,
+                   "persist_tile_on_forms": null,
+                   "custom_xml": null,
+                   "lookup_enabled": false,
+                   "pull_down_tile": null,
+                   "use_case_tiles": null,
+                   "lookup_extras": [
+                   ],
+                   "lookup_action": null,
+                   "display": "long",
+                   "columns": [
+                       {
+                           "case_tile_field": null,
+                           "doc_type": "DetailColumn",
+                           "filter_xpath": "",
+                           "format": "plain",
+                           "late_flag": 30,
+                           "enum": [
+                           ],
+                           "header": {
+                               "en": "Name"
+                           },
+                           "time_ago_interval": 365.25,
+                           "field": "name",
+                           "calc_xpath": ".",
+                           "model": "case",
+                           "graph_configuration": {
+                               "doc_type": "GraphConfiguration",
+                               "series": [
+                               ],
+                               "locale_specific_config": {
+                               },
+                               "graph_type": null,
+                               "config": {
+                               },
+                               "annotations": [
+                               ]
+                           },
+                           "advanced": ""
+                       }
+                   ],
+                   "lookup_responses": [
+                   ]
+               }
+           },
+           "doc_type": "Module",
+           "name": {
+               "en": "Management"
+           },
+           "case_type": "candy",
+           "task_list": {
+               "doc_type": "CaseList",
+               "show": false,
+               "media_audio": {
+               },
+               "media_image": {
+               },
+               "label": {
+               }
+           },
+           "fixture_select": {
+               "xpath": "",
+               "doc_type": "FixtureSelect",
+               "variable_column": null,
+               "fixture_type": null,
+               "active": false,
+               "localize": false,
+               "display_column": null
+           },
+           "media_audio": {
+               "en": ""
+           },
+           "unique_id": "1fb8a24c811cceb2fcee80bbb2dd6d518296b05d"
+       }
+   ],
+   "created_from_template": null,
+   "attribution_notes": null,
+   "commtrack_requisition_mode": null,
+   "translation_strategy": "select-known",
+   "case_sharing": false,
+   "_attachments": {
+       "b68a311749a6f45bdfda015b895d607012c91613.xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" ?> <h:html xmlns:h=\"http://www.w3.org/1999/xhtml\" xmlns:orx=\"http://openrosa.org/jr/xforms\" xmlns=\"http://www.w3.org/2002/xforms\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:jr=\"http://openrosa.org/javarosa\" xmlns:vellum=\"http://commcarehq.org/xforms/vellum\"> <h:head> <h:title>Buy Candy Corn</h:title> <model> <instance> <data xmlns:jrm=\"http://dev.commcarehq.org/jr/xforms\" xmlns=\"undefined\" uiVersion=\"1\" version=\"1\" name=\"Buy Candy Corn\"> <question1 /> <question3 /> <question2 /> </data> </instance> <bind nodeset=\"/data/question1\" type=\"xsd:string\" /> <bind nodeset=\"/data/question3\" type=\"xsd:int\" /> <bind nodeset=\"/data/question2\" /> <itext> <translation lang=\"en\" default=\"\"> <text id=\"question1-label\"> <value>question1</value> </text> <text id=\"question3-label\"> <value>question3</value> </text> <text id=\"question2-label\"> <value>question2</value> </text> <text id=\"question2-choice1-label\"> <value>choice1</value> </text> <text id=\"question2-choice2-label\"> <value>choice2</value> </text> </translation> </itext> </model> </h:head> <h:body> <input ref=\"/data/question1\"> <label ref=\"jr:itext('question1-label')\" /> </input> <input ref=\"/data/question3\"> <label ref=\"jr:itext('question3-label')\" /> </input> <select ref=\"/data/question2\"> <label ref=\"jr:itext('question2-label')\" /> <item> <label ref=\"jr:itext('question2-choice1-label')\" /> <value>choice1</value> </item> <item> <label ref=\"jr:itext('question2-choice2-label')\" /> <value>choice2</value> </item> </select> </h:body> </h:html>"
+   }
+}

--- a/corehq/apps/export/tests/test_export_data_schema.py
+++ b/corehq/apps/export/tests/test_export_data_schema.py
@@ -286,6 +286,7 @@ class TestBuildingCaseSchemaFromApplication(TestCase, TestXmlMixin):
         for app in cls.apps:
             app.save()
 
+
 def _build_case_type_metadata(*case_properties):
     case_type_metadata = CaseTypeMeta(
         name='candy',

--- a/corehq/apps/export/tests/test_export_data_schema.py
+++ b/corehq/apps/export/tests/test_export_data_schema.py
@@ -126,7 +126,7 @@ class TestMergingFormExportDataSchema(SimpleTestCase, TestXmlMixin):
             2
         )
 
-        return FormExportDataSchema._merge_schema(schema, schema2)
+        return FormExportDataSchema._merge_schemas(schema, schema2)
 
     def test_simple_merge(self):
         """Tests merging of a form that adds a question to the form"""

--- a/corehq/apps/export/tests/test_export_data_schema.py
+++ b/corehq/apps/export/tests/test_export_data_schema.py
@@ -3,17 +3,17 @@ import os
 from django.test import SimpleTestCase, TestCase
 from corehq.apps.app_manager.tests.util import TestXmlMixin
 from corehq.apps.app_manager.models import XForm, Application
-from corehq.apps.export.models import ExportDataSchema
+from corehq.apps.export.models import FormExportDataSchema
 
 
-class TestExportDataSchema(SimpleTestCase, TestXmlMixin):
+class TestFormExportDataSchema(SimpleTestCase, TestXmlMixin):
     file_path = ['data']
     root = os.path.dirname(__file__)
 
     def test_basic_xform_parsing(self):
         form_xml = self.get_xml('basic_form')
 
-        schema = ExportDataSchema._generate_schema_from_xform(
+        schema = FormExportDataSchema._generate_schema_from_xform(
             XForm(form_xml),
             ['en'],
             1
@@ -30,7 +30,7 @@ class TestExportDataSchema(SimpleTestCase, TestXmlMixin):
     def test_xform_parsing_with_repeat_group(self):
         form_xml = self.get_xml('repeat_group_form')
 
-        schema = ExportDataSchema._generate_schema_from_xform(
+        schema = FormExportDataSchema._generate_schema_from_xform(
             XForm(form_xml),
             ['en'],
             1
@@ -50,7 +50,7 @@ class TestExportDataSchema(SimpleTestCase, TestXmlMixin):
 
     def test_xform_parsing_with_multiple_choice(self):
         form_xml = self.get_xml('multiple_choice_form')
-        schema = ExportDataSchema._generate_schema_from_xform(
+        schema = FormExportDataSchema._generate_schema_from_xform(
             XForm(form_xml),
             ['en'],
             1
@@ -67,25 +67,25 @@ class TestExportDataSchema(SimpleTestCase, TestXmlMixin):
         self.assertEqual(group_schema.items[1].options[1].value, 'choice2')
 
 
-class TestMergingExportDataSchema(SimpleTestCase, TestXmlMixin):
+class TestMergingFormExportDataSchema(SimpleTestCase, TestXmlMixin):
     file_path = ['data']
     root = os.path.dirname(__file__)
 
     def _get_merged_schema(self, form_name1, form_name2):
         form_xml = self.get_xml(form_name1)
         form_xml2 = self.get_xml(form_name2)
-        schema = ExportDataSchema._generate_schema_from_xform(
+        schema = FormExportDataSchema._generate_schema_from_xform(
             XForm(form_xml),
             ['en'],
             1
         )
-        schema2 = ExportDataSchema._generate_schema_from_xform(
+        schema2 = FormExportDataSchema._generate_schema_from_xform(
             XForm(form_xml2),
             ['en'],
             2
         )
 
-        return ExportDataSchema._merge_schema(schema, schema2)
+        return FormExportDataSchema._merge_schema(schema, schema2)
 
     def test_simple_merge(self):
         """Tests merging of a form that adds a question to the form"""
@@ -191,7 +191,7 @@ class TestBuildingSchemaFromApplication(TestCase, TestXmlMixin):
     def test_basic_application_schema(self):
         app = self.current_app
 
-        schema = ExportDataSchema.generate_schema_from_builds(
+        schema = FormExportDataSchema.generate_schema_from_builds(
             app.domain,
             app._id,
             'b68a311749a6f45bdfda015b895d607012c91613'


### PR DESCRIPTION
@NoahCarnahan here's an initial implementation of case schema generation. i still have to iron out what exactly belongs in the this schema. still todo:
- [ ] Schema for parent cases and case history > parent cases
- [ ] way to signify the type of property (`update`, `info`, `meta`). i was thinking this can also be accomplished with the `path`. just prepend `update` to the path if it's an update property.
- [ ] TestCase for `generate_schema_from_builds` for `CaseExportDataSchema`
