### PR TITLE
stop flickering errors on deploy page

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases.html
@@ -45,7 +45,6 @@
         var releasesMain = new ReleasesMain(o);
         _.defer(function(){ releasesMain.getMoreSavedApps(); });
         el.koApplyBindings(releasesMain);
-        el.show();
     });
 
     analytics.workflow('Visited the Release Manager');
@@ -59,8 +58,8 @@
     });
 </script>
 
-<div id="releases-table">
-    <div class="alert alert-danger" data-bind="visible: brokenBuilds">
+<div id="releases-table" class="hide" data-bind="css: {hide: false}">
+    <div class="alert alert-danger hide" data-bind="visible: brokenBuilds, css: {hide: false}">
         <p>
             <i class="fa fa-exclamation-circle"></i>
             {% blocktrans %}
@@ -104,7 +103,7 @@
             </th>
         </tr>
         <tbody data-bind="visible: buildState, css: {hide: false}" class="hide">
-            <tr data-bind="visible: buildState() == 'pending'">
+            <tr data-bind="visible: buildState() == 'pending', css: {hide: false}" class="hide">
                 <td colspan="9">
                     <img src="{% new_static 'hqwebapp/img/ajax-loader.gif' %}"/>
                     <span class="label label-success">
@@ -112,7 +111,7 @@
                     </span>
                 </td>
             </tr>
-            <tr data-bind="visible: buildState() == 'error'">
+            <tr data-bind="visible: buildState() == 'error', css: {hide: false}" class="hide">
                 <td colspan="9">
                     <div class="alert alert-danger">{% trans "Whoops, that didn't go through. Reload the page and click Make New Version to try again." %}</div>
                 </td>
@@ -130,18 +129,20 @@
                 'error': build_broken
             }">
                 <td>
-                    <a href="#" data-bind="
+                    <a href="#" class="hide" data-bind="
                         openModal: 'delete-build-modal-template',
-                        visible: !_deleteState()
+                        visible: !_deleteState(),
+                        css: {hide: false}
                     ">
                         <i class="fa fa-remove"></i>
                     </a>
-                    <div class="pending" data-bind="visible: _deleteState() == 'pending'">
+                    <div class="pending hide" data-bind="visible: _deleteState() == 'pending', css: {hide: false}">
                         <img src="{% new_static 'hqwebapp/img/ajax-loader.gif' %}" alt="loading indicator" />
                     </div>
 
-                    <i class="fa fa-exclamation-circle" data-bind="
-                        visible: _deleteState() == 'error'
+                    <i class="fa fa-exclamation-circle" class="hide" data-bind="
+                        visible: _deleteState() == 'error',
+                        css: {hide: false}
                     "></i>
                 </td>
                 <td class="text-nowrap" data-bind="text: version"></td>
@@ -158,45 +159,59 @@
                             css: {'btn-primary': !build_broken(), 'btn-danger': build_broken},
                             click: clickDeploy
                         ">
-                            <span class="fa fa-exclamation-circle" data-bind="visible: build_broken"></span>
+                            <span class="fa fa-exclamation-circle hide"
+                                  data-bind="visible: build_broken, css: {hide: false}">
+                            </span>
                             {% trans "Deploy" %}
                         </a>
                     </div>
                 </td>
                 <td>
-                    <button class="btn btn-default" data-bind="
+                    <button class="btn btn-default hide" data-bind="
                         openModal: 'revert-build-modal-template',
-                        visible: version() !== $root.currentAppVersion()
+                        visible: version() !== $root.currentAppVersion(),
+                        css: {hide: false}
                     ">{% trans "Revert" %}</button>
                 </td>
                 <td>
-                    <div data-bind="visible: !editing_comment()">
-                        <b data-bind="visible: comment_user_name, text: comment_user_name"></b>
+                    <div class="hide" data-bind="visible: !editing_comment(), css: {hide: false}">
+                        <b class="hide"
+                           data-bind="visible: comment_user_name, text: comment_user_name">
+                        </b>
                         <span data-bind="text: build_comment"></span>
