### PR TITLE
Deferred blobs

### DIFF
--- a/corehq/blobs/exceptions.py
+++ b/corehq/blobs/exceptions.py
@@ -3,6 +3,10 @@ class Error(Exception):
     """BlobDB error"""
 
 
+class AmbiguousBlobStorageError(Error):
+    """Ambiguous blob storage backend error"""
+
+
 class ArgumentError(Error):
     """Raised on call with wrong arguments"""
 

--- a/corehq/blobs/mixin.py
+++ b/corehq/blobs/mixin.py
@@ -7,8 +7,8 @@ from collections import defaultdict
 from contextlib import contextmanager
 
 from corehq.blobs import BlobInfo, get_blob_db
-from corehq.blobs.exceptions import NotFound
-from corehq.blobs.util import ClosingContextProxy
+from corehq.blobs.exceptions import AmbiguousBlobStorageError, NotFound
+from corehq.blobs.util import ClosingContextProxy, document_method
 from couchdbkit.exceptions import InvalidAttachment, ResourceNotFound
 from dimagi.ext.couchdbkit import (
     Document,
@@ -70,6 +70,7 @@ class BlobMixin(Document):
         value.update(self.external_blobs)
         return value
 
+    @document_method
     def put_attachment(self, content, name=None, content_type=None, content_length=None):
         """Put attachment in blob database
 
@@ -107,6 +108,7 @@ class BlobMixin(Document):
             self._atomic_blobs[name].append(old_meta)
         return True
 
+    @document_method
     def fetch_attachment(self, name, stream=False):
         """Get named attachment
 
@@ -116,11 +118,15 @@ class BlobMixin(Document):
         """
         db = get_blob_db()
         try:
-            meta = self.external_blobs[name]
+            try:
+                meta = self.external_blobs[name]
+            except KeyError:
+                if self.migrating_blobs_from_couch:
+                    return super(BlobMixin, self) \
+                        .fetch_attachment(name, stream=stream)
+                raise NotFound
             blob = db.get(meta.id, self._blobdb_bucket())
-        except (KeyError, NotFound):
-            if self.migrating_blobs_from_couch:
-                return super(BlobMixin, self).fetch_attachment(name, stream=stream)
+        except NotFound:
             raise ResourceNotFound(u"{model} attachment: {name!r}".format(
                                    model=type(self).__name__, name=name))
         if stream:
@@ -153,6 +159,7 @@ class BlobMixin(Document):
             self.save()
         return deleted
 
+    @document_method
     def atomic_blobs(self, save=None):
         """Return a context manager to atomically save doc + blobs
 
@@ -210,6 +217,113 @@ class BlobMixin(Document):
                     if meta.id not in deleted:
                         db.delete(meta.id, bucket)
         return atomic_blobs_context()
+
+
+class BlobHelper(object):
+    """Helper to get/set blobs given a document dict and couch database
+
+    NOTE: attachments will be stored in couch and will be inaccessible
+    using the normal attachments API if this is used to copy a document
+    having "_attachments" but not "external_blobs" to a database in
+    which the "doc_type" uses external blob storage and is not in
+    `migrating_blobs_from_couch` mode. To work around this limitation,
+    put `"external_blobs": {}` in documents having a "doc_type" that
+    uses external blob storage. The same is true when copying a document
+    with "external_blobs" to a database that is not using an external
+    blob database. To work around that, remove the "external_blobs" item
+    from the document (after fetching all blobs) and be sure that the
+    document has an "_attachments" value that is not `None`.
+
+    Modifying "_attachments" or "external_blobs" values in a document is
+    not recommended while it is wrapped in this class.
+    """
+
+    def __init__(self, doc, database):
+        if doc.get("_id") is None:
+            raise TypeError("BlobHelper requires a real _id")
+        self._id = doc["_id"]
+        self.doc = doc
+        self.database = database
+        self.couch_only = "external_blobs" not in doc
+        self.migrating_blobs_from_couch = bool(doc.get("_attachments")) \
+            and not self.couch_only
+        self._attachments = doc.get("_attachments")
+        blobs = doc.get("external_blobs", {})
+        self.external_blobs = {n: BlobMeta.wrap(m.copy())
+                               for n, m in blobs.iteritems()}
+
+    _atomic_blobs = None
+
+    @property
+    def blobs(self):
+        return BlobMixin.blobs.fget(self)
+
+    def _blobdb_bucket(self):
+        return join(self.database.dbname, self._id)
+
+    def put_attachment(self, content, name=None, *args, **kw):
+        if self._attachments is None and self.couch_only:
+            raise AmbiguousBlobStorageError(" ".join("""
+                Ambiguous blob storage: doc has no _attachments and no
+                external_blobs. Put a dict (may be empty) in one or both
+                to indicate where blobs are located (_attachments ->
+                couch, external_blobs -> blob db). If both are present,
+                new blobs will be stored in the blob db, but existing
+                blobs will be fetched from couch if there is no
+                corresponding key in the external_blobs dict.
+            """.split()))
+        if self.couch_only:
+            self.database.put_attachment(self.doc, content, name, *args, **kw)
+        else:
+            BlobMixin.put_attachment(self, content, name, *args, **kw)
+            self._sync_doc()
+        return True
+
+    def fetch_attachment(self, name, *args, **kw):
+        if name in self.external_blobs:
+            return BlobMixin.fetch_attachment(self, name, *args, **kw)
+        return self.database.fetch_attachment(self._id, name, *args, **kw)
+
+    def delete_attachment(self, *args, **kw):
+        raise NotImplementedError
+
+    def atomic_blobs(self, save=None):
+        if save is not None:
+            original_save = save
+
+            def save():
+                self._sync_doc()
+                original_save()
+
+        if self.couch_only:
+            @contextmanager
+            def context():
+                (self.save if save is None else save)()
+                yield
+        else:
+            @contextmanager
+            def context():
+                try:
+                    with BlobMixin.atomic_blobs(self, save):
+                        yield
+                except:
+                    self.doc["_attachments"] = self._attachments
+                    self.doc["external_blobs"] = {name: meta.to_json()
+                        for name, meta in self.external_blobs.iteritems()}
+                    raise
+        return context()
+
+    def _sync_doc(self):
+        if "_attachments" in self.doc:
+            assert self.doc["_attachments"] == self._attachments
+        if "external_blobs" in self.doc:
+            # because put_attachment calls self.save()
+            self.doc["external_blobs"] = {name: meta.to_json()
+                for name, meta in self.external_blobs.iteritems()}
+
+    def save(self):
+        self._sync_doc()
+        self.database.save_doc(self.doc)
 
 
 class DeferredBlobMixin(BlobMixin):

--- a/corehq/blobs/s3db.py
+++ b/corehq/blobs/s3db.py
@@ -5,6 +5,7 @@ from threading import Lock
 
 from corehq.blobs import BlobInfo, DEFAULT_BUCKET
 from corehq.blobs.exceptions import BadName, NotFound
+from corehq.blobs.util import ClosingContextProxy
 
 import boto3
 from boto3.s3.transfer import S3Transfer, ReadFileChunk
@@ -130,21 +131,6 @@ def maybe_not_found(throw=None):
             raise
         if throw is not None:
             raise throw
-
-
-class ClosingContextProxy(object):
-
-    def __init__(self, obj):
-        self.obj = obj
-
-    def __getattr__(self, name):
-        return getattr(self.obj, name)
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *args):
-        self.obj.close()
 
 
 class OpenFileOSUtils(object):

