### PR TITLE
Report builder: activate/deactivate data sources on subscription change

### DIFF
--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -20,6 +20,7 @@ from corehq.apps.fixtures.models import FixtureDataType
 from corehq.apps.hqmedia.models import HQMediaMixin
 from corehq.apps.reminders.models import METHOD_SMS_SURVEY, METHOD_IVR_SURVEY
 from corehq.apps.users.models import CommCareUser, UserRole
+from corehq.apps.userreports.exceptions import DataSourceConfigurationNotFoundError
 from corehq.const import USER_DATE_FORMAT
 
 
@@ -80,7 +81,8 @@ class DomainDowngradeActionHandler(BaseModifySubscriptionActionHandler):
             privileges.ROLE_BASED_ACCESS: cls.response_role_based_access,
             privileges.DATA_CLEANUP: cls.response_data_cleanup,
             privileges.COMMCARE_LOGO_UPLOADER: cls.response_commcare_logo_uploader,
-            privileges.ADVANCED_DOMAIN_SECURITY: cls.response_domain_security
+            privileges.ADVANCED_DOMAIN_SECURITY: cls.response_domain_security,
+            privileges.REPORT_BUILDER: cls.response_report_builder,
         }
 
     @staticmethod
@@ -191,6 +193,21 @@ class DomainDowngradeActionHandler(BaseModifySubscriptionActionHandler):
             domain.secure_sessions = False
             domain.save()
 
