### PR TITLE
maintaining rebuild redis queue and removing skip arg

### DIFF
--- a/corehq/apps/domain/dbaccessors.py
+++ b/corehq/apps/domain/dbaccessors.py
@@ -48,8 +48,7 @@ def iterate_doc_ids_in_domain_by_type(domain, doc_type, chunk_size=10000,
     }
     if startkey_docid:
         view_kwargs.update({
-            'startkey_docid': startkey_docid,
-            'skip': 1
+            'startkey_docid': startkey_docid
         })
     for doc in paginate_view(
             database,

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -42,16 +42,18 @@ def _build_indicators(indicator_config_id, relevant_ids):
     redis_client = get_redis_client().client.get_client()
     redis_key = _get_redis_key_for_config(config)
 
+    last_id = None
     for doc in iter_docs(couchdb, relevant_ids, chunksize=500):
         try:
             # save is a noop if the filter doesn't match
             adapter.save(doc)
-            redis_client.srem(redis_key, doc.get('_id'))
+            last_id = doc.get('_id')
+            redis_client.srem(redis_key, last_id)
         except Exception as e:
             logging.exception('problem saving document {} to table. {}'.format(doc['_id'], e))
 
-    if not is_static(indicator_config_id):
-        redis_client.delete(redis_key)
+    if last_id:
+        redis_client.sadd(redis_key, last_id)
 
 
 @task(queue='ucr_queue', ignore_result=True)
@@ -109,6 +111,7 @@ def _iteratively_build_table(config, last_id=None):
         _build_indicators(indicator_config_id, relevant_ids)
 
     if not is_static(indicator_config_id):
+        redis_client.delete(redis_key)
         config.meta.build.finished = True
         try:
             config.save()


### PR DESCRIPTION
@benrudolph @NoahCarnahan @NickPell
Last shot at getting those massive tables to build. Paginate view wont take a skip parameter so I got rid of it. The last doc will get repeated in every chunk but thats 1 in 10000 so doesnt seem like a huge problem.
The major change was to maintain the redis queue after each chunk of building, since resumes rely on there being at least one document in redis to know where to start from.
