### PR TITLE
add hook for template-specific keyboard shortcuts

### DIFF
--- a/corehq/apps/style/templates/style/bootstrap3/base.html
+++ b/corehq/apps/style/templates/style/bootstrap3/base.html
@@ -486,6 +486,7 @@
         <![endif]-->
         
         {% include 'style/includes/keyboard_shortcuts.html' %}
+        {% block keyboard_shortcuts %}{% endblock keyboard_shortcuts %}
 
         {% block js-inline %}{% endblock js-inline %}
 

--- a/corehq/apps/style/templates/style/includes/keyboard_shortcuts.html
+++ b/corehq/apps/style/templates/style/includes/keyboard_shortcuts.html
@@ -222,6 +222,4 @@ KEYBOARD_SHORTCUTS = KEYBOARD_SHORTCUTS.concat([
     });
 {% endif %}
 </script>
-{% block keyboard_shortcuts %}
-{% endblock %}
 {% endif %}


### PR DESCRIPTION
Followup for https://github.com/dimagi/commcare-hq/pull/10495 - the page-specific shortcuts added in apps_base.html and form_designer.html aren't being included.

@biyeun / @gcapalbo 
