### PR TITLE
ILS: Handle already registered users in handler

### DIFF
--- a/custom/ilsgateway/tanzania/handlers/register.py
+++ b/custom/ilsgateway/tanzania/handlers/register.py
@@ -1,17 +1,10 @@
 import re
 
-from django.contrib.auth.models import User
+from corehq.apps.locations.models import SQLLocation
 
-from corehq.apps.locations.models import SQLLocation, Location
-
-from corehq.apps.sms.mixin import PhoneNumberInUseException, VerifiedNumber
-from corehq.apps.users.models import CommCareUser
 from custom.ilsgateway.tanzania.handlers.keyword import KeywordHandler
-from custom.ilsgateway.models import ILSGatewayConfig
-from custom.ilsgateway.tanzania.reminders import REGISTER_HELP, Languages, \
-    REGISTRATION_CONFIRM_DISTRICT, REGISTRATION_CONFIRM, Roles
-from custom.logistics.commtrack import add_location
-
+from custom.ilsgateway.tanzania.reminders import REGISTER_HELP, \
+    REGISTRATION_CONFIRM_DISTRICT, REGISTRATION_CONFIRM, Roles, REGISTER_UNKNOWN_DISTRICT, REGISTER_UNKNOWN_CODE
 
 DISTRICT_PREFIXES = ['d', 'm', 'tb', 'tg', 'dm', 'mz', 'mt', 'mb', 'ir', 'tb', 'ms']
 
@@ -21,33 +14,38 @@ class RegisterHandler(KeywordHandler):
 
     def help(self):
         self.respond(REGISTER_HELP)
+        return True
 
     def _get_facility_location(self, domain, msd_code):
-        return Location.by_site_code(domain, msd_code)
+        return SQLLocation.objects.get(
+            domain=domain,
+            location_type__name="FACILITY",
+            site_code__iexact=msd_code
+        ).couch_location
 
     def _get_district_location(self, domain, sp):
-        return SQLLocation.objects.filter(
+        return SQLLocation.objects.get(
             domain=domain,
             location_type__name="DISTRICT",
-            name=sp,
-        )[0].couch_location
+            name__iexact=sp,
+        ).couch_location
 
     def handle(self):
         text = ' '.join(self.msg.text.split()[1:])
         is_district = False
         sp = ""
         msd_code = ""
+        params = {}
 
         if text.find(self.DISTRICT_REG_DELIMITER) != -1:
             phrases = [x.strip() for x in text.split(":")]
             if len(phrases) != 2:
                 self.respond(REGISTER_HELP)
-                return
+                return True
             name = phrases[0]
             sp = phrases[1]
             role = Roles.DISTRICT_PHARMACIST
             message = REGISTRATION_CONFIRM_DISTRICT
-            params = {}
             is_district = True
         else:
             names = []
@@ -62,57 +60,45 @@ class RegisterHandler(KeywordHandler):
             name = " ".join(names)
             if len(msd_codes) != 1:
                 self.respond(REGISTER_HELP)
-                return
+                return True
             else:
                 [msd_code] = msd_codes
 
             role = Roles.IN_CHARGE
             message = REGISTRATION_CONFIRM
-            params = {
-                "msd_code": msd_code
-            }
 
