### PR TITLE
Increase the time before triggering a soft assert on periodic timing

### DIFF
--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -314,7 +314,7 @@ def track_periodic_data():
             end_time,
             sys.getsizeof(submit_json)
         )
-    _soft_assert(processing_time.seconds < 10, msg)
+    _soft_assert(processing_time.seconds < 100, msg)
 
     submit_data_to_hub_and_kiss(submit_json)
 


### PR DESCRIPTION
Originally I wanted to measure if as we add code to this task the time would go up significantly. It's above 10 seconds consistently now, but I'm not super worried about the run time. If it goes above 100 seconds then I will re-evaluate again.

@orangejenny
