### PR TITLE
Non form mm

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4739,7 +4739,11 @@ class ApplicationBase(VersionedDoc, SnapshotMixin,
             for form in self.get_forms(bare=False):
                 xml = XForm(form['form'].source)
                 for lang in self.langs:
-                    media = [path for path in xml.all_references(lang) if path is not None]
+                    media = []
+                    for path in xml.all_references(lang):
+                        if path is not None:
+                            media.append(path)
+                            self.multimedia_map[path].form_media = True
                     self.media_language_map[lang].media_refs.extend(media)
         else:
             self.media_language_map = {}

--- a/corehq/apps/app_manager/suite_xml/generator.py
+++ b/corehq/apps/app_manager/suite_xml/generator.py
@@ -107,7 +107,7 @@ class MediaSuiteGenerator(object):
                 media_list += self.app.media_language_map[lang].media_refs
             requested_media = set(media_list)
         for path, m in self.app.multimedia_map.items():
-            if filter_multimedia and path not in requested_media:
+            if filter_multimedia and m.form_media and path not in requested_media:
                 continue
             unchanged_path = path
             if path.startswith(PREFIX):

--- a/corehq/apps/app_manager/suite_xml/sections/resources.py
+++ b/corehq/apps/app_manager/suite_xml/sections/resources.py
@@ -46,6 +46,8 @@ class LocaleResourceContributor(SectionContributor):
             else self.app.build_profiles[self.build_profile_id].langs
         for lang in ["default"] + langs:
             path = './{lang}/app_strings.txt'.format(lang=lang)
+            if self.build_profile_id:
+                path += '?profile={profile}'.format(profile=self.build_profile_id)
             resource = LocaleResource(
                 language=lang,
                 id=id_strings.locale_resource(lang),

--- a/corehq/apps/hqmedia/models.py
+++ b/corehq/apps/hqmedia/models.py
@@ -392,6 +392,7 @@ class HQMediaMapItem(DocumentSchema):
     output_size = DictProperty()
     version = IntegerProperty()
     unique_id = StringProperty()
+    form_media = BooleanProperty(default=False)
 
     @property
     def url(self):
@@ -708,7 +709,7 @@ class HQMediaMixin(Document):
         expected_ids = [map_item.multimedia_id for map_item in self.multimedia_map.values()]
         raw_docs = dict((d["_id"], d) for d in iter_docs(CommCareMultimedia.get_db(), expected_ids))
         for path, map_item in self.multimedia_map.items():
-            if not filter_multimedia or path in requested_media:
+            if not filter_multimedia or not map_item.form_media or path in requested_media:
                 media_item = raw_docs.get(map_item.multimedia_id)
                 if media_item:
                     media_cls = CommCareMultimedia.get_doc_class(map_item.media_type)


### PR DESCRIPTION
@emord @czue @dannyroberts
Installs with build profiles were missing multimedia not referenced in forms. this fixes that and a discrepancy where ccz downloads and normal installs were getting different versions of `default/app_strings.txt`
