### PR TITLE
More agressive secure session timeout

### DIFF
--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -391,7 +391,7 @@ class Domain(QuickCachedDocumentMixin, Document, SnapshotMixin):
         return pytz.timezone(self.default_timezone)
 
     @staticmethod
-    @quickcache(['name'], timeout=24*60*60)
+    @quickcache(['name'], timeout=24 * 60 * 60)
     def is_secure_session_required(name):
         domain = Domain.get_by_name(name)
         return domain and domain.secure_sessions

--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -114,9 +114,12 @@ class TimeoutMiddleware(object):
             return
 
         secure_session = request.session.get('secure_session')
+        domain = getattr(request, "domain", None)
         now = datetime.datetime.utcnow()
 
-        if not secure_session and self._user_requires_secure_session(request.couch_user):
+        if not secure_session and (
+                (domain and Domain.is_secure_session_required(domain)) or
+                self._user_requires_secure_session(request.couch_user)):
             if self._session_expired(settings.SECURE_TIMEOUT, request.user.last_login, now):
                 django_logout(request, template_name=settings.BASE_TEMPLATE)
                 # this must be after logout so it is attached to the new session

--- a/corehq/middleware.py
+++ b/corehq/middleware.py
@@ -105,13 +105,9 @@ class TimeoutMiddleware(object):
             return False
 
     @staticmethod
-    @quickcache(['domain_name', 'secure_session'], timeout=10 * 60)
-    def _session_insecure_and_domain_requires_secure_session(secure_session, domain_name):
-        if secure_session:
-            return False
-        else:
-            domain = Domain.get_by_name(domain_name)
-            return domain and domain.secure_sessions
+    def _user_requires_secure_session(couch_user):
+        return couch_user and any(Domain.is_secure_session_required(domain)
+                                  for domain in couch_user.get_domains())
 
     def process_view(self, request, view_func, view_args, view_kwargs):
         if not request.user.is_authenticated():
@@ -120,8 +116,7 @@ class TimeoutMiddleware(object):
         secure_session = request.session.get('secure_session')
         now = datetime.datetime.utcnow()
 
-        if hasattr(request, 'domain') and \
-                self._session_insecure_and_domain_requires_secure_session(secure_session, request.domain):
+        if not secure_session and self._user_requires_secure_session(request.couch_user):
             if self._session_expired(settings.SECURE_TIMEOUT, request.user.last_login, now):
                 django_logout(request, template_name=settings.BASE_TEMPLATE)
                 # this must be after logout so it is attached to the new session


### PR DESCRIPTION
Secure session timeout was previously not effective unless the user visited a page on a domain with secure sessions enabled. This change makes the secure session timeout effective for all authenticated pages if the user is a member of any domain requiring secure sessions.

Tested locally.

@czue cc @calellowitz @dimagi/product 
