### PR TITLE
remove dao / manager from pillow checkpoint classes

### DIFF
--- a/corehq/apps/change_feed/pillow.py
+++ b/corehq/apps/change_feed/pillow.py
@@ -6,8 +6,7 @@ from corehq.apps.change_feed.topics import get_topic
 from corehq.apps.users.models import CommCareUser
 from corehq.util.couchdb_management import couch_config
 from couchforms.models import all_known_formlike_doc_types
-from pillowtop.checkpoints.manager import PillowCheckpoint, get_django_checkpoint_store, \
-    PillowCheckpointEventHandler
+from pillowtop.checkpoints.manager import PillowCheckpoint, PillowCheckpointEventHandler
 from pillowtop.couchdb import CachedCouchDB
 from pillowtop.feed.couch import CouchChangeFeed
 from pillowtop.feed.interface import ChangeMeta
@@ -63,7 +62,7 @@ def get_default_couch_db_change_feed_pillow():
     return ChangeFeedPillow(
         couch_db=default_couch_db,
         kafka=kafka_client,
-        checkpoint=PillowCheckpoint(get_django_checkpoint_store(), 'default-couch-change-feed')
+        checkpoint=PillowCheckpoint('default-couch-change-feed')
     )
 
 
@@ -76,7 +75,7 @@ def get_user_groups_db_kafka_pillow():
     processor = KafkaProcessor(
         kafka_client, data_source_type=data_sources.COUCH, data_source_name=user_groups_couch_db.dbname
     )
