### PR TITLE
ILS: Use nvd3 from bower

### DIFF
--- a/custom/ilsgateway/tanzania/__init__.py
+++ b/custom/ilsgateway/tanzania/__init__.py
@@ -17,6 +17,12 @@ from custom.ilsgateway.tanzania.reports.utils import make_url
 from dimagi.utils.parsing import ISO_DATE_FORMAT
 
 
+class ILSPieChart(PieChart):
+    def __init__(self, title, key, values, color=None):
+        super(ILSPieChart, self).__init__(title, key, values, color)
+        self.data = values
+
+
 class ILSData(object):
     show_table = False
     show_chart = True
@@ -105,7 +111,7 @@ class ILSData(object):
                     entry['description'] = "%.1f%% (%d) %s (%s)" % params
 
                     ret.append(entry)
-        chart = PieChart('', '', ret, color=colors)
+        chart = ILSPieChart('', '', ret, color=colors)
         chart.marginLeft = 10
         chart.marginRight = 10
         chart.height = 500

--- a/custom/ilsgateway/templates/ilsgateway/base_template.html
+++ b/custom/ilsgateway/templates/ilsgateway/base_template.html
@@ -3,13 +3,13 @@
 {% load hq_shared_tags %}
 
 {% block stylesheets %}{{ block.super }}
-    <link href="{% static 'hqwebapp/js/lib/nvd3/nv.d3.css' %}" rel="stylesheet">
+    <link href="{% static 'nvd3/src/nv.d3.css' %}" rel="stylesheet">
     <link href="{% static 'ilsgateway/css/ilsgateway.css' %}" rel="stylesheet">
 {% endblock %}
 
 {% block js %}{{ block.super }}
-    <script src="{% static 'hqwebapp/js/lib/nvd3/lib/d3.v3.js' %}"></script>
-    <script src="{% static 'hqwebapp/js/lib/nvd3/nv.d3.min.js' %}"></script>
+    <script src="{% static 'd3/d3.min.js' %}"></script>
+    <script src="{% static 'nvd3/nv.d3.min.js' %}"></script>
 {% endblock %}
 
 {% block export %}


### PR DESCRIPTION
@benrudolph @biyeun 
I was curious why this change: https://github.com/dimagi/commcare-hq/pull/10905/ broke pie charts in ILS reports.
It turns out that version in hqwebapp is v0.0.1 whereas in bower we have 1.1.10-beta and it seems that data in this form https://github.com/dimagi/commcare-hq/blob/b7b34ce2c01a5b637a499c6a28a17eea76d936cd/corehq/apps/reports/graph_models.py#L174
are not valid in 1.1.10-beta version. 
