### PR TITLE
Mobile ucr translations

### DIFF
--- a/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
+++ b/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
@@ -224,7 +224,7 @@ def _get_data_detail(config, domain):
                             lang=lang,
                         ),
                         "'{translation}'".format(
-                            translation=translation,
+                            translation=translation.replace("'", "''"),
                         ),
                         word_eval
                     )

--- a/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
+++ b/corehq/apps/app_manager/suite_xml/features/mobile_ucr.py
@@ -4,7 +4,7 @@ from corehq.apps.app_manager.models import ReportModule, ReportGraphConfig, \
 from corehq.apps.app_manager import models
 from corehq.apps.app_manager.suite_xml.xml_models import Locale, Text, Command, Entry, \
     SessionDatum, Detail, Header, Field, Template, Series, ConfigurationGroup, \
-    ConfigurationItem, GraphTemplate, Graph, Xpath
+    ConfigurationItem, GraphTemplate, Graph, Xpath, XpathVariable
 from corehq.util.quickcache import quickcache
 
 
@@ -206,6 +206,54 @@ def _get_summary_details(config, domain):
 
 def _get_data_detail(config, domain):
     def _column_to_field(column):
+        def _get_xpath(col):
+            def _get_conditional(condition, if_true, if_false):
+                return 'if({condition}, {if_true}, {if_false})'.format(
+                    condition=condition,
+                    if_true=if_true,
+                    if_false=if_false,
+                )
+
+            def _get_word_eval(word_translations, default_value):
+                word_eval = default_value
+                for lang_translation_pair in word_translations:
+                    lang = lang_translation_pair[0]
+                    translation = lang_translation_pair[1]
+                    word_eval = _get_conditional(
+                        "$lang = '{lang}'".format(
+                            lang=lang,
+                        ),
+                        "'{translation}'".format(
+                            translation=translation,
+                        ),
+                        word_eval
+                    )
+                return word_eval
+
+            transform = col['transform']
+            if transform.get('type') == 'translation':
+                default_val = "column[@id='{column_id}']"
+                xpath_function = default_val
+                for word, translations in transform['translations'].items():
+                    xpath_function = _get_conditional(
+                        "{value} = '{word}'".format(
+                            value=default_val,
+                            word=word,
+                        ),
+                        _get_word_eval(translations, default_val),
+                        xpath_function
+                    )
+                return Xpath(
+                    function=xpath_function.format(
+                        column_id=col.column_id
+                    ),
+                    variables=[XpathVariable(name='lang', locale_id='lang.current')],
+                )
+            else:
+                return Xpath(
+                    function="column[@id='{}']".format(col.column_id),
+                )
+
         return Field(
             header=Header(
                 text=Text(
@@ -216,7 +264,8 @@ def _get_data_detail(config, domain):
             ),
             template=Template(
                 text=Text(
-                    xpath=Xpath(function="column[@id='{}']".format(column.column_id)))
+                    xpath=_get_xpath(column),
+                )
             ),
         )
 

--- a/corehq/apps/app_manager/tests/data/suite/reports_module_data_detail-translated.xml
+++ b/corehq/apps/app_manager/tests/data/suite/reports_module_data_detail-translated.xml
@@ -13,7 +13,7 @@
       </header>
       <template>
         <text>
-          <xpath function="if(column[@id='owner'] = '2', if($lang = 'es', 'dos', if($lang = 'en', 'two', column[@id='owner'])), if(column[@id='owner'] = '1', if($lang = 'es', 'uno', if($lang = 'en', 'one', column[@id='owner'])), column[@id='owner']))">
+          <xpath function="if(column[@id='owner'] = '2', if($lang = 'es', 'dos''', if($lang = 'en', 'two', column[@id='owner'])), if(column[@id='owner'] = '1', if($lang = 'es', 'uno', if($lang = 'en', 'one', column[@id='owner'])), column[@id='owner']))">
             <variable name="lang">
               <locale id="lang.current"/>
             </variable>

