### PR TITLE
Casedb Fixtures

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/fixtures.py
+++ b/corehq/ex-submodules/casexml/apps/case/fixtures.py
@@ -1,0 +1,48 @@
+from casexml.apps.case.xml.generator import safe_element
+from casexml.apps.phone.xml import get_casedb_element
+
+
+class CaseDBFixture(object):
+    """Used to provide a casedb-like structure as a fixture
+
+    Does not follow the standard FixtureGenerator pattern since it is currently
+    not used during a regular sync operation, and is user-agnostic
+    """
+
+    id = "case"
+
+    def __init__(self, cases):
+        if not isinstance(cases, list):
+            self.cases = [cases]
+        else:
+            self.cases = cases
+
+    @property
+    def fixture(self):
+        """For a list of cases, return a fixture with all case properties
+
+        <fixture id="case">
+            <case case_id="" case_type="" owner_id="" status="">
+                <case_name/>
+                <date_opened/>
+                <last_modified/>
+                <case_property />
+                <index>
+                    <a12345 case_type="" relationship="" />
+                </index>
+                <attachment>
+                    <a12345 />
+                </attachment>
+            </case>
+            <case>
+            ...
+            </case>
+        </fixture>
+        """
+        element = safe_element("fixture")
+        element.attrib = {'id': self.id}
+
+        for case in self.cases:
+            element.append(get_casedb_element(case))
+
+        return element

--- a/corehq/ex-submodules/casexml/apps/case/fixtures.py
+++ b/corehq/ex-submodules/casexml/apps/case/fixtures.py
@@ -38,6 +38,9 @@ class CaseDBFixture(object):
             ...
             </case>
         </fixture>
