### PR TITLE
Support aggr decimal types

### DIFF
--- a/corehq/apps/userreports/sql/util.py
+++ b/corehq/apps/userreports/sql/util.py
@@ -48,3 +48,7 @@ def get_column_name(path):
 
     new_parts = path[-54:].split("/")
     return "_".join(new_parts + [_hash(parts)])
+
+
+def get_field_decimal_name(name):
+    return '{}_decimal'.format(name)

--- a/corehq/apps/userreports/tests/test_report_builder.py
+++ b/corehq/apps/userreports/tests/test_report_builder.py
@@ -1,25 +1,39 @@
 import os
 from django.test import TestCase
-from corehq.apps.app_manager.const import APP_V2
-from corehq.apps.app_manager.models import Application, Module
+from corehq.util.test_utils import TestFileMixin
+from corehq.apps.app_manager.tests.app_factory import AppFactory
 from corehq.apps.userreports.dbaccessors import delete_all_report_configs
 from corehq.apps.userreports.models import DataSourceConfiguration
-from corehq.apps.userreports.reports.builder.forms import ConfigureListReportForm
+from corehq.apps.userreports.sql.util import get_column_name
+from corehq.apps.userreports.reports.builder.forms import (
+    ConfigureListReportForm,
+    ConfigureTableReportForm,
+)
 
 
-def read(rel_path):
-    path = os.path.join(os.path.dirname(__file__), *rel_path)
-    with open(path) as f:
-        return f.read()
+class ReportBuilderTest(TestCase, TestFileMixin):
+    root = os.path.dirname(__file__)
+    file_path = ('data', 'forms')
 
-
-class ReportBuilderTest(TestCase):
+    case_type = 'primates'
 
     @classmethod
     def setUpClass(cls):
-        cls.app = Application.new_app('domain', 'Untitled Application', application_version=APP_V2)
-        module = cls.app.add_module(Module.new_module('Untitled Module', None))
-        cls.form = cls.app.new_form(module.id, "Untitled Form", 'en', read(['data', 'forms', 'simple.xml']))
+        cls.factory = AppFactory(domain='domain')
+        m0 = cls.factory.new_basic_module('Primates', 'primates')
+        f0 = cls.factory.new_form(m0[0])
+        f0.source = cls.get_xml('simple')
+        cls.factory.form_requires_case(
+            f0,
+            cls.case_type,
+            update={
+                'age': '/data/age',
+                'weight': '/data/weight',
+                'sex': '/data/sex',
+            }
+        )
+        cls.form = f0
+        cls.app = cls.factory.app
         cls.app.save()
 
     @classmethod
@@ -71,3 +85,78 @@ class ReportBuilderTest(TestCase):
         second_data_source_id = report.config_id
 
         self.assertNotEqual(first_data_source_id, second_data_source_id)
+
+    def test_build_aggregation_report(self):
+        # Make report
+        builder_form = ConfigureTableReportForm(
+            "Test Report",
+            self.app._id,
+            "case",
+            self.case_type,
+            existing_report=None,
+            data={
+                'filters': '[]',
+                'group_by': 'sex',
+                'columns': '[{"property": "age", "display_text": "Age", "calculation": "Average"}]',
+            }
+        )
+        self.assertTrue(builder_form.is_valid())
+        report = builder_form.create_report()
+        self._assertInColumns(get_column_name('age_decimal'), report.columns)
+
+    def test_build_aggregation_report_update(self):
+        builder_form = ConfigureTableReportForm(
+            "Test Report",
+            self.app._id,
+            "case",
+            self.case_type,
+            existing_report=None,
+            data={
+                'filters': '[]',
+                'group_by': 'sex',
+                'columns': '[{"property": "age", "display_text": "Age", "calculation": "Average"}]',
+            }
+        )
+        self.assertTrue(builder_form.is_valid())
+        builder_form.create_report()
+
+        builder_form = ConfigureTableReportForm(
+            "Test Report",
+            self.app._id,
+            "case",
+            self.case_type,
+            existing_report=None,
+            data={
+                'filters': '[]',
+                'group_by': 'sex',
+                'columns': '[{"property": "weight", "display_text": "Weight", "calculation": "Sum"}]',
+            }
+        )
+        self.assertTrue(builder_form.is_valid())
+        report = builder_form.create_report()
+        self._assertInColumns(get_column_name('weight_decimal'), report.columns)
+        self._assertNotInColumns(get_column_name('age_decimal'), report.columns)
+
+    def test_build_aggregation_report_with_same_group_by(self):
+        builder_form = ConfigureTableReportForm(
+            "Test Report",
+            self.app._id,
+            "case",
+            self.case_type,
+            existing_report=None,
+            data={
+                'filters': '[]',
+                'group_by': 'age',
+                'columns': '[{"property": "age", "display_text": "Age", "calculation": "Average"}]',
+            }
+        )
+        self.assertTrue(builder_form.is_valid())
+        report = builder_form.create_report()
+        self._assertInColumns(get_column_name('age_decimal'), report.columns)
+        self._assertInColumns(get_column_name('age'), report.columns)
+
+    def _assertInColumns(self, column_id, columns):
+        self.assertIn(column_id, map(lambda c: c['field'], columns))
+
+    def _assertNotInColumns(self, column_id, columns):
+        self.assertNotIn(column_id, map(lambda c: c['field'], columns))


### PR DESCRIPTION
@czue @NoahCarnahan Here's a WIP for supporting an extra column for aggregation types. It doesn't work completely yet because of this edge case:
1. Report A aggregates over age -> Build table with age column as decimal as well as string
2. Report B aggregates over weight -> Build table with weight column as decimal as well as string, but no longer has age decimal
3. Load Report A and then you get an internal server error cause that column no longer exists

This can be remedied by maintaining state of the previous report/ones created and always include those properties. This seems like a less than good solution though since it can get messy and bloated if people delete and create lots of reports. Noah had mentioned you guys had decided not to do the casting of the string to decimal in the sql query, but I'm not totally certain why that's not the better solution. The table is smaller and you don't ever have to rebuild it for aggregations. @czue do you remember the reasons for not wanting to go that route?

cc: @millerdev 
