### PR TITLE
Deploy specific commits

### DIFF
--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -109,7 +109,7 @@ def _require_target():
 class CodeToDeploy(object):
     def __init__(self, env):
         self.env = env
-        self.deploy_time = datetime.datetime.utcnow()
+        self.timestamp = datetime.datetime.utcnow().strftime('%Y-%m-%d_%H.%M')
         self._deploy_ref = None
 
     def _tag_commit(self):
@@ -117,10 +117,10 @@ class CodeToDeploy(object):
         pattern = "*{}*".format(self.env.environment)
         self.last_tag = sh.tail(sh.git.tag("-l", pattern), "-1").strip()
 
-        tag_name = "{:%Y-%m-%d_%H.%M}-{}-deploy".format(self.deploy_time, self.env.environment)
+        tag_name = "{}-{}-deploy".format(self.timestamp, self.env.environment)
         # turn whatever `code_branch` is into a commit
         deploy_commit = sh.git("rev-parse", self.env.code_branch).strip()
-        msg = "{} deploy at {}".format(self.env.environment, self.deploy_time.isoformat())
+        msg = "{} deploy at {}".format(self.env.environment, self.timestamp)
         sh.git.tag(tag_name, "-m", msg, deploy_commit)
         sh.git.push("origin", tag_name)
         self._deploy_ref = tag_name
@@ -201,8 +201,7 @@ def _setup_path():
     env.log_dir = posixpath.join(env.home, 'www', env.environment, 'log')
     env.releases = posixpath.join(env.root, 'releases')
     env.code_current = posixpath.join(env.root, 'current')
-    timestamp = time.strftime('%Y-%m-%d_%H.%M', time.gmtime(time.time()))
-    env.code_root = posixpath.join(env.releases, timestamp)
+    env.code_root = posixpath.join(env.releases, code_to_deploy.timestamp)
     env.project_root = posixpath.join(env.code_root, env.project)
     env.project_media = posixpath.join(env.code_root, 'media')
     env.virtualenv_current = posixpath.join(env.code_current, 'python_env')

--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -18,8 +18,8 @@ Server layout:
         (i.e. ~/www/staging/log and ~/www/production/log).
 
     ~/www/<environment>/releases/<YYYY-MM-DD-HH.SS>
-        This folder contains a release of commcarehq. Each release has its own virtual environment that can be
-        found in `python_env`.
+        This folder contains a release of commcarehq. Each release has its own
+        virtual environment that can be found in `python_env`.
 
     ~/www/<environment>/current
         This path is a symlink to the release that is being run
@@ -30,18 +30,16 @@ import json
 import os
 import posixpath
 import sh
-import sys
 import time
 import yaml
-from collections import defaultdict
 from distutils.util import strtobool
 
 from fabric import utils
 from fabric.api import run, roles, execute, task, sudo, env, parallel
 from fabric.colors import blue, red
-from fabric.context_managers import settings, cd, shell_env
+from fabric.context_managers import settings, cd
 from fabric.contrib import files, console
-from fabric.operations import require, local, prompt
+from fabric.operations import require
 
 
 ROLES_ALL_SRC = ['pg', 'django_monolith', 'django_app', 'django_celery', 'django_pillowtop', 'formsplayer', 'staticfiles']
@@ -165,7 +163,8 @@ def _setup_path():
     env.log_dir = posixpath.join(env.home, 'www', env.environment, 'log')
     env.releases = posixpath.join(env.root, 'releases')
     env.code_current = posixpath.join(env.root, 'current')
-    env.code_root = posixpath.join(env.releases, time.strftime('%Y-%m-%d_%H.%M', time.gmtime(time.time())))
+    timestamp = time.strftime('%Y-%m-%d_%H.%M', time.gmtime(time.time()))
+    env.code_root = posixpath.join(env.releases, timestamp)
     env.project_root = posixpath.join(env.code_root, env.project)
     env.project_media = posixpath.join(env.code_root, 'media')
     env.virtualenv_current = posixpath.join(env.code_current, 'python_env')
@@ -220,6 +219,7 @@ def swiss():
 @task
 def india():
     softlayer()
+
 
 @task
 def softlayer():
@@ -277,7 +277,8 @@ def staging():
     """staging.commcarehq.org"""
     if env.code_branch == 'master':
         env.code_branch = 'autostaging'
-        print ("using default branch of autostaging. you can override this with --set code_branch=<branch>")
+        print ("using default branch of autostaging. you can override this "
+               "with --set code_branch=<branch>")
 
     env.inventory = os.path.join('fab', 'inventory', 'staging')
     load_env('staging')
