### PR TITLE
Clear fixtures in sync

### DIFF
--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -83,13 +83,26 @@ class ItemListsProvider(object):
         fixtures = []
         all_types_to_sync = data_types.values() + global_types.values()
         for data_type in all_types_to_sync:
-            xFixture = ElementTree.Element('fixture', attrib={'id': ':'.join((self.id, data_type.tag)),
-                                                              'user_id': user.user_id})
-            xItemList = ElementTree.Element('%s_list' % data_type.tag)
-            xFixture.append(xItemList)
-            for item in sorted(items_by_type[data_type.get_id], key=lambda x: x.sort_key):
-                xItemList.append(item.to_xml())
-            fixtures.append(xFixture)
+            fixtures.append(self._get_fixture_element(
+                data_type.tag,
+                user.user_id,
+                sorted(items_by_type[data_type.get_id], key=lambda x: x.sort_key)
+            ))
         return fixtures
+
+    def _get_fixture_element(self, tag, user_id, items):
+        fixture_element = ElementTree.Element(
+            'fixture',
+            attrib={
+                'id': ':'.join((self.id, tag)),
+                'user_id': user_id
+            }
+        )
+        item_list_element = ElementTree.Element('%s_list' % tag)
+        fixture_element.append(item_list_element)
+        for item in items:
+            item_list_element.append(item.to_xml())
+        return fixture_element
+
 
 item_lists = ItemListsProvider()

--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -88,6 +88,9 @@ class ItemListsProvider(object):
                 user.user_id,
                 sorted(items_by_type[data_type.get_id], key=lambda x: x.sort_key)
             ))
+        for data_type_id, data_type in all_types.iteritems():
+            if data_type_id not in global_types and data_type_id not in data_types:
+                fixtures.append(self._get_fixture_element(data_type.tag, user.user_id, []))
         return fixtures
 
     def _get_fixture_element(self, tag, user_id, items):

--- a/corehq/apps/fixtures/fixturegenerators.py
+++ b/corehq/apps/fixtures/fixturegenerators.py
@@ -81,8 +81,8 @@ class ItemListsProvider(object):
             _set_cached_type(item, data_types[item.data_type_id])
 
         fixtures = []
-        all_types = data_types.values() + global_types.values()
-        for data_type in all_types:
+        all_types_to_sync = data_types.values() + global_types.values()
+        for data_type in all_types_to_sync:
             xFixture = ElementTree.Element('fixture', attrib={'id': ':'.join((self.id, data_type.tag)),
                                                               'user_id': user.user_id})
             xItemList = ElementTree.Element('%s_list' % data_type.tag)

--- a/corehq/apps/fixtures/tests.py
+++ b/corehq/apps/fixtures/tests.py
@@ -143,12 +143,12 @@ class FixtureDataTest(TestCase):
             """
             <fixture id="item-list:district" user_id="{}">
                 <district_list />
-            </fixture>'
+            </fixture>
             """.format(self.user.user_id),
             ElementTree.tostring(fixtures[0])
         )
 
-        self.data_item.add_user(self.user)
+        self.fixture_ownership = self.data_item.add_user(self.user)
 
     def test_get_indexed_items(self):
         with self.assertRaises(FixtureVersionError):

--- a/corehq/apps/fixtures/tests.py
+++ b/corehq/apps/fixtures/tests.py
@@ -128,6 +128,28 @@ class FixtureDataTest(TestCase):
         self.fixture_ownership = self.data_item.add_user(self.user)
         self.assertItemsEqual([self.user.get_id], self.data_item.get_all_users(wrap=False))
 
+    def test_fixture_removal(self):
+        """
+        An empty fixture list should be generated for each fixture that the
+        use does not have access to (within the domain).
+        """
+
+        self.data_item.remove_user(self.user)
+
+        fixtures = fixturegenerators.item_lists(self.user, V2)
+        self.assertEqual(1, len(fixtures))
+        check_xml_line_by_line(
+            self,
+            """
+            <fixture id="item-list:district" user_id="{}">
+                <district_list />
+            </fixture>'
+            """.format(self.user.user_id),
+            ElementTree.tostring(fixtures[0])
+        )
+
+        self.data_item.add_user(self.user)
+
     def test_get_indexed_items(self):
         with self.assertRaises(FixtureVersionError):
             fixtures = FixtureDataItem.get_indexed_items(self.domain,


### PR DESCRIPTION
Adresses http://manage.dimagi.com/default.asp?222443

This change generates a fixture with an empty item list for each fixture in the domain that the user does not have access to. This will result in the fixture data being cleared from the device if the user had access to it and it had been synced to the device previously.

@czue cc @esoergel 
best reviewed commit-by-commit
