### PR TITLE
Download formplayer jar from jenkins

### DIFF
--- a/fab/fabfile.py
+++ b/fab/fabfile.py
@@ -765,10 +765,10 @@ def copy_formplayer_properties():
 @task
 @roles(ROLES_TOUCHFORMS)
 def build_formplayer():
-    spring_dir = '{}/{}'.format(env.code_root, 'submodules/formplayer')
-    with shell_env(JAVA_HOME='/usr/lib/jvm/jdk1.7.0'):
-        with cd(spring_dir):
-            sudo('./gradlew build')
+    build_dir = '{}/{}'.format(env.code_root, 'submodules/formplayer/build/libs')
+    jenkins_formplayer_build_url = 'http://jenkins.dimagi.com/job/formplayer/lastSuccessfulBuild/artifact/build/libs/formplayer.jar'
+
+    sudo('wget {} -P {}'.format(jenkins_formplayer_build_url, build_dir))
 
 
 @parallel


### PR DESCRIPTION
@wpride @emord @esoergel this should help speed up deploys. it downloads most recent formplayer jar from jenkins instead of building it every time. going to test it out on staging
