### PR TITLE
changing periodic analytics to not fail hard for missing email

### DIFF
--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -283,7 +283,7 @@ def track_periodic_data():
     # max number of mobile workers
     submit = []
     for user in users_to_domains:
-        email = user['email']
+        email = user.get('username')
         if not email:
             continue
         max_forms = 0


### PR DESCRIPTION
was failing on a key error. this should stop it from failing hard, and username is probably a guaranteed field and will be their email
@NoahCarnahan @sravfeyn 
http://manage.dimagi.com/default.asp?216585#1087002
