### PR TITLE
Better case history label

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -181,11 +181,12 @@ class ExportColumn(DocumentSchema):
         :returns: An ExportColumn instance
         """
         is_case_update = item.tag == PROPERTY_TAG_CASE and not isinstance(item, CaseIndexItem)
+        is_case_history_update = item.tag == PROPERTY_TAG_UPDATE
 
         is_main_table = table_path == MAIN_TABLE
         constructor_args = {
             "item": item,
-            "label": item.readable_path,
+            "label": item.readable_path if not is_case_history_update else item.label,
             "is_advanced": is_case_update or False,
         }
 


### PR DESCRIPTION
@NoahCarnahan this broke when i switched to using `readable_path`. it makes sure we don't include the weird `actions.update_unknown_properties` in the label of the case history columns

cc: @sravfeyn 
