### PR TITLE
add scripts for ssh'ing by inventory

### DIFF
--- a/scripts/inventory/getinventory.py
+++ b/scripts/inventory/getinventory.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+import os
+
+
+def read_inventory_file(filename):
+    """
+    filename is a path to an ansible inventory file
+
+    returns a mapping of group names ("webworker", "proxy", etc.)
+    to lists of hosts (ip addresses)
+
+    """
+    from ansible.inventory import InventoryParser
+
+    return {name: [host.name for host in group.get_hosts()]
+            for name, group in InventoryParser(filename).groups.items()}
+
+
+def get_instance_group(instance, group):
+    servers = read_inventory_file(os.path.join('fab', 'inventory', instance))
+    return servers[group]
+
+if __name__ == '__main__':
+    import sys
+    instance = sys.argv[1]
+    group = sys.argv[2]
+    servers = get_instance_group(instance, group)
+    for server in servers:
+        print server

--- a/scripts/inventory/ssh
+++ b/scripts/inventory/ssh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# usage: scripts/inventory/ssh <environment> <group> [<n>]
+#
+#   environment   production, staging, or softlayer
+#   group         webworkers, postgresql, proxy, etc.
+#   n             the ordinal of the machine to pick if more than one
+#
+# Examples
+#   scripts/inventory/ssh production postgresql
+#   scripts/inventory/ssh production webworkers 2
+#
+# if <n> is greater than the total number, the last machine is picked
+
+env=$1
+group=$2
+i=$3
+TEMP=$(mktemp /tmp/sshinventory.XXX)
+scripts/inventory/getinventory.py ${env} ${group} > ${TEMP}
+COUNT=$(cat ${TEMP} | wc -l | sed 's/ *//g')
+if [[ ${COUNT} != '1' && -z ${i} ]]
+then
+    echo "There are ${COUNT} ${env} ${group} machines:"
+    echo
+    cat ${TEMP}
+    echo
+    echo 'Use `'"$0 ${env} ${group} 1"'` to get the first'
+    exit -1
+fi
+
+if [[ -z ${i} ]]
+then
+    CHOICE=$(cat ${TEMP} | head -n1)
+else
+    CHOICE=$(cat ${TEMP} | head -n${i} | tail -n1)
+fi
+
+echo "ssh ${CHOICE}"
+rm ${TEMP}
+ssh ${CHOICE}


### PR DESCRIPTION
It can get a little annoying keeping track of what machines are called (`hqpillowtop0`... or is it `hqpillowtop1` now?). Well, now you don't have to keep track, you can just run

```
scripts/inventory/ssh production pillowtop
```

and it'll (1) tell you and (2) ssh into that machine

```
$ scripts/inventory/ssh production pillowtop
ssh hqpillowtop0.internal.commcarehq.org
Welcome to Ubuntu 12.04.5 LTS (GNU/Linux 3.2.0-75-generic x86_64)

 * Documentation:  https://help.ubuntu.com/
New release '14.04.1 LTS' available.
Run 'do-release-upgrade' to upgrade to it.

Last login: Wed May  4 20:50:24 2016 from 192.168.237.194
droberts@hqpillowtop0:~$
```

If that doesn't uniquely identify a machine, it'll tell you what to do

```
$ scripts/inventory/ssh production webworkers
There are 3 production webworkers machines:

hqdjango12.internal.commcarehq.org
hqdjango13.internal.commcarehq.org
hqdjango14.internal.commcarehq.org

Use `scripts/inventory/ssh production webworkers 1` to get the first
```

And then you can run `scripts/inventory/ssh production webworkers 1` to get the first (or `2` for the second, etc.).
