### PR TITLE
upgrade django-websocket-redis to 0.4.6

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -73,7 +73,7 @@ git+git://github.com/smartfile/django-transfer.git@6e0dc94c3341c358fca8eb2bf74e2
 Pygments==2.0.2
 tinys3==0.1.11
 datadog==0.10.0
-django-websocket-redis==0.4.4
+django-websocket-redis==0.4.6
 django-redis-sessions==0.5.0
 django-uuidfield==0.5.0
 # required by ctable


### PR DESCRIPTION
https://django-websocket-redis.readthedocs.org/en/latest/changelog.html
