### PR TITLE
Fix report module icon path changes

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/report-module.js
+++ b/corehq/apps/app_manager/static/app_manager/js/report-module.js
@@ -308,9 +308,9 @@ var ReportModule = (function () {
         self.multimedia = function () {
             var multimedia = {};
             multimedia.mediaImage = {};
-            multimedia.mediaImage[self.lang] = self.menuImage.ref().path;
+            multimedia.mediaImage[self.lang] = self.menuImage.currentPath();
             multimedia.mediaAudio = {};
-            multimedia.mediaAudio[self.lang] = self.menuAudio.ref().path;
+            multimedia.mediaAudio[self.lang] = self.menuAudio.currentPath();
             return multimedia;
         };
 


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?212305
It might be worth adding some documentation to `AppMenuMediaManager`. There are few similar properties that all seem like they could signify similar things: `ref`, `currentPath`, `savedPath`, and `customPath`.

cc @calellowitz 
