### PR TITLE
pad shard ID's

### DIFF
--- a/corehq/sql_db/config.py
+++ b/corehq/sql_db/config.py
@@ -10,7 +10,7 @@ FORM_PROCESSING_GROUP = 'form_processing'
 PROXY_GROUP = 'proxy'
 MAIN_GROUP = 'main'
 
-SHARD_OPTION_TEMPLATE = "p{id} 'dbname={dbname} host={host} port={port}'"
+SHARD_OPTION_TEMPLATE = "p{id:04d} 'dbname={dbname} host={host} port={port}'"
 
 
 class LooslyEqualJsonObject(object):
@@ -140,7 +140,7 @@ def get_shards_to_update(existing_shards, new_shards):
     assert len(existing_shards) == len(new_shards)
     shards_to_update = []
     for existing, new in zip(existing_shards, new_shards):
-        assert existing.id == new.id
+        assert existing.id == new.id, '{} != {}'.format(existing.id, new.id)
         if existing != new:
             shards_to_update.append(new)
 

--- a/corehq/sql_db/management/commands/configure_pl_proxy_cluster.py
+++ b/corehq/sql_db/management/commands/configure_pl_proxy_cluster.py
@@ -135,7 +135,7 @@ def _get_existing_cluster_config(cluster_name):
     proxy_db = PartitionConfig().get_proxy_db()
     with connections[proxy_db].cursor() as cursor:
         cursor.execute('SELECT * from pg_foreign_server where srvname = %s', [cluster_name])
-        results = fetchall_as_namedtuple(cursor)
+        results = list(fetchall_as_namedtuple(cursor))
         if results:
             return results[0]
 

--- a/corehq/sql_db/tests/test_partition_config.py
+++ b/corehq/sql_db/tests/test_partition_config.py
@@ -105,12 +105,12 @@ class PlProxyTests(SimpleTestCase):
 
     def test_get_server_option_string(self):
         self.assertEqual(
-            "p0 'dbname=db1 host=hqdb0 port=5432'",
+            "p0000 'dbname=db1 host=hqdb0 port=5432'",
             ShardMeta(id=0, dbname='db1', host='hqdb0', port=5432).get_server_option_string()
         )
 
     def test_parse_existing_shard(self):
-        parsed = parse_existing_shard('p1=dbname=db1 host=hqdb0 port=5432')
+        parsed = parse_existing_shard('p0001=dbname=db1 host=hqdb0 port=5432')
         self.assertEqual(ShardMeta(id=1, dbname='db1', host='hqdb0', port=5432), parsed)
 
         parsed = parse_existing_shard('p25=dbname=db2 host=hqdb1 port=6432')


### PR DESCRIPTION
This may seem obvious but PostgreSQL sorts shards by name e.g. p2, p20 p200, p21

The desired ordering is maintained.

This shouldn't affect any existing config since we shouldn't ever need to re-create it. Can discuss more in the next meeting.

@dimagi/scale-team 
