### PR TITLE
Fix logging for static data source

### DIFF
--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -16,19 +16,19 @@ from corehq.apps.userreports.models import DataSourceConfiguration, StaticDataSo
 from corehq.apps.userreports.sql import IndicatorSqlAdapter
 
 
-def _is_static(config_id):
+def is_static(config_id):
     return config_id.startswith(StaticDataSourceConfiguration._datasource_id_prefix)
 
 
 def _get_config_by_id(indicator_config_id):
-    if _is_static(indicator_config_id):
+    if is_static(indicator_config_id):
         return StaticDataSourceConfiguration.by_id(indicator_config_id)
     else:
         return DataSourceConfiguration.get(indicator_config_id)
 
 
 def _get_redis_key_for_config(config):
-    if _is_static(config._id):
+    if is_static(config._id):
         rev = 'static'
     else:
         rev = config._rev
@@ -50,7 +50,7 @@ def _build_indicators(indicator_config_id, relevant_ids):
         except Exception as e:
             logging.exception('problem saving document {} to table. {}'.format(doc['_id'], e))
 
-    if not _is_static(indicator_config_id):
+    if not is_static(indicator_config_id):
         redis_client.delete(redis_key)
         config.meta.build.finished = True
         try:
@@ -71,7 +71,7 @@ def rebuild_indicators(indicator_config_id):
     redis_client = get_redis_client().client.get_client()
     redis_key = _get_redis_key_for_config(config)
 
-    if not _is_static(indicator_config_id):
+    if not is_static(indicator_config_id):
         # Save the start time now in case anything goes wrong. This way we'll be
         # able to see if the rebuild started a long time ago without finishing.
         config.meta.build.initiated = datetime.datetime.utcnow()


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?217906

The statement `config.get_db().get_rev(config._id)` runs into trouble with static data sources, since they are not stored in couch.  When the soft assert eventually gets removed, the added if-else in `rebuild_tables_if_necessary` can be removed.

:whale: 

@NoahCarnahan 
