### PR TITLE
Refactor Tabs

### DIFF
--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -281,7 +281,6 @@ class BaseProjectSettingsView(BaseDomainView):
         main_context.update({
             'active_tab': ProjectSettingsTab(
                 self.request,
-                self.urlname,
                 domain=self.domain,
                 couch_user=self.request.couch_user,
                 project=self.request.project
@@ -2147,7 +2146,6 @@ class DomainForwardingRepeatRecords(GenericTabularReport):
         context.update({
             'active_tab': ProjectSettingsTab(
                 self.request,
-                self.slug,
                 domain=self.domain,
                 couch_user=self.request.couch_user,
             )

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -100,7 +100,6 @@ class PrimeRestoreCacheView(BaseB3SectionPageView, DomainViewMixin):
         main_context.update({
             'active_tab': ProjectSettingsTab(
                 self.request,
-                self.urlname,
                 domain=self.domain,
                 couch_user=self.request.couch_user,
                 project=self.request.project

--- a/corehq/apps/reports/dispatcher.py
+++ b/corehq/apps/reports/dispatcher.py
@@ -196,18 +196,15 @@ class ReportDispatcher(View):
                     and cls.toggles_enabled(report, request)
                     and report.show_in_navigation(domain=domain, project=project, user=couch_user)
                 ):
-                    if hasattr(report, 'override_navigation_list'):
-                        report_contexts.extend(report.override_navigation_list(context))
-                    else:
-                        report_contexts.append({
-                            'is_active': report.slug == current_slug,
-                            'url': report.get_url(domain=domain, request=request),
-                            'description': _(report.description),
-                            'icon': report.icon,
-                            'title': _(report.name),
-                            'subpages': report.get_subpages(),
-                            'show_in_dropdown': report.display_in_dropdown(project=project),
-                        })
+                    report_contexts.append({
+                        'is_active': report.slug == current_slug,
+                        'url': report.get_url(domain=domain, request=request),
+                        'description': _(report.description),
+                        'icon': report.icon,
+                        'title': _(report.name),
+                        'subpages': report.get_subpages(),
+                        'show_in_dropdown': report.display_in_dropdown(project=project),
+                    })
             if report_contexts:
                 if hasattr(section_name, '__call__'):
                     section_name = section_name(project, couch_user)

--- a/corehq/apps/reports/dispatcher.py
+++ b/corehq/apps/reports/dispatcher.py
@@ -174,16 +174,12 @@ class ReportDispatcher(View):
         return ['json', 'async', 'filters', 'export', 'mobile', 'email', 'partial', 'print']
 
     @classmethod
-    def navigation_sections(cls, context):
-        request = context.get('request')
-        domain = context.get('domain') or getattr(request, 'domain', None)
+    def navigation_sections(cls, request, domain):
         project = getattr(request, 'project', None)
         couch_user = getattr(request, 'couch_user', None)
-        
         nav_context = []
 
         dispatcher = cls()  # uhoh
-        current_slug = context.get('report',{}).get('slug','')
 
         reports = dispatcher.get_reports(domain)
         for section_name, report_group in reports:
@@ -197,7 +193,6 @@ class ReportDispatcher(View):
                     and report.show_in_navigation(domain=domain, project=project, user=couch_user)
                 ):
                     report_contexts.append({
-                        'is_active': report.slug == current_slug,
                         'url': report.get_url(domain=domain, request=request),
                         'description': _(report.description),
                         'icon': report.icon,

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -647,7 +647,7 @@ class AddSavedReportConfigView(View):
                 delattr(self.config, "days")
 
         self.config.save()
-        ProjectReportsTab.clear_dropdown_cache(request, self.domain)
+        ProjectReportsTab.clear_dropdown_cache(self.domain, request.couch_user.get_id)
         touch_saved_reports_views(request.couch_user, self.domain)
 
         return json_response(self.config)
@@ -760,7 +760,7 @@ def delete_config(request, domain, config_id):
         raise Http404()
 
     config.delete()
-    ProjectReportsTab.clear_dropdown_cache(request, domain)
+    ProjectReportsTab.clear_dropdown_cache(domain, request.couch_user.get_id)
 
     touch_saved_reports_views(request.couch_user, domain)
     return HttpResponse()
@@ -900,7 +900,7 @@ def edit_scheduled_report(request, domain, scheduled_report_id=None,
             instance.day = calculate_day(instance.interval, instance.day, day_change)
 
         instance.save()
-        ProjectReportsTab.clear_dropdown_cache(request, domain)
+        ProjectReportsTab.clear_dropdown_cache(domain, request.couch_user.get_id)
         if is_new:
             messages.success(request, "Scheduled report added!")
         else:

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -6,7 +6,7 @@ from corehq.apps.domain.views import BaseDomainView
 from corehq.apps.hqwebapp.view_permissions import user_can_view_reports
 from corehq.apps.users.permissions import FORM_EXPORT_PERMISSION, CASE_EXPORT_PERMISSION, \
     DEID_EXPORT_PERMISSION
-from corehq.tabs.tabclasses import ReportsTab
+from corehq.tabs.tabclasses import ProjectReportsTab
 import langcodes
 import os
 import pytz
@@ -19,7 +19,6 @@ from urllib2 import URLError
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import permission_required
-from django.core.cache import cache
 from django.core.exceptions import PermissionDenied
 from django.core.files.base import ContentFile
 from django.core.servers.basehttp import FileWrapper
@@ -648,7 +647,7 @@ class AddSavedReportConfigView(View):
                 delattr(self.config, "days")
 
         self.config.save()
-        ReportsTab.clear_dropdown_cache(request, self.domain)
+        ProjectReportsTab.clear_dropdown_cache(request, self.domain)
         touch_saved_reports_views(request.couch_user, self.domain)
 
         return json_response(self.config)
@@ -761,7 +760,7 @@ def delete_config(request, domain, config_id):
         raise Http404()
 
     config.delete()
-    ReportsTab.clear_dropdown_cache(request, domain)
+    ProjectReportsTab.clear_dropdown_cache(request, domain)
 
     touch_saved_reports_views(request.couch_user, domain)
     return HttpResponse()
@@ -901,7 +900,7 @@ def edit_scheduled_report(request, domain, scheduled_report_id=None,
             instance.day = calculate_day(instance.interval, instance.day, day_change)
 
         instance.save()
-        ReportsTab.clear_dropdown_cache(request, domain)
+        ProjectReportsTab.clear_dropdown_cache(request, domain)
         if is_new:
             messages.success(request, "Scheduled report added!")
         else:

--- a/corehq/apps/style/templates/style/bootstrap2/base.html
+++ b/corehq/apps/style/templates/style/bootstrap2/base.html
@@ -86,7 +86,6 @@
                     {% endif %}
                     </div>
                 </div>
-                {% format_subtab_menu %}
             </header>
             {% endwith %}
             {% if request.project.is_snapshot %}

--- a/corehq/apps/style/templates/style/bootstrap3/base.html
+++ b/corehq/apps/style/templates/style/bootstrap3/base.html
@@ -253,7 +253,6 @@
                         {% endif %}
                         </div>
                     </nav>
-                    {% format_subtab_menu %}
                 </div>
             </div>
             {% if request.project.is_snapshot %}

--- a/corehq/apps/styleguide/tabs.py
+++ b/corehq/apps/styleguide/tabs.py
@@ -28,7 +28,7 @@ from corehq.apps.styleguide.views.docs import (
 class BaseSGTab(UITab):
 
     @property
-    def is_viewable(self):
+    def _is_viewable(self):
         docs_url = reverse('sg_examples_default')
         return self.request_path.startswith(docs_url)
 

--- a/corehq/apps/styleguide/tabs.py
+++ b/corehq/apps/styleguide/tabs.py
@@ -37,6 +37,8 @@ class SimpleCrispyFormSGExample(BaseSGTab):
     title = ugettext_noop("Simple Crispy Form")
     view = DefaultSimpleCrispyFormSectionView.urlname
 
+    url_prefix_formats = ('/styleguide/docs/simple_crispy/',)
+
     @property
     @memoized
     def sidebar_items(self):
@@ -69,6 +71,8 @@ class SimpleCrispyFormSGExample(BaseSGTab):
 class ControlsDemoSGExample(BaseSGTab):
     title = ugettext_noop("Form Controls")
     view = DefaultControlsDemoFormsView.urlname
+
+    url_prefix_formats = ('/styleguide/docs/controls_demo/',)
 
     @property
     @memoized
@@ -103,6 +107,8 @@ class ControlsDemoSGExample(BaseSGTab):
 class SGExampleTab(BaseSGTab):
     title = ugettext_noop("Style Guide")
     view = 'corehq.apps.styleguide.views.docs.default'
+
+    url_prefix_formats = ('/styleguide/docs/',)
 
     @property
     def dropdown_items(self):

--- a/corehq/apps/styleguide/tabs.py
+++ b/corehq/apps/styleguide/tabs.py
@@ -29,9 +29,8 @@ class BaseSGTab(UITab):
 
     @property
     def is_viewable(self):
-        full_path = self._request.get_full_path()
         docs_url = reverse('sg_examples_default')
-        return full_path.startswith(docs_url)
+        return self.request_path.startswith(docs_url)
 
 
 class SimpleCrispyFormSGExample(BaseSGTab):

--- a/corehq/apps/styleguide/tabs.py
+++ b/corehq/apps/styleguide/tabs.py
@@ -103,10 +103,6 @@ class ControlsDemoSGExample(BaseSGTab):
 class SGExampleTab(BaseSGTab):
     title = ugettext_noop("Style Guide")
     view = 'corehq.apps.styleguide.views.docs.default'
-    subtab_classes = (
-        SimpleCrispyFormSGExample,
-        ControlsDemoSGExample,
-    )
 
     @property
     def dropdown_items(self):

--- a/corehq/tabs/config.py
+++ b/corehq/tabs/config.py
@@ -2,7 +2,7 @@ from corehq.apps.styleguide.tabs import SGExampleTab, SimpleCrispyFormSGExample,
     ControlsDemoSGExample
 from corehq.tabs.tabclasses import DashboardTab, ProjectReportsTab, ProjectInfoTab, SetupTab, \
     ProjectDataTab, ApplicationsTab, CloudcareTab, MessagingTab, ProjectUsersTab, \
-    AdminTab, IndicatorAdminTab, SMSAdminTab
+    AdminTab, IndicatorAdminTab, SMSAdminTab, AccountingTab
 
 MENU_TABS = (
     DashboardTab,
@@ -18,6 +18,7 @@ MENU_TABS = (
     # Admin
     AdminTab,
     SMSAdminTab,
+    AccountingTab,
     # Styleguide
     SGExampleTab,
     SimpleCrispyFormSGExample,

--- a/corehq/tabs/config.py
+++ b/corehq/tabs/config.py
@@ -2,7 +2,7 @@ from corehq.apps.styleguide.tabs import SGExampleTab, SimpleCrispyFormSGExample,
     ControlsDemoSGExample
 from corehq.tabs.tabclasses import DashboardTab, ProjectReportsTab, ProjectInfoTab, SetupTab, \
     ProjectDataTab, ApplicationsTab, CloudcareTab, MessagingTab, ProjectUsersTab, \
-    AdminTab, IndicatorAdminTab
+    AdminTab, IndicatorAdminTab, SMSAdminTab
 
 MENU_TABS = (
     DashboardTab,
@@ -15,7 +15,9 @@ MENU_TABS = (
     ApplicationsTab,
     CloudcareTab,
     MessagingTab,
+    # Admin
     AdminTab,
+    SMSAdminTab,
     # Styleguide
     SGExampleTab,
     SimpleCrispyFormSGExample,

--- a/corehq/tabs/config.py
+++ b/corehq/tabs/config.py
@@ -1,12 +1,14 @@
-from corehq.apps.styleguide.tabs import SGExampleTab
-from corehq.tabs.tabclasses import DashboardTab, ReportsTab, ProjectInfoTab, SetupTab, \
+from corehq.apps.styleguide.tabs import SGExampleTab, SimpleCrispyFormSGExample, \
+    ControlsDemoSGExample
+from corehq.tabs.tabclasses import DashboardTab, ProjectReportsTab, ProjectInfoTab, SetupTab, \
     ProjectDataTab, ApplicationsTab, CloudcareTab, MessagingTab, ProjectUsersTab, \
-    AdminTab
+    AdminTab, IndicatorAdminTab
 
 MENU_TABS = (
     DashboardTab,
     ProjectInfoTab,
-    ReportsTab,
+    ProjectReportsTab,
+    IndicatorAdminTab,
     ProjectDataTab,
     SetupTab,
     ProjectUsersTab,
@@ -14,5 +16,8 @@ MENU_TABS = (
     CloudcareTab,
     MessagingTab,
     AdminTab,
+    # Styleguide
     SGExampleTab,
+    SimpleCrispyFormSGExample,
+    ControlsDemoSGExample,
 )

--- a/corehq/tabs/exceptions.py
+++ b/corehq/tabs/exceptions.py
@@ -1,0 +1,14 @@
+class TabClassError(Exception):
+    pass
+
+
+class UrlPrefixFormatsSuggestion(TabClassError):
+    pass
+
+
+class UrlPrefixFormatError(TabClassError):
+    pass
+
+
+class TabClassErrorSummary(Exception):
+    pass

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1300,6 +1300,9 @@ class AccountingTab(UITab):
     view = "accounting_default"
     dispatcher = AccountingAdminInterfaceDispatcher
 
+    url_prefix_formats = ('/hq/accounting/',)
+    show_by_default = False
+
     @property
     def is_viewable(self):
         return is_accounting_admin(self._request.user)
@@ -1344,6 +1347,7 @@ class SMSAdminTab(UITab):
     dispatcher = SMSAdminInterfaceDispatcher
 
     url_prefix_formats = ('/hq/sms/',)
+    show_by_default = False
 
     @property
     @memoized
@@ -1364,16 +1368,6 @@ class SMSAdminTab(UITab):
              'url': reverse('global_backend_map')},
         ]))
         return items
-
-    @property
-    def is_viewable(self):
-        return path_starts_with_url(self.request_path, self.url) and \
-            self.couch_user and self.couch_user.is_superuser
-
-
-class FeatureFlagsTab(UITab):
-    title = ugettext_noop("Feature Flags")
-    view = "toggle_list"
 
     @property
     def is_viewable(self):

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1407,7 +1407,7 @@ class AdminTab(UITab):
             #                      url=reverse("default_announcement_admin")),
         ]
         try:
-            if AccountingTab(self._request, self._current_url_name).is_viewable:
+            if AccountingTab(self._request).is_viewable:
                 submenu_context.append(
                     dropdown_dict(AccountingTab.title, url=reverse('accounting_default'))
                 )

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -37,12 +37,6 @@ class ProjectReportsTab(UITab):
     view = "corehq.apps.reports.views.default"
 
     @property
-    def is_active_shortcircuit(self):
-        # HACK. We need a more overarching way to avoid doing things this way
-        if 'reports/adm' in self.request_path:
-            return False
-
-    @property
     def is_viewable(self):
         return user_can_view_reports(self.project, self.couch_user)
 
@@ -882,23 +876,13 @@ class ProjectUsersTab(UITab):
                                 self.couch_user.can_edit_web_users())
 
     @property
-    def is_active_shortcircuit(self):
-        if not self.domain:
-            return False
-
-    @property
     @memoized
-    def is_active(self):
-        if super(ProjectUsersTab, self).is_active:
-            return True
-
-        if not self.domain:
-            return False
+    def urls(self):
+        urls = super(ProjectUsersTab, self).urls
 
         cloudcare_settings_url = reverse('cloudcare_app_settings',
                                          args=[self.domain])
-        full_path = self.request_path
-        return full_path.startswith(cloudcare_settings_url)
+        return urls + [cloudcare_settings_url]
 
     @property
     def can_view_cloudcare(self):

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -44,11 +44,7 @@ class ProjectReportsTab(UITab):
 
     @property
     def view(self):
-        return self.get_view(self.domain)
-
-    @staticmethod
-    def get_view(domain):
-        module = Domain.get_module_by_name(domain)
+        module = Domain.get_module_by_name(self.domain)
         if hasattr(module, 'DEFAULT_REPORT_CLASS'):
             return "corehq.apps.reports.views.default"
         return "corehq.apps.reports.views.saved_reports"

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -39,7 +39,7 @@ class ProjectReportsTab(UITab):
     @property
     def is_active_shortcircuit(self):
         # HACK. We need a more overarching way to avoid doing things this way
-        if 'reports/adm' in self._request.get_full_path():
+        if 'reports/adm' in self.request_path:
             return False
 
     @property
@@ -907,7 +907,7 @@ class ProjectUsersTab(UITab):
 
         cloudcare_settings_url = reverse('cloudcare_app_settings',
                                          args=[self.domain])
-        full_path = self._request.get_full_path()
+        full_path = self.request_path
         return full_path.startswith(cloudcare_settings_url)
 
     @property

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -39,7 +39,7 @@ class ProjectReportsTab(UITab):
     url_prefix_formats = ('/a/{domain}/reports/',)
 
     @property
-    def is_viewable(self):
+    def _is_viewable(self):
         return user_can_view_reports(self.project, self.couch_user)
 
     @property
@@ -80,7 +80,7 @@ class IndicatorAdminTab(UITab):
     url_prefix_formats = ('/a/{domain}/indicators/',)
 
     @property
-    def is_viewable(self):
+    def _is_viewable(self):
         indicator_enabled_projects = get_indicator_domains()
         return (self.couch_user.can_edit_data() and
                 self.domain in indicator_enabled_projects)
@@ -117,7 +117,7 @@ class DashboardTab(UITab):
     url_prefix_formats = ('/a/{domain}/dashboard/project/',)
 
     @property
-    def is_viewable(self):
+    def _is_viewable(self):
         if self.domain and self.project and not self.project.is_snapshot and self.couch_user:
             # domain hides Dashboard tab if user is non-admin
             if not user_has_custom_top_menu(self.domain, self.couch_user):
@@ -189,7 +189,7 @@ class ProjectInfoTab(UITab):
     url_prefix_formats = ('/exchange/{domain}/info/',)
 
     @property
-    def is_viewable(self):
+    def _is_viewable(self):
         return self.project and self.project.is_snapshot
 
 
@@ -234,7 +234,7 @@ class SetupTab(UITab):
         ]
 
     @property
-    def is_viewable(self):
+    def _is_viewable(self):
         return (self.couch_user.is_domain_admin() and
                 self.project.commtrack_enabled)
 
@@ -384,7 +384,7 @@ class ProjectDataTab(UITab):
         return domain_has_privilege(self.domain, privileges.LOOKUP_TABLES)
 
     @property
-    def is_viewable(self):
+    def _is_viewable(self):
         return self.domain and (self.can_edit_commcare_data or self.can_export_data)
 
     @property
@@ -597,7 +597,7 @@ class ApplicationsTab(UITab):
         return submenu_context
 
     @property
-    def is_viewable(self):
+    def _is_viewable(self):
         couch_user = self.couch_user
         return (self.domain and couch_user and
                 (couch_user.is_web_user() or couch_user.can_edit_apps()) and
@@ -615,7 +615,7 @@ class CloudcareTab(UITab):
     ga_tracker = GaTracker('CloudCare', 'Click Cloud-Care top-level nav')
 
     @property
-    def is_viewable(self):
+    def _is_viewable(self):
         return (
             has_privilege(self._request, privileges.CLOUDCARE)
             and self.domain
@@ -635,7 +635,7 @@ class MessagingTab(UITab):
     )
 
     @property
-    def is_viewable(self):
+    def _is_viewable(self):
         return (self.can_access_reminders or self.can_use_outbound_sms) and (
             self.project and not (self.project.is_snapshot or
                                   self.couch_user.is_commcare_user())
@@ -906,7 +906,7 @@ class ProjectUsersTab(UITab):
     )
 
     @property
-    def is_viewable(self):
+    def _is_viewable(self):
         return self.domain and (self.couch_user.can_edit_commcare_users() or
                                 self.couch_user.can_edit_web_users())
 
@@ -1078,7 +1078,7 @@ class ProjectSettingsTab(UITab):
     url_prefix_formats = ('/a/{domain}/settings/project/',)
 
     @property
-    def is_viewable(self):
+    def _is_viewable(self):
         return (self.domain and self.couch_user and
                 self.couch_user.is_domain_admin(self.domain))
 
@@ -1265,7 +1265,7 @@ class MySettingsTab(UITab):
     view = 'default_my_settings'
 
     @property
-    def is_viewable(self):
+    def _is_viewable(self):
         return self.couch_user is not None
 
     @property
@@ -1304,7 +1304,7 @@ class AccountingTab(UITab):
     show_by_default = False
 
     @property
-    def is_viewable(self):
+    def _is_viewable(self):
         return is_accounting_admin(self._request.user)
 
     @property
@@ -1370,7 +1370,7 @@ class SMSAdminTab(UITab):
         return items
 
     @property
-    def is_viewable(self):
+    def _is_viewable(self):
         return self.couch_user and self.couch_user.is_superuser
 
 
@@ -1401,7 +1401,7 @@ class AdminTab(UITab):
             #                      url=reverse("default_announcement_admin")),
         ]
         try:
-            if AccountingTab(self._request).is_viewable:
+            if AccountingTab(self._request)._is_viewable:
                 submenu_context.append(
                     dropdown_dict(AccountingTab.title, url=reverse('accounting_default'))
                 )
@@ -1480,7 +1480,7 @@ class AdminTab(UITab):
         ]
 
     @property
-    def is_viewable(self):
+    def _is_viewable(self):
         return (self.couch_user and
                 (self.couch_user.is_superuser or
                  toggles.IS_DEVELOPER.enabled(self.couch_user.username)))

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -178,7 +178,7 @@ class ReportsTab(UITab):
         reports = sidebar_to_dropdown(
             ProjectReportDispatcher.navigation_sections(
                 request=self._request, domain=self.domain),
-            current_url_name=self.url)
+            current_url=self.url)
         return saved_reports_dropdown + reports
 
 

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -36,6 +36,8 @@ class ProjectReportsTab(UITab):
     title = ugettext_noop("Reports")
     view = "corehq.apps.reports.views.default"
 
+    url_prefix_formats = ('/a/{domain}/reports/',)
+
     @property
     def is_viewable(self):
         return user_can_view_reports(self.project, self.couch_user)
@@ -109,6 +111,8 @@ class IndicatorAdminTab(UITab):
 class DashboardTab(UITab):
     title = ugettext_noop("Dashboard")
     view = 'corehq.apps.dashboard.views.dashboard_default'
+
+    url_prefix_formats = ('/a/{domain}/dashboard/project/',)
 
     @property
     def is_viewable(self):
@@ -188,6 +192,12 @@ class ProjectInfoTab(UITab):
 class SetupTab(UITab):
     title = ugettext_noop("Setup")
     view = "corehq.apps.commtrack.views.default"
+
+    url_prefix_formats = (
+        '/a/{domain}/settings/products/',
+        '/a/{domain}/settings/programs/',
+        '/a/{domain}/settings/commtrack/',
+    )
 
     @property
     def dropdown_items(self):
@@ -322,6 +332,10 @@ class SetupTab(UITab):
 class ProjectDataTab(UITab):
     title = ugettext_noop("Data")
     view = "corehq.apps.data_interfaces.views.default"
+    url_prefix_formats = (
+        '/a/{domain}/data/',
+        '/a/{domain}/fixtures/',
+    )
 
     @property
     @memoized
@@ -535,6 +549,8 @@ class ProjectDataTab(UITab):
 class ApplicationsTab(UITab):
     view = "corehq.apps.app_manager.views.view_app"
 
+    url_prefix_formats = ('/a/{domain}/apps/',)
+
     @property
     def title(self):
         return _("Applications")
@@ -590,6 +606,8 @@ class CloudcareTab(UITab):
     title = ugettext_noop("CloudCare")
     view = "corehq.apps.cloudcare.views.default"
 
+    url_prefix_formats = ('/a/{domain}/cloudcare/',)
+
     ga_tracker = GaTracker('CloudCare', 'Click Cloud-Care top-level nav')
 
     @property
@@ -604,6 +622,13 @@ class CloudcareTab(UITab):
 class MessagingTab(UITab):
     title = ugettext_noop("Messaging")
     view = "corehq.apps.sms.views.default"
+
+    url_prefix_formats = (
+        '/a/{domain}/sms/',
+        '/a/{domain}/reminders/',
+        '/a/{domain}/reports/message_log/',
+        '/a/{domain}/data/edit/case_groups/',
+    )
 
     @property
     def is_viewable(self):
@@ -870,19 +895,16 @@ class ProjectUsersTab(UITab):
     title = ugettext_noop("Users")
     view = "users_default"
 
+    url_prefix_formats = (
+        '/a/{domain}/settings/users/',
+        '/a/{domain}/settings/cloudcare/',
+        '/a/{domain}/settings/locations/',
+    )
+
     @property
     def is_viewable(self):
         return self.domain and (self.couch_user.can_edit_commcare_users() or
                                 self.couch_user.can_edit_web_users())
-
-    @property
-    @memoized
-    def urls(self):
-        urls = super(ProjectUsersTab, self).urls
-
-        cloudcare_settings_url = reverse('cloudcare_app_settings',
-                                         args=[self.domain])
-        return urls + [cloudcare_settings_url]
 
     @property
     def can_view_cloudcare(self):
@@ -1353,6 +1375,8 @@ class FeatureFlagsTab(UITab):
 class AdminTab(UITab):
     title = ugettext_noop("Admin")
     view = "corehq.apps.hqadmin.views.default"
+
+    url_prefix_formats = ('/hq/admin/',)
 
     @property
     def dropdown_items(self):

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -48,10 +48,6 @@ class ProjectReportsTab(UITab):
 
     @property
     def sidebar_items(self):
-        context = {
-            'request': self._request,
-            'domain': self.domain,
-        }
 
         tools = [(_("Tools"), [
             {'title': _('My Saved Reports'),
@@ -72,9 +68,10 @@ class ProjectReportsTab(UITab):
                 }]
             )]
 
-        project_reports = ProjectReportDispatcher.navigation_sections(context)
+        project_reports = ProjectReportDispatcher.navigation_sections(
+            request=self._request, domain=self.domain)
         custom_reports = CustomProjectReportDispatcher.navigation_sections(
-            context)
+            request=self._request, domain=self.domain)
 
         return tools + user_reports + project_reports + custom_reports
 
@@ -179,12 +176,9 @@ class ReportsTab(UITab):
         else:
             saved_reports_dropdown = []
 
-        context = {
-            'request': self._request,
-            'domain': self.domain,
-        }
         reports = sidebar_to_dropdown(
-            ProjectReportDispatcher.navigation_sections(context),
+            ProjectReportDispatcher.navigation_sections(
+                request=self._request, domain=self.domain),
             current_url_name=self.url)
         return saved_reports_dropdown + reports
 
@@ -386,11 +380,6 @@ class ProjectDataTab(UITab):
     def sidebar_items(self):
         items = []
 
-        context = {
-            'request': self._request,
-            'domain': self.domain,
-        }
-
         export_data_views = []
         if self.can_only_see_deid_exports:
             from corehq.apps.export.views import DeIdFormExportListView, DownloadFormExportView
@@ -502,7 +491,8 @@ class ProjectDataTab(UITab):
         if self.can_edit_commcare_data:
             from corehq.apps.data_interfaces.dispatcher \
                 import EditDataInterfaceDispatcher
-            edit_section = EditDataInterfaceDispatcher.navigation_sections(context)
+            edit_section = EditDataInterfaceDispatcher.navigation_sections(
+                request=self._request, domain=self.domain)
 
             from corehq.apps.data_interfaces.views \
                 import ArchiveFormView, AutomaticUpdateRuleListView
@@ -522,7 +512,8 @@ class ProjectDataTab(UITab):
 
         if self.can_use_lookup_tables:
             from corehq.apps.fixtures.dispatcher import FixtureInterfaceDispatcher
-            items.extend(FixtureInterfaceDispatcher.navigation_sections(context))
+            items.extend(FixtureInterfaceDispatcher.navigation_sections(
+                request=self._request, domain=self.domain))
 
         return items
 

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -26,7 +26,7 @@ from corehq.apps.users.decorators import get_permission_name
 from corehq.apps.users.models import Permissions
 from corehq.apps.users.permissions import FORM_EXPORT_PERMISSION
 from corehq.tabs.uitab import UITab
-from corehq.tabs.utils import dropdown_dict, sidebar_to_dropdown, path_starts_with_url
+from corehq.tabs.utils import dropdown_dict, sidebar_to_dropdown
 from corehq.toggles import OPENLMIS
 from dimagi.utils.decorators.memoized import memoized
 from django_prbac.utils import has_privilege

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -26,7 +26,7 @@ from corehq.apps.users.decorators import get_permission_name
 from corehq.apps.users.models import Permissions
 from corehq.apps.users.permissions import FORM_EXPORT_PERMISSION
 from corehq.tabs.uitab import UITab
-from corehq.tabs.utils import dropdown_dict, sidebar_to_dropdown
+from corehq.tabs.utils import dropdown_dict, sidebar_to_dropdown, path_starts_with_url
 from corehq.toggles import OPENLMIS
 from dimagi.utils.decorators.memoized import memoized
 from django_prbac.utils import has_privilege
@@ -1337,7 +1337,8 @@ class SMSAdminTab(UITab):
 
     @property
     def is_viewable(self):
-        return self.couch_user and self.couch_user.is_superuser
+        return path_starts_with_url(self.request_path, self.url) and \
+            self.couch_user and self.couch_user.is_superuser
 
 
 class FeatureFlagsTab(UITab):

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -137,7 +137,6 @@ class DashboardTab(UITab):
 
 class ReportsTab(UITab):
     title = ugettext_noop("Reports")
-    subtab_classes = (ProjectReportsTab, IndicatorAdminTab)
 
     @property
     def view(self):
@@ -1437,12 +1436,6 @@ class FeatureFlagsTab(UITab):
 class AdminTab(UITab):
     title = ugettext_noop("Admin")
     view = "corehq.apps.hqadmin.views.default"
-    subtab_classes = (
-        AdminReportsTab,
-        SMSAdminTab,
-        AccountingTab,
-        FeatureFlagsTab
-    )
 
     @property
     def dropdown_items(self):

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -77,6 +77,8 @@ class IndicatorAdminTab(UITab):
     view = "corehq.apps.indicators.views.default_admin"
     dispatcher = IndicatorAdminInterfaceDispatcher
 
+    url_prefix_formats = ('/a/{domain}/indicators/',)
+
     @property
     def is_viewable(self):
         indicator_enabled_projects = get_indicator_domains()
@@ -183,6 +185,8 @@ class ReportsTab(UITab):
 class ProjectInfoTab(UITab):
     title = ugettext_noop("Project Info")
     view = "corehq.apps.appstore.views.project_info"
+
+    url_prefix_formats = ('/exchange/{domain}/info/',)
 
     @property
     def is_viewable(self):
@@ -1071,6 +1075,8 @@ class ProjectSettingsTab(UITab):
     title = ugettext_noop("Project Settings")
     view = 'domain_settings_default'
 
+    url_prefix_formats = ('/a/{domain}/settings/project/',)
+
     @property
     def is_viewable(self):
         return (self.domain and self.couch_user and
@@ -1336,6 +1342,8 @@ class SMSAdminTab(UITab):
     title = ugettext_noop("SMS Connectivity & Billing")
     view = "default_sms_admin_interface"
     dispatcher = SMSAdminInterfaceDispatcher
+
+    url_prefix_formats = ('/hq/sms/',)
 
     @property
     @memoized

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -33,7 +33,7 @@ from django_prbac.utils import has_privilege
 
 
 class ProjectReportsTab(UITab):
-    title = ugettext_noop("Project Reports")
+    title = ugettext_noop("Reports")
     view = "corehq.apps.reports.views.default"
 
     @property
@@ -1283,74 +1283,6 @@ class MySettingsTab(UITab):
         return items
 
 
-class AdminReportsTab(UITab):
-    title = ugettext_noop("Admin Reports")
-    view = "corehq.apps.hqadmin.views.default"
-
-    @property
-    def sidebar_items(self):
-        # todo: convert these to dispatcher-style like other reports
-        if (self.couch_user and
-                (not self.couch_user.is_superuser and
-                 toggles.IS_DEVELOPER.enabled(self.couch_user.username))):
-            return [
-                (_('Administrative Reports'), [
-                    {'title': _('System Info'),
-                     'url': reverse('system_info')},
-                ])]
-
-        admin_operations = []
-
-        if self.couch_user and self.couch_user.is_staff:
-            from corehq.apps.hqadmin.views import AuthenticateAs
-            admin_operations.extend([
-                {'title': _('PillowTop Errors'),
-                 'url': reverse('admin_report_dispatcher',
-                                args=('pillow_errors',))},
-                {'title': _('Login as another user'),
-                 'url': reverse(AuthenticateAs.urlname)},
-                {'title': _('Look up user by email'),
-                 'url': reverse('web_user_lookup')},
-            ])
-        return [
-            (_('Administrative Reports'), [
-                {'title': _('Project Space List'),
-                 'url': reverse('admin_report_dispatcher', args=('domains',))},
-                {'title': _('Submission Map'),
-                 'url': reverse('dimagisphere')},
-                {'title': _('User List'),
-                 'url': reverse('admin_report_dispatcher', args=('user_list',))},
-                {'title': _('Application List'),
-                 'url': reverse('admin_report_dispatcher', args=('app_list',))},
-                {'title': _('System Info'),
-                 'url': reverse('system_info')},
-                {'title': _('Loadtest Report'),
-                 'url': reverse('loadtest_report')},
-                {'title': _('Download Malt table'),
-                 'url': reverse('download_malt')},
-            ]),
-            (_('Administrative Operations'), admin_operations),
-            (_('CommCare Reports'), [
-                {
-                    'title': report.name,
-                    'url': '%s?%s' % (reverse('admin_report_dispatcher',
-                                              args=(report.slug,)),
-                                      urlencode(report.default_params))
-                } for report in [
-                    RealProjectSpacesReport,
-                    CommConnectProjectSpacesReport,
-                    CommTrackProjectSpacesReport,
-                ]
-            ]),
-        ]
-
-    @property
-    def is_viewable(self):
-        return (self.couch_user and
-                (self.couch_user.is_superuser or
-                 toggles.IS_DEVELOPER.enabled(self.couch_user.username)))
-
-
 class AccountingTab(UITab):
     title = ugettext_noop("Accounting")
     view = "accounting_default"
@@ -1478,6 +1410,63 @@ class AdminTab(UITab):
             dropdown_dict(_("Django Admin"), url="/admin")
         ])
         return submenu_context
+
+    @property
+    def sidebar_items(self):
+        # todo: convert these to dispatcher-style like other reports
+        if (self.couch_user and
+                (not self.couch_user.is_superuser and
+                 toggles.IS_DEVELOPER.enabled(self.couch_user.username))):
+            return [
+                (_('Administrative Reports'), [
+                    {'title': _('System Info'),
+                     'url': reverse('system_info')},
+                ])]
+
+        admin_operations = []
+
+        if self.couch_user and self.couch_user.is_staff:
+            from corehq.apps.hqadmin.views import AuthenticateAs
+            admin_operations.extend([
+                {'title': _('PillowTop Errors'),
+                 'url': reverse('admin_report_dispatcher',
+                                args=('pillow_errors',))},
+                {'title': _('Login as another user'),
+                 'url': reverse(AuthenticateAs.urlname)},
+                {'title': _('Look up user by email'),
+                 'url': reverse('web_user_lookup')},
+            ])
+        return [
+            (_('Administrative Reports'), [
+                {'title': _('Project Space List'),
+                 'url': reverse('admin_report_dispatcher', args=('domains',))},
+                {'title': _('Submission Map'),
+                 'url': reverse('dimagisphere')},
+                {'title': _('User List'),
+                 'url': reverse('admin_report_dispatcher', args=('user_list',))},
+                {'title': _('Application List'),
+                 'url': reverse('admin_report_dispatcher', args=('app_list',))},
+                {'title': _('System Info'),
+                 'url': reverse('system_info')},
+                {'title': _('Loadtest Report'),
+                 'url': reverse('loadtest_report')},
+                {'title': _('Download Malt table'),
+                 'url': reverse('download_malt')},
+            ]),
+            (_('Administrative Operations'), admin_operations),
+            (_('CommCare Reports'), [
+                {
+                    'title': report.name,
+                    'url': '%s?%s' % (reverse('admin_report_dispatcher',
+                                              args=(report.slug,)),
+                                      urlencode(report.default_params))
+                } for report in [
+                    RealProjectSpacesReport,
+                    CommConnectProjectSpacesReport,
+                    CommTrackProjectSpacesReport,
+                ]
+            ]),
+        ]
 
     @property
     def is_viewable(self):

--- a/corehq/tabs/templates/tabs/menu_main.html
+++ b/corehq/tabs/templates/tabs/menu_main.html
@@ -3,7 +3,7 @@
 {% get_current_language as LANGUAGE_CODE %}
 <ul class="nav navbar-nav" role="menu">
     {% for tab in tabs %}
-    {% cache 500 header_tab tab.domain tab.org tab.view tab.is_active_tab tab.couch_user.get_id LANGUAGE_CODE %}
+    {% cache 500 header_tab tab.class_name tab.domain tab.is_active_tab tab.couch_user.get_id LANGUAGE_CODE %}
     {% with tab.dropdown_items as items %}
         <li id="mainmenu-{{ tab.css_id }}"
             class="{% if items %}dropdown{% endif %}{% if tab.is_active_tab %} active{% endif %}">

--- a/corehq/tabs/templatetags/menu_tags.py
+++ b/corehq/tabs/templatetags/menu_tags.py
@@ -82,7 +82,7 @@ class MainMenuNode(template.Node):
         if active_tab:
             active_tab.is_active_tab = True
 
-        visible_tabs = [tab for tab in all_tabs if tab.real_is_viewable]
+        visible_tabs = [tab for tab in all_tabs if tab.should_show()]
 
         # set the context variable in the highest scope so it can be used in
         # other blocks

--- a/corehq/tabs/templatetags/menu_tags.py
+++ b/corehq/tabs/templatetags/menu_tags.py
@@ -35,7 +35,7 @@ def _get_active_tab(visible_tabs, request_path):
         return tab
 
 
-def get_all_tabs(request, current_url_name, domain, couch_user, project):
+def get_all_tabs(request, domain, couch_user, project):
     """
     instantiate all UITabs, and aggregate all their TabClassErrors (if any)
     into a single TabClassErrorSummary
@@ -49,7 +49,7 @@ def get_all_tabs(request, current_url_name, domain, couch_user, project):
     for tab_class in MENU_TABS:
         try:
             tab = tab_class(
-                request, current_url_name, domain=domain,
+                request, domain=domain,
                 couch_user=couch_user, project=project)
         except TabClassError as e:
             instantiation_errors.append(e)
@@ -70,13 +70,12 @@ def get_all_tabs(request, current_url_name, domain, couch_user, project):
 class MainMenuNode(template.Node):
     def render(self, context):
         request = context['request']
-        current_url_name = context['current_url_name']
         couch_user = getattr(request, 'couch_user', None)
         project = getattr(request, 'project', None)
         domain = context.get('domain')
         visible_tabs = []
 
-        for tab in get_all_tabs(request, current_url_name, domain=domain,
+        for tab in get_all_tabs(request, domain=domain,
                                 couch_user=couch_user, project=project):
             tab.is_active_tab = False
             if tab.real_is_viewable:

--- a/corehq/tabs/templatetags/menu_tags.py
+++ b/corehq/tabs/templatetags/menu_tags.py
@@ -73,20 +73,20 @@ class MainMenuNode(template.Node):
         couch_user = getattr(request, 'couch_user', None)
         project = getattr(request, 'project', None)
         domain = context.get('domain')
-        visible_tabs = []
 
-        for tab in get_all_tabs(request, domain=domain,
-                                couch_user=couch_user, project=project):
-            tab.is_active_tab = False
-            if tab.real_is_viewable:
-                visible_tabs.append(tab)
+        all_tabs = get_all_tabs(request, domain=domain, couch_user=couch_user,
+                                project=project)
+
+        active_tab = _get_active_tab(all_tabs, request.get_full_path())
+
+        if active_tab:
+            active_tab.is_active_tab = True
+
+        visible_tabs = [tab for tab in all_tabs if tab.real_is_viewable]
 
         # set the context variable in the highest scope so it can be used in
         # other blocks
-        active_tab = context.dicts[0]['active_tab'] = _get_active_tab(
-            visible_tabs, request.get_full_path())
-        if active_tab:
-            active_tab.is_active_tab = True
+        context.dicts[0]['active_tab'] = active_tab
         return mark_safe(render_to_string('tabs/menu_main.html', {
             'tabs': visible_tabs,
         }))

--- a/corehq/tabs/templatetags/menu_tags.py
+++ b/corehq/tabs/templatetags/menu_tags.py
@@ -53,41 +53,12 @@ def format_main_menu(parser, token):
 
 
 @register.simple_tag(takes_context=True)
-def format_subtab_menu(context):
-    active_tab = context.get('active_tab', None)
-    if active_tab and active_tab.subtabs:
-        subtabs = [t for t in active_tab.subtabs if t.is_viewable]
-    else:
-        subtabs = None
-
-    return mark_safe(render_to_string("style/bootstrap2/partials/subtab_menu.html", {
-        'subtabs': subtabs if subtabs and len(subtabs) > 1 else None
-    }))
-
-
-@register.simple_tag(takes_context=True)
 def format_sidebar(context):
     current_url_name = context['current_url_name']
     active_tab = context.get('active_tab', None)
     request = context['request']
 
-    sections = None
-
-    if active_tab and active_tab.subtabs:
-        # if active_tab is active then at least one of its subtabs should have
-        # is_active == True, but we guard against the possibility of this not
-        # being the case by setting sections = None above
-        for s in active_tab.subtabs:
-            if s.is_active:
-                sections = s.sidebar_items
-                break
-        if sections is None:
-            for s in active_tab.subtabs:
-                if s.url and request.get_full_path().startswith(s.url):
-                    sections = s.sidebar_items
-                    break
-    else:
-        sections = active_tab.sidebar_items if active_tab else None
+    sections = active_tab.sidebar_items if active_tab else None
 
     def _strip_scheme(uri):
         return uri.lstrip('https')

--- a/corehq/tabs/templatetags/menu_tags.py
+++ b/corehq/tabs/templatetags/menu_tags.py
@@ -20,9 +20,9 @@ def _get_active_tab(visible_tabs, request_path):
         return matching_tabs[-1]
 
     for tab in visible_tabs:
-        if tab.urls:
-            if any(path_starts_with_url(url, tab.request_path) for url in tab.urls) or \
-                    tab._current_url_name in tab.subpage_url_names:
+        url_prefixes = tab.url_prefixes
+        if url_prefixes:
+            if any(path_starts_with_url(url, tab.request_path) for url in url_prefixes):
                 return tab
 
 

--- a/corehq/tabs/tests.py
+++ b/corehq/tabs/tests.py
@@ -1,0 +1,5 @@
+from corehq.tabs.utils import path_starts_with_url
+
+__test__ = {
+    'url_starts_with_path': path_starts_with_url
+}

--- a/corehq/tabs/uitab.py
+++ b/corehq/tabs/uitab.py
@@ -36,6 +36,10 @@ class UITab(object):
         self._current_url_name = current_url_name
 
     @property
+    def request_path(self):
+        return self._request.get_full_path()
+
+    @property
     def dropdown_items(self):
         # todo: add default implementation which looks at sidebar_items and
         # sees which ones have is_dropdown_visible or something like that.
@@ -102,8 +106,7 @@ class UITab(object):
         if shortcircuit is not None:
             return shortcircuit
 
-        request_path = self._request.get_full_path()
-        return self.url and request_path.startswith(self.url)
+        return self.url and self.request_path.startswith(self.url)
 
     @property
     @memoized
@@ -112,7 +115,6 @@ class UITab(object):
         if shortcircuit is not None:
             return shortcircuit
 
-        request_path = self._request.get_full_path()
         url_base = get_url_base()
 
         def url_matches(url, request_path):
@@ -121,7 +123,7 @@ class UITab(object):
             return request_path.startswith(url)
 
         if self.urls:
-            if (any(url_matches(url, request_path) for url in self.urls) or
+            if (any(url_matches(url, self.request_path) for url in self.urls) or
                     self._current_url_name in self.subpage_url_names):
                 return True
         elif self.subtabs and any(st.is_active for st in self.subtabs):

--- a/corehq/tabs/uitab.py
+++ b/corehq/tabs/uitab.py
@@ -60,7 +60,7 @@ class UITab(object):
         # todo: add default implementation which looks at sidebar_items and
         # sees which ones have is_dropdown_visible or something like that.
         return sidebar_to_dropdown(sidebar_items=self.sidebar_items,
-                                   domain=self.domain, current_url_name=self.url)
+                                   domain=self.domain, current_url=self.url)
 
     @property
     @memoized

--- a/corehq/tabs/uitab.py
+++ b/corehq/tabs/uitab.py
@@ -23,8 +23,7 @@ class UITab(object):
     # must be instance of GaTracker
     ga_tracker = None
 
-    def __init__(self, request, current_url_name, domain=None, couch_user=None,
-                 project=None):
+    def __init__(self, request, domain=None, couch_user=None, project=None):
 
         self.domain = domain
         self.couch_user = couch_user
@@ -33,7 +32,6 @@ class UITab(object):
         # This should not be considered as part of the subclass API unless it
         # is necessary. Try to add new explicit parameters instead.
         self._request = request
-        self._current_url_name = current_url_name
 
         # Do some preemptive checks on the subclass's configuration (if DEBUG)
         if settings.DEBUG:

--- a/corehq/tabs/uitab.py
+++ b/corehq/tabs/uitab.py
@@ -14,10 +14,9 @@ class UITab(object):
 
     dispatcher = None
 
-    # if a tab subclass has an expensive sidebar_items
-    # it should define its url_prefix_formats here explicitly
-    # e.g. ('/a/{domain}/reports/', '/a/{domain}/otherthing/')
-    # renderer can quickly tell which tab to highlight as active
+    # Tuple of prefixes that this UITab claims e.g.
+    #   ('/a/{domain}/reports/', '/a/{domain}/otherthing/')
+    # This is a required field.
     url_prefix_formats = ()
     show_by_default = True
 

--- a/corehq/tabs/uitab.py
+++ b/corehq/tabs/uitab.py
@@ -139,18 +139,13 @@ class UITab(object):
         return urls
 
     @classmethod
-    def clear_dropdown_cache(cls, request, domain):
+    def clear_dropdown_cache(cls, domain, user_id):
         for is_active in True, False:
-            if hasattr(cls, 'get_view'):
-                view = cls.get_view(domain)
-            else:
-                view = cls.view
             key = make_template_fragment_key('header_tab', [
+                cls.class_name(),
                 domain,
-                None,  # tab.org should be None for any non org page
-                view,
                 is_active,
-                request.couch_user.get_id,
+                user_id,
                 get_language(),
             ])
             cache.delete(key)
@@ -158,3 +153,7 @@ class UITab(object):
     @property
     def css_id(self):
         return self.__class__.__name__
+
+    @classmethod
+    def class_name(cls):
+        return cls.__name__

--- a/corehq/tabs/uitab.py
+++ b/corehq/tabs/uitab.py
@@ -19,6 +19,7 @@ class UITab(object):
     # e.g. ('/a/{domain}/reports/', '/a/{domain}/otherthing/')
     # renderer can quickly tell which tab to highlight as active
     url_prefix_formats = ()
+    show_by_default = True
 
     # must be instance of GaTracker
     ga_tracker = None
@@ -32,6 +33,9 @@ class UITab(object):
         # This should not be considered as part of the subclass API unless it
         # is necessary. Try to add new explicit parameters instead.
         self._request = request
+
+        # must be set manually (i.e. `tab.is_active_tab = True`)
+        self.is_active_tab = False
 
         # Do some preemptive checks on the subclass's configuration (if DEBUG)
         if settings.DEBUG:
@@ -55,8 +59,6 @@ class UITab(object):
 
     @property
     def dropdown_items(self):
-        # todo: add default implementation which looks at sidebar_items and
-        # sees which ones have is_dropdown_visible or something like that.
         return sidebar_to_dropdown(sidebar_items=self.sidebar_items,
                                    domain=self.domain, current_url=self.url)
 
@@ -83,6 +85,9 @@ class UITab(object):
     @property
     @memoized
     def real_is_viewable(self):
+        if not self.show_by_default and not self.is_active_tab:
+            return False
+
         try:
             return self.is_viewable
         except AttributeError:

--- a/corehq/tabs/uitab.py
+++ b/corehq/tabs/uitab.py
@@ -51,11 +51,7 @@ class UITab(object):
     @memoized
     def sidebar_items(self):
         if self.dispatcher:
-            context = {
-                'request': self._request,
-                'domain': self.domain,
-            }
-            return self.dispatcher.navigation_sections(context)
+            return self.dispatcher.navigation_sections(request=self._request, domain=self.domain)
         else:
             return []
 

--- a/corehq/tabs/uitab.py
+++ b/corehq/tabs/uitab.py
@@ -70,25 +70,24 @@ class UITab(object):
             return []
 
     @property
-    def is_viewable(self):
+    def _is_viewable(self):
         """
         Whether the tab should be displayed.  Subclass implementations can skip
         checking whether domain, couch_user, or project is not None before
         accessing an attribute of them -- this property is accessed in
-        real_is_viewable and wrapped in a try block that returns False in the
+        should_show and wrapped in a try block that returns False in the
         case of an AttributeError for any of those variables.
 
         """
         raise NotImplementedError()
 
-    @property
     @memoized
-    def real_is_viewable(self):
+    def should_show(self):
         if not self.show_by_default and not self.is_active_tab:
             return False
 
         try:
-            return self.is_viewable
+            return self._is_viewable
         except AttributeError:
             return False
 

--- a/corehq/tabs/uitab.py
+++ b/corehq/tabs/uitab.py
@@ -1,10 +1,9 @@
 from django.core.cache import cache
+from django.core.urlresolvers import reverse
 from django.utils.translation import get_language
-from corehq.tabs.utils import sidebar_to_dropdown
-from corehq.util.view_utils import absolute_reverse
+from corehq.tabs.utils import sidebar_to_dropdown, path_starts_with_url
 from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.django.cache import make_template_fragment_key
-from dimagi.utils.web import get_url_base
 
 
 class UITab(object):
@@ -72,45 +71,14 @@ class UITab(object):
     def url(self):
         try:
             if self.domain:
-                return absolute_reverse(self.view, args=[self.domain])
+                return reverse(self.view, args=[self.domain])
         except Exception:
             pass
 
         try:
-            return absolute_reverse(self.view)
+            return reverse(self.view)
         except Exception:
             return None
-
-    @property
-    def is_active_shortcircuit(self):
-        return None
-
-    @property
-    def is_active_fast(self):
-        shortcircuit = self.is_active_shortcircuit
-        if shortcircuit is not None:
-            return shortcircuit
-
-        return self.url and self.request_path.startswith(self.url)
-
-    @property
-    @memoized
-    def is_active(self):
-        shortcircuit = self.is_active_shortcircuit
-        if shortcircuit is not None:
-            return shortcircuit
-
-        url_base = get_url_base()
-
-        def url_matches(url, request_path):
-            if url.startswith(url_base):
-                return request_path.startswith(url[len(url_base):])
-            return request_path.startswith(url)
-
-        if self.urls:
-            if (any(url_matches(url, self.request_path) for url in self.urls) or
-                    self._current_url_name in self.subpage_url_names):
-                return True
 
     @property
     @memoized

--- a/corehq/tabs/utils.py
+++ b/corehq/tabs/utils.py
@@ -67,9 +67,6 @@ def sidebar_to_dropdown(sidebar_items, domain=None, current_url=None):
           'title': u'Project Users',
           'url': None},]
     """
-    if not sidebar_items:
-        # no need for "View All" if there aren't menu items
-        return []
     dropdown_items = []
     more_items_in_sidebar = False
     for side_header, side_list in sidebar_items:
@@ -95,7 +92,7 @@ def sidebar_to_dropdown(sidebar_items, domain=None, current_url=None):
         if current_dropdown_items:
             dropdown_items.extend([dropdown_header] + current_dropdown_items)
 
-    if more_items_in_sidebar and current_url:
+    if dropdown_items and more_items_in_sidebar and current_url:
         return dropdown_items + divider_and_more_menu(current_url)
     else:
         return dropdown_items

--- a/corehq/tabs/utils.py
+++ b/corehq/tabs/utils.py
@@ -15,7 +15,7 @@ def dropdown_dict(title, url=None, html=None,
                                        data_id=data_id,)
 
 
-def sidebar_to_dropdown(sidebar_items, domain=None, current_url_name=None):
+def sidebar_to_dropdown(sidebar_items, domain=None, current_url=None):
     """
     Formats sidebar_items as dropdown items
     Sample input:
@@ -92,8 +92,8 @@ def sidebar_to_dropdown(sidebar_items, domain=None, current_url_name=None):
         if current_dropdown_items:
             dropdown_items.extend([dropdown_header] + current_dropdown_items)
 
-    if more_items_in_sidebar and current_url_name:
-        return dropdown_items + divider_and_more_menu(current_url_name)
+    if more_items_in_sidebar and current_url:
+        return dropdown_items + divider_and_more_menu(current_url)
     else:
         return dropdown_items
 

--- a/corehq/tabs/utils.py
+++ b/corehq/tabs/utils.py
@@ -67,6 +67,9 @@ def sidebar_to_dropdown(sidebar_items, domain=None, current_url=None):
           'title': u'Project Users',
           'url': None},]
     """
+    if not sidebar_items:
+        # no need for "View All" if there aren't menu items
+        return []
     dropdown_items = []
     more_items_in_sidebar = False
     for side_header, side_list in sidebar_items:

--- a/corehq/tabs/utils.py
+++ b/corehq/tabs/utils.py
@@ -1,3 +1,4 @@
+import urlparse
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
 
@@ -139,3 +140,16 @@ def subpages_as_dropdowns(subpages, level, domain=None):
             subpage['title'],
             url=reverse(subpage['urlname'], args=[domain]))
             for subpage in subpages if is_dropdown(subpage)]
+
+
+def path_starts_with_url(path, url):
+    """
+    >>> path_starts_with_url('/a/test/reports/saved/', 'https://www.commcarehq.org/a/test/reports/')
+    True
+    >>> path_starts_with_url('/a/test/reports/saved/', '/a/test/reports/')
+    True
+    >>> path_starts_with_url('/a/test/reports/', '/a/test/reports/saved/')
+    False
+    """
+    url = urlparse.urlparse(url).path
+    return path.startswith(url)


### PR DESCRIPTION
🐡 
Probably the most important changes are:
- got rid of the concept of subtabs (UI had been inadvertently removed 6+ months ago)
- vastly simplified active tab election—UITabs now declare what url prefixes they're claiming, and there's no attempt at inference beyond that
  - in order to make it easy for myself to make this change without screwing it up, in DEBUG mode if a class doesn't have `url_prefix_formats` set, it goes through your urls (like it was doing live before) and infers the prefixes, and suggests them to you in an exception message.
- as a result of better tab election, a simple page went from ~9 sec to 1-2 (this was an apps setting page), and in general the header by itself now takes well under a second to load, where it had taken a lot longer before
