### PR TITLE
Bitly once

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases.js
@@ -9,62 +9,80 @@ function SavedApp(app_data, releasesMain) {
     if(!self.generating_url){
         self.generating_url = ko.observable(false);
     }
+    self.include_media.subscribe(function() {
+        // If we've generated an app code ensure that we update it when we toggle media
+        if (self.app_code()) {
+            self.get_app_code();
+        }
+    });
+    self.app_code = ko.observable(null);
+    self.failed_url_generation = ko.observable(false);
+    self.base_url = function() {
+        return '/a/' + self.domain() + '/apps/odk/' + self.id() + '/';
+    };
 
-    self.generate_short_url = function(url_type){
+    self.should_generate_url = function(url_type) {
+        var types = _.values(SavedApp.URL_TYPES);
+        return (types.indexOf(url_type) !== 1 &&
+            !ko.utils.unwrapObservable(self[url_type]));
+    };
+
+    self.generate_short_url = function(url_type) {
         //accepted_url_types = ['short_odk_url', 'short_odk_media_url', 'short_url']
-        url_type = url_type || 'short_odk_url';
-        var base_url = '/a/' + self.domain() + '/apps/odk/' + self.id() + '/',
-            should_generate_url = ((url_type === 'short_odk_url') && self.short_odk_url && !self.short_odk_url()) ||
-                                  ((url_type === 'short_odk_media_url') && self.short_odk_media_url && !self.short_odk_media_url()) ||
-                                  ((url_type === 'short_url') && self.short_url && !self.short_url());
+        url_type = url_type || SavedApp.URL_TYPES.SHORT_ODK_URL;
+        var base_url = self.base_url(),
+            should_generate_url = self.should_generate_url();
         
         if (should_generate_url && !self.generating_url()){
             self.generating_url(true);
             $.ajax({
                 url: base_url + url_type + '/'
             }).done(function(data){
+                var bitly_code = self.parse_bitly_url(data);
                 self[url_type](data);
+
+                self.failed_url_generation(!bitly_code);
+                self.app_code(bitly_code);
+
+            }).fail(function() {
+                self.app_code(null);
+                self.failed_url_generation(true);
             }).always(function(){
                 self.generating_url(false);
             });
         }
     };
 
-    self.get_short_odk_url = ko.computed(function() {
+    self.get_short_odk_url = function() {
+        var url_type;
         if (self.include_media()) {
-           if (self.short_odk_media_url) {
-                if (!self.short_odk_media_url()){
-                    self.generate_short_url('short_odk_media_url');
-                }
-               return self.short_odk_media_url();
-           }
+            url_type = SavedApp.URL_TYPES.SHORT_ODK_MEDIA_URL;
         } else {
-            if (self.short_odk_url) {
-                // short_odk_url is generated on first click. 
-                // not having `self.generate_short_url()` here prevents the 
-                // link from being automatically generated when a build is created.
-                return self.short_odk_url();
-            }
+            url_type = SavedApp.URL_TYPES.SHORT_ODK_URL;
         }
-        return false;
-    });
+        if (!ko.utils.unwrapObservable(self[url_type])) {
+            return self.generate_short_url(url_type);
+        } else {
+            return ko.utils.unwrapObservable(self[url_type]);
+        }
+    };
 
-    self.get_app_code = ko.computed(function() {
+    self.parse_bitly_url = function(url) {
+        // Matches "foo" in "http://bit.ly/foo" and "https://is.gd/X/foo/" ("*" is not greedy)
+        var re = /^http.*\/(\w+)\/?/;
+        var match = url.match(re);
+        if (match) {
+            return match[1];
+        }
+        return null;
+    };
+
+    self.get_app_code = function() {
         var short_odk_url = self.get_short_odk_url();
         if (short_odk_url) {
-            // Matches "foo" in "http://bit.ly/foo" and "https://is.gd/X/foo/" ("*" is not greedy)
-            var re = /^http.*\/(\w+)\/?/;
-            var match = short_odk_url.match(re);
-            if (match) {
-                return match[1];
-            }
+            self.app_code(self.parse_bitly_url(short_odk_url));
         }
-        return false;
-    });
-
-    self.get_short_odk_url_phonetic = ko.computed(function () {
-        return app_manager_utils.bitly_nato_phonetic(self.get_short_odk_url());
-    });
+    };
 
     self.allow_media_install = ko.computed(function(){
         return self.doc_type() !== "RemoteApp";  // remote apps don't support multimedia
@@ -125,7 +143,6 @@ function SavedApp(app_data, releasesMain) {
     };
 
     self.clickDeploy = function () {
-        self.generate_short_url('short_odk_url');
         ga_track_event('App Manager', 'Deploy Button', self.id());
         analytics.workflow('Clicked Deploy');
         $.post(releasesMain.options.urls.hubspot_click_deploy);
@@ -350,3 +367,9 @@ function ReleasesMain(o) {
         });
     };
 }
+
+SavedApp.URL_TYPES = {
+    SHORT_ODK_URL: 'short_odk_url',
+    SHORT_ODK_MEDIA_URL: 'short_odk_media_url',
+    SHORT_URL: 'short_url'
+};

--- a/corehq/apps/app_manager/static/app_manager/spec/releases_spec.js
+++ b/corehq/apps/app_manager/static/app_manager/spec/releases_spec.js
@@ -1,20 +1,35 @@
 /* global $, sinon */
 
 describe('App Releases', function() {
+    function get_saved_apps(num, extraProps) {
+        extraProps = extraProps || {};
+        return _.map(_.range(num), function (version) {
+            return _.extend({
+                id: version,
+                version: version,
+                doc_type: 'Application',
+                build_comment: '',
+                build_broken: false,
+                is_released: false,
+                domain: 'test-domain'
+            }, extraProps);
+        });
+    }
+    var urls = {
+            download_zip: 'download_zip_url ___',
+            download_multimedia: 'download_multimedia_url ___',
+            fetch: 'fetch_url',
+            odk_media: 'odk_media',
+            odk: 'odk'
+        },
+        options = {
+            urls: urls,
+            currentAppVersion: -1,
+            recipient_contacts: [],
+            download_modal_id: '#download-zip-modal-test'
+        };
     describe('SavedApp', function() {
         var releases = null,
-            urls = {
-                download_zip: 'download_zip_url ___',
-                download_multimedia: 'download_multimedia_url ___',
-                fetch: 'fetch_url',
-                odk_media: 'odk_media'
-            },
-            options = {
-                urls: urls,
-                currentAppVersion: -1,
-                recipient_contacts: [],
-                download_modal_id: '#download-zip-modal-test'
-            },
             ajax_stub;
 
         beforeEach(function() {
@@ -26,19 +41,6 @@ describe('App Releases', function() {
         afterEach(function() {
             ajax_stub.restore();
         });
-
-        function get_saved_apps(num) {
-            return _.map(_.range(num), function (version) {
-                return {
-                    id: version,
-                    version: version,
-                    doc_type: 'Application',
-                    build_comment: '',
-                    build_broken: false,
-                    is_released: false
-                };
-            });
-        }
 
         it('should only make one request when downloading zip', function() {
             app = releases.savedApps()[0];
@@ -73,6 +75,96 @@ describe('App Releases', function() {
                 assert.equal($.ajax.callCount, 2);
                 assert.equal(ajax_stub.firstCall.args[0].url, releases.url('download_zip', app.id()));
             });
+        });
+
+    });
+
+    describe('app_code', function() {
+        var savedApp,
+            releases;
+        beforeEach(function() {
+            releases = new ReleasesMain(options);
+
+            this.server = sinon.fakeServer.create();
+            this.server.respondWith(
+                "GET",
+                new RegExp(SavedApp.URL_TYPES.SHORT_ODK_MEDIA_URL),
+                [200, { "Content-type": "text/html" }, 'http://bit.ly/media/']
+            );
+            this.server.respondWith(
+                "GET",
+                new RegExp(SavedApp.URL_TYPES.SHORT_ODK_URL),
+                [200, { "Content-type": "text/html" }, 'http://bit.ly/nomedia/']
+            );
+        });
+
+        it('should correctly load media url', function() {
+            var props = { include_media: true };
+            props[SavedApp.URL_TYPES.SHORT_ODK_MEDIA_URL] = null;
+            releases.addSavedApps(get_saved_apps(1, props));
+
+            savedApp = releases.savedApps()[0];
+
+            savedApp.get_app_code();
+
+            assert.equal(savedApp.generating_url(), true);
+
+            this.server.respond();
+
+            assert.equal(savedApp.generating_url(), false);
+            assert.equal(savedApp.app_code(), 'media');
+        });
+
+        it('should correctly load non media url', function() {
+            var props = { include_media: false };
+            props[SavedApp.URL_TYPES.SHORT_ODK_URL] = null;
+            releases.addSavedApps(get_saved_apps(1, props));
+
+            savedApp = releases.savedApps()[0];
+
+            savedApp.get_app_code();
+
+            assert.equal(savedApp.generating_url(), true);
+
+            this.server.respond();
+
+            assert.equal(savedApp.generating_url(), false);
+            assert.equal(savedApp.app_code(), 'nomedia');
+        });
+
+        it('should correctly toggle between media and non media', function() {
+            var props = { include_media: false };
+
+            props[SavedApp.URL_TYPES.SHORT_ODK_URL] = null;
+            props[SavedApp.URL_TYPES.SHORT_ODK_MEDIA_URL] = null;
+            releases.addSavedApps(get_saved_apps(1, props));
+            savedApp = releases.savedApps()[0];
+
+            savedApp.get_app_code();
+
+            assert.equal(savedApp.generating_url(), true);
+
+            this.server.respond();
+
+            assert.equal(savedApp.generating_url(), false);
+            assert.equal(savedApp.app_code(), 'nomedia');
+
+            // Toggle to include media
+            savedApp.include_media(true);
+            assert.equal(savedApp.generating_url(), true);
+            this.server.respond();
+
+            assert.equal(savedApp.generating_url(), false);
+            assert.equal(savedApp.app_code(), 'media');
+
+            // Toggle and ensure no more ajax calls
+            savedApp.include_media(false);
+            assert.equal(savedApp.generating_url(), false);
+            assert.equal(savedApp.app_code(), 'nomedia');
+
+            savedApp.include_media(true);
+            assert.equal(savedApp.generating_url(), false);
+            assert.equal(savedApp.app_code(), 'media');
         });
     });
 });

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases_deploy_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases_deploy_modal.html
@@ -59,16 +59,9 @@
                                                 </div>
                                                 {% endif %}
                                                 <p>
-                                                    <span data-bind="visible: get_app_code()">
-                                                        {% blocktrans %}
-                                                        Open the app on your Android and use one of the following installation methods:
-                                                        {% endblocktrans %}
-                                                    </span>
-                                                    <span data-bind="visible: !get_app_code() && !generating_url()">
-                                                        {% blocktrans %}
-                                                        Open the app on your Android and use the following installation method:
-                                                        {% endblocktrans %}
-                                                    </span>
+                                                    {% blocktrans %}
+                                                    Open the app on your Android and use one of the following installation methods:
+                                                    {% endblocktrans %}
                                                 </p>
                                                 <p>
                                                     <a href="#" data-bind="
@@ -79,13 +72,20 @@
                                                     </a>
                                                 </p>
                                                 <p>
-                                                    <span data-bind="visible: get_app_code()">
-                                                        {% trans "Or Enter App Code:" %}
-                                                        <code class="bitly" data-bind="text: get_app_code()"></code>
+                                                    <button class="btn btn-xs btn-success" data-bind="
+                                                        click: get_app_code,
+                                                        visible: !app_code()
+                                                        ">
+                                                        {% trans "Enter App Code" %}
+                                                    </button>
+                                                    <span data-bind="visible: app_code">
+                                                        <code class="bitly" data-bind="text: app_code"></code>
                                                     </span>
                                                     <img data-bind="visible: generating_url()"
                                                         src="{% static 'hqwebapp/img/ajax-loader.gif' %}"/>
-                                                    <span class="text-warning" data-bind="visible: !get_app_code() && !generating_url()">
+                                                    <span class="text-warning" data-bind="
+                                                        visible: failed_url_generation() && !generating_url()
+                                                        ">
                                                         {% blocktrans %}
                                                         (No app code available. If you would like to use an app code instead
                                                         of scanning the application barcode, try making another version.)

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases_deploy_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases_deploy_modal.html
@@ -72,13 +72,14 @@
                                                     </a>
                                                 </p>
                                                 <p>
-                                                    <button class="btn btn-xs btn-success" data-bind="
+                                                    <a href="#" data-bind="
                                                         click: get_app_code,
-                                                        visible: !app_code()
+                                                        visible: !app_code() && !failed_url_generation() && !generating_url()
                                                         ">
                                                         {% trans "Enter App Code" %}
-                                                    </button>
+                                                    </a>
                                                     <span data-bind="visible: app_code">
+                                                        {% trans "Enter app code on installation screen: " %}
                                                         <code class="bitly" data-bind="text: app_code"></code>
                                                     </span>
                                                     <img data-bind="visible: generating_url()"


### PR DESCRIPTION
@proteusvacuum i've reworked the bitly generation to only get the modal on click. some of the logic confused me a bit, so i wanted your keen eye to make sure i didn't do anything crazy (and i think you were last to touch). http://manage.dimagi.com/default.asp?219698

@dimagi/product this is what it now looks like:

On initial load:
![screen shot 2016-03-03 at 6 24 43 pm](https://cloud.githubusercontent.com/assets/918514/13513295/ee30ae7e-e16d-11e5-949b-a0daa686d827.png)

On failure to get app code:
![screen shot 2016-03-03 at 6 24 10 pm](https://cloud.githubusercontent.com/assets/918514/13513304/fcd68a34-e16d-11e5-82e1-b5cd281bb9b9.png)

On success of getting app code:
![screen shot 2016-03-03 at 6 24 48 pm](https://cloud.githubusercontent.com/assets/918514/13513312/05fa2f80-e16e-11e5-92bd-31fec65eb9ec.png)
