### PR TITLE
Self-host jquery-cookie

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "underscore-legacy": "underscore#1.4.4",
     "jquery-form": "3.45.0",
     "jquery-form-2.94-legacy": "malsup/form#db3910b",
-    "jquery.cookie": "1.4.1",
+    "jquery.cookie": "dimagi/jquery-cookie#1.4.1",
     "jquery-timeago": "1.2.0",
     "jquery-ui": "1.11.4",
     "jquery-ui-1.8.23-legacy": "jquery-ui#1.8.23",


### PR DESCRIPTION
jquery-cookie is deprecated, and their repo no longer works (not sure why, but look at their [issues page](https://github.com/carhartl/jquery-cookie/issues)).
We should update to https://github.com/js-cookie/js-cookie, but it has a different API, and I don't think it makes sense to block deploys on updating that.

https://github.com/dimagi/jquery-cookie
@nickpell
