### PR TITLE
Add server date to devicelog report

### DIFF
--- a/corehq/ex-submodules/phonelog/reports.py
+++ b/corehq/ex-submodules/phonelog/reports.py
@@ -73,7 +73,10 @@ class BaseDeviceLogReport(GetParamsMixin, DatespanMixin, PaginatedReportMixin):
     @property
     def headers(self):
         return DataTablesHeader(
-            DataTablesColumn("Date", span=1, sort_type=DATE, prop_name='date',
+            DataTablesColumn("Log Date", span=1, sort_type=DATE, prop_name='date',
+                             sort_direction=[DTSortDirection.DSC,
+                                             DTSortDirection.ASC]),
+            DataTablesColumn("Server Date", span=1, sort_type=DATE, prop_name='server_date',
                              sort_direction=[DTSortDirection.DSC,
                                              DTSortDirection.ASC]),
             DataTablesColumn("Log Type", span=1, prop_name='type'),
@@ -200,8 +203,11 @@ class BaseDeviceLogReport(GetParamsMixin, DatespanMixin, PaginatedReportMixin):
                     'data-datatable-tooltip-text="%(tooltip)s">%(text)s</a>')
 
     def _create_row(self, log, matching_id, _device_users_by_xform, user_query, device_query):
-            ui_date = (ServerTime(log.date)
-                       .user_time(self.timezone).ui_string())
+            log_date = (ServerTime(log.date)
+                        .user_time(self.timezone).ui_string())
+
+            server_date = (ServerTime(log.server_date)
+                           .user_time(self.timezone).ui_string())
 
             username = log.username
             username_fmt = self._username_fmt % {
@@ -258,7 +264,7 @@ class BaseDeviceLogReport(GetParamsMixin, DatespanMixin, PaginatedReportMixin):
 
             app_version = get_version_from_appversion_text(log.app_version) or "unknown"
             commcare_version = get_commcare_version_from_appversion_text(log.app_version) or "unknown"
-            return [ui_date, log_tag_format, username_fmt,
+            return [log_date, server_date, log_tag_format, username_fmt,
                     device_users_fmt, device_fmt, log.msg, app_version, commcare_version]
 
     def _create_rows(self, logs, matching_id=None, range=None):


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?227465#1149703

Adds server date to the devicelog report, otherwise they are somewhat confusing as the 60 day purge acts on the `server_date`
