### PR TITLE
fix app configs for app_manager and cloudcare

### DIFF
--- a/corehq/apps/app_manager/__init__.py
+++ b/corehq/apps/app_manager/__init__.py
@@ -8,4 +8,8 @@ class AppManagerAppConfig(AppConfig):
 
     def ready(self):
         # Also sync this app's design docs to NEW_APPS_DB
-        ExtraPreindexPlugin.register('app_manager', __file__, settings.NEW_APPS_DB)
+        ExtraPreindexPlugin.register('app_manager', __file__,
+                                     (settings.APPS_DB, settings.NEW_APPS_DB))
+
+
+default_app_config = 'corehq.apps.app_manager.AppManagerAppConfig'

--- a/corehq/apps/cloudcare/__init__.py
+++ b/corehq/apps/cloudcare/__init__.py
@@ -8,8 +8,11 @@ class CloudcareAppConfig(AppConfig):
 
     def ready(self):
         # Also sync this app's design docs to NEW_APPS_DB
-        ExtraPreindexPlugin.register('cloudcare', __file__, settings.NEW_APPS_DB)
+        ExtraPreindexPlugin.register('cloudcare', __file__,
+                                     (settings.APPS_DB, settings.NEW_APPS_DB))
 
 
 # constants
 CLOUDCARE_DEVICE_ID = "cloudcare"
+
+default_app_config = 'corehq.apps.cloudcare.CloudcareAppConfig'


### PR DESCRIPTION
Caused cloudcare design doc not to get synced to new apps db.

@esoergel glad we caught this on staging!

cc: @kaapstorm 
