### PR TITLE
new elastic reindexer prework

### DIFF
--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -18,7 +18,7 @@ from dimagi.ext.couchdbkit import (
     StringListProperty, SchemaListProperty, TimeProperty, DecimalProperty
 )
 from django.core.urlresolvers import reverse
-from django.db import models, connection
+from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from corehq.apps.appstore.models import SnapshotMixin
 from corehq.util.quickcache import quickcache, skippable_quickcache

--- a/corehq/apps/domain/tests/test_utils.py
+++ b/corehq/apps/domain/tests/test_utils.py
@@ -1,0 +1,8 @@
+from corehq.apps.domain.models import Domain
+from corehq.util.test_utils import unit_testing_only
+
+
+@unit_testing_only
+def delete_all_domains():
+    domains = Domain.get_all()
+    Domain.bulk_delete(domains)

--- a/corehq/apps/hqcase/management/commands/ptop_fast_reindexer.py
+++ b/corehq/apps/hqcase/management/commands/ptop_fast_reindexer.py
@@ -8,7 +8,7 @@ import json
 from corehq.util.couch_helpers import paginate_view
 from pillowtop.couchdb import CachedCouchDB
 from pillowtop.es_utils import set_index_reindex_settings, set_index_normal_settings, create_index_for_pillow, \
-    initialize_mapping_if_necessary
+    initialize_mapping_if_necessary, get_index_info_from_pillow
 from pillowtop.feed.couch import change_from_couch_row
 from pillowtop.feed.interface import Change
 from pillowtop.listener import AliasedElasticPillow, PythonPillow
@@ -368,7 +368,10 @@ class ElasticReindexer(PtopReindexer):
             self.indexing_pillow.get_es_new().indices.delete(self.indexing_pillow.es_index)
             self.log("Recreating index")
             create_index_for_pillow(self.indexing_pillow)
-            initialize_mapping_if_necessary(self.indexing_pillow)
+            initialize_mapping_if_necessary(
+                self.indexing_pillow.get_es_new(),
+                get_index_info_from_pillow(self.indexing_pillow)
+            )
 
     def post_load_hook(self):
         if not self.in_place:

--- a/corehq/apps/hqcase/management/commands/ptop_reindexer_v2.py
+++ b/corehq/apps/hqcase/management/commands/ptop_reindexer_v2.py
@@ -1,5 +1,6 @@
 from django.core.management import BaseCommand, CommandError
 from corehq.pillows.case import get_couch_case_reindexer, get_sql_case_reindexer
+from corehq.pillows.domain import get_domain_reindexer
 from corehq.pillows.xform import get_couch_form_reindexer, get_sql_form_reindexer
 
 
