### PR TITLE
Renamed deactivated account of users with dup account names

### DIFF
--- a/custom/openclinica/study_metadata.xml
+++ b/custom/openclinica/study_metadata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ODM FileOID="Study-MetaD20160128145043+0300" Description="Study Metadata" CreationDateTime="2016-01-28T14:50:43+03:00" FileType="Snapshot" ODMVersion="1.3" xmlns="http://www.cdisc.org/ns/odm/v1.3" xmlns:OpenClinica="http://www.openclinica.org/ns/odm_ext_v130/v3.1" xmlns:OpenClinicaRules="http://www.openclinica.org/ns/rules/v3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cdisc.org/ns/odm/v1.3 OpenClinica-ODM1-3-0-OC2-0.xsd" >
+<ODM FileOID="Study-MetaD20160211142051+0300" Description="Study Metadata" CreationDateTime="2016-02-11T14:20:51+03:00" FileType="Snapshot" ODMVersion="1.3" xmlns="http://www.cdisc.org/ns/odm/v1.3" xmlns:OpenClinica="http://www.openclinica.org/ns/odm_ext_v130/v3.1" xmlns:OpenClinicaRules="http://www.openclinica.org/ns/rules/v3.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cdisc.org/ns/odm/v1.3 OpenClinica-ODM1-3-0-OC2-0.xsd" >
     <Study OID="S_DEFAULTS1">
         <GlobalVariables>
             <StudyName>An open-label, non-randomized study on Captopril</StudyName>
@@ -15887,15 +15887,15 @@
             <Organization>KEMRI</Organization>
         </User>
         <User OID="USR_4">
-            <FullName>Beatrice Irungu</FullName>
+            <FullName>Beatrice Ijungu</FullName>
             <FirstName>Beatrice</FirstName>
-            <LastName>Irungu</LastName>
+            <LastName>Ijungu</LastName>
             <Organization>KEMRI</Organization>
         </User>
         <User OID="USR_5">
-            <FullName>Rehema Mwachuo</FullName>
+            <FullName>Rehema Mw</FullName>
             <FirstName>Rehema</FirstName>
-            <LastName>Mwachuo</LastName>
+            <LastName>Mw</LastName>
             <Organization>KEMRI</Organization>
         </User>
         <User OID="USR_6">
@@ -15905,9 +15905,9 @@
             <Organization>KEMRI</Organization>
         </User>
         <User OID="USR_7">
-            <FullName>Sahara Hussein</FullName>
+            <FullName>Sahara Hh</FullName>
             <FirstName>Sahara</FirstName>
-            <LastName>Hussein</LastName>
+            <LastName>Hh</LastName>
             <Organization>KEMRI</Organization>
         </User>
         <User OID="USR_8">
@@ -15965,9 +15965,9 @@
             <Organization>KEMRI</Organization>
         </User>
         <User OID="USR_17">
-            <FullName>Pauline Mueni</FullName>
+            <FullName>Pauline Mm</FullName>
             <FirstName>Pauline</FirstName>
-            <LastName>Mueni</LastName>
+            <LastName>Mm</LastName>
             <Organization>KEMRI</Organization>
         </User>
         <User OID="USR_18">
@@ -16053,6 +16053,18 @@
             <FirstName>Norman</FirstName>
             <LastName>hooper</LastName>
             <Organization>dimagi</Organization>
+        </User>
+        <User OID="USR_32">
+            <FullName>Rukia Kibaya</FullName>
+            <FirstName>Rukia</FirstName>
+            <LastName>Kibaya</LastName>
+            <Organization>kemri</Organization>
+        </User>
+        <User OID="USR_33">
+            <FullName>George Owino</FullName>
+            <FirstName>George</FirstName>
+            <LastName>Owino</LastName>
+            <Organization>kemri</Organization>
         </User>
     </AdminData>
 </ODM>


### PR DESCRIPTION
Updated OpenClinica study metadata from KEMRI data manager.

He added two users, corrected the surname of one, and renamed the deactivated accounts of users who have duplicate accounts on OpenClinica. (OpenClinica does not allow you to delete users, just deactivate their accounts. This change allows CommCare to match mobile workers with the correct OpenClinica user.)

@NoahCarnahan cc @snopoke 
