### PR TITLE
Add url prefix for account settings page

### DIFF
--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1263,6 +1263,7 @@ class ProjectSettingsTab(UITab):
 class MySettingsTab(UITab):
     title = ugettext_noop("My Settings")
     view = 'default_my_settings'
+    url_prefix_formats = ('/account/',)
 
     @property
     def _is_viewable(self):


### PR DESCRIPTION
@dannyroberts
Got an error navigating to http://localhost:8000/account/settings/ on latest master.
I'm surprised this hasn't already been set, maybe I'm missing something?  I guess this feature is still behind a flag, yeah?