@@ -9,6 +10,7 @@ class Command(BaseCommand):
 
     def handle(self, index, *args, **options):
         reindex_fns = {
+            'domain': get_domain_reindexer,
             'case': get_couch_case_reindexer,
             'form': get_couch_form_reindexer,
             'sql-case': get_sql_case_reindexer,

--- a/corehq/ex-submodules/pillowtop/es_utils.py
+++ b/corehq/ex-submodules/pillowtop/es_utils.py
@@ -70,7 +70,7 @@ def completely_initialize_pillow_index(pillow):
     if not index_exists:
         create_index_for_pillow(pillow)
     pillow_logging.info("Pillowtop [%s] Initializing mapping in ES" % pillow.get_name())
-    initialize_mapping_if_necessary(pillow)
+    initialize_mapping_if_necessary(pillow.get_es_new(), get_index_info_from_pillow(pillow))
 
 
 def pillow_index_exists(pillow):
@@ -81,28 +81,27 @@ def create_index_for_pillow(pillow):
     return create_index_and_set_settings_normal(pillow.get_es_new(), pillow.es_index, pillow.es_meta)
 
 
-def pillow_mapping_exists(pillow):
+def mapping_exists(es, index_info):
     try:
-        return pillow.get_es_new().indices.get_mapping(pillow.es_index, pillow.es_type)
+        return es.indices.get_mapping(index_info.index, index_info.type)
     except TransportError:
         return {}
 
 
-def initialize_mapping_if_necessary(pillow):
+def initialize_mapping_if_necessary(es, index_info):
     """
     Initializes the elasticsearch mapping for this pillow if it is not found.
     """
-    es = pillow.get_es_new()
-    if not pillow_mapping_exists(pillow):
-        pillow_logging.info("Initializing elasticsearch mapping for [%s]" % pillow.es_type)
-        mapping = copy(pillow.default_mapping)
+    if not mapping_exists(es, index_info):
+        pillow_logging.info("Initializing elasticsearch mapping for [%s]" % index_info.type)
+        mapping = copy(index_info.mapping)
         mapping['_meta']['created'] = datetime.isoformat(datetime.utcnow())
-        mapping_res = es.indices.put_mapping(pillow.es_type, {pillow.es_type: mapping}, index=pillow.es_index)
+        mapping_res = es.indices.put_mapping(index_info.type, {index_info.type: mapping}, index=index_info.index)
         if mapping_res.get('ok', False) and mapping_res.get('acknowledged', False):
             # API confirms OK, trust it.
-            pillow_logging.info("Mapping set: [%s] %s" % (pillow.es_type, mapping_res))
+            pillow_logging.info("Mapping set: [%s] %s" % (index_info.type, mapping_res))
     else:
-        pillow_logging.info("Elasticsearch mapping for [%s] was already present." % pillow.es_type)
+        pillow_logging.info("Elasticsearch mapping for [%s] was already present." % index_info.type)
 
 
 def assume_alias_for_pillow(pillow):

--- a/corehq/ex-submodules/pillowtop/es_utils.py
+++ b/corehq/ex-submodules/pillowtop/es_utils.py
@@ -153,11 +153,15 @@ def get_all_expected_es_indices():
     for pillow in pillows:
         assert pillow.es_index not in seen_indices
         assert pillow.es_alias not in seen_aliases
-        yield ElasticsearchIndexInfo(
-            index=pillow.es_index,
-            alias=pillow.es_alias,
-            type=pillow.es_type,
-            meta=pillow.es_meta
-        )
+        yield get_index_info_from_pillow(pillow)
         seen_indices.add(pillow.es_index)
         seen_aliases.add(pillow.es_alias)
+
+
+def get_index_info_from_pillow(pillow):
+    return ElasticsearchIndexInfo(
+        index=pillow.es_index,
+        alias=pillow.es_alias,
+        type=pillow.es_type,
+        meta=pillow.es_meta
+    )

--- a/corehq/ex-submodules/pillowtop/es_utils.py
+++ b/corehq/ex-submodules/pillowtop/es_utils.py
@@ -32,6 +32,7 @@ class ElasticsearchIndexInfo(jsonobject.JsonObject):
     alias = jsonobject.StringProperty()
     type = jsonobject.StringProperty()
     meta = jsonobject.DictProperty()
+    mapping = jsonobject.DictProperty()
 
     def __unicode__(self):
         return u'{} ({})'.format(self.alias, self.index)
@@ -163,5 +164,6 @@ def get_index_info_from_pillow(pillow):
         index=pillow.es_index,
         alias=pillow.es_alias,
         type=pillow.es_type,
-        meta=pillow.es_meta
+        meta=pillow.es_meta,
+        mapping=pillow.default_mapping,
     )

--- a/corehq/ex-submodules/pillowtop/es_utils.py
+++ b/corehq/ex-submodules/pillowtop/es_utils.py
@@ -31,6 +31,7 @@ class ElasticsearchIndexInfo(jsonobject.JsonObject):
     index = jsonobject.StringProperty(required=True)
     alias = jsonobject.StringProperty()
     type = jsonobject.StringProperty()
