### PR TITLE
Accept `version` or `app_build` in device log

### DIFF
--- a/corehq/ex-submodules/couchforms/tests/data/devicelogs/devicelog.xml
+++ b/corehq/ex-submodules/couchforms/tests/data/devicelogs/devicelog.xml
@@ -59,7 +59,7 @@
           XPath evaluation: you messed up some types or something
       </msg>
       <session>frame: (COMMAND_ID m2) \ (COMMAND_ID m2-f1)</session>
-      <version>604</version>
+      <app_build>604</app_build>
       <app_id>36c0bdd028d14a52cbff95bb1bfd0962</app_id>
       <expr>/data/fake</expr>
     </user_error>

--- a/corehq/ex-submodules/phonelog/utils.py
+++ b/corehq/ex-submodules/phonelog/utils.py
@@ -108,7 +108,9 @@ def _process_user_error_subreport(domain, xform):
             xform_id=xform.form_id,
             i=i,
             app_id=error['app_id'],
-            version_number=int(error['version']),
+            # beta versions have 'version', but the name should now be
+            # 'app_build'.  Probably fine to remove after June 2016.
+            version_number=int(error.get('version', error['app_build'])),
             date=error["@date"],
             server_date=xform.received_on,
             user_id=error['user_id'],


### PR DESCRIPTION
@benrudolph
Mobile will be making this name less ambiguous, this should make sure we accept either version
