### PR TITLE
get rid of set_bootstrap3_status in favor of cleaner migration step

### DIFF
--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -539,12 +539,6 @@ class AdminReport(GenericTabularReport):
     base_template = "hqadmin/bootstrap3/faceted_report.html"
     report_template_path = "reports/async/bootstrap3/tabular.html"
 
-    @use_jquery_ui
-    @use_bootstrap3
-    @use_datatables
-    def set_bootstrap3_status(self, request, *args, **kwargs):
-        pass
-
 
 class AdminFacetedReport(AdminReport, ElasticTabularReport):
     default_sort = None
@@ -648,8 +642,8 @@ class AdminDomainStatsReport(AdminFacetedReport, DomainStatsReport):
     base_template = "hqadmin/domain_faceted_report.html"
 
     @use_nvd3
-    def set_bootstrap3_status(self, request, *args, **kwargs):
-        super(AdminDomainStatsReport, self).set_bootstrap3_status(request, *args, **kwargs)
+    def bootstrap3_dispatcher(self, request, *args, **kwargs):
+        super(AdminDomainStatsReport, self).bootstrap3_dispatcher(request, *args, **kwargs)
 
     @property
     def template_context(self):
@@ -836,9 +830,6 @@ class AdminDomainMapReport(AdminDomainStatsReport):
     base_template = "hqadmin/project_map.html"
 
     exportable = False
-
-    def set_bootstrap3_status(self, request, *args, **kwargs):
-        super(AdminDomainStatsReport, self).set_bootstrap3_status(request, *args, **kwargs)
 
     # a modified version of AdminDomainStatsReport.rows
     @property

--- a/corehq/apps/reports/dispatcher.py
+++ b/corehq/apps/reports/dispatcher.py
@@ -138,9 +138,10 @@ class ReportDispatcher(View):
             report = cls(request, domain=domain, **report_kwargs)
             report.rendered_as = render_as
             try:
-                report.set_bootstrap3_status(
-                    request, domain=domain, report_slug=report_slug, *args, **kwargs
-                )
+                if report.is_bootstrap3:
+                    report.bootstrap3_dispatcher(
+                        request, domain=domain, report_slug=report_slug, *args, **kwargs
+                    )
                 return getattr(report, '%s_response' % render_as)
             except BadRequestError, e:
                 return HttpResponseBadRequest(e)

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -17,6 +17,13 @@ from corehq.apps.reports.datatables import DataTablesHeader
 from corehq.apps.reports.filters.dates import DatespanFilter
 from corehq.apps.reports.util import \
     DEFAULT_CSS_FORM_ACTIONS_CLASS_REPORT_FILTER
+from corehq.apps.style.decorators import (
+    use_bootstrap3,
+    use_jquery_ui,
+    use_datatables,
+    use_select2,
+    use_daterangepicker,
+)
 from corehq.apps.users.models import CouchUser
 from corehq.util.timezones.utils import get_timezone_for_user
 from corehq.util.view_utils import absolute_reverse
@@ -693,12 +700,26 @@ class GenericReportView(object):
         """
         return []
 
-    def set_bootstrap3_status(self, request, *args, **kwargs):
+    @use_bootstrap3
+    @use_jquery_ui
+    @use_select2
+    @use_datatables
+    @use_daterangepicker
+    def bootstrap3_dispatcher(self, request, *args, **kwargs):
         """
-        Use this function to apply the bootstrap 3 decorators found in
-        style/decorators.py to a report. We're using this in the interim until
-        we overhaul the reports framework, but still want to migrate some
-        reports to bootstrap 3.
+        Decorate this method in your report subclass and call super to make sure
+        appropriate decorators are used to render the page and its javascript
+        libraries.
+
+        example:
+
+        class MyNewReport(GenericReport):
+            ...
+
+            @use_nvd3
+            def bootstrap3_dispatcher(self, request, *args, **kwargs):
+                super(MyNewReport, self).bootstrap3_dispatcher(request, *args, **kwargs)
+
         """
         pass
 


### PR DESCRIPTION
- now override bootstrap3_dispatcher only for special cases rather than each report migration
- added instructions for migrating report views here:

https://docs.google.com/document/d/1jOIrCZlrmECfzo-iyAYjeVFqBv7ilnXjdgDWjGLmqd4/edit#heading=h.7bpu0u2w0p7k

@benrudolph 
