### PR TITLE
Remove make new commtrack domain feature

### DIFF
--- a/corehq/apps/appstore/templates/appstore/project_info.html
+++ b/corehq/apps/appstore/templates/appstore/project_info.html
@@ -327,7 +327,7 @@
                     {% endif %}
                 {% else %}
                     {% url "login" DOMAIN_TYPE as login_url %}
-                    {% url "register_user" DOMAIN_TYPE as register_url %}
+                    {% url "register_user" %}
                     {% blocktrans %}
                         Please <a href="{{ login_url }}">sign in</a>
                         or <a href="{{ register_url }}">register</a>

--- a/corehq/apps/domain/templates/domain/select.html
+++ b/corehq/apps/domain/templates/domain/select.html
@@ -35,7 +35,7 @@
     <div class="span4">
         <aside class="well">
             <h3>{% trans "Have a new idea?" %}</h3>
-            <a class="btn btn-primary" href="{% url "registration_domain" DOMAIN_TYPE %}">{% trans "Create a Blank Project" %}</a>
+            <a class="btn btn-primary" href="{% url "registration_domain" %}">{% trans "Create a Blank Project" %}</a>
             <div>{% trans "or" %}</div>
             <a class="btn btn-primary" href="{% url "appstore" %}">{% trans "Copy from CommCare Exchange" %}</a>
         </aside>

--- a/corehq/apps/domain/templates/login_and_password/partials/login_full.html
+++ b/corehq/apps/domain/templates/login_and_password/partials/login_full.html
@@ -17,7 +17,7 @@
                  {% if allow_domain_requests %}
                    href="{% url "domain_request" domain %}"
                  {% else %}
-                   href="{% url "register_user" DOMAIN_TYPE %}"
+                   href="{% url "register_user" %}"
                  {% endif %}
               >
                 {% if allow_domain_requests %}

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -2,7 +2,6 @@ import copy
 import datetime
 from decimal import Decimal
 import logging
-import uuid
 import json
 import cStringIO
 
@@ -23,19 +22,14 @@ from django.contrib import messages
 from django.contrib.auth.views import password_reset_confirm
 from django.views.decorators.http import require_POST
 from PIL import Image
-from django.utils.translation import ugettext as _, ugettext_noop, ugettext_lazy
+from django.utils.translation import ugettext as _, ugettext_lazy
 from django.contrib.auth.models import User
 
 from corehq.const import USER_DATE_FORMAT
 from custom.dhis2.forms import Dhis2SettingsForm
 from custom.dhis2.models import Dhis2Settings
-from casexml.apps.case.mock import CaseBlock
-from casexml.apps.case.xml import V2
 from corehq.apps.accounting.async_handlers import Select2BillingInfoHandler
 from corehq.apps.accounting.invoicing import DomainWireInvoiceFactory
-from corehq.apps.accounting.decorators import (
-    requires_privilege_with_fallback,
-)
 from corehq.apps.hqwebapp.tasks import send_mail_async
 from corehq.apps.style.decorators import use_bootstrap3, use_jquery_ui, \
     use_jquery_ui_multiselect, use_select2
@@ -61,7 +55,6 @@ from corehq.apps.smsbillables.forms import SMSRateCalculatorForm
 from corehq.apps.users.models import Invitation, CouchUser
 from corehq.apps.fixtures.models import FixtureDataType
 from corehq.toggles import NAMESPACE_DOMAIN, all_toggles, CAN_EDIT_EULA, TRANSFER_DOMAIN
-from corehq.util.context_processors import get_domain_type
 from dimagi.utils.couch.resource_conflict import retry_resource
 from corehq import privileges, feature_previews
 from django_prbac.utils import has_privilege
@@ -70,7 +63,7 @@ from corehq.apps.accounting.models import (
     DefaultProductPlan, SoftwarePlanEdition, BillingAccount,
     BillingAccountType,
     Invoice, BillingRecord, InvoicePdf, PaymentMethodType,
-    PaymentMethod, EntryPoint, WireInvoice, SoftwarePlanVisibility, FeatureType,
+    EntryPoint, WireInvoice, SoftwarePlanVisibility, FeatureType,
     StripePaymentMethod, LastPayment,
     UNLIMITED_FEATURE_USAGE,
 )
