### PR TITLE
preventing 0 from being coerced to empty string

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/report-module.js
+++ b/corehq/apps/app_manager/static/app_manager/js/report-module.js
@@ -159,7 +159,7 @@ hqDefine('app_manager/js/report-module.js', function () {
                     'period'
                 ];
                 for(var filterFieldsIndex = 0; filterFieldsIndex < filterFields.length; filterFieldsIndex++) {
-                    startVal = filter.selectedValue[filterFields[filterFieldsIndex]]
+                    startVal = filter.selectedValue[filterFields[filterFieldsIndex]];
                     if (startVal === 0) {
                         filter.selectedValue[filterFields[filterFieldsIndex]] = ko.observable(0);
                     } else {

--- a/corehq/apps/app_manager/static/app_manager/js/report-module.js
+++ b/corehq/apps/app_manager/static/app_manager/js/report-module.js
@@ -159,7 +159,12 @@ hqDefine('app_manager/js/report-module.js', function () {
                     'period'
                 ];
                 for(var filterFieldsIndex = 0; filterFieldsIndex < filterFields.length; filterFieldsIndex++) {
-                    filter.selectedValue[filterFields[filterFieldsIndex]] = ko.observable(filter.selectedValue[filterFields[filterFieldsIndex]] || '');
+                    startVal = filter.selectedValue[filterFields[filterFieldsIndex]]
+                    if (startVal === 0) {
+                        filter.selectedValue[filterFields[filterFieldsIndex]] = ko.observable(0);
+                    } else {
+                        filter.selectedValue[filterFields[filterFieldsIndex]] = ko.observable(startVal || '');
+                    }
                 }
                 filter.selectedValue.value = ko.observable(filter.selectedValue.value ? filter.selectedValue.value.join(select2Separator) : '');
 


### PR DESCRIPTION
@emord @kaapstorm @nickpell cc:@NoahCarnahan
http://manage.dimagi.com/default.asp?218506#1112312
when 0 was used as the period, on subsequent pageloads the 0 was coalesced to an empty string which then broke future saves. This isnt a pretty solution, and I am open to better ways but it gets the job done.
