### PR TITLE
Schema version control

### DIFF
--- a/corehq/apps/app_manager/dbaccessors.py
+++ b/corehq/apps/app_manager/dbaccessors.py
@@ -209,7 +209,7 @@ def get_built_app_ids_for_app_id(domain, app_id, version=None):
     return [result['id'] for result in results]
 
 
-def get_latest_built_app_ids_and_versions(domain, app_id=None):
+def get_latest_app_ids_and_versions(domain, app_id=None):
     """
     Returns all the latest app_ids and versions in a dictionary.
     :param domain: The domain to get the app from
@@ -218,21 +218,23 @@ def get_latest_built_app_ids_and_versions(domain, app_id=None):
     :returns: {app_id: latest_version}
     """
     from .models import Application
-    key = [domain, app_id] if app_id else [domain]
+    key = [domain]
 
     results = Application.get_db().view(
-        'app_manager/saved_app',
+        'app_manager/applications_brief',
         startkey=key + [{}],
         endkey=key,
         descending=True,
         reduce=False,
-        include_docs=False,
+        include_docs=True,
     ).all()
 
     latest_ids_and_versions = {}
+    if app_id:
+        results = filter(lambda r: r['value']['_id'] == app_id, results)
     for result in results:
-        app_id = result['key'][1]
-        version = result['key'][2]
+        app_id = result['value']['_id']
+        version = result['value']['version']
 
         # Since we have sorted, we know the first instance is the latest version
         if app_id not in latest_ids_and_versions:

--- a/corehq/apps/app_manager/tests/test_dbaccessors.py
+++ b/corehq/apps/app_manager/tests/test_dbaccessors.py
@@ -10,7 +10,7 @@ from corehq.apps.app_manager.dbaccessors import (
     get_built_app_ids_for_app_id,
     get_current_app,
     get_latest_build_doc,
-    get_latest_built_app_ids_and_versions,
+    get_latest_app_ids_and_versions,
     get_latest_released_app_doc,
 )
 from corehq.apps.app_manager.models import Application, RemoteApp, Module
@@ -115,16 +115,16 @@ class DBAccessorsTest(TestCase, DocTestMixin):
         self.assertEqual(len(app_ids), 3)
 
     def test_get_latest_built_app_ids_and_versions(self):
-        build_ids_and_versions = get_latest_built_app_ids_and_versions(self.domain)
+        build_ids_and_versions = get_latest_app_ids_and_versions(self.domain)
         self.assertEqual(build_ids_and_versions, {
-            self.apps[0].get_id: 12,
-            '1234': 12,
+            self.apps[0].get_id: self.apps[0].version,
+            self.apps[1].get_id: self.apps[1].version,
         })
 
     def test_get_latest_built_app_ids_and_versions_with_app_id(self):
-        build_ids_and_versions = get_latest_built_app_ids_and_versions(self.domain, self.apps[0].get_id)
+        build_ids_and_versions = get_latest_app_ids_and_versions(self.domain, self.apps[0].get_id)
         self.assertEqual(build_ids_and_versions, {
-            self.apps[0].get_id: 12,
+            self.apps[0].get_id: self.apps[0].version,
         })
 
     def test_get_all_built_app_ids_and_versions(self):

--- a/corehq/apps/export/const.py
+++ b/corehq/apps/export/const.py
@@ -12,6 +12,10 @@ from corehq.apps.export.transforms import (
     owner_id_to_display,
 )
 
+# When fixing a bug that requires existing schemas to be rebuilt,
+# bump the version number.
+DATA_SCHEMA_VERSION = 1
+
 DEID_ID_TRANSFORM = "deid_id"
 DEID_DATE_TRANSFORM = "deid_date"
 DEID_TRANSFORM_FUNCTIONS = {

--- a/corehq/apps/export/dbaccessors.py
+++ b/corehq/apps/export/dbaccessors.py
@@ -1,3 +1,5 @@
+from dimagi.utils.couch.database import safe_delete
+from corehq.util.test_utils import unit_testing_only
 
 
 def get_latest_case_export_schema(domain, case_type):
@@ -79,3 +81,13 @@ def _properly_wrap_export_instance(doc):
         "CaseExportInstance": CaseExportInstance,
     }.get(doc['doc_type'], ExportInstance)
     return class_.wrap(doc)
