### PR TITLE
Full ucr startkey

### DIFF
--- a/corehq/apps/domain/dbaccessors.py
+++ b/corehq/apps/domain/dbaccessors.py
@@ -35,14 +35,14 @@ def get_doc_ids_in_domain_by_type(domain, doc_type, database=None):
 
 
 def iterate_doc_ids_in_domain_by_type(domain, doc_type, chunk_size=10000,
-                                      database=None, startkey_docid=None):
+                                      database=None, startkey=None, startkey_docid=None):
 
     if not database:
         database = get_db_by_doc_type(doc_type)
 
     view_kwargs = {
         'reduce': False,
-        'startkey': [domain, doc_type],
+        'startkey': startkey if startkey else [domain, doc_type],
         'endkey': [domain, doc_type, {}],
         'include_docs': False
     }

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -103,7 +103,7 @@ def _iteratively_build_table(config, last_id=None):
 
     start_key = None
     if last_id:
-        last_doc = globals()[config.referenced_doc_type].get(last_id)
+        last_doc = _DOC_TYPE_MAPPING[config.referenced_doc_type].get(last_id)
         start_key=[config.domain, config.referenced_doc_type, json_format_datetime(last_doc.recieved_on)]
 
     relevant_ids = []

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -103,7 +103,7 @@ def _iteratively_build_table(config, last_id=None):
 
     start_key = None
     if last_id:
-        last_doc = XFormInstance.get(last_id)
+        last_doc = globals()[config.referenced_doc_type].get(last_id)
         start_key=[config.domain, config.referenced_doc_type, json_format_datetime(last_doc.recieved_on)]
 
     relevant_ids = []

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -101,7 +101,10 @@ def _iteratively_build_table(config, last_id=None):
     redis_key = _get_redis_key_for_config(config)
     indicator_config_id = config._id
 
-    last_doc = XFormInstance.get('last_id')
+    start_key = None
+    if last_id:
+        last_doc = XFormInstance.get(last_id)
+        start_key=[config.domain, config.referenced_doc_type, json_format_datetime(last_doc.recieved_on)]
 
     relevant_ids = []
     for relevant_id in iterate_doc_ids_in_domain_by_type(
@@ -109,7 +112,7 @@ def _iteratively_build_table(config, last_id=None):
             config.referenced_doc_type,
             chunk_size=CHUNK_SIZE,
             database=couchdb,
-            startkey=[config.domain, config.referenced_doc_type, json_format_datetime(last_doc.recieved_on)],
+            startkey=start_key,
             startkey_docid=last_id):
         relevant_ids.append(relevant_id)
         if len(relevant_ids) >= CHUNK_SIZE:

--- a/corehq/apps/userreports/tasks.py
+++ b/corehq/apps/userreports/tasks.py
@@ -104,7 +104,7 @@ def _iteratively_build_table(config, last_id=None):
     start_key = None
     if last_id:
         last_doc = _DOC_TYPE_MAPPING[config.referenced_doc_type].get(last_id)
-        start_key=[config.domain, config.referenced_doc_type, json_format_datetime(last_doc.recieved_on)]
+        start_key = [config.domain, config.referenced_doc_type, json_format_datetime(last_doc.recieved_on)]
 
     relevant_ids = []
     for relevant_id in iterate_doc_ids_in_domain_by_type(


### PR DESCRIPTION
@emord @benrudolph @NoahCarnahan @nickpell 
without a full `startkey`, passing a `startkey_docid` had no effect, so after a resume, once the redis queue was finished the couch query began at the very beginning again. This remedies that by provide a full `startkey` for the couch query
