### PR TITLE
add sql reindexers + new lightweight reindexer framework

### DIFF
--- a/corehq/apps/hqcase/management/commands/ptop_reindexer_v2.py
+++ b/corehq/apps/hqcase/management/commands/ptop_reindexer_v2.py
@@ -1,6 +1,6 @@
 from django.core.management import BaseCommand, CommandError
 from corehq.pillows.case import get_couch_case_reindexer, get_sql_case_reindexer
-from corehq.pillows.xform import get_couch_form_reindexer
+from corehq.pillows.xform import get_couch_form_reindexer, get_sql_form_reindexer
 
 
 class Command(BaseCommand):
@@ -12,6 +12,7 @@ class Command(BaseCommand):
             'case': get_couch_case_reindexer,
             'form': get_couch_form_reindexer,
             'sql-case': get_sql_case_reindexer,
+            'sql-form': get_sql_form_reindexer,
         }
         if index not in reindex_fns:
             raise CommandError('Supported indices to reindex are: {}'.format(','.join(reindex_fns.keys())))

--- a/corehq/apps/hqcase/management/commands/ptop_reindexer_v2.py
+++ b/corehq/apps/hqcase/management/commands/ptop_reindexer_v2.py
@@ -1,5 +1,5 @@
 from django.core.management import BaseCommand, CommandError
-from corehq.pillows.case import get_couch_case_reindexer
+from corehq.pillows.case import get_couch_case_reindexer, get_sql_case_reindexer
 
 
 class Command(BaseCommand):
@@ -8,8 +8,8 @@ class Command(BaseCommand):
 
     def handle(self, index, *args, **options):
         reindex_fns = {
-            'case': get_couch_case_reindexer
-
+            'case': get_couch_case_reindexer,
+            'sql-case': get_sql_case_reindexer,
         }
         if index not in reindex_fns:
             raise CommandError('Supported indices to reindex are: {}'.format(','.join(reindex_fns.keys())))

--- a/corehq/apps/hqcase/management/commands/ptop_reindexer_v2.py
+++ b/corehq/apps/hqcase/management/commands/ptop_reindexer_v2.py
@@ -1,5 +1,6 @@
 from django.core.management import BaseCommand, CommandError
 from corehq.pillows.case import get_couch_case_reindexer, get_sql_case_reindexer
+from corehq.pillows.xform import get_couch_form_reindexer
 
 
 class Command(BaseCommand):
@@ -9,6 +10,7 @@ class Command(BaseCommand):
     def handle(self, index, *args, **options):
         reindex_fns = {
             'case': get_couch_case_reindexer,
+            'form': get_couch_form_reindexer,
             'sql-case': get_sql_case_reindexer,
         }
         if index not in reindex_fns:

--- a/corehq/apps/hqcase/management/commands/ptop_reindexer_v2.py
+++ b/corehq/apps/hqcase/management/commands/ptop_reindexer_v2.py
@@ -1,0 +1,18 @@
+from django.core.management import BaseCommand, CommandError
+from corehq.pillows.case import get_couch_case_reindexer
+
+
+class Command(BaseCommand):
+    args = 'index'
+    help = 'Reindex a pillowtop index'
+
+    def handle(self, index, *args, **options):
+        reindex_fns = {
+            'case': get_couch_case_reindexer
+
+        }
+        if index not in reindex_fns:
+            raise CommandError('Supported indices to reindex are: {}'.format(','.join(reindex_fns.keys())))
+
+        reindexer = reindex_fns[index]()
+        reindexer.reindex()

--- a/corehq/ex-submodules/pillowtop/reindexer/change_providers/couch.py
+++ b/corehq/ex-submodules/pillowtop/reindexer/change_providers/couch.py
@@ -4,6 +4,14 @@ from pillowtop.reindexer.change_providers.interface import ChangeProvider
 
 
 class CouchViewChangeProvider(ChangeProvider):
