### PR TITLE
explicitly pass parameters to ensure_plans

### DIFF
--- a/corehq/apps/accounting/generator.py
+++ b/corehq/apps/accounting/generator.py
@@ -37,15 +37,6 @@ from corehq.apps.smsbillables.models import (
 from corehq.apps.domain.models import Domain
 from corehq.apps.users.models import WebUser, CommCareUser
 
-# don't actually use the plan lists below for initializing new plans! the amounts have been changed to make
-# it easier for testing:
-
-SUBSCRIBABLE_EDITIONS = [
-    SoftwarePlanEdition.ADVANCED,
-    SoftwarePlanEdition.PRO,
-    SoftwarePlanEdition.STANDARD,
-]
-
 
 def instantiate_accounting_for_tests():
     call_command('cchq_prbac_bootstrap', testing=True)

--- a/corehq/apps/accounting/generator.py
+++ b/corehq/apps/accounting/generator.py
@@ -13,9 +13,22 @@ from corehq.apps.smsbillables.generator import DIRECTIONS
 from dimagi.utils.data import generator as data_gen
 
 from corehq.apps.accounting.models import (
-    Currency, BillingAccount, Subscription, Subscriber, SoftwareProductType,
-    DefaultProductPlan, SubscriptionAdjustment,
-    SoftwarePlanEdition, BillingContactInfo, SubscriptionType,
+    BillingAccount,
+    BillingContactInfo,
+    Currency,
+    DefaultProductPlan,
+    Feature,
+    FeatureRate,
+    SoftwarePlan,
+    SoftwarePlanEdition,
+    SoftwareProductType,
+    Subscriber,
+    Subscription,
+    SubscriptionAdjustment,
+    SubscriptionType,
+    SoftwarePlanVersion,
+    SoftwareProduct,
+    SoftwareProductRate,
 )
 from corehq.apps.smsbillables.models import (
     SmsGatewayFee, SmsGatewayFeeCriteria, SmsUsageFee, SmsUsageFeeCriteria,
@@ -36,7 +49,15 @@ SUBSCRIBABLE_EDITIONS = [
 
 def instantiate_accounting_for_tests():
     call_command('cchq_prbac_bootstrap', testing=True)
-    call_command('cchq_software_plan_bootstrap', testing=True, fresh_start=True)
+
+    DefaultProductPlan.objects.all().delete()
+    SoftwarePlanVersion.objects.all().delete()
+    SoftwarePlan.objects.all().delete()
+    SoftwareProductRate.objects.all().delete()
+    SoftwareProduct.objects.all().delete()
+    FeatureRate.objects.all().delete()
+    Feature.objects.all().delete()
+    call_command('cchq_software_plan_bootstrap', testing=True)
 
 
 def init_default_currency():

--- a/corehq/apps/accounting/generator.py
+++ b/corehq/apps/accounting/generator.py
@@ -9,7 +9,6 @@ import mock
 from django.conf import settings
 from django.core.management import call_command
 
-from corehq.apps.smsbillables.generator import DIRECTIONS
 from dimagi.utils.data import generator as data_gen
 
 from corehq.apps.accounting.models import (
@@ -30,11 +29,15 @@ from corehq.apps.accounting.models import (
     SoftwareProduct,
     SoftwareProductRate,
 )
-from corehq.apps.smsbillables.models import (
-    SmsGatewayFee, SmsGatewayFeeCriteria, SmsUsageFee, SmsUsageFeeCriteria,
-    SmsBillable,
-)
 from corehq.apps.domain.models import Domain
+from corehq.apps.smsbillables.generator import DIRECTIONS
+from corehq.apps.smsbillables.models import (
+    SmsBillable,
+    SmsGatewayFee,
+    SmsGatewayFeeCriteria,
+    SmsUsageFee,
+    SmsUsageFeeCriteria,
+)
 from corehq.apps.users.models import WebUser, CommCareUser
 
 

--- a/corehq/apps/accounting/management/commands/cchq_software_plan_bootstrap.py
+++ b/corehq/apps/accounting/management/commands/cchq_software_plan_bootstrap.py
@@ -37,6 +37,52 @@ EDITIONS = [
 FEATURE_TYPES = [f[0] for f in FeatureType.CHOICES]
 PRODUCT_TYPES = [p[0] for p in SoftwareProductType.CHOICES]
 
+BOOTSTRAP_FEATURE_RATES = {
+    SoftwarePlanEdition.COMMUNITY: {
+        FeatureType.USER: dict(monthly_limit=50, per_excess_fee=Decimal('1.00')),
+        FeatureType.SMS: dict(monthly_limit=0),
+    },
+    SoftwarePlanEdition.STANDARD: {
+        FeatureType.USER: dict(monthly_limit=100, per_excess_fee=Decimal('1.00')),
+        FeatureType.SMS: dict(monthly_limit=100),
+    },
+    SoftwarePlanEdition.PRO: {
+        FeatureType.USER: dict(monthly_limit=500, per_excess_fee=Decimal('1.00')),
+        FeatureType.SMS: dict(monthly_limit=500),
+    },
+    SoftwarePlanEdition.ADVANCED: {
+        FeatureType.USER: dict(monthly_limit=1000, per_excess_fee=Decimal('1.00')),
+        FeatureType.SMS: dict(monthly_limit=1000),
+    },
+    SoftwarePlanEdition.ENTERPRISE: {
+        FeatureType.USER: dict(monthly_limit=UNLIMITED_FEATURE_USAGE, per_excess_fee=Decimal('0.00')),
+        FeatureType.SMS: dict(monthly_limit=UNLIMITED_FEATURE_USAGE),
+    },
+}
+
+BOOTSTRAP_FEATURE_RATES_FOR_TESTING = {
+    SoftwarePlanEdition.COMMUNITY: {
+        FeatureType.USER: dict(monthly_limit=2, per_excess_fee=Decimal('1.00')),
+        FeatureType.SMS: dict(monthly_limit=0),
+    },
+    SoftwarePlanEdition.STANDARD: {
+        FeatureType.USER: dict(monthly_limit=4, per_excess_fee=Decimal('1.00')),
+        FeatureType.SMS: dict(monthly_limit=3),
+    },
+    SoftwarePlanEdition.PRO: {
+        FeatureType.USER: dict(monthly_limit=6, per_excess_fee=Decimal('1.00')),
+        FeatureType.SMS: dict(monthly_limit=5),
+    },
+    SoftwarePlanEdition.ADVANCED: {
+        FeatureType.USER: dict(monthly_limit=8, per_excess_fee=Decimal('1.00')),
+        FeatureType.SMS: dict(monthly_limit=7),
+    },
+    SoftwarePlanEdition.ENTERPRISE: {
+        FeatureType.USER: dict(monthly_limit=UNLIMITED_FEATURE_USAGE, per_excess_fee=Decimal('0.00')),
+        FeatureType.SMS: dict(monthly_limit=UNLIMITED_FEATURE_USAGE),
+    },
+}
+
 
 class Command(BaseCommand):
     help = 'Populate a fresh db with standard set of Software Plans.'
@@ -246,34 +292,12 @@ def _ensure_feature_rates(features, edition, dry_run, verbose, for_tests, apps):
         logger.info('Ensuring Feature Rates')
 
     feature_rates = []
-    BOOTSTRAP_FEATURE_RATES = {
-        SoftwarePlanEdition.COMMUNITY: {
-            FeatureType.USER: FeatureRate(monthly_limit=2 if for_tests else 50,
-                                          per_excess_fee=Decimal('1.00')),
-            FeatureType.SMS: FeatureRate(monthly_limit=0),  # use defaults here
-        },
-        SoftwarePlanEdition.STANDARD: {
-            FeatureType.USER: FeatureRate(monthly_limit=4 if for_tests else 100,
-                                          per_excess_fee=Decimal('1.00')),
-            FeatureType.SMS: FeatureRate(monthly_limit=3 if for_tests else 100),
-        },
-        SoftwarePlanEdition.PRO: {
-            FeatureType.USER: FeatureRate(monthly_limit=6 if for_tests else 500,
-                                          per_excess_fee=Decimal('1.00')),
-            FeatureType.SMS: FeatureRate(monthly_limit=5 if for_tests else 500),
-        },
-        SoftwarePlanEdition.ADVANCED: {
-            FeatureType.USER: FeatureRate(monthly_limit=8 if for_tests else 1000,
-                                          per_excess_fee=Decimal('1.00')),
-            FeatureType.SMS: FeatureRate(monthly_limit=7 if for_tests else 1000),
-        },
-        SoftwarePlanEdition.ENTERPRISE: {
-            FeatureType.USER: FeatureRate(monthly_limit=UNLIMITED_FEATURE_USAGE, per_excess_fee=Decimal('0.00')),
-            FeatureType.SMS: FeatureRate(monthly_limit=UNLIMITED_FEATURE_USAGE),
-        },
-    }
     for feature in features:
-        feature_rate = BOOTSTRAP_FEATURE_RATES[edition][feature.feature_type]
+        feature_rate_params = (
+            BOOTSTRAP_FEATURE_RATES_FOR_TESTING
+            if for_tests else BOOTSTRAP_FEATURE_RATES
+        )[edition][feature.feature_type]
+        feature_rate = FeatureRate(**feature_rate_params)
         feature_rate.feature = feature
         if dry_run:
             logger.info("[DRY RUN] Creating rate for feature '%s': %s" % (feature.name, feature_rate))

--- a/corehq/apps/accounting/management/commands/cchq_software_plan_bootstrap.py
+++ b/corehq/apps/accounting/management/commands/cchq_software_plan_bootstrap.py
@@ -111,10 +111,14 @@ class Command(BaseCommand):
         if for_tests:
             logger.info("Initializing Plans and Roles for Testing")
 
-        ensure_plans(dry_run=dry_run, verbose=verbose, for_tests=for_tests, apps=default_apps)
+        ensure_plans(
+            edition_to_role=BOOTSTRAP_EDITION_TO_ROLE,
+            dry_run=dry_run, verbose=verbose, for_tests=for_tests, apps=default_apps,
+        )
 
 
-def ensure_plans(dry_run, verbose, for_tests, apps):
+def ensure_plans(edition_to_role,
+                 dry_run, verbose, for_tests, apps):
     DefaultProductPlan = apps.get_model('accounting', 'DefaultProductPlan')
     SoftwarePlan = apps.get_model('accounting', 'SoftwarePlan')
     SoftwarePlanVersion = apps.get_model('accounting', 'SoftwarePlanVersion')
@@ -123,7 +127,7 @@ def ensure_plans(dry_run, verbose, for_tests, apps):
     edition_to_features = _ensure_features(dry_run=dry_run, verbose=verbose, apps=apps)
     for product_type in PRODUCT_TYPES:
         for edition in EDITIONS:
-            role_slug = BOOTSTRAP_EDITION_TO_ROLE[edition]
+            role_slug = edition_to_role[edition]
             try:
                 role = Role.objects.get(slug=role_slug)
             except Role.DoesNotExist:

--- a/corehq/apps/accounting/management/commands/cchq_software_plan_bootstrap.py
+++ b/corehq/apps/accounting/management/commands/cchq_software_plan_bootstrap.py
@@ -38,21 +38,11 @@ FEATURE_TYPES = [f[0] for f in FeatureType.CHOICES]
 PRODUCT_TYPES = [p[0] for p in SoftwareProductType.CHOICES]
 
 BOOTSTRAP_PRODUCT_RATES = {
-    SoftwarePlanEdition.COMMUNITY: [
-        dict(),
-    ],
-    SoftwarePlanEdition.STANDARD: [
-        dict(monthly_fee=Decimal('100.00')),
-    ],
-    SoftwarePlanEdition.PRO: [
-        dict(monthly_fee=Decimal('500.00')),
-    ],
-    SoftwarePlanEdition.ADVANCED: [
-        dict(monthly_fee=Decimal('1000.00')),
-    ],
-    SoftwarePlanEdition.ENTERPRISE: [
-        dict(monthly_fee=Decimal('0.00')),
-    ],
+    SoftwarePlanEdition.COMMUNITY: dict(),
+    SoftwarePlanEdition.STANDARD: dict(monthly_fee=Decimal('100.00')),
+    SoftwarePlanEdition.PRO: dict(monthly_fee=Decimal('500.00')),
+    SoftwarePlanEdition.ADVANCED: dict(monthly_fee=Decimal('1000.00')),
+    SoftwarePlanEdition.ENTERPRISE: dict(monthly_fee=Decimal('0.00')),
 }
 
 BOOTSTRAP_FEATURE_RATES = {
@@ -226,30 +216,26 @@ def _ensure_product_and_rate(product_type, edition, dry_run, verbose, apps):
     if edition == SoftwarePlanEdition.ENTERPRISE:
         product.name = "Dimagi Only %s" % product.name
 
-    product_rates = []
-
-    for product_rate in BOOTSTRAP_PRODUCT_RATES[edition]:
-        product_rate = SoftwareProductRate(**product_rate)
-        if dry_run:
-            logger.info("[DRY RUN] Creating Product: %s" % product)
-            logger.info("[DRY RUN] Corresponding product rate of $%d created." % product_rate.monthly_fee)
-        else:
-            try:
-                product = SoftwareProduct.objects.get(name=product.name)
-                if verbose:
-                    logger.info("Product '%s' already exists. Using "
-                                "existing product to add rate."
-                                % product.name)
-            except SoftwareProduct.DoesNotExist:
-                product.save()
-                if verbose:
-                    logger.info("Creating Product: %s" % product)
+    product_rate = SoftwareProductRate(**BOOTSTRAP_PRODUCT_RATES[edition])
+    if dry_run:
+        logger.info("[DRY RUN] Creating Product: %s" % product)
+        logger.info("[DRY RUN] Corresponding product rate of $%d created." % product_rate.monthly_fee)
+    else:
+        try:
+            product = SoftwareProduct.objects.get(name=product.name)
             if verbose:
-                logger.info("Corresponding product rate of $%d created."
-                            % product_rate.monthly_fee)
-        product_rate.product = product
-        product_rates.append(product_rate)
-    return product, product_rates
+                logger.info("Product '%s' already exists. Using "
+                            "existing product to add rate."
+                            % product.name)
+        except SoftwareProduct.DoesNotExist:
+            product.save()
+            if verbose:
+                logger.info("Creating Product: %s" % product)
+        if verbose:
+            logger.info("Corresponding product rate of $%d created."
+                        % product_rate.monthly_fee)
+    product_rate.product = product
+    return product, [product_rate]
 
 
 def _ensure_features(dry_run, verbose, apps):

--- a/corehq/apps/accounting/management/commands/cchq_software_plan_bootstrap.py
+++ b/corehq/apps/accounting/management/commands/cchq_software_plan_bootstrap.py
@@ -118,18 +118,19 @@ class Command(BaseCommand):
             edition_to_role=BOOTSTRAP_EDITION_TO_ROLE,
             edition_to_product_rate=BOOTSTRAP_PRODUCT_RATES,
             edition_to_feature_rate=edition_to_feature_rate,
+            feature_types=FEATURE_TYPES,
             dry_run=dry_run, verbose=verbose, for_tests=for_tests, apps=default_apps,
         )
 
 
-def ensure_plans(edition_to_role, edition_to_product_rate, edition_to_feature_rate,
+def ensure_plans(edition_to_role, edition_to_product_rate, edition_to_feature_rate, feature_types,
                  dry_run, verbose, for_tests, apps):
     DefaultProductPlan = apps.get_model('accounting', 'DefaultProductPlan')
     SoftwarePlan = apps.get_model('accounting', 'SoftwarePlan')
     SoftwarePlanVersion = apps.get_model('accounting', 'SoftwarePlanVersion')
     Role = apps.get_model('django_prbac', 'Role')
 
-    edition_to_features = _ensure_features(dry_run=dry_run, verbose=verbose, apps=apps)
+    edition_to_features = _ensure_features(feature_types, dry_run=dry_run, verbose=verbose, apps=apps)
     for product_type in PRODUCT_TYPES:
         for edition in EDITIONS:
             role_slug = edition_to_role[edition]
@@ -251,7 +252,7 @@ def _ensure_product_and_rate(edition_to_product_rate, product_type, edition, dry
     return product, product_rate
 
 
-def _ensure_features(dry_run, verbose, apps):
+def _ensure_features(feature_types, dry_run, verbose, apps):
     """
     Ensures that all the Features necessary for the plans are created.
     """
@@ -262,7 +263,7 @@ def _ensure_features(dry_run, verbose, apps):
 
     edition_to_features = defaultdict(list)
     for edition in EDITIONS:
-        for feature_type in FEATURE_TYPES:
+        for feature_type in feature_types:
             feature = Feature(name='%s %s' % (feature_type, edition), feature_type=feature_type)
             if edition == SoftwarePlanEdition.ENTERPRISE:
                 feature.name = "Dimagi Only %s" % feature.name

--- a/corehq/apps/accounting/management/commands/cchq_software_plan_bootstrap.py
+++ b/corehq/apps/accounting/management/commands/cchq_software_plan_bootstrap.py
@@ -42,11 +42,11 @@ class Command(BaseCommand):
     help = 'Populate a fresh db with standard set of Software Plans.'
 
     option_list = BaseCommand.option_list + (
-        make_option('--dry-run', action='store_true',  default=False,
+        make_option('--dry-run', action='store_true', default=False,
                     help='Do not actually modify the database, just verbosely log what happen'),
-        make_option('--verbose', action='store_true',  default=False,
+        make_option('--verbose', action='store_true', default=False,
                     help='Enable debug output'),
-        make_option('--testing', action='store_true',  default=False,
+        make_option('--testing', action='store_true', default=False,
                     help='Run this command for testing purposes.'),
     )
 

--- a/corehq/apps/accounting/management/commands/cchq_software_plan_bootstrap.py
+++ b/corehq/apps/accounting/management/commands/cchq_software_plan_bootstrap.py
@@ -119,11 +119,12 @@ class Command(BaseCommand):
             edition_to_product_rate=BOOTSTRAP_PRODUCT_RATES,
             edition_to_feature_rate=edition_to_feature_rate,
             feature_types=FEATURE_TYPES,
+            product_types=PRODUCT_TYPES,
             dry_run=dry_run, verbose=verbose, for_tests=for_tests, apps=default_apps,
         )
 
 
-def ensure_plans(edition_to_role, edition_to_product_rate, edition_to_feature_rate, feature_types,
+def ensure_plans(edition_to_role, edition_to_product_rate, edition_to_feature_rate, feature_types, product_types,
                  dry_run, verbose, for_tests, apps):
     DefaultProductPlan = apps.get_model('accounting', 'DefaultProductPlan')
     SoftwarePlan = apps.get_model('accounting', 'SoftwarePlan')
@@ -131,7 +132,7 @@ def ensure_plans(edition_to_role, edition_to_product_rate, edition_to_feature_ra
     Role = apps.get_model('django_prbac', 'Role')
 
     edition_to_features = _ensure_features(feature_types, dry_run=dry_run, verbose=verbose, apps=apps)
-    for product_type in PRODUCT_TYPES:
+    for product_type in product_types:
         for edition in EDITIONS:
             role_slug = edition_to_role[edition]
             try:

--- a/corehq/apps/accounting/management/commands/cchq_software_plan_bootstrap.py
+++ b/corehq/apps/accounting/management/commands/cchq_software_plan_bootstrap.py
@@ -51,7 +51,7 @@ class Command(BaseCommand):
     )
 
     def handle(self, dry_run=False, verbose=False, testing=False, *args, **options):
-        logger.info('Bootstrapping standard plans. Enterprise plans will have to be created via the admin UIs.')
+        logger.info('Bootstrapping standard plans. Custom plans will have to be created via the admin UIs.')
 
         for_tests = testing
         if for_tests:

--- a/corehq/apps/accounting/management/commands/cchq_software_plan_bootstrap.py
+++ b/corehq/apps/accounting/management/commands/cchq_software_plan_bootstrap.py
@@ -132,7 +132,7 @@ def ensure_plans(dry_run, verbose, for_tests, apps):
                 return
             software_plan_version = SoftwarePlanVersion(role=role)
 
-            product, product_rates = _ensure_product_and_rate(product_type, edition, dry_run=dry_run, verbose=verbose, apps=apps)
+            product, product_rate = _ensure_product_and_rate(product_type, edition, dry_run=dry_run, verbose=verbose, apps=apps)
             feature_rates = _ensure_feature_rates(edition_to_features[edition], edition, dry_run=dry_run, verbose=verbose, for_tests=for_tests, apps=apps)
             software_plan = SoftwarePlan(
                 name='%s Edition' % product.name, edition=edition, visibility=SoftwarePlanVisibility.PUBLIC
@@ -156,15 +156,13 @@ def ensure_plans(dry_run, verbose, for_tests, apps):
                     if hasattr(SoftwarePlanVersion, 'product_rates'):
                         software_plan_version.save()
 
-                    for product_rate in product_rates:
-                        product_rate.save()
-                        if hasattr(SoftwarePlanVersion, 'product_rates'):
-                            software_plan_version.product_rates.add(product_rate)
-                        elif hasattr(SoftwarePlanVersion, 'product_rate'):
-                            assert len(product_rates) == 1
-                            software_plan_version.product_rate = product_rate
-                        else:
-                            raise AccountingError('SoftwarePlanVersion does not have product_rate or product_rates field')
+                    product_rate.save()
+                    if hasattr(SoftwarePlanVersion, 'product_rates'):
+                        software_plan_version.product_rates.add(product_rate)
+                    elif hasattr(SoftwarePlanVersion, 'product_rate'):
+                        software_plan_version.product_rate = product_rate
+                    else:
+                        raise AccountingError('SoftwarePlanVersion does not have product_rate or product_rates field')
 
                     # must save before assigning many-to-many relationship
                     if hasattr(SoftwarePlanVersion, 'product_rate'):
@@ -235,7 +233,7 @@ def _ensure_product_and_rate(product_type, edition, dry_run, verbose, apps):
             logger.info("Corresponding product rate of $%d created."
                         % product_rate.monthly_fee)
     product_rate.product = product
-    return product, [product_rate]
+    return product, product_rate
 
 
 def _ensure_features(dry_run, verbose, apps):

--- a/corehq/apps/accounting/management/commands/cchq_software_plan_bootstrap.py
+++ b/corehq/apps/accounting/management/commands/cchq_software_plan_bootstrap.py
@@ -28,8 +28,15 @@ BOOTSTRAP_EDITION_TO_ROLE = {
     SoftwarePlanEdition.ENTERPRISE: 'enterprise_plan_v0',
 }
 
-FEATURE_TYPES = [f[0] for f in FeatureType.CHOICES]
-PRODUCT_TYPES = [p[0] for p in SoftwareProductType.CHOICES]
+FEATURE_TYPES = [
+    FeatureType.USER,
+    FeatureType.SMS,
+]
+PRODUCT_TYPES = [
+    SoftwareProductType.COMMCARE,
+    SoftwareProductType.COMMCONNECT,
+    SoftwareProductType.COMMTRACK,
+]
 
 BOOTSTRAP_PRODUCT_RATES = {
     SoftwarePlanEdition.COMMUNITY: dict(),

--- a/corehq/apps/accounting/management/commands/cchq_software_plan_bootstrap.py
+++ b/corehq/apps/accounting/management/commands/cchq_software_plan_bootstrap.py
@@ -27,13 +27,7 @@ BOOTSTRAP_EDITION_TO_ROLE = {
     SoftwarePlanEdition.ADVANCED: 'advanced_plan_v0',
     SoftwarePlanEdition.ENTERPRISE: 'enterprise_plan_v0',
 }
-EDITIONS = [
-    SoftwarePlanEdition.COMMUNITY,
-    SoftwarePlanEdition.STANDARD,
-    SoftwarePlanEdition.PRO,
-    SoftwarePlanEdition.ADVANCED,
-    SoftwarePlanEdition.ENTERPRISE,
-]
+
 FEATURE_TYPES = [f[0] for f in FeatureType.CHOICES]
 PRODUCT_TYPES = [p[0] for p in SoftwareProductType.CHOICES]
 
@@ -131,9 +125,10 @@ def ensure_plans(edition_to_role, edition_to_product_rate, edition_to_feature_ra
     SoftwarePlanVersion = apps.get_model('accounting', 'SoftwarePlanVersion')
     Role = apps.get_model('django_prbac', 'Role')
 
-    edition_to_features = _ensure_features(feature_types, dry_run=dry_run, verbose=verbose, apps=apps)
+    editions = edition_to_role.keys()
+    edition_to_features = _ensure_features(feature_types, editions, dry_run=dry_run, verbose=verbose, apps=apps)
     for product_type in product_types:
-        for edition in EDITIONS:
+        for edition in editions:
             role_slug = edition_to_role[edition]
             try:
                 role = Role.objects.get(slug=role_slug)
@@ -253,7 +248,7 @@ def _ensure_product_and_rate(edition_to_product_rate, product_type, edition, dry
     return product, product_rate
 
 
-def _ensure_features(feature_types, dry_run, verbose, apps):
+def _ensure_features(feature_types, editions, dry_run, verbose, apps):
     """
     Ensures that all the Features necessary for the plans are created.
     """
@@ -263,7 +258,7 @@ def _ensure_features(feature_types, dry_run, verbose, apps):
         logger.info('Ensuring Features')
 
     edition_to_features = defaultdict(list)
-    for edition in EDITIONS:
+    for edition in editions:
         for feature_type in feature_types:
             feature = Feature(name='%s %s' % (feature_type, edition), feature_type=feature_type)
             if edition == SoftwarePlanEdition.ENTERPRISE:

--- a/corehq/apps/accounting/management/commands/cchq_software_plan_bootstrap.py
+++ b/corehq/apps/accounting/management/commands/cchq_software_plan_bootstrap.py
@@ -37,6 +37,24 @@ EDITIONS = [
 FEATURE_TYPES = [f[0] for f in FeatureType.CHOICES]
 PRODUCT_TYPES = [p[0] for p in SoftwareProductType.CHOICES]
 
+BOOTSTRAP_PRODUCT_RATES = {
+    SoftwarePlanEdition.COMMUNITY: [
+        dict(),
+    ],
+    SoftwarePlanEdition.STANDARD: [
+        dict(monthly_fee=Decimal('100.00')),
+    ],
+    SoftwarePlanEdition.PRO: [
+        dict(monthly_fee=Decimal('500.00')),
+    ],
+    SoftwarePlanEdition.ADVANCED: [
+        dict(monthly_fee=Decimal('1000.00')),
+    ],
+    SoftwarePlanEdition.ENTERPRISE: [
+        dict(monthly_fee=Decimal('0.00')),
+    ],
+}
+
 BOOTSTRAP_FEATURE_RATES = {
     SoftwarePlanEdition.COMMUNITY: {
         FeatureType.USER: dict(monthly_limit=50, per_excess_fee=Decimal('1.00')),
@@ -209,25 +227,9 @@ def _ensure_product_and_rate(product_type, edition, dry_run, verbose, apps):
         product.name = "Dimagi Only %s" % product.name
 
     product_rates = []
-    BOOTSTRAP_PRODUCT_RATES = {
-        SoftwarePlanEdition.COMMUNITY: [
-            SoftwareProductRate(),  # use all the defaults
-        ],
-        SoftwarePlanEdition.STANDARD: [
-            SoftwareProductRate(monthly_fee=Decimal('100.00')),
-        ],
-        SoftwarePlanEdition.PRO: [
-            SoftwareProductRate(monthly_fee=Decimal('500.00')),
-        ],
-        SoftwarePlanEdition.ADVANCED: [
-            SoftwareProductRate(monthly_fee=Decimal('1000.00')),
-        ],
-        SoftwarePlanEdition.ENTERPRISE: [
-            SoftwareProductRate(monthly_fee=Decimal('0.00')),
-        ],
-    }
 
     for product_rate in BOOTSTRAP_PRODUCT_RATES[edition]:
+        product_rate = SoftwareProductRate(**product_rate)
         if dry_run:
             logger.info("[DRY RUN] Creating Product: %s" % product)
             logger.info("[DRY RUN] Corresponding product rate of $%d created." % product_rate.monthly_fee)

--- a/corehq/apps/accounting/migrations/0003_bootstrap.py
+++ b/corehq/apps/accounting/migrations/0003_bootstrap.py
@@ -6,6 +6,7 @@ from django.db import migrations
 from corehq.apps.accounting.management.commands.cchq_software_plan_bootstrap import ensure_plans
 from corehq.apps.accounting.management.commands.cchq_software_plan_bootstrap import (
     BOOTSTRAP_EDITION_TO_ROLE,
+    BOOTSTRAP_PRODUCT_RATES,
 )
 from corehq.sql_db.operations import HqRunPython
 
@@ -13,6 +14,7 @@ from corehq.sql_db.operations import HqRunPython
 def cchq_software_plan_bootstrap(apps, schema_editor):
     ensure_plans(
         edition_to_role=BOOTSTRAP_EDITION_TO_ROLE,
+        edition_to_product_rate=BOOTSTRAP_PRODUCT_RATES,
         dry_run=False, verbose=True, for_tests=False, apps=apps,
     )
 

--- a/corehq/apps/accounting/migrations/0003_bootstrap.py
+++ b/corehq/apps/accounting/migrations/0003_bootstrap.py
@@ -6,6 +6,7 @@ from django.db import migrations
 from corehq.apps.accounting.management.commands.cchq_software_plan_bootstrap import ensure_plans
 from corehq.apps.accounting.management.commands.cchq_software_plan_bootstrap import (
     BOOTSTRAP_EDITION_TO_ROLE,
+    BOOTSTRAP_FEATURE_RATES,
     BOOTSTRAP_PRODUCT_RATES,
 )
 from corehq.sql_db.operations import HqRunPython
@@ -15,6 +16,7 @@ def cchq_software_plan_bootstrap(apps, schema_editor):
     ensure_plans(
         edition_to_role=BOOTSTRAP_EDITION_TO_ROLE,
         edition_to_product_rate=BOOTSTRAP_PRODUCT_RATES,
+        edition_to_feature_rate=BOOTSTRAP_FEATURE_RATES,
         dry_run=False, verbose=True, for_tests=False, apps=apps,
     )
 

--- a/corehq/apps/accounting/migrations/0003_bootstrap.py
+++ b/corehq/apps/accounting/migrations/0003_bootstrap.py
@@ -9,6 +9,7 @@ from corehq.apps.accounting.management.commands.cchq_software_plan_bootstrap imp
     BOOTSTRAP_FEATURE_RATES,
     BOOTSTRAP_PRODUCT_RATES,
     FEATURE_TYPES,
+    PRODUCT_TYPES,
 )
 from corehq.sql_db.operations import HqRunPython
 
@@ -19,6 +20,7 @@ def cchq_software_plan_bootstrap(apps, schema_editor):
         edition_to_product_rate=BOOTSTRAP_PRODUCT_RATES,
         edition_to_feature_rate=BOOTSTRAP_FEATURE_RATES,
         feature_types=FEATURE_TYPES,
+        product_types=PRODUCT_TYPES,
         dry_run=False, verbose=True, for_tests=False, apps=apps,
     )
 

--- a/corehq/apps/accounting/migrations/0003_bootstrap.py
+++ b/corehq/apps/accounting/migrations/0003_bootstrap.py
@@ -8,6 +8,7 @@ from corehq.apps.accounting.management.commands.cchq_software_plan_bootstrap imp
     BOOTSTRAP_EDITION_TO_ROLE,
     BOOTSTRAP_FEATURE_RATES,
     BOOTSTRAP_PRODUCT_RATES,
+    FEATURE_TYPES,
 )
 from corehq.sql_db.operations import HqRunPython
 
@@ -17,6 +18,7 @@ def cchq_software_plan_bootstrap(apps, schema_editor):
         edition_to_role=BOOTSTRAP_EDITION_TO_ROLE,
         edition_to_product_rate=BOOTSTRAP_PRODUCT_RATES,
         edition_to_feature_rate=BOOTSTRAP_FEATURE_RATES,
+        feature_types=FEATURE_TYPES,
         dry_run=False, verbose=True, for_tests=False, apps=apps,
     )
 

--- a/corehq/apps/accounting/migrations/0003_bootstrap.py
+++ b/corehq/apps/accounting/migrations/0003_bootstrap.py
@@ -4,11 +4,17 @@ from __future__ import unicode_literals
 from django.db import migrations
 
 from corehq.apps.accounting.management.commands.cchq_software_plan_bootstrap import ensure_plans
+from corehq.apps.accounting.management.commands.cchq_software_plan_bootstrap import (
+    BOOTSTRAP_EDITION_TO_ROLE,
+)
 from corehq.sql_db.operations import HqRunPython
 
 
 def cchq_software_plan_bootstrap(apps, schema_editor):
-    ensure_plans(dry_run=False, verbose=True, for_tests=False, apps=apps)
+    ensure_plans(
+        edition_to_role=BOOTSTRAP_EDITION_TO_ROLE,
+        dry_run=False, verbose=True, for_tests=False, apps=apps,
+    )
 
 
 class Migration(migrations.Migration):

--- a/corehq/apps/hqadmin/tests/test_prbac.py
+++ b/corehq/apps/hqadmin/tests/test_prbac.py
@@ -9,6 +9,15 @@ from django.core.management import call_command
 from django_prbac.models import Grant, Role
 
 # CCHQ imports
+from corehq.apps.accounting.models import (
+    DefaultProductPlan,
+    Feature,
+    FeatureRate,
+    SoftwarePlan,
+    SoftwarePlanVersion,
+    SoftwareProduct,
+    SoftwareProductRate,
+)
 from corehq.apps.hqadmin.management.commands import cchq_prbac_bootstrap
 
 
@@ -26,7 +35,15 @@ class TestCchqPrbacBootstrap(TestCase):
     def tearDownClass(cls):
         # re-bootstrap for other tests
         call_command('cchq_prbac_bootstrap', testing=True)
-        call_command('cchq_software_plan_bootstrap', testing=True, fresh_start=True)
+
+        DefaultProductPlan.objects.all().delete()
+        SoftwarePlanVersion.objects.all().delete()
+        SoftwarePlan.objects.all().delete()
+        SoftwareProductRate.objects.all().delete()
+        SoftwareProduct.objects.all().delete()
+        FeatureRate.objects.all().delete()
+        Feature.objects.all().delete()
+        call_command('cchq_software_plan_bootstrap', testing=True)
 
     def test_dry_run(self):
         """


### PR DESCRIPTION
First step towards being able to use `ensure_plans` for all software plan bootstrapping needs, such as the user numbers changes.

Eventually want to have config files with all the constants, and a script for each update that calls `ensure_plans` with the right parameters.  At that point we won't need to have this as a management command either.

@benrudolph @proteusvacuum cc: @snopoke 

🐡 if you like that
