### PR TITLE
Handle update historical data resync

### DIFF
--- a/custom/ilsgateway/admin.py
+++ b/custom/ilsgateway/admin.py
@@ -1,0 +1,9 @@
+from django.contrib import admin
+
+from custom.ilsgateway.models import ReportRun
+
+
+class ReportRunAdmin(admin.ModelAdmin):
+    list_filter = ('domain', )
+
+admin.site.register(ReportRun, ReportRunAdmin)

--- a/custom/ilsgateway/migrations/0006_auto_20160211_1504.py
+++ b/custom/ilsgateway/migrations/0006_auto_20160211_1504.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import datetime
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ilsgateway', '0005_add_pending_reporting_data_recalculation'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='reportrun',
+            name='updating_historical_data',
+            field=models.BooleanField(default=False),
+            preserve_default=True,
+        )
+    ]

--- a/custom/ilsgateway/models.py
+++ b/custom/ilsgateway/models.py
@@ -458,6 +458,7 @@ class ReportRun(models.Model):
     complete = models.BooleanField(default=False)
     has_error = models.BooleanField(default=False)
     domain = models.CharField(max_length=60)
+    updating_historical_data = models.BooleanField(default=False)
     location = models.ForeignKey(SQLLocation, null=True, on_delete=models.PROTECT)
 
     class Meta:

--- a/custom/ilsgateway/tanzania/warehouse/updater.py
+++ b/custom/ilsgateway/tanzania/warehouse/updater.py
@@ -207,6 +207,10 @@ def _get_test_locations(domain):
 
 
 def populate_report_data(start_date, end_date, domain, runner, locations=None, strict=True):
+    if runner.updating_historical_data:
+        update_historical_data(domain)
+        return
+
     # first populate all the warehouse tables for all facilities
     # hard coded to know this is the first date with data
     start_date = max(start_date, default_start_date())
@@ -255,6 +259,7 @@ def populate_report_data(start_date, end_date, domain, runner, locations=None, s
         )()
         res.get()
     runner.location = None
+    runner.updating_historical_data = True
     runner.save()
     # finally go back through the history and initialize empty data for any
     # newly created facilities


### PR DESCRIPTION
@gcapalbo

`update_historical_data` is very long running function and during execution of this function task was killed. Currently our code can't properly handle restart after fail in this function. 

 Could you change `updating_historical_data` to `True` in ilsgateway-test-2 domain report run (there is only one run on that domain)?