+    """
+    A ChangeProvider on top of a couch view. Lets you parameterize how you query
+    the view and will then return an iterator over all the results of that view
+    query.
+
+    This is meant to eventually replace the logic in the PtopReindexer subclasses
+    that currently deal with this.
+    """
 
     def __init__(self, document_class, view_name, chunk_size=100, view_kwargs=None):
         self.document_class = document_class

--- a/corehq/ex-submodules/pillowtop/reindexer/change_providers/couch.py
+++ b/corehq/ex-submodules/pillowtop/reindexer/change_providers/couch.py
@@ -1,3 +1,4 @@
+from copy import copy
 from corehq.util.couch_helpers import paginate_view
 from pillowtop.reindexer.change_providers.interface import ChangeProvider
 
@@ -13,6 +14,7 @@ class CouchViewChangeProvider(ChangeProvider):
 
     def iter_changes(self, start_from=None):
         view_kwargs = copy(self._view_kwargs)
+        view_kwargs['reduce'] = False  # required to paginate a view
         if start_from is not None:
             # todo: should we abstract out how the keys work inside this class?
             view_kwargs['startkey'] = start_from

--- a/corehq/ex-submodules/pillowtop/reindexer/change_providers/couch.py
+++ b/corehq/ex-submodules/pillowtop/reindexer/change_providers/couch.py
@@ -1,0 +1,21 @@
+from corehq.util.couch_helpers import paginate_view
+from pillowtop.reindexer.change_providers.interface import ChangeProvider
+
+
+class CouchViewChangeProvider(ChangeProvider):
+
+    def __init__(self, document_class, view_name, chunk_size=100, view_kwargs=None):
+        self.document_class = document_class
+        self._couch_db = document_class.get_db()
+        self._view_name = view_name
+        self._chunk_size = chunk_size
+        self._view_kwargs = view_kwargs or {}
+
+    def iter_changes(self, start_from=None):
+        view_kwargs = copy(self._view_kwargs)
+        if start_from is not None:
+            # todo: should we abstract out how the keys work inside this class?
+            view_kwargs['startkey'] = start_from
+        for item in paginate_view(self._couch_db, self._view_name, self._chunk_size, **view_kwargs):
+            # todo: need to transform to a `Change` object
+            yield item

--- a/corehq/ex-submodules/pillowtop/reindexer/change_providers/interface.py
+++ b/corehq/ex-submodules/pillowtop/reindexer/change_providers/interface.py
@@ -1,0 +1,14 @@
+from abc import ABCMeta, abstractmethod
+
+
+class ChangeProvider(object):
+    """
+    `ChangeProvider`s are used in reindexing. They should support querying the complete
+    data set backing a particular `ChangeFeed` object, but are intentionally decoupled
+    from `ChangeFeed`s.
+    """
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def iter_changes(self, start_from=None):
+        pass

--- a/corehq/ex-submodules/pillowtop/reindexer/reindexer.py
+++ b/corehq/ex-submodules/pillowtop/reindexer/reindexer.py
@@ -1,0 +1,13 @@
+from pillowtop.pillow.interface import PillowRuntimeContext
+
+
+class PillowReindexer(object):
+
+    def __init__(self, pillow, change_provider):
+        self.pillow = pillow
+        self.change_provider = change_provider
+
+    def reindex(self, start_from=None):
+        reindexer_context = PillowRuntimeContext(do_set_checkpoint=False)
+        for change in self.change_provider.iter_changes(start_from=start_from):
+            self.pillow.processor(change, reindexer_context)

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -416,7 +416,8 @@ class CaseAccessorSQL(AbstractCaseAccessor):
             server_modified_on_since = datetime.min
         results = list(CommCareCaseSQL.objects.raw('SELECT * FROM get_all_cases_modified_since(%s, %s)',
                                                 [server_modified_on_since, limit]))
