### PR TITLE
start converting commtrack reports to elasticsearch

### DIFF
--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -3,7 +3,6 @@ from decimal import Decimal
 from django.db import models
 from django.db.models.signals import post_save
 from django.dispatch import receiver
-from django.utils.translation import ugettext as _
 from couchdbkit.exceptions import ResourceNotFound
 
 from corehq.form_processor.change_publishers import publish_ledger_v1_saved
@@ -12,9 +11,8 @@ from dimagi.utils.decorators.memoized import memoized
 
 from casexml.apps.case.cleanup import close_case
 from casexml.apps.case.models import CommCareCase
-from casexml.apps.case.xform import get_case_updates
 from casexml.apps.stock.consumption import (ConsumptionConfiguration, compute_default_monthly_consumption)
-from casexml.apps.stock.models import StockReport, DocDomainMapping
+from casexml.apps.stock.models import DocDomainMapping
 from casexml.apps.stock.utils import months_of_stock_remaining, state_stock_category
 from couchexport.models import register_column_type, ComplexExportColumn
 from couchforms.signals import xform_archived, xform_unarchived
@@ -26,7 +24,6 @@ from corehq.apps.domain.signals import commcare_domain_pre_delete
 from corehq.apps.locations.models import Location, SQLLocation
 from corehq.apps.products.models import Product, SQLProduct
 from corehq.form_processor.interfaces.supply import SupplyInterface
-from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAccessors
 from corehq.util.quickcache import quickcache
 from . import const
 from .const import StockActions, RequisitionActions, DAYS_IN_MONTH

--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -14,7 +14,7 @@ from casexml.apps.case.models import CommCareCase
 from casexml.apps.stock.consumption import ConsumptionConfiguration, ConsumptionHelper
 
 from casexml.apps.stock.models import DocDomainMapping
-from casexml.apps.stock.utils import months_of_stock_remaining, state_stock_category
+from casexml.apps.stock.utils import months_of_stock_remaining
 from couchexport.models import register_column_type, ComplexExportColumn
 from couchforms.signals import xform_archived, xform_unarchived
 from corehq.apps.cachehq.mixins import QuickCachedDocumentMixin
@@ -412,7 +412,7 @@ class StockState(models.Model):
 
     @property
     def stock_category(self):
-        return state_stock_category(self)
+        return self.consumption_helper.get_stock_category()
 
     @property
     @memoized

--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -14,7 +14,6 @@ from casexml.apps.case.models import CommCareCase
 from casexml.apps.stock.consumption import ConsumptionConfiguration, ConsumptionHelper
 
 from casexml.apps.stock.models import DocDomainMapping
-from casexml.apps.stock.utils import months_of_stock_remaining
 from couchexport.models import register_column_type, ComplexExportColumn
 from couchforms.signals import xform_archived, xform_unarchived
 from corehq.apps.cachehq.mixins import QuickCachedDocumentMixin
@@ -27,7 +26,7 @@ from corehq.apps.products.models import Product, SQLProduct
 from corehq.form_processor.interfaces.supply import SupplyInterface
 from corehq.util.quickcache import quickcache
 from . import const
-from .const import StockActions, RequisitionActions, DAYS_IN_MONTH
+from .const import StockActions, RequisitionActions
 
 
 STOCK_ACTION_ORDER = [

--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -398,7 +398,8 @@ class StockState(models.Model):
             section_id=self.section_id,
             entry_id=self.product_id,
             daily_consumption=self.daily_consumption,
-            balance=self.balance
+            balance=self.balance,
+            sql_location=self.sql_location,
         )
 
     @property
@@ -407,15 +408,7 @@ class StockState(models.Model):
 
     @property
     def resupply_quantity_needed(self):
-        monthly_consumption = self.get_monthly_consumption()
-        if monthly_consumption is not None and self.sql_location is not None:
-            overstock = self.sql_location.location_type.overstock_threshold
-            needed_quantity = int(
-                monthly_consumption * overstock
-            )
-            return int(max(needed_quantity - self.stock_on_hand, 0))
-        else:
-            return None
+        return self.consumption_helper.get_resupply_quantity_needed()
 
     @property
     def stock_category(self):

