### PR TITLE
Add REUSE_DB feature for nose test runner

### DIFF
--- a/corehq/sql_db/config.py
+++ b/corehq/sql_db/config.py
@@ -42,15 +42,8 @@ class DbShard(object):
         self.shard_id = shard_id
         self.django_dbname = django_dbname
 
-    def get_db_config(self):
-        from django.db.backends.creation import TEST_DATABASE_PREFIX
-        db_config = settings.DATABASES[self.django_dbname].copy()
-        if settings.UNIT_TESTING:
-            db_config['NAME'] = TEST_DATABASE_PREFIX + db_config['NAME']
-        return db_config
-
     def to_shard_meta(self, host_map):
-        config = self.get_db_config()
+        config = settings.DATABASES[self.django_dbname]
         host = host_map.get(config['HOST'], config['HOST'])
         return ShardMeta(
             id=self.shard_id,

--- a/corehq/sql_db/tests/test_partition_config.py
+++ b/corehq/sql_db/tests/test_partition_config.py
@@ -68,10 +68,10 @@ class TestPartitionConfig(SimpleTestCase):
         config = PartitionConfig()
         shards = config.get_shards()
         self.assertEquals(shards, [
-            ShardMeta(id=0, dbname='test_db1', host='hqdb1', port=5432),
-            ShardMeta(id=1, dbname='test_db1', host='hqdb1', port=5432),
-            ShardMeta(id=2, dbname='test_db2', host='hqdb2', port=5432),
-            ShardMeta(id=3, dbname='test_db2', host='hqdb2', port=5432),
+            ShardMeta(id=0, dbname='db1', host='hqdb1', port=5432),
+            ShardMeta(id=1, dbname='db1', host='hqdb1', port=5432),
+            ShardMeta(id=2, dbname='db2', host='hqdb2', port=5432),
+            ShardMeta(id=3, dbname='db2', host='hqdb2', port=5432),
         ])
 
     @override_settings(PARTITION_DATABASE_CONFIG=TEST_PARTITION_CONFIG_HOST_MAP)
@@ -79,8 +79,8 @@ class TestPartitionConfig(SimpleTestCase):
         config = PartitionConfig()
         shards = config.get_shards()
         self.assertEquals(shards, [
-            ShardMeta(id=0, dbname='test_db1', host='localhost', port=5432),
-            ShardMeta(id=1, dbname='test_db2', host='hqdb2', port=5432),
+            ShardMeta(id=0, dbname='db1', host='localhost', port=5432),
+            ShardMeta(id=1, dbname='db2', host='hqdb2', port=5432),
         ])
 
     @override_settings(PARTITION_DATABASE_CONFIG=INVALID_SHARD_RANGE_START)
@@ -105,8 +105,8 @@ class PlProxyTests(SimpleTestCase):
 
     def test_get_server_option_string(self):
         self.assertEqual(
-            "p0 'dbname=test_db1 host=hqdb0 port=5432'",
-            ShardMeta(id=0, dbname='test_db1', host='hqdb0', port=5432).get_server_option_string()
+            "p0 'dbname=db1 host=hqdb0 port=5432'",
+            ShardMeta(id=0, dbname='db1', host='hqdb0', port=5432).get_server_option_string()
         )
 
     def test_parse_existing_shard(self):

--- a/settings.py
+++ b/settings.py
@@ -1128,19 +1128,15 @@ else:
         ('django.template.loaders.cached.Loader', TEMPLATE_LOADERS),
     ]
 
+if helper.is_testing():
+    helper.assign_test_db_names(DATABASES)
+
 ### Reporting database - use same DB as main database
 
 db_settings = DATABASES["default"].copy()
 db_settings['PORT'] = db_settings.get('PORT', '5432')
 options = db_settings.get('OPTIONS')
 db_settings['OPTIONS'] = '?{}'.format(urlencode(options)) if options else ''
-# Use test database name, but only if running the test command.
-# Django uses different database names than the ones in DATABASES
-# when setting up for tests. However, UNIT_TESTING may be true in
-# some cases where django is not running tests (js tests on travis),
-# and therefore does not change the database name.
-db_settings['NAME'] = helper.get_db_name(db_settings['NAME'],
-                                         UNIT_TESTING and helper.is_testing())
 
 if not SQL_REPORTING_DATABASE_URL or UNIT_TESTING:
     SQL_REPORTING_DATABASE_URL = "postgresql+psycopg2://{USER}:{PASSWORD}@{HOST}:{PORT}/{NAME}{OPTIONS}".format(

--- a/settingshelper.py
+++ b/settingshelper.py
@@ -91,7 +91,7 @@ def get_dynamic_db_settings(server_root, username, password, dbname,
         'database': dbname,
     }
     return {
-        'COUCH_SERVER':  server_url,
+        'COUCH_SERVER': server_url,
         'COUCH_DATABASE': database,
     }
 
@@ -102,6 +102,18 @@ def get_db_name(dbname, is_test):
     :param is_test: Add test prefix if true.
     """
     return (TEST_DATABASE_PREFIX + dbname) if is_test else dbname
+
+
+def assign_test_db_names(dbs):
+    """Fix database names for REUSE_DB
+
+    Django automatically uses test database names when testing, but
+    only if the test database setup routine is called. This allows us
+    to safely skip the test database setup with REUSE_DB.
+    """
+    for db in dbs.values():
+        test_db_name = get_db_name(db['NAME'], True)
+        db['NAME'] = db.setdefault('TEST', {}).setdefault('NAME', test_db_name)
 
 
 class CouchSettingsHelper(namedtuple('CouchSettingsHelper',

--- a/testsettings.py
+++ b/testsettings.py
@@ -6,7 +6,7 @@ INSTALLED_APPS += (
     'testapps.test_pillowtop',
 ) + TEST_APPS
 
-TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
+TEST_RUNNER = 'django_nose.BasicNoseRunner'
 NOSE_ARGS = [
     #'--no-migrations' # trim ~120s from test run with db tests
     #'--with-fixture-bundling',


### PR DESCRIPTION
This can be used to greatly reduce test database setup time by setting up test databases once and then reusing them on subsequent test runs. See `HqdbContext` doc string for more details.

Usage: `REUSE_DB=1 ./manage.py test --settings=testsettings`

@benrudolph @esoergel cc @dimagi/team-commcare-hq 
