### PR TITLE
Preserve whitespace in app comments

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/less/app_manager.less
+++ b/corehq/apps/app_manager/static/app_manager/less/app_manager.less
@@ -53,6 +53,10 @@ nav.app-manager-content {
             color: white;
         }
     }
+
+    .app-comment {
+        white-space: pre;
+    }
 }
 
 // Used to indicate sortable table rows (i.e., case list rows)

--- a/corehq/apps/app_manager/static/app_manager/less/app_manager.less
+++ b/corehq/apps/app_manager/static/app_manager/less/app_manager.less
@@ -54,14 +54,16 @@ nav.app-manager-content {
         }
     }
 
-    .app-comment {
-        white-space: pre;
-    }
 }
 
 // Used to indicate sortable table rows (i.e., case list rows)
 .sortable-handle {
     cursor: move;
+}
+
+// Poor man's markdown for in-app comments
+.app-comment {
+   white-space: pre;
 }
 
 /* has to be more specific than the existing rule */

--- a/corehq/apps/app_manager/templates/app_manager/form_view_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view_base.html
@@ -191,7 +191,7 @@
 {% block form-view %}
     <div id="build_errors"></div>
     {% if form.short_comment %}
-        <div id="form_short_comment" class="well">{{ form.short_comment }}</div>
+        <div id="form_short_comment" class="app-comment well">{{ form.short_comment }}</div>
     {% endif %}
     <div class="pull-right">
         <form action="{% url "delete_form" domain app.id module.unique_id form.unique_id %}" method="post">

--- a/corehq/apps/app_manager/templates/app_manager/partials/app-settings.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/app-settings.html
@@ -169,7 +169,7 @@ todo fix
 
 <div class="tab-pane" id="commcare-settings">
     {% if app.short_comment %}
-        <div id="app_short_comment" class="well">{{ app.short_comment }}</div>
+        <div id="app_short_comment" class="app-comment well">{{ app.short_comment }}</div>
     {% endif %}
     <form class="form-horizontal">
         <div class="clearfix">

--- a/corehq/apps/app_manager/templates/app_manager/partials/module_view_heading.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/module_view_heading.html
@@ -2,7 +2,7 @@
 {% load xforms_extras %}
 <div id="build_errors"></div>
 {% if module.short_comment %}
-    <div id="module_short_comment" class="well">{{ module.short_comment }}</div>
+    <div id="module_short_comment" class="app-comment well">{{ module.short_comment }}</div>
 {% endif %}
 <div class="pull-right">
     <form action="{% url "delete_module" domain app.id module.unique_id %}" method="post">


### PR DESCRIPTION
`white-space: pre;` - the poor man's markdown.

@kaapstorm it looks like you added this originally.  Thoughts?
