### PR TITLE
Skip builds that don't have submissions and aren't the latest

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -920,8 +920,9 @@ class FormExportDataSchema(ExportDataSchema):
         )
 
         for app_doc in iter_docs(Application.get_db(), app_build_ids):
-            # TODO: Remove this when we mark applications that have been submitted
-            if USE_SQL_BACKEND.enabled(domain) and not app_doc.get('is_released', False):
+            # Skip if it doesn't have submissions and it's not the latest build
+            if (not app_doc.get('has_submissions', False) and
+                    app_build_ids[-1] != app_doc['_id']):
                 continue
 
             app = Application.wrap(app_doc)
@@ -1060,8 +1061,9 @@ class CaseExportDataSchema(ExportDataSchema):
         )
 
         for app_doc in iter_docs(Application.get_db(), app_build_ids):
-            # TODO: Remove this when we mark applications that have been submitted
-            if USE_SQL_BACKEND.enabled(domain) and not app_doc.get('is_released', False):
+            # Skip if it doesn't have submissions and it's not the latest build
+            if (not app_doc.get('has_submissions', False) and
+                    app_build_ids[-1] != app_doc['_id']):
                 continue
             app = Application.wrap(app_doc)
             case_property_mapping = get_case_properties(

--- a/corehq/apps/export/tests/test_export_data_schema.py
+++ b/corehq/apps/export/tests/test_export_data_schema.py
@@ -424,6 +424,50 @@ class TestBuildingSchemaFromApplication(TestCase, TestXmlMixin):
         self.assertEqual(new_schema.last_app_versions[app._id], 6)
         self.assertEqual(len(new_schema.group_schemas), 1)
 
+    def test_has_submissions_flag(self):
+        app = self.current_app
+
+        # After the first schema has been saved let's add a second app to process
+        second_build = Application.wrap(self.get_json('basic_application'))
+        second_build._id = '456'
+        second_build.copy_of = app.get_id
+        second_build.version = 6
+        second_build.save()
+        self.addCleanup(second_build.delete)
+
+        third_build = Application.wrap(self.get_json('basic_application'))
+        third_build._id = '789'
+        third_build.copy_of = app.get_id
+        third_build.version = 7
+        third_build.save()
+        self.addCleanup(third_build.delete)
+
+        with patch(
+                'corehq.apps.export.models.new.FormExportDataSchema._merge_schemas',
+                return_value=FormExportDataSchema()) as mock_merge:
+            new_schema = FormExportDataSchema.generate_schema_from_builds(
+                app.domain,
+                app._id,
+                'my_sweet_xmlns'
+            )
+            self.assertEqual(mock_merge.call_count, 1)
+        self.assertEqual(new_schema.last_app_versions[app._id], 7)
+
+        # Set the second build to have submissions
+        second_build.has_submissions = True
+        second_build.save()
+
+        with patch(
+                'corehq.apps.export.models.new.FormExportDataSchema._merge_schemas',
+                return_value=FormExportDataSchema()) as mock_merge:
+            new_schema = FormExportDataSchema.generate_schema_from_builds(
+                app.domain,
+                app._id,
+                'my_sweet_xmlns',
+                force_rebuild=True,
+            )
+            self.assertEqual(mock_merge.call_count, 2)
+
 
 class TestBuildingCaseSchemaFromApplication(TestCase, TestXmlMixin):
     file_path = ['data']

--- a/corehq/apps/export/tests/test_export_data_schema.py
+++ b/corehq/apps/export/tests/test_export_data_schema.py
@@ -425,6 +425,10 @@ class TestBuildingSchemaFromApplication(TestCase, TestXmlMixin):
         self.assertEqual(len(new_schema.group_schemas), 1)
 
     def test_has_submissions_flag(self):
+        """
+        Ensure that when an app has `has_submissions` set it gets processed, otherwise
+        it should be skipped.
+        """
         app = self.current_app
 
         # After the first schema has been saved let's add a second app to process


### PR DESCRIPTION
@NoahCarnahan @czue this is the logic part of the app tracker pillow that will skip apps if they don't have any submissions or aren't the latest app. hold off on merge until the pillow portion has been merged and has had a chance to run its course

cc: @biyeun 
