### PR TITLE
make multipart_count non-nullable

### DIFF
--- a/corehq/apps/smsbillables/migrations/0008__multipart_count__non_nullable.py
+++ b/corehq/apps/smsbillables/migrations/0008__multipart_count__non_nullable.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('smsbillables', '0007_smsbillable_multipart_count'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='smsbillable',
+            name='multipart_count',
+            field=models.IntegerField(default=1),
+            preserve_default=True,
+        ),
+    ]

--- a/corehq/apps/smsbillables/models.py
+++ b/corehq/apps/smsbillables/models.py
@@ -259,7 +259,7 @@ class SmsBillable(models.Model):
     gateway_fee_conversion_rate = models.DecimalField(default=Decimal('1.0'), null=True, max_digits=20,
                                                       decimal_places=EXCHANGE_RATE_DECIMAL_PLACES)
     usage_fee = models.ForeignKey(SmsUsageFee, null=True, on_delete=models.PROTECT)
-    multipart_count = models.IntegerField(null=True)
+    multipart_count = models.IntegerField(default=1)
     log_id = models.CharField(max_length=50, db_index=True)
     phone_number = models.CharField(max_length=50)
     is_valid = models.BooleanField(default=True, db_index=True)

--- a/corehq/apps/smsbillables/models.py
+++ b/corehq/apps/smsbillables/models.py
@@ -273,11 +273,11 @@ class SmsBillable(models.Model):
 
     @property
     def gateway_charge(self):
-        return (self.multipart_count if self.multipart_count is not None else 1) * self._single_gateway_charge
+        return self.multipart_count * self._single_gateway_charge
 
     @property
     def usage_charge(self):
-        return (self.multipart_count if self.multipart_count is not None else 1) * self._single_usage_charge
+        return self.multipart_count * self._single_usage_charge
 
     @property
     def _single_gateway_charge(self):


### PR DESCRIPTION
Intended to be run on prod outside of deploy.  Fine to run during deploy on other environments where the `SmsBillable` table is smaller.

For reference,

```
$ ./manage.py sqlmigrate smsbillables 0008
BEGIN;
ALTER TABLE "smsbillables_smsbillable" ALTER COLUMN "multipart_count" SET DEFAULT 1;
UPDATE "smsbillables_smsbillable" SET "multipart_count" = 1 WHERE "multipart_count" IS NULL;
ALTER TABLE "smsbillables_smsbillable" ALTER COLUMN "multipart_count" SET NOT NULL;
ALTER TABLE "smsbillables_smsbillable" ALTER COLUMN "multipart_count" DROP DEFAULT;

COMMIT;
```

@gcapalbo cc: @czue 
