### PR TITLE
AncestorLocationTypeFilter is not an AutoFilter

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -3494,11 +3494,6 @@ class AncestorLocationTypeFilter(ReportAppFilter):
     ancestor_location_type_name = StringProperty()
 
     def get_filter_value(self, user, ui_filter):
-        """
-        A list of locations who have the same ancestor as user param
-
-        :raises LocationType.DoesNotExist: if ancestor_location_type_name does not match a location type
-        """
         from corehq.apps.locations.models import SQLLocation
 
         try:

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -3499,7 +3499,7 @@ class AncestorLocationTypeFilter(ReportAppFilter):
         try:
             ancestor = user.sql_location.get_ancestors(include_self=True).\
                 get(location_type__name=self.ancestor_location_type_name)
-        except AttributeError, SQLLocation.DoesNotExist:
+        except (AttributeError, SQLLocation.DoesNotExist):
             # user.sql_location is None, or location does not have an ancestor of that type
             return None
         return ancestor.location_id

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -3274,6 +3274,7 @@ class ReportAppFilter(DocumentSchema):
                 'CustomDatespanFilter': CustomDatespanFilter,
                 'CustomMonthFilter': CustomMonthFilter,
                 'MobileSelectFilter': MobileSelectFilter,
+                'AncestorLocationTypeFilter': AncestorLocationTypeFilter,
             }
             try:
                 klass = doc_type_to_filter_class[doc_type]
@@ -3316,20 +3317,10 @@ def _filter_by_parent_location_id(user, ui_filter):
     return ui_filter.value(**{ui_filter.name: location_parent})
 
 
-def _filter_by_ancestor_location_type_id(user, ui_filter):
-    from corehq.apps.reports_core.filters import Choice
-    location = user.sql_location
-    return [
-        Choice(value=loc.location_type.id, display=loc.location_type.name)
-        for loc in location.get_ancestors()
-    ] if location else []
-
-
 _filter_type_to_func = {
     'case_sharing_group': _filter_by_case_sharing_group_id,
     'location_id': _filter_by_location_id,
     'parent_location_id': _filter_by_parent_location_id,
-    'ancestor_location_type_id': _filter_by_ancestor_location_type_id,
     'username': _filter_by_username,
     'user_id': _filter_by_user_id,
 }
@@ -3497,6 +3488,26 @@ class CustomMonthFilter(ReportAppFilter):
 class MobileSelectFilter(ReportAppFilter):
     def get_filter_value(self, user, ui_filter):
         return None
+
+
+class AncestorLocationTypeFilter(ReportAppFilter):
+    ancestor_location_type_name = StringProperty()
+
+    def get_filter_value(self, user, ui_filter):
+        """
+        A list of locations who have the same ancestor as user param
+
+        :raises LocationType.DoesNotExist: if ancestor_location_type_name does not match a location type
+        """
+        from corehq.apps.locations.models import SQLLocation
+
+        try:
+            ancestor = user.sql_location.get_ancestors(include_self=True).\
+                get(location_type__name=self.ancestor_location_type_name)
+        except AttributeError, SQLLocation.DoesNotExist:
+            # user.sql_location is None, or location does not have an ancestor of that type
+            return None
+        return ancestor.location_id
 
 
 class ReportAppConfig(DocumentSchema):

