### PR TITLE
Fix product credit lines

### DIFF
--- a/corehq/apps/accounting/migrations/0031_credit_line_feature_type_blank.py
+++ b/corehq/apps/accounting/migrations/0031_credit_line_feature_type_blank.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounting', '0030_remove_softwareplan_visibility_trial_internal'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='creditline',
+            name='feature_type',
+            field=models.CharField(blank=True, max_length=10, null=True, choices=[(b'User', b'User'), (b'SMS', b'SMS')]),
+            preserve_default=True,
+        ),
+    ]

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -2581,7 +2581,7 @@ class CreditLine(ValidateModelMixin, models.Model):
     subscription = models.ForeignKey(Subscription, on_delete=models.PROTECT, null=True, blank=True)
     product_type = models.CharField(max_length=25, null=True, blank=True,
                                     choices=((SoftwareProductType.ANY, SoftwareProductType.ANY),))
-    feature_type = models.CharField(max_length=10, null=True,
+    feature_type = models.CharField(max_length=10, null=True, blank=True,
                                     choices=FeatureType.CHOICES)
     date_created = models.DateTimeField(auto_now_add=True)
     balance = models.DecimalField(default=Decimal('0.0000'), max_digits=10, decimal_places=4)

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -2572,7 +2572,7 @@ class LineItem(models.Model):
         CreditLine.apply_credits_toward_balance(credit_lines, current_total, line_item=self)
 
 
-class CreditLine(models.Model):
+class CreditLine(ValidateModelMixin, models.Model):
     """
     The amount of money in USD that exists can can be applied toward a specific account,
     a specific subscription, or specific rates in that subscription.

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -2649,18 +2649,34 @@ class CreditLine(ValidateModelMixin, models.Model):
             line_item.feature_rate.feature.feature_type
             if line_item.feature_rate is not None else None
         )
-        return itertools.chain(
-            cls.get_credits_by_subscription_and_features(
+
+        for credit_line in cls.get_credits_by_subscription_and_features(
+            line_item.invoice.subscription,
+            product_type=product_type,
+            feature_type=feature_type,
+        ):
+            yield credit_line
+
+        if product_type is not None:
+            for credit_line in cls.get_credits_by_subscription_and_features(
                 line_item.invoice.subscription,
-                product_type=product_type,
-                feature_type=feature_type,
-            ),
-            cls.get_credits_for_account(
+                product_type=SoftwareProductType.ANY,
+            ):
+                yield credit_line
+
+        for credit_line in cls.get_credits_for_account(
+            line_item.invoice.subscription.account,
+            product_type=product_type,
+            feature_type=feature_type,
+        ):
+            yield credit_line
+
+        if product_type is not None:
+            for credit_line in cls.get_credits_for_account(
                 line_item.invoice.subscription.account,
-                product_type=product_type,
-                feature_type=feature_type,
-            )
-        )
+                product_type=SoftwareProductType.ANY,
+            ):
+                yield credit_line
 
     @classmethod
     def get_credits_for_invoice(cls, invoice):

--- a/corehq/apps/accounting/tests/test_credit_lines.py
+++ b/corehq/apps/accounting/tests/test_credit_lines.py
@@ -34,7 +34,7 @@ class TestCreditLines(BaseInvoiceTestCase):
         """
         rate_credit_by_account = CreditLine.add_credit(
             self.product_rate.monthly_fee, account=self.account,
-            product_type=self.product_rate.product.product_type
+            product_type=SoftwareProductType.ANY
         )
         self.assertEqual(CreditAdjustment.objects.filter(
             credit_line=rate_credit_by_account).count(), 1
@@ -42,7 +42,7 @@ class TestCreditLines(BaseInvoiceTestCase):
 
         rate_credit_by_subscription = CreditLine.add_credit(
             self.product_rate.monthly_fee,
-            product_type=self.product_rate.product.product_type,
+            product_type=SoftwareProductType.ANY,
             subscription=self.subscription
         )
         self.assertEqual(CreditAdjustment.objects.filter(
@@ -226,12 +226,12 @@ class TestCreditLines(BaseInvoiceTestCase):
         """
         product_credit = CreditLine.add_credit(
             self.product_rate.monthly_fee, account=self.account,
-            product_type=self.product_rate.product.product_type,
+            product_type=SoftwareProductType.ANY,
         )
         self.assertEqual(CreditAdjustment.objects.filter(credit_line=product_credit).count(), 1)
         CreditLine.add_credit(
             self.product_rate.monthly_fee, account=self.account,
-            product_type=self.product_rate.product.product_type,
+            product_type=SoftwareProductType.ANY,
         )
         self.assertEqual(CreditAdjustment.objects.filter(credit_line=product_credit).count(), 2)
         current_product_credit = CreditLine.objects.get(id=product_credit.id)
@@ -312,7 +312,7 @@ class TestCreditTransfers(BaseAccountingTest):
 
         product_credit = CreditLine.add_credit(
             self.product_credit_amt, subscription=first_sub,
-            product_type=SoftwareProductType.COMMCARE,
+            product_type=SoftwareProductType.ANY,
         )
         feature_credit = CreditLine.add_credit(
             self.feature_credit_amt, subscription=first_sub,


### PR DESCRIPTION
When I made https://github.com/dimagi/commcare-hq/pull/11233 I didn't set up validation to make sure that specific product types were not being used.  This allowed them to be used in tests, which caused http://manage.dimagi.com/default.asp?186378 to not be caught.

This change:
1. Enforces validation
2. Fixes tests (which causes the May 1 invoicing bug to be revealed)
3. Fixes the bug.

@biyeun 
