### PR TITLE
Widen case property saving section when vellum case management is on

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/case_config.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_config.html
@@ -34,7 +34,11 @@
                      data-bind="template: 'case-config:case-transaction:case-preload'"></div>
              </div>
         </div>
-        <div class="col-sm-6">
+        <div data-bind="css: {
+                          'col-sm-6': !allow.vellum_case_management(),
+                          'col-sm-9': allow.vellum_case_management(),
+                          'wide-select2s': allow.vellum_case_management(),
+                        }">
             <div class="panel panel-default case-properties"
                  data-bind="template: 'case-config:case-transaction:case-properties'"></div>
         </div>

--- a/corehq/apps/style/static/style/less/_hq/forms.less
+++ b/corehq/apps/style/static/style/less/_hq/forms.less
@@ -95,14 +95,25 @@ legend .subtext {
 }
 
 // Static width for select2 widgets, which otherwise grow too large on case management pages
-.app-manager-content .select2-container {
-    @width: 210px;
-    width: @width;
+.app-manager-select2s(@width) {
+    .select2-container {
+        width: @width;
+    }
 
     // This needs a static width so that text-overflow: ellipsis will work in Firefox.
     // Unusually specific selector to override select2's width: auto rule.
     > .select2-choice > .select2-chosen {
         width: @width - 35px;
+    }
+}
+
+.app-manager-content {
+    @select2Width: 210px;
+
+    .app-manager-select2s(@select2Width);
+
+    .wide-select2s {
+        .app-manager-select2s(@select2Width * 1.5);
     }
 }
 


### PR DESCRIPTION
Before:
<img width="1042" alt="screen shot 2016-06-30 at 5 47 32 pm" src="https://cloud.githubusercontent.com/assets/1486591/16505428/ee1e20ee-3eea-11e6-98be-d923745f54c6.png">

After:
<img width="1041" alt="screen shot 2016-06-30 at 5 48 29 pm" src="https://cloud.githubusercontent.com/assets/1486591/16505434/f3f4f56a-3eea-11e6-86d7-b5df1fcff46a.png">

@kaapstorm 
cc @amsagoff 
