### PR TITLE
Kafka domain pillow

### DIFF
--- a/corehq/apps/change_feed/document_types.py
+++ b/corehq/apps/change_feed/document_types.py
@@ -7,18 +7,15 @@ FORM = 'form'
 META = 'meta'
 
 
-class DocumentType(namedtuple('DocumentType', ['raw_doc_type', 'primary_type', 'subtype'])):
-
-    @property
-    def is_deletion(self):
-        # can be overridden
-        return self.raw_doc_type.endswith(DELETED_SUFFIX)
+DocumentType = namedtuple('DocumentType', ['raw_doc_type', 'primary_type', 'subtype', 'is_deletion'])
 
 
 def get_doc_type_object_from_document(document):
     raw_doc_type = _get_document_type(document)
     if raw_doc_type:
-        return DocumentType(raw_doc_type, get_primary_type(raw_doc_type), _get_document_subtype(document))
+        return DocumentType(
+            raw_doc_type, get_primary_type(raw_doc_type), _get_document_subtype(document), _is_deletion(raw_doc_type)
+        )
 
 
 def get_primary_type(raw_doc_type):
@@ -42,3 +39,7 @@ def _get_document_subtype(document_or_none):
     elif type in all_known_formlike_doc_types():
         return document_or_none.get('xmlns', None)
     return None
+
+def _is_deletion(raw_doc_type):
+    # can be overridden
+    return raw_doc_type.endswith(DELETED_SUFFIX)

--- a/corehq/apps/change_feed/document_types.py
+++ b/corehq/apps/change_feed/document_types.py
@@ -4,6 +4,7 @@ from dimagi.utils.couch.undo import DELETED_SUFFIX
 
 CASE = 'case'
 FORM = 'form'
+DOMAIN = 'domain'
 META = 'meta'
 
 
@@ -22,6 +23,8 @@ def _get_primary_type(raw_doc_type):
         return CASE
     elif raw_doc_type in all_known_formlike_doc_types():
         return FORM
+    elif raw_doc_type in ('Domain', 'Domain-Deleted', 'Domain-DUPLICATE'):
+        return DOMAIN
     else:
         # at some point we may want to make this more granular
         return META
@@ -32,6 +35,8 @@ def _make_document_type(raw_doc_type, primary_type, document):
         return _case_doc_type_constructor(raw_doc_type, document)
     elif primary_type == FORM:
         return _form_doc_type_constructor(raw_doc_type, document)
