### PR TITLE
add new app db dependencies for accounting

### DIFF
--- a/corehq/tests/app_test_db_dependencies.yml
+++ b/corehq/tests/app_test_db_dependencies.yml
@@ -333,6 +333,9 @@ corehq.apps.accounting:
   - auditcare
   - django_digest
   - django.contrib.admin
+  - django_otp.plugins.otp_static
+  - django_otp.plugins.otp_totp
+  - two_factor
   - tastypie
   - corehq.apps.dropbox
   - corehq.apps.tour


### PR DESCRIPTION
accounting tests are broken when ran alone - this fixes it.

@calellowitz @emord 
