### PR TITLE
Case import errors

### DIFF
--- a/corehq/apps/importer/const.py
+++ b/corehq/apps/importer/const.py
@@ -12,3 +12,4 @@ class ImportErrors:
     BlankExternalId = ugettext_noop('Blank External ID')
     CaseGeneration = ugettext_noop('Case Generation Error')
     DuplicateLocationName = ugettext_noop('Duplicated Location Name')
+    InvalidInteger = ugettext_noop('Invalid Integer')

--- a/corehq/apps/importer/exceptions.py
+++ b/corehq/apps/importer/exceptions.py
@@ -28,3 +28,16 @@ class ImporterExcelError(ImporterError, xlrd.XLRDError):
 
 class ImporterExcelFileEncrypted(ImporterExcelError):
     """Raised when a file cannot be open because it is encrypted (password-protected)"""
+
+
+class InvalidImportValueException(Exception):
+    def __init__(self, column=None):
+        self.column = column
+
+
+class InvalidDateException(InvalidImportValueException):
+    pass
+
+
+class InvalidIntegerException(InvalidImportValueException):
+    pass

--- a/corehq/apps/importer/tasks.py
+++ b/corehq/apps/importer/tasks.py
@@ -159,7 +159,7 @@ def do_import(spreadsheet_or_error, config, domain, task=None, chunksize=CASEBLO
                 continue
 
             if not uploaded_owner_id:
-                errors.add(ImportErrors.InvalidOwnerName, i + 1)
+                errors.add(ImportErrors.InvalidOwnerName, i + 1, 'owner_name')
                 continue
         if uploaded_owner_id:
             # If an owner_id mapping exists, verify it is a valid user
@@ -168,7 +168,7 @@ def do_import(spreadsheet_or_error, config, domain, task=None, chunksize=CASEBLO
                 owner_id = uploaded_owner_id
                 id_cache[uploaded_owner_id] = True
             else:
-                errors.add(ImportErrors.InvalidOwnerId, i + 1)
+                errors.add(ImportErrors.InvalidOwnerId, i + 1, 'owner_id')
                 id_cache[uploaded_owner_id] = False
                 continue
         else:
@@ -186,7 +186,7 @@ def do_import(spreadsheet_or_error, config, domain, task=None, chunksize=CASEBLO
                         parent_ref: (parent_case.type, parent_id)
                     }
             except ResourceNotFound:
-                errors.add(ImportErrors.InvalidParentId, i + 1)
+                errors.add(ImportErrors.InvalidParentId, i + 1, 'parent_id')
                 continue
         elif parent_external_id:
             parent_case, error = importer_util.lookup_case(

--- a/corehq/apps/importer/tasks.py
+++ b/corehq/apps/importer/tasks.py
@@ -104,8 +104,8 @@ def do_import(spreadsheet_or_error, config, domain, task=None, chunksize=CASEBLO
             if not any(fields_to_update.values()):
                 # if the row was blank, just skip it, no errors
                 continue
-        except importer_util.InvalidDateException:
-            errors.add(ImportErrors.InvalidDate, i + 1)
+        except importer_util.InvalidDateException as e:
+            errors.add(ImportErrors.InvalidDate, i + 1, e.column)
             continue
 
         external_id = fields_to_update.pop('external_id', None)

--- a/corehq/apps/importer/tasks.py
+++ b/corehq/apps/importer/tasks.py
@@ -107,6 +107,9 @@ def do_import(spreadsheet_or_error, config, domain, task=None, chunksize=CASEBLO
         except importer_util.InvalidDateException as e:
             errors.add(ImportErrors.InvalidDate, i + 1, e.column)
             continue
+        except importer_util.InvalidIntegerException as e:
+            errors.add(ImportErrors.InvalidInteger, i + 1, e.column)
+            continue
 
         external_id = fields_to_update.pop('external_id', None)
         parent_id = fields_to_update.pop('parent_id', None)

--- a/corehq/apps/importer/templates/importer/partials/excel_field_row.html
+++ b/corehq/apps/importer/templates/importer/partials/excel_field_row.html
@@ -30,7 +30,6 @@
         <option value="plain">{% trans "Plain" %}</option>
         <option value="date">{% trans "Date" %}</option>
         <option value="integer">{% trans "Integer" %}</option>
-        <option value="decimal">{% trans "Decimal" %}</option>
     </select>
 </td>
 

--- a/corehq/apps/importer/templates/importer/partials/import_status.html
+++ b/corehq/apps/importer/templates/importer/partials/import_status.html
@@ -40,19 +40,21 @@
         </div>
         {% if result.errors %}
         <div class="alert alert-warning">
-            {% for error, value in result.errors.iteritems %}
-                {% if value.rows %}
-                <p>
-                    <strong>{{ value.error }}</strong>
-                </p>
-                <p>
-                    {{ value.description }}
-                </p>
-                <p>
-                    <span>{% trans "Affected rows:" %}</span> {{ value.rows|join:", " }}
-                </p>
-                {% endif %}
-                <hr />
+            {% for error, columns in result.errors.iteritems %}
+                {% for column, value in columns.iteritems %}
+                    {% if value.rows %}
+                        <p>
+                            <strong>{{ value.error }}</strong> {% if column != None %} {% trans 'in column' %} <strong>{{ column }}</strong>{% endif %}
+                        </p>
+                        <p>
+                            {{ value.description }}
+                        </p>
+                        <p>
+                            <span>{% trans "Affected rows:" %}</span> {{ value.rows|join:", " }}
+                        </p>
+                    {% endif %}
+                    <hr />
+                {% endfor %}
             {% endfor %}
         </div>
         {% endif %}

--- a/corehq/apps/importer/tests.py
+++ b/corehq/apps/importer/tests.py
@@ -70,17 +70,18 @@ class ImporterTest(TestCase):
         self.couch_user.delete()
 
     def _config(self, col_names=None, search_column=None, case_type=None,
-                search_field='case_id', named_columns=False, create_new_cases=True):
+                search_field='case_id', named_columns=False, create_new_cases=True, type_fields=None):
         col_names = col_names or self.default_headers
         case_type = case_type or self.default_case_type
         search_column = search_column or col_names[0]
+        type_fields = type_fields if type_fields is not None else ['plain'] * len(col_names)
         return ImporterConfig(
             couch_user_id=self.couch_user._id,
             case_type=case_type,
             excel_fields=col_names,
             case_fields=[''] * len(col_names),
             custom_fields=col_names,
-            type_fields=['plain'] * len(col_names),
+            type_fields=type_fields,
             search_column=search_column,
             search_field=search_field,
             named_columns=named_columns,

--- a/corehq/apps/importer/tests.py
+++ b/corehq/apps/importer/tests.py
@@ -285,8 +285,9 @@ class ImporterTest(TestCase):
 
         # Should be unable to find parent case on `rows` cases
         res = do_import(file_missing, config, self.domain)
+        error_column_name = None
         self.assertEqual(rows,
-                         len(res['errors'][ImportErrors.InvalidParentId]['rows']),
+                         len(res['errors'][ImportErrors.InvalidParentId][error_column_name]['rows']),
                          "All cases should have missing parent")
 
     def import_mock_file(self, rows):
@@ -313,6 +314,7 @@ class ImporterTest(TestCase):
         make_loc('loc-2', 'Loc 2', self.domain, case_sharing)
         duplicate_loc = make_loc('loc-3', 'Loc 2', self.domain, case_sharing)
         improper_loc = make_loc('loc-4', 'Loc 4', self.domain, non_case_sharing)
+        error_column_name = None
 
         res = self.import_mock_file([
             ['case_id', 'name', 'owner_id', 'owner_name'],
@@ -330,11 +332,11 @@ class ImporterTest(TestCase):
 
         error_message = ImportErrors.DuplicateLocationName
         self.assertIn(error_message, res['errors'])
-        self.assertEqual(res['errors'][error_message]['rows'], [4])
+        self.assertEqual(res['errors'][error_message][error_column_name]['rows'], [4])
 
         error_message = ImportErrors.InvalidOwnerId
         self.assertIn(error_message, res['errors'])
-        self.assertEqual(res['errors'][error_message]['rows'], [5])
+        self.assertEqual(res['errors'][error_message][error_column_name]['rows'], [5])
 
 
 class ImporterUtilsTest(SimpleTestCase):

--- a/corehq/apps/importer/tests.py
+++ b/corehq/apps/importer/tests.py
@@ -339,6 +339,13 @@ class ImporterTest(TestCase):
         self.assertIn(error_message, res['errors'])
         self.assertEqual(res['errors'][error_message][error_column_name]['rows'], [5])
 
+    def testDateError(self):
+        config = self._config(self.default_headers, type_fields=['plain', 'date', 'plain', 'plain'])
+        file = MockExcelFile(header_columns=self.default_headers, num_rows=3)
+        res = do_import(file, config, self.domain)
+        self.assertIn(self.default_headers[1], res['errors'][error_message])
+        self.assertEqual(res['errors'][error_message][self.default_headers[1]]['rows'], [1,2,3])
+
 
 class ImporterUtilsTest(SimpleTestCase):
 

--- a/corehq/apps/importer/tests.py
+++ b/corehq/apps/importer/tests.py
@@ -286,7 +286,7 @@ class ImporterTest(TestCase):
 
         # Should be unable to find parent case on `rows` cases
         res = do_import(file_missing, config, self.domain)
-        error_column_name = None
+        error_column_name = 'parent_id'
         self.assertEqual(rows,
                          len(res['errors'][ImportErrors.InvalidParentId][error_column_name]['rows']),
                          "All cases should have missing parent")
@@ -315,7 +315,6 @@ class ImporterTest(TestCase):
         make_loc('loc-2', 'Loc 2', self.domain, case_sharing)
         duplicate_loc = make_loc('loc-3', 'Loc 2', self.domain, case_sharing)
         improper_loc = make_loc('loc-4', 'Loc 4', self.domain, non_case_sharing)
-        error_column_name = None
 
         res = self.import_mock_file([
             ['case_id', 'name', 'owner_id', 'owner_name'],
@@ -332,11 +331,13 @@ class ImporterTest(TestCase):
         self.assertEqual(cases['location-owner-name'].owner_id, location.group_id)
 
         error_message = ImportErrors.DuplicateLocationName
+        error_column_name = None
         self.assertIn(error_message, res['errors'])
         self.assertEqual(res['errors'][error_message][error_column_name]['rows'], [4])
 
         error_message = ImportErrors.InvalidOwnerId
         self.assertIn(error_message, res['errors'])
+        error_column_name = 'owner_id'
         self.assertEqual(res['errors'][error_message][error_column_name]['rows'], [5])
 
     def _typeTest(self, type_fields, error_message):

--- a/corehq/apps/importer/tests.py
+++ b/corehq/apps/importer/tests.py
@@ -344,7 +344,7 @@ class ImporterTest(TestCase):
         file = MockExcelFile(header_columns=self.default_headers, num_rows=3)
         res = do_import(file, config, self.domain)
         self.assertIn(self.default_headers[1], res['errors'][error_message])
-        self.assertEqual(res['errors'][error_message][self.default_headers[1]]['rows'], [1,2,3])
+        self.assertEqual(res['errors'][error_message][self.default_headers[1]]['rows'], [1, 2, 3])
 
     def testDateError(self):
         self._typeTest(['plain', 'date', 'plain', 'plain'], ImportErrors.InvalidDate)

--- a/corehq/apps/importer/tests.py
+++ b/corehq/apps/importer/tests.py
@@ -339,12 +339,18 @@ class ImporterTest(TestCase):
         self.assertIn(error_message, res['errors'])
         self.assertEqual(res['errors'][error_message][error_column_name]['rows'], [5])
 
-    def testDateError(self):
-        config = self._config(self.default_headers, type_fields=['plain', 'date', 'plain', 'plain'])
+    def _typeTest(self, type_fields, error_message):
+        config = self._config(self.default_headers, type_fields=type_fields)
         file = MockExcelFile(header_columns=self.default_headers, num_rows=3)
         res = do_import(file, config, self.domain)
         self.assertIn(self.default_headers[1], res['errors'][error_message])
         self.assertEqual(res['errors'][error_message][self.default_headers[1]]['rows'], [1,2,3])
+
+    def testDateError(self):
+        self._typeTest(['plain', 'date', 'plain', 'plain'], ImportErrors.InvalidDate)
+
+    def testIntegerError(self):
+        self._typeTest(['plain', 'integer', 'plain', 'plain'], ImportErrors.InvalidInteger)
 
 
 class ImporterUtilsTest(SimpleTestCase):

--- a/corehq/apps/importer/util.py
+++ b/corehq/apps/importer/util.py
@@ -226,7 +226,8 @@ def convert_custom_fields_to_struct(config):
 
 
 class InvalidDateException(Exception):
-    pass
+    def __init__(self, column=None):
+        self.column = column
 
 
 class ImportErrorDetail(object):
@@ -405,7 +406,10 @@ def populate_updated_fields(config, columns, row, datemode):
 
         if update_value is not None:
             if field_map[key]['type_field'] == 'date':
-                update_value = parse_excel_date(update_value, datemode)
+                try:
+                    update_value = parse_excel_date(update_value, datemode)
+                except InvalidDateException:
+                     raise InvalidDateException(key)
             elif field_map[key]['type_field'] == 'integer':
                 try:
                     update_value = str(int(update_value))

--- a/corehq/apps/importer/util.py
+++ b/corehq/apps/importer/util.py
@@ -267,18 +267,19 @@ class ImportErrorDetail(object):
     def __init__(self, *args, **kwargs):
         self.errors = defaultdict(dict)
 
-    def add(self, error, row_number):
-        self.errors[error]['error'] = _(error)
+    def add(self, error, row_number, column_name=None):
+        self.errors[error].setdefault(column_name, {})
+        self.errors[error][column_name]['error'] = _(error)
 
         try:
-            self.errors[error]['description'] = self.ERROR_MSG[error]
+            self.errors[error][column_name]['description'] = self.ERROR_MSG[error]
         except KeyError:
-            self.errors[error]['description'] = self.ERROR_MSG[ImportErrors.CaseGeneration]
+            self.errors[error][column_name]['description'] = self.ERROR_MSG[ImportErrors.CaseGeneration]
 
-        if 'rows' not in self.errors[error]:
-            self.errors[error]['rows'] = []
+        if 'rows' not in self.errors[error][column_name]:
+            self.errors[error][column_name]['rows'] = []
 
-        self.errors[error]['rows'].append(row_number)
+        self.errors[error][column_name]['rows'].append(row_number)
 
     def as_dict(self):
         return dict(self.errors)

--- a/corehq/apps/importer/util.py
+++ b/corehq/apps/importer/util.py
@@ -242,7 +242,7 @@ class ImportErrorDetail(object):
             "uploading because of these values."
         ),
         ImportErrors.InvalidDate: _(
-            "Date fields were specified that caused an error during"
+            "Date fields were specified that caused an error during "
             "conversion. This is likely caused by a value from excel having "
             "the wrong type or not being formatted properly."
         ),

--- a/corehq/apps/importer/util.py
+++ b/corehq/apps/importer/util.py
@@ -413,7 +413,7 @@ def populate_updated_fields(config, columns, row, datemode):
                 try:
                     update_value = parse_excel_date(update_value, datemode)
                 except InvalidDateException:
-                     raise InvalidDateException(key)
+                    raise InvalidDateException(key)
             elif field_map[key]['type_field'] == 'integer':
                 if str(update_value).strip() != '':
                     try:

--- a/corehq/apps/importer/util.py
+++ b/corehq/apps/importer/util.py
@@ -293,10 +293,7 @@ class ImportErrorDetail(object):
 def parse_excel_date(date_val, datemode):
     """ Convert field value from excel to a date value """
     if date_val:
-        try:
-            parsed_date = str(date(*xlrd.xldate_as_tuple(date_val, datemode)[:3]))
-        except Exception:
-            raise InvalidDateException
+        parsed_date = str(date(*xlrd.xldate_as_tuple(date_val, datemode)[:3]))
     else:
         parsed_date = ''
 
@@ -412,7 +409,7 @@ def populate_updated_fields(config, columns, row, datemode):
             if field_map[key]['type_field'] == 'date':
                 try:
                     update_value = parse_excel_date(update_value, datemode)
-                except InvalidDateException:
+                except Exception:
                     raise InvalidDateException(key)
             elif field_map[key]['type_field'] == 'integer':
                 if str(update_value).strip() != '':

--- a/corehq/apps/importer/util.py
+++ b/corehq/apps/importer/util.py
@@ -411,12 +411,11 @@ def populate_updated_fields(config, columns, row, datemode):
                     update_value = parse_excel_date(update_value, datemode)
                 except Exception:
                     raise InvalidDateException(key)
-            elif field_map[key]['type_field'] == 'integer':
-                if str(update_value).strip() != '':
-                    try:
-                        update_value = str(int(update_value))
-                    except ValueError:
-                        raise InvalidIntegerException(key)
+            elif field_map[key]['type_field'] == 'integer' and str(update_value).strip() != '':
+                try:
+                    update_value = str(int(update_value))
+                except ValueError:
+                    raise InvalidIntegerException(key)
             else:
                 update_value = convert_field_value(update_value)
 


### PR DESCRIPTION
@orangejenny 
This is my hackathon contribution...

Case import errors are very cryptic, as they just tell you which row a specific error comes from, not which column. If you have, for e.g. many date columns, you have to scan each column to figure out which one is the bad egg. 

This actually catches errors in `Integer` type columns, removes the selection for `Decimal` (since this wasn't doing anything afaik), and changes the error message for `Date` and `Integer` to show which column is the bad one.
