### PR TITLE
add different icons for advanced and report modules

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/managed_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/managed_app.html
@@ -185,9 +185,12 @@
                         data-index="{{ module.id }}">
                         <a href="{% url "view_module" domain app.id module.id %}">
                             <i class="drag_handle"></i>
-                            <i class="fa fa-folder-open"></i>
+                            {% if module.module_type == 'advanced' %}<i class="fa fa-exclamation-triangle"></i>
+                            {% elif module.module_type == 'report' %}<i class="fa fa-bar-chart"></i>
+                            {% else %}<i class="fa fa-folder-open"></i>{% endif %}
                             <span {% if module.id == selected_module.id %}class="variable-module_name"{% endif %}>
                                 {{ module.name|html_trans:langs }}
+
                             </span>
                         </a>
                         <ul class="nav nav-hq-sidebar {% ifequal module.id selected_module.id %}selected{% endifequal %} sortable-forms sortable">


### PR DESCRIPTION
this just adds different icons for advanced and report modules so you can tell what type of module something is in the navigation tree. http://manage.dimagi.com/default.asp?223736
![image](https://cloud.githubusercontent.com/assets/66555/15471010/a6448c5a-20c1-11e6-9c04-75c0d2991cd6.png)

I didn't think too hard about the icons, so if @orangejenny @biyeun or @dimagi/product want to propose something else feel free. I figured it wasn't super important since these are only R&D / mostly internal features.
