### PR TITLE
Fix js import errors

### DIFF
--- a/corehq/apps/cloudcare/templates/cloudcare/includes/touchforms-inline.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/includes/touchforms-inline.html
@@ -4,7 +4,9 @@
 <link rel="stylesheet" href="{% new_static 'jquery-ui/themes/base/jquery-ui.min.css' %}">
 <link rel="stylesheet" href="{% new_static 'nprogress/nprogress.css' %}">
 <link rel="stylesheet" href="{% new_static 'formplayer/style/webforms.css' %}">
+{% if not exclude_jquery_ui_import %}
 <script src="{% new_static 'jquery-ui/jquery-ui.min.js' %}"></script>
+{% endif %}
 <script src="{% new_static 'nprogress/nprogress.js' %}"></script>
 <script src="{% new_static 'formplayer/script/vendor/shortcut.js' %}"></script>
 <script src="{% new_static 'formplayer/script/vendor/markdown-it-4.2.0.min.js' %}"></script>

--- a/corehq/apps/reports/templates/reports/careplan/patient_careplan.html
+++ b/corehq/apps/reports/templates/reports/careplan/patient_careplan.html
@@ -22,6 +22,9 @@
             </script>
 
             <div class="row">
+                {# This is needed for rendering the case hierarchy. It's included here to prevent an
+                   import error on the case details page: http://manage.dimagi.com/default.asp?223100 #}
+                {% include 'cloudcare/includes/touchforms-inline.html' %}
                 {% render_case_hierarchy case case_hierarchy_options %}
             </div>
         </div>

--- a/corehq/apps/reports/templates/reports/careplan/patient_careplan.html
+++ b/corehq/apps/reports/templates/reports/careplan/patient_careplan.html
@@ -24,7 +24,7 @@
             <div class="row">
                 {# This is needed for rendering the case hierarchy. It's included here to prevent an #}
                 {# import error on the case details page: http://manage.dimagi.com/default.asp?223100 #}
-                {% include 'cloudcare/includes/touchforms-inline.html' %}
+                {% include 'cloudcare/includes/touchforms-inline.html' with exclude_jquery_ui_import=True %}
                 {% render_case_hierarchy case case_hierarchy_options %}
             </div>
         </div>

--- a/corehq/apps/reports/templates/reports/careplan/patient_careplan.html
+++ b/corehq/apps/reports/templates/reports/careplan/patient_careplan.html
@@ -22,8 +22,8 @@
             </script>
 
             <div class="row">
-                {# This is needed for rendering the case hierarchy. It's included here to prevent an
-                   import error on the case details page: http://manage.dimagi.com/default.asp?223100 #}
+                {# This is needed for rendering the case hierarchy. It's included here to prevent an #}
+                {# import error on the case details page: http://manage.dimagi.com/default.asp?223100 #}
                 {% include 'cloudcare/includes/touchforms-inline.html' %}
                 {% render_case_hierarchy case case_hierarchy_options %}
             </div>

--- a/corehq/apps/reports/templates/reports/form/edit_submission.html
+++ b/corehq/apps/reports/templates/reports/form/edit_submission.html
@@ -4,7 +4,6 @@
 
 {% block head %}{{ block.super }}
     {% include 'cloudcare/includes/touchforms-inline.html' %}
-    <script src="{% new_static 'cloudcare/js/util.js' %}"></script>
     <script>
     $(function () {
         GMAPS_API_KEY = '{{ maps_api_key|safe }}'; // maps api is a global variable depended on by touchforms

--- a/corehq/apps/reports/templates/reports/form/edit_submission.html
+++ b/corehq/apps/reports/templates/reports/form/edit_submission.html
@@ -2,8 +2,11 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 
+{% block js-inline %}{{ block.super }}
+{% include 'cloudcare/includes/touchforms-inline.html' %}
+{% endblock %}
+
 {% block head %}{{ block.super }}
-    {% include 'cloudcare/includes/touchforms-inline.html' %}
     <script>
     $(function () {
         GMAPS_API_KEY = '{{ maps_api_key|safe }}'; // maps api is a global variable depended on by touchforms

--- a/corehq/apps/reports/templates/reports/reportdata/case_details.html
+++ b/corehq/apps/reports/templates/reports/reportdata/case_details.html
@@ -54,6 +54,10 @@
         return false;
     });
     </script>
+
+    {# This is needed for rendering the case hierarchy. It's included here to prevent an
+       import error: http://manage.dimagi.com/default.asp?223100 #}
+    {% include 'cloudcare/includes/touchforms-inline.html' %}
 {% endblock %}
 
 {% block page_content %}

--- a/corehq/apps/reports/templates/reports/reportdata/case_details.html
+++ b/corehq/apps/reports/templates/reports/reportdata/case_details.html
@@ -55,8 +55,8 @@
     });
     </script>
 
-    {# This is needed for rendering the case hierarchy. It's included here to prevent an
-       import error: http://manage.dimagi.com/default.asp?223100 #}
+    {# This is needed for rendering the case hierarchy. It's included here to prevent an #}
+    {# import error: http://manage.dimagi.com/default.asp?223100 #}
     {% include 'cloudcare/includes/touchforms-inline.html' %}
 {% endblock %}
 

--- a/corehq/apps/style/templates/style/bootstrap3/base.html
+++ b/corehq/apps/style/templates/style/bootstrap3/base.html
@@ -319,7 +319,7 @@
                                 is copyright &copy;
                             {% endblocktrans %}{% now "Y" %}
                             <a href="http://www.dimagi.com/">Dimagi, Inc.</a>
-                            {% if user.is_authenticated %}
+                            {% if request.user.is_authenticated %}
                                 &nbsp;|&nbsp;
                                 <a href="{% trans 'http://www.commcarehq.org/home' %}">{% trans 'Learn more about CommCare HQ' %}</a>
                             {% endif %}

--- a/corehq/apps/style/templates/style/includes/modal_report_issue.html
+++ b/corehq/apps/style/templates/style/includes/modal_report_issue.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-{% if user.is_authenticated %}
+{% if request.user.is_authenticated %}
     <div class="modal fade" id="modalReportIssue">
         <div class="modal-dialog">
             <form id="hqwebapp-bugReportForm"

--- a/corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_hierarchy.html
+++ b/corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_hierarchy.html
@@ -129,7 +129,9 @@
                 {% if case.edit_data.edit_form_id != None or case.add_child_data.create_form_id != None %}
                 <br style="line-height:0">
                 <span class="indenter" style="line-height:0; padding-left:{{ case.edit_data.indent_px }}px"></span>
-                <div class="touchforms-inline" id="edit_{{ case.get_id }}"></div>
+                <div class="touchforms-inline" id="edit_{{ case.get_id }}">
+                    <section id="webforms" class="webforms" data-bind="template: { name: 'form-fullform-ko-template' }"></section>
+                </div>
                 {% endif %}
             </td>
 

--- a/corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_hierarchy.html
+++ b/corehq/ex-submodules/casexml/apps/case/templates/case/partials/case_hierarchy.html
@@ -1,8 +1,6 @@
 {% load i18n %}
 {% load hq_shared_tags %}
 
-{% include 'cloudcare/includes/touchforms-inline.html' %}
-
 <script src="{% static "case/js/lib/jquery-treetable/jquery.treetable.js" %}"></script>
 <link rel="stylesheet" type="text/css" href="{% static "case/js/lib/jquery-treetable/jquery.treetable.css" %}">
 <link rel="stylesheet" type="text/css" href="{% static "case/js/lib/jquery-treetable/jquery.treetable.theme.default.css" %}">

--- a/custom/_legacy/pact/templates/pact/patient/pactpatient_careplan.html
+++ b/custom/_legacy/pact/templates/pact/patient/pactpatient_careplan.html
@@ -9,8 +9,8 @@
 </script>
 
 <div class="row">
-    {# This is needed for rendering the case hierarchy. It's included here to prevent an
-       import error on the case details page: http://manage.dimagi.com/default.asp?223100 #}
+    {# This is needed for rendering the case hierarchy. It's included here to prevent an #}
+    {# import error on the case details page: http://manage.dimagi.com/default.asp?223100 #}
     {% include 'cloudcare/includes/touchforms-inline.html' %}
     {% render_case_hierarchy case case_hierarchy_options %}
 </div>

--- a/custom/_legacy/pact/templates/pact/patient/pactpatient_careplan.html
+++ b/custom/_legacy/pact/templates/pact/patient/pactpatient_careplan.html
@@ -9,6 +9,9 @@
 </script>
 
 <div class="row">
+    {# This is needed for rendering the case hierarchy. It's included here to prevent an
+       import error on the case details page: http://manage.dimagi.com/default.asp?223100 #}
+    {% include 'cloudcare/includes/touchforms-inline.html' %}
     {% render_case_hierarchy case case_hierarchy_options %}
 </div>
 {% endblock %}

--- a/custom/_legacy/pact/templates/pact/patient/pactpatient_careplan.html
+++ b/custom/_legacy/pact/templates/pact/patient/pactpatient_careplan.html
@@ -11,7 +11,7 @@
 <div class="row">
     {# This is needed for rendering the case hierarchy. It's included here to prevent an #}
     {# import error on the case details page: http://manage.dimagi.com/default.asp?223100 #}
-    {% include 'cloudcare/includes/touchforms-inline.html' %}
+    {% include 'cloudcare/includes/touchforms-inline.html' with exclude_jquery_ui_import=True %}
     {% render_case_hierarchy case case_hierarchy_options %}
 </div>
 {% endblock %}


### PR DESCRIPTION
details in http://manage.dimagi.com/default.asp?223100

I first started looking into how to get the imports to line up, and then noticed that removing this import altogether fixes the problem and doesn't seem to impact the case details page.

The only templates affected by a change in case_hierarchy.html are:

./custom/_legacy/pact/templates/pact/patient/pactpatient_careplan.html -> PactPatientInfoReport
@czue is see you've worked on this report before, do you have data locally still and would you be able to confirm this change doesn't affect that report (mainly when a case's case hierarchy is displayed)

./corehq/apps/reports/templates/reports/careplan/patient_careplan.html -> CareplanReport
@snopoke is see you've worked on this report before, do you have data locally still and would you be able to confirm this change doesn't affect that report (mainly when a case's case hierarchy is displayed)

./corehq/apps/reports/templates/reports/reportdata/case_details.html -> /a/{domain}/reports/case_data/{case id}
I tested this locally and it seems to be fine with this change

Alternatively, if someone can confirm this import is not needed when rendering a case hierarchy that would also work. Removing it doesn't seem to have any affect on rendering the case hierarchy for the case details page.

@NoahCarnahan @snopoke @dimagi/js-team 
