### PR TITLE
Start saving force close device logs

### DIFF
--- a/corehq/ex-submodules/couchforms/tests/data/devicelogs/devicelog.xml
+++ b/corehq/ex-submodules/couchforms/tests/data/devicelogs/devicelog.xml
@@ -64,4 +64,32 @@
       <expr>/data/fake</expr>
     </user_error>
   </user_error_subreport>
+  <force_close_subreport>
+    <force_close date="2016-03-15T13:37:04.573+05:45">
+      <type>forceclose</type>
+      <msg>java.lang.Exception: exception_text
+    at org.commcare.activities.CommCareHomeActivity.onResume(CommCareHomeActivity.java:1070)
+    at android.app.Instrumentation.callActivityOnResume(Instrumentation.java:1258)
+    at android.app.Activity.performResume(Activity.java:6327)
+    at android.app.ActivityThread.performResumeActivity(ActivityThread.java:3092)
+    at android.app.ActivityThread.handleResumeActivity(ActivityThread.java:3134)
+    at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2481)
+    at android.app.ActivityThread.-wrap11(ActivityThread.java)
+    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1344)
+    at android.os.Handler.dispatchMessage(Handler.java:102)
+    at android.os.Looper.loop(Looper.java:148)
+    at android.app.ActivityThread.main(ActivityThread.java:5422)
+    at java.lang.reflect.Method.invoke(Native Method)
+    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
+    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
+      </msg>
+      <app_build>15</app_build>
+      <app_id>36c0bdd028d14a52cbff95bb1bfd0962</app_id>
+      <android_version>6.0.1</android_version>
+      <device_model>Nexus 5X</device_model>
+      <user_id>ahelis3q3s0c33ms8r5is7yrei7t02m8</user_id>
+      <session_readable></session_readable>
+      <session_serialized>AAAAAA==</session_serialized>
+    </force_close>
+  </force_close_subreport>
 </device_report>

--- a/corehq/ex-submodules/couchforms/tests/test_devicelogs.py
+++ b/corehq/ex-submodules/couchforms/tests/test_devicelogs.py
@@ -22,50 +22,65 @@ class DeviceLogTest(TestCase, TestFileMixin):
         UserEntry.objects.all().delete()
         UserErrorEntry.objects.all().delete()
 
+    def assert_properties_equal(self, obj, expected):
+        for prop, value in expected:
+            self.assertEqual(getattr(obj, prop), value)
+
     @run_with_all_backends
     def test_basic_devicelog(self):
         xml = self.get_xml('devicelog')
         submit_form_locally(xml, 'test-domain')
+        self.assert_device_report_entries()
+        self.assert_user_entries()
+        self.assert_user_error_entries()
+        self.assert_force_close_entries()
 
-        # Assert Device Report Entries
+    def assert_device_report_entries(self):
         self.assertEqual(DeviceReportEntry.objects.count(), 7)
         first = DeviceReportEntry.objects.first()
 
-        self.assertEqual(first.type, 'resources')
-        self.assertEqual(first.domain, 'test-domain')
-        self.assertEqual(first.msg, 'Staging Sandbox: 54cfe6515fc24e3fafa1170b9a7c2a00')
-        self.assertEqual(first.device_id, '351780060530179')
-        self.assertEqual(
-            first.app_version,
-            'CommCare ODK, version "2.15.0"(335344). App v182. CommCare Version 2.15. Build 335344, built on: October-02-2014'
-        )
-        self.assertEqual(first.i, 0)
+        self.assert_properties_equal(first, (
+            ('type', 'resources'),
+            ('domain', 'test-domain'),
+            ('msg', 'Staging Sandbox: 54cfe6515fc24e3fafa1170b9a7c2a00'),
+            ('device_id', '351780060530179'),
+            ('i', 0),
+            ('app_version', 'CommCare ODK, version "2.15.0"(335344). App v182. '
+                            'CommCare Version 2.15. Build 335344, built on: '
+                            'October-02-2014')
+        ))
         self.assertIsNotNone(first.server_date)
         self.assertIsNotNone(first.date)
 
         second = DeviceReportEntry.objects.all()[1]
