### PR TITLE
Cleanup product credit

### DIFF
--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -750,7 +750,6 @@ class CreditForm(forms.Form):
         ),
         required=False,
     )
-    product_type = forms.ChoiceField(required=False, label=ugettext_lazy("Product Type"))
     feature_type = forms.ChoiceField(required=False, label=ugettext_lazy("Feature Type"))
     adjust = forms.CharField(widget=forms.HiddenInput, required=False)
 
@@ -761,7 +760,6 @@ class CreditForm(forms.Form):
 
         product_choices = [('', 'Any')]
         product_choices.extend(SoftwareProductType.CHOICES)
-        self.fields['product_type'].choices = product_choices
         self.fields['feature_type'].choices = FeatureType.CHOICES
 
         self.helper = FormHelper()
@@ -773,7 +771,6 @@ class CreditForm(forms.Form):
                 'amount',
                 'note',
                 crispy.Field('rate_type', data_bind="value: rateType"),
-                crispy.Div('product_type', data_bind="visible: showProduct"),
                 crispy.Div('feature_type', data_bind="visible: showFeature"),
                 'adjust'
             ),
@@ -804,7 +801,7 @@ class CreditForm(forms.Form):
     def adjust_credit(self, web_user=None):
         amount = self.cleaned_data['amount']
         note = self.cleaned_data['note']
-        product_type = (self.cleaned_data['product_type']
+        product_type = (SoftwareProductType.ANY
                         if self.cleaned_data['rate_type'] == 'Product' else None)
         feature_type = (self.cleaned_data['feature_type']
                         if self.cleaned_data['rate_type'] == 'Feature' else None)

--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -21,6 +21,7 @@ from corehq.apps.accounting.models import (
     SoftwarePlanEdition, CreditLine,
     EntryPoint, WireInvoice, WireBillingRecord,
     SMALL_INVOICE_THRESHOLD, UNLIMITED_FEATURE_USAGE,
+    SoftwareProductType
 )
 from corehq.apps.accounting.utils import (
     ensure_domain_instance,
@@ -451,7 +452,7 @@ class ProductLineItemFactory(LineItemFactory):
         CreditLine.add_credit(
             line_item.subtotal,
             subscription=self.subscription,
-            product_type=self.rate.product.product_type,
+            product_type=SoftwareProductType.ANY,
             permit_inactive=True,
         )
 

--- a/corehq/apps/accounting/migrations/0023__simplify__credit_line__product_type.py
+++ b/corehq/apps/accounting/migrations/0023__simplify__credit_line__product_type.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+from datetime import date
+
+from django.db import models, migrations
+from django.db.models import F, Q
+
+from corehq.sql_db.operations import HqRunPython
+
+
+def confirm_no_mismatched_subscription_credit(apps, schema_editor):
+    if apps.get_model('accounting', 'CreditLine').objects.filter(
+        product_type__isnull=False,
+        subscription__isnull=False,
+    ).exclude(
+        product_type=F('subscription__plan_version__product_rate__product__product_type'),
+    ).exclude(
+        balance=0,
+    ).exists():
+        raise Exception("""
+
+Running this migration will make previously inaccessible subscription credit usable.
+
+For production environments, reconcile credit lines on a case by case basis.
+
+For dev environments, simply delete problematic credit lines:
+
+from django.db.models import F
+from corehq.apps.accounting.models import CreditAdjustment, CreditLine
+problematic_credit_lines = CreditLine.objects.filter(
+    product_type__isnull=False,
+    subscription__isnull=False,
+).exclude(
+    product_type=F('subscription__plan_version__product_rate__product__product_type'),
+).exclude(
+    balance=0,
+)
+CreditAdjustment.objects.filter(credit_line__in=problematic_credit_lines).delete()
+CreditAdjustment.objects.filter(related_credit__in=problematic_credit_lines).delete()
+problematic_credit_lines.delete()
+            """
+        )
+
+
+def confirm_no_mismatched_account_credit_can_be_invoiced_automatically(apps, schema_editor):
+    previous_invoicing_date = date(date.today().year, date.today().month, 1)
+    subscriptions_in_future_invoicing_periods = apps.get_model('accounting', 'Subscription').objects.exclude(
+        date_end__lte=previous_invoicing_date,
+    )
+    if filter(
+        lambda sub: apps.get_model('accounting', 'CreditLine').objects.filter(
+            account=sub.account,
+            product_type__isnull=False,
+        ).exclude(
+            Q(product_type='') | Q(product_type=sub.plan_version.product_rate.product.product_type)
+        ).exclude(
+            balance=0
+        ).exists(),
+        subscriptions_in_future_invoicing_periods
+    ):
+        raise Exception("""
+
+Running this migration may allow subscriptions in future invoicing periods access to
+product credit not originally allocated to the subscription's product type.
+
+For production environments, reconcile credit lines on a case by case basis.
+
+For dev environments, simply delete problematic credit lines:
+
+from datetime import date
+from django.db.models import Q
+from corehq.apps.accounting.models import CreditAdjustment, CreditLine, Subscription
+previous_invoicing_date = date(date.today().year, date.today().month, 1)
+subscriptions_in_future_invoicing_periods = Subscription.objects.exclude(
+    date_end__lte=previous_invoicing_date,
+)
+for subscription in subscriptions_in_future_invoicing_periods:
+    problematic_credit_lines = CreditLine.objects.filter(
+        account=subscription.account,
+        product_type__isnull=False,
+    ).exclude(
+        Q(product_type='') | Q(product_type=subscription.plan_version.product_rate.product.product_type)
+    ).exclude(
+        balance=0
+    )
+    CreditAdjustment.objects.filter(credit_line__in=problematic_credit_lines).delete()
+    CreditAdjustment.objects.filter(related_credit__in=problematic_credit_lines).delete()
+    problematic_credit_lines.delete()
+            """
+        )
+
+
+def set_credit_line_product_types_to_any(apps, schema_editor):
+    apps.get_model('accounting', 'CreditLine').objects.filter(
+        product_type__isnull=False,
+    ).exclude(
+        product_type=''
+    ).update(product_type='')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounting', '0022_bootstrap_prbac_roles'),
+    ]
+
+    operations = [
+        HqRunPython(confirm_no_mismatched_subscription_credit),
+        HqRunPython(confirm_no_mismatched_account_credit_can_be_invoiced_automatically),
+        HqRunPython(set_credit_line_product_types_to_any),
+        migrations.AlterField(
+            model_name='creditline',
+            name='product_type',
+            field=models.CharField(blank=True, max_length=25, null=True, choices=[(b'', b'')]),
+            preserve_default=True,
+        ),
+    ]

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -2567,7 +2567,7 @@ class CreditLine(models.Model):
     account = models.ForeignKey(BillingAccount, on_delete=models.PROTECT)
     subscription = models.ForeignKey(Subscription, on_delete=models.PROTECT, null=True, blank=True)
     product_type = models.CharField(max_length=25, null=True, blank=True,
-                                    choices=SoftwareProductType.CHOICES)
+                                    choices=((SoftwareProductType.ANY, SoftwareProductType.ANY),))
     feature_type = models.CharField(max_length=10, null=True,
                                     choices=FeatureType.CHOICES)
     date_created = models.DateTimeField(auto_now_add=True)

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -2250,16 +2250,15 @@ class BillingRecord(BillingRecordBase):
         return credits
 
     def _add_product_credits(self, credits):
