### PR TITLE
Fix report builder data type inferencing 

### DIFF
--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -212,9 +212,13 @@ class DataSourceBuilder(object):
                     prop.source, prop.column_id
                 ))
             elif prop.type == "question":
-                ret.append(make_form_question_indicator(
+                indicator = make_form_question_indicator(
                     prop.source, prop.column_id
-                ))
+                )
+                if prop.source['type'] == "DataBindOnly" and number_columns:
+                    if indicator['column_id'] in number_columns:
+                        indicator['datatype'] = 'decimal'
+                ret.append(indicator)
             elif prop.type == 'case_property' and prop.source == 'computed/owner_name':
                 ret.append(make_owner_name_indicator(prop.column_id))
             elif prop.type == 'case_property' and prop.source == 'computed/user_name':


### PR DESCRIPTION
Addresses ticket [#231240](http://manage.dimagi.com/default.asp?231240).
When a user is creating a report in the report builder, if they indicate that they want a column to be summed or averaged, then the corresponding data source indicator should be of the "decimal" data type. (This inferencing is necessary for case properties and hidden value questions.) We were not setting the data type of hidden value questions correctly. This fixes that bug.
@gcapalbo 
