### PR TITLE
exlude rows with no doc

### DIFF
--- a/corehq/ex-submodules/pillowtop/couchdb.py
+++ b/corehq/ex-submodules/pillowtop/couchdb.py
@@ -51,4 +51,4 @@ class CachedCouchDB(Database):
             self._docs = {}
 
         docs = self.all_docs(keys=doc_ids, include_docs=True)
-        self._docs.update(dict((x['id'], x['doc']) for x in docs if 'id' in x))
+        self._docs.update(dict((x['id'], x['doc']) for x in docs if 'id' in x and 'doc' in x))


### PR DESCRIPTION
@czue @gcapalbo 

This shouldn't happen but could be something similar to that issue we had before with deleted doc's showing up in views.
