### PR TITLE
Limit UCR excel export size

### DIFF
--- a/corehq/apps/reports/static/reports/javascripts/reports.config.js
+++ b/corehq/apps/reports/static/reports/javascripts/reports.config.js
@@ -1,3 +1,4 @@
+/* global alert_user */
 var HQReport = function (options) {
     'use strict';
     var self = this;
@@ -26,6 +27,8 @@ var HQReport = function (options) {
     self.getReportRenderUrl = options.getReportRenderUrl || getReportRenderUrl;
     self.getReportBaseUrl = options.getReportBaseUrl || getReportBaseUrl;
     self.getReportParams = options.getReportParams || getReportParams;
+    self.getExportSizeCheckUrl = options.getExportSizeCheckUrl;
+    self.checkExportSize = options.checkExportSize || false;
 
     self.datespanCookie = self.domain+".hqreport.filterSetting.test.datespan";
 
@@ -56,10 +59,23 @@ var HQReport = function (options) {
                                 success: function() {
                                     alert_user("Your requested excel report will be sent to the email address " +
                                                "defined in your account settings.", "success");
-                                }
-                            })
+                                },
+                            });
                         } else {
-                            window.location.href = self.getReportRenderUrl("export");
+                            if (self.checkExportSize){
+                                $.ajax({
+                                    url: self.getExportSizeCheckUrl(),
+                                    success: function(data) {
+                                        if (data.export_allowed) {
+                                            window.location.href = self.getReportRenderUrl("export");
+                                        } else {
+                                            alert_user(data.message, "danger");
+                                        }
+                                    },
+                                });
+                            } else {
+                                window.location.href = self.getReportRenderUrl("export");
+                            }
                         }
                     });
                 }

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -55,6 +55,9 @@ from no_exceptions.exceptions import Http403
 from corehq.apps.reports.datatables import DataTablesHeader
 
 
+UCR_EXPORT_TO_EXCEL_ROW_LIMIT = 1000
+
+
 class ConfigurableReport(JSONResponseMixin, BaseDomainView):
     section_name = ugettext_noop("Reports")
     template_name = 'userreports/configurable_report.html'
@@ -191,6 +194,8 @@ class ConfigurableReport(JSONResponseMixin, BaseDomainView):
                 return self.excel_response
             elif request.GET.get('format', None) == "export":
                 return self.export_response
+            elif request.GET.get('format', None) == 'export_size_check':
+                return self.export_size_check_response
             elif request.is_ajax() or request.GET.get('format', None) == 'json':
                 return self.get_ajax(self.request)
             self.content_type = None
@@ -437,7 +442,47 @@ class ConfigurableReport(JSONResponseMixin, BaseDomainView):
 
     @property
     @memoized
+    def export_too_large(self):
+        data = self.data_source
+        data.set_filter_values(self.filter_values)
+        total_rows = data.get_total_records()
+        return total_rows > UCR_EXPORT_TO_EXCEL_ROW_LIMIT
+
+    @property
+    @memoized
+    def export_size_check_response(self):
+        try:
+            too_large = self.export_too_large
+        except UserReportsError as e:
+            if settings.DEBUG:
+                raise
+            return self.render_json_response({
+                'export_allowed': False,
+                'message': e.message,
+            })
+
+        if too_large:
+            return self.render_json_response({
+                'export_allowed': False,
+                'message': _(
+                    "Report export is limited to {number} rows. "
+                    "Please filter the data in your report to "
+                    "{number} or fewer rows before exporting"
+                ).format(number=UCR_EXPORT_TO_EXCEL_ROW_LIMIT),
+            })
+        return self.render_json_response({
+            "export_allowed": True,
+        })
+
+    @property
+    @memoized
     def export_response(self):
+        if self.export_too_large:
+            # Frontend should check size with export_size_check_response()
+            # Before hitting this endpoint, but we check the size again here
+            # in case the user modifies the url manually.
+            raise Http404
+
         temp = StringIO()
         export_from_tables(self.export_table, temp, Format.XLS_2007)
         return export_response(temp, Format.XLS_2007, self.title)

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -13,7 +13,7 @@ from dimagi.utils.modules import to_function
 from django.conf import settings
 from django.contrib import messages
 from django.core.urlresolvers import reverse