-        if not self.user:
-            domains = [config.domain for config in ILSGatewayConfig.get_all_configs()]
-            for domain in domains:
-                if is_district:
-                    loc = self._get_district_location(domain, sp)
-                else:
-                    loc = self._get_facility_location(domain, msd_code)
-                if not loc:
-                    continue
-                splited_name = name.split(' ', 1)
-                first_name = splited_name[0]
-                last_name = splited_name[1] if len(splited_name) > 1 else ""
-                clean_name = name.replace(' ', '.')
-                username = "%s@%s.commcarehq.org" % (clean_name, domain)
-                password = User.objects.make_random_password()
-                user = CommCareUser.create(domain=domain, username=username, password=password,
-                                           commit=False)
-                user.first_name = first_name
-                user.last_name = last_name
-                try:
-                    user.set_default_phone_number(self.msg.phone_number.replace('+', ''))
-                    user.save_verified_number(domain, self.msg.phone_number.replace('+', ''), True, self.msg.backend_api)
-                except PhoneNumberInUseException as e:
-                    v = VerifiedNumber.by_phone(self.msg.phone_number, include_pending=True)
-                    v.delete()
-                    user.save_verified_number(domain, self.msg.phone_number.replace('+', ''), True, self.msg.backend_api)
-                except CommCareUser.Inconsistent:
-                    continue
-                user.language = Languages.DEFAULT
-                params.update({
-                    'sdp_name': loc.name,
-                    'contact_name': name
-                })
+        if is_district:
+            try:
+                loc = self._get_district_location(self.domain, sp)
+                params['sdp_name'] = loc.name
+            except SQLLocation.DoesNotExist:
+                self.respond(REGISTER_UNKNOWN_DISTRICT, name=sp)
+                return True
+        else:
+            try:
+                loc = self._get_facility_location(self.domain, msd_code)
+                params['sdp_name'] = loc.name
+                params['msd_code'] = loc.site_code
+            except SQLLocation.DoesNotExist:
+                self.respond(REGISTER_UNKNOWN_CODE, msd_code=msd_code)
+                return True
 
-                user.user_data = {
-                    'role': role
-                }
+        self.user.set_location(loc)
+        split_name = name.split(' ', 2)
+        first_name = ''
+        last_name = ''
+        if len(split_name) == 2:
+            first_name, last_name = split_name
+        elif split_name:
+            first_name = split_name[0]
 
-                dm = user.get_domain_membership(domain)
-                dm.location_id = loc.location_id
-                user.save()
-                add_location(user, loc.location_id)
+        self.user.first_name = first_name
+        self.user.last_name = last_name
+        self.user.is_active = True
+        self.user.user_data['role'] = role
+        self.user.save()
+        params['contact_name'] = name
+
         if params:
             self.respond(message, **params)
+        return True

--- a/custom/ilsgateway/tanzania/handlers/register.py
+++ b/custom/ilsgateway/tanzania/handlers/register.py
@@ -92,8 +92,9 @@ class RegisterHandler(KeywordHandler):
         elif split_name:
             first_name = split_name[0]
 
-        self.user.first_name = first_name
-        self.user.last_name = last_name
+        if first_name or last_name:
+            self.user.first_name = first_name
+            self.user.last_name = last_name
         self.user.is_active = True
         self.user.user_data['role'] = role
         self.user.save()

--- a/custom/ilsgateway/tests/__init__.py
+++ b/custom/ilsgateway/tests/__init__.py
@@ -22,6 +22,7 @@ from .handlers.messageinitatior import *
 from .handlers.bugs import *
 from .handlers.deliverygroups import *
 from .handlers.help import *
+from .handlers.register import *
 from .test_reminders import *
 from .test_report_runner import *
 from .test_reminders2 import *

