### PR TITLE
Make app manager use knockout 3

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/apps_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/apps_base.html
@@ -19,12 +19,6 @@
 {% endblock %}
 
 {% block js %}{{ block.super }}
-    {# Explicitly include these because app manager doesn't really do class-based views, can't use the decorators #}
-    <script src="{% new_static 'knockout-2.3.0-legacy/knockout.js' %}"></script>
-    <script src="{% new_static 'style/lib/knockout_plugins/knockout_mapping.ko.min.js' %}"></script>
-    <script src="{% new_static 'style/ko/global_handlers.ko.js' %}"></script>
-    <script src="{% new_static 'style/ko/knockout_bindings.ko.js' %}"></script>
-
     <!--
         jQuery UI needs to be included before Bootstrap's JavaScript, otherwise the two
         tooltip widgets conflict. The B3 base template takes care of that when you use the

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases.html
@@ -150,7 +150,9 @@
                 <td class="text-nowrap" data-bind="text: built_on_date"></td>
                 <td class="text-nowrap" data-bind="text: built_on_time"></td>
                 <td class="text-nowrap">
-                    <span data-bind="if: menu_item_label(), text: menu_item_label()"></span>
+                    <!--ko if: menu_item_label() -->
+                    <span data-bind="text: menu_item_label()"></span>
+                    <!--/ko-->
                     <h6 data-bind="if: !built_with.signed()">{% trans "Unsigned Jar" %}</h6>
                 </td>
                 <td class="text-nowrap">

--- a/corehq/apps/app_manager/templates/app_manager/partials/supported-languages.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/supported-languages.html
@@ -32,7 +32,7 @@
                 {% if hide_deploy_column %}
                     <input type="checkbox" checked="checked" data-bind="value: deploy, visible: false" />
                 {% else %}
-                    <span data-bind="editableBool: deploy"></span>
+                    <input type="checkbox" checked="checked" data-bind="checked: deploy" />
                 {% endif %}
             </td>
             <td class="col-sm-1">

--- a/corehq/apps/app_manager/templates/app_manager/partials/supported-languages.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/supported-languages.html
@@ -36,8 +36,9 @@
                 {% endif %}
             </td>
             <td class="col-sm-1">
-                <span class="form-inline"
-                      data-bind="langcode: langcode, valueUpdate: 'textchange', inputHandlers: {hasfocus: $root.seen}">
+                <span class="form-inline">
+                      <input class="short form-control"
+                             data-bind="langcode: langcode, valueUpdate: 'textchange', inputHandlers: {hasfocus: $root.seen}"/>
                 </span>
             </td>
             <td class="col-sm-1">

--- a/corehq/apps/style/static/style/js/bootstrap3/main.js
+++ b/corehq/apps/style/static/style/js/bootstrap3/main.js
@@ -213,8 +213,10 @@ COMMCAREHQ.makeSaveButton = function(messageStrings, cssClass) {
                 fireChange = function () {
                     button.fire('change');
                 };
-            $form.find('*').change(fireChange);
-            $form.find('input, textarea').bind('textchange', fireChange);
+            _.defer(function () {
+                $form.find('*').change(fireChange);
+                $form.find('input, textarea').bind('textchange', fireChange);
+            });
             return button;
         },
         message: messageStrings

--- a/corehq/apps/style/static/style/ko/knockout_bindings.ko.js
+++ b/corehq/apps/style/static/style/ko/knockout_bindings.ko.js
@@ -50,7 +50,7 @@ ko.bindingHandlers.langcode = {
                 }
             };
         }()));
-        $('input', element).addClass('short code form-control').langcodes();
+        $(element).langcodes();
     },
     update: ko.bindingHandlers.value.update
 };

--- a/corehq/apps/style/static/style/ko/knockout_bindings.ko.js
+++ b/corehq/apps/style/static/style/ko/knockout_bindings.ko.js
@@ -4,61 +4,6 @@ try {
     var USE_BOOTSTRAP_3 = false;
 }
 
