### PR TITLE
Cache already compressed files

### DIFF
--- a/corehq/apps/style/management/commands/purge_compressed_files.py
+++ b/corehq/apps/style/management/commands/purge_compressed_files.py
@@ -1,0 +1,30 @@
+import os
+import json
+
+from django.core.management.base import BaseCommand
+from django.conf import settings
+
+CACHE_DIR = os.path.join(settings.STATIC_ROOT, settings.COMPRESS_OUTPUT_DIR)
+
+JS_CACHE_DIR = os.path.join(CACHE_DIR, 'js')
+MANIFEST_FILE = os.path.join(CACHE_DIR, settings.COMPRESS_OFFLINE_MANIFEST)
+
+
+class Command(BaseCommand):
+    help = "Purges all static files that aren't in the manifest.json file"
+
+    def handle(self, *args, **kwargs):
+        with open(MANIFEST_FILE, 'r+') as f:
+            manifest = json.loads(f.read())
+
+        for filename in os.listdir(JS_CACHE_DIR):
+            content_hash = filename.split('.')[0]
+            if not self._in_manifest(content_hash, manifest):
+                os.remove(os.path.join(JS_CACHE_DIR, filename))
+
+    def _in_manifest(self, content_hash, manifest):
+        paths = manifest.values()
+        for path in paths:
+            if content_hash in path:
+                return True
+        return False

--- a/corehq/apps/style/uglify.py
+++ b/corehq/apps/style/uglify.py
@@ -87,11 +87,13 @@ class JsUglifySourcemapCompressor(JsCompressor):
             filepath = self.get_filepath(concatenated_content, basename=None)
 
             # UglifySourcemapFilter writes the file directly, as it needs to
-            # output the sourcemap as well
-            UglifySourcemapFilter(content).output(
-                outfile=filepath,
-                content_meta=self.split_content,
-                root_location=self.storage.base_location)
+            # output the sourcemap as well. Only write the file if it doesn't
+            # already exist
+            if not os.path.exists(os.path.join(settings.STATIC_ROOT, filepath)):
+                UglifySourcemapFilter(content).output(
+                    outfile=filepath,
+                    content_meta=self.split_content,
+                    root_location=self.storage.base_location)
 
             return self.output_file(mode, filepath)
         else:

--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -773,6 +773,7 @@ def copy_node_modules():
 @roles(ROLES_STATIC)
 def copy_compressed_js_staticfiles():
     if files.exists('{}/staticfiles/CACHE/js'.format(env.code_current)):
+        sudo('mkdir -p {}/staticfiles/CACHE/js'.format(env.code_root))
         sudo('cp -r {}/staticfiles/CACHE/js {}/staticfiles/CACHE/js'.format(env.code_current, env.code_root))
 
 

--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -771,9 +771,9 @@ def copy_node_modules():
 
 @parallel
 @roles(ROLES_STATIC)
-def copy_staticfiles():
-    if files.exists('{}/staticfiles'.format(env.code_current)):
-        sudo('cp -r {}/staticfiles {}/staticfiles'.format(env.code_current, env.code_root))
+def copy_compressed_js_staticfiles():
+    if files.exists('{}/staticfiles/CACHE/js'.format(env.code_current)):
+        sudo('cp -r {}/staticfiles/CACHE/js {}/staticfiles/CACHE/js'.format(env.code_current, env.code_root))
 
 
 def copy_release_files():
@@ -781,7 +781,7 @@ def copy_release_files():
     execute(copy_tf_localsettings)
     execute(copy_components)
     execute(copy_node_modules)
-    execute(copy_staticfiles)
+    execute(copy_compressed_js_staticfiles)
 
 
 @task

--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -769,11 +769,19 @@ def copy_node_modules():
         sudo('mkdir {}/node_modules'.format(env.code_root))
 
 
+@parallel
+@roles(ROLES_STATIC)
+def copy_staticfiles():
+    if files.exists('{}/staticfiles'.format(env.code_current)):
+        sudo('cp -r {}/staticfiles {}/staticfiles'.format(env.code_current, env.code_root))
+
+
 def copy_release_files():
     execute(copy_localsettings)
     execute(copy_tf_localsettings)
     execute(copy_components)
     execute(copy_node_modules)
+    execute(copy_staticfiles)
 
 
 @task
@@ -1096,6 +1104,7 @@ def _do_compress(use_current_release=False):
     venv = env.virtualenv_root if not use_current_release else env.virtualenv_current
     with cd(env.code_root if not use_current_release else env.code_current):
         sudo('{}/bin/python manage.py compress --force -v 0'.format(venv))
+        sudo('{}/bin/python manage.py purge_compressed_files'.format(venv))
     update_manifest(save=True, use_current_release=use_current_release)
 
 


### PR DESCRIPTION
@dannyroberts D🐶 this'll shave 10 or so minutes off of deploy 😮 . gonna give this a go on staging first of course, but essentially this does the following:
1. do not rebuild compressed JS file if it already exists since the hash is based on the contents of the file
2. copy over staticfiles from previous release
3. purge any files in the staticfiles dir that do not exist in the `manifest.json`

cc: @sravfeyn @proteusvacuum 
