### PR TITLE
App code instead of bitly

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases.js
@@ -49,6 +49,19 @@ function SavedApp(app_data, releasesMain) {
         return false;
     });
 
+    self.get_app_code = ko.computed(function() {
+        var short_odk_url = self.get_short_odk_url();
+        if (short_odk_url) {
+            // Matches "foo" in "http://bit.ly/foo" and "https://is.gd/X/foo/" ("*" is not greedy)
+            var re = /^http.*\/(\w+)\/?/;
+            var match = short_odk_url.match(re);
+            if (match) {
+                return match[1];
+            }
+        }
+        return false;
+    });
+
     self.get_short_odk_url_phonetic = ko.computed(function () {
         return app_manager_utils.bitly_nato_phonetic(self.get_short_odk_url());
     });

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases_deploy_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases_deploy_modal.html
@@ -80,7 +80,7 @@
                                                 </p>
                                                 <p>
                                                     <span data-bind="visible: get_app_code()">
-                                                        Enter App Code:
+                                                        Or Enter App Code:
                                                         <code class="bitly" data-bind="text: get_app_code()"></code>
                                                     </span>
                                                     <img data-bind="visible: generating_url()"

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases_deploy_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases_deploy_modal.html
@@ -57,36 +57,42 @@
                                                         </span>
                                                     </label>
                                                 </div>
-                                            {% endif %}
-                                            <p>
-                                                <span data-bind="visible: get_short_odk_url()">
-                                                    {% blocktrans %}
-                                                        Install by typing the following URL
-                                                        into the CommCare application install screen:
-                                                    {% endblocktrans %}
-                                                    <code class="bitly"><a data-bind="
-                                                        attr: {
-                                                            href: get_short_odk_url(),
-                                                            title: get_short_odk_url_phonetic()
-                                                        },
-                                                        text: get_short_odk_url()
-                                                    "></a></code>
-                                                </span>
-                                                <img data-bind="visible: generating_url()"
-                                                    src="{% new_static 'hqwebapp/img/ajax-loader.gif' %}"/>
-                                                <span class="text-warning" data-bind="visible: !get_short_odk_url() && !generating_url()">
-                                                    {% trans "No short code available; try making another version." %}
-                                                </span>
-                                            </p>
-                                            <p>
-                                                {% trans "Or" %}
-                                                <a href="#" data-bind="
-                                                    openRemoteModal: get_odk_install_url,
-                                                    click: function() { ga_track_event('App Manager', 'Show Bar Code', '-'); }
-                                                ">{% trans "scan the bar code" %}</a>
-                                                {% trans "using the Barcode Scanner option within CommCare" %}
-                                            </p>
-                                        </div>
+                                                {% endif %}
+                                                <p>
+                                                    <span data-bind="visible: get_app_code()">
+                                                        {% blocktrans %}
+                                                        Open the app on your Android and use one of the following installation methods:
+                                                        {% endblocktrans %}
+                                                    </span>
+                                                    <span data-bind="visible: !get_app_code() && !generating_url()">
+                                                        {% blocktrans %}
+                                                        Open the app on your Android and use the following installation method:
+                                                        {% endblocktrans %}
+                                                    </span>
+                                                </p>
+                                                <p>
+                                                    <a href="#" data-bind="
+                                                        openRemoteModal: get_odk_install_url,
+                                                        click: function() { ga_track_event('App Manager', 'Show Bar Code', '-'); }
+                                                    ">
+                                                        {% trans "Scan Application Barcode" %}
+                                                    </a>
+                                                </p>
+                                                <p>
+                                                    <span data-bind="visible: get_app_code()">
+                                                        Enter App Code:
+                                                        <code class="bitly" data-bind="text: get_app_code()"></code>
+                                                    </span>
+                                                    <img data-bind="visible: generating_url()"
+                                                        src="{% static 'hqwebapp/img/ajax-loader.gif' %}"/>
+                                                    <span class="text-warning" data-bind="visible: !get_app_code() && !generating_url()">
+                                                        {% blocktrans %}
+                                                        (No app code available. If you would like to use an app code instead
+                                                        of scanning the application barcode, try making another version.)
+                                                        {% endblocktrans %}
+                                                    </span>
+                                                </p>
+                                            </div>
                                         <div class="tab-pane">
                                             <div data-bind="ifnot: COMMCAREHQ.app_manager.versionGE(build_spec.version(), '2.13.0')">
                                                 Upgrade to CommCare 2.13 to use this feature

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases_deploy_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases_deploy_modal.html
@@ -80,7 +80,7 @@
                                                 </p>
                                                 <p>
                                                     <span data-bind="visible: get_app_code()">
-                                                        Or Enter App Code:
+                                                        {% trans "Or Enter App Code:" %}
                                                         <code class="bitly" data-bind="text: get_app_code()"></code>
                                                     </span>
                                                     <img data-bind="visible: generating_url()"


### PR DESCRIPTION
Spec: https://docs.google.com/document/d/1GHLayNW9xHWWyj_sEeRGh5T7oepGsvldLLg6uyJZYH4/edit#heading=h.blt0fbwgkgt2

With app code:
![app_code](https://cloud.githubusercontent.com/assets/708421/12578268/64019cde-c428-11e5-88d0-4f16508e0563.png)

Without app code:
![app_code_falsey](https://cloud.githubusercontent.com/assets/708421/12578273/6c96bb0e-c428-11e5-904d-1b5ba68fdb48.png)

I'm not 100% happy with the appearance here, so I tried using a `<ul>` for the installation options. I'll PR it separately, and you can choose which one looks better. Labelling "hold off" for now.

Nitpicky, I know, but I ummmed and aaahed a bit about the "Android device" in one sentence and then "Android" in the next. I think calling it "an Android" is OK (like "a Blackberry", as opposed to, say, "an iOS" or "a Windows"), but I think it would sound better if we chose to use "Android" either as an adjective or a noun throughout. OK, that does sound super nitpicky. But I'll leave it in here so it can jump out at you too now. :smiling_imp: 

@amsagoff @biyeun cc @wpride 
