### PR TITLE
adding pyzxcvbn to uninstall requirements

### DIFF
--- a/requirements/uninstall-requirements.txt
+++ b/requirements/uninstall-requirements.txt
@@ -13,3 +13,4 @@ GitPython
 gitdb
 django-kombu
 rawes
+pyzxcvbn


### PR DESCRIPTION
@millerdev or whoever is awake
because the version number is the same, pip is leaving the current version of our password strength library installed instead of switching to our own fork. this wipes clean that library forcing it to pull our version from github. it can be removed after it is deployed once but is needed to get the new version. the old version is causing 500s that are blocking registration for users who submit passwords matching a certain pattern
