### PR TITLE
remove obsolete references to the product type

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -794,10 +794,6 @@ class SoftwarePlanVersion(models.Model):
         }
 
     @property
-    def core_product(self):
-        return self.product_rate.product.product_type
-
-    @property
     def version(self):
         return (self.plan.softwareplanversion_set.count() -
                 self.plan.softwareplanversion_set.filter(
@@ -1453,13 +1449,11 @@ class Subscription(models.Model):
         user_desc = self.plan_version.user_facing_description
         plan_name = user_desc['name']
         domain_name = self.subscriber.domain
-        product = self.plan_version.core_product
         emails = {a.username for a in WebUser.get_admins_by_domain(domain_name)}
         emails |= {e for e in WebUser.get_dimagi_emails_by_domain(domain_name)}
         if self.is_trial:
-            subject = _("%(product)s Alert: 30 day trial for '%(domain)s' "
+            subject = _("CommCare Alert: 30 day trial for '%(domain)s' "
                         "ends %(ending_on)s") % {
-                'product': product,
                 'domain': domain_name,
                 'ending_on': ending_on,
             }
@@ -1467,10 +1461,9 @@ class Subscription(models.Model):
             template_plaintext = 'accounting/trial_ending_reminder_email_plaintext.txt'
         else:
             subject = _(
-                "%(product)s Alert: %(domain)s's subscription to "
+                "CommCare Alert: %(domain)s's subscription to "
                 "%(plan_name)s ends %(ending_on)s"
             ) % {
-                'product': product,
                 'plan_name': plan_name,
                 'domain': domain_name,
                 'ending_on': ending_on,

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -745,12 +745,10 @@ class DefaultProductPlan(models.Model):
 
     @classmethod
     def get_default_plan_by_domain(cls, domain, edition=None, is_trial=False):
-        domain = ensure_domain_instance(domain)
         edition = edition or SoftwarePlanEdition.COMMUNITY
-        product_type = SoftwareProductType.get_type_by_domain(domain)
         try:
             default_product_plan = DefaultProductPlan.objects.select_related('plan').get(
-                product_type=product_type, edition=edition, is_trial=is_trial
+                product_type=SoftwareProductType.COMMCARE, edition=edition, is_trial=is_trial
             )
             return default_product_plan.plan.get_version()
         except DefaultProductPlan.DoesNotExist:

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -49,7 +49,7 @@ from corehq.apps.accounting.utils import (
     fmt_dollar_amount,
     get_address_from_invoice,
     get_change_status,
-    get_dimagi_from_email_by_product,
+    get_dimagi_from_email,
     get_privileges,
     is_active_subscription,
     log_accounting_error,
@@ -1506,7 +1506,7 @@ class Subscription(models.Model):
             send_html_email_async.delay(
                 subject, email, email_html,
                 text_content=email_plaintext,
-                email_from=get_dimagi_from_email_by_product(product),
+                email_from=get_dimagi_from_email(),
                 bcc=bcc,
             )
             log_accounting_info(
@@ -2421,7 +2421,7 @@ class BillingRecord(BillingRecordBase):
         }
 
     def email_from(self):
-        return get_dimagi_from_email_by_product(self.invoice.subscription.plan_version.core_product)
+        return get_dimagi_from_email()
 
     @staticmethod
     def _get_total_balance(credit_lines):

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -1490,7 +1490,6 @@ class Subscription(models.Model):
         context = {
             'domain': domain_name,
             'plan_name': plan_name,
-            'product': product,
             'ending_on': ending_on,
             'subscription_url': absolute_reverse(
                 DomainSubscriptionView.urlname, args=[self.subscriber.domain]),

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -112,14 +112,6 @@ class SoftwareProductType(object):
         (COMMCONNECT, COMMCONNECT),
     )
 
-    @classmethod
-    def get_type_by_domain(cls, domain):
-        if domain.commtrack_enabled:
-            return cls.COMMTRACK
-        if domain.commconnect_enabled:
-            return cls.COMMCONNECT
-        return cls.COMMCARE
-
 
 class SoftwarePlanEdition(object):
     COMMUNITY = "Community"

--- a/corehq/apps/accounting/payment_handlers.py
+++ b/corehq/apps/accounting/payment_handlers.py
@@ -171,7 +171,7 @@ class BaseStripePaymentHandler(object):
         additional_context = self.get_email_context()
         from corehq.apps.accounting.tasks import send_purchase_receipt
         send_purchase_receipt.delay(
-            payment_record, self.core_product, self.domain, self.receipt_email_template,
+            payment_record, self.domain, self.receipt_email_template,
             self.receipt_email_template_plaintext, additional_context
         )
 
@@ -458,8 +458,6 @@ class AutoPayInvoicePaymentHandler(object):
         receipt_email_template_plaintext = 'accounting/invoice_receipt_email_plaintext.txt'
         try:
             domain = invoice.subscription.subscriber.domain
-            product = SoftwareProductType.get_type_by_domain(Domain.get_by_name(domain))
-
             context = {
                 'invoicing_contact_email': settings.INVOICING_CONTACT_EMAIL,
                 'balance': fmt_dollar_amount(invoice.balance),
@@ -468,7 +466,7 @@ class AutoPayInvoicePaymentHandler(object):
                 'invoice_num': invoice.invoice_number,
             }
             send_purchase_receipt.delay(
-                payment_record, product, domain, receipt_email_template, receipt_email_template_plaintext, context,
+                payment_record, domain, receipt_email_template, receipt_email_template_plaintext, context,
             )
         except:
             self._handle_email_failure(payment_record)

--- a/corehq/apps/accounting/payment_handlers.py
+++ b/corehq/apps/accounting/payment_handlers.py
@@ -47,12 +47,6 @@ class BaseStripePaymentHandler(object):
         """
         raise NotImplementedError("you must implement cost_item_name")
 
-    @property
-    @memoized
-    def core_product(self):
-        domain = Domain.get_by_name(self.domain)
-        return SoftwareProductType.get_type_by_domain(domain)
-
     def create_charge(self, amount, card=None, customer=None):
         """Process the HTTPRequest used to make this payment
 

--- a/corehq/apps/accounting/payment_handlers.py
+++ b/corehq/apps/accounting/payment_handlers.py
@@ -331,7 +331,7 @@ class CreditStripePaymentHandler(BaseStripePaymentHandler):
         )
 
     def _humanized_features(self):
-        return [{'type': get_feature_name(feature['type'], self.core_product),
+        return [{'type': get_feature_name(feature['type'], SoftwareProductType.COMMCARE),
                  'amount': fmt_dollar_amount(feature['amount'])}
                 for feature in self.features]
 

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -41,7 +41,7 @@ from corehq.apps.accounting.payment_handlers import AutoPayInvoicePaymentHandler
 from corehq.apps.accounting.utils import (
     fmt_dollar_amount,
     get_change_status,
-    get_dimagi_from_email_by_product,
+    get_dimagi_from_email,
     has_subscription_already_ended,
     log_accounting_error,
     log_accounting_info,
@@ -372,7 +372,6 @@ def send_purchase_receipt(payment_record, core_product, domain,
         'amount': fmt_dollar_amount(payment_record.amount),
         'project': domain,
         'date_paid': payment_record.date_created.strftime(USER_DATE_FORMAT),
-        'product': core_product,
         'transaction_id': payment_record.public_transaction_id,
     }
     context.update(additional_context)
@@ -383,7 +382,7 @@ def send_purchase_receipt(payment_record, core_product, domain,
     send_HTML_email(
         ugettext("Payment Received - Thank You!"), email, email_html,
         text_content=email_plaintext,
-        email_from=get_dimagi_from_email_by_product(core_product),
+        email_from=get_dimagi_from_email(),
     )
 
 
@@ -418,7 +417,7 @@ def send_autopay_failed(invoice, payment_method):
         recipient=recipient,
         html_content=render_to_string(template_html, context),
         text_content=render_to_string(template_plaintext, context),
-        email_from=get_dimagi_from_email_by_product(subscription.plan_version.product_rate.product.product_type),
+        email_from=get_dimagi_from_email(),
     )
 
 

--- a/corehq/apps/accounting/tasks.py
+++ b/corehq/apps/accounting/tasks.py
@@ -351,7 +351,7 @@ def create_wire_credits_invoice(domain_name,
 
 
 @task(ignore_result=True)
-def send_purchase_receipt(payment_record, core_product, domain,
+def send_purchase_receipt(payment_record, domain,
                           template_html, template_plaintext,
                           additional_context):
     username = payment_record.payment_method.web_user

--- a/corehq/apps/accounting/templates/accounting/invoice_receipt_email.html
+++ b/corehq/apps/accounting/templates/accounting/invoice_receipt_email.html
@@ -39,7 +39,7 @@
 
 <p>
     {% blocktrans %}
-    Thank you for using {{ product }}. If you have any questions, please don't
+    Thank you for using CommCare. If you have any questions, please don't
     hesitate to contact {{ invoicing_contact_email }}.
     {% endblocktrans %}
 </p>
@@ -47,7 +47,7 @@
 <p>
     {% blocktrans %}
     Best Regards,<br />
-    The {{ product }} HQ Team<br />
+    The CommCare HQ Team<br />
     <a href="http://www.commcarehq.org/">www.commcarehq.org</a>
     {% endblocktrans %}
 </p>

--- a/corehq/apps/accounting/templates/accounting/invoice_receipt_email_plaintext.txt
+++ b/corehq/apps/accounting/templates/accounting/invoice_receipt_email_plaintext.txt
@@ -20,11 +20,11 @@ Remaining Balance: {{ balance }}
 Date Due: {{ date_due }}{% endblocktrans %}{% endif %}
 
 {% blocktrans %}
-Thank you for using {{ product }}. If you have any questions, please don't
+Thank you for using CommCare. If you have any questions, please don't
 hesitate to contact {{ invoicing_contact_email }}.
 
 Best Regards,
-The {{ product }} HQ Team
+The CommCare HQ Team
 www.commcarehq.org
 
 Email From:

--- a/corehq/apps/accounting/templates/accounting/subscription_ending_reminder_email.html
+++ b/corehq/apps/accounting/templates/accounting/subscription_ending_reminder_email.html
@@ -5,7 +5,7 @@
     {% blocktrans %}
     Your {{ plan_name }} subscription for {{ domain }} ends soon! If you do not
     renew your subscription before then, you will automatically be subscribed
-    to the {{ product }} Community plan and lose access to all pay-only
+    to the CommCare Community plan and lose access to all pay-only
     features {{ ending_on }}
     {% endblocktrans %}
 </p>
@@ -13,7 +13,7 @@
 <p>
     {% blocktrans %}
     To change or renew your subscription, please log into your project on
-    {{ product }} HQ and navigate to the
+    CommCare HQ and navigate to the
     <a href="{{ subscription_url }}">subscription page</a> in your
     project settings.
     {% endblocktrans %}
@@ -22,7 +22,7 @@
 <p>
     {% blocktrans %}
     If you have any questions, please don’t hesitate to contact {{ invoicing_contact_email }}.
-    Thank you for your use and support of {{ product }}.
+    Thank you for your use and support of CommCare.
     {% endblocktrans %}
 </p>
 
@@ -34,7 +34,7 @@
 </p>
 
 <p>
-    {% blocktrans %}The {{ product }} HQ Team{% endblocktrans %}<br />
+    {% blocktrans %}The CommCare HQ Team{% endblocktrans %}<br />
     {{ base_url }}
 </p>
 

--- a/corehq/apps/accounting/templates/accounting/subscription_ending_reminder_email_plaintext.html
+++ b/corehq/apps/accounting/templates/accounting/subscription_ending_reminder_email_plaintext.html
@@ -4,18 +4,18 @@ Dear {{ domain }} administrator,
 
 Your {{ plan_name }} subscription for {{ domain }} ends soon! If you do not
 renew your subscription before then, you will automatically be subscribed
-to the {{ product }} Community plan and lose access to all pay-only
+to the CommCare Community plan and lose access to all pay-only
 features {{ ending_on }}
 
 To change or renew your subscription, please log into your project on
-{{ product }} HQ and and navigate to the subscription page in your project
+CommCare HQ and and navigate to the subscription page in your project
 settings: {{ subscription_url }}
 
 If you have any questions, please don’t hesitate to contact {{ invoicing_contact_email }}.
-Thank you for your use and support of {{ product }}.
+Thank you for your use and support of CommCare.
 
 Best regards,
 
-The {{ product }} HQ Team
+The CommCare HQ Team
 {{ base_url }}
 {% endblocktrans %}

--- a/corehq/apps/accounting/utils.py
+++ b/corehq/apps/accounting/utils.py
@@ -187,9 +187,8 @@ def get_address_from_invoice(invoice):
         return Address()
 
 
-def get_dimagi_from_email_by_product(product):
-    return ("Dimagi %(product)s Accounts <%(email)s>" % {
-        'product': product,
+def get_dimagi_from_email():
+    return ("Dimagi CommCare Accounts <%(email)s>" % {
         'email': settings.INVOICING_CONTACT_EMAIL,
     })
 

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -632,7 +632,7 @@ class DomainAccountingSettings(BaseAdminProjectSettingsView):
     @property
     @memoized
     def product(self):
-        return SoftwareProductType.get_type_by_domain(self.domain_object)
+        return SoftwareProductType.COMMCARE
 
     @property
     @memoized

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1126,9 +1126,7 @@ class CreditsWireInvoiceView(DomainAccountingSettings):
         return json_response({'success': True})
 
     def _get_items(self, request):
-        product_type = SoftwareProductType.get_type_by_domain(Domain.get_by_name(self.domain))
-
-        features = [{'type': get_feature_name(feature_type[0], product_type),
+        features = [{'type': get_feature_name(feature_type[0], SoftwareProductType.COMMCARE),
                      'amount': Decimal(request.POST.get(feature_type[0], 0))}
                     for feature_type in FeatureType.CHOICES
                     if Decimal(request.POST.get(feature_type[0], 0)) > 0]


### PR DESCRIPTION
This should always be CommCare going forward, for all UIs and new model instances.

🐡 or 🏢 

@proteusvacuum / @benrudolph cc: @snopoke 
