### PR TITLE
Remove randomness from subscription generation

### DIFF
--- a/corehq/apps/accounting/generator.py
+++ b/corehq/apps/accounting/generator.py
@@ -118,46 +118,6 @@ def subscribable_plan(edition=SoftwarePlanEdition.STANDARD):
     ).plan.get_version()
 
 
-def generate_domain_subscription_from_date(date_start, billing_account, domain,
-                                           min_num_months=None, is_immediately_active=False,
-                                           delay_invoicing_until=None, save=True,
-                                           service_type=SubscriptionType.NOT_SET,
-                                           subscription_length=None,
-                                           plan_version=None,):
-    # make sure the first month is never a full month (for testing)
-    date_start = date_start.replace(day=max(2, date_start.day))
-
-    if subscription_length is None:
-        subscription_length = random.randint(min_num_months or 3, 25)
-
-    date_end_year, date_end_month = add_months(date_start.year, date_start.month, subscription_length)
-    date_end_last_day = calendar.monthrange(date_end_year, date_end_month)[1]
-
-    # make sure that the last month is never a full month (for testing)
-    if subscription_length > 0:
-        last_day = min(date_end_last_day - 1, date_start.day + 1)
-    else:
-        last_day = date_end_last_day
-
-    date_end = datetime.date(date_end_year, date_end_month, last_day)
-
-    subscriber, _ = Subscriber.objects.get_or_create(domain=domain)
-    subscription = Subscription(
-        account=billing_account,
-        plan_version=plan_version or subscribable_plan(),
-        subscriber=subscriber,
-        salesforce_contract_id=data_gen.arbitrary_unique_name("SFC")[:80],
-        date_start=date_start,
-        date_end=date_end,
-        is_active=is_immediately_active,
-        date_delay_invoicing=delay_invoicing_until,
-        service_type=service_type,
-    )
-    if save:
-        subscription.save()
-    return subscription, subscription_length
-
-
 def generate_domain_subscription(account, domain, date_start, date_end,
                                  plan_version=None, service_type=SubscriptionType.NOT_SET):
     subscriber, _ = Subscriber.objects.get_or_create(domain=domain.name)

