### PR TITLE
Fixed width for select2 widgets

### DIFF
--- a/corehq/apps/style/static/style/less/bootstrap3/forms.less
+++ b/corehq/apps/style/static/style/less/bootstrap3/forms.less
@@ -94,6 +94,11 @@ legend .subtext {
   }
 }
 
+// Static width for select2 widgets, which otherwise grow too large on case management pages
+.form-control.select2-container {
+  width: 210px;
+}
+
 .checkbox-table-cell {
   margin: 0;
   font-size: 20px;

--- a/corehq/apps/style/static/style/less/bootstrap3/forms.less
+++ b/corehq/apps/style/static/style/less/bootstrap3/forms.less
@@ -95,7 +95,7 @@ legend .subtext {
 }
 
 // Static width for select2 widgets, which otherwise grow too large on case management pages
-.form-control.select2-container {
+.app-manager-content .form-control.select2-container {
   width: 210px;
 }
 


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?216586

I'd rather do this by adding col-foo-foo classes to the table cells in the case management UI (i.e., https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/app_manager/templates/app_manager/partials/case_config_shared.html#L83-L103) but they don't constrain the select2 widget for very long questions.

Resorted to using a static width on select2 controls, which is what we were doing in B2 (via `.input-large`, which is no longer supported).

@esoergel / @biyeun 
