### PR TITLE
Refactor frontend exports 4 - DEID

### DIFF
--- a/corehq/apps/export/const.py
+++ b/corehq/apps/export/const.py
@@ -29,3 +29,8 @@ FORM_EXPORT = 'form'
 CASE_EXPORT = 'case'
 
 MAIN_TABLE = None
+
+TRANSFORM_FUNCTIONS = {
+    'deid_id': lambda x: x,  # TODO: map these to actual deid functions
+    'deid_date': lambda x: x
+}

--- a/corehq/apps/export/exceptions.py
+++ b/corehq/apps/export/exceptions.py
@@ -18,3 +18,7 @@ class ExportFormValidationException(Exception):
 
 class ExportAsyncException(Exception):
     pass
+
+
+class ExportInvalidTransform(Exception):
+    '''Thrown when an invalid transform constant gets added to an ExportColumn'''

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -21,6 +21,9 @@ from dimagi.ext.couchdbkit import (
     IntegerProperty,
     DateTimeProperty,
 )
+from corehq.apps.export.utils import (
+    is_valid_transform
+)
 from corehq.apps.export.const import (
     PROPERTY_TAG_UPDATE,
     PROPERTY_TAG_DELETED,
@@ -30,6 +33,7 @@ from corehq.apps.export.const import (
     FORM_EXPORT,
     CASE_EXPORT,
     MAIN_TABLE,
+    DEID_TRANSFORM_FUNCTIONS,
 )
 from corehq.apps.export.dbaccessors import (
     get_latest_case_export_schema,
@@ -75,6 +79,9 @@ class ExportColumn(DocumentSchema):
     is_advanced = BooleanProperty(default=False)
     selected = BooleanProperty(default=False)
     tags = ListProperty()
+
+    # A list of constants that map to functions to transform the column value
+    transforms = ListProperty(validators=is_valid_transform)
 
     def get_value(self, doc, base_path):
         """

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -33,7 +33,7 @@ from corehq.apps.export.const import (
     FORM_EXPORT,
     CASE_EXPORT,
     MAIN_TABLE,
-    DEID_TRANSFORM_FUNCTIONS,
+    TRANSFORM_FUNCTIONS,
 )
 from corehq.apps.export.dbaccessors import (
     get_latest_case_export_schema,

--- a/corehq/apps/export/static/export/js/const.js
+++ b/corehq/apps/export/static/export/js/const.js
@@ -11,3 +11,8 @@ Exports.Constants.EXPORT_FORMATS = {
     XLS: 'xls',
     XLSX: 'xlsx'
 };
+Exports.Constants.DEID_OPTIONS = {
+    NONE: null,
+    ID: 'deid_id',
+    DATE: 'deid_date'
+};

--- a/corehq/apps/export/static/export/js/models.js
+++ b/corehq/apps/export/static/export/js/models.js
@@ -4,6 +4,7 @@ Exports.ViewModels.ExportInstance = function(instanceJSON, options) {
     ko.mapping.fromJS(instanceJSON, Exports.ViewModels.ExportInstance.mapping, self);
     self.saveState = ko.observable(Exports.Constants.SAVE_STATES.READY);
     self.saveUrl = options.saveUrl;
+    self.isDeidColumnVisible = ko.observable(false);
 };
 
 Exports.ViewModels.ExportInstance.prototype.getFormatOptionValues = function() {
@@ -68,6 +69,12 @@ Exports.ViewModels.ExportInstance.prototype.recordSaveAnalytics = function() {
     if (self.isNew()) {
         analytics.workflow("Clicked 'Create' in export edit page");
     }
+};
+
+Exports.ViewModels.ExportInstance.prototype.showDeidColumn = function() {
+    Exports.Utils.animateToEl('#field-select', function() {
+        this.isDeidColumnVisible(true);
+    }.bind(this));
 };
 
 Exports.ViewModels.ExportInstance.prototype.toJS = function() {
@@ -141,12 +148,34 @@ Exports.ViewModels.ExportColumn.prototype.formatProperty = function() {
     return this.item.path().join('.');
 };
 
+Exports.ViewModels.ExportColumn.prototype.isDeidSelectVisible = function() {
+    return (this.item.path()[this.item.path().length - 1] !== '_id' || this.transform()) && !this.isCaseName();
+};
+
+Exports.ViewModels.ExportColumn.prototype.getDeidOptions = function() {
+    return _.map(Exports.Constants.DEID_OPTIONS, function(value, key) { return value; });
+};
+
+Exports.ViewModels.ExportColumn.prototype.getDeidOptionText = function(deidOption) {
+    if (deidOption === Exports.Constants.DEID_OPTIONS.ID) {
+        return gettext('Sensitive ID');
+    } else if (deidOption === Exports.Constants.DEID_OPTIONS.DATE) {
+        return gettext('Sensitive Date');
+    } else if (deidOption === Exports.Constants.DEID_OPTIONS.NONE) {
+        return gettext('None');
+    }
+};
+
 Exports.ViewModels.ExportColumn.prototype.isVisible = function(table) {
     return table.showAdvanced() || (!this.is_advanced() || this.selected());
 };
 
+Exports.ViewModels.ExportColumn.prototype.isCaseName = function() {
+    return this.item.isCaseName();
+};
+
 Exports.ViewModels.ExportColumn.mapping = {
-    include: ['item', 'label', 'is_advanced', 'selected', 'tags'],
+    include: ['item', 'label', 'is_advanced', 'selected', 'tags', 'transform'],
     item: {
         create: function(options) {
             return new Exports.ViewModels.ExportItem(options.data);
@@ -160,7 +189,7 @@ Exports.ViewModels.ExportItem = function(itemJSON) {
 };
 
 Exports.ViewModels.ExportItem.prototype.isCaseName = function() {
-    return self.path[self.path.length - 1] === 'case_name';
+    return this.path()[this.path().length - 1] === 'name';
 };
 
 Exports.ViewModels.ExportItem.mapping = {

--- a/corehq/apps/export/static/export/js/models.js
+++ b/corehq/apps/export/static/export/js/models.js
@@ -142,6 +142,13 @@ Exports.ViewModels.TableConfiguration.mapping = {
 Exports.ViewModels.ExportColumn = function(columnJSON) {
     var self = this;
     ko.mapping.fromJS(columnJSON, Exports.ViewModels.ExportColumn.mapping, self);
+    self.deidTransform = ko.observable(Exports.Constants.DEID_OPTIONS.NONE);
+    self.deidTransform.subscribe(function(newTransform) {
+        self.transforms(Exports.Utils.removeDeidTransforms(self.transforms()));
+        if (newTransform) {
+            self.transforms.push(newTransform);
+        }
+    });
 };
 
 Exports.ViewModels.ExportColumn.prototype.formatProperty = function() {
@@ -149,7 +156,7 @@ Exports.ViewModels.ExportColumn.prototype.formatProperty = function() {
 };
 
 Exports.ViewModels.ExportColumn.prototype.isDeidSelectVisible = function() {
-    return (this.item.path()[this.item.path().length - 1] !== '_id' || this.transform()) && !this.isCaseName();
+    return (this.item.path()[this.item.path().length - 1] !== '_id' || this.transforms()) && !this.isCaseName();
 };
 
 Exports.ViewModels.ExportColumn.prototype.getDeidOptions = function() {
@@ -175,7 +182,8 @@ Exports.ViewModels.ExportColumn.prototype.isCaseName = function() {
 };
 
 Exports.ViewModels.ExportColumn.mapping = {
-    include: ['item', 'label', 'is_advanced', 'selected', 'tags', 'transform'],
+    include: ['item', 'label', 'is_advanced', 'selected', 'tags', 'transforms'],
+    exclude: ['deidTransform'],
     item: {
         create: function(options) {
             return new Exports.ViewModels.ExportItem(options.data);

--- a/corehq/apps/export/static/export/js/utils.js
+++ b/corehq/apps/export/static/export/js/utils.js
@@ -9,3 +9,9 @@ Exports.Utils.getTagCSSClass = function(tag) {
 Exports.Utils.redirect = function(url) {
     window.location.href = url;
 };
+
+Exports.Utils.animateToEl = function(toElementSelector, callback) {
+    $('html, body').animate({
+        scrollTop: $(toElementSelector).offset().top + 'px'
+    }, 'slow', undefined, callback);
+};

--- a/corehq/apps/export/static/export/js/utils.js
+++ b/corehq/apps/export/static/export/js/utils.js
@@ -15,3 +15,9 @@ Exports.Utils.animateToEl = function(toElementSelector, callback) {
         scrollTop: $(toElementSelector).offset().top + 'px'
     }, 'slow', undefined, callback);
 };
+
+Exports.Utils.removeDeidTransforms = function(transforms) {
+    return _.filter(transforms, function(transform) {
+        return _.values(Exports.Constants.DEID_OPTIONS).indexOf(transform) === -1;
+    });
+};

--- a/corehq/apps/export/static/export/spec/ExportColumn.spec.js
+++ b/corehq/apps/export/static/export/spec/ExportColumn.spec.js
@@ -1,0 +1,12 @@
+describe('ExportColumn', function() {
+    it('Should properly append deidTransform', function() {
+        column = new Exports.ViewModels.ExportColumn({
+            transforms: ['username_transform']
+        });
+        column.deidTransform(Exports.Constants.DEID_OPTIONS.ID);
+        assert.sameMembers(column.transforms(), ['username_transform', Exports.Constants.DEID_OPTIONS.ID]);
+
+        column.deidTransform(Exports.Constants.DEID_OPTIONS.NONE);
+        assert.sameMembers(column.transforms(), ['username_transform']);
+    });
+});

--- a/corehq/apps/export/static/export/spec/Exports.Utils.spec.js
+++ b/corehq/apps/export/static/export/spec/Exports.Utils.spec.js
@@ -12,4 +12,10 @@ describe('Export Utility functions', function() {
         });
     });
 
+    describe('#removeDeidTransforms', function() {
+        it('Should remove all deid transforms', function() {
+            result = Exports.Utils.removeDeidTransforms(['deid_id', 'username_transform']);
+            assert.sameMembers(result, ['username_transform']);
+        });
+    });
 });

--- a/corehq/apps/export/templates/export/new_customize_export.html
+++ b/corehq/apps/export/templates/export/new_customize_export.html
@@ -105,21 +105,21 @@
         <fieldset data-bind="
             template: { foreach: tables, as: 'table', name: 'ko-table-configuration-template' }"
         ></fieldset>
-        {% if helper.allow_deid %}
+        {% if allow_deid %}
         <fieldset>
             <legend>{% trans "Privacy Settings" %}</legend>
             <div class="control-group">
                 <label for="is_safe" class="control-label"></label>
-                <div class="controls deid-column" data-bind="visible: $root.showDeidColumn()">
+                <div class="controls deid-column" data-bind="visible: isDeidColumnVisible()">
                     <label class="checkbox">
-                        <input type="checkbox" id="is_safe" data-bind="checked: export_instance.is_safe" />
-                        {% trans "Publish in" %} {{ DeidExportReport_name }}
+                        <input type="checkbox" id="is_deidentified" data-bind="checked: is_deidentified" />
+                        {% trans "Publish as De-Identified" %}
                     </label>
                     <span class="help-inline">{% trans "Check only if this export has been fully and safely de-identified." %}</span>
                 </div>
                 <button class="btn" data-bind="
-                    visible: !showDeidColumn(),
-                    click: animateShowDeidColumn
+                    visible: !isDeidColumnVisible(),
+                    click: showDeidColumn
                 ">
                     {% trans "Allow me to mark sensitive data" %}
                 </button>

--- a/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
+++ b/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
@@ -146,7 +146,7 @@
         {% if allow_deid %}
         <td class="deid-column" data-bind="visible: $root.isDeidColumnVisible()">
             <select data-bind="
-                value: transform,
+                value: deidTransform,
                 options: getDeidOptions(),
                 optionsText: getDeidOptionText,
                 visible: isDeidSelectVisible()

--- a/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
+++ b/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
@@ -1,5 +1,6 @@
 {% load hq_shared_tags %}
 {% load i18n %}
+<!-- Template for a Table (i.e. sheet) in the Export page -->
 <script type="text/html" id="ko-table-configuration-template">
     <div>
         <legend data-bind="visible: table.isVisible()">
@@ -63,8 +64,8 @@
                             {% if export_instance.type == 'case' and request|feature_preview_enabled:"SPLIT_MULTISELECT_CASE_EXPORT"%}
                             <th>{% trans "Type" %}</th>
                             {% endif %}
-                            {% if helper.allow_deid %}
-                            <!--<th class="deid-column" data-bind="visible: $root.showDeidColumn()">{% trans "Sensitivity" %}</th>-->
+                            {% if allow_deid %}
+                            <th class="deid-column" data-bind="visible: $root.isDeidColumnVisible()">{% trans "Sensitivity" %}</th>
                             {% endif %}
                         </tr>
                         </thead>
@@ -84,6 +85,7 @@
     </div>
 </script>
 
+<!-- Template for an ExportColumn in the Export page -->
 <script type="text/html" id="ko-export-column-template">
     <tr data-bind="
         visible: column.isVisible($parent)
@@ -141,17 +143,17 @@
             </div>
         </td>
         {% endif %}
-        {% if helper.allow_deid %}
-        <td class="deid-column" data-bind="visible: $root.showDeidColumn()">
+        {% if allow_deid %}
+        <td class="deid-column" data-bind="visible: $root.isDeidColumnVisible()">
             <select data-bind="
-                value: transform || '',
-                foreach: $root.deid_options,
-                visible: (index() !== 'id' || transform()) && !isCaseName()
+                value: transform,
+                options: getDeidOptions(),
+                optionsText: getDeidOptionText,
+                visible: isDeidSelectVisible()
             ">
-                <option data-bind="value: value, text: label"></option>
             </select>
             <span class="label label-info"
-                  data-bind="visible: $root.export_instance.is_safe() && isCaseName()">
+                  data-bind="visible: !isDeidSelectVisible()">
                 {% trans "Cannot be published in De-Identified Export." %}
             </span>
         </td>

--- a/corehq/apps/export/templates/export/spec/ko/mocha.html
+++ b/corehq/apps/export/templates/export/spec/ko/mocha.html
@@ -12,5 +12,6 @@
 {% block mocha_tests %}
 <script src="{% new_static 'export/spec/data/export_instances.js' %}"></script>
 <script src="{% new_static 'export/spec/ExportInstance.spec.js' %}"></script>
+<script src="{% new_static 'export/spec/ExportColumn.spec.js' %}"></script>
 <script src="{% new_static 'export/spec/Exports.Utils.spec.js' %}"></script>
 {% endblock %}

--- a/corehq/apps/export/tests/__init__.py
+++ b/corehq/apps/export/tests/__init__.py
@@ -3,4 +3,5 @@ from corehq.apps.export.tests.test_table_configuration import *
 from corehq.apps.export.tests.test_export_data_schema import *
 from corehq.apps.export.tests.test_export_instance import *
 from corehq.apps.export.tests.test_export_item import *
+from corehq.apps.export.tests.test_export_column import *
 from corehq.apps.export.tests.test_dbaccessors import *

--- a/corehq/apps/export/tests/test_export_column.py
+++ b/corehq/apps/export/tests/test_export_column.py
@@ -1,0 +1,15 @@
+from django.test import SimpleTestCase
+
+from corehq.apps.export.models import ExportColumn
+from corehq.apps.export.exceptions import ExportInvalidTransform
+
+
+class TestExportColumn(SimpleTestCase):
+
+    def test_invalid_transform_function(self):
+        with self.assertRaises(ExportInvalidTransform):
+            ExportColumn(transforms=['doesnotwork'])
+
+    def test_valid_transform_function(self):
+        col = ExportColumn(transforms=['deid_date', 'deid_id'])
+        self.assertEqual(col.transforms, ['deid_date', 'deid_id'])

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -3,9 +3,6 @@ from .exceptions import ExportInvalidTransform
 
 
 def is_valid_transform(value):
-    if value is None:
-        return True
-    if value in TRANSFORM_FUNCTIONS:
-        return True
-
-    raise ExportInvalidTransform('{} is not a valid transform'.format(value))
+    for transform in value:
+        if transform not in TRANSFORM_FUNCTIONS:
+            raise ExportInvalidTransform('{} is not a valid transform'.format(value))

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -1,0 +1,11 @@
+from .const import TRANSFORM_FUNCTIONS
+from .exceptions import ExportInvalidTransform
+
+
+def is_valid_transform(value):
+    if value is None:
+        return True
+    if value in TRANSFORM_FUNCTIONS:
+        return True
+
+    raise ExportInvalidTransform('{} is not a valid transform'.format(value))

--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -7,6 +7,7 @@ from django.core.exceptions import SuspiciousOperation
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect, HttpResponseBadRequest, Http404
 from django.template.defaultfilters import filesizeformat
+from django_prbac.utils import has_privilege
 from django.utils.decorators import method_decorator
 import json
 from django.utils.safestring import mark_safe
@@ -199,6 +200,7 @@ class BaseCreateNewCustomExportView(BaseExportView):
         return {
             'export_instance': self.export_instance,
             'export_home_url': reverse(self.urlname, args=(self.domain,)),
+            'allow_deid': has_privilege(self.request, privileges.DEIDENTIFIED_DATA),
         }
 
     def get_export_instance(self, schema, app_id=None):


### PR DESCRIPTION
@NoahCarnahan @snopoke this adds deid functionality to the exports page:

<img width="1180" alt="screen shot 2016-02-03 at 5 39 57 pm" src="https://cloud.githubusercontent.com/assets/918514/12799877/60c45c50-ca9f-11e5-8a06-4bb550514f88.png">

:fish: or :office: 
