### PR TITLE
include name property in case export

### DIFF
--- a/corehq/apps/export/system_properties.py
+++ b/corehq/apps/export/system_properties.py
@@ -248,7 +248,7 @@ TOP_MAIN_CASE_TABLE_PROPERTIES = [
     ExportColumn(
         label='name',
         item=ExportItem(path=[PathNode(name='name')]),
-        help_text=_("The id of the case"),
+        help_text=_("The name of the case"),
         selected=True
     ),
 ]

--- a/corehq/apps/export/system_properties.py
+++ b/corehq/apps/export/system_properties.py
@@ -245,6 +245,12 @@ TOP_MAIN_CASE_TABLE_PROPERTIES = [
         help_text=_("The id of the case"),
         selected=True
     ),
+    ExportColumn(
+        label='name',
+        item=ExportItem(path=[PathNode(name='name')]),
+        help_text=_("The id of the case"),
+        selected=True
+    ),
 ]
 
 BOTTOM_MAIN_CASE_TABLE_PROPERTIES = [


### PR DESCRIPTION
@NoahCarnahan the `name` property doesn't get returned in the function we use to get case properties. since name is always included, i decided to just make it a system property
