### PR TITLE
Filter out "_all" parameter for backwards compatability

### DIFF
--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -1159,7 +1159,8 @@ class WorkerActivityReport(WorkerMonitoringCaseReportTableBase, DatespanMixin):
 
     @property
     def group_ids(self):
-        return filter(None, self.request.GET.getlist('group'))
+        return [group_id for group_id in self.request.GET.getlist('group')
+                if group_id and group_id != '_all']
 
     @property
     @memoized


### PR DESCRIPTION
Doh.  I fixed this earlier then merged it badly.  This report was recently changed to a new filter which uses the absence of a "group" parameter to signify all groups, whereas the old version used "_all"
@orangejenny
