### PR TITLE
Alter rebuildstaging conflict resolution strategy

### DIFF
--- a/scripts/gitutils.py
+++ b/scripts/gitutils.py
@@ -59,19 +59,16 @@ def git_check_merge(branch1, branch2, git=None):
         git.checkout(branch2)
         is_behind = git.log('{0}..{1}'.format(branch2, branch1),
                             max_count=1).strip()
+        clean_merge = True
         if is_behind:
             try:
                 git.merge('--no-commit', '--no-ff', branch1).strip()
             except sh.ErrorReturnCode_1:
                 # git merge returns 1 when there's a conflict
-                return False
-            else:
-                return True
-            finally:
-                git.merge('--abort')
-                git.checkout(orig_branch)
-        else:
-            return True
+                clean_merge = False
+            git.merge('--abort')
+        git.checkout(orig_branch)
+        return clean_merge
 
 
 def has_merge_conflict(branch1, branch2, git):

--- a/scripts/gitutils.py
+++ b/scripts/gitutils.py
@@ -74,6 +74,10 @@ def git_check_merge(branch1, branch2, git=None):
             return True
 
 
+def has_merge_conflict(branch1, branch2, git):
+    return not git_check_merge(branch1, branch2, git=git)
+
+
 def git_bisect_merge_conflict(branch1, branch2, git=None):
     """
     return the branch2 commit that prevents branch1 from being merged in


### PR DESCRIPTION
@dannyroberts @millerdev 
Whenever I see a conflict on rebuildstaging, what I usually want to know is "does this conflict with master?" and if not, "what branches DOES it conflict with?".  This adopts that strategy and falls back to the current behavior if that doesn't find any conflicts.

If anyone objects to this change, I'd be happy to stick it behind a flag or something.  Here's what I see now, for instance:

```
$ python scripts/rebuildstaging.py < scripts/staging.yaml --no-push rebuild
  [.] Merging vellum-staging into autostaging ok
  [.] Merging app-blobs-testing+lang-profiles into autostaging FAIL
  [.] Merging app-blobs-testing into autostaging ok
  [.] Merging lang-profiles into autostaging FAIL
  [.] Merging b3-groups into autostaging ok
  [.] Merging b3-app-multimedia into autostaging ok
  [.] Merging notifications-perms-change into autostaging ok
  [.] Merging calculatedIcons into autostaging ok
  [.] Merging check-services into autostaging ok
You must fix the following merge conflicts before rebuilding:

[.] app-blobs-testing+lang-profiles => autostaging
app-blobs-testing+lang-profiles conflicts with master

[.] lang-profiles => autostaging
lang-profiles conflicts with app-blobs-testing
```
