### PR TITLE
More textareas

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list_filtering.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list_filtering.html
@@ -32,9 +32,9 @@
                     ></span>
                 </label>
                 <div class="col-sm-4">
-                    <input type="text" placeholder="Filter expression" class="ui-autocomplete-input form-control"
+                    <textarea type="text" placeholder="Filter expression" class="ui-autocomplete-input form-control"
                            data-bind="value: filterText"
-                    >
+                    ></textarea>
                 </div>
                 <div class="col-sm-1">
                     <button class="btn btn-danger" data-bind="click: function(data){showing(false);}">

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list_filtering.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list_filtering.html
@@ -32,7 +32,7 @@
                     ></span>
                 </label>
                 <div class="col-sm-4">
-                    <textarea type="text" placeholder="Filter expression" class="ui-autocomplete-input form-control"
+                    <textarea placeholder="Filter expression" class="ui-autocomplete-input form-control"
                            data-bind="value: filterText"
                     ></textarea>
                 </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/form_filter/value-or-none-ui.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/form_filter/value-or-none-ui.html
@@ -44,12 +44,12 @@
         <div data-bind="visible: allowed()">
             <div class="row">
                 <div class="col-sm-9">
-                    <input type="text" class="form-control" data-bind="
+                    <textarea type="text" class="form-control" data-bind="
                             xpathValidator: {text: inputValue, allowCaseHashtags: true, errorHtml: messages.invalidXpath},
                             hasfocus: hasFocus,
                             css: inputCss,
                             attr: inputAttr
-                    "/>
+                    "></textarea>
                 </div>
                 <div class="col-sm-3">
                     <a href="#" class="btn btn-danger" data-bind="exitInput: $data">

--- a/corehq/apps/app_manager/templates/app_manager/partials/form_filter/value-or-none-ui.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/form_filter/value-or-none-ui.html
@@ -44,7 +44,7 @@
         <div data-bind="visible: allowed()">
             <div class="row">
                 <div class="col-sm-9">
-                    <textarea type="text" class="form-control" data-bind="
+                    <textarea class="form-control" data-bind="
                             xpathValidator: {text: inputValue, allowCaseHashtags: true, errorHtml: messages.invalidXpath},
                             hasfocus: hasFocus,
                             css: inputCss,

--- a/corehq/apps/app_manager/templates/app_manager/partials/module_filter.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/module_filter.html
@@ -6,7 +6,7 @@
         {% trans "Module Filter" %}
     </label>
     <div class="col-sm-4 commcare-feature" data-since-version="2.20">
-        <input type="text"
+        <textarea type="text"
             class="form-control"
             placeholder="{% trans "XPath expression" %}"
             name="module_filter"
@@ -14,7 +14,7 @@
                 text: {% if ko_value %}{{ ko_value }}{% else %}xpath{% endif %},
                 allowCaseHashtags: false,
                 errorHtml: $('#module-filter-xpath-error-html').html()
-            }"/>
+            }"></textarea>
         <script type="text/html" id="module-filter-xpath-error-html">
             There is something wrong with the logic in the Module Filter.
             Check to make sure your parentheses match.

--- a/corehq/apps/app_manager/templates/app_manager/partials/module_filter.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/module_filter.html
@@ -6,7 +6,7 @@
         {% trans "Module Filter" %}
     </label>
     <div class="col-sm-4 commcare-feature" data-since-version="2.20">
-        <textarea type="text"
+        <textarea
             class="form-control"
             placeholder="{% trans "XPath expression" %}"
             name="module_filter"

--- a/corehq/apps/app_manager/templates/app_manager/partials/xpathValidator.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/xpathValidator.html
@@ -7,9 +7,9 @@
 <script src="{% static 'app_manager/js/xpathConfig.js' %}"></script>
 <script type="text/html" id="XPathValidator.template">
 <div class="js-xpath-input-target control-group" data-bind="css: {error: xpathValidator.error}">
-    <input type="text" class="form-control"
+    <textarea type="text" class="form-control"
            data-bind="attr: {name: input.getAttribute('name'), placeholder: input.getAttribute('placeholder')},
-                      value: xpathValidator.xpathText"/>
+                      value: xpathValidator.xpathText"></textarea>
     <!--ko if: xpathValidator.error()-->
     <div class="alert alert-danger" data-bind="html: errorHtml"></div>
     <!--/ko-->

--- a/corehq/apps/app_manager/templates/app_manager/partials/xpathValidator.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/xpathValidator.html
@@ -7,7 +7,7 @@
 <script src="{% static 'app_manager/js/xpathConfig.js' %}"></script>
 <script type="text/html" id="XPathValidator.template">
 <div class="js-xpath-input-target control-group" data-bind="css: {error: xpathValidator.error}">
-    <textarea type="text" class="form-control"
+    <textarea class="form-control"
            data-bind="attr: {name: input.getAttribute('name'), placeholder: input.getAttribute('placeholder')},
                       value: xpathValidator.xpathText"></textarea>
     <!--ko if: xpathValidator.error()-->


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?219937

This switches all valueOrNoneUI widgets (currently only used by form filters) and all elements that use the xpathValidator binding (currently form filters and module filters) to textareas, which I think is okay.

@gcapalbo / @dannyroberts 
