### PR TITLE
continue activating/deactivating subscriptions even if one encounters an error

### DIFF
--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -80,7 +80,10 @@ def activate_subscriptions(based_on_date=None):
         starting_subscriptions
     )
     for subscription in starting_subscriptions:
-        _activate_subscription(subscription)
+        try:
+            _activate_subscription(subscription)
+        except Exception as e:
+            log_accounting_error(e.message)
 
 
 @transaction.atomic
@@ -118,7 +121,10 @@ def deactivate_subscriptions(based_on_date=None):
         is_active=True,
     )
     for subscription in ending_subscriptions:
-        _deactivate_subscription(subscription, ending_date)
+        try:
+            _deactivate_subscription(subscription, ending_date)
+        except Exception as e:
+            log_accounting_error(e.message)
 
 
 def warn_subscriptions_still_active(based_on_date=None):


### PR DESCRIPTION
over the weekend one of the subscriptions failed to deactivate.  this also blocked deactivating other subscriptions.

this fix would prevent an error in deactivating/activating one subscription from affecting others.  the subscription which was not activated/deactivated will still be flagged daily by the `warn_subscriptions_still_active`/`warn_subscriptions_not_active` functions until manually fixed.

@sravfeyn 
