### PR TITLE
option to hide unreleased builds in deploy page

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases.js
@@ -126,6 +126,7 @@ function ReleasesMain(o) {
     var self = this;
     self.options = o;
     self.recipients = self.options.recipient_contacts;
+    self.showStarredOnly = ko.observable(false);
     self.savedApps = ko.observableArray();
     self.doneFetching = ko.observable(false);
     self.buildState = ko.observable('');

--- a/corehq/apps/app_manager/templates/app_manager/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/releases.html
@@ -137,7 +137,12 @@
             attr: {disabled: !buildButtonEnabled() ? 'disabled' : undefined},
             css: {disabled: !buildButtonEnabled()}
         ">{% trans 'Make New Version' %}</button>
-
+        <div class="checkbox pull-right">
+            <label>
+                <input type="checkbox" data-bind="checked: showStarredOnly">
+                {% trans 'Show only starred versions' %}
+            </label>
+        </div>
         <div id="build-errors-wrapper"></div>
         <table class="table">
             <tr>
@@ -181,7 +186,7 @@
                     'build-unreleased': !is_released(),
                     'build-latest-release': id() === $root.latestReleaseId(),
                     'error': build_broken
-                }">
+                }, visible:  !$parent.showStarredOnly() || ($parent.showStarredOnly() && is_released())">
                     <td>
                         <a href="#" data-bind="
                             openModal: 'delete-build-modal-template',


### PR DESCRIPTION
@nickpell 
Note checkbox on top-right corner
<img width="737" alt="screen shot 2016-02-15 at 3 40 23 pm" src="https://cloud.githubusercontent.com/assets/829142/13045640/81a52a08-d3fa-11e5-87d7-0c5840d2eec1.png">

FYI @dimagi/product (This was an idea from Sri)
