### PR TITLE
Fix sorting for SMS billables report

### DIFF
--- a/corehq/apps/smsbillables/interface.py
+++ b/corehq/apps/smsbillables/interface.py
@@ -4,6 +4,7 @@ from corehq.apps.reports.datatables import (
     DataTablesColumn,
     DataTablesHeader,
 )
+from corehq.apps.reports.datatables import DTSortType
 from corehq.apps.reports.generic import GenericTabularReport
 from corehq.apps.sms.models import (
     INCOMING,
@@ -52,7 +53,7 @@ class SMSBillablesInterface(GenericTabularReport):
     @property
     def headers(self):
         return DataTablesHeader(
-            DataTablesColumn("Date of Message", sort_type=DTSortType.DATE)
+            DataTablesColumn("Date of Message", sort_type=DTSortType.DATE),
             DataTablesColumn("Project Space"),
             DataTablesColumn("Direction"),
             DataTablesColumn("SMS parts"),

--- a/corehq/apps/smsbillables/interface.py
+++ b/corehq/apps/smsbillables/interface.py
@@ -53,7 +53,7 @@ class SMSBillablesInterface(GenericTabularReport):
     @property
     def headers(self):
         return DataTablesHeader(
-            DataTablesColumn("Date of Message", sort_type=DTSortType.DATE),
+            DataTablesColumn("Date of Message"),
             DataTablesColumn("Project Space"),
             DataTablesColumn("Direction"),
             DataTablesColumn("SMS parts"),
@@ -71,6 +71,7 @@ class SMSBillablesInterface(GenericTabularReport):
             'date_sent',
             'domain',
             'direction',
+            'multipart_count',
             'date_created',
         ]
         sort_index = int(self.request.GET.get('iSortCol_0', 2))

--- a/corehq/apps/smsbillables/interface.py
+++ b/corehq/apps/smsbillables/interface.py
@@ -72,10 +72,14 @@ class SMSBillablesInterface(GenericTabularReport):
             'domain',
             'direction',
             'multipart_count',
+            None,
+            None,
+            None,
+            None,
+            None,
             'date_created',
         ]
-        sort_index = int(self.request.GET.get('iSortCol_0', 2))
-        sort_index = 1 if sort_index == 0 else sort_index - 1
+        sort_index = int(self.request.GET.get('iSortCol_0', 1))
         field = sort_fields[sort_index]
         sort_descending = self.request.GET.get('sSortDir_0', 'asc') == 'desc'
         return field if not sort_descending else '-{0}'.format(field)

--- a/corehq/apps/smsbillables/interface.py
+++ b/corehq/apps/smsbillables/interface.py
@@ -52,7 +52,7 @@ class SMSBillablesInterface(GenericTabularReport):
     @property
     def headers(self):
         return DataTablesHeader(
-            DataTablesColumn("Date of Message"),
+            DataTablesColumn("Date of Message", sort_type=DTSortType.DATE)
             DataTablesColumn("Project Space"),
             DataTablesColumn("Direction"),
             DataTablesColumn("SMS parts"),

--- a/corehq/apps/smsbillables/interface.py
+++ b/corehq/apps/smsbillables/interface.py
@@ -4,7 +4,6 @@ from corehq.apps.reports.datatables import (
     DataTablesColumn,
     DataTablesHeader,
 )
-from corehq.apps.reports.datatables import DTSortType
 from corehq.apps.reports.generic import GenericTabularReport
 from corehq.apps.sms.models import (
     INCOMING,


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?223568

This wasn't sorting by the same column that the user clicked on.

The `- 1` line looks added intentionally in https://github.com/dimagi/commcare-hq/commit/54693b7164668f68e5a194a1b621af8826e7deed, but I'm not sure what its original purpose was.

@calellowitz / @snopoke 
