### PR TITLE
Refactor emailed_to

### DIFF
--- a/corehq/apps/accounting/templates/accounting/invoice.html
+++ b/corehq/apps/accounting/templates/accounting/invoice.html
@@ -58,7 +58,7 @@
                     {% for billing_record in billing_records %}
                         <tr>
                             <td>{{ billing_record.date_created }}</td>
-                            <td>{{ billing_record.emailed_to }}</td>
+                            <td>{{ billing_record.email_recipients }}</td>
                             <td>
                                 <a href="{% url 'domain_billing_statement_download' billing_record.invoice.get_domain billing_record.pdf_data_id %}">
                                     View PDF

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -732,7 +732,15 @@ class InvoiceSummaryViewBase(AccountingSectionView):
     @property
     def page_context(self):
         return {
-            'billing_records': self.billing_records,
+            'billing_records': [
+                {
+                    'date_created': billing_record.date_created,
+                    'email_recipients': ', '.join(billing_record.recipients),
+                    'invoice': billing_record.invoice,
+                    'pdf_data_id': billing_record.pdf_data_id,
+                }
+                for billing_record in self.billing_records
+            ],
             'can_send_email': self.can_send_email,
             'invoice_info_form': self.invoice_info_form,
             'resend_email_form': self.resend_email_form,

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -739,7 +739,7 @@ class InvoiceSummaryViewBase(AccountingSectionView):
                     'invoice': billing_record.invoice,
                     'pdf_data_id': billing_record.pdf_data_id,
                 }
-                for billing_record in self.billing_records
+                for billing_record in self.billing_records if not billing_record.skipped_email
             ],
             'can_send_email': self.can_send_email,
             'invoice_info_form': self.invoice_info_form,


### PR DESCRIPTION
:blowfish: 

First two commits ensure that the `emailed_to` field of `BaseBillingRecord` never is accessed directly (first step to changing the DB representation to something better than comma separated emails).

Third commit is a usability improvement.
