### PR TITLE
changing from gatracklink to ga_track_event for loc upload

### DIFF
--- a/corehq/apps/locations/templates/locations/manage/import.html
+++ b/corehq/apps/locations/templates/locations/manage/import.html
@@ -7,7 +7,9 @@
     <script type="text/javascript">
         $(function() {
             gaTrackLink($('#download_link'), 'Organization Structure', 'Bulk Import', 'Download');
-            gaTrackLink($("button[type='submit']"), 'Organization Structure', 'Bulk Import', 'Upload');
+            $("button[type='submit']").click(function() {
+               ga_track_event('Organization Structure', 'Bulk Import', 'Upload');
+            });
         });
     </script>
 {% endblock %}


### PR DESCRIPTION
@emord @czue 
The weird link redirect for `gatracklink` was preventing bulk import of locations, this should fix that, but I was not able to reproduce the bug locally.
