### PR TITLE
fix delete_couch_devicelogs memory issue

### DIFF
--- a/corehq/ex-submodules/phonelog/management/commands/delete_couch_devicelogs.py
+++ b/corehq/ex-submodules/phonelog/management/commands/delete_couch_devicelogs.py
@@ -38,7 +38,6 @@ class Command(BaseCommand):
             'couchforms/by_xmlns',
             key=DEVICE_LOG_XMLNS,
             reduce=False,
-            include_docs=True,
         )]
 
         with open(self.filename, 'w') as f:


### PR DESCRIPTION
- remove accidental include_docs=True when trying to get just ids
