### PR TITLE
Custom Calendar Month UCR filter

### DIFF
--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -64,7 +64,6 @@ from corehq.apps.accounting.models import (
 )
 from corehq.apps.accounting.tasks import send_subscription_reminder_emails
 from corehq.apps.accounting.utils import (
-    get_first_last_days,
     get_money_str,
     has_subscription_already_ended,
     make_anchor_tag,
@@ -73,6 +72,7 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.hqwebapp.crispy import BootstrapMultiField, TextField
 from corehq.apps.hqwebapp.tasks import send_html_email_async
 from corehq.apps.users.models import WebUser
+from corehq.util.dates import get_first_last_days
 
 
 class BillingAccountBasicForm(forms.Form):

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -27,20 +27,30 @@ from dimagi.utils.web import get_site_domain
 
 from corehq.apps.accounting.emails import send_subscription_change_alert
 from corehq.apps.accounting.exceptions import (
-    CreditLineError, AccountingError, SubscriptionAdjustmentError,
-    SubscriptionChangeError, NewSubscriptionError, InvoiceEmailThrottledError,
-    SubscriptionReminderError, SubscriptionRenewalError, ProductPlanNotFoundError,
+    AccountingError,
+    CreditLineError,
+    InvoiceEmailThrottledError,
+    NewSubscriptionError,
+    ProductPlanNotFoundError,
+    SubscriptionAdjustmentError,
+    SubscriptionChangeError,
+    SubscriptionReminderError,
+    SubscriptionRenewalError,
 )
 from corehq.apps.accounting.invoice_pdf import InvoiceTemplate
 from corehq.apps.accounting.signals import subscription_upgrade_or_downgrade
 from corehq.apps.accounting.subscription_changes import (
-    DomainDowngradeActionHandler, DomainUpgradeActionHandler,
+    DomainDowngradeActionHandler,
+    DomainUpgradeActionHandler,
 )
 from corehq.apps.accounting.utils import (
-    get_privileges, get_first_last_days,
-    get_address_from_invoice, get_dimagi_from_email_by_product,
-    fmt_dollar_amount, EXCHANGE_RATE_DECIMAL_PLACES,
-    ensure_domain_instance, get_change_status,
+    ensure_domain_instance,
+    EXCHANGE_RATE_DECIMAL_PLACES,
+    fmt_dollar_amount,
+    get_address_from_invoice,
+    get_change_status,
+    get_dimagi_from_email_by_product,
+    get_privileges,
     is_active_subscription,
     log_accounting_error,
     log_accounting_info,

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -50,6 +50,7 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.hqwebapp.tasks import send_html_email_async
 from corehq.apps.users.models import WebUser
 from corehq.const import USER_DATE_FORMAT
+from corehq.util.dates import get_first_last_days
 from corehq.util.quickcache import quickcache
 from corehq.util.view_utils import absolute_reverse
 

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -43,6 +43,7 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.users.models import FakeUser, WebUser
 from corehq.const import USER_DATE_FORMAT, USER_MONTH_FORMAT
 from corehq.util.view_utils import absolute_reverse
+from corehq.util.dates import get_previous_month_date_range
 
 
 @transaction.atomic()
@@ -146,7 +147,7 @@ def generate_invoices(based_on_date=None, check_existing=False, is_test=False):
     Generates all invoices for the past month.
     """
     today = based_on_date or datetime.date.today()
-    invoice_start, invoice_end = utils.get_previous_month_date_range(today)
+    invoice_start, invoice_end = get_previous_month_date_range(today)
     log_accounting_info("Starting up invoices for %(start)s - %(end)s" % {
         'start': invoice_start.strftime(USER_DATE_FORMAT),
         'end': invoice_end.strftime(USER_DATE_FORMAT),
@@ -196,7 +197,7 @@ def send_bookkeeper_email(month=None, year=None, emails=None):
 
     # now, make sure that we send out LAST month's invoices if we did
     # not specify a month or year.
-    today = utils.get_previous_month_date_range(today)[0]
+    today = get_previous_month_date_range(today)[0]
 
     month = month or today.month
     year = year or today.year

--- a/corehq/apps/accounting/tests/test_invoice_factory.py
+++ b/corehq/apps/accounting/tests/test_invoice_factory.py
@@ -8,7 +8,7 @@ from corehq.apps.accounting.models import (
     SubscriptionAdjustment,
 )
 from corehq.apps.accounting.tests.base_tests import BaseAccountingTest
-from corehq.apps.accounting.utils import get_previous_month_date_range
+from corehq.util.dates import get_previous_month_date_range
 
 
 class TestDomainInvoiceFactory(BaseAccountingTest):

--- a/corehq/apps/accounting/tests/test_models.py
+++ b/corehq/apps/accounting/tests/test_models.py
@@ -22,7 +22,7 @@ from corehq.apps.smsbillables.models import (
     SmsBillable,
 )
 from corehq.apps.accounting.tests.base_tests import BaseAccountingTest
-from corehq.apps.accounting.utils import get_previous_month_date_range
+from corehq.util.dates import get_previous_month_date_range
 
 
 class TestBillingAccount(BaseAccountingTest):

--- a/corehq/apps/accounting/utils.py
+++ b/corehq/apps/accounting/utils.py
@@ -1,4 +1,3 @@
-import calendar
 from collections import namedtuple
 import datetime
 from decimal import Decimal
@@ -31,26 +30,6 @@ def log_accounting_error(message):
 
 def log_accounting_info(message):
     logger.info("[BILLING] %s" % message)
-
-
-def get_first_last_days(year, month):
-    last_day = calendar.monthrange(year, month)[1]
-    date_start = datetime.date(year, month, 1)
-    date_end = datetime.date(year, month, last_day)
-    return date_start, date_end
-
-
-def get_current_month_date_range(reference_date=None):
-    reference_date = reference_date or datetime.date.today()
-    date_start = datetime.date(reference_date.year, reference_date.month, 1)
-    return date_start, reference_date
-
-
-def get_previous_month_date_range(reference_date=None):
-    reference_date = reference_date or datetime.date.today()
-
-    last_month_year, last_month = add_months(reference_date.year, reference_date.month, -1)
-    return get_first_last_days(last_month_year, last_month)
 
 
 def months_from_date(reference_date, months_from_date):

--- a/corehq/apps/accounting/utils.py
+++ b/corehq/apps/accounting/utils.py
@@ -40,6 +40,12 @@ def get_first_last_days(year, month):
     return date_start, date_end
 
 
+def get_current_month_date_range(reference_date=None):
+    reference_date = reference_date or datetime.date.today()
+    date_start = datetime.date(reference_date.year, reference_date.month, 1)
+    return date_start, reference_date
+
+
 def get_previous_month_date_range(reference_date=None):
     reference_date = reference_date or datetime.date.today()
 

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -3279,6 +3279,7 @@ class ReportAppFilter(DocumentSchema):
                 'StaticChoiceListFilter': StaticChoiceListFilter,
                 'StaticDatespanFilter': StaticDatespanFilter,
                 'CustomDatespanFilter': CustomDatespanFilter,
+                'CustomMonthFilter': CustomMonthFilter,
                 'MobileSelectFilter': MobileSelectFilter,
             }
             try:

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -3359,6 +3359,7 @@ class StaticDatespanFilter(ReportAppFilter):
         choices=[
             'last7',
             'last30',
+            'thismonth',
             'lastmonth',
             'lastyear',
         ],

--- a/corehq/apps/app_manager/static/app_manager/js/report-module.js
+++ b/corehq/apps/app_manager/static/app_manager/js/report-module.js
@@ -222,7 +222,7 @@ var ReportModule = (function () {
         // TODO - add user-friendly text
         this.filterDocTypes = [null, 'AutoFilter', 'StaticDatespanFilter', 'CustomDatespanFilter', 'CustomDataAutoFilter', 'StaticChoiceListFilter', 'StaticChoiceFilter', 'MobileSelectFilter'];
         this.autoFilterTypes = ['case_sharing_group', 'location_id', 'username', 'user_id'];
-        this.date_range_options = ['last7', 'last30', 'lastmonth', 'lastyear'];
+        this.date_range_options = ['last7', 'last30', 'thismonth', 'lastmonth', 'lastyear'];
         this.date_operators = ['=', '<', '<=', '>', '>=', 'between'];
     }
 

--- a/corehq/apps/app_manager/static/app_manager/js/report-module.js
+++ b/corehq/apps/app_manager/static/app_manager/js/report-module.js
@@ -155,7 +155,9 @@ var ReportModule = (function () {
                     'select_value',
                     'operator',
                     'date_number',
-                    'date_number2'
+                    'date_number2',
+                    'start_of_month',
+                    'period'
                 ];
                 for(var filterFieldsIndex = 0; filterFieldsIndex < filterFields.length; filterFieldsIndex++) {
                     filter.selectedValue[filterFields[filterFieldsIndex]] = ko.observable(filter.selectedValue[filterFields[filterFieldsIndex]] || '');
@@ -190,7 +192,8 @@ var ReportModule = (function () {
                         CustomDataAutoFilter: ['custom_data_property'],
                         StaticChoiceFilter: ['select_value'],
                         StaticDatespanFilter: ['date_range'],
-                        CustomDatespanFilter: ['operator', 'date_number', 'date_number2']
+                        CustomDatespanFilter: ['operator', 'date_number', 'date_number2'],
+                        CustomMonthFilter: ['start_of_month', 'period']
                     };
                     _.each(docTypeToField, function(field, docType) {
                         if(filter.selectedValue.doc_type() === docType) {
@@ -220,7 +223,17 @@ var ReportModule = (function () {
         };
 
         // TODO - add user-friendly text
-        this.filterDocTypes = [null, 'AutoFilter', 'StaticDatespanFilter', 'CustomDatespanFilter', 'CustomDataAutoFilter', 'StaticChoiceListFilter', 'StaticChoiceFilter', 'MobileSelectFilter'];
+        this.filterDocTypes = [
+            null,
+            'AutoFilter',
+            'StaticDatespanFilter',
+            'CustomDatespanFilter',
+            'CustomMonthFilter',
+            'CustomDataAutoFilter',
+            'StaticChoiceListFilter',
+            'StaticChoiceFilter',
+            'MobileSelectFilter'
+        ];
         this.autoFilterTypes = ['case_sharing_group', 'location_id', 'username', 'user_id'];
         this.date_range_options = ['last7', 'last30', 'thismonth', 'lastmonth', 'lastyear'];
         this.date_operators = ['=', '<', '<=', '>', '>=', 'between'];

--- a/corehq/apps/app_manager/templates/app_manager/partials/filter_configs.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/filter_configs.html
@@ -52,6 +52,22 @@
                             </div>
                         </div>
                     </div>
+                    <div data-bind="visible: filter.selectedValue.doc_type() === 'CustomMonthFilter'">
+                        <div class="form-inline">
+                            <div class="form-group">
+                                <label>Start of month</label>
+                                <input class="form-control"
+                                       type="number"
+                                       data-bind="value: filter.selectedValue.start_of_month"/>
+                            </div>
+                            <div class="form-group">
+                                <label>Period</label>
+                                <input class="form-control"
+                                       type="number"
+                                       data-bind="value: filter.selectedValue.period"/>
+                            </div>
+                        </div>
+                    </div>
                     <div data-bind="visible: filter.selectedValue.doc_type() === 'CustomDataAutoFilter'">
                         <input class="form-control" type="text" data-bind="value: filter.selectedValue.custom_data_property"/>
                     </div>

--- a/corehq/apps/app_manager/tests/__init__.py
+++ b/corehq/apps/app_manager/tests/__init__.py
@@ -21,6 +21,7 @@ try:
     from corehq.apps.app_manager.tests.test_days_ago_migration import *
     from corehq.apps.app_manager.tests.test_dbaccessors import *
     from corehq.apps.app_manager.tests.test_extension_case import *
+    from corehq.apps.app_manager.tests.test_filters import *
     from corehq.apps.app_manager.tests.test_form_preparation_v2 import *
     from corehq.apps.app_manager.tests.test_form_versioning import *
     from corehq.apps.app_manager.tests.test_form_workflow import *

--- a/corehq/apps/app_manager/tests/test_filters.py
+++ b/corehq/apps/app_manager/tests/test_filters.py
@@ -1,0 +1,133 @@
+import datetime
+from collections import namedtuple
+from contextlib import contextmanager
+from django.test import SimpleTestCase
+from mock import patch
+from corehq.apps.app_manager.models import CustomMonthFilter
+
+
+Date = namedtuple('Date', ('year', 'month', 'day'))
+
+
+MAY_15 = Date(2015, 05, 15)
+MAY_20 = Date(2015, 05, 20)
+MAY_21 = Date(2015, 05, 21)
+
+
+@contextmanager
+def patch_today(year, month, day):
+    date_class = datetime.date
+    with patch('datetime.date') as date_patch:
+        date_patch.today.return_value = date_class(year, month, day)
+        date_patch.side_effect = lambda *args, **kwargs: date_class(*args, **kwargs)
+        yield date_patch
+
+
+class CustomMonthFilterTests(SimpleTestCase):
+
+    def setUp(self):
+        self.date_class = datetime.date
+
+    # Assume it was May 15:
+    # Period 0, day 21, you would sync April 21-May 15th
+    # Period 1, day 21, you would sync March 21-April 20th
+    # Period 2, day 21, you would sync February 21-March 20th
+
+    def test_may15_period0(self):
+        with patch_today(*MAY_15):
+            filter_ = CustomMonthFilter(start_of_month=21, period=0)
+            date_span = filter_.get_filter_value(user=None, ui_filter=None)
+            self.assertEqual(date_span.startdate, self.date_class(year=2015, month=4, day=21))
+            self.assertEqual(date_span.enddate, self.date_class(*MAY_15))
+
+    def test_may15_period1(self):
+        with patch_today(*MAY_15):
+            filter_ = CustomMonthFilter(start_of_month=21, period=1)
+            date_span = filter_.get_filter_value(user=None, ui_filter=None)
+            self.assertEqual(date_span.startdate, self.date_class(year=2015, month=3, day=21))
+            self.assertEqual(date_span.enddate, self.date_class(year=2015, month=4, day=20))
+
+    def test_may15_period2(self):
+        with patch_today(*MAY_15):
+            filter_ = CustomMonthFilter(start_of_month=21, period=2)
+            date_span = filter_.get_filter_value(user=None, ui_filter=None)
+            self.assertEqual(date_span.startdate, self.date_class(year=2015, month=2, day=21))
+            self.assertEqual(date_span.enddate, self.date_class(year=2015, month=3, day=20))
+
+    # Assume it was May 20:
+    # Period 0, day 21, you would sync April 21-May 20th
+    # Period 1, day 21, you would sync March 21-April 20th
+    # Period 2, day 21, you would sync February 21-March 20th
+
+    def test_may20_period0(self):
+        with patch_today(*MAY_20):
+            filter_ = CustomMonthFilter(start_of_month=21, period=0)
+            date_span = filter_.get_filter_value(user=None, ui_filter=None)
+            self.assertEqual(date_span.startdate, self.date_class(year=2015, month=4, day=21))
+            self.assertEqual(date_span.enddate, self.date_class(*MAY_20))
+
+    def test_may20_period1(self):
+        with patch_today(*MAY_20):
+            filter_ = CustomMonthFilter(start_of_month=21, period=1)
+            date_span = filter_.get_filter_value(user=None, ui_filter=None)
+            self.assertEqual(date_span.startdate, self.date_class(year=2015, month=3, day=21))
+            self.assertEqual(date_span.enddate, self.date_class(year=2015, month=4, day=20))
+
+    def test_may20_period2(self):
+        with patch_today(*MAY_20):
+            filter_ = CustomMonthFilter(start_of_month=21, period=2)
+            date_span = filter_.get_filter_value(user=None, ui_filter=None)
+            self.assertEqual(date_span.startdate, self.date_class(year=2015, month=2, day=21))
+            self.assertEqual(date_span.enddate, self.date_class(year=2015, month=3, day=20))
+
+    # Assume it was May 21:
+    # Period 0, day 21, you would sync May 21-May 21th
+    # Period 1, day 21, you would sync April 21-May 20th
+    # Period 2, day 21, you would sync March 21-April 20th
+
+    def test_may21_period0(self):
+        with patch_today(*MAY_21):
+            filter_ = CustomMonthFilter(start_of_month=21, period=0)
+            date_span = filter_.get_filter_value(user=None, ui_filter=None)
+            self.assertEqual(date_span.startdate, self.date_class(*MAY_21))
+            self.assertEqual(date_span.enddate, self.date_class(*MAY_21))
+
+    def test_may21_period1(self):
+        with patch_today(*MAY_21):
+            filter_ = CustomMonthFilter(start_of_month=21, period=1)
+            date_span = filter_.get_filter_value(user=None, ui_filter=None)
+            self.assertEqual(date_span.startdate, self.date_class(year=2015, month=4, day=21))
+            self.assertEqual(date_span.enddate, self.date_class(*MAY_20))
+
+    def test_may21_period2(self):
+        with patch_today(*MAY_21):
+            filter_ = CustomMonthFilter(start_of_month=21, period=2)
+            date_span = filter_.get_filter_value(user=None, ui_filter=None)
+            self.assertEqual(date_span.startdate, self.date_class(year=2015, month=3, day=21))
+            self.assertEqual(date_span.enddate, self.date_class(year=2015, month=4, day=20))
+
+    # May 15 for 10 days from the end of the month (start_of_month = -10):
+    # Period 0, day 21, you would sync April 21-May 15th
+    # Period 1, day 21, you would sync March 21-April 20th
+    # Period 2, day 21, you would sync February 18-March 20th
+
+    def test_may15_minus10_period0(self):
+        with patch_today(*MAY_15):
+            filter_ = CustomMonthFilter(start_of_month=-10, period=0)
+            date_span = filter_.get_filter_value(user=None, ui_filter=None)
+            self.assertEqual(date_span.startdate, self.date_class(year=2015, month=4, day=21))
+            self.assertEqual(date_span.enddate, self.date_class(*MAY_15))
+
+    def test_may15_minus10_period1(self):
+        with patch_today(*MAY_15):
+            filter_ = CustomMonthFilter(start_of_month=-10, period=1)
+            date_span = filter_.get_filter_value(user=None, ui_filter=None)
+            self.assertEqual(date_span.startdate, self.date_class(year=2015, month=3, day=21))
+            self.assertEqual(date_span.enddate, self.date_class(year=2015, month=4, day=20))
+
+    def test_may15_minus10_period2(self):
+        with patch_today(*MAY_15):
+            filter_ = CustomMonthFilter(start_of_month=-10, period=2)
+            date_span = filter_.get_filter_value(user=None, ui_filter=None)
+            self.assertEqual(date_span.startdate, self.date_class(year=2015, month=2, day=18))
+            self.assertEqual(date_span.enddate, self.date_class(year=2015, month=3, day=20))

--- a/corehq/apps/reports/daterange.py
+++ b/corehq/apps/reports/daterange.py
@@ -1,8 +1,8 @@
 from collections import namedtuple
 import datetime
 from django.utils.translation import ugettext_lazy as _
-from corehq.apps.accounting.utils import get_previous_month_date_range, get_current_month_date_range
 from corehq.apps.reports.exceptions import InvalidDaterangeException
+from corehq.util.dates import get_current_month_date_range, get_previous_month_date_range
 
 
 DateRangeChoice = namedtuple('DateRangeChoice', ['slug', 'description', 'simple'])

--- a/corehq/apps/reports/daterange.py
+++ b/corehq/apps/reports/daterange.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 import datetime
 from django.utils.translation import ugettext_lazy as _
-from corehq.apps.accounting.utils import get_previous_month_date_range
+from corehq.apps.accounting.utils import get_previous_month_date_range, get_current_month_date_range
 from corehq.apps.reports.exceptions import InvalidDaterangeException
 
 
@@ -48,6 +48,8 @@ def get_daterange_start_end_dates(date_range, start_date=None, end_date=None, da
     elif date_range == 'range':
         start_date = start_date
         end_date = end_date
+    elif date_range == 'thismonth':
+        start_date, end_date = get_current_month_date_range()
     elif date_range == 'lastmonth':
         start_date, end_date = get_previous_month_date_range()
     elif date_range == 'lastyear':

--- a/corehq/apps/reports/tests/test_daterange.py
+++ b/corehq/apps/reports/tests/test_daterange.py
@@ -1,6 +1,11 @@
+import datetime
 from django.test import SimpleTestCase
-from corehq.apps.reports.daterange import get_simple_dateranges, get_daterange_start_end_dates, \
-    get_complex_dateranges
+from mock import patch
+from corehq.apps.reports.daterange import (
+    get_simple_dateranges,
+    get_daterange_start_end_dates,
+    get_complex_dateranges,
+)
 from corehq.apps.reports.exceptions import InvalidDaterangeException
 
 
@@ -14,3 +19,87 @@ class DateRangeTest(SimpleTestCase):
         for daterange in get_complex_dateranges():
             with self.assertRaises(InvalidDaterangeException):
                 get_daterange_start_end_dates(daterange.slug)
+
+
+class KnownRangesTests(SimpleTestCase):
+
+    def setUp(self):
+        # The first performance of the William Tell overture. You know, to test the known ranges.
+        self.first_performance = datetime.date(year=1829, month=8, day=3)
+        # Ta da dum, ta da dum, ta da dum dum dum.
+
+    @patch('datetime.date')
+    def test_since(self, date_patch):
+        date_patch.today.return_value = self.first_performance
+
+        saturday = datetime.date(year=1829, month=8, day=1)
+        start_date, end_date = get_daterange_start_end_dates('since', start_date=saturday)
+        self.assertEqual(start_date, saturday)
+        self.assertEqual(end_date, self.first_performance)
+
+    def test_range(self):
+        # Zane Grey dedicated his book "The Lone Star Ranger" to Texas Ranger Captain John R. Hughes in 1915
+        john_hughes_birthday = datetime.date(year=1855, month=2, day=11)
+
+        start_date, end_date = get_daterange_start_end_dates(
+            'range',
+            start_date=self.first_performance,
+            end_date=john_hughes_birthday,
+        )
+        self.assertEqual(start_date, self.first_performance)
+        self.assertEqual(end_date, john_hughes_birthday)
+
+    @patch('datetime.date')
+    def test_thismonth(self, date_patch):
+        date_patch.today.return_value = self.first_performance
+
+        start_date, end_date = get_daterange_start_end_dates('thismonth')
+        self.assertEqual(start_date, datetime.date(year=1829, month=8, day=1))
+        self.assertEqual(end_date, self.first_performance)
+
+    @patch('datetime.date')
+    def test_lastmonth(self, date_patch):
+        date_patch.today.return_value = self.first_performance
+
+        start_date, end_date = get_daterange_start_end_dates('lastmonth')
+        self.assertEqual(start_date, datetime.date(year=1829, month=7, day=1))
+        self.assertEqual(end_date, datetime.date(year=1829, month=7, day=31))
+
+    @patch('datetime.date')
+    def test_lastyear(self, date_patch):
+        date_patch.today.return_value = self.first_performance
+
+        start_date, end_date = get_daterange_start_end_dates('lastyear')
+        self.assertEqual(start_date, datetime.date(year=1828, month=1, day=1))
+        self.assertEqual(end_date, datetime.date(year=1828, month=12, day=31))
+
+    def test_last7(self):
+        date_class = datetime.date
+        with patch('datetime.date') as date_patch:
+            date_patch.today.return_value = self.first_performance
+            date_patch.side_effect = lambda *args, **kwargs: date_class(*args, **kwargs)
+
+            start_date, end_date = get_daterange_start_end_dates('last7')
+            self.assertEqual(start_date, datetime.date(year=1829, month=7, day=27))
+            self.assertEqual(end_date, self.first_performance)
+
+    def test_last30(self):
+        date_class = datetime.date
+        with patch('datetime.date') as date_patch:
+            date_patch.today.return_value = self.first_performance
+            date_patch.side_effect = lambda *args, **kwargs: date_class(*args, **kwargs)
+
+            start_date, end_date = get_daterange_start_end_dates('last30')
+            self.assertEqual(start_date, datetime.date(year=1829, month=7, day=4))  # Woo!
+            self.assertEqual(end_date, self.first_performance)
+
+    def test_lastn(self):
+        date_class = datetime.date
+        with patch('datetime.date') as date_patch:
+            date_patch.today.return_value = self.first_performance
+            date_patch.side_effect = lambda *args, **kwargs: date_class(*args, **kwargs)
+
+            start_date, end_date = get_daterange_start_end_dates('lastn', days=-14)  # In two weeks' time
+            self.assertEqual(start_date, datetime.date(year=1829, month=8, day=17))
+            self.assertEqual(end_date, self.first_performance)
+            # TODO: If the start date occurs after the end date, we should switch them.

--- a/corehq/util/dates.py
+++ b/corehq/util/dates.py
@@ -1,7 +1,9 @@
+import calendar
 import datetime
 import time
 
 from corehq.util.soft_assert import soft_assert
+from dimagi.utils.dates import add_months
 from dimagi.utils.parsing import ISO_DATE_FORMAT, ISO_DATETIME_FORMAT
 
 
@@ -66,3 +68,23 @@ def iso_string_to_date(iso_string):
 
     """
     return datetime.datetime.strptime(iso_string, ISO_DATE_FORMAT).date()
+
+
+def get_first_last_days(year, month):
+    last_day = calendar.monthrange(year, month)[1]
+    date_start = datetime.date(year, month, 1)
+    date_end = datetime.date(year, month, last_day)
+    return date_start, date_end
+
+
+def get_current_month_date_range(reference_date=None):
+    reference_date = reference_date or datetime.date.today()
+    date_start = datetime.date(reference_date.year, reference_date.month, 1)
+    return date_start, reference_date
+
+
+def get_previous_month_date_range(reference_date=None):
+    reference_date = reference_date or datetime.date.today()
+
+    last_month_year, last_month = add_months(reference_date.year, reference_date.month, -1)
+    return get_first_last_days(last_month_year, last_month)


### PR DESCRIPTION
This PR adds a calendar month filter for UCR that lets you filter by months that start with a day other than day 1. Days can be specified from 1 to 28, or 0 to -27 for counting from the end of the month.

See [FB 215656](http://manage.dimagi.com/default.asp?215656) for context

![custommonthfilter](https://cloud.githubusercontent.com/assets/708421/13178998/6037e6de-d72a-11e5-8b34-966d7b5a064b.png)

Also included in this PR is a "thismonth" date range for the-month-so-far-style reports. (Which I've cherry-picked out of #10363 cos it fits better in here.)

Hold off on merge pending tests.

@esoergel @nickpell cc @NoahCarnahan @czue 
