### PR TITLE
App aware export items

### DIFF
--- a/corehq/apps/app_manager/dbaccessors.py
+++ b/corehq/apps/app_manager/dbaccessors.py
@@ -176,6 +176,35 @@ def get_built_app_ids_for_app_id(domain, app_id, version=None):
     return [result['id'] for result in results]
 
 
+def get_latest_built_app_ids_and_versions(domain, app_id=None):
+    """
+    Returns all the latest build app_ids and version in a dictionary:
+    {app_id: latest_version}
+    """
+    from .models import Application
+    key = [domain, app_id] if app_id else [domain]
+
+    results = Application.get_db().view(
+        'app_manager/saved_app',
+        startkey=key + [{}],
+        endkey=key,
+        descending=True,
+        reduce=False,
+        include_docs=False,
+    ).all()
+
+    latest_ids_and_versions = {}
+    for result in results:
+        app_id = result['key'][1]
+        version = result['key'][2]
+
+        # Since we have sorted, we know the first instance is the latest version
+        if app_id not in latest_ids_and_versions:
+            latest_ids_and_versions[app_id] = version
+
+    return latest_ids_and_versions
+
+
 def get_all_apps(domain):
     """
     Returns a list of all the apps ever built and current Applications.

--- a/corehq/apps/app_manager/dbaccessors.py
+++ b/corehq/apps/app_manager/dbaccessors.py
@@ -178,8 +178,11 @@ def get_built_app_ids_for_app_id(domain, app_id, version=None):
 
 def get_latest_built_app_ids_and_versions(domain, app_id=None):
     """
-    Returns all the latest build app_ids and version in a dictionary:
-    {app_id: latest_version}
+    Returns all the latest app_ids and versions in a dictionary.
+    :param domain: The domain to get the app from
+    :param app_id: The app_id to get the latest version from. If not specified gets latest versions of all
+        apps in the domain
+    :returns: {app_id: latest_version}
     """
     from .models import Application
     key = [domain, app_id] if app_id else [domain]

--- a/corehq/apps/app_manager/tests/test_dbaccessors.py
+++ b/corehq/apps/app_manager/tests/test_dbaccessors.py
@@ -5,6 +5,7 @@ from corehq.apps.app_manager.dbaccessors import (
     domain_has_apps,
     get_built_app_ids_for_app_id,
     get_all_app_ids,
+    get_latest_built_app_ids_and_versions,
 )
 from corehq.apps.app_manager.models import Application, RemoteApp, Module
 from corehq.apps.domain.models import Domain
@@ -106,3 +107,16 @@ class DBAccessorsTest(TestCase, DocTestMixin):
     def test_get_all_app_ids_for_domain(self):
         app_ids = get_all_app_ids(self.domain)
         self.assertEqual(len(app_ids), 3)
+
+    def test_get_latest_built_app_ids_and_versions(self):
+        build_ids_and_versions = get_latest_built_app_ids_and_versions(self.domain)
+        self.assertEqual(build_ids_and_versions, {
+            self.apps[0].get_id: 12,
+            '1234': 12,
+        })
+
+    def test_get_latest_built_app_ids_and_versions_with_app_id(self):
+        build_ids_and_versions = get_latest_built_app_ids_and_versions(self.domain, self.apps[0].get_id)
+        self.assertEqual(build_ids_and_versions, {
+            self.apps[0].get_id: 12,
+        })

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -28,8 +28,13 @@ from corehq.apps.export.const import (
 class ExportItem(DocumentSchema):
     """
     An item for export.
-    path is a question path like ["my_group", "q1"] or a case property name
-    like ["date_of_birth"].
+
+    path: A question path like ["my_group", "q1"] or a case property name
+        like ["date_of_birth"].
+
+    label: The label of the corresponding form question, or the case property name
+    tag: Denotes whether the property is a system, meta, etc
+    last_occurrences: A dictionary that maps an app_id to the last version the export item was present
     """
     path = ListProperty()
     label = StringProperty()

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -195,8 +195,7 @@ class Option(DocumentSchema):
     """
     This object represents a multiple choice question option.
 
