### PR TITLE
A module has one search_config

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -2733,7 +2733,7 @@ class AdvancedModule(ModuleBase):
     has_schedule = BooleanProperty()
     schedule_phases = SchemaListProperty(SchedulePhase)
     get_schedule_phases = IndexedSchema.Getter('schedule_phases')
-    search_config = SchemaListProperty(CaseSearch)
+    search_config = SchemaProperty(CaseSearch)
 
     @classmethod
     def new_module(cls, name, lang):


### PR DESCRIPTION
`AdvancedModule.search_config` should be identical to `Module.search_config`.

Context: [FB 231186](http://manage.dimagi.com/default.asp?231186)

@dannyroberts @biyeun cc @orangejenny 
