### PR TITLE
use domain name not object to check toggle

### DIFF
--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -1046,7 +1046,7 @@ class Domain(QuickCachedDocumentMixin, Document, SnapshotMixin):
         left around for special applications, and not a feature
         flag that should be set normally.
         """
-        return toggles.MULTIPLE_LOCATIONS_PER_USER.enabled(self)
+        return toggles.MULTIPLE_LOCATIONS_PER_USER.enabled(self.name)
 
     def convert_to_commtrack(self):
         """


### PR DESCRIPTION
related to http://manage.dimagi.com/default.asp?218848

I think this was working because later the toggle code calls  `__unicode__` which just returns `self.name`, but was still confusing
