### PR TITLE
Filter invoices by subscription

### DIFF
--- a/corehq/apps/accounting/interface.py
+++ b/corehq/apps/accounting/interface.py
@@ -611,6 +611,8 @@ class InvoiceInterface(InvoiceInterfaceBase):
         'corehq.apps.accounting.interface.IsHiddenFilter',
     ]
 
+    subscription = None
+
     @property
     def headers(self):
         header = DataTablesHeader(
@@ -754,6 +756,9 @@ class InvoiceInterface(InvoiceInterfaceBase):
     def _invoices(self):
         queryset = Invoice.objects.all()
 
+        if self.subscription:
+            queryset = queryset.filter(subscription=self.subscription)
+
         account_name = NameFilter.get_value(self.request, self.domain)
         if account_name is not None:
             queryset = queryset.filter(
@@ -874,6 +879,9 @@ class InvoiceInterface(InvoiceInterfaceBase):
             'month': statement_start.strftime("%B"),
             'rows': self.rows,
         })
+
+    def filter_by_subscription(self, subscription):
+        self.subscription = subscription
 
 
 def _get_domain_from_payment_record(payment_record):

--- a/corehq/apps/accounting/templates/accounting/partials/invoice_table.html
+++ b/corehq/apps/accounting/templates/accounting/partials/invoice_table.html
@@ -2,7 +2,6 @@
 {% load report_tags %}
 {% load i18n %}
 
-<p class="alert alert-warning">Showing All Invoices for the Subscriber's Project Space</p>
 <a href="{{invoice_report_url}}"> {% trans "Go to All Invoices page for this Project Space" %}</a>
 <a href="{{invoice_export_url}}" class="btn btn-default" style="float:right">
     <i class="fa fa-share"></i> {% trans "Export to Excel" %}

--- a/corehq/apps/accounting/views.py
+++ b/corehq/apps/accounting/views.py
@@ -361,7 +361,7 @@ class EditSubscriptionView(AccountingSectionView, AsyncHandlerMixin):
         subscriber_domain = self.subscription.subscriber.domain
 
         invoice_report = InvoiceInterface(self.request)
-        invoice_report.filters.update(subscription__subscriber__domain=subscriber_domain)
+        invoice_report.filter_by_subscription(self.subscription)
         # Tied to InvoiceInterface.
         encoded_params = urlencode({'subscriber': subscriber_domain})
         invoice_report_url = "{}?{}".format(invoice_report.get_url(), encoded_params)


### PR DESCRIPTION
Fixes the bug http://manage.dimagi.com/default.asp?224967 and also filters invoices by subscription instead of project space, which was originally desired when adding this tab to the subscription page.
