### PR TITLE
Don't restore logos on remote apps

### DIFF
--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -17,6 +17,7 @@ from corehq.apps.cloudcare.dbaccessors import get_cloudcare_apps
 from corehq.apps.data_interfaces.models import AutomaticUpdateRule
 from corehq.apps.domain.models import Domain
 from corehq.apps.fixtures.models import FixtureDataType
+from corehq.apps.hqmedia.models import HQMediaMixin
 from corehq.apps.reminders.models import METHOD_SMS_SURVEY, METHOD_IVR_SURVEY
 from corehq.apps.users.models import CommCareUser, UserRole
 from corehq.const import USER_DATE_FORMAT
@@ -221,9 +222,10 @@ class DomainUpgradeActionHandler(BaseModifySubscriptionActionHandler):
         """
         try:
             for app in get_all_apps(domain.name):
-                has_restored = app.restore_logos()
-                if has_restored:
-                    app.save()
+                if isinstance(app, HQMediaMixin):
+                    has_restored = app.restore_logos()
+                    if has_restored:
+                        app.save()
             return True
         except Exception:
             log_accounting_error(


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?222840

This error is happening because `RemoteApp` doesn't implement the `HQMediaMixin` (https://github.com/dimagi/commcare-hq/blob/bbe3e7970675cc81992d1d612e070b9b1e7342b6/corehq/apps/hqmedia/models.py#L479) so `restore_logos()` is not a valid method call.

For now this PR excludes `RemoteApp`s from the `restore_logos()` call.  This seemed like the right thing to do, but am wondering if `RemoteApp`s should also implement the `HQMediaMixin`, or if that's something we intentionally don't support.

@NoahCarnahan @snopoke 
fyi @wpride @orangejenny @biyeun 