-    last_occurrences is an app build number representing the last version of the app in
-    which this option was present.
+    last_occurrences is a dictionary of app_ids mapped to the last version that the options was present.
     """
     last_occurrences = DictProperty()
     value = StringProperty()

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -310,7 +310,7 @@ class ExportDataSchema(Document):
 class FormExportDataSchema(ExportDataSchema):
 
     @staticmethod
-    def generate_schema_from_builds(domain, app_id, unique_form_id):
+    def generate_schema_from_builds(domain, app_id, form_xmlns):
         """Builds a schema from Application builds for a given identifier
 
         :param domain: The domain that the export belongs to
@@ -323,7 +323,10 @@ class FormExportDataSchema(ExportDataSchema):
 
         for app_doc in iter_docs(Application.get_db(), app_build_ids):
             app = Application.wrap(app_doc)
-            xform = app.get_form(unique_form_id).wrapped_xform()
+            xform = app.get_form_by_xmlns(form_xmlns, log_missing=False)
+            if not xform:
+                continue
+            xform = xform.wrapped_xform()
             xform_conf = FormExportDataSchema._generate_schema_from_xform(
                 xform,
                 app.langs,

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -163,7 +163,7 @@ class ExportInstance(Document):
         """Given an ExportDataSchema, this will generate an ExportInstance"""
         instance = ExportInstance()
 
-        build_ids_and_versions = get_latest_built_app_ids_and_versions(domain, app_id)
+        latest_build_ids_and_versions = get_latest_built_app_ids_and_versions(domain, app_id)
         for group_schema in schema.group_schemas:
             table = TableConfiguration(
                 path=group_schema.path
@@ -172,7 +172,7 @@ class ExportInstance(Document):
                 lambda item: ExportColumn.create_default_from_export_item(
                     table.path,
                     item,
-                    build_ids_and_versions,
+                    latest_build_ids_and_versions,
                 ),
                 group_schema.items,
             )

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -417,7 +417,6 @@ class CaseExportDataSchema(ExportDataSchema):
                     path=[prop],
                     label=prop,
                     last_occurrences={app_id: app_version},
-                    app_id=app_id,
                 ))
 
             schema.group_schemas.append(group_schema)
@@ -440,7 +439,6 @@ class CaseExportDataSchema(ExportDataSchema):
                 label=system_prop.name,
                 tag=system_prop.tag,
                 last_occurrences={app_id: app_version},
-                app_id=app_id,
             ))
 
         for case_type, case_properties in case_property_mapping.iteritems():
@@ -450,7 +448,6 @@ class CaseExportDataSchema(ExportDataSchema):
                     label=prop,
                     tag=PROPERTY_TAG_UPDATE,
                     last_occurrences={app_id: app_version},
-                    app_id=app_id,
                 ))
 
         schema.group_schemas.append(group_schema)

