### PR TITLE
Set child case ID

### DIFF
--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -2,6 +2,7 @@ from copy import copy
 from datetime import datetime, timedelta, date
 import itertools
 import json
+from uuid import uuid4
 
 from django.views.generic.base import TemplateView
 
@@ -1745,6 +1746,16 @@ class EditFormInstance(View):
             url = reverse('render_form_data', args=[domain, instance_id])
             return HttpResponseRedirect(url)
 
+        def get_non_parents(caseblocks):
+            return filter(lambda cb: cb.path == [], caseblocks)
+
+        def is_subcase(caseblock):
+            return 'create' in caseblock.caseblock
+
+        def get_matching_datum(caseblock, datums_):
+            datum_ = filter(lambda d: d.datum.id.endswith(caseblock.path[0]), datums_)
+            return datum_[0] if len(datum_) == 1 else None
+
         if not (has_privilege(request, privileges.DATA_CLEANUP)) or not instance_id:
             raise Http404()
 
@@ -1765,21 +1776,23 @@ class EditFormInstance(View):
             edit_session_data[USERCASE_ID] = usercase_id
 
         case_blocks = extract_case_blocks(instance, include_path=True)
-        if form.form_type == 'advanced_form':
-            datums = EntriesHelper(form.get_app()).get_datums_meta_for_form_generic(form)
-            for case_block in case_blocks:
+        datums = EntriesHelper(form.get_app()).get_datums_meta_for_form_generic(form)
+        for case_block in case_blocks:
+            if form.form_type == 'advanced_form':
                 path = case_block.path[0]  # all case blocks in advanced forms are nested one level deep
                 matching_datums = [datum for datum in datums if datum.action.form_element_name == path]
                 if len(matching_datums) == 1:
                     edit_session_data[matching_datums[0].datum.id] = case_block.caseblock.get(const.CASE_ATTR_ID)
