### PR TITLE
ILS: use role name not code

### DIFF
--- a/custom/ilsgateway/tanzania/reminders/__init__.py
+++ b/custom/ilsgateway/tanzania/reminders/__init__.py
@@ -172,10 +172,10 @@ class Roles(object):
     """
     HSA = HSA
     SENIOR_HSA = "sh"
-    IN_CHARGE = "ic"
+    IN_CHARGE = "Facility in-charge"
     CLUSTER_SUPERVISOR = "cs"
-    DISTRICT_SUPERVISOR = "ds"
-    DISTRICT_PHARMACIST = "dp"
+    DISTRICT_SUPERVISOR = "district supervisor"
+    DISTRICT_PHARMACIST = "District Pharmacist"
     IMCI_COORDINATOR = "im"
     ALL_ROLES = {
         HSA: "hsa",


### PR DESCRIPTION
I checked and these consts are used only in register handler. Role is user custom field so we need to use name instead of code.