-var generateEditableHandler = function (spec) {
-    return {
-        init: function (element, valueAccessor, allBindingsAccessor, viewModel) {
-            var input = spec.getEdit().appendTo(element);
-            var span = spec.getNonEdit().appendTo(element);
-            var editing = allBindingsAccessor().editing;
-            var inputHandlers = allBindingsAccessor().inputHandlers;
-            spec.editHandler.init(input.get(0), valueAccessor, allBindingsAccessor, viewModel);
-            (spec.nonEditHandler.init || function () {})(span.get(0), valueAccessor, allBindingsAccessor, viewModel);
-            for (var name in inputHandlers) {
-                if (inputHandlers.hasOwnProperty(name)) {
-                    ko.bindingHandlers[name].init(input.get(0), (function (name) {
-                        return function () {
-                            return inputHandlers[name];
-                        };
-                    }(name)), allBindingsAccessor, viewModel);
-                }
-            }
-
-            if (editing) {
-                editing.subscribe(function () {
-                    ko.bindingHandlers.editableString.update(element, valueAccessor, allBindingsAccessor, viewModel);
-                });
-            }
-        },
-        update: function (element, valueAccessor, allBindingsAccessor, viewModel) {
-            var input = spec.getEdit(element);
-            var span = spec.getNonEdit(element);
-            var editing = allBindingsAccessor().editing || function () { return true; };
-            var inputHandlers = allBindingsAccessor().inputHandlers;
-
-            spec.editHandler.update(input.get(0), valueAccessor, allBindingsAccessor, viewModel);
-            spec.nonEditHandler.update(span.get(0), valueAccessor, allBindingsAccessor, viewModel);
-
-            for (var name in inputHandlers) {
-                if (inputHandlers.hasOwnProperty(name)) {
-                    ko.bindingHandlers[name].update(input.get(0), (function (name) {
-                        return function () {
-                            return inputHandlers[name];
-                        };
-                    }(name)), allBindingsAccessor, viewModel);
-                }
-            }
-
-            if (editing()) {
-                input.show();
-                span.hide();
-            } else {
-                input.hide();
-                span.show();
-            }
-        }
-    };
-};
-
 ko.bindingHandlers.staticChecked = {
     init: function (element) {
         $('<span class="icon"></span>').appendTo(element);
@@ -78,44 +23,6 @@ ko.bindingHandlers.staticChecked = {
         }
     }
 };
-
-ko.bindingHandlers.editableString = generateEditableHandler({
-    editHandler: ko.bindingHandlers.value,
-    nonEditHandler: ko.bindingHandlers.text,
-    getEdit: function (element) {
-        if (element) {
-            return $('input', element);
-        } else {
-            return $('<input type="text"/>');
-        }
-    },
-    getNonEdit: function (element) {
-        if (element) {
-            return $('span', element);
-        } else {
-            return $('<span/>');
-        }
-    }
-});
-
-ko.bindingHandlers.editableBool = generateEditableHandler({
-    editHandler: ko.bindingHandlers.checked,
-    nonEditHandler: ko.bindingHandlers.staticChecked,
-    getEdit: function (element) {
-        if (element) {
-            return $('input', element);
-        } else {
-            return $('<input type="checkbox"/>');
-        }
-    },
-    getNonEdit: function (element) {
-        if (element) {
-            return $('span', element);
-        } else {
-            return $('<span/>');
-        }
-    }
-});
 
 ko.bindingHandlers.langcode = {
     init: function (element, valueAccessor, allBindings) {

--- a/corehq/apps/style/templates/style/includes/bootstrap3/ko.html
+++ b/corehq/apps/style/templates/style/includes/bootstrap3/ko.html
@@ -13,10 +13,9 @@
 {% else %}
 
 {% compress js %}
-<script type="text/javascript" src="{% new_static 'knockout/dist/knockout.js' %}"></script>
+<script type="text/javascript" src="{% new_static 'knockout/dist/knockout.debug.js' %}"></script>
 <script type="text/javascript" src="{% new_static 'style/lib/knockout_plugins/knockout_mapping.ko.min.js' %}"></script>
 <script type="text/javascript" src="{% new_static 'style/ko/global_handlers.ko.js' %}"></script>
 <script type="text/javascript" src="{% new_static 'style/ko/knockout_bindings.ko.js' %}"></script>
 {% endcompress %}
-
 {% endif %}


### PR DESCRIPTION
This seems to be enough to get app manager running on knockout 3. I haven't deeply tested each part of each page, just that each of the made pages loads fine. I would expect most errors related to a knockout upgrade to happen as soon as a page is loaded, but it's not inconceivable that it could happen only after a user action.
