### PR TITLE
Fix firefow ellipsis on case management select2 widgets

### DIFF
--- a/corehq/apps/style/static/style/less/bootstrap3/forms.less
+++ b/corehq/apps/style/static/style/less/bootstrap3/forms.less
@@ -96,7 +96,14 @@ legend .subtext {
 
 // Static width for select2 widgets, which otherwise grow too large on case management pages
 .app-manager-content .select2-container {
-  width: 210px;
+    @width: 210px;
+    width: @width;
+
+    // This needs a static width so that text-overflow: ellipsis will work in Firefox.
+    // Unusually specific selector to override select2's width: auto rule.
+    > .select2-choice > .select2-chosen {
+        width: @width - 35px;
+    }
 }
 
 // hack to fix issues with placeholder not showing up fully


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?227579

Looks like firefox won't apply `text-overflow: ellipsis` to an element that has `width: auto`. Force a static width, same size as parent minus some space for the dropdown arrow.

@sravfeyn 
