### PR TITLE
fix unicode in jar creation

### DIFF
--- a/corehq/apps/builds/jadjar.py
+++ b/corehq/apps/builds/jadjar.py
@@ -132,7 +132,7 @@ class JadJar(object):
         buffer = StringIO(self.jar)
         with ZipFile(buffer, 'a', ZIP_DEFLATED) as zipper:
             for path in files:
-                zipper.writestr(path, files[path])
+                zipper.writestr(path, files[path].encode('utf-8'))
         buffer.flush()
         jar = buffer.getvalue()
         buffer.close()


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?217527

Not clear why this bug manifested itself now.
