### PR TITLE
Kill date filters on supply reports

### DIFF
--- a/corehq/apps/reports/commtrack/data_sources.py
+++ b/corehq/apps/reports/commtrack/data_sources.py
@@ -275,8 +275,6 @@ class StockStatusDataSource(ReportDataSource, CommtrackDataSourceMixin):
 
         stock_states = StockState.objects.filter(
             section_id=STOCK_SECTION_TYPE,
-            last_modified_date__lte=self.end_date,
-            last_modified_date__gte=self.start_date,
         )
 
         if self.program_id:

--- a/corehq/apps/reports/commtrack/maps.py
+++ b/corehq/apps/reports/commtrack/maps.py
@@ -13,7 +13,6 @@ class StockStatusMapReport(GenericMapReport, CommtrackReportMixin):
     fields = [
         'corehq.apps.reports.filters.fixtures.AsyncLocationFilter',
         'corehq.apps.reports.filters.commtrack.ProgramFilter',
-        'corehq.apps.reports.filters.dates.DatespanFilter',
     ]
 
     data_source = {

--- a/corehq/apps/reports/commtrack/maps.py
+++ b/corehq/apps/reports/commtrack/maps.py
@@ -77,7 +77,6 @@ class StockStatusMapReport(GenericMapReport, CommtrackReportMixin):
                             'understock': '/static/commtrack/img/warning.png',
                             'adequate': '/static/commtrack/img/goodstock.png',
                             'overstock': '/static/commtrack/img/overstock.png',
-                            #'nodata': '/static/commtrack/img/no_data.png',
                             '_null': '/static/commtrack/img/no_data.png',
                         },
                     }

--- a/corehq/apps/reports/commtrack/standard.py
+++ b/corehq/apps/reports/commtrack/standard.py
@@ -112,7 +112,6 @@ class CurrentStockStatusReport(GenericTabularReport, CommtrackReportMixin):
                 _('Overstocked'),
                 help_text=_("A facility is counted as overstocked when \
                             its current stock is above the overstock level.")),
-            #DataTablesColumn(_('Non-reporting')),
             DataTablesColumn(
                 _('Insufficient Data'),
                 help_text=_("A facility is marked as insufficient data when \
@@ -184,10 +183,9 @@ class CurrentStockStatusReport(GenericTabularReport, CommtrackReportMixin):
             {"key": "under stock", "color": "#ffb100"},
             {"key": "adequate stock", "color": "#4ac925"},
             {"key": "overstocked", "color": "#b536da"},
-#            {"key": "nonreporting", "color": "#363636"},
             {"key": "unknown", "color": "#ABABAB"}
         ]
-        statuses = ['stocked out', 'under stock', 'adequate stock', 'overstocked', 'no data'] #'nonreporting', 'no data']
+        statuses = ['stocked out', 'under stock', 'adequate stock', 'overstocked', 'no data']
 
         for r in ret:
             r["values"] = []
@@ -200,7 +198,8 @@ class CurrentStockStatusReport(GenericTabularReport, CommtrackReportMixin):
 
     @property
     def charts(self):
-        if 'location_id' in self.request.GET: # hack: only get data if we're loading an actual report
+        # only get data if we're loading an actual report - this requires filters
+        if 'location_id' in self.request.GET:
             chart = MultiBarChart(None, Axis(_('Products')), Axis(_('% of Facilities'), ',.1d'))
             chart.data = self.get_data_for_graph()
             return [chart]

--- a/corehq/apps/reports/commtrack/standard.py
+++ b/corehq/apps/reports/commtrack/standard.py
@@ -81,7 +81,6 @@ class CurrentStockStatusReport(GenericTabularReport, CommtrackReportMixin):
     fields = [
         'corehq.apps.reports.filters.fixtures.AsyncLocationFilter',
         'corehq.apps.reports.filters.commtrack.ProgramFilter',
-        'corehq.apps.reports.filters.dates.DatespanFilter',
     ]
     exportable = True
     emailable = True
@@ -98,23 +97,21 @@ class CurrentStockStatusReport(GenericTabularReport, CommtrackReportMixin):
             DataTablesColumn(
                 _('Stocked Out'),
                 help_text=_("A facility is counted as stocked out when its \
-                            stock is below the emergency level during the date \
-                            range selected.")),
+                            current stock is below the emergency level.")),
             DataTablesColumn(
                 _('Understocked'),
                 help_text=_("A facility is counted as under stocked when its \
-                            stock is above the emergency level but below the \
-                            low stock level during the date range selected.")),
+                            current stock is above the emergency level but below the \
+                            low stock level.")),
             DataTablesColumn(
                 _('Adequate Stock'),
                 help_text=_("A facility is counted as adequately stocked when \
-                            its stock is above the low level but below the \
-                            overstock level during the date range selected.")),
+                            its current stock is above the low level but below the \
+                            overstock level.")),
             DataTablesColumn(
                 _('Overstocked'),
                 help_text=_("A facility is counted as overstocked when \
-                            its stock is above the overstock level \
-                            during the date range selected.")),
+                            its current stock is above the overstock level.")),
             #DataTablesColumn(_('Non-reporting')),
             DataTablesColumn(
                 _('Insufficient Data'),
@@ -138,8 +135,6 @@ class CurrentStockStatusReport(GenericTabularReport, CommtrackReportMixin):
 
         stock_states = StockState.objects.filter(
             case_id__in=sp_ids,
-            last_modified_date__lte=self.datespan.enddate_utc,
-            last_modified_date__gte=self.datespan.startdate_utc,
             section_id=STOCK_SECTION_TYPE
         )
 

--- a/corehq/apps/reports/commtrack/standard.py
+++ b/corehq/apps/reports/commtrack/standard.py
@@ -269,7 +269,6 @@ class InventoryReport(GenericTabularReport, CommtrackReportMixin):
     fields = [
         'corehq.apps.reports.filters.fixtures.AsyncLocationFilter',
         'corehq.apps.reports.filters.commtrack.ProgramFilter',
-        'corehq.apps.reports.filters.dates.DatespanFilter',
         'corehq.apps.reports.filters.commtrack.AdvancedColumns',
     ]
     exportable = True
@@ -319,8 +318,6 @@ class InventoryReport(GenericTabularReport, CommtrackReportMixin):
             'domain': self.domain,
             'location_id': self.request.GET.get('location_id'),
             'program_id': self.request.GET.get('program'),
-            'startdate': self.datespan.startdate_utc,
-            'enddate': self.datespan.enddate_utc,
             'aggregate': True,
             'advanced_columns': self.showing_advanced_columns(),
         }


### PR DESCRIPTION
:fish: 

These date filters were super misleading and confusing. All they actually did was filter the set of results to anything that was modified within that date range, but they never actually showed any historical information. This just removes them (confirmed with @rowenaluk that this was a good change).

@esoergel / @snopoke / anyone
