### PR TITLE
lang-text button still not working

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -317,7 +317,7 @@ hqDefine('app_manager/js/detail-screen-config.js', function () {
                 lookup_responses: _trimmed_responses(),
                 lookup_image: image_path,
                 lookup_display_results: self.lookup_display_results(),
-                lookup_field_header: self.lookup_field_header(),
+                lookup_field_header: self.lookup_field_header.val(),
                 lookup_field_template: self.lookup_field_template(),
             };
 
@@ -419,7 +419,14 @@ hqDefine('app_manager/js/detail-screen-config.js', function () {
         }
 
         self.lookup_display_results = ko.observable(state.lookup_display_results);
-        self.lookup_field_header = ko.observable(state.lookup_field_header[lang]);
+        self.lookup_field_header = uiElement.input().val(
+            typeof state.lookup_field_header[lang] !== 'undefined' ? state.lookup_field_header[lang] : ''
+        );
+        self.lookup_field_header.observableVal = ko.observable(self.lookup_field_header.val());
+        self.lookup_field_header.on('change', function () {
+            self.lookup_field_header.observableVal(self.lookup_field_header.val());
+            _fireChange();  // input node created too late for initSaveButtonListeners
+        });
         self.lookup_field_template = ko.observable(state.lookup_field_template || '@case_id');
 
         self.show_add_extra = ko.computed(function(){

--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -419,9 +419,21 @@ hqDefine('app_manager/js/detail-screen-config.js', function () {
         }
 
         self.lookup_display_results = ko.observable(state.lookup_display_results);
+        var invisible = "", visible = "";
+        if (state.lookup_field_header[lang]) {
+            visible = invisible = state.lookup_field_header[lang]
+        } else {
+            _.each(_.keys(state.lookup_field_header), function(lang) {
+                if (state.lookup_field_header[lang]) {
+                    visible = state.lookup_field_header[lang] + langcodeTag.LANG_DELIN + lang;
+                }
+            });
+        }
+
         self.lookup_field_header = uiElement.input().val(
-            typeof state.lookup_field_header[lang] !== 'undefined' ? state.lookup_field_header[lang] : ''
+            invisible
         );
+        self.lookup_field_header.setVisibleValue(visible);
         self.lookup_field_header.observableVal = ko.observable(self.lookup_field_header.val());
         self.lookup_field_header.on('change', function () {
             self.lookup_field_header.observableVal(self.lookup_field_header.val());

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list_lookup.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list_lookup.html
@@ -121,11 +121,7 @@
                     <label class="control-label col-sm-2">
                         {% trans "Results display text" %}
                     </label>
-                    <div class="col-sm-4">
-                        <input class="form-control" type="text"
-                               data-bind="value: lookup_field_header"
-                               placeholder="{% trans 'Accuracy' %}" />
-                    </div>
+                    <div class="col-sm-4" data-bind="jqueryElement: lookup_field_header.ui"></div>
                 </div>
                 <div class="form-group" id="{{ detail.type }}-results-property">
                     <label class="control-label col-sm-2">

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -826,7 +826,7 @@ def _save_case_list_lookup_params(short, case_list_lookup, lang):
     short.lookup_responses = case_list_lookup.get("lookup_responses", short.lookup_responses)
     short.lookup_image = case_list_lookup.get("lookup_image", short.lookup_image)
     short.lookup_display_results = case_list_lookup.get("lookup_display_results", short.lookup_display_results)
-    if case_list_lookup.get("lookup_field_header"):
+    if "lookup_field_header" in case_list_lookup:
         short.lookup_field_header[lang] = case_list_lookup["lookup_field_header"]
     short.lookup_field_template = case_list_lookup.get("lookup_field_template", short.lookup_field_template)
 


### PR DESCRIPTION
@orangejenny @biyeun can you see what I'm missing? There seem to be two things broken with this commit:
- Despite the fact that `lookup_field_header`'s [`setVisibleValue()`](https://github.com/dimagi/commcare-hq/blob/1c69c14c8c1ac97f039055b0fc9cda10442253b4/corehq/apps/style/static/style/js/ui-element.js#L81-L81) method is being called, the `lang-text` button is not created (or maybe just not shown, although [`val() === ""`](https://github.com/dimagi/commcare-hq/blob/1c69c14c8c1ac97f039055b0fc9cda10442253b4/corehq/apps/style/static/style/js/ui-element.js#L97-L97)).
- When the value is deleted, the empty string is not saved. 

The HTML it generates is:

``` HTML
<div class="col-sm-4" data-bind="jqueryElement: lookup_field_header.ui">
    <div class="app-designer-input">
        <input class="form-control" type="text">
    </div>
</div>
```
