### PR TITLE
publish changes from domain db to kafka

### DIFF
--- a/corehq/apps/change_feed/pillow.py
+++ b/corehq/apps/change_feed/pillow.py
@@ -72,18 +72,18 @@ class ChangeFeedPillow(PythonPillow):
 
 
 def get_default_couch_db_change_feed_pillow(pillow_id):
-    return _get_change_feed_pillow_for_db(pillow_id, CommCareCase.get_db())
+    return get_change_feed_pillow_for_db(pillow_id, CommCareCase.get_db())
 
 
 def get_user_groups_db_kafka_pillow(pillow_id):
-    return _get_change_feed_pillow_for_db(pillow_id, couch_config.get_db_for_class(CommCareUser))
+    return get_change_feed_pillow_for_db(pillow_id, couch_config.get_db_for_class(CommCareUser))
 
 
 def get_domain_db_kafka_pillow(pillow_id):
-    return _get_change_feed_pillow_for_db(pillow_id, couch_config.get_db_for_class(Domain))
+    return get_change_feed_pillow_for_db(pillow_id, couch_config.get_db_for_class(Domain))
 
 
-def _get_change_feed_pillow_for_db(pillow_id, couch_db):
+def get_change_feed_pillow_for_db(pillow_id, couch_db):
     kafka_client = get_kafka_client_or_none()
     processor = KafkaProcessor(
         kafka_client, data_source_type=data_sources.COUCH, data_source_name=couch_db.dbname

--- a/corehq/apps/change_feed/pillow.py
+++ b/corehq/apps/change_feed/pillow.py
@@ -83,16 +83,20 @@ def get_user_groups_db_kafka_pillow(pillow_id):
     # note: this is temporarily using ConstructedPillow as a test. If it is successful we should
     # flip the main one over as well
     user_groups_couch_db = couch_config.get_db_for_class(CommCareUser)
+    return _get_change_feed_pillow_for_db(pillow_id, user_groups_couch_db)
+
+
+def _get_change_feed_pillow_for_db(pillow_id, couch_db):
     kafka_client = get_kafka_client_or_none()
     processor = KafkaProcessor(
-        kafka_client, data_source_type=data_sources.COUCH, data_source_name=user_groups_couch_db.dbname
+        kafka_client, data_source_type=data_sources.COUCH, data_source_name=couch_db.dbname
     )
     checkpoint = PillowCheckpoint(pillow_id)
     return ConstructedPillow(
         name=pillow_id,
         document_store=None,  # because we're using include_docs we can be explicit about not using this
         checkpoint=checkpoint,
-        change_feed=CouchChangeFeed(user_groups_couch_db, include_docs=True),
+        change_feed=CouchChangeFeed(couch_db, include_docs=True),
         processor=processor,
         change_processed_event_handler=PillowCheckpointEventHandler(
             checkpoint=checkpoint, checkpoint_frequency=100,

--- a/corehq/apps/change_feed/pillow.py
+++ b/corehq/apps/change_feed/pillow.py
@@ -46,31 +46,6 @@ class KafkaProcessor(PillowProcessor):
             self._producer.send_change(get_topic(doc_meta), change_meta)
 
 
-class ChangeFeedPillow(PythonPillow):
-    """
-    This pillow takes changes from a CouchDB and republishes them to Kafka.
-    It is used as an intermediary to convert couch-based change listeners
-    to kafka-based ones.
-    """
-
-    def __init__(self, pillow_id, couch_db, kafka, checkpoint):
-        super(ChangeFeedPillow, self).__init__(couch_db=couch_db, checkpoint=checkpoint, chunk_size=10)
-        self._pillow_id = pillow_id
-        self._processor = KafkaProcessor(
-            kafka, data_source_type=data_sources.COUCH, data_source_name=self.get_db_name()
-        )
-
-    @property
-    def pillow_id(self):
-        return self._pillow_id
-
-    def get_db_name(self):
-        return self.get_couch_db().dbname
-
-    def process_change(self, change, is_retry_attempt=False):
-        self._processor.process_change(self, change)
-
-
 def get_default_couch_db_change_feed_pillow(pillow_id):
     return get_change_feed_pillow_for_db(pillow_id, CommCareCase.get_db())
 

--- a/corehq/apps/change_feed/pillow.py
+++ b/corehq/apps/change_feed/pillow.py
@@ -40,6 +40,8 @@ class KafkaProcessor(PillowProcessor):
         except MissingMetaInformationError:
             pass
         else:
+            # change.deleted is used for hard deletions, from which we don't currently
+            # get any metadata from so this should have raised a MissingMetaInformationError above
             assert not change.deleted
             self._producer.send_change(get_topic(doc_meta), change_meta)
 

--- a/corehq/apps/change_feed/pillow.py
+++ b/corehq/apps/change_feed/pillow.py
@@ -70,19 +70,10 @@ class ChangeFeedPillow(PythonPillow):
 
 
 def get_default_couch_db_change_feed_pillow(pillow_id):
-    default_couch_db = CachedCouchDB(CommCareCase.get_db().uri, readonly=False)
-    kafka_client = get_kafka_client_or_none()
-    return ChangeFeedPillow(
-        pillow_id=pillow_id,
-        couch_db=default_couch_db,
-        kafka=kafka_client,
-        checkpoint=PillowCheckpoint('default-couch-change-feed')
-    )
+    return _get_change_feed_pillow_for_db(pillow_id, CommCareCase.get_db())
 
 
 def get_user_groups_db_kafka_pillow(pillow_id):
-    # note: this is temporarily using ConstructedPillow as a test. If it is successful we should
-    # flip the main one over as well
     return _get_change_feed_pillow_for_db(pillow_id, couch_config.get_db_for_class(CommCareUser))
 
 

--- a/corehq/apps/change_feed/pillow.py
+++ b/corehq/apps/change_feed/pillow.py
@@ -6,6 +6,7 @@ from corehq.apps.change_feed.document_types import get_doc_meta_object_from_docu
 from corehq.apps.change_feed.exceptions import MissingMetaInformationError
 from corehq.apps.change_feed.producer import ChangeProducer
 from corehq.apps.change_feed.topics import get_topic
+from corehq.apps.domain.models import Domain
 from corehq.apps.users.models import CommCareUser
 from corehq.util.couchdb_management import couch_config
 from pillowtop.checkpoints.manager import PillowCheckpoint, PillowCheckpointEventHandler
@@ -82,8 +83,11 @@ def get_default_couch_db_change_feed_pillow(pillow_id):
 def get_user_groups_db_kafka_pillow(pillow_id):
     # note: this is temporarily using ConstructedPillow as a test. If it is successful we should
     # flip the main one over as well
-    user_groups_couch_db = couch_config.get_db_for_class(CommCareUser)
-    return _get_change_feed_pillow_for_db(pillow_id, user_groups_couch_db)
+    return _get_change_feed_pillow_for_db(pillow_id, couch_config.get_db_for_class(CommCareUser))
+
+
+def get_domain_db_kafka_pillow(pillow_id):
+    return _get_change_feed_pillow_for_db(pillow_id, couch_config.get_db_for_class(Domain))
 
 
 def _get_change_feed_pillow_for_db(pillow_id, couch_db):

--- a/corehq/apps/change_feed/tests/test_pillow.py
+++ b/corehq/apps/change_feed/tests/test_pillow.py
@@ -5,9 +5,8 @@ from fakecouch import FakeCouchDb
 from kafka import KafkaConsumer
 from kafka.common import ConsumerTimeout, KafkaUnavailableError
 from corehq.apps.change_feed import topics
-from corehq.apps.change_feed.connection import get_kafka_client
 from corehq.apps.change_feed.consumer.feed import change_meta_from_kafka_message
-from corehq.apps.change_feed.pillow import ChangeFeedPillow
+from corehq.apps.change_feed.pillow import get_change_feed_pillow_for_db
 from corehq.apps.change_feed.data_sources import COUCH
 from corehq.util.test_utils import trap_extra_setup
 from pillowtop.feed.interface import Change
@@ -26,9 +25,7 @@ class ChangeFeedPillowTest(SimpleTestCase):
                 bootstrap_servers=[settings.KAFKA_URL],
                 consumer_timeout_ms=100,
             )
-        self.pillow = ChangeFeedPillow(
-            'fake-changefeed-pillow-id', self._fake_couch, kafka=get_kafka_client(), checkpoint=None
-        )
+        self.pillow = get_change_feed_pillow_for_db('fake-changefeed-pillow-id', self._fake_couch)
 
     def test_process_change(self):
         document = {
@@ -36,7 +33,7 @@ class ChangeFeedPillowTest(SimpleTestCase):
             'type': 'mother',
             'domain': 'kafka-test-domain',
         }
-        self.pillow.process_change(Change(id='test-id', sequence_id='3', document=document))
+        self.pillow.processor(Change(id='test-id', sequence_id='3', document=document))
         message = self.consumer.next()
 
         change_meta = change_meta_from_kafka_message(message.value)
@@ -57,7 +54,7 @@ class ChangeFeedPillowTest(SimpleTestCase):
             'type': 'mother',
             'domain': u'हिंदी',
         }
-        self.pillow.process_change(Change(id='test-id', sequence_id='3', document=document))
+        self.pillow.processor(Change(id='test-id', sequence_id='3', document=document))
         message = self.consumer.next()
         change_meta = change_meta_from_kafka_message(message.value)
         self.assertEqual(document['domain'], change_meta.domain)
@@ -68,7 +65,7 @@ class ChangeFeedPillowTest(SimpleTestCase):
             'type': 'mother',
             'domain': None,
         }
