### PR TITLE
fix next subscription

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models, transaction
-from django.db.models import F
+from django.db.models import F, Q
 from django.db.models.manager import Manager
 from django.template.loader import render_to_string
 from django.utils.html import strip_tags
@@ -1086,7 +1086,7 @@ class Subscription(models.Model):
         return (Subscription.objects.
                 filter(subscriber=self.subscriber, date_start__gt=self.date_start).
                 exclude(pk=self.pk).
-                exclude(date_start=F('date_end')))
+                filter(Q(date_end__isnull=True) | ~Q(date_start=F('date_end'))))
 
     @property
     def is_renewed(self):

--- a/corehq/apps/accounting/tests/test_renew_subscription.py
+++ b/corehq/apps/accounting/tests/test_renew_subscription.py
@@ -78,3 +78,14 @@ class TestRenewSubscriptions(BaseAccountingTest):
 
         self.assertIsNone(self.subscription.next_subscription)
         self.assertFalse(self.subscription.is_renewed)
+
+    def test_next_subscription_filter_no_end_date(self):
+        next_subscription = Subscription(
+            account=self.subscription.account,
+            plan_version=self.subscription.plan_version,
+            subscriber=self.subscription.subscriber,
+            date_start=self.subscription.date_end,
+            date_end=None,
+        )
+        next_subscription.save()
+        self.assertEqual(next_subscription, self.subscription.next_subscription)

--- a/corehq/apps/accounting/tests/test_renew_subscription.py
+++ b/corehq/apps/accounting/tests/test_renew_subscription.py
@@ -7,7 +7,6 @@ from corehq.apps.accounting.models import (
     BillingAccount,
     DefaultProductPlan,
     SoftwarePlanEdition,
-    SubscriptionAdjustment,
 )
 
 
@@ -47,9 +46,10 @@ class TestRenewSubscriptions(BaseAccountingTest):
         self.subscription.save()
 
     def tearDown(self):
-        self.renewed_subscription.delete()
-        SubscriptionAdjustment.objects.filter(subscription=self.subscription).delete()
-        self.subscription.delete()
+        generator.delete_all_subscriptions()
+        generator.delete_all_accounts()
+        super(TestRenewSubscriptions, self).tearDown()
+        self.admin_user.delete()
 
     def test_simple_renewal(self):
         self.renewed_subscription = self.subscription.renew_subscription()


### PR DESCRIPTION
previously wouldn't return the next subscription if it didn't have an end date. this adds a test for the condition and fixes it.
