### PR TITLE
Move sync to couch to async task

### DIFF
--- a/corehq/apps/sms/models.py
+++ b/corehq/apps/sms/models.py
@@ -497,7 +497,13 @@ class SMSBase(SyncSQLToCouchMixin, Log):
 
 
 class SMS(SMSBase):
-    pass
+    def save(self, *args, **kwargs):
+        from corehq.apps.sms.tasks import sync_sms_to_couch
+
+        sync_to_couch = kwargs.pop('sync_to_couch', True)
+        super(SyncSQLToCouchMixin, self).save(*args, **kwargs)
+        if sync_to_couch:
+            sync_sms_to_couch.delay(self)
 
 
 class QueuedSMS(SMSBase):

--- a/corehq/apps/sms/tasks.py
+++ b/corehq/apps/sms/tasks.py
@@ -19,6 +19,7 @@ from dimagi.utils.chunked import chunked
 from dimagi.utils.couch.bulk import soft_delete_docs
 from dimagi.utils.couch.cache.cache_core import get_redis_client
 from dimagi.utils.couch import release_lock, CriticalSection
+from dimagi.utils.logging import notify_exception
 from dimagi.utils.rate_limit import rate_limit
 from threading import Thread
 
@@ -323,3 +324,12 @@ def _sync_case_phone_number(contact_case):
         else:
             if phone_number:
                 phone_number.delete()
+
+
+@task(queue='background_queue', ignore_result=True)
+def sync_sms_to_couch(sms):
+    try:
+        sms._migration_do_sync()
+    except:
+        message = 'Could not sync SMSLog from SMS %s' % sms.pk
+        notify_exception(None, message=message)


### PR DESCRIPTION
I'm going to remove the sync once the sms pillow is sorted out, but in the meantime it's better to move this to an asynchronous task to avoid slowing down sms processing tasks.

@benrudolph 
