### PR TITLE
Temporary workaround for stale view issue

### DIFF
--- a/corehq/apps/fixtures/dbaccessors.py
+++ b/corehq/apps/fixtures/dbaccessors.py
@@ -11,15 +11,19 @@ def get_number_of_fixture_data_types_in_domain(domain):
 
 
 def get_fixture_data_types_in_domain(domain):
+    # We're getting an odd error from cloudant where deleted docs are being
+    # returned in the view.  Until that's resolved, we can manually filter out
+    # deleted docs here.  See ticket for updates:
+    # http://manage.dimagi.com/default.asp?216573
     from corehq.apps.fixtures.models import FixtureDataType
-    return FixtureDataType.view(
+    return [row for row in FixtureDataType.view(
         'by_domain_doc_type_date/view',
         endkey=[domain, 'FixtureDataType'],
         startkey=[domain, 'FixtureDataType', {}],
         reduce=False,
         include_docs=True,
         descending=True,
-    )
+    ) if isinstance(row, FixtureDataType)]
 
 
 def get_owner_ids_by_type(domain, owner_type, data_item_id):


### PR DESCRIPTION
We're getting an odd error from cloudant where deleted docs are being returned
in the view.  Until that's resolved, we can manually filter out deleted docs
here.  See ticket for updates: http://manage.dimagi.com/default.asp?216573
@dannyroberts @TylerSheffels