-        product_type = self.invoice.subscription.plan_version.core_product
         credit_adjustments = CreditAdjustment.objects.filter(
             invoice=self.invoice,
-            line_item__product_rate__product__product_type=product_type,
+            line_item__product_rate__product__product_type__isnull=False,
         )
 
         subscription_credits = BillingRecord._get_total_balance(
             CreditLine.get_credits_by_subscription_and_features(
                 self.invoice.subscription,
-                product_type=product_type,
+                product_type=SoftwareProductType.ANY,
             )
         )
         if subscription_credits or credit_adjustments.filter(
@@ -2274,7 +2273,7 @@ class BillingRecord(BillingRecordBase):
         account_credits = BillingRecord._get_total_balance(
             CreditLine.get_credits_for_account(
                 self.invoice.subscription.account,
-                product_type=product_type,
+                product_type=SoftwareProductType.ANY,
             )
         )
         if account_credits or credit_adjustments.filter(

--- a/corehq/apps/accounting/payment_handlers.py
+++ b/corehq/apps/accounting/payment_handlers.py
@@ -384,7 +384,7 @@ class CreditStripePaymentHandler(BaseStripePaymentHandler):
                     plan_amount,
                     account=self.account,
                     subscription=self.subscription,
-                    product_type=product['type'],
+                    product_type=SoftwareProductType.ANY,
                     payment_record=payment_record,
                 ))
             else:

--- a/corehq/apps/accounting/static/accounting/js/credits-tab.js
+++ b/corehq/apps/accounting/static/accounting/js/credits-tab.js
@@ -4,9 +4,6 @@
         var CreditFormModel = function () {
             var self = this;
             self.rateType = ko.observable("");
-            self.showProduct = ko.computed(function() {
-                return self.rateType() == 'Product';
-            }, self);
             self.showFeature = ko.computed(function() {
                 return self.rateType() == 'Feature';
             }, self);

--- a/corehq/apps/accounting/templates/accounting/credits_tab.html
+++ b/corehq/apps/accounting/templates/accounting/credits_tab.html
@@ -33,9 +33,7 @@
                     </td>
                     {% endif %}
                     <td>
-                        {% if credit.product_type %}
-                        {{ credit.product_type }}
-                        {% elif credit.product_type == '' or credit.product_type == None and credit.feature_type == None %}
+                        {% if credit.product_type == '' or credit.product_type == None and credit.feature_type == None %}
                         {% trans "Any" %}
                         {% else %}
                         --

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -701,12 +701,12 @@ class DomainSubscriptionView(DomainAccountingSettings):
             'type': product_type,
             'subscription_credit': self._fmt_credit(self._credit_grand_total(
                 CreditLine.get_credits_by_subscription_and_features(
-                    subscription, product_type=product_type
+                    subscription, product_type=SoftwareProductType.ANY
                 ) if subscription else None
             )),
             'account_credit': self._fmt_credit(self._credit_grand_total(
                 CreditLine.get_credits_for_account(
-                    account, product_type=product_type
+                    account, product_type=SoftwareProductType.ANY
                 ) if account else None
             )),
         }


### PR DESCRIPTION
Addresses the backlog item from http://manage.dimagi.com/default.asp?221644#BugEvent.1112132.  Also prevents a CommTrack client who purchases plan credit from losing access to the plan credit if they switch to a CommCare subscription.

:white_check_mark: from Ops

:fish: or :european_post_office: 

@benrudolph cc: @czue 
