### PR TITLE
add username to 500 emails

### DIFF
--- a/corehq/apps/hqadmin/templates/hqadmin/email/error_email.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/email/error_email.html
@@ -17,6 +17,7 @@
 
 <p>Method: {{ method }}</p>
 <p>URL: {% if url %}<a href="{{ url }}">{{ url }}</a>{% else %}Unknown{% endif %}</p>
+<p>User: {% if username %}{{ username }}{% else %}Unknown{% endif %}</p>
 
 {% for line in tb_list %}
 {% if forloop.counter0 == 0 %}

--- a/corehq/util/log.py
+++ b/corehq/util/log.py
@@ -115,6 +115,7 @@ class HqAdminEmailHandler(AdminEmailHandler):
                 'get': request.GET,
                 'post': SafeExceptionReporterFilter().get_post_parameters(request),
                 'method': request.method,
+                'username': request.user.username if getattr(request, 'user', None) else "",
                 'url': request.build_absolute_uri(),
             })
         return context


### PR DESCRIPTION
this is one of the things I'll miss when we kill couchlog and I think no reason not to add. i don't believe we treat web user email as a "private" field.

@millerdev @dannyroberts @emord might have opinions

![image](https://cloud.githubusercontent.com/assets/66555/15851552/878cd80c-2c9d-11e6-8bec-fa350523b2cd.png)