+    elif primary_type == DOMAIN:
+        return _domain_doc_type_constructor(raw_doc_type)
     else:
         return DocumentType(
             raw_doc_type, primary_type, None, _is_deletion(raw_doc_type)
@@ -56,4 +61,11 @@ def _case_doc_type_constructor(raw_doc_type, document):
 def _form_doc_type_constructor(raw_doc_type, document):
     return DocumentType(
         raw_doc_type, FORM, document.get('xmlns', None), _is_deletion(raw_doc_type)
+    )
+
+
+def _domain_doc_type_constructor(raw_doc_type):
+    is_deletion = raw_doc_type == 'Domain-DUPLICATE' or _is_deletion(raw_doc_type)
+    return DocumentType(
+        raw_doc_type, DOMAIN, None, is_deletion
     )

--- a/corehq/apps/change_feed/document_types.py
+++ b/corehq/apps/change_feed/document_types.py
@@ -10,7 +10,9 @@ DOMAIN = 'domain'
 META = 'meta'
 
 
-DocumentMetadata = namedtuple('DocumentMetadata', ['raw_doc_type', 'primary_type', 'subtype', 'domain', 'is_deletion'])
+DocumentMetadata = namedtuple(
+    'DocumentMetadata', ['raw_doc_type', 'primary_type', 'subtype', 'domain', 'is_deletion']
+)
 
 
 def get_doc_meta_object_from_document(document):

--- a/corehq/apps/change_feed/document_types.py
+++ b/corehq/apps/change_feed/document_types.py
@@ -8,10 +8,10 @@ DOMAIN = 'domain'
 META = 'meta'
 
 
-DocumentType = namedtuple('DocumentType', ['raw_doc_type', 'primary_type', 'subtype', 'is_deletion'])
+DocumentMetadata = namedtuple('DocumentMetadata', ['raw_doc_type', 'primary_type', 'subtype', 'is_deletion'])
 
 
-def get_doc_type_object_from_document(document):
+def get_doc_meta_object_from_document(document):
     raw_doc_type = _get_document_type(document)
     if raw_doc_type:
         primary_type = _get_primary_type(raw_doc_type)
@@ -38,7 +38,7 @@ def _make_document_type(raw_doc_type, primary_type, document):
     elif primary_type == DOMAIN:
         return _domain_doc_type_constructor(raw_doc_type)
     else:
-        return DocumentType(
+        return DocumentMetadata(
             raw_doc_type, primary_type, None, _is_deletion(raw_doc_type)
         )
 
@@ -53,19 +53,19 @@ def _is_deletion(raw_doc_type):
 
 
 def _case_doc_type_constructor(raw_doc_type, document):
-    return DocumentType(
+    return DocumentMetadata(
         raw_doc_type, CASE, document.get('type', None), _is_deletion(raw_doc_type)
     )
 
 
 def _form_doc_type_constructor(raw_doc_type, document):
-    return DocumentType(
+    return DocumentMetadata(
         raw_doc_type, FORM, document.get('xmlns', None), _is_deletion(raw_doc_type)
     )
 
 
 def _domain_doc_type_constructor(raw_doc_type):
     is_deletion = raw_doc_type == 'Domain-DUPLICATE' or _is_deletion(raw_doc_type)
-    return DocumentType(
+    return DocumentMetadata(
         raw_doc_type, DOMAIN, None, is_deletion
     )

--- a/corehq/apps/change_feed/document_types.py
+++ b/corehq/apps/change_feed/document_types.py
@@ -1,12 +1,18 @@
 from collections import namedtuple
 from couchforms.models import all_known_formlike_doc_types
+from dimagi.utils.couch.undo import DELETED_SUFFIX
 
 CASE = 'case'
 FORM = 'form'
 META = 'meta'
 
 
-DocumentType = namedtuple('DocumentType', ['raw_doc_type', 'primary_type', 'subtype'])
+class DocumentType(namedtuple('DocumentType', ['raw_doc_type', 'primary_type', 'subtype'])):
+
+    @property
+    def is_deletion(self):
+        # can be overridden
+        return self.raw_doc_type.endswith(DELETED_SUFFIX)
 
 
 def get_doc_type_object_from_document(document):

--- a/corehq/apps/change_feed/document_types.py
+++ b/corehq/apps/change_feed/document_types.py
@@ -13,12 +13,11 @@ DocumentType = namedtuple('DocumentType', ['raw_doc_type', 'primary_type', 'subt
 def get_doc_type_object_from_document(document):
     raw_doc_type = _get_document_type(document)
     if raw_doc_type:
-        return DocumentType(
-            raw_doc_type, get_primary_type(raw_doc_type), _get_document_subtype(document), _is_deletion(raw_doc_type)
-        )
+        primary_type = _get_primary_type(raw_doc_type)
+        return _make_document_type(raw_doc_type, primary_type, document)
 
 
-def get_primary_type(raw_doc_type):
+def _get_primary_type(raw_doc_type):
     if raw_doc_type in ('CommCareCase', 'CommCareCase-Deleted'):
         return CASE
     elif raw_doc_type in all_known_formlike_doc_types():
@@ -28,18 +27,33 @@ def get_primary_type(raw_doc_type):
         return META
 
 
+def _make_document_type(raw_doc_type, primary_type, document):
+    if primary_type == CASE:
+        return _case_doc_type_constructor(raw_doc_type, document)
+    elif primary_type == FORM:
+        return _form_doc_type_constructor(raw_doc_type, document)
+    else:
+        return DocumentType(
+            raw_doc_type, primary_type, None, _is_deletion(raw_doc_type)
+        )
+
+
 def _get_document_type(document_or_none):
     return document_or_none.get('doc_type', None) if document_or_none else None
 
 
-def _get_document_subtype(document_or_none):
-    type = _get_document_type(document_or_none)
-    if type in ('CommCareCase', 'CommCareCase-Deleted'):
-        return document_or_none.get('type', None)
-    elif type in all_known_formlike_doc_types():
-        return document_or_none.get('xmlns', None)
-    return None
-
 def _is_deletion(raw_doc_type):
     # can be overridden
     return raw_doc_type.endswith(DELETED_SUFFIX)
+
+
+def _case_doc_type_constructor(raw_doc_type, document):
+    return DocumentType(
+        raw_doc_type, CASE, document.get('type', None), _is_deletion(raw_doc_type)
+    )
+
+
+def _form_doc_type_constructor(raw_doc_type, document):
+    return DocumentType(
+        raw_doc_type, FORM, document.get('xmlns', None), _is_deletion(raw_doc_type)
+    )

--- a/corehq/apps/change_feed/document_types.py
+++ b/corehq/apps/change_feed/document_types.py
@@ -1,0 +1,38 @@
+from collections import namedtuple
+from couchforms.models import all_known_formlike_doc_types
+
+CASE = 'case'
+FORM = 'form'
+META = 'meta'
+
+
+DocumentType = namedtuple('DocumentType', ['raw_doc_type', 'primary_type', 'subtype'])
+
+
+def get_doc_type_object_from_document(document):
+    raw_doc_type = _get_document_type(document)
+    if raw_doc_type:
+        return DocumentType(raw_doc_type, get_primary_type(raw_doc_type), _get_document_subtype(document))
+
+
+def get_primary_type(raw_doc_type):
+    if raw_doc_type in ('CommCareCase', 'CommCareCase-Deleted'):
+        return CASE
+    elif raw_doc_type in all_known_formlike_doc_types():
+        return FORM
+    else:
+        # at some point we may want to make this more granular
+        return META
+
+
+def _get_document_type(document_or_none):
+    return document_or_none.get('doc_type', None) if document_or_none else None
+
+
+def _get_document_subtype(document_or_none):
+    type = _get_document_type(document_or_none)
+    if type in ('CommCareCase', 'CommCareCase-Deleted'):
+        return document_or_none.get('type', None)
+    elif type in all_known_formlike_doc_types():
+        return document_or_none.get('xmlns', None)
+    return None

--- a/corehq/apps/change_feed/document_types.py
+++ b/corehq/apps/change_feed/document_types.py
@@ -80,6 +80,9 @@ def change_meta_from_doc_meta_and_document(doc_meta, document, data_source_type,
     if doc_meta is None:
         raise MissingMetaInformationError(u"Couldn't guess document type for {}!".format(document))
 
+    doc_id = doc_id or document.get('_id', None)
+    if not doc_id:
+        raise MissingMetaInformationError(u"No doc ID!!".format(document))
     return ChangeMeta(
         document_id=doc_id or document['_id'],
         data_source_type=data_source_type,

--- a/corehq/apps/change_feed/exceptions.py
+++ b/corehq/apps/change_feed/exceptions.py
@@ -2,3 +2,7 @@
 
 class UnknownDocumentStore(ValueError):
     pass
+
+
+class MissingMetaInformationError(Exception):
+    pass

--- a/corehq/apps/change_feed/pillow.py
+++ b/corehq/apps/change_feed/pillow.py
@@ -1,11 +1,11 @@
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.change_feed import data_sources
 from corehq.apps.change_feed.connection import get_kafka_client_or_none
+from corehq.apps.change_feed.document_types import get_doc_type_object_from_document
 from corehq.apps.change_feed.producer import ChangeProducer
 from corehq.apps.change_feed.topics import get_topic
 from corehq.apps.users.models import CommCareUser
 from corehq.util.couchdb_management import couch_config
-from couchforms.models import all_known_formlike_doc_types
 from pillowtop.checkpoints.manager import PillowCheckpoint, PillowCheckpointEventHandler
 from pillowtop.couchdb import CachedCouchDB
 from pillowtop.feed.couch import CouchChangeFeed
@@ -26,19 +26,19 @@ class KafkaProcessor(PillowProcessor):
         self._data_source_name = data_source_name
 
     def process_change(self, pillow_instance, change, do_set_checkpoint=False):
-        document_type = _get_document_type(change.document)
-        if document_type:
+        doc_type_object = get_doc_type_object_from_document(change.document)
+        if doc_type_object:
             assert change.document is not None
             change_meta = ChangeMeta(
                 document_id=change.id,
                 data_source_type=self._data_source_type,
                 data_source_name=self._data_source_name,
-                document_type=document_type,
-                document_subtype=_get_document_subtype(change.document),
+                document_type=doc_type_object.raw_doc_type,
+                document_subtype=doc_type_object.subtype,
                 domain=change.document.get('domain', None),
                 is_deletion=change.deleted,
             )
-            self._producer.send_change(get_topic(document_type), change_meta)
+            self._producer.send_change(get_topic(doc_type_object), change_meta)
 
 
 class ChangeFeedPillow(PythonPillow):
@@ -96,16 +96,3 @@ def get_user_groups_db_kafka_pillow(pillow_id):
             checkpoint=checkpoint, checkpoint_frequency=100,
         ),
     )
-
-
-def _get_document_type(document_or_none):
-    return document_or_none.get('doc_type', None) if document_or_none else None
-
-
-def _get_document_subtype(document_or_none):
-    type = _get_document_type(document_or_none)
-    if type in ('CommCareCase', 'CommCareCase-Deleted'):
-        return document_or_none.get('type', None)
-    elif type in all_known_formlike_doc_types():
-        return document_or_none.get('xmlns', None)
-    return None

--- a/corehq/apps/change_feed/pillow.py
+++ b/corehq/apps/change_feed/pillow.py
@@ -1,7 +1,7 @@
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.change_feed import data_sources
 from corehq.apps.change_feed.connection import get_kafka_client_or_none
-from corehq.apps.change_feed.document_types import get_doc_type_object_from_document
+from corehq.apps.change_feed.document_types import get_doc_meta_object_from_document
 from corehq.apps.change_feed.producer import ChangeProducer
 from corehq.apps.change_feed.topics import get_topic
 from corehq.apps.users.models import CommCareUser
@@ -26,7 +26,7 @@ class KafkaProcessor(PillowProcessor):
         self._data_source_name = data_source_name
 
     def process_change(self, pillow_instance, change, do_set_checkpoint=False):
-        doc_type_object = get_doc_type_object_from_document(change.document)
+        doc_type_object = get_doc_meta_object_from_document(change.document)
         if doc_type_object:
             assert change.document is not None
             change_meta = ChangeMeta(

--- a/corehq/apps/change_feed/pillow.py
+++ b/corehq/apps/change_feed/pillow.py
@@ -36,7 +36,7 @@ class KafkaProcessor(PillowProcessor):
                 document_type=doc_type_object.raw_doc_type,
                 document_subtype=doc_type_object.subtype,
                 domain=change.document.get('domain', None),
-                is_deletion=change.deleted,
+                is_deletion=change.deleted or doc_type_object.is_deletion,
             )
             self._producer.send_change(get_topic(doc_type_object), change_meta)
 

--- a/corehq/apps/change_feed/pillow.py
+++ b/corehq/apps/change_feed/pillow.py
@@ -39,6 +39,7 @@ class KafkaProcessor(PillowProcessor):
         except MissingMetaInformationError:
             pass
         else:
+            assert not change.deleted
             self._producer.send_change(get_topic(doc_meta), change_meta)
 
 

--- a/corehq/apps/change_feed/producer.py
+++ b/corehq/apps/change_feed/producer.py
@@ -25,7 +25,7 @@ def send_to_kafka(producer, topic, change_meta):
             try:
                 _send_to_kafka()
                 break
-            except (FailedPayloadsError, KafkaUnavailableError):
+            except (FailedPayloadsError, KafkaUnavailableError, LeaderNotAvailableError):
                 if i == (tries - 1):
                     # if it's the last try, fail hard
                     raise

--- a/corehq/apps/change_feed/tests/__init__.py
+++ b/corehq/apps/change_feed/tests/__init__.py
@@ -1,2 +1,3 @@
+from .test_document_types import *
 from .test_kafka_change_feed import *
 from .test_pillow import *

--- a/corehq/apps/change_feed/tests/test_document_types.py
+++ b/corehq/apps/change_feed/tests/test_document_types.py
@@ -1,5 +1,5 @@
 from django.test import SimpleTestCase
-from corehq.apps.change_feed.document_types import CASE, get_doc_type_object_from_document, FORM, META
+from corehq.apps.change_feed.document_types import CASE, get_doc_type_object_from_document, FORM, META, DOMAIN
 from corehq.util.test_utils import generate_cases
 
 
@@ -15,7 +15,7 @@ class DocumentTypeTest(SimpleTestCase):
     ({'doc_type': 'XFormDeprecated'}, FORM),
     ({'doc_type': 'XFormDuplicate'}, FORM),
     ({'doc_type': 'XFormError'}, FORM),
-    ({'doc_type': 'Domain'}, META),
+    ({'doc_type': 'Domain'}, DOMAIN),
     ({'doc_type': 'CommCareUser'}, META),
     # subtype tests
     ({'doc_type': 'CommCareCase', 'type': 'person'}, CASE, 'person'),
@@ -23,7 +23,8 @@ class DocumentTypeTest(SimpleTestCase):
     # deletion tests
     ({'doc_type': 'CommCareCase-Deleted'}, CASE, None, True),
     ({'doc_type': 'XFormInstance-Deleted'}, FORM, None, True),
-    ({'doc_type': 'Domain-Deleted'}, META, None, True),
+    ({'doc_type': 'Domain-Deleted'}, DOMAIN, None, True),
+    ({'doc_type': 'Domain-DUPLICATE'}, DOMAIN, None, True),
     ({'doc_type': 'CommCareUser-Deleted'}, META, None, True),
 ], DocumentTypeTest)
 def test_document_types(self, raw_doc, expected_primary_type, expected_subtype=None, expected_deletion=False):

--- a/corehq/apps/change_feed/tests/test_document_types.py
+++ b/corehq/apps/change_feed/tests/test_document_types.py
@@ -20,15 +20,22 @@ class DocumentTypeTest(SimpleTestCase):
     # subtype tests
     ({'doc_type': 'CommCareCase', 'type': 'person'}, CASE, 'person'),
     ({'doc_type': 'XFormInstance', 'xmlns': 'my-xmlns'}, FORM, 'my-xmlns'),
+    # domain tests
+    ({'doc_type': 'CommCareCase', 'domain': 'test-domain'}, CASE, None, 'test-domain'),
+    ({'doc_type': 'XFormInstance', 'domain': 'test-domain'}, FORM, None, 'test-domain'),
+    ({'doc_type': 'Domain', 'name': 'test-domain'}, DOMAIN, None, 'test-domain'),
+    ({'doc_type': 'Domain', 'domain': 'wrong', 'name': 'right'}, DOMAIN, None, 'right'),
     # deletion tests
-    ({'doc_type': 'CommCareCase-Deleted'}, CASE, None, True),
-    ({'doc_type': 'XFormInstance-Deleted'}, FORM, None, True),
-    ({'doc_type': 'Domain-Deleted'}, DOMAIN, None, True),
-    ({'doc_type': 'Domain-DUPLICATE'}, DOMAIN, None, True),
-    ({'doc_type': 'CommCareUser-Deleted'}, META, None, True),
+    ({'doc_type': 'CommCareCase-Deleted'}, CASE, None, None, True),
+    ({'doc_type': 'XFormInstance-Deleted'}, FORM, None, None, True),
+    ({'doc_type': 'Domain-Deleted'}, DOMAIN, None, None, True),
+    ({'doc_type': 'Domain-DUPLICATE'}, DOMAIN, None, None, True),
+    ({'doc_type': 'CommCareUser-Deleted'}, META, None, None, True),
 ], DocumentTypeTest)
-def test_document_types(self, raw_doc, expected_primary_type, expected_subtype=None, expected_deletion=False):
+def test_document_types(self, raw_doc, expected_primary_type, expected_subtype=None,
+                        expected_domain=None, expected_deletion=False):
     doc_type_object = get_doc_meta_object_from_document(raw_doc)
     self.assertEqual(expected_primary_type, doc_type_object.primary_type)
     self.assertEqual(expected_subtype, doc_type_object.subtype)
+    self.assertEqual(expected_domain, doc_type_object.domain)
     self.assertEqual(expected_deletion, doc_type_object.is_deletion)

--- a/corehq/apps/change_feed/tests/test_document_types.py
+++ b/corehq/apps/change_feed/tests/test_document_types.py
@@ -1,0 +1,29 @@
+from django.test import SimpleTestCase
+from corehq.apps.change_feed.document_types import CASE, get_doc_type_object_from_document, FORM, META
+from corehq.util.test_utils import generate_cases
+
+
+class DocumentTypeTest(SimpleTestCase):
+    pass
+
+
+@generate_cases([
+    # primary type tests
+    ({'doc_type': 'CommCareCase'}, CASE),
+    ({'doc_type': 'XFormInstance'}, FORM),
+    ({'doc_type': 'Domain'}, META),
+    ({'doc_type': 'CommCareUser'}, META),
+    # subtype tests
+    ({'doc_type': 'CommCareCase', 'type': 'person'}, CASE, 'person'),
+    ({'doc_type': 'XFormInstance', 'xmlns': 'my-xmlns'}, FORM, 'my-xmlns'),
+    # deletion tests
+    ({'doc_type': 'CommCareCase-Deleted'}, CASE, None, True),
+    ({'doc_type': 'XFormInstance-Deleted'}, FORM, None, True),
+    ({'doc_type': 'Domain-Deleted'}, META, None, True),
+    ({'doc_type': 'CommCareUser-Deleted'}, META, None, True),
+], DocumentTypeTest)
+def test_document_types(self, raw_doc, expected_primary_type, expected_subtype=None, expected_deletion=False):
+    doc_type_object = get_doc_type_object_from_document(raw_doc)
+    self.assertEqual(expected_primary_type, doc_type_object.primary_type)
+    self.assertEqual(expected_subtype, doc_type_object.subtype)
+    self.assertEqual(expected_deletion, doc_type_object.is_deletion)

--- a/corehq/apps/change_feed/tests/test_document_types.py
+++ b/corehq/apps/change_feed/tests/test_document_types.py
@@ -1,5 +1,7 @@
 from django.test import SimpleTestCase
-from corehq.apps.change_feed.document_types import CASE, get_doc_meta_object_from_document, FORM, META, DOMAIN
+from corehq.apps.change_feed.document_types import CASE, get_doc_meta_object_from_document, FORM, META, DOMAIN, \
+    change_meta_from_doc
+from corehq.apps.change_feed.exceptions import MissingMetaInformationError
 from corehq.util.test_utils import generate_cases
 
 
@@ -33,9 +35,36 @@ class DocumentTypeTest(SimpleTestCase):
     ({'doc_type': 'CommCareUser-Deleted'}, META, None, None, True),
 ], DocumentTypeTest)
 def test_document_meta(self, raw_doc, expected_primary_type, expected_subtype=None,
-                        expected_domain=None, expected_deletion=False):
+                       expected_domain=None, expected_deletion=False):
     doc_meta = get_doc_meta_object_from_document(raw_doc)
     self.assertEqual(expected_primary_type, doc_meta.primary_type)
     self.assertEqual(expected_subtype, doc_meta.subtype)
     self.assertEqual(expected_domain, doc_meta.domain)
     self.assertEqual(expected_deletion, doc_meta.is_deletion)
