### PR TITLE
Fix save button's subscription to filter state

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/filter_configs.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/filter_configs.html
@@ -97,4 +97,4 @@
     </tbody>
 </table>
 
-<div data-bind="subscribeFilters: filterConfig.addSubscribersToSaveButton()"></div>
+<div data-bind="event: {onload: filterConfig.addSubscribersToSaveButton()}"></div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/graph_configs.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/graph_configs.html
@@ -68,5 +68,5 @@
             </button>
         </fieldset>
     </div>
-    <div data-bind="subscribeGraphs: report.graphConfig.addSubscribersToSaveButton()"></div>
+    <div data-bind="event: {onload: filterConfig.addSubscribersToSaveButton()}"></div>
 </div>


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?223311
I'm not entirely sure how this used to work - it broke with the knockout 3 upgrade.  The docs said a lot changed around bindings - my guess is 2.x would evaluate the binding values even if the name wasn't recognized, and 3.x ignores the values.  At any rate, I believe this accomplishes roughly the same thing (And it makes the save button enable on filter change again).

@nickpell @orangejenny
