### PR TITLE
Properly load async javascsript

### DIFF
--- a/corehq/apps/reports/templates/reports/bootstrap2/standard/base_template.html
+++ b/corehq/apps/reports/templates/reports/bootstrap2/standard/base_template.html
@@ -1,6 +1,13 @@
 {% extends "style/bootstrap2/two_column.html" %}
 {% load hq_shared_tags %}
 {% load i18n %}
+
+{% block stylesheets %}{{ block.super }}
+    <link href="{% static 'select2-3.4.5-legacy/select2.css' %}" rel="stylesheet"/>
+    <link rel="stylesheet" type="text/css" href="{% static "reports/css/daterangepicker-bs2.css" %}">
+
+{% endblock %}
+
 {% block js %}{{ block.super }}
     {% block reports-js %}
     {% include "imports/datatables.html" %}
@@ -13,6 +20,15 @@
     <script src="{% static 'reports/javascripts/datepicker.js' %}"></script>
     <script src="{% static 'reports/javascripts/reports.config.js' %}"></script>
     <script src="{% static 'reports/javascripts/reports.async.js' %}"></script>
+
+    {# Datespan Javascript Lib dependencies #}
+    <script type="text/javascript" src="{% static 'reports/javascripts/bootstrap-daterangepicker/moment.min.js' %}"></script>
+    <script type="text/javascript" src="{% static 'reports/javascripts/bootstrap-daterangepicker/daterangepicker.min.js' %}"></script>
+    <script type="text/javascript" src="{% static 'reports/javascripts/daterangepicker.js' %}"></script>
+    {# end Datespan Javascript Lib dependencies #}
+
+    <script src="{% static 'select2-3.4.5-legacy/select2.min.js' %}"></script>
+
     {% endblock %}
 {% endblock %}
 

--- a/corehq/apps/reports/templates/reports/filters/bootstrap2/base_tags_filter.html
+++ b/corehq/apps/reports/templates/reports/filters/bootstrap2/base_tags_filter.html
@@ -4,8 +4,6 @@
     <input id="{{ css_id }}" class="{{ css_class }}" name="{{ slug }}" placeholder="{{ placeholder }}" value="{{ selected }}"/>
 {% endblock %}
 {% block filter_js %}
-<link href="{% static 'select2-3.4.5-legacy/select2.css' %}" rel="stylesheet"/>
-<script src="{% static 'select2-3.4.5-legacy/select2.min.js' %}"></script>
 <script type="text/javascript">
     $('#{{ css_id }}').select2({tags:{{ tags|JSON }}, allowClear: true});
 </script>

--- a/corehq/apps/reports/templates/reports/filters/bootstrap2/date_selector.html
+++ b/corehq/apps/reports/templates/reports/filters/bootstrap2/date_selector.html
@@ -6,9 +6,6 @@
 {% endblock %}
 {% block filter_js %}
 {% ifequal slug 'date'  %}
-    <link rel="stylesheet" type="text/css" href="{% static "reports/css/daterangepicker-bs2.css" %}">
-    <script type="text/javascript" src="{% static 'reports/javascripts/bootstrap-daterangepicker/moment.min.js' %}"></script>
-    <script type="text/javascript" src="{% static 'reports/javascripts/bootstrap-daterangepicker/daterangepicker.min.js' %}"></script>
     <script type="text/javascript">
         $(function () {
             $('#filter_date_selector').daterangepicker(

--- a/corehq/apps/reports/templates/reports/filters/bootstrap2/datespan.html
+++ b/corehq/apps/reports/templates/reports/filters/bootstrap2/datespan.html
@@ -25,9 +25,6 @@
 {% block filter_js %}
 {% ifequal slug 'datespan'  %}
     <link rel="stylesheet" type="text/css" href="{% static "reports/css/daterangepicker-bs2.css" %}">
-    <script type="text/javascript" src="{% static 'reports/javascripts/bootstrap-daterangepicker/moment.min.js' %}"></script>
-    <script type="text/javascript" src="{% static 'reports/javascripts/bootstrap-daterangepicker/daterangepicker.min.js' %}"></script>
-    <script type="text/javascript" src="{% static 'reports/javascripts/daterangepicker.js' %}"></script>
     <script type="text/javascript">
         $(function () {
             var separator = '{{ separator }}';

--- a/corehq/apps/reports/templates/reports/filters/bootstrap2/filter_users.html
+++ b/corehq/apps/reports/templates/reports/filters/bootstrap2/filter_users.html
@@ -24,14 +24,11 @@
     </div>
 {% endif %}
 
-<script type="text/javascript" src="{% static 'reports/javascripts/field.filter_buttons.js' %}"></script>
 <script type="text/javascript">
-    $(function() {
+    $.getScript("{% static 'reports/javascripts/field.filter_buttons.js' %}", function() {
         linkButtonGroup("{{ css_id }}");
     });
-</script>
 
-<script type="text/javascript">
     {% for user in toggle_users %}
     $("#btn-user-filter-{{ user.type }}").on('applied-click', function(data) {
         if(document.getElementById("user-filter-{{ user.type }}").checked ) {

--- a/corehq/apps/reports/templates/reports/filters/bootstrap2/form_app_module_drilldown.html
+++ b/corehq/apps/reports/templates/reports/filters/bootstrap2/form_app_module_drilldown.html
@@ -68,9 +68,8 @@
 
 {% block filter_js %} {{ block.super }}
 {% if unknown_available or display_app_type %}
-<script type="text/javascript" src="{% static 'reports/ko/report_filter.advanced_forms_options.js' %}"></script>
 <script type="text/javascript">
-    $(function () {
+    $.getScript("{% static 'reports/ko/report_filter.advanced_forms_options.js' %}", function() {
        $('#{{ css_id }}-advanced-options').advanceFormsOptions({
            show: {{ show_advanced|JSON }},
            is_unknown_shown: {{ unknown.show|yesno:'true,false' }},

--- a/corehq/apps/reports/templates/reports/filters/bootstrap2/location_async.html
+++ b/corehq/apps/reports/templates/reports/filters/bootstrap2/location_async.html
@@ -27,23 +27,22 @@
 </div>
 <input name="location_id" type="hidden" data-bind="value: selected_locid" />
 
-<script type="text/javascript" src="{% static 'locations/ko/location_drilldown.async.js' %}"></script>
 <script type="text/javascript">
 
-var LOAD_LOCS_URL = '{{ api_root }}';
+    var LOAD_LOCS_URL = '{{ api_root }}';
 
-$(function() {
+    $.getScript("{% static 'locations/ko/location_drilldown.async.js' %}", function() {
 
-  var locs = {{ locations|JSON }};
-  var selected = '{{ loc_id }}';
-  var hierarchy = {{ hierarchy|JSON }};
+        var locs = {{ locations|JSON }};
+        var selected = '{{ loc_id }}';
+        var hierarchy = {{ hierarchy|JSON }};
 
-  var show_location_filter = {% if make_optional and not loc_id %}'n'{% else %}'y'{% endif%};
-  var model = new LocationSelectViewModel(hierarchy, undefined, undefined, undefined, undefined, show_location_filter);
-  $('#group_{{ control_slug }}').koApplyBindings(model);
-  model.load(locs, selected);
+        var show_location_filter = {% if make_optional and not loc_id %}'n'{% else %}'y'{% endif%};
+        var model = new LocationSelectViewModel(hierarchy, undefined, undefined, undefined, undefined, show_location_filter);
+        $('#group_{{ control_slug }}').koApplyBindings(model);
+        model.load(locs, selected);
 
-});
+    });
 
 </script>
 

--- a/corehq/apps/reports/templates/reports/filters/bootstrap2/multi_option.html
+++ b/corehq/apps/reports/templates/reports/filters/bootstrap2/multi_option.html
@@ -18,8 +18,6 @@
     {% endif %}
 {% endblock %}
 {% block filter_js %}
-<link href="{% static 'select2-3.4.5-legacy/select2.css' %}" rel="stylesheet"/>
-<script src="{% static 'select2-3.4.5-legacy/select2.min.js' %}"></script>
 <script type="text/javascript">
     $(function () {
         $('#{{ css_id }}').parent().koApplyBindings({

--- a/corehq/apps/reports/templates/reports/filters/bootstrap2/single_option.html
+++ b/corehq/apps/reports/templates/reports/filters/bootstrap2/single_option.html
@@ -15,8 +15,6 @@
     {% endif %}
 {% endblock %}
 {% block filter_js %}
-<link href="{% static 'select2-3.4.5-legacy/select2.css' %}" rel="stylesheet"/>
-<script src="{% static 'select2-3.4.5-legacy/select2.min.js' %}"></script>
 <script type="text/javascript">
     $(function () {
         {% if pagination.enabled %}

--- a/corehq/apps/reports/templates/reports/filters/bootstrap3/form_app_module_drilldown.html
+++ b/corehq/apps/reports/templates/reports/filters/bootstrap3/form_app_module_drilldown.html
@@ -79,9 +79,8 @@
 
 {% block filter_js %} {{ block.super }}
 {% if unknown_available or display_app_type %}
-<script type="text/javascript" src="{% new_static 'reports/ko/report_filter.advanced_forms_options.js' %}"></script>
 <script type="text/javascript">
-    $(function () {
+    $.getScript("{% new_static 'reports/ko/report_filter.advanced_forms_options.js' %}", function () {
        $('#{{ css_id }}-advanced-options').advanceFormsOptions({
            show: {{ show_advanced|JSON }},
            is_unknown_shown: {{ unknown.show|yesno:'true,false' }},

--- a/custom/care_pathways/templates/care_pathways/filters/drilldown_options.html
+++ b/custom/care_pathways/templates/care_pathways/filters/drilldown_options.html
@@ -39,9 +39,8 @@
 
 {% block filter_js %}
 
-<script type="text/javascript" src="{% static 'care_pathways/ko/report_filter.drilldown_options.js' %}"></script>
 <script type="text/javascript">
-    $(function () {
+    $.getScript("{% static 'care_pathways/ko/report_filter.drilldown_options.js' %}", function () {
        $('#{{ css_id }}').drilldownOptionFilter({
            selected: {{ selected|JSON }},
            drilldown_map: {{ option_map|JSON }},

--- a/custom/care_pathways/templates/care_pathways/filters/drilldown_options.html
+++ b/custom/care_pathways/templates/care_pathways/filters/drilldown_options.html
@@ -38,8 +38,6 @@
 </div>
 
 {% block filter_js %}
-<link href="{% static 'select2-3.4.5-legacy/select2.css' %}" rel="stylesheet"/>
-<script src="{% static 'select2-3.4.5-legacy/select2.min.js' %}"></script>
 
 <script type="text/javascript" src="{% static 'care_pathways/ko/report_filter.drilldown_options.js' %}"></script>
 <script type="text/javascript">

--- a/custom/common/templates/common/drilldown_options.html
+++ b/custom/common/templates/common/drilldown_options.html
@@ -33,8 +33,8 @@
 {% block filter_js %}
 <script type="text/javascript">
     $.when(
-        "{% static 'reports/ko/report_filter.drilldown_options.js' %}",
-        "{% static 'common/ko/report_filter.drilldown_options.js' %}",
+        $.getScript("{% static 'reports/ko/report_filter.drilldown_options.js' %}"),
+        $.getScript("{% static 'common/ko/report_filter.drilldown_options.js' %}")
     ).done(function () {
        $('#{{ css_id }}').drilldownOptionFilter({
            drilldown_map: {{ option_map|JSON }},

--- a/custom/common/templates/common/drilldown_options.html
+++ b/custom/common/templates/common/drilldown_options.html
@@ -31,9 +31,6 @@
 </div>
 
 {% block filter_js %}
-<link href="{% static 'select2-3.4.5-legacy/select2.css' %}" rel="stylesheet"/>
-<script src="{% static 'select2-3.4.5-legacy/select2.min.js' %}"></script>
-
 <script type="text/javascript" src="{% static 'reports/ko/report_filter.drilldown_options.js' %}"></script>
 <script type="text/javascript" src="{% static 'common/ko/report_filter.drilldown_options.js' %}"></script>
 <script type="text/javascript">

--- a/custom/common/templates/common/drilldown_options.html
+++ b/custom/common/templates/common/drilldown_options.html
@@ -31,10 +31,11 @@
 </div>
 
 {% block filter_js %}
-<script type="text/javascript" src="{% static 'reports/ko/report_filter.drilldown_options.js' %}"></script>
-<script type="text/javascript" src="{% static 'common/ko/report_filter.drilldown_options.js' %}"></script>
 <script type="text/javascript">
-    $(function () {
+    $.when(
+        "{% static 'reports/ko/report_filter.drilldown_options.js' %}",
+        "{% static 'common/ko/report_filter.drilldown_options.js' %}",
+    ).done(function () {
        $('#{{ css_id }}').drilldownOptionFilter({
            drilldown_map: {{ option_map|JSON }},
            controls: {{ controls|JSON }},

--- a/custom/ewsghana/templates/ewsghana/datespan.html
+++ b/custom/ewsghana/templates/ewsghana/datespan.html
@@ -45,7 +45,6 @@
 
 {% endblock %}
 {% block filter_js %}
-<script type="text/javascript" src="{% static 'reports/javascripts/bootstrap-daterangepicker/moment.min.js' %}"></script>
 <script type="text/javascript">
     $(function () {
         ko.bindingHandlers.select2 = {

--- a/custom/ilsgateway/templates/ilsgateway/datespan.html
+++ b/custom/ilsgateway/templates/ilsgateway/datespan.html
@@ -42,8 +42,6 @@
 
 {% endblock %}
 {% block filter_js %}
-<link href="{% static 'select2-3.4.5-legacy/select2.css' %}" rel="stylesheet"/>
-<script src="{% static 'select2-3.4.5-legacy/select2.min.js' %}"></script>
 <script type="text/javascript">
     $(function () {
         ko.bindingHandlers.select2 = {

--- a/custom/intrahealth/templates/intrahealth/location_filter.html
+++ b/custom/intrahealth/templates/intrahealth/location_filter.html
@@ -16,8 +16,8 @@
     var REQUIRED = {{ required }}
 
     $.when(
-        "{% static 'locations/ko/location_drilldown.async.js' %}",
-        "{% static 'intrahealth/js/intrahealth_loc_drilldown.async.js' %}",
+        $.getScript("{% static 'locations/ko/location_drilldown.async.js' %}"),
+        $.getScript("{% static 'intrahealth/js/intrahealth_loc_drilldown.async.js' %}")
     ).done(function () {
         var locs = {{ locations|safe }};
         var selected = '{{ loc_id }}';

--- a/custom/intrahealth/templates/intrahealth/location_filter.html
+++ b/custom/intrahealth/templates/intrahealth/location_filter.html
@@ -10,24 +10,23 @@
 </div>
 <input name="location_id" type="hidden" data-bind="value: selected_locid" />
 
-<script type="text/javascript" src="{% static 'locations/ko/location_drilldown.async.js' %}"></script>
-<script type="text/javascript" src="{% static 'intrahealth/js/intrahealth_loc_drilldown.async.js' %}"></script>
 <script type="text/javascript">
 
-var LOAD_LOCS_URL = '{{ api_root }}';
-var REQUIRED = {{ required }}
+    var LOAD_LOCS_URL = '{{ api_root }}';
+    var REQUIRED = {{ required }}
 
-$(function() {
+    $.when(
+        "{% static 'locations/ko/location_drilldown.async.js' %}",
+        "{% static 'intrahealth/js/intrahealth_loc_drilldown.async.js' %}",
+    ).done(function () {
+        var locs = {{ locations|safe }};
+        var selected = '{{ loc_id }}';
+        var hierarchy = {{ hierarchy|JSON }};
 
-  var locs = {{ locations|safe }};
-  var selected = '{{ loc_id }}';
-  var hierarchy = {{ hierarchy|JSON }};
-
-  var model = new LocationSelectViewModel(hierarchy, false, null, false, IntrahealthLocModel);
-  $('#group_{{ control_slug }}').koApplyBindings(model);
-  model.load(locs, selected);
-
-});
+        var model = new LocationSelectViewModel(hierarchy, false, null, false, IntrahealthLocModel);
+        $('#group_{{ control_slug }}').koApplyBindings(model);
+        model.load(locs, selected);
+    });
 
 </script>
 

--- a/custom/up_nrhm/templates/up_nrhm/datespan.html
+++ b/custom/up_nrhm/templates/up_nrhm/datespan.html
@@ -3,10 +3,6 @@
 {% load i18n %}
 {% block filter_js %}
 {% ifequal slug 'datespan'  %}
-    <link rel="stylesheet" type="text/css" href="{% static "reports/css/daterangepicker-bs2.css" %}">
-    <script type="text/javascript" src="{% static 'reports/javascripts/bootstrap-daterangepicker/moment.min.js' %}"></script>
-    <script type="text/javascript" src="{% static 'reports/javascripts/bootstrap-daterangepicker/daterangepicker.min.js' %}"></script>
-    <script type="text/javascript" src="{% static 'reports/javascripts/daterangepicker.js' %}"></script>
     <script type="text/javascript">
         $(function () {
             var separator = '{{ separator }}';

--- a/custom/world_vision/templates/world_vision/location_filter.html
+++ b/custom/world_vision/templates/world_vision/location_filter.html
@@ -23,9 +23,9 @@
 {% endblock %}
 
 {% block filter_js %}
-<script type="text/javascript" src="{% static 'world_vision/ko/report_filter.drilldown_options.js' %}"></script>
+<script type="text/javascript" src=></script>
 <script type="text/javascript">
-    $(function () {
+    $.getScript("{% static 'world_vision/ko/report_filter.drilldown_options.js' %}", function() {
        $('#{{ css_id }}').drilldownOptionFilter({
            drilldown_map: {{ option_map|JSON }},
            controls: {{ controls|JSON }},

--- a/custom/world_vision/templates/world_vision/location_filter.html
+++ b/custom/world_vision/templates/world_vision/location_filter.html
@@ -23,9 +23,6 @@
 {% endblock %}
 
 {% block filter_js %}
-<link href="{% static 'select2-3.4.5-legacy/select2.css' %}" rel="stylesheet"/>
-<script src="{% static 'select2-3.4.5-legacy/select2.min.js' %}"></script>
-
 <script type="text/javascript" src="{% static 'world_vision/ko/report_filter.drilldown_options.js' %}"></script>
 <script type="text/javascript">
     $(function () {


### PR DESCRIPTION
@biyeun this should handle any issues with async javascript loading. i've tested this all locally accept for the custom reports. @kkrampa / @lwyszomi could you just load these 3 reports and ensure there are no javascript errors? :tropical_fish: with `w=1`
- care_pathways: Table Card Report
- intrahealth: Tableau De Bord
- world_vision: Child Report

fyi: @dimagi/team-commcare-hq if you ever need to load javascript asynchronously, use `getScript`. pageload event does _not_ work when you add a script tag after the page has loaded (which is what report filters do). this bug was uncovered through using the CDN to grab static files
