### PR TITLE
encoding group names in utf-8 for worker activity report

### DIFF
--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -1355,7 +1355,7 @@ class WorkerActivityReport(WorkerMonitoringCaseReportTableBase, DatespanMixin):
         url = self._make_url(base_url, params)
 
         return util.format_datatables_data(
-            self._html_anchor_tag(url, group_name),
+            self._html_anchor_tag(url, group_name.encode('utf-8')),
             group_name,
         )
 


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?226181#1140152
interrupt: @dannyroberts @kaapstorm @sravfeyn 
code buddy: @orangejenny 
I tested this on both group names that do and do not contain non-ascii characters and it works for both.
