### PR TITLE
Abt Benin sms data source

### DIFF
--- a/custom/abt/reports/data_sources/sms.json
+++ b/custom/abt/reports/data_sources/sms.json
@@ -1037,7 +1037,8 @@
                 "Ethiopia": 670303,
                 "Mali": 135717,
                 "Madagascar": 72120,
-                "Tanzania": 502934
+                "Tanzania": 502934,
+                "Benin": 270141
               },
               "type": "switch",
               "switch_on": {

--- a/custom/abt/reports/data_sources/sms.json
+++ b/custom/abt/reports/data_sources/sms.json
@@ -8,8 +8,7 @@
         "abtmali",
         "airsmadagascar",
         "airstanzania",
-        "airsghana",
-        "airsbenin"
+        "airsghana"
     ],
     "config": {
         "engine_id": "default",

--- a/custom/abt/reports/data_sources/sms_case.json
+++ b/custom/abt/reports/data_sources/sms_case.json
@@ -372,7 +372,29 @@
                   "property_name": "owner_id"
                 }
               }
-            }
+            },
+            "Benin": {
+                  "default": 0,
+                  "cases": {
+                      "Atacora": 270141
+                  },
+                  "type": "switch",
+                  "switch_on": {
+                    "value_expression": {
+                      "type": "property_path",
+                      "property_path": [
+                        "user_data",
+                        "level_1_name"
+                      ]
+                    },
+                    "type": "related_doc",
+                    "related_doc_type": "CommCareUser",
+                    "doc_id_expression": {
+                      "type": "property_name",
+                      "property_name": "owner_id"
+                    }
+                  }
+                }
           },
           "type": "switch",
           "switch_on": {
@@ -591,7 +613,37 @@
                   "property_name": "owner_id"
                 }
               }
-            }
+            },
+            "Benin": {
+                  "default": 0,
+                  "cases": {
+                    "boukoumbe": 29090,
+                    "cobly": 22044,
+                    "kerou": 40328,
+                    "kouande": 44275,
+                    "materi": 41474,
+                    "natitingou": 29385,
+                    "pehunco": 37137,
+                    "tanguieta": 13490,
+                    "toucountouna": 12918
+                  },
+                  "type": "switch",
+                  "switch_on": {
+                    "value_expression": {
+                      "type": "property_path",
+                      "property_path": [
+                        "user_data",
+                        "level_2_data"
+                      ]
+                    },
+                    "type": "related_doc",
+                    "related_doc_type": "CommCareUser",
+                    "doc_id_expression": {
+                      "type": "property_name",
+                      "property_name": "owner_id"
+                    }
+                  }
+                }
           },
           "type": "switch",
           "switch_on": {
@@ -942,7 +994,45 @@
                   "property_name": "owner_id"
                 }
               }
-            }
+            },
+            "Benin": {
+                  "default": 0,
+                  "cases": {
+                    "natta_base": 15078,
+                    "manta_base": 14012,
+                    "cobly_base": 22044,
+                    "kerou_centre_base": 27741,
+                    "firou_base": 10128,
+                    "kaoubagou_base": 2459,
+                    "kouande_base": 17279,
+                    "guilimaro_base": 16308,
+                    "birni_base": 10688,
+                    "materi_base": 24510,
+                    "dassari_base": 16964,
+                    "perma_base": 13065,
+                    "natitingou_base": 16320,
+                    "pehunco_base": 28313,
+                    "gnemasson_base": 8824,
+                    "tanguieta_base": 13490,
+                    "toucountouna_base": 12918
+                  },
+                  "type": "switch",
+                  "switch_on": {
+                    "value_expression": {
+                      "type": "property_path",
+                      "property_path": [
+                        "user_data",
+                        "level_3_data"
+                      ]
+                    },
+                    "type": "related_doc",
+                    "related_doc_type": "CommCareUser",
+                    "doc_id_expression": {
+                      "type": "property_name",
+                      "property_name": "owner_id"
+                    }
+                  }
+                }
           },
           "type": "switch",
           "switch_on": {
@@ -979,7 +1069,8 @@
             "Ethiopia": 670303,
             "Mali": 135717,
             "Madagascar": 72120,
-            "Tanzania": 502934
+            "Tanzania": 502934,
+            "Benin": 270141
           },
           "type": "switch",
           "switch_on": {

--- a/custom/abt/reports/data_sources/sms_case.json
+++ b/custom/abt/reports/data_sources/sms_case.json
@@ -243,7 +243,7 @@
       {
         "display_name": "username",
         "property_name": "username",
-        "datatype": "integer",
+        "datatype": "string",
         "is_primary_key": false,
         "column_id": "username",
         "is_nullable": true,

--- a/custom/abt/reports/data_sources/sms_case.json
+++ b/custom/abt/reports/data_sources/sms_case.json
@@ -203,7 +203,7 @@
       {
         "display_name": "date_of_data_collection",
         "property_name": "date_of_data_collection",
-        "datatype": "integer",
+        "datatype": "date",
         "is_primary_key": false,
         "column_id": "date_of_data_collection",
         "is_nullable": true,
@@ -1002,9 +1002,9 @@
       }
     ],
     "description": "",
-    "display_name": "SMS Indicators (static)",
+    "display_name": "SMS Case Indicators (static)",
     "named_filters": {},
-    "referenced_doc_type": "XFormInstance",
+    "referenced_doc_type": "CommCareCase",
     "table_id": "static-sms-indicators-001"
   }
 }


### PR DESCRIPTION
@nickpell cc @emord 
Turns our they've changed the Benin version of the Abt app, so it should use the `sms_case.json` data source instead (which also needed some repairs).
