### PR TITLE
Move logging enabled setting to to java phone settings

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/json/commcare-settings-layout.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-settings-layout.yaml
@@ -37,6 +37,8 @@
     - properties.cc-autosync-freq  # Auto-Sync Frequency
     - properties.unsent-time-limit  # Unsynced Time Limit
     - properties.password_format  # Password Format
+    - properties.logenabled  # Logging Enabled
+
 
 - title: 'Java Phone User Interface Settings'
   id: app-settings-j2me-ui
@@ -71,7 +73,6 @@
   id: app-settings-advanced
   collapse: true
   settings:
-    - properties.logenabled  # Logging Enabled
     - properties.log_prop_weekly  # Weekly Log Sending Frequency
     - properties.log_prop_daily  # Daily Log Sending Frequency
     - hq.secure_submissions


### PR DESCRIPTION
The ability to disable logging is meant to be a java phone-only setting, but currently appears under the general 'Advanced Settings' menu. My intention with this change is to remove it from there and add it to 'Java Phone General Settings', but was just taking a guess from looking at these files, so if this doesn't do that or is missing something, let me know.
