### PR TITLE
Fix UCR expanded column bug when value is `None`

### DIFF
--- a/corehq/apps/userreports/sql/columns.py
+++ b/corehq/apps/userreports/sql/columns.py
@@ -116,14 +116,17 @@ def _expand_column(report_column, distinct_values, lang):
     """
     columns = []
     for index, val in enumerate(distinct_values):
+        alias = u"{}-{}".format(report_column.column_id, index)
+        if val is None:
+            sql_agg_col = SumWhen(
+                whens={"{} is NULL".format(report_column.field): 1}, else_=0, alias=alias
+            )
+        else:
+            sql_agg_col = SumWhen(report_column.field, whens={val: 1}, else_=0, alias=alias)
+
         columns.append(DatabaseColumn(
             u"{}-{}".format(report_column.get_header(lang), val),
-            SumWhen(
-                report_column.field,
-                whens={val: 1},
-                else_=0,
-                alias=u"{}-{}".format(report_column.column_id, index),
-            ),
+            sql_agg_col,
             sortable=False,
             data_slug=u"{}-{}".format(report_column.column_id, index),
             format_fn=report_column.get_format_fn(),

--- a/corehq/apps/userreports/tests/test_columns.py
+++ b/corehq/apps/userreports/tests/test_columns.py
@@ -270,7 +270,7 @@ class TestExpandedColumn(TestCase):
         """
         field_name = 'my_field'
         submitted_vals = [None, None, 'foo']
-        data_source, column = self._build_report(submitted_vals, field=field_name)
+        data_source, _ = self._build_report(submitted_vals, field=field_name)
 
         headers = [column.header for column in data_source.columns]
         self.assertEqual(set(headers), {"{}-{}".format(field_name, x) for x in submitted_vals})

--- a/corehq/apps/userreports/tests/test_columns.py
+++ b/corehq/apps/userreports/tests/test_columns.py
@@ -142,7 +142,8 @@ class TestExpandedColumn(TestCase):
 
         # Create Cases
         for v in vals:
-            self._new_case({field: v}).save()
+            update_props = {field: v} if v is not None else {}
+            self._new_case(update_props).save()
 
         # Create report
         data_source_config = DataSourceConfiguration(
@@ -259,6 +260,35 @@ class TestExpandedColumn(TestCase):
         self.assertEqual(len(cols), 2)
         self.assertEqual(type(cols[0].view), SumWhen)
         self.assertEqual(cols[1].view.whens, {'negative': 1})
+
+    def test_none_in_values(self):
+        """
+        Confirm that expanded columns work when one of the distinct values is None.
+        This is an edge case because postgres uses different operators for comparing
+        columns to null than it does for comparing to non-null values. e.g.
+            "my_column = 4" vs "my_column is NULL"
+        """
+        field_name = 'my_field'
+        submitted_vals = [None, None, 'foo']
+        data_source, column = self._build_report(submitted_vals, field=field_name)
+
+        headers = [column.header for column in data_source.columns]
+        self.assertEqual(set(headers), {"{}-{}".format(field_name, x) for x in submitted_vals})
+
+        def get_expected_row(submitted_value, distinct_values):
+            # The headers looks like "my_field-foo", but the rows are dicts with
+            # keys like "my_field-1". So, we need use the index of the headers to
+            # to determine which keys in the rows correspond to which values.
+            row = {}
+            for value in distinct_values:
+                header_index = headers.index("{}-{}".format(field_name, value))
+                row_key = "{}-{}".format(field_name, header_index)
+                row[row_key] = 1 if submitted_value == value else 0
+            return row
+
+        expected_rows = [get_expected_row(v, set(submitted_vals)) for v in submitted_vals]
+        data = data_source.get_data()
+        self.assertEqual(sorted(expected_rows), sorted(data))
 
 
 class TestAggregateDateColumn(SimpleTestCase):


### PR DESCRIPTION
Addresses http://manage.dimagi.com/default.asp?230228

`ExpandedColumn`s weren't counting `None` results correctly, because the queries that sql agg/sql alchemy were generating always used the `=` operator for comparison, but sql requires the `is` operator for comparing to `NULL`.

@emord 
@czue and @nickpell might be interested too
