### PR TITLE
drop index for CaseAttachmentSQL.attachment_id

### DIFF
--- a/corehq/form_processor/migrations/0035_remove_varchar_pattern_ops_indexes.py
+++ b/corehq/form_processor/migrations/0035_remove_varchar_pattern_ops_indexes.py
@@ -16,6 +16,10 @@ class Migration(migrations.Migration):
     NOOP_REVERSE = 'SELECT 1'
     operations = [
         HqRunSQL(
+            'DROP INDEX IF EXISTS form_processor_caseattach_attachment_uuid_4c1d2c3ea75567cc_like',
+            NOOP_REVERSE
+        ),
+        HqRunSQL(
             'DROP INDEX IF EXISTS form_processor_xforminstancesql_form_uuid_12662b9ceadeeecc_like',
             NOOP_REVERSE
         ),


### PR DESCRIPTION
django 1.8 checks that the index has been dropped during migration `0036`, so need to add this for tests
