### PR TITLE
add docs for potential extensions to UCR for icds

### DIFF
--- a/corehq/apps/userreports/README.md
+++ b/corehq/apps/userreports/README.md
@@ -440,6 +440,7 @@ It would be cool if we could do custom reduces (by defining a function that take
   "reduce_statement": "x + y"  # required to only use these two variables
 }
 ```
+Behind the scenes that could use the evaluator pretty easily.
 
 #### Lookup Expression
 ```json
@@ -449,8 +450,6 @@ It would be cool if we could do custom reduces (by defining a function that take
     "index": 0,  # index of the item to do calculation on
     "value_expression": {}  # value expression to evaluate on the indexed item
 }
-
-Behind the scenes that could use the evaluator pretty easily.
 
 #### Flatten Expression
 

--- a/corehq/apps/userreports/README.md
+++ b/corehq/apps/userreports/README.md
@@ -441,6 +441,15 @@ It would be cool if we could do custom reduces (by defining a function that take
 }
 ```
 
+#### Lookup Expression
+```json
+{
+    "type": "lookup",  # not sure on name
+    "items_expression": {},  # expression should return a list
+    "index": 0,  # index of the item to do calculation on
+    "value_expression": {}  # value expression to evaluate on the indexed item
+}
+
 Behind the scenes that could use the evaluator pretty easily.
 
 #### Flatten Expression

--- a/corehq/apps/userreports/README.md
+++ b/corehq/apps/userreports/README.md
@@ -385,6 +385,76 @@ Variables can be any valid numbers (Python datatypes `int`, `float`, and `long` 
 
 More examples can be found on practical [examples page](corehq/apps/userreports/examples/examples.md#evaluator-examples).
 
+#### Case --> Form Lookup
+
+```json
+{
+   "type": "get_case_forms",
+   "case_id_expression": {},  # required
+   "filter": {},  # optional - possibly to remove for now in favor of filter expression
+}
+```
+
+Gets a list of forms from a case, optionally filtering (TBD if that belongs here).
+
+#### Filter Expression
+
+```json
+{
+  "type": "filter",  # not sure on name
+  "items_expression": {},  # expression should return a list
+  "filter_expression": {}  # will be called on each item, should return true or false indicating whether to include
+}
+```
+
+This should work just like python's `filter` function.
+
+#### Map Expression
+
+```json
+{
+  "type": "map",  # not sure on name
+  "items_expression": {},  # expression should return a list
+  "map_expression": {}  # expression to be evaluated on each item in the list
+}
+```
+
+In python the equivalent would be `map(lambda x: x.y, my_list)`, which would return a new list with the lambda function applied.
+
+#### Reduce Expression
+
+```json
+{
+  "type": "reduce",  # not sure on name
+  "items_expression":  {},  # expression should return a list
+  "aggregation_fn": "sum"  # one of a fixed set of allowed aggregation functions
+}
+```
+
+It would be cool if we could do custom reduces (by defining a function that takes in two values and spits out a single value). That might look like the following:
+
+```json
+{
+  "type": "custom_reduce",  # not sure on name
+  "items_expression":  {},  # expression should return a list
+  "reduce_statement": "x + y"  # required to only use these two variables
+}
+```
+
+Behind the scenes that could use the evaluator pretty easily.
+
+#### Flatten Expression
+
+```json
+{
+  "type": "flatten",  # not sure on name. in python this is itertools.chain
+  "items_expression":  {},  # expression should return a list of lists
+}
+```
+
+In python, `flatten([1, 2], [3, 4, 5], [6])` would return `[1, 2, 3, 4, 5, 6]`
+
+
 #### "Month Start Date" and "Month End Date" expressions
 
 `month_start_date` returns date of first day in the month of given date and `month_end_date` returns date of last day in the month of given date.


### PR DESCRIPTION
@sheelio this is what @sravfeyn and I came up with to support ICDS

The most complex (I think?) expression can be handled by this. Namely, summing a child's rations for a month, could be accomplished with the following chain:

```
get_all_forms --> list of forms
map --> convert to list of list of repeat data
flatten --> convert to flat list of repeat data
filter --> filter by case id
map --> convert to list of ration values
reduce --> convert to single number
```

@NoahCarnahan @nickpell curious if you guys have any feedback/concerns on this before we implement something
