### PR TITLE
Set height to 400 for report builder

### DIFF
--- a/corehq/apps/reports_core/static/reports_core/js/charts.js
+++ b/corehq/apps/reports_core/static/reports_core/js/charts.js
@@ -165,7 +165,7 @@ var charts = (function() {
                 }
                 var $svg = d3.select(chartContainer[0]).append("svg");
                 var id = 'chart-' + i;
-                $svg.attr({id: id, width: "50%", height: "200"});
+                $svg.attr({id: id, height: "400"});
                 nv.addGraph(chartMap[config.type](config, data, '#' + id));
             }
         }


### PR DESCRIPTION
@dimagi/product http://manage.dimagi.com/default.asp?217703 this makes the report builder height larger so the graphs aren't so small:
![screen shot 2016-02-22 at 3 34 58 pm](https://cloud.githubusercontent.com/assets/918514/13231859/15658218-d97a-11e5-8823-044644ad9673.png)
![screen shot 2016-02-22 at 3 34 39 pm](https://cloud.githubusercontent.com/assets/918514/13231860/15667038-d97a-11e5-9a98-888cbb915330.png)

@nickpell @gcapalbo 
