### PR TITLE
let KafkaChangeFeed support multiple topics

### DIFF
--- a/corehq/apps/change_feed/consumer/feed.py
+++ b/corehq/apps/change_feed/consumer/feed.py
@@ -1,3 +1,4 @@
+from abc import ABCMeta
 import json
 from dimagi.utils.logging import notify_error
 from django.conf import settings
@@ -17,18 +18,23 @@ class KafkaChangeFeed(ChangeFeed):
     Kafka-based implementation of a ChangeFeed
     """
 
-    def __init__(self, topic, group_id, partition=0):
+    def __init__(self, topics, group_id, partition=0):
         """
-        Create a change feed listener for a particular kafka topic, group ID, and partition.
+        Create a change feed listener for a list of kafka topics, a group ID, and partition.
 
         See http://kafka.apache.org/documentation.html#introduction for a description of what these are.
         """
-        self._topic = topic
+        self._topics = topics
         self._group_id = group_id
         self._partition = partition
 
     def __unicode__(self):
-        return u'KafkaChangeFeed: topic: {}, group: {}'.format(self._topic, self._group_id)
+        return u'KafkaChangeFeed: topics: {}, group: {}'.format(self._topics, self._group_id)
+
+    def _get_single_topic_or_fail(self):
+        if len(self._topics != 1):
+            raise ValueError("This function requires a single topic but found {}!".format(self._topics))
+        return self._topics[0]
 
     def iter_changes(self, since, forever):
         # a special value of since=None will start from the end of the change stream
@@ -39,6 +45,7 @@ class KafkaChangeFeed(ChangeFeed):
         reset = 'smallest' if since is not None else 'largest'
         consumer = self._get_consumer(timeout, auto_offset_reset=reset)
         if since is not None:
+            topic = self._get_single_topic_or_fail()
             try:
                 offset = int(since)  # coerce sequence IDs to ints
             except ValueError:
@@ -49,7 +56,7 @@ class KafkaChangeFeed(ChangeFeed):
                 # these once when each pillow moves over.
                 offset = 0
             # this is how you tell the consumer to start from a certain point in the sequence
-            consumer.set_topic_partitions((self._topic, self._partition, offset))
+            consumer.set_topic_partitions((topic, self._partition, offset))
         try:
             for message in consumer:
                 yield change_from_kafka_message(message)
@@ -58,6 +65,7 @@ class KafkaChangeFeed(ChangeFeed):
             # no need to do anything since this is just telling us we've reached the end of the feed
 
     def get_latest_change_id(self):
+        topic = self._get_single_topic_or_fail()
         consumer = self._get_consumer(MIN_TIMEOUT)
         # we have to fetch one change to populate the highwater offset
         try:
@@ -69,15 +77,18 @@ class KafkaChangeFeed(ChangeFeed):
                 e,
             ))
             return None
-        return consumer.offsets('highwater')[(self._topic, self._partition)]
+        return consumer.offsets('highwater')[(topic, self._partition)]
 
     def _get_consumer(self, timeout, auto_offset_reset='smallest'):
+        config = {
+            'group_id': self._group_id,
+            'bootstrap_servers': [settings.KAFKA_URL],
+            'consumer_timeout_ms': timeout,
+            'auto_offset_reset': auto_offset_reset,
+        }
         return KafkaConsumer(
-            self._topic,
-            group_id=self._group_id,
-            bootstrap_servers=[settings.KAFKA_URL],
-            consumer_timeout_ms=timeout,
-            auto_offset_reset=auto_offset_reset,
+            *self._topics,
+            **config
         )
 
 

--- a/corehq/apps/change_feed/consumer/feed.py
+++ b/corehq/apps/change_feed/consumer/feed.py
@@ -31,7 +31,7 @@ class KafkaChangeFeed(ChangeFeed):
         return u'KafkaChangeFeed: topics: {}, group: {}'.format(self._topics, self._group_id)
 
     def _get_single_topic_or_fail(self):
-        if len(self._topics != 1):
+        if len(self._topics) != 1:
             raise ValueError("This function requires a single topic but found {}!".format(self._topics))
         return self._topics[0]
 

--- a/corehq/apps/change_feed/management/commands/run_form_websocket_feed.py
+++ b/corehq/apps/change_feed/management/commands/run_form_websocket_feed.py
@@ -34,7 +34,7 @@ class Command(BaseCommand):
         since = options['from']
         sleep = float(options['sleep'] or '.01')
         last_domain = None
-        change_feed = KafkaChangeFeed(topic=topics.FORM, group_id='form-feed')
+        change_feed = KafkaChangeFeed(topics=[topics.FORM], group_id='form-feed')
         for change in change_feed.iter_changes(since=since, forever=True):
             if not change.deleted:
                 # this is just helpful for demos to find domain transitions

--- a/corehq/apps/change_feed/tests/__init__.py
+++ b/corehq/apps/change_feed/tests/__init__.py
@@ -1,1 +1,2 @@
+from .test_kafka_change_feed import *
 from .test_pillow import *

--- a/corehq/apps/change_feed/tests/test_kafka_change_feed.py
+++ b/corehq/apps/change_feed/tests/test_kafka_change_feed.py
@@ -1,0 +1,28 @@
+from django.test import SimpleTestCase
+from kafka import KeyedProducer
+from corehq.apps.change_feed import topics
+from corehq.apps.change_feed.connection import get_kafka_client_or_none
+from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed
+from corehq.apps.change_feed.producer import send_to_kafka
+from pillowtop.feed.interface import ChangeMeta
+
+
+class KafkaChangeFeedTest(SimpleTestCase):
+
+    def test_multiple_topics(self):
+        feed = KafkaChangeFeed(topics=[topics.FORM, topics.CASE], group_id='test-kafka-feed')
+        self.assertEqual(0, len(list(feed.iter_changes(since=None, forever=False))))
+        producer = KeyedProducer(get_kafka_client_or_none())
+        offsets = feed.get_current_offsets()
+        send_to_kafka(producer, topics.FORM,
+                      ChangeMeta(document_id='1', data_source_type='form', data_source_name='form'))
+        send_to_kafka(producer, topics.CASE,
+                      ChangeMeta(document_id='2', data_source_type='case', data_source_name='case'))
+        send_to_kafka(producer, topics.FORM_SQL,
+                      ChangeMeta(document_id='3', data_source_type='form-sql', data_source_name='form-sql'))
+        send_to_kafka(producer, topics.CASE_SQL,
+                      ChangeMeta(document_id='4', data_source_type='case-sql', data_source_name='case-sql'))
+
+        changes = list(feed.iter_changes(since=offsets, forever=False))
+        self.assertEqual(2, len(changes))
+        self.assertEqual(set(['1', '2']), set([change.id for change in changes]))

--- a/corehq/apps/change_feed/tests/test_pillow.py
+++ b/corehq/apps/change_feed/tests/test_pillow.py
@@ -16,17 +16,17 @@ from pillowtop.feed.interface import Change
 class ChangeFeedPillowTest(SimpleTestCase):
     # note: these tests require a valid kafka setup running
 
-    def setUp(cls):
-        cls._fake_couch = FakeCouchDb()
-        cls._fake_couch.dbname = 'test-couchdb'
+    def setUp(self):
+        self._fake_couch = FakeCouchDb()
+        self._fake_couch.dbname = 'test-couchdb'
         with trap_extra_setup(KafkaUnavailableError):
-            cls.consumer = KafkaConsumer(
+            self.consumer = KafkaConsumer(
                 topics.CASE,
                 group_id='test-consumer',
                 bootstrap_servers=[settings.KAFKA_URL],
                 consumer_timeout_ms=100,
             )
-        cls.pillow = ChangeFeedPillow(cls._fake_couch, kafka=get_kafka_client(), checkpoint=None)
+        self.pillow = ChangeFeedPillow(self._fake_couch, kafka=get_kafka_client(), checkpoint=None)
 
     def test_process_change(self):
         document = {

--- a/corehq/blobs/pillow.py
+++ b/corehq/blobs/pillow.py
@@ -41,7 +41,7 @@ def get_blob_deletion_pillow():
         name='BlobDeletionPillow',
         document_store=None,
         checkpoint=checkpoint,
-        change_feed=KafkaChangeFeed(topic=topics.META, group_id='blob-deletion-group'),
+        change_feed=KafkaChangeFeed(topics=[topics.META], group_id='blob-deletion-group'),
         processor=BlobDeletionProcessor(get_blob_db(), get_db(None).dbname),
         change_processed_event_handler=PillowCheckpointEventHandler(
             checkpoint=checkpoint,

--- a/corehq/ex-submodules/fluff/pillow.py
+++ b/corehq/ex-submodules/fluff/pillow.py
@@ -26,7 +26,7 @@ class FluffPillow(PythonPillow):
         # fluff pillows should default to SQL checkpoints
         checkpoint = checkpoint or get_default_django_checkpoint_for_legacy_pillow_class(self.__class__)
         if change_feed is None and self.kafka_topic:
-            change_feed = KafkaChangeFeed(topic=self.kafka_topic, group_id=self.__class__.__name__)
+            change_feed = KafkaChangeFeed(topics=[self.kafka_topic], group_id=self.__class__.__name__)
             preload_docs = False  # it's never necessary preload_docs for kafka pillows
         super(FluffPillow, self).__init__(
             chunk_size=chunk_size,

--- a/corehq/pillows/case.py
+++ b/corehq/pillows/case.py
@@ -89,7 +89,7 @@ def get_sql_case_to_elasticsearch_pillow():
         name='SqlCaseToElasticsearchPillow',
         document_store=None,
         checkpoint=checkpoint,
-        change_feed=KafkaChangeFeed(topic=topics.CASE_SQL, group_id='sql-cases-to-es'),
+        change_feed=KafkaChangeFeed(topics=[topics.CASE_SQL], group_id='sql-cases-to-es'),
         processor=case_processor,
         change_processed_event_handler=PillowCheckpointEventHandler(
             checkpoint=checkpoint, checkpoint_frequency=100,

--- a/corehq/pillows/xform.py
+++ b/corehq/pillows/xform.py
@@ -136,7 +136,7 @@ def get_sql_xform_to_elasticsearch_pillow():
         name='SqlXFormToElasticsearchPillow',
         document_store=None,
         checkpoint=checkpoint,
-        change_feed=KafkaChangeFeed(topic=topics.FORM_SQL, group_id='sql-forms-to-es'),
+        change_feed=KafkaChangeFeed(topics=[topics.FORM_SQL], group_id='sql-forms-to-es'),
         processor=form_processor,
         change_processed_event_handler=PillowCheckpointEventHandler(
             checkpoint=checkpoint, checkpoint_frequency=100,


### PR DESCRIPTION
:dolphin: 

this will eventually allow us to just run a single UCR pillow off of kafka rather than one pillow per topic.

still in progress (need to update the checkpoints to be able to handle multiple topics), though I think this should be totally backwards compatible.

wait for build

@snopoke cc @biyeun 
