### PR TITLE
upgrade django-compressor

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -63,7 +63,7 @@ twilio==3.6.4
 django-countries==3.3
 reportlab==3.0
 stripe==1.12.2
-django-compressor==1.4
+django-compressor==1.6
 django-angular==0.7.8
 Pycco==0.3.0
 django-mptt==0.7.4


### PR DESCRIPTION
Needed for django 1.8 compatibility.  Backwards compatible with 1.7

https://django-compressor.readthedocs.io/en/latest/changelog/
