### PR TITLE
Fix translations without named argument

### DIFF
--- a/custom/ewsghana/alerts/__init__.py
+++ b/custom/ewsghana/alerts/__init__.py
@@ -9,13 +9,7 @@ URGENT_NON_REPORTING = _('URGENT NON-REPORTING: More than half of the facilities
                          'have not reported for the past month. Please log in to http://ewsghana.com for details.')
 WEB_REMINDER = _('Dear %s, you have not visited ewsghana.com in a long time. '
                  'Please log in to find up-to-date info about stock availability and bottlenecks in Ghana.')
-REPORT_REMINDER = _('Dear %s, %s has not reported its stock this week.'
-                    'Please make sure that the SMS stock report is submitted. ')
-INCOMPLETE_REPORT = _('Dear Name, %s SMS stock report was INCOMPLETE.'
-                      'Please report for: %s')
 COMPLETE_REPORT = _('Dear %s, thank you for reporting the commodities you have in stock.')
-BELOW_REORDER_LEVELS = _('Dear %s, the following commodities are at or below re-order level at the %s. %s')
-ABOVE_THRESHOLD = _('Dear %s, these items are overstocked: %s. The district admin has been informed.')
 WITHOUT_RECEIPTS = _('Error! You submitted increases in stock levels of %s '
                      'without corresponding receipts. Please contact your DHIO or RHIO for assistance.')
 

--- a/custom/ewsghana/alerts/__init__.py
+++ b/custom/ewsghana/alerts/__init__.py
@@ -3,8 +3,8 @@ from django.utils.translation import ugettext as _
 ONGOING_NON_REPORTING = _('SMS report MISSING from these facilities over the past 3 weeks! Please follow up:\n%s')
 ONGOING_STOCKOUT_AT_SDP = _('Ongoing STOCKOUTS at these facilities over the past 3 weeks! Please follow up:\n%s')
 ONGOING_STOCKOUT_AT_RMS = _('Ongoing STOCKOUTS at these RMS over the past 3 weeks! Please follow up:\n%s ')
-URGENT_STOCKOUT = _('URGENT STOCKOUT: More than half of the facilities reporting to EWS in %s '
-                    'are experiencing stockouts of one or more of: %s.')
+URGENT_STOCKOUT = _('URGENT STOCKOUT: More than half of the facilities reporting to EWS in %(location)s '
+                    'are experiencing stockouts of one or more of: %(products)s.')
 URGENT_NON_REPORTING = _('URGENT NON-REPORTING: More than half of the facilities registered to EWS in %s '
                          'have not reported for the past month. Please log in to http://ewsghana.com for details.')
 WEB_REMINDER = _('Dear %s, you have not visited ewsghana.com in a long time. '

--- a/custom/ewsghana/alerts/alerts.py
+++ b/custom/ewsghana/alerts/alerts.py
@@ -70,6 +70,6 @@ class SOHAlerts(object):
 
         if super_message:
             stripped_message = super_message.strip().strip(';')
-            super_message = _('Dear %s, %s is experiencing the following problems: ') + stripped_message
+            super_message = _('Dear %(name)s, %(location)s is experiencing the following problems: ') + stripped_message
 
         return message.rstrip(), super_message

--- a/custom/ewsghana/alerts/urgent_alerts.py
+++ b/custom/ewsghana/alerts/urgent_alerts.py
@@ -64,9 +64,12 @@ class UrgentStockoutAlert(UrgentAlert):
         if not sql_products:
             return
 
-        return URGENT_STOCKOUT % (location_name, ', '.join(
-            sorted([sql_product.name for sql_product in sql_products])
-        ))
+        return URGENT_STOCKOUT % {
+            'location': location_name,
+            'products': ', '.join(
+                sorted([sql_product.name for sql_product in sql_products])
+            ),
+        }
 
     def get_notifications(self):
         for sql_location in self.get_sql_locations():

--- a/custom/ewsghana/handlers/soh.py
+++ b/custom/ewsghana/handlers/soh.py
@@ -143,7 +143,7 @@ class SOHHandler(KeywordHandler):
             if not phone_number:
                 continue
             send_sms(self.sql_location.domain, in_charge_user, phone_number,
-                     message % (in_charge_user.full_name, self.sql_location.name))
+                     message % {'name': in_charge_user.full_name, 'location': self.sql_location.name})
 
     @property
     def parser(self):

--- a/custom/ewsghana/reports/specific_reports/reporting_rates.py
+++ b/custom/ewsghana/reports/specific_reports/reporting_rates.py
@@ -61,13 +61,23 @@ class ReportingRates(ReportingRatesData):
             chart_data = sorted([
                 dict(value=non_reported_percent,
                      label=_('Non-Reporting %s%%') % non_reported_formatted,
-                     description=_("%s%% (%d) Non-Reported (%s)" %
-                                   (non_reported_formatted, data['non_reported'], self.datetext())),
+                     description=_(
+                         "%(formatted_percent)s%% (%(raw_number)d) Non-Reported (%(date_range)s)"
+                     ) % {
+                         'formatted_percent': non_reported_formatted,
+                         'raw_number': data['non_reported'],
+                         'date_range': self.datetext(),
+                     },
                      color='red'),
                 dict(value=reported_percent,
                      label=_('Reporting %s%%') % reported_formatted,
-                     description=_("%s%% (%d) Reported (%s)" % (reported_formatted, data['reported'],
-                                                                self.datetext())),
+                     description=_(
+                         "%(formatted_percent)s%% (%(raw_number)d) Reported (%(date_range)s)"
+                     ) % {
+                         'formatted_percent': reported_formatted,
+                         'raw_number': data['reported'],
+                         'date_range': self.datetext(),
+                     },
                      color='green'),
             ], key=lambda x: x['value'], reverse=True)
         pie_chart = EWSPieChart('', '', chart_data, [chart_data[0]['color'], chart_data[1]['color']])
