### PR TITLE
add id to instructions

### DIFF
--- a/corehq/apps/builds/templates/builds/edit_menu.html
+++ b/corehq/apps/builds/templates/builds/edit_menu.html
@@ -77,7 +77,7 @@
         <p><input id="submit-menu-form" class="btn btn-primary" type="Submit" value="Submit"></p>
     </form>
     </div>
-    <div class="container">
+    <div class="container" id="import_build">
         <h3>Import a new build from the build server</h3>
         <ol>
             <li><a href="http://jenkins.dimagi.com/view/CommCare%20Mobile/" target="_blank">Browse builds</a></li>


### PR DESCRIPTION
this way, we can link directly to the instructions so we don't have to duplicate them at https://confluence.dimagi.com/display/commcarehq/Add+a+new+mobile+build+to+staging

@sravfeyn 
