### PR TITLE
assert xmlns in json is correct

### DIFF
--- a/corehq/apps/cleanup/tests/test_fix_forms_with_missing_xmlns.py
+++ b/corehq/apps/cleanup/tests/test_fix_forms_with_missing_xmlns.py
@@ -180,3 +180,4 @@ class TestFixFormsWithMissingXmlns(TestCase, TestXmlMixin):
         for app in apps:
             for form in app.get_forms():
                 self.assertEqual(form.source.count('xmlns="undefined"'), 0)
+                self.assertNotEqual(form.xmlns, 'undefined')


### PR DESCRIPTION
@esoergel this asserts that the json is also properly converted. passed locally and also ensured that the json is `undefined` before it gets converted
