### PR TITLE
mobile UCR username filter should use the raw username

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -3318,7 +3318,7 @@ def _filter_by_location_id(user, ui_filter):
 
 def _filter_by_username(user, ui_filter):
     from corehq.apps.reports_core.filters import Choice
-    return Choice(value=user.username, display=None)
+    return Choice(value=user.raw_username, display=None)
 
 
 def _filter_by_user_id(user, ui_filter):


### PR DESCRIPTION
Data sources tend to have raw usernames instead of the fully qualified username, so this should have app building user.

Confirmed that this will not impact any apps on production/india/staging.

@dannyroberts 
