### PR TITLE
automate cloudant api key management

### DIFF
--- a/hqscripts/management/commands/list_couchdbs.py
+++ b/hqscripts/management/commands/list_couchdbs.py
@@ -1,0 +1,15 @@
+from django.core.management.base import BaseCommand
+from corehq.util.couchdb_management import couch_config
+
+
+class Command(BaseCommand):
+    """
+    Deletes sofabed cruft from couchlog.
+    """
+    help = "List names of active couchdb dbs"
+    args = ""
+    label = ""
+
+    def handle(self, *args, **options):
+        for name in couch_config.all_dbs_by_db_name.keys():
+            print name

--- a/scripts/cloudant/create_databases.py
+++ b/scripts/cloudant/create_databases.py
@@ -1,0 +1,17 @@
+from manage_cloudant import authenticate_cloudant_instance
+
+if __name__ == '__main__':
+
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Create New Cloudant databases')
+    parser.add_argument('--username', dest='username', required=True,
+                        help='Cloudant username')
+    parser.add_argument('--databases', dest='databases', nargs='+')
+    args = parser.parse_args()
+
+    cloudant_instance = authenticate_cloudant_instance(args.username)
+
+    for database in args.databases:
+        if not cloudant_instance.database_exists(database):
+            cloudant_instance.create_database(database)

--- a/scripts/cloudant/generate_api_key.py
+++ b/scripts/cloudant/generate_api_key.py
@@ -1,0 +1,19 @@
+from manage_cloudant import authenticate_cloudant_instance
+
+if __name__ == '__main__':
+
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Generate New Cloudant API key')
+    parser.add_argument('--username', dest='username', required=True,
+                        help='Cloudant username')
+    parser.add_argument('--databases', dest='databases', nargs='*')
+    args = parser.parse_args()
+
+    cloudant_instance = authenticate_cloudant_instance(args.username)
+    api_key, api_password = cloudant_instance.generate_api_key()
+    print 'New API key generated.'
+    print 'API Key:', api_key
+    print 'API Password:', api_password
+    for database in args.databases:
+        cloudant_instance.get_db(database).grant_api_key_access(api_key)

--- a/scripts/cloudant/grant_api_key.py
+++ b/scripts/cloudant/grant_api_key.py
@@ -1,0 +1,17 @@
+from manage_cloudant import authenticate_cloudant_instance
+
+if __name__ == '__main__':
+
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Grant Cloudant API key access to databases')
+    parser.add_argument('api_key_to_grant')
+    parser.add_argument('--databases', dest='databases', nargs='+')
+    parser.add_argument('--username', dest='username', required=True,
+                        help='Cloudant username')
+    args = parser.parse_args()
+
+    cloudant_instance = authenticate_cloudant_instance(args.username)
+
+    for database in args.databases:
+        cloudant_instance.get_db(database).grant_api_key_access(args.api_key_to_grant)

