### PR TITLE
bump gunicorn version

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -23,7 +23,7 @@ elasticsearch==1.9.0
 eulxml==0.18.0
 feedparser==5.1.3
 ghdiff==0.4
-gunicorn==18.0
+gunicorn==19.4
 lxml==3.4.4
 kafka-python==0.9.4
 mock==0.8.0


### PR DESCRIPTION
@snopoke skimmed changelog (a lot of stuff there) and most of it looks like fixes or stuff we don't use. if we bump the version, gunicorn has native statsd support: http://docs.gunicorn.org/en/stable/instrumentation.html. won't give us status codes, but will give us some more useful information. was also able to run gunicorn locally with the new version. gonna throw on to staging

cc: @proteusvacuum @sravfeyn 