+
+
+@generate_cases([
+    # primary type tests
+    (None,),
+    ({},),
+    ({'_id': 'id-without-type'},),
+    ({'doc_type': 'type-without-id'},),
+], DocumentTypeTest)
+def test_change_from_doc_failures(self, doc):
+    with self.assertRaises(MissingMetaInformationError):
+        change_meta_from_doc(doc, 'dummy-data-source', 'dummy-data-source-name')
+
+
+@generate_cases([
+    ({'_id': 'id', 'doc_type': 'CommCareCase', 'domain': 'test-domain'}, 'id'),
+], DocumentTypeTest)
+def test_change_from_doc_success(self, doc, expected_id):
+    change_meta = change_meta_from_doc(doc, 'dummy-data-source', 'dummy-data-source-name')
+    doc_meta = get_doc_meta_object_from_document(doc)
+    self.assertEqual(expected_id, change_meta.document_id)
+    self.assertEqual('dummy-data-source', change_meta.data_source_type)
+    self.assertEqual('dummy-data-source-name', change_meta.data_source_name)
+    self.assertEqual(doc_meta.raw_doc_type, change_meta.document_type)
+    self.assertEqual(doc_meta.subtype, change_meta.document_subtype)
+    self.assertEqual(doc_meta.domain, change_meta.domain)
+    self.assertEqual(doc_meta.is_deletion, change_meta.is_deletion)

