### PR TITLE
Don't fall over if a report config gets deleted

### DIFF
--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from datetime import datetime
 import logging
+from couchdbkit import ResourceNotFound
 from lxml.builder import E
 from django.conf import settings
 
@@ -11,7 +12,7 @@ from corehq.apps.app_manager.models import (
 )
 from corehq.util.xml_utils import serialize
 
-from corehq.apps.userreports.exceptions import UserReportsError
+from corehq.apps.userreports.exceptions import UserReportsError, BadReportConfigurationError
 from corehq.apps.userreports.models import ReportConfiguration
 from corehq.apps.userreports.reports.factory import ReportFactory
 from corehq.apps.app_manager.dbaccessors import get_apps_in_domain
@@ -42,6 +43,9 @@ class ReportFixturesProvider(object):
         for report_config in report_configs:
             try:
                 reports_elem.append(self._report_config_to_fixture(report_config, user))
+            except BadReportConfigurationError as err:
+                logging.exception('Error generating report fixture: {}'.format(err))
+                continue
             except UserReportsError:
                 if settings.UNIT_TESTING or settings.DEBUG:
                     raise
@@ -55,7 +59,12 @@ class ReportFixturesProvider(object):
     @staticmethod
     def _report_config_to_fixture(report_config, user):
         report_elem = E.report(id=report_config.uuid)
-        report = ReportConfiguration.get(report_config.report_id)
+        try:
+            report = ReportConfiguration.get(report_config.report_id)
+        except ResourceNotFound as err:
+            # ReportConfiguration not found
+            raise BadReportConfigurationError('Error getting ReportConfiguration with ID "{}": {}'.format(
+                report_config.report_id, err))
         data_source = ReportFactory.from_spec(report)
 
         all_filter_values = {

--- a/corehq/apps/userreports/exceptions.py
+++ b/corehq/apps/userreports/exceptions.py
@@ -56,3 +56,7 @@ class ReportConfigurationNotFoundError(UserReportsError):
 
 class InvalidQueryColumn(Exception):
     pass
+
+
+class BadReportConfigurationError(UserReportsError):
+    pass


### PR DESCRIPTION
Prevents mobile UCR fixtures breaking sync if their report config has been deleted.

```
2016-03-11 15:26:52,765 ERROR Error generating report fixture: Error retrieving ReportConfiguration with ID "c04ded44efe2eacccfa8b58
37609a71a": 
Traceback (most recent call last):
  File "/home/nhooper/src/commcare-hq/corehq/apps/app_manager/fixtures/mobile_ucr.py", line 45, in __call__
    reports_elem.append(self._report_config_to_fixture(report_config, user))
  File "/home/nhooper/src/commcare-hq/corehq/apps/app_manager/fixtures/mobile_ucr.py", line 67, in _report_config_to_fixture
    report_config.report_id, err))
BadReportConfigurationError: Error retrieving ReportConfiguration with ID "c04ded44efe2eacccfa8b5837609a71a": 
[11/Mar/2016 15:26:53] "GET /a/nhproject/phone/restore/f4df5782cbe92b328f41d29d2a3f9aba/?version=2.0&since=d30c60f0854085d2b6acd1513
0b8acad&state=ccsh%3A1097ae8d8305211c64ad58a3dcd119c2&items=true HTTP/1.0" 200 1230
```

(The exception is logged, but the request returns with a 200.)

Is logging this the best approach? Should I use a soft assert? Or just ignore? Might be better to invalidate an app that refers to a deleted report config, so that the user can't create a build.

@czue cc @dannyroberts 