+
+
+@unit_testing_only
+def delete_all_export_data_schemas():
+    from .models import ExportDataSchema
+
+    db = ExportDataSchema.get_db()
+    for row in db.view('schemas_by_xmlns_or_case_type/view', reduce=False):
+        doc_id = row['id']
+        safe_delete(db, doc_id)

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -17,7 +17,7 @@ from corehq.apps.userreports.expressions.getters import NestedDictGetter
 from corehq.apps.app_manager.dbaccessors import (
     get_built_app_ids_for_app_id,
     get_all_built_app_ids_and_versions,
-    get_latest_built_app_ids_and_versions,
+    get_latest_app_ids_and_versions,
 )
 from corehq.apps.app_manager.models import Application
 from corehq.apps.app_manager.util import get_case_properties, ParentCasePropertyBuilder
@@ -476,7 +476,7 @@ class ExportInstance(BlobMixin, Document):
 
         instance.name = instance.name or instance.defaults.get_default_instance_name(schema)
 
-        latest_app_ids_and_versions = get_latest_built_app_ids_and_versions(
+        latest_app_ids_and_versions = get_latest_app_ids_and_versions(
             schema.domain,
             getattr(schema, 'app_id', None),
         )

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -969,7 +969,9 @@ class FormExportDataSchema(ExportDataSchema):
         app_build_ids.append(app_id)
         for app_doc in iter_docs(Application.get_db(), app_build_ids):
             # TODO: Remove this when we mark applications that have been submitted
-            if USE_SQL_BACKEND.enabled(domain) and not app_doc.get('is_released', False):
+            if (USE_SQL_BACKEND.enabled(domain) and
+                    not app_doc.get('is_released', False) and
+                    app_doc.get('copy_of')):
                 continue
 
             app = Application.wrap(app_doc)
@@ -1111,8 +1113,11 @@ class CaseExportDataSchema(ExportDataSchema):
 
         for app_doc in iter_docs(Application.get_db(), app_build_ids):
             # TODO: Remove this when we mark applications that have been submitted
-            if USE_SQL_BACKEND.enabled(domain) and not app_doc.get('is_released', False):
+            if (USE_SQL_BACKEND.enabled(domain) and
+                    not app_doc.get('is_released', False) and
+                    app_doc.get('copy_of')):
                 continue
+
             app = Application.wrap(app_doc)
             current_case_schema = CaseExportDataSchema._process_app_build(
                 current_case_schema,

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -213,7 +213,11 @@ class ExportColumn(DocumentSchema):
         else:
             column = ExportColumn(**constructor_args)
         column.update_properties_from_app_ids_and_versions(app_ids_and_versions)
-        column.selected = not column._is_deleted(app_ids_and_versions) and is_main_table and not is_case_update
+        column.selected = (
+            not column._is_deleted(app_ids_and_versions) and
+            not is_case_update and
+            is_main_table
+        )
         return column
 
     def _is_deleted(self, app_ids_and_versions):

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -221,10 +221,7 @@ class ExportColumn(DocumentSchema):
         return column
 
     def _is_deleted(self, app_ids_and_versions):
-        return (
-            is_occurrence_deleted(self.item.last_occurrences, app_ids_and_versions) and
-            bool(app_ids_and_versions)  # If this is empty that means there are no builds
-        )
+        return is_occurrence_deleted(self.item.last_occurrences, app_ids_and_versions)
 
     def update_properties_from_app_ids_and_versions(self, app_ids_and_versions):
         """
@@ -486,10 +483,11 @@ class ExportInstance(BlobMixin, Document):
                 label=instance.defaults.get_default_table_name(group_schema.path),
                 selected=instance.defaults.default_is_table_selected(group_schema.path),
             )
-            table.is_deleted = (is_occurrence_deleted(
+            table.is_deleted = is_occurrence_deleted(
                 group_schema.last_occurrences,
                 latest_app_ids_and_versions,
-            ) and bool(latest_app_ids_and_versions))
+            )
+
             prev_index = 0
             for item in group_schema.items:
                 index, column = table.get_column(

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1012,7 +1012,7 @@ class FormExportDataSchema(ExportDataSchema):
             xform,
             case_updates,
             app.langs,
-            app.copy_of,
+            app.copy_of or app._id,  # If it's not a copy, must be current
             app.version,
         )
         return FormExportDataSchema._merge_schemas(current_schema, xform_schema)
@@ -1115,18 +1115,18 @@ class CaseExportDataSchema(ExportDataSchema):
         case_schemas.append(CaseExportDataSchema._generate_schema_from_case_property_mapping(
             case_property_mapping,
             parent_types,
-            app.copy_of,
+            app.copy_of or app._id,  # If not copy, must be current app
             app.version,
         ))
         if any(map(lambda relationship_tuple: relationship_tuple[1] == 'parent', parent_types)):
             case_schemas.append(CaseExportDataSchema._generate_schema_for_parent_case(
-                app.copy_of,
+                app.copy_of or app._id,
                 app.version,
             ))
 
         case_schemas.append(CaseExportDataSchema._generate_schema_for_case_history(
             case_property_mapping,
-            app.copy_of,
+            app.copy_of or app._id,
             app.version,
         ))
         case_schemas.append(current_schema)

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -982,18 +982,14 @@ class FormExportDataSchema(ExportDataSchema):
 
             current_xform_schema.record_update(app_id, app.version)
 
-        # Don't save the schema if there is already a saved schema object
-        # and we didn't update it with any app builds
-        if not original_id or app_build_ids:
-            current_xform_schema.domain = domain
-            current_xform_schema.app_id = app_id
-            current_xform_schema.xmlns = form_xmlns
-            current_xform_schema = FormExportDataSchema._save_export_schema(
-                current_xform_schema,
-                original_id,
-                original_rev
-            )
-
+        current_xform_schema.domain = domain
+        current_xform_schema.app_id = app_id
+        current_xform_schema.xmlns = form_xmlns
+        current_xform_schema = FormExportDataSchema._save_export_schema(
+            current_xform_schema,
+            original_id,
+            original_rev
+        )
         return current_xform_schema
 
     @staticmethod
@@ -1126,17 +1122,13 @@ class CaseExportDataSchema(ExportDataSchema):
             )
             current_case_schema.record_update(app.copy_of or app_id, app.version)
 
-        # Don't save the schema if there is already a saved schema object
-        # and we didn't update it with any app builds
-        if not original_id or app_build_ids:
-            current_case_schema.domain = domain
-            current_case_schema.case_type = case_type
-
-            current_case_schema = CaseExportDataSchema._save_export_schema(
-                current_case_schema,
-                original_id,
-                original_rev
-            )
+        current_case_schema.domain = domain
+        current_case_schema.case_type = case_type
+        current_case_schema = CaseExportDataSchema._save_export_schema(
+            current_case_schema,
+            original_id,
+            original_rev
+        )
         return current_case_schema
 
     @staticmethod

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -831,12 +831,64 @@ class ExportDataSchema(Document):
     domain = StringProperty()
     created_on = DateTimeProperty(default=datetime.utcnow)
     group_schemas = SchemaListProperty(ExportGroupSchema)
+    app_id = StringProperty()
 
     # A map of app_id to app_version. Represents the last time it saw an app and at what version
     last_app_versions = DictProperty()
 
     class Meta:
         app_label = 'export'
+
+    @classmethod
+    def generate_schema_from_builds(cls, domain, app_id, identifier, force_rebuild=False):
+        """Builds a schema from Application builds for a given identifier
+
+        :param domain: The domain that the export belongs to
+        :param app_id: The app_id that the export belongs to
+        :param identifier: The unique identifier of the schema being exported.
+            case_type for Case Exports and xmlns for Form Exports
+        :returns: Returns a FormExportDataSchema instance
+        """
+
+        original_id, original_rev = None, None
+        current_schema = cls.get_latest_export_schema(domain, app_id, identifier)
+        if current_schema and not force_rebuild:
+            original_id, original_rev = current_schema._id, current_schema._rev
+        else:
+            current_schema = cls()
+
+        app_build_ids = cls._get_app_build_ids_to_process(
+            domain,
+            app_id,
+            current_schema.last_app_versions,
+        )
+        app_build_ids.append(app_id)
+        for app_doc in iter_docs(Application.get_db(), app_build_ids):
+            # TODO: Remove this when we mark applications that have been submitted
+            if (USE_SQL_BACKEND.enabled(domain) and
+                    not app_doc.get('is_released', False) and
+                    app_doc.get('copy_of')):
+                continue
+
+            app = Application.wrap(app_doc)
+            current_schema = cls._process_app_build(
+                current_schema,
+                app,
+                app_id,
+                identifier,
+            )
+
+            current_schema.record_update(app_id, app.version)
+
+        current_schema.domain = domain
+        current_schema.app_id = app_id
+        current_schema._set_identifier(identifier)
+        current_schema = cls._save_export_schema(
+            current_schema,
+            original_id,
+            original_rev
+        )
+        return current_schema
 
     @classmethod
     def _merge_schemas(cls, *schemas):
@@ -921,7 +973,6 @@ class ExportDataSchema(Document):
 
 class FormExportDataSchema(ExportDataSchema):
 
-    app_id = StringProperty()
     xmlns = StringProperty()
     datatype_mapping = defaultdict(lambda: ScalarItem, {
         'MSelect': MultipleChoiceItem,
@@ -935,6 +986,9 @@ class FormExportDataSchema(ExportDataSchema):
     def type(self):
         return FORM_EXPORT
 
+    def _set_identifier(self, form_xmlns):
+        self.xmlns = form_xmlns
+
     @staticmethod
     def _get_app_build_ids_to_process(domain, app_id, last_app_versions):
         return get_built_app_ids_for_app_id(
@@ -944,53 +998,8 @@ class FormExportDataSchema(ExportDataSchema):
         )
 
     @staticmethod
-    def generate_schema_from_builds(domain, app_id, form_xmlns, force_rebuild=False):
-        """Builds a schema from Application builds for a given identifier
-
-        :param domain: The domain that the export belongs to
-        :param app_id: The app_id that the export belongs to
-        :param unique_form_id: The unique identifier of the schema being exported
-        :returns: Returns a FormExportDataSchema instance
-        """
-        original_id, original_rev = None, None
-        current_xform_schema = get_latest_form_export_schema(domain, app_id, form_xmlns)
-        if current_xform_schema and not force_rebuild:
-            original_id, original_rev = current_xform_schema._id, current_xform_schema._rev
-        else:
-            current_xform_schema = FormExportDataSchema()
-
-        app_build_ids = FormExportDataSchema._get_app_build_ids_to_process(
-            domain,
-            app_id,
-            current_xform_schema.last_app_versions,
-        )
-        app_build_ids.append(app_id)
-        for app_doc in iter_docs(Application.get_db(), app_build_ids):
-            # TODO: Remove this when we mark applications that have been submitted
-            if (USE_SQL_BACKEND.enabled(domain) and
-                    not app_doc.get('is_released', False) and
-                    app_doc.get('copy_of')):
-                continue
-
-            app = Application.wrap(app_doc)
-            current_xform_schema = FormExportDataSchema._process_app_build(
-                current_xform_schema,
-                app,
-                app_id,
-                form_xmlns,
-            )
-
-            current_xform_schema.record_update(app_id, app.version)
-
-        current_xform_schema.domain = domain
-        current_xform_schema.app_id = app_id
-        current_xform_schema.xmlns = form_xmlns
-        current_xform_schema = FormExportDataSchema._save_export_schema(
-            current_xform_schema,
-            original_id,
-            original_rev
-        )
-        return current_xform_schema
+    def get_latest_export_schema(domain, app_id, form_xmlns):
+        return get_latest_form_export_schema(domain, app_id, form_xmlns)
 
     @staticmethod
     def _process_app_build(current_schema, app, app_id, form_xmlns):
@@ -1072,8 +1081,11 @@ class CaseExportDataSchema(ExportDataSchema):
     def type(self):
         return CASE_EXPORT
 
+    def _set_identifier(self, case_type):
+        self.case_type = case_type
+
     @staticmethod
-    def _get_app_build_ids_to_process(domain, last_app_versions):
+    def _get_app_build_ids_to_process(domain, app_id, last_app_versions):
         app_build_verions = get_all_built_app_ids_and_versions(domain)
         # Filter by current app id
         app_build_verions = filter(
@@ -1085,54 +1097,8 @@ class CaseExportDataSchema(ExportDataSchema):
         return map(lambda app_build_version: app_build_version.build_id, app_build_verions)
 
     @staticmethod
-    def generate_schema_from_builds(domain, app_id, case_type, force_rebuild=False):
-        """Builds a schema from Application builds for a given identifier
-
-        :param domain: The domain that the export belongs to
-        :param app_id: The app_id that the export belongs to
-        :param case_type: The unique identifier of the schema being exported
-        :returns: Returns a CaseExportDataSchema instance
-        """
-
-        original_id, original_rev = None, None
-        current_case_schema = get_latest_case_export_schema(domain, case_type)
-
-        if current_case_schema and not force_rebuild:
-            # Save the original id an rev so we can later save the document under the same _id
-            original_id, original_rev = current_case_schema._id, current_case_schema._rev
-        else:
-            current_case_schema = CaseExportDataSchema()
-
-        app_build_ids = CaseExportDataSchema._get_app_build_ids_to_process(
-            domain,
-            current_case_schema.last_app_versions,
-        )
-        app_build_ids.append(app_id)
-
-        for app_doc in iter_docs(Application.get_db(), app_build_ids):
-            # TODO: Remove this when we mark applications that have been submitted
-            if (USE_SQL_BACKEND.enabled(domain) and
-                    not app_doc.get('is_released', False) and
-                    app_doc.get('copy_of')):
-                continue
-
-            app = Application.wrap(app_doc)
-            current_case_schema = CaseExportDataSchema._process_app_build(
-                current_case_schema,
-                app,
-                app.copy_of or app_id,  # If copy of doesn't exist, then it is the current app
-                case_type,
-            )
-            current_case_schema.record_update(app.copy_of or app_id, app.version)
-
-        current_case_schema.domain = domain
-        current_case_schema.case_type = case_type
-        current_case_schema = CaseExportDataSchema._save_export_schema(
-            current_case_schema,
-            original_id,
-            original_rev
-        )
-        return current_case_schema
+    def get_latest_export_schema(domain, app_id, case_type):
+        return get_latest_case_export_schema(domain, case_type)
 
     @staticmethod
     def _process_app_build(current_schema, app, app_id, case_type):

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -221,7 +221,10 @@ class ExportColumn(DocumentSchema):
         return column
 
     def _is_deleted(self, app_ids_and_versions):
-        return is_occurrence_deleted(self.item.last_occurrences, app_ids_and_versions)
+        return (
+            is_occurrence_deleted(self.item.last_occurrences, app_ids_and_versions) and
+            bool(app_ids_and_versions)  # If this is empty that means there are no builds
+        )
 
     def update_properties_from_app_ids_and_versions(self, app_ids_and_versions):
         """
@@ -483,10 +486,10 @@ class ExportInstance(BlobMixin, Document):
                 label=instance.defaults.get_default_table_name(group_schema.path),
                 selected=instance.defaults.default_is_table_selected(group_schema.path),
             )
-            table.is_deleted = is_occurrence_deleted(
+            table.is_deleted = (is_occurrence_deleted(
                 group_schema.last_occurrences,
                 latest_app_ids_and_versions,
-            )
+            ) and bool(latest_app_ids_and_versions))
             prev_index = 0
             for item in group_schema.items:
                 index, column = table.get_column(
@@ -963,6 +966,7 @@ class FormExportDataSchema(ExportDataSchema):
             app_id,
             current_xform_schema.last_app_versions,
         )
+        app_build_ids.append(app_id)
         for app_doc in iter_docs(Application.get_db(), app_build_ids):
             # TODO: Remove this when we mark applications that have been submitted
             if USE_SQL_BACKEND.enabled(domain) and not app_doc.get('is_released', False):
@@ -975,7 +979,8 @@ class FormExportDataSchema(ExportDataSchema):
                 app_id,
                 form_xmlns,
             )
