### PR TITLE
Force rebuilds on new exports

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -591,7 +591,7 @@ class FormExportDataSchema(ExportDataSchema):
         return FORM_EXPORT
 
     @staticmethod
-    def generate_schema_from_builds(domain, app_id, form_xmlns):
+    def generate_schema_from_builds(domain, app_id, form_xmlns, force_rebuild=False):
         """Builds a schema from Application builds for a given identifier
 
         :param domain: The domain that the export belongs to
@@ -601,7 +601,7 @@ class FormExportDataSchema(ExportDataSchema):
         """
         original_id, original_rev = None, None
         current_xform_schema = get_latest_form_export_schema(domain, app_id, form_xmlns)
-        if current_xform_schema:
+        if current_xform_schema and not force_rebuild:
             original_id, original_rev = current_xform_schema._id, current_xform_schema._rev
         else:
             current_xform_schema = FormExportDataSchema()
@@ -693,7 +693,7 @@ class CaseExportDataSchema(ExportDataSchema):
         return map(lambda app_build_version: app_build_version.build_id, app_build_verions)
 
     @staticmethod
-    def generate_schema_from_builds(domain, case_type):
+    def generate_schema_from_builds(domain, case_type, force_rebuild=False):
         """Builds a schema from Application builds for a given identifier
 
         :param domain: The domain that the export belongs to
@@ -704,7 +704,7 @@ class CaseExportDataSchema(ExportDataSchema):
         original_id, original_rev = None, None
         current_case_schema = get_latest_case_export_schema(domain, case_type)
 
-        if current_case_schema:
+        if current_case_schema and not force_rebuild:
             # Save the original id an rev so we can later save the document under the same _id
             original_id, original_rev = current_case_schema._id, current_case_schema._rev
         else:

--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -1305,6 +1305,7 @@ class CreateNewCustomFormExportView(BaseModifyNewCustomView):
             self.domain,
             app_id,
             xmlns,
+            force_rebuild=True,
         )
         self.export_instance = self.export_instance_cls.generate_instance_from_schema(schema)
 
@@ -1322,6 +1323,7 @@ class CreateNewCustomCaseExportView(BaseModifyNewCustomView):
         schema = CaseExportDataSchema.generate_schema_from_builds(
             self.domain,
             case_type,
+            force_rebuild=True,
         )
         self.export_instance = self.export_instance_cls.generate_instance_from_schema(schema)
 


### PR DESCRIPTION
@NoahCarnahan as discussed this makes it so exports get force rebuilt when we create a new one. good for now, maybe we can reevaluate if it's necessary when we're done refactoring
