### PR TITLE
CaseSelectionXPath.case() takes instance name

### DIFF
--- a/corehq/apps/app_manager/tests/test_xpath.py
+++ b/corehq/apps/app_manager/tests/test_xpath.py
@@ -1,5 +1,5 @@
 from django.test import SimpleTestCase
-from corehq.apps.app_manager.xpath import XPath
+from corehq.apps.app_manager.xpath import XPath, CaseSelectionXPath, LedgerdbXpath, CaseTypeXpath
 
 
 class XPathTest(SimpleTestCase):
@@ -55,3 +55,40 @@ class XPathTest(SimpleTestCase):
                 XPath.date('d').neq('today()')
             ))
         self.assertEqual("a = 1 and b != '' and (c = '' or date(d) != today())", xp)
+
+
+class CaseSelectionXPathTests(SimpleTestCase):
+
+    def setUp(self):
+        self.select_by_water = CaseSelectionXPath("'black'")
+        self.select_by_water.selector = 'water'
+
+    def test_case(self):
+        self.assertEqual(
+            self.select_by_water.case(),
+            u"instance('casedb')/casedb/case[water='black']"
+        )
+
+    def test_instance_name(self):
+        self.assertEqual(
+            self.select_by_water.case(instance_name='doobiedb'),
+            u"instance('doobiedb')/doobiedb/case[water='black']"
+        )
+
+    def test_case_name(self):
+        self.assertEqual(
+            self.select_by_water.case(instance_name='doobiedb', case_name='song'),
+            u"instance('doobiedb')/doobiedb/song[water='black']"
+        )
+
+    def test_case_type(self):
+        self.assertEqual(
+            CaseTypeXpath('song').case(),
+            u"instance('casedb')/casedb/case[@case_type='song']"
+        )
+
+    def test_ledger(self):
+        self.assertEqual(
+            LedgerdbXpath('ledger_id').ledger(),
+            u"instance('ledgerdb')/ledgerdb/ledger[@entity-id=instance('commcaresession')/session/data/ledger_id]"
+        )

--- a/corehq/apps/app_manager/xpath.py
+++ b/corehq/apps/app_manager/xpath.py
@@ -180,9 +180,8 @@ class CaseTypeXpath(CaseSelectionXPath):
     selector = '@case_type'
 
     def case(self, instance_name='casedb', case_name='case'):
-        return CaseXPath(u"instance('{inst}')/{inst}/{case}[{sel}='{self}']".format(
-            inst=instance_name, case=case_name, sel=self.selector, self=self
-        ))
+        quoted = CaseTypeXpath(u"'{}'".format(self))
+        return super(CaseTypeXpath, quoted).case(instance_name, case_name)
 
 
 class UserCaseXPath(XPath):

--- a/corehq/apps/app_manager/xpath.py
+++ b/corehq/apps/app_manager/xpath.py
@@ -166,8 +166,10 @@ class XPath(unicode):
 class CaseSelectionXPath(XPath):
     selector = ''
 
-    def case(self):
-        return CaseXPath(u"instance('casedb')/casedb/case[%s=%s]" % (self.selector, self))
+    def case(self, instance_name='casedb'):
+        return CaseXPath(u"instance('{inst}')/{inst}/case[{sel}={self}]".format(
+            inst=instance_name, sel=self.selector, self=self
+        ))
 
 
 class CaseIDXPath(CaseSelectionXPath):
@@ -177,8 +179,10 @@ class CaseIDXPath(CaseSelectionXPath):
 class CaseTypeXpath(CaseSelectionXPath):
     selector = '@case_type'
 
-    def case(self):
-        return CaseXPath(u"instance('casedb')/casedb/case[%s='%s']" % (self.selector, self))
+    def case(self, instance_name='casedb'):
+        return CaseXPath(u"instance('{inst}')/{inst}/case[{sel}='{self}']".format(
+            inst=instance_name, sel=self.selector, self=self
+        ))
 
 
 class UserCaseXPath(XPath):
@@ -284,7 +288,9 @@ class LocationXpath(XPath):
 class LedgerdbXpath(XPath):
 
     def ledger(self):
-        return LedgerXpath(u"instance('ledgerdb')/ledgerdb/ledger[@entity-id=instance('commcaresession')/session/data/%s]" % self)
+        entity_id_selection = CaseSelectionXPath(u"instance('commcaresession')/session/data/%s" % self)
+        entity_id_selection.selector = '@entity-id'
+        return LedgerXpath(entity_id_selection.case(instance_name='ledgerdb'))
 
 
 class LedgerXpath(XPath):

--- a/corehq/apps/app_manager/xpath.py
+++ b/corehq/apps/app_manager/xpath.py
@@ -287,7 +287,7 @@ class LocationXpath(XPath):
 class LedgerdbXpath(XPath):
 
     def ledger(self):
-        entity_id_selection = CaseSelectionXPath(u"instance('commcaresession')/session/data/%s" % self)
+        entity_id_selection = CaseSelectionXPath(session_var(self))
         entity_id_selection.selector = '@entity-id'
         return LedgerXpath(entity_id_selection.case(instance_name='ledgerdb', case_name='ledger'))
 

--- a/corehq/apps/app_manager/xpath.py
+++ b/corehq/apps/app_manager/xpath.py
@@ -166,9 +166,9 @@ class XPath(unicode):
 class CaseSelectionXPath(XPath):
     selector = ''
 
-    def case(self, instance_name='casedb'):
-        return CaseXPath(u"instance('{inst}')/{inst}/case[{sel}={self}]".format(
-            inst=instance_name, sel=self.selector, self=self
+    def case(self, instance_name='casedb', case_name='case'):
+        return CaseXPath(u"instance('{inst}')/{inst}/{case}[{sel}={self}]".format(
+            inst=instance_name, case=case_name, sel=self.selector, self=self
         ))
 
 
@@ -179,9 +179,9 @@ class CaseIDXPath(CaseSelectionXPath):
 class CaseTypeXpath(CaseSelectionXPath):
     selector = '@case_type'
 
-    def case(self, instance_name='casedb'):
-        return CaseXPath(u"instance('{inst}')/{inst}/case[{sel}='{self}']".format(
-            inst=instance_name, sel=self.selector, self=self
+    def case(self, instance_name='casedb', case_name='case'):
+        return CaseXPath(u"instance('{inst}')/{inst}/{case}[{sel}='{self}']".format(
+            inst=instance_name, case=case_name, sel=self.selector, self=self
         ))
 
 
@@ -290,7 +290,7 @@ class LedgerdbXpath(XPath):
     def ledger(self):
         entity_id_selection = CaseSelectionXPath(u"instance('commcaresession')/session/data/%s" % self)
         entity_id_selection.selector = '@entity-id'
-        return LedgerXpath(entity_id_selection.case(instance_name='ledgerdb'))
+        return LedgerXpath(entity_id_selection.case(instance_name='ledgerdb', case_name='ledger'))
 
 
 class LedgerXpath(XPath):


### PR DESCRIPTION
This change is to support a DRY & generic way to refer to the "results" instance for storing case search results.

It assumes the instance XPath follows the "instance('_name_')/_name_/" convention. True for "casedb" and "ledgerdb" but obviously shouldn't be used for "commcaresession".

Please wait for tests.

@millerdev @snopoke 