-        self.assertEqual(second.type, 'user')
-        self.assertEqual(second.username, 'ricatla')
-        self.assertEqual(second.user_id, '428d454aa9abc74e1964e16d3565d6b6')
+        self.assert_properties_equal(second, (
+            ('type', 'user'),
+            ('username', 'ricatla'),
+            ('user_id', '428d454aa9abc74e1964e16d3565d6b6'),
+        ))
 
-        # Assert UserEntries
+    def assert_user_entries(self):
         self.assertEqual(UserEntry.objects.count(), 1)
-        first = UserEntry.objects.first()
+        user_entry = UserEntry.objects.first()
 
-        self.assertIsNotNone(first.xform_id)
-        self.assertEqual(first.i, 0)
-        self.assertEqual(first.user_id, '428d454aa9abc74e1964e16d3565d6b6')
-        self.assertEqual(first.username, 'ricatla')
-        self.assertEqual(first.sync_token, '848609ceef09fa567e98ca61e3b0514d')
+        self.assertIsNotNone(user_entry.xform_id)
+        self.assert_properties_equal(user_entry, (
+            ('i', 0),
+            ('user_id', '428d454aa9abc74e1964e16d3565d6b6'),
+            ('username', 'ricatla'),
+            ('sync_token', '848609ceef09fa567e98ca61e3b0514d'),
+        ))
 
-        # Assert UserErrorEntries
+    def assert_user_error_entries(self):
         self.assertEqual(UserErrorEntry.objects.count(), 2)
         user_error = UserErrorEntry.objects.all()[1]
-        self.assertEqual(user_error.type, 'error-config')
-        self.assertEqual(user_error.user_id, '428d454aa9abc74e1964e16d3565d6b6')
-        self.assertEqual(user_error.version_number, 604)
-        self.assertEqual(user_error.app_id, '36c0bdd028d14a52cbff95bb1bfd0962')
-        self.assertEqual(user_error.expr, '/data/fake')
+        self.assert_properties_equal(user_error, (
+            ('type', 'error-config'),
+            ('user_id', '428d454aa9abc74e1964e16d3565d6b6'),
+            ('version_number', 604),
+            ('app_id', '36c0bdd028d14a52cbff95bb1bfd0962'),
+            ('expr', '/data/fake'),
+        ))
 
     @run_with_all_backends
     def test_subreports_that_shouldnt_fail(self):

--- a/corehq/ex-submodules/phonelog/admin.py
+++ b/corehq/ex-submodules/phonelog/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from .models import DeviceReportEntry, UserErrorEntry, UserEntry
+from .models import DeviceReportEntry, UserErrorEntry, UserEntry, ForceCloseEntry
 
 
 class DeviceReportEntryAdmin(admin.ModelAdmin):
@@ -57,6 +57,27 @@ class UserEntryAdmin(admin.ModelAdmin):
     ]
 
 
+class ForceCloseEntryAdmin(admin.ModelAdmin):
+    model = ForceCloseEntry
+    list_display = [
+        'domain',
+        'server_date',
+        'user_id',
+        'app_id',
+        'version_number',
+        'msg',
+        'session_readable',
+    ]
+    search_fields = [
+        'domain',
+        'user_id',
+        'app_id',
+        'version_number',
+        'msg',
+    ]
+
+
 admin.site.register(DeviceReportEntry, DeviceReportEntryAdmin)
 admin.site.register(UserErrorEntry, UserErrorEntryAdmin)
 admin.site.register(UserEntry, UserEntryAdmin)
+admin.site.register(ForceCloseEntry, ForceCloseEntryAdmin)

--- a/corehq/ex-submodules/phonelog/migrations/0005_add_forceclose_entry_20160408_1530.py
+++ b/corehq/ex-submodules/phonelog/migrations/0005_add_forceclose_entry_20160408_1530.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('phonelog', '0004_merge'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ForceCloseEntry',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('domain', models.CharField(max_length=100, db_index=True)),
+                ('xform_id', models.CharField(max_length=50)),
+                ('app_id', models.CharField(max_length=50, null=True)),
+                ('version_number', models.IntegerField()),
+                ('date', models.DateTimeField()),
+                ('server_date', models.DateTimeField(null=True)),
+                ('user_id', models.CharField(max_length=50, null=True)),
+                ('type', models.CharField(max_length=32)),
+                ('msg', models.TextField()),
+                ('android_version', models.CharField(max_length=32)),
+                ('device_model', models.CharField(max_length=32)),
+                ('session_readable', models.TextField()),
+                ('session_serialized', models.TextField()),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+        migrations.AlterIndexTogether(
+            name='forcecloseentry',
+            index_together=set([('domain', 'server_date')]),
+        ),
+    ]

