### PR TITLE
Changed version of nvd3 in ils reports

### DIFF
--- a/custom/ilsgateway/templates/ilsgateway/base_template.html
+++ b/custom/ilsgateway/templates/ilsgateway/base_template.html
@@ -3,13 +3,13 @@
 {% load hq_shared_tags %}
 
 {% block stylesheets %}{{ block.super }}
-    <link href="{% static 'nvd3/src/nv.d3.css' %}" rel="stylesheet">
+    <link href="{% static 'hqwebapp/js/lib/nvd3/nv.d3.css' %}" rel="stylesheet">
     <link href="{% static 'ilsgateway/css/ilsgateway.css' %}" rel="stylesheet">
 {% endblock %}
 
 {% block js %}{{ block.super }}
-    <script src="{% static 'd3/d3.min.js' %}"></script>
-    <script src="{% static 'nvd3/nv.d3.min.js' %}"></script>
+    <script src="{% static 'hqwebapp/js/lib/nvd3/lib/d3.v3.js' %}"></script>
+    <script src="{% static 'hqwebapp/js/lib/nvd3/nv.d3.min.js' %}"></script>
 {% endblock %}
 
 {% block export %}


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?220896
@czue , you was right about version. I have no idea why it worked before. I tested this locally and pie charts are loaded correctly.

@benrudolph 
