### PR TITLE
adding couch mixin for v1 case resource

### DIFF
--- a/corehq/apps/api/resources/v0_1.py
+++ b/corehq/apps/api/resources/v0_1.py
@@ -273,7 +273,7 @@ class WebUserResource(UserResource):
         return list(WebUser.by_domain(domain))
 
 
-class CommCareCaseResource(HqBaseResource, DomainSpecificResourceMixin):
+class CommCareCaseResource(CouchResourceMixin, HqBaseResource, DomainSpecificResourceMixin):
     type = "case"
     id = fields.CharField(attribute='get_id', readonly=True, unique=True)
     user_id = fields.CharField(attribute='user_id')


### PR DESCRIPTION
@nickpell cc: @emord 
http://manage.dimagi.com/default.asp?222457#1116625
This fixes the bug, and it looks like the `CouchResourceMixin` was just accidentally left out on the case resource. Before this merges, just want to make sure @nickpell didnt leave it off on purpose
