### PR TITLE
Improve blob migration options and progress output

### DIFF
--- a/corehq/blobs/management/commands/run_blob_migration.py
+++ b/corehq/blobs/management/commands/run_blob_migration.py
@@ -24,15 +24,18 @@ class Command(BaseCommand):
         make_option('--file', help="Migration intermediate storage file."),
         make_option('--reset', action="store_true", default=False,
             help="Discard any existing migration state."),
+        make_option('--chunk-size', type="int", default=100,
+            help="Maximum number of records to read from couch at once."),
     )
 
     @change_log_level('boto3', logging.WARNING)
     @change_log_level('botocore', logging.WARNING)
-    def handle(self, slug=None, file=None, reset=False, **options):
+    def handle(self, slug=None, file=None, reset=False, chunk_size=100,
+               **options):
         try:
             migrator = MIGRATIONS[slug]
         except KeyError:
             raise CommandError(USAGE)
-        total, skips = migrator.migrate(file, reset=reset)
+        total, skips = migrator.migrate(file, reset=reset, chunk_size=chunk_size)
         if skips:
             sys.exit(skips)

--- a/corehq/blobs/migrate.py
+++ b/corehq/blobs/migrate.py
@@ -273,6 +273,7 @@ def migrate(slug, doc_type_map, doc_migrator_class, filename=None, reset=False,
     if filename is None:
         dirpath = mkdtemp()
         filename = os.path.join(dirpath, "export.txt")
+    print("Migration log: {}".format(filename))
 
     def encode_content(data):
         if isinstance(data, unicode):

--- a/corehq/tests/nose.py
+++ b/corehq/tests/nose.py
@@ -345,6 +345,8 @@ class HqdbContext(DatabaseContext):
                 return  # skip remaining setup
 
         sys.__stdout__.write("\n")  # newline for creating database message
+        if "REUSE_DB" in os.environ:
+            sys.__stdout__.write("REUSE_DB={REUSE_DB!r} ".format(**os.environ))
         super(HqdbContext, self).setup()
 
     def teardown(self):

--- a/corehq/util/couch_helpers.py
+++ b/corehq/util/couch_helpers.py
@@ -286,6 +286,21 @@ class ResumableDocsByTypeIterator(object):
         self.state["retry"][doc_id] = retries
         self._save_state()
 
+    @property
+    def progress_info(self):
+        """Extra progress information
+
+        This property can be used to store and retrieve extra progress
+        information associated with the iteration. The information is
+        persisted with the iteration state in couch.
+        """
+        return self.state.get("progress_info")
+
+    @progress_info.setter
+    def progress_info(self, info):
+        self.state["progress_info"] = info
+        self._save_state()
+
     def _save_state(self):
         self.state["timestamp"] = datetime.datetime.utcnow().isoformat()
         self.db.save_doc(self.state)

--- a/corehq/util/tests/test_couch_helpers.py
+++ b/corehq/util/tests/test_couch_helpers.py
@@ -115,3 +115,17 @@ class TestResumableDocsByTypeIterator(TestCase):
                              self.sorted_keys)
         finally:
             self.create_doc("Bar", 0)
+
+    def test_iteration_with_progress_info(self):
+        itr = iter(self.itr)
+        self.assertEqual([next(itr)["_id"] for i in range(6)], self.sorted_keys[:6])
+        self.assertEqual(self.itr.progress_info, None)
+        self.itr.progress_info = {"visited": 6}
+        # stop/resume iteration
+        self.itr = self.get_iterator()
+        self.assertEqual(self.itr.progress_info, {"visited": 6})
+        self.itr.progress_info = {"visited": "six"}
+        # stop/resume iteration
+        self.itr = self.get_iterator()
+        self.assertEqual(self.itr.progress_info, {"visited": "six"})
+        self.assertEqual([doc["_id"] for doc in self.itr], self.sorted_keys[4:])


### PR DESCRIPTION
In anticipation of large migrations on prod.
- allow chunk size to be customized. This had to be done by manually editing the migration.py file on staging because the default chunk size was using all available memory, which crashed the migration.
- automatically assign and verify unique log filename. On previous migrations I found it way too easy to overwrite an existing log file by re-running a migration with the same `--file` option used in the previous run.
- improve status output and estimated time remaining for resumed migrations.

@dannyroberts cc @orangejenny 
