### PR TITLE
Cleanup 042016

### DIFF
--- a/corehq/apps/accounting/management/commands/cchq_accounting_bootstrap_new_editions_042016.py
+++ b/corehq/apps/accounting/management/commands/cchq_accounting_bootstrap_new_editions_042016.py
@@ -34,12 +34,8 @@ PRODUCT_TYPES = [
 ]
 
 BOOTSTRAP_PRODUCT_RATES = {
-    SoftwarePlanEdition.RESELLER: [
-        dict(monthly_fee=Decimal('1000.00')),
-    ],
-    SoftwarePlanEdition.MANAGED_HOSTING: [
-        dict(monthly_fee=Decimal('1000.00')),
-    ],
+    SoftwarePlanEdition.RESELLER: dict(monthly_fee=Decimal('1000.00')),
+    SoftwarePlanEdition.MANAGED_HOSTING: dict(monthly_fee=Decimal('1000.00')),
 }
 
 BOOTSTRAP_FEATURE_RATES = {

--- a/corehq/apps/accounting/management/commands/cchq_accounting_bootstrap_new_editions_042016.py
+++ b/corehq/apps/accounting/management/commands/cchq_accounting_bootstrap_new_editions_042016.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 # Standard library imports
-from collections import defaultdict
 from decimal import Decimal
 import logging
 from optparse import make_option
@@ -11,9 +10,9 @@ from optparse import make_option
 from django.apps import apps as default_apps
 from django.core.management.base import BaseCommand
 
-from corehq.apps.accounting.exceptions import AccountingError
+from corehq.apps.accounting.management.commands.cchq_software_plan_bootstrap import ensure_plans
 from corehq.apps.accounting.models import (
-    SoftwareProductType, SoftwarePlanEdition, SoftwarePlanVisibility, FeatureType,
+    SoftwareProductType, SoftwarePlanEdition, FeatureType,
 )
 
 
@@ -23,12 +22,47 @@ BOOTSTRAP_EDITION_TO_ROLE = {
     SoftwarePlanEdition.MANAGED_HOSTING: 'managed_hosting_plan_v0',
     SoftwarePlanEdition.RESELLER: 'reseller_plan_v0',
 }
-EDITIONS = [
-    SoftwarePlanEdition.MANAGED_HOSTING,
-    SoftwarePlanEdition.RESELLER,
+
+FEATURE_TYPES = [
+    FeatureType.USER,
+    FeatureType.SMS,
 ]
-FEATURE_TYPES = [f[0] for f in FeatureType.CHOICES]
-PRODUCT_TYPES = [p[0] for p in SoftwareProductType.CHOICES]
+PRODUCT_TYPES = [
+    SoftwareProductType.COMMCARE,
+    SoftwareProductType.COMMCONNECT,
+    SoftwareProductType.COMMTRACK,
+]
+
+BOOTSTRAP_PRODUCT_RATES = {
+    SoftwarePlanEdition.RESELLER: [
+        dict(monthly_fee=Decimal('1000.00')),
+    ],
+    SoftwarePlanEdition.MANAGED_HOSTING: [
+        dict(monthly_fee=Decimal('1000.00')),
+    ],
+}
+
+BOOTSTRAP_FEATURE_RATES = {
+    SoftwarePlanEdition.RESELLER: {
+        FeatureType.USER: dict(monthly_limit=10, per_excess_fee=Decimal('1.00')),
+        FeatureType.SMS: dict(monthly_limit=0),
+    },
+    SoftwarePlanEdition.MANAGED_HOSTING: {
+        FeatureType.USER: dict(monthly_limit=0, per_excess_fee=Decimal('1.00')),
+        FeatureType.SMS: dict(monthly_limit=0),
+    },
+}
+
+BOOTSTRAP_FEATURE_RATES_FOR_TESTING = {
+    SoftwarePlanEdition.RESELLER: {
+        FeatureType.USER: dict(monthly_limit=2, per_excess_fee=Decimal('1.00')),
+        FeatureType.SMS: dict(monthly_limit=0),
+    },
+    SoftwarePlanEdition.MANAGED_HOSTING: {
+        FeatureType.USER: dict(monthly_limit=0, per_excess_fee=Decimal('1.00')),
+        FeatureType.SMS: dict(monthly_limit=0),
+    },
+}
 
 
 class Command(BaseCommand):
@@ -45,189 +79,22 @@ class Command(BaseCommand):
     )
 
     def handle(self, dry_run=False, verbose=False,
-               flush=False, testing=False, *args, **options):
+               testing=False, *args, **options):
         logger.info('Bootstrapping Managed Hosting and Reseller plans')
 
         for_tests = testing
         if for_tests:
             logger.info("Initializing Managed Hosting and Reseller Plans "
                         "and Roles for Testing")
