### PR TITLE
Pull translations from apps db

### DIFF
--- a/corehq/apps/translations/models.py
+++ b/corehq/apps/translations/models.py
@@ -22,23 +22,10 @@ class TranslationMixin(Document):
     def set_translations(self, lang, translations):
         self.translations[lang] = translations
 
-    
-class TranslationDoc(TranslationMixin):
-    @classmethod
-    def create_from_txt(cls, lang, txt=None):
-        """
-        from corehq.apps.translations.models import *
-        TranslationDoc.create_from_txt("pt")
 
-        """
-        if txt:
-            dct = commcare_translations.loads(txt)
-        else:
-            dct = commcare_translations.load_translations(lang)
-        t = cls(translations={lang: dct})
-        t.save()
-        return t
-        
+class TranslationDoc(TranslationMixin):
+    pass
+
 
 class StandaloneTranslationDoc(TranslationDoc, CouchDocLockableMixIn):
     """

--- a/corehq/apps/translations/models.py
+++ b/corehq/apps/translations/models.py
@@ -4,6 +4,7 @@ from dimagi.ext.couchdbkit import (Document, DictProperty,
 import commcare_translations
 from dimagi.utils.couch import CouchDocLockableMixIn
 
+
 class TranslationMixin(Document):
     translations = DictProperty()
 
@@ -76,9 +77,10 @@ class StandaloneTranslationDoc(TranslationDoc, CouchDocLockableMixIn):
 class Translation(object):
     @classmethod
     def get_translations(cls, lang, key=None, one=False):
+        from corehq.apps.app_manager.models import Application
         if key:
             translations = []
-            r = TranslationDoc.get_db().view('app_translations_by_popularity/view',
+            r = Application.get_db().view('app_translations_by_popularity/view',
                 startkey=[lang, key],
                 endkey=[lang, key, {}],
                 group=True
@@ -92,7 +94,7 @@ class Translation(object):
             return translations
         else:
             translations = defaultdict(list)
-            r = TranslationDoc.get_db().view('app_translations_by_popularity/view',
+            r = Application.get_db().view('app_translations_by_popularity/view',
                 startkey=[lang],
                 endkey=[lang, {}],
                 group=True


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?222701

Since the app_translations_by_popularity view only operates on Application docs, this changes all references to that view to be called from the apps db.

@esoergel @dannyroberts 