-        return sorted(results, key=lambda case: case.server_modified_on)
+        # add additional limit in memory in case the sharded setup returns more than 1 case
+        return sorted(results, key=lambda case: case.server_modified_on)[:limit]
 
     @staticmethod
     @transaction.atomic

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -416,7 +416,8 @@ class CaseAccessorSQL(AbstractCaseAccessor):
             server_modified_on_since = datetime.min
         results = list(CommCareCaseSQL.objects.raw('SELECT * FROM get_all_cases_modified_since(%s, %s)',
                                                 [server_modified_on_since, limit]))
-        # add additional limit in memory in case the sharded setup returns more than 1 case
+        # sort and add additional limit in memory in case the sharded setup returns more than
+        # the requested number of cases
         return sorted(results, key=lambda case: case.server_modified_on)[:limit]
 
     @staticmethod

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -414,8 +414,9 @@ class CaseAccessorSQL(AbstractCaseAccessor):
         """
         if server_modified_on_since is None:
             server_modified_on_since = datetime.min
-        return list(CommCareCaseSQL.objects.raw('SELECT * FROM get_all_cases_modified_since(%s, %s)',
+        results = list(CommCareCaseSQL.objects.raw('SELECT * FROM get_all_cases_modified_since(%s, %s)',
                                                 [server_modified_on_since, limit]))
+        return sorted(results, key=lambda case: case.server_modified_on)
 
     @staticmethod
     @transaction.atomic

--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -1,5 +1,6 @@
 import logging
 from itertools import groupby
+from datetime import datetime
 
 from django.db import connections, InternalError, transaction
 from corehq.form_processor.exceptions import XFormNotFound, CaseNotFound, AttachmentNotFound, CaseSaveError
@@ -405,6 +406,16 @@ class CaseAccessorSQL(AbstractCaseAccessor):
     def delete_all_cases(domain=None):
         with get_cursor(CommCareCaseSQL) as cursor:
             cursor.execute('SELECT delete_all_cases(%s)', [domain])
+
+    @staticmethod
+    def get_all_cases_modified_since(server_modified_on_since=None, limit=100):
+        """
+        Iterate through all cases in the entire database.
+        """
+        if server_modified_on_since is None:
+            server_modified_on_since = datetime.min
+        return list(CommCareCaseSQL.objects.raw('SELECT * FROM get_all_cases_modified_since(%s, %s)',
+                                                [server_modified_on_since, limit]))
 
     @staticmethod
     @transaction.atomic

--- a/corehq/form_processor/change_providers.py
+++ b/corehq/form_processor/change_providers.py
@@ -1,0 +1,39 @@
+from datetime import datetime
+from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
+from corehq.form_processor.change_publishers import change_meta_from_sql_case
+from pillowtop.feed.interface import Change
+from pillowtop.reindexer.change_providers.interface import ChangeProvider
+
+
+class SqlCaseChangeProvider(ChangeProvider):
+
+    def __init__(self, chunk_size=500):
+        self.chunk_size = chunk_size
+
+    def iter_changes(self, start_from=None):
+        start_from = start_from or datetime.min
+        batch = CaseAccessorSQL.get_all_cases_modified_since(start_from, limit=self.chunk_size)
+        while len(batch) == self.chunk_size:
+            for case in batch:
+                yield _sql_case_to_change(case)
+                # todo: assumes cases are sorted by modified date -- may not be valid in a sharded setup
+                next_start_from = case.server_modified_on
+            # make sure we are making progress
+            assert next_start_from > start_from
+            start_from = next_start_from
+            batch = CaseAccessorSQL.get_all_cases_modified_since(start_from, limit=self.chunk_size)
+
+        # last batch
+        for case in batch:
+            yield _sql_case_to_change(case)
+
+
+def _sql_case_to_change(case):
+    return Change(
+        id=case.case_id,
+        sequence_id=None,
+        document=case.to_json(),
+        deleted=False,
+        metadata=change_meta_from_sql_case(case),
+        document_store=None,
+    )

--- a/corehq/form_processor/change_providers.py
+++ b/corehq/form_processor/change_providers.py
@@ -1,5 +1,5 @@
-from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
-from corehq.form_processor.change_publishers import change_meta_from_sql_case
+from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL, FormAccessorSQL
+from corehq.form_processor.change_publishers import change_meta_from_sql_case, change_meta_from_sql_form
 from pillowtop.feed.interface import Change
 from pillowtop.reindexer.change_providers.interface import ChangeProvider
 
@@ -21,5 +21,26 @@ def _sql_case_to_change(case):
         document=case.to_json(),
         deleted=False,
         metadata=change_meta_from_sql_case(case),
+        document_store=None,
+    )
+
+
+class SqlFormChangeProvider(ChangeProvider):
+
+    def __init__(self, chunk_size=500):
+        self.chunk_size = chunk_size
+
+    def iter_changes(self, start_from=None):
+        for form in FormAccessorSQL.get_all_forms_received_since(start_from, chunk_size=self.chunk_size):
+            yield _sql_form_to_change(form)
+
+
+def _sql_form_to_change(form):
+    return Change(
+        id=form.form_id,
+        sequence_id=None,
+        document=form.to_json(),
+        deleted=False,
+        metadata=change_meta_from_sql_form(form),
         document_store=None,
     )

--- a/corehq/form_processor/change_providers.py
+++ b/corehq/form_processor/change_providers.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
 from corehq.form_processor.change_publishers import change_meta_from_sql_case
 from pillowtop.feed.interface import Change
@@ -11,20 +10,7 @@ class SqlCaseChangeProvider(ChangeProvider):
         self.chunk_size = chunk_size
 
     def iter_changes(self, start_from=None):
-        start_from = start_from or datetime.min
-        batch = CaseAccessorSQL.get_all_cases_modified_since(start_from, limit=self.chunk_size)
-        while len(batch) == self.chunk_size:
-            for case in batch:
-                yield _sql_case_to_change(case)
-                # todo: assumes cases are sorted by modified date -- may not be valid in a sharded setup
-                next_start_from = case.server_modified_on
-            # make sure we are making progress
-            assert next_start_from > start_from
-            start_from = next_start_from
-            batch = CaseAccessorSQL.get_all_cases_modified_since(start_from, limit=self.chunk_size)
-
-        # last batch
-        for case in batch:
+        for case in CaseAccessorSQL.get_all_cases_modified_since(start_from, chunk_size=self.chunk_size):
             yield _sql_case_to_change(case)
 
 

--- a/corehq/form_processor/change_publishers.py
+++ b/corehq/form_processor/change_publishers.py
@@ -21,10 +21,10 @@ def _change_meta_from_sql_form(form):
 
 
 def publish_case_saved(case):
-    producer.send_change(topics.CASE_SQL, _change_meta_from_sql_case(case))
+    producer.send_change(topics.CASE_SQL, change_meta_from_sql_case(case))
 
 
-def _change_meta_from_sql_case(case):
+def change_meta_from_sql_case(case):
     return ChangeMeta(
         document_id=case.case_id,
         data_source_type=data_sources.CASE_SQL,

--- a/corehq/form_processor/change_publishers.py
+++ b/corehq/form_processor/change_publishers.py
@@ -5,10 +5,10 @@ from pillowtop.feed.interface import ChangeMeta
 
 
 def publish_form_saved(form):
-    producer.send_change(topics.FORM_SQL, _change_meta_from_sql_form(form))
+    producer.send_change(topics.FORM_SQL, change_meta_from_sql_form(form))
 
 
-def _change_meta_from_sql_form(form):
+def change_meta_from_sql_form(form):
     return ChangeMeta(
         document_id=form.form_id,
         data_source_type=data_sources.FORM_SQL,

--- a/corehq/form_processor/tests/test_case_dbaccessor.py
+++ b/corehq/form_processor/tests/test_case_dbaccessor.py
@@ -574,18 +574,18 @@ class CaseAccessorTestsSQL(TestCase):
         time.sleep(.01)
         end = datetime.utcnow()
 
-        cases_back = CaseAccessorSQL.get_all_cases_modified_since()
+        cases_back = list(CaseAccessorSQL.get_all_cases_modified_since())
         self.assertEqual(4, len(cases_back))
         self.assertEqual(set(case.case_id for case in cases_back),
                          set([case1.case_id, case2.case_id, case3.case_id, case4.case_id]))
 
-        cases_back = CaseAccessorSQL.get_all_cases_modified_since(middle)
+        cases_back = list(CaseAccessorSQL.get_all_cases_modified_since(middle))
         self.assertEqual(2, len(cases_back))
         self.assertEqual(set(case.case_id for case in cases_back),
                          set([case3.case_id, case4.case_id]))
 
-        self.assertEqual(0, len(CaseAccessorSQL.get_all_cases_modified_since(end)))
-        self.assertEqual(1, len(CaseAccessorSQL.get_all_cases_modified_since(limit=1)))
+        self.assertEqual(0, len(list(CaseAccessorSQL.get_all_cases_modified_since(end))))
+        self.assertEqual(1, len(CaseAccessorSQL.get_cases_modified_since(limit=1)))
 
 
 def _create_case(domain=None, form_id=None, case_type=None, user_id=None):

--- a/corehq/form_processor/tests/test_form_dbaccessor.py
+++ b/corehq/form_processor/tests/test_form_dbaccessor.py
@@ -262,6 +262,9 @@ class FormAccessorTestsSQL(TestCase):
         self.assertEqual(original_domain, saved_form.domain)
 
     def test_get_forms_received_since(self):
+        # since this test depends on the global form list just wipe everything
+        FormProcessorTestUtils.delete_all_sql_forms()
+
         form1 = create_form_for_test(DOMAIN)
         form2 = create_form_for_test(DOMAIN)
         middle = datetime.utcnow()

--- a/corehq/form_processor/tests/test_form_dbaccessor.py
+++ b/corehq/form_processor/tests/test_form_dbaccessor.py
@@ -1,4 +1,6 @@
 import uuid
+from datetime import datetime
+import time
 
 from django.core.files.uploadedfile import UploadedFile
 from django.test import TestCase
@@ -258,6 +260,29 @@ class FormAccessorTestsSQL(TestCase):
         self.assertEqual(XFormInstanceSQL.ERROR, saved_form.state)
         self.assertEqual(problem, saved_form.problem)
         self.assertEqual(original_domain, saved_form.domain)
+
+    def test_get_forms_received_since(self):
+        form1 = create_form_for_test(DOMAIN)
+        form2 = create_form_for_test(DOMAIN)
+        middle = datetime.utcnow()
+        time.sleep(.01)
+        form3 = create_form_for_test(DOMAIN)
+        form4 = create_form_for_test(DOMAIN)
+        time.sleep(.01)
+        end = datetime.utcnow()
+
+        forms_back = list(FormAccessorSQL.get_all_forms_received_since())
+        self.assertEqual(4, len(forms_back))
+        self.assertEqual(set(form.form_id for form in forms_back),
+                         set([form1.form_id, form2.form_id, form3.form_id, form4.form_id]))
+
+        forms_back = list(FormAccessorSQL.get_all_forms_received_since(middle))
+        self.assertEqual(2, len(forms_back))
+        self.assertEqual(set(form.form_id for form in forms_back),
+                         set([form3.form_id, form4.form_id]))
+
+        self.assertEqual(0, len(list(FormAccessorSQL.get_all_forms_received_since(end))))
+        self.assertEqual(1, len(list(FormAccessorSQL.get_forms_received_since(limit=1))))
 
     def _validate_deprecation(self, existing_form, new_form):
         saved_new_form = FormAccessorSQL.get_form(new_form.form_id)

--- a/corehq/pillows/case.py
+++ b/corehq/pillows/case.py
@@ -3,6 +3,7 @@ from casexml.apps.case.models import CommCareCase
 from corehq.apps.change_feed import topics
 from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed
 from corehq.elastic import get_es_new
+from corehq.form_processor.change_providers import SqlCaseChangeProvider
 from corehq.pillows.mappings.case_mapping import CASE_MAPPING, CASE_INDEX
 from dimagi.utils.couch import LockManager
 from dimagi.utils.decorators.memoized import memoized
@@ -101,3 +102,7 @@ def get_couch_case_reindexer():
         document_class=CommCareCase,
         view_name='cases_by_owner/view'
     ))
+
+
+def get_sql_case_reindexer():
+    return PillowReindexer(get_sql_case_to_elasticsearch_pillow(), SqlCaseChangeProvider())

--- a/corehq/pillows/case.py
+++ b/corehq/pillows/case.py
@@ -14,6 +14,8 @@ from pillowtop.es_utils import doc_exists, ElasticsearchIndexMeta
 from pillowtop.listener import lock_manager
 from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors.elastic import ElasticProcessor
+from pillowtop.reindexer.change_providers.couch import CouchViewChangeProvider
+from pillowtop.reindexer.reindexer import PillowReindexer
 
 
 UNKNOWN_DOMAIN = "__nodomain__"
@@ -92,3 +94,10 @@ def get_sql_case_to_elasticsearch_pillow():
             checkpoint=checkpoint, checkpoint_frequency=100,
         ),
     )
+
+
+def get_couch_case_reindexer():
+    return PillowReindexer(CasePillow(), CouchViewChangeProvider(
+        document_class=CommCareCase,
+        view_name='cases_by_owner/view'
+    ))

--- a/corehq/pillows/xform.py
+++ b/corehq/pillows/xform.py
@@ -15,6 +15,8 @@ from pillowtop.checkpoints.manager import PillowCheckpoint, get_django_checkpoin
 from pillowtop.es_utils import ElasticsearchIndexMeta
 from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors.elastic import ElasticProcessor
+from pillowtop.reindexer.change_providers.couch import CouchViewChangeProvider
+from pillowtop.reindexer.reindexer import PillowReindexer
 
 
 UNKNOWN_VERSION = 'XXX'
@@ -139,3 +141,14 @@ def get_sql_xform_to_elasticsearch_pillow():
             checkpoint=checkpoint, checkpoint_frequency=100,
         ),
     )
+
+
+def get_couch_form_reindexer():
+    return PillowReindexer(XFormPillow(), CouchViewChangeProvider(
+        document_class=XFormInstance,
+        view_name='all_docs/by_doc_type',
+        view_kwargs={
+            'startkey': ['XFormInstance'],
+            'endkey': ['XFormInstance', {}],
+        }
+    ))

--- a/corehq/pillows/xform.py
+++ b/corehq/pillows/xform.py
@@ -5,6 +5,7 @@ from corehq.apps.change_feed import topics
 from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed
 from corehq.elastic import get_es_new
 from corehq.form_processor.backends.sql.dbaccessors import doc_type_to_state
+from corehq.form_processor.change_providers import SqlFormChangeProvider
 from corehq.pillows.mappings.xform_mapping import XFORM_MAPPING, XFORM_INDEX
 from .base import HQPillow
 from couchforms.const import RESERVED_WORDS
@@ -152,3 +153,7 @@ def get_couch_form_reindexer():
             'endkey': ['XFormInstance', {}],
         }
     ))
+
+
+def get_sql_form_reindexer():
+    return PillowReindexer(get_sql_xform_to_elasticsearch_pillow(), SqlFormChangeProvider())

--- a/corehq/sql_accessors/migrations/0004_get_cases_modified_since_functions.py
+++ b/corehq/sql_accessors/migrations/0004_get_cases_modified_since_functions.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.conf import settings
+from django.db import migrations
+
+from corehq.sql_db.operations import RawSQLMigration
+
+
+migrator = RawSQLMigration(('corehq', 'sql_accessors', 'sql_templates'), {})
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sql_accessors', '0003_get_forms_by_user_id_functions')
+    ]
+
+    operations = [
+        migrator.get_migration('get_all_cases_modified_since.sql'),
+    ]

--- a/corehq/sql_accessors/migrations/0004_get_modified_since_functions.py
+++ b/corehq/sql_accessors/migrations/0004_get_modified_since_functions.py
@@ -7,17 +7,16 @@ from django.db import migrations
 from corehq.sql_db.operations import RawSQLMigration
 
 
-migrator = RawSQLMigration(('corehq', 'sql_proxy_accessors', 'sql_templates'), {
-    'PL_PROXY_CLUSTER_NAME': settings.PL_PROXY_CLUSTER_NAME
-})
+migrator = RawSQLMigration(('corehq', 'sql_accessors', 'sql_templates'), {})
 
 
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('sql_proxy_accessors', '0003_get_forms_by_user_id_functions')
+        ('sql_accessors', '0003_get_forms_by_user_id_functions')
     ]
 
     operations = [
         migrator.get_migration('get_all_cases_modified_since.sql'),
+        migrator.get_migration('get_all_forms_received_since.sql'),
     ]

--- a/corehq/sql_accessors/sql_templates/get_all_cases_modified_since.sql
+++ b/corehq/sql_accessors/sql_templates/get_all_cases_modified_since.sql
@@ -1,0 +1,12 @@
+DROP FUNCTION IF EXISTS get_all_cases_modified_since(timestamp with time zone, integer);
+
+CREATE FUNCTION get_all_cases_modified_since(reference_date timestamp with time zone, query_limit integer)
+RETURNS SETOF form_processor_commcarecasesql AS $$
+BEGIN
+    RETURN QUERY
+    SELECT * FROM form_processor_commcarecasesql as case_table
+    WHERE case_table.server_modified_on >= reference_date
+    LIMIT query_limit
+    ;
+END;
+$$ LANGUAGE plpgsql;

--- a/corehq/sql_accessors/sql_templates/get_all_forms_received_since.sql
+++ b/corehq/sql_accessors/sql_templates/get_all_forms_received_since.sql
@@ -1,0 +1,12 @@
+DROP FUNCTION IF EXISTS get_all_forms_received_since(timestamp with time zone, integer);
+
+CREATE FUNCTION get_all_forms_received_since(reference_date timestamp with time zone, query_limit integer)
+RETURNS SETOF form_processor_xforminstancesql AS $$
+BEGIN
+    RETURN QUERY
+    SELECT * FROM form_processor_xforminstancesql as form_table
+    WHERE form_table.received_on >= reference_date
+    LIMIT query_limit
+    ;
+END;
+$$ LANGUAGE plpgsql;

--- a/corehq/sql_proxy_accessors/migrations/0004_get_cases_modified_since_functions.py
+++ b/corehq/sql_proxy_accessors/migrations/0004_get_cases_modified_since_functions.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.conf import settings
+from django.db import migrations
+
+from corehq.sql_db.operations import RawSQLMigration
+
+
+migrator = RawSQLMigration(('corehq', 'sql_proxy_accessors', 'sql_templates'), {
+    'PL_PROXY_CLUSTER_NAME': settings.PL_PROXY_CLUSTER_NAME
+})
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sql_proxy_accessors', '0003_get_forms_by_user_id_functions')
+    ]
+
+    operations = [
+        migrator.get_migration('get_all_cases_modified_since.sql'),
+    ]

--- a/corehq/sql_proxy_accessors/migrations/0004_get_modified_since_functions.py
+++ b/corehq/sql_proxy_accessors/migrations/0004_get_modified_since_functions.py
@@ -7,15 +7,18 @@ from django.db import migrations
 from corehq.sql_db.operations import RawSQLMigration
 
 
-migrator = RawSQLMigration(('corehq', 'sql_accessors', 'sql_templates'), {})
+migrator = RawSQLMigration(('corehq', 'sql_proxy_accessors', 'sql_templates'), {
+    'PL_PROXY_CLUSTER_NAME': settings.PL_PROXY_CLUSTER_NAME
+})
 
 
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('sql_accessors', '0003_get_forms_by_user_id_functions')
+        ('sql_proxy_accessors', '0003_get_forms_by_user_id_functions')
     ]
 
     operations = [
         migrator.get_migration('get_all_cases_modified_since.sql'),
+        migrator.get_migration('get_all_forms_received_since.sql'),
     ]

--- a/corehq/sql_proxy_accessors/sql_templates/get_all_cases_modified_since.sql
+++ b/corehq/sql_proxy_accessors/sql_templates/get_all_cases_modified_since.sql
@@ -1,0 +1,7 @@
+DROP FUNCTION IF EXISTS get_all_cases_modified_since(timestamp with time zone, integer);
+
+CREATE FUNCTION get_all_cases_modified_since(reference_date timestamp with time zone, query_limit integer)
+RETURNS SETOF form_processor_commcarecasesql AS $$
+    CLUSTER '{{ PL_PROXY_CLUSTER_NAME }}';
+    RUN ON ALL;
+$$ LANGUAGE plproxy;

--- a/corehq/sql_proxy_accessors/sql_templates/get_all_forms_received_since.sql
+++ b/corehq/sql_proxy_accessors/sql_templates/get_all_forms_received_since.sql
@@ -1,0 +1,7 @@
+DROP FUNCTION IF EXISTS get_all_forms_received_since(timestamp with time zone, integer);
+
+CREATE FUNCTION get_all_forms_received_since(reference_date timestamp with time zone, query_limit integer)
+RETURNS SETOF form_processor_xforminstancesql AS $$
+    CLUSTER '{{ PL_PROXY_CLUSTER_NAME }}';
+    RUN ON ALL;
+$$ LANGUAGE plproxy;

--- a/testapps/test_pillowtop/tests/test_reindexer.py
+++ b/testapps/test_pillowtop/tests/test_reindexer.py
@@ -1,21 +1,18 @@
 import uuid
 from django.core.management import call_command
 from django.test import TestCase
-from casexml.apps.case.models import CommCareCase
-from casexml.apps.case.signals import case_post_save
 from corehq.apps.es import UserES, CaseES, FormES, ESQuery
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 from corehq.apps.users.models import CommCareUser
-from corehq.elastic import get_es_new
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.utils import TestFormMetadata
 from corehq.form_processor.tests.utils import FormProcessorTestUtils
 from corehq.pillows.case import CasePillow
 from corehq.pillows.mappings.case_mapping import CASE_INDEX
 from corehq.pillows.mappings.user_mapping import USER_INDEX
-from corehq.util.context_managers import drop_connected_signals
 from corehq.util.elastic import delete_es_index, ensure_index_deleted
 from corehq.util.test_utils import get_form_ready_to_save
+from testapps.test_pillowtop.utils import make_a_case
 
 
 DOMAIN = 'reindex-test-domain'
@@ -101,7 +98,5 @@ class PillowtopReindexerTest(TestCase):
 
 def _create_and_save_a_case():
     case_name = 'reindexer-test-case-{}'.format(uuid.uuid4().hex)
-    case = CommCareCase(domain=DOMAIN, name=case_name)
-    with drop_connected_signals(case_post_save):
-        case.save()
-    return case
+    case_id = uuid.uuid4().hex
+    return make_a_case(DOMAIN, case_id, case_name)


### PR DESCRIPTION
:tropical_fish: or :office: sorry, commits are a little big. 

this is still a bit of a sketch but the basic case is working and figured I'd get feedback on it now. the goal is to have a simpler way to do generic reindexing without having all the hard-to-understand bootstrap code. this will also allow us to reindex all of the sql data in elastic without having to wipe the index first (which seems like it will be something we want).

i'm going to work on forms now which may change the architecture a bit, but I think this should be good to go pending any feedback and tests.