@@ -111,13 +121,23 @@ class ReportingDetails(ReportingRatesData):
             chart_data = [
                 dict(value=complete_formatted,
                      label=_('Complete %s%%') % complete_formatted,
-                     description=_("%s%% (%d) Complete Reports in %s") %
-                                  (complete_formatted, data['complete'], self.datetext()),
+                     description=_(
+                         "%(formatted_percent)s%% (%(raw_number)d) Complete Reports in %(date_range)s"
+                     ) % {
+                         'formatted_percent': complete_formatted,
+                         'raw_number': data['complete'],
+                         'date_range': self.datetext()
+                     },
                      color='green'),
                 dict(value=incomplete_formatted,
                      label=_('Incomplete %s%%') % incomplete_formatted,
-                     description=_("%s%% (%d) Incomplete Reports in %s") %
-                                  (incomplete_formatted, data['incomplete'], self.datetext()),
+                     description=_(
+                         "%(formatted_percent)s%% (%(raw_number)d) Incomplete Reports in %(date_range)s"
+                     ) % {
+                         'formatted_percent': incomplete_formatted,
+                         'raw_number': data['incomplete'],
+                         'date_range': self.datetext(),
+                     },
                      color='purple'),
             ]
         pie_chart = EWSPieChart('', '', chart_data, ['green', 'purple'])

--- a/custom/ewsghana/reports/specific_reports/reporting_rates.py
+++ b/custom/ewsghana/reports/specific_reports/reporting_rates.py
@@ -60,12 +60,12 @@ class ReportingRates(ReportingRatesData):
 
             chart_data = sorted([
                 dict(value=non_reported_percent,
-                     label=_('Non-Reporting %s%%' % non_reported_formatted),
+                     label=_('Non-Reporting %s%%') % non_reported_formatted,
                      description=_("%s%% (%d) Non-Reported (%s)" %
                                    (non_reported_formatted, data['non_reported'], self.datetext())),
                      color='red'),
                 dict(value=reported_percent,
-                     label=_('Reporting %s%%' % reported_formatted),
+                     label=_('Reporting %s%%') % reported_formatted,
                      description=_("%s%% (%d) Reported (%s)" % (reported_formatted, data['reported'],
                                                                 self.datetext())),
                      color='green'),

--- a/custom/ewsghana/tests/test_urgent_alerts.py
+++ b/custom/ewsghana/tests/test_urgent_alerts.py
@@ -85,7 +85,10 @@ class TestUrgentAlerts(EWSTestCase):
 
         urgent_stockout_alert.send()
         self.assertEqual(SMS.objects.count(), 1)
-        self.assertEqual(SMS.objects.all().first().text, URGENT_STOCKOUT % (self.district.name, "Test Product2"))
+        self.assertEqual(SMS.objects.all().first().text, URGENT_STOCKOUT % {
+            'location': self.district.name,
+            'products': "Test Product2",
+        })
 
         create_stock_report(self.loc1, {'tp': 0})
         create_stock_report(self.loc2, {'tp': 0})
@@ -95,7 +98,10 @@ class TestUrgentAlerts(EWSTestCase):
         urgent_stockout_alert.send()
         smses = SMS.objects.filter(date__gte=now)
         self.assertEqual(smses.count(), 1)
-        self.assertEqual(smses.first().text, URGENT_STOCKOUT % (self.district.name, "Test Product, Test Product2"))
+        self.assertEqual(smses.first().text, URGENT_STOCKOUT % {
+            'location': self.district.name,
+            'products': "Test Product, Test Product2",
+        })
 
     def test_urgent_non_reporting_alert(self):
         urgent_non_reporting = UrgentNonReporting(TEST_DOMAIN)

--- a/custom/ilsgateway/tanzania/reports/stock_on_hand.py
+++ b/custom/ilsgateway/tanzania/reports/stock_on_hand.py
@@ -96,7 +96,12 @@ class SohPercentageTableData(ILSData):
             month = 'month'
 
         for p in products:
-            headers.add_column(DataTablesColumn(_('%s stock outs this %s') % (p.code, month)))
+            headers.add_column(DataTablesColumn(
+                _('%(code)s stock outs this %(month)s') % {
+                    'code': p.code,
+                    'month': month,
+                }
+            ))
 
         return headers
 


### PR DESCRIPTION
This gets rid of the last translations warnings about strings with multiple unnamed arguments.
