### PR TITLE
Case schema generation

### DIFF
--- a/corehq/apps/app_manager/dbaccessors.py
+++ b/corehq/apps/app_manager/dbaccessors.py
@@ -195,6 +195,20 @@ def get_all_apps(domain):
     return all_apps
 
 
+def get_all_app_ids(domain):
+    """
+    Returns a list of all the app_ids ever built and current Applications.
+    """
+    from .models import Application
+    results = Application.get_db().view(
+        'app_manager/saved_app',
+        startkey=[domain],
+        endkey=[domain, {}],
+        include_docs=False,
+    ).all()
+    return [result['id'] for result in results]
+
+
 def get_case_types_from_apps(domain):
     """Get the case types of modules in applications in the domain."""
     q = (AppES()

--- a/corehq/apps/app_manager/tests/test_dbaccessors.py
+++ b/corehq/apps/app_manager/tests/test_dbaccessors.py
@@ -4,6 +4,7 @@ from corehq.apps.app_manager.dbaccessors import (
     get_apps_in_domain,
     domain_has_apps,
     get_built_app_ids_for_app_id,
+    get_all_app_ids,
 )
 from corehq.apps.app_manager.models import Application, RemoteApp, Module
 from corehq.apps.domain.models import Domain
@@ -34,6 +35,9 @@ class DBAccessorsTest(TestCase, DocTestMixin):
             Application(domain=cls.domain, copy_of=cls.apps[0].get_id, version=cls.first_saved_version),
             # this one is another build
             Application(domain=cls.domain, copy_of=cls.apps[0].get_id, version=12),
+
+            # this one is another app
+            Application(domain=cls.domain, copy_of='1234', version=12),
             # this one is in the wrong domain
             Application(domain='decoy-domain', version=5)
         ]
@@ -98,3 +102,7 @@ class DBAccessorsTest(TestCase, DocTestMixin):
         app_ids = get_built_app_ids_for_app_id(self.domain, self.apps[0].get_id, self.first_saved_version)
         self.assertEqual(len(app_ids), 1)
         self.assertEqual(self.decoy_apps[1].get_id, app_ids[0])
+
+    def test_get_all_app_ids_for_domain(self):
+        app_ids = get_all_app_ids(self.domain)
+        self.assertEqual(len(app_ids), 3)

--- a/corehq/apps/export/const.py
+++ b/corehq/apps/export/const.py
@@ -8,3 +8,4 @@ CASE_HISTORY_PROPERTIES = [
     'xform_name',
     'sync_log_id',
 ]
+CASE_HISTORY_GROUP_NAME = 'history'

--- a/corehq/apps/export/const.py
+++ b/corehq/apps/export/const.py
@@ -1,0 +1,10 @@
+CASE_HISTORY_PROPERTIES = [
+    'action_type',
+    'user_id',
+    'date',
+    'server_date',
+    'xform_id',
+    'xform_xmlns',
+    'xform_name',
+    'sync_log_id',
+]

--- a/corehq/apps/export/const.py
+++ b/corehq/apps/export/const.py
@@ -1,11 +1,20 @@
+from collections import namedtuple
+
+SystemProperty = namedtuple('SystemProperty', ['tag', 'name'])
+
+PROPERTY_TAG_NONE = None
+PROPERTY_TAG_INFO = 'info'
+PROPERTY_TAG_UPDATE = 'update'
+PROPERTY_TAG_SERVER = 'server'
+
 CASE_HISTORY_PROPERTIES = [
-    'action_type',
-    'user_id',
-    'date',
-    'server_date',
-    'xform_id',
-    'xform_xmlns',
-    'xform_name',
-    'sync_log_id',
+    SystemProperty(PROPERTY_TAG_NONE, 'action_type'),
+    SystemProperty(PROPERTY_TAG_NONE, 'user_id'),
+    SystemProperty(PROPERTY_TAG_NONE, 'date'),
+    SystemProperty(PROPERTY_TAG_NONE, 'server_date'),
+    SystemProperty(PROPERTY_TAG_NONE, 'xform_id'),
+    SystemProperty(PROPERTY_TAG_NONE, 'xform_xmlns'),
+    SystemProperty(PROPERTY_TAG_NONE, 'xform_name'),
+    SystemProperty(PROPERTY_TAG_SERVER, 'state'),
 ]
 CASE_HISTORY_GROUP_NAME = 'history'

