### PR TITLE
move SaveButton declarations out of template

### DIFF
--- a/corehq/apps/style/static/style/js/bootstrap3/main.js
+++ b/corehq/apps/style/static/style/js/bootstrap3/main.js
@@ -222,6 +222,23 @@ COMMCAREHQ.makeSaveButton = function(messageStrings, cssClass) {
     return SaveButton;
 };
 
+COMMCAREHQ.SaveButton = COMMCAREHQ.makeSaveButton({
+    SAVE: django.gettext("Save"),
+    SAVING: django.gettext("Saving..."),
+    SAVED: django.gettext("Saved"),
+    RETRY: django.gettext("Try Again"),
+    ERROR_SAVING: django.gettext("There was an error saving")
+}, 'btn btn-success');
+
+COMMCAREHQ.DeleteButton = COMMCAREHQ.makeSaveButton({
+    SAVE: django.gettext("Delete"),
+    SAVING: django.gettext("Deleting..."),
+    SAVED: django.gettext("Deleted"),
+    RETRY: django.gettext("Try Again"),
+    ERROR_SAVING: django.gettext("There was an error deleting")
+}, 'btn btn-danger');
+
+
 COMMCAREHQ.beforeUnload = [];
 
 COMMCAREHQ.bindBeforeUnload = function (callback) {

--- a/corehq/apps/style/templates/style/bootstrap3/base.html
+++ b/corehq/apps/style/templates/style/bootstrap3/base.html
@@ -349,21 +349,6 @@
         {% endif %}
 
         <script type="text/javascript">
-            COMMCAREHQ.SaveButton = COMMCAREHQ.makeSaveButton({
-                SAVE: '{% trans "Save"|escapejs %}',
-                SAVING: '{% trans "Saving..."|escapejs %}',
-                SAVED: '{% trans "Saved"|escapejs %}',
-                RETRY: '{% trans "Try Again"|escapejs %}',
-                ERROR_SAVING: '{% trans "There was an error saving"|escapejs %}'
-            }, 'btn btn-success');
-            COMMCAREHQ.DeleteButton = COMMCAREHQ.makeSaveButton({
-                SAVE: '{% trans "Delete"|escapejs %}',
-                SAVING: '{% trans "Deleting..."|escapejs %}',
-                SAVED: '{% trans "Deleted"|escapejs %}',
-                RETRY: '{% trans "Try Again"|escapejs %}',
-                ERROR_SAVING: '{% trans "There was an error deleting"|escapejs %}'
-            }, 'btn btn-danger');
-
             $(function(){
                 $('.hq-help-template').each(function () {
                     COMMCAREHQ.transformHelpTemplate($(this), true);


### PR DESCRIPTION
and into main.js where they can use django.gettext

Just some clean up I noticed when I was poking around
@dimagi/js-team cc: @kaapstorm 
