### PR TITLE
Fix SMS invoicing for multipart messages

### DIFF
--- a/corehq/apps/accounting/generator.py
+++ b/corehq/apps/accounting/generator.py
@@ -176,7 +176,7 @@ def arbitrary_commcare_users_for_domain(domain, num_users, is_active=True):
     return num_users
 
 
-def arbitrary_sms_billables_for_domain(domain, message_month_date, num_sms, direction=None):
+def arbitrary_sms_billables_for_domain(domain, message_month_date, num_sms, direction=None, multipart_count=1):
     from corehq.apps.smsbillables.models import SmsBillable, SmsGatewayFee, SmsUsageFee
 
     direction = direction or random.choice(DIRECTIONS)
@@ -197,6 +197,7 @@ def arbitrary_sms_billables_for_domain(domain, message_month_date, num_sms, dire
             direction=direction,
             date_sent=datetime.date(message_month_date.year, message_month_date.month,
                                     random.randint(1, last_day_message)),
+            multipart_count=multipart_count,
         )
         sms_billable.save()
         billables.append(sms_billable)

--- a/corehq/apps/accounting/generator.py
+++ b/corehq/apps/accounting/generator.py
@@ -9,6 +9,7 @@ import mock
 from django.conf import settings
 from django.core.management import call_command
 