--- a/custom/ilsgateway/tests/handlers/register.py
+++ b/custom/ilsgateway/tests/handlers/register.py
@@ -1,0 +1,184 @@
+from corehq.apps.users.models import CommCareUser
+from corehq.util.translation import localize
+from custom.ilsgateway.tanzania.reminders import REGISTRATION_CONFIRM, REGISTER_UNKNOWN_CODE, \
+    REGISTRATION_CONFIRM_DISTRICT, REGISTER_UNKNOWN_DISTRICT, REGISTER_HELP
+from custom.ilsgateway.tests.handlers.utils import ILSTestScript
+
+
+class RegisterHandler(ILSTestScript):
+
+    def test_register_facility(self):
+        with localize('sw'):
+            response = unicode(REGISTRATION_CONFIRM)
+
+        script = """
+          5551234 > sajili Test Test d31049
+          5551234 < %(registration_confirm)s
+        """ % {
+            "registration_confirm": response % {
+                "sdp_name": self.facility3.name,
+                "msd_code": "d31049",
+                "contact_name": "Test Test"
+            }
+        }
+        self.run_script(script)
+        user = CommCareUser.get_by_username('stella')
+        self.assertEqual(user.location.site_code, 'd31049')
+        self.assertEqual(user.full_name, 'Test Test')
+
+    def test_register_facility_with_unknown_code(self):
+        with localize('sw'):
+            response = unicode(REGISTER_UNKNOWN_CODE)
+
+        script = """
+          5551234 > sajili Test Test d00000
+          5551234 < %(unknown_code)s
+        """ % {
+            "unknown_code": response % {
+                "msd_code": "d00000",
+            }
+        }
+        self.run_script(script)
+
+    def test_register_district_lowercase(self):
+        with localize('sw'):
+            response = unicode(REGISTRATION_CONFIRM_DISTRICT)
+
+        script = """
+          5551234 > sajili Test Test : testdistrict
+          5551234 < %(registration_confirm)s
+        """ % {
+            "registration_confirm": response % {
+                "sdp_name": self.district3.name,
+                "contact_name": "Test Test"
+            }
+        }
+        self.run_script(script)
+
+        self.assertEqual(CommCareUser.get_by_username('stella').location.site_code, 'd10102')
+
+    def test_register_district_uppercase(self):
+        with localize('sw'):
+            response = unicode(REGISTRATION_CONFIRM_DISTRICT)
+
+        script = """
+          5551234 > sajili Test Test : TESTDISTRICT
+          5551234 < %(registration_confirm)s
+        """ % {
+            "registration_confirm": response % {
+                "sdp_name": self.district3.name,
+                "contact_name": "Test Test"
+            }
+        }
+        self.run_script(script)
+
+        self.assertEqual(CommCareUser.get_by_username('stella').location.site_code, 'd10102')
+
+    def test_register_district_mixed_case(self):
+        with localize('sw'):
+            response = unicode(REGISTRATION_CONFIRM_DISTRICT)
+
+        script = """
+          5551234 > sajili Test Test : TESTDISTRICT
+          5551234 < %(registration_confirm)s
+        """ % {
+            "registration_confirm": response % {
+                "sdp_name": self.district3.name,
+                "contact_name": "Test Test"
+            }
+        }
+        self.run_script(script)
+
+        self.assertEqual(CommCareUser.get_by_username('stella').location.site_code, 'd10102')
+
+    def test_register_district_multiple_word(self):
+        with localize('sw'):
+            response = unicode(REGISTRATION_CONFIRM_DISTRICT)
+
+        script = """
+          5551234 > sajili Test Test : Test District 1
+          5551234 < %(registration_confirm)s
+        """ % {
+            "registration_confirm": response % {
+                "sdp_name": self.district.name,
+                "contact_name": "Test Test"
+            }
+        }
+        self.run_script(script)
+
+        self.assertEqual(CommCareUser.get_by_username('stella').location.site_code, 'dis1')
+
+    def test_register_district_multiple_word_does_not_exist(self):
+        with localize('sw'):
+            response = unicode(REGISTER_UNKNOWN_DISTRICT)
+
+        script = """
+          5551234 > sajili Test Test : Test District 1213
+          5551234 < %(unknown)s
+        """ % {
+            "unknown": response % {
+                "name": 'Test District 1213'
+            }
+        }
+        self.run_script(script)
+
+    def test_register_district_forgot_separator(self):
+        with localize('sw'):
+            response = unicode(REGISTER_HELP)
+
+        script = """
+          5551234 > sajili Test Test testdistrict
+          5551234 < %(register_help)s
+        """ % {
+            "register_help": response
+        }
+        self.run_script(script)
+
+    def test_register_district_forgot_code(self):
+        with localize('sw'):
+            response = unicode(REGISTER_HELP)
+
+        script = """
+          5551234 > sajili Test Test
+          5551234 < %(register_help)s
+        """ % {
+            "register_help": response
+        }
+        self.run_script(script)
+
+    def test_register_district_mixed_spacing_for_separator(self):
+        with localize('sw'):
+            response = unicode(REGISTRATION_CONFIRM_DISTRICT)
+
+        script = """
+          5551234 > sajili Test Test: testdistrict
+          5551234 < %(registration_confirm)s
+        """ % {
+            "registration_confirm": response % {
+                "sdp_name": self.district3.name,
+                "contact_name": "Test Test"
+            }
+        }
+        self.run_script(script)
+
+        script = """
+          5551234 > sajili Test Test :testdistrict
+          5551234 < %(registration_confirm)s
+        """ % {
+            "registration_confirm": response % {
+                "sdp_name": self.district3.name,
+                "contact_name": "Test Test"
+            }
+        }
+        self.run_script(script)
+
+        script = """
+          5551234 > sajili Test Test  :   testdistrict
+          5551234 < %(registration_confirm)s
+        """ % {
+            "registration_confirm": response % {
+                "sdp_name": self.district3.name,
+                "contact_name": "Test Test"
+            }
+        }
+        self.run_script(script)

