### PR TITLE
Use concurrent rotating file handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ celerybeat-schedule
 node_modules/
 /sharedfiles/
 docker/data
+*.lock

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -85,3 +85,4 @@ django-statici18n==1.1.5
 httpagentparser==1.7.8
 boto3==1.2.3
 simpleeval==0.8.7
+ConcurrentLogHandler==0.9.1

--- a/settings.py
+++ b/settings.py
@@ -945,7 +945,7 @@ LOGGING = {
         },
         'file': {
             'level': 'INFO',
-            'class': 'logging.handlers.RotatingFileHandler',
+            'class': 'cloghandler.ConcurrentRotatingFileHandler',
             'formatter': 'verbose',
             'filename': DJANGO_LOG_FILE,
             'maxBytes': 10 * 1024 * 1024,  # 10 MB
@@ -953,7 +953,7 @@ LOGGING = {
         },
         'couch-request-handler': {
             'level': 'DEBUG',
-            'class': 'logging.handlers.RotatingFileHandler',
+            'class': 'cloghandler.ConcurrentRotatingFileHandler',
             'formatter': 'couch-request-formatter',
             'filters': ['hqcontext'],
             'filename': COUCH_LOG_FILE,
@@ -962,7 +962,7 @@ LOGGING = {
         },
         'accountinglog': {
             'level': 'INFO',
-            'class': 'logging.handlers.RotatingFileHandler',
+            'class': 'cloghandler.ConcurrentRotatingFileHandler',
             'formatter': 'verbose',
             'filename': ACCOUNTING_LOG_FILE,
             'maxBytes': 10 * 1024 * 1024,  # 10 MB
@@ -970,7 +970,7 @@ LOGGING = {
         },
         'analyticslog': {
             'level': 'DEBUG',
-            'class': 'logging.handlers.RotatingFileHandler',
+            'class': 'cloghandler.ConcurrentRotatingFileHandler',
             'formatter': 'verbose',
             'filename': ANALYTICS_LOG_FILE,
             'maxBytes': 10 * 1024 * 1024,  # 10 MB
@@ -978,7 +978,7 @@ LOGGING = {
         },
         'datadog': {
             'level': 'INFO',
-            'class': 'logging.handlers.RotatingFileHandler',
+            'class': 'cloghandler.ConcurrentRotatingFileHandler',
             'formatter': 'datadog',
             'filename': DATADOG_LOG_FILE,
             'maxBytes': 10 * 1024 * 1024,  # 10 MB


### PR DESCRIPTION
@NoahCarnahan @dannyroberts we've been seeing some weird issues with logging to a file with data dog. my guess is the fact that we're using `RotatingFileHandler` for multiple processes that log to the same file. Python docs say this:

> Although logging is thread-safe, and logging to a single file from multiple threads in a single process is supported, logging to a single file from multiple processes is not supported, because there is no standard way to serialize access to a single file across multiple processes in Python. If you need to log to a single file from multiple processes, one way of doing this is to have all the processes log to a SocketHandler, and have a separate process which implements a socket server which reads from the socket and logs to file. (If you prefer, you can dedicate one thread in one of the existing processes to perform this function.) This section documents this approach in more detail and includes a working socket receiver which can be used as a starting point for you to adapt in your own applications.

i'm pretty sure using this library is the easiest way to get around the suggestions in that paragraph. tested out locally on single thread and it works, but hard to test multi threadedness locally...
