### PR TITLE
add statsd host

### DIFF
--- a/fab/services/templates/supervisor_django.conf
+++ b/fab/services/templates/supervisor_django.conf
@@ -2,7 +2,7 @@
 directory={{ code_current }}/
 ; gunicorn
 environment={% for name, value in supervisor_env_vars.items %}{{ name }}="{{ value }}"{% if not forloop.last %},{% endif %}{% endfor %}
-command={{ new_relic_command }}{{ virtualenv_current }}/bin/gunicorn deployment.gunicorn.commcarehq_wsgi:application -c deployment/gunicorn/gunicorn_conf.py -k gevent --bind {{ django_bind }}:{{ django_port }} --log-file {{ log_dir }}/{{ project }}.gunicorn.log --log-level --statsd-host=localhost:8125 debug
+command={{ new_relic_command }}{{ virtualenv_current }}/bin/gunicorn deployment.gunicorn.commcarehq_wsgi:application -c deployment/gunicorn/gunicorn_conf.py -k gevent --bind {{ django_bind }}:{{ django_port }} --log-file {{ log_dir }}/{{ project }}.gunicorn.log --log-level debug --statsd-host localhost:8125
 user={{ sudo_user }}
 autostart=true
 autorestart=true

--- a/fab/services/templates/supervisor_django.conf
+++ b/fab/services/templates/supervisor_django.conf
@@ -2,7 +2,7 @@
 directory={{ code_current }}/
 ; gunicorn
 environment={% for name, value in supervisor_env_vars.items %}{{ name }}="{{ value }}"{% if not forloop.last %},{% endif %}{% endfor %}
-command={{ new_relic_command }}{{ virtualenv_current }}/bin/gunicorn deployment.gunicorn.commcarehq_wsgi:application -c deployment/gunicorn/gunicorn_conf.py -k gevent --bind {{ django_bind }}:{{ django_port }} --log-file {{ log_dir }}/{{ project }}.gunicorn.log --log-level debug
+command={{ new_relic_command }}{{ virtualenv_current }}/bin/gunicorn deployment.gunicorn.commcarehq_wsgi:application -c deployment/gunicorn/gunicorn_conf.py -k gevent --bind {{ django_bind }}:{{ django_port }} --log-file {{ log_dir }}/{{ project }}.gunicorn.log --log-level --statsd-host=localhost:8125 debug
 user={{ sudo_user }}
 autostart=true
 autorestart=true


### PR DESCRIPTION
@snopoke this'll add the statsd host to collect metrics. looks like dogstatsd by default runs on port 8125. if that seems wrong to you let me know. i think i'll load this up on staging first (even though we can `rollback` service changes now :open_mouth:)