--- a/corehq/apps/change_feed/tests/test_document_types.py
+++ b/corehq/apps/change_feed/tests/test_document_types.py
@@ -11,6 +11,10 @@ class DocumentTypeTest(SimpleTestCase):
     # primary type tests
     ({'doc_type': 'CommCareCase'}, CASE),
     ({'doc_type': 'XFormInstance'}, FORM),
+    ({'doc_type': 'XFormArchived'}, FORM),
+    ({'doc_type': 'XFormDeprecated'}, FORM),
+    ({'doc_type': 'XFormDuplicate'}, FORM),
+    ({'doc_type': 'XFormError'}, FORM),
     ({'doc_type': 'Domain'}, META),
     ({'doc_type': 'CommCareUser'}, META),
     # subtype tests

--- a/corehq/apps/change_feed/tests/test_document_types.py
+++ b/corehq/apps/change_feed/tests/test_document_types.py
@@ -32,10 +32,10 @@ class DocumentTypeTest(SimpleTestCase):
     ({'doc_type': 'Domain-DUPLICATE'}, DOMAIN, None, None, True),
     ({'doc_type': 'CommCareUser-Deleted'}, META, None, None, True),
 ], DocumentTypeTest)
-def test_document_types(self, raw_doc, expected_primary_type, expected_subtype=None,
+def test_document_meta(self, raw_doc, expected_primary_type, expected_subtype=None,
                         expected_domain=None, expected_deletion=False):
-    doc_type_object = get_doc_meta_object_from_document(raw_doc)
-    self.assertEqual(expected_primary_type, doc_type_object.primary_type)
-    self.assertEqual(expected_subtype, doc_type_object.subtype)
-    self.assertEqual(expected_domain, doc_type_object.domain)
-    self.assertEqual(expected_deletion, doc_type_object.is_deletion)
+    doc_meta = get_doc_meta_object_from_document(raw_doc)
+    self.assertEqual(expected_primary_type, doc_meta.primary_type)
+    self.assertEqual(expected_subtype, doc_meta.subtype)
+    self.assertEqual(expected_domain, doc_meta.domain)
+    self.assertEqual(expected_deletion, doc_meta.is_deletion)

--- a/corehq/apps/change_feed/tests/test_document_types.py
+++ b/corehq/apps/change_feed/tests/test_document_types.py
@@ -1,5 +1,5 @@
 from django.test import SimpleTestCase
-from corehq.apps.change_feed.document_types import CASE, get_doc_type_object_from_document, FORM, META, DOMAIN
+from corehq.apps.change_feed.document_types import CASE, get_doc_meta_object_from_document, FORM, META, DOMAIN
 from corehq.util.test_utils import generate_cases
 
 
@@ -28,7 +28,7 @@ class DocumentTypeTest(SimpleTestCase):
     ({'doc_type': 'CommCareUser-Deleted'}, META, None, True),
 ], DocumentTypeTest)
 def test_document_types(self, raw_doc, expected_primary_type, expected_subtype=None, expected_deletion=False):
