### PR TITLE
Mobile soft assert logs

### DIFF
--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -545,6 +545,7 @@ class AdminReport(GenericTabularReport):
 
     base_template = "hqadmin/bootstrap3/faceted_report.html"
     report_template_path = "reports/async/bootstrap3/tabular.html"
+    section_name = ugettext_noop("ADMINREPORT")
 
 
 class AdminFacetedReport(AdminReport, ElasticTabularReport):
@@ -556,7 +557,6 @@ class AdminFacetedReport(AdminReport, ElasticTabularReport):
     es_queried = False
     es_facet_list = []
     es_facet_mapping = []
-    section_name = ugettext_noop("ADMINREPORT")
     es_index = None
 
     @property
@@ -999,7 +999,6 @@ class AdminAppReport(AdminFacetedReport):
 
 class GlobalAdminReports(AdminDomainStatsReport):
     base_template = "hqadmin/indicator_report.html"
-    section_name = ugettext_noop("ADMINREPORT")  # not sure why ...
 
     @property
     def template_context(self):

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -11,11 +11,12 @@ from corehq.apps.app_manager.models import Application
 from corehq.apps.reports.dispatcher import AdminReportDispatcher
 from corehq.apps.reports.generic import ElasticTabularReport, GenericTabularReport
 from corehq.apps.reports.standard.domains import DomainStatsReport, es_domain_query
-from django.utils.translation import ugettext as _, ugettext_noop
+from django.utils.translation import ugettext as _, ugettext_noop, ugettext_lazy
 from corehq.elastic import es_query, parse_args_for_es, fill_mapping_with_facets
 from corehq.apps.app_manager.commcare_settings import get_custom_commcare_settings
 from corehq.apps.reports.datatables import DataTablesHeader, DataTablesColumn, DTSortType
-
+from phonelog.reports import BaseDeviceLogReport
+from phonelog.models import DeviceReportEntry
 
 INDICATOR_DATA = {
     "active_domain_count": {
@@ -546,6 +547,8 @@ class AdminReport(GenericTabularReport):
     base_template = "hqadmin/bootstrap3/faceted_report.html"
     report_template_path = "reports/async/bootstrap3/tabular.html"
     section_name = ugettext_noop("ADMINREPORT")
+    default_params = {}
+    is_admin_report = True
 
 
 class AdminFacetedReport(AdminReport, ElasticTabularReport):
@@ -1102,3 +1105,57 @@ class CommTrackProjectSpacesReport(GlobalAdminReports):
         'unique_locations',
         'location_types',
     ]
+
+
+class DeviceLogSoftAssertReport(BaseDeviceLogReport, AdminReport):
+    base_template = 'reports/bootstrap3/base_template.html'
+
+    slug = 'device_log_soft_asserts'
+    name = ugettext_lazy("Global Device Logs Soft Asserts")
+
+    fields = [
+        'corehq.apps.reports.filters.dates.DatespanFilter',
+        'corehq.apps.reports.filters.devicelog.DeviceLogDomainFilter',
+    ]
+    emailable = False
+    default_rows = 10
+
+    _username_fmt = "%(username)s"
+    _device_users_fmt = "%(username)s"
+    _device_id_fmt = "%(device)s"
+    _log_tag_fmt = "<label class='%(classes)s'>%(text)s</label>"
+
+    @property
+    def selected_domain(self):
+        selected_domain = self.request.GET.get('domain', None)
+        return selected_domain if selected_domain != u'' else None
+
+    @property
+    def headers(self):
+        headers = super(DeviceLogSoftAssertReport, self).headers
+        headers.add_column(DataTablesColumn("Domain"))
+        return headers
+
+    @property
+    def rows(self):
+        logs = self._filter_logs()
+        rows = self._create_rows(
+            logs,
+            range=slice(self.pagination.start, self.pagination.start + self.pagination.count)
+        )
+        return rows
+
+    def _filter_logs(self):
+        logs = DeviceReportEntry.objects.filter(
+            date__range=[self.datespan.startdate_param_utc, self.datespan.enddate_param_utc]
+        ).filter(type='soft-assert')
+
+        if self.selected_domain is not None:
+            logs = logs.filter(domain__exact=self.selected_domain)
+
+        return logs
+
+    def _create_row(self, log, *args, **kwargs):
+        row = super(DeviceLogSoftAssertReport, self)._create_row(log, *args, **kwargs)
+        row.append(log.domain)
+        return row

--- a/corehq/apps/reports/filters/devicelog.py
+++ b/corehq/apps/reports/filters/devicelog.py
@@ -1,5 +1,5 @@
 from django.utils.translation import ugettext_noop, ugettext_lazy
-from corehq.apps.reports.filters.base import BaseReportFilter, BaseSingleOptionFilter, BaseMultipleOptionFilter
+from corehq.apps.reports.filters.base import BaseReportFilter, BaseSingleOptionFilter
 from corehq.util.queries import fast_distinct, fast_distinct_in_domain
 from corehq.util.quickcache import quickcache
 from phonelog.models import DeviceReportEntry

--- a/corehq/apps/reports/filters/devicelog.py
+++ b/corehq/apps/reports/filters/devicelog.py
@@ -1,5 +1,5 @@
-from django.utils.translation import ugettext_noop
-from corehq.apps.reports.filters.base import BaseReportFilter
+from django.utils.translation import ugettext_noop, ugettext_lazy
+from corehq.apps.reports.filters.base import BaseReportFilter, BaseSingleOptionFilter, BaseMultipleOptionFilter
 from corehq.util.queries import fast_distinct, fast_distinct_in_domain
 from corehq.util.quickcache import quickcache
 from phonelog.models import DeviceReportEntry
@@ -30,6 +30,15 @@ class DeviceLogTagFilter(BaseReportFilter):
             self.errors_only_slug: errors_only,
         }
         return context
