### PR TITLE
Allow form filter if module filter enabled

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/form_view_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view_base.html
@@ -100,12 +100,12 @@
             {% if allow_form_filtering %}
             var putInRoot = {{ module.put_in_root|BOOL }};
             var isUserCaseInUse = {{ is_usercase_in_use|BOOL }};
+            var isModuleFilterEnabled = {{ is_module_filter_enabled|BOOL }};
             var formFilter = {{ form.form_filter|JSON }};
             var allOtherFormsRequireACase = {{ form.all_other_forms_require_a_case|BOOL }};
             var formFilterAllowed = ko.computed(function () {
-                return ((allOtherFormsRequireACase &&
-                         form_requires() === 'case') ||
-                        isUserCaseInUse) && !putInRoot;
+                return ((allOtherFormsRequireACase && form_requires() === 'case' && !putInRoot) ||
+                        isUserCaseInUse || isModuleFilterEnabled);
             });
             $('#form-filter').koApplyBindings({
                     formFilter: ko.observable(formFilter),

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -22,7 +22,7 @@ from corehq.apps.app_manager.views.schedules import get_schedule_context
 from corehq.apps.app_manager.views.utils import back_to_main, \
     CASE_TYPE_CONFLICT_MSG
 
-from corehq import toggles, privileges
+from corehq import toggles, privileges, feature_previews
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.app_manager.exceptions import (
     BlankXFormError,
@@ -458,6 +458,8 @@ def get_form_view_context_and_template(request, domain, form, langs, messages=me
         'allow_form_workflow': not isinstance(form, CareplanForm),
         'allow_usercase': domain_has_privilege(request.domain, privileges.USER_CASE),
         'is_usercase_in_use': is_usercase_in_use(request.domain),
+        'is_module_filter_enabled': (feature_previews.MODULE_FILTER.enabled(request.domain) and
+                                     app.enable_module_filtering),
     }
 
     if tours.NEW_APP.is_enabled(request.user):


### PR DESCRIPTION
Allow form filtering if module filtering is enabled. (For now) leave it up to app builders to be responsible enough not to filter on case properties that aren't available. (In the future, make sure they aren't using normal case properties when a normal case isn't available.) 

More context at [FB 217791](http://manage.dimagi.com/default.asp?217791)

@calellowitz @benrudolph cc buddy @dannyroberts 

**BEFORE** (disabled)
![allow_form_filter_before](https://cloud.githubusercontent.com/assets/708421/13528188/1d8889e4-e21d-11e5-8314-16aa38f209ec.png)

**AFTER** (enabled)
![allow_form_filter_after](https://cloud.githubusercontent.com/assets/708421/13528200/24a391d8-e21d-11e5-8f1d-d6852bbc1de6.png)