-    doc_type_object = get_doc_type_object_from_document(raw_doc)
+    doc_type_object = get_doc_meta_object_from_document(raw_doc)
     self.assertEqual(expected_primary_type, doc_type_object.primary_type)
     self.assertEqual(expected_subtype, doc_type_object.subtype)
     self.assertEqual(expected_deletion, doc_type_object.is_deletion)

--- a/corehq/apps/change_feed/topics.py
+++ b/corehq/apps/change_feed/topics.py
@@ -1,9 +1,9 @@
-from couchforms.models import all_known_formlike_doc_types
+from .document_types import CASE, FORM, META
 
-
-CASE = 'case'
-FORM = 'form'
-META = 'meta'
+# this is redundant but helps avoid import warnings until nothing references these
+CASE = CASE
+FORM = FORM
+META = META
 
 # new models
 CASE_SQL = 'case-sql'
@@ -16,11 +16,5 @@ ALL = (
 )
 
 
-def get_topic(document_type):
-    if document_type in ('CommCareCase', 'CommCareCase-Deleted'):
-        return CASE
-    elif document_type in all_known_formlike_doc_types():
-        return FORM
-    else:
-        # at some point we may want to make this more granular
-        return META
+def get_topic(document_type_object):
+    return document_type_object.primary_type

