### PR TITLE
call warn_subscriptions_not_active after updating subscriptions

### DIFF
--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -137,6 +137,7 @@ def update_subscriptions():
     deactivate_subscriptions()
     activate_subscriptions()
     warn_subscriptions_still_active()
+    warn_subscriptions_not_active()
 
 
 @periodic_task(run_every=crontab(hour=13, minute=0, day_of_month='1'))


### PR DESCRIPTION
actually call the error checking code I wrote

@dannyroberts @benrudolph 
