### PR TITLE
indicate when media paths are set and allow unsetting

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/nav_menu_media_single_type.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/nav_menu_media_single_type.html
@@ -71,7 +71,7 @@
                    name="{{ qualifier|default_if_none:"" }}media_{{ type }}"
                    data-bind="value: savedPath" />
         </div>
-        <div class="col-sm-1">
+        <div class="col-sm-2">
             <button type="button" class="btn btn-default"
                     data-bind="
                         visible: showCustomPath,
@@ -79,6 +79,15 @@
                     ">
                 <i class="fa fa-remove"></i>
                 {% trans 'Use Default Path' %}
+            </button>
+            <button type="button" class="btn btn-danger"
+                    data-bind="
+                        visible: showCustomPath,
+                        event: {
+                            click: removeMedia
+                        }
+                    ">
+                <i class="fa fa-remove"></i>
             </button>
         </div>
     </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/nav_menu_media_single_type.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/nav_menu_media_single_type.html
@@ -31,7 +31,7 @@
             </button>
             <button type="button" class="btn btn-danger"
                     data-bind="
-                        visible: isMediaMatched,
+                        visible: refHasPath,
                         event: {
                             click: removeMedia
                         }
@@ -71,7 +71,7 @@
                    name="{{ qualifier|default_if_none:"" }}media_{{ type }}"
                    data-bind="value: savedPath" />
         </div>
-        <div class="col-sm-2">
+        <div class="col-sm-1">
             <button type="button" class="btn btn-default"
                     data-bind="
                         visible: showCustomPath,
@@ -79,15 +79,6 @@
                     ">
                 <i class="fa fa-remove"></i>
                 {% trans 'Use Default Path' %}
-            </button>
-            <button type="button" class="btn btn-danger"
-                    data-bind="
-                        visible: showCustomPath,
-                        event: {
-                            click: removeMedia
-                        }
-                    ">
-                <i class="fa fa-remove"></i>
             </button>
         </div>
     </div>


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?221122
@amsagoff @biyeun @orangejenny 

I opted for putting the 'remove' button on the main control row to also cover the case where the media path is the default but no media has been uploaded. See images below:
#### Media with custom path

![image](https://cloud.githubusercontent.com/assets/249606/14206041/7a994d22-f810-11e5-9154-c06073213fc2.png)
#### Media with default path but no matching binary

![image](https://cloud.githubusercontent.com/assets/249606/14206046/84a5a7a2-f810-11e5-9aba-51a3822a2c99.png)
