### PR TITLE
Improve short_decimal_display UCR transform

### DIFF
--- a/corehq/apps/userreports/transforms/custom/numeric.py
+++ b/corehq/apps/userreports/transforms/custom/numeric.py
@@ -1,2 +1,5 @@
 def get_short_decimal_display(num):
-    return round(num, 2)
+    try:
+        return round(num, 2)
+    except:
+        return num


### PR DESCRIPTION
If rounding fails, return the value. This could happen if the user adds this transform to a column containing text or other non-numeric data.
@snopoke  / anyone
