### PR TITLE
Bring back static versioning

### DIFF
--- a/corehq/apps/hqadmin/templates/hqadmin/project_map.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/project_map.html
@@ -38,7 +38,7 @@
   {% endcompress %}
 
   {% compress js %}
-  <script src="{% new_static 'less/dist/less-1.7.3.min.js' cache=True %}"></script>
+  <script src="{% new_static 'less/dist/less-1.7.3.min.js' %}"></script>
   <script type="text/javascript" src="{% new_static 'jquery/dist/jquery.min.js' %}"></script>
   <script type="text/javascript" src="{% new_static 'bootstrap/dist/js/bootstrap.min.js' %}"></script>
   <script type="text/javascript" src="{% new_static 'knockout/dist/knockout.js' %}"></script>

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -105,27 +105,9 @@ def cachebuster(url):
     return resource_versions.get(url, "")
 
 
-@register.simple_tag
+@register.simple_tag()
 def new_static(url, **kwargs):
-    """Caching must explicitly be defined on tags with any of the extensions
-    that could be compressed by django compressor. The static tag above will
-    eventually turn into this tag.
-    :param url:
-    :param kwargs:
-    :return:
-    """
-    can_be_compressed = url.endswith(('.less', '.css', '.js'))
-    use_cache = kwargs.pop('cache', False)
-    use_versions = not can_be_compressed or use_cache
-
-    resource_url = url
-    url = settings.STATIC_CDN + settings.STATIC_URL + url
-    if use_versions:
-        version = resource_versions.get(resource_url)
-        if version:
-            url += "?version=%s" % version
-
-    return url
+    return static(url, **kwargs)
 
 
 @quickcache(['couch_user.username'])

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 import json
+import warnings
 from dimagi.utils.make_uuid import random_hex
 from django import template
 from django.conf import settings
@@ -107,7 +108,9 @@ def cachebuster(url):
 
 @register.simple_tag()
 def new_static(url, **kwargs):
-    return static(url, **kwargs)
+    if kwargs:
+        warnings.warn('new_static no longer accepts arguments', PendingDeprecationWarning)
+    return static(url)
 
 
 @quickcache(['couch_user.username'])

--- a/corehq/apps/style/templates/style/bootstrap3/base.html
+++ b/corehq/apps/style/templates/style/bootstrap3/base.html
@@ -213,7 +213,7 @@
                     relativeUrls: false
                 };
             </script>
-            <script src="{% new_static 'less/dist/less-1.7.3.min.js' cache=True %}"></script>
+            <script src="{% new_static 'less/dist/less-1.7.3.min.js' %}"></script>
             {% if less_watch %}<script>less.watch();</script>{% endif %}
         {% endif %}
     </head>

--- a/corehq/apps/styleguide/templates/styleguide/base.html
+++ b/corehq/apps/styleguide/templates/styleguide/base.html
@@ -72,7 +72,7 @@
                     relativeUrls: false
                 };
             </script>
-            <script src="{% new_static 'less/dist/less-1.7.3.min.js' cache=True %}"></script>
+            <script src="{% new_static 'less/dist/less-1.7.3.min.js' %}"></script>
             {% if less_watch %}<script>less.watch();</script>{% endif %}
         {% endif %}
     </head>

--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -1152,7 +1152,7 @@ def update_manifest(save=False, soft=False, use_current_release=False):
         )
 
 
-@roles(ROLES_DJANGO)
+@roles(set(ROLES_STATIC + ROLES_DJANGO))
 @parallel
 def version_static():
     """

--- a/scripts/staging.yaml
+++ b/scripts/staging.yaml
@@ -45,6 +45,7 @@
 trunk: master
 name: autostaging
 branches:
+  - bring-back-static-versioning  # Danny 3/7
   - cloudcare-on-apps-db  # Danny 3/7
   - flip_apps_db  # Danny 3/1
   - calculatedIcons+use-hqImport # Sravan 3/2
@@ -91,4 +92,5 @@ submodules:
   submodules/django-prbac-src:
     branches: []
   corehq/apps/prelogin:
-    branches: []
+    branches: #[]
+      - bring-back-static-versioning  # Danny 3/7


### PR DESCRIPTION
This brings back version=<foo> on all static urls, making `new_static` just the same thing as `static`. I found the bug that made us switch to not having it by default in the first place, (we weren't running `./manage.py resource_static` on proxy, but we were on web workers, which made the hashes in the manifest different from the hashes calculated on the web workers, resulting in an `OfflineGenerationError`. I fixed this by running resource_static on the proxy in fab as well; works like a charm. Already tested it works by throwing this dummy commit up on staging: https://github.com/dimagi/commcare-hq/commit/4e73a18515d1ad8f083eee8596eafbfec07e9a02

Merge with https://github.com/dimagi/commcarehq-prelogin/pull/66
