### PR TITLE
removing duplicate toggle

### DIFF
--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -750,13 +750,6 @@ CUSTOM_APP_BASE_URL = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
-TF_USES_SQLITE_BACKEND = StaticToggle(
-    'tf_sql_backend',
-    'Use a SQLite backend for Touchforms',
-    TAG_PRODUCT_PATH,
-    [NAMESPACE_DOMAIN]
-)
-
 
 CASE_LIST_DISTANCE_SORT = StaticToggle(
     'case_list_distance_sort',


### PR DESCRIPTION
removing a toggle that is defined twice
@millerdev @benrudolph 
(its at line 737 as well)