+    meta = jsonobject.DictProperty()
 
     def __unicode__(self):
         return u'{} ({})'.format(self.alias, self.index)
@@ -152,6 +153,11 @@ def get_all_expected_es_indices():
     for pillow in pillows:
         assert pillow.es_index not in seen_indices
         assert pillow.es_alias not in seen_aliases
-        yield ElasticsearchIndexInfo(index=pillow.es_index, alias=pillow.es_alias, type=pillow.es_type)
+        yield ElasticsearchIndexInfo(
+            index=pillow.es_index,
+            alias=pillow.es_alias,
+            type=pillow.es_type,
+            meta=pillow.es_meta
+        )
         seen_indices.add(pillow.es_index)
         seen_aliases.add(pillow.es_alias)

--- a/corehq/ex-submodules/pillowtop/es_utils.py
+++ b/corehq/ex-submodules/pillowtop/es_utils.py
@@ -1,5 +1,4 @@
 from dimagi.ext import jsonobject
-from collections import namedtuple
 from copy import copy
 from datetime import datetime
 from elasticsearch import TransportError

--- a/corehq/ex-submodules/pillowtop/reindexer/reindexer.py
+++ b/corehq/ex-submodules/pillowtop/reindexer/reindexer.py
@@ -1,6 +1,6 @@
 from corehq.util.elastic import ensure_index_deleted, ensure_production_index_deleted
 from pillowtop.es_utils import create_index_and_set_settings_normal, set_index_reindex_settings, \
-    set_index_normal_settings, get_index_info_from_pillow
+    set_index_normal_settings, get_index_info_from_pillow, initialize_mapping_if_necessary
 from pillowtop.pillow.interface import PillowRuntimeContext
 
 
@@ -37,6 +37,7 @@ class ElasticPillowReindexer(PillowReindexer):
     def _delete_and_prepare_index_for_reindex(self):
         ensure_production_index_deleted(self.index_info.index)
         self.es.indices.create(index=self.index_info.index, body=self.index_info.meta)
+        initialize_mapping_if_necessary(self.es, self.index_info)
         set_index_reindex_settings(self.es, self.index_info.index)
 
     def _prepare_index_for_usage(self):

--- a/corehq/ex-submodules/pillowtop/reindexer/reindexer.py
+++ b/corehq/ex-submodules/pillowtop/reindexer/reindexer.py
@@ -28,9 +28,7 @@ class ElasticPillowReindexer(PillowReindexer):
             # when not resuming force delete and create the index
             self._delete_and_prepare_index_for_reindex()
 
-        reindexer_context = PillowRuntimeContext(do_set_checkpoint=False)
-        for change in self.change_provider.iter_changes(start_from=start_from):
-            self.pillow.processor(change, reindexer_context)
+        super(ElasticPillowReindexer, self).reindex(start_from)
 
         self._prepare_index_for_usage()
 

--- a/corehq/ex-submodules/pillowtop/reindexer/reindexer.py
+++ b/corehq/ex-submodules/pillowtop/reindexer/reindexer.py
@@ -1,3 +1,6 @@
+from corehq.util.elastic import ensure_index_deleted, ensure_production_index_deleted
+from pillowtop.es_utils import create_index_and_set_settings_normal, set_index_reindex_settings, \
+    set_index_normal_settings
 from pillowtop.pillow.interface import PillowRuntimeContext
 
 
@@ -11,3 +14,31 @@ class PillowReindexer(object):
         reindexer_context = PillowRuntimeContext(do_set_checkpoint=False)
         for change in self.change_provider.iter_changes(start_from=start_from):
             self.pillow.processor(change, reindexer_context)
