### PR TITLE
Make __repr__ indicate object's class

### DIFF
--- a/corehq/apps/userreports/indicators/__init__.py
+++ b/corehq/apps/userreports/indicators/__init__.py
@@ -19,7 +19,7 @@ class Column(object):
         return truncate_value(self.id)
 
     def __repr__(self):
-        return self.id
+        return "Column('{}', '{}')".format(self.id, self.datatype)
 
 
 class ColumnValue(object):
@@ -29,7 +29,7 @@ class ColumnValue(object):
         self.value = value
 
     def __repr__(self):
-        return '{0}: {1}'.format(self.column, self.value)
+        return "ColumnValue({}, {})".format(self.column.id, self.value)
 
 
 class ConfigurableIndicatorMixIn(object):


### PR DESCRIPTION
@czue I made this branch a while back and never got around to PRing it.  Do you know what the deal with the old `__repr__`s was?  Just want to make sure it isn't used in the UI or anything, as that's really hard to tell from code inspection.