-    checkpoint = PillowCheckpoint(get_django_checkpoint_store(), pillow_name)
+    checkpoint = PillowCheckpoint(pillow_name)
     return ConstructedPillow(
         name=pillow_name,
         document_store=None,  # because we're using include_docs we can be explicit about not using this

--- a/corehq/apps/hqadmin/tests/test_utils.py
+++ b/corehq/apps/hqadmin/tests/test_utils.py
@@ -15,7 +15,7 @@ class DummyPillow(BasicPillow):
 
 @override_settings(PILLOWTOPS={'test': ['corehq.apps.hqadmin.tests.test_utils.DummyPillow']})
 class TestPillowCheckpointSeqStore(TestCase):
-    dependent_apps = []
+    dependent_apps = ['pillowtop']
 
     def setUp(self):
         self.pillow = DummyPillow()

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -9,7 +9,7 @@ from corehq.apps.userreports.tasks import rebuild_indicators
 from corehq.sql_db.connections import connection_manager
 from corehq.util.soft_assert import soft_assert
 from fluff.signals import get_migration_context, get_tables_to_rebuild
-from pillowtop.checkpoints.manager import PillowCheckpoint, get_django_checkpoint_store
+from pillowtop.checkpoints.manager import PillowCheckpoint
 from pillowtop.couchdb import CachedCouchDB
 from pillowtop.listener import PythonPillow
 
@@ -24,7 +24,7 @@ class ConfigurableIndicatorPillow(PythonPillow):
     def __init__(self, pillow_checkpoint_id=UCR_CHECKPOINT_ID):
         # todo: this will need to not be hard-coded if we ever split out forms and cases into their own domains
         couch_db = CachedCouchDB(CommCareCase.get_db().uri, readonly=False)
-        checkpoint = PillowCheckpoint(get_django_checkpoint_store(), pillow_checkpoint_id)
+        checkpoint = PillowCheckpoint(pillow_checkpoint_id)
         super(ConfigurableIndicatorPillow, self).__init__(couch_db=couch_db, checkpoint=checkpoint)
         self.bootstrapped = False
         self.last_bootstrapped = datetime.utcnow()

--- a/corehq/blobs/pillow.py
+++ b/corehq/blobs/pillow.py
@@ -3,8 +3,7 @@ from corehq.apps.change_feed import topics
 from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed
 from corehq.blobs import get_blob_db
 from dimagi.utils.couch.database import get_db
-from pillowtop.checkpoints.manager import PillowCheckpoint, \
-    PillowCheckpointEventHandler, get_django_checkpoint_store
+from pillowtop.checkpoints.manager import PillowCheckpoint, PillowCheckpointEventHandler
 from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors import PillowProcessor
 
@@ -34,7 +33,6 @@ def get_blob_deletion_pillow():
     Using the KafkaChangeFeed ties this to the main couch database.
     """
     checkpoint = PillowCheckpoint(
-        get_django_checkpoint_store(),
         'kafka-blob-deletion-pillow-checkpoint',
     )
     return ConstructedPillow(

--- a/corehq/ex-submodules/fluff/tests/tests.py
+++ b/corehq/ex-submodules/fluff/tests/tests.py
@@ -575,8 +575,7 @@ def mock_checkpoint():
     # in the future we may want to explicitly use django tests instead of regular tests
     # if we're going to depend on a django environment.
     from pillowtop.checkpoints.manager import PillowCheckpoint
-    from pillowtop.dao.mock import MockDocumentStore
-    return PillowCheckpoint(MockDocumentStore(), 'mock-checkpoint')
+    return PillowCheckpoint('mock-checkpoint')
 
 
 class MockDoc(Document):

--- a/corehq/ex-submodules/pillowtop/checkpoints/manager.py
+++ b/corehq/ex-submodules/pillowtop/checkpoints/manager.py
@@ -14,32 +14,6 @@ from pillowtop.pillow.interface import ChangeEventHandler
 DocGetOrCreateResult = namedtuple('DocGetOrCreateResult', ['document', 'created'])
 
 
-class PillowCheckpointManager(object):
-
-    def __init__(self, dao):
-        self._dao = dao
-
-    def get_or_create_checkpoint(self, checkpoint_id):
-        created = False
-        try:
-            checkpoint_doc = self._dao.get_document(checkpoint_id)
-        except DocumentNotFoundError:
-            checkpoint_doc = {'seq': '0', 'timestamp': get_formatted_current_timestamp()}
-            self._dao.save_document(checkpoint_id, checkpoint_doc)
-            created = True
-        return DocGetOrCreateResult(checkpoint_doc, created)
-
-    def reset_checkpoint(self, checkpoint_id):
-        checkpoint_doc = self.get_or_create_checkpoint(checkpoint_id).document
-        checkpoint_doc['old_seq'] = checkpoint_doc['seq']
-        checkpoint_doc['seq'] = '0'
-        checkpoint_doc['timestamp'] = get_formatted_current_timestamp()
-        self._dao.save_document(checkpoint_id, checkpoint_doc)
-
-    def update_checkpoint(self, checkpoint_id, checkpoint_doc):
-        self._dao.save_document(checkpoint_id, checkpoint_doc)
-
-
 def get_or_create_checkpoint(checkpoint_id):
     created = False
     try:

--- a/corehq/ex-submodules/pillowtop/checkpoints/manager.py
+++ b/corehq/ex-submodules/pillowtop/checkpoints/manager.py
@@ -102,11 +102,5 @@ class PillowCheckpointEventHandler(ChangeEventHandler):
             self.checkpoint.update_to(change['seq'])
 
 
-def get_django_checkpoint_store():
-    return DjangoDocumentStore(
-        DjangoPillowCheckpoint, DjangoPillowCheckpoint.to_dict, DjangoPillowCheckpoint.from_dict,
-    )
-
-
 def get_default_django_checkpoint_for_legacy_pillow_class(pillow_class):
     return PillowCheckpoint(pillow_class.get_legacy_name())

--- a/corehq/ex-submodules/pillowtop/checkpoints/manager.py
+++ b/corehq/ex-submodules/pillowtop/checkpoints/manager.py
@@ -1,10 +1,5 @@
 from collections import namedtuple
 from datetime import datetime
-from dateutil import parser
-import pytz
-from pillowtop.checkpoints.util import get_formatted_current_timestamp
-from pillowtop.dao.django import DjangoDocumentStore
-from pillowtop.dao.exceptions import DocumentNotFoundError
 from pillowtop.exceptions import PillowtopCheckpointReset
 from pillowtop.logger import pillow_logging
 from pillowtop.models import DjangoPillowCheckpoint

--- a/corehq/ex-submodules/pillowtop/checkpoints/manager.py
+++ b/corehq/ex-submodules/pillowtop/checkpoints/manager.py
@@ -54,7 +54,7 @@ class PillowCheckpoint(object):
         return result
 
     def get_current_sequence_id(self):
-        return get_or_create_checkpoint(self.checkpoint_id).sequence
+        return get_or_create_checkpoint(self.checkpoint_id).document.sequence
 
     def update_to(self, seq):
         pillow_logging.info(

--- a/corehq/ex-submodules/pillowtop/listener.py
+++ b/corehq/ex-submodules/pillowtop/listener.py
@@ -16,8 +16,7 @@ import sys
 from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.couch import LockManager
 from pillow_retry.models import PillowError
-from pillowtop.checkpoints.manager import PillowCheckpoint, get_default_django_checkpoint_for_legacy_pillow_class, \
-    get_django_checkpoint_store
+from pillowtop.checkpoints.manager import PillowCheckpoint, get_default_django_checkpoint_for_legacy_pillow_class
 from pillowtop.checkpoints.util import get_machine_id, construct_checkpoint_doc_id_from_name
 from pillowtop.const import CHECKPOINT_FREQUENCY
 from pillowtop.couchdb import CachedCouchDB

--- a/corehq/ex-submodules/pillowtop/listener.py
+++ b/corehq/ex-submodules/pillowtop/listener.py
@@ -124,7 +124,6 @@ class BasicPillow(PillowBase):
 
     def _get_default_checkpoint(self):
         return PillowCheckpoint(
-            get_django_checkpoint_store(),
             construct_checkpoint_doc_id_from_name(self.get_name()),
         )
 

--- a/corehq/ex-submodules/pillowtop/listener.py
+++ b/corehq/ex-submodules/pillowtop/listener.py
@@ -16,7 +16,8 @@ import sys
 from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.couch import LockManager
 from pillow_retry.models import PillowError
-from pillowtop.checkpoints.manager import PillowCheckpoint, get_default_django_checkpoint_for_legacy_pillow_class
+from pillowtop.checkpoints.manager import PillowCheckpoint, get_default_django_checkpoint_for_legacy_pillow_class, \
+    get_django_checkpoint_store
 from pillowtop.checkpoints.util import get_machine_id, construct_checkpoint_doc_id_from_name
 from pillowtop.const import CHECKPOINT_FREQUENCY
 from pillowtop.couchdb import CachedCouchDB
@@ -123,7 +124,7 @@ class BasicPillow(PillowBase):
 
     def _get_default_checkpoint(self):
         return PillowCheckpoint(
-            self.document_store,
+            get_django_checkpoint_store(),
             construct_checkpoint_doc_id_from_name(self.get_name()),
         )
 

--- a/corehq/ex-submodules/pillowtop/tests/test_checkpoints.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_checkpoints.py
@@ -2,7 +2,7 @@ from abc import ABCMeta, abstractproperty, abstractmethod
 from django.test import SimpleTestCase, override_settings, TestCase
 import time
 from dimagi.utils.decorators.memoized import memoized
-from pillowtop.checkpoints.manager import PillowCheckpointManager, PillowCheckpoint
+from pillowtop.checkpoints.manager import PillowCheckpointManager, PillowCheckpoint, DaoFreePillowCheckpoint
 from pillowtop.checkpoints.util import get_machine_id
 from pillowtop.dao.django import DjangoDocumentStore
 from pillowtop.dao.mock import MockDocumentStore
@@ -129,3 +129,16 @@ class SQLPillowCheckpointDaoTest(TestCase, PillowCheckpointDaoTestMixin):
         return DjangoDocumentStore(
             DjangoPillowCheckpoint, DjangoPillowCheckpoint.to_dict, DjangoPillowCheckpoint.from_dict,
         )
+
+
+class DjangoPillowCheckpointTest(TestCase, PillowCheckpointDbTestMixin):
+
+    @property
+    @memoized
+    def checkpoint(self):
+        return DaoFreePillowCheckpoint(self._checkpoint_id)
+
+    def save_checkpoint(self, checkpoint_id, sequence_id):
+        checkpoint = DjangoPillowCheckpoint.objects.get_or_create(checkpoint_id=checkpoint_id)[0]
+        checkpoint.sequence = sequence_id
+        checkpoint.save()

--- a/corehq/ex-submodules/pillowtop/tests/test_checkpoints.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_checkpoints.py
@@ -39,6 +39,9 @@ class PillowCheckpointDaoTestMixin(object):
     def checkpoint(self):
         return PillowCheckpoint(self.dao, self._checkpoint_id)
 
+    def save_checkpoint(self, checkpoint_id, sequence_id):
+        self.dao.save_document(checkpoint_id, {'seq': sequence_id})
+
     def test_get_or_create_empty(self):
         checkpoint_manager = PillowCheckpointManager(MockDocumentStore())
         checkpoint, created = checkpoint_manager.get_or_create_checkpoint('some-id')
@@ -53,7 +56,7 @@ class PillowCheckpointDaoTestMixin(object):
 
     def test_db_changes_returned(self):
         self.checkpoint.get_or_create()
-        self.dao.save_document(self._checkpoint_id, {'seq': '1'})
+        self.save_checkpoint(self._checkpoint_id, '1')
         checkpoint = self.checkpoint.get_or_create().document
         self.assertEqual('1', checkpoint['seq'])
 
@@ -64,7 +67,7 @@ class PillowCheckpointDaoTestMixin(object):
 
     def test_verify_unchanged_fail(self):
         self.checkpoint.get_or_create()
-        self.dao.save_document(self._checkpoint_id, {'seq': '1'})
+        self.save_checkpoint(self._checkpoint_id, '1')
         with self.assertRaises(PillowtopCheckpointReset):
             self.checkpoint.get_or_create(verify_unchanged=True)
 
@@ -76,7 +79,7 @@ class PillowCheckpointDaoTestMixin(object):
 
     def test_update_verify_unchanged_fail(self):
         self.checkpoint.get_or_create()
-        self.dao.save_document(self._checkpoint_id, {'seq': '1'})
+        self.save_checkpoint(self._checkpoint_id, '1')
         with self.assertRaises(PillowtopCheckpointReset):
             self.checkpoint.update_to('2')
 

--- a/corehq/ex-submodules/pillowtop/tests/test_import_pillows.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_import_pillows.py
@@ -1,4 +1,4 @@
-from django.test import override_settings, SimpleTestCase
+from django.test import override_settings, SimpleTestCase, TestCase
 from pillowtop import get_all_pillow_instances, get_all_pillow_classes, get_pillow_by_name
 from pillowtop.checkpoints.manager import PillowCheckpoint
 from pillowtop.dao.mock import MockDocumentStore
@@ -95,7 +95,7 @@ class PillowFactoryFunctionTestCase(SimpleTestCase):
 
 
 @override_settings(PILLOWTOPS=PILLOWTOPS_OVERRIDE)
-class PillowTestCase(SimpleTestCase):
+class PillowTestCase(TestCase):
 
     def test_pillow_reset_checkpoint(self):
         pillow = make_fake_constructed_pillow()

--- a/corehq/ex-submodules/pillowtop/tests/test_import_pillows.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_import_pillows.py
@@ -48,7 +48,7 @@ def make_fake_constructed_pillow():
     pillow = FakeConstructedPillow(
         name='FakeConstructedPillowName',
         document_store=fake_dao,
-        checkpoint=PillowCheckpoint(fake_dao, 'fake-constructed-pillow'),
+        checkpoint=PillowCheckpoint('fake-constructed-pillow'),
         change_feed=RandomChangeFeed(10),
         processor=LoggingProcessor(),
     )

--- a/corehq/pillows/case.py
+++ b/corehq/pillows/case.py
@@ -9,8 +9,7 @@ from dimagi.utils.couch import LockManager
 from dimagi.utils.decorators.memoized import memoized
 from .base import HQPillow
 import logging
-from pillowtop.checkpoints.manager import PillowCheckpoint, get_django_checkpoint_store, \
-    PillowCheckpointEventHandler
+from pillowtop.checkpoints.manager import PillowCheckpoint, PillowCheckpointEventHandler
 from pillowtop.es_utils import doc_exists, ElasticsearchIndexMeta
 from pillowtop.listener import lock_manager
 from pillowtop.pillow.interface import ConstructedPillow
@@ -77,7 +76,6 @@ def transform_case_for_elasticsearch(doc_dict):
 
 def get_sql_case_to_elasticsearch_pillow():
     checkpoint = PillowCheckpoint(
-        get_django_checkpoint_store(),
         'sql-cases-to-elasticsearch',
     )
     case_processor = ElasticProcessor(

--- a/corehq/pillows/xform.py
+++ b/corehq/pillows/xform.py
@@ -11,8 +11,7 @@ from .base import HQPillow
 from couchforms.const import RESERVED_WORDS
 from couchforms.models import XFormInstance
 from dateutil import parser
-from pillowtop.checkpoints.manager import PillowCheckpoint, get_django_checkpoint_store, \
-    PillowCheckpointEventHandler
+from pillowtop.checkpoints.manager import PillowCheckpoint, PillowCheckpointEventHandler
 from pillowtop.es_utils import ElasticsearchIndexMeta
 from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors.elastic import ElasticProcessor
@@ -125,7 +124,6 @@ def _get_doc_type_from_state(state):
 
 def get_sql_xform_to_elasticsearch_pillow():
     checkpoint = PillowCheckpoint(
-        get_django_checkpoint_store(),
         'sql-xforms-to-elasticsearch',
     )
     form_processor = ElasticProcessor(

--- a/corehq/tests/app_test_db_dependencies.yml
+++ b/corehq/tests/app_test_db_dependencies.yml
@@ -128,6 +128,8 @@ corehq.apps.app_manager:
   - custom.ewsghana
   - corehq.apps.smsforms
   - corehq.apps.commtrack
+corehq.apps.change_feed:
+  - pillowtop
 corehq.apps.commtrack:
   - auditcare
   - couchforms


### PR DESCRIPTION
small-ish prefactor to pillow checkpoints (no functional changes).

now that everything is on django the abstraction layer of the dao is not helpful and was making the code a bit harder to parse.

:fish: or :office: @snopoke cc @biyeun 

wait for tests
