### PR TITLE
Fix transform value in exports

### DIFF
--- a/corehq/apps/export/templates/export/customize_export_old.html
+++ b/corehq/apps/export/templates/export/customize_export_old.html
@@ -260,13 +260,14 @@
                                         {% endif %}
                                         {% if helper.allow_deid %}
                                         <td class="deid-column" data-bind="visible: $root.showDeidColumn()">
+                                            <!-- ko if: (index() !== 'id' || transform()) && !isCaseName() -->
                                             <select class="form-control" data-bind="
                                                 value: transform || '',
                                                 foreach: $root.deid_options,
-                                                visible: (index() !== 'id' || transform()) && !isCaseName()
                                             ">
                                                 <option data-bind="value: value, text: label"></option>
                                             </select>
+                                            <!-- /ko -->
 
                                             <span class="label label-info"
                                                   data-bind="visible: $root.custom_export.is_safe() && isCaseName()">


### PR DESCRIPTION
@czue holy 🐮  this must've broken some time ago and no one ever noticed. my hunch is it broke when we upgraded to knockout 3 (aka b3) which made the `value:` key behave somewhat differently. essentially the `value:` key was setting every `transform` to `''` which made the case_name column lose its transform. #howlongtilnewexports 😈 (i'm sure i'll be regretting that in the weeks to come haha)

http://manage.dimagi.com/default.asp?230541#1171475

cc: @biyeun 
