### PR TITLE
Supervisory report workaround for airstanzania

### DIFF
--- a/custom/abt/reports/data_sources/supervisory.json
+++ b/custom/abt/reports/data_sources/supervisory.json
@@ -203,10 +203,10 @@
                     "type": "conditional",
                     "test": {
                         "type": "boolean_expression",
-                        "operator": "not_eq",
+                        "operator": "eq",
                         "expression": {
                             "expression": {
-                                "datatype": null,
+                                "datatype": "string",
                                 "property_path": [
                                     "form",
                                     "location_data",
@@ -216,7 +216,7 @@
                             },
                             "type": "root_doc"
                         },
-                        "property_value": null
+                        "property_value": ""
                     },
                     "expression_if_true": {
                         "expression": {
@@ -224,7 +224,7 @@
                             "property_path": [
                                 "form",
                                 "location_data",
-                                "level_4_name"
+                                "level_3_name"
                             ],
                             "type": "property_path"
                         },
@@ -236,7 +236,7 @@
                             "property_path": [
                                 "form",
                                 "location_data",
-                                "level_3_name"
+                                "level_4_name"
                             ],
                             "type": "property_path"
                         },

--- a/custom/abt/reports/data_sources/supervisory.json
+++ b/custom/abt/reports/data_sources/supervisory.json
@@ -350,6 +350,6 @@
         "display_name": "Supervisory Indicators",
         "named_filters": {},
         "referenced_doc_type": "XFormInstance",
-        "table_id": "supervisory-004"
+        "table_id": "supervisory-005"
     }
 }

--- a/custom/abt/reports/incident_report.json
+++ b/custom/abt/reports/incident_report.json
@@ -9,7 +9,7 @@
       "airszimbabwe",
       "airstanzania"
     ],
-   "data_source_table":"supervisory-004",
+   "data_source_table":"supervisory-005",
    "report_id":"incident-report",
    "custom_configurable_report":"custom.abt.reports.views.FormattedSupervisoryReport",
    "config":{

--- a/custom/abt/reports/supervisory_report.json
+++ b/custom/abt/reports/supervisory_report.json
@@ -10,7 +10,7 @@
         "airstanzania"
     ],
     "report_id": "supervisory_report",
-    "data_source_table": "supervisory-004",
+    "data_source_table": "supervisory-005",
     "config": {
         "doc_type": "ReportConfiguration",
         "domain": "airs",


### PR DESCRIPTION
Correctly checks for situations when `level_4` is blank.

@NoahCarnahan 

No test coverage
