### PR TITLE
Allow aggregation by a missing user id in Application Status report

### DIFF
--- a/corehq/apps/es/aggregations.py
+++ b/corehq/apps/es/aggregations.py
@@ -217,7 +217,6 @@ class MissingAggregation(Aggregation):
 
     :param name: aggregation name
     :param field: name of the field to bucket on
-    :param size:
     """
     type = "missing"
     result_class = MissingResult

--- a/corehq/apps/es/aggregations.py
+++ b/corehq/apps/es/aggregations.py
@@ -41,6 +41,8 @@ import datetime
 
 from corehq.elastic import SIZE_LIMIT
 
+MISSING_KEY = None
+
 
 class AggregationResult(object):
     def __init__(self, raw, aggregation):
@@ -173,7 +175,7 @@ class Bucket(object):
 
     @property
     def key(self):
-        return self.result.get('key', None)
+        return self.result.get('key', MISSING_KEY)
 
     @property
     def doc_count(self):

--- a/corehq/apps/es/tests/test_aggregations.py
+++ b/corehq/apps/es/tests/test_aggregations.py
@@ -12,6 +12,7 @@ from corehq.apps.es.aggregations import (
     StatsAggregation,
     ExtendedStatsAggregation,
     TopHitsAggregation,
+    MissingAggregation,
 )
 from corehq.apps.es.es_query import HQESQuery, ESQuerySet
 from corehq.apps.es.tests.utils import ElasticTestMixin
@@ -289,6 +290,35 @@ class TestAggregations(ElasticTestMixin, SimpleTestCase):
                 is_ascending=False,
                 size=2,
                 include=['title'])
+        )
+        self.checkQuery(query, json_output)
+
+    def test_missing_aggregation(self):
+        json_output = {
+            "query": {
+                "filtered": {
+                    "filter": {
+                        "and": [
+                            {"match_all": {}}
+                        ]
+                    },
+                    "query": {"match_all": {}}
+                }
+            },
+            "aggs": {
+                "missing_user_id": {
+                    "missing": {
+                        "field": "user_id"
+                    }
+                },
+            },
+            "size": SIZE_LIMIT
+        }
+        query = HQESQuery('cases').aggregation(
+            MissingAggregation(
+                'missing_user_id',
+                'user_id',
+            )
         )
         self.checkQuery(query, json_output)
 

--- a/corehq/apps/reports/analytics/esaccessors.py
+++ b/corehq/apps/reports/analytics/esaccessors.py
@@ -2,8 +2,17 @@ from collections import defaultdict, namedtuple
 from datetime import datetime
 
 from corehq.apps.es import FormES, UserES, GroupES, CaseES, filters
-from corehq.apps.es.aggregations import TermsAggregation, ExtendedStatsAggregation, TopHitsAggregation
-from corehq.apps.es.forms import submitted as submitted_filter, completed as completed_filter
+from corehq.apps.es.aggregations import (
+    TermsAggregation,
+    ExtendedStatsAggregation,
+    TopHitsAggregation,
+    MissingAggregation,
+)
+from corehq.apps.es.forms import (
+    submitted as submitted_filter,
+    completed as completed_filter,
+    user_id as user_id_filter
+)
 from corehq.apps.es.cases import closed_range
 from corehq.util.quickcache import quickcache
 from dimagi.utils.parsing import string_to_datetime
@@ -106,10 +115,23 @@ def get_last_form_submission_for_xmlns(domain, xmlns):
 
 def get_last_form_submissions_by_user(domain, user_ids, app_id=None):
 
+    missing_users = None in user_ids
+
+    user_ids = filter(None, user_ids)
+
+    if not missing_users:
+        user_filter = user_id_filter(user_ids)
+    else:
+        user_filter = filters.OR(
+            user_id_filter(user_ids),
+            filters.missing('form.meta.userID'),
+        )
+
     query = (
         FormES()
         .domain(domain)
-        .user_id(user_ids)
+        .filter(user_filter)
+        .remove_default_filter('has_user')
         .aggregation(
             TermsAggregation('user_id', 'form.meta.userID').aggregation(
                 TopHitsAggregation(
@@ -125,8 +147,24 @@ def get_last_form_submissions_by_user(domain, user_ids, app_id=None):
     if app_id:
         query = query.app(app_id)
 
-    buckets_dict = query.run().aggregations.user_id.buckets_dict
     result = {}
+    if missing_users:
+        query = query.aggregation(
+            MissingAggregation('missing_user_id', 'form.meta.userID').aggregation(
+                TopHitsAggregation(
+                    'top_hits_last_form_submissions',
+                    'received_on',
+                    is_ascending=False,
+                )
+            )
+        )
+
+    aggregations = query.run().aggregations
+
+    if missing_users:
+        result[None] = aggregations.missing_user_id.bucket.top_hits_last_form_submissions.hits
+
+    buckets_dict = aggregations.user_id.buckets_dict
     for user_id, bucket in buckets_dict.iteritems():
         result[user_id] = bucket.top_hits_last_form_submissions.hits
 

--- a/corehq/apps/reports/analytics/esaccessors.py
+++ b/corehq/apps/reports/analytics/esaccessors.py
@@ -7,6 +7,7 @@ from corehq.apps.es.aggregations import (
     ExtendedStatsAggregation,
     TopHitsAggregation,
     MissingAggregation,
+    MISSING_KEY,
 )
 from corehq.apps.es.forms import (
     submitted as submitted_filter,
@@ -162,7 +163,7 @@ def get_last_form_submissions_by_user(domain, user_ids, app_id=None):
     aggregations = query.run().aggregations
 
     if missing_users:
-        result[None] = aggregations.missing_user_id.bucket.top_hits_last_form_submissions.hits
+        result[MISSING_KEY] = aggregations.missing_user_id.bucket.top_hits_last_form_submissions.hits
 
     buckets_dict = aggregations.user_id.buckets_dict
     for user_id, bucket in buckets_dict.iteritems():

--- a/corehq/apps/reports/tests/test_esaccessors.py
+++ b/corehq/apps/reports/tests/test_esaccessors.py
@@ -306,6 +306,11 @@ class TestFormESAccessors(BaseESAccessorsTest):
             'app_id': '1234',
             'domain': self.domain,
         }
+        kwargs_u3 = {
+            'user_id': None,
+            'app_id': '1234',
+            'domain': self.domain,
+        }
 
         first = datetime(2013, 7, 15, 0, 0, 0)
         second = datetime(2013, 7, 16, 0, 0, 0)
@@ -319,12 +324,35 @@ class TestFormESAccessors(BaseESAccessorsTest):
         self._send_form_to_es(received_on=third, xmlns='third', **kwargs_u2)
         self._send_form_to_es(received_on=first, xmlns='first', **kwargs_u2)
 
+        self._send_form_to_es(received_on=second, xmlns='second', **kwargs_u3)
+        self._send_form_to_es(received_on=third, xmlns='third', **kwargs_u3)
+        self._send_form_to_es(received_on=first, xmlns='first', **kwargs_u3)
+
         result = get_last_form_submissions_by_user(self.domain, ['u1', 'u2', 'missing'])
         self.assertEqual(result['u1'][0]['xmlns'], 'third')
         self.assertEqual(result['u2'][0]['xmlns'], 'third')
 
         result = get_last_form_submissions_by_user(self.domain, ['u1'], '1234')
         self.assertEqual(result['u1'][0]['xmlns'], 'third')
+
+        result = get_last_form_submissions_by_user(self.domain, ['u1', None], '1234')
+        self.assertEqual(result['u1'][0]['xmlns'], 'third')
+        self.assertEqual(result[None][0]['xmlns'], 'third')
+
+    def test_get_last_form_submission_for_missing_user(self):
+        kwargs_u1 = {
+            'user_id': None,
+            'app_id': '1234',
+            'domain': self.domain,
+        }
+        first = datetime(2013, 7, 15, 0, 0, 0)
+        second = datetime(2013, 7, 16, 0, 0, 0)
+        third = datetime(2013, 7, 17, 0, 0, 0)
+
+        self._send_form_to_es(received_on=second, xmlns='second', **kwargs_u1)
+        self._send_form_to_es(received_on=third, xmlns='third', **kwargs_u1)
+        self._send_form_to_es(received_on=first, xmlns='first', **kwargs_u1)
+
 
     def test_get_form_counts_by_user_xmlns(self):
         user1, user2 = 'u1', 'u2'

--- a/corehq/apps/reports/tests/test_esaccessors.py
+++ b/corehq/apps/reports/tests/test_esaccessors.py
@@ -339,21 +339,6 @@ class TestFormESAccessors(BaseESAccessorsTest):
         self.assertEqual(result['u1'][0]['xmlns'], 'third')
         self.assertEqual(result[None][0]['xmlns'], 'third')
 
-    def test_get_last_form_submission_for_missing_user(self):
-        kwargs_u1 = {
-            'user_id': None,
-            'app_id': '1234',
-            'domain': self.domain,
-        }
-        first = datetime(2013, 7, 15, 0, 0, 0)
-        second = datetime(2013, 7, 16, 0, 0, 0)
-        third = datetime(2013, 7, 17, 0, 0, 0)
-
-        self._send_form_to_es(received_on=second, xmlns='second', **kwargs_u1)
-        self._send_form_to_es(received_on=third, xmlns='third', **kwargs_u1)
-        self._send_form_to_es(received_on=first, xmlns='first', **kwargs_u1)
-
-
     def test_get_form_counts_by_user_xmlns(self):
         user1, user2 = 'u1', 'u2'
         app1, app2 = '123', '567'

--- a/corehq/form_processor/utils/xform.py
+++ b/corehq/form_processor/utils/xform.py
@@ -49,6 +49,10 @@ def get_simple_form_xml(form_id, case_id=None, metadata=None):
     if case_id:
         case_block = CaseBlock(create=True, case_id=case_id).as_string()
     form_xml = SIMPLE_FORM.format(uuid=form_id, case_block=case_block, **metadata.to_json())
+
+    if not metadata.user_id:
+        form_xml = form_xml.replace('<n1:userID>{}</n1:userID>'.format(metadata.user_id), '')
+
     return form_xml
 
 


### PR DESCRIPTION
@snopoke handles the case where `None` gets passed into the ES query: http://manage.dimagi.com/default.asp?218389

cc: @NoahCarnahan 