-            current_xform_schema.record_update(app.copy_of, app.version)
+
+            current_xform_schema.record_update(app_id, app.version)
 
         # Don't save the schema if there is already a saved schema object
         # and we didn't update it with any app builds
@@ -1002,7 +1007,7 @@ class FormExportDataSchema(ExportDataSchema):
             xform,
             case_updates,
             app.langs,
-            app.copy_of,
+            app_id,
             app.version,
         )
         return FormExportDataSchema._merge_schemas(current_schema, xform_schema)
@@ -1084,10 +1089,11 @@ class CaseExportDataSchema(ExportDataSchema):
         return map(lambda app_build_version: app_build_version.build_id, app_build_verions)
 
     @staticmethod
-    def generate_schema_from_builds(domain, case_type, force_rebuild=False):
+    def generate_schema_from_builds(domain, app_id, case_type, force_rebuild=False):
         """Builds a schema from Application builds for a given identifier
 
         :param domain: The domain that the export belongs to
+        :param app_id: The app_id that the export belongs to
         :param case_type: The unique identifier of the schema being exported
         :returns: Returns a CaseExportDataSchema instance
         """
@@ -1105,6 +1111,7 @@ class CaseExportDataSchema(ExportDataSchema):
             domain,
             current_case_schema.last_app_versions,
         )
