### PR TITLE
use pypi for crispy forms

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -52,9 +52,6 @@
 [submodule "corehq/apps/hqmedia/static/hqmedia/MediaUploader"]
 	path = corehq/apps/hqmedia/static/hqmedia/MediaUploader
 	url = git://github.com/dimagi/MediaUploader.git
-[submodule "submodules/bootstrap3_crispy"]
-	path = submodules/bootstrap3_crispy
-	url = https://github.com/dimagi/django-crispy-forms.git
 [submodule "corehq/apps/prelogin"]
 	path = corehq/apps/prelogin
 	url = https://github.com/dimagi/commcarehq-prelogin.git

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -89,3 +89,4 @@ simpleeval==0.8.7
 laboratory==0.2.0
 ConcurrentLogHandler==0.9.1
 github3.py==1.0.0a4
+django-crispy-forms==1.5.2


### PR DESCRIPTION
Get needed upgrades for django 1.8/1.9.  Shouldn't need to use our own submodule now that we use a single version of bootstrap across the site.
