### PR TITLE
Sort fast reindex

### DIFF
--- a/corehq/apps/hqcase/management/commands/ptop_fast_reindex_cases.py
+++ b/corehq/apps/hqcase/management/commands/ptop_fast_reindex_cases.py
@@ -9,3 +9,7 @@ class Command(ElasticReindexer):
     doc_class = CommCareCase
     view_name = 'cases_by_owner/view'
     pillow_class = CasePillow
+
+    @staticmethod
+    def sort_key(row):
+        return row['doc'].get('server_modified_on', 'None')

--- a/corehq/apps/hqcase/management/commands/ptop_fast_reindex_xforms.py
+++ b/corehq/apps/hqcase/management/commands/ptop_fast_reindex_xforms.py
@@ -15,6 +15,8 @@ class Command(ElasticReindexer):
 
     view_name = 'all_docs/by_doc_type'
 
+    sort_key_include_docs = True
+
     def get_extra_view_kwargs(self):
         return {
             'startkey': ['XFormInstance'],
@@ -33,3 +35,7 @@ class Command(ElasticReindexer):
         else:
             logging.warning('Unexpected input to custom_filter: {}'.format(view_row))
             return False
+
+    @staticmethod
+    def sort_key(row):
+        return row['doc'].get('received_on', 'None')

--- a/corehq/apps/hqcase/management/commands/ptop_fast_reindexer.py
+++ b/corehq/apps/hqcase/management/commands/ptop_fast_reindexer.py
@@ -173,6 +173,21 @@ class PtopReindexer(NoArgsCommand):
         self.log("View and sequence written to disk: %s" % datetime.utcnow().isoformat())
 
     def _load_from_view_and_sort(self):
+        """
+        load view rows, sorted as specified by sort_key, into a file
+        via a temporary file with the '.presort.tmp' suffix
+
+        implementation walkthrough:
+            - dumps sort-key-prefixed rows into  *.presort.tmp using the line format:
+                <sort key> <TAB> <row json>
+            - uses POSIX sort the lines in descending order (by sort key since that begins lines)
+            - uses POSIX cut to remove the sort key column (and the <TAB>)
+            - writes the result to the file
+
+            this has the result of producing a file with the same format as _load_from_view
+            but with the rows sorted by sort_key
+
+        """
         dump_filename = self.get_dump_filename()
         dump_presort_filename = dump_filename + '.presort.tmp'
         self.log('Writing dump file to disk: {}, starting at {}'.format(

--- a/corehq/apps/hqcase/management/commands/ptop_fast_reindexer.py
+++ b/corehq/apps/hqcase/management/commands/ptop_fast_reindexer.py
@@ -180,6 +180,8 @@ class PtopReindexer(NoArgsCommand):
         with open(dump_presort_filename, 'w') as fout:
             for row in self.full_couch_view_iter():
                 sort_key = self.sort_key(row)
+                assert (isinstance(sort_key, basestring)
+                        and not any(c in sort_key for c in '\t\n\r')), repr(sort_key)
                 if self.sort_key_include_docs and not self.pillow_class.include_docs:
                     del row['doc']
                 fout.write('{}\t{}\n'.format(sort_key, json.dumps(row)))


### PR DESCRIPTION
Functional change:
- Cases sort by `server_date_modified` (descending)
- Forms sort by `received_on` (descending)

Framework feature:
- an `ElasticReindexer` subclass can specify a `sort_key` function that takes in a row and returns a string; view rows will then be processed in the order specified by this sort key.
- they may also specify `sort_key_include_docs` (boolean), which if set to `True` will `include_docs` on the view for the sake of the `sort_key` function (but otherwise stripping it).
- by default (and you currently can't change the default) rows are sorted descending. (This is because our current only use case is to index most recent dates first.)

Implementation detail:
- used POSIX `sort` rather than implementing something in python because it's optimized and memory efficient for large files (i.e. I believe it does a merge sort using temp files on disk so it never has to read the entire file into memory)
