### PR TITLE
Show errors when saving a report fails

### DIFF
--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -604,7 +604,8 @@ class AddSavedReportConfigView(View):
         self.domain = domain
 
         if not self.saved_report_config_form.is_valid():
-            return HttpResponseBadRequest()
+            errors = self.saved_report_config_form.errors.get('__all__', [])
+            return HttpResponseBadRequest(', '.join(errors))
 
         update_config_data = copy(self.saved_report_config_form.cleaned_data)
         del update_config_data['_id']


### PR DESCRIPTION
If we know what the errors are, tell the user.

[FB 216174](http://manage.dimagi.com/default.asp?216174) 

![duplicate_report_name](https://cloud.githubusercontent.com/assets/708421/13501292/c14232f6-e16e-11e5-957e-3bd0c684fdfd.png)

@calellowitz @benrudolph cc @dannyroberts 
