### PR TITLE
Support cmitfb for advanced form with non duplicate case types

### DIFF
--- a/corehq/apps/app_manager/tests/test_util.py
+++ b/corehq/apps/app_manager/tests/test_util.py
@@ -1,7 +1,9 @@
 import corehq.apps.app_manager.util as util
 from corehq.apps.app_manager.const import APP_V2
 from corehq.apps.app_manager.models import (
-    Application, Module, OpenCaseAction, OpenSubCaseAction)
+    Application, Module, AdvancedModule, OpenCaseAction, OpenSubCaseAction,
+    LoadUpdateAction
+)
 from django.test.testcases import SimpleTestCase
 from mock import patch
 
@@ -81,6 +83,43 @@ class SchemaTest(SimpleTestCase):
             },
         })
 
+    def test_get_session_schema_for_advanced_form_without_cases(self):
+        app = self.make_app()
+        form = self.add_advanced_form(app)
+        schema = util.get_session_schema(form)
+        self.assertDictEqual(schema["structure"], {})
+
+    def test_get_session_schema_for_advanced_form_with_one_case(self):
+        app = self.make_app()
+        form = self.add_advanced_form(app, ["village"])
+        schema = util.get_session_schema(form)
+        self.assertDictEqual(schema["structure"]["case_id_load_village_0"], {
+            "reference": {
+                "source": "casedb",
+                "subset": "village",
+                "key": "@case_id",
+            },
+        })
+
+    def test_get_session_schema_for_advanced_form_with_multiple_case(self):
+        app = self.make_app()
+        form = self.add_advanced_form(app, ["village", "family"])
+        schema = util.get_session_schema(form)
+        self.assertDictEqual(schema["structure"]["case_id_load_village_0"], {
+            "reference": {
+                "source": "casedb",
+                "subset": "village",
+                "key": "@case_id",
+            },
+        })
+        self.assertDictEqual(schema["structure"]["case_id_load_family_0"], {
+            "reference": {
+                "source": "casedb",
+                "subset": "family",
+                "key": "@case_id",
+            },
+        })
+
     # -- helpers --
 
     def assert_has_kv_pairs(self, test_dict, expected_dict):
@@ -91,6 +130,16 @@ class SchemaTest(SimpleTestCase):
         """
         for key, value in expected_dict.items():
             self.assertEqual(test_dict[key], value)
+
+    def add_advanced_form(self, app, case_types=list(), module_id=None):
+        if module_id is None:
+            module_id = len(app.modules)
+            m = app.add_module(AdvancedModule.new_module('Advanced Module{}'.format(module_id), lang='en'))
+        form = app.new_form(module_id, 'form {}'.format(', '.join(case_types)), lang='en')
+        form.actions.load_update_cases = []
+        for case_type in case_types:
+            form.actions.load_update_cases.append(LoadUpdateAction(case_type=case_type, case_tag='load_' + case_type + '_0'))
+        return form
 
     def add_form(self, app, case_type=None, module_id=None):
         if module_id is None:

--- a/corehq/apps/app_manager/tests/test_util.py
+++ b/corehq/apps/app_manager/tests/test_util.py
@@ -134,11 +134,13 @@ class SchemaTest(SimpleTestCase):
     def add_advanced_form(self, app, case_types=list(), module_id=None):
         if module_id is None:
             module_id = len(app.modules)
-            m = app.add_module(AdvancedModule.new_module('Advanced Module{}'.format(module_id), lang='en'))
+            app.add_module(AdvancedModule.new_module('Advanced Module{}'.format(module_id), lang='en'))
         form = app.new_form(module_id, 'form {}'.format(', '.join(case_types)), lang='en')
         form.actions.load_update_cases = []
         for case_type in case_types:
-            form.actions.load_update_cases.append(LoadUpdateAction(case_type=case_type, case_tag='load_' + case_type + '_0'))
+            form.actions.load_update_cases.append(
+                LoadUpdateAction(case_type=case_type, case_tag='load_' + case_type + '_0')
+            )
         return form
 
     def add_form(self, app, case_type=None, module_id=None):

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -346,20 +346,24 @@ def get_session_schema(form):
     """Get form session schema definition
     """
     structure = {}
-    # TODO handle advanced modules with more than one case
-    if hasattr(form, 'get_module'):
-        case_type = form.get_module().case_type
-    else:
-        case_type = None
+    cases = []
+    # TODO handle advanced modules with more than one use of the same case
+    if form.doc_type == "AdvancedForm":
+        for action in form.actions.load_update_cases:
+            cases.append((action.case_type, action.case_session_var))
+    elif hasattr(form, 'get_module'):
+        if form.get_module().case_type:
+            cases.append((form.get_module().case_type, 'case_id'))
 
-    if case_type:
-        structure["case_id"] = {
+    for case in cases:
+        structure[case[1]] = {
             "reference": {
                 "source": "casedb",
-                "subset": case_type,
+                "subset": case[0],
                 "key": "@case_id",
             },
         }
+
     return {
         "id": "commcaresession",
         "uri": "jr://instance/session",

--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -70,7 +70,7 @@ def form_designer(request, domain, app_id, module_id=None, form_id=None):
         vellum_plugins.append("commtrack")
     if toggles.VELLUM_SAVE_TO_CASE.enabled(domain):
         vellum_plugins.append("saveToCase")
-    if toggles.VELLUM_EXPERIMENTAL_UI.enabled(domain) and module and module.case_type and form.requires_case():
+    if toggles.VELLUM_EXPERIMENTAL_UI.enabled(domain) and form.requires_case():
         vellum_plugins.append("databrowser")
 
     vellum_features = toggles.toggles_dict(username=request.user.username,


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?223790#1127986

Supports case management in the form builder for advanced forms as long as two of the same case type are not loaded at the same time. (it still half works in that case, but you can't access the second case)

This is fixable now, but once hashtag syntax is released #case/type/prop becomes ambiguous (do you select the first or second case). So I'm going to wait on doing that until we decide on a good way to fix the ambiguity.

@millerdev 

code buddy @proteusvacuum 
