### PR TITLE
Fix hard-coded db name

### DIFF
--- a/corehq/apps/hqadmin/views.py
+++ b/corehq/apps/hqadmin/views.py
@@ -577,8 +577,10 @@ def _lookup_id_in_database(doc_id, db_name=None):
         db = _SQL_DBS.get(db_name, None)
         if db:
             dbs = [db]
+        elif db_name == couch_config.get_db(None).dbname:
+            dbs = [couch_config.get_db(None)]
         else:
-            dbs = [couch_config.get_db(None if db_name == 'commcarehq' else db_name)]
+            dbs = [couch_config.get_db(db_name)]
     else:
         couch_dbs = couch_config.all_dbs_by_slug.values()
         sql_dbs = _SQL_DBS.values()


### PR DESCRIPTION
Fix 500 error: https://staging.commcarehq.org/hq/admin/raw_couch/?id=8748f714-4299-457b-93f4-68707fe44687&db_name=staging_commcarehq

@esoergel cc @orangejenny 
