### PR TITLE
Reuse next_subscription filter for is_renewed

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1081,25 +1081,24 @@ class Subscription(models.Model):
         return ['do_not_invoice', 'no_invoice_reason', 'salesforce_contract_id']
 
     @property
+    def next_subscription_filter(self):
+        return (Subscription.objects.
+                filter(subscriber=self.subscriber, date_start__gt=self.date_start).
+                exclude(pk=self.pk).
+                exclude(date_start=F('date_end')))
+
+    @property
     def is_renewed(self):
         """
         Checks to see if there's another Subscription for this subscriber
         that starts after this subscription.
         """
-        return Subscription.objects.filter(
-            subscriber=self.subscriber, date_start__gt=self.date_start
-        ).exclude(pk=self.pk).exists()
+        return self.next_subscription_filter.exists()
 
     @property
     def next_subscription(self):
         try:
-            return Subscription.objects.filter(
-                subscriber=self.subscriber, date_start__gt=self.date_start
-            ).exclude(
-                pk=self.pk
-            ).exclude(
-                date_start=F('date_end')
-            ).order_by('date_start')[0]
+            return self.next_subscription_filter.order_by('date_start')[0]
         except (Subscription.DoesNotExist, IndexError):
             return None
 


### PR DESCRIPTION
Context [FB 221066](http://manage.dimagi.com/default.asp?221066)

subscription.is_renewed was returning True but subscription.next_subscription was returning None. Reusing the same filter resolves.

Added tearDown to the test to ensure order of tests doesn't affect results.

@calellowitz @benrudolph cc @dannyroberts @biyeun 
