### PR TITLE
do not skip invoicing community subscriptions with charges that are missing contact info

### DIFF
--- a/corehq/apps/accounting/exceptions.py
+++ b/corehq/apps/accounting/exceptions.py
@@ -50,10 +50,6 @@ class PaymentHandlerError(Exception):
     pass
 
 
-class BillingContactInfoError(Exception):
-    pass
-
-
 class CreateAccountingAdminError(Exception):
     pass
 

--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -18,7 +18,6 @@ from corehq.apps.accounting.exceptions import (
     LineItemError,
     InvoiceError,
     InvoiceEmailThrottledError,
-    BillingContactInfoError,
     InvoiceAlreadyCreatedError,
 )
 from corehq.apps.accounting.models import (

--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -120,14 +120,6 @@ class DomainInvoiceFactory(object):
                 "was null for domain %s" % self.domain.name
             )
             do_not_invoice = True
-        if not BillingContactInfo.objects.filter(account=account).exists():
-            # No contact information exists for this account.
-            # This shouldn't happen, but if it does, we can't continue
-            # with the invoice generation.
-            raise BillingContactInfoError(
-                "Project %s has incurred charges, but does not have their "
-                "Billing Contact Info filled out." % self.domain.name
-            )
         # First check to make sure none of the existing subscriptions is set
         # to do not invoice. Let's be on the safe side and not send a
         # community invoice out, if that's the case.

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -22,7 +22,6 @@ from dimagi.utils.django.email import send_HTML_email
 
 from corehq.apps.accounting import utils
 from corehq.apps.accounting.exceptions import (
-    BillingContactInfoError,
     CreditLineError,
     InvoiceAlreadyCreatedError,
     InvoiceError,
@@ -175,8 +174,6 @@ def generate_invoices(based_on_date=None):
                 "There was an error utilizing credits for "
                 "domain %s: %s" % (domain.name, e)
             )
-        except BillingContactInfoError as e:
-            log_accounting_error("BillingContactInfoError: %s" % e)
         except InvoiceError as e:
             log_accounting_error(
                 "Could not create invoice for domain %s: %s" % (domain.name, e)


### PR DESCRIPTION
For all paid plans, invoices are sent to web admins if there are no billing contacts listed.  This change makes invoicing consistent for community subscriptions that have incurred charges (ie for > 50 mobile workers) during the billing cycle.

:blowfish: 
