### PR TITLE
update requiements in web image during build

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -26,6 +26,9 @@ Initial setup
     the login details above.
 
 * Configure your localsettings
+    
+    **NOTE** this is only necessary if you want to run CommCare HQ inside the docker container. If you just want
+    to use the services skip this step.
 
     Make your `localsettings.py` extend `dockersettings.py` and comment out / delete your current
     settings for PostgreSQL, Redis, CouchDB, Elasticsearch
@@ -40,20 +43,30 @@ Initial setup
     
 General usage
 -------------
-The following commands assumes that you have updated your localsettings as described above.
-
-**Print the help**
 
 ```
   $ ./dockerhq.sh --help
 ```
 
-**Start/stop the services (couch, postgres, elastic, redis)**
+**The services (couch, postgres, elastic, redis, zookeeper, kafka)**
 ```
   $ ./dockerhq.sh services start
+  $ ./dockerhq.sh services stop
+  $ ./dockerhq.sh services logs postgres
 ```
+The following services are included. Their ports are mapped to the local host so you can connect to them
+directly.
+
+* Easticsearch (9200 & 9300)
+* PostgreSQL (5432)
+* CouchDB (5984)
+* Redis (6397)
+* Zookeeper (2181)
+* Kafka (9092)
 
 **Run the django server**
+
+Assumes that you have updated your localsettings as described above.
 
 ```
   $ ./dockerhq.sh runserver

--- a/docker/dockerfiles/Dockerfile_commcarehq
+++ b/docker/dockerfiles/Dockerfile_commcarehq
@@ -1,7 +1,24 @@
 FROM dimagi/commcarehq_base:latest
 
+RUN mkdir requirements
+COPY scripts/uninstall-requirements.sh requirements/uninstall-requirements.sh
+COPY requirements/uninstall-requirements.txt requirements/uninstall-requirements.txt
+
+RUN requirements/uninstall-requirements.sh
+
+COPY requirements/requirements.txt /vendor/requirements.txt
+COPY requirements/dev-requirements.txt /vendor/dev-requirements.txt
+COPY requirements/test-requirements.txt /vendor/test-requirements.txt
+
+RUN pip install \
+    -r /vendor/requirements.txt \
+    -r /vendor/dev-requirements.txt \
+    --user --upgrade \
+    && rm -rf /root/.cache/pip
+
 WORKDIR /mnt
-COPY docker/entrypoint.sh /mnt/docker/entrypoint.sh
+
+ADD docker/entrypoint.sh /mnt/docker/entrypoint.sh
 
 ENTRYPOINT ["/mnt/docker/entrypoint.sh"]
 CMD ["help"]

--- a/dockerhq.sh
+++ b/dockerhq.sh
@@ -47,16 +47,7 @@ function usage() {
 }
 
 function rebuild() {
-    git_branch=$(git symbolic-ref HEAD 2>/dev/null)
-    git_branch=${git_branch#refs/heads/}
-
-    tag="$git_branch"
-    if [ "$git_branch" = "master" ]; then
-        tag="latest"
-    fi
-
     web_runner down
-    sudo docker build -f $DOCKER_DIR/Dockerfile_commcarehq_base -t dimagi/commcarehq_base:$tag .
     web_runner build
 }
 


### PR DESCRIPTION
@emord 
This should make it much easier to update requirements. Now if you change a requirements file you don't have to rebuild the base image, just the 'web' image which will be much faster. This is what we do for Travis as well to ensure it has the latest requirements.