--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -11,7 +11,8 @@ from dimagi.utils.decorators.memoized import memoized
 
 from casexml.apps.case.cleanup import close_case
 from casexml.apps.case.models import CommCareCase
-from casexml.apps.stock.consumption import (ConsumptionConfiguration, compute_default_monthly_consumption)
+from casexml.apps.stock.consumption import (ConsumptionConfiguration,
+                                            get_default_monthly_consumption_for_case_and_entry)
 from casexml.apps.stock.models import DocDomainMapping
 from casexml.apps.stock.utils import months_of_stock_remaining, state_stock_category
 from couchexport.models import register_column_type, ComplexExportColumn
@@ -447,16 +448,7 @@ class StockState(models.Model):
 
     def _get_default_monthly_consumption(self):
         domain = self.get_domain()
-        if domain and domain.commtrack_settings:
-            config = domain.commtrack_settings.get_consumption_config()
-        else:
-            config = None
-
-        return compute_default_monthly_consumption(
-            self.case_id,
-            self.product_id,
-            config
-        )
+        return get_default_monthly_consumption_for_case_and_entry(domain, self.case_id, self.product_id)
 
     def to_json(self):
         from corehq.form_processor.serializers import StockStateSerializer

--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -444,22 +444,10 @@ class StockState(models.Model):
         return Domain.get_by_name(self.domain)
 
     def get_daily_consumption(self):
-        if self.daily_consumption is not None:
-            return self.daily_consumption
-        else:
-            monthly = self._get_default_monthly_consumption()
-            if monthly is not None:
-                return Decimal(monthly) / Decimal(DAYS_IN_MONTH)
+        return self.consumption_helper.get_daily_consumption()
 
     def get_monthly_consumption(self):
-
-        if self.daily_consumption is not None:
-            return self.daily_consumption * Decimal(DAYS_IN_MONTH)
-        else:
-            return self._get_default_monthly_consumption()
-
-    def _get_default_monthly_consumption(self):
-        return self.consumption_helper.get_default_monthly_consumption()
+        return self.consumption_helper.get_monthly_consumption()
 
     def to_json(self):
         from corehq.form_processor.serializers import StockStateSerializer

--- a/corehq/apps/commtrack/models.py
+++ b/corehq/apps/commtrack/models.py
@@ -403,10 +403,7 @@ class StockState(models.Model):
 
     @property
     def months_remaining(self):
-        return months_of_stock_remaining(
-            self.stock_on_hand,
-            self.get_daily_consumption()
-        )
+        return self.consumption_helper.get_months_remaining()
 
     @property
     def resupply_quantity_needed(self):

--- a/corehq/apps/reports/commtrack/data_sources.py
+++ b/corehq/apps/reports/commtrack/data_sources.py
@@ -16,7 +16,7 @@ from corehq.apps.reports.api import ReportDataSource
 from datetime import datetime, timedelta
 from dateutil import parser
 from casexml.apps.stock.const import SECTION_TYPE_STOCK
-from casexml.apps.stock.models import StockTransaction, StockReport
+from casexml.apps.stock.models import StockReport
 from casexml.apps.stock.utils import months_of_stock_remaining, stock_category
 from couchforms.models import XFormInstance
 from corehq.apps.reports.commtrack.util import get_relevant_supply_point_ids

--- a/corehq/apps/reports/commtrack/data_sources.py
+++ b/corehq/apps/reports/commtrack/data_sources.py
@@ -305,17 +305,18 @@ class StockStatusDataSource(ReportDataSource, CommtrackDataSourceMixin):
             result = {
                 'product_id': state.sql_product.product_id,
                 'product_name': state.sql_product.name,
-                'current_stock': format_decimal(state.stock_on_hand),
+                'current_stock': format_decimal(state.balance),
             }
 
             if self._include_advanced_data():
