### PR TITLE
Fix community subscription length

### DIFF
--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -63,8 +63,10 @@ class DomainInvoiceFactory(object):
     def _get_subscriptions(self):
         subscriptions = Subscription.objects.filter(
             subscriber=self.subscriber, date_start__lte=self.date_end
-        ).filter(Q(date_end=None) | Q(date_end__gt=self.date_start)
-        ).filter(Q(date_end=None) | Q(date_end__gt=F('date_start'))
+        ).filter(
+            Q(date_end=None) | Q(date_end__gt=self.date_start)
+        ).filter(
+            Q(date_end=None) | Q(date_end__gt=F('date_start'))
         ).order_by('date_start', 'date_end').all()
         return list(subscriptions)
 
@@ -116,10 +118,7 @@ class DomainInvoiceFactory(object):
                 return date_start
 
         def _get_invoice_end(sub, date_end):
-            if (
-                sub.date_end is not None
-                and sub.date_end <= date_end
-            ):
+            if sub.date_end is not None and sub.date_end <= date_end:
                 # Since the Subscription is actually terminated on date_end
                 # have the invoice period be until the day before date_end.
                 return sub.date_end - datetime.timedelta(days=1)
@@ -169,9 +168,10 @@ class DomainInvoiceFactory(object):
                     community_ranges.append((prev_sub_end, sub.date_start))
                 prev_sub_end = sub.date_end
 
-                if (ind == len(subscriptions) - 1
-                    and sub.date_end is not None
-                    and sub.date_end <= self.date_end
+                if (
+                    ind == len(subscriptions) - 1 and
+                    sub.date_end is not None and
+                    sub.date_end <= self.date_end
                 ):
                     # the last subscription ended BEFORE the end of
                     # the invoicing period

--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -155,7 +155,7 @@ class DomainInvoiceFactory(object):
     def _get_community_ranges(self, subscriptions):
         community_ranges = []
         if len(subscriptions) == 0:
-            community_ranges.append((self.date_start, self.date_end))
+            return [(self.date_start, self.date_end + datetime.timedelta(days=1))]
         else:
             prev_sub_end = self.date_end
             for ind, sub in enumerate(subscriptions):
@@ -178,7 +178,7 @@ class DomainInvoiceFactory(object):
                     community_ranges.append(
                         (sub.date_end, self.date_end + datetime.timedelta(days=1))
                     )
-        return community_ranges
+            return community_ranges
 
     def _generate_invoice(self, subscription, invoice_start, invoice_end):
         invoice, is_new_invoice = Invoice.objects.get_or_create(

--- a/corehq/apps/accounting/tests/test_invoice_factory.py
+++ b/corehq/apps/accounting/tests/test_invoice_factory.py
@@ -111,4 +111,4 @@ class TestDomainInvoiceFactory(BaseAccountingTest):
         subscriptions = self.invoice_factory._get_subscriptions()
         self.assertEqual(len(subscriptions), 0)
         community_ranges = self.invoice_factory._get_community_ranges(subscriptions)
-        self.assertEqual(len(community_ranges), 1)
+        self.assertEqual(community_ranges, [(self.invoice_start, self.invoice_end + datetime.timedelta(days=1))])

--- a/corehq/apps/accounting/tests/test_invoicing.py
+++ b/corehq/apps/accounting/tests/test_invoicing.py
@@ -3,23 +3,36 @@ import random
 import datetime
 
 from django.core.exceptions import ObjectDoesNotExist
-from django.core.management import call_command
-from corehq.apps.accounting.tests.base_tests import BaseAccountingTest
 
 from dimagi.utils.dates import add_months_to_date
 
 from corehq.apps.sms.models import INCOMING, OUTGOING
 from corehq.apps.smsbillables.models import (
-    SmsGatewayFee, SmsGatewayFeeCriteria, SmsUsageFee, SmsUsageFeeCriteria,
     SmsBillable,
+    SmsGatewayFee,
+    SmsGatewayFeeCriteria,
+    SmsUsageFee,
+    SmsUsageFeeCriteria,
 )
 from corehq.apps.accounting import generator, tasks, utils
 from corehq.apps.accounting.models import (
-    Invoice, FeatureType, LineItem, Subscriber, DefaultProductPlan,
-    CreditAdjustment, CreditLine, SubscriptionAdjustment, SoftwareProductType,
-    SoftwarePlanEdition, BillingRecord, BillingAccount, SubscriptionType,
-    InvoiceBaseManager, SMALL_INVOICE_THRESHOLD, Subscription
+    SMALL_INVOICE_THRESHOLD,
+    BillingAccount,
+    BillingRecord,
+    CreditAdjustment,
+    CreditLine,
+    DefaultProductPlan,
+    FeatureType,
+    Invoice,
+    LineItem,
+    SoftwarePlanEdition,
+    SoftwareProductType,
+    Subscriber,
+    Subscription,
+    SubscriptionAdjustment,
+    SubscriptionType,
 )
+from corehq.apps.accounting.tests.base_tests import BaseAccountingTest
 
 
 class BaseInvoiceTestCase(BaseAccountingTest):


### PR DESCRIPTION
Makes sure that subscriptions like [this](https://www.commcarehq.org/hq/accounting/subscriptions/11025/) don't end before the first of the next month, so the [invoicing periods](https://www.commcarehq.org/hq/accounting/invoices/?account_name=&subscriber=benin&payment_status=&report_filter_statement_period_use_filter=on&report_filter_statement_period_month=2&report_filter_statement_period_year=2016&report_filter_due_date_month=4&report_filter_due_date_year=2016&salesforce_account_id=&salesforce_contract_id=&plan_name=&billing_contact=&is_hidden=) don't omit the last day of the month

🐟 
