### PR TITLE
catch UserReportsErrors

### DIFF
--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -259,6 +259,10 @@ class ConfigurableReport(JSONResponseMixin, BaseDomainView):
                 data_source.set_order_by(
                     [(data_source.column_configs[int(sort_column)].column_id, sort_order.upper())]
                 )
+
+            datatables_params = DatatablesParams.from_request_dict(request.GET)
+            page = list(data_source.get_data(start=datatables_params.start, limit=datatables_params.count))
+
             total_records = data_source.get_total_records()
         except UserReportsError as e:
             if settings.DEBUG:
@@ -283,9 +287,6 @@ class ConfigurableReport(JSONResponseMixin, BaseDomainView):
             return self.render_json_response({
                 'warning': msg
             })
-
-        datatables_params = DatatablesParams.from_request_dict(request.GET)
-        page = list(data_source.get_data(start=datatables_params.start, limit=datatables_params.count))
 
         json_response = {
             'aaData': page,

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -296,9 +296,7 @@ class ConfigurableReport(JSONResponseMixin, BaseDomainView):
             "iTotalDisplayRecords": total_records,
         }
         if total_row is not None:
-            json_response.update({
-                "total_row": total_row,
-            })
+            json_response["total_row"] = total_row
         return self.render_json_response(json_response)
 
     def _get_initial(self, request, **kwargs):

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -264,6 +264,7 @@ class ConfigurableReport(JSONResponseMixin, BaseDomainView):
             page = list(data_source.get_data(start=datatables_params.start, limit=datatables_params.count))
 
             total_records = data_source.get_total_records()
+            total_row = data_source.get_total_row() if data_source.has_total_row else None
         except UserReportsError as e:
             if settings.DEBUG:
                 raise
@@ -294,10 +295,9 @@ class ConfigurableReport(JSONResponseMixin, BaseDomainView):
             "iTotalRecords": total_records,
             "iTotalDisplayRecords": total_records,
         }
-        if data_source.has_total_row:
-            # TODO - use sqlagg to get total_row
+        if total_row is not None:
             json_response.update({
-                "total_row": data_source.get_total_row(),
+                "total_row": total_row,
             })
         return self.render_json_response(json_response)
 


### PR DESCRIPTION
and display relevant feedback to user (instead of showing "INTERNAL SERVER ERROR" and logging 500s)

also makes it clear that there are 3 independent SQL queries executed serially, which could be parallelized to reduce response time
