### PR TITLE
Reduce cchq docker image size, build time and layers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
-.git
-
+*
+!requirements
+!package.json

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,4 +1,1 @@
-/*.sh
-/*.yml
-/localsettings.py
-/Dockerfile_commcarehq_base
+*

--- a/docker/Dockerfile_commcarehq_base
+++ b/docker/Dockerfile_commcarehq_base
@@ -1,21 +1,16 @@
 FROM python:2.7
 MAINTAINER Dimagi <devops@dimagi.com>
 
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONUSERBASE=/vendor \
+    PATH=/vendor/bin:$PATH
 
-RUN curl -sL https://deb.nodesource.com/setup_5.x | bash -
-
-RUN apt-get update && apt-get -y install \
+RUN curl -sL https://deb.nodesource.com/setup_5.x | bash - \
+ && apt-get -y install \
     nodejs \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
-
-RUN npm -g install \
-    bower \
-    grunt-cli \
-    uglify-js
-
-RUN echo '{ "allow_root": true }' > /root/.bowerrc
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* \
+ && mkdir /vendor
 
 RUN wget -O jdk.tar.gz --quiet --no-check-certificate --no-cookies --header "Cookie: oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jdk/7u67-b01/jdk-7u67-linux-x64.tar.gz \
  && tar -xzf jdk.tar.gz --absolute-names \
@@ -27,30 +22,28 @@ RUN wget -O jdk.tar.gz --quiet --no-check-certificate --no-cookies --header "Coo
  && update-alternatives --auto java \
  && rm -f jdk.tar.gz
 
+COPY requirements/requirements.txt \
+     requirements/dev-requirements.txt \
+     requirements/test-requirements.txt \
+     package.json \
+     /vendor/
+
 # prefer https for git checkouts made by pip
-RUN git config --global url."https://".insteadOf git://
-
-RUN pip install --upgrade pip
-
-RUN mkdir /vendor
-ENV PYTHONUSERBASE /vendor
-
-COPY requirements/requirements.txt /vendor/requirements.txt
-COPY requirements/dev-requirements.txt /vendor/dev-requirements.txt
-COPY requirements/test-requirements.txt /vendor/test-requirements.txt
-
-RUN pip install \
+RUN git config --global url."https://".insteadOf git:// \
+ && pip install --upgrade pip \
+ && pip install \
     -r /vendor/requirements.txt \
     -r /vendor/dev-requirements.txt \
     ipython \
     --user --upgrade \
-    && rm -rf /root/.cache/pip
+ && rm -rf /root/.cache/pip
 
-COPY package.json /vendor/package.json
-
-RUN cd /vendor \
-    && npm shrinkwrap \
-    && npm -g install \
-    && npm cache clean
-
-ENV PATH=/vendor/bin:$PATH
+RUN npm -g install \
+    bower \
+    grunt-cli \
+    uglify-js \
+ && echo '{ "allow_root": true }' > /root/.bowerrc \
+ && cd /vendor \
+ && npm shrinkwrap \
+ && npm -g install \
+ && npm cache clean


### PR DESCRIPTION
We may be able to further reduce build time and improve caching by making a separate image with python+node+java and then use that as the base image of commcarehq_base.
