### PR TITLE
remove json content type from xml case repeater

### DIFF
--- a/corehq/apps/repeaters/repeater_generators.py
+++ b/corehq/apps/repeaters/repeater_generators.py
@@ -63,10 +63,6 @@ class CaseRepeaterXMLPayloadGenerator(BasePayloadGenerator):
     def get_payload(self, repeat_record, payload_doc):
         return payload_doc.to_xml(self.repeater.version or V2, include_case_on_closed=True)
 
-    @property
-    def content_type(self):
-        return 'application/json'
-
     def get_test_payload(self):
         from casexml.apps.case.mock import CaseBlock
         return CaseBlock(


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?221133 we were incorrectly applying json content type to an xml payload (the default content type is XML)

cc: @gcapalbo 
