### PR TITLE
Save app once when downgrading user-as-a-case

### DIFF
--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -761,9 +761,9 @@ def drop_user_case(request, domain, app_id):
                 for action in list(form.actions.load_update_cases):
                     if action.auto_select and action.auto_select.mode == AUTO_SELECT_USERCASE:
                         form.actions.load_update_cases.remove(action)
-            app.save()
-            messages.success(
-                request,
-                _('You have successfully removed User Case properties from this application.')
-            )
+    app.save()
+    messages.success(
+        request,
+        _('You have successfully removed User Case properties from this application.')
+    )
     return back_to_main(request, domain, app_id=app_id)


### PR DESCRIPTION
Can't explain why I would ever have put `app.save()` inside a `for` loop. Also can't explain why it didn't remove user case properties. However, this change undoes the dumb, and fixes bug [FB 220571](http://manage.dimagi.com/default.asp?220571).

@calellowitz @benrudolph cc @dannyroberts 
