### PR TITLE
ES_CALCED_PROPS doesn't seem to be used anywhere

### DIFF
--- a/corehq/apps/domain/calculations.py
+++ b/corehq/apps/domain/calculations.py
@@ -288,13 +288,6 @@ def _all_domain_stats():
             "forms": form_counts,
             "cases": case_counts}
 
-ES_CALCED_PROPS = ["cp_n_web_users", "cp_n_active_cc_users", "cp_n_cc_users",
-                   "cp_n_active_cases", "cp_n_cases", "cp_n_forms",
-                   "cp_first_form", "cp_last_form", "cp_is_active",
-                   'cp_has_app', "cp_n_in_sms", "cp_n_out_sms", "cp_n_sms_ever",
-                   "cp_n_sms_30_d", "cp_sms_ever", "cp_sms_30_d", "cp_n_sms_in_30_d",
-                   "cp_n_sms_out_30_d"]
-
 
 def total_distinct_users(domains=None):
     """


### PR DESCRIPTION
Can we drop [`ES_CALCED_PROPS`](https://github.com/dimagi/commcare-hq/blob/07174057b845e878aabd056aef4572f2b3e57fc2/corehq/apps/domain/calculations.py#L300-L300)? It doesn't seem to be used anywhere.

@dannyroberts @emord cc @TylerSheffels  
