### PR TITLE
fix production caching of toggles js

### DIFF
--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -1,5 +1,6 @@
 import functools
 import logging
+import mimetypes
 import os
 import datetime
 from django.conf import settings
@@ -156,7 +157,14 @@ class NoCacheMiddleware(object):
             response['Expires'] = "-1"
             response['Pragma'] = "no-cache"
         else:
+            content_type, _ = mimetypes.guess_type(request.path)
             response['Cache-Control'] = "max-age=31536000"
+            del response['Vary']
+            del response['Set-Cookie']
+            response['Content-Type'] = content_type
+            del response['Content-Language']
+            response['Content-Length'] = len(response.content)
+            del response['HTTP_X_OPENROSA_VERSION']
         return response
 
     @staticmethod

--- a/settings.py
+++ b/settings.py
@@ -131,6 +131,7 @@ TEMPLATE_LOADERS = (
 CSRF_SOFT_MODE = True
 
 MIDDLEWARE_CLASSES = [
+    'corehq.middleware.NoCacheMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
@@ -139,7 +140,6 @@ MIDDLEWARE_CLASSES = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.common.BrokenLinkEmailsMiddleware',
     'corehq.middleware.OpenRosaMiddleware',
-    'corehq.middleware.NoCacheMiddleware',
     'corehq.util.global_request.middleware.GlobalRequestMiddleware',
     'corehq.apps.users.middleware.UsersMiddleware',
     'corehq.middleware.TimeoutMiddleware',


### PR DESCRIPTION
When requesting toggles.js (which is different per-user/domain and thus not a static file) doesn't get cached by the browser, it's a pretty big hit on the effective page load time. This should fix that.
