### PR TITLE
New APT requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ The Python libraries you will be installing in the next step require the followi
 
     $ sudo apt-get install rabbitmq-server \
           libpq-dev \
+          libffi-dev \
           libfreetype6-dev \
           libjpeg-dev \
           libtiff-dev \

--- a/requirements/apt-packages.txt
+++ b/requirements/apt-packages.txt
@@ -13,6 +13,7 @@ apache2
 redis-server # [travis_ignore]
 
 # dependencies for the pip modules
+libffi-dev
 libfreetype6-dev
 libjpeg-dev
 libtiff-dev


### PR DESCRIPTION
`libffi-dev` is required to install Python package `github3.py` in [requirements/dev-requirements.txt](https://github.com/dimagi/commcare-hq/blob/34995543ec3e5407b02efebfe808f484166b057c/requirements/dev-requirements.txt#L24-L24).

@dannyroberts 