-        self.pillow.process_change(Change(id='test-id', sequence_id='3', document=document))
+        self.pillow.processor(Change(id='test-id', sequence_id='3', document=document))
         message = self.consumer.next()
         change_meta = change_meta_from_kafka_message(message.value)
         self.assertEqual(document['domain'], change_meta.domain)

--- a/corehq/apps/cleanup/migrations/0010_rename_default_change_feed_checkpoint.py
+++ b/corehq/apps/cleanup/migrations/0010_rename_default_change_feed_checkpoint.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from corehq.sql_db.operations import HqRunPython
+
+
+def copy_checkpoint(apps, schema_editor):
+    DjangoPillowCheckpoint = apps.get_model('pillowtop', 'DjangoPillowCheckpoint')
+    try:
+        checkpoint = DjangoPillowCheckpoint.objects.get(checkpoint_id='default-couch-change-feed')
+        # since checkpoint_id is the primary key, this should make a new model
+        # which is good in case we need to rollback
+        checkpoint.checkpoint_id = 'DefaultChangeFeedPillow'
+        checkpoint.save()
+    except DjangoPillowCheckpoint.DoesNotExist:
+        pass
+
+
+def delete_checkpoint(apps, schema_editor):
+    DjangoPillowCheckpoint = apps.get_model('pillowtop', 'DjangoPillowCheckpoint')
+    try:
+        checkpoint = DjangoPillowCheckpoint.objects.get(checkpoint_id='DefaultChangeFeedPillow')
+        checkpoint.delete()
+    except DjangoPillowCheckpoint.DoesNotExist:
+        pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cleanup', '0009_convert_final_checkpoints_to_sql'),
+        ('pillowtop', '0002_djangopillowcheckpoint_sequence_format'),
+    ]
+
+    operations = [
+        HqRunPython(copy_checkpoint, delete_checkpoint)
+    ]

