### PR TITLE
Make blob migrations more resiliant/scalable

### DIFF
--- a/corehq/blobs/management/commands/run_blob_migration.py
+++ b/corehq/blobs/management/commands/run_blob_migration.py
@@ -20,13 +20,15 @@ class Command(BaseCommand):
     help = USAGE
     option_list = BaseCommand.option_list + (
         make_option('--file', help="Migration intermediate storage file."),
+        make_option('--reset', action="store_true", default=False,
+            help="Discard any existing migration state."),
     )
 
-    def handle(self, slug=None, file=None, **options):
+    def handle(self, slug=None, file=None, reset=False, **options):
         try:
             migrator = MIGRATIONS[slug]
         except KeyError:
             raise CommandError(USAGE)
-        total, skips = migrator.migrate(file)
+        total, skips = migrator.migrate(file, reset=reset)
         if skips:
             sys.exit(skips)

--- a/corehq/util/couch_helpers.py
+++ b/corehq/util/couch_helpers.py
@@ -1,9 +1,11 @@
 import base64
-from copy import copy
-import hashlib
-from mimetypes import guess_type
 import datetime
+import hashlib
 import threading
+from copy import copy
+from mimetypes import guess_type
+
+from couchdbkit import ResourceNotFound
 
 
 class CouchAttachmentsBuilder(object):
