### PR TITLE
use new user reindexer

### DIFF
--- a/corehq/apps/hqcase/management/commands/ptop_preindex.py
+++ b/corehq/apps/hqcase/management/commands/ptop_preindex.py
@@ -25,7 +25,7 @@ def get_reindex_commands(alias_name):
         'xforms': ['ptop_fast_reindex_xforms'],
         # groupstousers indexing must happen after all users are indexed
         'hqusers': [
-            'ptop_fast_reindex_users',
+            ('ptop_reindexer_v2', {'index': 'user'}),
             add_demo_user_to_user_index,
             'ptop_fast_reindex_groupstousers',
             # 'ptop_fast_reindex_unknownusers',  removed until we have a better workflow for this


### PR DESCRIPTION
@snopoke I ran this back to back with the current functionality. the current one bulk saves to ES and this one does it one at a time (they both now bulk-get from couch). the result was that the user pillow reindex goes from 30 minutes to 51 minutes (for 95,500 docs). I think this is probably ok, but a 67% increase may not be acceptable for forms and cases so might still need to eventually do more to optimize.

doc counts and everything else looked good.
