### PR TITLE
Add SimpleReportConfiguration API endpoint

### DIFF
--- a/corehq/apps/api/tests.py
+++ b/corehq/apps/api/tests.py
@@ -1570,7 +1570,6 @@ class TestSimpleReportConfigurationResource(APIResourceTest):
         )
         cls.report_configuration.save()
 
-
     def test_get_detail(self):
         self.client.login(username=self.username, password=self.password)
         response = self.client.get(

--- a/corehq/apps/api/tests.py
+++ b/corehq/apps/api/tests.py
@@ -1603,3 +1603,16 @@ class TestSimpleReportConfigurationResource(APIResourceTest):
 
         response = self.client.get(self.list_endpoint)
         self.assertEqual(response.status_code, 405)
+
+    def test_auth(self):
+
+        wrong_domain = Domain.get_or_create_with_name('dvorak', is_active=True)
+        new_user = WebUser.create(wrong_domain.name, 'test', 'testpass')
+        new_user.save()
+
+        self.client.login(username='test', password='testpass')
+        response = self.client.get(self.single_endpoint(self.report_configuration._id))
+        self.assertEqual(response.status_code, 401)  # 401 is "Unauthorized"
+
+        wrong_domain.delete()
+        new_user.delete()

--- a/corehq/apps/api/urls.py
+++ b/corehq/apps/api/urls.py
@@ -71,6 +71,7 @@ API_LIST = (
         DomainMetadataResource,
         locations.v0_5.LocationResource,
         locations.v0_5.LocationTypeResource,
+        v0_5.SimpleReportConfigurationResource,
     )),
 )
 


### PR DESCRIPTION
Spec [here](https://docs.google.com/document/d/1qkwGcl4GmVYYBnf5jzxOgfS_FE7kE6xlyAhvcSAtP-I/edit#heading=h.blt0fbwgkgt2).

This API endpoint returns a very simplified view of the `ReportConfiguration` model.
@gcapalbo 
