### PR TITLE
switching to our own fork of pyzxcvbn

### DIFF
--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -959,14 +959,11 @@ pwd_pattern = re.compile( r"([-\w]){"  + str(min_pwd) + ',' + str(max_pwd) + '}'
 
 def clean_password(txt):
     # TODO: waiting on upstream PR to fix TypeError https://github.com/taxpon/pyzxcvbn/pull/1
-    try:
-        strength = zxcvbn(txt, user_inputs=['commcare', 'hq', 'dimagi', 'commcarehq'])
-    except TypeError:
-        raise forms.ValidationError(_('Please do not use years in your password.'))
-    else:
-        if strength['score'] < 2:
-            raise forms.ValidationError(_('Password is not strong enough. Try making your password more complex.'))
-        return txt
+    # until then, we are using a dimagi hosted fork
+    strength = zxcvbn(txt, user_inputs=['commcare', 'hq', 'dimagi', 'commcarehq'])
+    if strength['score'] < 2:
+        raise forms.ValidationError(_('Password is not strong enough. Try making your password more complex.'))
+    return txt
 
 
 class HQPasswordResetForm(forms.Form):

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -78,7 +78,7 @@ django-uuidfield==0.5.0
 # required by ctable
 SQLAlchemy==1.0.9
 alembic==0.6.4
-pyzxcvbn==0.5.0
+git+git://github.com/dimagi/pyzxcvbn.git
 django-statici18n==1.1.5
 httpagentparser==1.7.8
 boto3==1.2.3

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -78,7 +78,7 @@ django-uuidfield==0.5.0
 # required by ctable
 SQLAlchemy==1.0.9
 alembic==0.6.4
-git+git://github.com/dimagi/pyzxcvbn.git
+git+git://github.com/dimagi/pyzxcvbn.git#egg=pyzxcvbn
 django-statici18n==1.1.5
 httpagentparser==1.7.8
 boto3==1.2.3


### PR DESCRIPTION
@millerdev
still waiting on https://github.com/taxpon/pyzxcvbn/pull/1
in the meantime, we can host our own fork with the bug fixed. now users can use numbers that look like years in their passwords again.
