### PR TITLE
removing fullstory from apps base and adding to individual templates

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/app_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/app_view.html
@@ -3,6 +3,9 @@
 {% load hq_shared_tags %}
 {% load i18n %}
 {% load crispy_forms_tags %}
+{% block head %}{{ block.super }}
+    {% include 'analytics/fullstory.html' %}
+{% endblock %}
 {% block js %}{{ block.super }}
     <script src="{% new_static 'app_manager/js/commcaresettings.js' %}"></script>
     <script src="{% new_static 'hqwebapp/ko/bulk_upload_file.js' %}"></script>

--- a/corehq/apps/app_manager/templates/app_manager/apps_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/apps_base.html
@@ -18,9 +18,6 @@
     {% endcompress %}
 {% endblock %}
 
-{% block head %}{{ block.super }}
-    {% include 'analytics/fullstory.html' %}
-{% endblock %}
 {% block js %}{{ block.super }}
     <!--
         jQuery UI needs to be included before Bootstrap's JavaScript, otherwise the two

--- a/corehq/apps/app_manager/templates/app_manager/form_view_base.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_view_base.html
@@ -10,6 +10,10 @@
     <link rel="stylesheet" href="{% new_static 'syntaxhighlighter/styles/shCoreDefault.css' %}"/>
 {% endblock %}
 
+{% block head %}{{ block.super }}
+    {% include 'analytics/fullstory.html' %}
+{% endblock %}
+
 {% block js %}{{ block.super }}
     {% compress js %}
     <script src="{% new_static 'syntaxhighlighter/scripts/XRegExp.js' %}"></script>

--- a/corehq/apps/app_manager/templates/app_manager/module_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/module_view.html
@@ -2,6 +2,9 @@
 {% load xforms_extras %}
 {% load hq_shared_tags %}
 {% load i18n %}
+{% block head %}{{ block.super }}
+    {% include 'analytics/fullstory.html' %}
+{% endblock %}
 {% block js %}{{ block.super }}
     <script src="{% new_static 'hqwebapp/js/guidGenerator.js' %}"></script>
     <script src="{% new_static 'hqwebapp/js/key-value-mapping.js' %}"></script>


### PR DESCRIPTION
@emord @biyeun 
fullstory take 2. this takes it out of the app manager base template, and puts it only the pages we need so as not to have it in the form builder
