### PR TITLE
Fix report builder title

### DIFF
--- a/corehq/apps/userreports/templates/userreports/partials/report_builder_configure_report.html
+++ b/corehq/apps/userreports/templates/userreports/partials/report_builder_configure_report.html
@@ -7,7 +7,12 @@
     <script src="{% new_static 'app_manager/js/case-knockout-bindings.js' %}"></script>
 {% endblock %}
 
-{% block page_title %}{% trans "Step 2 of 2 - Configure Report Settings" %}{% endblock page_title %}
+{% block page_title %}
+    {% if not editing_existing_report %}
+    {% trans "Step 2 of 2" %} -
+    {% endif %}
+    {% trans "Configure Report Settings" %}
+{% endblock page_title %}
 
 {% block js-inline %}{{ block.super }}
     <script type="text/javascript">

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -535,6 +535,7 @@ class ConfigureChartReport(ReportBuilderView):
             },
             'report_type': self.report_type,
             'form': self.report_form,
+            'editing_existing_report': bool(self.existing_report),
             'property_options': [p._asdict() for p in self.report_form.data_source_properties.values()],
             'initial_filters': [f._asdict() for f in self.report_form.initial_filters],
             'initial_columns': [


### PR DESCRIPTION
When you edit an existing report builder report, the title would include "Step 2 of 2", we only want to show that if users are creating a new report.
@esoergel 