+
+
+class ElasticPillowReindexer(PillowReindexer):
+
+    def __init__(self, pillow, change_provider, elasticsearch, index_info):
+        super(ElasticPillowReindexer, self).__init__(pillow, change_provider)
+        self.es = elasticsearch
+        self.index_info = index_info
+
+    def reindex(self, start_from=None):
+        if not start_from:
+            # when not resuming force delete and create the index
+            self._delete_and_prepare_index_for_reindex()
+
+        reindexer_context = PillowRuntimeContext(do_set_checkpoint=False)
+        for change in self.change_provider.iter_changes(start_from=start_from):
+            self.pillow.processor(change, reindexer_context)
+
+        self._prepare_index_for_usage()
+
+    def _delete_and_prepare_index_for_reindex(self):
+        ensure_production_index_deleted(self.index_info.index)
+        self.es.indices.create(index=self.index_info.index, body=self.index_info.meta)
+        set_index_reindex_settings(self.es, self.index_info.index)
+
+    def _prepare_index_for_usage(self):
+        set_index_normal_settings(self.es, self.index_info.index)
+        self.es.indices.refresh(self.index_info.index)

--- a/corehq/ex-submodules/pillowtop/reindexer/reindexer.py
+++ b/corehq/ex-submodules/pillowtop/reindexer/reindexer.py
@@ -1,5 +1,5 @@
-from corehq.util.elastic import ensure_index_deleted, ensure_production_index_deleted
-from pillowtop.es_utils import create_index_and_set_settings_normal, set_index_reindex_settings, \
+from corehq.util.elastic import ensure_production_index_deleted
+from pillowtop.es_utils import set_index_reindex_settings, \
     set_index_normal_settings, get_index_info_from_pillow, initialize_mapping_if_necessary
 from pillowtop.pillow.interface import PillowRuntimeContext
 

--- a/corehq/ex-submodules/pillowtop/reindexer/reindexer.py
+++ b/corehq/ex-submodules/pillowtop/reindexer/reindexer.py
@@ -1,6 +1,6 @@
 from corehq.util.elastic import ensure_index_deleted, ensure_production_index_deleted
 from pillowtop.es_utils import create_index_and_set_settings_normal, set_index_reindex_settings, \
-    set_index_normal_settings
+    set_index_normal_settings, get_index_info_from_pillow
 from pillowtop.pillow.interface import PillowRuntimeContext
 
 
@@ -42,3 +42,12 @@ class ElasticPillowReindexer(PillowReindexer):
     def _prepare_index_for_usage(self):
         set_index_normal_settings(self.es, self.index_info.index)
         self.es.indices.refresh(self.index_info.index)
+
+
+def get_default_reindexer_for_elastic_pillow(pillow, change_provider):
+    return ElasticPillowReindexer(
+        pillow=pillow,
+        change_provider=change_provider,
+        elasticsearch=pillow.get_es_new(),
+        index_info=get_index_info_from_pillow(pillow),
+    )

--- a/corehq/ex-submodules/pillowtop/tests/test_elasticsearch.py
+++ b/corehq/ex-submodules/pillowtop/tests/test_elasticsearch.py
@@ -8,7 +8,7 @@ from corehq.util.elastic import ensure_index_deleted
 from corehq.util.test_utils import trap_extra_setup
 from pillowtop.es_utils import INDEX_REINDEX_SETTINGS, INDEX_STANDARD_SETTINGS, update_settings, \
     set_index_reindex_settings, set_index_normal_settings, create_index_for_pillow, assume_alias_for_pillow, \
-    pillow_index_exists, pillow_mapping_exists, completely_initialize_pillow_index
+    pillow_index_exists, completely_initialize_pillow_index, mapping_exists, get_index_info_from_pillow
 from pillowtop.feed.interface import Change
 from pillowtop.listener import send_to_elasticsearch, PillowtopIndexingError
 from pillowtop.pillow.interface import PillowRuntimeContext
@@ -48,7 +48,7 @@ class ElasticPillowTest(SimpleTestCase):
 
     def test_mapping_initialization_on_pillow_creation(self):
         pillow = TestElasticPillow()
