### PR TITLE
Graceful downgrade

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -339,7 +339,6 @@ class TableConfiguration(DocumentSchema):
 
 class ExportInstance(BlobMixin, Document):
     name = StringProperty()
-    type = StringProperty()
     domain = StringProperty()
     tables = ListProperty(TableConfiguration)
     export_format = StringProperty(default='csv')
@@ -559,11 +558,11 @@ class ExportInstance(BlobMixin, Document):
 
 class CaseExportInstance(ExportInstance):
     case_type = StringProperty()
+    type = CASE_EXPORT
 
     @classmethod
     def _new_from_schema(cls, schema):
         return cls(
-            type=schema.type,
             domain=schema.domain,
             case_type=schema.case_type,
         )
@@ -572,6 +571,7 @@ class CaseExportInstance(ExportInstance):
 class FormExportInstance(ExportInstance):
     xmlns = StringProperty()
     app_id = StringProperty()
+    type = FORM_EXPORT
 
     # Whether to include duplicates and other error'd forms in export
     include_errors = BooleanProperty(default=False)
@@ -583,7 +583,6 @@ class FormExportInstance(ExportInstance):
     @classmethod
     def _new_from_schema(cls, schema):
         return cls(
-            type=schema.type,
             domain=schema.domain,
             xmlns=schema.xmlns,
             app_id=schema.app_id,

--- a/corehq/apps/export/tests/test_export_conversion.py
+++ b/corehq/apps/export/tests/test_export_conversion.py
@@ -340,8 +340,7 @@ class TestConvertSavedExportSchemaToFormExportInstance(TestCase, TestFileMixin):
 
 class TestRevertNewExports(TestCase):
 
-    @classmethod
-    def setUpClass(cls):
+    def setUp(cls):
         cls.new_exports = [
             FormExportInstance(),
             CaseExportInstance(),
@@ -349,8 +348,7 @@ class TestRevertNewExports(TestCase):
         for export in cls.new_exports:
             export.save()
 
-    @classmethod
-    def tearDownClass(cls):
+    def tearDown(cls):
         for export in cls.new_exports:
             export.delete()
 

--- a/corehq/apps/export/tests/test_export_conversion.py
+++ b/corehq/apps/export/tests/test_export_conversion.py
@@ -3,6 +3,7 @@ import mock
 
 from django.test import TestCase, SimpleTestCase
 
+from dimagi.utils.couch.undo import DELETED_SUFFIX
 from couchexport.models import SavedExportSchema
 
 from corehq.util.test_utils import TestFileMixin, generate_cases
@@ -11,10 +12,13 @@ from corehq.apps.export.models import (
     CaseExportDataSchema,
     ExportGroupSchema,
     ExportItem,
+    FormExportInstance,
+    CaseExportInstance,
 )
 from corehq.apps.export.utils import (
     convert_saved_export_to_export_instance,
     _convert_index_to_path_nodes,
+    revert_new_exports,
 )
 from corehq.apps.export.const import (
     DEID_ID_TRANSFORM,
@@ -59,6 +63,7 @@ class TestConvertSavedExportSchemaToCaseExportInstance(TestCase, TestFileMixin):
                 ),
             ],
         )
+
 
     def test_basic_conversion(self):
         saved_export_schema = SavedExportSchema.wrap(self.get_json('case'))
@@ -191,6 +196,7 @@ class TestConvertSavedExportSchemaToFormExportInstance(TestCase, TestFileMixin):
                 ),
             ],
         )
+
 
     def test_basic_conversion(self):
 
@@ -330,6 +336,40 @@ class TestConvertSavedExportSchemaToFormExportInstance(TestCase, TestFileMixin):
         for path, transforms, selected in expected_paths:
             column = table.get_column(path, transforms)
             self.assertEqual(column.selected, selected, '{} selected is not {}'.format(path, selected))
+
+
+class TestRevertNewExports(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.new_exports = [
+            FormExportInstance(),
+            CaseExportInstance(),
+        ]
+        for export in cls.new_exports:
+            export.save()
+
+    @classmethod
+    def tearDownClass(cls):
+        for export in cls.new_exports:
+            export.delete()
+
+    def test_revert_new_exports(self):
+        reverted = revert_new_exports(self.new_exports)
+        self.assertListEqual(reverted, [])
+        for export in self.new_exports:
+            self.assertTrue(export.doc_type.endswith(DELETED_SUFFIX))
+
+    def test_revert_new_exports_restore_old(self):
+        saved_export_schema = SavedExportSchema(index=['my-domain', 'xmlns'])
+        saved_export_schema.doc_type += DELETED_SUFFIX
+        saved_export_schema.save()
+        self.new_exports[0].legacy_saved_export_schema_id = saved_export_schema._id
+
+        reverted = revert_new_exports(self.new_exports)
+        self.assertEqual(len(reverted), 1)
+        self.assertFalse(reverted[0].doc_type.endswith(DELETED_SUFFIX))
+        saved_export_schema.delete()
 
 
 class TestConvertIndexToPath(SimpleTestCase):

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -195,6 +195,13 @@ def _convert_index_to_path_nodes(index):
 
 
 def revert_new_exports(new_exports):
+    """
+    Takes a list of new style ExportInstance and marks them as deleted as well as restoring
+    the old export it was converted from (if it was converted from an old export)
+
+    :param new_exports: List of ExportInstance
+    :returns: Any old exports that were restored when decommissioning the new exports
+    """
     reverted_exports = []
     for new_export in new_exports:
         if new_export.legacy_saved_export_schema_id:

--- a/corehq/tests/app_test_db_dependencies.yml
+++ b/corehq/tests/app_test_db_dependencies.yml
@@ -345,6 +345,7 @@ corehq.apps.export:
   - corehq.apps.export
   - corehq.couchapps
   - corehq.apps.app_manager
+  - couchexport
 corehq.apps.callcenter:
   - auditcare
   - casexml.apps.case


### PR DESCRIPTION
@NoahCarnahan this handles graceful fallback. if you have the toggle on, and convert to new style and then turn it off again, it will restore your old export. it will also remove any new style exports you have instead of trying to convert them to old style (out of scope)
:fish: or :office:

cc: @esoergel
