### PR TITLE
"click here" instead of URL

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/odk_install.html
+++ b/corehq/apps/app_manager/templates/app_manager/odk_install.html
@@ -14,9 +14,9 @@
                 <img src="{{ qr_code }}" width=250 alt="Download" >
             </p>
             <p>
-                {% trans "You can also visit:" %}
-                <code><a href="{{ profile_url }}">{{ profile_url }}</a></code>
-                {% trans "in your mobile browser." %}
+                {% blocktrans %}
+                You can also click <strong><a href="{{ profile_url }}">here</a></strong> in your mobile browser.
+                {% endblocktrans %}
             </p>
             <p>
                 {% trans "For more about CommCare on Android, visit" %}


### PR DESCRIPTION
Use a link instead of showing Bitly / app URL in QR code modal.

Context: [FB 218708](http://manage.dimagi.com/default.asp?218708) and PR #10650.

![click_here](https://cloud.githubusercontent.com/assets/708421/13629759/de2f81b0-e5e3-11e5-93e6-848da4b7c9d7.png)

Implements feedback from @benrudolph and @amsagoff in previous PR. This approach appeals to me the most because it has the simplest UI and isn't affected by whether the app has an app code.

@benrudolph @calellowitz @amsagoff cc @dannyroberts @dimagi/product 
