### PR TITLE
More robust unknown case checking

### DIFF
--- a/corehq/apps/app_manager/fields.py
+++ b/corehq/apps/app_manager/fields.py
@@ -346,9 +346,10 @@ class ApplicationDataRMIHelper(object):
             choices = map(lambda c: c._asdict(), choices)
         return choices
 
-    def _get_app_type_choices_for_cases(self):
+    def _get_app_type_choices_for_cases(self, has_unknown_case_types=False):
         choices = [(_("Applications"), self.APP_TYPE_ALL)]
-        choices.append((_("Unknown"), self.APP_TYPE_UNKNOWN))
+        if has_unknown_case_types:
+            choices.append((_("Unknown"), self.APP_TYPE_UNKNOWN))
         choices = map(
             lambda choice: RMIDataChoice(id=choice[1], text=choice[0], data={}),
             choices
@@ -517,7 +518,9 @@ class ApplicationDataRMIHelper(object):
         if self.as_dict:
             apps_by_type = self._map_chosen_by_choice_as_dict(apps_by_type)
         response = AppCaseRMIResponse(
-            app_types=self._get_app_type_choices_for_cases(),
+            app_types=self._get_app_type_choices_for_cases(
+                has_unknown_case_types=bool(case_types_by_app.get(self.UNKNOWN_SOURCE))
+            ),
             apps_by_type=apps_by_type,
             case_types_by_app=case_types_by_app,
             placeholders=self.case_placeholders


### PR DESCRIPTION
@czue this should fix the ability to export commcare-user cases: http://manage.dimagi.com/default.asp?230344. Before it'd only let you select an Unknown Application -> commcare-user if you had unknown forms. This piece of code is due for some refactoring and testing. Felt like it was out of scope for this and felt the Friday time crunch. Open to push back though

cc: @biyeun 
