### PR TITLE
Finished rebuilding

### DIFF
--- a/corehq/apps/domain/dbaccessors.py
+++ b/corehq/apps/domain/dbaccessors.py
@@ -35,7 +35,7 @@ def get_doc_ids_in_domain_by_type(domain, doc_type, database=None):
 
 
 def iterate_doc_ids_in_domain_by_type(domain, doc_type, chunk_size=10000,
-                                      database=None, startkey_docid=None, skip=0):
+                                      database=None, startkey_docid=None):
 
     if not database:
         database = get_db_by_doc_type(doc_type)
@@ -49,7 +49,7 @@ def iterate_doc_ids_in_domain_by_type(domain, doc_type, chunk_size=10000,
     if startkey_docid:
         view_kwargs.update({
             'startkey_docid': startkey_docid,
-            'skip': skip
+            'skip': 1
         })
     for doc in paginate_view(
             database,

--- a/corehq/apps/domain/dbaccessors.py
+++ b/corehq/apps/domain/dbaccessors.py
@@ -34,7 +34,8 @@ def get_doc_ids_in_domain_by_type(domain, doc_type, database=None):
     )]
 
 
-def iterate_doc_ids_in_domain_by_type(domain, doc_type, chunk_size=10000, database=None):
+def iterate_doc_ids_in_domain_by_type(domain, doc_type, chunk_size=10000,
+                                      database=None, startkey_docid=None, skip=0):
 
     if not database:
         database = get_db_by_doc_type(doc_type)
@@ -45,6 +46,11 @@ def iterate_doc_ids_in_domain_by_type(domain, doc_type, chunk_size=10000, databa
         'endkey': [domain, doc_type, {}],
         'include_docs': False
     }
+    if startkey_docid:
+        view_kwargs.update({
+            'startkey_docid': startkey_docid,
+            'skip': skip
+        })
     for doc in paginate_view(
             database,
             'by_domain_doc_type_date/view',

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -52,16 +52,6 @@ def _build_indicators(indicator_config_id, relevant_ids):
 
     if not is_static(indicator_config_id):
         redis_client.delete(redis_key)
-        config.meta.build.finished = True
-        try:
-            config.save()
-        except ResourceConflict:
-            current_config = DataSourceConfiguration.get(config._id)
-            # check that a new build has not yet started
-            if config.meta.build.initiated == current_config.meta.build.initiated:
-                current_config.meta.build.finished = True
-                current_config.save()
-
 
 @task(queue='ucr_queue', ignore_result=True, acks_late=True)
 def rebuild_indicators(indicator_config_id):
@@ -95,6 +85,17 @@ def rebuild_indicators(indicator_config_id):
     if relevant_ids_chunk:
         redis_client.sadd(redis_key, *relevant_ids_chunk)
         _build_indicators(indicator_config_id, relevant_ids_chunk)
+
+    if not is_static(indicator_config_id):
+        config.meta.build.finished = True
+        try:
+            config.save()
+        except ResourceConflict:
+            current_config = DataSourceConfiguration.get(config._id)
+            # check that a new build has not yet started
+            if config.meta.build.initiated == current_config.meta.build.initiated:
+                current_config.meta.build.finished = True
+                current_config.save()
 
 
 @task(queue='ucr_queue', ignore_result=True, acks_late=True)

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -91,14 +91,12 @@ def _iteratively_build_table(config, last_id=None):
     indicator_config_id = config._id
 
     relevant_ids = []
-    skip_num = 1 if last_id else 0
     for relevant_id in iterate_doc_ids_in_domain_by_type(
             config.domain,
             config.referenced_doc_type,
             chunk_size=CHUNK_SIZE,
             database=couchdb,
-            startkey_docid=last_id,
-            skip=skip_num):
+            startkey_docid=last_id):
         relevant_ids.append(relevant_id)
         if len(relevant_ids) >= CHUNK_SIZE:
             redis_client.sadd(redis_key, *relevant_ids)


### PR DESCRIPTION
@benrudolph @nickpell @NoahCarnahan 
I did a little refactor of the indicator rebuilding and resuming to hopefully fix the issues some of our larger reports are having. This is mostly to address http://manage.dimagi.com/default.asp?218516#1100231 which was caused by builds being marked as finished after the first chunk so when killed, they never resumed, but should provide a resume framework that will support larger tables (though may require multiple resumes)

Theoretically if a task is killed with an empty redis queue, it will not be able to resume but that seems unlikely as the build stage (where redis has already been populated) appears to be where the memory issues are.
