### PR TITLE
Don't serialize case search properties if not enabled

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -1131,7 +1131,8 @@ hqDefine('app_manager/js/detail-screen-config.js', function () {
                             containsFixtureConfiguration: (columnType == "short" && COMMCAREHQ.toggleEnabled('FIXTURE_CASE_SELECTION')),
                             containsFilterConfiguration: columnType == "short",
                             containsCaseListLookupConfiguration: (columnType == "short" && COMMCAREHQ.toggleEnabled('CASE_LIST_LOOKUP')),
-                            containsSearchConfiguration: columnType === "short",
+                            // TODO: Check case_search_enabled_for_domain(), not toggle. FB 225343
+                            containsSearchConfiguration: (columnType === "short" && COMMCAREHQ.toggleEnabled('SYNC_SEARCH_CASE_CLAIM')),
                             containsCustomXMLConfiguration: columnType == "short",
                             allowsTabs: columnType == 'long',
                             allowsEmptyColumns: columnType == 'long'


### PR DESCRIPTION
This fixes [FB 225343](http://manage.dimagi.com/default.asp?225343), where empty case settings were being serialised for domains that don't have case search enabled.

@sravfeyn @benrudolph cc @millerdev 

It would be _really great_ to get this deployed to India soon, if possible. (Not crucial but ... ) Kriti would like to include changing a case list in a demo in the morning.
