### PR TITLE
don't fail hard if no build date available

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4274,8 +4274,9 @@ class ApplicationBase(VersionedDoc, SnapshotMixin,
                     name: (contents if isinstance(contents, str) else contents.encode('utf-8'))
                     for name, contents in all_files.items()
                 }
+                release_date = self.built_with.datetime or datetime.datetime.utcnow()
                 jad_settings = {
-                    'Released-on': self.built_with.datetime.strftime("%Y-%b-%d %H:%M"),
+                    'Released-on': release_date.strftime("%Y-%b-%d %H:%M"),
                 }
                 jad_settings.update(self.jad_settings)
                 jadjar = self.get_jadjar().pack(all_files, jad_settings)


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?221489

wasn't totally sure how the app got into this state, but the property allows `None` so it seems like this is reasonable.

@snopoke / anyone