@@ -124,7 +117,7 @@ PAYMENT_ERROR_MESSAGES = {
 def select(request, domain_select_template='domain/select.html', do_not_redirect=False):
     domains_for_user = Domain.active_for_user(request.user)
     if not domains_for_user:
-        return redirect('registration_domain', domain_type=get_domain_type(None, request))
+        return redirect('registration_domain')
 
     email = request.couch_user.get_email()
     open_invitations = [e for e in Invitation.by_email(email) if not e.is_expired]

--- a/corehq/apps/hqwebapp/templates/home.html
+++ b/corehq/apps/hqwebapp/templates/home.html
@@ -70,7 +70,7 @@
     <div style="padding-top:1em; text-align: right; clear:both; margin-top:1em;">
         <p>
             <span class="attention">{% trans "Want to learn more?" %}</span>
-            <button class="try" onClick="parent.location='{% url "register_user" DOMAIN_TYPE %}'" title='{% trans "Sign up for a new account" %}'>
+            <button class="try" onClick="parent.location='{% url "register_user" %}'" title='{% trans "Sign up for a new account" %}'>
                 {% trans "Try it now!" %}
             </button>
         </p>

--- a/corehq/apps/hqwebapp/views.py
+++ b/corehq/apps/hqwebapp/views.py
@@ -47,14 +47,12 @@ from corehq.apps.reports.util import is_mobile_worker_with_report_access
 from corehq.apps.users.models import CouchUser
 from corehq.apps.users.util import format_username
 from corehq.apps.hqwebapp.doc_info import get_doc_info
-from corehq.util.cache_utils import ExponentialBackoff
-from corehq.util.context_processors import get_domain_type
 from corehq.util.datadog.utils import create_datadog_event, log_counter, sanitize_url
 from corehq.util.datadog.metrics import JSERROR_COUNT
 from corehq.util.datadog.const import DATADOG_UNKNOWN
 from dimagi.utils.couch.database import get_db
 from dimagi.utils.decorators.memoized import memoized
-from dimagi.utils.logging import notify_exception, notify_js_exception
+from dimagi.utils.logging import notify_exception
 from dimagi.utils.web import get_url_base, json_response, get_site_domain
 from dimagi.utils.couch.cache.cache_core import get_redis_default_cache
 from corehq.apps.hqadmin.management.commands.celery_deploy_in_progress import CELERY_DEPLOY_IN_PROGRESS_FLAG
@@ -202,7 +200,7 @@ def redirect_to_default(req, domain=None):
         else:
             domains = Domain.active_for_user(req.user)
         if 0 == len(domains) and not req.user.is_superuser:
-            return redirect('registration_domain', domain_type=get_domain_type(None, req))
+            return redirect('registration_domain')
         elif 1 == len(domains):
             if domains[0]:
                 domain = domains[0].name

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -31,8 +31,6 @@ class DomainRegistrationForm(forms.Form):
 
     org = forms.CharField(widget=forms.HiddenInput(), required=False)
     hr_name = forms.CharField(label=_('Project Name'), max_length=max_name_length)
-    domain_type = forms.CharField(widget=forms.HiddenInput(), required=False,
-                                  initial='commcare')
 
     def __init__(self, *args, **kwargs):
         super(DomainRegistrationForm, self).__init__(*args, **kwargs)
@@ -43,7 +41,6 @@ class DomainRegistrationForm(forms.Form):
         self.helper.layout = crispy.Layout(
             'hr_name',
             'org',
-            'domain_type',
             hqcrispy.FormActions(
                 twbscrispy.StrictButton(
                     _("Create Project"),
@@ -52,10 +49,6 @@ class DomainRegistrationForm(forms.Form):
                 )
             )
         )
-
-    def clean_domain_type(self):
-        data = self.cleaned_data.get('domain_type', '').strip().lower()
-        return data if data else 'commcare'
 
     def clean(self):
         for field in self.cleaned_data:

--- a/corehq/apps/registration/templates/registration/create_new_user.html
+++ b/corehq/apps/registration/templates/registration/create_new_user.html
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block registration-content %}
-    <form name="form" class="form-horizontal" method="post" action="{% url "register_user" domain_type=domain_type %}?">
+    <form name="form" class="form-horizontal" method="post" action="{% url "register_user" %}?">
         {% csrf_token %}
         {% for global_error in form.non_field_errors %}
             <div class="alert alert-error">

--- a/corehq/apps/registration/templates/registration/domain_request.html
+++ b/corehq/apps/registration/templates/registration/domain_request.html
@@ -9,7 +9,7 @@
     <div class="container">
         <div class="page-header">
             <h1>
-                {% if is_new %}
+                {% if is_new_user %}
                     {% blocktrans %}Welcome to {{ SITE_NAME }}!
                         <small>It's time to create your first project.</small>{% endblocktrans %}
                 {% else %}
@@ -20,7 +20,7 @@
 
         {% block registration-content %}
             <div>
-                {% if is_new %}
+                {% if is_new_user %}
                     <p>
                         {% blocktrans with request.couch_user.first_name as first_name %}
                             Congratulations, {{ first_name }}&mdash;you've successfully joined {{ SITE_NAME }}.

