### PR TITLE
ILS: Warehouse runner tweak v2

### DIFF
--- a/custom/ilsgateway/admin.py
+++ b/custom/ilsgateway/admin.py
@@ -1,0 +1,9 @@
+from django.contrib import admin
+
+from custom.ilsgateway.models import ReportRun
+
+
+class ReportRunAdmin(admin.ModelAdmin):
+    list_filter = ('domain', )
+
+admin.site.register(ReportRun, ReportRunAdmin)

--- a/custom/ilsgateway/management/commands/test_report_data_generation.py
+++ b/custom/ilsgateway/management/commands/test_report_data_generation.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from django.core.management import BaseCommand
 from corehq.apps.locations.models import SQLLocation
 from custom.ilsgateway.models import ILSGatewayConfig, ReportRun, SupplyPointStatus, DeliveryGroupReport, \
-    SupplyPointWarehouseRecord, OrganizationSummary, ProductAvailabilityData, Alert
+    OrganizationSummary, ProductAvailabilityData, Alert
 
 from custom.ilsgateway.tasks import report_run
 from custom.ilsgateway.tanzania.warehouse import updater
@@ -32,7 +32,6 @@ def _clear_data(domain):
     ReportRun.objects.filter(domain=domain).delete()
     SupplyPointStatus.objects.all().delete()
     DeliveryGroupReport.objects.all().delete()
-    SupplyPointWarehouseRecord.objects.all().delete()
     OrganizationSummary.objects.all().delete()
     ProductAvailabilityData.objects.all().delete()
     Alert.objects.all().delete()

--- a/custom/ilsgateway/migrations/0006_delete_supply_point_warehouse_record.py
+++ b/custom/ilsgateway/migrations/0006_delete_supply_point_warehouse_record.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import datetime
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ilsgateway', '0005_add_pending_reporting_data_recalculation'),
+    ]
+
+    operations = [
+        migrations.DeleteModel(
+            name='SupplyPointWarehouseRecord',
+        )
+    ]

--- a/custom/ilsgateway/models.py
+++ b/custom/ilsgateway/models.py
@@ -221,19 +221,6 @@ class ReportingModel(models.Model):
         abstract = True
 
 
-# Ported from: https://github.com/dimagi/rapidsms-logistics/blob/master/logistics/warehouse_models.py#L44
-class SupplyPointWarehouseRecord(models.Model):
-    """
-    When something gets updated in the warehouse, create a record of having
-    done that.
-    """
-    supply_point = models.CharField(max_length=100, db_index=True)
-    create_date = models.DateTimeField()
-
-    class Meta:
-        app_label = 'ilsgateway'
-
-
 # Ported from:
 # https://github.com/dimagi/logistics/blob/tz-master/logistics_project/apps/tanzania/reporting/models.py#L9
 class OrganizationSummary(ReportingModel):
@@ -578,7 +565,6 @@ def domain_pre_delete_receiver(domain, **kwargs):
             return
 
         DeliveryGroupReport.objects.filter(location_id__in=locations_ids).delete()
-        SupplyPointWarehouseRecord.objects.filter(supply_point__in=locations_ids).delete()
 
         with connection.cursor() as cursor:
             cursor.execute(

--- a/custom/ilsgateway/tasks.py
+++ b/custom/ilsgateway/tasks.py
@@ -24,8 +24,7 @@ from custom.ilsgateway.temporary import fix_stock_data
 from custom.ilsgateway.utils import send_for_day, send_for_all_domains
 from custom.logistics.commtrack import bootstrap_domain as ils_bootstrap_domain, save_stock_data_checkpoint
 from custom.ilsgateway.models import ILSGatewayConfig, SupplyPointStatus, DeliveryGroupReport, ReportRun, \
-    GroupSummary, OrganizationSummary, ProductAvailabilityData, Alert, SupplyPointWarehouseRecord, \
-    PendingReportingDataRecalculation
+    GroupSummary, OrganizationSummary, ProductAvailabilityData, Alert, PendingReportingDataRecalculation
 from custom.logistics.models import StockDataCheckpoint
 from custom.logistics.tasks import stock_data_task
 from dimagi.utils.dates import get_business_day_of_month
@@ -186,7 +185,6 @@ def clear_report_data(domain):
     OrganizationSummary.objects.filter(location_id__in=locations_ids).delete()
     ProductAvailabilityData.objects.filter(location_id__in=locations_ids).delete()
     Alert.objects.filter(location_id__in=locations_ids).delete()
-    SupplyPointWarehouseRecord.objects.filter(supply_point__in=locations_ids).delete()
     ReportRun.objects.filter(domain=domain).delete()
 
 

--- a/custom/ilsgateway/tests/test_delete_domain.py
+++ b/custom/ilsgateway/tests/test_delete_domain.py
@@ -3,9 +3,8 @@ from django.test import TestCase
 from corehq.apps.domain.models import Domain
 from corehq.apps.locations.models import LocationType, Location
 from corehq.apps.products.models import Product
-from custom.ilsgateway.models import ProductAvailabilityData, DeliveryGroupReport, SupplyPointWarehouseRecord, \
-    Alert, OrganizationSummary, GroupSummary, SupplyPointStatus, HistoricalLocationGroup, ReportRun, ILSNotes, \
-    SupervisionDocument
+from custom.ilsgateway.models import ProductAvailabilityData, DeliveryGroupReport, Alert, OrganizationSummary, \
+    GroupSummary, SupplyPointStatus, HistoricalLocationGroup, ReportRun, ILSNotes, SupervisionDocument
 
 
 class TestDeleteDomain(TestCase):
@@ -28,11 +27,6 @@ class TestDeleteDomain(TestCase):
             quantity=1,
             message='test',
             delivery_group='A'
-        )
-
-        SupplyPointWarehouseRecord.objects.create(
-            supply_point=location.get_id,
-            create_date=datetime.utcnow()
         )
 
         Alert.objects.create(
@@ -126,11 +120,6 @@ class TestDeleteDomain(TestCase):
 
         self.assertEqual(DeliveryGroupReport.objects.filter(location_id=self.locations['test']).count(), 0)
         self.assertEqual(DeliveryGroupReport.objects.filter(location_id=self.locations['test2']).count(), 1)
-
-        self.assertEqual(SupplyPointWarehouseRecord.objects.filter(supply_point=self.locations['test']).count(), 0)
-        self.assertEqual(SupplyPointWarehouseRecord.objects.filter(
-            supply_point=self.locations['test2']
-        ).count(), 1)
 
         self.assertEqual(SupplyPointStatus.objects.filter(location_id=self.locations['test']).count(), 0)
         self.assertEqual(SupplyPointStatus.objects.filter(location_id=self.locations['test2']).count(), 1)


### PR DESCRIPTION
@gcapalbo 

I moved updating historical data into smaller facility subtasks.

Please read commit by commit.

Could you just set has_error to False for ilsgateway-test-2 report run. Generating historical data isn't needed for initial report run.
