### PR TITLE
Fix forms that have broken xml but not broken json xmlns

### DIFF
--- a/corehq/apps/cleanup/management/commands/fix_forms_with_missing_xmlns.py
+++ b/corehq/apps/cleanup/management/commands/fix_forms_with_missing_xmlns.py
@@ -221,7 +221,9 @@ def set_xmlns_on_form(form_id, xmlns, app_build, log_file, dry_run):
     except FormNotFoundException:
         return
 
-    if form_in_build.xmlns == "undefined":
+    if form_in_build.xmlns == "undefined" or form_in_build.source.count('xmlns="undefined"') > 0:
+        if form_in_build.xmlns != "undefined":
+            assert form_in_build.xmlns == xmlns
         xml = form_in_build.source
         wrapped_xml = XForm(xml)
 

--- a/corehq/apps/cleanup/tests/test_fix_forms_with_missing_xmlns.py
+++ b/corehq/apps/cleanup/tests/test_fix_forms_with_missing_xmlns.py
@@ -1,3 +1,4 @@
+from mock import MagicMock
 import os
 import uuid
 
@@ -9,8 +10,10 @@ from corehq.apps.app_manager.const import APP_V2
 from corehq.apps.app_manager.models import Application, Module
 from corehq.apps.app_manager.tests import TestXmlMixin
 from corehq.apps.app_manager.util import get_correct_app_class
-from corehq.apps.cleanup.management.commands.fix_forms_with_missing_xmlns import \
-    generate_random_xmlns
+from corehq.apps.cleanup.management.commands.fix_forms_with_missing_xmlns import (
+    generate_random_xmlns,
+    set_xmlns_on_form,
+)
 from corehq.apps.receiverwrapper import submit_form_locally
 from corehq.pillows.xform import XFormPillow
 from corehq.util.elastic import ensure_index_deleted
@@ -123,6 +126,23 @@ class TestFixFormsWithMissingXmlns(TestCase, TestXmlMixin):
 
         return form, good_build, bad_build, good_xform, bad_xform
 
+    def build_app_with_bad_source_and_good_json(self):
+        """
+        Generates an app with a form that has a converted json xmlns but an unconverted source
+        """
+        form_name = "Untitled Form"
+
+        app = Application.new_app(DOMAIN, 'Normal App', APP_V2)
+        module = app.add_module(Module.new_module('New Module', lang='en'))
+        form_source = self.get_xml('form_template').format(
+            xmlns="undefined", name=form_name
+        )
+        form = module.new_form(form_name, "en", form_source)
+        form.xmlns = 'not-at-all-undefined'
+        app.save()
+
+        return form, app
+
     def test_normal_app(self):
         form, xform = self.build_normal_app()
         self._refresh_pillow()
@@ -161,6 +181,17 @@ class TestFixFormsWithMissingXmlns(TestCase, TestXmlMixin):
             self.assertTrue(bad_build._id in log)
             self.assertTrue(good_xform._id not in log)
             self.assertTrue(bad_xform._id in log)
+        self.assertNoMissingXmlnss()
+
+    def test_app_with_good_form_json_and_bad_source(self):
+        form, app = self.build_app_with_bad_source_and_good_json()
+        set_xmlns_on_form(
+            form.unique_id,
+            'not-at-all-undefined',
+            app,
+            MagicMock(),
+            False
+        )
         self.assertNoMissingXmlnss()
 
     def assertNoMissingXmlnss(self):


### PR DESCRIPTION
@NoahCarnahan @esoergel ethan your hunch was correct and there are some apps that have proper form json xmlns, but incorrect source xmlns. this fix should correct for that

cc: @millerdev 
