### PR TITLE
ILS: Ignore case of product code in la handler

### DIFF
--- a/custom/ilsgateway/tanzania/handlers/la.py
+++ b/custom/ilsgateway/tanzania/handlers/la.py
@@ -39,7 +39,7 @@ class LossAndAdjustment(KeywordHandler):
         error = False
         for product_code, quantity in parsed_report:
             try:
-                product_id = SQLProduct.objects.get(domain=self.domain, code=product_code).product_id
+                product_id = SQLProduct.objects.get(domain=self.domain, code__iexact=product_code).product_id
                 self._create_stock_transaction(report, product_id, quantity)
             except SQLProduct.DoesNotExist:
                 error = True

--- a/custom/ilsgateway/tests/handlers/loss_adjust.py
+++ b/custom/ilsgateway/tests/handlers/loss_adjust.py
@@ -31,7 +31,7 @@ class ILSLossesAdjustmentsTest(ILSTestScript):
             self.assertEqual(ps.stock_on_hand, sohs[ps.sql_product.code])
 
         script = """
-            5551234 > um id -3 dp -5 ip 13
+            5551234 > um ID -3 dp -5 IP 13
             5551234 < {0}
         """.format(response2)
         self.run_script(script)


### PR DESCRIPTION
@czue @gcapalbo 
I think it's worth to deploy this change when you will be online because they mostly report data using upper case. 