+
+
+class DeviceLogDomainFilter(BaseSingleOptionFilter):
+    slug = "domain"
+    label = ugettext_lazy("Filter Logs by Domain")
+
+    @property
+    def options(self):
+        return [(d, d) for d in fast_distinct(DeviceReportEntry, 'domain')]
 
 
 class BaseDeviceLogFilter(BaseReportFilter):

--- a/corehq/apps/reports/filters/devicelog.py
+++ b/corehq/apps/reports/filters/devicelog.py
@@ -37,6 +37,7 @@ class DeviceLogDomainFilter(BaseSingleOptionFilter):
     label = ugettext_lazy("Filter Logs by Domain")
 
     @property
+    @quickcache([], timeout=60 * 60)
     def options(self):
         return [(d, d) for d in fast_distinct(DeviceReportEntry, 'domain')]
 

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -467,7 +467,7 @@ class GenericReportView(object):
                 is_emailable=self.emailable,
                 is_export_all = self.exportable_all,
                 is_printable=self.printable,
-                is_admin=self.is_admin_report,   # todo is this necessary???
+                is_admin=self.is_admin_report,
                 special_notice=self.special_notice,
                 report_title=self.report_title or self.rendered_report_title,
                 report_subtitles=self.report_subtitles,

--- a/corehq/apps/reports/templates/reports/bootstrap2/base_template.html
+++ b/corehq/apps/reports/templates/reports/bootstrap2/base_template.html
@@ -65,29 +65,32 @@
                 {% trans 'Apply' %}
             </button>
         </div>
-        <div class="btn-group">
-            <a class="btn dropdown-toggle" data-toggle="dropdown">
-                {% trans 'Favorites' %}<span class="caret"></span>
-            </a>
 
-            <ul class="dropdown-menu">
-                <li data-bind="ifnot: reportConfigs().length">
-                    <a href="#">{% trans "You don't have any favorites" %}</a>
-                </li>
-                <!-- ko foreach: reportConfigs -->
-                <li>
-                    <a href="#" tabindex="-1"
-                        data-bind="text: name, attr: { title: description }, click: $root.setConfigBeingViewed">
-                    </a>
-                </li>
-                <!-- /ko -->
-            </ul>
-        </div>
+        {% if not report.is_admin %}
+            <div class="btn-group">
+                <a class="btn dropdown-toggle" data-toggle="dropdown">
+                    {% trans 'Favorites' %}<span class="caret"></span>
+                </a>
 
