### PR TITLE
UCRs to kafka

### DIFF
--- a/corehq/apps/change_feed/consumer/feed.py
+++ b/corehq/apps/change_feed/consumer/feed.py
@@ -48,9 +48,10 @@ class KafkaChangeFeed(ChangeFeed):
         # in milliseconds, -1 means wait forever for changes
         timeout = -1 if forever else MIN_TIMEOUT
 
-        reset = 'smallest' if since is not None else 'largest'
+        start_from_latest = since is None
+        reset = 'smallest' if not start_from_latest else 'largest'
         consumer = self._get_consumer(timeout, auto_offset_reset=reset)
-        if since is not None:
+        if not start_from_latest:
             if isinstance(since, dict):
                 # multiple topics
                 offsets = [(topic, self._partition, offset) for topic, offset in since.items()]

--- a/corehq/apps/change_feed/consumer/feed.py
+++ b/corehq/apps/change_feed/consumer/feed.py
@@ -56,7 +56,7 @@ class KafkaChangeFeed(ChangeFeed):
                 self._processed_topic_offsets = copy(since)
             else:
                 # single topic
-                topic = self._get_single_topic_or_fail()
+                single_topic = self._get_single_topic_or_fail()
                 try:
                     offset = int(since)  # coerce sequence IDs to ints
                 except ValueError:
@@ -66,7 +66,7 @@ class KafkaChangeFeed(ChangeFeed):
                     # since kafka only keeps 7 days of data this isn't a big deal. Hopefully we will only see
                     # these once when each pillow moves over.
                     offset = 0
-                self._processed_topic_offsets = {topic: offset}
+                self._processed_topic_offsets = {single_topic: offset}
 
             offsets = [(topic, self._partition, self._processed_topic_offsets.get(topic, 0))
                        for topic in self._topics]

--- a/corehq/apps/change_feed/consumer/feed.py
+++ b/corehq/apps/change_feed/consumer/feed.py
@@ -7,7 +7,7 @@ from kafka.common import ConsumerTimeout, KafkaConfigurationError, KafkaUnavaila
 from corehq.apps.change_feed.data_sources import get_document_store
 from corehq.apps.change_feed.exceptions import UnknownDocumentStore
 import logging
-from pillowtop.checkpoints.manager import PillowCheckpointEventHandler
+from pillowtop.checkpoints.manager import PillowCheckpointEventHandler, DEFAULT_EMPTY_CHECKPOINT_SEQUENCE
 from pillowtop.feed.interface import ChangeFeed, Change, ChangeMeta
 
 
@@ -139,6 +139,9 @@ class MultiTopicCheckpointEventHandler(PillowCheckpointEventHandler):
         checkpoint_doc = self.checkpoint.get_or_create_wrapped().document
         if checkpoint_doc.sequence_format != 'json':
             checkpoint_doc.sequence_format = 'json'
+            # convert initial default to json default
+            if checkpoint_doc.sequence == DEFAULT_EMPTY_CHECKPOINT_SEQUENCE:
+                checkpoint_doc.sequence = '{}'
             checkpoint_doc.save()
 
     def fire_change_processed(self, change, context):

--- a/corehq/apps/change_feed/topics.py
+++ b/corehq/apps/change_feed/topics.py
@@ -9,6 +9,10 @@ META = 'meta'
 CASE_SQL = 'case-sql'
 FORM_SQL = 'form-sql'
 