--- a/custom/ilsgateway/tests/handlers/utils.py
+++ b/custom/ilsgateway/tests/handlers/utils.py
@@ -38,17 +38,19 @@ class ILSTestScript(TestScript):
         region = make_loc(code="reg1", name="Test Region 1", type="REGION",
                           domain=domain.name, parent=msdzone)
 
-        district = make_loc(code="dis1", name="Test District 1", type="DISTRICT",
+        cls.district = make_loc(code="dis1", name="Test District 1", type="DISTRICT",
                             domain=domain.name, parent=region)
         cls.district2 = make_loc(code="d10101", name="Test District 2", type="DISTRICT",
-                             domain=domain.name, parent=region)
+                                 domain=domain.name, parent=region)
+        cls.district3 = make_loc(code="d10102", name="TESTDISTRICT", type="DISTRICT",
+                                 domain=domain.name, parent=region)
         facility = make_loc(code="loc1", name="Test Facility 1", type="FACILITY",
-                            domain=domain.name, parent=district, metadata={'group': 'A'})
+                            domain=domain.name, parent=cls.district, metadata={'group': 'A'})
         cls.facility_sp_id = facility.sql_location.supply_point_id
         facility2 = make_loc(code="loc2", name="Test Facility 2", type="FACILITY",
-                             domain=domain.name, parent=district, metadata={'group': 'B'})
+                             domain=domain.name, parent=cls.district, metadata={'group': 'B'})
         cls.facility3 = make_loc(
-            code="d31049", name="Test Facility 3", type="FACILITY", domain=domain.name, parent=district,
+            code="d31049", name="Test Facility 3", type="FACILITY", domain=domain.name, parent=cls.district,
             metadata={'group': 'C'}
         )
         cls.user1 = bootstrap_user(
@@ -57,9 +59,9 @@ class ILSTestScript(TestScript):
         )
         bootstrap_user(facility2, username='bella', domain=domain.name, home_loc='loc2', phone_number='5555678',
                        first_name='bella', last_name='Test', language='sw')
-        bootstrap_user(district, username='trella', domain=domain.name, home_loc='dis1', phone_number='555',
+        bootstrap_user(cls.district, username='trella', domain=domain.name, home_loc='dis1', phone_number='555',
                        first_name='trella', last_name='Test', language='sw')
-        bootstrap_user(district, username='msd_person', domain=domain.name, phone_number='111',
+        bootstrap_user(cls.district, username='msd_person', domain=domain.name, phone_number='111',
                        first_name='MSD', last_name='Person', user_data={'role': 'MSD'}, language='sw')
 
         for x in xrange(1, 4):


### PR DESCRIPTION
@gcapalbo 
They use registration handler in v1 e.g to change location or reactivate account. (https://github.com/dimagi/logistics/blob/tz-master/logistics_project/apps/tanzania/handlers/register.py). We added global keyword `#LOCATION` to handle changing location but users have no idea that they can use it.

Is there an easy way to handle keywords from non verified numbers in ILS custom module? Maybe forward all messages from push backend to our custom module. Then we can easily implement registration process in the same way as in v1. It's probably training thing but I guess most users will try to use register keyword from v1.
