### PR TITLE
Make default link settings, not deploy

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/managed_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/managed_app.html
@@ -128,7 +128,7 @@
         <li {% if not module and not form and not release_manager %}class="app-name-div
                 {% if not copy_app_form or not copy_app_form.is_bound %}active{% endif %}"
             {% endif %}>
-            <a href="{% url "view_app" domain app.id %}#app-settings" data-toggle="tab">
+            <a href="{% url "view_app" domain app.id %}#app-settings" data-toggle="tab" data-default="1">
                 <i class="fa fa-cog"></i>
                 {% trans "Settings" %}
             </a>

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/lib/bootstrap-tab-history-custom.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/lib/bootstrap-tab-history-custom.js
@@ -35,6 +35,12 @@ $(function () {
             // where State.data.tab won't be available
             link = $('a[data-toggle="tab"][href^="' + window.location.pathname + '"]');
             if (link.length !== 0) {
+                if (link.length > 1) {
+                    var defaultLink = link.filter("[data-default='1']");
+                    if (defaultLink.length) {
+                        link = defaultLink;
+                    }
+                }
                 link = link.first();
                 History.replaceState({
                     tab: link.attr('href').split('#')[1]


### PR DESCRIPTION
https://github.com/dimagi/commcare-hq/pull/10443 inadvertently switched the default app view (i.e., the page you get to by picking an app from the applications top menu) from settings to deploy.

@gcapalbo 
@nickpell this should go out in today's deploy

@dimagi/product  This happened because the code assumes that the default / most important item in a menu is the top link, which strikes me as a reasonable assumption, but "deploy" is above "settings" in the app manager's left-hand nav. Any thoughts on reordering that, or on actually changing the app landing page? I'd guess that deploy is used much more often than settings. I don't feel strongly about this, though, understand if it isn't a priority to think about right now.
