### PR TITLE
Deprecate jQuery UI accordion

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
@@ -353,9 +353,6 @@ var AdvancedCase = (function () {
 
         self.addFormAction = function (action) {
             if (action.value === 'load' || action.value === 'auto_select') {
-                // Collapse any open panels
-                //$('#case-open-accordion .collapse').collapse('hide')
-
                 var index = self.load_update_cases().length;
                 var tag_prefix = action.value === 'auto_select'? 'auto' : '';
                 var action_data = {
@@ -385,9 +382,6 @@ var AdvancedCase = (function () {
                 self.load_update_cases.push(LoadUpdateAction.wrap(action_data, self.config));
                 self.config.applyAccordion('load', index);
             } else if (action.value === 'open') {
-                // Collapse any open panels
-                //$('#case-load-accordion .collapse').collapse('hide')
-
                 var index = self.open_cases().length;
                 self.open_cases.push(OpenCaseAction.wrap({
                     case_type: config.caseType,

--- a/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
@@ -154,7 +154,7 @@ var AdvancedCase = (function () {
         // TODO: if index is supplied, open that panel
         self.applyAccordion = function (type, index) {
             if (index) {
-                options.active = index;
+                //options.active = index;
             }
         };
 

--- a/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
@@ -151,20 +151,15 @@ var AdvancedCase = (function () {
 
         self.caseConfigViewModel = new CaseConfigViewModel(self, params);
 
-        // TODO: if index is supplied, open that panel
         self.applyAccordion = function (type, index) {
-            if (!type || type === 'open') {
-                $('#case-open-accordion .panel-collapse.in').collapse('hide')
+            _.each(_.map(type ? [type] : ['open', 'load'], function(t) {
+                return $("#case-" + t + "-accordion");
+            }), function($accordion) {
+                $accordion.find('.panel-collapse.in').collapse('hide')
                 if (index !== undefined) {
-                    $('#case-open-accordion > .panel:nth-child(' + (index + 1) + ') .panel-collapse').collapse('show');
+                    $accordion.find(' > .panel:nth-child(' + (index + 1) + ') .panel-collapse').collapse('show');
                 }
-            }
-            if (!type || type === 'load') {
-                $('#case-load-accordion .panel-collapse.in').collapse('hide')
-                if (index !== undefined) {
-                    $('#case-load-accordion > .panel:nth-child(' + (index + 1) + ') .panel-collapse').collapse('show');
-                }
-            }
+            });
         };
 
         self.init = function () {
@@ -602,22 +597,7 @@ var AdvancedCase = (function () {
                 return config.getModulesForCaseType(self.case_type(), self.show_product_stock());
             });
 
-            self.case_type.subscribe(function (value) {
-                // TODO: delete?
-                // fix for resizing of accordion when content changes
-                /*if (!value) {
-                    var index = self.config.caseConfigViewModel.load_update_cases.indexOf(self);
-                    self.config.applyAccordion('load', index);
-                }*/
-            }, null, 'beforeChange');
-
             if (self.auto_select) {
-                self.auto_select.mode.subscribe(function (value) {
-                    // TODO: delete?
-                    // fix for resizing of accordion when content changes
-                    /*var index = self.config.caseConfigViewModel.load_update_cases.indexOf(self);
-                    self.config.applyAccordion('load', index);*/
-                }, null, 'beforeChange');
                 self.auto_select.mode.subscribe(function (value) {
                     // suggestedProperties need to be those of case type "commcare-user"
                     if (value === 'usercase') {
@@ -851,14 +831,6 @@ var AdvancedCase = (function () {
                     return true;
                 }
             };
-
-            // TODO: delete?
-            /*self.case_type.subscribe(function (value) {
-                if (!value) {
-                    var index = self.config.caseConfigViewModel.open_cases.indexOf(self);
-                    self.config.applyAccordion('open', index);
-                }
-            }, null, 'beforeChange');*/
 
             self.disable_tag = ko.computed(function () {
                 return false;

--- a/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
@@ -156,9 +156,7 @@ var AdvancedCase = (function () {
                 return $("#case-" + t + "-accordion");
             }), function($accordion) {
                 $accordion.find('.panel-collapse.in').collapse('hide')
-                if (index !== undefined) {
-                    $accordion.find(' > .panel:nth-child(' + (index + 1) + ') .panel-collapse').collapse('show');
-                }
+                $accordion.find(' > .panel:nth-child(' + (index + 1) + ') .panel-collapse').collapse('show');
             });
         };
 

--- a/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
@@ -182,8 +182,14 @@ var AdvancedCase = (function () {
 
                 self.ensureBlankProperties();
                 $('#case-configuration-tab').on('click', function () {
-                    self.applyAccordion('open', 0);
-                    self.applyAccordion('load', 0);
+                    // Leave all the actions, collapsed, unless there's just
+                    // one in the section, and then open it
+                    if ($('#case-load-accordion > .panel').length === 1) {
+                        self.applyAccordion('load', 0);
+                    }
+                    if ($('#case-open-accordion > .panel').length === 1) {
+                        self.applyAccordion('open', 0);
+                    }
                 });
             });
         };

--- a/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
@@ -152,11 +152,18 @@ var AdvancedCase = (function () {
         self.caseConfigViewModel = new CaseConfigViewModel(self, params);
 
         self.applyAccordion = function (type, index) {
-            _.each(_.map(type ? [type] : ['open', 'load'], function(t) {
-                return $("#case-" + t + "-accordion");
-            }), function($accordion) {
-                $accordion.find('.panel-collapse.in').collapse('hide')
-                $accordion.find(' > .panel:nth-child(' + (index + 1) + ') .panel-collapse').collapse('show');
+            _.each(type ? [type] : ['open', 'load'], function(t) {
+                var selector = "#case-" + t + "-accordion";
+
+                // Make sure all parents are set correctly so panels behave like an accordion
+                $(selector + ' > .panel > .panel-collapse').collapse({
+                    parent: selector,
+                    toggle: false,
+                });
+
+                // Hide all panels, then show the requested one
+                $(selector + ' .panel-collapse.in').collapse('hide')
+                $(selector + ' > .panel:nth-child(' + (index + 1) + ') .panel-collapse').collapse('show');
             });
         };
 

--- a/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
@@ -151,16 +151,10 @@ var AdvancedCase = (function () {
 
         self.caseConfigViewModel = new CaseConfigViewModel(self, params);
 
+        // TODO: if index is supplied, open that panel
         self.applyAccordion = function (type, index) {
-            var options = {header: '> div > h3', heightStyle: 'content', collapsible: true, autoFill: true};
             if (index) {
                 options.active = index;
-            }
-            if (!type || type === 'open') {
-                $('#case-open-accordion').accordion("destroy").accordion(options);
-            }
-            if (!type || type === 'load') {
-                $('#case-load-accordion').accordion("destroy").accordion(options);
             }
         };
 
@@ -179,7 +173,6 @@ var AdvancedCase = (function () {
 
                 self.ensureBlankProperties();
                 $('#case-configuration-tab').on('click', function () {
-                    // re-apply accordion settings
                     self.applyAccordion();
                 });
             });
@@ -350,7 +343,8 @@ var AdvancedCase = (function () {
 
         self.addFormAction = function (action) {
             if (action.value === 'load' || action.value === 'auto_select') {
-                $('#case-open-accordion').accordion({active: false});
+                // TODO: collapse any open panels
+                //$('#case-open-accordion').accordion({active: false});
                 var index = self.load_update_cases().length;
                 var tag_prefix = action.value === 'auto_select'? 'auto' : '';
                 var action_data = {
@@ -380,7 +374,8 @@ var AdvancedCase = (function () {
                 self.load_update_cases.push(LoadUpdateAction.wrap(action_data, self.config));
                 self.config.applyAccordion('load', index);
             } else if (action.value === 'open') {
-                $('#case-load-accordion').accordion({active: false});
+                // TODO: collapse any open panels
+                //$('#case-load-accordion').accordion({active: false});
                 var index = self.open_cases().length;
                 self.open_cases.push(OpenCaseAction.wrap({
                     case_type: config.caseType,
@@ -596,6 +591,7 @@ var AdvancedCase = (function () {
             });
 
             self.case_type.subscribe(function (value) {
+                // TODO: delete?
                 // fix for resizing of accordion when content changes
                 if (!value) {
                     var index = self.config.caseConfigViewModel.load_update_cases.indexOf(self);
@@ -605,6 +601,7 @@ var AdvancedCase = (function () {
 
             if (self.auto_select) {
                 self.auto_select.mode.subscribe(function (value) {
+                    // TODO: delete?
                     // fix for resizing of accordion when content changes
                     var index = self.config.caseConfigViewModel.load_update_cases.indexOf(self);
                     self.config.applyAccordion('load', index);

--- a/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case-config-ui-advanced.js
@@ -153,8 +153,17 @@ var AdvancedCase = (function () {
 
         // TODO: if index is supplied, open that panel
         self.applyAccordion = function (type, index) {
-            if (index) {
-                //options.active = index;
+            if (!type || type === 'open') {
+                $('#case-open-accordion .panel-collapse.in').collapse('hide')
+                if (index !== undefined) {
+                    $('#case-open-accordion > .panel:nth-child(' + (index + 1) + ') .panel-collapse').collapse('show');
+                }
+            }
+            if (!type || type === 'load') {
+                $('#case-load-accordion .panel-collapse.in').collapse('hide')
+                if (index !== undefined) {
+                    $('#case-load-accordion > .panel:nth-child(' + (index + 1) + ') .panel-collapse').collapse('show');
+                }
             }
         };
 
@@ -173,7 +182,8 @@ var AdvancedCase = (function () {
 
                 self.ensureBlankProperties();
                 $('#case-configuration-tab').on('click', function () {
-                    self.applyAccordion();
+                    self.applyAccordion('open', 0);
+                    self.applyAccordion('load', 0);
                 });
             });
         };
@@ -343,8 +353,9 @@ var AdvancedCase = (function () {
 
         self.addFormAction = function (action) {
             if (action.value === 'load' || action.value === 'auto_select') {
-                // TODO: collapse any open panels
-                //$('#case-open-accordion').accordion({active: false});
+                // Collapse any open panels
+                //$('#case-open-accordion .collapse').collapse('hide')
+
                 var index = self.load_update_cases().length;
                 var tag_prefix = action.value === 'auto_select'? 'auto' : '';
                 var action_data = {
@@ -374,8 +385,9 @@ var AdvancedCase = (function () {
                 self.load_update_cases.push(LoadUpdateAction.wrap(action_data, self.config));
                 self.config.applyAccordion('load', index);
             } else if (action.value === 'open') {
-                // TODO: collapse any open panels
-                //$('#case-load-accordion').accordion({active: false});
+                // Collapse any open panels
+                //$('#case-load-accordion .collapse').collapse('hide')
+
                 var index = self.open_cases().length;
                 self.open_cases.push(OpenCaseAction.wrap({
                     case_type: config.caseType,
@@ -593,18 +605,18 @@ var AdvancedCase = (function () {
             self.case_type.subscribe(function (value) {
                 // TODO: delete?
                 // fix for resizing of accordion when content changes
-                if (!value) {
+                /*if (!value) {
                     var index = self.config.caseConfigViewModel.load_update_cases.indexOf(self);
                     self.config.applyAccordion('load', index);
-                }
+                }*/
             }, null, 'beforeChange');
 
             if (self.auto_select) {
                 self.auto_select.mode.subscribe(function (value) {
                     // TODO: delete?
                     // fix for resizing of accordion when content changes
-                    var index = self.config.caseConfigViewModel.load_update_cases.indexOf(self);
-                    self.config.applyAccordion('load', index);
+                    /*var index = self.config.caseConfigViewModel.load_update_cases.indexOf(self);
+                    self.config.applyAccordion('load', index);*/
                 }, null, 'beforeChange');
                 self.auto_select.mode.subscribe(function (value) {
                     // suggestedProperties need to be those of case type "commcare-user"
@@ -840,12 +852,13 @@ var AdvancedCase = (function () {
                 }
             };
 
-            self.case_type.subscribe(function (value) {
+            // TODO: delete?
+            /*self.case_type.subscribe(function (value) {
                 if (!value) {
                     var index = self.config.caseConfigViewModel.open_cases.indexOf(self);
                     self.config.applyAccordion('open', index);
                 }
-            }, null, 'beforeChange');
+            }, null, 'beforeChange');*/
 
             self.disable_tag = ko.computed(function () {
                 return false;

--- a/corehq/apps/app_manager/static/app_manager/js/case-knockout-bindings.js
+++ b/corehq/apps/app_manager/static/app_manager/js/case-knockout-bindings.js
@@ -98,22 +98,6 @@ ko.bindingHandlers.casePropertyTypeahead = {
     }
 };
 
-ko.bindingHandlers.accordion = {
-    init: function(element, valueAccessor) {
-        var options = valueAccessor() || {};
-        $(element).accordion(options);
-
-        //handle disposal (if KO removes by the template binding)
-        ko.utils.domNodeDisposal.addDisposeCallback(element, function(){
-            $(element).accordion("destroy");
-        });
-    },
-    update: function(element, valueAccessor) {
-        var options = valueAccessor() || {};
-        $(element).accordion("destroy").accordion(options);
-    }
-};
-
 // Originally from http://stackoverflow.com/a/17998880
 ko.extenders.withPrevious = function (target) {
     // Define new properties for previous value and whether it's changed

--- a/corehq/apps/app_manager/templates/app_manager/apps_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/apps_base.html
@@ -35,7 +35,6 @@
     <script src="{% new_static 'jquery-ui/ui/minified/widget.min.js' %}"></script>
     <script src="{% new_static 'jquery-ui/ui/minified/mouse.min.js' %}"></script>
     <script src="{% new_static 'jquery-ui/ui/minified/position.min.js' %}"></script>
-    <script src="{% new_static 'jquery-ui/ui/minified/accordion.min.js' %}"></script>
     <script src="{% new_static 'jquery-ui/ui/minified/autocomplete.min.js' %}"></script>
     <script src="{% new_static 'jquery-ui/ui/minified/draggable.min.js' %}"></script>
     <script src="{% new_static 'jquery-ui/ui/minified/droppable.min.js' %}"></script>

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_config_advanced.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_config_advanced.html
@@ -45,6 +45,7 @@
         </div>
     </div>
     <!-- ko if:  actionType !== 'load' || !auto_select || auto_select.mode() !== 'usercase' -->
+    <div class="spacer"></div>
     <div class="panel panel-default">
         <div class="panel-body">
             <div class="form-horizontal">
@@ -163,9 +164,10 @@
 <script type="text/html" id="case-config:case-action">
     <div class="panel-heading">
         <!-- TODO: increase click target size -->
-        <a data-toggle="collapse" href="#TODO-{{ forloop.counter0 }}" data-bind="html: header"></a>
+        <a data-toggle="collapse" data-parent="#case-config-ko"
+           data-bind="html: header, attr: {href: '#action-' + $index()}"></a>
     </div>
-    <div class="panel-collapse collapse" id="TODO-{{ forloop.counter0 }}">
+    <div class="panel-collapse collapse" data-bind="attr: {id: 'action-' + $index()}">
         <div class="panel-body">
             <button class="pull-right btn btn-danger"
                     data-bind="openModal: 'remove-action-modal-template', visible: true">
@@ -247,9 +249,10 @@
 
 <script type="text/html" id="case-config:case-action-auto-select">
     <div class="panel-heading">
-        <a data-toggle="collapse" href="#TODO-{{ forloop.counter0 }}" data-bind="html: header"></a>
+        <a data-toggle="collapse" data-parent="#case-config-ko"
+           data-bind="html: header, attr: {href: '#action-' + $index()}"></a>
     </div>
-    <div class="panel-collapse collapse" id="TODO-{{ forloop.counter0 }}">
+    <div class="panel-collapse collapse" data-bind="attr: {id: 'action-' + $index()}">
         <div class="panel-body">
             <button class="pull-right btn btn-danger"
                     data-bind="openModal: 'remove-action-modal-template', visible: true">

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_config_advanced.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_config_advanced.html
@@ -163,11 +163,12 @@
 
 <script type="text/html" id="case-config:case-action">
     <div class="panel-heading clickable" data-toggle="collapse"
-         data-bind="html: header,
-                    attr: {
+         data-bind="attr: {
                         href: '#' + actionType + $index(),
                         'data-parent': actionType == 'open' ?  '#case-open-accordion' : '#case-load-accordion'
-                    }"></div>
+                    }">
+        <h3 class="panel-title" data-bind="html: header"></h3>
+    </div>
     <div class="panel-collapse"
          data-bind="attr: {id: actionType + $index()},
                     css: {collapse: !!$index(), in: !$index()}">
@@ -252,11 +253,12 @@
 
 <script type="text/html" id="case-config:case-action-auto-select">
     <div class="panel-heading clickable" data-toggle="collapse"
-         data-bind="html: header,
-                    attr: {
+         data-bind="attr: {
                         href: '#' + actionType + $index(),
                         'data-parent': actionType == 'open' ?  '#case-open-accordion' : '#case-load-accordion'
-                    }"></div>
+                    }">
+        <h3 class="panel-title" data-bind="html: header"></h3>
+    </div>
     <div class="panel-collapse"
          data-bind="attr: {id: actionType + $index()},
                     css: {collapse: !!$index(), in: !$index()}">

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_config_advanced.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_config_advanced.html
@@ -166,46 +166,46 @@
         <a data-toggle="collapse" href="#TODO-{{ forloop.counter0 }}" data-bind="html: header"></a>
     </div>
     <div class="panel-collapse collapse" id="TODO-{{ forloop.counter0 }}">
-    <div class="panel-body">
-        <button class="pull-right btn btn-danger"
-                data-bind="openModal: 'remove-action-modal-template', visible: true">
-            <i class="fa fa-trash"></i>
-            {% trans "Remove action" %}
-        </button>
-        <div class="form-inline" data-bind="css: {'has-warning': validate()}">
-            <div class="form-group">
-                <label>{% trans "Case Type" %}</label>
-                <select class="form-control" data-bind="
-                    options: config.caseTypes,
-                    value: case_type,
-                    optionsCaption: 'Choose a Case Type...'
-                "></select>
+        <div class="panel-body">
+            <button class="pull-right btn btn-danger"
+                    data-bind="openModal: 'remove-action-modal-template', visible: true">
+                <i class="fa fa-trash"></i>
+                {% trans "Remove action" %}
+            </button>
+            <div class="form-inline" data-bind="css: {'has-warning': validate()}">
+                <div class="form-group">
+                    <label>{% trans "Case Type" %}</label>
+                    <select class="form-control" data-bind="
+                        options: config.caseTypes,
+                        value: case_type,
+                        optionsCaption: 'Choose a Case Type...'
+                    "></select>
+                </div>
+                <!-- ko if: actionType == 'load'-->
+                <div class="form-group">
+                    &nbsp;
+                    <label>{% trans "Case List" %}</label>
+                    <select class="form-control" data-bind="optstr: available_modules,
+                        optstrValue: 'id',
+                        optstrText: 'module_name',
+                        value: details_module">
+                    </select>
+                </div>
+                <!-- /ko -->
+                <div class="form-group">
+                    &nbsp;
+                    <label>{% trans "Case Tag" %}</label>
+                    <input type="text" class="form-control" data-bind="value: case_tag, disable: disable_tag" />
+                </div>
+                <span class="help-block" data-bind="text: validate"></span>
             </div>
-            <!-- ko if: actionType == 'load'-->
-            <div class="form-group">
-                &nbsp;
-                <label>{% trans "Case List" %}</label>
-                <select class="form-control" data-bind="optstr: available_modules,
-                    optstrValue: 'id',
-                    optstrText: 'module_name',
-                    value: details_module">
-                </select>
+            <div class="help-block" data-bind="visible: !case_type">
+                {% trans "Please select a case type." %}
             </div>
-            <!-- /ko -->
-            <div class="form-group">
-                &nbsp;
-                <label>{% trans "Case Tag" %}</label>
-                <input type="text" class="form-control" data-bind="value: case_tag, disable: disable_tag" />
+            <div data-bind="visible: case_type">
+                <!-- ko template: {name: 'case-config:case-action:body'} --><!-- /ko -->
             </div>
-            <span class="help-block" data-bind="text: validate"></span>
         </div>
-        <div class="help-block" data-bind="visible: !case_type">
-            {% trans "Please select a case type." %}
-        </div>
-        <div data-bind="visible: case_type">
-            <!-- ko template: {name: 'case-config:case-action:body'} --><!-- /ko -->
-        </div>
-    </div>
     </div>
 </script>
 
@@ -250,39 +250,39 @@
         <a data-toggle="collapse" href="#TODO-{{ forloop.counter0 }}" data-bind="html: header"></a>
     </div>
     <div class="panel-collapse collapse" id="TODO-{{ forloop.counter0 }}">
-    <div class="panel-body">
-        <button class="pull-right btn btn-danger"
-                data-bind="openModal: 'remove-action-modal-template', visible: true">
-            <i class="fa fa-trash"></i>
-            {% trans "Remove action" %}
-        </button>
-        <div class="form-inline" data-bind="css: {'has-warning': validate()}">
-            <!-- ko with: auto_select -->
-            <div class="form-group">
-                <label>{% trans "Autoselect mode" %}</label>
-                <select class="form-control" data-bind="
-                    optstr: $parent.auto_select_modes,
-                    value: mode,
-                    optionsCaption: 'Choose a mode...'
-                "></select>
+        <div class="panel-body">
+            <button class="pull-right btn btn-danger"
+                    data-bind="openModal: 'remove-action-modal-template', visible: true">
+                <i class="fa fa-trash"></i>
+                {% trans "Remove action" %}
+            </button>
+            <div class="form-inline" data-bind="css: {'has-warning': validate()}">
+                <!-- ko with: auto_select -->
+                <div class="form-group">
+                    <label>{% trans "Autoselect mode" %}</label>
+                    <select class="form-control" data-bind="
+                        optstr: $parent.auto_select_modes,
+                        value: mode,
+                        optionsCaption: 'Choose a mode...'
+                    "></select>
+                </div>
+                <div class="form-group">
+                    <!-- ko template: {name: 'auto-select:' + mode()} --><!-- /ko -->
+                </div>
+                <!-- /ko -->
+                <div class="form-group">
+                    <label>{% trans "Case Tag" %}</label>
+                    <input type="text" class="form-control" data-bind="value: case_tag, disable: disable_tag" />
+                </div>
+                <span class="help-block" data-bind="text: validate"></span>
             </div>
-            <div class="form-group">
-                <!-- ko template: {name: 'auto-select:' + mode()} --><!-- /ko -->
+            <div data-bind="visible: !auto_select.mode()">
+                <em>{% trans "Please select an autoselection mode." %}</em>
             </div>
-            <!-- /ko -->
-            <div class="form-group">
-                <label>{% trans "Case Tag" %}</label>
-                <input type="text" class="form-control" data-bind="value: case_tag, disable: disable_tag" />
+            <div data-bind="visible: auto_select.mode()">
+                <!-- ko template: {name: 'case-config:case-action:body'} --><!-- /ko -->
             </div>
-            <span class="help-block" data-bind="text: validate"></span>
         </div>
-        <div data-bind="visible: !auto_select.mode()">
-            <em>{% trans "Please select an autoselection mode." %}</em>
-        </div>
-        <div data-bind="visible: auto_select.mode()">
-            <!-- ko template: {name: 'case-config:case-action:body'} --><!-- /ko -->
-        </div>
-    </div>
     </div>
 </script>
 
@@ -308,28 +308,26 @@
             <span class="text-muted">{% trans "Add Action" %}</span>
         </div>
         <div class="spacer"></div>
-        <div class="container-fluid">
-            <div class="row">
-                <legend data-bind="visible: load_update_cases().length">
-                    {% trans "Load / Update / Close Cases" %}
-                </legend>
-                <div id="case-load-accordion" class="panel-group" data-bind="foreach: load_update_cases">
-                    <!-- ko if: auto_select -->
-                    <div class="panel panel-default" data-bind="template: {name: 'case-config:case-action-auto-select'}"></div>
-                    <!-- /ko -->
-                    <!-- ko ifnot: auto_select -->
-                    <div class="panel panel-default" data-bind="template: {name: 'case-config:case-action'}"></div>
-                    <!-- /ko -->
-                </div>
+        <div>
+            <legend data-bind="visible: load_update_cases().length">
+                {% trans "Load / Update / Close Cases" %}
+            </legend>
+            <div id="case-load-accordion" class="panel-group" data-bind="foreach: load_update_cases">
+                <!-- ko if: auto_select -->
+                <div class="panel panel-default" data-bind="template: {name: 'case-config:case-action-auto-select'}"></div>
+                <!-- /ko -->
+                <!-- ko ifnot: auto_select -->
+                <div class="panel panel-default" data-bind="template: {name: 'case-config:case-action'}"></div>
+                <!-- /ko -->
             </div>
-            <div class="spacer" data-bind="visible: open_cases().length && load_update_cases().length"></div>
-            <div class="row">
-                <legend data-bind="visible: open_cases().length">
-                    {% trans "Open New Cases" %}
-                </legend>
-                <div id="case-open-accordion" class="panel-group" data-bind="foreach: open_cases">
-                    <div class="panel panel-default" data-bind="template: {name: 'case-config:case-action'}"></div>
-                </div>
+        </div>
+        <div class="spacer" data-bind="visible: open_cases().length && load_update_cases().length"></div>
+        <div>
+            <legend data-bind="visible: open_cases().length">
+                {% trans "Open New Cases" %}
+            </legend>
+            <div id="case-open-accordion" class="panel-group" data-bind="foreach: open_cases">
+                <div class="panel panel-default" data-bind="template: {name: 'case-config:case-action'}"></div>
             </div>
         </div>
     </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_config_advanced.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_config_advanced.html
@@ -163,10 +163,7 @@
 
 <script type="text/html" id="case-config:case-action">
     <div class="panel-heading clickable" data-toggle="collapse"
-         data-bind="attr: {
-                        href: '#' + actionType + $index(),
-                        'data-parent': actionType == 'open' ?  '#case-open-accordion' : '#case-load-accordion'
-                    }">
+         data-bind="attr: {href: '#' + actionType + $index()}">
         <h3 class="panel-title" data-bind="html: header"></h3>
     </div>
     <div class="panel-collapse collapse" data-bind="attr: {id: actionType + $index()}">
@@ -251,10 +248,7 @@
 
 <script type="text/html" id="case-config:case-action-auto-select">
     <div class="panel-heading clickable" data-toggle="collapse"
-         data-bind="attr: {
-                        href: '#' + actionType + $index(),
-                        'data-parent': actionType == 'open' ?  '#case-open-accordion' : '#case-load-accordion'
-                    }">
+         data-bind="attr: {href: '#' + actionType + $index()}">
         <h3 class="panel-title" data-bind="html: header"></h3>
     </div>
     <div class="panel-collapse collapse" data-bind="attr: {id: actionType + $index()}">

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_config_advanced.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_config_advanced.html
@@ -164,10 +164,14 @@
 <script type="text/html" id="case-config:case-action">
     <div class="panel-heading">
         <!-- TODO: increase click target size -->
-        <a data-toggle="collapse" data-parent="#case-config-ko"
-           data-bind="html: header, attr: {href: '#action-' + $index()}"></a>
+        <a data-toggle="collapse"
+           data-bind="html: header,
+                      attr: {
+                          href: '#' + actionType + $index(),
+                          'data-parent': actionType == 'open' ?  '#case-open-accordion' : '#case-load-accordion'
+                      }"></a>
     </div>
-    <div class="panel-collapse collapse" data-bind="attr: {id: 'action-' + $index()}">
+    <div class="panel-collapse collapse" data-bind="attr: {id: actionType + $index()}">
         <div class="panel-body">
             <button class="pull-right btn btn-danger"
                     data-bind="openModal: 'remove-action-modal-template', visible: true">
@@ -249,10 +253,15 @@
 
 <script type="text/html" id="case-config:case-action-auto-select">
     <div class="panel-heading">
-        <a data-toggle="collapse" data-parent="#case-config-ko"
-           data-bind="html: header, attr: {href: '#action-' + $index()}"></a>
+        <!-- TODO: increase click target size -->
+        <a data-toggle="collapse"
+           data-bind="html: header,
+                      attr: {
+                          href: '#' + actionType + $index(),
+                          'data-parent': actionType == 'open' ?  '#case-open-accordion' : '#case-load-accordion'
+                      }"></a>
     </div>
-    <div class="panel-collapse collapse" data-bind="attr: {id: 'action-' + $index()}">
+    <div class="panel-collapse collapse" data-bind="attr: {id: actionType + $index()}">
         <div class="panel-body">
             <button class="pull-right btn btn-danger"
                     data-bind="openModal: 'remove-action-modal-template', visible: true">

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_config_advanced.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_config_advanced.html
@@ -162,15 +162,12 @@
 </script>
 
 <script type="text/html" id="case-config:case-action">
-    <div class="panel-heading">
-        <!-- TODO: increase click target size -->
-        <a data-toggle="collapse"
-           data-bind="html: header,
-                      attr: {
-                          href: '#' + actionType + $index(),
-                          'data-parent': actionType == 'open' ?  '#case-open-accordion' : '#case-load-accordion'
-                      }"></a>
-    </div>
+    <div class="panel-heading clickable" data-toggle="collapse"
+         data-bind="html: header,
+                    attr: {
+                        href: '#' + actionType + $index(),
+                        'data-parent': actionType == 'open' ?  '#case-open-accordion' : '#case-load-accordion'
+                    }"></div>
     <div class="panel-collapse collapse" data-bind="attr: {id: actionType + $index()}">
         <div class="panel-body">
             <button class="pull-right btn btn-danger"
@@ -252,15 +249,12 @@
 </script>
 
 <script type="text/html" id="case-config:case-action-auto-select">
-    <div class="panel-heading">
-        <!-- TODO: increase click target size -->
-        <a data-toggle="collapse"
-           data-bind="html: header,
-                      attr: {
-                          href: '#' + actionType + $index(),
-                          'data-parent': actionType == 'open' ?  '#case-open-accordion' : '#case-load-accordion'
-                      }"></a>
-    </div>
+    <div class="panel-heading clickable" data-toggle="collapse"
+         data-bind="html: header,
+                    attr: {
+                        href: '#' + actionType + $index(),
+                        'data-parent': actionType == 'open' ?  '#case-open-accordion' : '#case-load-accordion'
+                    }"></div>
     <div class="panel-collapse collapse" data-bind="attr: {id: actionType + $index()}">
         <div class="panel-body">
             <button class="pull-right btn btn-danger"

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_config_advanced.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_config_advanced.html
@@ -169,9 +169,9 @@
                     }">
         <h3 class="panel-title" data-bind="html: header"></h3>
     </div>
-    <div class="panel-collapse"
+    <div class="panel-collapse collapse"
          data-bind="attr: {id: actionType + $index()},
-                    css: {collapse: !!$index(), in: !$index()}">
+                    css: {in: !$index()}"><!-- open first panel -->
         <div class="panel-body">
             <button class="pull-right btn btn-danger"
                     data-bind="openModal: 'remove-action-modal-template', visible: true">
@@ -259,9 +259,9 @@
                     }">
         <h3 class="panel-title" data-bind="html: header"></h3>
     </div>
-    <div class="panel-collapse"
+    <div class="panel-collapse collapse"
          data-bind="attr: {id: actionType + $index()},
-                    css: {collapse: !!$index(), in: !$index()}">
+                    css: {in: !$index()}"><!-- open first panel -->
         <div class="panel-body">
             <button class="pull-right btn btn-danger"
                     data-bind="openModal: 'remove-action-modal-template', visible: true">

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_config_advanced.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_config_advanced.html
@@ -161,15 +161,18 @@
 </script>
 
 <script type="text/html" id="case-config:case-action">
-    <h3>
-        <a href="#" data-bind="html: header" class="header"></a>
-    </h3>
-    <div>
-                <button class="pull-right btn btn-danger"
-                        data-bind="openModal: 'remove-action-modal-template', visible: true">
-                    <i class="fa fa-trash"></i>
-                    {% trans "Remove action" %}
-                </button>
+<div class="panel panel-default">
+    <div class="panel-heading">
+        <!-- TODO: increase click target size -->
+        <a data-toggle="collapse" href="#TODO-{{ forloop.counter0 }}" data-bind="html: header"></a>
+    </div>
+    <div class="panel-collapse collapse" id="TODO-{{ forloop.counter0 }}">
+    <div class="panel-body">
+        <button class="pull-right btn btn-danger"
+                data-bind="openModal: 'remove-action-modal-template', visible: true">
+            <i class="fa fa-trash"></i>
+            {% trans "Remove action" %}
+        </button>
         <div class="form-inline" data-bind="css: {'has-warning': validate()}">
             <div class="form-group">
                 <label>{% trans "Case Type" %}</label>
@@ -204,6 +207,8 @@
             <!-- ko template: {name: 'case-config:case-action:body'} --><!-- /ko -->
         </div>
     </div>
+    </div>
+</div>
 </script>
 
 <script type="text/html" id="auto-select:undefined">
@@ -243,10 +248,12 @@
 </script>
 
 <script type="text/html" id="case-config:case-action-auto-select">
-    <h3>
-        <a href="#" data-bind="html: header" class="header"></a>
-    </h3>
-    <div>
+<div class="panel panel-default">
+    <div class="panel-heading">
+        <a data-toggle="collapse" href="#TODO-{{ forloop.counter0 }}" data-bind="html: header"></a>
+    </div>
+    <div class="panel-collapse collapse" id="TODO-{{ forloop.counter0 }}">
+    <div class="panel-body">
         <button class="pull-right btn btn-danger"
                 data-bind="openModal: 'remove-action-modal-template', visible: true">
             <i class="fa fa-trash"></i>
@@ -279,6 +286,8 @@
             <!-- ko template: {name: 'case-config:case-action:body'} --><!-- /ko -->
         </div>
     </div>
+    </div>
+</div>
 </script>
 
 <div id="case-config-ko">
@@ -308,7 +317,7 @@
                 <legend data-bind="visible: load_update_cases().length">
                     {% trans "Load / Update / Close Cases" %}
                 </legend>
-                <div id="case-load-accordion" data-bind="foreach: load_update_cases, accordion: {header: '> div > h3', heightStyle: 'content', collapsible: true, autoFill: true}">
+                <div id="case-load-accordion" data-bind="foreach: load_update_cases">
                     <!-- ko if: auto_select -->
                     <div class="group" data-bind="template: {name: 'case-config:case-action-auto-select'}"></div>
                     <!-- /ko -->
@@ -322,8 +331,8 @@
                 <legend data-bind="visible: open_cases().length">
                     {% trans "Open New Cases" %}
                 </legend>
-                <div id="case-open-accordion" data-bind="foreach: open_cases, accordion: {header: '> div > h3', heightStyle: 'content', collapsible: true, autoFill: true}">
-                    <div class="group" data-bind="template: {name: 'case-config:case-action'}"></div>
+                <div id="case-open-accordion" class="panel-group" data-bind="foreach: open_cases">
+                    <div class="panel-group" data-bind="template: {name: 'case-config:case-action'}"></div>
                 </div>
             </div>
         </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_config_advanced.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_config_advanced.html
@@ -169,9 +169,7 @@
                     }">
         <h3 class="panel-title" data-bind="html: header"></h3>
     </div>
-    <div class="panel-collapse collapse"
-         data-bind="attr: {id: actionType + $index()},
-                    css: {in: !$index()}"><!-- open first panel -->
+    <div class="panel-collapse collapse" data-bind="attr: {id: actionType + $index()}">
         <div class="panel-body">
             <button class="pull-right btn btn-danger"
                     data-bind="openModal: 'remove-action-modal-template', visible: true">
@@ -259,9 +257,7 @@
                     }">
         <h3 class="panel-title" data-bind="html: header"></h3>
     </div>
-    <div class="panel-collapse collapse"
-         data-bind="attr: {id: actionType + $index()},
-                    css: {in: !$index()}"><!-- open first panel -->
+    <div class="panel-collapse collapse" data-bind="attr: {id: actionType + $index()}">
         <div class="panel-body">
             <button class="pull-right btn btn-danger"
                     data-bind="openModal: 'remove-action-modal-template', visible: true">

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_config_advanced.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_config_advanced.html
@@ -161,7 +161,6 @@
 </script>
 
 <script type="text/html" id="case-config:case-action">
-<div class="panel panel-default">
     <div class="panel-heading">
         <!-- TODO: increase click target size -->
         <a data-toggle="collapse" href="#TODO-{{ forloop.counter0 }}" data-bind="html: header"></a>
@@ -208,7 +207,6 @@
         </div>
     </div>
     </div>
-</div>
 </script>
 
 <script type="text/html" id="auto-select:undefined">
@@ -248,7 +246,6 @@
 </script>
 
 <script type="text/html" id="case-config:case-action-auto-select">
-<div class="panel panel-default">
     <div class="panel-heading">
         <a data-toggle="collapse" href="#TODO-{{ forloop.counter0 }}" data-bind="html: header"></a>
     </div>
@@ -287,7 +284,6 @@
         </div>
     </div>
     </div>
-</div>
 </script>
 
 <div id="case-config-ko">
@@ -317,12 +313,12 @@
                 <legend data-bind="visible: load_update_cases().length">
                     {% trans "Load / Update / Close Cases" %}
                 </legend>
-                <div id="case-load-accordion" data-bind="foreach: load_update_cases">
+                <div id="case-load-accordion" class="panel-group" data-bind="foreach: load_update_cases">
                     <!-- ko if: auto_select -->
-                    <div class="group" data-bind="template: {name: 'case-config:case-action-auto-select'}"></div>
+                    <div class="panel panel-default" data-bind="template: {name: 'case-config:case-action-auto-select'}"></div>
                     <!-- /ko -->
                     <!-- ko ifnot: auto_select -->
-                    <div class="group" data-bind="template: {name: 'case-config:case-action'}"></div>
+                    <div class="panel panel-default" data-bind="template: {name: 'case-config:case-action'}"></div>
                     <!-- /ko -->
                 </div>
             </div>
@@ -332,7 +328,7 @@
                     {% trans "Open New Cases" %}
                 </legend>
                 <div id="case-open-accordion" class="panel-group" data-bind="foreach: open_cases">
-                    <div class="panel-group" data-bind="template: {name: 'case-config:case-action'}"></div>
+                    <div class="panel panel-default" data-bind="template: {name: 'case-config:case-action'}"></div>
                 </div>
             </div>
         </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_config_advanced.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_config_advanced.html
@@ -168,7 +168,9 @@
                         href: '#' + actionType + $index(),
                         'data-parent': actionType == 'open' ?  '#case-open-accordion' : '#case-load-accordion'
                     }"></div>
-    <div class="panel-collapse collapse" data-bind="attr: {id: actionType + $index()}">
+    <div class="panel-collapse"
+         data-bind="attr: {id: actionType + $index()},
+                    css: {collapse: !!$index(), in: !$index()}">
         <div class="panel-body">
             <button class="pull-right btn btn-danger"
                     data-bind="openModal: 'remove-action-modal-template', visible: true">
@@ -255,7 +257,9 @@
                         href: '#' + actionType + $index(),
                         'data-parent': actionType == 'open' ?  '#case-open-accordion' : '#case-load-accordion'
                     }"></div>
-    <div class="panel-collapse collapse" data-bind="attr: {id: actionType + $index()}">
+    <div class="panel-collapse"
+         data-bind="attr: {id: actionType + $index()},
+                    css: {collapse: !!$index(), in: !$index()}">
         <div class="panel-body">
             <button class="pull-right btn btn-danger"
                     data-bind="openModal: 'remove-action-modal-template', visible: true">

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases_deploy_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases_deploy_modal.html
@@ -19,7 +19,7 @@
                 <a href="{% url "mobile_workers" domain %}">{% trans "create your first mobile worker" %}</a>.
             </div>
         {% else %}
-            <div class="panel-group" data-bind="bootstrapCollapse: true" id="deploy-accordion">
+            <div class="panel-group" id="deploy-accordion">
                 <div class="panel panel-default">
                     <div class="panel-heading">
                         <a data-toggle="collapse" data-parent="#deploy-accordion" href="#panel-android" aria-expanded="true" aria-controls="panel-android">

--- a/corehq/apps/style/static/style/ko/knockout_bindings.ko.js
+++ b/corehq/apps/style/static/style/ko/knockout_bindings.ko.js
@@ -373,17 +373,6 @@ ko.bindingHandlers.starred = {
     }
 };
 
-ko.bindingHandlers.bootstrapCollapse = {
-    init: function (element) {
-        $(element).on('click', 'a.accordion-toggle', function () {
-            var $a = $(this);
-            if (!$a.attr('href')) {
-                $a.parent().parent().find('.collapse').collapse('toggle');
-            }
-        });
-    }
-};
-
 ko.bindingHandlers.bootstrapTabs = {
     init: function (element) {
         var tabLinkSelector = 'ul.nav > li > a';

--- a/corehq/apps/style/static/style/less/bootstrap3/utils.less
+++ b/corehq/apps/style/static/style/less/bootstrap3/utils.less
@@ -1,3 +1,7 @@
+.clickable {
+  cursor: pointer;
+}
+
 .spacer {
   height: 20px;
   width: 100%;

--- a/corehq/apps/style/templates/style/bootstrap3/base.html
+++ b/corehq/apps/style/templates/style/bootstrap3/base.html
@@ -163,7 +163,6 @@
             <script src="{% new_static 'jquery-ui/ui/position.js' %}"></script>
 
             <!-- Individual widgets and interactions -->
-            <script src="{% new_static 'jquery-ui/ui/accordion.js' %}"></script><!-- TODO: kill & replace with bootstrap -->
             <script src="{% new_static 'jquery-ui/ui/menu.js' %}"></script>
             <script src="{% new_static 'jquery-ui/ui/autocomplete.js' %}"></script>
             <script src="{% new_static 'jquery-ui/ui/button.js' %}"></script>


### PR DESCRIPTION
The last one was in case management for forms in advanced modules.

@gcapalbo / @snopoke 

Before
<img width="1161" alt="screen shot 2016-02-23 at 9 35 44 pm" src="https://cloud.githubusercontent.com/assets/1486591/13284032/9efe8a1a-dabf-11e5-81cf-d8f43b5fde2b.png">

After
<img width="1157" alt="screen shot 2016-02-23 at 9 36 28 pm" src="https://cloud.githubusercontent.com/assets/1486591/13284035/a2f29b98-dabf-11e5-8a4b-afe8a77c23ae.png">
