### PR TITLE
get default plan without passing domain

### DIFF
--- a/corehq/apps/accounting/invoicing.py
+++ b/corehq/apps/accounting/invoicing.py
@@ -73,8 +73,8 @@ class DomainInvoiceFactory(object):
 
     @transaction.atomic
     def _ensure_full_coverage(self, subscriptions):
-        plan_version = DefaultProductPlan.get_default_plan_by_domain(
-            self.domain, edition=SoftwarePlanEdition.COMMUNITY
+        plan_version = DefaultProductPlan.get_default_plan(
+            edition=SoftwarePlanEdition.COMMUNITY
         ).plan.get_version()
         if not plan_version.feature_charges_exist_for_domain(self.domain):
             return

--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -736,7 +736,7 @@ class DefaultProductPlan(models.Model):
         app_label = 'accounting'
 
     @classmethod
-    def get_default_plan_by_domain(cls, domain, edition=None, is_trial=False):
+    def get_default_plan(cls, edition=None, is_trial=False):
         edition = edition or SoftwarePlanEdition.COMMUNITY
         try:
             default_product_plan = DefaultProductPlan.objects.select_related('plan').get(
@@ -752,8 +752,8 @@ class DefaultProductPlan(models.Model):
     def get_lowest_edition_by_domain(cls, domain, requested_privileges,
                                      return_plan=False):
         for edition in SoftwarePlanEdition.SELF_SERVICE_ORDER:
-            plan_version = cls.get_default_plan_by_domain(
-                domain, edition=edition
+            plan_version = cls.get_default_plan(
+                edition=edition
             )
             privileges = get_privileges(plan_version) - REPORT_BUILDER_ADD_ON_PRIVS
             if privileges.issuperset(requested_privileges):
@@ -940,7 +940,7 @@ class Subscriber(models.Model):
         upgraded_privileges is the list of privileges that should be added
         """
         if new_plan_version is None:
-            new_plan_version = DefaultProductPlan.get_default_plan_by_domain(self.domain)
+            new_plan_version = DefaultProductPlan.get_default_plan()
 
         if downgraded_privileges is None or upgraded_privileges is None:
             change_status_result = get_change_status(None, new_plan_version)
@@ -1580,7 +1580,7 @@ class Subscription(models.Model):
         subscriber = Subscriber.objects.safe_get(domain=domain.name)
         plan_version, subscription = cls._get_plan_by_subscriber(subscriber) if subscriber else (None, None)
         if plan_version is None:
-            plan_version = DefaultProductPlan.get_default_plan_by_domain(domain)
+            plan_version = DefaultProductPlan.get_default_plan()
         return plan_version, subscription
 
     @classmethod

--- a/corehq/apps/accounting/tests/test_credit_lines.py
+++ b/corehq/apps/accounting/tests/test_credit_lines.py
@@ -301,11 +301,11 @@ class TestCreditTransfers(BaseAccountingTest):
         return transferred_credits
 
     def test_transfers(self):
-        advanced_plan = DefaultProductPlan.get_default_plan_by_domain(
-            self.domain, edition=SoftwarePlanEdition.ADVANCED
+        advanced_plan = DefaultProductPlan.get_default_plan(
+            edition=SoftwarePlanEdition.ADVANCED
         )
-        standard_plan = DefaultProductPlan.get_default_plan_by_domain(
-            self.domain, edition=SoftwarePlanEdition.STANDARD
+        standard_plan = DefaultProductPlan.get_default_plan(
+            edition=SoftwarePlanEdition.STANDARD
         )
         first_sub = Subscription.new_domain_subscription(
             self.account, self.domain, advanced_plan

--- a/corehq/apps/accounting/tests/test_invoice_factory.py
+++ b/corehq/apps/accounting/tests/test_invoice_factory.py
@@ -22,8 +22,7 @@ class TestDomainInvoiceFactory(BaseAccountingTest):
         self.account = BillingAccount.get_or_create_account_by_domain(
             domain=self.domain.name, created_by="TEST"
         )[0]
-        self.community = DefaultProductPlan.get_default_plan_by_domain(
-            self.domain).plan.get_version()
+        self.community = DefaultProductPlan.get_default_plan().plan.get_version()
         generator.arbitrary_commcare_users_for_domain(
             self.domain.name, self.community.user_limit + 1
         )

--- a/corehq/apps/accounting/tests/test_new_domain_subscription.py
+++ b/corehq/apps/accounting/tests/test_new_domain_subscription.py
@@ -33,10 +33,8 @@ class TestNewDomainSubscription(BaseAccountingTest):
             self.domain.name, created_by=self.admin_user.username)[0]
         self.account2 = BillingAccount.get_or_create_account_by_domain(
             self.domain2.name, created_by=self.admin_user.username)[0]
-        self.standard_plan = DefaultProductPlan.get_default_plan_by_domain(
-            self.domain.name, edition=SoftwarePlanEdition.STANDARD)
-        self.advanced_plan = DefaultProductPlan.get_default_plan_by_domain(
-            self.domain.name, edition=SoftwarePlanEdition.ADVANCED)
+        self.standard_plan = DefaultProductPlan.get_default_plan(edition=SoftwarePlanEdition.STANDARD)
+        self.advanced_plan = DefaultProductPlan.get_default_plan(edition=SoftwarePlanEdition.ADVANCED)
 
     def test_new_susbscription_in_future(self):
         """

--- a/corehq/apps/accounting/tests/test_renew_subscription.py
+++ b/corehq/apps/accounting/tests/test_renew_subscription.py
@@ -28,8 +28,7 @@ class TestRenewSubscriptions(BaseAccountingTest):
         self.account = BillingAccount.get_or_create_account_by_domain(
             self.domain.name, created_by=self.admin_user.username)[0]
 
-        self.standard_plan = DefaultProductPlan.get_default_plan_by_domain(
-            self.domain.name, edition=SoftwarePlanEdition.STANDARD)
+        self.standard_plan = DefaultProductPlan.get_default_plan(edition=SoftwarePlanEdition.STANDARD)
 
         today = datetime.date.today()
         yesterday = today + datetime.timedelta(days=-1)
@@ -61,7 +60,7 @@ class TestRenewSubscriptions(BaseAccountingTest):
 
     def test_change_plan_on_renewal(self):
         new_edition = SoftwarePlanEdition.ADVANCED
-        new_plan = DefaultProductPlan.get_default_plan_by_domain(self.domain.name, new_edition)
+        new_plan = DefaultProductPlan.get_default_plan(new_edition)
 
         self.renewed_subscription = self.subscription.renew_subscription(
             new_version=new_plan

--- a/corehq/apps/accounting/tests/test_subscription_changes.py
+++ b/corehq/apps/accounting/tests/test_subscription_changes.py
@@ -62,8 +62,7 @@ class TestUserRoleSubscriptionChanges(BaseAccountingTest):
 
         self.account = BillingAccount.get_or_create_account_by_domain(
             self.domain.name,created_by=self.admin_user.username)[0]
-        self.advanced_plan = DefaultProductPlan.get_default_plan_by_domain(
-            self.domain.name,edition=SoftwarePlanEdition.ADVANCED)
+        self.advanced_plan = DefaultProductPlan.get_default_plan(edition=SoftwarePlanEdition.ADVANCED)
 
     def test_cancellation(self):
         subscription = Subscription.new_domain_subscription(

--- a/corehq/apps/accounting/tests/test_subscription_permissions_changes.py
+++ b/corehq/apps/accounting/tests/test_subscription_permissions_changes.py
@@ -31,8 +31,7 @@ class TestSubscriptionPermissionsChanges(BaseAccountingTest):
 
         self.account = BillingAccount.get_or_create_account_by_domain(
             self.project.name, created_by=self.admin_user.username)[0]
-        self.advanced_plan = DefaultProductPlan.get_default_plan_by_domain(
-            self.project.name, edition=SoftwarePlanEdition.ADVANCED)
+        self.advanced_plan = DefaultProductPlan.get_default_plan(edition=SoftwarePlanEdition.ADVANCED)
         self._init_pro_with_rb_plan_and_version()
 
     def _init_pro_with_rb_plan_and_version(self):

--- a/corehq/apps/accounting/tests/utils.py
+++ b/corehq/apps/accounting/tests/utils.py
@@ -11,9 +11,7 @@ class DomainSubscriptionMixin(object):
     def setup_subscription(cls, domain_name, software_plan):
         generator.instantiate_accounting()
 
-        plan = DefaultProductPlan.get_default_plan_by_domain(
-            domain_name, edition=software_plan
-        )
+        plan = DefaultProductPlan.get_default_plan(edition=software_plan)
         cls.account = BillingAccount.get_or_create_account_by_domain(
             domain_name, created_by="automated-test" + cls.__name__
         )[0]

--- a/corehq/apps/analytics/tests/test_subscription_properties.py
+++ b/corehq/apps/analytics/tests/test_subscription_properties.py
@@ -42,9 +42,7 @@ class TestSubscriptionProperties(TestCase):
 
     @classmethod
     def _setup_subscription(cls, domain_name, software_plan):
-        plan = DefaultProductPlan.get_default_plan_by_domain(
-            domain_name, edition=software_plan
-        )
+        plan = DefaultProductPlan.get_default_plan(edition=software_plan)
         account = BillingAccount.get_or_create_account_by_domain(
             domain_name, created_by="automated-test" + cls.__name__
         )[0]

--- a/corehq/apps/api/tests.py
+++ b/corehq/apps/api/tests.py
@@ -72,7 +72,7 @@ class FakeXFormES(object):
 
 def set_up_subscription(cls):
     cls.account = BillingAccount.get_or_create_account_by_domain(cls.domain.name, created_by="automated-test")[0]
-    plan = DefaultProductPlan.get_default_plan_by_domain(cls.domain.name, edition=SoftwarePlanEdition.ADVANCED)
+    plan = DefaultProductPlan.get_default_plan(edition=SoftwarePlanEdition.ADVANCED)
     cls.subscription = Subscription.new_domain_subscription(cls.account, cls.domain.name, plan)
     cls.subscription.is_active = True
     cls.subscription.save()
@@ -1220,8 +1220,7 @@ class TestSingleSignOnResource(APIResourceTest):
         # have to set up subscription for the bad domain or it will fail on authorization
         new_account = BillingAccount.get_or_create_account_by_domain(wrong_domain.name,
                                                                      created_by="automated-test")[0]
-        plan = DefaultProductPlan.get_default_plan_by_domain(wrong_domain.name,
-                                                             edition=SoftwarePlanEdition.ADVANCED)
+        plan = DefaultProductPlan.get_default_plan(edition=SoftwarePlanEdition.ADVANCED)
         new_subscription = Subscription.new_domain_subscription(new_account, wrong_domain.name, plan)
         new_subscription.is_active = True
         new_subscription.save()

--- a/corehq/apps/domain/forms.py
+++ b/corehq/apps/domain/forms.py
@@ -1706,8 +1706,8 @@ class DimagiOnlyEnterpriseForm(InternalSubscriptionManagementForm):
 
     @transaction.atomic
     def process_subscription_management(self):
-        enterprise_plan_version = DefaultProductPlan.get_default_plan_by_domain(
-            self.domain, SoftwarePlanEdition.ENTERPRISE
+        enterprise_plan_version = DefaultProductPlan.get_default_plan(
+            SoftwarePlanEdition.ENTERPRISE
         ).plan.get_version()
         if self.current_subscription:
             self.current_subscription.change_plan(
@@ -1794,8 +1794,8 @@ class AdvancedExtendedTrialForm(InternalSubscriptionManagementForm):
 
     @transaction.atomic
     def process_subscription_management(self):
-        advanced_trial_plan_version = DefaultProductPlan.get_default_plan_by_domain(
-            self.domain, edition=SoftwarePlanEdition.ADVANCED, is_trial=True,
+        advanced_trial_plan_version = DefaultProductPlan.get_default_plan(
+            edition=SoftwarePlanEdition.ADVANCED, is_trial=True,
         )
         if self.current_subscription:
             self.current_subscription.change_plan(
@@ -1978,8 +1978,8 @@ class ContractedPartnerForm(InternalSubscriptionManagementForm):
                 "CommCare %s edition with privilege REPORT_BUILDER_5 was not found! Requires manual setup."
                 % edition
             )
-            new_plan_version = DefaultProductPlan.get_default_plan_by_domain(
-                self.domain, edition=self.cleaned_data['software_plan_edition'],
+            new_plan_version = DefaultProductPlan.get_default_plan(
+                edition=self.cleaned_data['software_plan_edition'],
             )
 
         if (

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1492,7 +1492,7 @@ class ConfirmSelectedPlanView(SelectPlanView):
     @property
     @memoized
     def selected_plan_version(self):
-        return DefaultProductPlan.get_default_plan_by_domain(self.domain, self.edition).plan.get_version()
+        return DefaultProductPlan.get_default_plan(self.edition).plan.get_version()
 
     @property
     def downgrade_messages(self):
@@ -1680,7 +1680,7 @@ class ConfirmSubscriptionRenewalView(DomainAccountingSettings, AsyncHandlerMixin
     @property
     @memoized
     def next_plan_version(self):
-        plan_version = DefaultProductPlan.get_default_plan_by_domain(self.domain, self.new_edition)
+        plan_version = DefaultProductPlan.get_default_plan(self.new_edition)
         if plan_version is None:
             log_accounting_error(
                 "Could not find a matching renewable plan "

--- a/corehq/apps/registration/utils.py
+++ b/corehq/apps/registration/utils.py
@@ -231,8 +231,8 @@ You can view the %s here: %s""" % (
 # Only new-users are eligible for advanced trial
 def create_30_day_advanced_trial(domain_obj):
     # Create a 30 Day Trial subscription to the Advanced Plan
-    advanced_plan_version = DefaultProductPlan.get_default_plan_by_domain(
-        domain_obj, edition=SoftwarePlanEdition.ADVANCED, is_trial=True
+    advanced_plan_version = DefaultProductPlan.get_default_plan(
+        edition=SoftwarePlanEdition.ADVANCED, is_trial=True
     )
     expiration_date = date.today() + timedelta(days=30)
     trial_account = BillingAccount.objects.get_or_create(

--- a/custom/ewsghana/utils.py
+++ b/custom/ewsghana/utils.py
@@ -143,8 +143,8 @@ def prepare_domain(domain_name):
         domain.name,
         created_by="automated-test",
     )[0]
-    plan = DefaultProductPlan.get_default_plan_by_domain(
-        domain, edition=SoftwarePlanEdition.ADVANCED
+    plan = DefaultProductPlan.get_default_plan(
+        edition=SoftwarePlanEdition.ADVANCED
     )
     subscription = Subscription.new_domain_subscription(
         account,

--- a/custom/ilsgateway/tests/handlers/utils.py
+++ b/custom/ilsgateway/tests/handlers/utils.py
@@ -137,8 +137,8 @@ def prepare_domain(domain_name):
         domain.name,
         created_by="automated-test",
     )[0]
-    plan = DefaultProductPlan.get_default_plan_by_domain(
-        domain, edition=SoftwarePlanEdition.ADVANCED
+    plan = DefaultProductPlan.get_default_plan(
+        edition=SoftwarePlanEdition.ADVANCED
     )
     commtrack = domain.commtrack_settings
     commtrack.actions.append(


### PR DESCRIPTION
`domain` is unused in `DefaultProductPlan. get_default_plan_by_domain`, so remove from list of arguments