-
-        if not flush:
-            ensure_plans(dry_run=dry_run, verbose=verbose, for_tests=for_tests, apps=default_apps)
-
-
-def ensure_plans(dry_run, verbose, for_tests, apps):
-    SoftwarePlan = apps.get_model('accounting', 'SoftwarePlan')
-    SoftwarePlanVersion = apps.get_model('accounting', 'SoftwarePlanVersion')
-    Role = apps.get_model('django_prbac', 'Role')
-
-    edition_to_features = _ensure_features(dry_run=dry_run, verbose=verbose, apps=apps)
-    advanced_role = Role.objects.get(slug='advanced_plan_v0')
-
-    for product_type in PRODUCT_TYPES:
-        for edition in EDITIONS:
-            software_plan_version = SoftwarePlanVersion(role=advanced_role)
-
-            product, product_rates = _ensure_product_and_rate(
-                product_type, edition, dry_run=dry_run, verbose=verbose, apps=apps
-            )
-            feature_rates = _ensure_feature_rates(
-                edition_to_features[edition], edition, dry_run=dry_run,
-                verbose=verbose, for_tests=for_tests, apps=apps
-            )
-
-            software_plan = SoftwarePlan(
-                name='%s Edition' % product.name, edition=edition,
-                visibility=SoftwarePlanVisibility.INTERNAL
-            )
-            if dry_run:
-                logger.info("[DRY RUN] Creating Software Plan: %s" % software_plan.name)
-            else:
-                try:
-                    software_plan = SoftwarePlan.objects.get(name=software_plan.name)
-                    if verbose:
-                        logger.info("Plan '%s' already exists. Using existing plan to add version."
-                                    % software_plan.name)
-                except SoftwarePlan.DoesNotExist:
-                    software_plan.save()
-                    if verbose:
-                        logger.info("Creating Software Plan: %s" % software_plan.name)
-
-                    software_plan_version.plan = software_plan
-
-                    # must save before assigning many-to-many relationship
-                    if hasattr(SoftwarePlanVersion, 'product_rates'):
-                        software_plan_version.save()
-
-                    for product_rate in product_rates:
-                        product_rate.save()
-                        if hasattr(SoftwarePlanVersion, 'product_rates'):
-                            software_plan_version.product_rates.add(product_rate)
-                        elif hasattr(SoftwarePlanVersion, 'product_rate'):
-                            assert len(product_rates) == 1
-                            software_plan_version.product_rate = product_rate
-                        else:
-                            raise AccountingError(
-                                'SoftwarePlanVersion does not have product_rate '
-                                'or product_rates field'
-                            )
-
-                    # must save before assigning many-to-many relationship
-                    if hasattr(SoftwarePlanVersion, 'product_rate'):
-                        software_plan_version.save()
-
-                    for feature_rate in feature_rates:
-                        feature_rate.save()
-                        software_plan_version.feature_rates.add(feature_rate)
-                    software_plan_version.save()
-
-
-def _ensure_product_and_rate(product_type, edition, dry_run, verbose, apps):
-    """
-    Ensures that all the necessary SoftwareProducts and SoftwareProductRates are created for the plan.
-    """
-    SoftwareProduct = apps.get_model('accounting', 'SoftwareProduct')
-    SoftwareProductRate = apps.get_model('accounting', 'SoftwareProductRate')
-
-    if verbose:
-        logger.info('Ensuring Products and Product Rates')
-
-    product = SoftwareProduct(name='%s %s' % (product_type, edition), product_type=product_type)
-
-    product_rates = []
-    BOOTSTRAP_PRODUCT_RATES = {
-        SoftwarePlanEdition.RESELLER: [
-            SoftwareProductRate(monthly_fee=Decimal('1000.00')),
-        ],
-        SoftwarePlanEdition.MANAGED_HOSTING: [
-            SoftwareProductRate(monthly_fee=Decimal('1000.00')),
-        ],
-    }
-
-    for product_rate in BOOTSTRAP_PRODUCT_RATES[edition]:
-        if dry_run:
-            logger.info("[DRY RUN] Creating Product: %s" % product)
-            logger.info("[DRY RUN] Corresponding product rate of $%d created." % product_rate.monthly_fee)
+            edition_to_feature_rate = BOOTSTRAP_FEATURE_RATES_FOR_TESTING
         else:
