### PR TITLE
Fix deploy link in firefox

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/app_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/app_view.html
@@ -89,7 +89,7 @@
                 $loading = $main.find(".hq-loading").remove(),
                 $loadingError = $main.find(".hq-loading-error").remove();
 
-            $('#demand-releases').on('show.bs.tab', _.throttle(function () {
+            $('#demand-releases').on('show.bs.tab', _.throttle(function (event) {
                 if (event && (event.metaKey || event.ctrlKey || event.which === 2)) {
                     window.open("{% url 'release_manager' domain app.get_id %}", '_blank');
                     return


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?229726

looks like was introduced in https://github.com/dimagi/commcare-hq/pull/12034

@snopoke 
