### PR TITLE
Remove api_response

### DIFF
--- a/corehq/apps/smsbillables/migrations/0006_remove_smsbillable_api_response.py
+++ b/corehq/apps/smsbillables/migrations/0006_remove_smsbillable_api_response.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+from corehq.sql_db.operations import HqRunPython
+
+
+def confirm_no_data_loss(apps, schema_editor):
+    if apps.get_model('smsbillables', 'SmsBillable').objects.filter(api_response__isnull=False).exists():
+        raise Exception(
+            'There exists an SmsBillable with api_response != None.'
+            ' Preventing this migration because data would be lost.'
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('smsbillables', '0005_update_http_backend_criteria'),
+    ]
+
+    operations = [
+        HqRunPython(confirm_no_data_loss),
+        migrations.RemoveField(
+            model_name='smsbillable',
+            name='api_response',
+        ),
+    ]

--- a/corehq/apps/smsbillables/models.py
+++ b/corehq/apps/smsbillables/models.py
@@ -261,7 +261,6 @@ class SmsBillable(models.Model):
     usage_fee = models.ForeignKey(SmsUsageFee, null=True, on_delete=models.PROTECT)
     log_id = models.CharField(max_length=50, db_index=True)
     phone_number = models.CharField(max_length=50)
-    api_response = models.TextField(null=True, blank=True)
     is_valid = models.BooleanField(default=True, db_index=True)
     domain = models.CharField(max_length=25, db_index=True)
     direction = models.CharField(max_length=10, db_index=True, choices=DIRECTION_CHOICES)

--- a/corehq/apps/smsbillables/models.py
+++ b/corehq/apps/smsbillables/models.py
@@ -250,10 +250,10 @@ class SmsBillable(models.Model):
     """
     A record of matching a fee to a particular SMS.
 
-    If on closer inspection we determine a particular SmsBillable is invalid (whether something is
-    awry with the api_response, or we used the incorrect fee and want to recalculate) we can set
-    this billable to is_valid = False and it will not be used toward calculating the SmsLineItem in
-    the monthly Invoice.
+    If on closer inspection we determine a particular SmsBillable is invalid
+    (we used the incorrect fee and want to recalculate)
+    we can set this billable to is_valid = False and it will not be used toward
+    calculating the SmsLineItem in the monthly Invoice.
     """
     gateway_fee = models.ForeignKey(SmsGatewayFee, null=True, on_delete=models.PROTECT)
     gateway_fee_conversion_rate = models.DecimalField(default=Decimal('1.0'), null=True, max_digits=20,
@@ -294,7 +294,7 @@ class SmsBillable(models.Model):
         return Decimal('0.0')
 
     @classmethod
-    def create(cls, message_log, api_response=None):
+    def create(cls, message_log):
         phone_number = clean_phone_number(message_log.phone_number)
         direction = message_log.direction
         domain = message_log.domain
@@ -311,9 +311,6 @@ class SmsBillable(models.Model):
             message_log.backend_api, message_log.backend_id, phone_number, direction, log_id
         )
         billable.usage_fee = cls._get_usage_fee(domain, direction)
-
-        if api_response is not None:
-            billable.api_response = api_response
 
         if message_log.backend_api == SQLTestSMSBackend.get_api_id():
             billable.is_valid = False


### PR DESCRIPTION
`api_response` is never assigned or used, and is never non-null on prod and india.

@gcapalbo cc: @sravfeyn 