--- a/corehq/apps/export/models/__init__.py
+++ b/corehq/apps/export/models/__init__.py
@@ -5,6 +5,7 @@ from .new import (
     ExportRow,
     ExportInstance,
     ExportDataSchema,
+    FormExportDataSchema,
     ExportGroupSchema,
     TableConfiguration,
     ScalarItem,

--- a/corehq/apps/export/models/__init__.py
+++ b/corehq/apps/export/models/__init__.py
@@ -6,6 +6,7 @@ from .new import (
     ExportInstance,
     ExportDataSchema,
     FormExportDataSchema,
+    CaseExportDataSchema,
     ExportGroupSchema,
     TableConfiguration,
     ScalarItem,

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -319,6 +319,7 @@ class CaseExportDataSchema(ExportDataSchema):
                 app.version,
             )
             case_history_schema = CaseExportDataSchema._generate_schema_for_case_history(
+                case_property_mapping,
                 app.version,
             )
 

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -3,7 +3,7 @@ from collections import defaultdict, OrderedDict
 from couchdbkit import SchemaListProperty, SchemaProperty, BooleanProperty
 
 from corehq.apps.userreports.expressions.getters import NestedDictGetter
-from corehq.apps.app_manager.dbaccessors import get_built_app_ids_for_app_id
+from corehq.apps.app_manager.dbaccessors import get_built_app_ids_for_app_id, get_all_app_ids
 from corehq.apps.app_manager.models import Application
 from dimagi.utils.couch.database import iter_docs
 from dimagi.ext.couchdbkit import (
@@ -294,8 +294,14 @@ class FormExportDataSchema(ExportDataSchema):
 class CaseExportDataSchema(ExportDataSchema):
 
     @staticmethod
-    def generate_schema_from_builds(domain, app_id, case_type):
-        app_build_ids = get_built_app_ids_for_app_id(domain, app_id)
+    def generate_schema_from_builds(domain, case_type):
+        """Builds a schema from Application builds for a given identifier
+
+        :param domain: The domain that the export belongs to
+        :param unique_form_id: The unique identifier of the item being exported
+        :returns: Returns a ExportDataSchema instance
+        """
+        app_build_ids = get_all_app_ids(domain)
         all_case_schema = CaseExportDataSchema()
 
         for app_doc in iter_docs(Application.get_db(), app_build_ids):

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -200,7 +200,7 @@ class ExportDataSchema(DocumentSchema):
     })
 
     @staticmethod
-    def _merge_schema(*schemas):
+    def _merge_schemas(*schemas):
         """Merges two ExportDataSchemas together
 
         :param schema1: The first ExportDataSchema
@@ -252,7 +252,7 @@ class FormExportDataSchema(ExportDataSchema):
             app = Application.wrap(app_doc)
             xform = app.get_form(unique_form_id).wrapped_xform()
             xform_conf = FormExportDataSchema._generate_schema_from_xform(xform, app.langs, app.version)
-            all_xform_conf = FormExportDataSchema._merge_schema(all_xform_conf, xform_conf)
+            all_xform_conf = FormExportDataSchema._merge_schemas(all_xform_conf, xform_conf)
 
         return all_xform_conf
 
@@ -302,7 +302,7 @@ class CaseExportDataSchema(ExportDataSchema):
                 app.version,
             )
 
-            all_case_schema = CaseExportDataSchema._merge_schema(
+            all_case_schema = CaseExportDataSchema._merge_schemas(
                 all_case_schema,
                 case_schema,
                 case_history_schema

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -225,16 +225,16 @@ class ExportDataSchema(DocumentSchema):
             group_schema.items = items
             return group_schema
 
-        previous_schema = schemas[0]
+        previous_group_schemas = schemas[0].group_schemas
         for current_schema in schemas[1:]:
             group_schemas = _merge_lists(
-                previous_schema.group_schemas,
+                previous_group_schemas,
                 current_schema.group_schemas,
                 keyfn=lambda group_schema: _list_path_to_string(group_schema.path),
                 resolvefn=resolvefn,
                 copyfn=lambda group_schema: ExportGroupSchema(group_schema.to_json())
             )
-            previous_schema = current_schema
+            previous_group_schemas = group_schemas
 
         schema.group_schemas = group_schemas
 

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -243,6 +243,17 @@ class ExportDataSchema(DocumentSchema):
 
         return schema
 
+    @staticmethod
+    def generate_schema_from_builds(domain, app_id, identifier):
+        """Builds a schema from Application builds for a given identifier (either form_id or case type)
+
+        :param domain: The domain that the export belongs to
+        :param app_id: The app_id that the export belongs to
+        :param identifier: The unique identifier of the item being exported
+        :returns: Returns a ExportDataSchema instance
+        """
+        raise NotImplementedError()
+
 
 class FormExportDataSchema(ExportDataSchema):
 

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -195,7 +195,7 @@ class ExportGroupSchema(DocumentSchema):
     last_occurrence = IntegerProperty()
 
 
-class ExportDataSchema(DocumentSchema):
+class ExportDataSchema(Document):
     """
     An object representing the things that can be exported for a particular
     form xmlns or case type. It contains a list of ExportGroupSchema.

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -243,22 +243,18 @@ class ExportDataSchema(DocumentSchema):
 
         return schema
 
