### PR TITLE
move touchforms to django3-staging

### DIFF
--- a/fab/inventory/staging
+++ b/fab/inventory/staging
@@ -27,7 +27,7 @@ hqdb0-staging.internal.commcarehq.org
 hqdb0-staging.internal.commcarehq.org
 
 [touchforms]
-hqdjango2-staging.internal.commcarehq.org
+hqdjango3-staging.internal.commcarehq.org
 
 [redis]
 hqdb0-staging.internal.commcarehq.org


### PR DESCRIPTION
Ben Rudolph [10:55 PM] 
i’ve been looking into the formtranslate weirdness on staging. it’s really hard to figure out what is causing this, but from running `strace` it seems like all the formtranslate processes are deadlocked. though that doesn’t make too much sense to me
[10:59] 
part of me doesn’t think it has to do with formtranslate at all. it seems that only hqdjango2 gets these stale processes
[10:59] 
which we run `zookeeper`, `kafka`, `touchforms`, `formplayer` and `elasticsearch` on
[10:59] 
all of which are also java programs

@dannyroberts maybe this will help?
