### PR TITLE
require output format to be json

### DIFF
--- a/corehq/apps/api/resources/v0_1.py
+++ b/corehq/apps/api/resources/v0_1.py
@@ -349,7 +349,7 @@ class XFormInstanceResource(CouchResourceMixin, HqBaseResource, DomainSpecificRe
         detail_allowed_methods = ['get']
         resource_name = 'form'
         ordering = ['received_on']
-        serializer = XFormInstanceSerializer()
+        serializer = XFormInstanceSerializer(formats=['json'])
 
 def _safe_bool(bundle, param, default=False):
     try:


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?221182

output cannot be xml, since `'@uiversion'` etc are not valid XML tags

also, is consistent with the docs at https://confluence.dimagi.com/display/commcarepublic/List+Forms
