### PR TITLE
Allow restore from web user to mobile user for edit forms

### DIFF
--- a/corehq/apps/ota/tests/test_utils.py
+++ b/corehq/apps/ota/tests/test_utils.py
@@ -13,6 +13,7 @@ class RestorePermissionsTest(TestCase):
 
     @classmethod
     def setUpClass(cls):
+        super(RestorePermissionsTest, cls).setUpClass()
         cls.project = Domain(name=cls.domain)
         cls.project.save()
 
@@ -39,6 +40,7 @@ class RestorePermissionsTest(TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        super(RestorePermissionsTest, cls).tearDownClass()
         cls.web_user.delete()
         cls.commcare_user.delete()
         cls.super_user.delete()
@@ -136,6 +138,7 @@ class GetRestoreUserTest(TestCase):
 
     @classmethod
     def setUpClass(cls):
+        super(GetRestoreUserTest, cls).setUpClass()
         cls.project = Domain(name=cls.domain)
         cls.project.save()
 
@@ -152,6 +155,7 @@ class GetRestoreUserTest(TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        super(GetRestoreUserTest, cls).tearDownClass()
         cls.web_user.delete()
         cls.commcare_user.delete()
         cls.project.delete()

--- a/corehq/apps/ota/tests/test_utils.py
+++ b/corehq/apps/ota/tests/test_utils.py
@@ -1,0 +1,181 @@
+from django.test import TestCase
+
+from corehq.apps.users.models import WebUser, CommCareUser
+from corehq.apps.users.util import format_username
+from corehq.apps.domain.models import Domain
+
+from corehq.apps.ota.utils import is_permitted_to_restore, get_restore_user
+
+
+class RestorePermissionsTest(TestCase):
+    domain = 'goats'
+    other_domain = 'sheep'
+
+    @classmethod
+    def setUpClass(cls):
+        cls.project = Domain(name=cls.domain)
+        cls.project.save()
+
+        cls.other_project = Domain(name=cls.other_domain)
+        cls.other_project.save()
+
+        cls.web_user = WebUser.create(
+            username='billy@goats.com',
+            domain=cls.domain,
+            password='***',
+        )
+        cls.super_user = WebUser.create(
+            username='super@woman.com',
+            domain=cls.other_domain,
+            password='***',
+        )
+        cls.super_user.is_superuser = True
+        cls.super_user.save()
+        cls.commcare_user = CommCareUser.create(
+            username=format_username('super', cls.domain),
+            domain=cls.domain,
+            password='***',
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.web_user.delete()
+        cls.commcare_user.delete()
+        cls.super_user.delete()
+        cls.project.delete()
+        cls.other_project.delete()
+
+    def test_commcare_user_permitted(self):
+        is_permitted, message = is_permitted_to_restore(
+            self.domain,
+            self.commcare_user,
+            None,
+            False,
+        )
+        self.assertTrue(is_permitted)
+        self.assertIsNone(message)
+
+    def test_commcare_user_wrong_domain(self):
+        is_permitted, message = is_permitted_to_restore(
+            'wrong-domain',
+            self.commcare_user,
+            None,
+            False,
+        )
+        self.assertFalse(is_permitted)
+        self.assertIsNotNone(message)
+
+    def test_web_user_permitted(self):
+        is_permitted, message = is_permitted_to_restore(
+            self.domain,
+            self.web_user,
+            None,
+            False,
+        )
+        self.assertTrue(is_permitted)
+        self.assertIsNone(message)
+
+    def test_web_user_as_user_permitted(self):
+        is_permitted, message = is_permitted_to_restore(
+            self.domain,
+            self.web_user,
+            u'{}@{}'.format(self.commcare_user.raw_username, self.domain),
+            True,
+        )
+        self.assertTrue(is_permitted)
+        self.assertIsNone(message)
+
+    def test_web_user_as_user_bad_privelege(self):
+        is_permitted, message = is_permitted_to_restore(
+            self.domain,
+            self.web_user,
+            u'{}@{}'.format(self.commcare_user.raw_username, self.domain),
+            False,
+        )
+        self.assertFalse(is_permitted)
+        self.assertIsNotNone(message)
+
+    def test_web_user_as_user_bad_username(self):
+        is_permitted, message = is_permitted_to_restore(
+            self.domain,
+            self.web_user,
+            u'{}'.format(self.commcare_user),  # Malformed, should include domain
+            True,
+        )
+        self.assertFalse(is_permitted)
+        self.assertIsNotNone(message)
+
+    def test_web_user_as_user_bad_domain(self):
+        is_permitted, message = is_permitted_to_restore(
+            self.domain,
+            self.web_user,
+            u'{}@wrong-domain'.format(self.commcare_user),  # Malformed, should include domain
+            True,
+        )
+        self.assertFalse(is_permitted)
+        self.assertIsNotNone(message)
+
+    def test_super_user_as_user_other_domain(self):
+        """
+        Superusers should be able to restore as other mobile users even if it's the wrong domain
+        """
+
+        is_permitted, message = is_permitted_to_restore(
+            self.domain,
+            self.super_user,
+            u'{}@{}'.format(self.commcare_user.raw_username, self.domain),
+            False,
+        )
+        self.assertTrue(is_permitted)
+        self.assertIsNone(message)
+
+
+class GetRestoreUserTest(TestCase):
+
+    domain = 'goats'
+
+    @classmethod
+    def setUpClass(cls):
+        cls.project = Domain(name=cls.domain)
+        cls.project.save()
+
+        cls.web_user = WebUser.create(
+            username='billy@goats.com',
+            domain=cls.domain,
+            password='***',
+        )
+        cls.commcare_user = CommCareUser.create(
+            username=format_username('jane', cls.domain),
+            domain=cls.domain,
+            password='***',
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.web_user.delete()
+        cls.commcare_user.delete()
+        cls.project.delete()
+
+    def test_get_restore_user_web_user(self):
+        self.assertIsNotNone(get_restore_user(self.domain, self.web_user, None))
+
+    def test_get_restore_user_commcare_user(self):
+        self.assertIsNotNone(get_restore_user(self.domain, self.commcare_user, None))
+
+    def test_get_restore_user_as_user(self):
+        self.assertIsNotNone(
+            get_restore_user(
+                self.domain,
+                self.web_user,
+                '{}@{}'.format(self.commcare_user.raw_username, self.domain)
+            )
+        )
+
+    def test_get_restore_user_not_found(self):
+        self.assertIsNone(
+            get_restore_user(
+                self.domain,
+                self.web_user,
+                '{}@wrong-domain'.format(self.commcare_user.raw_username, self.domain)
+            )
+        )

--- a/corehq/apps/ota/utils.py
+++ b/corehq/apps/ota/utils.py
@@ -4,6 +4,8 @@ from casexml.apps.phone.restore import RestoreConfig, RestoreParams
 from corehq.apps.domain.models import Domain
 from dimagi.utils.logging import notify_exception
 
+from corehq.apps.users.models import CommCareUser
+
 from .models import DemoUserRestore
 
 
@@ -88,8 +90,9 @@ def is_permitted_to_restore(domain, couch_user, as_user, has_data_cleanup_privel
         message = u"{} was not in the domain {}".format(couch_user.username, domain)
     elif couch_user.is_web_user() and domain not in couch_user.domains and not couch_user.is_superuser:
         message = u"{} was not in the domain {}".format(couch_user.username, domain)
-    elif couch_user.is_web_user() and domain in couch_user.domains and as_user is not None:
-        if not has_data_cleanup_privelege:
+    elif ((couch_user.is_web_user() and domain in couch_user.domains and as_user is not None) or
+            (couch_user.is_superuser and as_user is not None)):
+        if not has_data_cleanup_privelege and not couch_user.is_superuser:
             message = u"{} does not have permissions to restore as {}".format(
                 couch_user.username,
                 as_user,

--- a/corehq/apps/ota/utils.py
+++ b/corehq/apps/ota/utils.py
@@ -85,6 +85,17 @@ def demo_restore_date_created(commcare_user):
 
 
 def is_permitted_to_restore(domain, couch_user, as_user, has_data_cleanup_privelege):
+    """
+    This function determines if the couch_user is permitted to restore
+    for the domain and/or as_user
+    :param domain: Domain of restore
+    :param couch_user: The couch user attempting authentication
+    :param as_user: a string <user>@<domain> that the couch_user is attempting to get
+        a restore for. If None will get restore of the couch_user.
+    :param has_data_cleanup_privelege: Whether the user has permissions to do DATA_CLEANUP
+    :returns: a tuple - first a boolean if the user is permitted,
+        secondly a message explaining why a user was rejected if not permitted
+    """
     message = None
     if couch_user.is_commcare_user() and domain != couch_user.domain:
         message = u"{} was not in the domain {}".format(couch_user.username, domain)
@@ -111,6 +122,15 @@ def is_permitted_to_restore(domain, couch_user, as_user, has_data_cleanup_privel
 
 
 def get_restore_user(domain, couch_user, as_user):
+    """
+    This will retrieve the restore_user from the couch_user or the as_user
+    if specified
+    :param domain: Domain of restore
+    :param couch_user: The couch user attempting authentication
+    :param as_user: a string <user>@<domain> that the couch_user is attempting to get
+        a restore user for. If None will get restore of the couch_user.
+    :returns: An instance of OTARestoreUser
+    """
     if couch_user.is_commcare_user():
         restore_user = couch_user.to_ota_restore_user()
     elif (couch_user.is_web_user() and as_user is not None):

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -122,7 +122,7 @@ def get_restore_response(domain, couch_user, app_id=None, since=None, version='1
     if couch_user.is_commcare_user() and domain != couch_user.domain:
         return HttpResponse("%s was not in the domain %s" % (couch_user.username, domain),
                             status=401), None
-    elif couch_user.is_web_user() and domain not in couch_user.domains:
+    elif couch_user.is_web_user() and domain not in couch_user.domains and not couch_user.is_superuser:
         return HttpResponse("%s was not in the domain %s" % (couch_user.username, domain),
                             status=401), None
 

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -167,10 +167,15 @@ def _is_permitted_to_restore(domain, couch_user, as_user):
                 as_user,
             )
 
-        username = as_user.split('@')[0]
-        user_domain = as_user.split('@')[1]
-        if user_domain != domain:
-            message = u"{} was not in the domain {}".format(username, domain)
+        try:
+            username = as_user.split('@')[0]
+            user_domain = as_user.split('@')[1]
+        except IndexError:
+            message = u"Invalid to restore user {}. Format is <user>@<domain>".format(as_user)
+
+        else:
+            if user_domain != domain:
+                message = u"{} was not in the domain {}".format(username, domain)
     return message is None, message
 
 

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -109,14 +109,15 @@ def get_restore_params(request):
         'version': request.GET.get('version', "1.0"),
         'state': request.GET.get('state'),
         'items': request.GET.get('items') == 'true',
-        'force_restore_mode': request.GET.get('mode')
+        'force_restore_mode': request.GET.get('mode'),
+        'as_user': request.GET.get('as'),
     }
 
 
 def get_restore_response(domain, couch_user, app_id=None, since=None, version='1.0',
                          state=None, items=False, force_cache=False,
                          cache_timeout=None, overwrite_cache=False,
-                         force_restore_mode=None):
+                         force_restore_mode=None, as_user=None):
     # not a view just a view util
     if couch_user.is_commcare_user() and domain != couch_user.domain:
         return HttpResponse("%s was not in the domain %s" % (couch_user.username, domain),
@@ -133,7 +134,7 @@ def get_restore_response(domain, couch_user, app_id=None, since=None, version='1
     app = get_app(domain, app_id) if app_id else None
     restore_config = RestoreConfig(
         project=project,
-        restore_user=_get_restore_user(domain, couch_user),
+        restore_user=_get_restore_user(domain, couch_user, as_user),
         params=RestoreParams(
             sync_log_id=since,
             version=version,
@@ -151,7 +152,7 @@ def get_restore_response(domain, couch_user, app_id=None, since=None, version='1
     return restore_config.get_response(), restore_config.timing_context
 
 
-def _get_restore_user(domain, couch_user):
+def _get_restore_user(domain, couch_user, as_user):
     if couch_user.is_commcare_user():
         restore_user = couch_user.to_ota_restore_user()
     elif couch_user.is_web_user():


### PR DESCRIPTION
@snopoke (mind taking a look at this while cory is gone?) @wpride this should enable a web user to restore as a mobile user as long as they have data cleanup permission or are superusers. this is necessary for the Edit Forms workflow with the new sqlite backend. essentially when we edit a form, touchforms sends a request to restore as the mobile user, but has the auth of the web worker, which makes sense. this allows that to happen without receiving an unauthorized error. 🎣 or 🏠 

http://manage.dimagi.com/default.asp?230455

cc: @proteusvacuum @sravfeyn 