--- a/corehq/ex-submodules/pillowtop/feed/interface.py
+++ b/corehq/ex-submodules/pillowtop/feed/interface.py
@@ -8,7 +8,7 @@ class ChangeMeta(jsonobject.JsonObject):
     """
     Metadata about a change. If available, this will be set on Change.metadata.
 
-    This is currently only used in kafka-based pillows.
+    This is only used in kafka-based pillows.
     """
     document_id = jsonobject.StringProperty(required=True)
     data_source_type = jsonobject.StringProperty(required=True)
@@ -36,6 +36,9 @@ class Change(object):
         self.id = id
         self.sequence_id = sequence_id
         self.document = document
+        # on couch-based change feeds .deleted represents a hard deletion.
+        # on kafka-based feeds, .deleted represents a soft deletion and is equivalent
+        # to change.metadata.is_deletion.
         self.deleted = deleted
         self.metadata = metadata
         self.document_store = document_store

--- a/corehq/pillows/mappings/domain_mapping.py
+++ b/corehq/pillows/mappings/domain_mapping.py
@@ -1,4 +1,5 @@
 from corehq.util.elastic import es_index
+from pillowtop.es_utils import ElasticsearchIndexInfo
 
 DOMAIN_INDEX = es_index("hqdomains_20160318_1339")
 DOMAIN_MAPPING = {'_meta': {'comment': 'j$ modified on 2016/03/18',
@@ -254,3 +255,31 @@ DOMAIN_MAPPING = {'_meta': {'comment': 'j$ modified on 2016/03/18',
                                                'type': 'string'}},
                           'type': 'multi_field'},
                 'yt_id': {'type': 'string'}}}