-            try:
-                product = SoftwareProduct.objects.get(name=product.name)
-                if verbose:
-                    logger.info("Product '%s' already exists. Using "
-                                "existing product to add rate."
-                                % product.name)
-            except SoftwareProduct.DoesNotExist:
-                product.save()
-                if verbose:
-                    logger.info("Creating Product: %s" % product)
-            if verbose:
-                logger.info("Corresponding product rate of $%d created."
-                            % product_rate.monthly_fee)
-        product_rate.product = product
-        product_rates.append(product_rate)
-    return product, product_rates
+            edition_to_feature_rate = BOOTSTRAP_FEATURE_RATES
 
-
-def _ensure_features(dry_run, verbose, apps):
-    """
-    Ensures that all the Features necessary for the plans are created.
-    """
-    Feature = apps.get_model('accounting', 'Feature')
-
-    if verbose:
-        logger.info('Ensuring Features')
-
-    edition_to_features = defaultdict(list)
-    for edition in EDITIONS:
-        for feature_type in FEATURE_TYPES:
-            feature = Feature(name='%s %s' % (feature_type, edition), feature_type=feature_type)
-            if edition == SoftwarePlanEdition.ENTERPRISE:
-                feature.name = "Dimagi Only %s" % feature.name
-            if dry_run:
-                logger.info("[DRY RUN] Creating Feature: %s" % feature)
-            else:
-                try:
-                    feature = Feature.objects.get(name=feature.name)
-                    if verbose:
-                        logger.info("Feature '%s' already exists. Using "
-                                    "existing feature to add rate."
-                                    % feature.name)
-                except Feature.DoesNotExist:
-                    feature.save()
-                    if verbose:
-                        logger.info("Creating Feature: %s" % feature)
-            edition_to_features[edition].append(feature)
-    return edition_to_features
-
-
-def _ensure_feature_rates(features, edition, dry_run, verbose, for_tests, apps):
-    """
-    Ensures that all the FeatureRates necessary for the plans are created.
-    """
-    FeatureRate = apps.get_model('accounting', 'FeatureRate')
-
-    if verbose:
-        logger.info('Ensuring Feature Rates')
-
-    feature_rates = []
-    BOOTSTRAP_FEATURE_RATES = {
-        SoftwarePlanEdition.RESELLER: {
-            FeatureType.USER: FeatureRate(monthly_limit=2 if for_tests else 10,
-                                          per_excess_fee=Decimal('1.00')),
-            FeatureType.SMS: FeatureRate(monthly_limit=0),
-        },
-        SoftwarePlanEdition.MANAGED_HOSTING: {
-            FeatureType.USER: FeatureRate(monthly_limit=0,
-                                          per_excess_fee=Decimal('1.00')),
-            FeatureType.SMS: FeatureRate(monthly_limit=0),
-        },
-    }
-    for feature in features:
-        feature_rate = BOOTSTRAP_FEATURE_RATES[edition][feature.feature_type]
-        feature_rate.feature = feature
-        if dry_run:
-            logger.info("[DRY RUN] Creating rate for feature '%s': %s" % (feature.name, feature_rate))
-        elif verbose:
-            logger.info("Creating rate for feature '%s': %s" % (feature.name, feature_rate))
-        feature_rates.append(feature_rate)
-    return feature_rates
+        ensure_plans(
+            edition_to_role=BOOTSTRAP_EDITION_TO_ROLE,
+            edition_to_product_rate=BOOTSTRAP_PRODUCT_RATES,
+            edition_to_feature_rate=edition_to_feature_rate,
+            feature_types=FEATURE_TYPES,
+            product_types=PRODUCT_TYPES,
+            dry_run=dry_run, verbose=verbose, apps=default_apps,
+        )

--- a/corehq/apps/accounting/management/commands/cchq_software_plan_bootstrap.py
+++ b/corehq/apps/accounting/management/commands/cchq_software_plan_bootstrap.py
@@ -108,8 +108,7 @@ class Command(BaseCommand):
     def handle(self, dry_run=False, verbose=False, testing=False, *args, **options):
         logger.info('Bootstrapping standard plans. Custom plans will have to be created via the admin UIs.')
 
