### PR TITLE
use autoflake to remove unused imports

### DIFF
--- a/corehq/apps/accounting/forms.py
+++ b/corehq/apps/accounting/forms.py
@@ -17,7 +17,7 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_noop, ugettext as _, ugettext_lazy
 
 from crispy_forms import layout as crispy
-from crispy_forms.bootstrap import FormActions, StrictButton, InlineField
+from crispy_forms.bootstrap import InlineField, StrictButton
 from crispy_forms.helper import FormHelper
 from corehq.apps.style import crispy as hqcrispy
 from django_countries.data import COUNTRIES

--- a/corehq/apps/accounting/management/commands/2014_06_30_recalc_sms_line_items.py
+++ b/corehq/apps/accounting/management/commands/2014_06_30_recalc_sms_line_items.py
@@ -1,4 +1,3 @@
-from optparse import make_option
 from django.core.management import BaseCommand
 from corehq.apps.accounting.invoicing import SmsLineItemFactory
 from corehq.apps.accounting.models import LineItem, FeatureType

--- a/corehq/apps/accounting/migrations/0004_merge.py
+++ b/corehq/apps/accounting/migrations/0004_merge.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+from django.db import migrations
 
 
 class Migration(migrations.Migration):

--- a/corehq/apps/accounting/migrations/0005_merge.py
+++ b/corehq/apps/accounting/migrations/0005_merge.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+from django.db import migrations
 
 
 class Migration(migrations.Migration):

--- a/corehq/apps/accounting/migrations/0009_add_extended_trial_subscription_type.py
+++ b/corehq/apps/accounting/migrations/0009_add_extended_trial_subscription_type.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
-import django.core.validators
 
 
 class Migration(migrations.Migration):

--- a/corehq/apps/accounting/migrations/0012_billing_metadata_data_migration.py
+++ b/corehq/apps/accounting/migrations/0012_billing_metadata_data_migration.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+from django.db import migrations
 
 
 def migrate_metadata(apps, schema_editor):

--- a/corehq/apps/accounting/migrations/0019_remove_softwareplanversion_product_rates.py
+++ b/corehq/apps/accounting/migrations/0019_remove_softwareplanversion_product_rates.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+from django.db import migrations
 
 
 class Migration(migrations.Migration):

--- a/corehq/apps/accounting/migrations/0022_bootstrap_prbac_roles.py
+++ b/corehq/apps/accounting/migrations/0022_bootstrap_prbac_roles.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+from django.db import migrations
 from corehq.apps.hqadmin.management.commands.cchq_prbac_bootstrap import cchq_prbac_bootstrap
 from corehq.sql_db.operations import HqRunPython
 

--- a/corehq/apps/accounting/migrations/0029_merge.py
+++ b/corehq/apps/accounting/migrations/0029_merge.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+from django.db import migrations
 
 
 class Migration(migrations.Migration):

--- a/corehq/apps/accounting/tests/test_autopay.py
+++ b/corehq/apps/accounting/tests/test_autopay.py
@@ -1,5 +1,3 @@
-import datetime
-import random
 import mock
 
 from stripe import Charge


### PR DESCRIPTION
Experimenting with [autoflake](https://github.com/myint/autoflake) to cleanup imports.  Seems like the output should be manually reviewed since it does things like removing imports from `__init__.py` files of tests.  Perhaps could be more useful if used in conjunction with regex.