-    @staticmethod
-    def generate_schema_from_builds(domain, app_id, identifier):
-        """Builds a schema from Application builds for a given identifier (either form_id or case type)
-
-        :param domain: The domain that the export belongs to
-        :param app_id: The app_id that the export belongs to
-        :param identifier: The unique identifier of the item being exported
-        :returns: Returns a ExportDataSchema instance
-        """
-        raise NotImplementedError()
-
 
 class FormExportDataSchema(ExportDataSchema):
 
     @staticmethod
     def generate_schema_from_builds(domain, app_id, unique_form_id):
+        """Builds a schema from Application builds for a given identifier
+
+        :param domain: The domain that the export belongs to
+        :param app_id: The app_id that the export belongs to
+        :param unique_form_id: The unique identifier of the item being exported
+        :returns: Returns a ExportDataSchema instance
+        """
         app_build_ids = get_built_app_ids_for_app_id(domain, app_id)
         all_xform_conf = ExportDataSchema()
 

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -333,7 +333,7 @@ class CaseExportDataSchema(ExportDataSchema):
 
     @staticmethod
     def _generate_schema_from_case_property_mapping(case_property_mapping, appVersion):
-        # we should only generate for one case type
+        """Generates the schema for the main Case tab on the export page"""
         assert len(case_property_mapping.keys()) == 1
         schema = CaseExportDataSchema()
 
@@ -355,6 +355,7 @@ class CaseExportDataSchema(ExportDataSchema):
 
     @staticmethod
     def _generate_schema_for_case_history(case_property_mapping, appVersion):
+        """Generates the schema for the Case History tab on the export page"""
         assert len(case_property_mapping.keys()) == 1
         schema = CaseExportDataSchema()
 

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -205,6 +205,9 @@ class ExportDataSchema(Document):
         'MSelect': MultipleChoiceItem,
     })
 