-        else:
-            # a bit hacky - the app manager puts the main case directly in the form, so it won't have
-            # any other path associated with it. This allows us to differentiate from parent cases.
-            # You might think that you need to populate other session variables like parent_id, but those
-            # are never actually used in the form.
-            non_parents = filter(lambda cb: cb.path == [], case_blocks)
-            if len(non_parents) == 1:
-                edit_session_data['case_id'] = non_parents[0].caseblock.get(const.CASE_ATTR_ID)
+            else:
+                if case_block.path == [] and len(get_non_parents(case_blocks)) == 1:
+                    # a bit hacky - the app manager puts the main case directly in the form, so it won't have
+                    # any other path associated with it. This allows us to differentiate from parent cases.
+                    edit_session_data['case_id'] = case_block.caseblock.get(const.CASE_ATTR_ID)
+                elif is_subcase(case_block) and not case_block.caseblock.get(const.CASE_ATTR_ID):
+                    # We need to populate child case IDs if this form can create new child cases
+                    datum = get_matching_datum(case_block, datums)
+                    if datum is not None:
+                        edit_session_data[datum.datum.id] = uuid4().hex
 
         edit_session_data['is_editing'] = True
         edit_session_data['function_context'] = {


### PR DESCRIPTION
@wspride, @benrudolph this one has left my wheelhouse. (Some context: [FB 229942](http://manage.dimagi.com/default.asp?229942) and possibly [FB 230621](http://manage.dimagi.com/default.asp?230621).) 

It seems that xformplayer is not populating the case ID of new subcases from the ID given in the session. This PR shows my useless attempt to populate the ID, before realising that setting the ID in the session wasn't where the bug was. 

The ID gets set in the session later, asynchronously. [`xformplayer.open_form()`](https://github.com/dimagi/touchforms/blob/39707a40a01bafddb49f448693824b9f4dc10ff3/touchforms/backend/xformplayer.py#L658-L658) gets the IDs of new subcases from [`xformserver.handle_request()`](https://github.com/dimagi/touchforms/blob/9a634a82b3d6efd7f7b4feaa64a2a13ad2f5fe6e/touchforms/backend/xformserver.py#L194-L194). But those IDs don't seem to get used to set the case ID of new subcases. So when the form is POSTed, and the case ID is empty, the case can't be created. e.g.:

``` xml
<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/52D111C9-79C6-403F-BF4C-D24B64A872E2" uiVersion="1" version="119" name="Visit">
  <welcome_message/>
  <sample_choice_question>choice3</sample_choice_question>
  <sample_number_question>3</sample_number_question>
  <create_subcase>y</create_subcase>
  <subcase_0>
    <n0:case xmlns:n0="http://commcarehq.org/case/transaction/v2" case_id="" date_modified="" user_id="">
      <n0:create>
        <n0:case_name>y</n0:case_name>
        <n0:owner_id>818b240ffc3abe73fb50b1e675da398e</n0:owner_id>
        <n0:case_type>subcase</n0:case_type>
      </n0:create>
      <n0:update/>
      <n0:index>
        <n0:parent case_type="case">df36b297dde3457d871e16ed818a395d</n0:parent>
      </n0:index>
    </n0:case>
  </subcase_0>
  <subcase_1/>
  <n1:case xmlns:n1="http://commcarehq.org/case/transaction/v2" case_id="df36b297dde3457d871e16ed818a395d" date_modified="2016-06-27T14:05:37.216+02" user_id="818b240ffc3abe73fb50b1e675da398e">
    <n1:update>
      <n1:sample_choice_question>choice3</n1:sample_choice_question>
      <n1:sample_number_question>3</n1:sample_number_question>
    </n1:update>
  </n1:case>
  <n2:meta xmlns:n2="http://openrosa.org/jr/xforms">
    <n2:deviceID>cloudcare</n2:deviceID>
    <n2:timeStart>2016-06-27T14:05:26.184+02</n2:timeStart>
    <n2:timeEnd>2016-06-27T14:05:37.216+02</n2:timeEnd>
    <n2:username>n</n2:username>
    <n2:userID>818b240ffc3abe73fb50b1e675da398e</n2:userID>
    <n2:instanceID>5b771c38-6db0-4196-bf3b-deeeb2e8d48a</n2:instanceID>
    <n3:appVersion xmlns:n3="http://commcarehq.org/xforms">2.0</n3:appVersion>
  </n2:meta>
</data>
```

(Note `/data/subcase_0/case/@case_id` is empty) The above XML is the value of "instance-content" in the following POST data, as at [`formplayer.api.post_data()`](https://github.com/dimagi/touchforms/blob/7a9a264e8438e4e281cdc95a8121238890d9748b/touchforms/formplayer/api.py#L270-L270):

``` javascript
{
  "lang": "en", 
  "session-id": null, 
  "uses_sql_backend": false, 
  "session-data": {
    "username": "n", 
    "domain": "demo", 
    "app_id": "a8202404fb6a38a6bd81895ff9e9c1bb", 
    "user_data": {
      "commcare_first_name": "", 
      "commcare_last_name": "", 
      "commcare_phone_number": null
    }, 
    "host": "http://10.0.0.137", 
    "function_context": {
      "static-date": [
        {
          "name": "now", 
          "value": "2016-06-27T12:05:37.216000Z"
        }, 
        {
          "name": "today", 
          "value": "2016-06-27"
        }
      ]
    }, 
    "device_id": "cloudcare", 
    "additional_filters": {
      "footprint": true
    }, 
    "user_id": "818b240ffc3abe73fb50b1e675da398e", 
    "case_id_new_subcase_0": "28ee4566979845b5b51b80c5cf9c6b4b", 
    "case_id_new_subcase_1": "6bd2d2f92002412e83ad4ed0340c0a9d", 
    "is_editing": true, 
    "case_id": "df36b297dde3457d871e16ed818a395d", 
    "session_name": "Case Management > Visit", 
    "app_version": "2.0"
  }, 
  "hq_auth": {
    "type": "django-session", 
    "key": "ngoer593m9qswfmqhkg772df1vh4akkx"
  }, 
  "action": "new-form", 
  "instance-content": "/*** AS ABOVE ***/", 
  "nav": "fao", 
  "session_id": null, 
  "form-url": "http://10.0.0.137/a/demo/apps/download/a8202404fb6a38a6bd81895ff9e9c1bb/modules-1/forms-0.xml"
}
```

As you can see, `case_id_new_subcase_0` and `case_id_new_subcase_1` in `session-data` both have values. The ID for subcase_0 is the value that `/data/subcase_0/case/@case_id` should be set to. I just can't tell where that is supposed to happen.

I hope my explanation isn't too garbled. Could I hand this over to one of you? Or could you point me in the right direction?

cc @dannyroberts, @biyeun 