-        <button class="btn" data-bind="click: setConfigBeingEdited"
-                onclick="ga_track_event('Scheduled Reports', 'Configure a saved report', '-');">
-            {% trans "Save" %}...
-        </button>
+                <ul class="dropdown-menu">
+                    <li data-bind="ifnot: reportConfigs().length">
+                        <a href="#">{% trans "You don't have any favorites" %}</a>
+                    </li>
+                    <!-- ko foreach: reportConfigs -->
+                    <li>
+                        <a href="#" tabindex="-1"
+                           data-bind="text: name, attr: { title: description }, click: $root.setConfigBeingViewed">
+                        </a>
+                    </li>
+                    <!-- /ko -->
+                </ul>
+            </div>
+
+            <button class="btn" data-bind="click: setConfigBeingEdited"
+                    onclick="ga_track_event('Scheduled Reports', 'Configure a saved report', '-');">
+                {% trans "Save" %}...
+            </button>
+        {% endif %}
 
         {% if report.is_emailable %}
             <div style="display: inline-block; margin-left:0.5em;" class="label label-info" id="email-enabled">

--- a/corehq/apps/reports/templates/reports/bootstrap3/base_template.html
+++ b/corehq/apps/reports/templates/reports/bootstrap3/base_template.html
@@ -52,29 +52,30 @@
         data-standard-text="{% trans 'Apply' %}">
         {% trans 'Apply' %}
     </button>
-    <div class="btn-group">
-        <button type="button" class="btn dropdown-toggle btn-default" data-toggle="dropdown">
-            {% trans 'Favorites' %} <span class="caret"></span>
+    {% if not report.is_admin %}
+        <div class="btn-group">
+            <button type="button" class="btn dropdown-toggle btn-default" data-toggle="dropdown">
+                {% trans 'Favorites' %} <span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu">
+                <li data-bind="ifnot: reportConfigs().length">
+                    <a href="#">{% trans "You don't have any favorites" %}</a>
+                </li>
+                <!-- ko foreach: reportConfigs -->
+                <li>
+                    <a href="#" tabindex="-1"
+                       data-bind="text: name, attr: { title: description }, click: $root.setConfigBeingViewed">
+                    </a>
+                </li>
+                <!-- /ko -->
+            </ul>
+        </div>
+
+        <button class="btn btn-default" data-bind="click: setConfigBeingEdited"
+                onclick="ga_track_event('Scheduled Reports', 'Configure a saved report', '-');">
+            {% trans "Save" %}...
         </button>
-        <ul class="dropdown-menu">
-            <li data-bind="ifnot: reportConfigs().length">
-                <a href="#">{% trans "You don't have any favorites" %}</a>
-            </li>
-            <!-- ko foreach: reportConfigs -->
-            <li>
-                <a href="#" tabindex="-1"
-                    data-bind="text: name, attr: { title: description }, click: $root.setConfigBeingViewed">
-                </a>
-            </li>
-            <!-- /ko -->
-        </ul>
-    </div>
-
-    <button class="btn btn-default" data-bind="click: setConfigBeingEdited"
-            onclick="ga_track_event('Scheduled Reports', 'Configure a saved report', '-');">
-        {% trans "Save" %}...
-    </button>
-
+    {% endif %}
     {% if report.is_emailable %}
         <div style="display: inline-block; margin-left:0.5em;" class="label label-info" id="email-enabled">
             <i class="fa fa-info-circle"></i> {% trans "Email Supported" %}

--- a/corehq/ex-submodules/phonelog/reports.py
+++ b/corehq/ex-submodules/phonelog/reports.py
@@ -40,7 +40,7 @@ TAGS = {
 }
 
 
