### PR TITLE
don't autopay an invoice that has zero balance

### DIFF
--- a/corehq/apps/accounting/payment_handlers.py
+++ b/corehq/apps/accounting/payment_handlers.py
@@ -418,6 +418,8 @@ class AutoPayInvoicePaymentHandler(object):
         for invoice in autopayable_invoices:
             log_accounting_info("[Autopay] Autopaying invoice {}".format(invoice.id))
             amount = invoice.balance.quantize(Decimal(10) ** -2)
+            if not amount:
+                return
 
             auto_payer = invoice.subscription.account.auto_pay_user
             payment_method = StripePaymentMethod.objects.get(web_user=auto_payer)


### PR DESCRIPTION
prevents unnecessary error messages like http://manage.dimagi.com/default.asp?215969

@benrudolph cc: @dannyroberts  