--- a/corehq/apps/change_feed/topics.py
+++ b/corehq/apps/change_feed/topics.py
@@ -1,8 +1,9 @@
-from .document_types import CASE, FORM, META
+from .document_types import CASE, FORM, DOMAIN, META
 
 # this is redundant but helps avoid import warnings until nothing references these
 CASE = CASE
 FORM = FORM
+DOMAIN = DOMAIN
 META = META
 
 # new models

--- a/corehq/pillows/domain.py
+++ b/corehq/pillows/domain.py
@@ -1,10 +1,16 @@
 import copy
 from corehq.apps.accounting.models import Subscription
+from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed
+from corehq.apps.change_feed.document_types import DOMAIN
 from corehq.apps.domain.models import Domain
+from corehq.elastic import get_es_new
 from corehq.pillows.base import HQPillow
 from corehq.pillows.mappings.domain_mapping import DOMAIN_MAPPING, DOMAIN_INDEX
 from django_countries.data import COUNTRIES
-from pillowtop.es_utils import doc_exists
+from pillowtop.checkpoints.manager import PillowCheckpoint, PillowCheckpointEventHandler
+from pillowtop.es_utils import doc_exists, get_index_info_from_pillow
+from pillowtop.pillow.interface import ConstructedPillow
+from pillowtop.processors import ElasticProcessor
 from pillowtop.reindexer.change_providers.couch import CouchViewChangeProvider
 from pillowtop.reindexer.reindexer import get_default_reindexer_for_elastic_pillow
 
