### PR TITLE
couch xform to kafak pillow + reindexer

### DIFF
--- a/corehq/apps/hqcase/management/commands/ptop_reindexer_v2.py
+++ b/corehq/apps/hqcase/management/commands/ptop_reindexer_v2.py
@@ -12,7 +12,7 @@ from corehq.pillows.ledger import get_ledger_v2_reindexer, get_ledger_v1_reindex
 from corehq.pillows.sms import get_sms_reindexer
 from corehq.pillows.user import get_user_reindexer
 from corehq.pillows.xform import (
-    get_couch_form_reindexer, get_sql_form_reindexer, get_resumable_couch_form_reindexer
+    get_couch_form_reindexer, get_sql_form_reindexer
 )
 
 
@@ -59,7 +59,6 @@ class Command(BaseCommand):
             'case': get_couch_case_reindexer,
             'resumable-case': get_resumable_couch_case_reindexer,
             'form': get_couch_form_reindexer,
-            'resumable-form': get_resumable_couch_form_reindexer,
             'sql-case': get_sql_case_reindexer,
             'sql-form': get_sql_form_reindexer,
             'case-search': get_case_search_reindexer,

--- a/corehq/pillows/xform.py
+++ b/corehq/pillows/xform.py
@@ -18,7 +18,6 @@ from couchforms.const import RESERVED_WORDS, DEVICE_LOG_XMLNS
 from couchforms.jsonobject_extensions import GeoPointProperty
 from couchforms.models import XFormInstance
 from pillowtop.checkpoints.manager import PillowCheckpoint, PillowCheckpointEventHandler
-from pillowtop.es_utils import get_index_info_from_pillow
 from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors.elastic import ElasticProcessor
 from pillowtop.processors.form import AppFormSubmissionTrackerProcessor

--- a/corehq/pillows/xform.py
+++ b/corehq/pillows/xform.py
@@ -224,9 +224,5 @@ def get_sql_form_reindexer():
         pillow=get_sql_xform_to_elasticsearch_pillow(),
         change_provider=SqlFormChangeProvider(),
         elasticsearch=get_es_new(),
-        index_info=_get_xform_index_info(),
+        index_info=XFORM_INDEX_INFO,
     )
-
-
-def _get_xform_index_info():
-    return get_index_info_from_pillow(XFormPillow(online=False))

--- a/settings.py
+++ b/settings.py
@@ -1479,6 +1479,11 @@ PILLOWTOPS = {
             'instance': 'corehq.pillows.xform.get_sql_xform_to_elasticsearch_pillow',
         },
         {
+            'name': 'CouchXFormToElasticsearchPillow',
+            'class': 'pillowtop.pillow.interface.ConstructedPillow',
+            'instance': 'corehq.pillows.xform.get_couch_xform_to_elasticsearch_pillow',
+        },
+        {
             'name': 'SqlCaseToElasticsearchPillow',
             'class': 'pillowtop.pillow.interface.ConstructedPillow',
             'instance': 'corehq.pillows.case.get_sql_case_to_elasticsearch_pillow',

--- a/testapps/test_pillowtop/tests/data/all-pillow-meta.json
+++ b/testapps/test_pillowtop/tests/data/all-pillow-meta.json
@@ -122,6 +122,13 @@
         "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
         "name": "CouchCaseToElasticsearchPillow"
     },
+    "CouchXFormToElasticsearchPillow": {
+        "advertised_name": "CouchXFormToElasticsearchPillow",
+        "change_feed_type": "KafkaChangeFeed",
+        "checkpoint_id": "couch-xforms-to-elasticsearch",
+        "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
+        "name": "CouchXFormToElasticsearchPillow"
+    },
     "CouvertureFluffPillow": {
         "advertised_name": "fluff.CouvertureFluffPillow.testhq",
         "change_feed_type": "KafkaChangeFeed",

--- a/testapps/test_pillowtop/tests/test_xform_pillow.py
+++ b/testapps/test_pillowtop/tests/test_xform_pillow.py
@@ -12,11 +12,14 @@ from corehq.form_processor.tests.utils import FormProcessorTestUtils
 from corehq.pillows.xform import (
     XFormPillow,
     get_sql_xform_to_elasticsearch_pillow,
-    transform_xform_for_elasticsearch
-)
+    transform_xform_for_elasticsearch,
+    get_couch_xform_to_elasticsearch_pillow)
 from corehq.util.elastic import delete_es_index, ensure_index_deleted
 from corehq.util.test_utils import get_form_ready_to_save, trap_extra_setup
 from elasticsearch.exceptions import ConnectionError
+
+from dimagi.utils.couch.database import get_db
+from pillowtop.feed.couch import get_current_seq
 
 
 class XFormPillowTest(TestCase):
@@ -48,6 +51,42 @@ class XFormPillowTest(TestCase):
         self.assertEqual(metadata.xmlns, form_doc['xmlns'])
         self.assertEqual('XFormInstance', form_doc['doc_type'])
         form.delete()
+
+    def test_couch_xform_to_es_pillow(self):
+        consumer = get_test_kafka_consumer(topics.FORM)
+
+        # have to get the seq id before the change is processed
+        kafka_seq = consumer.offsets()['fetch'][(topics.FORM, 0)]
+        couch_seq = get_current_seq(get_db())
+
+        metadata = TestFormMetadata(domain=self.domain)
+        form = get_form_ready_to_save(metadata, is_db_test=True)
+        form_processor = FormProcessorInterface(domain=self.domain)
+        form_processor.save_processed_models([form])
+
+        from corehq.apps.change_feed.pillow import get_default_couch_db_change_feed_pillow
+        change_feed_pillow = get_default_couch_db_change_feed_pillow('test')
+        change_feed_pillow.process_changes(couch_seq, forever=False)
+
+        # confirm change made it to kafka
+        message = consumer.next()
+        change_meta = change_meta_from_kafka_message(message.value)
+        self.assertEqual(form.form_id, change_meta.document_id)
+        self.assertEqual(self.domain, change_meta.domain)
+
+        # send to elasticsearch
+        sql_pillow = get_couch_xform_to_elasticsearch_pillow()
+        sql_pillow.process_changes(since=kafka_seq, forever=False)
+        self.elasticsearch.indices.refresh(self.pillow.es_index)
+
+        # confirm change made it to elasticserach
+        results = FormES().run()
+        self.assertEqual(1, results.total)
+        form_doc = results.hits[0]
+        self.assertEqual(self.domain, form_doc['domain'])
+        self.assertEqual(metadata.xmlns, form_doc['xmlns'])
+        self.assertEqual('XFormInstance', form_doc['doc_type'])
+
 
     @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
     def test_xform_pillow_sql(self):


### PR DESCRIPTION
@emord 

@dimagi/scale-team 

This adds a new pillow that sends xforms to ES from the kafka change feed. Once this pillow has caught up we can remove the `XFormPillow` and combine the couch and sql xform kafka pillows.
