### PR TITLE
get extension chain with case_id

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -273,7 +273,7 @@ def _is_change_of_ownership(previous_owner_id, next_owner_id):
 def get_extensions_to_close(case, domain):
     outgoing_indices = case.indices
     if not outgoing_indices and case.closed and EXTENSION_CASES_SYNC_ENABLED.enabled(domain):
-        return get_extension_chain([case], domain)
+        return get_extension_chain([case.case_id], domain)
     else:
         return set()
 


### PR DESCRIPTION
Not sure how this got through... but basically I think `get_reverse_indices_info` was using object ids rather than case ids, and was returning this:

``` py
(Pdb) self.cases
[CommCareCase(name=u'test.lily', type=u'FLW', id=u'db386f078f934ad19639699af4fee9cd')]
(Pdb) len(list(self.extensions_to_close))
359267
```

http://manage.dimagi.com/default.asp?200797

@czue @snopoke (since cory's offline) @gcapalbo 
Thanks @TylerSheffels for teaching me about `pdb.pm()` which allows you all the power in the world if you can recreate a bug. 
