### PR TITLE
re-raise ImportError unless it's on localsettings

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -903,7 +903,9 @@ try:
                 globals()[attr] = getattr(custom_settings_module, attr)
     else:
         from localsettings import *
-except ImportError:
+except ImportError as error:
+    if error.message != 'No module named localsettings':
+        raise error
     # fallback in case nothing else is found - used for readthedocs
     from dev_settings import *
 


### PR DESCRIPTION
If there's an ImportError inside localsettings, settings will silently swallow it and ignore localsettings. Purpose of the original code seems to be only to catch errors caused by localsettings itself not being available.

@proteusvacuum / @emord 
