### PR TITLE
useLabels and useIds for export display

### DIFF
--- a/corehq/apps/export/static/export/js/models.js
+++ b/corehq/apps/export/static/export/js/models.js
@@ -235,7 +235,7 @@ Exports.ViewModels.ExportItem.prototype.isCaseName = function() {
 Exports.ViewModels.ExportItem.prototype.readablePath = function() {
     return _.map(this.path(), function(pathNode) {
         return pathNode.name();
-    }).join('.')
+    }).join('.');
 };
 
 Exports.ViewModels.ExportItem.mapping = {

--- a/corehq/apps/export/static/export/js/models.js
+++ b/corehq/apps/export/static/export/js/models.js
@@ -139,6 +139,22 @@ Exports.ViewModels.TableConfiguration.prototype.selectNone = function(table) {
     table._select(false);
 };
 
+Exports.ViewModels.TableConfiguration.prototype.useLabels = function(table) {
+    _.each(table.columns(), function(column) {
+        if (column.isQuestion()) {
+            column.label(column.item.label() || column.label());
+        }
+    });
+};
+
+Exports.ViewModels.TableConfiguration.prototype.useIds = function(table) {
+    _.each(table.columns(), function(column) {
+        if (column.isQuestion()) {
+            column.label(column.item.readablePath() || column.label());
+        }
+    });
+};
+
 Exports.ViewModels.TableConfiguration.mapping = {
     include: ['name', 'path', 'columns', 'selected', 'label', 'is_deleted'],
     columns: {
@@ -156,6 +172,12 @@ Exports.ViewModels.TableConfiguration.mapping = {
 Exports.ViewModels.ExportColumn = function(columnJSON) {
     var self = this;
     ko.mapping.fromJS(columnJSON, Exports.ViewModels.ExportColumn.mapping, self);
+};
+
+Exports.ViewModels.ExportColumn.prototype.isQuestion = function() {
+    var disallowedTags = ['info', 'case', 'server', 'row', 'app', 'stock'],
+        self = this;
+    return !_.any(disallowedTags, function(tag) { return _.include(self.tags(), tag); });
 };
 
 Exports.ViewModels.ExportColumn.prototype.formatProperty = function() {
@@ -208,6 +230,12 @@ Exports.ViewModels.ExportItem = function(itemJSON) {
 
 Exports.ViewModels.ExportItem.prototype.isCaseName = function() {
     return this.path()[this.path().length - 1].name === 'name';
+};
+
+Exports.ViewModels.ExportItem.prototype.readablePath = function() {
+    return _.map(this.path(), function(pathNode) {
+        return pathNode.name();
+    }).join('.')
 };
 
 Exports.ViewModels.ExportItem.mapping = {

--- a/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
+++ b/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
@@ -53,9 +53,10 @@
                         <thead>
                         <tr class="nodrag nodrop">
                             <th></th>
-                            <th>{% trans "Include this Field?" %}<br>
+                            <th>{% trans "Include this Field?" %}<br />
                                 <a class="btn btn-mini" data-bind="click: table.selectAll">{% trans "Select All" %}</a>
-                                <a class="btn btn-mini btn-inverse" data-bind="click: table.selectNone">{% trans "Select None" %}</a></th>
+                                <a class="btn btn-mini btn-inverse" data-bind="click: table.selectNone">{% trans "Select None" %}</a>
+                            </th>
                             <th>
                             {% if export_instance.type == 'form' %}
                                 {% trans "Question" %}
@@ -63,7 +64,21 @@
                                 {% trans "Property" %}
                             {% endif %}
                             </th>
-                            <th>{% trans "Display" %}</th>
+                            <th>
+                                {% trans "Display" %}<br />
+                                {% if export_instance.type == 'form' %}
+                                <a
+                                    class="btn btn-mini"
+                                    data-bind="click: table.useLabels">
+                                    {% trans "Use question labels" %}
+                                </a>
+                                <a
+                                    class="btn btn-mini btn-inverse"
+                                    data-bind="click: table.useIds">
+                                    {% trans "Use question ids" %}
+                                </a>
+                                {% endif %}
+                            </th>
                             {% if export_instance.type == 'case' and request|feature_preview_enabled:"SPLIT_MULTISELECT_CASE_EXPORT"%}
                             <th>{% trans "Type" %}</th>
                             {% endif %}


### PR DESCRIPTION
@NoahCarnahan this allows users to switch between labels and ids if they wish on exports 🍨 : https://dimagi.uservoice.com/forums/194740-data/suggestions/6863099-displaying-question-labels-as-excel-column-header

<img width="987" alt="screen shot 2016-04-13 at 7 15 43 pm" src="https://cloud.githubusercontent.com/assets/918514/14531772/a5c2513a-022c-11e6-8426-7c49593d00dd.png">

fyi: @dimagi/product, only available for new exports