@@ -408,7 +409,8 @@ def _remove_submodule_source_main(path, use_current_release=False):
 @roles(ROLES_DB_ONLY)
 def preindex_views():
     """
-    Creates a new release that runs preindex_everything. Clones code from `current` release and updates it.
+    Creates a new release that runs preindex_everything. Clones code from
+    `current` release and updates it.
     """
     setup_release()
     _preindex_views()
@@ -428,7 +430,6 @@ def _preindex_views():
             '+%%m%%d%%H%%M.%%S`'
         ) % env)
         version_static()
-
 
 
 @roles(ROLES_ALL_SRC)
@@ -611,7 +612,7 @@ def _deploy_without_asking():
                 _execute_with_timing(stop_celery_tasks)
             _execute_with_timing(_migrate)
         else:
-            print(blue("No migration required, skipping."))
+            print blue("No migration required, skipping.")
         _execute_with_timing(do_update_translations)
         if do_migrate:
             _execute_with_timing(flip_es_aliases)
@@ -721,8 +722,8 @@ def copy_release_files():
 @task
 def rollback():
     """
-    Rolls back the servers to the previous release if it exists and is same across servers. Note this will not
-    rollback the supervisor services.
+    Rolls back the servers to the previous release if it exists and is same
+    across servers. Note this will not rollback the supervisor services.
     """
     number_of_releases = execute(get_number_of_releases)
     if not all(map(lambda n: n > 1, number_of_releases)):
@@ -740,7 +741,7 @@ def rollback():
 
     if not unique_release:
         print red('Aborting because release path is empty. '
-            'This probably means there are no releases to rollback to.')
+                  'This probably means there are no releases to rollback to.')
         exit()
 
     if not console.confirm('Do you wish to rollback to release: {}'.format(unique_release), default=False):

--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -106,7 +106,7 @@ def _require_target():
             provided_by=('staging', 'preview', 'production', 'old_india', 'softlayer', 'zambia'))
 
 
-class CodeToDeploy(object):
+class DeployMetadata(object):
     def __init__(self, env):
         self.env = env
         self.timestamp = datetime.datetime.utcnow().strftime('%Y-%m-%d_%H.%M')
@@ -141,7 +141,7 @@ class CodeToDeploy(object):
         return self._deploy_ref
 
 
-code_to_deploy = CodeToDeploy(env)
+deploy_metadata = DeployMetadata(env)
 
 
 def format_env(current_env, extra=None):
@@ -201,7 +201,7 @@ def _setup_path():
     env.log_dir = posixpath.join(env.home, 'www', env.environment, 'log')
     env.releases = posixpath.join(env.root, 'releases')
     env.code_current = posixpath.join(env.root, 'current')
-    env.code_root = posixpath.join(env.releases, code_to_deploy.timestamp)
+    env.code_root = posixpath.join(env.releases, deploy_metadata.timestamp)
     env.project_root = posixpath.join(env.code_root, env.project)
     env.project_media = posixpath.join(env.code_root, 'media')
     env.virtualenv_current = posixpath.join(env.code_current, 'python_env')
@@ -570,7 +570,7 @@ def hotfix_deploy():
     _require_target()
     run('echo ping!')  # workaround for delayed console response
     try:
-        execute(update_code, code_to_deploy.tag, True)
+        execute(update_code, deploy_metadata.tag, True)
     except Exception:
         execute(mail_admins, "Deploy failed", "You had better check the logs.")
         # hopefully bring the server back to life
@@ -578,7 +578,7 @@ def hotfix_deploy():
         raise
     else:
         execute(services_restart)
-        url = code_to_deploy.diff_url
+        url = deploy_metadata.diff_url
         execute(record_successful_deploy, url)
 
 
@@ -594,7 +594,7 @@ def _confirm_translated():
 @task
 def setup_release():
     _execute_with_timing(create_code_dir)
-    _execute_with_timing(update_code, code_to_deploy.tag)
+    _execute_with_timing(update_code, deploy_metadata.tag)
     _execute_with_timing(update_virtualenv)
 
     _execute_with_timing(copy_release_files)
@@ -674,7 +674,7 @@ def _deploy_without_asking():
         _execute_with_timing(update_current)
         _execute_with_timing(services_restart)
         _execute_with_timing(record_successful_release)
-        url = code_to_deploy.diff_url
+        url = deploy_metadata.diff_url
         _execute_with_timing(record_successful_deploy, url)
 
 


### PR DESCRIPTION
I wanna do a little more testing before merging this, but figured I'd open it for feedback now.

Basically the idea is to deploy a specific tagged commit rather than a branch.  This was triggered by [this ticket](http://manage.dimagi.com/default.asp?216565) which points out that what gets deployed isn't always the same thing that gets tagged.  Since each server runs `git checkout origin/master`, they're not even guaranteed to end up with the same commit (someone could merge a PR at the exact wrong time).  I figured it made sense to tag at the beginning, then tell each machine to checkout that tag.
@gcapalbo @benrudolph 
