### PR TITLE
putting dashboard links in div to change styling

### DIFF
--- a/corehq/apps/dashboard/static/dashboard/ng_partials/paginated_tile.html
+++ b/corehq/apps/dashboard/static/dashboard/ng_partials/paginated_tile.html
@@ -28,8 +28,7 @@
                             <i class="{{ item.secondary_url_icon }}"></i>
                         </a>
                     </div>
-                    <a class="list-group-item"
-                       href="{{ item.url }}"
+                    <div class="list-group-item"
                        data-ng-repeat="item in paginatedItems"
                        data-ng-if="!item.secondary_url"
                        popover-placement="right"
@@ -38,8 +37,8 @@
                        popover-trigger="mouseenter"
                        track-analytics=""
                        title="">
-                        {{ item.name }}
-                    </a>
+                      <a href="{{ item.url }}">{{ item.name }}</a>
+                    </div>
             </div>
             <pagination direction-links="true"
                         total-items="total"


### PR DESCRIPTION
@biyeun @kaapstorm @benrudolph cc: @NoahCarnahan 
http://manage.dimagi.com/default.asp?221113#1107279
anchors that are also have class `list-group-item` have their color overridden. I wrapped in in a div so it could keep standard anchor color but get the rest of the list-group-item styling, which is what the other lists do.
