### PR TITLE
Remove script tag for swfobject.js

### DIFF
--- a/corehq/apps/hqmedia/templates/hqmedia/partials/multimedia_js.html
+++ b/corehq/apps/hqmedia/templates/hqmedia/partials/multimedia_js.html
@@ -7,7 +7,6 @@
         loaderPath: "static/hqmedia/MediaUploader/yui-loader.js"
     }
 </script>
-<script type="text/javascript" src="{% static 'hqmedia/MediaUploader/swfobject.js' %}"></script>
 <script type="text/javascript" src="{% static 'hqmedia/MediaUploader/yui-base.js' %}"></script>
 <script type="text/javascript" src="{% static 'hqmedia/MediaUploader/yui-uploader.js' %}"></script>
 <script type="text/javascript" src="{% static 'hqmedia/MediaUploader/hqmedia.upload_controller.js' %}"></script>


### PR DESCRIPTION
https://github.com/dimagi/MediaUploader/pull/15 removed swfobject.js

This is currently throwing a js error but isn't preventing users from uploading media.

@sravfeyn / @emord 
