### PR TITLE
Biometric search from case list

### DIFF
--- a/corehq/apps/app_manager/app_strings.py
+++ b/corehq/apps/app_manager/app_strings.py
@@ -93,6 +93,9 @@ def _create_custom_app_strings(app, lang, for_default=False):
             for tab in detail.get_tabs():
                 yield id_strings.detail_tab_title_locale(module, detail_type, tab), trans(tab.header)
 
+            if getattr(detail, 'lookup_display_results'):
+                yield id_strings.callout_header_locale(module), trans(detail.lookup_field_header)
+
         yield id_strings.module_locale(module), maybe_add_index(trans(module.name))
 
         icon = module.icon_app_string(lang, for_default=for_default)

--- a/corehq/apps/app_manager/id_strings.py
+++ b/corehq/apps/app_manager/id_strings.py
@@ -164,6 +164,11 @@ def case_list_form_locale(module):
     return u"case_list_form.m{module.id}".format(module=module)
 
 
+@pattern('case_lists.m%d.callout.header')
+def callout_header_locale(module):
+    return u"case_lists.m{module.id}.callout.header".format(module=module)
+
+
 @pattern('case_search.m%d')
 def case_search_locale(module):
     return u"case_search.m{module.id}".format(module=module)

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1708,11 +1708,17 @@ class SortOnlyDetailColumn(DetailColumn):
 
 class CaseListLookupMixin(DocumentSchema):
     """
-        Allows for the addition of Android Callouts to do lookups from the CaseList
+    Allows for the addition of Android Callouts to do lookups from the CaseList
+
         <lookup action="" image="" name="">
-            <extra key="" value = "" />
-            <response key ="" />
+            <extra key="" value="" />
+            <response key="" />
+            <field>
+                <header><text><locale id=""/></text></header>
+                <template><text><xpath function=""/></text></template>
+            </field>
         </lookup>
+
     """
     lookup_enabled = BooleanProperty(default=False)
     lookup_action = StringProperty()
@@ -1721,6 +1727,10 @@ class CaseListLookupMixin(DocumentSchema):
 
     lookup_extras = SchemaListProperty()
     lookup_responses = SchemaListProperty()
+
+    lookup_display_results = BooleanProperty(default=False)  # Display callout results in case list?
+    lookup_field_header = DictProperty()
+    lookup_field_template = StringProperty()
 
 
 class Detail(IndexedSchema, CaseListLookupMixin):

