### PR TITLE
Add message id to message log report

### DIFF
--- a/corehq/apps/reports/standard/sms.py
+++ b/corehq/apps/reports/standard/sms.py
@@ -317,6 +317,11 @@ class MessageLogReport(BaseCommConnectLogReport):
 
     @property
     @memoized
+    def include_metadata(self):
+        return toggles.MESSAGE_LOG_METADATA.enabled(self.request.couch_user.username)
+
+    @property
+    @memoized
     def uses_locations(self):
         return (toggles.LOCATIONS_IN_REPORTS.enabled(self.domain)
                 and Domain.get_by_name(self.domain).uses_locations)
@@ -426,7 +431,7 @@ class MessageLogReport(BaseCommConnectLogReport):
                 message.text,
                 ', '.join(self._get_message_types(message)),
             ]
-            if include_log_id:
+            if include_log_id and self.include_metadata:
                 row.append(message.couch_id)
             yield row
 
@@ -457,8 +462,9 @@ class MessageLogReport(BaseCommConnectLogReport):
     @property
     def export_table(self):
         result = super(MessageLogReport, self).export_table
-        table = result[0][1]
-        table[0].append(_("Message Log ID"))
+        if self.include_metadata:
+            table = result[0][1]
+            table[0].append(_("Message Log ID"))
         return result
 
 

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -711,6 +711,13 @@ TELERIVET_SETUP_WALKTHROUGH = StaticToggle(
     [NAMESPACE_DOMAIN],
 )
 
+MESSAGE_LOG_METADATA = StaticToggle(
+    'message_log_metadata',
+    'Include message id in Message Log export.',
+    TAG_ONE_OFF,
+    [NAMESPACE_USER],
+)
+
 ABT_REMINDER_RECIPIENT = StaticToggle(
     'abt_reminder_recipient',
     "Ability to send a reminder to the case owner's location's parent location",


### PR DESCRIPTION
Adds the ability to include a column for message id in the export of the message log report.
@calellowitz 
