### PR TITLE
Autoclose cases

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/dbaccessors/related.py
+++ b/corehq/ex-submodules/casexml/apps/case/dbaccessors/related.py
@@ -87,10 +87,10 @@ def get_reverse_indices_for_case_id(domain, case_id):
             for raw in get_reverse_indices_json(domain, case_id)]
 
 
-def get_extension_chain(cases, domain):
-    """given a list of cases, returns a list of all extensions of that case"""
+def get_extension_chain(case_ids, domain):
+    """given a list of case_ids, returns a list of all extensions of those cases"""
     extension_chain_ids = set()
-    incoming_extensions = set(get_extension_case_ids(domain, cases))
+    incoming_extensions = set(get_extension_case_ids(domain, case_ids))
     all_extension_ids = set(incoming_extensions)
     new_extensions = set(incoming_extensions)
     while new_extensions:

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_close_extension_chain.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_close_extension_chain.py
@@ -2,8 +2,8 @@ from datetime import datetime
 
 from casexml.apps.case.mock import CaseFactory, CaseIndex, CaseStructure
 from casexml.apps.case.models import CommCareCase
-from casexml.apps.case.xform import get_extension_chain, \
-    get_extensions_to_close
+from casexml.apps.case.dbaccessors import get_extension_chain
+from casexml.apps.case.xform import get_extensions_to_close
 from casexml.apps.phone.models import User
 from casexml.apps.phone.tests.test_sync_mode import SyncBaseTest
 from corehq.apps.domain.models import Domain

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_close_extension_chain.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_close_extension_chain.py
@@ -19,7 +19,7 @@ class AutoCloseExtensionsTest(SyncBaseTest):
         self.project = Domain(name=self.domain)
         self.user = User(user_id='user', username='name', password="changeme",
                          date_joined=datetime(2011, 6, 9))
-        self.factory = CaseFactory()
+        self.factory = CaseFactory(domain=self.domain)
         self.extension_ids = ['1', '2', '3']
         self.host = CaseStructure(case_id='host')
         self.extension = CaseStructure(
@@ -46,7 +46,7 @@ class AutoCloseExtensionsTest(SyncBaseTest):
 
     def test_get_extension_chain_simple(self):
         self.factory.create_or_update_cases([self.extension])
-        self.assertEqual(set(self.extension_ids[0]), get_extension_chain([self.host], self.domain))
+        self.assertEqual(set(self.extension_ids[0]), get_extension_chain([self.host.case_id], self.domain))
 
     def test_get_extension_chain_multiple(self):
         self.factory.create_or_update_cases([self.extension_3])

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -273,7 +273,7 @@ def _is_change_of_ownership(previous_owner_id, next_owner_id):
 def get_extensions_to_close(case, domain):
     outgoing_indices = case.indices
     if not outgoing_indices and case.closed and EXTENSION_CASES_SYNC_ENABLED.enabled(domain):
-        return get_extension_chain([case], domain)
+        return get_extension_chain([case.case_id], domain)
     else:
         return set()
 


### PR DESCRIPTION
@snopoke @gcapalbo 
supercededs https://github.com/dimagi/commcare-hq/pull/10139

Tests were not running correctly (missing domain parameter), which is how the previous thing slipped through. 