--- a/corehq/ex-submodules/phonelog/models.py
+++ b/corehq/ex-submodules/phonelog/models.py
@@ -72,3 +72,33 @@ class UserEntry(models.Model):
 
     def __repr__(self):
         return u"UserEntry(username='{}')".format(self.username)
+
+
+class ForceCloseEntry(models.Model):
+    # Information about the device log this came from
+    domain = models.CharField(max_length=100, db_index=True)
+    xform_id = models.CharField(max_length=COUCH_UUID_MAX_LEN)
+
+    # The context around when/how this happened
+    app_id = models.CharField(max_length=COUCH_UUID_MAX_LEN, null=True)
+    version_number = models.IntegerField()
+    date = models.DateTimeField()
+    server_date = models.DateTimeField(null=True)
+    user_id = models.CharField(max_length=COUCH_UUID_MAX_LEN, null=True)
+
+    # Information about the specific error
+    type = models.CharField(max_length=32)
+    msg = models.TextField()
+    android_version = models.CharField(max_length=32)
+    device_model = models.CharField(max_length=32)
+    session_readable = models.TextField()
+    session_serialized = models.TextField()
+
+    class Meta:
+        app_label = 'phonelog'
+        index_together = [
+            ("domain", "server_date"),
+        ]
+
+    def __repr__(self):
+        return u"ForceCloseEntry(domain='{}', msg='{}')".format(self.domain, self.msg)

--- a/corehq/ex-submodules/phonelog/utils.py
+++ b/corehq/ex-submodules/phonelog/utils.py
@@ -1,7 +1,7 @@
 from django.db import transaction
 from corehq.apps.users.util import format_username
 from corehq.apps.users.dbaccessors import get_user_id_by_username
-from .models import UserEntry, DeviceReportEntry, UserErrorEntry
+from .models import UserEntry, DeviceReportEntry, UserErrorEntry, ForceCloseEntry
 
 
 def device_users_by_xform(xform_id):
@@ -44,6 +44,7 @@ def process_device_log(domain, xform):
     _process_user_subreport(xform)
     _process_log_subreport(domain, xform)
     _process_user_error_subreport(domain, xform)
+    _process_force_close_subreport(domain, xform)
 
 
 def _process_user_subreport(xform):
@@ -122,3 +123,33 @@ def _process_user_error_subreport(domain, xform):
         )
         to_save.append(entry)
     UserErrorEntry.objects.bulk_create(to_save)
+
+
+def _process_force_close_subreport(domain, xform):
+    force_closures = _get_logs(xform.form_data, 'force_close_subreport', 'force_close')
+    to_save = []
+    for force_closure in force_closures:
+        # There are some testing versions going around with an outdated schema
+        # This never made it into an official release, but:
+        # app_id and user_id might be missing
+        # early versions have 'build_number' - the name should now be 'app_build'
+        # All of this is probably fine to remove after, say June 2016.
+        version = (force_closure['app_build'] if 'app_build' in force_closure
+                   else force_closure['build_number'])
+        entry = ForceCloseEntry(
+            domain=domain,
+            xform_id=xform.form_id,
+            app_id=force_closure.get('app_id'),
+            version_number=int(version),
+            date=force_closure["@date"],
+            server_date=xform.received_on,
+            user_id=force_closure.get('user_id'),
+            type=force_closure['type'],
+            msg=force_closure['msg'],
+            android_version=force_closure['android_version'],
+            device_model=force_closure['device_model'],
+            session_readable=force_closure['session_readable'],
+            session_serialized=force_closure['session_serialized'],
+        )
+        to_save.append(entry)
+    ForceCloseEntry.objects.bulk_create(to_save)


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?221203
@NoahCarnahan @amstone326 FYI

:tropical_fish: is easiest, although it looks like :octocat: is showing them in chronological order (I rebased, so they're not actually in chronological order).  Should make sense either way.
