### PR TITLE
Set file encoding

### DIFF
--- a/corehq/apps/commtrack/tests/test_utils.py
+++ b/corehq/apps/commtrack/tests/test_utils.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-
+# coding=utf-8
 from django.test import TestCase
 import unittest
 from corehq.apps.commtrack.util import unicode_slug, generate_code

--- a/corehq/ex-submodules/couchforms/tests/test_xml.py
+++ b/corehq/ex-submodules/couchforms/tests/test_xml.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-
+# coding=utf-8
 import uuid
 import os
 from django.test import TestCase


### PR DESCRIPTION
Addresses Travis failure. ([FB 230333](http://manage.dimagi.com/default.asp?230333))

The test didn't fail the same way locally, but this fixed them, and I suspect the cause might be the same. (Also dropped shebang because this file never gets executed directly.)

@sravfeyn @czue 
