### PR TITLE
don't yell about using static

### DIFF
--- a/corehq/apps/style/tests/test_compress_command.py
+++ b/corehq/apps/style/tests/test_compress_command.py
@@ -37,15 +37,10 @@ class TestDjangoCompressOffline(SimpleTestCase):
             return
         for tag in DISALLOWED_TAGS:
             self.assertNotRegexpMatches(tag[0], line.strip(), tag[1])
-        if 'src' not in line and 'href' not in line:
-            return
-        self.assertIn(
-            'new_static', line, msg='new_static not found in %s in file %s' % (safe_repr(line), filename)
-        )
 
     def _is_b3(self, filename):
         if filename in IGNORED_FILES:
-            return  False
+            return False
 
         if filename.endswith(B3_BASE):
             return True


### PR DESCRIPTION
@dannyroberts we can remove this check now that we can use either static (this could also be used as a good sanity check if we ever decided to do a full find and replace) 

cc: @gcapalbo 
