### PR TITLE
221522: [production] ERROR: ValueError: Invalid tag name u'128 by 128.png'

### DIFF
--- a/corehq/apps/api/domain_metadata.py
+++ b/corehq/apps/api/domain_metadata.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 import logging
+
+from corehq.apps.api.serializers import XFormInstanceSerializer
 from corehq.apps.domain.models import Domain
 from corehq.apps.accounting.models import Subscription
 from corehq.apps.api.resources import HqBaseResource, CouchResourceMixin
@@ -116,3 +118,4 @@ class DomainMetadataResource(CouchResourceMixin, HqBaseResource):
         detail_allowed_methods = ['get']
         object_class = Domain
         resource_name = 'project_space_metadata'
+        serializer = XFormInstanceSerializer(formats=['json'])


### PR DESCRIPTION
@czue 
As recommended, I've set the default format to JSON.
