### PR TITLE
all UCRs to kafka

### DIFF
--- a/corehq/apps/userreports/README.md
+++ b/corehq/apps/userreports/README.md
@@ -1371,7 +1371,7 @@ They conform to a slightly different style:
 ```
 
 Having defined the data source you need to add the path to the data source file to the `STATIC_DATA_SOURCES`
-setting in `settings.py`. Now when the `StaticDataSourcePillow` is run it will pick up the data source
+setting in `settings.py`. Now when the static data source pillow is run it will pick up the data source
 and rebuild it.
 
 Changes to the data source require restarting the pillow which will rebuild the SQL table. Alternately you

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
 from alembic.autogenerate.api import compare_metadata
 from datetime import datetime, timedelta
-from casexml.apps.case.models import CommCareCase
 from corehq.apps.change_feed import topics
 from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed, MultiTopicCheckpointEventHandler
 from corehq.apps.userreports.data_source_providers import DynamicDataSourceProvider, StaticDataSourceProvider
@@ -13,8 +12,6 @@ from corehq.toggles import KAFKA_UCRS
 from corehq.util.soft_assert import soft_assert
 from fluff.signals import get_migration_context, get_tables_to_rebuild
 from pillowtop.checkpoints.manager import PillowCheckpoint
-from pillowtop.couchdb import CachedCouchDB
-from pillowtop.listener import PythonPillow
 from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors import PillowProcessor
 

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -189,7 +189,7 @@ class ConfigurableReportKafkaPillow(ConstructedPillow):
     # we could easily remove the class and push all the stuff in __init__ to
     # get_kafka_ucr_pillow below if we wanted.
 
-    def __init__(self, data_source_provider, pillow_name):
+    def __init__(self, processor, pillow_name):
         change_feed = KafkaChangeFeed(topics.ALL, group_id=pillow_name)
         checkpoint = PillowCheckpoint(pillow_name)
         event_handler = MultiTopicCheckpointEventHandler(
@@ -199,7 +199,7 @@ class ConfigurableReportKafkaPillow(ConstructedPillow):
             name=pillow_name,
             document_store=None,
             change_feed=change_feed,
-            processor=ConfigurableReportPillowProcessor(data_source_provider),
+            processor=processor,
             checkpoint=checkpoint,
             change_processed_event_handler=event_handler
         )
@@ -213,11 +213,19 @@ class ConfigurableReportKafkaPillow(ConstructedPillow):
 
 def get_kafka_ucr_pillow():
     return ConfigurableReportKafkaPillow(
-        data_source_provider=DynamicDataSourceProvider(), pillow_name='kafka-ucr-main'
+        processor=ConfigurableReportPillowProcessor(
+            data_source_provider=DynamicDataSourceProvider(),
+            auto_repopulate_tables=False,
+        ),
+        pillow_name='kafka-ucr-main',
     )
 
 
 def get_kafka_ucr_static_pillow():
     return ConfigurableReportKafkaPillow(
-        data_source_provider=StaticDataSourceProvider(), pillow_name='kafka-ucr-static'
+        processor=ConfigurableReportPillowProcessor(
+            data_source_provider=StaticDataSourceProvider(),
+            auto_repopulate_tables=True,
+        ),
+        pillow_name='kafka-ucr-static',
     )

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -149,16 +149,6 @@ class ConfigurableIndicatorPillow(ConfigurableReportTableManagerMixin, PythonPil
                 table.delete(doc)
 
 
-class StaticDataSourcePillow(ConfigurableIndicatorPillow):
-
-    def __init__(self):
-        super(StaticDataSourcePillow, self).__init__(
-            data_source_provider=StaticDataSourceProvider(),
-            auto_repopulate_tables=True,
-            pillow_checkpoint_id=UCR_STATIC_CHECKPOINT_ID,
-        )
-
-
 class ConfigurableReportPillowProcessor(ConfigurableReportTableManagerMixin, PillowProcessor):
 
     def process_change(self, pillow_instance, change, do_set_checkpoint):

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -110,7 +110,8 @@ class ConfigurableReportTableManagerMixin(object):
 
 class ConfigurableIndicatorPillow(ConfigurableReportTableManagerMixin, PythonPillow):
 
-    def __init__(self, data_source_provider=None, pillow_checkpoint_id=UCR_CHECKPOINT_ID):
+    def __init__(self, data_source_provider=None, auto_repopulate_tables=False,
+                 pillow_checkpoint_id=UCR_CHECKPOINT_ID):
         # todo: this will need to not be hard-coded if we ever split out forms and cases into their own databases
         couch_db = CachedCouchDB(CommCareCase.get_db().uri, readonly=False)
         checkpoint = PillowCheckpoint(pillow_checkpoint_id)

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -201,6 +201,9 @@ class ConfigurableReportKafkaPillow(ConstructedPillow):
     def bootstrap(self, configs=None):
         self._processor.bootstrap(configs)
 
+    def rebuild_table(self, sql_adapter):
+        self._processor.rebuild_table(sql_adapter)
+
 
 def get_kafka_ucr_pillow():
     return ConfigurableReportKafkaPillow(

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -8,7 +8,6 @@ from corehq.apps.userreports.exceptions import TableRebuildError, StaleRebuildEr
 from corehq.apps.userreports.sql import IndicatorSqlAdapter, metadata
 from corehq.apps.userreports.tasks import is_static, rebuild_indicators
 from corehq.sql_db.connections import connection_manager
-from corehq.toggles import KAFKA_UCRS
 from corehq.util.soft_assert import soft_assert
 from fluff.signals import get_migration_context, get_tables_to_rebuild
 from pillowtop.checkpoints.manager import PillowCheckpoint
@@ -121,7 +120,7 @@ class ConfigurableReportPillowProcessor(ConfigurableReportTableManagerMixin, Pil
             return
 
         for table in self.table_adapters:
-            if table.config.domain == domain and KAFKA_UCRS.enabled(domain):
+            if table.config.domain == domain:
                 # only bother getting the document if we have a domain match from the metadata
                 doc = change.get_document()
                 if table.config.filter(doc):

--- a/corehq/apps/userreports/tests/test_multi_db.py
+++ b/corehq/apps/userreports/tests/test_multi_db.py
@@ -5,13 +5,15 @@ from mock import patch
 from sqlalchemy import create_engine
 from sqlalchemy.exc import ProgrammingError
 from corehq.apps.userreports.models import DataSourceConfiguration, ReportConfiguration
-from corehq.apps.userreports.pillow import ConfigurableIndicatorPillow
+from corehq.apps.userreports.pillow import get_kafka_ucr_pillow
 from corehq.apps.userreports.reports.factory import ReportFactory
 from corehq.apps.userreports.sql.connection import get_engine_id
 from corehq.apps.userreports.tests.utils import get_sample_data_source, get_sample_doc_and_indicators, \
-    get_sample_report_config
+    get_sample_report_config, doc_to_change
 from corehq.apps.userreports.sql import IndicatorSqlAdapter
 from corehq.sql_db import connections
+from corehq.toggles import KAFKA_UCRS
+from corehq.util.decorators import temporarily_enable_toggle
 
 
 class UCRMultiDBTest(TestCase):
@@ -105,23 +107,25 @@ class UCRMultiDBTest(TestCase):
         self.assertEqual(settings.SQL_REPORTING_DATABASE_URL, str(self.ds1_adapter.engine.url))
         self.assertEqual(self.db2_url, str(self.ds2_adapter.engine.url))
 
+    @temporarily_enable_toggle(KAFKA_UCRS, 'user-reports')
     def test_pillow_save_to_multiple_databases(self):
         self.assertNotEqual(self.ds1_adapter.engine.url, self.ds2_adapter.engine.url)
-        pillow = ConfigurableIndicatorPillow()
+        pillow = get_kafka_ucr_pillow()
         pillow.bootstrap(configs=[self.ds_1, self.ds_2])
         self.assertNotEqual(self.ds1_adapter.engine.url, self.ds2_adapter.engine.url)
         sample_doc, _ = get_sample_doc_and_indicators()
-        pillow.change_transport(sample_doc)
+        pillow.processor(doc_to_change(sample_doc))
         self.assertNotEqual(self.ds1_adapter.engine.url, self.ds2_adapter.engine.url)
         self.assertEqual(1, self.ds1_adapter.get_query_object().count())
         self.assertEqual(1, self.ds2_adapter.get_query_object().count())
 
+    @temporarily_enable_toggle(KAFKA_UCRS, 'user-reports')
     def test_pillow_save_to_one_database_at_a_time(self):
-        pillow = ConfigurableIndicatorPillow()
+        pillow = get_kafka_ucr_pillow()
         pillow.bootstrap(configs=[self.ds_1])
 
         sample_doc, _ = get_sample_doc_and_indicators()
-        pillow.change_transport(sample_doc)
+        pillow.processor(doc_to_change(sample_doc))
 
         self.assertEqual(1, self.ds1_adapter.get_query_object().count())
         self.assertEqual(0, self.ds2_adapter.get_query_object().count())
@@ -130,12 +134,13 @@ class UCRMultiDBTest(TestCase):
         pillow.bootstrap(configs=[self.ds_2])
         orig_id = sample_doc['_id']
         sample_doc['_id'] = uuid.uuid4().hex
-        pillow.change_transport(sample_doc)
+        pillow.processor(doc_to_change(sample_doc))
         self.assertEqual(1, self.ds1_adapter.get_query_object().count())
         self.assertEqual(1, self.ds2_adapter.get_query_object().count())
         self.assertEqual(1, self.ds1_adapter.get_query_object().filter_by(doc_id=orig_id).count())
         self.assertEqual(1, self.ds2_adapter.get_query_object().filter_by(doc_id=sample_doc['_id']).count())
 
+    @temporarily_enable_toggle(KAFKA_UCRS, 'user-reports')
     def test_report_data_source(self):
         # bootstrap report data sources against indicator data sources
         report_config_template = get_sample_report_config()

--- a/corehq/apps/userreports/tests/test_multi_db.py
+++ b/corehq/apps/userreports/tests/test_multi_db.py
@@ -12,8 +12,6 @@ from corehq.apps.userreports.tests.utils import get_sample_data_source, get_samp
     get_sample_report_config, doc_to_change
 from corehq.apps.userreports.sql import IndicatorSqlAdapter
 from corehq.sql_db import connections
-from corehq.toggles import KAFKA_UCRS
-from corehq.util.decorators import temporarily_enable_toggle
 
 
 class UCRMultiDBTest(TestCase):
@@ -107,7 +105,6 @@ class UCRMultiDBTest(TestCase):
         self.assertEqual(settings.SQL_REPORTING_DATABASE_URL, str(self.ds1_adapter.engine.url))
         self.assertEqual(self.db2_url, str(self.ds2_adapter.engine.url))
 
-    @temporarily_enable_toggle(KAFKA_UCRS, 'user-reports')
     def test_pillow_save_to_multiple_databases(self):
         self.assertNotEqual(self.ds1_adapter.engine.url, self.ds2_adapter.engine.url)
         pillow = get_kafka_ucr_pillow()
@@ -119,7 +116,6 @@ class UCRMultiDBTest(TestCase):
         self.assertEqual(1, self.ds1_adapter.get_query_object().count())
         self.assertEqual(1, self.ds2_adapter.get_query_object().count())
 
-    @temporarily_enable_toggle(KAFKA_UCRS, 'user-reports')
     def test_pillow_save_to_one_database_at_a_time(self):
         pillow = get_kafka_ucr_pillow()
         pillow.bootstrap(configs=[self.ds_1])
@@ -140,7 +136,6 @@ class UCRMultiDBTest(TestCase):
         self.assertEqual(1, self.ds1_adapter.get_query_object().filter_by(doc_id=orig_id).count())
         self.assertEqual(1, self.ds2_adapter.get_query_object().filter_by(doc_id=sample_doc['_id']).count())
 
-    @temporarily_enable_toggle(KAFKA_UCRS, 'user-reports')
     def test_report_data_source(self):
         # bootstrap report data sources against indicator data sources
         report_config_template = get_sample_report_config()

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -19,9 +19,7 @@ from corehq.apps.userreports.tasks import rebuild_indicators
 from corehq.apps.userreports.tests.utils import get_sample_data_source, get_sample_doc_and_indicators, \
     doc_to_change
 from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
-from corehq.util.decorators import temporarily_enable_toggle
 from corehq.util.test_utils import softer_assert
-from corehq.toggles import KAFKA_UCRS
 from corehq.util.context_managers import drop_connected_signals
 from testapps.test_pillowtop.utils import get_current_kafka_seq
 
@@ -95,7 +93,6 @@ class IndicatorPillowTest(IndicatorPillowTestBase):
         self.pillow = get_kafka_ucr_pillow()
         self.pillow.bootstrap(configs=[self.config])
 
-    @temporarily_enable_toggle(KAFKA_UCRS, 'user-reports')
     def test_stale_rebuild(self):
         later_config = copy(self.config)
         later_config.save()
@@ -104,7 +101,6 @@ class IndicatorPillowTest(IndicatorPillowTestBase):
             self.pillow.rebuild_table(IndicatorSqlAdapter(self.config))
 
     @patch('corehq.apps.userreports.specs.datetime')
-    @temporarily_enable_toggle(KAFKA_UCRS, 'user-reports')
     def test_change_transport(self, datetime_mock):
         datetime_mock.utcnow.return_value = self.fake_time_now
         sample_doc, expected_indicators = get_sample_doc_and_indicators(self.fake_time_now)
@@ -112,7 +108,6 @@ class IndicatorPillowTest(IndicatorPillowTestBase):
         self._check_sample_doc_state(expected_indicators)
 
     @patch('corehq.apps.userreports.specs.datetime')
-    @temporarily_enable_toggle(KAFKA_UCRS, 'user-reports')
     def test_rebuild_indicators(self, datetime_mock):
         datetime_mock.utcnow.return_value = self.fake_time_now
         self.config.save()
@@ -121,7 +116,6 @@ class IndicatorPillowTest(IndicatorPillowTestBase):
         rebuild_indicators(self.config._id)
         self._check_sample_doc_state(expected_indicators)
 
-    @temporarily_enable_toggle(KAFKA_UCRS, 'user-reports')
     def test_bad_integer_datatype(self):
         self.config.save()
         bad_ints = ['a', '', None]
@@ -137,7 +131,6 @@ class IndicatorPillowTest(IndicatorPillowTestBase):
         self.assertEqual(len(bad_ints), self.adapter.get_query_object().count())
 
     @patch('corehq.apps.userreports.specs.datetime')
-    @temporarily_enable_toggle(KAFKA_UCRS, 'user-reports')
     def test_basic_doc_processing(self, datetime_mock):
         datetime_mock.utcnow.return_value = self.fake_time_now
         sample_doc, expected_indicators = get_sample_doc_and_indicators(self.fake_time_now)
@@ -145,7 +138,6 @@ class IndicatorPillowTest(IndicatorPillowTestBase):
         self._check_sample_doc_state(expected_indicators)
 
     @patch('corehq.apps.userreports.specs.datetime')
-    @temporarily_enable_toggle(KAFKA_UCRS, 'user-reports')
     def test_process_doc_from_couch(self, datetime_mock):
         datetime_mock.utcnow.return_value = self.fake_time_now
         sample_doc, expected_indicators = get_sample_doc_and_indicators(self.fake_time_now)
@@ -166,7 +158,6 @@ class IndicatorPillowTest(IndicatorPillowTestBase):
 
     @patch('corehq.apps.userreports.specs.datetime')
     @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
-    @temporarily_enable_toggle(KAFKA_UCRS, 'user-reports')
     def test_process_doc_from_sql(self, datetime_mock):
         datetime_mock.utcnow.return_value = self.fake_time_now
         sample_doc, expected_indicators = get_sample_doc_and_indicators(self.fake_time_now)

--- a/corehq/apps/userreports/tests/test_pillow.py
+++ b/corehq/apps/userreports/tests/test_pillow.py
@@ -83,6 +83,11 @@ class IndicatorPillowTestBase(TestCase):
 
 
 class IndicatorPillowTest(IndicatorPillowTestBase):
+    dependent_apps = [
+        'couchforms', 'pillowtop', 'corehq.couchapps', 'corehq.apps.tzmigration',
+        'corehq.form_processor', 'corehq.sql_accessors', 'corehq.sql_proxy_accessors',
+        'casexml.apps.case', 'casexml.apps.phone'
+    ]
 
     @softer_assert
     def setUp(self):
@@ -130,20 +135,6 @@ class IndicatorPillowTest(IndicatorPillowTestBase):
             }))
         # make sure we saved rows to the table for everything
         self.assertEqual(len(bad_ints), self.adapter.get_query_object().count())
-
-
-class KafkaIndicatorPillowTest(IndicatorPillowTestBase):
-    dependent_apps = [
-        'couchforms', 'pillowtop', 'corehq.couchapps', 'corehq.apps.tzmigration',
-        'corehq.form_processor', 'corehq.sql_accessors', 'corehq.sql_proxy_accessors',
-        'casexml.apps.case', 'casexml.apps.phone'
-    ]
-
-    @softer_assert
-    def setUp(self):
-        super(KafkaIndicatorPillowTest, self).setUp()
-        self.pillow = get_kafka_ucr_pillow()
-        self.pillow.bootstrap(configs=[self.config])
 
     @patch('corehq.apps.userreports.specs.datetime')
     @temporarily_enable_toggle(KAFKA_UCRS, 'user-reports')

--- a/corehq/apps/userreports/tests/utils.py
+++ b/corehq/apps/userreports/tests/utils.py
@@ -3,8 +3,11 @@ from decimal import Decimal
 import json
 import os
 import uuid
+from casexml.apps.case.models import CommCareCase
+from corehq.apps.change_feed import data_sources
 from corehq.apps.userreports.models import DataSourceConfiguration, ReportConfiguration
 from dimagi.utils.parsing import json_format_datetime
+from pillowtop.feed.interface import Change, ChangeMeta
 
 
 def get_sample_report_config():
@@ -55,3 +58,20 @@ def get_sample_doc_and_indicators(fake_time_now=None):
         'inserted_at': fake_time_now,
     }
     return sample_doc, expected_indicators
+
+
+def doc_to_change(doc):
+    return Change(
+        id=doc['_id'],
+        sequence_id='0',
+        document=doc,
+        metadata=ChangeMeta(
+            document_id=doc['_id'],
+            data_source_type=data_sources.COUCH,
+            data_source_name=CommCareCase.get_db().dbname,
+            document_type=doc['doc_type'],
+            document_subtype=doc['type'],
+            domain=doc['domain'],
+            is_deletion=False,
+        )
+    )

--- a/corehq/ex-submodules/pillow_retry/models.py
+++ b/corehq/ex-submodules/pillow_retry/models.py
@@ -134,8 +134,8 @@ class PillowError(models.Model):
                 (models.Q(total_attempts__lte=multi_attempts_cutoff) & models.Q(current_attempt__lte=max_attempts))
             )
 
-        # temporarily disable queuing of ConfigurableIndicatorPillow errors
-        query = query.filter(~models.Q(pillow='corehq.apps.userreports.pillow.ConfigurableIndicatorPillow'))
+        # temporarily disable queuing of ConfigurableReportKafkaPillow errors
+        query = query.filter(~models.Q(pillow='corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow'))
 
         if not fetch_full:
             query = query.values('id', 'date_next_attempt')

--- a/corehq/ex-submodules/pillow_retry/tasks.py
+++ b/corehq/ex-submodules/pillow_retry/tasks.py
@@ -67,8 +67,8 @@ def process_pillow_retry(error_doc_id):
 
         try:
             try:
-                from corehq.apps.userreports.pillow import ConfigurableIndicatorPillow
-                if isinstance(pillow, ConfigurableIndicatorPillow):
+                from corehq.apps.userreports.pillow import ConfigurableReportKafkaPillow
+                if isinstance(pillow, ConfigurableReportKafkaPillow):
                     raise Exception('this is temporarily not supported!')
             except ImportError:
                 pass

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -330,13 +330,6 @@ REPORT_BUILDER_MAP_REPORTS = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
-KAFKA_UCRS = StaticToggle(
-    'kafka-ucrs',
-    'Use new kafka-based UCR processing',
-    TAG_EXPERIMENTAL,
-    [NAMESPACE_DOMAIN]
-)
-
 STOCK_TRANSACTION_EXPORT = StaticToggle(
     'ledger_export',
     'Show "export transactions" link on case details page',

--- a/settings.py
+++ b/settings.py
@@ -1350,7 +1350,11 @@ PILLOWTOPS = {
         'corehq.pillows.reportcase.ReportCasePillow',
         'corehq.pillows.reportxform.ReportXFormPillow',
         'corehq.apps.userreports.pillow.ConfigurableIndicatorPillow',
-        'corehq.apps.userreports.pillow.StaticDataSourcePillow',
+        {
+            'name': 'kafka-ucr-static',
+            'class': 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow',
+            'instance': 'corehq.apps.userreports.pillow.get_kafka_ucr_static_pillow',
+        },
     ],
     'cache': [
         {
@@ -1422,11 +1426,6 @@ PILLOWTOPS = {
             'name': 'kafka-ucr-main',
             'class': 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow',
             'instance': 'corehq.apps.userreports.pillow.get_kafka_ucr_pillow',
-        },
-        {
-            'name': 'kafka-ucr-static',
-            'class': 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow',
-            'instance': 'corehq.apps.userreports.pillow.get_kafka_ucr_static_pillow',
         },
     ]
 }

--- a/settings.py
+++ b/settings.py
@@ -1349,7 +1349,11 @@ PILLOWTOPS = {
     'core_ext': [
         'corehq.pillows.reportcase.ReportCasePillow',
         'corehq.pillows.reportxform.ReportXFormPillow',
-        'corehq.apps.userreports.pillow.ConfigurableIndicatorPillow',
+        {
+            'name': 'kafka-ucr-main',
+            'class': 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow',
+            'instance': 'corehq.apps.userreports.pillow.get_kafka_ucr_pillow',
+        },
         {
             'name': 'kafka-ucr-static',
             'class': 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow',
@@ -1421,11 +1425,6 @@ PILLOWTOPS = {
             'name': 'SqlCaseToElasticsearchPillow',
             'class': 'pillowtop.pillow.interface.ConstructedPillow',
             'instance': 'corehq.pillows.case.get_sql_case_to_elasticsearch_pillow',
-        },
-        {
-            'name': 'kafka-ucr-main',
-            'class': 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow',
-            'instance': 'corehq.apps.userreports.pillow.get_kafka_ucr_pillow',
         },
     ]
 }

--- a/settings.py
+++ b/settings.py
@@ -1350,6 +1350,16 @@ PILLOWTOPS = {
         'corehq.pillows.reportcase.ReportCasePillow',
         'corehq.pillows.reportxform.ReportXFormPillow',
         {
+            'name': 'DefaultChangeFeedPillow',
+            'class': 'corehq.apps.change_feed.pillow.ChangeFeedPillow',
+            'instance': 'corehq.apps.change_feed.pillow.get_default_couch_db_change_feed_pillow',
+        },
+        {
+            'name': 'UserGroupsDbKafkaPillow',
+            'class': 'pillowtop.pillow.interface.ConstructedPillow',
+            'instance': 'corehq.apps.change_feed.pillow.get_user_groups_db_kafka_pillow',
+        },
+        {
             'name': 'kafka-ucr-main',
             'class': 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow',
             'instance': 'corehq.apps.userreports.pillow.get_kafka_ucr_pillow',
@@ -1401,16 +1411,6 @@ PILLOWTOPS = {
         'mvp_docs.pillows.MVPCaseIndicatorPillow',
     ],
     'experimental': [
-        {
-            'name': 'DefaultChangeFeedPillow',
-            'class': 'corehq.apps.change_feed.pillow.ChangeFeedPillow',
-            'instance': 'corehq.apps.change_feed.pillow.get_default_couch_db_change_feed_pillow',
-        },
-        {
-            'name': 'UserGroupsDbKafkaPillow',
-            'class': 'pillowtop.pillow.interface.ConstructedPillow',
-            'instance': 'corehq.apps.change_feed.pillow.get_user_groups_db_kafka_pillow',
-        },
         {
             'name': 'BlobDeletionPillow',
             'class': 'pillowtop.pillow.interface.ConstructedPillow',

--- a/testapps/test_pillowtop/tests/data/all-pillow-meta.json
+++ b/testapps/test_pillowtop/tests/data/all-pillow-meta.json
@@ -114,19 +114,6 @@
         "name": "CasePillow",
         "unique_id": "d94ad23a98ddd2e9c36a9dc73bb58bac"
     },
-    "ConfigurableIndicatorPillow": {
-        "advertised_name": "corehq.apps.userreports.pillow.ConfigurableIndicatorPillow.testhq",
-        "change_feed_type": "CouchChangeFeed",
-        "checkpoint_id": "pillow-checkpoint-ucr-main",
-        "couch_filter": null,
-        "couchdb_type": "CachedCouchDB",
-        "couchdb_uri": "http://{COUCH_SERVER_ROOT}/test_commcarehq",
-        "document_class": null,
-        "extra_args": {},
-        "full_class_name": "corehq.apps.userreports.pillow.ConfigurableIndicatorPillow",
-        "include_docs": false,
-        "name": "ConfigurableIndicatorPillow"
-    },
     "CouvertureFluffPillow": {
         "advertised_name": "fluff.CouvertureFluffPillow.testhq",
         "change_feed_type": "KafkaChangeFeed",

--- a/testapps/test_pillowtop/tests/data/all-pillow-meta.json
+++ b/testapps/test_pillowtop/tests/data/all-pillow-meta.json
@@ -505,19 +505,6 @@
         "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
         "name": "SqlXFormToElasticsearchPillow"
     },
-    "StaticDataSourcePillow": {
-        "advertised_name": "corehq.apps.userreports.pillow.StaticDataSourcePillow.testhq",
-        "change_feed_type": "CouchChangeFeed",
-        "checkpoint_id": "pillow-checkpoint-ucr-static",
-        "couch_filter": null,
-        "couchdb_type": "CachedCouchDB",
-        "couchdb_uri": "http://{COUCH_SERVER_ROOT}/test_commcarehq",
-        "document_class": null,
-        "extra_args": {},
-        "full_class_name": "corehq.apps.userreports.pillow.StaticDataSourcePillow",
-        "include_docs": false,
-        "name": "StaticDataSourcePillow"
-    },
     "TauxDeRuptureFluffPillow": {
         "advertised_name": "fluff.TauxDeRuptureFluffPillow.testhq",
         "change_feed_type": "KafkaChangeFeed",


### PR DESCRIPTION
@snopoke cc @dimagi/scale-team 

this fully cuts over UCRs to kafka and removes the old code. I've been enabling domains on prod and everything is looking good as best as I can tell. If something goes horribly wrong we can always revert and the old code/checkpoint should be there to catch up the data sources.

:fish: or :office: 
