### PR TITLE
Kill cross project reports privilege

### DIFF
--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -252,7 +252,6 @@ class DomainDowngradeStatusHandler(BaseModifySubscriptionHandler):
         privileges.CLOUDCARE,
         privileges.LOOKUP_TABLES,
         privileges.CUSTOM_BRANDING,
-        privileges.CROSS_PROJECT_REPORTS,
         privileges.OUTBOUND_SMS,
         privileges.INBOUND_SMS,
         privileges.DEIDENTIFIED_DATA,
@@ -323,13 +322,6 @@ class DomainDowngradeStatusHandler(BaseModifySubscriptionHandler):
             return self._fmt_alert(_("You are using custom branding. "
                                      "Selecting this plan will remove this "
                                      "feature."))
-
-    @property
-    def response_cross_project_reports(self):
-        """
-        Organization menu and corresponding reports are hidden on downgrade.
-        """
-        return None
 
     @property
     @memoized

--- a/corehq/apps/accounting/user_text.py
+++ b/corehq/apps/accounting/user_text.py
@@ -121,7 +121,6 @@ class PricingTableCategories(object):
             cls.ANALYTICS: (
                 f.DATA_EXPORT,
                 f.STANDARD_REPORTS,
-                f.CROSS_PROJECT_REPORTS,
                 f.CUSTOM_REPORTS,
                 f.ADM,
             ),
@@ -168,7 +167,6 @@ class PricingTableFeatures(object):
 
     DATA_EXPORT = 'data_export'
     STANDARD_REPORTS = 'standard_reports'
-    CROSS_PROJECT_REPORTS = 'cross_project_reports'
     CUSTOM_REPORTS = 'custom_reports'
     ADM = 'adm'
 
@@ -222,7 +220,6 @@ class PricingTableFeatures(object):
             cls.CUSTOM_BRANDING: _("Custom Branding"),
             cls.DATA_EXPORT: _("Data Export"),
             cls.STANDARD_REPORTS: _("Standard Reports"),
-            cls.CROSS_PROJECT_REPORTS: _("Cross-Project Reports"),
             cls.CUSTOM_REPORTS: _("Custom Reports Access"),
             cls.ADM: _('Active Data Management (<a href="http://www.commcarehq.org/tour/adm/">read more</a>)'),
             cls.OUTBOUND_SMS: _("Outbound Messaging"),
@@ -266,7 +263,6 @@ class PricingTableFeatures(object):
             cls.CUSTOM_BRANDING: (False, False, False, True, True),
             cls.DATA_EXPORT: (True, True, True, True, True),
             cls.STANDARD_REPORTS: (True, True, True, True, True),
-            cls.CROSS_PROJECT_REPORTS: (False, True, True, True, True),
             cls.CUSTOM_REPORTS: (False, False, True, True, True),
             cls.ADM: (False, False, False, True, True),
             cls.OUTBOUND_SMS: (False, True, True, True, True),

--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -44,7 +44,6 @@ def load_domain(req, domain):
     domain_name = normalize_domain_name(domain)
     domain = Domain.get_by_name(domain_name)
     req.project = domain
-    req.can_see_organization = has_privilege(req, privileges.CROSS_PROJECT_REPORTS)
     return domain_name, domain
 
 ########################################################################################################

--- a/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
+++ b/corehq/apps/hqadmin/management/commands/cchq_prbac_bootstrap.py
@@ -129,7 +129,6 @@ class Command(BaseCommand):
         Role(slug=privileges.CLOUDCARE, name='Web-based Applications (CloudCare)', description=''),
         Role(slug=privileges.CUSTOM_BRANDING, name='Custom Branding', description=''),
         Role(slug=privileges.ACTIVE_DATA_MANAGEMENT, name='Active Data Management', description=''),
-        Role(slug=privileges.CROSS_PROJECT_REPORTS, name='Cross-Project Reports', description=''),
         Role(slug=privileges.CUSTOM_REPORTS, name='Custom Reports', description=''),
         Role(slug=privileges.ROLE_BASED_ACCESS, name='Role-based Access', description=''),
         Role(slug=privileges.OUTBOUND_SMS, name='Outbound SMS',
@@ -173,7 +172,6 @@ class Command(BaseCommand):
     standard_plan_features = community_plan_features + [
         privileges.API_ACCESS,
         privileges.LOOKUP_TABLES,
-        privileges.CROSS_PROJECT_REPORTS,
         privileges.OUTBOUND_SMS,
         privileges.REMINDERS_FRAMEWORK,
         privileges.CUSTOM_SMS_GATEWAY,

--- a/corehq/privileges.py
+++ b/corehq/privileges.py
@@ -8,7 +8,6 @@ CLOUDCARE = 'cloudcare'
 ACTIVE_DATA_MANAGEMENT = 'active_data_management'
 CUSTOM_BRANDING = 'custom_branding'
 
-CROSS_PROJECT_REPORTS = 'cross_project_reports'
 CUSTOM_REPORTS = 'custom_reports'
 REPORT_BUILDER = 'user_configurable_report_builder'
 
@@ -44,7 +43,6 @@ MAX_PRIVILEGES = [
     CLOUDCARE,
     ACTIVE_DATA_MANAGEMENT,
     CUSTOM_BRANDING,
-    CROSS_PROJECT_REPORTS,
     CUSTOM_REPORTS,
     ROLE_BASED_ACCESS,
     OUTBOUND_SMS,
@@ -83,7 +81,6 @@ class Titles(object):
             CLOUDCARE: _("Web-Based Apps (CloudCare)"),
             ACTIVE_DATA_MANAGEMENT: _("Active Data Management"),
             CUSTOM_BRANDING: _("Custom Branding"),
-            CROSS_PROJECT_REPORTS: _("Cross-Project Reports"),
             ROLE_BASED_ACCESS: _("Advanced Role-Based Access"),
             OUTBOUND_SMS: _("Outgoing Messaging"),
             INBOUND_SMS: _("Incoming Messaging"),


### PR DESCRIPTION
Looks like all usages of `can_see_organization` were removed in https://github.com/dimagi/commcare-hq/pull/8739, so this removes the setting and the corresponding privilege.

@dannyroberts @biyeun 