--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -316,7 +316,7 @@ hqDefine('app_manager/js/detail-screen-config.js', function () {
                 lookup_extras: _trimmed_extras(),
                 lookup_responses: _trimmed_responses(),
                 lookup_image: image_path,
-                lookup_display_results: self.lookup_attach_results() && self.lookup_display_results(),
+                lookup_display_results: self.lookup_display_results(),
                 lookup_field_header: self.lookup_field_header(),
                 lookup_field_template: self.lookup_field_template(),
             };
@@ -418,7 +418,6 @@ hqDefine('app_manager/js/detail-screen-config.js', function () {
             self.add_item('responses');
         }
 
-        self.lookup_attach_results = ko.observable(state.lookup_display_results);  // We don't store lookup_attach_results
         self.lookup_display_results = ko.observable(state.lookup_display_results);
         self.lookup_field_header = ko.observable(state.lookup_field_header[lang]);
         self.lookup_field_template = ko.observable(state.lookup_field_template || '@case_id');

--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -249,7 +249,7 @@ hqDefine('app_manager/js/detail-screen-config.js', function () {
         };
     };
 
-    var caseListLookupViewModel = function($el, state, saveButton) {
+    var caseListLookupViewModel = function($el, state, lang, saveButton) {
         'use strict';
         var self = this,
             detail_type = $el.data('detail-type');
@@ -316,6 +316,9 @@ hqDefine('app_manager/js/detail-screen-config.js', function () {
                 lookup_extras: _trimmed_extras(),
                 lookup_responses: _trimmed_responses(),
                 lookup_image: image_path,
+                lookup_display_results: self.lookup_attach_results() && self.lookup_display_results(),
+                lookup_field_header: self.lookup_field_header(),
+                lookup_field_template: self.lookup_field_template(),
             };
 
             return data;
@@ -414,6 +417,11 @@ hqDefine('app_manager/js/detail-screen-config.js', function () {
         if (self.responses().length === 0){
             self.add_item('responses');
         }
+
+        self.lookup_attach_results = ko.observable(state.lookup_display_results);  // We don't store lookup_attach_results
+        self.lookup_display_results = ko.observable(state.lookup_display_results);
+        self.lookup_field_header = ko.observable(state.lookup_field_header[lang]);
+        self.lookup_field_template = ko.observable(state.lookup_field_template || '@case_id');
 
         self.show_add_extra = ko.computed(function(){
             if (self.extras().length){
@@ -1169,7 +1177,12 @@ hqDefine('app_manager/js/detail-screen-config.js', function () {
                         that.shortScreen.saveButton.fire("change");
                     });
                     var $case_list_lookup_el = $("#" + spec.state.type + "-list-callout-configuration");
-                    this.caseListLookup = new caseListLookupViewModel($case_list_lookup_el, spec.state.short, this.shortScreen.saveButton);
+                    this.caseListLookup = new caseListLookupViewModel(
+                        $case_list_lookup_el,
+                        spec.state.short,
+                        spec.lang,
+                        this.shortScreen.saveButton
+                    );
                     // Set up case search
                     this.search = new searchViewModel(
                         spec.searchProperties || [],

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -7,6 +7,7 @@ from django.utils.translation import ugettext_lazy as _
 from eulxml.xmlmap.core import load_xmlobject_from_string
 
 from corehq.apps.app_manager.const import RETURN_TO
+from corehq.apps.app_manager.id_strings import callout_header_locale
 from corehq.apps.app_manager.suite_xml.const import FIELD_TYPE_LEDGER
 from corehq.apps.app_manager.suite_xml.contributors import SectionContributor
 from corehq.apps.app_manager.suite_xml.post_process.instances import EntryInstances
@@ -128,7 +129,7 @@ class DetailContributor(SectionContributor):
         else:
             # Add lookup
             if detail.lookup_enabled and detail.lookup_action:
-                d.lookup = self._get_lookup_element(detail)
+                d.lookup = self._get_lookup_element(detail, module)
 
             # Add variables
             variables = list(
@@ -165,13 +166,26 @@ class DetailContributor(SectionContributor):
                 # only yield the Detail if it has Fields
                 return d
 
-    def _get_lookup_element(self, detail):
+    def _get_lookup_element(self, detail, module):
+        if detail.lookup_display_results:
+            field = Field(
+                header=Header(
+                    width=None if detail.lookup_field_header else 0,
+                    text=Text(locale_id=callout_header_locale(module)) if detail.lookup_field_header else None,
+                ),
+                template=Template(
+                    text=Text(xpath_function=detail.lookup_field_template)
+                ),
+            )
+        else:
+            field = None
         return Lookup(
             name=detail.lookup_name or None,
             action=detail.lookup_action,
             image=detail.lookup_image or None,
             extras=[Extra(**e) for e in detail.lookup_extras],
             responses=[Response(**r) for r in detail.lookup_responses],
+            field=field,
         )
 
     def _add_reg_form_action_to_detail(self, detail, module):

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -543,16 +543,6 @@ class Response(XmlObject):
     key = StringField("@key")
 
 
-class Lookup(XmlObject):
-    ROOT_NAME = 'lookup'
-
-    name = StringField("@name")
-    action = StringField("@action", required=True)
-    image = StringField("@image")
-    extras = NodeListField('extra', Extra)
-    responses = NodeListField('response', Response)
-
-
 class Field(OrderedXmlObject):
     ROOT_NAME = 'field'
     ORDER = ('header', 'template', 'sort_node')
@@ -563,6 +553,17 @@ class Field(OrderedXmlObject):
     template = NodeField('template', Template)
     sort_node = NodeField('sort', Sort)
     background = NodeField('background/text', Text)
+
+
+class Lookup(XmlObject):
+    ROOT_NAME = 'lookup'
+
+    name = StringField("@name")
+    action = StringField("@action", required=True)
+    image = StringField("@image")
+    extras = NodeListField('extra', Extra)
+    responses = NodeListField('response', Response)
+    field = NodeField('field', Field)
 
 
 class ActionMixin(OrderedXmlObject):

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -555,8 +555,9 @@ class Field(OrderedXmlObject):
     background = NodeField('background/text', Text)
 
 
-class Lookup(XmlObject):
+class Lookup(OrderedXmlObject):
     ROOT_NAME = 'lookup'
+    ORDER = ('extras', 'responses', 'field')
 
     name = StringField("@name")
     action = StringField("@action", required=True)

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list_lookup.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list_lookup.html
@@ -108,6 +108,47 @@
                 {% endwith %}
                 <!-- /ko -->
             </div>
+            <div class="form-group">
+                <label class="col-sm-2 control-label">
+                    {% trans "Attach results to case list" %}
+                </label>
+                <div class="col-sm-4 checkbox">
+                    <input type="checkbox" data-bind="checked: lookup_attach_results"/>
+                </div>
+            </div>
+            <div data-bind="visible: lookup_attach_results">
+                <div class="form-group">
+                    <label class="col-sm-2 control-label">
+                        {% trans "Display results in case list" %}
+                    </label>
+                    <div class="col-sm-4 checkbox">
+                        <input type="checkbox" data-bind="checked: lookup_display_results"/>
+                    </div>
+                </div>
+                <div data-bind="visible: lookup_display_results">
+                    <div class="form-group" id="{{ detail.type }}-results-text">
+                        <label class="control-label col-sm-2">
+                            {% trans "Results display text" %}
+                        </label>
+                        <div class="col-sm-4">
+                            <input class="form-control" type="text"
+                                   data-bind="value: lookup_field_header"
+                                   placeholder="{% trans 'Accuracy' %}" />
+                        </div>
+                    </div>
+                    <div class="form-group" id="{{ detail.type }}-results-property">
+                        <label class="control-label col-sm-2">
+                            {% trans "Results mapping property" %}
+                            <span class="hq-help-template"
+                                  data-content="{% trans 'Case property or attribute used to map each result row to the correct case.' %}"></span>
+                        </label>
+                        <div class="col-sm-4">
+                            <input class="form-control" type="text"
+                                   data-bind="value: lookup_field_template"/>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </form>
     </div>
 </div>

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list_lookup.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list_lookup.html
@@ -110,42 +110,32 @@
             </div>
             <div class="form-group">
                 <label class="col-sm-2 control-label">
-                    {% trans "Attach results to case list" %}
+                    {% trans "Display results in case list" %}
                 </label>
                 <div class="col-sm-4 checkbox">
-                    <input type="checkbox" data-bind="checked: lookup_attach_results"/>
+                    <input type="checkbox" data-bind="checked: lookup_display_results"/>
                 </div>
             </div>
-            <div data-bind="visible: lookup_attach_results">
-                <div class="form-group">
-                    <label class="col-sm-2 control-label">
-                        {% trans "Display results in case list" %}
+            <div data-bind="visible: lookup_display_results">
+                <div class="form-group" id="{{ detail.type }}-results-text">
+                    <label class="control-label col-sm-2">
+                        {% trans "Results display text" %}
                     </label>
-                    <div class="col-sm-4 checkbox">
-                        <input type="checkbox" data-bind="checked: lookup_display_results"/>
+                    <div class="col-sm-4">
+                        <input class="form-control" type="text"
+                               data-bind="value: lookup_field_header"
+                               placeholder="{% trans 'Accuracy' %}" />
                     </div>
                 </div>
-                <div data-bind="visible: lookup_display_results">
-                    <div class="form-group" id="{{ detail.type }}-results-text">
-                        <label class="control-label col-sm-2">
-                            {% trans "Results display text" %}
-                        </label>
-                        <div class="col-sm-4">
-                            <input class="form-control" type="text"
-                                   data-bind="value: lookup_field_header"
-                                   placeholder="{% trans 'Accuracy' %}" />
-                        </div>
-                    </div>
-                    <div class="form-group" id="{{ detail.type }}-results-property">
-                        <label class="control-label col-sm-2">
-                            {% trans "Results mapping property" %}
-                            <span class="hq-help-template"
-                                  data-content="{% trans 'Case property or attribute used to map each result row to the correct case.' %}"></span>
-                        </label>
-                        <div class="col-sm-4">
-                            <input class="form-control" type="text"
-                                   data-bind="value: lookup_field_template"/>
-                        </div>
+                <div class="form-group" id="{{ detail.type }}-results-property">
+                    <label class="control-label col-sm-2">
+                        {% trans "Results mapping property" %}
+                        <span class="hq-help-template"
+                              data-content="{% trans 'Case property or attribute used to map each result row to the correct case.' %}"></span>
+                    </label>
+                    <div class="col-sm-4">
+                        <input class="form-control" type="text"
+                               data-bind="value: lookup_field_template"/>
                     </div>
                 </div>
             </div>

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -636,6 +636,7 @@ def edit_module_detail_screens(request, domain, app_id, module_id):
         except AttributeError:
             return HttpResponseBadRequest("Unknown detail type '%s'" % detail_type)
 
+    lang = request.COOKIES.get('lang', app.langs[0])
     if short is not None:
         detail.short.columns = map(DetailColumn.wrap, short)
         if persist_case_context is not None:
@@ -647,7 +648,7 @@ def edit_module_detail_screens(request, domain, app_id, module_id):
         if pull_down_tile is not None:
             detail.short.pull_down_tile = pull_down_tile
         if case_list_lookup is not None:
-            _save_case_list_lookup_params(detail.short, case_list_lookup)
+            _save_case_list_lookup_params(detail.short, case_list_lookup, lang)
 
     if long is not None:
         detail.long.columns = map(DetailColumn.wrap, long)
@@ -672,7 +673,6 @@ def edit_module_detail_screens(request, domain, app_id, module_id):
     if fixture_select is not None:
         module.fixture_select = FixtureSelect.wrap(fixture_select)
     if search_properties is not None:
-        lang = request.COOKIES.get('lang', app.langs[0])
         module.search_config = CaseSearch(properties=[
             CaseSearchProperty.wrap(p) for p in _update_search_properties(module, search_properties, lang)
         ])
@@ -794,13 +794,17 @@ def _new_careplan_module(request, domain, app, name, lang):
     return response
 
 
-def _save_case_list_lookup_params(short, case_list_lookup):
+def _save_case_list_lookup_params(short, case_list_lookup, lang):
     short.lookup_enabled = case_list_lookup.get("lookup_enabled", short.lookup_enabled)
     short.lookup_action = case_list_lookup.get("lookup_action", short.lookup_action)
     short.lookup_name = case_list_lookup.get("lookup_name", short.lookup_name)
     short.lookup_extras = case_list_lookup.get("lookup_extras", short.lookup_extras)
     short.lookup_responses = case_list_lookup.get("lookup_responses", short.lookup_responses)
     short.lookup_image = case_list_lookup.get("lookup_image", short.lookup_image)
+    short.lookup_display_results = case_list_lookup.get("lookup_display_results", short.lookup_display_results)
+    if case_list_lookup.get("lookup_field_header"):
+        short.lookup_field_header[lang] = case_list_lookup["lookup_field_header"]
+    short.lookup_field_template = case_list_lookup.get("lookup_field_template", short.lookup_field_template)
 
 
 @require_GET


### PR DESCRIPTION
Allows an Android callout for biometric search from case list.

This change extends the Case List Search Callout UI under the Case List tab in the (basic) module page in the app builder, and uses the values to build a "lookup/field" node in the case list's "detail" node in suite.xml.

Spec: https://docs.google.com/document/d/13mRCH3hHBsTCLzCt2bQMILxu7e8DD-CwFdEW1DsiCyI/edit#
(This feature is behind the "Allow external android callouts to search the caselist" flag.)

:tropical_fish:  Please hold off merge until tests added.

@orangejenny, @snopoke cc @phillipm, @NoahCarnahan 