--- a/corehq/apps/app_manager/static/app_manager/js/report-module.js
+++ b/corehq/apps/app_manager/static/app_manager/js/report-module.js
@@ -156,7 +156,8 @@ hqDefine('app_manager/js/report-module.js', function () {
                     'date_number',
                     'date_number2',
                     'start_of_month',
-                    'period'
+                    'period',
+                    'ancestor_location_type_name'
                 ];
                 for(var filterFieldsIndex = 0; filterFieldsIndex < filterFields.length; filterFieldsIndex++) {
                     startVal = filter.selectedValue[filterFields[filterFieldsIndex]];

--- a/corehq/apps/app_manager/static/app_manager/js/report-module.js
+++ b/corehq/apps/app_manager/static/app_manager/js/report-module.js
@@ -197,7 +197,8 @@ hqDefine('app_manager/js/report-module.js', function () {
                         StaticChoiceFilter: ['select_value'],
                         StaticDatespanFilter: ['date_range'],
                         CustomDatespanFilter: ['operator', 'date_number', 'date_number2'],
-                        CustomMonthFilter: ['start_of_month', 'period']
+                        CustomMonthFilter: ['start_of_month', 'period'],
+                        AncestorLocationTypeFilter: ['ancestor_location_type_name']
                     };
                     _.each(docTypeToField, function(field, docType) {
                         if(filter.selectedValue.doc_type() === docType) {
@@ -236,13 +237,13 @@ hqDefine('app_manager/js/report-module.js', function () {
             'CustomDataAutoFilter',
             'StaticChoiceListFilter',
             'StaticChoiceFilter',
-            'MobileSelectFilter'
+            'MobileSelectFilter',
+            'AncestorLocationTypeFilter'
         ];
         this.autoFilterTypes = [
             'case_sharing_group',
             'location_id',
             'parent_location_id',
-            'ancestor_location_type_id',
             'username',
             'user_id'
         ];

--- a/corehq/apps/app_manager/templates/app_manager/partials/filter_configs.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/filter_configs.html
@@ -86,6 +86,11 @@
                             value: filter.selectedValue.select_value
                         "></select>
                     </div>
+                    <div data-bind="visible: filter.selectedValue.doc_type() === 'AncestorLocationTypeFilter'">
+                        <input class="form-control"
+                               type="text"
+                               data-bind="value: filter.selectedValue.ancestor_location_type_name"/>
+                    </div>
                 </div>
             </th>
         </tr>

--- a/corehq/apps/app_manager/tests/test_filters.py
+++ b/corehq/apps/app_manager/tests/test_filters.py
@@ -8,7 +8,6 @@ from corehq.apps.app_manager.models import (
     _filter_by_case_sharing_group_id,
     _filter_by_location_id,
     _filter_by_parent_location_id,
-    _filter_by_ancestor_location_type_id,
     _filter_by_username,
     _filter_by_user_id,
 )
@@ -270,14 +269,6 @@ class AutoFilterTests(TestCase):
         result = _filter_by_parent_location_id(self.jon, self.ui_filter)
         self.ui_filter.value.assert_called_with(test_filter=self.massachusetts.location_id)
         self.assertEqual(result, 'result')
-
-    def test_filter_by_ancestor_location_type_id(self):
-        result = _filter_by_ancestor_location_type_id(self.nate, None)
-        self.assertEqual(result, [
-            Choice(value=self.country.id, display='country'),
-            Choice(value=self.state.id, display='state'),
-            # Note: These are ancestors, so the user's own location type is excluded
-        ])
 
     def test_filter_by_username(self):
         result = _filter_by_username(self.sheel, None)

--- a/corehq/apps/app_manager/tests/test_filters.py
+++ b/corehq/apps/app_manager/tests/test_filters.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 from django.test import SimpleTestCase, TestCase
 from mock import Mock, patch
 from corehq.apps.app_manager.models import (
+    AncestorLocationTypeFilter,
     CustomMonthFilter,
     _filter_by_case_sharing_group_id,
     _filter_by_location_id,
@@ -277,3 +278,9 @@ class AutoFilterTests(TestCase):
     def test_filter_by_user_id(self):
         result = _filter_by_user_id(self.sheel, None)
         self.assertEqual(result, Choice(value=self.sheel._id, display=None))
+
+    # AncestorLocationTypeFilter is not an AutoFilter, but we'll hitch a ride here to reuse setup and teardown
+    def test_ancestor_location_type_filter(self):
+        filt = AncestorLocationTypeFilter(ancestor_location_type_name='state')
+        nate_state = filt.get_filter_value(self.nate, None)
+        self.assertEqual(nate_state, self.massachusetts.location_id)


### PR DESCRIPTION
I should revert the commit that added `_filter_by_ancestor_location_type_id` and `_filter_by_parent_location_id`, and then rebase this on top.

I got the original design wrong: This is not supposed to be an AutoFilter, in that the device user doesn't get to choose the ancestor location type. The report creator sets it.

The UI is currently producing a JS error. (It seems that `filter.selectedValue[value]` ([report-module.js:201](https://github.com/dimagi/commcare-hq/blob/e85d4351431ec8704d4fde56a87b6f953db941d4/corehq/apps/app_manager/static/app_manager/js/report-module.js#L201-L201)) is not an observable for this filter. I don't understand why -- it is for all the other filters.)

Context: [FB 220703](http://manage.dimagi.com/default.asp?220703), [FB 215658](http://manage.dimagi.com/default.asp?215658), [Trello](https://trello.com/c/q1MDLHl7/99-mobile-ucr-custom-location-id-options)

Anyway. Open for review. 

@benrudolph @calellowitz cc @czue @dannyroberts @nickpell 
