### PR TITLE
Delete case search pillow

### DIFF
--- a/corehq/apps/es/case_search.py
+++ b/corehq/apps/es/case_search.py
@@ -12,7 +12,7 @@ from corehq.apps.es import case_search as case_search_es
 from . import filters, queries
 
 from corehq.apps.es.cases import CaseES
-from corehq.pillows.const import CASE_SEARCH_ALIAS
+from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_ALIAS
 
 
 PATH = "case_properties"

--- a/corehq/pillows/case.py
+++ b/corehq/pillows/case.py
@@ -6,7 +6,7 @@ from corehq.apps.change_feed import topics
 from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed
 from corehq.elastic import get_es_new
 from corehq.form_processor.change_providers import SqlCaseChangeProvider
-from corehq.pillows.mappings.case_mapping import CASE_MAPPING, CASE_INDEX
+from corehq.pillows.mappings.case_mapping import CASE_MAPPING, CASE_INDEX, CASE_ES_TYPE
 from corehq.pillows.utils import get_user_type
 from dimagi.utils.couch import LockManager
 from dimagi.utils.decorators.memoized import memoized
@@ -24,7 +24,6 @@ from pillowtop.reindexer.reindexer import get_default_reindexer_for_elastic_pill
 
 UNKNOWN_DOMAIN = "__nodomain__"
 UNKNOWN_TYPE = "__notype__"
-CASE_ES_TYPE = 'case'
 
 
 pillow_logging = logging.getLogger("pillowtop")

--- a/corehq/pillows/case_search.py
+++ b/corehq/pillows/case_search.py
@@ -17,9 +17,8 @@ from corehq.form_processor.utils.general import should_use_sql_backend
 from corehq.pillows.case import CasePillow
 from corehq.pillows.mappings.case_mapping import CASE_ES_TYPE
 from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_INDEX, \
-    CASE_SEARCH_MAPPING, CASE_SEARCH_ALIAS
+    CASE_SEARCH_MAPPING, CASE_SEARCH_ALIAS, CASE_SEARCH_INDEX_INFO
 from pillowtop.checkpoints.manager import PillowCheckpoint
-from pillowtop.es_utils import ElasticsearchIndexInfo
 from pillowtop.feed.interface import Change
 from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors.elastic import ElasticProcessor
@@ -91,7 +90,7 @@ def get_case_search_to_elasticsearch_pillow(pillow_id='CaseSearchToElasticsearch
     )
     case_processor = CaseSearchPillowProcessor(
         elasticsearch=get_es_new(),
-        index_info=ElasticsearchIndexInfo(index=CASE_SEARCH_INDEX, type=CASE_ES_TYPE),
+        index_info=CASE_SEARCH_INDEX_INFO,
         doc_prep_fn=transform_case_for_elasticsearch
     )
     change_feed = KafkaChangeFeed(topics=[topics.CASE, topics.CASE_SQL], group_id='cases-to-es')

--- a/corehq/pillows/case_search.py
+++ b/corehq/pillows/case_search.py
@@ -14,7 +14,8 @@ from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed, MultiTopicChe
 from corehq.apps.es import CaseSearchES
 from corehq.elastic import get_es_new
 from corehq.form_processor.utils.general import should_use_sql_backend
-from corehq.pillows.case import CASE_ES_TYPE, CasePillow
+from corehq.pillows.case import CasePillow
+from corehq.pillows.mappings.case_mapping import CASE_ES_TYPE
 from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_INDEX, \
     CASE_SEARCH_MAPPING, CASE_SEARCH_ALIAS
 from pillowtop.checkpoints.manager import PillowCheckpoint
