### PR TITLE
Sync payload refactor

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/tests/test_close_extension_chain.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_close_extension_chain.py
@@ -1,15 +1,15 @@
+from django.test import TestCase
 from casexml.apps.case.mock import CaseFactory, CaseIndex, CaseStructure
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from casexml.apps.case.xform import get_extensions_to_close
 from casexml.apps.phone.tests.utils import create_restore_user
-from casexml.apps.phone.tests.test_sync_mode import SyncBaseTest
 from corehq.apps.domain.models import Domain
 from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends
 from corehq.util.test_utils import flag_enabled
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 
 
-class AutoCloseExtensionsTest(SyncBaseTest):
+class AutoCloseExtensionsTest(TestCase):
 
     def setUp(self):
         FormProcessorTestUtils.delete_all_cases()

--- a/corehq/ex-submodules/casexml/apps/case/xml/__init__.py
+++ b/corehq/ex-submodules/casexml/apps/case/xml/__init__.py
@@ -16,7 +16,7 @@ NS_REVERSE_LOOKUP_MAP = dict((v, k) for k, v in NS_VERSION_MAP.items())
 
 
 def check_version(version):
-    if not version in LEGAL_VERSIONS:
+    if version not in LEGAL_VERSIONS:
         raise BadVersionException(
             "%s is not a legal version, must be one of: %s" %
             (version, ", ".join(LEGAL_VERSIONS))

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/clean_owners.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/clean_owners.py
@@ -50,7 +50,6 @@ class CleanOwnerSyncPayload(object):
 
     def _get_next_case_batch(self):
         ids = pop_ids(self.case_ids_to_sync, chunk_size)
-        # TODO: see if we can avoid wrapping - serialization depends on it heavily for now
         return [
             case for case in self.case_accessor.get_cases(ids)
             if not case.is_deleted and case_needs_to_sync(case, last_sync_log=self.restore_state.last_sync_log)

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/clean_owners.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/clean_owners.py
@@ -70,11 +70,11 @@ class CleanOwnerCaseSyncOperation(object):
         while case_ids_to_sync:
             ids = pop_ids(case_ids_to_sync, chunk_size)
             # todo: see if we can avoid wrapping - serialization depends on it heavily for now
-            case_batch = filter(
-                partial(case_needs_to_sync, last_sync_log=self.restore_state.last_sync_log),
-                [case for case in self.case_accessor.get_cases(ids)
-                 if not case.is_deleted]
-            )
+            case_batch = [
+                case
+                for case in self.case_accessor.get_cases(ids)
+                if not case.is_deleted and case_needs_to_sync(case, last_sync_log=self.restore_state.last_sync_log)
+            ]
             updates = get_case_sync_updates(
                 self.restore_state.domain, case_batch, self.restore_state.last_sync_log
             )

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/clean_owners.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/clean_owners.py
@@ -71,9 +71,9 @@ class CleanOwnerSyncPayload(object):
     def _add_commtrack_elements_to_response(self, updates):
         # commtrack ledger sections for this batch
         commtrack_elements = get_stock_payload(
-                self.restore_state.project, self.restore_state.stock_settings,
-                [CaseStub(update.case.case_id, update.case.type) for update in updates]
-            )
+            self.restore_state.project, self.restore_state.stock_settings,
+            [CaseStub(update.case.case_id, update.case.type) for update in updates]
+        )
         self.response.extend(commtrack_elements)
 
     def _process_case_update(self, case):

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/clean_owners.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/clean_owners.py
@@ -143,7 +143,7 @@ class CleanOwnerSyncPayload(object):
         self.restore_state.current_sync_log.closed_cases = self.closed_cases
 
     def purge_and_get_irrelevant_cases(self):
-        original_case_ids_on_phone = self.restore_state.current_sync_log.case_ids_on_phone
+        original_case_ids_on_phone = self.restore_state.current_sync_log.case_ids_on_phone.copy()
         self.restore_state.current_sync_log.purge_dependent_cases()
         purged_cases = original_case_ids_on_phone - self.restore_state.current_sync_log.case_ids_on_phone
         # don't sync purged cases that were never on the phone

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/clean_owners.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/clean_owners.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 from copy import copy
-from functools import partial
 from datetime import datetime
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.toggles import EXTENSION_CASES_SYNC_ENABLED
@@ -9,7 +8,7 @@ from casexml.apps.phone.cleanliness import get_case_footprint_info
 from casexml.apps.phone.data_providers.case.load_testing import get_elements_for_response
 from casexml.apps.phone.data_providers.case.stock import get_stock_payload
 from casexml.apps.phone.data_providers.case.utils import get_case_sync_updates, CaseStub
-from casexml.apps.phone.models import OwnershipCleanlinessFlag, LOG_FORMAT_SIMPLIFIED, IndexTree, SimplifiedSyncLog
+from casexml.apps.phone.models import OwnershipCleanlinessFlag, IndexTree
 from corehq.apps.users.cases import get_owner_id
 from dimagi.utils.decorators.memoized import memoized
 

--- a/corehq/ex-submodules/casexml/apps/phone/data_providers/case/load_testing.py
+++ b/corehq/ex-submodules/casexml/apps/phone/data_providers/case/load_testing.py
@@ -20,7 +20,7 @@ def transform_loadtest_update(update, factor):
     return CaseSyncUpdate(case, update.sync_token, required_updates=update.required_updates)
 
 
-def get_elements_for_response(update, restore_state):
+def get_xml_for_response(update, restore_state):
     """
     Adds the XML from the case_update to the restore response.
     If factor is > 1 it will append that many updates to the response for load testing purposes.

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -21,6 +21,7 @@ from casexml.apps.phone.models import (
     LOG_FORMAT_SIMPLIFIED,
     get_sync_log_class_by_format,
     OTARestoreUser,
+    SimplifiedSyncLog,
 )
 import logging
 from dimagi.utils.couch.database import get_db, get_safe_write_kwargs
@@ -430,6 +431,13 @@ class RestoreState(object):
     @memoized
     def loadtest_factor(self):
         return self.restore_user.loadtest_factor
+
+    def mark_as_new_format(self):
+        self.current_sync_log = SimplifiedSyncLog.wrap(
+            self.current_sync_log.to_json()
+        )
+        self.current_sync_log.log_format = LOG_FORMAT_SIMPLIFIED
+        self.current_sync_log.extensions_checked = True
 
 
 class RestoreConfig(object):

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_extension_indexes.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_extension_indexes.py
@@ -24,6 +24,7 @@ def get_test_file_json(filename):
     return json.loads(file_contents)
 
 
+@nottest
 def get_test_name(test_name):
     return str("test_%s" % re.sub("\s", "_", test_name))
 

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_extension_indexes.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_extension_indexes.py
@@ -24,6 +24,10 @@ def get_test_file_json(filename):
     return json.loads(file_contents)
 
 
+def get_test_name(test_name):
+    return str("test_%s" % re.sub("\s", "_", test_name))
+
+
 @nottest
 def test_generator(test_name, skip=False):
     @softer_assert
@@ -37,6 +41,8 @@ def test_generator(test_name, skip=False):
         self.assertEqual(sync_log.case_ids_on_phone, set(desired_cases))
         assert_user_has_cases(self, self.user, desired_cases)
         assert_user_doesnt_have_cases(self, self.user, undesired_cases)
+
+    test.__name__ = get_test_name(test_name)
     return run_with_all_backends(test)
 
 
@@ -50,7 +56,7 @@ class TestSequenceMeta(type):
 
         for test in [(test['name'], test.get('skip', False)) for test in tests_to_run]:
             # Create a new testcase that the test runner is able to find
-            dict["test_%s" % re.sub("\s", "_", test[0])] = test_generator(test[0], test[1])
+            dict[get_test_name(test[0])] = test_generator(test[0], test[1])
 
         return type.__new__(mcs, name, bases, dict)
 


### PR DESCRIPTION
Breaking the `get_payload` method of `CleanOwnerCaseSyncOperation` into its own class. 

Hopefully this should make it easier to profile individual parts of the sync operation, since there has been some issues with workers with a large number of cases (also every time I looked at the previous method I got a bit confused since it was doing so much). 

Not sure if this was the right way of doing this, but figured I'd throw this up to get some comments on it.
@snopoke @czue 
cc: @emord 
