### PR TITLE
accept 0 as being valid field value

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/backbone/cases.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/backbone/cases.js
@@ -173,7 +173,7 @@ hqDefine('cloudcare/js/backbone/cases.js', function () {
             var self = this,
                 text = self.lookupField(col),
                 td = $("<td/>");
-            if (text) {
+            if (text || text == 0) {
                 return td.text(text);
             } else {
                 return td.append(

--- a/corehq/apps/cloudcare/static/cloudcare/js/backbone/cases.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/backbone/cases.js
@@ -173,7 +173,7 @@ hqDefine('cloudcare/js/backbone/cases.js', function () {
             var self = this,
                 text = self.lookupField(col),
                 td = $("<td/>");
-            if (text || text == 0) {
+            if (text || text === 0) {
                 return td.text(text);
             } else {
                 return td.append(

--- a/corehq/apps/cloudcare/static/cloudcare/js/backbone/cases.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/backbone/cases.js
@@ -173,7 +173,7 @@ hqDefine('cloudcare/js/backbone/cases.js', function () {
             var self = this,
                 text = self.lookupField(col),
                 td = $("<td/>");
-            if (text || text === 0) {
+            if (text !== null) {
                 return td.text(text);
             } else {
                 return td.append(


### PR DESCRIPTION
We weren't accepting '0' as being a valid field value because if(0) is false in JS, however, this can sometimes be a valid field value. Please let me know if there's a more elegant truth check to do this.

See http://manage.dimagi.com/default.asp?229183
