### PR TITLE
Compress CSS

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -819,6 +819,8 @@ COMPRESS_PRECOMPILERS = (
 COMPRESS_ENABLED = True
 COMPRESS_JS_COMPRESSOR = 'corehq.apps.style.uglify.JsUglifySourcemapCompressor'
 # use 'compressor.js.JsCompressor' for faster local compressing (will get rid of source maps)
+COMPRESS_CSS_FILTERS = ['compressor.filters.css_default.CssAbsoluteFilter',
+'compressor.filters.cssmin.rCSSMinFilter']
 
 LESS_B3_PATHS = {
     'variables': '../../../style/less/bootstrap3/includes/variables',


### PR DESCRIPTION
@dannyroberts so i was playing around with google page insights and they were yelling at us saying that we didn't compress our CSS files. and i was like that's bullshit, we definitely compress. then i took a look at one of our CSS files and low and behold it was not compressed! this compresses the css, of course not without a battle (as to be expected when working with DjangoCompressor). putting tag just to make sure it works on staging but otherwise g2g, no binaries to install

cc: @esoergel @biyeun 
