### PR TITLE
reorder args to match api

### DIFF
--- a/corehq/ex-submodules/pillowtop/es_utils.py
+++ b/corehq/ex-submodules/pillowtop/es_utils.py
@@ -87,7 +87,7 @@ def initialize_mapping_if_necessary(pillow):
         pillow_logging.info("Initializing elasticsearch mapping for [%s]" % pillow.es_type)
         mapping = copy(pillow.default_mapping)
         mapping['_meta']['created'] = datetime.isoformat(datetime.utcnow())
-        mapping_res = es.indices.put_mapping(pillow.es_type, {pillow.es_type: mapping}, index=pillow.es_index)
+        mapping_res = es.indices.put_mapping(pillow.es_index, pillow.es_type, {pillow.es_type: mapping})
         if mapping_res.get('ok', False) and mapping_res.get('acknowledged', False):
             # API confirms OK, trust it.
             pillow_logging.info("Mapping set: [%s] %s" % (pillow.es_type, mapping_res))


### PR DESCRIPTION
@snopoke 
I was getting errors when preindexing and flipping aliases pillowtop because `put_mapping` was receiving multiple values for `index`
