### PR TITLE
use form received_on as ledger modified date

### DIFF
--- a/corehq/apps/commtrack/tests/test_xml.py
+++ b/corehq/apps/commtrack/tests/test_xml.py
@@ -658,8 +658,8 @@ def _report_soh(soh_reports, case_id, domain):
         )
         for report in soh_reports
     ]
-    submit_case_blocks(balance_blocks, domain)
-    return report_date
+    form_id = submit_case_blocks(balance_blocks, domain)
+    return json_format_datetime(FormAccessors(domain).get_form(form_id).received_on)
 
 
 def _get_ota_balance_blocks(project, user):

--- a/corehq/apps/domain/tests/test_delete_domain.py
+++ b/corehq/apps/domain/tests/test_delete_domain.py
@@ -23,7 +23,8 @@ class TestDeleteDomain(TestCase):
             type='balance',
             domain=domain_name,
             form_id='fake',
-            date=datetime.utcnow()
+            date=datetime.utcnow(),
+            server_date=datetime.utcnow(),
         )
 
         StockTransaction.objects.create(

--- a/corehq/ex-submodules/casexml/apps/stock/signals.py
+++ b/corehq/ex-submodules/casexml/apps/stock/signals.py
@@ -110,7 +110,7 @@ def update_stock_state_for_transaction(instance):
             )
         )
         instance = latest_transaction
-    state.last_modified_date = instance.report.date
+    state.last_modified_date = instance.report.server_date
     state.last_modified_form_id = instance.report.form_id
     state.stock_on_hand = instance.stock_on_hand
 

--- a/corehq/ex-submodules/casexml/apps/stock/tests/test_logistics_consumption.py
+++ b/corehq/ex-submodules/casexml/apps/stock/tests/test_logistics_consumption.py
@@ -1,5 +1,7 @@
 import uuid
 from decimal import Decimal
+
+from datetime import datetime
 from django.test import TestCase
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.stock.models import StockReport, StockTransaction
@@ -35,6 +37,7 @@ class LogisticsConsumptionTest(TestCase):
         report = StockReport.objects.create(
             form_id=uuid.uuid4().hex,
             date=ago(2),
+            server_date=datetime.utcnow(),
             type=const.REPORT_TYPE_BALANCE,
             domain=domain
         )
@@ -52,6 +55,7 @@ class LogisticsConsumptionTest(TestCase):
         report2 = StockReport.objects.create(
             form_id=uuid.uuid4().hex,
             date=ago(1),
+            server_date=datetime.utcnow(),
             type=const.REPORT_TYPE_BALANCE,
             domain=domain
         )

--- a/corehq/ex-submodules/casexml/apps/stock/tests/test_stock_transaction.py
+++ b/corehq/ex-submodules/casexml/apps/stock/tests/test_stock_transaction.py
@@ -1,5 +1,7 @@
 from decimal import Decimal
 import uuid
+
+from datetime import datetime
 from django.test import TestCase
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.stock.models import StockTransaction, StockReport
@@ -33,6 +35,7 @@ class StockTransactionTests(TestCase):
         report = StockReport.objects.create(
             form_id=uuid.uuid4().hex,
             date=ago(1),
+            server_date=datetime.utcnow(),
             type=const.REPORT_TYPE_BALANCE
         )
 

--- a/corehq/form_processor/backends/sql/ledger.py
+++ b/corehq/form_processor/backends/sql/ledger.py
@@ -79,7 +79,7 @@ class LedgerProcessorSQL(LedgerProcessorInterface):
         ledger_value.track_create(transaction)
         # only do this after we've created the transaction otherwise we'll get the wrong delta
         ledger_value.balance = new_ledger_values.balance
-        ledger_value.last_modified = stock_trans.timestamp
+        ledger_value.last_modified = stock_report_helper.server_date  # form.received_on
         ledger_value.last_modified_form_id = stock_report_helper.form_id
         return ledger_value
 

--- a/custom/ewsghana/tests/handlers/utils.py
+++ b/custom/ewsghana/tests/handlers/utils.py
@@ -43,6 +43,7 @@ class EWSScriptTest(EWSTestCase, TestScript):
         report = StockReport(
             form_id=xform._id,
             date=(now - datetime.timedelta(days=10)).replace(second=0, microsecond=0),
+            server_date=now,
             type='balance',
             domain=TEST_DOMAIN
         )

--- a/custom/ewsghana/tests/test_reminders.py
+++ b/custom/ewsghana/tests/test_reminders.py
@@ -22,13 +22,15 @@ from custom.ewsghana.utils import prepare_domain, bootstrap_user, bootstrap_web_
 TEST_DOMAIN = 'ews-reminders-test-domain'
 
 
-def create_stock_report(location, products_quantities, date=datetime.utcnow()):
+def create_stock_report(location, products_quantities, date=None):
+    date = date or datetime.utcnow()
     sql_location = location.sql_location
     report = StockReport.objects.create(
         form_id='ews-reminders-test',
         domain=sql_location.domain,
         type='balance',
-        date=date
+        date=date,
+        server_date=datetime.utcnow()
     )
     for product_code, quantity in products_quantities.iteritems():
         StockTransaction(

--- a/custom/ewsghana/tests/test_reminders.py
+++ b/custom/ewsghana/tests/test_reminders.py
@@ -30,7 +30,7 @@ def create_stock_report(location, products_quantities, date=None):
         domain=sql_location.domain,
         type='balance',
         date=date,
-        server_date=datetime.utcnow()
+        server_date=date
     )
     for product_code, quantity in products_quantities.iteritems():
         StockTransaction(

--- a/custom/ilsgateway/tanzania/handlers/la.py
+++ b/custom/ilsgateway/tanzania/handlers/la.py
@@ -30,9 +30,11 @@ class LossAndAdjustment(KeywordHandler):
             self.respond(LOSS_ADJUST_BAD_FORMAT)
             return True
 
+        now = datetime.utcnow()
         report = StockReport.objects.create(
             form_id='ilsgateway-xform',
-            date=datetime.utcnow(),
+            date=now,
+            server_date=now,
             type='balance',
             domain=self.domain
         )

--- a/custom/ilsgateway/utils.py
+++ b/custom/ilsgateway/utils.py
@@ -74,13 +74,15 @@ def make_loc(code, name, domain, type, metadata=None, parent=None):
     return loc
 
 
-def create_stock_report(location, products_quantities, date=datetime.utcnow()):
+def create_stock_report(location, products_quantities, date=None):
     sql_location = location.sql_location
+    date = date or datetime.utcnow()
     report = StockReport.objects.create(
         form_id='test-form-id',
         domain=sql_location.domain,
         type='balance',
-        date=date
+        date=date,
+        server_date=date,
     )
     for product_code, quantity in products_quantities.iteritems():
         StockTransaction(


### PR DESCRIPTION
@dannyroberts @czue 

I think this is all that needs changing. Should the consumption calculations also use the server dates i.e. for selecting which transactions are in the window?
