### PR TITLE
Fix CustomDatespanFilter operator dropdown

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/filter_configs.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/filter_configs.html
@@ -91,7 +91,7 @@
                                type="text"
                                data-bind="value: filter.selectedValue.ancestor_location_type_name"/>
                     </div>
-                    <div data-bind="visible: filter.selectedValue.doc_type() === 'NumericFilter'">
+                    <!-- ko if: filter.selectedValue.doc_type() === 'NumericFilter' -->
                         <div class="form-inline">
                             <div class="form-group">
                                 <select
@@ -106,7 +106,7 @@
                                 <input type="number" class="form-control" data-bind="value: filter.selectedValue.operand"/>
                             </div>
                         </div>
-                    </div>
+                    <!-- /ko -->
                 </div>
             </th>
         </tr>


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?224047

Having two selects use the same value binding (`value: filter.selectedValue.operator`) links those two together - updating one will update the other - and you end up not being able to select options that exist in one select but not the other.

@nickpell / @calellowitz 