+
+
+DOMAIN_META = {
+    "settings": {
+        "analysis": {
+            "analyzer": {
+                "default": {
+                    "type": "custom",
+                    "tokenizer": "whitespace",
+                    "filter": ["lowercase"]
+                },
+                "comma": {
+                    "type": "pattern",
+                    "pattern": "\s*,\s*"
+                },
+            }
+        }
+    }
+}
+
+
+DOMAIN_INDEX_INFO = ElasticsearchIndexInfo(
+    index=DOMAIN_INDEX,
+    alias='hqdomains',
+    type='hqdomain',
+    meta=DOMAIN_META,
+    mapping=DOMAIN_MAPPING,
+)

--- a/docs/change_feeds.rst
+++ b/docs/change_feeds.rst
@@ -60,7 +60,8 @@ From Couch
 
 Publishing changes from couch is easy since couch already has a great change feed implementation with the ``_changes`` API.
 For any database that you want to publish changes from the steps are very simple.
-Just create an instance of a ``ChangeFeedPillow`` pointed at the database you wish to publish from.
+Just create a ``ConstructedPillow`` with a ``CouchChangeFeed`` feed pointed at the database you wish to publish from and a ``KafkaProcessor`` to publish the changes.
+There is a utility function (``get_change_feed_pillow_for_db``) which creates this pillow object for you.
 
 
 From SQL

