### PR TITLE
Remove couchdb from the staging/prod inventories

### DIFF
--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -393,7 +393,6 @@ def env_common():
     proxy = servers['proxy']
     webworkers = servers['webworkers']
     postgresql = servers['postgresql']
-    couchdb = servers['couchdb']
     touchforms = servers['touchforms']
     elasticsearch = servers['elasticsearch']
     celery = servers['celery']
@@ -404,7 +403,6 @@ def env_common():
     deploy = servers.get('deploy', servers['postgresql'])[:1]
 
     env.roledefs = {
-        'couch': couchdb,
         'pg': postgresql,
         'rabbitmq': rabbitmq,
         'django_celery': celery,

--- a/fab/inventory/production
+++ b/fab/inventory/production
@@ -9,9 +9,6 @@ hqdjango14.internal.commcarehq.org
 [webworkers:vars]
 newrelic_app_name=django
 
-[couchdb]
-hqdb0.internal.commcarehq.org
-
 [postgresql]
 hqdb0.internal.commcarehq.org
 

--- a/fab/inventory/softlayer
+++ b/fab/inventory/softlayer
@@ -1,7 +1,3 @@
-[_test1]
-#10.162.36.196
-localhost ansible_connection=local
-
 [celery0]
 10.162.36.233
 
@@ -32,9 +28,6 @@ proxy0
 [webworkers:children]
 django0
 django1
-
-[couchdb:children]
-_test1
 
 [postgresql:children]
 db0

--- a/fab/inventory/staging
+++ b/fab/inventory/staging
@@ -5,9 +5,6 @@ hqproxy4.internal.commcarehq.org
 hqdjango4-staging.internal.commcarehq.org
 hqdjango5-staging.internal.commcarehq.org
 
-[couchdb]
-hqdb0-staging.internal.commcarehq.org
-
 [postgresql]
 hqdb0-staging.internal.commcarehq.org
 

--- a/fab/inventory/staging-va
+++ b/fab/inventory/staging-va
@@ -5,9 +5,6 @@ proxy0-staging.internal-va.commcarehq.org
 hqdjango0-staging.internal-va.commcarehq.org
 hqdjango1-staging.internal-va.commcarehq.org
 
-[couchdb]
-hqdb0-staging.internal-va.commcarehq.org
-
 [postgresql]
 hqdb0-staging.internal-va.commcarehq.org
 


### PR DESCRIPTION
With it in there, a full stack ansible deploy attempts to compile couchdb on those machines.  We don't appear to be using it on a fab deploy anyways.

@dannyroberts we spoke about this on Friday, just want to double check that this is what we had in mind.
