### PR TITLE
Make sms_settings.html and sms.js use hqDefine

### DIFF
--- a/corehq/apps/commtrack/static/commtrack/ko/sms.js
+++ b/corehq/apps/commtrack/static/commtrack/ko/sms.js
@@ -1,197 +1,199 @@
-$(function() {
-    var model = new CommtrackSettingsViewModel();
-    $('#settings').submit(function() {
-        return model.presubmit();
-    });
+hqDefine('commtrack/ko/sms.js', function () {
+    function CommtrackSettingsViewModel(other_sms_codes) {
+        this.keyword = ko.observable();
+        this.actions = ko.observableArray();
+        this.requisition_config = ko.observable();
 
-    model.load(settings);
-    $("#settings").koApplyBindings(model);
-});
+        this.json_payload = ko.observable();
 
-function CommtrackSettingsViewModel() {
-    this.keyword = ko.observable();
-    this.actions = ko.observableArray();
-    this.requisition_config = ko.observable();
+        this.keyword_error = ko.observable();
 
-    this.json_payload = ko.observable();
+        // TODO: sort out possibly removing this redundant declaration in js
+        this.action_types = [
+            {label: 'Stock on hand', value: 'stockonhand'},
+            {label: 'Receipts', value: 'receipts'},
+            {label: 'Consumption', value: 'consumption'},
+            {label: 'Stock out', value: 'stockout'},
+        ];
 
-    this.keyword_error = ko.observable();
+        this.load = function(data) {
+            this.keyword(data.keyword);
+            this.actions($.map(data.actions, function(e) {
+                return new ActionModel(e);
+            }));
+            this.requisition_config(new RequisitionConfigModel(data.requisition_config));
+        };
 
-    // TODO: sort out possibly removing this redundant declaration in js
-    this.action_types = [
-        {label: 'Stock on hand', value: 'stockonhand'},
-        {label: 'Receipts', value: 'receipts'},
-        {label: 'Consumption', value: 'consumption'},
-        {label: 'Stock out', value: 'stockout'},
-    ];
+        var settings = this;
 
-    this.load = function(data) {
-        this.keyword(data.keyword);
-        this.actions($.map(data.actions, function(e) {
-            return new ActionModel(e);
+        this.remove_action = function(action) {
+            settings.actions.remove(action);
+        };
+
+        this.new_action = function() {
+            settings.actions.push(new ActionModel({}));
+        };
+
+        this.validate = function() {
+            this.keyword_error(null);
+
+            var that = this;
+            var valid = true;
+
+            if (!this.keyword()) {
+                this.keyword_error('required');
+                valid = false;
+            }
+            if (!this.validate_sms(this, 'keyword', 'command', 'stock_report')) {
+                valid = false;
+            }
+
+            $.each(this.actions(), function(i, e) {
+                    if (!e.validate(that)) {
+                        valid = false;
+                    }
+                });
+
+            return valid;
+        };
+
+        this.presubmit = function() {
+            if (!this.validate()) {
+                return false;
+            }
+
+            payload = this.to_json();
+            this.json_payload(JSON.stringify(payload));
+        };
+
+        this.all_sms_codes = function() {
+            keywords = [];
+
+            $.each(other_sms_codes, function(k, v) {
+                    keywords.push({keyword: k, type: v[0], name: 'product "' + v[1] + '"', id: null});
+                });
+
+            keywords.push({keyword: this.keyword(), type: 'command', name: 'stock report', id: 'stock_report'});
+
+            $.each(this.actions(), function(i, e) {
+                    keywords.push({keyword: e.keyword(), type: 'action', name: e.caption(), id: i});
+                });
+
+            return keywords;
+        };
+
+        this.sms_code_uniqueness = function(keyword, type, id) {
+            var conflict = null;
+            $.each(this.all_sms_codes(), function(i, e) {
+                    if (keyword == e.keyword && !(type == e.type && id == e.id)) {
+                        conflict = e;
+                        return false;
+                    }
+                });
+            return conflict;
+        };
+
+        this.validate_sms = function(model, attr, type, id) {
+            var conflict = this.sms_code_uniqueness(model[attr](), type, id);
+            if (conflict) {
+                model[attr + '_error']('conficts with ' + conflict.name);
+                return false;
+            }
+            return true;
+        };
+
+        this.to_json = function() {
+            return {
+                keyword: this.keyword(),
+                actions: $.map(this.actions(), function(e) { return e.to_json(); }),
+                requisition_config: this.requisition_config().to_json(),
+            };
+        };
+    }
+
+    function ActionModel(data) {
+        this.keyword = ko.observable(data.keyword);
+        this.caption = ko.observable(data.caption);
+        this.type = ko.observable(data.type);
+        this.name = data.name;
+
+        this.keyword_error = ko.observable();
+        this.caption_error = ko.observable();
+
+        this.validate = function(root) {
+            this.keyword_error(null);
+            this.caption_error(null);
+
+            valid = true;
+
+            if (!this.keyword()) {
+                this.keyword_error('required');
+                valid = false;
+            }
+            if (!this.caption()) {
+                this.caption_error('required');
+                valid = false;
+            }
+
+            if (!root.validate_sms(this, 'keyword', 'action', root.actions().indexOf(this))) {
+                valid = false;
+            }
+
+            return valid;
+        };
+
+        this.to_json = function() {
+            return {
+                keyword: this.keyword(),
+                caption: this.caption(),
+                type: this.type(),
+                name: this.name
+            };
+        };
+    }
+
+    function RequisitionConfigModel(data) {
+        // TODO: sort out possibly removing this redundant declaration in js
+        this.action_types = [
+            {label: 'Request', value: 'request'},
+            {label: 'Approval', value: 'approval'},
+            {label: 'Pack', value: 'pack'},
+            {label: 'Receipts (Requisition)', value: 'requisition-receipts'}
+        ];
+
+        this.enabled = ko.observable(data.enabled);
+        this.actions = ko.observableArray($.map(data.actions, function(item) {
+            return new ActionModel(item);
         }));
-        this.requisition_config(new RequisitionConfigModel(data.requisition_config));
-    };
-
-    var settings = this;
-
-    this.remove_action = function(action) {
-        settings.actions.remove(action);
-    };
-
-    this.new_action = function() {
-        settings.actions.push(new ActionModel({}));
-    };
-
-    this.validate = function() {
-        this.keyword_error(null);
 
         var that = this;
-        var valid = true;
-
-        if (!this.keyword()) {
-            this.keyword_error('required');
-            valid = false;
-        }
-        if (!this.validate_sms(this, 'keyword', 'command', 'stock_report')) {
-            valid = false;
-        }
-
-        $.each(this.actions(), function(i, e) {
-                if (!e.validate(that)) {
-                    valid = false;
-                }
-            });
-
-        return valid;
-    };
-
-    this.presubmit = function() {
-        if (!this.validate()) {
-            return false;
-        }
-
-        payload = this.to_json();
-        this.json_payload(JSON.stringify(payload));
-    };
-
-    this.all_sms_codes = function() {
-        keywords = [];
-
-        $.each(other_sms_codes, function(k, v) {
-                keywords.push({keyword: k, type: v[0], name: 'product "' + v[1] + '"', id: null});
-            });
-
-        keywords.push({keyword: this.keyword(), type: 'command', name: 'stock report', id: 'stock_report'});
-
-        $.each(this.actions(), function(i, e) {
-                keywords.push({keyword: e.keyword(), type: 'action', name: e.caption(), id: i});
-            });
-
-        return keywords;
-    };
-
-    this.sms_code_uniqueness = function(keyword, type, id) {
-        var conflict = null;
-        $.each(this.all_sms_codes(), function(i, e) {
-                if (keyword == e.keyword && !(type == e.type && id == e.id)) {
-                    conflict = e;
-                    return false;
-                }
-            });
-        return conflict;
-    };
-
-    this.validate_sms = function(model, attr, type, id) {
-        var conflict = this.sms_code_uniqueness(model[attr](), type, id);
-        if (conflict) {
-            model[attr + '_error']('conficts with ' + conflict.name);
-            return false;
-        }
-        return true;
-    };
-
-    this.to_json = function() {
-        return {
-            keyword: this.keyword(),
-            actions: $.map(this.actions(), function(e) { return e.to_json(); }),
-            requisition_config: this.requisition_config().to_json(),
+        this.remove_action = function(action) {
+            that.actions.remove(action);
         };
-    };
-}
 
-function ActionModel(data) {
-    this.keyword = ko.observable(data.keyword);
-    this.caption = ko.observable(data.caption);
-    this.type = ko.observable(data.type);
-    this.name = data.name;
-
-    this.keyword_error = ko.observable();
-    this.caption_error = ko.observable();
-
-    this.validate = function(root) {
-        this.keyword_error(null);
-        this.caption_error(null);
-
-        valid = true;
-
-        if (!this.keyword()) {
-            this.keyword_error('required');
-            valid = false;
-        }
-        if (!this.caption()) {
-            this.caption_error('required');
-            valid = false;
-        }
-
-        if (!root.validate_sms(this, 'keyword', 'action', root.actions().indexOf(this))) {
-            valid = false;
-        }
-
-        return valid;
-    };
-
-    this.to_json = function() {
-        return {
-            keyword: this.keyword(),
-            caption: this.caption(),
-            type: this.type(),
-            name: this.name
+        this.new_action = function() {
+            that.actions.push(new ActionModel({}));
         };
-    };
-}
 
-function RequisitionConfigModel(data) {
-    // TODO: sort out possibly removing this redundant declaration in js
-    this.action_types = [
-        {label: 'Request', value: 'request'},
-        {label: 'Approval', value: 'approval'},
-        {label: 'Pack', value: 'pack'},
-        {label: 'Receipts (Requisition)', value: 'requisition-receipts'}
-    ];
-
-    this.enabled = ko.observable(data.enabled);
-    this.actions = ko.observableArray($.map(data.actions, function(item) {
-        return new ActionModel(item);
-    }));
-
-    var that = this;
-    this.remove_action = function(action) {
-        that.actions.remove(action);
-    };
-
-    this.new_action = function() {
-        that.actions.push(new ActionModel({}));
-    };
-
-    this.to_json = function() {
-        return {
-            enabled: this.enabled(),
-            actions: $.map(this.actions(), function(e) { return e.to_json(); })
+        this.to_json = function() {
+            return {
+                enabled: this.enabled(),
+                actions: $.map(this.actions(), function(e) { return e.to_json(); })
+            };
         };
-    };
-}
+    }
+    return {
+        initCommtrackSettingsView: function($element, settings, other_sms_codes) {
+            var model = new CommtrackSettingsViewModel(other_sms_codes);
+            $element.submit(function() {
+                return model.presubmit();
+            });
 
+            model.load(settings);
+            $element.koApplyBindings(model);
+        }
+    };
+});
 
 // TODO move to shared library
 ko.bindingHandlers.bind_element = {

--- a/corehq/apps/commtrack/static/commtrack/ko/sms.js
+++ b/corehq/apps/commtrack/static/commtrack/ko/sms.js
@@ -1,4 +1,6 @@
+/*globals hqDefine, ko, $ */
 hqDefine('commtrack/ko/sms.js', function () {
+    'use strict';
     function CommtrackSettingsViewModel(other_sms_codes) {
         this.keyword = ko.observable();
         this.actions = ko.observableArray();
@@ -16,9 +18,9 @@ hqDefine('commtrack/ko/sms.js', function () {
             {label: 'Stock out', value: 'stockout'},
         ];
 
-        this.load = function(data) {
+        this.load = function (data) {
             this.keyword(data.keyword);
-            this.actions($.map(data.actions, function(e) {
+            this.actions($.map(data.actions, function (e) {
                 return new ActionModel(e);
             }));
             this.requisition_config(new RequisitionConfigModel(data.requisition_config));
@@ -26,15 +28,15 @@ hqDefine('commtrack/ko/sms.js', function () {
 
         var settings = this;
 
-        this.remove_action = function(action) {
+        this.remove_action = function (action) {
             settings.actions.remove(action);
         };
 
-        this.new_action = function() {
+        this.new_action = function () {
             settings.actions.push(new ActionModel({}));
         };
 
-        this.validate = function() {
+        this.validate = function () {
             this.keyword_error(null);
 
             var that = this;
@@ -48,52 +50,52 @@ hqDefine('commtrack/ko/sms.js', function () {
                 valid = false;
             }
 
-            $.each(this.actions(), function(i, e) {
-                    if (!e.validate(that)) {
-                        valid = false;
-                    }
-                });
+            $.each(this.actions(), function (i, e) {
+                if (!e.validate(that)) {
+                    valid = false;
+                }
+            });
 
             return valid;
         };
 
-        this.presubmit = function() {
+        this.presubmit = function () {
             if (!this.validate()) {
                 return false;
             }
 
-            payload = this.to_json();
+            var payload = this.to_json();
             this.json_payload(JSON.stringify(payload));
         };
 
-        this.all_sms_codes = function() {
-            keywords = [];
+        this.all_sms_codes = function () {
+            var keywords = [];
 
-            $.each(other_sms_codes, function(k, v) {
-                    keywords.push({keyword: k, type: v[0], name: 'product "' + v[1] + '"', id: null});
-                });
+            $.each(other_sms_codes, function (k, v) {
+                keywords.push({keyword: k, type: v[0], name: 'product "' + v[1] + '"', id: null});
+            });
 
             keywords.push({keyword: this.keyword(), type: 'command', name: 'stock report', id: 'stock_report'});
 
-            $.each(this.actions(), function(i, e) {
-                    keywords.push({keyword: e.keyword(), type: 'action', name: e.caption(), id: i});
-                });
+            $.each(this.actions(), function (i, e) {
+                keywords.push({keyword: e.keyword(), type: 'action', name: e.caption(), id: i});
+            });
 
             return keywords;
         };
 
-        this.sms_code_uniqueness = function(keyword, type, id) {
+        this.sms_code_uniqueness = function (keyword, type, id) {
             var conflict = null;
-            $.each(this.all_sms_codes(), function(i, e) {
-                    if (keyword == e.keyword && !(type == e.type && id == e.id)) {
-                        conflict = e;
-                        return false;
-                    }
-                });
+            $.each(this.all_sms_codes(), function (i, e) {
+                if (keyword === e.keyword && !(type === e.type && id === e.id)) {
+                    conflict = e;
+                    return false;
+                }
+            });
             return conflict;
         };
 
-        this.validate_sms = function(model, attr, type, id) {
+        this.validate_sms = function (model, attr, type, id) {
             var conflict = this.sms_code_uniqueness(model[attr](), type, id);
             if (conflict) {
                 model[attr + '_error']('conficts with ' + conflict.name);
@@ -102,10 +104,10 @@ hqDefine('commtrack/ko/sms.js', function () {
             return true;
         };
 
-        this.to_json = function() {
+        this.to_json = function () {
             return {
                 keyword: this.keyword(),
-                actions: $.map(this.actions(), function(e) { return e.to_json(); }),
+                actions: $.map(this.actions(), function (e) { return e.to_json(); }),
                 requisition_config: this.requisition_config().to_json(),
             };
         };
@@ -120,11 +122,11 @@ hqDefine('commtrack/ko/sms.js', function () {
         this.keyword_error = ko.observable();
         this.caption_error = ko.observable();
 
-        this.validate = function(root) {
+        this.validate = function (root) {
             this.keyword_error(null);
             this.caption_error(null);
 
-            valid = true;
+            var valid = true;
 
             if (!this.keyword()) {
                 this.keyword_error('required');
@@ -142,7 +144,7 @@ hqDefine('commtrack/ko/sms.js', function () {
             return valid;
         };
 
-        this.to_json = function() {
+        this.to_json = function () {
             return {
                 keyword: this.keyword(),
                 caption: this.caption(),
@@ -162,30 +164,30 @@ hqDefine('commtrack/ko/sms.js', function () {
         ];
 
         this.enabled = ko.observable(data.enabled);
-        this.actions = ko.observableArray($.map(data.actions, function(item) {
+        this.actions = ko.observableArray($.map(data.actions, function (item) {
             return new ActionModel(item);
         }));
 
         var that = this;
-        this.remove_action = function(action) {
+        this.remove_action = function (action) {
             that.actions.remove(action);
         };
 
-        this.new_action = function() {
+        this.new_action = function () {
             that.actions.push(new ActionModel({}));
         };
 
-        this.to_json = function() {
+        this.to_json = function () {
             return {
                 enabled: this.enabled(),
-                actions: $.map(this.actions(), function(e) { return e.to_json(); })
+                actions: $.map(this.actions(), function (e) { return e.to_json(); })
             };
         };
     }
     return {
-        initCommtrackSettingsView: function($element, settings, other_sms_codes) {
+        initCommtrackSettingsView: function ($element, settings, other_sms_codes) {
             var model = new CommtrackSettingsViewModel(other_sms_codes);
-            $element.submit(function() {
+            $element.submit(function () {
                 return model.presubmit();
             });
 
@@ -195,17 +197,19 @@ hqDefine('commtrack/ko/sms.js', function () {
     };
 });
 
-// TODO move to shared library
-ko.bindingHandlers.bind_element = {
-    init: function(element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
-        var field = valueAccessor() || '$e';
-        if (viewModel[field]) {
-            console.log('warning: element already bound');
-            return;
+(function () {
+    'use strict';
+    ko.bindingHandlers.bind_element = {
+        init: function (element, valueAccessor, allBindingsAccessor, viewModel, bindingContext) {
+            var field = valueAccessor() || '$e';
+            if (viewModel[field]) {
+                console.log('warning: element already bound');
+                return;
+            }
+            viewModel[field] = element;
+            if (viewModel.onBind) {
+                viewModel.onBind(bindingContext);
+            }
         }
-        viewModel[field] = element;
-        if (viewModel.onBind) {
-            viewModel.onBind(bindingContext);
-        }
-    }
-};
+    };
+}());

--- a/corehq/apps/domain/templates/domain/admin/sms_settings.html
+++ b/corehq/apps/domain/templates/domain/admin/sms_settings.html
@@ -10,8 +10,12 @@
 
 {% block js-inline %} {{ block.super }}
     <script type="text/javascript">
+    $(function () {
         var settings = {{ settings|JSON }};
         var other_sms_codes = {{ other_sms_codes|JSON }};
+        var initCommtrackSettingsView = hqImport('commtrack/ko/sms.js').initCommtrackSettingsView;
+        initCommtrackSettingsView($('#settings'), settings, other_sms_codes);
+    });
     </script>
 {% endblock %}
 


### PR DESCRIPTION
and encapsulate init boilerplate in a function instead of using global variables!

Just going through and converting files one by one to use hqDefine instead of global variables, something the @dimagi/js-team has been pushing. Beyond my own hometown of app_manager, this just happens to be the first one I've tried my hand at.

@gcapalbo original author was tyler wymer, but I think this is closest to your territory? Anyhow, relatively easy for anyone to review. Tested it locally and there should be no user-facing difference.