-                        <b data-bind="visible: !build_comment()">{% trans "(No Comment)" %}</b>
+                        <b class="hide" data-bind="visible: !build_comment(), css: {hide: false}">
+                            {% trans "(No Comment)" %}
+                        </b>
                         <a class="edit-comment-pencil" href="#"
                            data-bind="click: function () {editing_comment(true);}">
                             <i class="fa fa-pencil"></i>
                         </a>
                     </div>
-                    <div data-bind="visible: editing_comment()">
+                    <div class="hide" data-bind="visible: editing_comment(), css: {hide: false}">
                         <form class="form-inline" data-bind="submit: submit_new_comment">
                             <div class="form-group">
                             <input type="text" class="form-control" data-bind="value: new_comment"></input>
-                            <a href="#" data-bind="click: submit_new_comment,
-                                                   visible: !pending_comment_update()">
+                            <a href="#" class="hide" data-bind="
+                                click: submit_new_comment,
+                                visible: !pending_comment_update(),
+                                css: {hide: false}
+                            ">
                                 <span class="fa fa-check"></span>
                             </a>
-                            <a href="#" data-bind="click: function () {editing_comment(false);}, visible: !pending_comment_update()">
+                            <a href="#" class="hide" data-bind="
+                                click: function () {editing_comment(false);},
+                                visible: !pending_comment_update(),
+                                css: {hide: false}
+                            ">
                                 <i class="fa fa-remove"></i>
                             </a>
                             </div>
                         </form>
-                        <span data-bind="visible: pending_comment_update()">
+                        <span class="hide" data-bind="visible: pending_comment_update(), css: {hide: false}">
                             <img src="{% new_static 'hqwebapp/img/ajax-loader.gif' %}"/>
                         </span>
                     </div>
-                    <div data-bind="visible: comment_update_error()" class="alert alert-danger">
+                    <div data-bind="visible: comment_update_error(), css: {hide: false}" class="alert alert-danger hide">
                         {% trans "Error updating comment.  Please try again" %}
                     </div>
                     {% if request|toggle_enabled:"VIEW_BUILD_SOURCE" %}
@@ -207,19 +222,26 @@
                                 or
                                 <a data-bind="attr: {href: $root.url('source', id)}" class="view-source-files-link">source files</a>
                                 <br />
-                                <a href="#" data-bind="click: function() {
+                                <a href="#" class="hide" data-bind="click: function() {
                                         $root.selectingVersion(id());
-                                    }, visible: !$root.selectingVersion()">
+                                    }, visible: !$root.selectingVersion(),
+                                    css: {hide: false}
+                                ">
                                     Compare with another version
                                 </a>
-                                <a href="#"
-                                   data-bind="visible: $root.selectingVersion() === id(), click: function() {$root.selectingVersion('')}">
+                                <a href="#" class="hide" data-bind="
+                                    visible: $root.selectingVersion() === id(),
+                                    click: function() {$root.selectingVersion('')},
+                                    css: {hide: false}
+                                ">
                                     Cancel
                                 </a>
-                                <a href="#" class="btn btn-xs btn-success"
+                                <a href="#" class="btn btn-xs btn-success hide"
                                    data-bind="
                                         attr: {href: $root.url('compare', $root.selectingVersion(), id())},
-                                        visible: $root.selectingVersion() && $root.selectingVersion() != id()">
+                                        visible: $root.selectingVersion() && $root.selectingVersion() != id(),
+                                        css: {hide: false}
+                                    ">
                                     Compare
                                 </a>
                             {% endblocktrans %}


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?218464

Elements hidden with knockout's `visible` binding will be visible until the binding gets applied, which is distracting on the deploy page, which has a lot of elements using `visible` that are usually going to be hidden.

Looks like Knockout 3.3 might handle this better with synchronous components (http://www.knockmeout.net/2015/02/knockout-3-3-released.html), but for now, hide these elements with `.hide` and then have knockout remove `hide` class when it runs.

@gcapalbo 
