### PR TITLE
App manager parent select filters

### DIFF
--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -345,7 +345,17 @@ class EntriesHelper(object):
                     filter_xpath_template.replace('$fixture_value', fixture_value)
                 )
 
-            filter_xpath = EntriesHelper.get_filter_xpath(module) if use_filter else ''
+            # If the module has a parent_select, and we are building the xpath for the parent, then we'll need
+            # to use the parent's xpath expression, not the child's.
+            if module.parent_select.active and not parent_id:
+                filter_module = filter(
+                    lambda d: d['module'].unique_id == module.parent_select.module_id,
+                    datums_meta,
+                )[0]['module']
+            else:
+                filter_module = module
+            filter_xpath = EntriesHelper.get_filter_xpath(filter_module) if use_filter else ''
+
             datums.append(FormDatumMeta(
                 datum=SessionDatum(
                     id=datum['session_var'],

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -345,16 +345,7 @@ class EntriesHelper(object):
                     filter_xpath_template.replace('$fixture_value', fixture_value)
                 )
 
-            # If the module has a parent_select, and we are building the xpath for the parent, then we'll need
-            # to use the parent's xpath expression, not the child's.
-            if module.parent_select.active and not parent_id:
-                filter_module = filter(
-                    lambda d: d['module'].unique_id == module.parent_select.module_id,
-                    datums_meta,
-                )[0]['module']
-            else:
-                filter_module = datum['module']
-            filter_xpath = EntriesHelper.get_filter_xpath(filter_module) if use_filter else ''
+            filter_xpath = EntriesHelper.get_filter_xpath(datum['module']) if use_filter else ''
 
             datums.append(FormDatumMeta(
                 datum=SessionDatum(

--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -353,7 +353,7 @@ class EntriesHelper(object):
                     datums_meta,
                 )[0]['module']
             else:
-                filter_module = module
+                filter_module = datum['module']
             filter_xpath = EntriesHelper.get_filter_xpath(filter_module) if use_filter else ''
 
             datums.append(FormDatumMeta(

--- a/corehq/apps/app_manager/tests/data/suite/advanced_module_parent_filters.xml
+++ b/corehq/apps/app_manager/tests/data/suite/advanced_module_parent_filters.xml
@@ -1,0 +1,17 @@
+<partial>
+  <entry>
+    <form>http://id_m1-f0</form>
+    <command id="m1-f0">
+      <text>
+        <locale id="forms.m1f0"/>
+      </text>
+    </command>
+    <instance id="casedb" src="jr://instance/casedb"/>
+    <instance id="commcaresession" src="jr://instance/session"/>
+    <session>
+      <datum id="parent_id" nodeset="instance('casedb')/casedb/case[@case_type='parent'][@status='open'][parent_filter = 1]" value="./@case_id" detail-select="m0_case_short"/>
+      <datum id="case_id" nodeset="instance('casedb')/casedb/case[@case_type='child'][@status='open'][child_filter = 1][index/parent=instance('commcaresession')/session/data/parent_id]" value="./@case_id" detail-select="m1_case_short" detail-confirm="m1_case_long"/>
+    </session>
+  </entry>
+</partial>
+

--- a/corehq/apps/app_manager/tests/test_advanced_suite.py
+++ b/corehq/apps/app_manager/tests/test_advanced_suite.py
@@ -157,3 +157,25 @@ class AdvancedSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         child_form.requires = 'case'
 
         self.assertXmlPartialEqual(self.get_xml('advanced_module_parent'), app.create_suite(), "./entry[1]")
+
+    def test_tiered_select_with_advanced_module_as_parent_with_filters(self):
+        app = Application.new_app('domain', "Untitled Application", application_version=APP_V2)
+
+        parent_module = app.add_module(AdvancedModule.new_module('parent', None))
+        parent_module.case_type = 'parent'
+        parent_module.unique_id = 'id_parent_module'
+        parent_module.case_details.short.filter = 'parent_filter = 1'
+
+        child_module = app.add_module(Module.new_module("Untitled Module", None))
+        child_module.case_type = 'child'
+        child_module.parent_select.active = True
+        child_module.case_details.short.filter = 'child_filter = 1'
+
+        # make child module point to advanced module as parent
+        child_module.parent_select.module_id = parent_module.unique_id
+
+        child_form = app.new_form(1, "Untitled Form", None)
+        child_form.xmlns = 'http://id_m1-f0'
+        child_form.requires = 'case'
+
+        self.assertXmlPartialEqual(self.get_xml('advanced_module_parent_filters'), app.create_suite(), "./entry[1]")

--- a/corehq/apps/app_manager/tests/test_advanced_suite.py
+++ b/corehq/apps/app_manager/tests/test_advanced_suite.py
@@ -14,6 +14,7 @@ from corehq.apps.app_manager.models import (
     Module,
 )
 from corehq.apps.app_manager.tests.util import SuiteMixin, TestXmlMixin, commtrack_enabled
+from corehq.apps.app_manager.tests.app_factory import AppFactory
 
 
 class AdvancedSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
@@ -159,27 +160,21 @@ class AdvancedSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         self.assertXmlPartialEqual(self.get_xml('advanced_module_parent'), app.create_suite(), "./entry[1]")
 
     def test_tiered_select_with_advanced_module_as_parent_with_filters(self):
-        app = Application.new_app('domain', "Untitled Application", application_version=APP_V2)
-
-        parent_module = app.add_module(AdvancedModule.new_module('parent', None))
-        parent_module.case_type = 'parent'
-        parent_module.unique_id = 'id_parent_module'
+        factory = AppFactory(build_version='2.25')
+        parent_module, parent_form = factory.new_advanced_module('parent', 'parent')
         parent_module.case_details.short.filter = 'parent_filter = 1'
 
-        child_module = app.add_module(Module.new_module("Untitled Module", None))
-        child_module.case_type = 'child'
-        child_module.parent_select.active = True
+        child_module, child_form = factory.new_basic_module('child', 'child')
+        child_form.xmlns = 'http://id_m1-f0'
         child_module.case_details.short.filter = 'child_filter = 1'
+        factory.form_requires_case(child_form)
 
         # make child module point to advanced module as parent
+        child_module.parent_select.active = True
         child_module.parent_select.module_id = parent_module.unique_id
-
-        child_form = app.new_form(1, "Untitled Form", None)
-        child_form.xmlns = 'http://id_m1-f0'
-        child_form.requires = 'case'
 
         self.assertXmlPartialEqual(
             self.get_xml('advanced_module_parent_filters'),
-            app.create_suite(),
-            "./entry[1]"
+            factory.app.create_suite(),
+            "./entry[2]"
         )

--- a/corehq/apps/app_manager/tests/test_advanced_suite.py
+++ b/corehq/apps/app_manager/tests/test_advanced_suite.py
@@ -178,4 +178,8 @@ class AdvancedSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
         child_form.xmlns = 'http://id_m1-f0'
         child_form.requires = 'case'
 
-        self.assertXmlPartialEqual(self.get_xml('advanced_module_parent_filters'), app.create_suite(), "./entry[1]")
+        self.assertXmlPartialEqual(
+            self.get_xml('advanced_module_parent_filters'),
+            app.create_suite(),
+            "./entry[1]"
+        )


### PR DESCRIPTION
@snopoke this is a tricky one and i think you have the most context on it based on blame: http://manage.dimagi.com/default.asp?217812

basically what was happening is this:
1. someone would define a parent select and use cases from a different module for the parent screen
2. on the parent module there would be a filter defined
3. when the detail was generated it would use the filter from the child instead of the parent

this PR makes sure it uses the filter from the parent for the parent screen

cc: @NoahCarnahan 