-        for_tests = testing
-        if for_tests:
+        if testing:
             logger.info("Initializing Plans and Roles for Testing")
             edition_to_feature_rate = BOOTSTRAP_FEATURE_RATES_FOR_TESTING
         else:
@@ -121,12 +120,12 @@ class Command(BaseCommand):
             edition_to_feature_rate=edition_to_feature_rate,
             feature_types=FEATURE_TYPES,
             product_types=PRODUCT_TYPES,
-            dry_run=dry_run, verbose=verbose, for_tests=for_tests, apps=default_apps,
+            dry_run=dry_run, verbose=verbose, apps=default_apps,
         )
 
 
 def ensure_plans(edition_to_role, edition_to_product_rate, edition_to_feature_rate, feature_types, product_types,
-                 dry_run, verbose, for_tests, apps):
+                 dry_run, verbose, apps):
     DefaultProductPlan = apps.get_model('accounting', 'DefaultProductPlan')
     SoftwarePlan = apps.get_model('accounting', 'SoftwarePlan')
     SoftwarePlanVersion = apps.get_model('accounting', 'SoftwarePlanVersion')
@@ -151,7 +150,7 @@ def ensure_plans(edition_to_role, edition_to_product_rate, edition_to_feature_ra
             )
             feature_rates = _ensure_feature_rates(
                 edition_to_feature_rate, edition_to_features[edition], edition,
-                dry_run=dry_run, verbose=verbose, for_tests=for_tests, apps=apps,
+                dry_run=dry_run, verbose=verbose, apps=apps,
             )
             software_plan = SoftwarePlan(
                 name='%s Edition' % product.name, edition=edition, visibility=SoftwarePlanVisibility.PUBLIC
@@ -287,7 +286,7 @@ def _ensure_features(feature_types, editions, dry_run, verbose, apps):
     return edition_to_features
 
 
-def _ensure_feature_rates(edition_to_feature_rate, features, edition, dry_run, verbose, for_tests, apps):
+def _ensure_feature_rates(edition_to_feature_rate, features, edition, dry_run, verbose, apps):
     """
     Ensures that all the FeatureRates necessary for the plans are created.
     """

--- a/corehq/apps/accounting/migrations/0003_bootstrap.py
+++ b/corehq/apps/accounting/migrations/0003_bootstrap.py
@@ -21,7 +21,7 @@ def cchq_software_plan_bootstrap(apps, schema_editor):
         edition_to_feature_rate=BOOTSTRAP_FEATURE_RATES,
         feature_types=FEATURE_TYPES,
         product_types=PRODUCT_TYPES,
-        dry_run=False, verbose=True, for_tests=False, apps=apps,
+        dry_run=False, verbose=True, apps=apps,
     )
 
 

--- a/corehq/apps/accounting/migrations/0028_bootstrap_new_editions.py
+++ b/corehq/apps/accounting/migrations/0028_bootstrap_new_editions.py
@@ -3,12 +3,26 @@ from __future__ import unicode_literals
 
 from django.db import migrations
 
-from corehq.apps.accounting.management.commands.cchq_accounting_bootstrap_new_editions_042016 import ensure_plans
+from corehq.apps.accounting.management.commands.cchq_software_plan_bootstrap import ensure_plans
+from corehq.apps.accounting.management.commands.cchq_accounting_bootstrap_new_editions_042016 import (
+    BOOTSTRAP_EDITION_TO_ROLE,
+    BOOTSTRAP_FEATURE_RATES,
+    BOOTSTRAP_PRODUCT_RATES,
+    FEATURE_TYPES,
+    PRODUCT_TYPES,
+)
 from corehq.sql_db.operations import HqRunPython
 
 
 def cchq_new_editions_bootstrap(apps, schema_editor):
-    ensure_plans(dry_run=False, verbose=True, for_tests=False, apps=apps)
+    ensure_plans(
+        edition_to_role=BOOTSTRAP_EDITION_TO_ROLE,
+        edition_to_product_rate=BOOTSTRAP_PRODUCT_RATES,
+        edition_to_feature_rate=BOOTSTRAP_FEATURE_RATES,
+        feature_types=FEATURE_TYPES,
+        product_types=PRODUCT_TYPES,
+        dry_run=False, verbose=True, apps=apps,
+    )
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
reuses the same `ensure_plans` function in two migration and two management commands, and cleans up a couple other pieces of obsolete code.  Recommend 🐡 
