### PR TITLE
Deactivated source bug

### DIFF
--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -462,7 +462,8 @@ class DataSourceForm(forms.Form):
             existing_sources = DataSourceConfiguration.by_domain(self.domain)
             active_source = filter(lambda config: not config.is_deactivated, existing_sources)
             if len(active_source) >= 5:
-                if not ds_builder.get_existing_match():
+                match = ds_builder.get_existing_match()
+                if not match or match.is_deactivated:
                     raise forms.ValidationError(_(
                         "Too many data sources!\n"
                         "Creating this report would cause you to go over the maximum "


### PR DESCRIPTION
@NoahCarnahan @nickpell 
cc: @emord 
This fixes a few bugs related to deactivated data sources in the report builder, i found while trying to work on aggregations.
1. it now correctly prevents users from creating a new data source when they already have 5 active ones
2. when checking for the number of existing data sources it excludes deactivated ones
3. when a new report uses a deactivated data source, it successfully rebuilds that data source
