### PR TITLE
Make Application Error Report

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases.js
@@ -16,6 +16,7 @@ hqDefine('app_manager/js/releases.js', function () {
                 self.get_app_code();
             }
         });
+        self.num_errors = ko.observable(app_data.num_errors || 0);
         self.app_code = ko.observable(null);
         self.failed_url_generation = ko.observable(false);
         self.base_url = function() {

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases.html
@@ -96,7 +96,7 @@
             <th></th>
             <th></th>
             <th>{% trans "Comments" %}</th>
-            {% if request|toggle_enabled:"SUPPORT" or request|toggle_enabled:"USER_ERROR_REPORT" %}
+            {% if request|toggle_enabled:"USER_ERROR_REPORT" %}
                 <th>Errors</th>
             {% endif %}
             <th>
@@ -256,7 +256,7 @@
                         </h6>
                     {% endif %}
                 </td>
-                {% if request|toggle_enabled:"SUPPORT" or request|toggle_enabled:"USER_ERROR_REPORT" %}
+                {% if request|toggle_enabled:"USER_ERROR_REPORT" %}
                 <td>
                     <a data-bind="text: num_errors,
                                   attr: {href: $root.url('application_errors', version())}" />

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases.html
@@ -96,7 +96,7 @@
             <th></th>
             <th></th>
             <th>{% trans "Comments" %}</th>
-            {% if request|toggle_enabled:"USER_ERROR_REPORT" %}
+            {% if request|toggle_enabled:"APPLICATION_ERROR_REPORT" %}
                 <th>Errors</th>
             {% endif %}
             <th>
@@ -256,7 +256,7 @@
                         </h6>
                     {% endif %}
                 </td>
-                {% if request|toggle_enabled:"USER_ERROR_REPORT" %}
+                {% if request|toggle_enabled:"APPLICATION_ERROR_REPORT" %}
                 <td>
                     <a data-bind="text: num_errors,
                                   attr: {href: $root.url('application_errors', version())}" />

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases.html
@@ -34,7 +34,9 @@
             update_build_comment: '{% url "update_build_comment" domain app.id %}',
             hubspot_click_deploy: '{% url "hubspot_click_deploy" %}',
             download_zip: '{% url "download_ccz" app.domain '___' %}',
-            download_multimedia: '{% url "download_multimedia_zip" app.domain '___' %}'
+            download_multimedia: '{% url "download_multimedia_zip" app.domain '___' %}',
+            application_errors: ('{% url "project_report_dispatcher" app.domain 'application_error' %}'
+                                 + '?app={{ app.id }}&version_number=___'),
         };
         var o = {
             urls: urls,
@@ -94,6 +96,9 @@
             <th></th>
             <th></th>
             <th>{% trans "Comments" %}</th>
+            {% if request|toggle_enabled:"SUPPORT" or request|toggle_enabled:"USER_ERROR_REPORT" %}
+                <th>Errors</th>
+            {% endif %}
             <th>
                 {% trans "Released" %}
                 <span class="hq-help-template"
@@ -251,6 +256,12 @@
                         </h6>
                     {% endif %}
                 </td>
+                {% if request|toggle_enabled:"SUPPORT" or request|toggle_enabled:"USER_ERROR_REPORT" %}
+                <td>
+                    <a data-bind="text: num_errors,
+                                  attr: {href: $root.url('application_errors', version())}" />
+                </td>
+                {% endif %}
                 <td class="build-is-released">
                     <div data-bind="starred: is_released, click: $root.toggleRelease"></div>
                 </td>

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -1,45 +1,39 @@
 import json
 
+from django.contrib import messages
+from django.core.urlresolvers import reverse
+from django.http import HttpResponse, Http404
+from django.http import HttpResponseRedirect
+from django.shortcuts import render
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy
 from django.views.decorators.cache import cache_control
-from django.http import HttpResponse, Http404
-from django.http import HttpResponseRedirect
-from django.core.urlresolvers import reverse
-from django.shortcuts import render
-from couchdbkit.resource import ResourceNotFound
-from django.contrib import messages
-import ghdiff
-from corehq.apps.app_manager.views.apps import get_apps_base_context
-from corehq.apps.app_manager.views.download import source_files
 
-from corehq.apps.app_manager.views.utils import back_to_main, encode_if_unicode, \
-    get_langs
+import ghdiff
+from couchdbkit.resource import ResourceNotFound
+from dimagi.utils.web import json_response
+from phonelog.models import UserErrorEntry
+
 from corehq import privileges, toggles
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.analytics.tasks import track_built_app_on_hubspot
-from corehq.apps.app_manager.exceptions import (
-    ModuleIdMissingException,
-)
+from corehq.apps.domain.dbaccessors import get_doc_count_in_domain_by_class
+from corehq.apps.domain.decorators import login_and_domain_required
 from corehq.apps.domain.views import LoginAndDomainMixin, DomainViewMixin
 from corehq.apps.hqwebapp.views import BasePageView
 from corehq.apps.sms.views import get_sms_autocomplete_context
 from corehq.apps.style.decorators import use_bootstrap3, use_angular_js
-from dimagi.utils.web import json_response
-from corehq.util.timezones.utils import get_timezone_for_user
-from corehq.apps.domain.dbaccessors import get_doc_count_in_domain_by_class
-from corehq.apps.domain.decorators import (
-    login_and_domain_required,
-)
-from corehq.apps.app_manager.dbaccessors import get_app, get_latest_build_doc
-from corehq.apps.app_manager.models import (
-    Application,
-    SavedAppBuild,
-)
-from corehq.apps.app_manager.decorators import no_conflict_require_POST, \
-    require_can_edit_apps, require_deploy_apps
 from corehq.apps.users.models import CommCareUser
-from phonelog.models import UserErrorEntry
+from corehq.util.timezones.utils import get_timezone_for_user
+
+from corehq.apps.app_manager.dbaccessors import get_app, get_latest_build_doc
+from corehq.apps.app_manager.decorators import (
+    no_conflict_require_POST, require_can_edit_apps, require_deploy_apps)
+from corehq.apps.app_manager.exceptions import ModuleIdMissingException
+from corehq.apps.app_manager.models import Application, SavedAppBuild
+from corehq.apps.app_manager.views.apps import get_apps_base_context
+from corehq.apps.app_manager.views.download import source_files
+from corehq.apps.app_manager.views.utils import (back_to_main, encode_if_unicode, get_langs)
 
 
 @cache_control(no_cache=True, no_store=True)

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -39,6 +39,7 @@ from corehq.apps.app_manager.models import (
 from corehq.apps.app_manager.decorators import no_conflict_require_POST, \
     require_can_edit_apps, require_deploy_apps
 from corehq.apps.users.models import CommCareUser
+from phonelog.models import UserErrorEntry
 
 
 @cache_control(no_cache=True, no_store=True)
@@ -68,8 +69,11 @@ def paginate_releases(request, domain, app_id):
 
         if (toggles.USER_ERROR_REPORT.enabled(request.couch_user.username)
                 or toggles.SUPPORT.enabled(request.couch_user.username)):
-            # TODO
-            app['num_errors'] = 3
+            app['num_errors'] = UserErrorEntry.objects.filter(
+                domain=domain,
+                app_id=app['copy_of'],
+                version_number=app['version'],
+            ).count()
     return json_response(saved_apps)
 
 

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -72,7 +72,7 @@ def paginate_releases(request, domain, app_id):
     for app in saved_apps:
         app['include_media'] = app['doc_type'] != 'RemoteApp'
 
-    if toggles.USER_ERROR_REPORT.enabled(request.couch_user.username):
+    if toggles.APPLICATION_ERROR_REPORT.enabled(request.couch_user.username):
         versions = [app['version'] for app in saved_apps]
         num_errors_dict = _get_error_counts(domain, app_id, versions)
         for app in saved_apps:

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -15,7 +15,7 @@ from corehq.apps.app_manager.views.download import source_files
 
 from corehq.apps.app_manager.views.utils import back_to_main, encode_if_unicode, \
     get_langs
-from corehq import privileges
+from corehq import privileges, toggles
 from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.analytics.tasks import track_built_app_on_hubspot
 from corehq.apps.app_manager.exceptions import (
@@ -65,6 +65,11 @@ def paginate_releases(request, domain, app_id):
     ).all()
     for app in saved_apps:
         app['include_media'] = app['doc_type'] != 'RemoteApp'
+
+        if (toggles.USER_ERROR_REPORT.enabled(request.couch_user.username)
+                or toggles.SUPPORT.enabled(request.couch_user.username)):
+            # TODO
+            app['num_errors'] = 3
     return json_response(saved_apps)
 
 

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -67,8 +67,7 @@ def paginate_releases(request, domain, app_id):
     for app in saved_apps:
         app['include_media'] = app['doc_type'] != 'RemoteApp'
 
-        if (toggles.USER_ERROR_REPORT.enabled(request.couch_user.username)
-                or toggles.SUPPORT.enabled(request.couch_user.username)):
+        if toggles.USER_ERROR_REPORT.enabled(request.couch_user.username):
             app['num_errors'] = UserErrorEntry.objects.filter(
                 domain=domain,
                 app_id=app['copy_of'],

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -335,6 +335,14 @@ class ApplicationErrorReport(GenericTabularReport, ProjectReport):
                 or toggles.SUPPORT.enabled(user.username))
 
     @property
+    def shared_pagination_GET_params(self):
+        app_slug = SelectApplicationFilter.slug
+        shared_params = super(ApplicationErrorReport, self).shared_pagination_GET_params
+        shared_params.append({'name': app_slug,
+                              'value': self.request.GET.get(app_slug, None)})
+        return shared_params
+
+    @property
     def headers(self):
         return DataTablesHeader(
             DataTablesColumn(_("Expression")),
@@ -348,8 +356,10 @@ class ApplicationErrorReport(GenericTabularReport, ProjectReport):
     @property
     @memoized
     def queryset(self):
-        app_id = self.request.GET.get('app', None)
+        app_id = self.request.GET.get(SelectApplicationFilter.slug, None)
         qs = UserErrorEntry.objects.filter(domain=self.domain)
+        if app_id:
+            qs = qs.filter(app_id=app_id)
         return qs
 
     @property

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -338,12 +338,10 @@ class ApplicationErrorReport(GenericTabularReport, ProjectReport):
 
     @classmethod
     def show_in_navigation(cls, domain=None, project=None, user=None):
-        return (toggles.USER_ERROR_REPORT.enabled(user.username)
-                or toggles.SUPPORT.enabled(user.username))
+        return toggles.USER_ERROR_REPORT.enabled(user.username)
 
     @property
     def shared_pagination_GET_params(self):
-        app_slug = SelectApplicationFilter.slug
         shared_params = super(ApplicationErrorReport, self).shared_pagination_GET_params
         shared_params.extend([
             {'name': param, 'value': self.request.GET.get(param, None)}

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -340,7 +340,7 @@ class ApplicationErrorReport(GenericTabularReport, ProjectReport):
 
     @classmethod
     def show_in_navigation(cls, domain=None, project=None, user=None):
-        return toggles.USER_ERROR_REPORT.enabled(user.username)
+        return toggles.APPLICATION_ERROR_REPORT.enabled(user.username)
 
     @property
     def shared_pagination_GET_params(self):

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -1,32 +1,34 @@
 # coding=utf-8
 from datetime import date, datetime, timedelta
-from casexml.apps.phone.analytics import get_sync_logs_for_user
-from corehq import toggles
+
 from django.contrib.humanize.templatetags.humanize import naturaltime
 from django.core.urlresolvers import reverse
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
-from casexml.apps.phone.models import SyncLog, properly_wrap_sync_log, SyncLogAssertionError
-from corehq.apps.receiverwrapper.util import get_meta_appversion_text, BuildVersionSource, get_app_version_info
+from django.utils.translation import ugettext_noop, ugettext as _
+
+from casexml.apps.phone.analytics import get_sync_logs_for_user
+from casexml.apps.phone.models import SyncLog, SyncLogAssertionError
 from couchdbkit import ResourceNotFound
 from couchexport.export import SCALAR_NEVER_WAS
-from corehq.apps.app_manager.dbaccessors import get_app, get_brief_apps_in_domain
-from corehq.apps.reports.filters.select import SelectApplicationFilter
-from corehq.apps.reports.standard import ProjectReportParametersMixin, ProjectReport
-from corehq.apps.reports.datatables import DataTablesHeader, DataTablesColumn, DTSortType
-from corehq.apps.reports.generic import GenericTabularReport
-from corehq.apps.reports.util import format_datatables_data
-from corehq.apps.users.models import CommCareUser
-from corehq.const import USER_DATE_FORMAT
-from corehq.util.couch import get_document_or_404
-from corehq.apps.reports.analytics.esaccessors import get_last_form_submissions_by_user
-from django.utils.translation import ugettext_noop
-from django.utils.translation import ugettext as _
-from dimagi.utils.couch.database import iter_docs
 from dimagi.utils.dates import safe_strftime
 from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.parsing import string_to_utc_datetime
 from phonelog.models import UserErrorEntry
+
+from corehq import toggles
+from corehq.apps.app_manager.dbaccessors import get_app, get_brief_apps_in_domain
+from corehq.apps.receiverwrapper.util import get_meta_appversion_text, BuildVersionSource, get_app_version_info
+from corehq.apps.users.models import CommCareUser
+from corehq.const import USER_DATE_FORMAT
+from corehq.util.couch import get_document_or_404
+
+from corehq.apps.reports.analytics.esaccessors import get_last_form_submissions_by_user
+from corehq.apps.reports.datatables import DataTablesHeader, DataTablesColumn, DTSortType
+from corehq.apps.reports.filters.select import SelectApplicationFilter
+from corehq.apps.reports.generic import GenericTabularReport
+from corehq.apps.reports.standard import ProjectReportParametersMixin, ProjectReport
+from corehq.apps.reports.util import format_datatables_data
 
 
 class DeploymentsReport(GenericTabularReport, ProjectReport, ProjectReportParametersMixin):

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -327,6 +327,7 @@ class ApplicationErrorReport(GenericTabularReport, ProjectReport):
     name = ugettext_noop("Application Error Report")
     slug = "application_error"
     ajax_pagination = True
+    sortable = False
     fields = ['corehq.apps.reports.filters.select.SelectApplicationFilter']
 
     # Filter parameters to pull from the URL
@@ -392,7 +393,7 @@ class ApplicationErrorReport(GenericTabularReport, ProjectReport):
     def rows(self):
         start = self.pagination.start
         end = start + self.pagination.count
-        for error in self._queryset[start:end]:
+        for error in self._queryset.order_by('-date')[start:end]:
             yield [
                 error.expr,
                 error.msg,

--- a/corehq/reports.py
+++ b/corehq/reports.py
@@ -82,6 +82,7 @@ def REPORTS(project):
             receiverwrapper.SubmissionErrorReport,
             phonelog.DeviceLogDetailsReport,
             deployments.SyncHistoryReport,
+            deployments.ApplicationErrorReport,
         )),
         (ugettext_lazy("Demos"), (
             DemoMapReport, DemoMapReport2, DemoMapCaseList,

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -606,6 +606,13 @@ CLOUDCARE_CACHE = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN],
 )
 
+USER_ERROR_REPORT = StaticToggle(
+    'user_error_report',
+    'Show User Error Report',
+    TAG_EXPERIMENTAL,
+    namespaces=[NAMESPACE_USER],
+)
+
 OPENLMIS = StaticToggle(
     'openlmis',
     'Offer OpenLMIS settings',

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -606,9 +606,9 @@ CLOUDCARE_CACHE = StaticToggle(
     namespaces=[NAMESPACE_DOMAIN],
 )
 
-USER_ERROR_REPORT = StaticToggle(
-    'user_error_report',
-    'Show User Error Report',
+APPLICATION_ERROR_REPORT = StaticToggle(
+    'application_error_report',
+    'Show Application Error Report',
     TAG_EXPERIMENTAL,
     namespaces=[NAMESPACE_USER],
 )


### PR DESCRIPTION
@NoahCarnahan
This is a first release of this feature.  It's under a feature flag for now, with the intention to improve upon it and come up with some sort of fully releasable variation.  At the very least, this will be useful for support workflows.

It's a two-parter - a report that shows mobile errors that are likely due to user's app-builder mistakes, and a link on the deploys page for that report filtered to a particular version, showing the number of errors found in that app version.
I'd still like to add a users column and filter - that's probably the next thing I'll do on this, but figured it was working well enough to merge.
![screenshot from 2016-05-09 14-16-55](https://cloud.githubusercontent.com/assets/2367539/15123297/323a4ffa-15f1-11e6-983b-c8454540b02a.png)
![screenshot from 2016-05-09 14-19-35](https://cloud.githubusercontent.com/assets/2367539/15123308/380aaa56-15f1-11e6-88af-08526cf56c53.png)

:fish: by :tropical_fish: might be easiest
