### PR TITLE
Index domain and date together caseactiondata

### DIFF
--- a/corehq/apps/sofabed/models.py
+++ b/corehq/apps/sofabed/models.py
@@ -310,6 +310,7 @@ class CaseActionData(models.Model):
     class Meta:
         app_label = 'sofabed'
         unique_together = ("case", "index")
+        index_together = [['domain', 'date']]
 
 
 class CaseIndexData(models.Model):


### PR DESCRIPTION
@snopoke was looking into the spikes we see on datadog and finding, as you might suspect, that CallCenterIndicators tend wreck our database. Most of the time datadog alerts for a spike, new relic points to postgres being the issue. I found from the logs that it's almost definitely this query: https://github.com/dimagi/commcare-hq/blob/index-together-domain-date-case-action/corehq/apps/callcenter/indicator_sets.py#L329 and it's almost always `hsph-betterbirth`.

The exact query looks like this:

```
SELECT ( case_type )                                      AS "type", 
       "sofabed_caseactiondata"."case_owner", 
       Count(DISTINCT "sofabed_caseactiondata"."case_id") AS "count" 
FROM   "sofabed_caseactiondata" 
WHERE  ( NOT ( "sofabed_caseactiondata"."case_type" = 'flw' 
               AND "sofabed_caseactiondata"."case_type" IS NOT NULL ) 
         AND "sofabed_caseactiondata"."domain" = 'hsph-betterbirth' 
         AND "sofabed_caseactiondata"."case_owner" IN 
             (*) 
         AND "sofabed_caseactiondata"."date" < '2016-03-01 00:00:00' 
         AND "sofabed_caseactiondata"."date" >= '2016-01-31 00:00:00' ) 
GROUP  BY "sofabed_caseactiondata"."case_owner", 
          ( case_type ) 
```

i ran explain, but it didn't provide that much insight except for the fact that we just have a bunch solitary indexes on the column. how do you feel about indexing both `domain` and `date`? i didn't setup the run currently index thing yet, hence the label
