### PR TITLE
cache device log filters for 10 minutes

### DIFF
--- a/corehq/apps/reports/filters/devicelog.py
+++ b/corehq/apps/reports/filters/devicelog.py
@@ -1,6 +1,7 @@
 from django.utils.translation import ugettext_noop
 from corehq.apps.reports.filters.base import BaseReportFilter
 from corehq.util.queries import fast_distinct, fast_distinct_in_domain
+from corehq.util.quickcache import quickcache
 from phonelog.models import DeviceReportEntry
 
 
@@ -11,6 +12,7 @@ class DeviceLogTagFilter(BaseReportFilter):
     template = "reports/filters/bootstrap2/devicelog_tags.html"
 
     @property
+    @quickcache(['self.domain'], timeout=10 * 60)
     def filter_context(self):
         errors_only = bool(self.request.GET.get(self.errors_only_slug, False))
         selected_tags = self.request.GET.getlist(self.slug)
@@ -37,6 +39,7 @@ class BaseDeviceLogFilter(BaseReportFilter):
     label = ugettext_noop("Filter Logs By")
     url_param_map = {'Unknown': None}
 
+    @quickcache(['self.domain', 'selected'], timeout=10 * 60)
     def get_filters(self, selected):
         show_all = bool(not selected)
         values = fast_distinct_in_domain(DeviceReportEntry, self.field, self.domain)


### PR DESCRIPTION
I forgot to do this earlier. Device log filters can take a long time to compute and rarely ever change.
