### PR TITLE
Allow '..' in blob filename

### DIFF
--- a/corehq/blobs/s3db.py
+++ b/corehq/blobs/s3db.py
@@ -100,7 +100,10 @@ class S3BlobDB(AbstractBlobDB):
 
 
 def safepath(path):
-    if path.startswith(("/", ".")) or ".." in path or not SAFENAME.match(path):
+    if (path.startswith(("/", ".")) or
+            "/../" in path or
+            path.endswith("/..") or
+            not SAFENAME.match(path)):
         raise BadName(u"unsafe path name: %r" % path)
     return path
 

--- a/corehq/blobs/tests/test_fsdb.py
+++ b/corehq/blobs/tests/test_fsdb.py
@@ -51,6 +51,12 @@ class TestFilesystemBlobDB(TestCase):
         with self.assertRaises(mod.NotFound):
             self.db.get(info.identifier)
 
+    def test_put_with_double_dotted_name(self):
+        name = "nations..mp3"
+        info = self.db.put(StringIO(b"content"), name)
+        with self.db.get(info.identifier) as fh:
+            self.assertEqual(fh.read(), b"content")
+
     def test_delete(self):
         name = "test.4"
         bucket = "doc.4"

--- a/corehq/blobs/tests/test_s3db.py
+++ b/corehq/blobs/tests/test_s3db.py
@@ -122,6 +122,12 @@ class TestS3BlobDB(TestCase):
         with self.assertRaises(mod.NotFound):
             self.db.get(info.identifier)
 
+    def test_put_with_double_dotted_name(self):
+        name = "nations..mp3"
+        info = self.db.put(StringIO(b"content"), name)
+        with self.db.get(info.identifier) as fh:
+            self.assertEqual(fh.read(), b"content")
+
     def test_delete(self):
         name = "test.4"
         bucket = "doc.4"


### PR DESCRIPTION
Ran into a filename containing `..` while migrating staging. Need this to continue the migration.

@snopoke cc @orangejenny 
