### PR TITLE
restore() expects to unpack a tuple

### DIFF
--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -118,10 +118,10 @@ def get_restore_response(domain, couch_user, app_id=None, since=None, version='1
     # not a view just a view util
     if couch_user.is_commcare_user() and domain != couch_user.domain:
         return HttpResponse("%s was not in the domain %s" % (couch_user.username, domain),
-                            status=401)
+                            status=401), None
     elif couch_user.is_web_user() and domain not in couch_user.domains:
         return HttpResponse("%s was not in the domain %s" % (couch_user.username, domain),
-                            status=401)
+                            status=401), None
 
     if couch_user.is_commcare_user():
         restore_user = couch_user.to_ota_restore_user()


### PR DESCRIPTION
This goes part of the way to resolve [FB 230455](http://manage.dimagi.com/default.asp?230455). It doesn't explain why `couch_user.is_commcare_user() and domain != couch_user.domain` is false though. 

@dannyroberts @biyeun cc @sravfeyn 
