### PR TITLE
Bump repeat record queue concurrency and max tasks

### DIFF
--- a/fab/environments.yml
+++ b/fab/environments.yml
@@ -143,7 +143,7 @@ production:
       email_queue:
         concurrency: 2
       repeat_record_queue:
-        concurrency: 3
+        concurrency: 6
     hqcelery1:
       reminder_queue:
         concurrency: 8

--- a/fab/services/templates/supervisor_celery_repeat_record_queue.conf
+++ b/fab/services/templates/supervisor_celery_repeat_record_queue.conf
@@ -1,6 +1,6 @@
 [program:{{ project }}-{{ environment }}-celery_repeat_record_queue]
 environment={% for name, value in supervisor_env_vars.items %}{{ name }}="{{ value }}"{% if not forloop.last %},{% endif %}{% endfor %}
-command={{ new_relic_command }}{{ virtualenv_current }}/bin/python {{ code_current }}/manage.py celery worker --queues=repeat_record_queue --events --loglevel=INFO --hostname={{ host_string }}_repeat_record_queue --maxtasksperchild=5 --concurrency={{ celery_params.concurrency }} -Ofair
+command={{ new_relic_command }}{{ virtualenv_current }}/bin/python {{ code_current }}/manage.py celery worker --queues=repeat_record_queue --events --loglevel=INFO --hostname={{ host_string }}_repeat_record_queue --maxtasksperchild=500 --concurrency={{ celery_params.concurrency }} -Ofair
 directory={{ code_current }}
 user={{ sudo_user }}
 numprocs=1


### PR DESCRIPTION
@gcapalbo @czue offlined with gio. these changes should help a bit. there's still some RAM we can take advantage of on celery0. looks like 6.8/8 during peak times