--- a/corehq/apps/app_manager/tests/data/suite/reports_module_data_detail-translated.xml
+++ b/corehq/apps/app_manager/tests/data/suite/reports_module_data_detail-translated.xml
@@ -1,0 +1,49 @@
+<partial>
+  <detail id="reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.data" nodeset="rows/row">
+    <title>
+      <text>
+        <locale id="cchq.report_data_table"/>
+      </text>
+    </title>
+    <field>
+      <header>
+        <text>
+          <locale id="cchq.reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.headers.owner"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="if(column[@id='owner'] = '2', if($lang = 'es', 'dos', if($lang = 'en', 'two', column[@id='owner'])), if(column[@id='owner'] = '1', if($lang = 'es', 'uno', if($lang = 'en', 'one', column[@id='owner'])), column[@id='owner']))">
+            <variable name="lang">
+              <locale id="lang.current"/>
+            </variable>
+          </xpath>
+        </text>
+      </template>
+    </field>
+    <field>
+      <header>
+        <text>
+          <locale id="cchq.reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.headers.count"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="column[@id='count']"/>
+        </text>
+      </template>
+    </field>
+    <field>
+      <header>
+        <text>
+          <locale id="cchq.reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.headers.is_starred"/>
+        </text>
+      </header>
+      <template>
+        <text>
+          <xpath function="column[@id='is_starred']"/>
+        </text>
+      </template>
+    </field>
+  </detail>
+</partial>

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -25,6 +25,7 @@ from corehq.apps.app_manager.xpath import (
     session_var,
 )
 from corehq.apps.hqmedia.models import HQMediaMapItem
+from corehq.apps.userreports.models import ReportConfiguration
 from corehq.toggles import NAMESPACE_DOMAIN
 from corehq.feature_previews import MODULE_FILTER
 from toggle.shortcuts import update_toggle_cache, clear_toggle_cache
@@ -726,4 +727,24 @@ class SuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
             self.get_xml('reports_module_summary_detail_use_localized_description'),
             app.create_suite(),
             "./detail[@id='reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.summary']",
+        )
+
+        report_app_config._report.columns[0]['transform'] = {
+            'type': 'translation',
+            'translations': {
+                '1': [
+                    ['en', 'one'],
+                    ['es', 'uno'],
+                ],
+                '2': [
+                    ['en', 'two'],
+                    ['es', 'dos'],
+                ],
+            }
+        }
+        report_app_config._report = ReportConfiguration.wrap(report_app_config._report._doc)
+        self.assertXmlPartialEqual(
+            self.get_xml('reports_module_data_detail-translated'),
+            app.create_suite(),
+            "./detail/detail[@id='reports.ip1bjs8xtaejnhfrbzj2r6v1fi6hia4i.data']",
         )

--- a/corehq/apps/app_manager/tests/test_suite.py
+++ b/corehq/apps/app_manager/tests/test_suite.py
@@ -738,7 +738,7 @@ class SuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
                 ],
                 '2': [
                     ['en', 'two'],
-                    ['es', 'dos'],
+                    ['es', 'dos\''],
                 ],
             }
         }

--- a/corehq/apps/userreports/transforms/factory.py
+++ b/corehq/apps/userreports/transforms/factory.py
@@ -2,7 +2,12 @@ import json
 from django.utils.translation import ugettext as _
 from jsonobject.exceptions import BadValueError
 from corehq.apps.userreports.exceptions import BadSpecError
-from corehq.apps.userreports.transforms.specs import CustomTransform, DateFormatTransform, NumberFormatTransform
+from corehq.apps.userreports.transforms.specs import (
+    CustomTransform,
+    DateFormatTransform,
+    NumberFormatTransform,
+    TranslationTransform,
+)
 
 
 class TransformFactory(object):
@@ -10,6 +15,7 @@ class TransformFactory(object):
         'custom': CustomTransform,
         'date_format': DateFormatTransform,
         'number_format': NumberFormatTransform,
+        'translation': TranslationTransform,
     }
 
     @classmethod

--- a/corehq/apps/userreports/transforms/specs.py
+++ b/corehq/apps/userreports/transforms/specs.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from dimagi.ext.jsonobject import JsonObject, StringProperty
+from dimagi.ext.jsonobject import DictProperty, JsonObject, StringProperty
 from corehq.apps.userreports.specs import TypeProperty
 from corehq.apps.userreports.transforms.custom.date import get_month_display, days_elapsed_from_date
 from corehq.apps.userreports.transforms.custom.numeric import \
@@ -73,5 +73,18 @@ class NumberFormatTransform(Transform):
                 return self.format_string.format(value)
             except Exception:
                 return value
+
+        return transform_function
+
+
+class TranslationTransform(Transform):
+    type = TypeProperty('translation')
+    translations = DictProperty()
+
+    def get_transform_function(self):
+
+        # For now, use the identity function
+        def transform_function(value):
+            return value
 
         return transform_function


### PR DESCRIPTION
https://trello.com/c/YwYi8mSC/115-mobile-ucr-id-mapping-for-variables

Allows for specifying translation for values in mobile UCR rows using a transform in the report configuration.  I chose to store the translations here (instead of in the app) because we might want to do translations in web reports in the future and it would be good to have one source of truth.  Another reason was that if we decided to move the translations, it would be easier to go from report -> app than app -> report since each report app config has one report and not vice versa.

@NoahCarnahan @czue @orangejenny 
