### PR TITLE
add function to assign explicit community subscriptions

### DIFF
--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -541,3 +541,7 @@ def update_exchange_rates(app_id=settings.OPEN_EXCHANGE_RATES_API_ID):
             })
     except Exception as e:
         log_accounting_error("Error updating exchange rates: %s" % e.message)
+
+
+def assign_explicit_community_subscriptions(apps, from_date):
+    pass

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -30,12 +30,14 @@ from corehq.apps.accounting.models import (
     BillingAccount,
     Currency,
     DefaultProductPlan,
+    EntryPoint,
     SoftwarePlanEdition,
     StripePaymentMethod,
     Subscription,
     SubscriptionAdjustment,
     SubscriptionAdjustmentMethod,
     SubscriptionAdjustmentReason,
+    SubscriptionType,
     WirePrepaymentBillingRecord,
     WirePrepaymentInvoice,
 )
@@ -573,6 +575,7 @@ def assign_explicit_community_subscriptions(from_date):
                 account=BillingAccount.get_or_create_account_by_domain(
                     domain_name,
                     created_by='assign_explicit_community_subscriptions',
+                    entry_point=EntryPoint.SELF_STARTED,
                 )[0],
                 domain=domain_name,
                 plan_version=DefaultProductPlan.get_default_plan(
@@ -580,4 +583,7 @@ def assign_explicit_community_subscriptions(from_date):
                 ).plan.get_version(),
                 date_start=from_date,
                 date_end=end_date,
+                adjustment_method=SubscriptionAdjustmentMethod.TASK,
+                internal_change=True,
+                service_type=SubscriptionType.PRODUCT,
             )

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -6,7 +6,7 @@ from urllib import urlencode
 
 from django.conf import settings
 from django.db import transaction