--- a/scripts/cloudant/manage_cloudant.py
+++ b/scripts/cloudant/manage_cloudant.py
@@ -1,0 +1,101 @@
+"""
+See https://cloudant.com/for-developers/faq/auth/ for cloudant reference
+"""
+from collections import namedtuple
+from getpass import getpass
+import requests
+
+Auth = namedtuple('Auth', 'username password')
+
+
+class CloudantInstance(Auth):
+
+    def create_database(self, db_name):
+        return CloudantDatabase(self, db_name).create()
+
+    def database_exists(self, db_name):
+        return CloudantDatabase(self, db_name).exists()
+
+    def get_db(self, db_name):
+        return CloudantDatabase(self, db_name)
+
+    def generate_api_key(self, ask=True):
+        if ask:
+            ask_user('Generating new API key for {}'.format(self.username))
+        new_api_key_response = requests.post(
+            'https://{username}.cloudant.com/_api/v2/api_keys'.format(username=self.username),
+            auth=self).json()
+        assert new_api_key_response['ok'] is True
+        return Auth(new_api_key_response['key'], new_api_key_response['password'])
+
+
+class CloudantDatabase(namedtuple('CloudantInstance', 'instance db_name')):
+    def _get_db_uri(self):
+        return (
+            'https://{username}.cloudant.com/{database}'
+            .format(username=self.instance.username, database=self.db_name)
+        )
+
+    def _get_security_url(self):
+        return (
+            'https://{username}.cloudant.com/_api/v2/db/{database}/_security'
+            .format(username=self.instance.username, database=self.db_name)
+        )
+
+    def create(self, ask=True):
+        db_uri = self._get_db_uri()
+        if ask:
+            ask_user('Creating database {}'.format(db_uri))
+
+        response = requests.put(db_uri, auth=self.instance).json()
+        print response
+
+    def exists(self):
+        db_uri = self._get_db_uri()
+        status_code = requests.get(db_uri, auth=self.instance).status_code
+        return status_code == 200
+
+    def grant_api_key_access(self, api_key, ask=True):
+        db_uri = self._get_db_uri()
+        security_url = self._get_security_url()
+        security = requests.get(security_url, auth=self.instance).json()
+        assert api_key
+        if ask:
+            ask_user('Granting api_key {} access to database {}'.format(api_key, db_uri))
+        if not security:
+            security = {'cloudant': {}}
+        security['cloudant'][api_key] = ['_admin']
+
+        security = requests.put(security_url, auth=self.instance, json=security).json()
+        print security
+
+    def revoke_api_key_access(self, api_key, ask=True):
+        db_uri = self._get_db_uri()
+        security_url = self._get_security_url()
+        security = requests.get(security_url, auth=self.instance).json()
+        assert api_key
+        if ask:
+            ask_user('Revoking api_key {} access to database {}'.format(api_key, db_uri))
+        if not security:
+            security = {'cloudant': {}}
+        if api_key in security['cloudant']:
+            del security['cloudant'][api_key]
+
+        security = requests.put(security_url, auth=self.instance, json=security).json()
+        print security
+
+
+def get_cloudant_password(username):
+    print 'Provide password for Cloudant user {}'.format(username)
+    return getpass()
+
+
+def ask_user(statement):
+    y = raw_input('{}. Ok? (y/n)'.format(statement))
+    if y != 'y':
+        print 'Aborting'
+        exit(0)
+
+
+def authenticate_cloudant_instance(username):
+    return CloudantInstance(username, get_cloudant_password(username))

--- a/scripts/cloudant/revoke_api_key.py
+++ b/scripts/cloudant/revoke_api_key.py
@@ -1,0 +1,17 @@
+from manage_cloudant import authenticate_cloudant_instance
+
+if __name__ == '__main__':
+
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Revoke Cloudant API key access to databases')
+    parser.add_argument('api_key_to_revoke')
+    parser.add_argument('--databases', dest='databases', nargs='+')
+    parser.add_argument('--username', dest='username', required=True,
+                        help='Cloudant username')
+    args = parser.parse_args()
+
+    cloudant_instance = authenticate_cloudant_instance(args.username)
+
+    for database in args.databases:
+        cloudant_instance.get_db(database).revoke_api_key_access(args.api_key_to_revoke)

--- a/settingshelper.py
+++ b/settingshelper.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from collections import namedtuple
 import os
 import sys
@@ -192,8 +193,8 @@ def fix_logger_obfuscation(fix_logger_obfuscation_, logging_config):
         for handler in logging_config["handlers"].values():
             if handler["class"].startswith("corehq."):
                 if fix_logger_obfuscation_ != 'quiet':
-                    print "{} logger is being changed to {}".format(
+                    print("{} logger is being changed to {}".format(
                         handler['class'],
                         'logging.StreamHandler'
-                    )
+                    ), file=sys.stderr)
                 handler["class"] = "logging.StreamHandler"


### PR DESCRIPTION
Assuming your localsettings is set to the same db prefix as you're trying to create on cloudant (e.g. `commcarehq` or `staging_commcarehq`

Create all necessary databases

```
python scripts/cloudant/create_databases.py --databases `./manage.py list_couchdbs` --username dimagi-danny
```

Generate a new api key and add it to all necessary dbs

```
python scripts/cloudant/generate_api_key.py --databases `./manage.py list_couchdbs` --username dimagi-danny
```

Revoke a api key from all necessary dbs

```
python scripts/cloudant/revoke_api_key.py mynolongernecessaryapikey --databases `./manage.py list_couchdbs` --username dimagi-danny
```

And for completeness, if you already have an API (and don't want to create a new one), add it to all necessary dbs

```
python scripts/cloudant/grant_api_key.py myexistingapikey --databases `./manage.py list_couchdbs` --username dimagi-danny
```
