### PR TITLE
Register subjects and schedule events with OpenClinica web service

### DIFF
--- a/corehq/ex-submodules/couchexport/writers.py
+++ b/corehq/ex-submodules/couchexport/writers.py
@@ -534,4 +534,26 @@ class CdiscOdmExportWriter(InMemoryExportWriter):
                 self.context['subjects'].append(dict(zip(self.subject_keys, row)))
 
     def _close(self):
+        from custom.openclinica.models import OpenClinicaAPI, OpenClinicaSettings
+
+        # Create the subjects and events that are in the ODM export using the API
+        oc_settings = OpenClinicaSettings.for_domain(self.context['domain'])
+        if oc_settings.study.is_ws_enabled:
+            api = OpenClinicaAPI(
+                oc_settings.study.url,
+                oc_settings.study.username,
+                oc_settings.study.password,
+                oc_settings.study.protocol_id
+            )
+            subject_keys = api.get_subject_keys()
+            for subject in self.context['subjects']:
+                if subject['subject_key'][3:] not in subject_keys:
+                    # Skip 'SS_' prefix   ^^ that OpenClinica wants in ODM, but isn't in API's subject keys
+                    api.create_subject(subject)
+                    # NOTE: In the interests of keeping data in OpenClinica tidy, we are only scheduling events for
+                    # subjects who don't yet exist in OpenClinica. New events of existing subjects must be added
+                    # manually, or subjects must be deleted from OpenClinica before a re-import.
+                    for event in subject['events']:
+                        api.schedule_event(subject, event)
+
         self.file.write(render_to_string('couchexport/odm_export.xml', self.context))

--- a/corehq/ex-submodules/couchexport/writers.py
+++ b/corehq/ex-submodules/couchexport/writers.py
@@ -1,3 +1,4 @@
+from base64 import b64decode
 from codecs import BOM_UTF8
 import os
 import re
@@ -5,6 +6,7 @@ import tempfile
 import zipfile
 import csv
 import json
+import bz2
 from django.template import Context
 from django.template.loader import render_to_string, get_template
 import xlwt
@@ -539,10 +541,11 @@ class CdiscOdmExportWriter(InMemoryExportWriter):
         # Create the subjects and events that are in the ODM export using the API
         oc_settings = OpenClinicaSettings.for_domain(self.context['domain'])
         if oc_settings.study.is_ws_enabled:
+            password = bz2.decompress(b64decode(oc_settings.study.password))
             api = OpenClinicaAPI(
                 oc_settings.study.url,
                 oc_settings.study.username,
-                oc_settings.study.password,
+                password,
                 oc_settings.study.protocol_id
             )
             subject_keys = api.get_subject_keys()

--- a/custom/openclinica/models.py
+++ b/custom/openclinica/models.py
@@ -156,6 +156,52 @@ class OpenClinicaAPI(object):
         odm = soap_env.xpath('./SOAP-ENV:Body/OC:createResponse/OC:odm', namespaces=nsmap)[0]
         return odm.text
 
+    def get_subject_keys(self):
+        subject_client = self.get_client('studySubject')
+        resp = subject_client.service.listAllByStudy({'identifier': self._study_id})
+        return [s.subject.uniqueIdentifier for s in resp.studySubjects.studySubject] if resp.studySubjects else []
+
+    def create_subject(self, subject):
+        subject_client = self.get_client('studySubject')
+        subject_data = {
+            'label': subject['study_subject_id'],
+            'enrollmentDate': str(subject['enrollment_date']),
+            'subject': {
+                'uniqueIdentifier': subject['subject_key'][3:],  # Drop the initial 'SS_'
+                'gender': {'1': 'm', '2': 'f'}[subject['sex']],
+                'dateOfBirth': str(subject['dob']),
+            },
+            'studyRef': {
+                'identifier': self._study_id,
+            },
+        }
+        resp = subject_client.service.create(subject_data)
+        if resp.result != 'Success':
+            raise OpenClinicaIntegrationError(
+                'Unable to register subject "{}" via OpenClinica webservice'.format(subject['subject_key'])
+            )
+
+    def schedule_event(self, subject, event):
+        event_client = self.get_client('event')
+        event_data = {
+            'studySubjectRef': {
+                'label': subject['study_subject_id'],
+            },
+            'studyRef': {
+                'identifier': self._study_id,
+            },
+            'eventDefinitionOID': event['study_event_oid'],
+            'startDate': event['start_long'].split()[0],  # e.g. 1999-12-31
+            'startTime': event['start_short'].split()[1],  # e.g. 23:59
+            'endDate': event['end_long'].split()[0],
+            'endTime': event['end_short'].split()[1],
+        }
+        resp = event_client.service.schedule(event_data)
+        if resp.result != 'Success':
+            raise OpenClinicaIntegrationError(
+                'Unable to schedule event "{}"  via OpenClinica webservice'.format(event['study_event_oid'])
+            )
+
 
 class StudySettings(DocumentSchema):
     is_ws_enabled = BooleanProperty()
@@ -461,7 +507,9 @@ class Subject(object):
                     eventslist.append({
                         'study_event_oid': oid,
                         'repeat_key': i + 1,
+                        'start_short': study_event.start_short,
                         'start_long': study_event.start_long,
+                        'end_short': study_event.end_short,
                         'end_long': study_event.end_long,
                         'forms': mkformslist(study_event.forms)
                     })

--- a/custom/openclinica/reports.py
+++ b/custom/openclinica/reports.py
@@ -82,6 +82,7 @@ class OdmExportReport(ProjectReport, CaseListMixin, GenericReportView):
             # "admin_data_xml" which come from the study metadata.
             'study_xml': get_study_constant(self.domain, 'study_xml'),
             'admin_data_xml': get_study_constant(self.domain, 'admin_data_xml'),
+            'domain': self.domain,
         }
         return [
             [
@@ -141,6 +142,9 @@ class OdmExportReport(ProjectReport, CaseListMixin, GenericReportView):
             row = [
                 'SS_' + subject.subject_key,  # OpenClinica prefixes subject key with "SS_" to make the OID
                 subject.study_subject_id,
+                subject.enrollment_date,
+                subject.sex,
+                subject.dob,
                 subject.get_export_data(),
             ]
             yield row


### PR DESCRIPTION
When exporting to OpenClinica from CommCare, the most time-consuming task is to register each subject, and schedule each of their events. This automates this process when the export document is generated by using the OpenClinica web service.

@snopoke cc @sravfeyn 
