### PR TITLE
use clearer text when feature usage is over limit

### DIFF
--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -733,14 +733,16 @@ class DomainSubscriptionView(DomainAccountingSettings):
         def _get_feature_info(feature_rate):
             usage = FeatureUsageCalculator(feature_rate, self.domain).get_usage()
             feature_type = feature_rate.feature.feature_type
+            if feature_rate.monthly_limit == UNLIMITED_FEATURE_USAGE:
+                remaining = _('Unlimited')
+            else:
+                remaining = feature_rate.monthly_limit - usage
+                if remaining < 0:
+                    remaining = _("%d over limit") % (-1 * remaining)
             return {
                 'name': get_feature_name(feature_type, self.product),
                 'usage': usage,
-                'remaining': (
-                    feature_rate.monthly_limit - usage
-                    if feature_rate.monthly_limit != UNLIMITED_FEATURE_USAGE
-                    else _('Unlimited')
-                ),
+                'remaining': remaining,
                 'type': feature_type,
                 'recurring_interval': get_feature_recurring_interval(feature_type),
                 'subscription_credit': self._fmt_credit(self._credit_grand_total(


### PR DESCRIPTION
Before (on current subscription page):
<img width="228" alt="screen shot 2016-06-11 at 3 53 44 pm" src="https://cloud.githubusercontent.com/assets/1757035/16011164/446e45ec-3152-11e6-9904-4abe50d18a89.png">

After:
<img width="237" alt="screen shot 2016-06-11 at 3 45 18 pm" src="https://cloud.githubusercontent.com/assets/1757035/16011170/4b3d1600-3152-11e6-829b-20ca0fcdeb0d.png">

@dimagi/product for feedback

@esoergel @biyeun 