+ALL = (
+    CASE, FORM, META, CASE_SQL, FORM_SQL
+)
+
 
 def get_topic(document_type):
     if document_type in ('CommCareCase', 'CommCareCase-Deleted'):

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -177,6 +177,10 @@ class ConfigurableReportPillowProcessor(ConfigurableReportTableManagerMixin, Pil
 
 
 class ConfigurableReportKafkaPillow(ConstructedPillow):
+    # the only reason this is a class is to avoid exposing _processor
+    # for tests to be able to call bootstrap on it.
+    # we could easily remove the class and push all the stuff in __init__ to
+    # get_kafka_ucr_pillow below if we wanted.
 
     def __init__(self, pillow_name):
         change_feed = KafkaChangeFeed(topics.ALL, group_id=pillow_name)

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -29,6 +29,7 @@ class ConfigurableReportTableManagerMixin(object):
     def __init__(self, *args, **kwargs):
         self.bootstrapped = False
         self.last_bootstrapped = datetime.utcnow()
+        super(ConfigurableReportTableManagerMixin, self).__init__(*args, **kwargs)
 
     def get_all_configs(self):
         return filter(lambda config: not config.is_deactivated, DataSourceConfiguration.all())

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -107,7 +107,7 @@ class ConfigurableReportTableManagerMixin(object):
 class ConfigurableIndicatorPillow(ConfigurableReportTableManagerMixin, PythonPillow):
 
     def __init__(self, pillow_checkpoint_id=UCR_CHECKPOINT_ID):
-        # todo: this will need to not be hard-coded if we ever split out forms and cases into their own domains
+        # todo: this will need to not be hard-coded if we ever split out forms and cases into their own databases
         couch_db = CachedCouchDB(CommCareCase.get_db().uri, readonly=False)
         checkpoint = PillowCheckpoint(pillow_checkpoint_id)
         super(ConfigurableIndicatorPillow, self).__init__(couch_db=couch_db, checkpoint=checkpoint)

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -21,9 +21,7 @@ UCR_STATIC_CHECKPOINT_ID = 'pillow-checkpoint-ucr-static'
 
 class ConfigurableReportTableManagerMixin(object):
 
-    def init(self):
-        # not a true `__init__` method since this is primarily used as a mixin
-        # must be called manually
+    def __init__(self, *args, **kwargs):
         self.bootstrapped = False
         self.last_bootstrapped = datetime.utcnow()
 
@@ -107,7 +105,6 @@ class ConfigurableIndicatorPillow(ConfigurableReportTableManagerMixin, PythonPil
         couch_db = CachedCouchDB(CommCareCase.get_db().uri, readonly=False)
         checkpoint = PillowCheckpoint(pillow_checkpoint_id)
         super(ConfigurableIndicatorPillow, self).__init__(couch_db=couch_db, checkpoint=checkpoint)
-        self.init()  # table manager init
 
     def run(self):
         self.bootstrap()

--- a/corehq/apps/userreports/tests/data/configs/sample_data_source.json
+++ b/corehq/apps/userreports/tests/data/configs/sample_data_source.json
@@ -18,7 +18,7 @@
             "column_id": "date",
             "type": "raw",
             "display_name": "date opened",
-            "datatype": "date",
+            "datatype": "datetime",
             "property_name": "opened_on"
         },
         {

--- a/corehq/apps/userreports/tests/test_multi_db.py
+++ b/corehq/apps/userreports/tests/test_multi_db.py
@@ -128,11 +128,12 @@ class UCRMultiDBTest(TestCase):
 
         # save to the other
         pillow.bootstrap(configs=[self.ds_2])
+        orig_id = sample_doc['_id']
         sample_doc['_id'] = uuid.uuid4().hex
         pillow.change_transport(sample_doc)
         self.assertEqual(1, self.ds1_adapter.get_query_object().count())
         self.assertEqual(1, self.ds2_adapter.get_query_object().count())
-        self.assertEqual(1, self.ds1_adapter.get_query_object().filter_by(doc_id='some-doc-id').count())
+        self.assertEqual(1, self.ds1_adapter.get_query_object().filter_by(doc_id=orig_id).count())
         self.assertEqual(1, self.ds2_adapter.get_query_object().filter_by(doc_id=sample_doc['_id']).count())
 
     def test_report_data_source(self):

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -19,7 +19,7 @@ from corehq.util.test_utils import softer_assert
 from corehq.toggles import KAFKA_UCRS
 from corehq.util.context_managers import drop_connected_signals
 from pillowtop.feed.interface import Change, ChangeMeta
-from testapps.test_pillowtop.utils import get_test_kafka_consumer, get_current_kafka_seq
+from testapps.test_pillowtop.utils import get_current_kafka_seq
 
 
 class ConfigurableReportTableManagerTest(SimpleTestCase):

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -18,6 +18,7 @@ from corehq.apps.userreports.sql import IndicatorSqlAdapter
 from corehq.apps.userreports.tasks import rebuild_indicators
 from corehq.apps.userreports.tests.utils import get_sample_data_source, get_sample_doc_and_indicators
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from corehq.util.decorators import temporarily_enable_toggle
 from corehq.util.test_utils import softer_assert
 from corehq.toggles import KAFKA_UCRS
 from corehq.util.context_managers import drop_connected_signals
@@ -127,6 +128,7 @@ class IndicatorPillowTest(IndicatorPillowTestBase):
         self.assertEqual(len(bad_ints), self.adapter.get_query_object().count())
 
 
+@temporarily_enable_toggle(KAFKA_UCRS, 'user-reports')
 class KafkaIndicatorPillowTest(IndicatorPillowTestBase):
     dependent_apps = [
         'couchforms', 'pillowtop', 'corehq.couchapps', 'corehq.apps.tzmigration',
@@ -139,7 +141,6 @@ class KafkaIndicatorPillowTest(IndicatorPillowTestBase):
         super(KafkaIndicatorPillowTest, self).setUp()
         self.pillow = get_kafka_ucr_pillow()
         self.pillow.bootstrap(configs=[self.config])
-        KAFKA_UCRS.set('user-reports', True, namespace='domain')
 
     @patch('corehq.apps.userreports.specs.datetime')
     def test_basic_doc_processing(self, datetime_mock):

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -6,37 +6,39 @@ from mock import patch
 from datetime import datetime, timedelta
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.userreports.exceptions import StaleRebuildError
-from corehq.apps.userreports.pillow import ConfigurableIndicatorPillow, REBUILD_CHECK_INTERVAL
+from corehq.apps.userreports.pillow import ConfigurableIndicatorPillow, REBUILD_CHECK_INTERVAL, \
+    ConfigurableReportTableManagerMixin
 from corehq.apps.userreports.sql import IndicatorSqlAdapter
 from corehq.apps.userreports.tasks import rebuild_indicators
 from corehq.apps.userreports.tests.utils import get_sample_data_source, get_sample_doc_and_indicators
 from corehq.util.test_utils import softer_assert
 
 
-class PillowBootstrapTest(TestCase):
+class ConfigurableReportTableManagerTest(SimpleTestCase):
 
     def test_needs_bootstrap_on_initialization(self):
-        pillow = ConfigurableIndicatorPillow()
-        self.assertTrue(pillow.needs_bootstrap())
+        table_manager = ConfigurableReportTableManagerMixin()
+        table_manager.init()
+        self.assertTrue(table_manager.needs_bootstrap())
 
     def test_bootstrap_sets_time(self):
         before_now = datetime.utcnow() - timedelta(microseconds=1)
-        pillow = ConfigurableIndicatorPillow()
-        pillow.bootstrap([])
+        table_manager = ConfigurableReportTableManagerMixin()
+        table_manager.bootstrap([])
         after_now = datetime.utcnow() + timedelta(microseconds=1)
-        self.assertTrue(pillow.bootstrapped)
-        self.assertTrue(before_now < pillow.last_bootstrapped)
-        self.assertTrue(after_now > pillow.last_bootstrapped)
-        self.assertFalse(pillow.needs_bootstrap())
+        self.assertTrue(table_manager.bootstrapped)
+        self.assertTrue(before_now < table_manager.last_bootstrapped)
+        self.assertTrue(after_now > table_manager.last_bootstrapped)
+        self.assertFalse(table_manager.needs_bootstrap())
 
     def test_needs_bootstrap_window(self):
         before_now = datetime.utcnow() - timedelta(microseconds=1)
-        pillow = ConfigurableIndicatorPillow()
-        pillow.bootstrap([])
-        pillow.last_bootstrapped = before_now - timedelta(seconds=REBUILD_CHECK_INTERVAL - 5)
-        self.assertFalse(pillow.needs_bootstrap())
-        pillow.last_bootstrapped = before_now - timedelta(seconds=REBUILD_CHECK_INTERVAL)
-        self.assertTrue(pillow.needs_bootstrap())
+        table_manager = ConfigurableReportTableManagerMixin()
+        table_manager.bootstrap([])
+        table_manager.last_bootstrapped = before_now - timedelta(seconds=REBUILD_CHECK_INTERVAL - 5)
+        self.assertFalse(table_manager.needs_bootstrap())
+        table_manager.last_bootstrapped = before_now - timedelta(seconds=REBUILD_CHECK_INTERVAL)
+        self.assertTrue(table_manager.needs_bootstrap())
 
 
 class IndicatorPillowTest(TestCase):

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -50,7 +50,6 @@ class ConfigurableReportTableManagerTest(SimpleTestCase):
 
 class IndicatorPillowTestBase(TestCase):
 
-    @softer_assert
     def setUp(self):
         self.config = get_sample_data_source()
         self.config.save()
@@ -77,6 +76,7 @@ class IndicatorPillowTestBase(TestCase):
 
 class IndicatorPillowTest(IndicatorPillowTestBase):
 
+    @softer_assert
     def setUp(self):
         super(IndicatorPillowTest, self).setUp()
         self.pillow = ConfigurableIndicatorPillow()

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -20,7 +20,6 @@ class ConfigurableReportTableManagerTest(SimpleTestCase):
 
     def test_needs_bootstrap_on_initialization(self):
         table_manager = ConfigurableReportTableManagerMixin()
-        table_manager.init()
         self.assertTrue(table_manager.needs_bootstrap())
 
     def test_bootstrap_sets_time(self):

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -71,7 +71,7 @@ class IndicatorPillowTestBase(TestCase):
             if isinstance(expected_indicators[k], decimal.Decimal):
                 self.assertAlmostEqual(expected_indicators[k], v)
             else:
-                self.assertEqual(expected_indicators[k], v)
+                self.assertEqual(expected_indicators[k], v, 'mismatched property: {}'.format(k))
 
 
 class IndicatorPillowTest(IndicatorPillowTestBase):

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -74,7 +74,12 @@ class IndicatorPillowTestBase(TestCase):
             if isinstance(expected_indicators[k], decimal.Decimal):
                 self.assertAlmostEqual(expected_indicators[k], v)
             else:
-                self.assertEqual(expected_indicators[k], v, 'mismatched property: {}'.format(k))
+                self.assertEqual(
+                    expected_indicators[k], v,
+                    'mismatched property: {} (expected {}, was {})'.format(
+                        k, expected_indicators[k], v
+                    )
+                )
 
 
 class IndicatorPillowTest(IndicatorPillowTestBase):

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -173,13 +173,13 @@ class KafkaIndicatorPillowTest(IndicatorPillowTestBase):
         datetime_mock.utcnow.return_value = self.fake_time_now
         sample_doc, expected_indicators = get_sample_doc_and_indicators(self.fake_time_now)
 
-        since = get_current_kafka_seq(topics.CASE_SQL)
+        since = self.pillow.get_change_feed().get_current_offsets()
 
         # save case to DB - should also publish to kafka
         case = _save_sql_case(sample_doc)
 
         # run pillow and check changes
-        self.pillow.process_changes(since={topics.CASE_SQL: since}, forever=False)
+        self.pillow.process_changes(since=since, forever=False)
         self._check_sample_doc_state(expected_indicators)
 
         CaseAccessors(domain=case.domain).db_accessor.hard_delete_cases(case.domain, [case.case_id])

--- a/corehq/apps/userreports/tests/utils.py
+++ b/corehq/apps/userreports/tests/utils.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from decimal import Decimal
 import json
 import os
+import uuid
 from corehq.apps.userreports.models import DataSourceConfiguration, ReportConfiguration
 from corehq.util.dates import iso_string_to_date
 from dimagi.utils.parsing import json_format_datetime
@@ -28,7 +29,7 @@ def get_sample_doc_and_indicators(fake_time_now=None):
         fake_time_now = datetime.utcnow()
     date_opened = datetime(2014, 6, 21)
     sample_doc = dict(
-        _id='some-doc-id',
+        _id=uuid.uuid4().hex,
         opened_on=json_format_datetime(date_opened),
         owner_id='some-user-id',
         doc_type="CommCareCase",
@@ -42,7 +43,7 @@ def get_sample_doc_and_indicators(fake_time_now=None):
         priority=4,
     )
     expected_indicators = {
-        'doc_id': 'some-doc-id',
+        'doc_id': sample_doc['_id'],
         'repeat_iteration': 0,
         'date': date_opened,
         'owner': 'some-user-id',

--- a/corehq/apps/userreports/tests/utils.py
+++ b/corehq/apps/userreports/tests/utils.py
@@ -4,6 +4,7 @@ import json
 import os
 from corehq.apps.userreports.models import DataSourceConfiguration, ReportConfiguration
 from corehq.util.dates import iso_string_to_date
+from dimagi.utils.parsing import json_format_datetime
 
 
 def get_sample_report_config():
@@ -25,10 +26,10 @@ def get_sample_data_source():
 def get_sample_doc_and_indicators(fake_time_now=None):
     if fake_time_now is None:
         fake_time_now = datetime.utcnow()
-    date_opened = "2014-06-21"
+    date_opened = datetime(2014, 6, 21)
     sample_doc = dict(
         _id='some-doc-id',
-        opened_on=date_opened,
+        opened_on=json_format_datetime(date_opened),
         owner_id='some-user-id',
         doc_type="CommCareCase",
         domain='user-reports',
@@ -42,7 +43,7 @@ def get_sample_doc_and_indicators(fake_time_now=None):
     expected_indicators = {
         'doc_id': 'some-doc-id',
         'repeat_iteration': 0,
-        'date': iso_string_to_date(date_opened),
+        'date': date_opened,
         'owner': 'some-user-id',
         'count': 1,
         'category_bug': 1, 'category_feature': 0, 'category_app': 0, 'category_schedule': 0,

--- a/corehq/apps/userreports/tests/utils.py
+++ b/corehq/apps/userreports/tests/utils.py
@@ -33,6 +33,7 @@ def get_sample_doc_and_indicators(fake_time_now=None):
         owner_id='some-user-id',
         doc_type="CommCareCase",
         domain='user-reports',
+        name='sample name',
         type='ticket',
         category='bug',
         tags='easy-win public',

--- a/corehq/ex-submodules/pillowtop/checkpoints/manager.py
+++ b/corehq/ex-submodules/pillowtop/checkpoints/manager.py
@@ -6,6 +6,8 @@ from pillowtop.models import DjangoPillowCheckpoint
 from pillowtop.pillow.interface import ChangeEventHandler
 
 
+DEFAULT_EMPTY_CHECKPOINT_SEQUENCE = '0'
+
 DocGetOrCreateResult = namedtuple('DocGetOrCreateResult', ['document', 'created'])
 
 
@@ -16,7 +18,7 @@ def get_or_create_checkpoint(checkpoint_id):
     except DjangoPillowCheckpoint.DoesNotExist:
         checkpoint = DjangoPillowCheckpoint.objects.create(
             checkpoint_id=checkpoint_id,
-            sequence='0',
+            sequence=DEFAULT_EMPTY_CHECKPOINT_SEQUENCE,
             timestamp=datetime.utcnow(),
         )
         created = True
@@ -26,7 +28,7 @@ def get_or_create_checkpoint(checkpoint_id):
 def reset_checkpoint(checkpoint_id):
     checkpoint = get_or_create_checkpoint(checkpoint_id).document
     checkpoint.old_sequence = checkpoint.sequence
-    checkpoint.sequence = '0'
+    checkpoint.sequence = DEFAULT_EMPTY_CHECKPOINT_SEQUENCE
     checkpoint.timestamp = datetime.utcnow()
     checkpoint.save()
 

--- a/corehq/ex-submodules/pillowtop/utils.py
+++ b/corehq/ex-submodules/pillowtop/utils.py
@@ -97,6 +97,9 @@ def get_pillow_config_by_name(pillow_name):
 def force_seq_int(seq):
     if seq is None or seq == '':
         return None
+    elif isinstance(seq, dict):
+        # multi-topic checkpoints don't support a single sequence id
+        return None
     elif isinstance(seq, basestring):
         return int(seq.split('-')[0])
     else:
@@ -132,11 +135,15 @@ def get_pillow_json(pillow_config):
     else:
         time_since_last = ''
         hours_since_last = None
+    try:
+        db_seq = pillow.get_change_feed().get_latest_change_id()
+    except ValueError:
+        db_seq = None
     return {
         'name': pillow_config.name,
-        'seq': force_seq_int(checkpoint.sequence),
+        'seq': force_seq_int(checkpoint.wrapped_sequence),
         'old_seq': force_seq_int(checkpoint.old_sequence) or 0,
-        'db_seq': force_seq_int(pillow.get_change_feed().get_latest_change_id()),
+        'db_seq': force_seq_int(db_seq),
         'time_since_last': time_since_last,
         'hours_since_last': hours_since_last
     }

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -537,7 +537,11 @@ class CommCareCaseSQL(DisabledDbMixin, models.Model, RedisLockableMixIn,
     def to_json(self):
         from .serializers import CommCareCaseSQLSerializer
         serializer = CommCareCaseSQLSerializer(self)
-        return serializer.data
+        ret = serializer.data
+        for key in self.case_json:
+            if key not in ret:
+                ret[key] = self.case_json[key]
+        return ret
 
     def dumps(self, pretty=False):
         indent = 4 if pretty else None

--- a/corehq/form_processor/serializers.py
+++ b/corehq/form_processor/serializers.py
@@ -43,6 +43,7 @@ class CommCareCaseSQLSerializer(serializers.ModelSerializer):
     user_id = serializers.CharField(source='modified_by')
     indices = CommCareCaseIndexSQLSerializer(many=True, read_only=True)
     actions = CaseTransactionActionSerializer(many=True, read_only=True, source='non_revoked_transactions')
+    case_json = serializers.JSONField()
 
     class Meta:
         model = CommCareCaseSQL

--- a/corehq/tests/app_test_db_dependencies.yml
+++ b/corehq/tests/app_test_db_dependencies.yml
@@ -201,6 +201,7 @@ corehq.apps.locations:
   - corehq.apps.tour
 corehq.apps.userreports:
   - casexml.apps.case
+  - casexml.apps.phone
   - casexml.apps.stock
   - corehq.couchapps
   - corehq.form_processor
@@ -217,6 +218,7 @@ corehq.apps.userreports:
   - corehq.apps.users
   - couchforms
   - corehq.apps.smsforms
+  - pillowtop
 couchforms:
   - casexml.apps.case
   - casexml.apps.phone

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -308,6 +308,13 @@ REPORT_BUILDER_MAP_REPORTS = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
+KAFKA_UCRS = StaticToggle(
+    'kafka-ucrs',
+    'Use new kafka-based UCR processing',
+    TAG_EXPERIMENTAL,
+    [NAMESPACE_DOMAIN]
+)
+
 STOCK_TRANSACTION_EXPORT = StaticToggle(
     'ledger_export',
     'Show "export transactions" link on case details page',

--- a/corehq/util/couchdb_management.py
+++ b/corehq/util/couchdb_management.py
@@ -76,7 +76,9 @@ class CouchConfig(object):
         try:
             return self.all_dbs_by_db_name[db_name]
         except KeyError:
-            raise DatabaseNotFound('no database with name {} in settings!'.format(db_name))
+            raise DatabaseNotFound('no database with name {} in settings! Options are: {}'.format(
+                db_name, ', '.join(self.all_dbs_by_db_name.keys())
+            ))
 
 
 couch_config = CouchConfig()

--- a/settings.py
+++ b/settings.py
@@ -1415,6 +1415,11 @@ PILLOWTOPS = {
             'class': 'pillowtop.pillow.interface.ConstructedPillow',
             'instance': 'corehq.pillows.case.get_sql_case_to_elasticsearch_pillow',
         },
+        {
+            'name': 'kafka-ucr-main',
+            'class': 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow',
+            'instance': 'corehq.apps.userreports.pillow.get_kafka_ucr_pillow',
+        },
     ]
 }
 

--- a/testapps/test_pillowtop/tests/data/all-pillow-meta.json
+++ b/testapps/test_pillowtop/tests/data/all-pillow-meta.json
@@ -680,5 +680,12 @@
         "include_docs": false,
         "name": "XFormPillow",
         "unique_id": "test_xforms_20150403-1728"
+    },
+    "kafka-ucr-main": {
+        "advertised_name": "kafka-ucr-main",
+        "change_feed_type": "KafkaChangeFeed",
+        "checkpoint_id": "kafka-ucr-main",
+        "full_class_name": "corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow",
+        "name": "kafka-ucr-main"
     }
 }

--- a/testapps/test_pillowtop/utils.py
+++ b/testapps/test_pillowtop/utils.py
@@ -25,6 +25,12 @@ def get_test_kafka_consumer(topic):
         )
 
 
+def get_current_kafka_seq(topic):
+    consumer = get_test_kafka_consumer(topic)
+    # have to get the seq id before the change is processed
+    return consumer.offsets()['fetch'][(topic, 0)]
+
+
 def make_a_case(domain, case_id, case_name):
     # this avoids having to deal with all the reminders code bootstrap
     with drop_connected_signals(case_post_save):


### PR DESCRIPTION
:blowfish: #tbt

This adds a second kafka-based pillow that can be used (by a toggle) to send data to UCRs instead of the main one.

Plan would be to test this out on a few test domains and make sure it's all good and then cut over and delete the old pillows.

Not quite ready yet, so just opening for tests / review.

@dimagi/scale-team fyi. 
