### PR TITLE
Put services dir in `current` dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ dump.rdb
 /staticmedia*
 .transifexrc
 python_env
+services
 
 submodules/formdesigner
 submodules/vellum/Vellum

--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -1141,7 +1141,7 @@ def version_static():
 
 
 def _rebuild_supervisor_conf_file(conf_command, filename, params=None):
-    sudo('mkdir -p {}', posixpath.join(env.services, 'supervisor'))
+    sudo('mkdir -p {}'.format(posixpath.join(env.services, 'supervisor')))
 
     with cd(env.code_root):
         sudo((

--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -228,6 +228,7 @@ def _setup_path():
     env.virtualenv_current = posixpath.join(env.code_current, 'python_env')
     env.virtualenv_root = posixpath.join(env.code_root, 'python_env')
     env.services = posixpath.join(env.code_root, 'services')
+    env.services_old = posixpath.join(env.home, 'services')
     env.jython_home = '/usr/local/lib/jython'
     env.db = '%s_%s' % (env.project, env.environment)
 
@@ -662,6 +663,7 @@ def _deploy_without_asking():
         _execute_with_timing(_do_collectstatic)
         _execute_with_timing(_do_compress)
 
+        _execute_with_timing(clear_services_dir)
         _set_supervisor_config()
 
         do_migrate = env.should_migrate
@@ -975,6 +977,34 @@ def update_virtualenv():
 
 
 @task
+def wipe_supervisor_conf():
+    _require_target()
+    execute(clear_services_dir, current=True)
+    execute(services_restart)
+
+
+@roles(ROLES_ALL_SERVICES)
+@parallel
+def clear_services_dir(current=False):
+    """
+    remove old confs from directory first
+    the clear_supervisor_confs management command will scan the directory and find prefixed conf files of the supervisord files
+    and delete them matching the prefix of the current server environment
+    """
+    code_root = env.code_current if current else env.code_root
+    venv_root = env.virtualenv_current if current else env.virtualenv_root
+    services_dir = posixpath.join(env.services_old, u'supervisor')
+    with cd(code_root):
+        sudo((
+            '%(virtualenv_root)s/bin/python manage.py '
+            'clear_supervisor_confs --conf_location "%(conf_location)s"'
+        ) % {
+            'virtualenv_root': venv_root,
+            'conf_location': services_dir,
+        })
+
+
+@task
 def supervisorctl(command):
     require('supervisor_roles',
             provided_by=('staging', 'preview', 'production', 'old_india', 'softlayer', 'zambia'))
@@ -1156,6 +1186,20 @@ def _rebuild_supervisor_conf_file(conf_command, filename, params=None):
             'destination': posixpath.join(env.services, 'supervisor'),
             'params': format_env(env, params)
         })
+
+        sudo((
+            '%(virtualenv_root)s/bin/python manage.py '
+            '%(conf_command)s --traceback --conf_file "%(filename)s" '
+            '--conf_destination "%(destination)s" --params \'%(params)s\''
+        ) % {
+
+            'conf_command': conf_command,
+            'virtualenv_root': env.virtualenv_root,
+            'filename': filename,
+            'destination': posixpath.join(env.services_old, 'supervisor'),
+            'params': format_env(env, params)
+        })
+
 
 
 def get_celery_queues():


### PR DESCRIPTION
@dannyroberts last week a deploy failed during "clear_supervisor_conf" and when services were restarted, one of the nodes went down and it had me scrambling. by moving the `services` dir into the `current` dir it will be managed by the symlink cutover. this also has the benefit of being able to rollback service confs. one downside is that this really explicitly makes our supervisor coupled with cchq. in my opinion this is OK since we already use cchq to generate all the supervisor confs anyways. it also means we can't have multiple environments on one machine (staging and production etc) which in a way is a pro cause that's always a nightmare when that happens

cc: @gcapalbo 
