### PR TITLE
If more than one result, try a non-fuzzy one

### DIFF
--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -708,9 +708,12 @@ class FormCompletionTimeReport(WorkerMonitoringFormReportTableBase, DatespanMixi
     @property
     @memoized
     def selected_form_data(self):
-        data = FormsByApplicationFilter.get_value(self.request, self.domain)
-        if len(data) == 1 and data.values()[0]['xmlns']:
-            return data.values()[0]
+        forms = FormsByApplicationFilter.get_value(self.request, self.domain).values()
+        if len(forms) == 1 and forms[0]['xmlns']:
+            return forms[0]
+        non_fuzzy_forms = [form for form in forms if not form['is_fuzzy']]
+        if len(non_fuzzy_forms) == 1:
+            return non_fuzzy_forms[0]
 
     @property
     def headers(self):


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?215688

The filter is surprisingly complicated.

At least with the bug I was working on, the filters selected returned a fuzzy and a non-fuzzy match.  `selected_form_data` returns None if not precisely one match is found.  This is a strict improvement on that, although it doesn't feel like an ideal solution.

This filtering could use a big refactor or rewrite, but I don't have enough context and it's not clearly worth the effort at this time.

@gcapalbo
@czue it looks like you did some work in this area recently - flagging in case this suggests something to you that I'm missing.
