### PR TITLE
Add load_from_form to AdvancedFormActions

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -545,7 +545,6 @@ class AdvancedOpenCaseAction(AdvancedAction):
 
 class AdvancedFormActions(DocumentSchema):
     load_update_cases = SchemaListProperty(LoadUpdateAction)
-    load_from_form = SchemaProperty(PreloadAction)
 
     open_cases = SchemaListProperty(AdvancedOpenCaseAction)
 

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -545,6 +545,8 @@ class AdvancedOpenCaseAction(AdvancedAction):
 
 class AdvancedFormActions(DocumentSchema):
     load_update_cases = SchemaListProperty(LoadUpdateAction)
+    load_from_form = SchemaProperty(PreloadAction)
+
     open_cases = SchemaListProperty(AdvancedOpenCaseAction)
 
     get_load_update_actions = IndexedSchema.Getter('load_update_cases')

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -350,7 +350,9 @@ def patch_xform(request, domain, app_id, unique_form_id):
     xform, _ = dmp.patch_apply(dmp.patch_fromText(patch), current_xml)
     save_xform(app, form, xform)
 
-    form.actions.load_from_form = PreloadAction.wrap(case_references)
+    # for case management in the form builder
+    if form.form_type == 'module_form':
+        form.actions.load_from_form = PreloadAction.wrap(case_references)
 
     response_json = {
         'status': 'ok',


### PR DESCRIPTION
@emord @snopoke AdvancedForms were broken on prod I believe due to this: https://github.com/dimagi/commcare-hq/commit/c89ac7bc (here's the ticket: http://manage.dimagi.com/default.asp?225242). I really have no context on what this does, just pattern matching based on that commit. At the very least this lets you save advanced forms again

cc: @millerdev 
