### PR TITLE
Fix remote apps not building

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4668,6 +4668,7 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
 
         return app
 
+    @property
     def profile_url(self):
         return self.hq_profile_url
 

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4217,7 +4217,7 @@ class ApplicationBase(VersionedDoc, SnapshotMixin,
         return '/a/%s/api/custom/pact_formdata/v1/' % self.domain
 
     @absolute_url_property
-    def profile_url(self):
+    def hq_profile_url(self):
         return "%s?latest=true" % (
             reverse('download_profile', args=[self.domain, self._id])
         )
@@ -4667,6 +4667,9 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
         app.build_broken = False
 
         return app
+
+    def profile_url(self):
+        return self.hq_profile_url
 
     @absolute_url_property
     def suite_url(self):

--- a/corehq/apps/app_manager/remote_app.py
+++ b/corehq/apps/app_manager/remote_app.py
@@ -65,7 +65,7 @@ def make_remote_profile(app):
 
         if app.manage_urls:
             profile_xml.auto_set_versions(app.version)
-            profile_xml.set_attribute('update', app.profile_url)
+            profile_xml.set_attribute('update', app.hq_profile_url)
             profile_xml.set_property("ota-restore-url", app.ota_restore_url)
             profile_xml.set_property("PostURL", app.post_url)
             profile_xml.set_property("cc_user_domain", cc_user_domain(app.domain))


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?227088#1149422
This is pretty confusing... RemoteApps have a `profile_url` which are
remote. Having a property in ApplicationBase called `profile_url` messes
this up.

Introduced here: https://github.com/dimagi/commcare-hq/pull/9554/commits/34eb33cf1ecb854fe58187045211fa7e5b7d8a8c
@benrudolph @nickpell
cc: @dannyroberts
