### PR TITLE
Custom experienced

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -3970,6 +3970,9 @@ class ApplicationBase(VersionedDoc, SnapshotMixin,
     minimum_use_threshold = StringProperty(
         default='15'
     )
+    experienced_threshold = StringProperty(
+        default='3'
+    )
 
     # exchange properties
     cached_properties = DictProperty()

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yaml
@@ -182,6 +182,15 @@
   min_value: 1
   max_value: 100
 
+- id: experienced_threshold
+  name: 'Minimum months of use until experienced'
+  description: 'This field indicates the minimum number of months a user must submit forms to be considered experienced enough to generate a WAM. The default value is 3. Please see <a href="https://confluence.dimagi.com/display/internal/WAMs+and+PAMs">confluence</a> or the data team for further clarification.'
+  widget: number
+  preview: true
+  warning: 'The experienced threshold must be between 1 and 100'
+  min_value: 1
+  max_value: 100
+
 - id: comment
   name: 'Comment'
   description: >

--- a/corehq/apps/app_manager/static/app_manager/json/commcare-settings-layout.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-settings-layout.yaml
@@ -81,6 +81,7 @@
     - hq.amplifies_workers
     - hq.amplifies_project
     - hq.minimum_use_threshold
+    - hq.experienced_threshold
 
 - title: 'Disabled'
   id: app-settings-disabled

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -587,6 +587,7 @@ def edit_app_attr(request, domain, app_id, attr):
         ('amplifies_workers', None),
         ('amplifies_project', None),
         ('minimum_use_threshold', None),
+        ('experienced_threshold', None),
         ('use_grid_menus', None),
         ('comment', None),
         ('custom_base_url', None),

--- a/corehq/apps/data_analytics/malt_generator.py
+++ b/corehq/apps/data_analytics/malt_generator.py
@@ -1,5 +1,6 @@
 import logging
 
+from collections import namedtuple
 from corehq.apps.app_manager.const import AMPLIFIES_NOT_SET
 from corehq.apps.app_manager.dbaccessors import get_app
 from corehq.apps.data_analytics.esaccessors import get_app_submission_breakdown_es
@@ -16,6 +17,7 @@ from django.http.response import Http404
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
+MaltAppData = namedtuple('MaltAppData', 'wam pam use_threshold experienced_threshold is_app_deleted')
 
 class MALTTableGenerator(object):
     """
@@ -48,7 +50,7 @@ class MALTTableGenerator(object):
             app_id = app_row.app_id
             num_of_forms = app_row.doc_count
             try:
-                wam, pam, threshold, is_app_deleted = self._app_data(domain_name, app_id)
+                app_data = self._app_data(domain_name, app_id)
                 user_id, username, user_type, email = self._user_data(
                     app_row.user_id,
                     app_row.username,
@@ -69,10 +71,11 @@ class MALTTableGenerator(object):
                 'num_of_forms': num_of_forms,
                 'app_id': app_id or MISSING_APP_ID,
                 'device_id': app_row.device_id,
-                'wam': MALTRow.AMPLIFY_COUCH_TO_SQL_MAP.get(wam, MALTRow.NOT_SET),
-                'pam': MALTRow.AMPLIFY_COUCH_TO_SQL_MAP.get(pam, MALTRow.NOT_SET),
-                'threshold': threshold,
-                'is_app_deleted': is_app_deleted,
+                'wam': MALTRow.AMPLIFY_COUCH_TO_SQL_MAP.get(app_data.wam, MALTRow.NOT_SET),
+                'pam': MALTRow.AMPLIFY_COUCH_TO_SQL_MAP.get(app_data.pam, MALTRow.NOT_SET),
+                'use_threshold': app_data.use_threshold,
+                'experienced_threshold': app_data.experienced_threshold,
+                'is_app_deleted': app_data.is_app_deleted,
             }
             malt_row_dicts.append(malt_dict)
         return malt_row_dicts
@@ -120,7 +123,7 @@ class MALTTableGenerator(object):
     @classmethod
     @quickcache(['domain', 'app_id'])
     def _app_data(cls, domain, app_id):
-        defaults = (AMPLIFIES_NOT_SET, AMPLIFIES_NOT_SET, 15, False)
+        defaults = MaltAppData(AMPLIFIES_NOT_SET, AMPLIFIES_NOT_SET, 15, 3, False)
         if not app_id:
             return defaults
         try:
@@ -128,10 +131,11 @@ class MALTTableGenerator(object):
         except Http404:
             logger.debug("App not found %s" % app_id)
             return defaults
-        return (getattr(app, 'amplifies_workers', AMPLIFIES_NOT_SET),
-                getattr(app, 'amplifies_project', AMPLIFIES_NOT_SET),
-                getattr(app, 'minimum_use_threshold', 15),
-                app.is_deleted())
+        return MaltAppData(getattr(app, 'amplifies_workers', AMPLIFIES_NOT_SET),
+                           getattr(app, 'amplifies_project', AMPLIFIES_NOT_SET),
+                           getattr(app, 'minimum_use_threshold', 15),
+                           getattr(app, 'experienced_threshold', 3),
+                           app.is_deleted())
 
     @classmethod
     def _user_data(cls, user_id, username, all_users_by_id):

--- a/corehq/apps/data_analytics/migrations/0004_experienced_threshold.py
+++ b/corehq/apps/data_analytics/migrations/0004_experienced_threshold.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('data_analytics', '0003_auto_20160205_0927'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='maltrow',
+            old_name='threshold',
+            new_name='use_threshold',
+        ),
+        migrations.AddField(
+            model_name='maltrow',
+            name='experience_threshold',
+            field=models.PositiveSmallIntegerField(default=3, null=True),
+            preserve_default=True,
+        ),
+    ]

--- a/corehq/apps/data_analytics/migrations/0004_experienced_threshold.py
+++ b/corehq/apps/data_analytics/migrations/0004_experienced_threshold.py
@@ -18,7 +18,7 @@ class Migration(migrations.Migration):
         ),
         migrations.AddField(
             model_name='maltrow',
-            name='experience_threshold',
+            name='experienced_threshold',
             field=models.PositiveSmallIntegerField(default=3, null=True),
             preserve_default=True,
         ),

--- a/corehq/apps/data_analytics/migrations/0004_experienced_threshold.py
+++ b/corehq/apps/data_analytics/migrations/0004_experienced_threshold.py
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='maltrow',
             name='experienced_threshold',
-            field=models.PositiveSmallIntegerField(default=3, null=True),
+            field=models.PositiveSmallIntegerField(default=3),
             preserve_default=True,
         ),
     ]

--- a/corehq/apps/data_analytics/models.py
+++ b/corehq/apps/data_analytics/models.py
@@ -34,7 +34,7 @@ class MALTRow(models.Model):
         AMPLIFIES_NOT_SET: NOT_SET
     }
     use_threshold = models.PositiveSmallIntegerField(default=15)
-    experience_threshold = models.PositiveSmallIntegerField(default=3, null=True)
+    experienced_threshold = models.PositiveSmallIntegerField(default=3, null=True)
 
     class Meta:
         unique_together = ('month', 'domain_name', 'user_id', 'app_id', 'device_id')

--- a/corehq/apps/data_analytics/models.py
+++ b/corehq/apps/data_analytics/models.py
@@ -34,7 +34,7 @@ class MALTRow(models.Model):
         AMPLIFIES_NOT_SET: NOT_SET
     }
     use_threshold = models.PositiveSmallIntegerField(default=15)
-    experienced_threshold = models.PositiveSmallIntegerField(default=3, null=True)
+    experienced_threshold = models.PositiveSmallIntegerField(default=3)
 
     class Meta:
         unique_together = ('month', 'domain_name', 'user_id', 'app_id', 'device_id')

--- a/corehq/apps/data_analytics/models.py
+++ b/corehq/apps/data_analytics/models.py
@@ -33,7 +33,8 @@ class MALTRow(models.Model):
         AMPLIFIES_NO: NO,
         AMPLIFIES_NOT_SET: NOT_SET
     }
-    threshold = models.PositiveSmallIntegerField(default=15)
+    use_threshold = models.PositiveSmallIntegerField(default=15)
+    experience_threshold = models.PositiveSmallIntegerField(default=3, null=True)
 
     class Meta:
         unique_together = ('month', 'domain_name', 'user_id', 'app_id', 'device_id')


### PR DESCRIPTION
@czue @millerdev 
This pr adds the ability to specify a custom experience threshold for calculating WAMs, instead of the default 3 months.
Screen shots:
<img width="785" alt="screen shot 2016-04-04 at 2 59 01 pm" src="https://cloud.githubusercontent.com/assets/6844721/14259658/e284b05e-fa75-11e5-9336-e1ec9ceb75fb.png">
<img width="676" alt="screen shot 2016-04-04 at 2 59 11 pm" src="https://cloud.githubusercontent.com/assets/6844721/14259656/e21dd186-fa75-11e5-8cdb-5418cc711e75.png">