+                consumption_helper = state.consumption_helper
                 result.update({
                     'location_id': state.sql_location.location_id if state.sql_location else '',
                     'location_lineage': None,
-                    'category': state.stock_category,
-                    'consumption': state.get_monthly_consumption(),
-                    'months_remaining': state.months_remaining,
-                    'resupply_quantity_needed': state.resupply_quantity_needed
+                    'category': consumption_helper.get_stock_category(),
+                    'consumption': consumption_helper.get_monthly_consumption(),
+                    'months_remaining': consumption_helper.get_months_remaining(),
+                    'resupply_quantity_needed': consumption_helper.get_resupply_quantity_needed()
                 })
 
             yield result

--- a/corehq/apps/reports/commtrack/data_sources.py
+++ b/corehq/apps/reports/commtrack/data_sources.py
@@ -84,6 +84,14 @@ class CommtrackDataSourceMixin(object):
             return prog_id
 
     @property
+    @memoized
+    def product_ids(self):
+        if self.program_id:
+            return SQLProduct.objects\
+                .filter(domain=self.domain, program_id=self.program_id)\
+                .values_list('product_id', flat=True)
+
+    @property
     def start_date(self):
         return self.config.get('startdate') or (datetime.utcnow() - timedelta(30)).date()
 
@@ -159,14 +167,6 @@ class SimplifiedInventoryDataSource(ReportDataSource, CommtrackDataSourceMixin):
 
 
 class SimplifiedInventoryDataSourceNew(SimplifiedInventoryDataSource):
-
-    @property
-    @memoized
-    def product_ids(self):
-        if self.program_id:
-            return SQLProduct.objects\
-                .filter(domain=self.domain, program_id=self.program_id)\
-                .values_list('product_id', flat=True)
 
     def get_data(self):
         from corehq.form_processor.backends.sql.dbaccessors import LedgerAccessorSQL

--- a/corehq/apps/reports/commtrack/data_sources.py
+++ b/corehq/apps/reports/commtrack/data_sources.py
@@ -18,7 +18,7 @@ from casexml.apps.stock.models import StockReport
 from casexml.apps.stock.utils import months_of_stock_remaining, stock_category
 from couchforms.models import XFormInstance
 from corehq.apps.reports.commtrack.util import get_relevant_supply_point_ids, \
-    get_consumption_helper_from_ledger_value, StockLedgerValueWrapper
+    get_consumption_helper_from_ledger_value
 from corehq.apps.reports.commtrack.const import STOCK_SECTION_TYPE
 from corehq.apps.reports.standard.monitoring import MultiFormDrilldownMixin
 from decimal import Decimal
@@ -308,8 +308,12 @@ class StockStatusDataSource(ReportDataSource, CommtrackDataSourceMixin):
                 return self.raw_product_states(stock_states)
 
     def leaf_node_data(self, supply_point_id):
-        stock_states = self._get_stock_states([supply_point_id])
-        ledger_values = [StockLedgerValueWrapper.from_stock_state(state) for state in stock_states]
+        ledger_values = get_wrapped_ledger_values(
+            self.domain,
+            [supply_point_id],
+            section_id=STOCK_SECTION_TYPE,
+            entry_ids=self.product_ids
+        )
         for ledger_value in ledger_values:
             result = {
                 'product_id': ledger_value.sql_product.product_id,

--- a/corehq/apps/reports/commtrack/data_sources.py
+++ b/corehq/apps/reports/commtrack/data_sources.py
@@ -1,6 +1,10 @@
 import logging
 from couchdbkit.exceptions import ResourceNotFound
+from django.core.exceptions import ObjectDoesNotExist
+from casexml.apps.stock.consumption import ConsumptionHelper
+from corehq.apps.domain.models import Domain
 from corehq.apps.reports.analytics.couchaccessors import get_ledger_values_for_case_as_of
+from dimagi.ext import jsonobject
 
 from dimagi.utils.couch.database import iter_docs
 from dimagi.utils.decorators.memoized import memoized
@@ -44,6 +48,76 @@ def _location_map(location_ids):
     }
 
 
