### PR TITLE
Store strings instead of Elements

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/load_testing.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/load_testing.py
@@ -4,6 +4,7 @@ from casexml.apps.phone.data_providers.case.utils import CaseSyncUpdate
 from casexml.apps.phone.xml import get_case_element
 from corehq.apps.app_manager.const import USERCASE_TYPE
 from corehq.toggles import ENABLE_LOADTEST_USERS
+from casexml.apps.phone.xml import tostring
 
 
 def get_loadtest_factor(domain, user):
@@ -42,7 +43,7 @@ def get_elements_for_response(update, restore_state):
     elements = []
     while current_count < restore_state.loadtest_factor:
         element = get_case_element(update.case, update.required_updates, restore_state.version)
-        elements.append(element)
+        elements.append(tostring(element))
         current_count += 1
         if current_count < restore_state.loadtest_factor:
             update = transform_loadtest_update(original_update, current_count)


### PR DESCRIPTION
See: https://github.com/dimagi/commcare-hq/pull/11581 for more context (same test environment)
This change:
Before: `Resident Set Size total: 202936kb`
After: `Resident Set Size total: 125248kb`
This is still >100MB of non gc'd memory, but getting somewhere...

@dannyroberts 
