### PR TITLE
Add "kombu.transport.django" to DEFAULT_APPS

### DIFF
--- a/dev_settings.py
+++ b/dev_settings.py
@@ -9,6 +9,7 @@ import os
 
 LOCAL_APPS = (
     'django_extensions',
+    'kombu.transport.django',
     # for tests
     'testapps.test_elasticsearch',
     'testapps.test_pillowtop',


### PR DESCRIPTION
This allows a new installation with `CELERY_ALWAYS_EAGER = False` not to die with `ProgrammingError: relation "djkombu_queue" does not exist`. 

It's also in the [installation instructions](https://github.com/ask/django-kombu#deprecated) to upgrade from the deprecated django-kombu package that we no longer use. (Should be followed by a `./manage.py migrate` but we would do that anyway.)

@snopoke cc @gcapalbo, buddy @czue 
