### PR TITLE
Fix "undefined" xmlns

### DIFF
--- a/corehq/apps/cleanup/management/commands/fix_forms_with_missing_xmlns.py
+++ b/corehq/apps/cleanup/management/commands/fix_forms_with_missing_xmlns.py
@@ -64,7 +64,6 @@ class Command(BaseCommand):
                 xmlns = match.group(1)
                 form_unique_id = match.group(2)
                 unique_id_to_xmlns_map[form_unique_id] = xmlns
-                print form_unique_id
 
                 try:
                     form = Form.get_form(form_unique_id)

--- a/corehq/apps/cleanup/tests/test_fix_forms_with_missing_xmlns.py
+++ b/corehq/apps/cleanup/tests/test_fix_forms_with_missing_xmlns.py
@@ -125,7 +125,7 @@ class TestFixFormsWithMissingXmlns(TestCase, TestXmlMixin):
         form, xform = self.build_normal_app()
         self._refresh_pillow()
 
-        call_command('fix_forms_with_missing_xmlns', 'log.txt')
+        call_command('fix_forms_with_missing_xmlns', '/dev/null', 'log.txt')
 
         with open("log.txt") as log_file:
             log = log_file.read()
@@ -136,7 +136,7 @@ class TestFixFormsWithMissingXmlns(TestCase, TestXmlMixin):
         good_form, bad_form, good_xform, bad_xforms = self.build_app_with_bad_form()
         self._refresh_pillow()
 
-        call_command('fix_forms_with_missing_xmlns', 'log.txt')
+        call_command('fix_forms_with_missing_xmlns', '/dev/null', 'log.txt')
 
         with open("log.txt") as log_file:
             log = log_file.read()
@@ -150,7 +150,7 @@ class TestFixFormsWithMissingXmlns(TestCase, TestXmlMixin):
         form, good_build, bad_build, good_xform, bad_xform = self.build_app_with_recently_fixed_form()
         self._refresh_pillow()
 
-        call_command('fix_forms_with_missing_xmlns', 'log.txt')
+        call_command('fix_forms_with_missing_xmlns', '/dev/null', 'log.txt')
 
         with open("log.txt") as log_file:
             log = log_file.read()


### PR DESCRIPTION
Follow on from https://github.com/dimagi/commcare-hq/pull/11188
Sooo... the script crashed about a third of the way way through. This PR adds code to automatically rebuild the processed form dictionaries (`unique_id_to_xmlns_map` and `app_to_unique_ids_map`). It also changes the logging such that it's easier to rebuild those dicts. (I ran another script to get my first log into the new expected shape). I'm going to run a full dry run from this branch and see if it completes. If it does, I'll run it for real again.
@czue @emord (best reviewed by full diff)
