### PR TITLE
catch `AttributeError`

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/templatetags/case_tags.py
+++ b/corehq/ex-submodules/casexml/apps/case/templatetags/case_tags.py
@@ -146,7 +146,7 @@ class SupplyPointDisplayWrapper(CaseDisplayWrapper):
         })
         try:
             location = SQLLocation.objects.get(location_id=self.case.location_id)
-        except SQLLocation.DoesNotExist:
+        except (SQLLocation.DoesNotExist, AttributeError):
             pass
         else:
             data['location_type'] = location.location_type_name


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?217958#1094448

(Looks like this was introduced here https://github.com/dimagi/commcare-hq/commit/66eda2a9f61e5a1022b07a0a123c5ce796b5514e)

Not sure why those cases in the bug don't have a `location_id` and not sure I have all the context to understand if this change is actually the right thing to do @snopoke 

cc @czue 
