### PR TITLE
Fail hard if data source not found

### DIFF
--- a/corehq/apps/userreports/reports/data_source.py
+++ b/corehq/apps/userreports/reports/data_source.py
@@ -11,11 +11,10 @@ from corehq.apps.reports.sqlreport import SqlData, DatabaseColumn
 from corehq.apps.userreports.exceptions import (
     UserReportsError, TableNotFoundWarning,
     SortConfigurationError)
-from corehq.apps.userreports.models import DataSourceConfiguration
+from corehq.apps.userreports.models import DataSourceConfiguration, get_datasource_config
 from corehq.apps.userreports.reports.sorting import get_default_sort_value, DESCENDING
 from corehq.apps.userreports.sql import get_table_name
 from corehq.apps.userreports.sql.connection import get_engine_id
-from corehq.apps.userreports.views import get_datasource_config_or_404
 from dimagi.utils.decorators.memoized import memoized
 
 
@@ -55,7 +54,7 @@ class ConfigurableReportDataSource(SqlData):
     @property
     def config(self):
         if self._config is None:
-            self._config, _ = get_datasource_config_or_404(self._config_id, self.domain)
+            self._config, _ = get_datasource_config(self._config_id, self.domain)
         return self._config
 
     @property


### PR DESCRIPTION
@gcapalbo @NoahCarnahan @czue
http://manage.dimagi.com/default.asp?216024
This was causing a confusing 404.  I was a little hesitant about this change at first, but I figure worst-case scenario is that we'll get some 500s that should be 404s (whereas we're currently getting 404s that should be 500s).  If that does happen, we can just catch the `DataSourceConfigurationNotFoundError` in the view where appropriate and raise a 404 there.

I also checked and only one place in `corehq/apps/userreports` catches an `Http404`, and it doesn't look related.
