### PR TITLE
only include extra app manager shortcuts if user has shortcuts enabled

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/apps_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/apps_base.html
@@ -67,6 +67,7 @@
     </script>
 {% endblock %}
 {% block keyboard_shortcuts %}
+    {% if request.couch_user.keyboard_shortcuts.enabled %}
     <script>
         var nav_key = {{ request.couch_user.keyboard_shortcuts.main_key|JSON }};
 
@@ -106,6 +107,7 @@
             reset_index: false
         });
     </script>
+    {% endif %}
 {% endblock %}
 
 {% block page_breadcrumbs %}

--- a/corehq/apps/app_manager/templates/app_manager/form_designer.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_designer.html
@@ -140,6 +140,7 @@
 {% endblock %}
 
 {% block keyboard_shortcuts %}
+    {% if request.couch_user.keyboard_shortcuts.enabled %}
     <script>
         var nav_key = {{ request.couch_user.keyboard_shortcuts.main_key|JSON }};
 
@@ -254,6 +255,7 @@
             }
         ]);
     </script>
+    {% endif %}
 {% endblock %}
 
 {% block title %}{{ form.name|clean_trans:langs }}{% endblock %}


### PR DESCRIPTION
This is the unfortunate love child of https://github.com/dimagi/commcare-hq/pull/10495 and https://github.com/dimagi/commcare-hq/pull/10513: https://github.com/dimagi/commcare-hq/pull/10495 added keyboard shortcuts back into B3, but only included keyboard_navigator.js if the user had shortcuts enabled. https://github.com/dimagi/commcare-hq/pull/10513 added back app manager's keyboard shortcuts, but added it regardless of whether or not the user had shortcuts enabled.
