### PR TITLE
_filter_by_parent_location_id should return siblings, not parent

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -3319,9 +3319,15 @@ def _filter_by_user_id(user, ui_filter):
 
 
 def _filter_by_parent_location_id(user, ui_filter):
+    """
+    A list of location IDs that share the same parent (i.e. siblings)
+    """
+    from corehq.apps.reports_core.filters import Choice
     location = user.sql_location
-    location_parent = location.parent.location_id if location and location.parent else None
-    return ui_filter.value(**{ui_filter.name: location_parent})
+    if location and location.parent:
+        return [Choice(value=l.location_id, display=None) for l in location.parent.get_children()]
+    else:
+        return []
 
 
 def _filter_by_ancestor_location_type_id(user, ui_filter):


### PR DESCRIPTION
Relates to PR #10718

I haven't tested this. Original filter returns the parent location ID. This returns a list of sibling location IDs. I'm pretty sure this filter is supposed to do the latter, not the former. I'll confirm with Sheel, but feedback welcome.

@czue @dannyroberts @nickpell
