### PR TITLE
Revert "TEMP commit to support both old/new services dir"

### DIFF
--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -230,7 +230,6 @@ def _setup_path():
     env.virtualenv_current = posixpath.join(env.code_current, 'python_env')
     env.virtualenv_root = posixpath.join(env.code_root, 'python_env')
     env.services = posixpath.join(env.code_root, 'services')
-    env.services_old = posixpath.join(env.home, 'services')
     env.jython_home = '/usr/local/lib/jython'
     env.db = '%s_%s' % (env.project, env.environment)
 
@@ -668,7 +667,6 @@ def _deploy_without_asking():
         _execute_with_timing(_do_collectstatic)
         _execute_with_timing(_do_compress)
 
-        _execute_with_timing(clear_services_dir)
         _set_supervisor_config()
 
         do_migrate = env.should_migrate
@@ -982,34 +980,6 @@ def update_virtualenv():
 
 
 @task
-def wipe_supervisor_conf():
-    _require_target()
-    execute(clear_services_dir, current=True)
-    execute(services_restart)
-
-
-@roles(ROLES_ALL_SERVICES)
-@parallel
-def clear_services_dir(current=False):
-    """
-    remove old confs from directory first
-    the clear_supervisor_confs management command will scan the directory and find prefixed conf files of the supervisord files
-    and delete them matching the prefix of the current server environment
-    """
-    code_root = env.code_current if current else env.code_root
-    venv_root = env.virtualenv_current if current else env.virtualenv_root
-    services_dir = posixpath.join(env.services_old, u'supervisor')
-    with cd(code_root):
-        sudo((
-            '%(virtualenv_root)s/bin/python manage.py '
-            'clear_supervisor_confs --conf_location "%(conf_location)s"'
-        ) % {
-            'virtualenv_root': venv_root,
-            'conf_location': services_dir,
-        })
-
-
-@task
 def supervisorctl(command):
     require('supervisor_roles',
             provided_by=('staging', 'preview', 'production', 'old_india', 'softlayer', 'zambia'))
@@ -1198,20 +1168,6 @@ def _rebuild_supervisor_conf_file(conf_command, filename, params=None):
             'destination': posixpath.join(env.services, 'supervisor'),
             'params': format_env(env, params)
         })
-
-        sudo((
-            '%(virtualenv_root)s/bin/python manage.py '
-            '%(conf_command)s --traceback --conf_file "%(filename)s" '
-            '--conf_destination "%(destination)s" --params \'%(params)s\''
-        ) % {
-
-            'conf_command': conf_command,
-            'virtualenv_root': env.virtualenv_root,
-            'filename': filename,
-            'destination': posixpath.join(env.services_old, 'supervisor'),
-            'params': format_env(env, params)
-        })
-
 
 
 def get_celery_queues():


### PR DESCRIPTION
This reverts commit 11b9d47ad4d5417a62985c8e7ddfb8927e639d79.

@dannyroberts this'll revert the commit that made it so we deployed to two services directories. once this is merged we'll only deploy to the new one inside of `current`. need to update swiss and zambia before that though

cc: @esoergel @biyeun 
