### PR TITLE
bump max retry wait for repeaters

### DIFF
--- a/corehq/apps/repeaters/const.py
+++ b/corehq/apps/repeaters/const.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 
 
-MAX_RETRY_WAIT = timedelta(days=3)
+MAX_RETRY_WAIT = timedelta(days=7)
 MIN_RETRY_WAIT = timedelta(minutes=60)
 CHECK_REPEATERS_INTERVAL = timedelta(minutes=5)
 CHECK_REPEATERS_KEY = 'check-repeaters-key'

--- a/corehq/apps/repeaters/const.py
+++ b/corehq/apps/repeaters/const.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 
 
-MAX_RETRY_WAIT = timedelta(days=1)
+MAX_RETRY_WAIT = timedelta(days=3)
 MIN_RETRY_WAIT = timedelta(minutes=60)
 CHECK_REPEATERS_INTERVAL = timedelta(minutes=5)
 CHECK_REPEATERS_KEY = 'check-repeaters-key'


### PR DESCRIPTION
@gcapalbo @czue sorry for all the mini prs, but they're all pretty much independent. this means we can back off of a repeater to up 3 days instead of 1. open to making a longer. maybe a week? before it was infinite
