### PR TITLE
call clean() when saving

### DIFF
--- a/corehq/apps/accounting/migrations/0025_creditadjustment_permit_blank_fields.py
+++ b/corehq/apps/accounting/migrations/0025_creditadjustment_permit_blank_fields.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounting', '0024_date_created_to_datetime'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='creditadjustment',
+            name='invoice',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, blank=True, to='accounting.Invoice', null=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='creditadjustment',
+            name='line_item',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, blank=True, to='accounting.LineItem', null=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='creditadjustment',
+            name='note',
+            field=models.TextField(blank=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='creditadjustment',
+            name='payment_record',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, blank=True, to='accounting.PaymentRecord', null=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='creditadjustment',
+            name='related_credit',
+            field=models.ForeignKey(related_name='creditadjustment_related', on_delete=django.db.models.deletion.PROTECT, blank=True, to='accounting.CreditLine', null=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='creditadjustment',
+            name='web_user',
+            field=models.CharField(max_length=80, null=True, blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -61,6 +61,7 @@ from corehq.apps.hqwebapp.tasks import send_html_email_async
 from corehq.apps.users.models import WebUser
 from corehq.const import USER_DATE_FORMAT
 from corehq.util.dates import get_first_last_days
+from corehq.util.mixin import ValidateModelMixin
 from corehq.util.quickcache import quickcache
 from corehq.util.view_utils import absolute_reverse
 from corehq.apps.analytics.tasks import track_workflow
@@ -2957,7 +2958,7 @@ class PaymentRecord(models.Model):
         )
 
 
-class CreditAdjustment(models.Model):
+class CreditAdjustment(ValidateModelMixin, models.Model):
     """
     A record of any additions (positive amounts) or deductions (negative amounts) that contributed to the
     current balance of the associated CreditLine.

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -2966,16 +2966,16 @@ class CreditAdjustment(ValidateModelMixin, models.Model):
     credit_line = models.ForeignKey(CreditLine, on_delete=models.PROTECT)
     reason = models.CharField(max_length=25, default=CreditAdjustmentReason.MANUAL,
                               choices=CreditAdjustmentReason.CHOICES)
-    note = models.TextField()
+    note = models.TextField(blank=True)
     amount = models.DecimalField(default=Decimal('0.0000'), max_digits=10, decimal_places=4)
-    line_item = models.ForeignKey(LineItem, on_delete=models.PROTECT, null=True)
-    invoice = models.ForeignKey(Invoice, on_delete=models.PROTECT, null=True)
+    line_item = models.ForeignKey(LineItem, on_delete=models.PROTECT, null=True, blank=True)
+    invoice = models.ForeignKey(Invoice, on_delete=models.PROTECT, null=True, blank=True)
     payment_record = models.ForeignKey(PaymentRecord,
-                                       on_delete=models.PROTECT, null=True)
+                                       on_delete=models.PROTECT, null=True, blank=True)
     related_credit = models.ForeignKey(CreditLine, on_delete=models.PROTECT,
-                                       null=True, related_name='creditadjustment_related')
+                                       null=True, blank=True, related_name='creditadjustment_related')
     date_created = models.DateTimeField(auto_now_add=True)
-    web_user = models.CharField(max_length=80, null=True)
+    web_user = models.CharField(max_length=80, null=True, blank=True)
     last_modified = models.DateTimeField(auto_now=True)
 
     class Meta:

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -2985,5 +2985,5 @@ class CreditAdjustment(ValidateModelMixin, models.Model):
         """
         Only one of either a line item or invoice may be specified as the adjuster.
         """
-        if self.line_item and self.invoice is not None:
+        if self.line_item and self.invoice:
             raise ValidationError(_("You can't specify both an invoice and a line item."))

--- a/corehq/apps/accounting/tests/__init__.py
+++ b/corehq/apps/accounting/tests/__init__.py
@@ -12,3 +12,4 @@ from .test_forms import *
 from .test_autopay import *
 from .test_stripe_payment import *
 from .test_subscription_permissions_changes import *
+from .test_model_validation import *

--- a/corehq/apps/accounting/tests/test_model_validation.py
+++ b/corehq/apps/accounting/tests/test_model_validation.py
@@ -1,0 +1,54 @@
+from datetime import date
+
+from django.core.exceptions import ValidationError
+from django.test import TransactionTestCase
+
+from corehq.apps.accounting import generator
+from corehq.apps.accounting.models import (
+    BillingAccount,
+    CreditAdjustment,
+    Invoice,
+    LineItem,
+    Subscriber,
+    Subscription,
+)
+
+
+class TestCreditAdjustmentValidation(TransactionTestCase):
+
+    def tearDown(self):
+        super(TestCreditAdjustmentValidation, self).tearDown()
+        CreditAdjustment.objects.all().delete()
+        LineItem.objects.all().delete()
+        Invoice.objects.all().delete()
+        generator.delete_all_subscriptions()
+        generator.delete_all_accounts()
+
+    def test_clean(self):
+        account = BillingAccount.objects.create(
+            currency=generator.init_default_currency(),
+        )
+        subscription = Subscription.objects.create(
+            account=account,
+            date_start=date.today(),
+            plan_version=generator.subscribable_plan(),
+            subscriber=Subscriber.objects.create(domain='test')
+        )
+        invoice = Invoice.objects.create(
+            date_start=date.today(),
+            date_end=date.today(),
+            subscription=subscription,
+        )
+        line_item = LineItem.objects.create(
+            invoice=invoice,
+        )
+
+        with self.assertRaises(ValidationError):
+            try:
+                CreditAdjustment(
+                    invoice=invoice,
+                    line_item=line_item,
+                ).save()
+            except ValidationError as e:
+                self.assertIn('__all__', e.error_dict)
+                raise e

--- a/corehq/util/mixin.py
+++ b/corehq/util/mixin.py
@@ -29,3 +29,10 @@ class UUIDGeneratorMixin(object):
             value = getattr(self, field_name)
             if not value:
                 setattr(self, field_name, uuid.uuid4().hex)
+
+
+# https://gist.github.com/glarrain/5448253
+class ValidateModelMixin(object):
+    def save(self, *args, **kwargs):
+        self.full_clean()
+        super(ValidateModelMixin, self).save(*args, **kwargs)


### PR DESCRIPTION
`clean` was implemented, but was never actually used.  This ensures that `clean` is called during `save`.

@esoergel 
