### PR TITLE
App manager should consistently handle ctrl+click on links

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/app_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/app_view.html
@@ -53,6 +53,14 @@
         });
 
         {% if not app.is_remote_app %}
+        $(function() {
+            $("a[data-toggle='tab']").on("click", function(event) {
+                if (event && (event.metaKey || event.ctrlKey || event.which === 2)) {
+                    window.open($(event.target).attr("href"), '_blank');
+                }
+            });
+        });
+
         $(function () {
             var multimedia_tab = (function () {
                 var self = {};
@@ -89,11 +97,7 @@
                 $loading = $main.find(".hq-loading").remove(),
                 $loadingError = $main.find(".hq-loading-error").remove();
 
-            $('#demand-releases').on('show.bs.tab', _.throttle(function (event) {
-                if (event && (event.metaKey || event.ctrlKey || event.which === 2)) {
-                    window.open("{% url 'release_manager' domain app.get_id %}", '_blank');
-                    return
-                }
+            $('#demand-releases').on('show.bs.tab', _.throttle(function () {
                 if (state === "loading" || state === "loaded") {
                     return;
                 }

--- a/corehq/apps/app_manager/templates/app_manager/app_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/app_view.html
@@ -53,14 +53,6 @@
         });
 
         {% if not app.is_remote_app %}
-        $(function() {
-            $("a[data-toggle='tab']").on("click", function(event) {
-                if (event && (event.metaKey || event.ctrlKey || event.which === 2)) {
-                    window.open($(event.target).attr("href"), '_blank');
-                }
-            });
-        });
-
         $(function () {
             var multimedia_tab = (function () {
                 var self = {};
@@ -97,7 +89,7 @@
                 $loading = $main.find(".hq-loading").remove(),
                 $loadingError = $main.find(".hq-loading-error").remove();
 
-            $('#demand-releases').on('show.bs.tab', _.throttle(function () {
+            $('#demand-releases').on('show.bs.tab', function () {
                 if (state === "loading" || state === "loaded") {
                     return;
                 }
@@ -123,7 +115,7 @@
                     showSpinner = false;
                     $main.html($loadingError.html());
                 });
-            }, 300));
+            });
         });
 
     </script>

--- a/corehq/apps/app_manager/templates/app_manager/app_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/app_view.html
@@ -75,7 +75,7 @@
                 return self;
             }());
             $("#multimedia").koApplyBindings(multimedia_tab);
-            $('#demand-multimedia').on('show.bs.tab', function () {
+            $('#demand-multimedia').on('shown.bs.tab', function () {
                 if (multimedia_tab.load_state() === null) {
                     multimedia_tab.load_if_necessary();
                 }
@@ -89,7 +89,7 @@
                 $loading = $main.find(".hq-loading").remove(),
                 $loadingError = $main.find(".hq-loading-error").remove();
 
-            $('#demand-releases').on('show.bs.tab', function () {
+            $('#demand-releases').on('shown.bs.tab', function () {
                 if (state === "loading" || state === "loaded") {
                     return;
                 }

--- a/corehq/apps/app_manager/templates/app_manager/managed_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/managed_app.html
@@ -290,13 +290,13 @@
     {% endif %}
     <li class="text-hq-nav-header">Actions</li>
     <li class="app-name-div{% if copy_app_form and copy_app_form.is_bound %} active{% endif %}">
-        <a href="{% url "view_app" domain app.id %}copy/#copy" data-toggle="tab">
+        <a href="{% url "view_app" domain app.id %}copy/#copy" {% if is_app_view %}data-toggle="tab"{% endif %}>
             <i class="fa fa-copy"></i>
             {% trans "Copy Application" %}
         </a>
     </li>
     <li>
-        <a href="{% url "view_app" domain app.id %}delete/#delete" data-toggle="tab">
+        <a href="{% url "view_app" domain app.id %}delete/#delete" {% if is_app_view %}data-toggle="tab"{% endif %}>
             <i class="fa fa-trash"></i>
             {% trans "Delete Application" %}
         </a>

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/lib/bootstrap-tab-history-custom.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/lib/bootstrap-tab-history-custom.js
@@ -63,8 +63,7 @@ $(function () {
         }
     });
 
-    $('a[data-toggle="tab"]').on('show show.bs.tab', function (event) {
-
+    $('a[data-toggle="tab"]').on('shown.bs.tab', function (event) {
         // Set the selected tab to be the current state. But don't update the URL.
         var url = event.target.href.split("#")[0];
         var tab = event.target.href.split("#")[1];
@@ -92,6 +91,16 @@ $(function () {
                 event.preventDefault();
                 loadPage(url);
             }
+        }
+    });
+
+    // Handle control-click, middle-click, etc.
+    $("a[data-toggle='tab']").on("click", function(event) {
+        if (event && (event.metaKey || event.ctrlKey || event.which === 2)) {
+            window.open($(event.target).attr("href"), '_blank');
+            $(event.target).one("show.bs.tab", function() {
+                return false;
+            });
         }
     });
 });

--- a/corehq/apps/hqwebapp/static/hqwebapp/js/lib/bootstrap-tab-history-custom.js
+++ b/corehq/apps/hqwebapp/static/hqwebapp/js/lib/bootstrap-tab-history-custom.js
@@ -94,10 +94,12 @@ $(function () {
         }
     });
 
-    // Handle control-click, middle-click, etc.
+    // Handle control-click, middle-click, etc. opening in a new window
     $("a[data-toggle='tab']").on("click", function(event) {
         if (event && (event.metaKey || event.ctrlKey || event.which === 2)) {
             window.open($(event.target).attr("href"), '_blank');
+
+            // Prevent the tab from showing in the current window
             $(event.target).one("show.bs.tab", function() {
                 return false;
             });


### PR DESCRIPTION
Followup for https://github.com/dimagi/commcare-hq/pull/12034 / http://manage.dimagi.com/default.asp?222501

@millerdev / @snopoke 

"tabs" in app manager are deploy, settings, multimedia, languages, copy, delete
"non-tabs" are module view, form view, form edit, app summary

Verified that
- while on a tab, you can ctrl+click to open another tab in a new window
- while on a non-tab, you can ctrl+click to open a tab in a new window
- browser's back/forward buttons work as expected, handling tabs & non-tabs
- loading a tab URL works
