### PR TITLE
Add check authentication route

### DIFF
--- a/corehq/apps/hqadmin/urls.py
+++ b/corehq/apps/hqadmin/urls.py
@@ -10,6 +10,7 @@ from .views import (
     LoadtestReportView,
     ManagementCommandsView,
     CallcenterUCRCheck,
+    AuthenticationAPI,
     DimagisphereView)
 
 from corehq.apps.api.urls import admin_urlpatterns as admin_api_urlpatterns
@@ -27,6 +28,7 @@ urlpatterns = patterns('corehq.apps.hqadmin.views',
     url(r'^auth_as/(?P<username>[^/]*)/$', AuthenticateAs.as_view(), name=AuthenticateAs.urlname),
     url(r'^auth_as/(?P<username>[^/]*)/(?P<domain>{})/$'.format(new_domain_re),
         AuthenticateAs.as_view(), name=AuthenticateAs.urlname),
+    url(r'^is_authenticated/$', AuthenticationAPI.as_view(), name=AuthenticationAPI.urlname),
     url(r'^management_commands/$', ManagementCommandsView.as_view(),
         name=ManagementCommandsView.urlname),
     url(r'^run_command/$', 'run_command', name="run_management_command"),

--- a/corehq/apps/hqadmin/views.py
+++ b/corehq/apps/hqadmin/views.py
@@ -10,6 +10,7 @@ from StringIO import StringIO
 import dateutil
 from django.utils.datastructures import SortedDict
 from django.views.decorators.http import require_POST
+from django.views.generic import View
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.models import User
@@ -144,6 +145,16 @@ class AuthenticateAs(BaseAdminSectionView):
             login(request, request.user)
             return HttpResponseRedirect('/')
         return self.get(request, *args, **kwargs)
+
+
+class AuthenticationAPI(View):
+    urlname = 'is_authenticated'
+
+    def post(self, request):
+        if request.user.is_authenticated:
+            return json_response({'status': 'authenticated'})
+
+        return json_response({'status': 'forbidden'}, status_code=403)
 
 
 class RecentCouchChangesView(BaseAdminSectionView):


### PR DESCRIPTION
@snopoke @wpride this feels wrong, but i'm not sure of a better way to do this. essentially we're going to have formplayer middleware forward the request to django to authenticate the session id. is there a better way of doing this?

will, you'd have to send a post request to `/hq/admin/is_authenticated/`
