### PR TITLE
Use placeholder hack more widely

### DIFF
--- a/corehq/apps/reports/templates/reports/filters/bootstrap2/base_tags_filter.html
+++ b/corehq/apps/reports/templates/reports/filters/bootstrap2/base_tags_filter.html
@@ -8,8 +8,5 @@
 <script src="{% static 'select2-3.4.5-legacy/select2.min.js' %}"></script>
 <script type="text/javascript">
     $('#{{ css_id }}').select2({tags:{{ tags|JSON }}, allowClear: true});
-
-    //hack to fix issues with placeholder not showing up fully
-    $('.select2-search-field').width('100%').find('.select2-input').width('100%')
 </script>
 {% endblock %}

--- a/corehq/apps/reports/templates/reports/filters/bootstrap3/base_tags_filter.html
+++ b/corehq/apps/reports/templates/reports/filters/bootstrap3/base_tags_filter.html
@@ -10,8 +10,5 @@
 {% block filter_js %}
 <script type="text/javascript">
     $('#{{ css_id }}').select2({tags:{{ tags|JSON }}, allowClear: true});
-
-    //hack to fix issues with placeholder not showing up fully
-    $('.select2-search-field').width('100%').find('.select2-input').width('100%')
 </script>
 {% endblock %}

--- a/corehq/apps/style/static/style/less/bootstrap2/forms.less
+++ b/corehq/apps/style/static/style/less/bootstrap2/forms.less
@@ -9,6 +9,17 @@ select[size^=""] {
     width: 100%;
 }
 
+// hack to fix issues with placeholder not showing up fully
+.select2-container {
+    .select2-search-field {
+        width: 100% !important;
+    }
+    
+    .select2-input {
+        width: 100% !important;
+    }
+}
+
 .autocompletetextarea {
     width: 100%;
     height: @inputHeight*2;

--- a/corehq/apps/style/static/style/less/bootstrap2/forms.less
+++ b/corehq/apps/style/static/style/less/bootstrap2/forms.less
@@ -10,6 +10,7 @@ select[size^=""] {
 }
 
 // hack to fix issues with placeholder not showing up fully
+// !important is necessary because this is overriding an inline style set by select2 javascript
 .select2-container {
     .select2-search-field {
         width: 100% !important;

--- a/corehq/apps/style/static/style/less/bootstrap3/forms.less
+++ b/corehq/apps/style/static/style/less/bootstrap3/forms.less
@@ -99,6 +99,17 @@ legend .subtext {
   width: 210px;
 }
 
+// hack to fix issues with placeholder not showing up fully
+.select2-container {
+    .select2-search-field {
+        width: 100% !important;
+    }
+    
+    .select2-input {
+        width: 100% !important;
+    }
+}
+
 .checkbox-table-cell {
   margin: 0;
   font-size: 20px;

--- a/corehq/apps/style/static/style/less/bootstrap3/forms.less
+++ b/corehq/apps/style/static/style/less/bootstrap3/forms.less
@@ -100,6 +100,7 @@ legend .subtext {
 }
 
 // hack to fix issues with placeholder not showing up fully
+// !important is necessary because this is overriding an inline style set by select2 javascript
 .select2-container {
     .select2-search-field {
         width: 100% !important;


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?217103

The cut-off inputs use multi_option.html, which doesn't have the hack to resize select2 inputs. Move logic to CSS so it's applied globally.

@proteusvacuum 
