### PR TITLE
Fix groups filters

### DIFF
--- a/corehq/apps/reports/filters/select.py
+++ b/corehq/apps/reports/filters/select.py
@@ -9,7 +9,6 @@ from corehq.apps.commtrack.const import USER_LOCATION_OWNER_MAP_TYPE
 
 from corehq.apps.hqcase.dbaccessors import get_case_types_for_domain
 
-from corehq.apps.app_manager.models import Application
 from corehq.apps.groups.models import Group
 from corehq.apps.reports.filters.base import BaseSingleOptionFilter, BaseMultipleOptionFilter
 

--- a/corehq/apps/reports/standard/__init__.py
+++ b/corehq/apps/reports/standard/__init__.py
@@ -98,10 +98,7 @@ class ProjectReportParametersMixin(object):
     @property
     @memoized
     def group(self):
-        if self.group_id:
-            return Group.get(self.group_id)
-        else:
-            return self.groups[0] if len(self.groups) else None
+        return Group.get(self.group_id) if self.group_id else None
 
     @property
     def group_ids(self):


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?216601
:tropical_fish: :whale: 
The main fix is commit 1, the rest is cleanup

The problem was that the same handlers were being used for reports with the single-select groups filter, and the Worker Activity Report, which uses a multi-select group filter.  The logic got convoluted.  Since the WAR is the only report which uses the multi-select group filter, I moved the utils for parsing the URL params into that report.
@gcapalbo 
