### PR TITLE
remove superfluous form get

### DIFF
--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -1584,7 +1584,6 @@ def download_form(request, domain, instance_id):
     instance = _get_form_or_404(domain, instance_id)
     assert(domain == instance.domain)
 
-    instance = XFormInstance.get(instance_id)
     response = HttpResponse(content_type='application/xml')
     response.write(instance.get_xml())
     return response


### PR DESCRIPTION
@snopoke we seemed to be getting the form instance twice and the second time isn't sql compatible. http://manage.dimagi.com/default.asp?225437

cc: @millerdev 