@@ -33,7 +34,6 @@ class CaseSearchPillow(CasePillow):
     Nested case properties indexer.
     """
     es_alias = CASE_SEARCH_ALIAS
-
     es_index = CASE_SEARCH_INDEX
     default_mapping = CASE_SEARCH_MAPPING
 

--- a/corehq/pillows/case_search.py
+++ b/corehq/pillows/case_search.py
@@ -15,9 +15,8 @@ from corehq.apps.es import CaseSearchES
 from corehq.elastic import get_es_new
 from corehq.form_processor.utils.general import should_use_sql_backend
 from corehq.pillows.case import CASE_ES_TYPE, CasePillow
-from corehq.pillows.const import CASE_SEARCH_ALIAS
 from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_INDEX, \
-    CASE_SEARCH_MAPPING
+    CASE_SEARCH_MAPPING, CASE_SEARCH_ALIAS
 from pillowtop.checkpoints.manager import PillowCheckpoint
 from pillowtop.es_utils import ElasticsearchIndexInfo
 from pillowtop.feed.interface import Change

--- a/corehq/pillows/case_search.py
+++ b/corehq/pillows/case_search.py
@@ -14,30 +14,16 @@ from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed, MultiTopicChe
 from corehq.apps.es import CaseSearchES
 from corehq.elastic import get_es_new
 from corehq.form_processor.utils.general import should_use_sql_backend
-from corehq.pillows.case import CasePillow
 from corehq.pillows.mappings.case_mapping import CASE_ES_TYPE
 from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_INDEX, \
-    CASE_SEARCH_MAPPING, CASE_SEARCH_ALIAS, CASE_SEARCH_INDEX_INFO
+    CASE_SEARCH_MAPPING, CASE_SEARCH_INDEX_INFO
 from pillowtop.checkpoints.manager import PillowCheckpoint
+from pillowtop.es_utils import initialize_index_and_mapping
 from pillowtop.feed.interface import Change
 from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors.elastic import ElasticProcessor
 from pillowtop.reindexer.change_providers.case import get_domain_case_change_provider
 from pillowtop.reindexer.reindexer import PillowReindexer
-
-
-class CaseSearchPillow(CasePillow):
-    # TODO: Remove this once elasticsearch gets bootstrapped with new pillows
-    # (Used in order to set up index)
-    """
-    Nested case properties indexer.
-    """
-    es_alias = CASE_SEARCH_ALIAS
-    es_index = CASE_SEARCH_INDEX
-    default_mapping = CASE_SEARCH_MAPPING
-
-    def run(self, changes_dict):
-        return
 
 
 def transform_case_for_elasticsearch(doc_dict):
@@ -125,7 +111,7 @@ def get_case_search_reindexer(domain=None):
     """Returns a reindexer that will return either all domains with case search
     enabled, or a single domain if passed in
     """
-    CaseSearchPillow()          # TODO: remove this
+    initialize_index_and_mapping(get_es_new(), CASE_SEARCH_INDEX_INFO)
     try:
         if domain is not None:
             if not case_search_enabled_for_domain(domain):

--- a/corehq/pillows/const.py
+++ b/corehq/pillows/const.py
@@ -1,1 +1,0 @@
-CASE_SEARCH_ALIAS = "case_search"

--- a/corehq/pillows/mappings/case_mapping.py
+++ b/corehq/pillows/mappings/case_mapping.py
@@ -3,7 +3,7 @@ from corehq.pillows.mappings import NULL_VALUE
 from corehq.util.elastic import es_index
 
 CASE_INDEX = es_index("hqcases_2016-03-04")
-
+CASE_ES_TYPE = 'case'
 
 CASE_MAPPING = {
     'date_detection': False,

--- a/corehq/pillows/mappings/case_search_mapping.py
+++ b/corehq/pillows/mappings/case_search_mapping.py
@@ -1,12 +1,16 @@
 import json
 import os
+from corehq.pillows.base import DEFAULT_META
 
 from corehq.pillows.core import DATE_FORMATS_ARR, DATE_FORMATS_STRING
+from corehq.pillows.mappings.case_mapping import CASE_ES_TYPE
 from corehq.util.elastic import es_index
+from pillowtop.es_utils import ElasticsearchIndexInfo
 
 
 CASE_SEARCH_INDEX = es_index("case_search_2016-03-15")
 CASE_SEARCH_ALIAS = "case_search"
+
 
 def _CASE_SEARCH_MAPPING():
     with open(os.path.join(os.path.dirname(__file__), 'case_search_mapping.json')) as f:
@@ -17,3 +21,12 @@ def _CASE_SEARCH_MAPPING():
     return mapping
 
 CASE_SEARCH_MAPPING = _CASE_SEARCH_MAPPING()
+
+
+CASE_SEARCH_INDEX_INFO = ElasticsearchIndexInfo(
+    index=CASE_SEARCH_INDEX,
+    alias=CASE_SEARCH_ALIAS,
+    type=CASE_ES_TYPE,
+    meta=DEFAULT_META,
+    mapping=CASE_SEARCH_MAPPING,
+)

--- a/corehq/pillows/mappings/case_search_mapping.py
+++ b/corehq/pillows/mappings/case_search_mapping.py
@@ -6,7 +6,7 @@ from corehq.util.elastic import es_index
 
 
 CASE_SEARCH_INDEX = es_index("case_search_2016-03-15")
-
+CASE_SEARCH_ALIAS = "case_search"
 
 def _CASE_SEARCH_MAPPING():
     with open(os.path.join(os.path.dirname(__file__), 'case_search_mapping.json')) as f:

--- a/corehq/pillows/utils.py
+++ b/corehq/pillows/utils.py
@@ -1,6 +1,7 @@
 from corehq.apps.commtrack.const import COMMTRACK_USERNAME
 from corehq.apps.users.models import CouchUser
 from corehq.apps.users.util import SYSTEM_USER_ID, DEMO_USER_ID
+from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_INDEX_INFO
 from corehq.pillows.mappings.domain_mapping import DOMAIN_INDEX_INFO
 from corehq.pillows.mappings.group_mapping import GROUP_INDEX_INFO
 from corehq.pillows.mappings.sms_mapping import SMS_INDEX_INFO
@@ -77,3 +78,4 @@ def get_all_expected_es_indices():
     yield DOMAIN_INDEX_INFO
     yield GROUP_INDEX_INFO
     yield SMS_INDEX_INFO
+    yield CASE_SEARCH_INDEX_INFO

--- a/settings.py
+++ b/settings.py
@@ -1441,8 +1441,6 @@ PILLOWTOPS = {
         'corehq.pillows.user.GroupToUserPillow',
         'corehq.pillows.sofabed.FormDataPillow',
         'corehq.pillows.sofabed.CaseDataPillow',
-        # TODO: Remove this once ConstructedPillows can deal with their own indices
-        'corehq.pillows.case_search.CaseSearchPillow',
         {
             'name': 'SqlSMSPillow',
             'class': 'pillowtop.pillow.interface.ConstructedPillow',

--- a/testapps/test_pillowtop/tests/data/all-pillow-meta.json
+++ b/testapps/test_pillowtop/tests/data/all-pillow-meta.json
@@ -114,23 +114,6 @@
         "name": "CasePillow",
         "unique_id": "85e1a25ff57c5892b6fa95caf949ae4c"
     },
-    "CaseSearchPillow": {
-        "advertised_name": "corehq.pillows.case_search.CaseSearchPillow.37eb28449299eb76faf589cba4eb2121.testhq",
-        "change_feed_type": "CouchChangeFeed",
-        "checkpoint_id": "corehq.pillows.case_search.CaseSearchPillow.37eb28449299eb76faf589cba4eb2121.testhq",
-        "couch_filter": "case/casedocs",
-        "couchdb_type": "Database",
-        "couchdb_uri": "http://{COUCH_SERVER_ROOT}/test_commcarehq",
-        "document_class": "CommCareCase",
-        "es_alias": "case_search",
-        "es_index": "test_case_search_2016-03-15",
-        "es_type": "case",
-        "extra_args": {},
-        "full_class_name": "corehq.pillows.case_search.CaseSearchPillow",
-        "include_docs": true,
-        "name": "CaseSearchPillow",
-        "unique_id": "37eb28449299eb76faf589cba4eb2121"
-    },
     "CaseSearchToElasticsearchPillow": {
         "advertised_name": "CaseSearchToElasticsearchPillow",
         "change_feed_type": "KafkaChangeFeed",

--- a/testapps/test_pillowtop/tests/test_case_search_pillow.py
+++ b/testapps/test_pillowtop/tests/test_case_search_pillow.py
@@ -10,13 +10,13 @@ from corehq.apps.es import CaseSearchES
 from corehq.apps.userreports.tests.utils import doc_to_change
 from corehq.elastic import get_es_new
 from corehq.form_processor.tests.utils import FormProcessorTestUtils
-from corehq.pillows.case_search import CaseSearchPillow, \
-    delete_case_search_cases, get_case_search_to_elasticsearch_pillow, \
+from corehq.pillows.case_search import delete_case_search_cases, get_case_search_to_elasticsearch_pillow, \
     get_case_search_reindexer
-from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_INDEX
+from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_INDEX, CASE_SEARCH_INDEX_INFO
 from corehq.util.elastic import ensure_index_deleted
 from django.test import TestCase, override_settings
 from mock import MagicMock, patch
+from pillowtop.es_utils import initialize_index_and_mapping
 from testapps.test_pillowtop.utils import get_current_kafka_seq, \
     get_test_kafka_consumer
 from corehq.util.test_utils import create_and_save_a_case
@@ -33,7 +33,7 @@ class CaseSearchPillowTest(TestCase):
         ensure_index_deleted(CASE_SEARCH_INDEX)
 
         # Bootstrap ES
-        CaseSearchPillow()
+        initialize_index_and_mapping(get_es_new(), CASE_SEARCH_INDEX_INFO)
 
     def tearDown(self):
         ensure_index_deleted(CASE_SEARCH_INDEX)

--- a/testapps/test_pillowtop/tests/test_reindexer.py
+++ b/testapps/test_pillowtop/tests/test_reindexer.py
@@ -13,10 +13,10 @@ from corehq.apps.groups.models import Group
 from corehq.apps.groups.tests.test_utils import delete_all_groups
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 from corehq.apps.users.models import CommCareUser, WebUser
+from corehq.elastic import get_es_new
 from corehq.form_processor.tests.utils import FormProcessorTestUtils, \
     run_with_all_backends
 from corehq.pillows.case import CasePillow
-from corehq.pillows.case_search import CaseSearchPillow
 from corehq.pillows.mappings.case_mapping import CASE_INDEX
 from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_INDEX
 from corehq.pillows.mappings.domain_mapping import DOMAIN_INDEX
@@ -82,7 +82,7 @@ class PillowtopReindexerTest(TestCase):
         # With case search not enabled, case should not make it to ES
         CaseSearchConfig.objects.all().delete()
         call_command('ptop_reindexer_v2', 'case-search')
-        CaseSearchPillow().get_es_new().indices.refresh(CASE_SEARCH_INDEX)  # as well as refresh the index
+        get_es_new().indices.refresh(CASE_SEARCH_INDEX)  # as well as refresh the index
         self._assert_es_empty(esquery=CaseSearchES())
 
         # With case search enabled, it should get indexed
@@ -90,7 +90,7 @@ class PillowtopReindexerTest(TestCase):
         self.addCleanup(CaseSearchConfig.objects.all().delete)
         call_command('ptop_reindexer_v2', 'case-search')
 
-        CaseSearchPillow().get_es_new().indices.refresh(CASE_SEARCH_INDEX)  # as well as refresh the index
+        get_es_new().indices.refresh(CASE_SEARCH_INDEX)  # as well as refresh the index
         self._assert_case_is_in_es(case, esquery=CaseSearchES())
 
     def test_xform_reindexer(self):

--- a/testapps/test_pillowtop/tests/test_reindexer.py
+++ b/testapps/test_pillowtop/tests/test_reindexer.py
@@ -74,6 +74,7 @@ class PillowtopReindexerTest(TestCase):
 
     @run_with_all_backends
     def test_case_search_reindexer(self):
+        es = get_es_new()
         FormProcessorTestUtils.delete_all_cases()
         case = _create_and_save_a_case()
 
@@ -82,7 +83,7 @@ class PillowtopReindexerTest(TestCase):
         # With case search not enabled, case should not make it to ES
         CaseSearchConfig.objects.all().delete()
         call_command('ptop_reindexer_v2', 'case-search')
-        get_es_new().indices.refresh(CASE_SEARCH_INDEX)  # as well as refresh the index
+        es.indices.refresh(CASE_SEARCH_INDEX)  # as well as refresh the index
         self._assert_es_empty(esquery=CaseSearchES())
 
         # With case search enabled, it should get indexed
@@ -90,7 +91,7 @@ class PillowtopReindexerTest(TestCase):
         self.addCleanup(CaseSearchConfig.objects.all().delete)
         call_command('ptop_reindexer_v2', 'case-search')
 
-        get_es_new().indices.refresh(CASE_SEARCH_INDEX)  # as well as refresh the index
+        es.indices.refresh(CASE_SEARCH_INDEX)  # as well as refresh the index
         self._assert_case_is_in_es(case, esquery=CaseSearchES())
 
     def test_xform_reindexer(self):


### PR DESCRIPTION
very similar to https://github.com/dimagi/commcare-hq/pull/11394, this was only being used for index management which can now be handled via IndexInfo objects.

@proteusvacuum @snopoke :fish: or :office: 
