### PR TITLE
publish SQL changes outside of transaction

### DIFF
--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -70,7 +70,8 @@ class FormProcessorSQL(object):
                     CaseAccessorSQL.save_case(case)
             for stock_update in stock_updates or []:
                 stock_update.commit()
-            cls._publish_changes(processed_forms, cases)
+
+        cls._publish_changes(processed_forms, cases)
 
     @staticmethod
     def _publish_changes(processed_forms, cases):


### PR DESCRIPTION
Otherwise the pillow may attempt to fetch the doc before the transaction has been committed.
@benrudolph 
