### PR TITLE
Fix shadow module case list filter

### DIFF
--- a/corehq/apps/app_manager/suite_xml/sections/entries.py
+++ b/corehq/apps/app_manager/suite_xml/sections/entries.py
@@ -348,7 +348,7 @@ class EntriesHelper(object):
                     filter_xpath_template.replace('$fixture_value', fixture_value)
                 )
 
-            filter_xpath = EntriesHelper.get_filter_xpath(datum['module']) if use_filter else ''
+            filter_xpath = EntriesHelper.get_filter_xpath(detail_module) if use_filter else ''
 
             datums.append(FormDatumMeta(
                 datum=SessionDatum(


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?222616

The issue here was that the shadow module was pulling the case list filter from the source module rather than from itself.

@orangejenny I tested all four combinations of having a filter or not for shadow module and it's source module locally, and the suite.xml was generated properly

@NoahCarnahan @snopoke 