-from django.db.models import Q
+from django.db.models import F, Q
 from django.http import HttpRequest, QueryDict
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext
@@ -29,6 +29,8 @@ from corehq.apps.accounting.invoicing import DomainInvoiceFactory
 from corehq.apps.accounting.models import (
     BillingAccount,
     Currency,
+    DefaultProductPlan,
+    SoftwarePlanEdition,
     StripePaymentMethod,
     Subscription,
     SubscriptionAdjustment,
@@ -543,5 +545,39 @@ def update_exchange_rates(app_id=settings.OPEN_EXCHANGE_RATES_API_ID):
         log_accounting_error("Error updating exchange rates: %s" % e.message)
 
 
-def assign_explicit_community_subscriptions(apps, from_date):
-    pass
+def assign_explicit_community_subscriptions(from_date):
+    consistent_dates_check = Q(date_start__lt=F('date_end')) | Q(date_end__isnull=True)
+
+    all_domain_ids = [d['id'] for d in Domain.get_all(include_docs=False)]
+    for domain_doc in iter_docs(Domain.get_db(), all_domain_ids):
+        domain_name = domain_doc['name']
+        if not Subscription.objects.filter(
+            consistent_dates_check
+        ).filter(
+            Q(date_end__gt=from_date) | Q(date_end__isnull=True),
+            date_start__lte=from_date,
+            subscriber__domain=domain_name,
+        ).exists():
+            future_subscriptions = Subscription.objects.filter(
+                consistent_dates_check
+            ).filter(
+                date_start__gt=from_date,
+                subscriber__domain=domain_name,
+            )
+            if future_subscriptions.exists():
+                end_date = future_subscriptions.latest('date_start').date_start
+            else:
+                end_date = None
+
+            Subscription.new_domain_subscription(
+                account=BillingAccount.get_or_create_account_by_domain(
+                    domain_name,
+                    created_by='assign_explicit_community_subscriptions',
+                )[0],
+                domain=domain_name,
+                plan_version=DefaultProductPlan.get_default_plan(
+                    SoftwarePlanEdition.COMMUNITY
+                ).plan.get_version(),
+                date_start=from_date,
+                date_end=end_date,
+            )

--- a/corehq/apps/accounting/tests/test_migrations.py
+++ b/corehq/apps/accounting/tests/test_migrations.py
@@ -1,0 +1,134 @@
+import random
+from datetime import date, timedelta
+
+from django.test import TestCase
+
+from corehq.apps.accounting.tests import generator
+from corehq.apps.accounting.models import (
+    BillingAccount,
+    DefaultProductPlan,
+    SoftwarePlanEdition,
+    Subscription,
+)
+from corehq.apps.accounting.tasks import assign_explicit_community_subscriptions
+from corehq.apps.domain.models import Domain
+
+
+class TestExplicitCommunitySubscriptions(TestCase):
+
+    domain = None
+    from_date = None
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestExplicitCommunitySubscriptions, cls).setUpClass()
+
+        cls.domain = Domain(name='test')
+        cls.domain.save()
+        cls.from_date = date.today()
+
+    def setUp(self):
+        super(TestExplicitCommunitySubscriptions, self).setUp()
+        generator.instantiate_accounting()
+        assert Subscription.objects.count() == 0
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.domain.delete()
+        super(TestExplicitCommunitySubscriptions, cls).tearDownClass()
+
+    def tearDown(self):
+        generator.delete_all_subscriptions()
+        generator.delete_all_accounts()
+        super(TestExplicitCommunitySubscriptions, self).tearDown()
+
+    def test_no_preexisting_subscription(self):
+        self._assign_community_subscriptions()
+
+        self.assertEqual(Subscription.objects.count(), 1)
+        subscription = Subscription.objects.all()[0]
+        self.assertEqual(subscription.subscriber.domain, self.domain.name)
+        self.assertEqual(subscription.date_start, self.from_date)
+        self.assertIsNone(subscription.date_end)
+        self.assertEqual(subscription.plan_version, self._most_recently_created_community_plan_version)
+
+    def test_preexisting_current_subscription(self):
+        preexisting_subscription = Subscription.new_domain_subscription(
+            self._preexisting_subscription_account,
+            self.domain.name,
+            self._random_plan_version,
+        )
+
+        self._assign_community_subscriptions()
+
+        self.assertEqual(Subscription.objects.count(), 1)
+        self.assertFalse(Subscription.objects.exclude(subscriber__domain=self.domain.name).exists())
+        self.assertEqual(Subscription.objects.all()[0], preexisting_subscription)
+
+    def test_preexisting_future_subscription(self):
+        future_subscription_start_date = self.from_date + timedelta(days=10)
+        plan_version = self._random_plan_version
+        Subscription.new_domain_subscription(
+            self._preexisting_subscription_account,
+            self.domain.name,
+            plan_version,
+            date_start=future_subscription_start_date,
+        )
+
+        self._assign_community_subscriptions()
+
+        self.assertEqual(Subscription.objects.count(), 2)
+        self.assertFalse(Subscription.objects.exclude(subscriber__domain=self.domain.name).exists())
+        self.assertIsNotNone(Subscription.objects.get(
+            date_start=self.from_date,
+            date_end=future_subscription_start_date,
+            plan_version=self._most_recently_created_community_plan_version,
+        ))
+        self.assertIsNotNone(Subscription.objects.get(
+            date_start=future_subscription_start_date,
+            plan_version=plan_version,
+        ))
+
+    def test_preexisting_past_subscription(self):
+        past_subscription_end_date = self.from_date - timedelta(days=10)
+        past_subscription_start_date = past_subscription_end_date - timedelta(days=5)
+        plan_version = self._random_plan_version
+        Subscription.new_domain_subscription(
+            self._preexisting_subscription_account,
+            self.domain.name,
+            plan_version,
+            date_start=past_subscription_start_date,
+            date_end=past_subscription_end_date,
+        )
+
+        self._assign_community_subscriptions()
+
+        self.assertEqual(Subscription.objects.count(), 2)
+        self.assertFalse(Subscription.objects.exclude(subscriber__domain=self.domain.name).exists())
+        self.assertIsNotNone(Subscription.objects.get(
+            date_start=self.from_date,
+            date_end=None,
+            plan_version=self._most_recently_created_community_plan_version,
+        ))
+        self.assertIsNotNone(Subscription.objects.get(
+            date_start=past_subscription_start_date,
+            date_end=past_subscription_end_date,
+            plan_version=plan_version,
+        ))
+
+    def _assign_community_subscriptions(self):
+        assign_explicit_community_subscriptions(self.from_date)
+
+    @property
+    def _most_recently_created_community_plan_version(self):
+        return DefaultProductPlan.get_default_plan(edition=SoftwarePlanEdition.COMMUNITY)
+
+    @property
+    def _random_plan_version(self):
+        return DefaultProductPlan.get_default_plan(
+            edition=random.choice(SoftwarePlanEdition.SELF_SERVICE_ORDER + [SoftwarePlanEdition.ENTERPRISE]),
+        )
+
+    @property
+    def _preexisting_subscription_account(self):
+        return BillingAccount.get_or_create_account_by_domain(self.domain.name, created_by=self.domain.name)[0]

--- a/corehq/apps/accounting/tests/test_migrations.py
+++ b/corehq/apps/accounting/tests/test_migrations.py
@@ -23,6 +23,12 @@ class TestExplicitCommunitySubscriptions(TestCase):
     def setUpClass(cls):
         super(TestExplicitCommunitySubscriptions, cls).setUpClass()
 
+        # TODO - remove once messy tests are cleaned up
+        for domain in Domain.get_all():
+            domain.delete()
+
+        assert len(list(Domain.get_all())) == 0
+
         cls.domain = Domain(name='test')
         cls.domain.save()
         cls.from_date = date.today()


### PR DESCRIPTION
Adds a task for assigning community subscriptions to any domains that don't have a subscription as of a specific date.  Needed for grandfathering-in domains with no subscription (ie, implicit community) when the allowed number of free users is updated.
