### PR TITLE
Do not double load date picker

### DIFF
--- a/corehq/apps/reports/templates/reports/async/bootstrap2/filters.html
+++ b/corehq/apps/reports/templates/reports/async/bootstrap2/filters.html
@@ -10,4 +10,3 @@
         </fieldset>
     {% endfor %}
 </fieldset>
-<script type="text/javascript" src="{% static 'reports/javascripts/datepicker.js' %}"></script>

--- a/corehq/apps/reports/templates/reports/async/bootstrap3/filters.html
+++ b/corehq/apps/reports/templates/reports/async/bootstrap3/filters.html
@@ -10,4 +10,3 @@
         </fieldset>
     {% endfor %}
 </fieldset>
-<script type="text/javascript" src="{% new_static 'reports/javascripts/datepicker.js' %}"></script>


### PR DESCRIPTION
@dannyroberts we were double loading datepicker on every report page. this eliminates that. we also load in the base template: https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/reports/templates/reports/bootstrap3/standard/base_template.html#L11
https://github.com/dimagi/commcare-hq/blob/master/corehq/apps/reports/templates/reports/bootstrap2/standard/base_template.html#L20

data from the cdn led me to this:
<img width="1060" alt="screen shot 2016-03-24 at 1 18 14 pm" src="https://cloud.githubusercontent.com/assets/918514/14025146/eb76edaa-f1c2-11e5-99bb-8939b4793cb4.png">

cc: @esoergel 
