### PR TITLE
don't double email on aborted saves

### DIFF
--- a/corehq/form_processor/exceptions.py
+++ b/corehq/form_processor/exceptions.py
@@ -20,6 +20,10 @@ class AttachmentNotFound(UnicodeMixIn, ResourceNotFound, ObjectDoesNotExist):
         return "Attachment '{}' not found".format(self.attachment_name)
 
 
+class CouchSaveAborted(Exception):
+    pass
+
+
 class CaseSaveError(Exception):
     pass
 


### PR DESCRIPTION
@snopoke @dannyroberts does this seem like a reasonable change? currently we get two emails for each "aborting because doc update..." and this downgrades the second one ("error in case or stock processing") to just be logged.
