### PR TITLE
Add ability to turn off code mirror in UCR

### DIFF
--- a/corehq/apps/userreports/templates/userreports/userreports_base.html
+++ b/corehq/apps/userreports/templates/userreports/userreports_base.html
@@ -23,6 +23,7 @@
 </style>
 <script>
     $(function () {
+        {% if not code_mirror_off %}
         $('.jsonwidget').each(function () {
             var elem = this;
             var codeMirror = CodeMirror.fromTextArea(elem, {
@@ -48,6 +49,7 @@
             }
             adjustToggleAppearance();
         });
+        {% endif %}
         $('.btn-danger').click(function (e) {
             var warning = "{% trans 'Are you sure you want to do this? Deleting things is permanent and not undoable!' %}";
             return window.confirm(warning);

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -185,6 +185,7 @@ class BaseEditConfigReportView(BaseUserConfigReportsView):
         return {
             'form': self.edit_form,
             'report': self.config,
+            'code_mirror_off': self.request.GET.get('code_mirror', 'true') == 'false',
         }
 
     @property

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -929,7 +929,8 @@ class BaseEditDataSourceView(BaseUserConfigReportsView):
         return {
             'form': self.edit_form,
             'data_source': self.config,
-            'read_only': self.read_only
+            'read_only': self.read_only,
+            'code_mirror_off': self.request.GET.get('code_mirror', 'true') == 'false',
         }
 
     @property


### PR DESCRIPTION
When visiting a UCR datasource with `?code_mirror=false`, allows browser plugins like [It's All Text!](https://addons.mozilla.org/EN-us/firefox/addon/its-all-text/) which allow you to directly edit `<textarea>` elements in a text editor (e.g. emacs or vim which probably include some form of json linter / beautifier / snippet completion)
@benrudolph @sravfeyn 
