### PR TITLE
ensure that failure reason is string

### DIFF
--- a/corehq/apps/repeaters/tasks.py
+++ b/corehq/apps/repeaters/tasks.py
@@ -49,7 +49,7 @@ def check_repeaters():
         # Short circuit task creation if we already know the URL is failing
         result = simple_post_cache_value(record.url)
         if result:
-            record.update_failure(result)
+            record.update_failure(unicode(result))
             record.save()
             continue
 


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?221534

@gcapalbo sometimes the error is a class. we do a similar thing here: https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/repeaters/models.py#L572
