### PR TITLE
restore original test case

### DIFF
--- a/corehq/apps/accounting/tests/test_credit_lines.py
+++ b/corehq/apps/accounting/tests/test_credit_lines.py
@@ -146,7 +146,7 @@ class TestCreditLines(BaseInvoiceTestCase):
 
         other_subscription = generator.generate_domain_subscription(
             self.account,
-            self.domain,
+            other_domain,
             date_start=new_subscription_start,
             date_end=add_months_to_date(new_subscription_start, self.min_subscription_length),
         )


### PR DESCRIPTION
reverts a (likely unintended) side effect of 3743a6b1c374439f33bae056e72df6fb47935b96.

found by doing an `autoflake` pass for unused variables.
