### PR TITLE
Don't allow users to change case type in bulk import

### DIFF
--- a/corehq/apps/importer/exceptions.py
+++ b/corehq/apps/importer/exceptions.py
@@ -30,6 +30,11 @@ class ImporterExcelFileEncrypted(ImporterExcelError):
     """Raised when a file cannot be open because it is encrypted (password-protected)"""
 
 
+class InvalidCustomFieldNameException(Exception):
+    """Raised when a custom field name is reserved (e.g. "type")"""
+    pass
+
+
 class InvalidImportValueException(Exception):
 
     def __init__(self, column=None):


### PR DESCRIPTION
Bulk import currently allows users to set a custom field called "type". This changes the case type, and can have serious negative consequences. ([FB 222044](http://manage.dimagi.com/default.asp?222044)) Prevent users for doing this by accident (or intentionally). 

(When bulk import hits an error, the UI doesn't give a very useful message to the user:
![import_failed](https://cloud.githubusercontent.com/assets/708421/15019483/87c36ef6-121e-11e6-8c86-f1262555c1ec.png)
That's not really within the scope of this bug, but maybe worth opening another ticket for.)

@czue 