+class StockLedgerValueWrapper(jsonobject.JsonObject):
+    domain = jsonobject.StringProperty()
+    case_id = jsonobject.StringProperty()
+    section_id = jsonobject.StringProperty()
+    entry_id = jsonobject.StringProperty()
+    balance = jsonobject.DecimalProperty()  # todo: should this be an int?
+    last_modified = jsonobject.DateTimeProperty()
+    last_modified_form_id = jsonobject.StringProperty()
+    daily_consumption = jsonobject.FloatProperty()
+    location_id = jsonobject.StringProperty()
+
+    _sql_product = None
+    _sql_location = None
+
+    def __init__(self, _obj=None, sql_product=None, sql_location=None, *args, **kwargs):
+        self._sql_product = sql_product
+        self._sql_location = sql_location
+        super(StockLedgerValueWrapper, self).__init__(_obj, *args, **kwargs)
+
+    @property
+    def sql_product(self):
+        if self.entry_id and not self._sql_product:
+            try:
+                self._sql_product = SQLProduct.objects.get(domain=self.domain, product_id=self.entry_id)
+            except ObjectDoesNotExist:
+                # todo: cache this result so multiple failing calls don't keep hitting the DB
+                return None
+
+        return self._sql_product
+
+    @property
+    def sql_location(self):
+        if self.location_id and not self._sql_location:
+            try:
+                self._sql_location = SQLLocation.objects.get(domain=self.domain, location_id=self.location_id)
+            except ObjectDoesNotExist:
+                # todo: cache this result so multiple failing calls don't keep hitting the DB
+                return None
+
+        return self._sql_location
+
+    @classmethod
+    def from_stock_state(cls, stock_state):
+        return cls(
+            case_id=stock_state.case_id,
+            section_id=stock_state.section_id,
+            entry_id=stock_state.product_id,
+            balance=stock_state.stock_on_hand,
+            last_modified=stock_state.last_modified_date,
+            last_modified_form_id=stock_state.last_modified_form_id,
+            daily_consumption=stock_state.daily_consumption,
+            location_id=stock_state.sql_location.location_id if stock_state.sql_location else None,
+            sql_location=stock_state.sql_location,
+            sql_product=stock_state.sql_product,
+        )
+
+
+def get_consumption_helper_from_ledger_value(domain, ledger_value):
+    assert isinstance(ledger_value, StockLedgerValueWrapper)
+    return ConsumptionHelper(
+        domain=domain,
+        case_id=ledger_value.case_id,
+        section_id=ledger_value.section_id,
+        entry_id=ledger_value.entry_id,
+        daily_consumption=ledger_value.daily_consumption,
+        balance=ledger_value.balance,
+        sql_location=ledger_value.sql_location,
+    )
+
+
 def geopoint(location):
     if None in (location.latitude, location.longitude):
         return None
@@ -55,6 +129,11 @@ class CommtrackDataSourceMixin(object):
     @property
     def domain(self):
         return self.config.get('domain')
+
+    @property
+    @memoized
+    def project(self):
+        return Domain.get_by_name(self.domain)
 
     @property
     @memoized
@@ -301,15 +380,16 @@ class StockStatusDataSource(ReportDataSource, CommtrackDataSourceMixin):
 
     def leaf_node_data(self, supply_point_id):
         stock_states = self._get_stock_states([supply_point_id])
-        for state in stock_states:
+        ledger_values = [StockLedgerValueWrapper.from_stock_state(state) for state in stock_states]
+        for ledger_value in ledger_values:
             result = {
-                'product_id': state.sql_product.product_id,
-                'product_name': state.sql_product.name,
-                'current_stock': format_decimal(state.balance),
+                'product_id': ledger_value.sql_product.product_id,
+                'product_name': ledger_value.sql_product.name,
+                'current_stock': format_decimal(ledger_value.balance),
             }
 
             if self._include_advanced_data():
