### PR TITLE
install npm packages in base image

### DIFF
--- a/docker/dockerfiles/Dockerfile_commcarehq_base
+++ b/docker/dockerfiles/Dockerfile_commcarehq_base
@@ -46,4 +46,11 @@ RUN pip install \
     --user --upgrade \
     && rm -rf /root/.cache/pip
 
+COPY package.json /vendor/package.json
+
+RUN cd /vendor \
+    && npm shrinkwrap \
+    && npm -g install \
+    && npm cache clean
+
 ENV PATH=/vendor/bin:$PATH


### PR DESCRIPTION
Cherry picked from https://github.com/dimagi/commcare-hq/pull/10996 so that the automated docker build can build images with the npm modules included.

@NoahCarnahan 
