### PR TITLE
More export conversion

### DIFF
--- a/corehq/apps/export/const.py
+++ b/corehq/apps/export/const.py
@@ -9,6 +9,7 @@ from couchexport.deid import (
 from corehq.apps.export.transforms import (
     case_id_to_case_name,
     user_id_to_username,
+    owner_id_to_display,
 )
 
 DEID_ID_TRANSFORM = "deid_id"
@@ -19,9 +20,11 @@ DEID_TRANSFORM_FUNCTIONS = {
 }
 CASE_NAME_TRANSFORM = "case_name_transform"
 USERNAME_TRANSFORM = "username_transform"
+OWNER_ID_TRANSFORM = "owner_id_transform"
 TRANSFORM_FUNCTIONS = {
     CASE_NAME_TRANSFORM: case_id_to_case_name,
     USERNAME_TRANSFORM: user_id_to_username,
+    OWNER_ID_TRANSFORM: owner_id_to_display,
 }
 TRANSFORM_FUNCTIONS.update(DEID_TRANSFORM_FUNCTIONS)
 
@@ -38,38 +41,3 @@ PROPERTY_TAG_APP = "app"
 
 FORM_EXPORT = 'form'
 CASE_EXPORT = 'case'
-
-# Mapping from old properties to new. Can delete once all exports have been migrated
-FORM_PROPERTY_MAPPING = {
-    ("form.case.@date_modified", None): ("", None),
-    ("form.case.@user_id", None): ("form.meta.userID", None),
-    ("form.case.@xmlns", None): ("xmlns", None),
-    ("form.case.create.case_name", None): ('form.case.create.case_name', None),
-    ("form.case.create.case_type", None): ('form.case.create.case_type', None),
-    ("form.case.create.owner_id", None): ('form.case.create.owner_id', None),
-    ("form.meta.@xmlns", None): ('xmlns', None),
-    ("form.meta.appVersion.#text", None): ('form.meta.appVersion', None),
-    ("form.meta.appVersion.@xmlns", None): ('xmlns', None),
-    ("form.case.@case_id", None): ("form.case.@case_id", "corehq.apps.export.transforms.case_id_to_case_name"),
-    ("form.case.@case_id", None): ("form.case.@case_id", None),
-    ("form.meta.timeEnd", None): ("form.meta.timeEnd", None),
-    ("form.meta.deviceID", None): ("form.meta.deviceID", None),
-    ("form.meta.instanceID", None): ("form.meta.instanceID", None),
-    ("_id", None): ("form.meta.instanceID", None),
-    ("form.meta.timeStart", None): ("form.meta.timeStart", None),
-    ("form.meta.userID", None): ("form.meta.userID", None),
-    ("form.meta.username", None): ("form.meta.username", None),
-    ("app_id", None): ("app_id", None),
-    ("build_id", None): ("build_id", None),
-    ("doc_type", None): ("doc_type", None),
-    ("domain", None): ("domain", None),
-    ("edited_on", None): ("edited_on", None),
-    ("last_sync_token", None): ("last_sync_token", None),
-    ("partial_submission", None): ("partial_submission", None),
-    ("problem", None): ("problem", None),
-    ("received_on", None): ("received_on", None),
-    ("submit_ip", None): ("submit_ip", None),
-    ("xmlns", None): ("xmlns", None),
-    ("form.@name", None): ("form.@name", None),
-    ("form.@xmlns", None): ("xmlns", None),
-}

--- a/corehq/apps/export/const.py
+++ b/corehq/apps/export/const.py
@@ -2,12 +2,20 @@
 Some of these constants correspond to constants set in corehq/apps/export/static/export/js/const.js
 so if changing a value, ensure that both places reflect the change
 """
-from corehq.apps.export.transforms import case_id_to_case_name, \
-    user_id_to_username
+from couchexport.deid import (
+    deid_ID,
+    deid_date
+)
+from corehq.apps.export.transforms import (
+    case_id_to_case_name,
+    user_id_to_username,
+)
 
+DEID_ID_TRANSFORM = "deid_id"
+DEID_DATE_TRANSFORM = "deid_date"
 DEID_TRANSFORM_FUNCTIONS = {
-    'deid_id': lambda x: x,  # TODO: map these to actual deid functions
-    'deid_date': lambda x: x,
+    DEID_ID_TRANSFORM: deid_ID,
+    DEID_DATE_TRANSFORM: deid_date,
 }
 CASE_NAME_TRANSFORM = "case_name_transform"
 USERNAME_TRANSFORM = "username_transform"

--- a/corehq/apps/export/const.py
+++ b/corehq/apps/export/const.py
@@ -30,3 +30,38 @@ PROPERTY_TAG_APP = "app"
 
 FORM_EXPORT = 'form'
 CASE_EXPORT = 'case'
+
+# Mapping from old properties to new. Can delete once all exports have been migrated
+FORM_PROPERTY_MAPPING = {
+    ("form.case.@date_modified", None): ("", None),
+    ("form.case.@user_id", None): ("form.meta.userID", None),
+    ("form.case.@xmlns", None): ("xmlns", None),
+    ("form.case.create.case_name", None): ('form.case.create.case_name', None),
+    ("form.case.create.case_type", None): ('form.case.create.case_type', None),
+    ("form.case.create.owner_id", None): ('form.case.create.owner_id', None),
+    ("form.meta.@xmlns", None): ('xmlns', None),
+    ("form.meta.appVersion.#text", None): ('form.meta.appVersion', None),
+    ("form.meta.appVersion.@xmlns", None): ('xmlns', None),
+    ("form.case.@case_id", None): ("form.case.@case_id", "corehq.apps.export.transforms.case_id_to_case_name"),
+    ("form.case.@case_id", None): ("form.case.@case_id", None),
+    ("form.meta.timeEnd", None): ("form.meta.timeEnd", None),
+    ("form.meta.deviceID", None): ("form.meta.deviceID", None),
+    ("form.meta.instanceID", None): ("form.meta.instanceID", None),
+    ("_id", None): ("form.meta.instanceID", None),
+    ("form.meta.timeStart", None): ("form.meta.timeStart", None),
+    ("form.meta.userID", None): ("form.meta.userID", None),
+    ("form.meta.username", None): ("form.meta.username", None),
+    ("app_id", None): ("app_id", None),
+    ("build_id", None): ("build_id", None),
+    ("doc_type", None): ("doc_type", None),
+    ("domain", None): ("domain", None),
+    ("edited_on", None): ("edited_on", None),
+    ("last_sync_token", None): ("last_sync_token", None),
+    ("partial_submission", None): ("partial_submission", None),
+    ("problem", None): ("problem", None),
+    ("received_on", None): ("received_on", None),
+    ("submit_ip", None): ("submit_ip", None),
+    ("xmlns", None): ("xmlns", None),
+    ("form.@name", None): ("form.@name", None),
+    ("form.@xmlns", None): ("xmlns", None),
+}

--- a/corehq/apps/export/conversion_mappings.py
+++ b/corehq/apps/export/conversion_mappings.py
@@ -80,3 +80,7 @@ PARENT_CASE_PROPERTY_MAPPING = {
     ('relationship', None): ([PathNode(name='indices', is_repeat=True), PathNode(name='relationship')], None),
     ('doc_type', None): ([PathNode(name='indices', is_repeat=True), PathNode(name='doc_type')], None),
 }
+
+REPEAT_GROUP_PROPERTY_MAPPING = {
+    ('id', None): ([PathNode(name='number')], None),
+}

--- a/corehq/apps/export/conversion_mappings.py
+++ b/corehq/apps/export/conversion_mappings.py
@@ -77,7 +77,7 @@ PARENT_CASE_PROPERTY_MAPPING = {
     ('id', None): ([PathNode(name='number')], None),
     ('referenced_id', None): ([PathNode(name='indices', is_repeat=True), PathNode(name='referenced_id')], None),
     ('referenced_type', None): ([PathNode(name='indices', is_repeat=True), PathNode(name='referenced_type')], None),
-    ('relationship', None): ([PathNode(name='indices', is_repeat=True), PathNode(name='relationship')], None),
+    ('identifier', None): ([PathNode(name='indices', is_repeat=True), PathNode(name='relationship')], None),
     ('doc_type', None): ([PathNode(name='indices', is_repeat=True), PathNode(name='doc_type')], None),
 }
 

--- a/corehq/apps/export/conversion_mappings.py
+++ b/corehq/apps/export/conversion_mappings.py
@@ -1,0 +1,82 @@
+from corehq.apps.export.const import (
+    CASE_NAME_TRANSFORM,
+    USERNAME_TRANSFORM,
+    OWNER_ID_TRANSFORM,
+)
+from corehq.apps.export.models import PathNode
+
+# Mapping from old properties to new. Can delete once all exports have been migrated
+FORM_PROPERTY_MAPPING = {
+    ("form.case.@user_id", None): ([PathNode(name='form'), PathNode(name='meta'), PathNode(name='userID')], None),
+    ("form.case.@xmlns", None): ([PathNode(name="xmlns")], None),
+    ("form.case.create.case_name", None): ([PathNode(name='form'), PathNode(name='case'), PathNode(name='create'), PathNode(name='case_name')], None),
+    ("form.case.create.case_type", None): ([PathNode(name='form'), PathNode(name='case'), PathNode(name='create'), PathNode(name='case_type')], None),
+    ("form.case.create.owner_id", None): ([PathNode(name='form'), PathNode(name='case'), PathNode(name='create'), PathNode(name='owner_id')], None),
+    ("form.meta.@xmlns", None): ([PathNode(name='xmlns')], None),
+    ("form.meta.appVersion.#text", None): ([PathNode(name='form'), PathNode(name='meta'), PathNode(name='appVersion')], None),
+    ("form.meta.appVersion.@xmlns", None): ([PathNode(name='xmlns')], None),
+    ("form.case.@case_id", CASE_NAME_TRANSFORM): ([PathNode(name='form'), PathNode(name='case'), PathNode(name='@case_id')], CASE_NAME_TRANSFORM),
+    ("form.case.@case_id", None): ([PathNode(name='form'), PathNode(name='case'), PathNode(name='@case_id')], None),
+    ("form.meta.timeEnd", None): ([PathNode(name='form'), PathNode(name='meta'), PathNode(name='timeEnd')], None),
+    ("form.meta.deviceID", None): ([PathNode(name='form'), PathNode(name='meta'), PathNode(name='deviceID')], None),
+    ("form.meta.instanceID", None): ([PathNode(name='form'), PathNode(name='meta'), PathNode(name='instanceID')], None),
+    ("_id", None): ([PathNode(name='form'), PathNode(name='meta'), PathNode(name='instanceID')], None),
+    ("form.meta.timeStart", None): ([PathNode(name='form'), PathNode(name='meta'), PathNode(name='timeStart')], None),
+    ("form.meta.userID", None): ([PathNode(name='form'), PathNode(name='meta'), PathNode(name='userID')], None),
+    ("form.meta.username", None): ([PathNode(name='form'), PathNode(name='meta'), PathNode(name='username')], None),
+    ("app_id", None): ([PathNode(name="app_id")], None),
+    ("build_id", None): ([PathNode(name="build_id")], None),
+    ("doc_type", None): ([PathNode(name="doc_type")], None),
+    ("domain", None): ([PathNode(name="domain")], None),
+    ("edited_on", None): ([PathNode(name="edited_on")], None),
+    ("last_sync_token", None): ([PathNode(name="last_sync_token")], None),
+    ("partial_submission", None): ([PathNode(name="partial_submission")], None),
+    ("problem", None): ([PathNode(name="problem")], None),
+    ("received_on", None): ([PathNode(name="received_on")], None),
+    ("submit_ip", None): ([PathNode(name="submit_ip")], None),
+    ("xmlns", None): ([PathNode(name="xmlns")], None),
+    ("form.@name", None): ("form.@name", None),
+    ("form.@xmlns", None): ([PathNode(name="xmlns")], None),
+    ("id", None): ([PathNode(name="number")], None),
+}
+
+CASE_PROPERTY_MAPPING = {
+    ("id", None): ([PathNode(name="number")], None),
+    ("_id", None): ([PathNode(name='caseid')], None),
+    ('type', None): ([PathNode(name='type')], None),
+    ('closed', None): ([PathNode(name='closed')], None),
+    ('closed_by', None): ([PathNode(name='closed_by')], None),
+    ('closed_by', 'corehq.apps.export.transforms.user_id_to_username'): ([PathNode(name='closed_by')], USERNAME_TRANSFORM),
+    ('closed_on', None): ([PathNode(name='closed_on')], None),
+    ('external_id', None): ([PathNode(name='external_id')], None),
+    ('user_id', None): ([PathNode(name='user_id')], None),
+    ('user_id', 'corehq.apps.export.transforms.user_id_to_username'): ([PathNode(name='user_id')], USERNAME_TRANSFORM),
+    ('modified_on', None): ([PathNode(name='modified_on')], None),
+    ('opened_by', None): ([PathNode(name='opened_by')], None),
+    ('opened_by', 'corehq.apps.export.transforms.user_id_to_username'): ([PathNode(name='opened_by')], USERNAME_TRANSFORM),
+    ('opened_on', None): ([PathNode(name='opened_on')], None),
+    ('owner_id', None): ([PathNode(name='owner_id')], None),
+    ('owner_id', 'corehq.apps.export.transforms.owner_id_to_display'): ([PathNode(name='owner_id')], OWNER_ID_TRANSFORM),
+    ('server_modified_on', None): ([PathNode(name='server_modified_on')], None),
+    ('doc_type', None): ([PathNode(name='doc_type')], None),
+}
+
+CASE_HISTORY_PROPERTY_MAPPING = {
+    ("id", None): ([PathNode(name="number")], None),
+    ('action_type', None): ([PathNode(name='actions', is_repeat=True), PathNode(name='action_type')], None),
+    ('user_id', None): ([PathNode(name='actions', is_repeat=True), PathNode(name='user_id')], None),
+    ('server_date', None): ([PathNode(name='actions', is_repeat=True), PathNode(name='server_date')], None),
+    ('xform_id', None): ([PathNode(name='actions', is_repeat=True), PathNode(name='xform_id')], None),
+    ('xform_name', None): ([PathNode(name='actions', is_repeat=True), PathNode(name='xform_name')], None),
+    ('xform_xmlns', None): ([PathNode(name='actions', is_repeat=True), PathNode(name='xform_xmlns')], None),
+    ('deprecated', None): ([PathNode(name='actions', is_repeat=True), PathNode(name='deprecated')], None),
+    ('sync_log_id', None): ([PathNode(name='actions', is_repeat=True), PathNode(name='sync_log_id')], None),
+}
+
+PARENT_CASE_PROPERTY_MAPPING = {
+    ('id', None): ([PathNode(name='number')], None),
+    ('referenced_id', None): ([PathNode(name='indices', is_repeat=True), PathNode(name='referenced_id')], None),
+    ('referenced_type', None): ([PathNode(name='indices', is_repeat=True), PathNode(name='referenced_type')], None),
+    ('relationship', None): ([PathNode(name='indices', is_repeat=True), PathNode(name='relationship')], None),
+    ('doc_type', None): ([PathNode(name='indices', is_repeat=True), PathNode(name='doc_type')], None),
+}

--- a/corehq/apps/export/models/__init__.py
+++ b/corehq/apps/export/models/__init__.py
@@ -14,6 +14,7 @@ from .new import (
     ScalarItem,
     Option,
     MultipleChoiceItem,
+    PathNode,
     MAIN_TABLE,
     CASE_HISTORY_TABLE,
     PARENT_CASE_TABLE,

--- a/corehq/apps/export/models/__init__.py
+++ b/corehq/apps/export/models/__init__.py
@@ -14,4 +14,7 @@ from .new import (
     ScalarItem,
     Option,
     MultipleChoiceItem,
+    MAIN_TABLE,
+    CASE_HISTORY_TABLE,
+    PARENT_CASE_TABLE,
 )

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -863,8 +863,11 @@ class FormExportDataSchema(ExportDataSchema):
         questions = xform.get_questions(langs)
         repeats = [r['value'] for r in xform.get_questions(langs, include_groups=True) if r['tag'] == 'repeat']
         schema = FormExportDataSchema()
+        question_keyfn = lambda q: q['repeat']
 
-        question_groups = [(x, list(y)) for x, y in groupby(questions, lambda q: q['repeat'])]
+        question_groups = [(x, list(y)) for x, y in groupby(
+            sorted(questions, key=question_keyfn), question_keyfn
+        )]
         if None not in [x[0] for x in question_groups]:
             # If there aren't any questions in the main table, a group for
             # it anyways.

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1010,6 +1010,7 @@ class CaseExportDataSchema(ExportDataSchema):
 
     @staticmethod
     def _generate_schema_for_parent_case(app_id, app_version):
+        # TODO: conditionally add this table only if there's a parent case
         schema = CaseExportDataSchema()
         schema.group_schemas.append(ExportGroupSchema(
             path=PARENT_CASE_TABLE,

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -459,7 +459,7 @@ class ExportInstance(BlobMixin, Document):
     def _insert_parent_case_system_properties(cls, table, columns):
         from corehq.apps.export.system_properties import PARENT_CASE_TABLE_PROPERTIES
 
-        for static_column in PARENT_CASE_TABLE_PROPERTIES:
+        for static_column in reversed(PARENT_CASE_TABLE_PROPERTIES):
             existing_column = table.get_column(static_column.item.path, static_column.transforms)
             columns.insert(0, existing_column or static_column)
 

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -105,6 +105,10 @@ class ExportItem(DocumentSchema):
         item.last_occurrences = _merge_dicts(one.last_occurrences, two.last_occurrences, max)
         return item
 
+    @property
+    def readable_path(self):
+        return '.'.join(map(lambda node: node.name, self.path))
+
 
 class ExportColumn(DocumentSchema):
     item = SchemaProperty(ExportItem)

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -444,7 +444,7 @@ class ExportInstance(BlobMixin, Document):
             elif table.path == CASE_HISTORY_TABLE:
                 cls._insert_case_history_system_properties(table, columns)
             elif table.path == PARENT_CASE_TABLE:
-                cls._insert_parent_case_table(table, columns)
+                cls._insert_parent_case_system_properties(table, columns)
 
     @classmethod
     def _insert_form_repeat_system_properties(cls, table, columns):
@@ -456,7 +456,7 @@ class ExportInstance(BlobMixin, Document):
         columns.insert(0, existing_column or ROW_NUMBER_COLUMN)
 
     @classmethod
-    def _insert_parent_case_table(cls, table, columns):
+    def _insert_parent_case_system_properties(cls, table, columns):
         from corehq.apps.export.system_properties import PARENT_CASE_TABLE_PROPERTIES
 
         for static_column in PARENT_CASE_TABLE_PROPERTIES:

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -286,9 +286,12 @@ class TableConfiguration(DocumentSchema):
 
     def get_column(self, item_path, column_transforms):
         # Columns should be unique by item path and column.transforms minus any deid transforms
+        filtered_column_transforms = [
+            t for t in column_transforms if t not in DEID_TRANSFORM_FUNCTIONS.keys()
+        ]
         for column in self.columns:
             transforms = [t for t in column.transforms if t not in DEID_TRANSFORM_FUNCTIONS.keys()]
-            if column.item.path == item_path and transforms == column_transforms:
+            if column.item.path == item_path and transforms == filtered_column_transforms:
                 return column
         return None
 

--- a/corehq/apps/export/static/export/js/models.js
+++ b/corehq/apps/export/static/export/js/models.js
@@ -138,6 +138,11 @@ Exports.ViewModels.TableConfiguration.mapping = {
         create: function(options) {
             return new Exports.ViewModels.ExportColumn(options.data);
         }
+    },
+    path: {
+        create: function(options) {
+            return new Exports.ViewModels.PathNode(options.data);
+        }
     }
 };
 
@@ -157,12 +162,13 @@ Exports.ViewModels.ExportColumn.prototype.formatProperty = function() {
     if (this.tags().length !== 0){
         return this.label();
     } else {
-        return this.item.path().join('.');
+        return _.map(this.item.path(), function(node) { return node.name(); }).join('.');
     }
 };
 
 Exports.ViewModels.ExportColumn.prototype.isDeidSelectVisible = function() {
-    return (this.item.path()[this.item.path().length - 1] !== '_id' || this.transforms()) && !this.isCaseName();
+    var nodes = this.item.path();
+    return (nodes[nodes.length - 1].name !== '_id' || this.transforms()) && !this.isCaseName();
 };
 
 Exports.ViewModels.ExportColumn.prototype.getDeidOptions = function() {
@@ -203,14 +209,22 @@ Exports.ViewModels.ExportItem = function(itemJSON) {
 };
 
 Exports.ViewModels.ExportItem.prototype.isCaseName = function() {
-    return this.path()[this.path().length - 1] === 'name';
+    return this.path()[this.path().length - 1].name === 'name';
 };
 
 Exports.ViewModels.ExportItem.mapping = {
     include: ['path', 'label', 'tag'],
     path: {
         create: function(options) {
-            return options.data.name;
+            return new Exports.ViewModels.PathNode(options.data);
         }
     }
+};
+
+Exports.ViewModels.PathNode = function(pathNodeJSON) {
+    ko.mapping.fromJS(pathNodeJSON, Exports.ViewModels.PathNode.mapping, this);
+};
+
+Exports.ViewModels.PathNode.mapping = {
+    include: ['name', 'is_repeat']
 };

--- a/corehq/apps/export/system_properties.py
+++ b/corehq/apps/export/system_properties.py
@@ -11,6 +11,7 @@ from corehq.apps.export.const import (
     PROPERTY_TAG_CASE,
     CASE_NAME_TRANSFORM,
     USERNAME_TRANSFORM,
+    OWNER_ID_TRANSFORM,
     PROPERTY_TAG_NONE)
 from corehq.apps.export.models import ExportColumn, ExportItem
 from corehq.apps.export.models.new import PathNode
@@ -20,6 +21,7 @@ TOP_MAIN_FORM_TABLE_PROPERTIES = [
     ExportColumn(
         tags=[PROPERTY_TAG_ROW],
         label="number",
+        item=ExportItem(path=[PathNode(name='number')]),
         selected=True,
     ),
     ExportColumn(
@@ -331,7 +333,7 @@ BOTTOM_MAIN_CASE_TABLE_PROPERTIES = [
         label='owner_name',
         item=ExportItem(path=[PathNode(name='owner_id')]),
         help_text=_("The username of the user who owns the case"),
-        transforms=[USERNAME_TRANSFORM],
+        transforms=[OWNER_ID_TRANSFORM],
         selected=True
     ),
     ExportColumn(

--- a/corehq/apps/export/system_properties.py
+++ b/corehq/apps/export/system_properties.py
@@ -13,8 +13,7 @@ from corehq.apps.export.const import (
     USERNAME_TRANSFORM,
     OWNER_ID_TRANSFORM,
     PROPERTY_TAG_NONE)
-from corehq.apps.export.models import ExportColumn, ExportItem
-from corehq.apps.export.models.new import PathNode
+from corehq.apps.export.models import ExportColumn, ExportItem, PathNode
 
 # System properties to be displayed above the form questions
 TOP_MAIN_FORM_TABLE_PROPERTIES = [

--- a/corehq/apps/export/tests/data/repeat_group_form.xml
+++ b/corehq/apps/export/tests/data/repeat_group_form.xml
@@ -45,7 +45,7 @@
 				</input>
 			</repeat>
 		</group>
-		<input ref="/data/question1">
+		<input ref="/data/zendquestion">
 			<label ref="jr:itext('zendquestion-label')" />
 		</input>
 	</h:body>

--- a/corehq/apps/export/tests/data/repeat_group_form.xml
+++ b/corehq/apps/export/tests/data/repeat_group_form.xml
@@ -14,6 +14,7 @@
 			<bind nodeset="/data/question1" type="xsd:string" />
 			<bind nodeset="/data/question3" />
 			<bind nodeset="/data/question3/question4" type="xsd:string" />
+			<bind nodeset="/data/zendquestion" type="xsd:string"/>
 			<itext>
 				<translation lang="en" default="">
 					<text id="question1-label">
@@ -24,6 +25,9 @@
 					</text>
 					<text id="question3/question4-label">
 						<value>question4</value>
+					</text>
+					<text id="zendquestion-label">
+						<value>end question</value>
 					</text>
 				</translation>
 			</itext>
@@ -41,5 +45,8 @@
 				</input>
 			</repeat>
 		</group>
+		<input ref="/data/question1">
+			<label ref="jr:itext('zendquestion-label')" />
+		</input>
 	</h:body>
 </h:html>

--- a/corehq/apps/export/tests/data/saved_export_schemas/case.json
+++ b/corehq/apps/export/tests/data/saved_export_schemas/case.json
@@ -1,0 +1,329 @@
+{
+   "_id": "92e5f9a6624a637c2080957475cd446d",
+   "_rev": "2-c5dde9983fa0c0cbd1499a4830d7843f",
+   "doc_type": "SavedExportSchema",
+   "domain": null,
+   "name": "Case Example",
+   "index": "[\"aspace\", \"RegCase\"]",
+   "transform_dates": true,
+   "filter_function": "[]",
+   "schema_id": "92e5f9a6624a637c2080957475cd3a85",
+   "tables": [
+       {
+           "index": "#",
+           "display": "Cases",
+           "columns": [
+               {
+                   "index": "DOB",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "DOB Saved"
+               },
+               {
+                   "index": "ag",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "ag"
+               },
+               {
+                   "index": "age",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "age"
+               },
+               {
+                   "index": "balding",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "balding"
+               },
+               {
+                   "index": "birthday",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "birthday"
+               },
+               {
+                   "index": "dob",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "dob"
+               },
+               {
+                   "index": "name",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "name"
+               },
+               {
+                   "index": "question1",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "question1"
+               },
+               {
+                   "index": "question4",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "question4"
+               },
+               {
+                   "index": "question6",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "question6"
+               },
+               {
+                   "index": "village",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "village"
+               },
+               {
+                   "index": "_id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.case_id"
+               },
+               {
+                   "index": "type",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.case_type"
+               },
+               {
+                   "index": "closed",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.closed"
+               },
+               {
+                   "index": "closed_by",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.closed_by_user_id"
+               },
+               {
+                   "index": "closed_by",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": "corehq.apps.export.transforms.user_id_to_username",
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.closed_by_username"
+               },
+               {
+                   "index": "closed_on",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.closed_date"
+               },
+               {
+                   "index": "computed_modified_on_",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.computed_modified_on_"
+               },
+               {
+                   "index": "domain",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.domain"
+               },
+               {
+                   "index": "external_id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.external_id"
+               },
+               {
+                   "index": "user_id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.last_modified_by_user_id"
+               },
+               {
+                   "index": "user_id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": "corehq.apps.export.transforms.user_id_to_username",
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.last_modified_by_username"
+               },
+               {
+                   "index": "modified_on",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.last_modified_date"
+               },
+               {
+                   "index": "opened_by",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.opened_by_user_id"
+               },
+               {
+                   "index": "opened_by",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": "corehq.apps.export.transforms.user_id_to_username",
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.opened_by_username"
+               },
+               {
+                   "index": "opened_on",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.opened_date"
+               },
+               {
+                   "index": "owner_id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.owner_id"
+               },
+               {
+                   "index": "owner_id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": "corehq.apps.export.transforms.owner_id_to_display",
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.owner_name"
+               },
+               {
+                   "index": "server_modified_on",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.server_last_modified_date"
+               },
+               {
+                   "index": "version",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.version"
+               },
+               {
+                   "index": "_rev",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "server._rev"
+               },
+               {
+                   "index": "doc_type",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "server.doc_type"
+               },
+               {
+                   "index": "initial_processing_complete",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "server.initial_processing_complete"
+               },
+               {
+                   "index": "id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "row.number"
+               }
+           ],
+           "doc_type": "ExportTable"
+       }
+    ],
+   "default_format": "csv",
+   "type": "case",
+   "is_safe": false
+}

--- a/corehq/apps/export/tests/data/saved_export_schemas/case_history.json
+++ b/corehq/apps/export/tests/data/saved_export_schemas/case_history.json
@@ -1,0 +1,236 @@
+{
+   "_id": "92e5f9a6624a637c2080957475cd446e",
+   "_rev": "2-c5dde9983fa0c0cbd1499a4830d7843f",
+   "doc_type": "SavedExportSchema",
+   "domain": null,
+   "name": "Case Example",
+   "index": "[\"aspace\", \"RegCase\"]",
+   "transform_dates": true,
+   "filter_function": "[]",
+   "schema_id": "92e5f9a6624a637c2080957475cd3a85",
+   "tables": [
+       {
+           "index": "#",
+           "display": "Cases",
+           "columns": []
+       },
+       {
+           "index": "#.actions.#",
+           "display": "Case History",
+           "columns": [
+               {
+                   "index": "id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "row.number"
+               },
+               {
+                   "index": "action_type",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "action_type"
+               },
+               {
+                   "index": "date",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "date"
+               },
+               {
+                   "index": "deprecated",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "deprecated"
+               },
+               {
+                   "index": "server_date",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "server_date"
+               },
+               {
+                   "index": "user_id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "user_id"
+               },
+               {
+                   "index": "xform_id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "xform_id"
+               },
+               {
+                   "index": "xform_name",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "xform_name"
+               },
+               {
+                   "index": "xform_xmlns",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "xform_xmlns"
+               },
+               {
+                   "index": "updated_unknown_properties.DOB",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "DOB"
+               },
+               {
+                   "index": "updated_unknown_properties.ag",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "ag"
+               },
+               {
+                   "index": "updated_unknown_properties.age",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "age"
+               },
+               {
+                   "index": "updated_unknown_properties.birthday",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "birthday"
+               },
+               {
+                   "index": "updated_unknown_properties.dob",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "dob"
+               },
+               {
+                   "index": "updated_known_properties.name",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "name"
+               },
+               {
+                   "index": "updated_unknown_properties.name",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "name"
+               },
+               {
+                   "index": "updated_known_properties.owner_id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "owner_id"
+               },
+               {
+                   "index": "updated_unknown_properties.question1",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "question1"
+               },
+               {
+                   "index": "updated_unknown_properties.question4",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "question4"
+               },
+               {
+                   "index": "updated_unknown_properties.question6",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "question6"
+               },
+               {
+                   "index": "updated_known_properties.type",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "type"
+               },
+               {
+                   "index": "updated_unknown_properties.village",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "village"
+               },
+               {
+                   "index": "doc_type",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "server.doc_type"
+               }
+           ],
+           "doc_type": "ExportTable"
+       }
+   ],
+   "default_format": "csv",
+   "type": "case",
+   "is_safe": false
+}
+

--- a/corehq/apps/export/tests/data/saved_export_schemas/deid_transforms.json
+++ b/corehq/apps/export/tests/data/saved_export_schemas/deid_transforms.json
@@ -1,0 +1,42 @@
+{
+   "doc_type": "SavedExportSchema",
+   "domain": null,
+   "name": "DEID Transforms",
+   "index": "[\"aspace\", \"http://openrosa.org/formdesigner/2A2DAB92-8580-4296-B33E-385670FF9E1D\"]",
+   "transform_dates": true,
+   "filter_function": "[]",
+   "app_id": "6a48b8838d06febeeabb28c8c9516ab6",
+   "schema_id": "136ce24f5ad162315653a83d85e0f0b9",
+   "split_multiselects": false,
+   "tables": [
+       {
+           "index": "#",
+           "display": "Forms",
+           "columns": [
+               {
+                   "index": "form.deid_id",
+                   "show": false,
+                   "is_sensitive": true,
+                   "transform": "couchexport.deid.deid_ID",
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "question"
+               },
+               {
+                   "index": "form.deid_date",
+                   "show": false,
+                   "is_sensitive": true,
+                   "transform": "couchexport.deid.deid_date",
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "Long"
+               }
+           ],
+           "doc_type": "ExportTable"
+       }
+   ],
+   "include_errors": false,
+   "default_format": "csv",
+   "type": "form",
+   "is_safe": false
+}

--- a/corehq/apps/export/tests/data/saved_export_schemas/parent_case.json
+++ b/corehq/apps/export/tests/data/saved_export_schemas/parent_case.json
@@ -1,0 +1,84 @@
+{
+   "_id": "88703ffa92090f8601e0226b960c76e0",
+   "_rev": "1-cae3a8c85c862ebbc4e36ff3f37f71ce",
+   "doc_type": "SavedExportSchema",
+   "domain": null,
+   "name": "Parent Cases Example",
+   "index": "[\"aspace\", \"parent_child\"]",
+   "transform_dates": true,
+   "filter_function": "[]",
+   "schema_id": "92e5f9a6624a637c2080957475ed25b2",
+   "tables": [
+       {
+           "index": "#",
+           "display": "Cases",
+           "columns": [
+               {
+                   "index": "id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "row.number"
+               }
+           ],
+           "doc_type": "ExportTable"
+       },
+       {
+           "index": "#.indices.#",
+           "display": "Parent Cases",
+           "columns": [
+               {
+                   "index": "id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "row.number"
+               },
+               {
+                   "index": "referenced_id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "case_id"
+               },
+               {
+                   "index": "identifier",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "relationship"
+               },
+               {
+                   "index": "relationship",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "relationship"
+               },
+               {
+                   "index": "doc_type",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "server.doc_type"
+               }
+           ],
+           "doc_type": "ExportTable"
+       }
+   ],
+   "default_format": "csv",
+   "type": "case",
+   "is_safe": false
+}

--- a/corehq/apps/export/tests/data/saved_export_schemas/repeat.json
+++ b/corehq/apps/export/tests/data/saved_export_schemas/repeat.json
@@ -78,6 +78,15 @@
            "display": "Repeat: question1",
            "columns": [
                {
+                   "index": "id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "row.number"
+               },
+               {
                    "index": "question2",
                    "show": false,
                    "is_sensitive": false,

--- a/corehq/apps/export/tests/data/saved_export_schemas/repeat_nested.json
+++ b/corehq/apps/export/tests/data/saved_export_schemas/repeat_nested.json
@@ -1,0 +1,72 @@
+{
+   "doc_type": "SavedExportSchema",
+   "domain": null,
+   "name": "Nested Repeat",
+   "index": "[\"aspace\", \"http://openrosa.org/formdesigner/C3AC339C-F744-4E06-9F90-145627567095\"]",
+   "transform_dates": true,
+   "filter_function": "[]",
+   "app_id": "6a48b8838d06febeeabb28c8c9516ab6",
+   "schema_id": "ce14e965dc3457dc8cb35684ddb555c5",
+   "split_multiselects": false,
+   "tables": [
+       {
+           "index": "#",
+           "display": "Forms",
+           "columns": [
+           ],
+           "doc_type": "ExportTable"
+       },
+       {
+           "index": "#.form.repeat.#",
+           "display": "Repeat: One",
+           "columns": [
+               {
+                   "index": "question2",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "Modified Question Two"
+               }
+           ],
+           "doc_type": "ExportTable"
+       },
+       {
+           "index": "#.form.repeat.#.repeat_nested.#",
+           "display": "Repeat: One.#.Two",
+           "columns": [
+               {
+                   "index": "nested",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "Modified Nested"
+               }
+           ],
+           "doc_type": "ExportTable"
+       },
+       {
+           "index": "#.form.One.#.Two.#.Three.#",
+           "display": "Repeat: One.#.Two",
+           "columns": [
+               {
+                   "index": "nested",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "Modified Nested"
+               }
+           ],
+           "doc_type": "ExportTable"
+       }
+   ],
+   "include_errors": false,
+   "default_format": "csv",
+   "type": "form",
+   "is_safe": false
+}

--- a/corehq/apps/export/tests/data/saved_export_schemas/system_properties.json
+++ b/corehq/apps/export/tests/data/saved_export_schemas/system_properties.json
@@ -1,0 +1,490 @@
+{
+   "doc_type": "SavedExportSchema",
+   "domain": null,
+   "name": "System Properties",
+   "index": "[\"aspace\", \"http://openrosa.org/formdesigner/2A2DAB92-8580-4296-B33E-385670FF9E1D\"]",
+   "transform_dates": true,
+   "filter_function": "[]",
+   "app_id": "6a48b8838d06febeeabb28c8c9516ab6",
+   "schema_id": "0dfa2e361076249519122aff7740bcc0",
+   "split_multiselects": false,
+   "tables": [
+       {
+           "index": "#",
+           "display": "Forms",
+           "columns": [
+               {
+                   "index": "id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "row.number"
+               },
+               {
+                   "index": "form.label",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "label"
+               },
+               {
+                   "index": "form.case.@date_modified",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "case.@date_modified"
+               },
+               {
+                   "index": "form.case.@user_id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "case.@user_id"
+               },
+               {
+                   "index": "form.case.@xmlns",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "case.@xmlns"
+               },
+               {
+                   "index": "form.case.create.case_name",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "case.create.case_name"
+               },
+               {
+                   "index": "form.case.create.case_type",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "case.create.case_type"
+               },
+               {
+                   "index": "form.case.create.owner_id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "case.create.owner_id"
+               },
+               {
+                   "index": "form.meta.@xmlns",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.@xmlns"
+               },
+               {
+                   "index": "form.meta.appVersion.#text",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.appVersion.#text"
+               },
+               {
+                   "index": "form.meta.appVersion.@xmlns",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.appVersion.@xmlns"
+               },
+               {
+                   "index": "form.case.@case_id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": "corehq.apps.export.transforms.case_id_to_case_name",
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.case_name"
+               },
+               {
+                   "index": "form.case.@case_id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.caseid"
+               },
+               {
+                   "index": "form.meta.timeEnd",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.completed_time"
+               },
+               {
+                   "index": "form.meta.deviceID",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.deviceID"
+               },
+               {
+                   "index": "_id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.formid"
+               },
+               {
+                   "index": "form.meta.instanceID",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.instanceID"
+               },
+               {
+                   "index": "form.meta.timeStart",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.started_time"
+               },
+               {
+                   "index": "form.meta.userID",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.userID"
+               },
+               {
+                   "index": "form.meta.username",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.username"
+               },
+               {
+                   "index": "-deletion_id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "server.-deletion_id"
+               },
+               {
+                   "index": "_rev",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "server._rev"
+               },
+               {
+                   "index": "app_id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "server.app_id"
+               },
+               {
+                   "index": "auth_context.authenticated",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "server.auth_context.authenticated"
+               },
+               {
+                   "index": "auth_context.doc_type",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "server.auth_context.doc_type"
+               },
+               {
+                   "index": "auth_context.domain",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "server.auth_context.domain"
+               },
+               {
+                   "index": "auth_context.user_id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "server.auth_context.user_id"
+               },
+               {
+                   "index": "build_id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "server.build_id"
+               },
+               {
+                   "index": "computed_modified_on_",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "server.computed_modified_on_"
+               },
+               {
+                   "index": "date_header",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "server.date_header"
+               },
+               {
+                   "index": "deprecated_form_id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "server.deprecated_form_id"
+               },
+               {
+                   "index": "doc_type",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "server.doc_type"
+               },
+               {
+                   "index": "domain",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "server.domain"
+               },
+               {
+                   "index": "edited_on",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "server.edited_on"
+               },
+               {
+                   "index": "initial_processing_complete",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "server.initial_processing_complete"
+               },
+               {
+                   "index": "last_sync_token",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "server.last_sync_token"
+               },
+               {
+                   "index": "openrosa_headers.HTTP_ACCEPT_LANGUAGE",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "server.openrosa_headers.HTTP_ACCEPT_LANGUAGE"
+               },
+               {
+                   "index": "orig_id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "server.orig_id"
+               },
+               {
+                   "index": "partial_submission",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "server.partial_submission"
+               },
+               {
+                   "index": "path",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "server.path"
+               },
+               {
+                   "index": "problem",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "server.problem"
+               },
+               {
+                   "index": "received_on",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "server.received_on"
+               },
+               {
+                   "index": "submit_ip",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "server.submit_ip"
+               },
+               {
+                   "index": "xmlns",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "server.xmlns"
+               },
+               {
+                   "index": "form.#type",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "tag.#type"
+               },
+               {
+                   "index": "form.@name",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "tag.@name"
+               },
+               {
+                   "index": "form.@uiVersion",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "tag.@uiVersion"
+               },
+               {
+                   "index": "form.@version",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "tag.@version"
+               },
+               {
+                   "index": "form.@xmlns",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "tag.@xmlns"
+               }
+           ],
+           "doc_type": "ExportTable"
+       },
+       {
+           "index": "#.form.repeat.#",
+           "display": "Repeat: repeat",
+           "columns": [
+               {
+                   "index": "id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "row.number"
+               },
+               {
+                   "index": "single_answer",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "single_answer"
+               }
+           ],
+           "doc_type": "ExportTable"
+       }
+   ],
+   "include_errors": false,
+   "default_format": "csv",
+   "type": "form",
+   "is_safe": false
+}

--- a/corehq/apps/export/tests/data/saved_export_schemas/system_properties.json
+++ b/corehq/apps/export/tests/data/saved_export_schemas/system_properties.json
@@ -407,7 +407,7 @@
                    "transform": null,
                    "doc_type": "ExportColumn",
                    "tag": null,
-                   "display": "server.xmlns"
+                   "display": "Custom XMLNS"
                },
                {
                    "index": "form.#type",

--- a/corehq/apps/export/tests/test_export_conversion.py
+++ b/corehq/apps/export/tests/test_export_conversion.py
@@ -173,27 +173,27 @@ class TestConvertSavedExportSchemaToFormExportInstance(TestCase, TestFileMixin):
         self.assertEqual(column.label, 'Modified Nested')
         self.assertEqual(column.selected, True)
 
-#    def test_transform_conversion(self):
-#        saved_export_schema = SavedExportSchema.wrap(self.get_json('deid_transforms'))
-#        with mock.patch(
-#                'corehq.apps.export.models.new.FormExportDataSchema.generate_schema_from_builds',
-#                return_value=self.schema):
-#            instance = convert_saved_export_to_export_instance(saved_export_schema)
-#
-#        table = instance.get_table(MAIN_TABLE)
-#
-#        column = table.get_column(
-#            [PathNode(name='form'), PathNode(name='deid_id')],
-#            [DEID_ID_TRANSFORM]
-#        )
-#        self.assertEqual(column.transform, DEID_ID_TRANSFORM)
-#
-#        column = table.get_column(
-#            [PathNode(name='form'), PathNode(name='deid_date')],
-#            [DEID_DATE_TRANSFORM]
-#        )
-#        self.assertEqual(column.transform, DEID_DATE_TRANSFORM)
-#
+    def test_transform_conversion(self):
+        saved_export_schema = SavedExportSchema.wrap(self.get_json('deid_transforms'))
+        with mock.patch(
+                'corehq.apps.export.models.new.FormExportDataSchema.generate_schema_from_builds',
+                return_value=self.schema):
+            instance = convert_saved_export_to_export_instance(saved_export_schema)
+
+        table = instance.get_table(MAIN_TABLE)
+
+        column = table.get_column(
+            [PathNode(name='form'), PathNode(name='deid_id')],
+            []
+        )
+        self.assertEqual(column.transforms, [DEID_ID_TRANSFORM])
+
+        column = table.get_column(
+            [PathNode(name='form'), PathNode(name='deid_date')],
+            []
+        )
+        self.assertEqual(column.transforms, [DEID_DATE_TRANSFORM])
+
 #    def test_system_property_conversion(self):
 #        saved_export_schema = SavedExportSchema.wrap(self.get_json('system_properties'))
 #        with mock.patch(

--- a/corehq/apps/export/tests/test_export_conversion.py
+++ b/corehq/apps/export/tests/test_export_conversion.py
@@ -70,6 +70,7 @@ class TestConvertSavedExportSchemaToCaseExportInstance(TestCase, TestFileMixin):
 
         table = instance.get_table(MAIN_TABLE)
         self.assertEqual(table.label, 'Cases')
+        self.assertTrue(table.selected)
 
         column = table.get_column([PathNode(name='DOB')], [])
         self.assertEqual(column.label, 'DOB Saved')
@@ -84,6 +85,7 @@ class TestConvertSavedExportSchemaToCaseExportInstance(TestCase, TestFileMixin):
 
         table = instance.get_table(PARENT_CASE_TABLE)
         self.assertEqual(table.label, 'Parent Cases')
+        self.assertTrue(table.selected)
 
         expected_paths = [
             ([PathNode(name='indices', is_repeat=True), PathNode(name='referenced_id')], True),
@@ -218,6 +220,7 @@ class TestConvertSavedExportSchemaToFormExportInstance(TestCase, TestFileMixin):
         self.assertEqual(instance.name, 'Repeat Tester')
         table = instance.get_table([PathNode(name='form'), PathNode(name='repeat', is_repeat=True)])
         self.assertEqual(table.label, 'Repeat: question1')
+        self.assertTrue(table.selected)
 
         column = table.get_column(
             [PathNode(name='form'),
@@ -239,6 +242,7 @@ class TestConvertSavedExportSchemaToFormExportInstance(TestCase, TestFileMixin):
 
         # Check for first repeat table
         table = instance.get_table([PathNode(name='form'), PathNode(name='repeat', is_repeat=True)])
+        self.assertTrue(table.selected)
         self.assertEqual(table.label, 'Repeat: One')
 
         column = table.get_column(
@@ -257,6 +261,7 @@ class TestConvertSavedExportSchemaToFormExportInstance(TestCase, TestFileMixin):
             PathNode(name='repeat_nested', is_repeat=True)],
         )
         self.assertEqual(table.label, 'Repeat: One.#.Two')
+        self.assertTrue(table.selected)
 
         column = table.get_column(
             [PathNode(name='form'),

--- a/corehq/apps/export/tests/test_export_conversion.py
+++ b/corehq/apps/export/tests/test_export_conversion.py
@@ -235,6 +235,12 @@ class TestConvertSavedExportSchemaToFormExportInstance(TestCase, TestFileMixin):
         self.assertEqual(column.label, 'Question Two')
         self.assertEqual(column.selected, True)
 
+        column = table.get_column(
+            [PathNode(name='number')],
+            []
+        )
+        self.assertEqual(column.selected, True)
+
     def test_nested_repeat_conversion(self):
         saved_export_schema = SavedExportSchema.wrap(self.get_json('repeat_nested'))
         with mock.patch(

--- a/corehq/apps/export/tests/test_export_conversion.py
+++ b/corehq/apps/export/tests/test_export_conversion.py
@@ -146,7 +146,12 @@ class TestConvertSavedExportSchemaToFormExportInstance(TestCase, TestFileMixin):
         table = instance.get_table([PathNode(name='form'), PathNode(name='repeat', is_repeat=True)])
         self.assertEqual(table.label, 'Repeat: One')
 
-        column = table.get_column( [PathNode(name='form'), PathNode(name='repeat', is_repeat=True), PathNode(name='question2')], [])
+        column = table.get_column(
+            [PathNode(name='form'),
+             PathNode(name='repeat', is_repeat=True),
+             PathNode(name='question2')],
+            []
+        )
         self.assertEqual(column.label, 'Modified Question Two')
         self.assertEqual(column.selected, True)
 

--- a/corehq/apps/export/tests/test_export_conversion.py
+++ b/corehq/apps/export/tests/test_export_conversion.py
@@ -39,7 +39,7 @@ class TestConvertSavedExportSchemaToFormExportInstance(TestCase, TestFileMixin):
                     last_occurrences={cls.app_id: 3},
                 ),
                 ExportGroupSchema(
-                    path=[PathNode(name='data'), PathNode(name='repeat', is_repeat=True)],
+                    path=[PathNode(name='form'), PathNode(name='repeat', is_repeat=True)],
                     items=[
                         ExportItem(
                             path=[
@@ -101,7 +101,7 @@ class TestConvertSavedExportSchemaToFormExportInstance(TestCase, TestFileMixin):
             instance = convert_saved_export_to_export_instance(saved_export_schema)
 
         self.assertEqual(instance.name, 'Repeat Tester')
-        table = instance.get_table([PathNode(name='data'), PathNode(name='repeat', is_repeat=True)])
+        table = instance.get_table([PathNode(name='form'), PathNode(name='repeat', is_repeat=True)])
         self.assertEqual(table.label, 'Repeat: question1')
 
         column = table.get_column(

--- a/corehq/apps/export/tests/test_export_conversion.py
+++ b/corehq/apps/export/tests/test_export_conversion.py
@@ -53,6 +53,10 @@ class TestConvertSavedExportSchemaToCaseExportInstance(TestCase, TestFileMixin):
                     path=CASE_HISTORY_TABLE,
                     last_occurrences={cls.app_id: 3},
                 ),
+                ExportGroupSchema(
+                    path=PARENT_CASE_TABLE,
+                    last_occurrences={cls.app_id: 3},
+                ),
             ],
         )
 

--- a/corehq/apps/export/tests/test_export_conversion.py
+++ b/corehq/apps/export/tests/test_export_conversion.py
@@ -194,24 +194,27 @@ class TestConvertSavedExportSchemaToFormExportInstance(TestCase, TestFileMixin):
         )
         self.assertEqual(column.transforms, [DEID_DATE_TRANSFORM])
 
-#    def test_system_property_conversion(self):
-#        saved_export_schema = SavedExportSchema.wrap(self.get_json('system_properties'))
-#        with mock.patch(
-#                'corehq.apps.export.models.new.FormExportDataSchema.generate_schema_from_builds',
-#                return_value=self.schema):
-#            instance = convert_saved_export_to_export_instance(saved_export_schema)
-#
-#        self.assertEqual(instance.name, 'System Properties')
-#
-#        # Check for first repeat table
-#        table = instance.get_table(MAIN_TABLE)
-#        self.assertEqual(table.label, 'Forms')
-#
-#        string_path = FORM_PROPERTY_MAPPING[("form.meta.@xmlns", None)][0]
-#        column = table.get_column(string_path.split('.'), None)
-#        self.assertEqual(column.label, 'Custom XMLNS')
-#        self.assertEqual(column.selected, True)
-#
+    def test_system_property_conversion(self):
+        saved_export_schema = SavedExportSchema.wrap(self.get_json('system_properties'))
+        with mock.patch(
+                'corehq.apps.export.models.new.FormExportDataSchema.generate_schema_from_builds',
+                return_value=self.schema):
+            instance = convert_saved_export_to_export_instance(saved_export_schema)
+
+        self.assertEqual(instance.name, 'System Properties')
+
+        # Check for first repeat table
+        table = instance.get_table(MAIN_TABLE)
+        self.assertEqual(table.label, 'Forms')
+
+        string_path = FORM_PROPERTY_MAPPING[("form.meta.@xmlns", None)][0]
+        column = table.get_column(
+            map(lambda name: PathNode(name=name), string_path.split('.')),
+            [],
+        )
+        self.assertEqual(column.label, 'Custom XMLNS')
+        self.assertEqual(column.selected, True)
+
 
 class TestConvertIndexToPath(SimpleTestCase):
     """Test the conversion of old style index to new style path"""

--- a/corehq/apps/export/tests/test_export_conversion.py
+++ b/corehq/apps/export/tests/test_export_conversion.py
@@ -166,7 +166,6 @@ class TestConvertSavedExportSchemaToFormExportInstance(TestCase, TestFileMixin):
 
         table = instance.get_table(MAIN_TABLE)
 
-        import ipdb; ipdb.set_trace()
         column = table.get_column(['form', 'deid_id'], DEID_ID_TRANSFORM)
         self.assertEqual(column.transform, DEID_ID_TRANSFORM)
 

--- a/corehq/apps/export/tests/test_export_conversion.py
+++ b/corehq/apps/export/tests/test_export_conversion.py
@@ -15,6 +15,9 @@ from corehq.apps.export.utils import (
     convert_saved_export_to_export_instance,
     _convert_index_to_path_nodes,
 )
+from corehq.apps.export.const import (
+    FORM_PROPERTY_MAPPING
+)
 from corehq.apps.export.models.new import MAIN_TABLE, PathNode
 
 
@@ -142,6 +145,24 @@ class TestConvertSavedExportSchemaToFormExportInstance(TestCase, TestFileMixin):
         self.assertEqual(column.label, 'Modified Nested')
         self.assertEqual(column.selected, True)
 
+#    def test_system_property_conversion(self):
+#        saved_export_schema = SavedExportSchema.wrap(self.get_json('system_properties'))
+#        with mock.patch(
+#                'corehq.apps.export.models.new.FormExportDataSchema.generate_schema_from_builds',
+#                return_value=self.schema):
+#            instance = convert_saved_export_to_export_instance(saved_export_schema)
+#
+#        self.assertEqual(instance.name, 'System Properties')
+#
+#        # Check for first repeat table
+#        table = instance.get_table(MAIN_TABLE)
+#        self.assertEqual(table.label, 'Forms')
+#
+#        string_path = FORM_PROPERTY_MAPPING[("form.meta.@xmlns", None)][0]
+#        column = table.get_column(string_path.split('.'), None)
+#        self.assertEqual(column.label, 'Custom XMLNS')
+#        self.assertEqual(column.selected, True)
+#
 
 class TestConvertIndexToPath(SimpleTestCase):
     """Test the conversion of old style index to new style path"""

--- a/corehq/apps/export/tests/test_export_data_schema.py
+++ b/corehq/apps/export/tests/test_export_data_schema.py
@@ -52,11 +52,12 @@ class TestFormExportDataSchema(SimpleTestCase, TestXmlMixin):
         self.assertEqual(len(schema.group_schemas), 2)
 
         group_schema = schema.group_schemas[0]
-        self.assertEqual(len(group_schema.items), 1)
+        self.assertEqual(len(group_schema.items), 2)
         self.assertEqual(group_schema.path, MAIN_TABLE)
 
         form_items = filter(lambda item: item.tag is None, group_schema.items)
         self.assertEqual(form_items[0].path, [PathNode(name='form'), PathNode(name='question1')])
+        self.assertEqual(form_items[1].path, [PathNode(name='form'), PathNode(name='zendquestion')])
 
         group_schema = schema.group_schemas[1]
         self.assertEqual(len(group_schema.items), 1)
@@ -66,7 +67,7 @@ class TestFormExportDataSchema(SimpleTestCase, TestXmlMixin):
         )
         self.assertEqual(
             group_schema.items[0].path,
-            [PathNode(name='form'), PathNode(name='question3'), PathNode(name='question4')]
+            [PathNode(name='form'), PathNode(name='question3', is_repeat=True), PathNode(name='question4')]
         )
 
     def test_xform_parsing_with_multiple_choice(self):
@@ -287,7 +288,7 @@ class TestMergingFormExportDataSchema(SimpleTestCase, TestXmlMixin):
         group_schema2 = merged.group_schemas[1]
 
         self.assertEqual(group_schema1.last_occurrences[self.app_id], 2)
-        self.assertEqual(len(group_schema1.items), 2)
+        self.assertEqual(len(group_schema1.items), 3)
 
         self.assertEqual(group_schema2.last_occurrences[self.app_id], 1)
         self.assertEqual(len(group_schema2.items), 1)
@@ -448,8 +449,8 @@ class TestBuildingCaseSchemaFromApplication(TestCase, TestXmlMixin):
     def test_basic_application_schema(self):
         schema = CaseExportDataSchema.generate_schema_from_builds(self.domain, self.case_type)
 
-        # One for case, one for case history.
-        self.assertEqual(len(schema.group_schemas), 2)
+        # One for case, one for case history, one for parent cases.
+        self.assertEqual(len(schema.group_schemas), 3)
 
         group_schema = schema.group_schemas[0]
         self.assertEqual(group_schema.last_occurrences[self.current_app._id], 3)
@@ -464,7 +465,8 @@ class TestBuildingCaseSchemaFromApplication(TestCase, TestXmlMixin):
         )
 
         self.assertEqual(schema.last_app_versions[app._id], 3)
-        self.assertEqual(len(schema.group_schemas), 2)
+        # One for case, one for case history, one for parent cases.
+        self.assertEqual(len(schema.group_schemas), 3)
 
         # After the first schema has been saved let's add a second app to process
         second_build = Application.wrap(self.get_json('basic_case_application'))
@@ -481,4 +483,5 @@ class TestBuildingCaseSchemaFromApplication(TestCase, TestXmlMixin):
 
         self.assertEqual(new_schema._id, schema._id)
         self.assertEqual(new_schema.last_app_versions[app._id], 6)
-        self.assertEqual(len(new_schema.group_schemas), 2)
+        # One for case, one for case history, one for parent cases.
+        self.assertEqual(len(new_schema.group_schemas), 3)

--- a/corehq/apps/export/tests/test_table_configuration.py
+++ b/corehq/apps/export/tests/test_table_configuration.py
@@ -65,7 +65,7 @@ class TableConfigurationTest(SimpleTestCase):
                 PathNode(name='repeat1', is_repeat=True),
                 PathNode(name='DoesNotExist')
             ],
-            None
+            []
         )
         self.assertIsNone(column)
 
@@ -75,6 +75,7 @@ class TableConfigurationTest(SimpleTestCase):
             [USERNAME_TRANSFORM]
         )
         self.assertIsNotNone(column)
+
 
 class TableConfigurationGetSubDocumentsTest(SimpleTestCase):
     def test_basic(self):

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -1,6 +1,6 @@
 from dimagi.utils.couch.undo import DELETED_SUFFIX
 
-from .const import TRANSFORM_FUNCTIONS
+from .const import TRANSFORM_FUNCTIONS, FORM_PROPERTY_MAPPING
 from .exceptions import ExportInvalidTransform
 
 
@@ -56,6 +56,9 @@ def convert_saved_export_to_export_instance(saved_export):
             # so replace that parts that could be repeats with the table path
             column_path = table_path + column_path[len(table_path):]
 
+            if _get_system_property(column.index, column.transform):
+                index, transform = _get_system_property(column.index, column.transform)
+
             new_column = new_table.get_column(
                 column_path,
                 transform,
@@ -84,6 +87,20 @@ def _strip_repeat_index(index):
     index = index.strip('#.')
     index = index.replace('#.', '')  # For nested repeats
     return index
+
+
+def _convert_index_to_path(index):
+    from corehq.apps.export.models.new import MAIN_TABLE
+    if index == '#':
+        return MAIN_TABLE
+    elif _is_repeat(index):
+        return _strip_repeat_index(index).split('.')
+    else:
+        return index.split('.')
+
+
+def _get_system_property(index, transform):
+    return FORM_PROPERTY_MAPPING.get((index, transform))
 
 
 def _convert_index_to_path_nodes(index):

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -94,7 +94,7 @@ def _convert_index_to_path_nodes(index):
             for n in _strip_repeat_index(index).split('.')[1:]
         ]
     else:
-        return [PathNode(name='data')] + [PathNode(name=n) for n in index.split('.')[1:]]
+        return [PathNode(name=n) for n in index.split('.')]
 
 
 def _convert_serializable_function_to_transform(serializable_function):

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -107,16 +107,6 @@ def _convert_transform(serializable_transform):
     return None
 
 
-def _convert_index_to_path(index):
-    from corehq.apps.export.models.new import MAIN_TABLE
-    if index == '#':
-        return MAIN_TABLE
-    elif _is_repeat(index):
-        return _strip_repeat_index(index).split('.')
-    else:
-        return index.split('.')
-
-
 def _get_system_property(index, transform):
     return FORM_PROPERTY_MAPPING.get((index, transform))
 

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -30,11 +30,11 @@ def convert_saved_export_to_export_instance(saved_export):
     instance.legacy_saved_export_schema_id = saved_export._id
 
     # With new export instance, copy over preferences from previous export
-    for table in saved_export.tables:
-        table_path = _convert_index_to_path_nodes(table.index)
-        new_table = instance.get_table(table_path)
+    for old_table in saved_export.tables:
+        table_path = _convert_index_to_path_nodes(old_table.index)
+        new_table = instance.get_table(_convert_index_to_path_nodes(old_table.index))
         if new_table:
-            new_table.label = table.display
+            new_table.label = old_table.display
         else:
             continue
 
@@ -43,11 +43,11 @@ def convert_saved_export_to_export_instance(saved_export):
         for new_column in new_table.columns:
             new_column.selected = False
 
-        for column in table.columns:
+        for column in old_table.columns:
             index = column.index
             if _is_repeat(table.index):
                 index = '{table_index}.{column_index}'.format(
-                    table_index=_strip_repeat_index(table.index),
+                    table_index=_strip_repeat_index(old_table.index),
                     column_index=column.index,
                 )
             column_path = _convert_index_to_path_nodes(index)

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -149,13 +149,16 @@ def _get_system_property(index, transform, export_type, table_path):
         FORM_PROPERTY_MAPPING,
         CASE_PROPERTY_MAPPING,
         CASE_HISTORY_PROPERTY_MAPPING,
-        PARENT_CASE_PROPERTY_MAPPING
+        PARENT_CASE_PROPERTY_MAPPING,
+        REPEAT_GROUP_PROPERTY_MAPPING,
     )
 
     system_property = None
     if export_type == FORM_EXPORT:
         if table_path == MAIN_TABLE:
             system_property = FORM_PROPERTY_MAPPING.get((index, transform))
+        elif table_path[-1].is_repeat:
+            system_property = REPEAT_GROUP_PROPERTY_MAPPING.get((index, transform))
     elif export_type == CASE_EXPORT:
         if table_path == MAIN_TABLE:
             system_property = CASE_PROPERTY_MAPPING.get((index, transform))

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -134,11 +134,3 @@ def _convert_index_to_path_nodes(index):
         return path
     else:
         return [PathNode(name=n) for n in index.split('.')]
-
-
-def _convert_serializable_function_to_transform(serializable_function):
-    if serializable_function is None:
-        return []
-    else:
-        # TODO: Write this
-        raise NotImplementedError

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -57,6 +57,7 @@ def convert_saved_export_to_export_instance(saved_export):
         new_table = instance.get_table(_convert_index_to_path_nodes(old_table.index))
         if new_table:
             new_table.label = old_table.display
+            new_table.selected = True
         else:
             continue
 

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -63,7 +63,7 @@ def convert_saved_export_to_export_instance(saved_export):
 
             if _get_system_property(column.index, column.transform):
                 index, transform = _get_system_property(column.index, column.transform)
-                transforms = [transform]
+                transforms = [transform] if transform else []
 
             new_column = new_table.get_column(
                 column_path,

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -46,7 +46,11 @@ def convert_saved_export_to_export_instance(saved_export):
 
         for column in old_table.columns:
             index = column.index
-            transform = _convert_transform(column.transform)
+            transforms = []
+
+            if column.transform:
+                transforms = [_convert_transform(column.transform)]
+
             if _is_repeat(old_table.index):
                 index = '{table_index}.{column_index}'.format(
                     table_index=_strip_repeat_index(old_table.index),
@@ -59,17 +63,18 @@ def convert_saved_export_to_export_instance(saved_export):
 
             if _get_system_property(column.index, column.transform):
                 index, transform = _get_system_property(column.index, column.transform)
+                transforms = [transform]
 
             new_column = new_table.get_column(
                 column_path,
-                transform,
+                transforms,
             )
             if not new_column:
                 continue
             new_column.label = column.display
             new_column.selected = True
-            if transform:
-                new_column.transforms = [transform]
+            if transforms:
+                new_column.transforms = transforms
 
     saved_export.doc_type += DELETED_SUFFIX
     saved_export.save()

--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -82,6 +82,7 @@ from corehq.apps.users.permissions import FORM_EXPORT_PERMISSION, CASE_EXPORT_PE
     DEID_EXPORT_PERMISSION
 from corehq.util.couch import get_document_or_404_lite
 from corehq.util.timezones.utils import get_timezone_for_user
+from corehq.util.soft_assert import soft_assert
 from couchexport.models import SavedExportSchema, ExportSchema
 from couchexport.schema import build_latest_schema
 from couchexport.util import SerializableFunction
@@ -1494,8 +1495,19 @@ class BaseEditNewCustomExportView(BaseModifyNewCustomView):
                 )
 
                 export_instance = convert_saved_export_to_export_instance(export_helper.custom_export)
+
             except ResourceNotFound:
                 raise Http404()
+            except Exception, e:
+                _soft_assert = soft_assert('{}@{}'.format('brudolph', 'dimagi.com'))
+                _soft_assert(False, 'Failed to convert export {}. {}'.format(self.export_id, e))
+                messages.error(
+                    request,
+                    mark_safe(
+                        _("Export failed to convert to new version. Try creating another export")
+                    )
+                )
+                return HttpResponseRedirect(self.export_home_url)
 
         schema = self.get_export_schema(export_instance)
         self.export_instance = self.export_instance_cls.generate_instance_from_schema(


### PR DESCRIPTION
@NoahCarnahan this does the following:
- [x] ensures case main table and form main table are properly converted
- [x] repeat group tables are converted properly
- [x] case history/parent case tables are converted properly
- [x] moves parent case property table generation to schema (like we discussed)

i have a couple of questions about a couple of the system properties. still to do, but in later PR
- [x] handle transforms better (https://github.com/dimagi/commcare-hq/pull/11014)
- [ ] view tests
- [x] somewhat graceful handling of reverting the export flag after having it on (https://github.com/dimagi/commcare-hq/pull/10998)
- [x] maintain the order of questions when users move them around (https://github.com/dimagi/commcare-hq/pull/11007)

:fish: , but there's a fair bit of churn midway through
