### PR TITLE
filtering for languages in advanced and careplan forms

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2325,7 +2325,7 @@ class AdvancedForm(IndexedFormBase, NavMenuItemMediaMixin):
                 pass
 
     def add_stuff_to_xform(self, xform, build_profile_id=None):
-        super(AdvancedForm, self).add_stuff_to_xform(xform)
+        super(AdvancedForm, self).add_stuff_to_xform(xform, build_profile_id)
         xform.add_case_and_meta_advanced(self)
 
     def requires_case(self):
@@ -3033,7 +3033,7 @@ class CareplanForm(IndexedFormBase, NavMenuItemMediaMixin):
             return super(CareplanForm, cls).wrap(data)
 
     def add_stuff_to_xform(self, xform, build_profile_id=None):
-        super(CareplanForm, self).add_stuff_to_xform(xform)
+        super(CareplanForm, self).add_stuff_to_xform(xform, build_profile_id)
         xform.add_care_plan(self)
 
     def get_case_updates(self, case_type):


### PR DESCRIPTION
@emord @czue 
application profiles were not working correctly in advnaced forms and careplan forms because of a missing argument.
