### PR TITLE
Add variable for Docker for Mac

### DIFF
--- a/docker/_include.sh
+++ b/docker/_include.sh
@@ -1,15 +1,17 @@
 DOCKER_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+XDG_DATA_HOME=${XDG_DATA_HOME:-$HOME/.local/share}
+UDO=""
 
-if [ `uname` == 'Linux' ]; then
-    XDG_DATA_HOME=${XDG_DATA_HOME:-$HOME/.local/share}
+if [ "$DOCKER_BETA" == "true" ]; then
+    DOCKER_DATA_HOME=$XDG_DATA_HOME/dockerhq
+elif [ `uname` == 'Linux' ]; then
     DOCKER_DATA_HOME=$XDG_DATA_HOME/dockerhq
     UDO="sudo"
 else
     DOCKER_DATA_HOME=/data
-    UDO=""
 fi
 
-if [ `uname` == 'Darwin' ]; then
+if [ `uname` == 'Darwin' -a "$DOCKER_BETA" != "true" ]; then
     docker-machine ssh $DOCKER_MACHINE_NAME sudo mkdir -p $DOCKER_DATA_HOME
 else
     mkdir -p $DOCKER_DATA_HOME

--- a/docker/docker-services.sh
+++ b/docker/docker-services.sh
@@ -4,7 +4,7 @@
 
 ES_CLUSTER_NAME=$(hostname)
 PROJECT_NAME=hqservice
-if [ `uname` == 'Darwin' ]; then
+if [ `uname` == 'Darwin' -a "$DOCKER_BETA" != "true" ]; then
     # use boot2docker host ip
     KAFKA_ADVERTISED_HOST_NAME=$(docker-machine ip $DOCKER_MACHINE_NAME)
 else


### PR DESCRIPTION
Sample usage:

```
DOCKER_BETA=true
./dockerhq.sh services start
```

Currently all services start except elasticsearch, which has a known issue: https://forums.docker.com/t/cant-start-elasticsearch-with-mounted-data-directory-f-stat-v-fs-family-of-functions/8705

Docker for Mac is currently in private beta.

@snopoke cc @dannyroberts 
FYI members of @dimagi/team-commcare-hq using Mac