@@ -67,6 +73,27 @@ def transform_domain_for_elasticsearch(doc_dict):
     return doc_ret
 
 
+def get_domain_kafka_to_elasticsearch_pillow(pillow_id='domain-kafka-to-es'):
+    checkpoint = PillowCheckpoint(
+        pillow_id,
+    )
+    domain_processor = ElasticProcessor(
+        elasticsearch=get_es_new(),
+        index_info=_get_domain_index_info(),
+        doc_prep_fn=transform_domain_for_elasticsearch
+    )
+    return ConstructedPillow(
+        name=pillow_id,
+        document_store=None,
+        checkpoint=checkpoint,
+        change_feed=KafkaChangeFeed(topics=[DOMAIN], group_id='domains-to-es'),
+        processor=domain_processor,
+        change_processed_event_handler=PillowCheckpointEventHandler(
+            checkpoint=checkpoint, checkpoint_frequency=100,
+        ),
+    )
+
+
 def get_domain_reindexer():
     return get_default_reindexer_for_elastic_pillow(
         pillow=DomainPillow(online=False),
@@ -79,3 +106,7 @@ def get_domain_reindexer():
             }
         ),
     )
+
+
+def _get_domain_index_info():
+    return get_index_info_from_pillow(DomainPillow(online=False))

--- a/corehq/pillows/domain.py
+++ b/corehq/pillows/domain.py
@@ -51,16 +51,20 @@ class DomainPillow(HQPillow):
             return doc_dict
 
     def change_transform(self, doc_dict):
-        doc_ret = copy.deepcopy(doc_dict)
-        sub = Subscription.objects.filter(subscriber__domain=doc_dict['name'], is_active=True)
-        doc_ret['deployment'] = doc_dict.get('deployment', None) or {}
-        countries = doc_ret['deployment'].get('countries', [])
-        doc_ret['deployment']['countries'] = []
-        if sub:
-            doc_ret['subscription'] = sub[0].plan_version.plan.edition
-        for country in countries:
-            doc_ret['deployment']['countries'].append(COUNTRIES[country].upper())
-        return doc_ret
+        return transform_domain_for_elasticsearch(doc_dict)
+
+
+def transform_domain_for_elasticsearch(doc_dict):
+    doc_ret = copy.deepcopy(doc_dict)
+    sub = Subscription.objects.filter(subscriber__domain=doc_dict['name'], is_active=True)
+    doc_ret['deployment'] = doc_dict.get('deployment', None) or {}
+    countries = doc_ret['deployment'].get('countries', [])
+    doc_ret['deployment']['countries'] = []
+    if sub:
+        doc_ret['subscription'] = sub[0].plan_version.plan.edition
+    for country in countries:
+        doc_ret['deployment']['countries'].append(COUNTRIES[country].upper())
+    return doc_ret
 
 
 def get_domain_reindexer():

--- a/docker/utils.sh
+++ b/docker/utils.sh
@@ -32,5 +32,5 @@ create_topics() {
 create_kafka_topics() {
     kafka_topics=$(docker_run kafka find /opt -name kafka-topics.sh | tr -d '\n' | tr -d '\r')
     zookeeper_ip=$(get_container_ip "commcare.name" "kafka")
-    create_topics $kafka_topics $zookeeper_ip "case form meta case-sql form-sql sms"
+    create_topics $kafka_topics $zookeeper_ip "case form meta case-sql form-sql sms domain"
 }

--- a/settings.py
+++ b/settings.py
@@ -1466,6 +1466,16 @@ PILLOWTOPS = {
             'class': 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow',
             'instance': 'corehq.apps.userreports.pillow.get_kafka_ucr_static_pillow',
         },
+        {
+            'name': 'SqlXFormToElasticsearchPillow',
+            'class': 'pillowtop.pillow.interface.ConstructedPillow',
+            'instance': 'corehq.pillows.xform.get_sql_xform_to_elasticsearch_pillow',
+        },
+        {
+            'name': 'SqlCaseToElasticsearchPillow',
+            'class': 'pillowtop.pillow.interface.ConstructedPillow',
+            'instance': 'corehq.pillows.case.get_sql_case_to_elasticsearch_pillow',
+        },
     ],
     'cache': [
         {
@@ -1512,16 +1522,6 @@ PILLOWTOPS = {
             'name': 'BlobDeletionPillow',
             'class': 'pillowtop.pillow.interface.ConstructedPillow',
             'instance': 'corehq.blobs.pillow.get_blob_deletion_pillow',
-        },
-        {
-            'name': 'SqlXFormToElasticsearchPillow',
-            'class': 'pillowtop.pillow.interface.ConstructedPillow',
-            'instance': 'corehq.pillows.xform.get_sql_xform_to_elasticsearch_pillow',
-        },
-        {
-            'name': 'SqlCaseToElasticsearchPillow',
-            'class': 'pillowtop.pillow.interface.ConstructedPillow',
-            'instance': 'corehq.pillows.case.get_sql_case_to_elasticsearch_pillow',
         },
     ]
 }

