### PR TITLE
Remove unneeded libs

### DIFF
--- a/corehq/apps/reports/templates/reports/bootstrap3/standard/base_template.html
+++ b/corehq/apps/reports/templates/reports/bootstrap3/standard/base_template.html
@@ -12,13 +12,6 @@
     <script src="{% new_static 'reports/javascripts/reports.config.js' %}"></script>
     <script src="{% new_static 'reports/javascripts/reports.async.js' %}"></script>
 
-    {# Datespan Javascript Lib dependencies #}
-    <script type="text/javascript" src="{% static 'reports/javascripts/bootstrap-daterangepicker/moment.min.js' %}"></script>
-    <script type="text/javascript" src="{% static 'reports/javascripts/bootstrap-daterangepicker/daterangepicker.min.js' %}"></script>
-    <script type="text/javascript" src="{% static 'reports/javascripts/daterangepicker.js' %}"></script>
-    {# end Datespan Javascript Lib dependencies #}
-    <script src="{% static 'select2-3.4.5-legacy/select2.min.js' %}"></script>
-
     {% endcompress %}
     {% endblock %}
 {% endblock %}


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?220781

@biyeun don't need these libs for b3 base. when i had tested locally i just checked to ensure no javascript errors, but didn't try loading the report after selecting dates (dumb).

introduced here: https://github.com/dimagi/commcare-hq/pull/10654
