### PR TITLE
Remove view references to messaging log doc types

### DIFF
--- a/corehq/couchapps/by_domain_doc_type_date/views/view/map.js
+++ b/corehq/couchapps/by_domain_doc_type_date/views/view/map.js
@@ -16,12 +16,6 @@ function (doc) {
             case "CommCareUser":
             case "WebUser":
                 return doc.created_on;
-            case "MessageLog":
-            case "CallLog":
-            case "SMSLog":
-                return doc.date;
-            case "EventLog":
-                return doc.date;
             case "Application":
             case "Application-Deleted":
             case "RemoteApp":

--- a/corehq/couchapps/domain_shows/shows/domain_date.js
+++ b/corehq/couchapps/domain_shows/shows/domain_date.js
@@ -15,12 +15,6 @@ function (doc, req) {
             case "CommCareUser":
             case "WebUser":
                 return doc.created_on;
-            case "MessageLog":
-            case "CallLog":
-            case "SMSLog":
-                return doc.date;
-            case "EventLog":
-                return doc.date;
             case "Application":
             case "Application-Deleted":
             case "RemoteApp":


### PR DESCRIPTION
This can be merged anytime but will cause a reindex so we just have to be mindful of when we do it
