### PR TITLE
poc for ICDS UCR data source

### DIFF
--- a/corehq/apps/userreports/tests/__init__.py
+++ b/corehq/apps/userreports/tests/__init__.py
@@ -7,6 +7,7 @@ from .test_expressions import *
 from .test_filters import *
 from .test_getters import *
 from .test_data_source_config import *
+from .test_data_source_icds import *
 from .test_data_source_repeats import *
 from .test_multi_db import *
 from .test_indicators import *

--- a/corehq/apps/userreports/tests/data/configs/icds_poc.json
+++ b/corehq/apps/userreports/tests/data/configs/icds_poc.json
@@ -1,0 +1,121 @@
+{
+    "domain": "icds-test",
+    "doc_type": "DataSourceConfiguration",
+    "referenced_doc_type": "XFormInstance",
+    "table_id": "sample-repeat",
+    "display_name": "ICDS Sample",
+    "base_item_expression": {
+        "type": "iterator",
+        "expressions": [
+            -90,
+            -60,
+            -30,
+            0,
+            30,
+            60,
+            90
+        ]
+    },
+    "configured_filter": {
+    },
+    "configured_indicators": [
+        {
+            "type": "expression",
+            "expression": {
+                "type": "identity"
+            },
+            "column_id": "offset",
+            "datatype": "integer",
+            "display_name": "month offset"
+        },
+        {
+            "type": "expression",
+            "expression": {
+                "type": "named",
+                "name": "received_on"
+            },
+            "column_id": "received_on",
+            "datatype": "date",
+            "display_name": "received on"
+        },
+        {
+            "type": "expression",
+            "expression": {
+                "type": "named",
+                "name": "offset_date"
+            },
+            "column_id": "offset_date",
+            "datatype": "date",
+            "display_name": "offset date"
+        },
+        {
+            "type": "boolean",
+            "column_id": "was_open",
+            "filter": {
+                "type": "and",
+                "filters": [
+                    {
+                        "type": "boolean_expression",
+                        "expression": {
+                            "type": "named",
+                            "name": "case_opened_on"
+                        },
+                        "operator": "lt",
+                        "property_value": {
+                            "type": "named",
+                            "name": "offset_date"
+                        }
+                    },
+                    {
+                        "type": "boolean_expression",
+                        "expression": {
+                            "type": "named",
+                            "name": "case_closed_on"
+                        },
+                        "operator": "gt",
+                        "property_value": {
+                            "type": "named",
+                            "name": "offset_date"
+                        }
+                    }
+                ]
+            }
+        }
+    ],
+    "named_expressions": {
+        "received_on": {
+            "type": "root_doc",
+            "expression": {
+                "type": "property_name",
+                "property_name": "received_on"
+            }
+        },
+        "case_opened_on": {
+            "type": "root_doc",
+            "expression": {
+                "type": "property_name",
+                "property_name": "case_opened_on"
+            }
+        },
+        "case_closed_on": {
+            "type": "root_doc",
+            "expression": {
+                "type": "property_name",
+                "property_name": "case_closed_on"
+            }
+        },
+        "offset_date": {
+            "type": "add_days",
+            "date_expression": {
+                "type": "root_doc",
+                "expression": {
+                    "type": "property_name",
+                    "property_name": "received_on"
+                }
+            },
+            "count_expression": {
+                "type": "identity"
+            }
+        }
+    }
+}

--- a/corehq/apps/userreports/tests/test_data_source_icds.py
+++ b/corehq/apps/userreports/tests/test_data_source_icds.py
@@ -1,0 +1,27 @@
+import json
+import os
+from datetime import date
+from django.test import SimpleTestCase
+from corehq.apps.userreports.models import DataSourceConfiguration
+
+
+class ICDSDataSourceConfigurationTest(SimpleTestCase):
+
+    def setUp(self):
+        folder = os.path.join(os.path.dirname(__file__), 'data', 'configs')
+        sample_file = os.path.join(folder, 'icds_poc.json')
+        with open(sample_file) as f:
+            self.config = DataSourceConfiguration.wrap(json.loads(f.read()))
+
+    def test_items(self):
+        doc = {
+            "domain": "icds-test",
+            "doc_type": "XFormInstance",
+            "received_on": date(2016, 1, 29),
+            "case_opened_on": date(2015, 11, 15),
+            "case_closed_on": date(2016, 2, 15),
+        }
+
+        for row in self.config.get_all_values(doc):
+            print row
+


### PR DESCRIPTION
(don't merge)

@sheelio @TylerSheffels I think we can basically do this completely in stock UCR. There are a few annoying things to work out around datatypes (dates/strings/datetime comparisons are super annoying) and guessing we need to add a "add_months" expression similar to add_days. Think this should work out fine though (here's the output):

```
[doc_id: None, inserted_at: 2016-01-29 13:04:11.183884, repeat_iteration: 0, offset: -90, received_on: 2016-01-29, offset_date: 2015-10-31, was_open: 0]
[doc_id: None, inserted_at: 2016-01-29 13:04:11.183998, repeat_iteration: 1, offset: -60, received_on: 2016-01-29, offset_date: 2015-11-30, was_open: 1]
[doc_id: None, inserted_at: 2016-01-29 13:04:11.184126, repeat_iteration: 2, offset: -30, received_on: 2016-01-29, offset_date: 2015-12-30, was_open: 1]
[doc_id: None, inserted_at: 2016-01-29 13:04:11.184238, repeat_iteration: 3, offset: 0, received_on: 2016-01-29, offset_date: 2016-01-29, was_open: 1]
[doc_id: None, inserted_at: 2016-01-29 13:04:11.184335, repeat_iteration: 4, offset: 30, received_on: 2016-01-29, offset_date: 2016-02-28, was_open: 0]
[doc_id: None, inserted_at: 2016-01-29 13:04:11.184430, repeat_iteration: 5, offset: 60, received_on: 2016-01-29, offset_date: 2016-03-29, was_open: 0]
[doc_id: None, inserted_at: 2016-01-29 13:04:11.184526, repeat_iteration: 6, offset: 90, received_on: 2016-01-29, offset_date: 2016-04-28, was_open: 0]
```
