### PR TITLE
Put instead of delete lazy attachment in cache on save

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -3953,22 +3953,9 @@ class LazyBlobDoc(BlobMixin):
                 self._LAZY_ATTACHMENTS_CACHE[name] = content
         return content
 
-    def __remove_cached_attachment(self, name):
+    def put_attachment(self, content, name=None, *args, **kw):
         cache.delete(self.__attachment_cache_key(name))
         self._LAZY_ATTACHMENTS_CACHE.pop(name, None)
-
-    def __store_lazy_attachment(self, content, name=None, content_type=None,
-                                content_length=None):
-        info = {
-            'content': content,
-            'content_type': content_type,
-            'content_length': content_length,
-        }
-        self._LAZY_ATTACHMENTS[name] = info
-        return info
-
-    def put_attachment(self, content, name=None, *args, **kw):
-        self.__remove_cached_attachment(name)
         return super(LazyBlobDoc, self).put_attachment(content, name, *args, **kw)
 
     def lazy_put_attachment(self, content, name=None, content_type=None,
@@ -3978,7 +3965,11 @@ class LazyBlobDoc(BlobMixin):
         and that upon self.save(), the attachments are put to the doc as well
 
         """
-        self.__store_lazy_attachment(content, name, content_type, content_length)
+        self._LAZY_ATTACHMENTS[name] = {
+            'content': content,
+            'content_type': content_type,
+            'content_length': content_length,
+        }
 
     def lazy_fetch_attachment(self, name):
         # it has been put/lazy-put already during this request


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?229098

The theory of this fix is based on the read/write characteristics of Riak CS. I have not been able to reproduce it, but in the process of troubleshooting [FB 230194](http://manage.dimagi.com/default.asp?230194) I observed several form objects with cached `ResourceNotFound` while the form source was in Riak CS (removing the cache keys resolved the issue). Here's my understanding of how that scenario happens:
- New version of lazy attachment (old version in cache) added to app
- Save app
  - Lazy attachment removed from cache
  - A race starts here, but not the one we're worried about: if a request comes in before the save completes then a stale version of the app will be cached, effectively masking the saved version. This race condition should also be fixed by this PR.
  - Attachment is written into Riak CS with a new unique blob identifier (this [may return a successful response](http://docs.basho.com/riak/kv/2.1.4/developing/usage/creating-objects/#write-parameters) before all vnodes have a copy of the data)
  - App JSON is saved in couch, updating the unique blob identifier for the attachment
  - THE RACE IS ON

At the point marked THE RACE IS ON but before the attachment has been fully replicated to all vnodes in Riak CS, a request comes in for the attachment. The cache misses and the attachment is fetched from Riak CS which [may return `notfound`](http://docs.basho.com/riak/kv/2.1.4/developing/usage/reading-objects/#read-parameters) (more on this below). ResourceNotFound is stored in the cache (for 24 hours), and now all subsequent requests for the attachment are raising ResourceNotFound for the next 24 hours. Meanwhile the attachment has been saved in the blob db and is waiting for the cache to expire.

Our Riak CS buckets have the following default properties:

```
# values queried with in docker riakcs, which uses same config as prod
# curl -v http://127.0.0.1:8098/buckets/blobdb/props
n_val: 3
r: quorum (2)
w: quorum (2)
notfound_ok: true
```

This means that a successful write requires at least 2 replicas (`w`) to be written, and a successful read requires at least 2 vnodes (`r`) to respond, but a single `notfound` vnode response is considered authoritative, and the eventual number of nodes each object will be written to is 3 (`n_val`). Therefore it is possible that the object would appear to be not found for a bit after successful write response is returned but before it has been replicated to 3 vnodes.

Souces:
- http://docs.basho.com/riak/kv/2.1.4/developing/usage/creating-objects/#write-parameters
- http://docs.basho.com/riak/kv/2.1.4/developing/usage/reading-objects/#read-parameters
- http://www.littleriakbook.com/#toc_8
- http://docs.basho.com/riak/kv/2.1.4/developing/api/http/get-bucket-props/
- https://github.com/basho/riak_cs/wiki/Architecture-Overview

Review commits individually. The first commit (c9ecef8) is the main change. The rest are refactoring.

@snopoke cc @orangejenny 
