### PR TITLE
Worker Activity Times in ES

### DIFF
--- a/corehq/apps/reports/tests/test_esaccessors.py
+++ b/corehq/apps/reports/tests/test_esaccessors.py
@@ -94,7 +94,7 @@ class TestFormESAccessors(BaseESAccessorsTest):
             user_id=user_id,
         )
 
-        forms = get_forms(
+        paged_result = get_forms(
             self.domain,
             start,
             end,
@@ -102,10 +102,10 @@ class TestFormESAccessors(BaseESAccessorsTest):
             app_ids=app_id,
             xmlnss=xmlns,
         )
-        self.assertEqual(len(forms), 1)
-        self.assertEqual(forms[0]['xmlns'], xmlns)
-        self.assertEqual(forms[0]['form']['meta']['userID'], user_id)
-        self.assertEqual(forms[0]['received_on'], '2013-07-02T00:00:00.000000Z')
+        self.assertEqual(paged_result.total, 1)
+        self.assertEqual(paged_result.hits[0]['xmlns'], xmlns)
+        self.assertEqual(paged_result.hits[0]['form']['meta']['userID'], user_id)
+        self.assertEqual(paged_result.hits[0]['received_on'], '2013-07-02T00:00:00.000000Z')
 
     def test_get_forms_multiple_apps_xmlnss(self):
         start = datetime(2013, 7, 1)
@@ -137,7 +137,7 @@ class TestFormESAccessors(BaseESAccessorsTest):
         )
         self.assertEqual(len(forms), 2)
 
-        forms = get_forms(
+        paged_result = get_forms(
             self.domain,
             start,
             end,
@@ -145,9 +145,9 @@ class TestFormESAccessors(BaseESAccessorsTest):
             app_ids=[app_id1, app_id2],
             xmlnss=[xmlns1],
         )
-        self.assertEqual(len(forms), 1)
+        self.assertEqual(paged_result.total, 1)
 
-        forms = get_forms(
+        paged_result = get_forms(
             self.domain,
             start,
             end,
@@ -155,7 +155,7 @@ class TestFormESAccessors(BaseESAccessorsTest):
             app_ids=[app_id1],
             xmlnss=[xmlns2],
         )
-        self.assertEqual(len(forms), 0)
+        self.assertEqual(paged_result.total, 0)
 
     def test_basic_completed_by_user(self):
         start = datetime(2013, 7, 1)


### PR DESCRIPTION
@snopoke this converts the Worker Activity Times report to use ES. note this is :evergreen_tree: 

![screen shot 2016-02-18 at 9 59 12 pm](https://cloud.githubusercontent.com/assets/918514/13165359/dbffb760-d68a-11e5-8c1f-b2487481ddd2.png)

cc: @gcapalbo 
