### PR TITLE
Fix Edit User Fields modal

### DIFF
--- a/corehq/apps/custom_data_fields/static/custom_data_fields/js/custom_data_fields.js
+++ b/corehq/apps/custom_data_fields/static/custom_data_fields/js/custom_data_fields.js
@@ -58,6 +58,8 @@ function CustomDataField () {
 function CustomDataFieldsModel () {
     var self = this;
     self.data_fields = ko.observableArray();
+    // The data field that the "remove field modal" currently refers to.
+    self.modalField = ko.observable();
 
     self.addField = function () {
         self.data_fields.push(new CustomDataField());
@@ -67,11 +69,13 @@ function CustomDataFieldsModel () {
         self.data_fields.remove(field);
     };
 
-    // Manually remove modal backrop because it is not part of the div
-    // we delete otherwise
-    self.removeFieldAndModal = function (field) {
-        self.removeField(field);
-        $(".modal-backdrop").remove();
+    self.setModalField = function (field) {
+        self.modalField(field);
+    };
+
+    self.confirmRemoveField = function () {
+        // Remove the field that the "remove field modal" currently refers to.
+        self.removeField(self.modalField());
     };
 
     self.init = function (initialFields) {

--- a/corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html
+++ b/corehq/apps/custom_data_fields/templates/custom_data_fields/custom_data_fields.html
@@ -171,45 +171,11 @@
                                         <a type="button"
                                            class="btn btn-danger"
                                            data-toggle="modal"
-                                           data-bind="attr: {href: '#delete-confirm-modal' + $index()}">
+                                           href="#delete-confirm-modal"
+                                           data-bind="click: $root.setModalField"
+                                        >
                                             <i class="fa fa-times"></i> {% trans "Delete" %}
                                         </a>
-                                        <div data-bind="attr: {id: 'delete-confirm-modal' + $index()}"
-                                             class="modal fade"
-                                             tabindex="-1"
-                                             role="dialog"
-                                             aria-labelledby="delete-confirm-modal-label"
-                                             aria-hidden="true">
-                                            <div class="modal-dialog">
-                                                <div class="modal-content">
-                                                    <div class="modal-header">
-                                                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                                                        <h3 class="modal-title" id="delete-confirm-modal-label">{% trans "Are you sure you want to delete this field?" %}</h3>
-                                                    </div>
-
-                                                    <div class="modal-body" style="line-height: 18px">
-                                                        {% blocktrans with entity_string=view.entity_string|lower %}
-                                                        <p>
-                                                            Deleting this field can cause you to lose data for any {{ entity_string }} with information stored in this field.
-                                                        </p>
-                                                        <p>
-                                                            Data will show up on the edit {{ entity_string }} page but
-                                                            will be removed the next time the {{ entity_string }} is saved.
-                                                        </p>
-                                                        {% endblocktrans %}
-                                                    </div>
-
-                                                    <div class="modal-footer">
-                                                        <a href="#" data-dismiss="modal" class="btn btn-default">Cancel</a>
-                                                        <button aria-hidden="true"
-                                                                data-bind="click: $root.removeFieldAndModal"
-                                                                class="btn btn-danger">
-                                                            {% trans "Delete Field" %}
-                                                        </button>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
                                     </td>
                                 </tr>
                             </tbody>
@@ -224,5 +190,46 @@
                 <button id="save-custom-fields" class="btn btn-primary disable-on-submit" type="submit" disabled>Save Fields</button>
             </div>
         </div>
+
+        <div
+            id="delete-confirm-modal"
+            class="modal fade"
+            tabindex="-1"
+            role="dialog"
+            aria-labelledby="delete-confirm-modal-label"
+            aria-hidden="true"
+        >
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                        <h3 class="modal-title" id="delete-confirm-modal-label">{% trans "Are you sure you want to delete this field?" %}</h3>
+                    </div>
+
+                    <div class="modal-body" style="line-height: 18px">
+                        {% blocktrans with entity_string=view.entity_string|lower %}
+                        <p>
+                            Deleting this field can cause you to lose data for any {{ entity_string }} with information stored in this field.
+                        </p>
+                        <p>
+                            Data will show up on the edit {{ entity_string }} page but
+                            will be removed the next time the {{ entity_string }} is saved.
+                        </p>
+                        {% endblocktrans %}
+                    </div>
+
+                    <div class="modal-footer">
+                        <a href="#" data-dismiss="modal" class="btn btn-default">Cancel</a>
+                        <button aria-hidden="true"
+                                data-dismiss="modal"
+                                data-bind="click: $root.confirmRemoveField"
+                                class="btn btn-danger">
+                            {% trans "Delete Field" %}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
     </form>
 {% endblock %}


### PR DESCRIPTION
Addresses [#229434](http://manage.dimagi.com/default.asp?229434).

The delete user field confirmation modal was not being hidden/removed from the DOM correctly. There was actually modal markup in each row of the table, and knockout would destroy those nodes before the animation could finish, which resulted in the modal not being cleaned up correctly.
This PR fixes the issue by moving the modal out of the table, so that there is only one instance of it.

@kaapstorm 
