### PR TITLE
stopping ucr build tasks from acking late

### DIFF
--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -77,7 +77,8 @@ def resume_building_indicators(indicator_config_id):
     redis_key = _get_redis_key_for_config(config)
 
     if len(redis_client.smembers(redis_key)) > 0:
-        relevant_ids = redis_client.smembers(redis_key)
+        # redis returns a set, which we cant pull a last member from
+        relevant_ids = tuple(redis_client.smembers(redis_key))
         _build_indicators(indicator_config_id, relevant_ids)
         last_id = relevant_ids[-1]
 

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -54,7 +54,7 @@ def _build_indicators(indicator_config_id, relevant_ids):
         redis_client.delete(redis_key)
 
 
-@task(queue='ucr_queue', ignore_result=True, acks_late=True)
+@task(queue='ucr_queue', ignore_result=True)
 def rebuild_indicators(indicator_config_id):
     config = _get_config_by_id(indicator_config_id)
     adapter = IndicatorSqlAdapter(config)
@@ -70,7 +70,7 @@ def rebuild_indicators(indicator_config_id):
     _iteratively_build_table(config)
 
 
-@task(queue='ucr_queue', ignore_result=True, acks_late=True)
+@task(queue='ucr_queue', ignore_result=True)
 def resume_building_indicators(indicator_config_id):
     config = _get_config_by_id(indicator_config_id)
     redis_client = get_redis_client().client.get_client()


### PR DESCRIPTION
@nickpell @benrudolph @czue @NoahCarnahan 
This is meant to address the problem where UCR builds get restarted on deploy. I also fixed a bug I had seen in the 500 emails with the new resume behavior.

In a more general sense, we should not be using `acks_late` for any task that stopping halfway through and restarting would have negative effects, as the celery docs point out. It is only for tasks that are safe to retry.
