### PR TITLE
Handle user refreshing page after convert

### DIFF
--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -133,9 +133,11 @@ def convert_saved_export_to_export_instance(domain, saved_export):
                 # Must be deid transform
                 new_column.deid_transform = transform
 
-    saved_export.doc_type += DELETED_SUFFIX
-    saved_export.save()
     instance.save()
+
+    saved_export.doc_type += DELETED_SUFFIX
+    saved_export.converted_saved_export_id = instance._id
+    saved_export.save()
 
     return instance
 

--- a/corehq/ex-submodules/couchexport/models.py
+++ b/corehq/ex-submodules/couchexport/models.py
@@ -599,6 +599,9 @@ class SavedExportSchema(BaseSavedExportSchema, UnicodeMixIn):
     # For us right now, 'form' or 'case'
     type = StringProperty()
 
+    # ID of  the new style export that it was converted to
+    converted_saved_export_id = StringProperty()
+
     def __unicode__(self):
         return "%s (%s)" % (self.name, self.index)
 


### PR DESCRIPTION
@NoahCarnahan saw this in the soft asserts. i think some users are refreshing the export page after the export has been converted causing us to convert the doc twice which results in an error

cc: @sravfeyn 
