### PR TITLE
E-mail if isEmailable, not isExportAll

### DIFF
--- a/corehq/apps/reports/static/reports/javascripts/reports.config.js
+++ b/corehq/apps/reports/static/reports/javascripts/reports.config.js
@@ -51,13 +51,13 @@ var HQReport = function (options) {
                 if (self.isExportable) {
                     $(self.exportReportButton).click(function (e) {
                         e.preventDefault();
-                        if (self.isExportAll) {
+                        if (self.isEmailable) {
                             $.ajax({
                                 url: getReportBaseUrl("export"),
                                 data: getReportParams(undefined),
                                 type: "POST",
                                 success: function() {
-                                    alert_user("Your requested excel report will be sent to the email address " +
+                                    alert_user("Your requested Excel report will be sent to the email address " +
                                                "defined in your account settings.", "success");
                                 },
                             });


### PR DESCRIPTION
Seems like a mistake ... BUT this change would mean that custom reports marked `emailable = False` but `exportable_all = True` will no longer be e-mailable, and users might be accustomed to the current behavior. 

Affects the following reports:
- [SMSBillablesInterface](https://github.com/dimagi/commcare-hq/blob/7150cddae3179e46069112b1fcb4f537e2142cd5/corehq/apps/smsbillables/interface.py#L31-L31)
- [SMSGatewayFeeCriteriaInterface](https://github.com/dimagi/commcare-hq/blob/7150cddae3179e46069112b1fcb4f537e2142cd5/corehq/apps/smsbillables/interface.py#L195-L195)
- [ChildMCHRegister](https://github.com/dimagi/commcare-hq/blob/dedf2496c5e264b78a6a4acaa6c186184cd3159d/custom/bihar/reports/mch_reports.py#L306-L306)
- [MotherMCHRegister](https://github.com/dimagi/commcare-hq/blob/dedf2496c5e264b78a6a4acaa6c186184cd3159d/custom/bihar/reports/mch_reports.py#L122-L122)
- [McctProjectReview](https://github.com/dimagi/commcare-hq/blob/fe0ae64358c8a3eece3ab1b164f03b715d11c327/custom/m4change/reports/mcct_project_review.py#L173-L173)
- [McctClientApprovalPage](https://github.com/dimagi/commcare-hq/blob/fe0ae64358c8a3eece3ab1b164f03b715d11c327/custom/m4change/reports/mcct_project_review.py#L279-L279)
- [McctClientPaymentPage](https://github.com/dimagi/commcare-hq/blob/fe0ae64358c8a3eece3ab1b164f03b715d11c327/custom/m4change/reports/mcct_project_review.py#L310-L310)
- [McctRejectedClientPage](https://github.com/dimagi/commcare-hq/blob/fe0ae64358c8a3eece3ab1b164f03b715d11c327/custom/m4change/reports/mcct_project_review.py#L317-L317)
- [McctPaidClientsPage](https://github.com/dimagi/commcare-hq/blob/fe0ae64358c8a3eece3ab1b164f03b715d11c327/custom/m4change/reports/mcct_project_review.py#L461-L461)
- [McctClientLogPage](https://github.com/dimagi/commcare-hq/blob/fe0ae64358c8a3eece3ab1b164f03b715d11c327/custom/m4change/reports/mcct_project_review.py#L383-L383)

@snopoke @dannyroberts cc @nickpell 