+    @staticmethod
+    def response_report_builder(project):
+        from corehq.apps.userreports.models import ReportConfiguration
+        reports = ReportConfiguration.by_domain(project.name)
+        builder_reports = filter(lambda report: report.report_meta.created_by_builder, reports)
+        for report in builder_reports:
+            try:
+                report.config.deactivate()
+                # It's theoretically possible that someone could have a
+                # hand-built report based on one of these data sources,
+                # in which case they will be sad.
+            except DataSourceConfigurationNotFoundError:
+                pass
+        return True
+
 
 class DomainUpgradeActionHandler(BaseModifySubscriptionActionHandler):
     """
@@ -205,6 +222,7 @@ class DomainUpgradeActionHandler(BaseModifySubscriptionActionHandler):
         return {
             privileges.ROLE_BASED_ACCESS: cls.response_role_based_access,
             privileges.COMMCARE_LOGO_UPLOADER: cls.response_commcare_logo_uploader,
+            privileges.REPORT_BUILDER: cls.response_report_builder,
         }
 
     @staticmethod
@@ -234,6 +252,21 @@ class DomainUpgradeActionHandler(BaseModifySubscriptionActionHandler):
             )
             return False
 
+    @staticmethod
+    def response_report_builder(project):
+        from corehq.apps.userreports.models import ReportConfiguration
+        from corehq.apps.userreports.tasks import rebuild_indicators
+        reports = ReportConfiguration.by_domain(project.name)
+        builder_reports = filter(lambda report: report.report_meta.created_by_builder, reports)
+        for report in builder_reports:
+            try:
+                if report.config.is_deactivated:
+                    report.config.is_deactivated = False
+                    report.config.save()
+                    rebuild_indicators.delay(report.config._id)
+            except DataSourceConfigurationNotFoundError:
+                pass
+        return True
 
 # TODO - cache
 def _active_reminder_methods(domain):

--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -195,6 +195,7 @@ class DomainDowngradeActionHandler(BaseModifySubscriptionActionHandler):
 
     @staticmethod
     def response_report_builder(project):
+        # TODO: Should we be limiting access to the existing reports too? I think yes. Does that already happen?
         from corehq.apps.userreports.models import ReportConfiguration
         reports = ReportConfiguration.by_domain(project.name)
         builder_reports = filter(lambda report: report.report_meta.created_by_builder, reports)
@@ -292,6 +293,7 @@ class DomainDowngradeStatusHandler(BaseModifySubscriptionHandler):
 
     @classmethod
     def privilege_to_response_function(cls):
+        # TODO: Probably need to add something here too
         return {
             privileges.CLOUDCARE: cls.response_cloudcare,
             privileges.LOOKUP_TABLES: cls.response_lookup_tables,

--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -202,9 +202,6 @@ class DomainDowngradeActionHandler(BaseModifySubscriptionActionHandler):
         for report in builder_reports:
             try:
                 report.config.deactivate()
-                # It's theoretically possible that someone could have a
-                # hand-built report based on one of these data sources,
-                # in which case they will be sad.
             except DataSourceConfigurationNotFoundError:
                 pass
         return True

--- a/corehq/apps/accounting/tests/test_subscription_permissions_changes.py
+++ b/corehq/apps/accounting/tests/test_subscription_permissions_changes.py
@@ -6,6 +6,8 @@ from corehq.apps.accounting.models import BillingAccount, DefaultProductPlan, \
 from corehq.apps.accounting.tests import BaseAccountingTest
 from corehq.apps.app_manager.models import Application
 from corehq.apps.domain.models import Domain
+from corehq.apps.userreports.models import DataSourceConfiguration, \
+    ReportConfiguration, ReportMeta, get_datasource_config
 
 
 class TestSubscriptionPermissionsChanges(BaseAccountingTest):
@@ -27,14 +29,19 @@ class TestSubscriptionPermissionsChanges(BaseAccountingTest):
         self.advanced_plan = DefaultProductPlan.get_default_plan_by_domain(
             self.domain.name, edition=SoftwarePlanEdition.ADVANCED)
 
+    def _subscribe_to_advanced(self):
+        return Subscription.new_domain_subscription(
+            self.account, self.domain.name, self.advanced_plan,
+            web_user=self.admin_user.username
+        )
+
+
     def test_app_icon_permissions(self):
         LOGO_HOME = u'hq_logo_android_home'
         LOGO_LOGIN = u'hq_logo_android_login'
 
-        advanced_sub = Subscription.new_domain_subscription(
-            self.account, self.domain.name, self.advanced_plan,
-            web_user=self.admin_user.username
-        )
+        advanced_sub = self._subscribe_to_advanced()
+
         with open(os.path.join(os.path.dirname(__file__), 'data', 'app-commcare-icon-standard.json')) as f:
             standard_source = json.load(f)
         with open(os.path.join(os.path.dirname(__file__), 'data', 'app-commcare-icon-build.json')) as f:
@@ -63,10 +70,7 @@ class TestSubscriptionPermissionsChanges(BaseAccountingTest):
         self.assertFalse(LOGO_HOME in app_build.logo_refs.keys())
         self.assertFalse(LOGO_LOGIN in app_build.logo_refs.keys())
 
-        Subscription.new_domain_subscription(
-            self.account, self.domain.name, self.advanced_plan,
-            web_user=self.admin_user.username
-        )
+        self._subscribe_to_advanced()
 
         app_standard = Application.get(app_standard._id)
         app_build = Application.get(app_build._id)
@@ -75,6 +79,62 @@ class TestSubscriptionPermissionsChanges(BaseAccountingTest):
         self.assertTrue(LOGO_LOGIN in app_standard.logo_refs.keys())
         self.assertTrue(LOGO_HOME in app_build.logo_refs.keys())
         self.assertTrue(LOGO_LOGIN in app_build.logo_refs.keys())
+
+    def test_report_builder_datasource_deactivation(self):
+
+        def _get_data_source(id_):
+            return get_datasource_config(id_, self.domain.name)[0]
+
+        # Upgrade the domain
+        advanced_sub = self._subscribe_to_advanced()
+
+        # Create reports and data sources
+        builder_report_data_source = DataSourceConfiguration(
+            domain=self.domain.name,
+            is_deactivated=False,
+            referenced_doc_type="XFormInstance",
+            table_id="foo",
+
+        )
+        other_data_source = DataSourceConfiguration(
+            domain=self.domain.name,
+            is_deactivated=False,
+            referenced_doc_type="XFormInstance",
+            table_id="bar",
+        )
+        builder_report_data_source.save()
+        other_data_source.save()
+        report_builder_report = ReportConfiguration(
+            domain=self.domain.name,
+            config_id=builder_report_data_source._id,
+            report_meta=ReportMeta(created_by_builder=True),
+        )
+        report_builder_report.save()
+
+        # downgrade the domain
+        advanced_sub.cancel_subscription(web_user=self.admin_user.username)
+
+        # Check that the builder data source is deactivated
+        builder_report_data_source = _get_data_source(builder_report_data_source._id)
+        self.assertTrue(builder_report_data_source.is_deactivated)
+        # Check that the other data source is not deactivate
+        other_data_source = _get_data_source(other_data_source._id)
+        self.assertFalse(other_data_source.is_deactivated)
+
+        # upgrade the domain
+        advanced_sub = self._subscribe_to_advanced()
+
+        # check that the data source is activated
+        builder_report_data_source = _get_data_source(builder_report_data_source._id)
+        self.assertFalse(builder_report_data_source.is_deactivated)
+
+        # delete the data sources
+        builder_report_data_source.delete()
+        other_data_source.delete()
+        report_builder_report.delete()
+
+        # reset the subscription
+        advanced_sub.cancel_subscription(web_user=self.admin_user.username)
 
     def tearDown(self):
         self.domain.delete()

--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -319,6 +319,7 @@ class ReportConfiguration(UnicodeMixIn, QuickCachedDocumentMixin, Document):
     def __unicode__(self):
         return u'{} - {}'.format(self.domain, self.title)
 
+
     @property
     @memoized
     def config(self):


### PR DESCRIPTION
https://trello.com/c/h2TVDNMe/20-disable-data-sources-on-downgrade-deletion-of-reports

When a domain loses report builder access, deactivate its report builder data sources. (deactivate means sql tables are deleted, but configuration document stays).
When a domain gets report builder access, reactivate its report builder data sources.

@nickpell cc @esoergel 
