### PR TITLE
Allow named expressions to be used in named filters

### DIFF
--- a/corehq/apps/userreports/models.py
+++ b/corehq/apps/userreports/models.py
@@ -162,7 +162,7 @@ class DataSourceConfiguration(UnicodeMixIn, CachedCouchDocumentMixin, Document):
     @property
     @memoized
     def named_filter_objects(self):
-        return {name: FilterFactory.from_spec(filter, FactoryContext.empty())
+        return {name: FilterFactory.from_spec(filter, FactoryContext(self.named_expression_objects, {}))
                 for name, filter in self.named_filters.items()}
 
     def _get_factory_context(self):

--- a/corehq/apps/userreports/tests/test_data_source_config.py
+++ b/corehq/apps/userreports/tests/test_data_source_config.py
@@ -302,6 +302,12 @@ class IndicatorNamedFilterTest(SimpleTestCase):
             'domain': 'test',
             'referenced_doc_type': 'CommCareCase',
             'table_id': 'mother_indicators',
+            'named_expressions': {
+                'on_a_date': {
+                    'type': 'property_name',
+                    'property_name': 'on_date',
+                }
+            },
             'named_filters': {
                 'pregnant': {
                     'type': 'property_match',
@@ -311,6 +317,15 @@ class IndicatorNamedFilterTest(SimpleTestCase):
                 'evil': {
                     'type': 'property_match',
                     'property_name': 'evil',
+                    'property_value': 'yes',
+                },
+                'has_alibi': {
+                    'type': 'boolean_expression',
+                    'expression': {
+                        'type': 'named',
+                        'name': 'on_a_date'
+                    },
+                    'operator': 'eq',
                     'property_value': 'yes',
                 }
             },


### PR DESCRIPTION
Was having issues with using named expressions in named filters (would always fail with `BadSpecError: {expression} not found in list of named expressions!`)

The additions to the test case were failing hard on initialization, which is why I didn't write an explicit test case.

@benrudolph @sravfeyn 
