### PR TITLE
Use _rev instead of _id when checking to clear cache

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -4717,7 +4717,7 @@ class ApplicationBase(VersionedDoc, SnapshotMixin,
         return record
 
     def save(self, response_json=None, increment_version=None, **params):
-        if not self._id and not domain_has_apps(self.domain):
+        if not self._rev and not domain_has_apps(self.domain):
             domain_has_apps.clear(self.domain)
         super(ApplicationBase, self).save(
             response_json=response_json, increment_version=increment_version, **params)


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?229526

Looks like in the process of copying an app it gets assigned an _id here https://github.com/dimagi/commcare-hq/blob/440208c426199fc19fe08e049139b46aa1292c1c/corehq/blobs/mixin.py#L179 before it gets saved, so the check for clearing the cache was failing. This uses _rev instead.

@dannyroberts 
