### PR TITLE
Strip bitly from URL on QR code modal

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/odk_install.html
+++ b/corehq/apps/app_manager/templates/app_manager/odk_install.html
@@ -15,7 +15,7 @@
             </p>
             <p>
                 {% trans "You can also visit:" %}
-                <code><a href="{{ profile_url }}">{{ profile_url }}</a></code>
+                <code class="bitly"><a href="{{ profile_url }}">{{ app_code }}</a></code>
                 {% trans "in your mobile browser." %}
             </p>
             <p>

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy
@@ -207,13 +208,22 @@ def delete_copy(request, domain, app_id):
 
 
 def odk_install(request, domain, app_id, with_media=False):
+
+    def strip_bitly(url):
+        """
+        Given a bitly URL, returns an app code. Other URLs, "" and None returned as-is
+        """
+        return re.sub(r'^https?://bit\.ly/(\w+)/?', r'\1', url) if url else url
+
     app = get_app(domain, app_id)
     qr_code_view = "odk_qr_code" if not with_media else "odk_media_qr_code"
+    profile_url = app.odk_profile_display_url if not with_media else app.odk_media_profile_display_url
     context = {
         "domain": domain,
         "app": app,
         "qr_code": reverse("corehq.apps.app_manager.views.%s" % qr_code_view, args=[domain, app_id]),
-        "profile_url": app.odk_profile_display_url if not with_media else app.odk_media_profile_display_url,
+        "profile_url": profile_url,
+        "app_code": strip_bitly(profile_url),
     }
     return render(request, "app_manager/odk_install.html", context)
 


### PR DESCRIPTION
Addresses (actual) issue in [FB 218708](http://manage.dimagi.com/default.asp?218708).

Bitly URLs converted to app codes, other URLs unchanged:

![bitly_stripped](https://cloud.githubusercontent.com/assets/708421/13602714/ede55b1e-e540-11e5-91b7-d5521d34ad0a.png)

@calellowitz @benrudolph cc @dannyroberts 