--- a/corehq/apps/export/tests/data/basic_application.json
+++ b/corehq/apps/export/tests/data/basic_application.json
@@ -215,7 +215,7 @@
                {
                    "comment": "",
                    "doc_type": "Form",
-                   "xmlns": "undefined",
+                   "xmlns": "my_sweet_xmlns",
                    "name": {
                        "en": "Buy Candy Corn"
                    },

--- a/corehq/apps/export/tests/test_export_data_schema.py
+++ b/corehq/apps/export/tests/test_export_data_schema.py
@@ -287,7 +287,7 @@ class TestBuildingSchemaFromApplication(TestCase, TestXmlMixin):
         schema = FormExportDataSchema.generate_schema_from_builds(
             app.domain,
             app._id,
-            'b68a311749a6f45bdfda015b895d607012c91613'
+            'my_sweet_xmlns'
         )
 
         self.assertEqual(len(schema.group_schemas), 1)

--- a/corehq/apps/export/tests/test_export_instance.py
+++ b/corehq/apps/export/tests/test_export_instance.py
@@ -1,3 +1,4 @@
+import mock
 from django.test import SimpleTestCase
 
 from corehq.apps.export.models import (
@@ -10,9 +11,10 @@ from corehq.apps.export.models import (
 
 class TestExportInstanceGeneration(SimpleTestCase):
 
-    def setUp(self):
-        self.app_id = '1234'
-        self.schema = ExportDataSchema(
+    @classmethod
+    def setUpClass(cls):
+        cls.app_id = '1234'
+        cls.schema = ExportDataSchema(
             group_schemas=[
                 ExportGroupSchema(
                     path=[None],
@@ -20,10 +22,10 @@ class TestExportInstanceGeneration(SimpleTestCase):
                         ExportItem(
                             path=['data', 'question1'],
                             label='Question 1',
-                            last_occurrence={self.app_id: 3},
+                            last_occurrences={cls.app_id: 3},
                         )
                     ],
-                    last_occurrence={self.app_id: 3},
+                    last_occurrences={cls.app_id: 3},
                 ),
                 ExportGroupSchema(
                     path=['data', 'repeat'],
@@ -31,17 +33,26 @@ class TestExportInstanceGeneration(SimpleTestCase):
                         ExportItem(
                             path=['data', 'repeat', 'q2'],
                             label='Question 2',
-                            last_occurrence={self.app_id: 2},
+                            last_occurrences={cls.app_id: 2},
                         )
                     ],
-                    last_occurrence={self.app_id: 2},
+                    last_occurrences={cls.app_id: 2},
                 ),
             ],
         )
 
     def test_generate_instance_from_schema(self):
         """Only questions that are in the main table and of the same version should be shown"""
-        instance = ExportInstance.generate_instance_from_schema(self.schema, 3)
+        build_ids_and_versions = {self.app_id: 3}
+        with mock.patch(
+                'corehq.apps.export.models.new.get_latest_built_app_ids_and_versions',
+                return_value=build_ids_and_versions):
+
+            instance = ExportInstance.generate_instance_from_schema(
+                self.schema,
+                'dummy',
+                self.app_id
+            )
 
         self.assertEqual(len(instance.tables), 2)
 
@@ -58,9 +69,109 @@ class TestExportInstanceGeneration(SimpleTestCase):
 
     def test_generate_instance_from_schema_deleted(self):
         """Given a higher app_version, all the old questions should not be shown or selected"""
-        instance = ExportInstance.generate_instance_from_schema(self.schema, 4)
+        build_ids_and_versions = {self.app_id: 4}
+        with mock.patch(
+                'corehq.apps.export.models.new.get_latest_built_app_ids_and_versions',
+                return_value=build_ids_and_versions):
+            instance = ExportInstance.generate_instance_from_schema(
+                self.schema,
+                'dummy',
+                self.app_id
+            )
 
         self.assertEqual(len(instance.tables), 2)
+
+        selected = filter(
+            lambda column: column.selected,
+            instance.tables[0].columns + instance.tables[1].columns
+        )
+        shown = filter(
+            lambda column: column.selected,
+            instance.tables[0].columns + instance.tables[1].columns
+        )
+        self.assertEqual(len(selected), 0)
+        self.assertEqual(len(shown), 0)
+
+
+class TestExportInstanceGenerationMultipleApps(SimpleTestCase):
+    """Test Instance generation when the schema is made from multiple apps"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.app_id = '1234'
+        cls.second_app_id = '5678'
+        cls.schema = ExportDataSchema(
+            group_schemas=[
+                ExportGroupSchema(
+                    path=[None],
+                    items=[
+                        ExportItem(
+                            path=['data', 'question1'],
+                            label='Question 1',
+                            last_occurrences={
+                                cls.app_id: 2,
+                                cls.second_app_id: 4
+                            },
+                        )
+                    ],
+                    last_occurrences={
+                        cls.app_id: 2,
+                        cls.second_app_id: 4,
+                    },
+                ),
+                ExportGroupSchema(
+                    path=['data', 'repeat'],
+                    items=[
+                        ExportItem(
+                            path=['data', 'repeat', 'q2'],
+                            label='Question 2',
+                            last_occurrences={
+                                cls.app_id: 3,
+                            },
+                        )
+                    ],
+                    last_occurrences={
+                        cls.app_id: 3,
+                    },
+                ),
+            ],
+        )
+
+    def test_ensure_that_column_is_not_deleted(self):
+        """This test ensures that as long as ONE app in last_occurrences is the most recent version then the
+        column is still marked as is_deleted=False
+        """
+
+        build_ids_and_versions = {
+            self.app_id: 3,
+            self.second_app_id: 4,
+        }
+        with mock.patch(
+                'corehq.apps.export.models.new.get_latest_built_app_ids_and_versions',
+                return_value=build_ids_and_versions):
+            instance = ExportInstance.generate_instance_from_schema(self.schema, 'dummy-domain')
+
+        selected = filter(
+            lambda column: column.selected,
+            instance.tables[0].columns + instance.tables[1].columns
+        )
+        shown = filter(
+            lambda column: column.selected,
+            instance.tables[0].columns + instance.tables[1].columns
+        )
+        self.assertEqual(len(selected), 1)
+        self.assertEqual(len(shown), 1)
+
+    def test_ensure_that_column_is_deleted(self):
+        """If both apps are out of date then, the question is indeed deleted"""
+        build_ids_and_versions = {
+            self.app_id: 3,
+            self.second_app_id: 5,
+        }
+        with mock.patch(
+                'corehq.apps.export.models.new.get_latest_built_app_ids_and_versions',
+                return_value=build_ids_and_versions):
+            instance = ExportInstance.generate_instance_from_schema(self.schema, 'dummy-domain')
 
         selected = filter(
             lambda column: column.selected,

--- a/corehq/apps/export/tests/test_export_instance.py
+++ b/corehq/apps/export/tests/test_export_instance.py
@@ -11,6 +11,7 @@ from corehq.apps.export.models import (
 class TestExportInstanceGeneration(SimpleTestCase):
 
     def setUp(self):
+        self.app_id = '1234'
         self.schema = ExportDataSchema(
             group_schemas=[
                 ExportGroupSchema(
@@ -19,10 +20,10 @@ class TestExportInstanceGeneration(SimpleTestCase):
                         ExportItem(
                             path=['data', 'question1'],
                             label='Question 1',
-                            last_occurrence=3,
+                            last_occurrence={self.app_id: 3},
                         )
                     ],
-                    last_occurrence=3,
+                    last_occurrence={self.app_id: 3},
                 ),
                 ExportGroupSchema(
                     path=['data', 'repeat'],
@@ -30,10 +31,10 @@ class TestExportInstanceGeneration(SimpleTestCase):
                         ExportItem(
                             path=['data', 'repeat', 'q2'],
                             label='Question 2',
-                            last_occurrence=2,
+                            last_occurrence={self.app_id: 2},
                         )
                     ],
-                    last_occurrence=2,
+                    last_occurrence={self.app_id: 2},
                 ),
             ],
         )

--- a/corehq/apps/export/tests/test_export_item.py
+++ b/corehq/apps/export/tests/test_export_item.py
@@ -7,30 +7,31 @@ from corehq.apps.export.models import (
 
 
 class TestExportItemGeneration(SimpleTestCase):
+    app_id = '1234'
 
     def setUp(self):
         self.item = ExportItem(
             path=['data', 'question1'],
             label='Question One',
-            last_occurrence=3,
+            last_occurrences={self.app_id: 3},
         )
 
     def test_create_default_from_export_item(self):
-        column = ExportColumn.create_default_from_export_item([None], self.item, 3)
+        column = ExportColumn.create_default_from_export_item([None], self.item, {self.app_id: 3})
 
         self.assertEqual(column.show, True)
         self.assertEqual(column.label, 'Question One')
         self.assertEqual(column.selected, True)
 
     def test_create_default_from_export_item_deleted(self):
-        column = ExportColumn.create_default_from_export_item([None], self.item, 4)
+        column = ExportColumn.create_default_from_export_item([None], self.item, {self.app_id: 4})
 
         self.assertEqual(column.show, False)
         self.assertEqual(column.label, 'Question One')
         self.assertEqual(column.selected, False)
 
     def test_create_default_from_export_item_not_main_table(self):
-        column = ExportColumn.create_default_from_export_item(['other_table'], self.item, 3)
+        column = ExportColumn.create_default_from_export_item(['other_table'], self.item, {self.app_id: 3})
 
         self.assertEqual(column.show, True)
         self.assertEqual(column.label, 'Question One')


### PR DESCRIPTION
@NoahCarnahan @snopoke This allows for `ExportItems` to be "app aware". The main change is the fact that `last_occurrence` changed to `last_occurences` and that is a dict of app_id -> version. This allows the export to properly know if a case property is deleted in one app but not the other.
:fishing_pole_and_fish: 
cc: @emord @millerdev 