-class DeviceLogDetailsReport(GetParamsMixin, DeploymentsReport, DatespanMixin, PaginatedReportMixin):
+class BaseDeviceLogReport(GetParamsMixin, DatespanMixin, PaginatedReportMixin):
     name = ugettext_noop("Device Log Details")
     slug = "log_details"
     fields = ['corehq.apps.reports.filters.dates.DatespanFilter',
@@ -187,22 +187,19 @@ class DeviceLogDetailsReport(GetParamsMixin, DeploymentsReport, DatespanMixin, P
         logs = self._filter_logs()
         return self._create_rows(logs)
 
-    def _create_rows(self, logs, matching_id=None, range=None):
-        _device_users_by_xform = memoized(device_users_by_xform)
-        row_set = []
-        user_query = self._filter_query_by_slug(DeviceLogUsersFilter.slug)
-        device_query = self._filter_query_by_slug(DeviceLogDevicesFilter.slug)
+    _username_fmt = '<a href="%(url)s">%(username)s</a>'
+    _device_users_fmt = '<a href="%(url)s">%(username)s</a>'
+    _device_id_fmt = '<a href="%(url)s">%(device)s</a>'
+    _log_tag_fmt = ('<a href="%(url)s" class="%(classes)s"%(extra_params)s '
+                    'data-datatable-tooltip="right" '
+                    'data-datatable-tooltip-text="%(tooltip)s">%(text)s</a>')
 
-        self.total_records = logs.count()
-        logs = logs.order_by(self.ordering)
-        if range:
-            logs = logs[range]
-        for log in logs:
+    def _create_row(self, log, matching_id, _device_users_by_xform, user_query, device_query):
             ui_date = (ServerTime(log.date)
-                        .user_time(self.timezone).ui_string())
+                       .user_time(self.timezone).ui_string())
 
             username = log.username
-            username_fmt = '<a href="%(url)s">%(username)s</a>' % {
+            username_fmt =  self._username_fmt % {
                 "url": "%s?%s=%s&%s" % (
                     self.get_url(domain=self.domain),
                     DeviceLogUsersFilter.slug,
@@ -217,7 +214,7 @@ class DeviceLogDetailsReport(GetParamsMixin, DeploymentsReport, DatespanMixin, P
 
             device_users = _device_users_by_xform(log.xform_id)
             device_users_fmt = ', '.join([
-                '<a href="%(url)s">%(username)s</a>' % {
+                 self._device_users_fmt % {
                     "url": "%s?%s=%s&%s" % (self.get_url(domain=self.domain),
                                             DeviceLogUsersFilter.slug,
                                             username,
@@ -232,11 +229,10 @@ class DeviceLogDetailsReport(GetParamsMixin, DeploymentsReport, DatespanMixin, P
             if log_tag in self.tag_labels:
                 tag_classes.append(self.tag_labels[log_tag])
 
-            log_tag_format = (
-                '<a href="%(url)s" class="%(classes)s"%(extra_params)s '
-                'data-datatable-tooltip="right" '
-                'data-datatable-tooltip-text="%(tooltip)s">%(text)s</a>'
-            ) % {
+            if len(tag_classes) == 1:
+                tag_classes.append('label-info')
+
+            log_tag_format = self._log_tag_fmt % {
                 "url": "%s?goto=%s" % (self.get_url(domain=self.domain),
                                        html.escape(json.dumps(log.id))),
                 "classes": " ".join(tag_classes),
@@ -247,7 +243,7 @@ class DeviceLogDetailsReport(GetParamsMixin, DeploymentsReport, DatespanMixin, P
             }
 
             device = log.device_id
-            device_fmt = '<a href="%(url)s">%(device)s</a>' % {
+            device_fmt = self._device_id_fmt % {
                 "url": "%s?%s=%s&%s" % (self.get_url(domain=self.domain),
                                         DeviceLogDevicesFilter.slug,
                                         device,
@@ -262,8 +258,22 @@ class DeviceLogDetailsReport(GetParamsMixin, DeploymentsReport, DatespanMixin, P
                 '<i class="icon icon-info-sign"></i></a>'
             ) % (version.split(' ')[0], html.escape(version))
 
-            row_set.append([ui_date, log_tag_format, username_fmt,
-                            device_users_fmt, device_fmt, log.msg, ver_format])
+            return [ui_date, log_tag_format, username_fmt,
+                    device_users_fmt, device_fmt, log.msg, ver_format]
+
+    def _create_rows(self, logs, matching_id=None, range=None):
+        _device_users_by_xform = memoized(device_users_by_xform)
+        row_set = []
+        user_query = self._filter_query_by_slug(DeviceLogUsersFilter.slug)
+        device_query = self._filter_query_by_slug(DeviceLogDevicesFilter.slug)
+
+        self.total_records = logs.count()
+        logs = logs.order_by(self.ordering)
+        if range:
+            logs = logs[range]
+        for log in logs:
+            row_set.append(self._create_row(log, matching_id, _device_users_by_xform, user_query, device_query))
+
         return row_set
 
     def _filter_logs(self):
@@ -288,3 +298,7 @@ class DeviceLogDetailsReport(GetParamsMixin, DeploymentsReport, DatespanMixin, P
 
     def _filter_query_by_slug(self, slug):
         return urlencode({k: v for (k, v) in self.request.GET.iteritems() if not k.startswith(slug)})
+
+
+class DeviceLogDetailsReport(BaseDeviceLogReport, DeploymentsReport):
+    pass

--- a/corehq/ex-submodules/phonelog/reports.py
+++ b/corehq/ex-submodules/phonelog/reports.py
@@ -199,7 +199,7 @@ class BaseDeviceLogReport(GetParamsMixin, DatespanMixin, PaginatedReportMixin):
                        .user_time(self.timezone).ui_string())
 
             username = log.username
-            username_fmt =  self._username_fmt % {
+            username_fmt = self._username_fmt % {
                 "url": "%s?%s=%s&%s" % (
                     self.get_url(domain=self.domain),
                     DeviceLogUsersFilter.slug,
@@ -214,7 +214,7 @@ class BaseDeviceLogReport(GetParamsMixin, DatespanMixin, PaginatedReportMixin):
 
             device_users = _device_users_by_xform(log.xform_id)
             device_users_fmt = ', '.join([
-                 self._device_users_fmt % {
+                self._device_users_fmt % {
                     "url": "%s?%s=%s&%s" % (self.get_url(domain=self.domain),
                                             DeviceLogUsersFilter.slug,
                                             username,

--- a/corehq/reports.py
+++ b/corehq/reports.py
@@ -10,6 +10,7 @@ from corehq.apps.hqadmin.reports import (
     RealProjectSpacesReport,
     CommConnectProjectSpacesReport,
     CommTrackProjectSpacesReport,
+    DeviceLogSoftAssertReport,
 )
 from corehq.apps.hqpillow_retry.views import PillowErrorsReport
 from corehq.apps.reports.standard import (monitoring, inspect, export,
@@ -305,6 +306,7 @@ ADMIN_REPORTS = (
         RealProjectSpacesReport,
         CommConnectProjectSpacesReport,
         CommTrackProjectSpacesReport,
+        DeviceLogSoftAssertReport,
     )),
 )
 

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -11,7 +11,8 @@ from corehq.apps.app_manager.dbaccessors import domain_has_apps, get_brief_apps_
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.utils import user_has_custom_top_menu
 from corehq.apps.hqadmin.reports import RealProjectSpacesReport, \
-    CommConnectProjectSpacesReport, CommTrackProjectSpacesReport
+    CommConnectProjectSpacesReport, CommTrackProjectSpacesReport, \
+    DeviceLogSoftAssertReport
 from corehq.apps.hqwebapp.models import GaTracker
 from corehq.apps.hqwebapp.view_permissions import user_can_view_reports
 from corehq.apps.indicators.dispatcher import IndicatorAdminInterfaceDispatcher
@@ -1471,6 +1472,7 @@ class AdminTab(UITab):
                     RealProjectSpacesReport,
                     CommConnectProjectSpacesReport,
                     CommTrackProjectSpacesReport,
+                    DeviceLogSoftAssertReport,
                 ]
             ]),
         ]

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1463,9 +1463,10 @@ class AdminTab(UITab):
             (_('CommCare Reports'), [
                 {
                     'title': report.name,
-                    'url': '%s?%s' % (reverse('admin_report_dispatcher',
-                                              args=(report.slug,)),
-                                      urlencode(report.default_params))
+                    'url': '{url}{params}'.format(
+                        url=reverse('admin_report_dispatcher', args=(report.slug,)),
+                        params="?{}".format(urlencode(report.default_params)) if report.default_params else ""
+                    )
                 } for report in [
                     RealProjectSpacesReport,
                     CommConnectProjectSpacesReport,


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?190730
Admin report that shows all soft-asserts from the device logs. 

Not sure why I found this so hard to do, but it was the first time I've explored our reporting framework. :chart_with_upwards_trend: :bookmark_tabs: 

Also, not sure if dumping all domains into a filter is the best idea, but I figure if it causes issues we can remove that filter as I'm not sure whether it is useful or not. I couldn't find a simple way of doing async stuff with filters and select2 and figured that might be out of scope here (might have missed it though). 

@benrudolph @sravfeyn 
