### PR TITLE
add temporary non-null value to PaymentRecord before charging Stripe

### DIFF
--- a/corehq/apps/accounting/payment_handlers.py
+++ b/corehq/apps/accounting/payment_handlers.py
@@ -108,7 +108,7 @@ class BaseStripePaymentHandler(object):
                     customer = self.payment_method.customer
 
                 payment_record = PaymentRecord.create_record(
-                    self.payment_method, None, amount
+                    self.payment_method, 'temp', amount
                 )
                 self.update_credits(payment_record)
 


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?222999

not sure why this didn't generate an error when running tests.
