### PR TITLE
Make dashboard tile text colors match

### DIFF
--- a/corehq/apps/dashboard/static/dashboard/ng_partials/paginated_tile.html
+++ b/corehq/apps/dashboard/static/dashboard/ng_partials/paginated_tile.html
@@ -16,7 +16,6 @@
             <div class="list-group" ng-show="showItemList()">
                     <div class="list-group-item"
                          data-ng-repeat="item in paginatedItems"
-                         data-ng-if="item.secondary_url"
                          popover-placement="right"
                          popover-title="{{ item.name_full }}"
                          popover="{{ item.description }}"
@@ -24,22 +23,12 @@
                          track-analytics=""
                          title="">
                         <a href="{{ item.url }}">{{ item.name }}</a>
-                        <a class="list-group-item-icon" href="{{ item.secondary_url }}">
+                        <a class="list-group-item-icon"
+                           data-ng-if="item.secondary_url"
+                           href="{{ item.secondary_url }}">
                             <i class="{{ item.secondary_url_icon }}"></i>
                         </a>
                     </div>
-                    <a class="list-group-item"
-                       href="{{ item.url }}"
-                       data-ng-repeat="item in paginatedItems"
-                       data-ng-if="!item.secondary_url"
-                       popover-placement="right"
-                       popover-title="{{ item.name_full }}"
-                       popover="{{ item.description }}"
-                       popover-trigger="mouseenter"
-                       track-analytics=""
-                       title="">
-                        {{ item.name }}
-                    </a>
             </div>
             <pagination direction-links="true"
                         total-items="total"


### PR DESCRIPTION
It's weird that the dashboard tile text comes in different colors, and the click targets are slightly different (for apps, each item has two distinct links, while for the others, there's just one url so the whole item is a click target).

Before:
<img width="870" alt="screen shot 2016-03-14 at 10 07 26 am" src="https://cloud.githubusercontent.com/assets/1486591/13747021/a8a9722a-e9cc-11e5-98a1-22123af7bfdb.png">

After:
Everything is blue links.

@sravfeyn 
