### PR TITLE
make change/renew self-service subscription same for all users

### DIFF
--- a/corehq/apps/accounting/static/accounting/ko/accounting.pricing_table.js
+++ b/corehq/apps/accounting/static/accounting/ko/accounting.pricing_table.js
@@ -1,9 +1,8 @@
-var PricingTable = function (pricing_table, current_edition, isNonAccountingSuperuser, isRenewal) {
+var PricingTable = function (pricing_table, current_edition, isRenewal) {
     'use strict';
     var self = this;
 
     self.currentEdition = current_edition;
-    self.isNonAccountingSuperuser = isNonAccountingSuperuser;
     self.title = ko.observable(pricing_table.title);
     self.isRenewal = isRenewal;
     self.editions = ko.observableArray(_.map(pricing_table.editions, function (edition) {
@@ -21,17 +20,11 @@ var PricingTable = function (pricing_table, current_edition, isNonAccountingSupe
     self.visit_wiki_text = ko.observable(pricing_table.visit_wiki_text);
 
     self.selected_edition = ko.observable(isRenewal ? current_edition : false);
-    self.isEditionSelectable = ko.computed(function () {
-        return !self.isNonAccountingSuperuser || ['community', 'enterprise'].indexOf(self.selected_edition()) >= 0;
-    });
     self.isSubmitVisible = ko.computed(function () {
         if (isRenewal){
             return true;
         }
-        return !! self.selected_edition() && !(self.selected_edition() === self.currentEdition) && self.isEditionSelectable();
-    });
-    self.isSuperuserNoticeVisible = ko.computed(function () {
-        return !(self.selected_edition() === self.currentEdition) && !self.isEditionSelectable() && !! self.selected_edition();
+        return !! self.selected_edition() && !(self.selected_edition() === self.currentEdition);
     });
     self.selectCurrentPlan = function () {
         self.selected_edition(self.currentEdition);

--- a/corehq/apps/domain/templates/domain/select_plan.html
+++ b/corehq/apps/domain/templates/domain/select_plan.html
@@ -27,7 +27,7 @@
 
 {% block js-inline %}{{ block.super }}
     <script>
-        var pricingTable = new PricingTable({{ pricing_table|JSON }}, '{{ current_edition }}', {{ is_non_ops_superuser|BOOL }}, {{ is_renewal|BOOL }});
+        var pricingTable = new PricingTable({{ pricing_table|JSON }}, '{{ current_edition }}', {{ is_renewal|BOOL }});
         $('#pricing-table').koApplyBindings(pricingTable);
         pricingTable.init();
     </script>

--- a/corehq/apps/domain/templates/domain/select_plan.html
+++ b/corehq/apps/domain/templates/domain/select_plan.html
@@ -59,29 +59,6 @@
             <input type="hidden" name="from_plan_page" value="true">
             {% endif %}
             <input type="hidden" name="plan_edition" data-bind="value: selected_edition">
-            {% if is_non_ops_superuser %}
-            <div class="alert alert-info" data-bind="visible: isSuperuserNoticeVisible">
-                {% blocktrans %}
-                    <p>
-                        <strong>Hey there, Dimagi!</strong>
-                    </p>
-                    <p>
-                        Sorry, but you can only sign up projects for
-                        Community or the Dimagi Enterprise Plan
-                        <strong>(internal projects only, please!)</strong>.
-                    </p>
-                    <p>
-                        If you want to sign this project space up for a
-                        different plan, please have one of the non-Dimagi
-                        project admins sign up or talk to someone on
-                        the Operations Team to deal with contracts.
-                    </p>
-                    <p>
-                        Thanks! <3
-                    </p>
-                {% endblocktrans %}
-            </div>
-            {% endif %}
 
             <div class="pricing-table-bg-container">
                 <div class="pricing-table-bg">

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1559,24 +1559,13 @@ class ConfirmBillingAccountInfoView(ConfirmSelectedPlanView, AsyncHandlerMixin):
     @property
     @memoized
     def billing_account_info_form(self):
-        initial = None
-        if self.edition == SoftwarePlanEdition.ENTERPRISE and self.request.couch_user.is_superuser:
-            initial = {
-                'company_name': "Dimagi",
-                'first_line': "585 Massachusetts Ave",
-                'second_line': "Suite 4",
-                'city': "Cambridge",
-                'state_province_region': "MA",
-                'postal_code': "02139",
-                'country': "US",
-            }
         if self.request.method == 'POST' and self.is_form_post:
             return ConfirmNewSubscriptionForm(
                 self.account, self.domain, self.request.couch_user.username,
-                self.selected_plan_version, self.current_subscription, data=self.request.POST, initial=initial
+                self.selected_plan_version, self.current_subscription, data=self.request.POST
             )
         return ConfirmNewSubscriptionForm(self.account, self.domain, self.request.couch_user.username,
-                                          self.selected_plan_version, self.current_subscription, initial=initial)
+                                          self.selected_plan_version, self.current_subscription)
 
     @property
     def page_context(self):
@@ -1589,8 +1578,6 @@ class ConfirmBillingAccountInfoView(ConfirmSelectedPlanView, AsyncHandlerMixin):
     def post(self, request, *args, **kwargs):
         if self.async_response is not None:
             return self.async_response
-        if self.edition == SoftwarePlanEdition.ENTERPRISE and not self.request.couch_user.is_superuser:
-            return HttpResponseRedirect(reverse(SelectedEnterprisePlanView.urlname, args=[self.domain]))
         if self.is_form_post and self.billing_account_info_form.is_valid():
             is_saved = self.billing_account_info_form.save()
             software_plan_name = DESC_BY_EDITION[self.selected_plan_version.plan.edition]['name'].encode('utf-8')

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1318,12 +1318,6 @@ class SelectPlanView(DomainAccountingSettings):
             return DESC_BY_EDITION[self.edition]['name']
 
     @property
-    def is_non_ops_superuser(self):
-        if not self.request.couch_user.is_superuser:
-            return False
-        return not has_privilege(self.request, privileges.ACCOUNTING_ADMIN)
-
-    @property
     def parent_pages(self):
         return [
             {
@@ -1362,7 +1356,6 @@ class SelectPlanView(DomainAccountingSettings):
                                 if self.current_subscription is not None
                                 and not self.current_subscription.is_trial
                                 else ""),
-            'is_non_ops_superuser': self.is_non_ops_superuser,
         }
 
 


### PR DESCRIPTION
Reduces complexity by showing the same options to all users.

Prevents superusers from creating self-service enterprise subscriptions, since this is available via the Interanal Subscripton Management page.

@esoergel 
