### PR TITLE
catching key errors for case properties

### DIFF
--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -802,7 +802,9 @@ class ConfigureNewReportBase(forms.Form):
         )
 
     def _get_property_from_column(self, col):
-        return self._properties_by_column[col].id
+        column =  self._properties_by_column.get(col)
+        if column:
+            return column.id
 
     def _column_exists(self, column_id):
         """

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -802,7 +802,7 @@ class ConfigureNewReportBase(forms.Form):
         )
 
     def _get_property_from_column(self, col):
-        column =  self._properties_by_column.get(col)
+        column = self._properties_by_column.get(col)
         if column:
             return column.id
 


### PR DESCRIPTION
@NoahCarnahan 
cc: @emord @kaapstorm 
Fixes http://manage.dimagi.com/default.asp?218852#1099524
It was 500ing when a deleted case property was set as the aggregation column for a report.