+from corehq.apps.smsbillables.generator import DIRECTIONS
 from dimagi.utils.data import generator as data_gen
 
 from corehq.apps.accounting.models import (
@@ -175,8 +176,10 @@ def arbitrary_commcare_users_for_domain(domain, num_users, is_active=True):
     return num_users
 
 
-def arbitrary_sms_billables_for_domain(domain, direction, message_month_date, num_sms):
+def arbitrary_sms_billables_for_domain(domain, message_month_date, num_sms, direction=None):
     from corehq.apps.smsbillables.models import SmsBillable, SmsGatewayFee, SmsUsageFee
+
+    direction = direction or random.choice(DIRECTIONS)
 
     gateway_fee = SmsGatewayFee.create_new('MACH', direction, Decimal(0.5))
     usage_fee = SmsUsageFee.create_new(direction, Decimal(0.25))

--- a/corehq/apps/accounting/generator.py
+++ b/corehq/apps/accounting/generator.py
@@ -186,6 +186,7 @@ def arbitrary_sms_billables_for_domain(domain, message_month_date, num_sms, dire
 
     _, last_day_message = calendar.monthrange(message_month_date.year, message_month_date.month)
 
+    billables = []
     for _ in range(0, num_sms):
         sms_billable = SmsBillable(
             gateway_fee=gateway_fee,
@@ -198,6 +199,8 @@ def arbitrary_sms_billables_for_domain(domain, message_month_date, num_sms, dire
                                     random.randint(1, last_day_message)),
         )
         sms_billable.save()
+        billables.append(sms_billable)
+    return billables
 
 
 def create_excess_community_users(domain):

--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -3,7 +3,7 @@ import datetime
 from decimal import Decimal
 
 from django.db import transaction
-from django.db.models import F, Q, Min, Max
+from django.db.models import F, Q, Min, Max, Sum
 from django.utils.translation import ugettext as _, ungettext
 
 from dimagi.utils.decorators.memoized import memoized
@@ -518,14 +518,18 @@ class SmsLineItemFactory(FeatureLineItemFactory):
 
         sms_count = 0
         for billable in self.sms_billables:
-            sms_count += 1
+            sms_count += billable.multipart_count
             if sms_count <= self.rate.monthly_limit:
                 # don't count fees until the free monthly limit is exceeded
                 continue
-            if billable.usage_fee:
-                total_excess += billable.usage_fee.amount
-            if billable.gateway_fee:
-                total_excess += billable.gateway_charge
+            else:
+                total_message_charge = billable.gateway_charge + billable.usage_charge
+                num_parts_over_limit = sms_count - self.rate.monthly_limit
+                already_over_limit = num_parts_over_limit >= billable.multipart_count
+                if already_over_limit:
+                    total_excess += total_message_charge
+                else:
+                    total_excess += total_message_charge * num_parts_over_limit / billable.multipart_count
         return Decimal("%.2f" % round(total_excess, 2))
 
     @property
@@ -582,7 +586,7 @@ class SmsLineItemFactory(FeatureLineItemFactory):
     @property
     @memoized
     def num_sms(self):
-        return self.sms_billables_queryset.count()
+        return self.sms_billables_queryset.aggregate(Sum('multipart_count'))['multipart_count__sum'] or 0
 
     @property
     @memoized

--- a/corehq/apps/accounting/tests/test_invoicing.py
+++ b/corehq/apps/accounting/tests/test_invoicing.py
@@ -488,10 +488,10 @@ class TestSmsLineItem(BaseInvoiceTestCase):
 
         num_sms = random.randint(0, self.sms_rate.monthly_limit/2)
         generator.arbitrary_sms_billables_for_domain(
-            self.subscription.subscriber.domain, INCOMING, sms_date, num_sms
+            self.subscription.subscriber.domain, sms_date, num_sms, direction=INCOMING
         )
         generator.arbitrary_sms_billables_for_domain(
-            self.subscription.subscriber.domain, OUTGOING, sms_date, num_sms
+            self.subscription.subscriber.domain, sms_date, num_sms, direction=OUTGOING
         )
 
         tasks.generate_invoices(invoice_date)
@@ -525,10 +525,10 @@ class TestSmsLineItem(BaseInvoiceTestCase):
 
         num_sms = random.randint(self.sms_rate.monthly_limit + 1, self.sms_rate.monthly_limit + 2)
         generator.arbitrary_sms_billables_for_domain(
-            self.subscription.subscriber.domain, INCOMING, sms_date, num_sms
+            self.subscription.subscriber.domain, sms_date, num_sms, direction=INCOMING
         )
         generator.arbitrary_sms_billables_for_domain(
-            self.subscription.subscriber.domain, OUTGOING, sms_date, num_sms
+            self.subscription.subscriber.domain, sms_date, num_sms, direction=OUTGOING
         )
 
         tasks.generate_invoices(invoice_date)

--- a/corehq/apps/accounting/tests/test_invoicing.py
+++ b/corehq/apps/accounting/tests/test_invoicing.py
@@ -500,10 +500,7 @@ class TestSmsLineItem(BaseInvoiceTestCase):
         generator.arbitrary_sms_billables_for_domain(
             self.subscription.subscriber.domain, self.sms_date, num_sms, direction=OUTGOING
         )
-
-        tasks.generate_invoices(self.invoice_date)
-        invoice = self.subscription.invoice_set.latest('date_created')
-        sms_line_item = invoice.lineitem_set.get_feature_by_type(FeatureType.SMS).get()
+        sms_line_item = self._create_sms_line_item()
 
         # there is no base cost
         self.assertIsNone(sms_line_item.base_description)
@@ -529,10 +526,7 @@ class TestSmsLineItem(BaseInvoiceTestCase):
         billables = generator.arbitrary_sms_billables_for_domain(
             self.subscription.subscriber.domain, self.sms_date, num_sms
         )
-
-        tasks.generate_invoices(self.invoice_date)
-        invoice = self.subscription.invoice_set.latest('date_created')
-        sms_line_item = invoice.lineitem_set.get_feature_by_type(FeatureType.SMS).get()
+        sms_line_item = self._create_sms_line_item()
 
         # there is no base cost
         self.assertIsNone(sms_line_item.base_description)
@@ -549,6 +543,11 @@ class TestSmsLineItem(BaseInvoiceTestCase):
 
         self.assertEqual(sms_line_item.subtotal, sms_cost)
         self.assertEqual(sms_line_item.total, sms_cost)
+
+    def _create_sms_line_item(self):
+        tasks.generate_invoices(self.invoice_date)
+        invoice = self.subscription.invoice_set.latest('date_created')
+        return invoice.lineitem_set.get_feature_by_type(FeatureType.SMS).get()
 
     def _delete_sms_billables(self):
         SmsBillable.objects.all().delete()

--- a/corehq/apps/accounting/tests/test_invoicing.py
+++ b/corehq/apps/accounting/tests/test_invoicing.py
@@ -473,6 +473,10 @@ class TestSmsLineItem(BaseInvoiceTestCase):
         super(TestSmsLineItem, self).setUp()
         self.sms_rate = self.subscription.plan_version.feature_rates.filter(feature__feature_type=FeatureType.SMS).get()
 
+    def tearDown(self):
+        self._delete_sms_billables()
+        super(TestSmsLineItem, self).tearDown()
+
     def test_under_limit(self):
         """
         Make sure that the Line Item for the SMS Rate has the following:
@@ -507,8 +511,6 @@ class TestSmsLineItem(BaseInvoiceTestCase):
         self.assertIsNotNone(sms_line_item.unit_description)
         self.assertEqual(sms_line_item.subtotal, Decimal('0.0000'))
         self.assertEqual(sms_line_item.total, Decimal('0.0000'))
-
-        self._delete_sms_billables()
 
     def test_over_limit(self):
         """
@@ -545,8 +547,6 @@ class TestSmsLineItem(BaseInvoiceTestCase):
 
         self.assertGreater(sms_line_item.subtotal, Decimal('0.0000'))
         self.assertGreater(sms_line_item.total, Decimal('0.0000'))
-
-        self._delete_sms_billables()
 
     def _delete_sms_billables(self):
         SmsBillable.objects.all().delete()


### PR DESCRIPTION
Our software plans include a number of free SMSs per month.  We previously accounted for multipart SMS by storing multiple `SmsBillable` objects, but changed to storing one object per message and using `multipart_count` to store the number of message parts.

This broke our way of accounting for SMS parts towards the free limit.  I added a failing test https://github.com/dimagi/commcare-hq/commit/c82f5ddb590deaa67caa62d9dd6627d72a46d8c3 that shows the bug and fixed it https://github.com/dimagi/commcare-hq/commit/8e070d0ff9335fccc6a816114cb12f35241bc6d0

I also added a working test https://github.com/dimagi/commcare-hq/commit/acdd61ea1ce990b2886b65a45a00bc86b182923a and performed a bunch of test cleanup.

Recommend 🐡 

@gcapalbo @millerdev cc: @kaapstorm 
