### PR TITLE
Frontend export sorting and saving

### DIFF
--- a/corehq/apps/export/static/export/js/const.js
+++ b/corehq/apps/export/static/export/js/const.js
@@ -16,3 +16,7 @@ Exports.Constants.DEID_OPTIONS = {
     ID: 'deid_id',
     DATE: 'deid_date'
 };
+Exports.Constants.ANALYTICS_EVENT_CATEGORIES = {
+    'form': 'Form Exports',
+    'case': 'Case Exports'
+};

--- a/corehq/apps/export/static/export/js/models.js
+++ b/corehq/apps/export/static/export/js/models.js
@@ -37,13 +37,12 @@ Exports.ViewModels.ExportInstance.prototype.save = function() {
 
     self.saveState(Exports.Constants.SAVE_STATES.SAVING);
     serialized = self.toJS();
-    $.post(self.saveUrl, serialized)
+    $.post(self.saveUrl, JSON.stringify(serialized))
         .success(function(data) {
-            var eventCategory;
-
-            self.saveState(Exports.Constants.SAVE_STATES.SUCCESS);
-
-            self.recordSaveAnalytics(Exports.Utils.redirect.bind(null, data.redirect));
+            self.recordSaveAnalytics(function() {
+                self.saveState(Exports.Constants.SAVE_STATES.SUCCESS);
+                Exports.Utils.redirect(data.redirect);
+            });
         })
         .fail(function(response) {
             self.saveState(Exports.Constants.SAVE_STATES.ERROR);

--- a/corehq/apps/export/static/export/js/models.js
+++ b/corehq/apps/export/static/export/js/models.js
@@ -66,7 +66,7 @@ Exports.ViewModels.ExportInstance.prototype.recordSaveAnalytics = function(callb
         analytics.usage.apply(null, args);
     }
     if (this.isNew()) {
-        eventCategory = Exports.Utils.getEventCategory(this.type());
+        eventCategory = Exports.Constants.ANALYTICS_EVENT_CATEGORIES[this.type()];
         analytics.usage(eventCategory, 'Custom export creation', '');
         analytics.workflow("Clicked 'Create' in export edit page", callback);
     }

--- a/corehq/apps/export/templates/export/new_customize_export.html
+++ b/corehq/apps/export/templates/export/new_customize_export.html
@@ -6,6 +6,7 @@
     {{ block.super }}
     <script src="{% static 'style/lib/knockout_plugins/knockout_mapping.ko.min.js' %}"></script>
     <script src="{% static 'style/ko/knockout_bindings.ko.js' %}"></script>
+    <script src="{% static 'jquery-ui-1.8.23-legacy/jquery-ui.min.js' %}"></script>
     <script src="{% static 'export/js/exports.js' %}"></script>
     <script src="{% static 'export/js/const.js' %}"></script>
     <script src="{% static 'export/js/models.js' %}"></script>

--- a/corehq/apps/export/templates/export/new_customize_export.html
+++ b/corehq/apps/export/templates/export/new_customize_export.html
@@ -16,14 +16,6 @@
 {% block js-inline %}{{ block.super }}
     <script>
         $(function () {
-            var translations = {
-                forms: "{% trans 'Forms'|escapejs %}",
-                repeat: "{% trans 'Repeat: '|escapejs %}",
-                cases: "{% trans 'Cases'|escapejs %}",
-                case_history: "{% trans 'Case History'|escapejs %}",
-                history_to_parents: "{% trans 'Case History > Parent Cases'|escapejs %}",
-                parent_cases: "{% trans 'Parent Cases'|escapejs %}",
-            };
             var customExportView = new Exports.ViewModels.ExportInstance({{ export_instance|JSON }});
 
             $('#customize-export').koApplyBindings(customExportView);

--- a/corehq/apps/export/templates/export/new_customize_export.html
+++ b/corehq/apps/export/templates/export/new_customize_export.html
@@ -16,7 +16,12 @@
 {% block js-inline %}{{ block.super }}
     <script>
         $(function () {
-            var customExportView = new Exports.ViewModels.ExportInstance({{ export_instance|JSON }});
+            var customExportView = new Exports.ViewModels.ExportInstance(
+                {{ export_instance|JSON }},
+                {
+                    saveUrl: {{ request.get_full_path|safe|JSON }}
+                }
+            );
 
             $('#customize-export').koApplyBindings(customExportView);
         });
@@ -122,7 +127,8 @@
         <div class="form-actions">
             <button type="submit" class="btn btn-large btn-primary" data-bind="
                 click: save,
-                disable: saveState() === Exports.Constants.SAVE_STATES.SAVING
+                disable: (saveState() === Exports.Constants.SAVE_STATES.SAVING ||
+                          saveState() === Exports.Constants.SAVE_STATES.SUCCESS)
             ">
                 <span data-bind="
                     visible: saveState() === Exports.Constants.SAVE_STATES.READY,
@@ -134,6 +140,9 @@
                 </span>
                 <span data-bind="visible: saveState() === Exports.Constants.SAVE_STATES.ERROR">
                     {% trans "Try Again" %}
+                </span>
+                <span data-bind="visible: saveState() === Exports.Constants.SAVE_STATES.SUCCESS">
+                    {% trans "Saved!" %}
                 </span>
             </button>
             <a class="btn btn-large" href="{{ export_home_url }}">{% trans "Cancel" %}</a>

--- a/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
+++ b/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
@@ -70,93 +70,89 @@
                         </tr>
                         </thead>
                         <tbody data-bind="
-                            template: {
-                                foreach: table.columns,
+                            sortable: {
+                                data: table.columns,
                                 as: 'column',
                                 name: 'ko-export-column-template'
                             }
                         ">
-                        <!--<tbody data-bind="sortable: column_configuration">--> 
+                            <tr data-bind="
+                                visible: column.isVisible($parent),
+                                attr: {'data-order': _sortableOrder}
+                                ">
+                                <td class="sortable-handle">
+                                    <i class="icon-resize-vertical"></i>
+                                </td>
+                                <td>
+                                    <!--ko if: ($root.is_deidentified() && column.item.isCaseName()) -->
+                                    <input type="checkbox"
+                                           class="field-include"
+                                           disabled="disabled" />
+                                    <!--/ko-->
+                                    <!--ko ifnot: ($root.is_deidentified() && column.item.isCaseName()) -->
+                                    <input type="checkbox"
+                                           class="field-include"
+                                           data-bind="checked: column.selected" />
+                                    <!--/ko-->
+                                </td>
+                                <td>
+                                    <span data-bind="foreach: { data: column.tags, as: 'tag' }">
+                                        <span data-bind="
+                                            text: tag,
+                                            attr: { class: Exports.Utils.getTagCSSClass(tag) }"></span>
+                                    </span>
+                                    <code data-bind="text: column.formatProperty()"></code>
+                                </td>
+                                <td><input class="input-xlarge" type="text" data-bind="value: column.label" /></td>
+                                {% if export_instance.type == 'case' and request|feature_preview_enabled:"SPLIT_MULTISELECT_CASE_EXPORT"%}
+                                <td class="input">
+                                    <div data-bind="if: !allOptions()">
+                                        <select disabled>
+                                            <option>{% trans "plain" %}</option>
+                                        </select>
+                                    </div>
+                                    <div data-bind="if: allOptions">
+                                        <select data-bind="
+                                            value: doc_type,
+                                            foreach: $root.column_type_options
+                                        "/>
+                                            <option data-bind="value: value, text: label"></option>
+                                        </select>
+                                        <span data-bind="makeHqHelp: {name: '{% trans "Split multi-select data" %}', placement: 'left'}"></span>
+                                        <div data-bind="if: doc_type() === 'SplitColumn'">
+                                            <a href="#" data-bind="visible: !showOptions(), click: function() {showOptions(true);}">{% trans "Show Options" %}</a>
+                                            <div data-bind="visible: showOptions">
+                                                <select class="select2" data-bind="options: allOptions, selectedOptions: options" multiple="true">
+                                                </select>
+                                                <br/>
+                                                <input class="input input-small" type="text" data-bind="value: newOption"/>
+                                                <button class="btn" data-bind="click: addOption">{% trans "Add" %}</button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </td>
+                                {% endif %}
+                                {% if allow_deid %}
+                                <td class="deid-column" data-bind="visible: $root.isDeidColumnVisible()">
+                                    <select data-bind="
+                                        value: deidTransform,
+                                        options: getDeidOptions(),
+                                        optionsText: getDeidOptionText,
+                                        visible: isDeidSelectVisible()
+                                    ">
+                                    </select>
+                                    <span class="label label-info"
+                                          data-bind="visible: !isDeidSelectVisible()">
+                                        {% trans "Cannot be published in De-Identified Export." %}
+                                    </span>
+                                </td>
+                                {% endif %}
+                            </tr>
+
                         </tbody>
                     </table>
                 </div>
             </div>
         </div>
     </div>
-</script>
-
-<!-- Template for an ExportColumn in the Export page -->
-<script type="text/html" id="ko-export-column-template">
-    <tr data-bind="
-        visible: column.isVisible($parent)
-        {% if False %}, attr: {'data-order': _sortableOrder}{% endif %}
-        ">
-        <td class="sortable-handle">
-            <i class="icon-resize-vertical"></i>
-        </td>
-        <td>
-            <!--ko if: ($root.is_deidentified() && column.item.isCaseName()) -->
-            <input type="checkbox"
-                   class="field-include"
-                   disabled="disabled" />
-            <!--/ko-->
-            <!--ko ifnot: ($root.is_deidentified() && column.item.isCaseName()) -->
-            <input type="checkbox"
-                   class="field-include"
-                   data-bind="checked: column.selected" />
-            <!--/ko-->
-        </td>
-        <td>
-            <span data-bind="foreach: { data: column.tags, as: 'tag' }">
-                <span data-bind="
-                    text: tag,
-                    attr: { class: Exports.Utils.getTagCSSClass(tag) }"></span>
-            </span>
-            <code data-bind="text: column.formatProperty()"></code>
-        </td>
-        <td><input class="input-xlarge" type="text" data-bind="value: column.label" /></td>
-        {% if export_instance.type == 'case' and request|feature_preview_enabled:"SPLIT_MULTISELECT_CASE_EXPORT"%}
-        <td class="input">
-            <div data-bind="if: !allOptions()">
-                <select disabled>
-                    <option>{% trans "plain" %}</option>
-                </select>
-            </div>
-            <div data-bind="if: allOptions">
-                <select data-bind="
-                    value: doc_type,
-                    foreach: $root.column_type_options
-                "/>
-                    <option data-bind="value: value, text: label"></option>
-                </select>
-                <span data-bind="makeHqHelp: {name: '{% trans "Split multi-select data" %}', placement: 'left'}"></span>
-                <div data-bind="if: doc_type() === 'SplitColumn'">
-                    <a href="#" data-bind="visible: !showOptions(), click: function() {showOptions(true);}">{% trans "Show Options" %}</a>
-                    <div data-bind="visible: showOptions">
-                        <select class="select2" data-bind="options: allOptions, selectedOptions: options" multiple="true">
-                        </select>
-                        <br/>
-                        <input class="input input-small" type="text" data-bind="value: newOption"/>
-                        <button class="btn" data-bind="click: addOption">{% trans "Add" %}</button>
-                    </div>
-                </div>
-            </div>
-        </td>
-        {% endif %}
-        {% if allow_deid %}
-        <td class="deid-column" data-bind="visible: $root.isDeidColumnVisible()">
-            <select data-bind="
-                value: deidTransform,
-                options: getDeidOptions(),
-                optionsText: getDeidOptionText,
-                visible: isDeidSelectVisible()
-            ">
-            </select>
-            <span class="label label-info"
-                  data-bind="visible: !isDeidSelectVisible()">
-                {% trans "Cannot be published in De-Identified Export." %}
-            </span>
-        </td>
-        {% endif %}
-    </tr>
 </script>

--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -195,6 +195,19 @@ class BaseExportView(BaseProjectDataView):
 class BaseCreateNewCustomExportView(BaseExportView):
     template_name = 'export/new_customize_export.html'
 
+    def commit(self, request):
+        export = ExportInstance.wrap(json.loads(request.body))
+        export.save()
+        messages.success(
+            request,
+            mark_safe(
+                _(u"Export <strong>{}</strong> created.").format(
+                    export.name
+                )
+            )
+        )
+        return export._id
+
     @property
     def page_context(self):
         return {


### PR DESCRIPTION
@NoahCarnahan @snopoke this allows you to sort the export columns in the UI and save them to the database

next up: listing exports on the export list page and then converting old exports to new ones!
