### PR TITLE
Export optimization idea

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4197,6 +4197,7 @@ class ApplicationBase(VersionedDoc, SnapshotMixin,
     # AFAIK this is fixed in code, but my rear its ugly head in an as-yet-not-understood
     # way for apps that already had this problem. Just keep an eye out
     is_released = BooleanProperty(default=False)
+    released_at_least_once = BooleanProperty(default=False)
 
     # django-style salted hash of the admin password
     admin_password = StringProperty()

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4781,6 +4781,9 @@ def validate_detail_screen_field(field):
 
 class SavedAppBuild(ApplicationBase):
 
+    # Whether the application has had data submitted against it
+    has_submissions = BooleanProperty(default=None)
+
     def to_saved_build_json(self, timezone):
         data = super(SavedAppBuild, self).to_json().copy()
         for key in ('modules', 'user_registration', 'external_blobs',

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1036,6 +1036,7 @@ class CaseExportDataSchema(ExportDataSchema):
         else:
             current_case_schema = CaseExportDataSchema()
 
+        # Only grab apps that have data submitted to them and the latest build
         app_build_ids = CaseExportDataSchema._get_app_build_ids_to_process(
             domain,
             current_case_schema.last_app_versions,

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -85,6 +85,7 @@ class SubmissionPost(object):
 
         xform.app_id = self.app_id
         xform.build_id = self.build_id
+        # Async set the application has_submissions
         xform.export_tag = ["domain", "xmlns"]
         xform.partial_submission = self.partial_submission
         return xform


### PR DESCRIPTION
@dimagi/scale-team I'm trying to find a way to optimize the new export code so that giant apps like ICDS can build exports. It's challenging because the applications for ICDS are huge. I did some initial profiling and I get the sense that a lot of the issues come from searching through the giant couch doc to get properties as well as wrapping the huge doc. See profiling data on this ticket if curious (I also have more locally) http://manage.dimagi.com/default.asp?227649

Originally I was thinking of optimizing the how we get case properties, but that seemed like a rat's nest. So I decided to try and fetch less apps. I came up with two strategies to do this, and curious to hear if you have any feedback:

**Idea 1** (https://github.com/dimagi/commcare-hq/commit/2a7d4b4af8fe9ec88f953bfabd4eb514fe4df21c):
Mark all builds with a flag that says whether or not it has had form submissions. Then when we fetch apps during the export process we only fetch those that have had data submitted against them

Pros:
- More aggressive optimization and less apps pulled down (potentially only a few)

Cons:
- Adds logic to our form processing code

**Idea 2** (https://github.com/dimagi/commcare-hq/commit/942de756b84e1748506c05ab17f29f44baf81805):
Mark builds that have been marked as released at least one time (so that there is the possibility of data submissions)

Pros:
- Doesn't touch our form processing code

Cons:
- Could falsely analyze apps that have had no data submitted against them
- Seems like this could actually miss potential apps that have had data submitted to them
