### PR TITLE
Fixed admin reports charts

### DIFF
--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -1033,7 +1033,7 @@ class GlobalAdminReports(AdminDomainStatsReport):
 class RealProjectSpacesReport(GlobalAdminReports):
     slug = 'real_project_spaces'
     name = ugettext_noop('All Project Spaces')
-    default_params = {'es_is_test': 'false'}
+    default_params = {'es_is_test': ['none', 'false']}
     indicators = [
         'domain_count',
         'domain_self_started_count',
@@ -1059,7 +1059,7 @@ class CommConnectProjectSpacesReport(GlobalAdminReports):
     slug = 'commconnect_project_spaces'
     name = ugettext_noop('Project Spaces Using Messaging')
     default_params = {
-        'es_is_test': 'false',
+        'es_is_test': ['none', 'false'],
         'es_cp_sms_ever': 'T',
     }
     indicators = [
@@ -1084,7 +1084,7 @@ class CommTrackProjectSpacesReport(GlobalAdminReports):
     slug = 'commtrack_project_spaces'
     name = ugettext_noop('CommCare Supply Project Spaces')
     default_params = {
-        'es_is_test': 'false',
+        'es_is_test': ['none', 'false'],
         'es_internal.commtrack_domain': 'T',
     }
     indicators = [

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1481,7 +1481,9 @@ class AdminTab(UITab):
                     'title': report.name,
                     'url': '{url}{params}'.format(
                         url=reverse('admin_report_dispatcher', args=(report.slug,)),
-                        params="?{}".format(urlencode(report.default_params)) if report.default_params else ""
+                        params="?{}".format(
+                            urlencode(report.default_params, True)
+                        ) if report.default_params else ""
                     )
                 } for report in [
                     RealProjectSpacesReport,


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?226421

@benrudolph 

By default url in menu contains `es_is_test=false` param which includes only domains with param `is_test` set to false. I checked data on staging and most domains there have `is_test` set to none. I don't know if it's the case on prod because I don't have access to admin reports.
