### PR TITLE
datatables footer overlapping fix

### DIFF
--- a/corehq/apps/reports/static/reports/javascripts/config.dataTables.bootstrap.js
+++ b/corehq/apps/reports/static/reports/javascripts/config.dataTables.bootstrap.js
@@ -210,6 +210,20 @@ function HQReportDataTables(options) {
                 datatable.fnAdjustColumnSizing();
             }, 10);
 
+            // This fixes a display bug in some browsers where the pagination
+            // overlaps the footer when resizing from 10 to 100 or 10 to 50 rows
+            // (perhaps other lengths are affected...unknown). This makes sure
+            // that columns are redrawn on the first hit of a new length,
+            // as fnAdjustColumnSizing fixes the issue and it remains fixed
+            // without intervention afterward.
+            self._lengthsSeen = [];
+            datatable.on( 'length.dt', function (e, settings, length) {
+                if (self._lengthsSeen.indexOf(length) < 0) {
+                    datatable.fnAdjustColumnSizing();
+                    self._lengthsSeen.push(length);
+                }
+            } );
+
             var $dataTablesFilter = $(".dataTables_filter");
             if($dataTablesFilter && $("#extra-filter-info")) {
                 if($dataTablesFilter.length > 1) {


### PR DESCRIPTION
fixes a very odd display bug with datatables described in: http://manage.dimagi.com/default.asp?221474

The bug only displays show a malformed footer for the first time you view that length (50 or 100 rows) and when you change away and change back the footer appears correctly. This led me to think it was another column resizing bug. 

@dannyroberts @kaapstorm / cc @benrudolph 
