### PR TITLE
Add `by_domain_doc_type_date` view to synclogs db

### DIFF
--- a/corehq/couchapps/__init__.py
+++ b/corehq/couchapps/__init__.py
@@ -10,7 +10,7 @@ CouchAppsPreindexPlugin.register('couchapps', __file__, {
         settings.NEW_DOMAINS_DB, settings.NEW_APPS_DB),
     'by_domain_doc_type_date': (
         None, settings.NEW_USERS_GROUPS_DB, settings.NEW_FIXTURES_DB, 'meta',
-        settings.NEW_DOMAINS_DB, settings.NEW_APPS_DB),
+        settings.NEW_DOMAINS_DB, settings.NEW_APPS_DB, settings.SYNCLOGS_DB),
 
     # register these views to both the main db AND the apps db.
     'app_translations_by_popularity': (None, settings.NEW_APPS_DB),


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?189649
The `copy_domain` management command assumes this couchapp is present on each database it operates on, so `copy_domain` currently raises an exception.

 @dannyroberts @esoergel I think you guys have a plan for when reindexes happen? Should this not be merged until some specific time? Feel free to remove the "open for review" tag when it's safe to merge.