+
+        https://github.com/dimagi/commcare/wiki/casedb
+        https://github.com/dimagi/commcare/wiki/fixtures
         """
         element = safe_element("fixture")
         element.attrib = {'id': self.id}

--- a/corehq/ex-submodules/casexml/apps/case/tests/__init__.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/__init__.py
@@ -22,6 +22,7 @@ try:
     from .test_domains import *
     from .test_close_extension_chain import *
     from .test_strict_datetimes import *
+    from .test_fixtures import *
 except ImportError, e:
     # for some reason the test harness squashes these so log them here for clarity
     # otherwise debugging is a pain

--- a/corehq/ex-submodules/casexml/apps/case/tests/data/case_fixture.xml
+++ b/corehq/ex-submodules/casexml/apps/case/tests/data/case_fixture.xml
@@ -1,0 +1,22 @@
+<fixture id="case">
+    <case case_id="redwoman" case_type="priestess" owner_id="lordoflight" status="open">
+        <case_name>melisandre</case_name>
+        <date_opened>2016-05-31T00:00:00.000000Z</date_opened>
+        <last_modified>2016-05-31T00:00:00.000000Z</last_modified>
+        <hometown>asshai</hometown>
+        <power>prophecy</power>
+        <index>
+            <advisor case_type="human" relationship="extension">stannis</advisor>
+        </index>
+    </case>
+    <case case_id="redwoman" case_type="priestess" owner_id="lordoflight" status="open">
+        <case_name>melisandre</case_name>
+        <date_opened>2016-05-31T00:00:00.000000Z</date_opened>
+        <last_modified>2016-05-31T00:00:00.000000Z</last_modified>
+        <hometown>asshai</hometown>
+        <power>prophecy</power>
+        <index>
+            <advisor case_type="human" relationship="extension">stannis</advisor>
+        </index>
+    </case>
+</fixture>

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_fixtures.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_fixtures.py
@@ -1,0 +1,40 @@
+import datetime
+
+import os.path
+from casexml.apps.case.fixtures import CaseDBFixture
+from casexml.apps.case.models import CommCareCase
+from casexml.apps.case.sharedmodels import CommCareCaseIndex
+from corehq.apps.app_manager.tests.util import TestXmlMixin
+from django.test import SimpleTestCase
+from xml.etree import ElementTree
+
+
+class TestFixtures(TestXmlMixin, SimpleTestCase):
+    root = os.path.dirname(__file__)
+    file_path = ['data']
+
+    domain = 'winterfell'
+
+    def setUp(self):
+        self.case = CommCareCase(
+            domain=self.domain,
+            opened_on=datetime.datetime(2016, 05, 31),
+            modified_on=datetime.datetime(2016, 05, 31),
+            type='priestess',
+            closed=False,
+            name='melisandre',
+            owner_id='lordoflight',
+            indices=[CommCareCaseIndex(
+                identifier='advisor',
+                referenced_type='human',
+                referenced_id='stannis',
+                relationship='extension',
+            )]
+        )
+        self.case._id = 'redwoman'
+        self.case.power = 'prophecy'
+        self.case.hometown = 'asshai'
+
+    def test_fixture(self):
+        fixture = CaseDBFixture([self.case, self.case]).fixture
+        self.assertXmlEqual(ElementTree.tostring(fixture, encoding="utf-8"), self.get_xml('case_fixture'))

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_fixtures.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_fixtures.py
@@ -18,8 +18,8 @@ class TestFixtures(TestXmlMixin, SimpleTestCase):
     def setUp(self):
         self.case = CommCareCase(
             domain=self.domain,
-            opened_on=datetime.datetime(2016, 05, 31),
-            modified_on=datetime.datetime(2016, 05, 31),
+            opened_on=datetime.datetime(2016, 5, 31),
+            modified_on=datetime.datetime(2016, 5, 31),
             type='priestess',
             closed=False,
             name='melisandre',

--- a/corehq/ex-submodules/casexml/apps/phone/tests/__init__.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/__init__.py
@@ -12,6 +12,7 @@ try:
     from .test_sync_logs import *
     from .test_sync_mode import *
     from .test_extension_indexes import *
+    from .test_xml import *
     from .test_ota_fixtures import OtaFixtureTest
     # uncomment to run performance tests
     # from .performance_tests import SyncPerformanceTest

--- a/corehq/ex-submodules/casexml/apps/phone/tests/data/case_db_block.xml
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/data/case_db_block.xml
@@ -1,0 +1,10 @@
+<case case_id="redwoman" case_type="priestess" owner_id="lordoflight" status="open">
+    <case_name>melisandre</case_name>
+    <date_opened>2016-05-31T00:00:00.000000Z</date_opened>
+    <last_modified>2016-05-31T00:00:00.000000Z</last_modified>
+    <hometown>asshai</hometown>
+    <power>prophecy</power>
+    <index>
+        <advisor case_type="human" relationship="extension">stannis</advisor>
+    </index>
+</case>

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_xml.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_xml.py
@@ -18,8 +18,8 @@ class TestCaseDBElement(TestXmlMixin, SimpleTestCase):
     def setUp(self):
         self.case = CommCareCase(
             domain=self.domain,
-            opened_on=datetime.datetime(2016, 05, 31),
-            modified_on=datetime.datetime(2016, 05, 31),
+            opened_on=datetime.datetime(2016, 5, 31),
+            modified_on=datetime.datetime(2016, 5, 31),
             type='priestess',
             closed=False,
             name='melisandre',

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_xml.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_xml.py
@@ -1,0 +1,39 @@
+import datetime
+
+import os.path
+from casexml.apps.case.models import CommCareCase
+from casexml.apps.case.sharedmodels import CommCareCaseIndex
+from casexml.apps.phone.xml import get_casedb_xml
+from django.test import SimpleTestCase
+
+from corehq.apps.app_manager.tests.util import TestXmlMixin
+
+
+class TestCaseDBElement(TestXmlMixin, SimpleTestCase):
+    root = os.path.dirname(__file__)
+    file_path = ['data']
+
+    domain = 'winterfell'
+
+    def setUp(self):
+        self.case = CommCareCase(
+            domain=self.domain,
+            opened_on=datetime.datetime(2016, 05, 31),
+            modified_on=datetime.datetime(2016, 05, 31),
+            type='priestess',
+            closed=False,
+            name='melisandre',
+            owner_id='lordoflight',
+            indices=[CommCareCaseIndex(
+                identifier='advisor',
+                referenced_type='human',
+                referenced_id='stannis',
+                relationship='extension',
+            )]
+        )
+        self.case._id = 'redwoman'
+        self.case.power = 'prophecy'
+        self.case.hometown = 'asshai'
+
+    def test_generate_xml(self):
+        self.assertXmlEqual(get_casedb_xml(self.case), self.get_xml('case_db_block'))

--- a/corehq/ex-submodules/casexml/apps/phone/xml.py
+++ b/corehq/ex-submodules/casexml/apps/phone/xml.py
@@ -5,7 +5,7 @@ from xml.etree import ElementTree
 from casexml.apps.case import const
 from casexml.apps.case.xml import check_version, V1
 from casexml.apps.case.xml.generator import get_generator, date_to_xml_string,\
-    safe_element
+    safe_element, CaseDBXMLGenerator
 
 USER_REGISTRATION_XMLNS_DEPRECATED = "http://openrosa.org/user-registration"
 USER_REGISTRATION_XMLNS = "http://openrosa.org/user/registration"
@@ -83,6 +83,31 @@ def get_case_element(case, updates, version=V1):
 def get_case_xml(case, updates, version=V1):
     check_version(version)
     return tostring(get_case_element(case, updates, version))
+
+
+def get_casedb_element(case):
+    """
+    Returns a case element as in the casedb
+
+    <case case_id="" case_type="" owner_id="" status="">
+        <case_name/>
+        <date_opened/>
+        <last_modified/>
+        <case_property />
+        <index>
+            <parent case_type="" relationship="">id</parent>
+        </index>
+        <attachment>
+            <a12345 />
+        </attachment>
+    </case>
+    https://github.com/dimagi/commcare/wiki/casedb
+    """
+    return CaseDBXMLGenerator(case).get_element()
+
+
+def get_casedb_xml(case):
+    return tostring(get_casedb_element(case))
 
 
 def get_registration_element(user):


### PR DESCRIPTION
Adds the ability to create a casedb-like structure in a fixture block. 

Might change slightly when connecting it with case search (https://github.com/dimagi/commcare-hq/pull/10981) at a later time. 
Adding in a different PR, since that one is big enough already, and this works as a separate change anyway.

FYI: @kaapstorm @czue 
cc: @orangejenny @gcapalbo 
