### PR TITLE
unicode string for path and initialQuery

### DIFF
--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -26,14 +26,14 @@ def item_lists_by_domain(domain):
         ret.append({
             'id': data_type.tag,
             'uri': uri,
-            'path': "/{tag}_list/{tag}".format(tag=data_type.tag),
+            'path': u"/{tag}_list/{tag}".format(tag=data_type.tag),
             'name': data_type.tag,
             'structure': structure,
 
             # DEPRECATED PROPERTIES
             'sourceUri': uri,
             'defaultId': data_type.tag,
-            'initialQuery': "instance('{tag}')/{tag}_list/{tag}".format(tag=data_type.tag),
+            'initialQuery': u"instance('{tag}')/{tag}_list/{tag}".format(tag=data_type.tag),
         })
 
     products = product_fixture_generator_json(domain)


### PR DESCRIPTION
@nickpell http://manage.dimagi.com/default.asp?218055

fyi you can repro this by hitting this URL locally: http://localhost:8000/a/<domain>/fixtures/metadata/ and changing one of your FixtureDataType's tags to be a unicode field

cc: @NoahCarnahan 
