### PR TITLE
Don't keep all cases around in memory all the time

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/clean_owners.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/clean_owners.py
@@ -6,7 +6,7 @@ from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.toggles import EXTENSION_CASES_SYNC_ENABLED
 from casexml.apps.case.const import CASE_INDEX_EXTENSION, CASE_INDEX_CHILD
 from casexml.apps.phone.cleanliness import get_case_footprint_info
-from casexml.apps.phone.data_providers.case.load_testing import append_update_to_response
+from casexml.apps.phone.data_providers.case.load_testing import get_elements_for_response
 from casexml.apps.phone.data_providers.case.stock import get_stock_payload
 from casexml.apps.phone.data_providers.case.utils import get_case_sync_updates, CaseStub
 from casexml.apps.phone.models import OwnershipCleanlinessFlag, LOG_FORMAT_SIMPLIFIED, IndexTree, SimplifiedSyncLog
@@ -66,7 +66,7 @@ class CleanOwnerCaseSyncOperation(object):
         extension_indices = defaultdict(set)
         all_dependencies_syncing = set()
         closed_cases = set()
-        potential_updates_to_sync = []
+        potential_elements_to_sync = {}
         while case_ids_to_sync:
             ids = pop_ids(case_ids_to_sync, chunk_size)
             # todo: see if we can avoid wrapping - serialization depends on it heavily for now
@@ -81,8 +81,7 @@ class CleanOwnerCaseSyncOperation(object):
             for update in updates:
                 case = update.case
                 all_synced.add(case.case_id)
-                potential_updates_to_sync.append(update)
-
+                potential_elements_to_sync[case.case_id] = get_elements_for_response(update, self.restore_state)
                 # update the indices in the new sync log
                 if case.indices:
                     extension_indices[case.case_id] = {
@@ -155,9 +154,10 @@ class CleanOwnerCaseSyncOperation(object):
         else:
             irrelevant_cases = purged_cases - self.restore_state.last_sync_log.case_ids_on_phone
 
-        for update in potential_updates_to_sync:
-            if update.case.case_id not in irrelevant_cases:
-                append_update_to_response(response, update, self.restore_state)
+        for element_case_id, elements in potential_elements_to_sync.iteritems():
+            if element_case_id not in irrelevant_cases:
+                for element in elements:
+                    response.append(element)
 
         return response
 

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/load_testing.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/load_testing.py
@@ -32,19 +32,21 @@ def transform_loadtest_update(update, factor):
     return CaseSyncUpdate(case, update.sync_token, required_updates=update.required_updates)
 
 
-def append_update_to_response(response, update, restore_state):
+def get_elements_for_response(update, restore_state):
     """
     Adds the XML from the case_update to the restore response.
     If factor is > 1 it will append that many updates to the response for load testing purposes.
     """
     current_count = 0
     original_update = update
+    elements = []
     while current_count < restore_state.loadtest_factor:
         element = get_case_element(update.case, update.required_updates, restore_state.version)
-        response.append(element)
+        elements.append(element)
         current_count += 1
         if current_count < restore_state.loadtest_factor:
             update = transform_loadtest_update(original_update, current_count)
-        #only add user case on the first iteration
+        # only add user case on the first iteration
         if original_update.case.type == USERCASE_TYPE:
-            return
+            break
+    return elements

--- a/corehq/ex-submodules/casexml/apps/phone/management/commands/mem_profile_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/management/commands/mem_profile_restore.py
@@ -1,0 +1,46 @@
+from optparse import make_option
+from django.core.management import BaseCommand
+from corehq.apps.users.models import CommCareUser
+from casexml.apps.phone.restore import RestoreParams, RestoreCacheSettings, RestoreConfig
+from casexml.apps.case.xml import V2
+import resource
+
+
+class Command(BaseCommand):
+    """Prints out the memory allocated to this thread before and after a restore
+    operation. Used to debug:
+    http://manage.dimagi.com/default.asp?223540#1142280 and
+    http://manage.dimagi.com/default.asp?225944#1142206
+
+    Usage: ./manage.py mem_profile_restore --username large_caseload@domain.commcarehq.org
+    """
+    option_list = BaseCommand.option_list + (
+        make_option('--username', action='store', dest='username'),
+    )
+
+    def handle(self, *args, **options):
+        username = options['username']
+        if not username:
+            print "You need a username!"
+            print "Usage: ./manage.py mem_profile_restore --username large_caseload@domain.commcarehq.org"
+            return
+
+        couch_user = CommCareUser.get_by_username(username)
+        project = couch_user.project
+
+        restore_config = RestoreConfig(
+            project=project,
+            user=couch_user.to_casexml_user(),
+            params=RestoreParams(
+                version=V2,
+                include_item_count=True,
+            ),
+            cache_settings=RestoreCacheSettings(
+                force_cache=True,
+                cache_timeout=1,
+                overwrite_cache=False,
+            )
+        )
+        print 'Memory usage: %s (kb)' % resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        restore_config.get_payload()
+        print 'Memory usage: %s (kb)' % resource.getrusage(resource.RUSAGE_SELF).ru_maxrss


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?223540#1142280
http://manage.dimagi.com/default.asp?225944#1142206
This was a good one. Not quite sure if I've totally fixed it but...

With a caseload of 15076 cases:

```
$ djm mem_profile_restore --username large_caseload@farid.commcarehq.org
Memory usage: 176672 (kb) # Before
Memory usage: 934940 (kb) # After
```

This means that `restore_config.get_payload()` uses 758MB of memory with the new restore code, which was not getting garbage collected during a sync. Printing out memory usage at various points showed me that memory was growing every time we fetched cases from the db, which led me to believe that cases were never getting gc'd.

However, the `potential_updates_to_sync` list was actually holding references to every case that was to be synced, so they never got gc'd. I'm assuming that in the instance in the bug, that meant that over 50,000 cases were being held in memory during a restore (including, I think, whatever attachments they contain, etc.). This is pretty bad.

I rewrote the `get_payload` method slightly so that we only reference those cases within the loop that they are fetched, and only keep around the element that we are going to potentially add to the response. This way the cases are gc'd and all we keep around in memory is what we are going to write to the response.

After change:

```
$ djm mem_profile_restore --username large_caseload@farid.commcarehq.org
Memory usage: 176196 (kb) # Before
Memory usage: 383824 (kb) # After
```

i.e. 207MB of memory is allocated (but not released), which seems more reasonable.

Even with the fix, the amount of memory consumed by python grows since we are still compiling the response in a dict. However, with this PR, it at least doesn't grow quite as fast... 

Wait for tests... 
@czue @sravfeyn 
