### PR TITLE
User groups pillow tests and tweaks

### DIFF
--- a/corehq/apps/change_feed/document_types.py
+++ b/corehq/apps/change_feed/document_types.py
@@ -10,6 +10,7 @@ DOMAIN = 'domain'
 META = 'meta'
 COMMCARE_USER = 'commcare-user'
 WEB_USER = 'web-user'
+GROUP = 'group'
 
 
 DocumentMetadata = namedtuple(
@@ -35,6 +36,8 @@ def _get_primary_type(raw_doc_type):
         return COMMCARE_USER
     elif raw_doc_type in ('WebUser', 'WebUser-Deleted'):
         return WEB_USER
+    elif raw_doc_type in ('Group', 'Group-Deleted'):
+        return GROUP
     else:
         # at some point we may want to make this more granular
         return META

--- a/corehq/apps/change_feed/tests/test_document_types.py
+++ b/corehq/apps/change_feed/tests/test_document_types.py
@@ -1,6 +1,6 @@
 from django.test import SimpleTestCase
 from corehq.apps.change_feed.document_types import CASE, get_doc_meta_object_from_document, FORM, META, DOMAIN, \
-    change_meta_from_doc, COMMCARE_USER, WEB_USER
+    change_meta_from_doc, COMMCARE_USER, WEB_USER, GROUP
 from corehq.apps.change_feed.exceptions import MissingMetaInformationError
 from corehq.util.test_utils import generate_cases
 
@@ -20,6 +20,7 @@ class DocumentTypeTest(SimpleTestCase):
     ({'doc_type': 'Domain'}, DOMAIN),
     ({'doc_type': 'CommCareUser'}, COMMCARE_USER),
     ({'doc_type': 'WebUser'}, WEB_USER),
+    ({'doc_type': 'Group'}, GROUP),
     ({'doc_type': 'Location'}, META),
     # subtype tests
     ({'doc_type': 'CommCareCase', 'type': 'person'}, CASE, 'person'),
@@ -36,6 +37,7 @@ class DocumentTypeTest(SimpleTestCase):
     ({'doc_type': 'Domain-DUPLICATE'}, DOMAIN, None, None, True),
     ({'doc_type': 'CommCareUser-Deleted'}, COMMCARE_USER, None, None, True),
     ({'doc_type': 'WebUser-Deleted'}, WEB_USER, None, None, True),
+    ({'doc_type': 'Group-Deleted'}, GROUP, None, None, True),
     ({'doc_type': 'Location-Deleted'}, META, None, None, True),
 ], DocumentTypeTest)
 def test_document_meta(self, raw_doc, expected_primary_type, expected_subtype=None,

--- a/corehq/apps/hqcase/management/commands/ptop_fast_reindexer.py
+++ b/corehq/apps/hqcase/management/commands/ptop_fast_reindexer.py
@@ -127,11 +127,7 @@ class PtopReindexer(NoArgsCommand):
         return paginate_view(*args, **kwargs)
 
     def full_couch_view_iter(self):
-        if hasattr(self.pillow, 'include_docs_when_preindexing'):
-            include_docs = self.pillow.include_docs_when_preindexing
-        else:
-            include_docs = self.pillow.include_docs
-        view_kwargs = {"include_docs": include_docs}
+        view_kwargs = {"include_docs": self.pillow.include_docs}
         if self.couch_key is not None:
             view_kwargs["key"] = self.couch_key
 

--- a/corehq/ex-submodules/pillowtop/listener.py
+++ b/corehq/ex-submodules/pillowtop/listener.py
@@ -1,7 +1,6 @@
 from functools import wraps
 import logging
 from couchdbkit.exceptions import ResourceNotFound
-from elasticsearch import Elasticsearch
 from elasticsearch.exceptions import RequestError, ConnectionError, NotFoundError, ConflictError
 from psycopg2._psycopg import InterfaceError as Psycopg2InterfaceError
 from django.db.utils import InterfaceError as DjangoInterfaceError

--- a/corehq/pillows/user.py
+++ b/corehq/pillows/user.py
@@ -1,6 +1,7 @@
 from casexml.apps.case.xform import is_device_report
 from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed
-from corehq.apps.change_feed.document_types import COMMCARE_USER, WEB_USER
+from corehq.apps.change_feed.document_types import COMMCARE_USER, WEB_USER, get_doc_meta_object_from_document, \
+    GROUP
 from corehq.apps.users.models import CommCareUser, CouchUser
 from corehq.apps.users.util import WEIRD_USER_IDS
 from corehq.elastic import (
@@ -49,7 +50,8 @@ class GroupToUserPillow(PythonPillow):
         self.es_type = ES_META['users'].type
 
     def python_filter(self, change):
-        return change.get_document().get('doc_type', None) in ('Group', 'Group-Deleted')
+        doc_meta = get_doc_meta_object_from_document(change.get_document())
+        return doc_meta and doc_meta.primary_type == GROUP
 
     def change_transport(self, doc_dict):
         update_es_user_with_groups(doc_dict, self.es)

--- a/corehq/pillows/user.py
+++ b/corehq/pillows/user.py
@@ -79,7 +79,6 @@ class UnknownUsersPillow(PythonPillow):
     """
     document_class = XFormInstance
     include_docs_when_preindexing = False
-    es_path = USER_INDEX + "/user/"
 
     def __init__(self):
         checkpoint = get_default_django_checkpoint_for_legacy_pillow_class(self.__class__)

--- a/corehq/pillows/user.py
+++ b/corehq/pillows/user.py
@@ -49,7 +49,7 @@ class GroupToUserPillow(PythonPillow):
         self.es_type = ES_META['users'].type
 
     def python_filter(self, change):
-        return change.document.get('doc_type', None) in ('Group', 'Group-Deleted')
+        return change.get_document().get('doc_type', None) in ('Group', 'Group-Deleted')
 
     def change_transport(self, doc_dict):
         update_es_user_with_groups(doc_dict, self.es)

--- a/corehq/pillows/user.py
+++ b/corehq/pillows/user.py
@@ -54,7 +54,26 @@ class GroupToUserPillow(PythonPillow):
         return doc_meta and doc_meta.primary_type == GROUP
 
     def change_transport(self, doc_dict):
-        update_es_user_with_groups(doc_dict, self.es)
+        doc_meta = get_doc_meta_object_from_document(doc_dict)
+        if doc_meta.is_deletion:
+            remove_group_from_users(doc_dict, self.es)
+        else:
+            update_es_user_with_groups(doc_dict, self.es)
+
+
+def remove_group_from_users(group_doc, es_client):
+    user_ids = group_doc.get("users", [])
+    q = {"filter": {"and": [{"terms": {"_id": user_ids}}]}}
+    for user_source in stream_es_query(es_index='users', q=q, fields=["__group_ids", "__group_names"]):
+        group_ids = user_source.get('fields', {}).get("__group_ids", [])
+        group_ids = set(group_ids) if isinstance(group_ids, list) else {group_ids}
+        group_names = user_source.get('fields', {}).get("__group_names", [])
+        group_names = set(group_names) if isinstance(group_names, list) else {group_names}
+        if group_doc["name"] in group_names or group_doc["_id"] in group_ids:
+            group_ids.remove(group_doc["_id"])
+            group_names.remove(group_doc["name"])
+            doc = {"__group_ids": list(group_ids), "__group_names": list(group_names)}
+            es_client.update(USER_INDEX, ES_META['users'].type, user_source["_id"], body={"doc": doc})
 
 
 def update_es_user_with_groups(group_doc, es_client=None):

--- a/corehq/pillows/user.py
+++ b/corehq/pillows/user.py
@@ -118,9 +118,6 @@ class UnknownUsersPillow(PythonPillow):
     def _user_exists(self, user_id):
         return self.user_db.doc_exist(user_id)
 
-    def _user_indexed(self, user_id):
-        return doc_exists_in_es('users', user_id)
-
     def change_transport(self, doc_dict):
         doc = doc_dict
         user_id, username, domain, xform_id = _get_user_fields_from_form_doc(doc)
@@ -129,7 +126,7 @@ class UnknownUsersPillow(PythonPillow):
             user_id = None
 
         if (user_id and not self._user_exists(user_id)
-                and not self._user_indexed(user_id)):
+                and not doc_exists_in_es('users', user_id)):
             doc_type = "AdminUser" if username == "admin" else "UnknownUser"
             doc = {
                 "_id": user_id,

--- a/corehq/pillows/user.py
+++ b/corehq/pillows/user.py
@@ -101,7 +101,6 @@ class UnknownUsersPillow(PythonPillow):
     This pillow adds users from xform submissions that come in to the User Index if they don't exist in HQ
     """
     document_class = XFormInstance
-    include_docs_when_preindexing = False
 
     def __init__(self):
         checkpoint = get_default_django_checkpoint_for_legacy_pillow_class(self.__class__)

--- a/docker/utils.sh
+++ b/docker/utils.sh
@@ -32,5 +32,5 @@ create_topics() {
 create_kafka_topics() {
     kafka_topics=$(docker_run kafka find /opt -name kafka-topics.sh | tr -d '\n' | tr -d '\r')
     zookeeper_ip=$(get_container_ip "commcare.name" "kafka")
-    create_topics $kafka_topics $zookeeper_ip "case form meta case-sql form-sql sms domain commcare-user web-user"
+    create_topics $kafka_topics $zookeeper_ip "case form meta case-sql form-sql sms domain commcare-user web-user group"
 }

--- a/settings.py
+++ b/settings.py
@@ -1436,7 +1436,6 @@ PILLOWTOPS = {
         'corehq.pillows.group.GroupPillow',
         'corehq.pillows.sms.SMSPillow',
         'corehq.pillows.user.GroupToUserPillow',
-        'corehq.pillows.user.UnknownUsersPillow',
         'corehq.pillows.sofabed.FormDataPillow',
         'corehq.pillows.sofabed.CaseDataPillow',
         # TODO: Remove this once ConstructedPillows can deal with their own indices
@@ -1489,6 +1488,11 @@ PILLOWTOPS = {
             'name': 'SqlCaseToElasticsearchPillow',
             'class': 'pillowtop.pillow.interface.ConstructedPillow',
             'instance': 'corehq.pillows.case.get_sql_case_to_elasticsearch_pillow',
+        },
+        {
+            'name': 'UnknownUsersPillow',
+            'class': 'pillowtop.pillow.interface.ConstructedPillow',
+            'instance': 'corehq.pillows.user.get_unknown_users_pillow',
         },
     ],
     'cache': [

--- a/testapps/test_pillowtop/tests/data/all-pillow-meta.json
+++ b/testapps/test_pillowtop/tests/data/all-pillow-meta.json
@@ -563,16 +563,10 @@
         "name": "UCLAPatientFluffPillow"
     },
     "UnknownUsersPillow": {
-        "advertised_name": "corehq.pillows.user.UnknownUsersPillow.testhq",
-        "change_feed_type": "CouchChangeFeed",
-        "checkpoint_id": "corehq.pillows.user.UnknownUsersPillow.testhq",
-        "couch_filter": null,
-        "couchdb_type": "CachedCouchDB",
-        "couchdb_uri": "http://{COUCH_SERVER_ROOT}/test_commcarehq",
-        "document_class": "XFormInstance",
-        "extra_args": {},
-        "full_class_name": "corehq.pillows.user.UnknownUsersPillow",
-        "include_docs": false,
+        "advertised_name": "UnknownUsersPillow",
+        "change_feed_type": "KafkaChangeFeed",
+        "checkpoint_id": "UnknownUsersPillow",
+        "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
         "name": "UnknownUsersPillow"
     },
     "UserCacheInvalidatePillow": {

--- a/testapps/test_pillowtop/tests/test_grouptouser_pillow.py
+++ b/testapps/test_pillowtop/tests/test_grouptouser_pillow.py
@@ -23,18 +23,8 @@ class GroupToUserPillowTest(SimpleTestCase):
         ensure_index_deleted(USER_INDEX)
 
     def _check_es_user(self, group_ids=None, group_names=None):
-        self.es_client.indices.refresh(USER_INDEX)
-        es_user = self.es_client.get(USER_INDEX, self.user_id)
-        user_doc = es_user['_source']
-        if group_ids is None:
-            self.assertTrue('__group_ids' not in user_doc)
-        else:
-            self.assertEqual(set(user_doc['__group_ids']), set(group_ids))
-
-        if group_names is None:
-            self.assertTrue('__group_names' not in user_doc)
-        else:
-            self.assertEqual(set(user_doc['__group_names']), set(group_names))
+        _assert_es_user_and_groups(
+            self, self.es_client, self.user_id, group_ids, group_names)
 
     def test_update_es_user_with_groups(self):
         group_doc = {
@@ -64,6 +54,21 @@ class GroupToUserPillowTest(SimpleTestCase):
         }
         update_es_user_with_groups(new_group)
         self._check_es_user(['group1', 'group2'], ['g1', 'g2'])
+
+
+def _assert_es_user_and_groups(test_case, es_client, user_id, group_ids=None, group_names=None):
+    es_client.indices.refresh(USER_INDEX)
+    es_user = es_client.get(USER_INDEX, user_id)
+    user_doc = es_user['_source']
+    if group_ids is None:
+        test_case.assertTrue('__group_ids' not in user_doc)
+    else:
+        test_case.assertEqual(set(user_doc['__group_ids']), set(group_ids))
+
+    if group_names is None:
+        test_case.assertTrue('__group_names' not in user_doc)
+    else:
+        test_case.assertEqual(set(user_doc['__group_names']), set(group_names))
 
 
 def _create_es_user(es_client, user_id, domain):

--- a/testapps/test_pillowtop/tests/test_reindexer.py
+++ b/testapps/test_pillowtop/tests/test_reindexer.py
@@ -8,13 +8,11 @@ from elasticsearch.exceptions import ConnectionError
 from corehq.apps.case_search.models import CaseSearchConfig
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.domain.tests.test_utils import delete_all_domains
-from corehq.apps.es import CaseES, CaseSearchES, DomainES, ESQuery, FormES, UserES
+from corehq.apps.es import CaseES, CaseSearchES, DomainES, FormES, UserES
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 from corehq.apps.users.models import CommCareUser, WebUser
-from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.tests.utils import FormProcessorTestUtils, \
     run_with_all_backends
-from corehq.form_processor.utils import TestFormMetadata
 from corehq.pillows.case import CasePillow
 from corehq.pillows.case_search import CaseSearchPillow
 from corehq.pillows.mappings.case_mapping import CASE_INDEX
@@ -23,8 +21,8 @@ from corehq.pillows.mappings.domain_mapping import DOMAIN_INDEX
 from corehq.pillows.mappings.user_mapping import USER_INDEX
 from corehq.pillows.mappings.xform_mapping import XFORM_INDEX
 from corehq.util.elastic import delete_es_index, ensure_index_deleted
-from corehq.util.test_utils import get_form_ready_to_save, trap_extra_setup, create_and_save_a_form, \
-    create_and_save_a_case
+from corehq.util.test_utils import trap_extra_setup, create_and_save_a_form, create_and_save_a_case
+
 
 DOMAIN = 'reindex-test-domain'
 

--- a/testapps/test_pillowtop/tests/test_user_pillow.py
+++ b/testapps/test_pillowtop/tests/test_user_pillow.py
@@ -1,19 +1,23 @@
+from django.conf import settings
 from django.test import TestCase
 from corehq.apps.change_feed import data_sources
 from corehq.apps.change_feed import document_types
 from corehq.apps.change_feed.document_types import change_meta_from_doc
 from corehq.apps.change_feed.producer import producer
+from corehq.apps.change_feed.topics import FORM_SQL
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.es import UserES, ESQuery
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 from corehq.apps.users.models import CommCareUser
 from corehq.elastic import get_es_new
+from corehq.form_processor.change_publishers import change_meta_from_sql_form
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
-from corehq.form_processor.tests import FormProcessorTestUtils
+from corehq.form_processor.tests import FormProcessorTestUtils, run_with_all_backends
 from corehq.form_processor.utils import TestFormMetadata
 from corehq.pillows.mappings.user_mapping import USER_INDEX_INFO
-from corehq.pillows.user import UserPillow, get_user_kafka_to_elasticsearch_pillow, UnknownUsersPillow
+from corehq.pillows.user import UserPillow, get_user_kafka_to_elasticsearch_pillow, get_unknown_users_pillow
 from corehq.util.elastic import ensure_index_deleted
+from couchforms.models import XFormInstance
 from dimagi.utils.couch.undo import DELETED_SUFFIX
 from corehq.util.test_utils import get_form_ready_to_save
 from pillowtop.es_utils import initialize_index
@@ -111,6 +115,7 @@ class UnknownUserPillowTest(UserPillowTestBase):
         'corehq.sql_proxy_accessors',
     ]
 
+    @run_with_all_backends
     def test_unknown_user_pillow(self):
         FormProcessorTestUtils.delete_all_xforms()
         user_id = 'test-unknown-user'
@@ -118,10 +123,14 @@ class UnknownUserPillowTest(UserPillowTestBase):
         form = get_form_ready_to_save(metadata)
         FormProcessorInterface(domain=TEST_DOMAIN).save_processed_models([form])
 
+        # send to kafka
+        topic = FORM_SQL if settings.TESTS_SHOULD_USE_SQL_BACKEND else document_types.FORM
+        since = get_current_kafka_seq(topic)
+        producer.send_change(topic, _form_to_change_meta(form))
+
         # send to elasticsearch
-        pillow = UnknownUsersPillow()
-        pillow.use_chunking = False  # hack - make sure the pillow doesn't chunk
-        pillow.process_changes(since=0, forever=False)
+        pillow = get_unknown_users_pillow()
+        pillow.process_changes(since={topic: since}, forever=False)
         self.elasticsearch.indices.refresh(self.index_info.index)
 
         # the default query doesn't include unknown users so should have no results
@@ -136,7 +145,17 @@ class UnknownUserPillowTest(UserPillowTestBase):
         self.assertEqual(TEST_DOMAIN, user_doc['domain'])
         self.assertEqual(user_id, user_doc['_id'])
         self.assertEqual('UnknownUser', user_doc['doc_type'])
-        form.delete()
+
+
+def _form_to_change_meta(form):
+    if settings.TESTS_SHOULD_USE_SQL_BACKEND:
+        return change_meta_from_sql_form(form)
+    else:
+        return change_meta_from_doc(
+            document=form.to_json(),
+            data_source_type=data_sources.COUCH,
+            data_source_name=XFormInstance.get_db().dbname,
+        )
 
 
 def _user_to_change_meta(user):

--- a/testapps/test_pillowtop/tests/test_user_pillow.py
+++ b/testapps/test_pillowtop/tests/test_user_pillow.py
@@ -97,7 +97,7 @@ class UserPillowTest(UserPillowTestBase):
         self.assertEqual(username, user_doc['username'])
 
 
-class UnknownUserTest(UserPillowTestBase):
+class UnknownUserPillowTest(UserPillowTestBase):
     dependent_apps = [
         'auditcare',
         'django_digest',


### PR DESCRIPTION
some more prework and tests for converting the user pillows over to kafka.

probably easier to review this commit by commit now. in addition to adding tests and fixes for the `GroupToUserPillow` it also migrates the `UnknownUsersPillow` to kafka and makes it SQL compatible.

@snopoke 
