### PR TITLE
back to RotatingFileHandler

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -947,7 +947,7 @@ LOGGING = {
         },
         'file': {
             'level': 'INFO',
-            'class': 'cloghandler.ConcurrentRotatingFileHandler',
+            'class': 'logging.handlers.RotatingFileHandler',
             'formatter': 'verbose',
             'filename': DJANGO_LOG_FILE,
             'maxBytes': 10 * 1024 * 1024,  # 10 MB
@@ -955,7 +955,7 @@ LOGGING = {
         },
         'couch-request-handler': {
             'level': 'DEBUG',
-            'class': 'cloghandler.ConcurrentRotatingFileHandler',
+            'class': 'logging.handlers.RotatingFileHandler',
             'formatter': 'couch-request-formatter',
             'filters': ['hqcontext'],
             'filename': COUCH_LOG_FILE,
@@ -964,7 +964,7 @@ LOGGING = {
         },
         'accountinglog': {
             'level': 'INFO',
-            'class': 'cloghandler.ConcurrentRotatingFileHandler',
+            'class': 'logging.handlers.RotatingFileHandler',
             'formatter': 'verbose',
             'filename': ACCOUNTING_LOG_FILE,
             'maxBytes': 10 * 1024 * 1024,  # 10 MB
@@ -972,7 +972,7 @@ LOGGING = {
         },
         'analyticslog': {
             'level': 'DEBUG',
-            'class': 'cloghandler.ConcurrentRotatingFileHandler',
+            'class': 'logging.handlers.RotatingFileHandler',
             'formatter': 'verbose',
             'filename': ANALYTICS_LOG_FILE,
             'maxBytes': 10 * 1024 * 1024,  # 10 MB


### PR DESCRIPTION
@gcapalbo this reverts most of the RotatingFileHandler changes. it's unclear if the RotatingFileHandler works 100% of the time based on the docs below, but at least it won't cause downtime.

> Although logging is thread-safe, and logging to a single file from multiple threads in a single process is supported, logging to a single file from multiple processes is not supported, because there is no standard way to serialize access to a single file across multiple processes in Python. If you need to log to a single file from multiple processes, one way of doing this is to have all the processes log to a SocketHandler, and have a separate process which implements a socket server which reads from the socket and logs to file. (If you prefer, you can dedicate one thread in one of the existing processes to perform this function.) This section documents this approach in more detail and includes a working socket receiver which can be used as a starting point for you to adapt in your own applications.

i've kept the clog for just the datadog logger since using it has fixed some issues i was seeing and it's used far less than the other logs, so i don't think it'll be a problem