-                consumption_helper = state.consumption_helper
+                consumption_helper = get_consumption_helper_from_ledger_value(self.project, ledger_value)
                 result.update({
                     'location_id': state.sql_location.location_id if state.sql_location else '',
                     'location_lineage': None,

--- a/corehq/apps/reports/commtrack/data_sources.py
+++ b/corehq/apps/reports/commtrack/data_sources.py
@@ -320,7 +320,7 @@ class StockStatusDataSource(ReportDataSource, CommtrackDataSourceMixin):
             if self._include_advanced_data():
                 consumption_helper = get_consumption_helper_from_ledger_value(self.project, ledger_value)
                 result.update({
-                    'location_id': state.sql_location.location_id if state.sql_location else '',
+                    'location_id': ledger_value.location_id,
                     'location_lineage': None,
                     'category': consumption_helper.get_stock_category(),
                     'consumption': consumption_helper.get_monthly_consumption(),

--- a/corehq/apps/reports/commtrack/data_sources.py
+++ b/corehq/apps/reports/commtrack/data_sources.py
@@ -290,17 +290,17 @@ class StockStatusDataSource(ReportDataSource, CommtrackDataSourceMixin):
 
     def get_data(self):
         sp_ids = get_relevant_supply_point_ids(self.domain, self.active_location)
-        stock_states = self._get_stock_states(sp_ids)
-
         if len(sp_ids) == 1:
-            return self.leaf_node_data(stock_states)
+            return self.leaf_node_data(sp_ids[0])
         else:
+            stock_states = self._get_stock_states(sp_ids)
             if self.config.get('aggregate'):
                 return self.aggregated_data(stock_states)
             else:
                 return self.raw_product_states(stock_states)
 
-    def leaf_node_data(self, stock_states):
+    def leaf_node_data(self, supply_point_id):
+        stock_states = self._get_stock_states([supply_point_id])
         for state in stock_states:
             product = Product.get(state.product_id)
 

--- a/corehq/apps/reports/commtrack/data_sources.py
+++ b/corehq/apps/reports/commtrack/data_sources.py
@@ -13,7 +13,7 @@ from datetime import datetime, timedelta
 from dateutil import parser
 from casexml.apps.stock.const import SECTION_TYPE_STOCK
 from casexml.apps.stock.models import StockTransaction, StockReport
-from casexml.apps.stock.utils import months_of_stock_remaining, stock_category, state_stock_category
+from casexml.apps.stock.utils import months_of_stock_remaining, stock_category
 from couchforms.models import XFormInstance
 from corehq.apps.reports.commtrack.util import get_relevant_supply_point_ids
 from corehq.apps.reports.commtrack.const import STOCK_SECTION_TYPE
@@ -369,7 +369,7 @@ class StockStatusDataSource(ReportDataSource, CommtrackDataSourceMixin):
                         'current_stock': format_decimal(state.stock_on_hand),
                         'count': 1,
                         'consumption': consumption,
-                        'category': state_stock_category(state),
+                        'category': state.stock_category,
                         'months_remaining': months_of_stock_remaining(
                             state.stock_on_hand,
                             _convert_to_daily(consumption)

--- a/corehq/apps/reports/commtrack/data_sources.py
+++ b/corehq/apps/reports/commtrack/data_sources.py
@@ -310,7 +310,7 @@ class StockStatusDataSource(ReportDataSource, CommtrackDataSourceMixin):
 
             if self._include_advanced_data():
                 result.update({
-                    'location_id': SupplyPointCase.get(state.case_id).location_id,
+                    'location_id': state.sql_location.location_id if state.sql_location else '',
                     'location_lineage': None,
                     'category': state.stock_category,
                     'consumption': state.get_monthly_consumption(),

--- a/corehq/apps/reports/commtrack/data_sources.py
+++ b/corehq/apps/reports/commtrack/data_sources.py
@@ -302,11 +302,9 @@ class StockStatusDataSource(ReportDataSource, CommtrackDataSourceMixin):
     def leaf_node_data(self, supply_point_id):
         stock_states = self._get_stock_states([supply_point_id])
         for state in stock_states:
-            product = Product.get(state.product_id)
-
             result = {
-                'product_id': product._id,
-                'product_name': product.name,
+                'product_id': state.sql_product.product_id,
+                'product_name': state.sql_product.name,
                 'current_stock': format_decimal(state.stock_on_hand),
             }
 

--- a/corehq/apps/reports/commtrack/standard.py
+++ b/corehq/apps/reports/commtrack/standard.py
@@ -335,7 +335,6 @@ class InventoryReport(GenericTabularReport, CommtrackReportMixin):
                     fmt(row[StockStatusDataSource.SLUG_CONSUMPTION], int),
                     fmt(row[StockStatusDataSource.SLUG_MONTHS_REMAINING], lambda k: '%.1f' % k),
                     fmt(row[StockStatusDataSource.SLUG_CATEGORY], lambda k: statuses.get(k, k)),
-                    # fmt(row[StockStatusDataSource.SLUG_RESUPPLY_QUANTITY_NEEDED])
                 ]
             yield result
 

--- a/corehq/apps/reports/commtrack/util.py
+++ b/corehq/apps/reports/commtrack/util.py
@@ -6,6 +6,9 @@ from dimagi.ext import jsonobject
 
 
 class StockLedgerValueWrapper(jsonobject.JsonObject):
+    """
+    Wrapper class to abstract StockState and the equivalent model coming out of Elasticsearch
+    """
     domain = jsonobject.StringProperty()
     case_id = jsonobject.StringProperty()
     section_id = jsonobject.StringProperty()

--- a/corehq/apps/reports/commtrack/util.py
+++ b/corehq/apps/reports/commtrack/util.py
@@ -1,4 +1,78 @@
+from django.core.exceptions import ObjectDoesNotExist
+from casexml.apps.stock.consumption import ConsumptionHelper
 from corehq.apps.locations.models import SQLLocation
+from corehq.apps.products.models import SQLProduct
+from dimagi.ext import jsonobject
+
+
+class StockLedgerValueWrapper(jsonobject.JsonObject):
+    domain = jsonobject.StringProperty()
+    case_id = jsonobject.StringProperty()
+    section_id = jsonobject.StringProperty()
+    entry_id = jsonobject.StringProperty()
+    balance = jsonobject.DecimalProperty()  # todo: should this be an int?
+    last_modified = jsonobject.DateTimeProperty()
+    last_modified_form_id = jsonobject.StringProperty()
+    daily_consumption = jsonobject.FloatProperty()
+    location_id = jsonobject.StringProperty()
+
+    _sql_product = None
+    _sql_location = None
+
+    def __init__(self, _obj=None, sql_product=None, sql_location=None, *args, **kwargs):
+        self._sql_product = sql_product
+        self._sql_location = sql_location
+        super(StockLedgerValueWrapper, self).__init__(_obj, *args, **kwargs)
+
+    @property
+    def sql_product(self):
+        if self.entry_id and not self._sql_product:
+            try:
+                self._sql_product = SQLProduct.objects.get(domain=self.domain, product_id=self.entry_id)
+            except ObjectDoesNotExist:
+                # todo: cache this result so multiple failing calls don't keep hitting the DB
+                return None
+
+        return self._sql_product
+
+    @property
+    def sql_location(self):
+        if self.location_id and not self._sql_location:
+            try:
+                self._sql_location = SQLLocation.objects.get(domain=self.domain, location_id=self.location_id)
+            except ObjectDoesNotExist:
+                # todo: cache this result so multiple failing calls don't keep hitting the DB
+                return None
+
+        return self._sql_location
+
+    @classmethod
+    def from_stock_state(cls, stock_state):
+        return cls(
+            case_id=stock_state.case_id,
+            section_id=stock_state.section_id,
+            entry_id=stock_state.product_id,
+            balance=stock_state.stock_on_hand,
+            last_modified=stock_state.last_modified_date,
+            last_modified_form_id=stock_state.last_modified_form_id,
+            daily_consumption=stock_state.daily_consumption,
+            location_id=stock_state.sql_location.location_id if stock_state.sql_location else None,
+            sql_location=stock_state.sql_location,
+            sql_product=stock_state.sql_product,
+        )
+
+
+def get_consumption_helper_from_ledger_value(domain, ledger_value):
+    assert isinstance(ledger_value, StockLedgerValueWrapper)
+    return ConsumptionHelper(
+        domain=domain,
+        case_id=ledger_value.case_id,
+        section_id=ledger_value.section_id,
+        entry_id=ledger_value.entry_id,
+        daily_consumption=ledger_value.daily_consumption,
+        balance=ledger_value.balance,
+        sql_location=ledger_value.sql_location,
+    )
 
 
 def get_relevant_supply_point_ids(domain, active_location=None):

--- a/corehq/ex-submodules/casexml/apps/stock/consumption.py
+++ b/corehq/ex-submodules/casexml/apps/stock/consumption.py
@@ -1,5 +1,6 @@
 import json
 from decimal import Decimal
+from casexml.apps.stock.utils import months_of_stock_remaining
 from corehq.apps.consumption.const import DAYS_IN_MONTH
 
 from dimagi.utils import parsing as dateparse
@@ -37,6 +38,12 @@ class ConsumptionHelper(object):
             return self.daily_consumption * Decimal(DAYS_IN_MONTH)
         else:
             return self.get_default_monthly_consumption()
+
+    def get_months_remaining(self):
+        return months_of_stock_remaining(
+            self.balance,
+            self.get_daily_consumption()
+        )
 
 
 class ConsumptionConfiguration(object):

--- a/corehq/ex-submodules/casexml/apps/stock/consumption.py
+++ b/corehq/ex-submodules/casexml/apps/stock/consumption.py
@@ -8,6 +8,22 @@ from casexml.apps.stock import const
 DEFAULT_CONSUMPTION_FUNCTION = lambda case_id, product_id: None
 
 
+class ConsumptionHelper(object):
+
+    def __init__(self, domain, case_id, section_id, entry_id, daily_consumption, balance):
+        self.domain = domain
+        self.case_id = case_id
+        self.section_id = section_id
+        self.entry_id = entry_id
+        self.daily_consumption = daily_consumption
+        self.balance = balance
+
+    def get_default_monthly_consumption(self):
+        return get_default_monthly_consumption_for_case_and_entry(
+            self.domain, self.case_id, self.entry_id
+        )
+
+
 class ConsumptionConfiguration(object):
     DEFAULT_MIN_PERIODS = 2
     DEFAULT_MIN_WINDOW = 10

--- a/corehq/ex-submodules/casexml/apps/stock/consumption.py
+++ b/corehq/ex-submodules/casexml/apps/stock/consumption.py
@@ -1,6 +1,6 @@
 import json
 from decimal import Decimal
-from casexml.apps.stock.utils import months_of_stock_remaining
+from casexml.apps.stock.utils import months_of_stock_remaining, stock_category
 from corehq.apps.consumption.const import DAYS_IN_MONTH
 
 from dimagi.utils import parsing as dateparse
@@ -61,6 +61,17 @@ class ConsumptionHelper(object):
             return int(max(needed_quantity - self.balance, 0))
         else:
             return None
+
+    def get_stock_category(self):
+        if not self.sql_location:
+            return 'nodata'
+        location_type = self.sql_location.location_type
+        return stock_category(
+            self.balance,
+            self.get_daily_consumption(),
+            location_type.understock_threshold,
+            location_type.overstock_threshold,
+        )
 
 
 class ConsumptionConfiguration(object):

--- a/corehq/ex-submodules/casexml/apps/stock/consumption.py
+++ b/corehq/ex-submodules/casexml/apps/stock/consumption.py
@@ -6,11 +6,15 @@ from corehq.apps.consumption.const import DAYS_IN_MONTH
 from dimagi.utils import parsing as dateparse
 from datetime import datetime, timedelta
 from casexml.apps.stock import const
+from dimagi.utils.decorators.memoized import memoized
 
 DEFAULT_CONSUMPTION_FUNCTION = lambda case_id, product_id: None
 
 
 class ConsumptionHelper(object):
+    """
+    Helper object for dealing with consumption at the individual domain/case/entry level
+    """
 
     def __init__(self, domain, case_id, section_id, entry_id, daily_consumption, balance):
         self.domain = domain
@@ -25,6 +29,7 @@ class ConsumptionHelper(object):
             self.domain, self.case_id, self.entry_id
         )
 
+    @memoized
     def get_daily_consumption(self):
         if self.daily_consumption is not None:
             return self.daily_consumption

--- a/corehq/ex-submodules/casexml/apps/stock/consumption.py
+++ b/corehq/ex-submodules/casexml/apps/stock/consumption.py
@@ -118,6 +118,19 @@ def compute_consumption_or_default(
         )
 
 
+def get_default_monthly_consumption_for_case_and_entry(domain, case_id, entry_id):
+    if domain and domain.commtrack_settings:
+        config = domain.commtrack_settings.get_consumption_config()
+    else:
+        config = None
+
+    return compute_default_monthly_consumption(
+        case_id,
+        entry_id,
+        config
+    )
+
+
 def compute_default_monthly_consumption(case_id, product_id, configuration):
     return configuration.default_monthly_consumption_function(
         case_id,

--- a/corehq/ex-submodules/casexml/apps/stock/consumption.py
+++ b/corehq/ex-submodules/casexml/apps/stock/consumption.py
@@ -16,13 +16,14 @@ class ConsumptionHelper(object):
     Helper object for dealing with consumption at the individual domain/case/entry level
     """
 
-    def __init__(self, domain, case_id, section_id, entry_id, daily_consumption, balance):
+    def __init__(self, domain, case_id, section_id, entry_id, daily_consumption, balance, sql_location):
         self.domain = domain
         self.case_id = case_id
         self.section_id = section_id
         self.entry_id = entry_id
         self.daily_consumption = daily_consumption
         self.balance = balance
+        self.sql_location = sql_location
 
     def get_default_monthly_consumption(self):
         return get_default_monthly_consumption_for_case_and_entry(
@@ -49,6 +50,17 @@ class ConsumptionHelper(object):
             self.balance,
             self.get_daily_consumption()
         )
+
+    def get_resupply_quantity_needed(self):
+        monthly_consumption = self.get_monthly_consumption()
+        if monthly_consumption is not None and self.sql_location is not None:
+            overstock = self.sql_location.location_type.overstock_threshold
+            needed_quantity = int(
+                monthly_consumption * overstock
+            )
+            return int(max(needed_quantity - self.balance, 0))
+        else:
+            return None
 
 
 class ConsumptionConfiguration(object):

--- a/corehq/ex-submodules/casexml/apps/stock/consumption.py
+++ b/corehq/ex-submodules/casexml/apps/stock/consumption.py
@@ -1,5 +1,6 @@
 import json
 from decimal import Decimal
+from corehq.apps.consumption.const import DAYS_IN_MONTH
 
 from dimagi.utils import parsing as dateparse
 from datetime import datetime, timedelta
@@ -22,6 +23,20 @@ class ConsumptionHelper(object):
         return get_default_monthly_consumption_for_case_and_entry(
             self.domain, self.case_id, self.entry_id
         )
+
+    def get_daily_consumption(self):
+        if self.daily_consumption is not None:
+            return self.daily_consumption
+        else:
+            monthly = self.get_default_monthly_consumption()
+            if monthly is not None:
+                return Decimal(monthly) / Decimal(DAYS_IN_MONTH)
+
+    def get_monthly_consumption(self):
+        if self.daily_consumption is not None:
+            return self.daily_consumption * Decimal(DAYS_IN_MONTH)
+        else:
+            return self.get_default_monthly_consumption()
 
 
 class ConsumptionConfiguration(object):

--- a/corehq/ex-submodules/casexml/apps/stock/utils.py
+++ b/corehq/ex-submodules/casexml/apps/stock/utils.py
@@ -30,18 +30,6 @@ def stock_category(stock, daily_consumption, understock, overstock):
         return 'adequate'
 
 
-def state_stock_category(state):
-    if not state.sql_location:
-        return 'nodata'
-    location_type = state.sql_location.location_type
-    return stock_category(
-        state.stock_on_hand,
-        state.get_daily_consumption(),
-        location_type.understock_threshold,
-        location_type.overstock_threshold,
-    )
-
-
 def get_current_ledger_state(case_ids, ensure_form_id=False):
     """
     Given a list of cases returns a dict of all current ledger data of the following format:


### PR DESCRIPTION
mostly just prework to make this easier. high level changes are pulling out the consumption-related utilities into a helper class, and adding an abstraction-layer class that can be used compatibly with `StockState`s and the equivalent model coming out of elasticsearch.

easiest read commit-wise. this only actually changes one code branch of many to use elastic - that change happens here: https://github.com/dimagi/commcare-hq/commit/e5627f57ecb18ed5861006abf635dcac0f3eccbe

@snopoke cc @gcapalbo 
