### PR TITLE
move script loading out of release ajax

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/app_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/app_view.html
@@ -9,6 +9,11 @@
     <script src="{% new_static 'app_manager/js/supported-languages.js' %}"></script>
     <script src="{% new_static 'app_manager/js/password_setter.jquery.js' %}"></script>
     <script type="text/javascript" src="{% new_static 'hqmedia/js/hqmedia.reference_controller.js' %}"></script>
+
+    {# these scripts are for releases.html, but including them there causes hard-to-reproduce problems #}
+    <script src="{% new_static 'app_manager/js/app_manager_utils.js' %}"></script>
+    <script src="{% new_static 'app_manager/js/download_async_modal.js' %}"></script>
+    <script src="{% new_static 'app_manager/js/releases.js' %}"></script>
 {% endblock %}
 {% block js-inline %}
     {{ block.super }}

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases.html
@@ -5,13 +5,6 @@
 {% load timezone_tags %}
 {% load i18n %}
 
-{% block js %}
-    <script src="{% new_static 'app_manager/js/app_manager_utils.js' %}"></script>
-    <script src="{% new_static 'app_manager/js/download_async_modal.js' %}"></script>
-    <script src="{% new_static 'app_manager/js/releases.js' %}"></script>
-{% endblock %}
-
-{% block js-inline %}
 <script>
     $(function () {
        $('.hq-help-template').each(function () {
@@ -65,7 +58,6 @@
         gaTrackLink('a.view-source-files-link', 'App Manager', 'Deploy Type', 'View Source Files');
     });
 </script>
-{% endblock %}
 
 <div id="releases-table">
     <div class="alert alert-danger" data-bind="visible: brokenBuilds">


### PR DESCRIPTION
On staging (but not locally) I noticed this causing items in an included script to be referenced before they were defined. It may have been only after we switched to using a CDN, but I'm not sure.
