### PR TITLE
Use OpenClinica flag to show OpenClinica report

### DIFF
--- a/corehq/reports.py
+++ b/corehq/reports.py
@@ -53,6 +53,7 @@ from corehq.apps.smsbillables.interface import (
     SMSGatewayFeeCriteriaInterface,
 )
 from corehq.apps.domain.views import DomainForwardingRepeatRecords
+from custom.openclinica.reports import OdmExportReport
 
 
 def REPORTS(project):
@@ -76,7 +77,7 @@ def REPORTS(project):
             ProjectHealthDashboard,
         )),
         (ugettext_lazy("Inspect Data"), (
-            inspect.SubmitHistory, CaseListReport,
+            inspect.SubmitHistory, CaseListReport, OdmExportReport,
         )),
         (ugettext_lazy("Manage Deployments"), (
             deployments.ApplicationStatusReport,

--- a/custom/openclinica/__init__.py
+++ b/custom/openclinica/__init__.py
@@ -1,8 +1,0 @@
-from custom.openclinica.reports import OdmExportReport
-
-
-CUSTOM_REPORTS = (
-    ('Custom Reports', (
-        OdmExportReport,
-    )),
-)

--- a/custom/openclinica/reports.py
+++ b/custom/openclinica/reports.py
@@ -1,8 +1,9 @@
 from datetime import datetime
 from casexml.apps.case.models import CommCareCase
+from corehq import toggles
 from corehq.apps.reports.datatables import DataTablesHeader, DataTablesColumn
 from corehq.apps.reports.generic import GenericReportView
-from corehq.apps.reports.standard import CustomProjectReport
+from corehq.apps.reports.standard import ProjectReport
 from corehq.apps.reports.standard.cases.basic import CaseListMixin
 from corehq.elastic import SIZE_LIMIT
 from corehq.util.timezones.utils import get_timezone_for_user
@@ -17,7 +18,7 @@ from custom.openclinica.models import Subject
 from custom.openclinica.utils import get_study_constant
 
 
-class OdmExportReport(CustomProjectReport, CaseListMixin, GenericReportView):
+class OdmExportReport(ProjectReport, CaseListMixin, GenericReportView):
     """
     An XML-based export report for OpenClinica integration
 
@@ -28,10 +29,14 @@ class OdmExportReport(CustomProjectReport, CaseListMixin, GenericReportView):
     exportable_all = True
     emailable = True
     asynchronous = True
-    name = "ODM Export"
+    name = "Clinical Study Data"
     slug = "odm_export"
 
     export_format_override = Format.CDISC_ODM
+
+    @classmethod
+    def show_in_navigation(cls, domain=None, project=None, user=None):
+        return toggles.OPENCLINICA.enabled(domain)
 
     @property
     def headers(self):

--- a/settings.py
+++ b/settings.py
@@ -332,6 +332,7 @@ HQ_APPS = (
     'corehq.tabs',
     'custom.apps.wisepill',
     'custom.fri',
+    'custom.openclinica',
     'fluff',
     'fluff.fluff_filter',
     'soil',
@@ -385,7 +386,6 @@ HQ_APPS = (
     'custom.common',
 
     'custom.dhis2',
-    'custom.openclinica',
     'custom.icds_reports',
 )
 
@@ -1756,8 +1756,6 @@ DOMAIN_MODULE_MAP = {
     'pathways-tanzania': 'custom.care_pathways',
     'care-macf-malawi': 'custom.care_pathways',
     'care-macf-bangladesh': 'custom.care_pathways',
-    'kemri': 'custom.openclinica',
-    'novartis': 'custom.openclinica',
 }
 
 CASEXML_FORCE_DOMAIN_CHECK = True


### PR DESCRIPTION
Following up on discussion at #12049, treat the OpenClinica report as a normal report, and show/hide it based on the OpenClinica flag.

I wasn't sure about which section to list the report under. I chose **Inspect Data** because it seemed more appropriate than the others, and renamed the report to "Clinical Study Data". Open to suggestions.

@snopoke cc @sravfeyn 
