### PR TITLE
Only update column if it exists

### DIFF
--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -86,8 +86,9 @@ def convert_saved_export_to_export_instance(domain, saved_export):
                     'ExportItem',
                     None,
                 )
-                new_column.selected = True
-                new_column.label = column.display
+                if new_column:
+                    new_column.selected = True
+                    new_column.label = column.display
                 continue
 
             if column.transform:


### PR DESCRIPTION
@NoahCarnahan since in the old version you can add stock to both case and form exports and in the new version you can only add it to case exports, we need to make this conditional in the conversion process

@sravfeyn 
