### PR TITLE
Split jQuery UI includes

### DIFF
--- a/corehq/apps/style/templates/style/bootstrap3/base.html
+++ b/corehq/apps/style/templates/style/bootstrap3/base.html
@@ -141,27 +141,27 @@
 
         {% if request.use_jquery_ui %}
         {% compress js %}
-            <script src="{% new_static 'jquery-ui/ui/minified/core.min.js' %}"></script>
-            <script src="{% new_static 'jquery-ui/ui/minified/widget.min.js' %}"></script>
-            <script src="{% new_static 'jquery-ui/ui/minified/mouse.min.js' %}"></script>
-            <script src="{% new_static 'jquery-ui/ui/minified/position.min.js' %}"></script>
-            <script src="{% new_static 'jquery-ui/ui/minified/accordion.min.js' %}"></script>
-            <script src="{% new_static 'jquery-ui/ui/minified/menu.min.js' %}"></script>
-            <script src="{% new_static 'jquery-ui/ui/minified/autocomplete.min.js' %}"></script>
-            <script src="{% new_static 'jquery-ui/ui/minified/button.min.js' %}"></script>
-            <script src="{% new_static 'jquery-ui/ui/minified/datepicker.min.js' %}"></script>
-            <script src="{% new_static 'jquery-ui/ui/minified/draggable.min.js' %}"></script>
-            <script src="{% new_static 'jquery-ui/ui/minified/resizable.min.js' %}"></script>
-            <script src="{% new_static 'jquery-ui/ui/minified/dialog.min.js' %}"></script>
-            <script src="{% new_static 'jquery-ui/ui/minified/droppable.min.js' %}"></script>
-            <script src="{% new_static 'jquery-ui/ui/minified/progressbar.min.js' %}"></script>
-            <script src="{% new_static 'jquery-ui/ui/minified/selectable.min.js' %}"></script>
-            <script src="{% new_static 'jquery-ui/ui/minified/selectmenu.min.js' %}"></script>
-            <script src="{% new_static 'jquery-ui/ui/minified/slider.min.js' %}"></script>
-            <script src="{% new_static 'jquery-ui/ui/minified/sortable.min.js' %}"></script>
-            <script src="{% new_static 'jquery-ui/ui/minified/spinner.min.js' %}"></script>
-            <script src="{% new_static 'jquery-ui/ui/minified/tabs.min.js' %}"></script>
-            <script src="{% new_static 'jquery-ui/ui/minified/tooltip.min.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/core.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/widget.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/mouse.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/position.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/accordion.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/menu.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/autocomplete.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/button.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/datepicker.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/draggable.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/resizable.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/dialog.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/droppable.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/progressbar.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/selectable.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/selectmenu.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/slider.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/sortable.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/spinner.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/tabs.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/tooltip.js' %}"></script>
         {% endcompress %}
         {% endif %}
 

--- a/corehq/apps/style/templates/style/bootstrap3/base.html
+++ b/corehq/apps/style/templates/style/bootstrap3/base.html
@@ -141,7 +141,27 @@
 
         {% if request.use_jquery_ui %}
         {% compress js %}
-        <script type="text/javascript" src="{% new_static 'jquery-ui/jquery-ui.min.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/minified/core.min.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/minified/widget.min.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/minified/mouse.min.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/minified/position.min.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/minified/accordion.min.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/minified/menu.min.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/minified/autocomplete.min.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/minified/button.min.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/minified/datepicker.min.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/minified/draggable.min.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/minified/resizable.min.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/minified/dialog.min.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/minified/droppable.min.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/minified/progressbar.min.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/minified/selectable.min.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/minified/selectmenu.min.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/minified/slider.min.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/minified/sortable.min.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/minified/spinner.min.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/minified/tabs.min.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/minified/tooltip.min.js' %}"></script>
         {% endcompress %}
         {% endif %}
 

--- a/corehq/apps/style/templates/style/bootstrap3/base.html
+++ b/corehq/apps/style/templates/style/bootstrap3/base.html
@@ -141,27 +141,23 @@
 
         {% if request.use_jquery_ui %}
         {% compress js %}
+            <!-- UI libraries needed for all other widgets and interactions -->
             <script src="{% new_static 'jquery-ui/ui/core.js' %}"></script>
             <script src="{% new_static 'jquery-ui/ui/widget.js' %}"></script>
             <script src="{% new_static 'jquery-ui/ui/mouse.js' %}"></script>
             <script src="{% new_static 'jquery-ui/ui/position.js' %}"></script>
-            <script src="{% new_static 'jquery-ui/ui/accordion.js' %}"></script>
+
+            <!-- Individual widgets and interactions -->
+            <script src="{% new_static 'jquery-ui/ui/accordion.js' %}"></script><!-- TODO: kill & replace with bootstrap -->
             <script src="{% new_static 'jquery-ui/ui/menu.js' %}"></script>
             <script src="{% new_static 'jquery-ui/ui/autocomplete.js' %}"></script>
             <script src="{% new_static 'jquery-ui/ui/button.js' %}"></script>
             <script src="{% new_static 'jquery-ui/ui/datepicker.js' %}"></script>
             <script src="{% new_static 'jquery-ui/ui/draggable.js' %}"></script>
             <script src="{% new_static 'jquery-ui/ui/resizable.js' %}"></script>
-            <script src="{% new_static 'jquery-ui/ui/dialog.js' %}"></script>
+            <script src="{% new_static 'jquery-ui/ui/dialog.js' %}"></script><!-- TODO: kill & replace with bootstrap -->
             <script src="{% new_static 'jquery-ui/ui/droppable.js' %}"></script>
-            <script src="{% new_static 'jquery-ui/ui/progressbar.js' %}"></script>
-            <script src="{% new_static 'jquery-ui/ui/selectable.js' %}"></script>
-            <script src="{% new_static 'jquery-ui/ui/selectmenu.js' %}"></script>
-            <script src="{% new_static 'jquery-ui/ui/slider.js' %}"></script>
             <script src="{% new_static 'jquery-ui/ui/sortable.js' %}"></script>
-            <script src="{% new_static 'jquery-ui/ui/spinner.js' %}"></script>
-            <script src="{% new_static 'jquery-ui/ui/tabs.js' %}"></script>
-            <script src="{% new_static 'jquery-ui/ui/tooltip.js' %}"></script>
         {% endcompress %}
         {% endif %}
 


### PR DESCRIPTION
In the interest of reducing jQuery UI usage, at least reducing how often it conflicts with other libraries, include individual components instead of the entire monstrosity. It's a bunch more script requests, but I suspect we aren't actually using a lot of these (I can take a pass at figuring out which ones we aren't using).

Doesn't include jQuery effects.

@dimagi/js-team 