--- a/corehq/apps/registration/urls.py
+++ b/corehq/apps/registration/urls.py
@@ -4,8 +4,8 @@ from corehq.apps.registration.views import RegisterDomainView
 
 urlpatterns = patterns('corehq.apps.registration.views',
     url(r'^$', 'registration_default', name='registration_default'),
-    url(r'^user/(?P<domain_type>\w+)?/?$', 'register_user', name='register_user'),
-    url(r'^domain/(?P<domain_type>\w+)?/?$', RegisterDomainView.as_view(), name='registration_domain'),
+    url(r'^user/?$', 'register_user', name='register_user'),
+    url(r'^domain/$', RegisterDomainView.as_view(), name='registration_domain'),
     url(r'^domain/confirm(?:/(?P<guid>\w+))?/$', 'confirm_domain', name='registration_confirm_domain'),
     url(r'^resend/$', 'resend_confirmation', name='registration_resend_domain_confirmation'),
     url(r'^eula_agreement/$', 'eula_agreement', name="agree_to_eula"),

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -30,39 +30,25 @@ from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.web import get_ip
 from corehq.util.context_processors import get_per_domain_context
 
-DOMAIN_TYPES = (
-    'commcare',
-    'commtrack'
-)
 
-def get_domain_context(domain_type='commcare'):
-    """
-    Set context variables that are normally set based on the domain type
-    according to what user/domain type is being registered.
-    """
-    from corehq.apps.domain.utils import get_dummy_domain
-    dummy_domain = get_dummy_domain(domain_type)
-    return get_per_domain_context(dummy_domain)
+def get_domain_context():
+    return get_per_domain_context(Domain())
+
 
 def registration_default(request):
     return redirect(register_user)
 
 
 @transaction.atomic
-def register_user(request, domain_type=None):
-    domain_type = domain_type or 'commcare'
-    if domain_type not in DOMAIN_TYPES:
-        raise Http404()
-
+def register_user(request):
     prefilled_email = request.GET.get('e', '')
-
-    context = get_domain_context(domain_type)
+    context = get_domain_context()
 
     if request.user.is_authenticated():
         # Redirect to a page which lets user choose whether or not to create a new account
         domains_for_user = Domain.active_for_user(request.user)
         if len(domains_for_user) == 0:
-            return redirect("registration_domain", domain_type=domain_type)
+            return redirect("registration_domain")
         else:
             return redirect("homepage")
     else:
@@ -81,7 +67,7 @@ def register_user(request, domain_type=None):
                 if form.cleaned_data['create_domain']:
                     try:
                         requested_domain = request_new_domain(
-                            request, form, is_new_user=True, domain_type=domain_type)
+                            request, form, is_new_user=True)
                     except NameUnavailableException:
                         context.update({
                             'error_msg': _('Project name already taken - please try another'),
@@ -89,7 +75,7 @@ def register_user(request, domain_type=None):
                         })
                         return render(request, 'error.html', context)
 
