### PR TITLE
Drop .form-control from select2s because Firefox doesn't like it

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/case_config_shared.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_config_shared.html
@@ -11,7 +11,11 @@
             <i class="fa fa-remove"></i>
         </a>
         {% trans "Only if the answer to" %}
-        <input type="hidden" class="form-control" data-bind="
+        <!-- 
+            This would normally use .form-control, but it's going to become a select2,
+            which adds wonky height & borders on Firefox when it uses .form-control
+        -->
+        <input type="hidden" data-bind="
             questionsSelect: $root.getQuestions('select select1', false, $parent.config.allow.repeats()),
             value: question,
             optionsCaption: ' '
@@ -35,7 +39,11 @@
 </script>
 
 <script type="text/html" id="case-config:case-properties:question">
-    <input type="hidden" class="form-control" data-bind="
+    <!-- 
+        This would normally use .form-control, but it's going to become a select2,
+        which adds wonky height & borders on Firefox when it uses .form-control
+    -->
+    <input type="hidden" data-bind="
         questionsSelect: $root.getQuestions('all', false, case_transaction.allow.repeats(), true),
         value: path,
         optionsCaption: ' '


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?217574

Reverts https://github.com/dimagi/commcare-hq/commit/200877a86f0f52c2be86a396706d14cea551ff46 which is no longer needed because https://github.com/dimagi/commcare-hq/pull/10222 fixed the same problem (and fixed it better).

@esoergel
