### PR TITLE
Upgrade django json field

### DIFF
--- a/corehq/apps/accounting/migrations/0014_billingcontactinfo_email_list.py
+++ b/corehq/apps/accounting/migrations/0014_billingcontactinfo_email_list.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from django.db import migrations
 
-import json_field.fields
+import jsonfield.fields
 
 
 class Migration(migrations.Migration):
@@ -16,7 +16,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='billingcontactinfo',
             name='email_list',
-            field=json_field.fields.JSONField(default=[], help_text='We will email communications regarding your account to the emails specified here.', verbose_name='Contact Emails'),
+            field=jsonfield.fields.JSONField(default=[], help_text='We will email communications regarding your account to the emails specified here.', verbose_name='Contact Emails'),
             preserve_default=True,
         ),
     ]

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -16,7 +16,7 @@ from django.utils.html import strip_tags
 from django.utils.translation import ugettext_lazy as _
 from django_prbac.models import Role
 
-import json_field
+import jsonfield
 import stripe
 
 from couchdbkit import ResourceNotFound
@@ -498,7 +498,7 @@ class BillingContactInfo(models.Model):
         max_length=50, null=True, blank=True, verbose_name=_("Last Name")
     )
     # TODO - replace with models.ArrayField once django >= 1.9
-    email_list = json_field.JSONField(
+    email_list = jsonfield.JSONField(
         default=[],
         verbose_name=_("Contact Emails"),
         help_text=_("We will email communications regarding your account "

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -11,6 +11,7 @@ django==1.7.11
 django-braces==1.8.1
 django-celery==3.1.16
 django-json-field==0.5.7
+jsonfield==1.0.3
 dropbox==2.2.0
 defusedxml==0.4.1
 diff-match-patch==20120106


### PR DESCRIPTION
First steps towards upgrading django json field, which is necessary for when we want to upgrade django.  The python package name and the module name changed, so it's possible to transition fields to the upgraded version one at a time.  I'm starting with accounting since I'm familiar with that use case.

I've tested this locally and on staging to make sure that existing data is unchanged and new data can be added.
