### PR TITLE
Don't 500 before Location cache is cleared

### DIFF
--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -251,7 +251,7 @@ class CommtrackConfig(QuickCachedDocumentMixin, Document):
             if self.consumption_config.use_supply_point_type_default_consumption:
                 try:
                     supply_point = SupplyInterface(self.domain).get_supply_point(case_id)
-                    facility_type = supply_point.location.location_type
+                    facility_type = supply_point.sql_location.location_type_name
                 except ResourceNotFound:
                     pass
             return get_default_monthly_consumption(self.domain, product_id, facility_type, case_id)
@@ -352,11 +352,15 @@ class SupplyPointCase(CommCareCase):
             'location_site_code': None,
             'location_parent_name': None,
         })
-        if self.location:
-            data['location_type'] = self.location.location_type
-            data['location_site_code'] = self.location.site_code
-            if self.location.parent:
-                data['location_parent_name'] = self.location.parent.name
+        try:
+            location = self.sql_location
+        except SQLLocation.DoesNotExist:
+            pass
+        else:
+            data['location_type'] = location.location_type_name
+            data['location_site_code'] = location.site_code
+            if location.parent:
+                data['location_parent_name'] = location.parent.name
 
         return data
 

--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -407,6 +407,14 @@ class SQLLocation(MPTTModel):
         except:
             return None
 
+    @property
+    def location_type_object(self):
+        return self.location_type
+
+    @property
+    def location_type_name(self):
+        return self.location_type.name
+
 
 def _filter_for_archived(locations, include_archive_ancestors):
     """


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?215635
The cache isn't being cleared on bulk_delete, because our cache invalidation doesn't support that functionality.  I'll address that root cause in another PR.
