### PR TITLE
Autopay test refactor

### DIFF
--- a/corehq/apps/accounting/tests/base_tests.py
+++ b/corehq/apps/accounting/tests/base_tests.py
@@ -6,7 +6,8 @@ from django_prbac.models import Role
 
 
 class BaseAccountingTest(TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         Role.get_cache().clear()
         generator.instantiate_accounting_for_tests()
 

--- a/corehq/apps/accounting/tests/test_autopay.py
+++ b/corehq/apps/accounting/tests/test_autopay.py
@@ -17,45 +17,69 @@ from corehq.apps.accounting.payment_handlers import AutoPayInvoicePaymentHandler
 class TestBillingAutoPay(BaseInvoiceTestCase):
     def setUp(self):
         super(TestBillingAutoPay, self).setUp()
-        self.account.created_by_domain = self.domain
-        self.account.save()
+        self._generate_autopayable_entities()
+        self._generate_non_autopayable_entities()
+        self._generate_invoices()
 
-        self.currency = generator.init_default_currency()
-
-        self.web_user = generator.arbitrary_web_user()
-        self.dimagi_user = generator.arbitrary_web_user(is_dimagi=True)
+    def _generate_autopayable_entities(self):
+        """
+        Create account, domain and subscription linked to the autopay user that have autopay enabled
+        """
+        self.autopay_account = self.account
+        self.autopay_account.created_by_domain = self.domain
+        self.autopay_account.save()
+        self.autopay_user = generator.arbitrary_web_user()
         self.fake_card = FakeStripeCard()
         self.fake_stripe_customer = FakeStripeCustomer(cards=[self.fake_card])
+        self.autopay_account.update_autopay_user(self.autopay_user.username, self.domain)
 
-        self.account.update_autopay_user(self.web_user.username, self.domain)
-        self.invoice_date = utils.months_from_date(self.subscription.date_start,
-                                                   random.randint(2, self.subscription_length))
-
-        self.account_2 = generator.billing_account(self.dimagi_user, self.web_user)
-        self.domain_2 = generator.arbitrary_domain()
-
-        self.subscription_length_2 = self.min_subscription_length  # months
-        subscription_start_date = datetime.date(2016, 2, 23)
-        subscription_end_date = add_months_to_date(subscription_start_date, self.subscription_length_2)
-        self.subscription_2 = generator.generate_domain_subscription(
-            self.account_2,
-            self.domain_2,
-            date_start=subscription_start_date,
-            date_end=subscription_end_date,
+    def _generate_non_autopayable_entities(self):
+        """
+        Create account, domain, and subscription linked to the autopay user, but that don't have autopay enabled
+        """
+        self.non_autopay_account = generator.billing_account(
+            web_user_creator=generator.arbitrary_web_user(is_dimagi=True),
+            web_user_contact=self.autopay_user
+        )
+        self.non_autopay_domain = generator.arbitrary_domain()
+        # Non-autopay subscription has same parameters as the autopayable subscription
+        self.non_autopay_subscription = generator.generate_domain_subscription(
+            self.non_autopay_account,
+            self.non_autopay_domain,
+            date_start=self.subscription.date_start,
+            date_end=add_months_to_date(self.subscription.date_start, self.subscription_length),
         )
 
-        tasks.generate_invoices(self.invoice_date)
+    def _generate_invoices(self):
+        """
+        Create invoices for both autopayable and non-autopayable subscriptions
+        """
+        # invoice date is 2 months before the end of the subscription (this is arbitrary)
+        invoice_date = utils.months_from_date(self.subscription.date_start, self.subscription_length - 2)
+        tasks.generate_invoices(invoice_date)
 
     @mock.patch.object(StripePaymentMethod, 'customer')
     def test_get_autopayable_invoices(self, fake_customer):
+        """
+        Invoice.autopayable_invoices() should return invoices that can be automatically paid
+        """
         self._create_autopay_method(fake_customer)
-
         autopayable_invoice = Invoice.objects.filter(subscription=self.subscription)
         date_due = autopayable_invoice.first().date_due
 
         autopayable_invoices = Invoice.autopayable_invoices(date_due)
 
         self.assertItemsEqual(autopayable_invoices, autopayable_invoice)
+
+    def test_get_autopayable_invoices_returns_nothing(self):
+        """
+        Invoice.autopayable_invoices() should not return invoices if the customer does not have an autopay method
+        """
+        not_autopayable_invoice = Invoice.objects.filter(subscription=self.non_autopay_subscription)
+        date_due = not_autopayable_invoice.first().date_due
+        autopayable_invoices = Invoice.autopayable_invoices(date_due)
+        self.assertItemsEqual(autopayable_invoices, [])
+
 
     @mock.patch.object(StripePaymentMethod, 'customer')
     @mock.patch.object(Charge, 'create')
@@ -74,7 +98,7 @@ class TestBillingAutoPay(BaseInvoiceTestCase):
 
     def _create_autopay_method(self, fake_customer):
         fake_customer.__get__ = mock.Mock(return_value=self.fake_stripe_customer)
-        self.payment_method = StripePaymentMethod(web_user=self.web_user.username,
+        self.payment_method = StripePaymentMethod(web_user=self.autopay_user.username,
                                                   customer_id=self.fake_stripe_customer.id)
-        self.payment_method.set_autopay(self.fake_card, self.account, self.domain)
+        self.payment_method.set_autopay(self.fake_card, self.autopay_account, self.domain)
         self.payment_method.save()


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?217913

Refactored autopay tests to make them more comprehensible.

Also, the `setUpClass` thing (https://github.com/dimagi/commcare-hq/commit/e1e1ddeb8802b301976a92476556541d73fbde16) seemed to work locally, and was faster by 50 seconds (~15% faster). Will wait for travis to tell me if this was a good idea or not. 

@nickpell 
