### PR TITLE
exlude rows with no doc

### DIFF
--- a/corehq/ex-submodules/pillowtop/couchdb.py
+++ b/corehq/ex-submodules/pillowtop/couchdb.py
@@ -51,4 +51,4 @@ class CachedCouchDB(Database):
             self._docs = {}
 
         docs = self.all_docs(keys=doc_ids, include_docs=True)
-        self._docs.update(dict((x['id'], x['doc']) for x in docs if 'id' in x))
+        self._docs.update({x['id']: x['doc'] for x in docs if 'id' in x and x['doc']})


### PR DESCRIPTION
@czue @gcapalbo

This shouldn't happen but for some reason we're getting deleted docs like this one: `11493CAA783C11E5AD16F99641510BD2`