+        app_build_ids.append(app_id)
 
         for app_doc in iter_docs(Application.get_db(), app_build_ids):
             # TODO: Remove this when we mark applications that have been submitted
@@ -1114,9 +1121,10 @@ class CaseExportDataSchema(ExportDataSchema):
             current_case_schema = CaseExportDataSchema._process_app_build(
                 current_case_schema,
                 app,
+                app.copy_of or app_id,  # If copy of doesn't exist, then it is the current app
                 case_type,
             )
-            current_case_schema.record_update(app.copy_of, app.version)
+            current_case_schema.record_update(app.copy_of or app_id, app.version)
 
         # Don't save the schema if there is already a saved schema object
         # and we didn't update it with any app builds
@@ -1132,7 +1140,7 @@ class CaseExportDataSchema(ExportDataSchema):
         return current_case_schema
 
     @staticmethod
-    def _process_app_build(current_schema, app, case_type):
+    def _process_app_build(current_schema, app, app_id, case_type):
         case_property_mapping = get_case_properties(
             app,
             [case_type],
@@ -1146,18 +1154,18 @@ class CaseExportDataSchema(ExportDataSchema):
         case_schemas.append(CaseExportDataSchema._generate_schema_from_case_property_mapping(
             case_property_mapping,
             parent_types,
-            app.copy_of,
+            app_id,
             app.version,
         ))
         if any(map(lambda relationship_tuple: relationship_tuple[1] == 'parent', parent_types)):
             case_schemas.append(CaseExportDataSchema._generate_schema_for_parent_case(
-                app.copy_of,
+                app_id,
                 app.version,
             ))
 
         case_schemas.append(CaseExportDataSchema._generate_schema_for_case_history(
             case_property_mapping,
-            app.copy_of,
+            app_id,
             app.version,
         ))
         case_schemas.append(current_schema)

--- a/corehq/apps/export/tests/test_export_data_schema.py
+++ b/corehq/apps/export/tests/test_export_data_schema.py
@@ -5,12 +5,12 @@ from django.test import SimpleTestCase, TestCase
 
 from corehq.apps.export.models.new import MAIN_TABLE, \
     PathNode, _question_path_to_path_nodes
-from dimagi.utils.couch.database import safe_delete
 
 from corehq.util.context_managers import drop_connected_signals
 from corehq.apps.app_manager.tests.util import TestXmlMixin
 from corehq.apps.app_manager.models import XForm, Application
 from corehq.apps.app_manager.signals import app_post_save
+from corehq.apps.export.dbaccessors import delete_all_export_data_schemas
 from corehq.apps.export.models import (
     FormExportDataSchema,
     CaseExportDataSchema,
@@ -379,10 +379,7 @@ class TestBuildingSchemaFromApplication(TestCase, TestXmlMixin):
         # to circumvent domain.delete()'s recursive deletion that this test doesn't need
 
     def tearDown(self):
-        db = ExportDataSchema.get_db()
-        for row in db.view('schemas_by_xmlns_or_case_type/view', reduce=False):
-            doc_id = row['id']
-            safe_delete(db, doc_id)
+        delete_all_export_data_schemas()
 
     def test_basic_application_schema(self):
         app = self.current_app
@@ -442,10 +439,7 @@ class TestExportDataSchemaVersionControl(TestCase, TestXmlMixin):
         cls.current_app.delete()
 
     def tearDown(self):
-        db = ExportDataSchema.get_db()
-        for row in db.view('schemas_by_xmlns_or_case_type/view', reduce=False):
-            doc_id = row['id']
-            safe_delete(db, doc_id)
+        delete_all_export_data_schemas()
 
     def test_rebuild_version_control(self):
         app = self.current_app
@@ -505,10 +499,7 @@ class TestBuildingCaseSchemaFromApplication(TestCase, TestXmlMixin):
             app.delete()
 
     def tearDown(self):
-        db = ExportDataSchema.get_db()
-        for row in db.view('schemas_by_xmlns_or_case_type/view', reduce=False):
-            doc_id = row['id']
-            safe_delete(db, doc_id)
+        delete_all_export_data_schemas()
 
     def test_basic_application_schema(self):
         schema = CaseExportDataSchema.generate_schema_from_builds(
@@ -581,10 +572,7 @@ class TestBuildingParentCaseSchemaFromApplication(TestCase, TestXmlMixin):
             app.delete()
 
     def tearDown(self):
-        db = ExportDataSchema.get_db()
-        for row in db.view('schemas_by_xmlns_or_case_type/view', reduce=False):
-            doc_id = row['id']
-            safe_delete(db, doc_id)
+        delete_all_export_data_schemas()
 
     def test_parent_case_table_generation(self):
         """

--- a/corehq/apps/export/tests/test_export_data_schema.py
+++ b/corehq/apps/export/tests/test_export_data_schema.py
@@ -195,6 +195,7 @@ class TestCaseExportDataSchema(SimpleTestCase, TestXmlMixin):
                 return_value=results):
             build_ids = CaseExportDataSchema._get_app_build_ids_to_process(
                 'dummy',
+                'dummy-app-id',
                 last_app_versions
             )
         self.assertEqual(sorted(build_ids), ['2', '4'])

--- a/corehq/apps/export/tests/test_export_instance.py
+++ b/corehq/apps/export/tests/test_export_instance.py
@@ -69,7 +69,7 @@ class TestExportInstanceGeneration(SimpleTestCase):
         """Only questions that are in the main table and of the same version should be shown"""
         build_ids_and_versions = {self.app_id: 3}
         with mock.patch(
-                'corehq.apps.export.models.new.get_latest_built_app_ids_and_versions',
+                'corehq.apps.export.models.new.get_latest_app_ids_and_versions',
                 return_value=build_ids_and_versions):
 
             instance = FormExportInstance.generate_instance_from_schema(self.schema)
@@ -99,7 +99,7 @@ class TestExportInstanceGeneration(SimpleTestCase):
         """Given a higher app_version, all the old questions should not be shown or selected"""
         build_ids_and_versions = {self.app_id: 4}
         with mock.patch(
-                'corehq.apps.export.models.new.get_latest_built_app_ids_and_versions',
+                'corehq.apps.export.models.new.get_latest_app_ids_and_versions',
                 return_value=build_ids_and_versions):
             instance = FormExportInstance.generate_instance_from_schema(self.schema)
 
@@ -198,7 +198,7 @@ class TestExportInstanceGenerationMultipleApps(SimpleTestCase):
             self.second_app_id: 4,
         }
         with mock.patch(
-                'corehq.apps.export.models.new.get_latest_built_app_ids_and_versions',
+                'corehq.apps.export.models.new.get_latest_app_ids_and_versions',
                 return_value=build_ids_and_versions):
             instance = FormExportInstance.generate_instance_from_schema(self.schema)
 
@@ -222,7 +222,7 @@ class TestExportInstanceGenerationMultipleApps(SimpleTestCase):
             self.second_app_id: 5,
         }
         with mock.patch(
-                'corehq.apps.export.models.new.get_latest_built_app_ids_and_versions',
+                'corehq.apps.export.models.new.get_latest_app_ids_and_versions',
                 return_value=build_ids_and_versions):
             instance = FormExportInstance.generate_instance_from_schema(self.schema)
 
@@ -367,7 +367,7 @@ class TestExportInstanceFromSavedInstance(TestCase):
             self.app_id: 3,
         }
         with mock.patch(
-                'corehq.apps.export.models.new.get_latest_built_app_ids_and_versions',
+                'corehq.apps.export.models.new.get_latest_app_ids_and_versions',
                 return_value=build_ids_and_versions):
             instance = FormExportInstance.generate_instance_from_schema(self.schema)
 
@@ -383,7 +383,7 @@ class TestExportInstanceFromSavedInstance(TestCase):
         self.assertFalse(instance.tables[0].columns[first_non_system_property].selected)
 
         with mock.patch(
-                'corehq.apps.export.models.new.get_latest_built_app_ids_and_versions',
+                'corehq.apps.export.models.new.get_latest_app_ids_and_versions',
                 return_value=build_ids_and_versions):
 
             instance = FormExportInstance.generate_instance_from_schema(
@@ -404,7 +404,7 @@ class TestExportInstanceFromSavedInstance(TestCase):
             self.app_id: 3,
         }
         with mock.patch(
-                'corehq.apps.export.models.new.get_latest_built_app_ids_and_versions',
+                'corehq.apps.export.models.new.get_latest_app_ids_and_versions',
                 return_value=build_ids_and_versions):
             instance = FormExportInstance.generate_instance_from_schema(self.schema)
 
@@ -418,7 +418,7 @@ class TestExportInstanceFromSavedInstance(TestCase):
             self.app_id: 4,
         }
         with mock.patch(
-                'corehq.apps.export.models.new.get_latest_built_app_ids_and_versions',
+                'corehq.apps.export.models.new.get_latest_app_ids_and_versions',
                 return_value=build_ids_and_versions):
 
             instance = FormExportInstance.generate_instance_from_schema(

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -16,7 +16,7 @@ from .const import (
 def is_occurrence_deleted(last_occurrences, app_ids_and_versions):
     is_deleted = True
     for app_id, version in app_ids_and_versions.iteritems():
-        if last_occurrences.get(app_id) == version:
+        if last_occurrences.get(app_id) >= version:
             is_deleted = False
             break
     return is_deleted

--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -1402,6 +1402,11 @@ class CaseExportListView(BaseExportListView):
             raise ExportFormValidationException()
         case_type = create_form.cleaned_data['case_type']
         app_id = create_form.cleaned_data['application']
+        if app_id == ApplicationDataRMIHelper.UNKNOWN_SOURCE:
+            app_id_param = ''
+        else:
+            app_id_param = '&app_id={}'.format(app_id)
+
         if toggles.NEW_EXPORTS.enabled(self.domain):
             cls = CreateNewCustomCaseExportView
         else:
@@ -1409,9 +1414,9 @@ class CaseExportListView(BaseExportListView):
         return reverse(
             cls.urlname,
             args=[self.domain],
-        ) + ('?export_tag="{export_tag}"&app_id={app_id}'.format(
+        ) + ('?export_tag="{export_tag}"{app_id_param}'.format(
             export_tag=case_type,
-            app_id=app_id,
+            app_id_param=app_id_param,
         ))
 
 

--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -1401,6 +1401,7 @@ class CaseExportListView(BaseExportListView):
         if not create_form.is_valid():
             raise ExportFormValidationException()
         case_type = create_form.cleaned_data['case_type']
+        app_id = create_form.cleaned_data['application']
         if toggles.NEW_EXPORTS.enabled(self.domain):
             cls = CreateNewCustomCaseExportView
         else:
@@ -1408,8 +1409,9 @@ class CaseExportListView(BaseExportListView):
         return reverse(
             cls.urlname,
             args=[self.domain],
-        ) + ('?export_tag="{export_tag}"'.format(
+        ) + ('?export_tag="{export_tag}"&app_id={app_id}'.format(
             export_tag=case_type,
+            app_id=app_id,
         ))
 
 
@@ -1482,9 +1484,11 @@ class CreateNewCustomCaseExportView(BaseModifyNewCustomView):
 
     def get(self, request, *args, **kwargs):
         case_type = request.GET.get('export_tag').strip('"')
+        app_id = request.GET.get('app_id')
 
         schema = CaseExportDataSchema.generate_schema_from_builds(
             self.domain,
+            app_id,
             case_type,
         )
         self.export_instance = self.export_instance_cls.generate_instance_from_schema(schema)


### PR DESCRIPTION
@NoahCarnahan @czue this includes https://github.com/dimagi/commcare-hq/pull/12174. Only commits after https://github.com/dimagi/commcare-hq/commit/a15fabe083e4c59505d9935c13e08b21af5ebcff are relevant for the PR. This will allow us to version control our schemas so we can force a rebuild when bugs occur (if they ever do 😆 )
