### PR TITLE
Catch bad string format when converting to date

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -172,7 +172,11 @@ class ExportColumn(DocumentSchema):
         if self.item.transform:
             value = TRANSFORM_FUNCTIONS[self.item.transform](value, doc)
         if self.deid_transform:
-            value = DEID_TRANSFORM_FUNCTIONS[self.deid_transform](value, doc)
+            try:
+                value = DEID_TRANSFORM_FUNCTIONS[self.deid_transform](value, doc)
+            except ValueError:
+                # Unable to convert the string to a date
+                pass
         return value
 
     @staticmethod


### PR DESCRIPTION
@NoahCarnahan this'll catch errors when attempting to transform a string that isn't a date. We may want to do some intelligent guessing as whether a field can be coerced into a date in the future

http://manage.dimagi.com/default.asp?228907

cc: @biyeun 
