### PR TITLE
Case index attributes

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/mock.py
+++ b/corehq/ex-submodules/casexml/apps/case/mock.py
@@ -1,13 +1,19 @@
 from __future__ import absolute_import
 import copy
+from collections import namedtuple
 from datetime import datetime, date
 import uuid
+from functools import partial
 from xml.etree import ElementTree
 
 from casexml.apps.case.util import post_case_blocks
 from dimagi.utils.parsing import json_format_datetime
 from casexml.apps.case.xml import V1, NS_VERSION_MAP, V2
 from casexml.apps.case.const import DEFAULT_CASE_INDEX_IDENTIFIERS, CASE_INDEX_CHILD
+
+
+IndexAttrs = namedtuple('IndexAttrs', ['case_type', 'case_id', 'relationship'])
+ChildIndexAttrs = partial(IndexAttrs, relationship='child')
 
 
 class CaseBlock(dict):

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_indexes.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_indexes.py
@@ -3,7 +3,7 @@ import re
 from xml.etree import ElementTree
 import datetime
 from django.test.utils import override_settings
-from casexml.apps.case.mock import CaseBlock, CaseBlockError
+from casexml.apps.case.mock import CaseBlock, CaseBlockError, IndexAttrs, ChildIndexAttrs
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.sharedmodels import CommCareCaseIndex
 from casexml.apps.case.tests.util import check_user_has_case
@@ -168,8 +168,6 @@ class IndexTest(TestCase):
 
 class CaseBlockIndexRelationshipTests(SimpleTestCase):
 
-    IndexAttrs = namedtuple('IndexAttrs', ['case_type', 'case_id', 'relationship'])
-
     def test_case_block_index_supports_relationship(self):
         """
         CaseBlock index should allow the relationship to be set
@@ -179,7 +177,7 @@ class CaseBlockIndexRelationshipTests(SimpleTestCase):
             case_type='at_risk',
             date_modified='2015-07-24',
             index={
-                'host': self.IndexAttrs(case_type='newborn', case_id='123456', relationship='extension')
+                'host': IndexAttrs(case_type='newborn', case_id='123456', relationship='extension')
             },
         )
 
@@ -206,7 +204,7 @@ class CaseBlockIndexRelationshipTests(SimpleTestCase):
             case_type='newborn',
             date_modified='2015-07-24',
             index={
-                'parent': ('mother', '789abc', 'child')
+                'parent': IndexAttrs(case_type='mother', case_id='789abc', relationship='child')
             },
         )
 
@@ -233,7 +231,7 @@ class CaseBlockIndexRelationshipTests(SimpleTestCase):
             case_type='newborn',
             date_modified='2015-07-24',
             index={
-                'parent': ('mother', '789abc')
+                'parent': ChildIndexAttrs(case_type='mother', case_id='789abc')
             },
         )
 
@@ -262,6 +260,6 @@ class CaseBlockIndexRelationshipTests(SimpleTestCase):
                 case_type='at_risk',
                 date_modified='2015-07-24',
                 index={
-                    'host': self.IndexAttrs(case_type='newborn', case_id='123456', relationship='parent')
+                    'host': IndexAttrs(case_type='newborn', case_id='123456', relationship='parent')
                 },
             )


### PR DESCRIPTION
Just pulling out the small things that are sitting in one of the branches I'm working in and that should get PRed separately.

This lets you refer to case index attributes by name. The "Attrs" feels clumsy; I prefer "Index" and "ChildIndex", but "index" might be ambiguous. ... Ended up keeping the original name.

@millerdev @snopoke 