--- a/testapps/test_pillowtop/tests/test_domain_pillow.py
+++ b/testapps/test_pillowtop/tests/test_domain_pillow.py
@@ -1,14 +1,21 @@
 from django.test import TestCase
+from corehq.apps.change_feed import data_sources
+from corehq.apps.change_feed import document_types
+from corehq.apps.change_feed.document_types import get_doc_meta_object_from_document
+from corehq.apps.change_feed.producer import producer
+from corehq.apps.domain.models import Domain
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.domain.signals import commcare_domain_post_save
 from corehq.apps.domain.tests.test_utils import delete_all_domains
 from corehq.apps.es import DomainES
-from corehq.pillows.domain import DomainPillow
+from corehq.pillows.domain import DomainPillow, get_domain_kafka_to_elasticsearch_pillow
 from corehq.util.context_managers import drop_connected_signals
 from corehq.util.elastic import ensure_index_deleted
 from corehq.util.test_utils import trap_extra_setup
 from elasticsearch.exceptions import ConnectionError
 from pillowtop.es_utils import get_index_info_from_pillow, initialize_index
+from pillowtop.feed.interface import Change, ChangeMeta
+from testapps.test_pillowtop.utils import get_current_kafka_seq
 
 
 class DomainPillowTest(TestCase):
@@ -45,9 +52,46 @@ class DomainPillowTest(TestCase):
         # verify there
         self._verify_domain_in_es(domain_name)
 
+    def test_kafka_domain_pillow(self):
+        # make a domain
+        domain_name = 'domain-pillowtest-kafka'
+        with drop_connected_signals(commcare_domain_post_save):
+            domain = create_domain(domain_name)
+
+        # send to kafka
+        since = get_current_kafka_seq(document_types.DOMAIN)
+        producer.send_change(document_types.DOMAIN, domain_to_change(domain).metadata)
+
+        # send to elasticsearch
+        pillow = get_domain_kafka_to_elasticsearch_pillow()
+        pillow.process_changes(since={document_types.DOMAIN: since}, forever=False)
+        self.elasticsearch.indices.refresh(self.index_info.index)
+
+        # verify there
+        self._verify_domain_in_es(domain_name)
+
     def _verify_domain_in_es(self, domain_name):
         results = DomainES().run()
         self.assertEqual(1, results.total)
         domain_doc = results.hits[0]
         self.assertEqual(domain_name, domain_doc['name'])
         self.assertEqual('Domain', domain_doc['doc_type'])
+
+
+def domain_to_change(domain):
+    domain_doc = domain.to_json()
+    doc_info = get_doc_meta_object_from_document(domain_doc)
+    return Change(
+        id=domain_doc['_id'],
+        sequence_id='0',
+        document=domain_doc,
+        metadata=ChangeMeta(
+            document_id=domain_doc['_id'],
+            data_source_type=data_sources.COUCH,
+            data_source_name=Domain.get_db().dbname,
+            document_type=doc_info.raw_doc_type,
+            document_subtype=doc_info.subtype,
+            domain=domain_doc['name'],
+            is_deletion=False,
+        )
+    )

--- a/testapps/test_pillowtop/tests/test_domain_pillow.py
+++ b/testapps/test_pillowtop/tests/test_domain_pillow.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 from corehq.apps.change_feed import data_sources
 from corehq.apps.change_feed import document_types
-from corehq.apps.change_feed.document_types import get_doc_meta_object_from_document, change_meta_from_doc
+from corehq.apps.change_feed.document_types import change_meta_from_doc
 from corehq.apps.change_feed.producer import producer
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.shortcuts import create_domain
@@ -14,7 +14,6 @@ from corehq.util.elastic import ensure_index_deleted
 from corehq.util.test_utils import trap_extra_setup
 from elasticsearch.exceptions import ConnectionError
 from pillowtop.es_utils import get_index_info_from_pillow, initialize_index
-from pillowtop.feed.interface import Change, ChangeMeta
 from testapps.test_pillowtop.utils import get_current_kafka_seq
 
 

--- a/testapps/test_pillowtop/utils.py
+++ b/testapps/test_pillowtop/utils.py
@@ -28,4 +28,4 @@ def get_test_kafka_consumer(topic):
 def get_current_kafka_seq(topic):
     consumer = get_test_kafka_consumer(topic)
     # have to get the seq id before the change is processed
-    return consumer.offsets()['fetch'][(topic, 0)]
+    return consumer.offsets()['fetch'].get((topic, 0), 0)


### PR DESCRIPTION
This adds code and tests for (though doesn't hook up) a kafka-based domain ES pillow.

It also attempts to standardize/centralize some of our document type --> metadata logic, adds deletion support for kafka-based elasticsearch pillows, and makes a few small tweaks and fixes.

:fish: or :office: wait for tests.
