### PR TITLE
handle when no ids get returned

### DIFF
--- a/corehq/apps/repeaters/dbaccessors.py
+++ b/corehq/apps/repeaters/dbaccessors.py
@@ -30,6 +30,8 @@ def get_repeat_record_count(domain, repeater_id=None, state=None):
         endkey = [domain, repeater_id, state]
     elif not repeater_id and state:
         ids = sorted(_get_repeater_ids_by_domain(domain))
+        if not ids:
+            return 0
         startkey = [domain, ids[0], state]
         endkey = [domain, ids[-1], state]
 

--- a/corehq/apps/repeaters/tests/test_dbaccessors.py
+++ b/corehq/apps/repeaters/tests/test_dbaccessors.py
@@ -5,6 +5,7 @@ from corehq.apps.repeaters.dbaccessors import (
     get_pending_repeat_record_count,
     get_success_repeat_record_count,
     get_failure_repeat_record_count,
+    get_repeat_record_count,
     get_repeaters_by_domain,
     get_paged_repeat_records,
     iterate_repeat_records,
@@ -74,6 +75,10 @@ class TestRepeatRecordDBAccessors(TestCase):
     def test_get_failure_repeat_record_count(self):
         count = get_failure_repeat_record_count(self.domain, self.repeater_id)
         self.assertEqual(count, 1)
+
+    def test_get_paged_repeat_records_with_state_and_no_records(self):
+        count = get_repeat_record_count('wrong-domain', state=RECORD_PENDING_STATE)
+        self.assertEqual(count, 0)
 
     def test_get_paged_repeat_records(self):
         records = get_paged_repeat_records(self.domain, 0, 2)


### PR DESCRIPTION
Saw this in the error logs

```
IndexError: list index out of range
  File "/home/cchq/www/production/releases/2016-03-17_14.28/corehq/apps/repeaters/dbaccessors.py", line 33, in get_repeat_record_count
    startkey = [domain, ids[0], state]
```

cc: @gcapalbo 