--- a/corehq/blobs/tests/test_mixin.py
+++ b/corehq/blobs/tests/test_mixin.py
@@ -716,6 +716,9 @@ class PutInOldCopyToNewBlobDB(TemporaryMigratingBlobDB):
 
 class BaseFakeDocument(Document):
 
+    class Meta:
+        app_label = "couch"
+
     saved = False
 
     def save(self):

--- a/corehq/blobs/tests/test_mixin.py
+++ b/corehq/blobs/tests/test_mixin.py
@@ -125,6 +125,8 @@ class TestBlobMixin(BaseTestCase):
         content = b"<xml />"
         obj.deferred_put_attachment(content, name, content_type="text/xml")
         self.assertTrue(obj.delete_attachment(name))
+        with self.assertRaises(mod.ResourceNotFound):
+            self.obj.fetch_attachment(name)
 
     def test_save_persists_unsaved_blob(self):
         obj = self.make_doc(DeferredPutBlobDocument)

--- a/corehq/blobs/util.py
+++ b/corehq/blobs/util.py
@@ -1,0 +1,18 @@
+
+class ClosingContextProxy(object):
+    """Context manager wrapper for object with close() method
+
+    Calls `wrapped_object.close()` on exit context.
+    """
+
+    def __init__(self, obj):
+        self._obj = obj
+
+    def __getattr__(self, name):
+        return getattr(self._obj, name)
+
+    def __enter__(self):
+        return self._obj
+
+    def __exit__(self, *args):
+        self._obj.close()

--- a/corehq/blobs/util.py
+++ b/corehq/blobs/util.py
@@ -16,3 +16,26 @@ class ClosingContextProxy(object):
 
     def __exit__(self, *args):
         self._obj.close()
+
+
+class document_method(object):
+    """Document method
+
+    A document method is a twist between a static method and an instance
+    method. It can be called as a normal instance method, in which case
+    the first argument (`self`) is an instance of the method's class
+    type, or it can be called like a static method:
+
+        Document.method(obj, other, args)
+
+    in which case the first argument is passed as `self` and need not
+    be an instance of `Document`.
+    """
+
+    def __init__(self, func):
+        self.func = func
+
+    def __get__(self, obj, owner):
+        if obj is None:
+            return self.func
+        return self.func.__get__(obj, owner)


### PR DESCRIPTION
Add `DeferredBlobMixin` and `BlobHelper`, which will be used when `XFormInstance` attachments are migrated to the blob db.

Review commits individually.

@dannyroberts cc @snopoke @esoergel 