-        self.assertTrue(pillow_mapping_exists(pillow))
+        self.assertTrue(mapping_exists(self.es, get_index_info_from_pillow(pillow)))
         mapping = get_index_mapping(self.es, self.index, pillow.es_type)
         # we can't compare the whole dicts because ES adds a bunch of stuff to them
         self.assertEqual(

--- a/corehq/pillows/domain.py
+++ b/corehq/pillows/domain.py
@@ -4,9 +4,9 @@ from corehq.apps.domain.models import Domain
 from corehq.pillows.base import HQPillow
 from corehq.pillows.mappings.domain_mapping import DOMAIN_MAPPING, DOMAIN_INDEX
 from django_countries.data import COUNTRIES
-from pillowtop.es_utils import doc_exists, get_index_info_from_pillow
+from pillowtop.es_utils import doc_exists
 from pillowtop.reindexer.change_providers.couch import CouchViewChangeProvider
-from pillowtop.reindexer.reindexer import ElasticPillowReindexer, get_default_reindexer_for_elastic_pillow
+from pillowtop.reindexer.reindexer import get_default_reindexer_for_elastic_pillow
 
 
 class DomainPillow(HQPillow):

--- a/corehq/pillows/domain.py
+++ b/corehq/pillows/domain.py
@@ -6,7 +6,7 @@ from corehq.pillows.mappings.domain_mapping import DOMAIN_MAPPING, DOMAIN_INDEX
 from django_countries.data import COUNTRIES
 from pillowtop.es_utils import doc_exists, get_index_info_from_pillow
 from pillowtop.reindexer.change_providers.couch import CouchViewChangeProvider
-from pillowtop.reindexer.reindexer import ElasticPillowReindexer
+from pillowtop.reindexer.reindexer import ElasticPillowReindexer, get_default_reindexer_for_elastic_pillow
 
 
 class DomainPillow(HQPillow):
@@ -64,9 +64,8 @@ class DomainPillow(HQPillow):
 
 
 def get_domain_reindexer():
-    pillow = DomainPillow(online=False)
-    return ElasticPillowReindexer(
-        pillow=pillow,
+    return get_default_reindexer_for_elastic_pillow(
+        pillow=DomainPillow(online=False),
         change_provider=CouchViewChangeProvider(
             document_class=Domain,
             view_name='all_docs/by_doc_type',
@@ -75,6 +74,4 @@ def get_domain_reindexer():
                 'endkey': ['Domain', {}],
             }
         ),
-        elasticsearch=pillow.get_es_new(),
-        index_info=get_index_info_from_pillow(pillow),
     )

--- a/corehq/pillows/xform.py
+++ b/corehq/pillows/xform.py
@@ -17,7 +17,7 @@ from pillowtop.es_utils import ElasticsearchIndexInfo, get_index_info_from_pillo
 from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors.elastic import ElasticProcessor
 from pillowtop.reindexer.change_providers.couch import CouchViewChangeProvider
-from pillowtop.reindexer.reindexer import PillowReindexer, get_default_reindexer_for_elastic_pillow, \
+from pillowtop.reindexer.reindexer import get_default_reindexer_for_elastic_pillow, \
     ElasticPillowReindexer
 
 

--- a/corehq/pillows/xform.py
+++ b/corehq/pillows/xform.py
@@ -13,11 +13,12 @@ from couchforms.const import RESERVED_WORDS
 from couchforms.models import XFormInstance
 from dateutil import parser
 from pillowtop.checkpoints.manager import PillowCheckpoint, PillowCheckpointEventHandler
-from pillowtop.es_utils import ElasticsearchIndexInfo
+from pillowtop.es_utils import ElasticsearchIndexInfo, get_index_info_from_pillow
 from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors.elastic import ElasticProcessor
 from pillowtop.reindexer.change_providers.couch import CouchViewChangeProvider
-from pillowtop.reindexer.reindexer import PillowReindexer
+from pillowtop.reindexer.reindexer import PillowReindexer, get_default_reindexer_for_elastic_pillow, \
+    ElasticPillowReindexer
 
 
 UNKNOWN_VERSION = 'XXX'
@@ -146,15 +147,27 @@ def get_sql_xform_to_elasticsearch_pillow(pillow_id='SqlXFormToElasticsearchPill
 
 
 def get_couch_form_reindexer():
-    return PillowReindexer(XFormPillow(), CouchViewChangeProvider(
-        document_class=XFormInstance,
-        view_name='all_docs/by_doc_type',
-        view_kwargs={
-            'startkey': ['XFormInstance'],
-            'endkey': ['XFormInstance', {}],
-        }
-    ))
+    return get_default_reindexer_for_elastic_pillow(
+        pillow=XFormPillow(online=False),
+        change_provider=CouchViewChangeProvider(
+            document_class=XFormInstance,
+            view_name='all_docs/by_doc_type',
+            view_kwargs={
+                'startkey': ['XFormInstance'],
+                'endkey': ['XFormInstance', {}],
+            }
+        )
+    )
 
 
 def get_sql_form_reindexer():
-    return PillowReindexer(get_sql_xform_to_elasticsearch_pillow(), SqlFormChangeProvider())
+    return ElasticPillowReindexer(
+        pillow=get_sql_xform_to_elasticsearch_pillow(),
+        change_provider=SqlFormChangeProvider(),
+        elasticsearch=XFormPillow(online=False).get_es_new(),
+        index_info=_get_xform_index_info(),
+    )
+
+
+def _get_xform_index_info():
+    return get_index_info_from_pillow(XFormPillow(online=False))

--- a/corehq/tests/app_test_db_dependencies.yml
+++ b/corehq/tests/app_test_db_dependencies.yml
@@ -12,7 +12,9 @@ testapps.test_elasticsearch: []
 testapps.test_pillowtop:
   - auditcare
   - django_digest
+  - django_prbac
   - casexml.apps.case
+  - corehq.apps.accounting
   - corehq.apps.domain
   - corehq.apps.hqadmin
   - corehq.apps.users

--- a/corehq/util/elastic.py
+++ b/corehq/util/elastic.py
@@ -13,14 +13,28 @@ def es_index(index):
 
 @unit_testing_only
 def ensure_index_deleted(es_index):
+    ensure_production_index_deleted(es_index)
+
+
+def ensure_production_index_deleted(es_index):
+    """
+    Like ensure_index_deleted but usable outside unit tests
+    """
     try:
-        delete_es_index(es_index)
+        delete_production_es_index(es_index)
     except NotFoundError:
         pass
 
 
 @unit_testing_only
 def delete_es_index(es_index):
+    delete_production_es_index(es_index)
+
+
+def delete_production_es_index(es_index):
+    """
+    Like delete_es_index but usable outside unit tests
+    """
     from corehq.elastic import get_es_new
 
     if es_index.startswith(TEST_ES_PREFIX):

--- a/corehq/util/elastic.py
+++ b/corehq/util/elastic.py
@@ -28,7 +28,11 @@ def ensure_production_index_deleted(es_index):
 
 @unit_testing_only
 def delete_es_index(es_index):
-    delete_production_es_index(es_index)
+    if es_index.startswith(TEST_ES_PREFIX):
+        delete_production_es_index(es_index)
+
+    else:
+        raise DeleteProductionESIndex('You cannot delete a production index in tests!!')
 
 
 def delete_production_es_index(es_index):
@@ -36,12 +40,8 @@ def delete_production_es_index(es_index):
     Like delete_es_index but usable outside unit tests
     """
     from corehq.elastic import get_es_new
-
-    if es_index.startswith(TEST_ES_PREFIX):
-        es = get_es_new()
-        es.indices.delete(index=es_index)
-    else:
-        raise DeleteProductionESIndex('You cannot delete a production index in tests!!')
+    es = get_es_new()
+    es.indices.delete(index=es_index)
 
 
 class DeleteProductionESIndex(Exception):

--- a/testapps/test_elasticsearch/tests/test_prod_es_indices.py
+++ b/testapps/test_elasticsearch/tests/test_prod_es_indices.py
@@ -17,6 +17,8 @@ class ProdIndexManagementTest(SimpleTestCase):
 
     def test_prod_config(self):
         found_prod_indices = [info.to_json() for info in get_all_expected_es_indices()]
+        for info in found_prod_indices:
+            del info['meta']
         found_prod_indices = sorted(found_prod_indices, key=lambda info: info['index'])
         self.assertEqual(EXPECTED_PROD_INDICES, found_prod_indices)
 

--- a/testapps/test_elasticsearch/tests/test_prod_es_indices.py
+++ b/testapps/test_elasticsearch/tests/test_prod_es_indices.py
@@ -18,7 +18,11 @@ class ProdIndexManagementTest(SimpleTestCase):
     def test_prod_config(self):
         found_prod_indices = [info.to_json() for info in get_all_expected_es_indices()]
         for info in found_prod_indices:
+            # for now don't test these two properties, just ensure they exist
+            self.assertTrue(info['meta'])
             del info['meta']
+            self.assertTrue(info['mapping'])
+            del info['mapping']
         found_prod_indices = sorted(found_prod_indices, key=lambda info: info['index'])
         self.assertEqual(EXPECTED_PROD_INDICES, found_prod_indices)
 

--- a/testapps/test_pillowtop/tests/test_reindexer.py
+++ b/testapps/test_pillowtop/tests/test_reindexer.py
@@ -11,11 +11,8 @@ from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.utils import TestFormMetadata
 from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends
 from corehq.pillows.case import CasePillow
-from corehq.pillows.mappings.case_mapping import CASE_INDEX
 from corehq.pillows.mappings.domain_mapping import DOMAIN_INDEX
 from corehq.pillows.mappings.user_mapping import USER_INDEX
-from corehq.pillows.mappings.xform_mapping import XFORM_INDEX
-from corehq.pillows.xform import XFormPillow
 from corehq.util.elastic import delete_es_index, ensure_index_deleted
 from corehq.util.test_utils import get_form_ready_to_save, trap_extra_setup, create_and_save_a_form, \
     create_and_save_a_case
@@ -73,10 +70,8 @@ class PillowtopReindexerTest(TestCase):
         FormProcessorTestUtils.delete_all_cases()
         case = _create_and_save_a_case()
 
-        ensure_index_deleted(CASE_INDEX)  # new reindexer doesn't force delete the index so do it in the test
         index_id = 'sql-case' if settings.TESTS_SHOULD_USE_SQL_BACKEND else 'case'
         call_command('ptop_reindexer_v2', index_id)
-        CasePillow().get_es_new().indices.refresh(CASE_INDEX)  # as well as refresh the index
 
         self._assert_case_is_in_es(case)
 

--- a/testapps/test_pillowtop/tests/test_reindexer.py
+++ b/testapps/test_pillowtop/tests/test_reindexer.py
@@ -94,11 +94,8 @@ class PillowtopReindexerTest(TestCase):
         FormProcessorTestUtils.delete_all_xforms()
         form = create_and_save_a_form(DOMAIN)
 
-        ensure_index_deleted(XFORM_INDEX)
         index_id = 'sql-form' if settings.TESTS_SHOULD_USE_SQL_BACKEND else 'form'
-
         call_command('ptop_reindexer_v2', index_id)
-        XFormPillow().get_es_new().indices.refresh(XFORM_INDEX)
 
         self._assert_form_is_in_es(form)
 


### PR DESCRIPTION
more prework to untangle elasticsearch index management from pillows. no functional changes other than a new (not yet used) domain reindexer and better index management support in the new reindexers.

@dimagi/scale-team cc @nickpell 
