### PR TITLE
Add email field help text to email report modals

### DIFF
--- a/corehq/apps/reports/templates/reports/bootstrap2/standard/base_template.html
+++ b/corehq/apps/reports/templates/reports/bootstrap2/standard/base_template.html
@@ -187,7 +187,12 @@
                             <textarea rows="3"
                                       id="email-report-recipient_emails"
                                       name="recipient_emails"
+                                      aria-describedby="email-report-recipient_emails-help-block"
                                       data-bind="value: recipient_emails"></textarea>
+                            <span id="email-report-recipient_emails-help-block"
+                                  class="help-block">
+                                Separate email addresses with commas
+                            </span>
                         </div>
                     </div>
                     <div class="control-group">

--- a/corehq/apps/reports/templates/reports/bootstrap3/standard/base_template.html
+++ b/corehq/apps/reports/templates/reports/bootstrap3/standard/base_template.html
@@ -203,7 +203,12 @@
                                           id="email-report-recipient_emails"
                                           name="recipient_emails"
                                           data-bind="value: recipient_emails"
+                                          aria-describedby="email-report-recipient_emails-help-block"
                                           class="form-control"></textarea>
+                                <span id="email-report-recipient_emails-help-block"
+                                      class="help-block">
+                                    Separate email addresses with commas
+                                </span>
                             </div>
                         </div>
                         <div class="form-group">


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?215636
Added "Separate email addresses with commas" help text. This will appear for all reports that use this modal, not just the worker activity report pictured in the screenshot.
FYI @dimagi/product 

<img width="597" alt="screen shot 2016-01-29 at 10 54 25 am" src="https://cloud.githubusercontent.com/assets/2117127/12680373/7d1e0422-c677-11e5-9fe1-3572f1f3583e.png">