+    class Meta:
+        app_label = 'export'
+
     @staticmethod
     def _merge_schemas(*schemas):
         """Merges two ExportDataSchemas together

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -13,7 +13,10 @@ from dimagi.ext.couchdbkit import (
     StringProperty,
     IntegerProperty,
 )
-from corehq.apps.export.const import CASE_HISTORY_PROPERTIES
+from corehq.apps.export.const import (
+    CASE_HISTORY_PROPERTIES,
+    CASE_HISTORY_GROUP_NAME,
+)
 
 
 class ExportItem(DocumentSchema):
@@ -334,7 +337,7 @@ class CaseExportDataSchema(ExportDataSchema):
     def _generate_schema_for_case_history(appVersion):
         schema = CaseExportDataSchema()
         group_schema = ExportGroupSchema(
-            path=['history'],
+            path=[CASE_HISTORY_GROUP_NAME],
             last_occurrence=appVersion,
         )
         for prop in CASE_HISTORY_PROPERTIES:

--- a/corehq/apps/export/tests/data/basic_case_application.json
+++ b/corehq/apps/export/tests/data/basic_case_application.json
@@ -1,0 +1,531 @@
+{
+   "_id": "58b0156dc3a8420669efb286bc81e048",
+   "comment": "",
+   "short_odk_url": null,
+   "domain": "aspace",
+   "build_langs": [
+       "en"
+   ],
+   "auto_gps_capture": false,
+   "short_url": null,
+   "deployment_date": null,
+   "user_type": null,
+   "text_input": "roman",
+   "secure_submissions": true,
+   "build_broken": false,
+   "minimum_use_threshold": "15",
+   "custom_base_url": null,
+   "copy_of": null,
+   "show_user_registration": false,
+   "phone_model": null,
+   "build_signed": true,
+   "recipients": "",
+   "copy_history": [
+   ],
+   "is_released": false,
+   "application_version": "2.0",
+   "platform": "nokia/s40",
+   "version": 12,
+   "admin_password": null,
+   "build_spec": {
+       "doc_type": "BuildSpec",
+       "version": "2.19.0",
+       "build_number": null,
+       "latest": true
+   },
+   "admin_password_charset": "n",
+   "logo_refs": {
+   },
+   "short_odk_media_url": null,
+   "profile": {
+       "custom_properties": {
+       },
+       "features": {
+           "users": "true",
+           "sense": "false"
+       },
+       "properties": {
+           "cc-days-form-retain": "-1",
+           "cc-show-saved": "yes",
+           "restore-tolerance": "loose",
+           "cc-user-mode": "cc-u-normal",
+           "cc-fuzzy-search-enabled": "yes",
+           "cc-autoup-freq": "freq-never",
+           "purge-freq": "0",
+           "server-tether": "push-only",
+           "user_reg_server": "required",
+           "extra_key_action": "audio",
+           "log_prop_daily": "log_never",
+           "ViewStyle": "v_chatterbox",
+           "cc-resize-images": "none",
+           "cc-entry-mode": "cc-entry-quick",
+           "cc-send-procedure": "cc-send-http",
+           "cc-login-images": "No",
+           "log_prop_weekly": "log_short",
+           "cc-show-incomplete": "yes",
+           "cc-send-unsent": "cc-su-auto",
+           "loose_media": "no",
+           "password_format": "n",
+           "unsent-number-limit": "5",
+           "cc-content-valid": "no",
+           "logenabled": "Enabled"
+       }
+   },
+   "amplifies_workers": "not_set",
+   "comment_from": null,
+   "cloudcare_enabled": false,
+   "description": null,
+   "user_registration": {
+       "doc_type": "UserRegistrationForm",
+       "xmlns": null,
+       "name": {
+       },
+       "password_path": "password",
+       "auto_gps_capture": false,
+       "schedule_form_id": null,
+       "show_count": false,
+       "version": null,
+       "no_vellum": false,
+       "form_links": [
+       ],
+       "post_form_workflow": "default",
+       "form_type": "user_registration",
+       "data_paths": {
+       },
+       "unique_id": null,
+       "username_path": "username"
+   },
+   "use_grid_menus": false,
+   "translations": {
+   },
+   "built_on": null,
+   "built_with": {
+       "doc_type": "BuildRecord",
+       "build_number": null,
+       "signed": true,
+       "datetime": null,
+       "version": null,
+       "latest": null
+   },
+   "multimedia_map": {
+   },
+   "archived_media": {
+   },
+   "langs": [
+       "en"
+   ],
+   "use_custom_suite": false,
+   "build_comment": null,
+   "build_broken_reason": null,
+   "doc_type": "Application",
+   "cached_properties": {
+   },
+   "name": "Candy",
+   "amplifies_project": "not_set",
+   "modules": [
+       {
+           "comment": "",
+           "referral_label": {
+               "en": "Referrals"
+           },
+           "case_list": {
+               "doc_type": "CaseList",
+               "show": false,
+               "media_audio": {
+                   "en": ""
+               },
+               "media_image": {
+                   "en": ""
+               },
+               "label": {
+               }
+           },
+           "auto_select_case": false,
+           "put_in_root": false,
+           "root_module_id": null,
+           "ref_details": {
+               "doc_type": "DetailPair",
+               "short": {
+                   "doc_type": "Detail",
+                   "lookup_name": null,
+                   "sort_elements": [
+                   ],
+                   "tabs": [
+                   ],
+                   "persist_case_context": null,
+                   "lookup_image": null,
+                   "filter": null,
+                   "persist_tile_on_forms": null,
+                   "custom_xml": null,
+                   "lookup_enabled": false,
+                   "lookup_extras": [
+                   ],
+                   "use_case_tiles": null,
+                   "pull_down_tile": null,
+                   "lookup_action": null,
+                   "display": "short",
+                   "columns": [
+                   ],
+                   "lookup_responses": [
+                   ]
+               },
+               "long": {
+                   "doc_type": "Detail",
+                   "lookup_name": null,
+                   "sort_elements": [
+                   ],
+                   "tabs": [
+                   ],
+                   "persist_case_context": null,
+                   "lookup_image": null,
+                   "filter": null,
+                   "persist_tile_on_forms": null,
+                   "custom_xml": null,
+                   "lookup_enabled": false,
+                   "lookup_extras": [
+                   ],
+                   "use_case_tiles": null,
+                   "pull_down_tile": null,
+                   "lookup_action": null,
+                   "display": "long",
+                   "columns": [
+                   ],
+                   "lookup_responses": [
+                   ]
+               }
+           },
+           "case_label": {
+               "en": "Cases"
+           },
+           "referral_list": {
+               "doc_type": "CaseList",
+               "show": false,
+               "media_audio": {
+               },
+               "media_image": {
+               },
+               "label": {
+               }
+           },
+           "media_image": {
+               "en": ""
+           },
+           "parent_select": {
+               "active": false,
+               "module_id": null,
+               "relationship": "parent",
+               "doc_type": "ParentSelect"
+           },
+           "forms": [
+               {
+                   "comment": "",
+                   "doc_type": "Form",
+                   "xmlns": "undefined",
+                   "name": {
+                       "en": "Buy Candy Corn"
+                   },
+                   "auto_gps_capture": false,
+                   "schedule_form_id": null,
+                   "requires": "none",
+                   "media_audio": {
+                       "en": ""
+                   },
+                   "post_form_workflow": "default",
+                   "actions": {
+                       "doc_type": "FormActions",
+                       "subcases": [
+                       ],
+                       "usercase_preload": {
+                           "preload": {
+                           },
+                           "doc_type": "PreloadAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "update_case": {
+                           "doc_type": "UpdateCaseAction",
+                           "update": {
+                               "question3": "/data/question3",
+                               "question2": "/data/question2"
+                           },
+                           "condition": {
+                               "answer": null,
+                               "type": "always",
+                               "question": null,
+                               "operator": null,
+                               "doc_type": "FormActionCondition"
+                           }
+                       },
+                       "close_referral": {
+                           "doc_type": "FormAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "open_referral": {
+                           "name_path": null,
+                           "doc_type": "OpenReferralAction",
+                           "followup_date": null,
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "open_case": {
+                           "name_path": "/data/question1",
+                           "doc_type": "OpenCaseAction",
+                           "external_id": null,
+                           "condition": {
+                               "operator": null,
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "always"
+                           }
+                       },
+                       "usercase_update": {
+                           "doc_type": "UpdateCaseAction",
+                           "update": {
+                           },
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "update_referral": {
+                           "doc_type": "UpdateReferralAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           },
+                           "followup_date": null
+                       },
+                       "referral_preload": {
+                           "preload": {
+                           },
+                           "doc_type": "PreloadAction",
+                           "condition": {
+                               "operator": "=",
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       },
+                       "case_preload": {
+                           "preload": {
+                           },
+                           "doc_type": "PreloadAction",
+                           "condition": {
+                               "answer": null,
+                               "type": "always",
+                               "question": null,
+                               "operator": null,
+                               "doc_type": "FormActionCondition"
+                           }
+                       },
+                       "close_case": {
+                           "doc_type": "FormAction",
+                           "condition": {
+                               "operator": null,
+                               "doc_type": "FormActionCondition",
+                               "answer": null,
+                               "question": null,
+                               "type": "never"
+                           }
+                       }
+                   },
+                   "version": null,
+                   "no_vellum": false,
+                   "media_image": {
+                       "en": ""
+                   },
+                   "form_links": [
+                   ],
+                   "show_count": false,
+                   "form_type": "module_form",
+                   "form_filter": "",
+                   "unique_id": "b68a311749a6f45bdfda015b895d607012c91613"
+               }
+           ],
+           "module_filter": null,
+           "module_type": "basic",
+           "case_list_form": {
+               "doc_type": "CaseListForm",
+               "media_image": {
+                   "en": ""
+               },
+               "media_audio": {
+                   "en": ""
+               },
+               "form_id": "",
+               "label": {
+                   "en": ""
+               }
+           },
+           "case_details": {
+               "doc_type": "DetailPair",
+               "short": {
+                   "doc_type": "Detail",
+                   "persist_case_context": null,
+                   "sort_elements": [
+                   ],
+                   "tabs": [
+                   ],
+                   "lookup_name": null,
+                   "lookup_image": null,
+                   "filter": null,
+                   "persist_tile_on_forms": null,
+                   "custom_xml": null,
+                   "lookup_enabled": false,
+                   "pull_down_tile": null,
+                   "use_case_tiles": null,
+                   "lookup_extras": [
+                   ],
+                   "lookup_action": null,
+                   "display": "short",
+                   "columns": [
+                       {
+                           "case_tile_field": null,
+                           "doc_type": "DetailColumn",
+                           "filter_xpath": "",
+                           "format": "plain",
+                           "late_flag": 30,
+                           "enum": [
+                           ],
+                           "header": {
+                               "en": "Name"
+                           },
+                           "time_ago_interval": 365.25,
+                           "field": "name",
+                           "calc_xpath": ".",
+                           "model": "case",
+                           "graph_configuration": {
+                               "doc_type": "GraphConfiguration",
+                               "series": [
+                               ],
+                               "locale_specific_config": {
+                               },
+                               "graph_type": null,
+                               "config": {
+                               },
+                               "annotations": [
+                               ]
+                           },
+                           "advanced": ""
+                       }
+                   ],
+                   "lookup_responses": [
+                   ]
+               },
+               "long": {
+                   "doc_type": "Detail",
+                   "persist_case_context": null,
+                   "sort_elements": [
+                   ],
+                   "tabs": [
+                   ],
+                   "lookup_name": null,
+                   "lookup_image": null,
+                   "filter": null,
+                   "persist_tile_on_forms": null,
+                   "custom_xml": null,
+                   "lookup_enabled": false,
+                   "pull_down_tile": null,
+                   "use_case_tiles": null,
+                   "lookup_extras": [
+                   ],
+                   "lookup_action": null,
+                   "display": "long",
+                   "columns": [
+                       {
+                           "case_tile_field": null,
+                           "doc_type": "DetailColumn",
+                           "filter_xpath": "",
+                           "format": "plain",
+                           "late_flag": 30,
+                           "enum": [
+                           ],
+                           "header": {
+                               "en": "Name"
+                           },
+                           "time_ago_interval": 365.25,
+                           "field": "name",
+                           "calc_xpath": ".",
+                           "model": "case",
+                           "graph_configuration": {
+                               "doc_type": "GraphConfiguration",
+                               "series": [
+                               ],
+                               "locale_specific_config": {
+                               },
+                               "graph_type": null,
+                               "config": {
+                               },
+                               "annotations": [
+                               ]
+                           },
+                           "advanced": ""
+                       }
+                   ],
+                   "lookup_responses": [
+                   ]
+               }
+           },
+           "doc_type": "Module",
+           "name": {
+               "en": "Management"
+           },
+           "case_type": "candy",
+           "task_list": {
+               "doc_type": "CaseList",
+               "show": false,
+               "media_audio": {
+               },
+               "media_image": {
+               },
+               "label": {
+               }
+           },
+           "fixture_select": {
+               "xpath": "",
+               "doc_type": "FixtureSelect",
+               "variable_column": null,
+               "fixture_type": null,
+               "active": false,
+               "localize": false,
+               "display_column": null
+           },
+           "media_audio": {
+               "en": ""
+           },
+           "unique_id": "1fb8a24c811cceb2fcee80bbb2dd6d518296b05d"
+       }
+   ],
+   "created_from_template": null,
+   "attribution_notes": null,
+   "commtrack_requisition_mode": null,
+   "translation_strategy": "select-known",
+   "case_sharing": false,
+   "_attachments": {
+       "b68a311749a6f45bdfda015b895d607012c91613.xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" ?> <h:html xmlns:h=\"http://www.w3.org/1999/xhtml\" xmlns:orx=\"http://openrosa.org/jr/xforms\" xmlns=\"http://www.w3.org/2002/xforms\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" xmlns:jr=\"http://openrosa.org/javarosa\" xmlns:vellum=\"http://commcarehq.org/xforms/vellum\"> <h:head> <h:title>Buy Candy Corn</h:title> <model> <instance> <data xmlns:jrm=\"http://dev.commcarehq.org/jr/xforms\" xmlns=\"undefined\" uiVersion=\"1\" version=\"1\" name=\"Buy Candy Corn\"> <question1 /> <question3 /> <question2 /> </data> </instance> <bind nodeset=\"/data/question1\" type=\"xsd:string\" /> <bind nodeset=\"/data/question3\" type=\"xsd:int\" /> <bind nodeset=\"/data/question2\" /> <itext> <translation lang=\"en\" default=\"\"> <text id=\"question1-label\"> <value>question1</value> </text> <text id=\"question3-label\"> <value>question3</value> </text> <text id=\"question2-label\"> <value>question2</value> </text> <text id=\"question2-choice1-label\"> <value>choice1</value> </text> <text id=\"question2-choice2-label\"> <value>choice2</value> </text> </translation> </itext> </model> </h:head> <h:body> <input ref=\"/data/question1\"> <label ref=\"jr:itext('question1-label')\" /> </input> <input ref=\"/data/question3\"> <label ref=\"jr:itext('question3-label')\" /> </input> <select ref=\"/data/question2\"> <label ref=\"jr:itext('question2-label')\" /> <item> <label ref=\"jr:itext('question2-choice1-label')\" /> <value>choice1</value> </item> <item> <label ref=\"jr:itext('question2-choice2-label')\" /> <value>choice2</value> </item> </select> </h:body> </h:html>"
+   }
+}

--- a/corehq/apps/export/tests/test_export_data_schema.py
+++ b/corehq/apps/export/tests/test_export_data_schema.py
@@ -286,6 +286,7 @@ class TestBuildingCaseSchemaFromApplication(TestCase, TestXmlMixin):
         for app in cls.apps:
             app.save()
 
+
 def _build_case_type_metadata(*case_properties):
     case_type_metadata = CaseTypeMeta(
         name='candy',

--- a/corehq/apps/export/tests/test_export_data_schema.py
+++ b/corehq/apps/export/tests/test_export_data_schema.py
@@ -126,7 +126,7 @@ class TestMergingFormExportDataSchema(SimpleTestCase, TestXmlMixin):
             2
         )
 
-        return FormExportDataSchema._merge_schema(schema, schema2)
+        return FormExportDataSchema._merge_schemas(schema, schema2)
 
     def test_simple_merge(self):
         """Tests merging of a form that adds a question to the form"""

--- a/corehq/apps/export/tests/test_export_data_schema.py
+++ b/corehq/apps/export/tests/test_export_data_schema.py
@@ -230,7 +230,10 @@ class TestMergingCaseExportDataSchema(SimpleTestCase, TestXmlMixin):
         self.assertEqual(len(items), 1)
 
         self.assertEqual(group_schema2.last_occurrence, 2)
-        self.assertEqual(len(group_schema2.items), len(CASE_HISTORY_PROPERTIES))
+        self.assertEqual(
+            len(group_schema2.items),
+            len(CASE_HISTORY_PROPERTIES) + len(case_property_mapping['candy'])
+        )
 
 
 class TestBuildingSchemaFromApplication(TestCase, TestXmlMixin):
@@ -291,6 +294,11 @@ class TestBuildingCaseSchemaFromApplication(TestCase, TestXmlMixin):
         ]
         for app in cls.apps:
             app.save()
+
+    @classmethod
+    def tearDownClass(cls):
+        for app in cls.apps:
+            app.delete()
 
     def test_basic_application_schema(self):
         schema = CaseExportDataSchema.generate_schema_from_builds(self.domain, 'candy')

--- a/corehq/apps/export/tests/test_export_data_schema.py
+++ b/corehq/apps/export/tests/test_export_data_schema.py
@@ -3,17 +3,17 @@ import os
 from django.test import SimpleTestCase, TestCase
 from corehq.apps.app_manager.tests.util import TestXmlMixin
 from corehq.apps.app_manager.models import XForm, Application
-from corehq.apps.export.models import ExportDataSchema
+from corehq.apps.export.models import FormExportDataSchema
 
 
-class TestExportDataSchema(SimpleTestCase, TestXmlMixin):
+class TestFormExportDataSchema(SimpleTestCase, TestXmlMixin):
     file_path = ['data']
     root = os.path.dirname(__file__)
 
     def test_basic_xform_parsing(self):
         form_xml = self.get_xml('basic_form')
 
-        schema = ExportDataSchema._generate_schema_from_xform(
+        schema = FormExportDataSchema._generate_schema_from_xform(
             XForm(form_xml),
             ['en'],
             1
@@ -30,7 +30,7 @@ class TestExportDataSchema(SimpleTestCase, TestXmlMixin):
     def test_xform_parsing_with_repeat_group(self):
         form_xml = self.get_xml('repeat_group_form')
 
-        schema = ExportDataSchema._generate_schema_from_xform(
+        schema = FormExportDataSchema._generate_schema_from_xform(
             XForm(form_xml),
             ['en'],
             1
@@ -50,7 +50,7 @@ class TestExportDataSchema(SimpleTestCase, TestXmlMixin):
 
     def test_xform_parsing_with_multiple_choice(self):
         form_xml = self.get_xml('multiple_choice_form')
-        schema = ExportDataSchema._generate_schema_from_xform(
+        schema = FormExportDataSchema._generate_schema_from_xform(
             XForm(form_xml),
             ['en'],
             1
@@ -67,25 +67,25 @@ class TestExportDataSchema(SimpleTestCase, TestXmlMixin):
         self.assertEqual(group_schema.items[1].options[1].value, 'choice2')
 
 
-class TestMergingExportDataSchema(SimpleTestCase, TestXmlMixin):
+class TestMergingFormExportDataSchema(SimpleTestCase, TestXmlMixin):
     file_path = ['data']
     root = os.path.dirname(__file__)
 
     def _get_merged_schema(self, form_name1, form_name2):
         form_xml = self.get_xml(form_name1)
         form_xml2 = self.get_xml(form_name2)
-        schema = ExportDataSchema._generate_schema_from_xform(
+        schema = FormExportDataSchema._generate_schema_from_xform(
             XForm(form_xml),
             ['en'],
             1
         )
-        schema2 = ExportDataSchema._generate_schema_from_xform(
+        schema2 = FormExportDataSchema._generate_schema_from_xform(
             XForm(form_xml2),
             ['en'],
             2
         )
 
-        return ExportDataSchema._merge_schema(schema, schema2)
+        return FormExportDataSchema._merge_schema(schema, schema2)
 
     def test_simple_merge(self):
         """Tests merging of a form that adds a question to the form"""
@@ -191,7 +191,7 @@ class TestBuildingSchemaFromApplication(TestCase, TestXmlMixin):
     def test_basic_application_schema(self):
         app = self.current_app
 
-        schema = ExportDataSchema.generate_schema_from_builds(
+        schema = FormExportDataSchema.generate_schema_from_builds(
             app.domain,
             app._id,
             'b68a311749a6f45bdfda015b895d607012c91613'


### PR DESCRIPTION
@NoahCarnahan @czue @snopoke (against master)
- [x] Schema for parent cases and case history > parent cases
- [x] way to signify the type of property (`update`, `info`, `meta`). i was thinking this can also be accomplished with the `path`. just prepend `update` to the path if it's an update property.
- [x] TestCase for `generate_schema_from_builds` for `CaseExportDataSchema`
