### PR TITLE
Ucr redis list

### DIFF
--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -81,9 +81,13 @@ def resume_building_indicators(indicator_config_id):
     redis_client = get_redis_client().client.get_client()
     redis_key = _get_redis_key_for_config(config)
 
-    if len(redis_client.lrange(redis_key, 0, -1)) > 0:
-        # redis returns a set, which we cant pull a last member from
+    # maintaining support for existing sets in redis while the
+    # transition to lists occurs
+    try:
         relevant_ids = redis_client.lrange(redis_key, 0, -1)
+    except:
+        relevant_ids = tuple(redis_client.smembers(redis_key))
+    if len(relevant_ids) > 0:
         _build_indicators(indicator_config_id, relevant_ids)
         last_id = relevant_ids[-1]
 

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -48,12 +48,12 @@ def _build_indicators(indicator_config_id, relevant_ids):
             # save is a noop if the filter doesn't match
             adapter.save(doc)
             last_id = doc.get('_id')
-            redis_client.srem(redis_key, last_id)
+            redis_client.lrem(redis_key, 1, last_id)
         except Exception as e:
             logging.exception('problem saving document {} to table. {}'.format(doc['_id'], e))
 
     if last_id:
-        redis_client.sadd(redis_key, last_id)
+        redis_client.rpush(redis_key, last_id)
 
 
 @task(queue='ucr_queue', ignore_result=True)
@@ -78,9 +78,9 @@ def resume_building_indicators(indicator_config_id):
     redis_client = get_redis_client().client.get_client()
     redis_key = _get_redis_key_for_config(config)
 
-    if len(redis_client.smembers(redis_key)) > 0:
+    if len(redis_client.lrange(redis_key, 0, -1)) > 0:
         # redis returns a set, which we cant pull a last member from
-        relevant_ids = tuple(redis_client.smembers(redis_key))
+        relevant_ids = redis_client.lrange(redis_key, 0, -1)
         _build_indicators(indicator_config_id, relevant_ids)
         last_id = relevant_ids[-1]
 
@@ -102,12 +102,12 @@ def _iteratively_build_table(config, last_id=None):
             startkey_docid=last_id):
         relevant_ids.append(relevant_id)
         if len(relevant_ids) >= CHUNK_SIZE:
-            redis_client.sadd(redis_key, *relevant_ids)
+            redis_client.rpush(redis_key, *relevant_ids)
             _build_indicators(indicator_config_id, relevant_ids)
             relevant_ids = []
 
     if relevant_ids:
-        redis_client.sadd(redis_key, *relevant_ids)
+        redis_client.rpush(redis_key, *relevant_ids)
         _build_indicators(indicator_config_id, relevant_ids)
 
     if not is_static(indicator_config_id):

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -48,7 +48,10 @@ def _build_indicators(indicator_config_id, relevant_ids):
             # save is a noop if the filter doesn't match
             adapter.save(doc)
             last_id = doc.get('_id')
-            redis_client.lrem(redis_key, 1, last_id)
+            try:
+                redis_client.lrem(redis_key, 1, last_id)
+            except:
+                redis_client.srem(redis_key, last_id)
         except Exception as e:
             logging.exception('problem saving document {} to table. {}'.format(doc['_id'], e))
 


### PR DESCRIPTION
@nickpell @NoahCarnahan @benrudolph 
Changes the redis queue for ucr resumes/rebuilds to be a list instead of set. That way resumes happen in the same order as the couch view, preventing document repeats. Most importantly, the last ID (which is used as the startkey of the next couch request) will now be the last doc of the previous couch view instead of whichever doc hashed into the last bucket of the set. This could theoretically save up to 10000 duplicate docs per resume.
