### PR TITLE
cases use case_name

### DIFF
--- a/corehq/apps/app_manager/tests/test_util.py
+++ b/corehq/apps/app_manager/tests/test_util.py
@@ -40,7 +40,7 @@ class SchemaTest(SimpleTestCase):
         self.assert_has_kv_pairs(schema["subsets"][0], {
             'id': 'village',
             'key': '@case_type',
-            'structure': {'name': {}},
+            'structure': {'case_name': {}},
             'related': None,
         })
 

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -265,7 +265,7 @@ def get_casedb_schema(app):
     """
     case_types = app.get_case_types()
     per_type_defaults = get_per_type_defaults(app.domain, case_types)
-    builder = ParentCasePropertyBuilder(app, ['name'], per_type_defaults)
+    builder = ParentCasePropertyBuilder(app, ['case_name'], per_type_defaults)
     related = builder.get_parent_type_map(case_types)
     map = builder.get_case_property_map(case_types, include_parent_properties=False)
     return {


### PR DESCRIPTION
@millerdev @benrudolph 

HQ uses name in the UI, but case_name in the xml. This will use case_name in the data tree,.
