### PR TITLE
Bump checkbox over

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list_lookup.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list_lookup.html
@@ -113,7 +113,9 @@
                     {% trans "Display results in case list" %}
                 </label>
                 <div class="col-sm-4 checkbox">
-                    <input type="checkbox" data-bind="checked: lookup_display_results"/>
+                    <label>
+                         <input type="checkbox" data-bind="checked: lookup_display_results"/>
+                    </label>
                 </div>
             </div>
             <div data-bind="visible: lookup_display_results">


### PR DESCRIPTION
This markup is oddly squished, at least in Chrome.

before
<img width="588" alt="screen shot 2016-06-15 at 9 54 26 am" src="https://cloud.githubusercontent.com/assets/1486591/16082542/ca884072-32df-11e6-9d2b-8d0ccd7019df.png">

after
<img width="535" alt="screen shot 2016-06-15 at 9 57 37 am" src="https://cloud.githubusercontent.com/assets/1486591/16082546/ce4ba906-32df-11e6-879a-8065bb622209.png">

@kaapstorm / @millerdev 

no test coverage, canceling build