-                context = get_domain_context(form.cleaned_data['domain_type']).update({
+                context.update({
                     'alert_message': _("An email has been sent to %s.") % request.user.username,
                     'requested_domain': requested_domain,
                     'track_domain_registration': True,
@@ -98,12 +84,11 @@ def register_user(request, domain_type=None):
             context.update({'create_domain': form.cleaned_data['create_domain']})
         else:
             form = NewWebUserRegistrationForm(
-                initial={'domain_type': domain_type, 'email': prefilled_email, 'create_domain': True})
+                initial={'email': prefilled_email, 'create_domain': True})
             context.update({'create_domain': True})
 
         context.update({
             'form': form,
-            'domain_type': domain_type,
         })
         return render(request, 'registration/create_new_user.html', context)
 
@@ -121,7 +106,7 @@ class RegisterDomainView(TemplateView):
         if self.is_new_user:
             pending_domains = Domain.active_for_user(request.user, is_active=False)
             if len(pending_domains) > 0:
-                context = get_domain_context(kwargs.get('domain_type') or 'commcare')
+                context = get_domain_context()
                 context['requested_domain'] = domains_for_user[0]
                 return render(request, 'registration/confirmation_waiting.html', context)
         return super(RegisterDomainView, self).get(request, *args, **kwargs)
@@ -134,7 +119,6 @@ class RegisterDomainView(TemplateView):
 
     @transaction.atomic
     def post(self, request, *args, **kwargs):
-        domain_type = kwargs.get('domain_type') or 'commcare'
         referer_url = request.GET.get('referer', '')
         nextpage = request.POST.get('next')
         form = DomainRegistrationForm(request.POST)
@@ -153,7 +137,7 @@ class RegisterDomainView(TemplateView):
 
             try:
                 domain_name = request_new_domain(
-                    request, form, is_new_user=self.is_new_user, domain_type=domain_type)
+                    request, form, is_new_user=self.is_new_user)
             except NameUnavailableException:
                 context.update({
                     'error_msg': _('Project name already taken - please try another'),
@@ -179,15 +163,14 @@ class RegisterDomainView(TemplateView):
 
     def get_context_data(self, **kwargs):
         request = self.request
-        domain_type = kwargs.get('domain_type') or 'commcare'
-        if domain_type not in DOMAIN_TYPES or (not request.couch_user) or request.couch_user.is_commcare_user():
+        if (not request.couch_user) or request.couch_user.is_commcare_user():
             raise Http404()
 
         context = super(RegisterDomainView, self).get_context_data(**kwargs)
-        context.update(get_domain_context(domain_type))
+        context.update(get_domain_context())
 
         context.update({
-            'form': kwargs.get('form') or DomainRegistrationForm(initial={'domain_type': domain_type}),
+            'form': kwargs.get('form') or DomainRegistrationForm(),
             'is_new_user': self.is_new_user,
         })
         return context
@@ -200,7 +183,7 @@ def resend_confirmation(request):
         dom_req = RegistrationRequest.get_request_for_username(request.user.username)
     except Exception:
         dom_req = None
-        
+
     if not dom_req:
         inactive_domains_for_user = Domain.active_for_user(request.user, is_active=False)
         if len(inactive_domains_for_user) > 0:
@@ -209,7 +192,7 @@ def resend_confirmation(request):
                 domain.save()
         return redirect('domain_select')
 
-    context = get_domain_context(dom_req.project.domain_type)
+    context = get_domain_context()
 
     if request.method == 'POST':
         try:

--- a/corehq/apps/settings/templates/settings/my_projects.html
+++ b/corehq/apps/settings/templates/settings/my_projects.html
@@ -73,6 +73,6 @@
         </table>
     </div>
     <p>
-        <a class="btn btn-success" href="{% url "registration_domain" DOMAIN_TYPE %}?referer={{ request.path }}"><i class="fa fa-plus"></i> {% trans 'Create a New Project' %}</a>
+        <a class="btn btn-success" href="{% url "registration_domain" %}?referer={{ request.path }}"><i class="fa fa-plus"></i> {% trans 'Create a New Project' %}</a>
     </p>
 {% endblock %}

--- a/corehq/apps/style/templates/style/bootstrap2/partials/domain_list_dropdown.html
+++ b/corehq/apps/style/templates/style/bootstrap2/partials/domain_list_dropdown.html
@@ -15,6 +15,6 @@
         {% endif %}
     {% endif %}
     <li class="divider"></li>
-    <li><a href="{% url 'registration_domain' DOMAIN_TYPE %}">{% trans 'New Project' %}</a></li>
+    <li><a href="{% url 'registration_domain' %}">{% trans 'New Project' %}</a></li>
     <li><a href="{% url 'appstore'%}">{% trans 'CommCare Exchange' %}</a></li>
 </ul>

--- a/corehq/apps/style/templates/style/bootstrap3/partials/domain_list_dropdown.html
+++ b/corehq/apps/style/templates/style/bootstrap3/partials/domain_list_dropdown.html
@@ -25,7 +25,7 @@
     {% endif %}
 
     <li>
-        <a href="{% url 'registration_domain' DOMAIN_TYPE %}">
+        <a href="{% url 'registration_domain' %}">
             <i class="fa fa-plus"></i> {% trans 'Add Project' %}
         </a>
     </li>

--- a/corehq/util/context_processors.py
+++ b/corehq/util/context_processors.py
@@ -33,21 +33,15 @@ def is_commtrack(project, request):
         return False
 
 
-def get_domain_type(project, request):
-    if is_commtrack(project, request):
-        return COMMTRACK
-    else:
-        return COMMCARE
-
-
 def get_per_domain_context(project, request=None):
-    domain_type = get_domain_type(project, request)
-    if domain_type == COMMTRACK:
+    if is_commtrack(project, request):
+        domain_type = COMMTRACK
         logo_url = static('hqstyle/img/commcaresupply-logo.png')
         site_name = "CommCare Supply"
         public_site = "http://www.commtrack.org"
         can_be_your = _("mobile logistics solution")
     else:
+        domain_type = COMMCARE
         logo_url = static('hqstyle/img/commcare-logo.png')
         site_name = "CommCare HQ"
         public_site = "http://www.commcarehq.org"
@@ -78,14 +72,13 @@ def current_url_name(request):
     """
     Adds the name for the matched url pattern for the current request to the
     request context.
-    
     """
     try:
         match = resolve(request.path)
         url_name = match.url_name
     except Http404:
         url_name = None
-    
+
     return {
         'current_url_name': url_name
     }


### PR DESCRIPTION
:blowfish: :x: :blowfish: = :arrow_up:  :moneybag: 
This feature was wicked confusing - if you happened to be logged in to a commtrack domain when you created a new domain, that would also be commtrack.  Also, if you tried to create a new web user from a commtrack domain, the domain created would also be commtrack.
