### PR TITLE
For now, just skip all non-study apps

### DIFF
--- a/custom/openclinica/const.py
+++ b/custom/openclinica/const.py
@@ -1,3 +1,6 @@
+# Only for the KEMRI study. This whole file is dropped for generic study apps
+STUDY_APPS = ('Captopril Study',)
+
 # CommCare case type of OpenClinica study subjects
 CC_SUBJECT_CASE_TYPE = 'subject'
 

--- a/custom/openclinica/utils.py
+++ b/custom/openclinica/utils.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from corehq.apps.app_manager.util import all_apps_by_domain
 from corehq.util.quickcache import quickcache
 from couchforms.models import XFormDeprecated
-from custom.openclinica.const import MODULE_EVENTS, FORM_QUESTION_ITEM, FORM_EVENTS
+from custom.openclinica.const import MODULE_EVENTS, FORM_QUESTION_ITEM, FORM_EVENTS, STUDY_APPS
 
 
 class OpenClinicaIntegrationError(Exception):
@@ -137,6 +137,8 @@ def get_question_items(domain):
         openclinica_domains = (d for d, m in settings.DOMAIN_MODULE_MAP.iteritems() if m == 'custom.openclinica')
         for domain_ in openclinica_domains:
             for app in all_apps_by_domain(domain_):
+                if app.name not in STUDY_APPS:
+                    continue
                 for ccmodule in app.get_modules():
                     for ccform in ccmodule.get_forms():
                         form = data[ccform.xmlns]


### PR DESCRIPTION
[FB 227031](http://manage.dimagi.com/default.asp?227031): Export to OpenClinica is currently failing for the KEMRI Captopril project because a dictionary of modules expects only modules from one particular app, and it's getting modules from multiple apps.

This is an ugly change, but at least it's temporary. Once this project-specific export is done, PR #10519 drops hardcoded config like this.

@snopoke, cc @czue 