--- a/corehq/apps/accounting/generator.py
+++ b/corehq/apps/accounting/generator.py
@@ -158,6 +158,20 @@ def generate_domain_subscription_from_date(date_start, billing_account, domain,
     return subscription, subscription_length
 
 
+def generate_domain_subscription(account, domain, date_start, date_end):
+    subscriber, _ = Subscriber.objects.get_or_create(domain=domain.name)
+    subscription = Subscription(
+        account=account,
+        plan_version=subscribable_plan(),
+        subscriber=subscriber,
+        date_start=date_start,
+        date_end=date_end,
+        service_type=SubscriptionType.NOT_SET,
+    )
+    subscription.save()
+    return subscription
+
+
 def delete_all_subscriptions():
     SubscriptionAdjustment.objects.all().delete()
     Subscription.objects.all().delete()

--- a/corehq/apps/accounting/generator.py
+++ b/corehq/apps/accounting/generator.py
@@ -158,15 +158,16 @@ def generate_domain_subscription_from_date(date_start, billing_account, domain,
     return subscription, subscription_length
 
 
-def generate_domain_subscription(account, domain, date_start, date_end):
+def generate_domain_subscription(account, domain, date_start, date_end,
+                                 plan_version=None, service_type=SubscriptionType.NOT_SET):
     subscriber, _ = Subscriber.objects.get_or_create(domain=domain.name)
     subscription = Subscription(
         account=account,
-        plan_version=subscribable_plan(),
+        plan_version=plan_version or subscribable_plan(),
         subscriber=subscriber,
         date_start=date_start,
         date_end=date_end,
-        service_type=SubscriptionType.NOT_SET,
+        service_type=service_type,
     )
     subscription.save()
     return subscription

--- a/corehq/apps/accounting/tests/test_autopay.py
+++ b/corehq/apps/accounting/tests/test_autopay.py
@@ -1,8 +1,11 @@
+import datetime
 import random
 import mock
 
 from stripe import Charge
 from django.core import mail
+
+from dimagi.utils.dates import add_months_to_date
 
 from corehq.apps.accounting.tests.test_invoicing import BaseInvoiceTestCase
 from corehq.apps.accounting import generator, utils, tasks
@@ -31,9 +34,14 @@ class TestBillingAutoPay(BaseInvoiceTestCase):
         self.account_2 = generator.billing_account(self.dimagi_user, self.web_user)
         self.domain_2 = generator.arbitrary_domain()
 
-        self.subscription_2, self.subscription_length_2 = generator.generate_domain_subscription_from_date(
-            generator.get_start_date(), self.account_2, self.domain_2.name,
-            min_num_months=self.min_subscription_length,
+        self.subscription_length_2 = self.min_subscription_length  # months
+        subscription_start_date = datetime.date(2016, 2, 23)
+        subscription_end_date = add_months_to_date(subscription_start_date, self.subscription_length_2)
+        self.subscription_2 = generator.generate_domain_subscription(
+            self.account,
+            self.domain,
+            date_start=subscription_start_date,
+            date_end=subscription_end_date,
         )
 
         tasks.generate_invoices(self.invoice_date)

--- a/corehq/apps/accounting/tests/test_credit_lines.py
+++ b/corehq/apps/accounting/tests/test_credit_lines.py
@@ -1,6 +1,9 @@
 from decimal import Decimal
 import random
 import datetime
+
+from dimagi.utils.dates import add_months_to_date
+
 from corehq.apps.accounting import tasks, utils, generator
 from corehq.apps.accounting.models import (
     CreditLine, CreditAdjustment, FeatureType, SoftwareProductType,
@@ -140,9 +143,14 @@ class TestCreditLines(BaseInvoiceTestCase):
         other_domain = generator.arbitrary_domain()
         # so that the other subscription doesn't draw from the same account credits, have it start 4 months later
         new_subscription_start = utils.months_from_date(self.subscription.date_start, 4)
-        other_subscription, _ = generator.generate_domain_subscription_from_date(
-            new_subscription_start, self.account, other_domain.name, min_num_months=self.min_subscription_length,
+
+        other_subscription = generator.generate_domain_subscription(
+            self.account,
+            self.domain,
+            date_start=new_subscription_start,
+            date_end=add_months_to_date(new_subscription_start, self.min_subscription_length),
         )
+
         # other account credit that shouldn't count toward this invoice
         other_account = generator.billing_account(self.dimagi_user, generator.arbitrary_web_user())
 

--- a/corehq/apps/accounting/tests/test_models.py
+++ b/corehq/apps/accounting/tests/test_models.py
@@ -132,13 +132,13 @@ class TestSubscription(BaseAccountingTest):
 
     def test_next_subscription(self):
         this_subscription_date_end = self.subscription.date_end
-        already_canceled_future_subscription= generator.generate_domain_subscription(
+        already_canceled_future_subscription = generator.generate_domain_subscription(  # noqa
             self.account,
             self.domain,
             date_start=this_subscription_date_end,
             date_end=this_subscription_date_end
         )
-        next_future_subscription= generator.generate_domain_subscription(
+        next_future_subscription = generator.generate_domain_subscription(
             self.account,
             self.domain,
             date_start=this_subscription_date_end,

--- a/corehq/apps/accounting/tests/test_models.py
+++ b/corehq/apps/accounting/tests/test_models.py
@@ -167,8 +167,15 @@ class TestBillingRecord(BaseAccountingTest):
         self.invoice_start, self.invoice_end = get_previous_month_date_range()
         self.currency = generator.init_default_currency()
         self.account = generator.billing_account(self.dimagi_user, self.billing_contact)
-        self.subscription, self.subscription_length = generator.generate_domain_subscription_from_date(
-            datetime.date.today(), self.account, self.domain.name
+
+        self.subscription_length = 4  # months
+        subscription_start_date = datetime.date(2016, 2, 23)
+        subscription_end_date = add_months_to_date(subscription_start_date, self.subscription_length)
+        self.subscription = generator.generate_domain_subscription(
+            self.account,
+            self.domain,
+            date_start=subscription_start_date,
+            date_end=subscription_end_date,
         )
         self.invoice = Invoice(
             subscription=self.subscription,

--- a/corehq/apps/accounting/tests/test_models.py
+++ b/corehq/apps/accounting/tests/test_models.py
@@ -5,6 +5,8 @@ import mock
 from django.core import mail
 from corehq.apps.domain.models import Domain
 
+from dimagi.utils.dates import add_months_to_date
+
 from corehq.apps.accounting import generator, tasks
 from corehq.apps.accounting.generator import FakeStripeCard, FakeStripeCustomer
 from corehq.apps.accounting.models import (
@@ -79,8 +81,15 @@ class TestSubscription(BaseAccountingTest):
         self.domain.save()
         self.currency = generator.init_default_currency()
         self.account = generator.billing_account(self.dimagi_user, self.billing_contact)
-        self.subscription, self.subscription_length = generator.generate_domain_subscription_from_date(
-            datetime.date.today(), self.account, self.domain.name, subscription_length=15,
+
+        self.subscription_length = 15  # months
+        subscription_start_date = datetime.date(2016, 2, 23)
+        subscription_end_date = add_months_to_date(subscription_start_date, self.subscription_length)
+        self.subscription = generator.generate_domain_subscription(
+            self.account,
+            self.domain,
+            date_start=subscription_start_date,
+            date_end=subscription_end_date,
         )
 
     def test_creation(self):
@@ -123,13 +132,17 @@ class TestSubscription(BaseAccountingTest):
 
     def test_next_subscription(self):
         this_subscription_date_end = self.subscription.date_end
-        already_canceled_future_subscription, _ = generator.generate_domain_subscription_from_date(
-            this_subscription_date_end, self.account, self.domain.name,
-            subscription_length=0
+        already_canceled_future_subscription= generator.generate_domain_subscription(
+            self.account,
+            self.domain,
+            date_start=this_subscription_date_end,
+            date_end=this_subscription_date_end
         )
-        next_future_subscription, _ = generator.generate_domain_subscription_from_date(
-            this_subscription_date_end, self.account, self.domain.name,
-            subscription_length=1
+        next_future_subscription= generator.generate_domain_subscription(
+            self.account,
+            self.domain,
+            date_start=this_subscription_date_end,
+            date_end=add_months_to_date(this_subscription_date_end, 1),
         )
         self.assertEqual(self.subscription.next_subscription, next_future_subscription)
 


### PR DESCRIPTION
Made the generation method much more explicit (you now have to explicitly say start and end dates).

Still haven't figured out how to replicate this failure locally, so this is another shot in the dark. 
http://manage.dimagi.com/default.asp?217913#1094412

@nickpell, as discussed https://github.com/dimagi/commcare-hq/pull/10389#commitcomment-16211148 @orangejenny 
