### PR TITLE
responding 404 for deleted cases

### DIFF
--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1368,7 +1368,7 @@ def _get_form_or_404(domain, id):
 def _get_case_or_404(domain, case_id):
     try:
         case = CaseAccessors(domain).get_case(case_id)
-        if case.domain != domain:
+        if case.domain != domain or case.is_deleted:
             raise Http404()
         return case
     except CaseNotFound:

--- a/corehq/form_processor/backends/couch/dbaccessors.py
+++ b/corehq/form_processor/backends/couch/dbaccessors.py
@@ -19,7 +19,7 @@ from corehq.dbaccessors.couchapps.cases_by_server_date.by_owner_server_modified_
     get_case_ids_modified_with_owner_since
 from corehq.dbaccessors.couchapps.cases_by_server_date.by_server_modified_on import \
     get_last_modified_dates
-from corehq.form_processor.exceptions import AttachmentNotFound, CaseNotFound
+from corehq.form_processor.exceptions import AttachmentNotFound
 from corehq.form_processor.interfaces.dbaccessors import (
     AbstractCaseAccessor, AbstractFormAccessor, AttachmentContent,
     AbstractLedgerAccessor)
@@ -96,11 +96,7 @@ class CaseAccessorCouch(AbstractCaseAccessor):
 
     @staticmethod
     def get_case(case_id):
-        case = CommCareCase.get(case_id)
-        if 'Deleted' in case.doc_type:
-            raise CaseNotFound
-        else:
-            return case
+        return CommCareCase.get(case_id)
 
     @staticmethod
     def get_cases(case_ids, ordered=False):

--- a/corehq/form_processor/backends/couch/dbaccessors.py
+++ b/corehq/form_processor/backends/couch/dbaccessors.py
@@ -19,7 +19,7 @@ from corehq.dbaccessors.couchapps.cases_by_server_date.by_owner_server_modified_
     get_case_ids_modified_with_owner_since
 from corehq.dbaccessors.couchapps.cases_by_server_date.by_server_modified_on import \
     get_last_modified_dates
-from corehq.form_processor.exceptions import AttachmentNotFound
+from corehq.form_processor.exceptions import AttachmentNotFound, CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import (
     AbstractCaseAccessor, AbstractFormAccessor, AttachmentContent,
     AbstractLedgerAccessor)
@@ -96,7 +96,11 @@ class CaseAccessorCouch(AbstractCaseAccessor):
 
     @staticmethod
     def get_case(case_id):
-        return CommCareCase.get(case_id)
+        case = CommCareCase.get(case_id)
+        if 'Deleted' in case.doc_type:
+            raise CaseNotFound
+        else:
+            return case
 
     @staticmethod
     def get_cases(case_ids, ordered=False):


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?221372#1112426
@emord @snopoke @czue 
`_get_case_or_404` used to enforce doc type and domain matching. The new one only enforced domain. I chose only to filter out deleted cases instead of enforcing full type matching because i wasnt sure how this would interact SQL cases that dont have doc types

Note: description edited after I changed how this worked between commits