@@ -167,6 +169,153 @@ def paginate_view(db, view_name, chunk_size,
             view_kwargs['startkey'] = result['key']
             view_kwargs['startkey_docid'] = result['id']
             view_kwargs['skip'] = 1
+
+
+class ResumableDocsByTypeIterator(object):
+    """Perform one-time resumable iteration over documents by type
+
+    Iteration can be efficiently stopped and resumed. The iteration may
+    omit documents that are added after the iteration begins or resumes
+    and may include deleted documents.
+
+    :param db: Couchdb database.
+    :param doc_types: A list of doc type names to iterate on.
+    :param iteration_key: A unique key identifying the iteration. This
+    key will be used in combination with `doc_types` to maintain state
+    about an iteration that is in progress. The state will be maintained
+    indefinitely unless it is removed with `discard_state()`.
+    :param chunk_size: Number of documents to yield before updating the
+    iteration checkpoint. In the worst case about this many documents
+    that were previously yielded may be yielded again if the iteration
+    is stopped and later resumed.
+    """
+
+    def __init__(self, db, doc_types, iteration_key, chunk_size=100):
+        if isinstance(doc_types, str):
+            raise TypeError("expected list of strings, got %r" % (doc_types,))
+        self.db = db
+        self.original_doc_types = doc_types = sorted(doc_types)
+        self.iteration_key = iteration_key
+        self.chunk_size = chunk_size
+        iteration_name = "{}/{}".format(iteration_key, " ".join(doc_types))
+        self.iteration_id = hashlib.sha1(iteration_name).hexdigest()
+        try:
+            self.state = db.get(self.iteration_id)
+        except ResourceNotFound:
+            # new iteration
+            self.state = {
+                "_id": self.iteration_id,
+                "doc_type": "ResumableDocsByTypeIteratorState",
+                "retry": {},
+
+                # for humans
+                "name": iteration_name,
+                "timestamp": datetime.datetime.utcnow().isoformat()
+            }
+            args = {}
+        else:
+            # resume iteration
+            args = self.state.get("offset", {}).copy()
+            if args:
+                assert args.get("startkey"), args
+                doc_type = args["startkey"][0]
+                # skip doc types before offset
+                doc_types = doc_types[doc_types.index(doc_type):]
+            else:
+                # non-retry phase of iteration is complete
+                doc_types = []
+        args.update(
+            view_name='all_docs/by_doc_type',
+            chunk_size=chunk_size,
+            log_handler=ResumableDocsByTypeLogHandler(self),
+            include_docs=True,
+            reduce=False,
+        )
+        self.view_args = args
+        self.doc_types = doc_types
+
+    def __iter__(self):
+        args = self.view_args
+        for doc_type in self.doc_types:
+            if args.get("startkey", [None])[0] != doc_type:
+                args.pop("startkey_docid", None)
+                args["startkey"] = [doc_type]
+            args["endkey"] = [doc_type, {}]
+            for result in paginate_view(self.db, **args):
+                yield result['doc']
+
+        retried = {}
+        while self.state["retry"] != retried:
+            for doc_id, retries in list(self.state["retry"].iteritems()):
+                if retries == retried.get(doc_id):
+                    continue  # skip already retried (successfully)
+                retried[doc_id] = retries
+                try:
+                    yield self.db.get(doc_id)
+                except ResourceNotFound:
+                    pass
+
+        # save iteration state without offset to signal completion
+        self.state.pop("offset", None)
+        self.state["retry"] = {}
+        self._save_state()
+
+    def retry(self, doc, max_retry=3):
+        """Add document to be yielded at end of iteration
+
+        Iteration order of retry documents is undefined. All retry
+        documents will be yielded after the initial non-retry phase of
+        iteration has completed, and every retry document will be
+        yielded each time the iterator is stopped and resumed during the
+        retry phase. This method is relatively inefficient because it
+        forces the iteration state to be saved to couch. If you find
+        yourself calling this for many documents during the iteration
+        you may want to consider a different retry strategy.
+
+        :param doc: The doc dict to retry. It will be re-fetched from
+        the database before being yielded from the iteration.
+        :param max_retry: Maximum number of times a given document may
+        be retried.
+        :raises: `TooManyRetries` if this method has been called too
+        many times with a given document.
+        """
+        doc_id = doc["_id"]
+        retries = self.state["retry"].get(doc_id, 0) + 1
+        if retries > max_retry:
+            raise TooManyRetries(doc_id)
+        self.state["retry"][doc_id] = retries
+        self._save_state()
+
+    def _save_state(self):
+        self.state["timestamp"] = datetime.datetime.utcnow().isoformat()
+        self.db.save_doc(self.state)
+
+    def discard_state(self):
+        try:
+            self.db.delete_doc(self.iteration_id)
+        except ResourceNotFound:
+            pass
+        self.__init__(
+            self.db,
+            self.original_doc_types,
+            self.iteration_key,
+            self.chunk_size,
+        )
+
+
+class ResumableDocsByTypeLogHandler(PaginateViewLogHandler):
+
+    def __init__(self, iterator):
+        self.iterator = iterator
+
+    def view_starting(self, db, view_name, kwargs, total_emitted):
+        offset = {k: v for k, v in kwargs.items() if k.startswith("startkey")}
+        self.iterator.state["offset"] = offset
+        self.iterator._save_state()
+
+
+class TooManyRetries(Exception):
+    pass
 
 
 _override_db = threading.local()

--- a/corehq/util/tests/test_couch_helpers.py
+++ b/corehq/util/tests/test_couch_helpers.py
@@ -1,0 +1,117 @@
+from django.test import TestCase
+
+from couchdbkit import ResourceConflict, ResourceNotFound
+from corehq.util.couch_helpers import ResumableDocsByTypeIterator, TooManyRetries
+from dimagi.utils.couch.database import get_db
+
+
+class TestResumableDocsByTypeIterator(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.db = get_db()
+        cls.docs = []
+        for i in range(3):
+            cls.create_doc("Foo", i)
+            cls.create_doc("Bar", i)
+            cls.create_doc("Baz", i)
+        cls.doc_types = ["Foo", "Bar", "Baz"]
+
+    @classmethod
+    def tearDownClass(cls):
+        for doc_id in set(d["_id"] for d in cls.docs):
+            try:
+                cls.db.delete_doc(doc_id)
+            except ResourceNotFound:
+                pass
+
+    def setUp(self):
+        self.domain = "TEST"
+        self.sorted_keys = ["{}-{}".format(n, i)
+            for n in ["bar", "baz", "foo"]
+            for i in range(3)]
+        self.itr = self.get_iterator()
+
+    def tearDown(self):
+        self.itr.discard_state()
+
+    @classmethod
+    def create_doc(cls, doc_type, ident):
+        doc = {
+            "_id": "{}-{}".format(doc_type.lower(), ident),
+            "doc_type": doc_type,
+        }
+        cls.docs.append(doc)
+        try:
+            cls.db.save_doc(doc)
+        except ResourceConflict:
+            pass
+        return doc
+
+    def get_iterator(self):
+        return ResumableDocsByTypeIterator(self.db, self.doc_types, "test", 2)
+
+    def test_iteration(self):
+        self.assertEqual([doc["_id"] for doc in self.itr], self.sorted_keys)
+
+    def test_resume_iteration(self):
+        itr = iter(self.itr)
+        self.assertEqual([next(itr)["_id"] for i in range(6)], self.sorted_keys[:6])
+        # stop/resume iteration
+        self.itr = self.get_iterator()
+        self.assertEqual([doc["_id"] for doc in self.itr], self.sorted_keys[4:])
+
+    def test_resume_iteration_after_complete_iteration(self):
+        self.assertEqual([doc["_id"] for doc in self.itr], self.sorted_keys)
+        # resume iteration
+        self.itr = self.get_iterator()
+        self.assertEqual([doc["_id"] for doc in self.itr], [])
+
+    def test_iteration_with_retry(self):
+        itr = iter(self.itr)
+        doc = next(itr)
+        self.itr.retry(doc)
+        self.assertEqual(doc["_id"], "bar-0")
+        self.assertEqual(["bar-0"] + [d["_id"] for d in itr],
+                         self.sorted_keys + ["bar-0"])
+
+    def test_iteration_complete_after_retry(self):
+        itr = iter(self.itr)
+        self.itr.retry(next(itr))
+        list(itr)
+        self.itr = self.get_iterator()
+        self.assertEqual([doc["_id"] for doc in self.itr], [])
+
+    def test_iteration_with_max_retry(self):
+        itr = iter(self.itr)
+        doc = next(itr)
+        ids = [doc["_id"]]
+        self.assertEqual(doc["_id"], "bar-0")
+        self.itr.retry(doc)
+        retries = 1
+        for doc in itr:
+            ids.append(doc["_id"])
+            if doc["_id"] == "bar-0":
+                if retries < 3:
+                    self.itr.retry(doc)
+                    retries += 1
+                else:
+                    break
+        self.assertEqual(doc["_id"], "bar-0")
+        with self.assertRaises(TooManyRetries):
+            self.itr.retry(doc)
+        self.assertEqual(ids, self.sorted_keys + ["bar-0", "bar-0", "bar-0"])
+        self.assertEqual(list(itr), [])
+        self.assertEqual(list(self.get_iterator()), [])
+
+    def test_iteration_with_missing_retry_doc(self):
+        itr = iter(self.itr)
+        doc = next(itr)
+        self.assertEqual(doc["_id"], "bar-0")
+        self.itr.retry(doc)
+        self.db.delete_doc(doc)
+        try:
+            self.assertEqual(["bar-0"] + [d["_id"] for d in itr],
+                             self.sorted_keys)
+        finally:
+            self.create_doc("Bar", 0)


### PR DESCRIPTION
- Add support for stop/resume migration
- Add support for retry on documents with concurrent modifications.
- Improve progresss output during migration.
- Do not use `<DocType>.wrap(doc)`, which can be problematic for very old documents.

@dannyroberts @snopoke cc @benrudolph 
