### PR TITLE
Don't include docs on a reduced view

### DIFF
--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -416,6 +416,7 @@ class DomainDowngradeStatusHandler(BaseModifySubscriptionHandler):
             startkey=startkey,
             endkey=endkey,
             include_docs=True,
+            reduce=False,
         )
         num_deid_reports = len(filter(lambda r: r.is_safe, reports))
         if num_deid_reports > 0:


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?223805
Views without a `reduce.js` default to `reduce=False`, but then if you add a `reduce.js` later, those view calls change the default to `reduce=True`.  This means you have to manually update any view calls that aren't explicit about `reduce`.

@NoahCarnahan
@nickpell @benrudolph FYI