-from django.http import HttpResponse, Http404
+from django.http import HttpResponse, Http404, HttpResponseBadRequest
 from django.utils.translation import ugettext as _, ugettext_noop
 from braces.views import JSONResponseMixin
 from corehq.apps.reports.dispatcher import (
@@ -481,7 +481,7 @@ class ConfigurableReport(JSONResponseMixin, BaseDomainView):
             # Frontend should check size with export_size_check_response()
             # Before hitting this endpoint, but we check the size again here
             # in case the user modifies the url manually.
-            raise Http404
+            return HttpResponseBadRequest()
 
         temp = StringIO()
         export_from_tables(self.export_table, temp, Format.XLS_2007)

--- a/corehq/apps/userreports/templates/userreports/configurable_report.html
+++ b/corehq/apps/userreports/templates/userreports/configurable_report.html
@@ -61,6 +61,7 @@
     </script>
     {% endif %}
     <script type="text/javascript">
+        var urlSerialize = hqImport('reports/javascripts/reports.util.js').urlSerialize;
         var standardHQReport = new HQReport({
             domain: '{{ domain }}',
             urlRoot: '{{ report.url_root }}',
@@ -70,15 +71,19 @@
             filterSet: {{ report.filter_set|JSON }},
             needsFilters: {{ report.needs_filters|JSON }},
             isExportable: {{ report.is_exportable|JSON }},
+            checkExportSize: true,
             isExportAll: {{ report.is_export_all|JSON }},
             isEmailable: {{ report.is_emailable|JSON }},
             emailDefaultSubject: {{ report.title|JSON }},
             emailSuccessMessage: "{% trans 'Report successfully emailed' %}",
             emailErrorMessage: "{% trans 'An error occurred emailing you report. Please try again.' %}",
             getReportRenderUrl: function(renderType, additionalParams) {
-                var urlSerialize = hqImport('reports/javascripts/reports.util.js').urlSerialize;
                 var params = urlSerialize($('#paramSelectorForm'), ['format']);
                 return window.location.pathname + "?format=" + renderType + "&" + params;
+            },
+            getExportSizeCheckUrl: function() {
+                var params = urlSerialize($('#paramSelectorForm'), ['format']);
+                return window.location.pathname + "?format=export_size_check" + "&" + params;
             },
 
             {% if request.datespan %}

--- a/corehq/apps/userreports/tests/test_view.py
+++ b/corehq/apps/userreports/tests/test_view.py
@@ -1,7 +1,6 @@
 import json
 import uuid
 
-from django.http import Http404
 from mock import patch
 
 from django.test import TestCase

--- a/corehq/apps/userreports/tests/test_view.py
+++ b/corehq/apps/userreports/tests/test_view.py
@@ -185,7 +185,7 @@ class ConfigurableReportViewTest(ConfigurableReportTestMixin, TestCase):
 
         with patch(
             'corehq.apps.userreports.reports.data_source.ConfigurableReportDataSource.get_total_records',
-            return_value=UCR_EXPORT_TO_EXCEL_ROW_LIMIT+1
+            return_value=UCR_EXPORT_TO_EXCEL_ROW_LIMIT + 1
         ):
             response = json.loads(view.export_size_check_response.content)
         self.assertEqual(response['export_allowed'], False)

--- a/corehq/apps/userreports/tests/test_view.py
+++ b/corehq/apps/userreports/tests/test_view.py
@@ -190,8 +190,7 @@ class ConfigurableReportViewTest(ConfigurableReportTestMixin, TestCase):
             response = json.loads(view.export_size_check_response.content)
         self.assertEqual(response['export_allowed'], False)
 
-        with self.assertRaises(Http404):
-            view.export_response
+        self.assertEqual(view.export_response.status_code, 400)
 
     def test_paginated_build_table(self):
         """

--- a/corehq/apps/userreports/tests/test_view.py
+++ b/corehq/apps/userreports/tests/test_view.py
@@ -1,4 +1,7 @@
+import json
 import uuid
+
+from django.http import Http404
 from mock import patch
 
 from django.test import TestCase
@@ -12,7 +15,8 @@ from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.tests.util import delete_all_cases
 from casexml.apps.case.util import post_case_blocks
-from corehq.apps.userreports.reports.view import ConfigurableReport
+from corehq.apps.userreports.reports.view import ConfigurableReport, \
+    UCR_EXPORT_TO_EXCEL_ROW_LIMIT
 from corehq.sql_db.connections import Session
 from corehq.util.context_managers import drop_connected_signals
 
@@ -45,7 +49,7 @@ class ConfigurableReportTestMixin(object):
 class ConfigurableReportViewTest(ConfigurableReportTestMixin, TestCase):
 
     @classmethod
-    def _build_report(cls):
+    def _build_report_and_view(cls):
 
         # Create Cases
         cls._new_case({'fruit': 'apple', 'num1': 4, 'num2': 6}).save()
@@ -134,7 +138,13 @@ class ConfigurableReportViewTest(ConfigurableReportTestMixin, TestCase):
             ],
         )
         report_config.save()
-        return report_config
+
+        view = ConfigurableReport()
+        view._domain = cls.domain
+        view._lang = "en"
+        view._report_config_id = report_config._id
+
+        return report_config, view
 
     @classmethod
     def tearDown(cls):
@@ -151,12 +161,7 @@ class ConfigurableReportViewTest(ConfigurableReportTestMixin, TestCase):
         """
         Test the output of ConfigurableReport.export_table()
         """
-        report = self._build_report()
-        # Create a configurable report
-        view = ConfigurableReport()
-        view._domain = self.domain
-        view._lang = "en"
-        view._report_config_id = report._id
+        report, view = self._build_report_and_view()
 
         expected = [
             [
@@ -169,18 +174,32 @@ class ConfigurableReportViewTest(ConfigurableReportTestMixin, TestCase):
         ]
         self.assertEqual(view.export_table, expected)
 
+    def test_export_to_excel_size_under_limit(self):
+        report, view = self._build_report_and_view()
+
+        response = json.loads(view.export_size_check_response.content)
+        self.assertEqual(response['export_allowed'], True)
+
+    def test_export_to_excel_size_over_limit(self):
+        report, view = self._build_report_and_view()
+
+        with patch(
+            'corehq.apps.userreports.reports.data_source.ConfigurableReportDataSource.get_total_records',
+            return_value=UCR_EXPORT_TO_EXCEL_ROW_LIMIT+1
+        ):
+            response = json.loads(view.export_size_check_response.content)
+        self.assertEqual(response['export_allowed'], False)
+
+        with self.assertRaises(Http404):
+            view.export_response
+
     def test_paginated_build_table(self):
         """
         Simulate building a report where chunking occurs
         """
 
         with patch('corehq.apps.userreports.tasks.ID_CHUNK_SIZE', 1):
-            report = self._build_report()
-
-        view = ConfigurableReport()
-        view._domain = self.domain
-        view._lang = "en"
-        view._report_config_id = report._id
+            report, view = self._build_report_and_view()
 
         expected = [
             [


### PR DESCRIPTION
Limits UCRs exported with the "Export to Excel" button on the ucr report view page to 1000 rows.
@kaapstorm 
