### PR TITLE
check should_send_emails outside of send_emails

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -2060,11 +2060,6 @@ class BillingRecordBase(models.Model):
         raise NotImplementedError()
 
     def send_email(self, contact_emails=None):
-        if not self.should_send_email:
-            self.skipped_email = True
-            self.save()
-            return
-
         pdf_attachment = {
             'title': self.pdf.get_filename(self.invoice),
             'file_obj': StringIO(self.pdf.get_data(self.invoice)),

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -328,10 +328,14 @@ def create_wire_credits_invoice(domain_name,
     wire_invoice.items = invoice_items
 
     record = WirePrepaymentBillingRecord.generate_record(wire_invoice)
-    try:
-        record.send_email(contact_emails=contact_emails)
-    except Exception as e:
-        log_accounting_error(e.message)
+    if record.should_send_email:
+        try:
+            record.send_email(contact_emails=contact_emails)
+        except Exception as e:
+            log_accounting_error(e.message)
+    else:
+        record.skipped_email = True
+        record.save()
 
 
 @task(ignore_result=True)


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?222986

allows manually re-sending an invoice by email even if the invoice was not originally emailed
