### PR TITLE
Fix saved Worker Activity Reports

### DIFF
--- a/corehq/apps/reports/standard/__init__.py
+++ b/corehq/apps/reports/standard/__init__.py
@@ -105,7 +105,8 @@ class ProjectReportParametersMixin(object):
 
     @property
     def group_ids(self):
-        return filter(None, self.request.GET.getlist('group'))
+        return [group_id for group_id in self.request.GET.getlist('group')
+                if group_id and group_id != '_all']
 
     @property
     @memoized


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?216457
The filter here was recently upgraded, but saved reports still refer to the old filter params, so the report thinks `"_all"` is a group id.
@gcapalbo @snopoke FYI
