### PR TITLE
remove FutureWarning

### DIFF
--- a/corehq/apps/users/fixturegenerators.py
+++ b/corehq/apps/users/fixturegenerators.py
@@ -16,7 +16,7 @@ class UserGroupsFixtureProvider(object):
         they are a part of.
         """
         fixture = self.get_group_fixture(user, last_sync)
-        if fixture:
+        if len(fixture):
             return [fixture]
         else:
             return []


### PR DESCRIPTION
removes warning

```
corehq/apps/users/fixturegenerators.py:21: FutureWarning: The behavior of this method will change in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.
  if fixture:
```

when downloading the restore
