### PR TITLE
Speed up run_doctype_migration

### DIFF
--- a/corehq/doctypemigrations/bulk_migrate.py
+++ b/corehq/doctypemigrations/bulk_migrate.py
@@ -1,44 +1,21 @@
-import base64
-import json
-
 from corehq.dbaccessors.couchapps.all_docs import get_all_docs_with_doc_types
 from corehq.util.couch import IterDB
 
 
-def _encode_data(attachment_dict):
-    data = attachment_dict['data']
-    # couchdbkit is annoying and auto-converts
-    # anything that looks like utf-8 to unicode
-    if isinstance(data, unicode):
-        data = data.encode('utf-8')
-    attachment_dict['data'] = base64.b64encode(data)
-    return attachment_dict
-
-
 def _insert_attachments(db, doc_json):
     if '_attachments' not in doc_json:
-        return
+        return doc_json
     else:
-        full_doc = db.get(doc_json['_id'], attachments=True)
-        doc_json['_attachments'] = {
-            name: _encode_data(attachment_dict)
-            for name, attachment_dict in full_doc['_attachments'].items()
-        }
+        return db.get(doc_json['_id'], attachments=True)
 
 
-def bulk_migrate(source_db, target_db, doc_types, filename):
+def bulk_migrate(source_db, target_db, doc_types):
 
-    with open(filename, 'w') as f:
+    with IterDB(target_db, new_edits=False) as iter_db:
         for doc in get_all_docs_with_doc_types(source_db, doc_types):
             # It turns out that Cloudant does not support attachments=true
-            # on views or on _all_docs, only on single doc gets
-            # instead, we have to fetch each attachment individually
+            # on views or on _all_docs, only on single doc gets, so we have
+            # to manually re-query for the full doc + attachments.
             # (And I think there's literally no other way.)
-            _insert_attachments(source_db, doc)
-            f.write('{}\n'.format(json.dumps(doc)))
-
-    with open(filename, 'r') as f:
-        with IterDB(target_db, new_edits=False) as iter_db:
-            for line in f:
-                doc = json.loads(line)
-                iter_db.save(doc)
+            doc = _insert_attachments(source_db, doc)
+            iter_db.save(doc)

--- a/corehq/doctypemigrations/bulk_migrate.py
+++ b/corehq/doctypemigrations/bulk_migrate.py
@@ -5,37 +5,25 @@ from corehq.dbaccessors.couchapps.all_docs import get_all_docs_with_doc_types
 from corehq.util.couch import IterDB
 
 
-def fetch_binary_attachment(db, doc_id, name):
-    data = db.fetch_attachment(doc_id, name)
+def _encode_data(attachment_dict):
+    data = attachment_dict['data']
     # couchdbkit is annoying and auto-converts
     # anything that looks like utf-8 to unicode
     if isinstance(data, unicode):
         data = data.encode('utf-8')
-    return data
+    attachment_dict['data'] = base64.b64encode(data)
+    return attachment_dict
 
 
-def insert_attachment(db, doc_json):
-    """
-    fetch attachment bodies for doc_json with attachment stubs
-    and insert them into the doc_json
-
-    """
+def _insert_attachments(db, doc_json):
     if '_attachments' not in doc_json:
         return
     else:
-        for name, value in doc_json['_attachments'].items():
-            # it's a bit of a wash whether to fetch attachments individually
-            # or re-fetch the whole doc with attachments.
-            # For a doc with a single attachment this is faster,
-            # so I'll go with it for now
-            data = fetch_binary_attachment(db, doc_json['_id'], name)
-            doc_json['_attachments'][name] = {
-                'data': base64.b64encode(data),
-                'length': value['length'],
-                'content_type': value['content_type'],
-                'digest': value['digest'],
-                'revpos': value['revpos']
-            }
+        full_doc = db.get(doc_json['_id'], attachments=True)
+        doc_json['_attachments'] = {
+            name: _encode_data(attachment_dict)
+            for name, attachment_dict in full_doc['_attachments'].items()
+        }
 
 
 def bulk_migrate(source_db, target_db, doc_types, filename):
@@ -46,7 +34,7 @@ def bulk_migrate(source_db, target_db, doc_types, filename):
             # on views or on _all_docs, only on single doc gets
             # instead, we have to fetch each attachment individually
             # (And I think there's literally no other way.)
-            insert_attachment(source_db, doc)
+            _insert_attachments(source_db, doc)
             f.write('{}\n'.format(json.dumps(doc)))
 
     with open(filename, 'r') as f:

--- a/corehq/doctypemigrations/tests.py
+++ b/corehq/doctypemigrations/tests.py
@@ -62,8 +62,7 @@ class TestDocTypeMigrations(TestCase):
     def test_bulk_migrate(self):
         bulk_migrate(
             self.migration.source_db, self.migration.target_db,
-            self.migration.doc_types,
-            self.migration.data_dump_filename)
+            self.migration.doc_types)
         self.assert_in_sync()
 
     def test_phase_1_bulk_migrate(self):


### PR DESCRIPTION
@dannyroberts cc @gcapalbo 
This has two changes:
1. Individually re-fetch all documents with attachments in order to get the attachments.  (Previously this was getting each attachment individually)
2. Don't write the docs to an intermediate log file.  This loses the atomicity of the operation - if there's a failure during the reads, some of the writes will have already happened. Unfortunately, we estimate the size of the intermediate file to be in the hundreds of GBs, which just isn't feasible.
