### PR TITLE
remove SEND_BROKEN_LINK_EMAILS

### DIFF
--- a/docker/localsettings.py
+++ b/docker/localsettings.py
@@ -192,7 +192,6 @@ if os.environ.get("COMMCAREHQ_BOOTSTRAP") == "yes":
     UNIT_TESTING = False
     ADMINS = (('Admin', 'admin@example.com'),)
 
-    SEND_BROKEN_LINK_EMAILS = True
     CELERY_SEND_TASK_ERROR_EMAILS = True
 
     LESS_DEBUG = True

--- a/localsettings.example.py
+++ b/localsettings.example.py
@@ -121,7 +121,6 @@ TEMPLATE_DEBUG = DEBUG
 DJANGO_LOG_FILE = "/tmp/commcare-hq.django.log"
 LOG_FILE = "/tmp/commcare-hq.log"
 
-SEND_BROKEN_LINK_EMAILS = True
 CELERY_SEND_TASK_ERROR_EMAILS = True
 CELERY_PERIODIC_QUEUE = 'celery' # change this to something else if you want a different queue for periodic tasks
 CELERY_FLOWER_URL = 'http://127.0.0.1:5555'

--- a/settings.py
+++ b/settings.py
@@ -1330,8 +1330,8 @@ EMAIL_HOST = EMAIL_SMTP_HOST
 EMAIL_PORT = EMAIL_SMTP_PORT
 EMAIL_HOST_USER = EMAIL_LOGIN
 EMAIL_HOST_PASSWORD = EMAIL_PASSWORD
-# EMAIL_USE_TLS and SEND_BROKEN_LINK_EMAILS are set above
-# so they can be overridden in localsettings (e.g. in a dev environment)
+# EMAIL_USE_TLS is set above
+# so it can be overridden in localsettings (e.g. in a dev environment)
 
 NO_HTML_EMAIL_MESSAGE = """
 This is an email from CommCare HQ. You're seeing this message because your


### PR DESCRIPTION
`SEND_BROKEN_LINK_EMAILS` is removed in django 1.8.  This variable is not set in any of our production localsettings.
