### PR TITLE
Use sensitive_post_parameters as @method_decorator

### DIFF
--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -550,7 +550,7 @@ class EditOpenClinicaSettingsView(BaseProjectSettingsView):
     def page_context(self):
         return {'openclinica_settings_form': self.openclinica_settings_form}
 
-    @sensitive_post_parameters('username', 'password')
+    @method_decorator(sensitive_post_parameters('username', 'password'))
     def post(self, request, *args, **kwargs):
         if self.openclinica_settings_form.is_valid():
             if self.openclinica_settings_form.save(self.domain_object):


### PR DESCRIPTION
If `sensitive_post_parameters` decorates a method, then it needs to be wrapped with `@method_decorator`, otherwise its first argument is `self` instead of `request`. ([FB 230824](http://manage.dimagi.com/default.asp?230824))

@dannyroberts @biyeun cc @orangejenny 
