### PR TITLE
ILS: Make sure that supply_point_id in sql is set

### DIFF
--- a/custom/ilsgateway/api.py
+++ b/custom/ilsgateway/api.py
@@ -549,9 +549,14 @@ class ILSGatewayAPI(APISynchronization):
             location.save()
 
             interface = SupplyInterface(self.domain)
-            if ilsgateway_location.type == 'FACILITY' and not interface.get_by_location(location):
-                interface.create_from_location(self.domain, location)
-                location.save()
+            if ilsgateway_location.type == 'FACILITY':
+                if not interface.get_by_location(location):
+                    interface.create_from_location(self.domain, location)
+                    location.save()
+                else:
+                    sql_location = location.sql_location
+                    if not sql_location.supply_point_id:
+                        location.save()
         else:
             location_dict = {
                 'name': ilsgateway_location.name,

--- a/custom/ilsgateway/templates/ilsgateway/balance.html
+++ b/custom/ilsgateway/templates/ilsgateway/balance.html
@@ -19,6 +19,9 @@
                 <th>
                     SMS Users
                 </th>
+                <th>
+                    Facilities with filled supply_point_id / All facilities
+                </th>
             </tr>
         </thead>
         <tr>
@@ -27,6 +30,7 @@
             <td>{{ locations_count }} / {{ stats.locations_count }}</td>
             <td>{{ web_users_count }} / {{ stats.web_users_count }}</td>
             <td>{{ sms_users_count }} / {{ stats.sms_users_count }}</td>
+            <td>{{ supply_points_count }} / {{ facilites_count }}</td>
         </tr>
     </table>
     <table id="problems-table" class="table table-bordered">

--- a/custom/ilsgateway/views.py
+++ b/custom/ilsgateway/views.py
@@ -387,5 +387,11 @@ class BalanceMigrationView(BaseDomainView):
             'locations_count': SQLLocation.objects.filter(domain=self.domain).exclude(is_archived=True).count(),
             'web_users_count': WebUser.by_domain(self.domain, reduce=True)[0]['value'],
             'sms_users_count': CommCareUser.by_domain(self.domain, reduce=True)[0]['value'],
+            'supply_points_count': SQLLocation.active_objects.filter(
+                domain=self.domain, location_type__name='FACILITY'
+            ).exclude(supply_point_id__isnull=True).count(),
+            'facilites_count': SQLLocation.active_objects.filter(
+                domain=self.domain, location_type__name='FACILITY'
+            ).count(),
             'problems': ILSMigrationProblem.objects.filter(domain=self.domain)
         }


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?215842#1083617

@gcapalbo I believe that problem started to occur after that change: https://github.com/dimagi/commcare-hq/pull/9946/files#diff-a2c9183455842303ef415bfcd036fdc3R245.
Before that change we were creating supply point in custom module.

I'm not able to explain why sometimes this id is equal to None. It seems that for all non-administrative locations it has to be set.
