### PR TITLE
Don't validate jar stuff until building jar

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4253,6 +4253,7 @@ class ApplicationBase(VersionedDoc, SnapshotMixin,
                                          'files/%s' % filepath)
 
     def create_jadjar_from_build_files(self, save=False):
+        self.validate_jar_path()
         with CriticalSection(['create_jadjar_' + self._id]):
             try:
                 return (
@@ -4290,7 +4291,6 @@ class ApplicationBase(VersionedDoc, SnapshotMixin,
         try:
             self.validate_fixtures()
             self.validate_intents()
-            self.validate_jar_path()
             self.create_all_files()
         except CaseXPathValidationError as cve:
             errors.append({


### PR DESCRIPTION
This allows you to build apps locally without doing that whole business of installing commcare builds.  Any reason why this might not be a good idea?  If `validate_jar_path` raises an `AppEditingError`, that message will pop up as an alert on the page.

@NoahCarnahan @nickpell @dannyroberts
(wait on tests)
