### PR TITLE
App manager unused functions

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -193,15 +193,6 @@ def load_form_template(filename):
         return f.read()
 
 
-def partial_escape(xpath):
-    """
-    Copied from http://stackoverflow.com/questions/275174/how-do-i-perform-html-decoding-encoding-using-python-django
-    but without replacing the single quote
-
-    """
-    return mark_safe(force_unicode(xpath).replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;').replace('"', '&quot;'))
-
-
 class IndexedSchema(DocumentSchema):
     """
     Abstract class.

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -36,15 +36,6 @@ from dimagi.utils.make_uuid import random_hex
 logger = logging.getLogger(__name__)
 
 
-def get_app_id(form):
-    """
-    Given an XForm instance, try to grab the app id, returning
-    None if not available. This is just a shortcut since the app_id
-    might not always be set.
-    """
-    return getattr(form, "app_id", None)
-
-
 def split_path(path):
     path_parts = path.split('/')
     name = path_parts.pop(-1)

--- a/corehq/apps/app_manager/xpath.py
+++ b/corehq/apps/app_manager/xpath.py
@@ -190,9 +190,6 @@ class CaseXPath(XPath):
     def property(self, property):
         return self.slash(property)
 
-    def status_open(self):
-        return self.select('@status', 'open')
-
 
 class LocationXpath(XPath):
 


### PR DESCRIPTION
Testing out the waters here. Just found this tool called `vulture` that will scan your python code for unused definitions, and I came up with a filtered list of just functions, excluding views and tests files to start with (since view functions always appear "unused" due to how they're referenced dynamically by Django internals).

@snopoke, let me know if you want to argue for keeping `convert_module_to_advanced` around; looks like a useful function, but it wasn't referenced anywhere.
