### PR TITLE
Report builder UCR chart category limit

### DIFF
--- a/corehq/apps/reports_core/static/reports_core/js/charts.js
+++ b/corehq/apps/reports_core/static/reports_core/js/charts.js
@@ -170,6 +170,11 @@ hqDefine('reports_core/js/charts.js', function() {
             }
         }
     };
+
+    fn.clear = function(chartContainer) {
+        chartContainer.hide();
+        chartContainer.empty();
+    };
     return fn;
 
 });

--- a/corehq/apps/reports_core/static/reports_core/js/charts.js
+++ b/corehq/apps/reports_core/static/reports_core/js/charts.js
@@ -1,4 +1,4 @@
-var charts = (function() {
+hqDefine('reports_core/js/charts.js', function() {
     var fn = {};
     var renderPie = function (config, data, svgSelector) {
         return function () {
@@ -172,4 +172,4 @@ var charts = (function() {
     };
     return fn;
 
-})();
+});

--- a/corehq/apps/reports_core/templates/reports_core/base_template_new.html
+++ b/corehq/apps/reports_core/templates/reports_core/base_template_new.html
@@ -34,6 +34,7 @@
             return base_url;
         }
     $(function() {
+        var charts = hqImport('reports_core/js/charts.js');
         var chartSpecs = {{ report.spec.charts|JSON }};
         var updateCharts = function (data) {
             if (chartSpecs !== null && chartSpecs.length > 0) {

--- a/corehq/apps/reports_core/templates/reports_core/base_template_new.html
+++ b/corehq/apps/reports_core/templates/reports_core/base_template_new.html
@@ -38,8 +38,14 @@
         var chartSpecs = {{ report.spec.charts|JSON }};
         var updateCharts = function (data) {
             if (chartSpecs !== null && chartSpecs.length > 0) {
-                // draw graph
-                charts.render(chartSpecs, data.aaData, $("#chart-container"));
+                var isReportBuilderReport = {{ report.spec.report_meta.created_by_builder|JSON }};
+                if (data.iTotalRecords > 25 && isReportBuilderReport) {
+                    $("#chart-warning").removeClass("hide");
+                    charts.clear($("#chart-container"))
+                } else {
+                    $("#chart-warning").addClass("hide");
+                    charts.render(chartSpecs, data.aaData, $("#chart-container"));
+                }
             }
         };
 
@@ -204,6 +210,11 @@
     <div id="reportContent" class="hide">
         {% block reportcharts %}
         <section id="chart-container" style="display: none;">
+        </section>
+        <section id="chart-warning" class="alert alert-warning hide">
+        {% blocktrans %}
+            Charts cannot be displayed with more than 25 categories. Please filter the data or change your report to limit the number of rows.
+        {% endblocktrans %}
         </section>
         <section id="map-container" style="display: none;" >
         </section>

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -209,6 +209,7 @@ class ConfigurableReport(JSONResponseMixin, BaseDomainView):
     def page_context(self):
         context = {
             'report': self,
+            'report_table': {'default_rows': 25},
             'filter_context': self.filter_context,
             'url': self.url,
             'headers': self.headers


### PR DESCRIPTION
https://trello.com/c/kN1FZahk/23-handle-paging-in-charts-and-maps
- Limits charts to 25 categories
- Changes default UCR page size to 25 
- Bonus: Use `hqDefine` for charts.js

@esoergel 
