### PR TITLE
ILS: Added task to recalculate data for current month, changed status validation function

### DIFF
--- a/custom/ilsgateway/tasks.py
+++ b/custom/ilsgateway/tasks.py
@@ -198,6 +198,25 @@ def fix_stock_data_task(domain):
     fix_stock_data(domain)
 
 
+@task(queue='logistics_background_queue', ignore_result=True)
+def recalculate_march_reporting_data_task(domain):
+    locations_ids = list(SQLLocation.objects.filter(domain=domain).values_list('location_id', flat=True))
+    GroupSummary.objects.filter(
+        org_summary__location_id=locations_ids, org_summary__date__gte=datetime(2016, 3, 1)
+    ).delete()
+    OrganizationSummary.objects.filter(location_id__in=locations_ids, date__gte=datetime(2016, 3, 1)).delete()
+    ProductAvailabilityData.objects.filter(
+        location_id__in=locations_ids,
+        date__gte=datetime(2016, 3, 1)
+    ).delete()
+    stock_data_checkpoint = StockDataCheckpoint.objects.get(domain=domain)
+    end_date = stock_data_checkpoint.date
+    ReportRun.objects.create(start=datetime(2016, 3, 1), end=end_date,
+                             start_run=datetime.utcnow(), domain=domain, complete=True, has_error=True)
+
+    report_run.delay(domain)
+
+
 # @periodic_task(run_every=timedelta(days=1), queue=getattr(settings, 'CELERY_PERIODIC_QUEUE', 'celery'))
 @task(queue='logistics_background_queue', ignore_result=True)
 def report_run(domain, locations=None, strict=True):

--- a/custom/ilsgateway/templates/ilsgateway/ilsconfig.html
+++ b/custom/ilsgateway/templates/ilsgateway/ilsconfig.html
@@ -189,6 +189,15 @@
                 </div>
             </div>
         </div>
+        <div class="row-fluid">
+            <div class="span12">
+                <div class="btn-toolbar">
+                    <button class="btn" id="recalculate_march_reporting_data">
+                        {% trans "Recalculate March reporting data" %}
+                    </button>
+                </div>
+            </div>
+        </div>
     {% endif %}
 {% endblock %}
 
@@ -258,6 +267,12 @@
 
         $("#fix_stock_data").click(function() {
             var url = '{% url 'fix_stock_data' domain %}';
+            var successMessage = "{% trans "Started" %}";
+            _post(this, url, {success: successMessage});
+        });
+
+        $("#recalculate_march_reporting_data").click(function() {
+            var url = '{% url 'recalculate_march_reporting_data' domain %}';
             var successMessage = "{% trans "Started" %}";
             _post(this, url, {success: successMessage});
         });

--- a/custom/ilsgateway/urls.py
+++ b/custom/ilsgateway/urls.py
@@ -33,5 +33,7 @@ urlpatterns = patterns('custom.ilsgateway.views',
         name='product_availability_delete'
     ),
     url(r'^fix_stock_data/$', 'fix_stock_data_view', name='fix_stock_data'),
+    url(r'^recalculate_march_reporting_data/$', 'recalculate_march_reporting_data',
+        name='recalculate_march_reporting_data'),
     url(r'^balance/$', BalanceMigrationView.as_view(), name='balance_migration')
 )

--- a/custom/ilsgateway/views.py
+++ b/custom/ilsgateway/views.py
@@ -33,7 +33,7 @@ from custom.ilsgateway.tanzania.reports.delivery import DeliveryReport
 from custom.ilsgateway.tanzania.reports.randr import RRreport
 from custom.ilsgateway.tanzania.reports.stock_on_hand import StockOnHandReport
 from custom.ilsgateway.tanzania.reports.supervision import SupervisionReport
-from custom.ilsgateway.tasks import clear_report_data, fix_stock_data_task
+from custom.ilsgateway.tasks import clear_report_data, fix_stock_data_task, recalculate_march_reporting_data_task
 from casexml.apps.stock.models import StockTransaction
 from custom.logistics.models import StockDataCheckpoint
 from custom.logistics.tasks import fix_groups_in_location_task, resync_web_users
@@ -328,6 +328,13 @@ def change_runner_date_to_last_migration(request, domain):
     last_run = ReportRun.last_success(domain)
     last_run.end = checkpoint.date
     last_run.save()
+    return HttpResponse('OK')
+
+
+@domain_admin_required
+@require_POST
+def recalculate_march_reporting_data(request, domain):
+    recalculate_march_reporting_data_task.delay(domain)
     return HttpResponse('OK')
 
 


### PR DESCRIPTION
@gcapalbo 
There is a problem with reporting data for current month on `ils-gateway` domain. A bunch of locations wasn't correctly matched to theirs groups. Unfortunately I can't reproduce this locally. The only place where something can be broken is `_is_valid_status` function. I removed all stuff responsible for getting historical location group because it was needed only in initial run when data for previous months were generated and it's no longer needed. I guess this part caused problem for data from current month. 