--- a/settings.py
+++ b/settings.py
@@ -1448,7 +1448,7 @@ PILLOWTOPS = {
         'corehq.pillows.reportxform.ReportXFormPillow',
         {
             'name': 'DefaultChangeFeedPillow',
-            'class': 'corehq.apps.change_feed.pillow.ChangeFeedPillow',
+            'class': 'pillowtop.pillow.interface.ConstructedPillow',
             'instance': 'corehq.apps.change_feed.pillow.get_default_couch_db_change_feed_pillow',
         },
         {

--- a/settings.py
+++ b/settings.py
@@ -1457,6 +1457,11 @@ PILLOWTOPS = {
             'instance': 'corehq.apps.change_feed.pillow.get_user_groups_db_kafka_pillow',
         },
         {
+            'name': 'DomainDbKafkaPillow',
+            'class': 'pillowtop.pillow.interface.ConstructedPillow',
+            'instance': 'corehq.apps.change_feed.pillow.get_domain_db_kafka_pillow',
+        },
+        {
             'name': 'kafka-ucr-main',
             'class': 'corehq.apps.userreports.pillow.ConfigurableReportKafkaPillow',
             'instance': 'corehq.apps.userreports.pillow.get_kafka_ucr_pillow',

--- a/testapps/test_elasticsearch/tests/test_prod_es_indices.py
+++ b/testapps/test_elasticsearch/tests/test_prod_es_indices.py
@@ -1,6 +1,8 @@
 from django.conf import settings
 from django.test import SimpleTestCase
-from pillowtop.es_utils import get_all_expected_es_indices
+from corehq.pillows.domain import DomainPillow
+from corehq.pillows.mappings.domain_mapping import DOMAIN_INDEX_INFO
+from pillowtop.es_utils import get_all_expected_es_indices, get_index_info_from_pillow
 
 
 class ProdIndexManagementTest(SimpleTestCase):
@@ -25,6 +27,10 @@ class ProdIndexManagementTest(SimpleTestCase):
             del info['mapping']
         found_prod_indices = sorted(found_prod_indices, key=lambda info: info['index'])
         self.assertEqual(EXPECTED_PROD_INDICES, found_prod_indices)
+
+    def test_domain_index_info(self):
+        self.assertEqual(DOMAIN_INDEX_INFO.to_json(),
+                         get_index_info_from_pillow(DomainPillow(online=False)).to_json())
 
 
 EXPECTED_PROD_INDICES = [

--- a/testapps/test_pillowtop/tests/data/all-pillow-meta.json
+++ b/testapps/test_pillowtop/tests/data/all-pillow-meta.json
@@ -479,19 +479,19 @@
         "name": "SMSPillow",
         "unique_id": "708c77f8e5fe00286fa5791e9fa7d45f"
     },
-    "SqlSMSPillow": {
-        "advertised_name": "SqlSMSPillow",
-        "change_feed_type": "KafkaChangeFeed",
-        "checkpoint_id": "sql-sms-to-es",
-        "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
-        "name": "SqlSMSPillow"
-    },
     "SqlCaseToElasticsearchPillow": {
         "advertised_name": "SqlCaseToElasticsearchPillow",
         "change_feed_type": "KafkaChangeFeed",
         "checkpoint_id": "sql-cases-to-elasticsearch",
         "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
         "name": "SqlCaseToElasticsearchPillow"
+    },
+    "SqlSMSPillow": {
+        "advertised_name": "SqlSMSPillow",
+        "change_feed_type": "KafkaChangeFeed",
+        "checkpoint_id": "sql-sms-to-es",
+        "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
+        "name": "SqlSMSPillow"
     },
     "SqlXFormToElasticsearchPillow": {
         "advertised_name": "SqlXFormToElasticsearchPillow",

--- a/testapps/test_pillowtop/tests/data/all-pillow-meta.json
+++ b/testapps/test_pillowtop/tests/data/all-pillow-meta.json
@@ -131,16 +131,10 @@
         "name": "CouvertureFluffPillow"
     },
     "DefaultChangeFeedPillow": {
-        "advertised_name": "corehq.apps.change_feed.pillow.ChangeFeedPillow.testhq",
+        "advertised_name": "DefaultChangeFeedPillow",
         "change_feed_type": "CouchChangeFeed",
-        "checkpoint_id": "default-couch-change-feed",
-        "couch_filter": null,
-        "couchdb_type": "CachedCouchDB",
-        "couchdb_uri": "http://{COUCH_SERVER_ROOT}/test_commcarehq",
-        "document_class": null,
-        "extra_args": {},
-        "full_class_name": "corehq.apps.change_feed.pillow.ChangeFeedPillow",
-        "include_docs": false,
+        "checkpoint_id": "DefaultChangeFeedPillow",
+        "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
         "name": "DefaultChangeFeedPillow"
     },
     "DomainDbKafkaPillow": {

--- a/testapps/test_pillowtop/tests/data/all-pillow-meta.json
+++ b/testapps/test_pillowtop/tests/data/all-pillow-meta.json
@@ -143,6 +143,13 @@
         "include_docs": false,
         "name": "DefaultChangeFeedPillow"
     },
+    "DomainDbKafkaPillow": {
+        "advertised_name": "DomainDbKafkaPillow",
+        "change_feed_type": "CouchChangeFeed",
+        "checkpoint_id": "DomainDbKafkaPillow",
+        "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
+        "name": "DomainDbKafkaPillow"
+    },
     "DomainPillow": {
         "advertised_name": "corehq.pillows.domain.DomainPillow.test_hqdomains_20160318_1339.testhq",
         "change_feed_type": "CouchChangeFeed",


### PR DESCRIPTION
also fully replaces `ChangeFeedPillow` with the constructed version which seems to be working fine.

:fish: or :office: 

@snopoke / @nickpell 
