### PR TITLE
Kafka case to ES pillow

### DIFF
--- a/corehq/apps/reports/tests/test_esaccessors.py
+++ b/corehq/apps/reports/tests/test_esaccessors.py
@@ -26,7 +26,7 @@ from corehq.form_processor.utils import TestFormMetadata
 from casexml.apps.case.models import CommCareCase, CommCareCaseAction
 from casexml.apps.case.const import CASE_ACTION_CREATE
 from corehq.pillows.xform import transform_xform_for_elasticsearch
-from corehq.pillows.case import get_sql_case_to_elasticsearch_pillow, transform_case_for_elasticsearch
+from corehq.pillows.case import transform_case_for_elasticsearch
 from corehq.apps.reports.analytics.esaccessors import (
     get_submission_counts_by_user,
     get_completed_counts_by_user,
@@ -51,8 +51,7 @@ from corehq.apps.reports.analytics.esaccessors import (
 )
 from corehq.apps.es.aggregations import MISSING_KEY
 from corehq.util.test_utils import make_es_ready_form, trap_extra_setup
-from pillowtop.es_utils import initialize_index_and_mapping, get_index_info_from_pillow
-from pillowtop.feed.interface import Change
+from pillowtop.es_utils import initialize_index_and_mapping
 
 
 class BaseESAccessorsTest(SimpleTestCase):

--- a/corehq/apps/reports/tests/test_esaccessors.py
+++ b/corehq/apps/reports/tests/test_esaccessors.py
@@ -11,7 +11,7 @@ from corehq.elastic import get_es_new, send_to_elasticsearch
 from corehq.form_processor.models import CommCareCaseSQL, CaseTransaction
 from corehq.form_processor.tests.utils import run_with_all_backends
 from corehq.form_processor.utils.xform import add_couch_properties_to_sql_form_json
-from corehq.pillows.mappings.case_mapping import CASE_INDEX
+from corehq.pillows.mappings.case_mapping import CASE_INDEX, CASE_INDEX_INFO
 from corehq.pillows.mappings.group_mapping import GROUP_INDEX
 from corehq.pillows.mappings.user_mapping import USER_INDEX, USER_INDEX_INFO
 from corehq.pillows.mappings.xform_mapping import XFORM_INDEX_INFO
@@ -26,7 +26,7 @@ from corehq.form_processor.utils import TestFormMetadata
 from casexml.apps.case.models import CommCareCase, CommCareCaseAction
 from casexml.apps.case.const import CASE_ACTION_CREATE
 from corehq.pillows.xform import transform_xform_for_elasticsearch
-from corehq.pillows.case import CasePillow, get_sql_case_to_elasticsearch_pillow
+from corehq.pillows.case import get_sql_case_to_elasticsearch_pillow, transform_case_for_elasticsearch
 from corehq.apps.reports.analytics.esaccessors import (
     get_submission_counts_by_user,
     get_completed_counts_by_user,
@@ -863,17 +863,13 @@ class TestGroupESAccessors(SimpleTestCase):
 
 class TestCaseESAccessors(BaseESAccessorsTest):
 
-    es_index_info = get_index_info_from_pillow(CasePillow(online=False))
+    es_index_info = CASE_INDEX_INFO
 
     def setUp(self):
         super(TestCaseESAccessors, self).setUp()
         self.owner_id = 'batman'
         self.user_id = 'robin'
         self.case_type = 'heroes'
-        self.pillow = self._get_pillow()
-
-    def _get_pillow(self):
-        return CasePillow(online=False)
 
     def _send_case_to_es(self,
             domain=None,
@@ -900,8 +896,8 @@ class TestCaseESAccessors(BaseESAccessorsTest):
             closed_by=user_id or self.user_id,
             actions=actions,
         )
-        self.pillow.change_transport(case.to_json())
-        self.pillow.get_es_new().indices.refresh(self.pillow.es_index)
+        send_to_elasticsearch('cases', case.to_json())
+        self.es.indices.refresh(CASE_INDEX_INFO.index)
         return case
 
     def test_get_active_case_counts(self):
@@ -1020,9 +1016,6 @@ class TestCaseESAccessors(BaseESAccessorsTest):
 @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
 class TestCaseESAccessorsSQL(TestCaseESAccessors):
 
-    def _get_pillow(self):
-        return get_sql_case_to_elasticsearch_pillow()
-
     def _send_case_to_es(self,
             domain=None,
             owner_id=None,
@@ -1050,12 +1043,7 @@ class TestCaseESAccessorsSQL(TestCaseESAccessors):
             server_date=opened_on,
         ))
 
-        change = Change(
-            id=case.case_id,
-            sequence_id='123',
-            document=case.to_json(),
-        )
-        self.pillow.process_change(change)
-        es = get_es_new()
-        es.indices.refresh(CASE_INDEX)
+        es_case = transform_case_for_elasticsearch(case.to_json())
+        send_to_elasticsearch('cases', es_case)
+        self.es.indices.refresh(CASE_INDEX)
         return case

--- a/corehq/pillows/case.py
+++ b/corehq/pillows/case.py
@@ -6,7 +6,7 @@ from corehq.apps.change_feed import topics
 from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed
 from corehq.elastic import get_es_new
 from corehq.form_processor.change_providers import SqlCaseChangeProvider
-from corehq.pillows.mappings.case_mapping import CASE_MAPPING, CASE_INDEX, CASE_ES_TYPE
+from corehq.pillows.mappings.case_mapping import CASE_MAPPING, CASE_INDEX, CASE_ES_TYPE, CASE_ES_ALIAS
 from corehq.pillows.utils import get_user_type
 from dimagi.utils.couch import LockManager
 from .base import HQPillow
@@ -34,7 +34,7 @@ class CasePillow(HQPillow):
     """
     document_class = CommCareCase
     couch_filter = "case/casedocs"
-    es_alias = "hqcases"
+    es_alias = CASE_ES_ALIAS
     es_type = CASE_ES_TYPE
 
     es_index = CASE_INDEX

--- a/corehq/pillows/mappings/case_mapping.py
+++ b/corehq/pillows/mappings/case_mapping.py
@@ -1,6 +1,8 @@
+from corehq.pillows.base import DEFAULT_META
 from corehq.pillows.core import DATE_FORMATS_ARR, DATE_FORMATS_STRING
 from corehq.pillows.mappings import NULL_VALUE
 from corehq.util.elastic import es_index
+from pillowtop.es_utils import ElasticsearchIndexInfo
 
 ##################
 # NOTE to the next person who updates this name:
@@ -102,3 +104,13 @@ CASE_MAPPING = {
                                  'type': 'string'},
     }
 }
+
+CASE_ES_ALIAS = "hqcases"
+
+CASE_INDEX_INFO = ElasticsearchIndexInfo(
+    index=CASE_INDEX,
+    alias=CASE_ES_ALIAS,
+    type=CASE_ES_TYPE,
+    meta=DEFAULT_META,
+    mapping=CASE_MAPPING
+)

--- a/settings.py
+++ b/settings.py
@@ -1479,6 +1479,11 @@ PILLOWTOPS = {
             'instance': 'corehq.pillows.case.get_sql_case_to_elasticsearch_pillow',
         },
         {
+            'name': 'CouchCaseToElasticsearchPillow',
+            'class': 'pillowtop.pillow.interface.ConstructedPillow',
+            'instance': 'corehq.pillows.case.get_couch_case_to_elasticsearch_pillow',
+        },
+        {
             'name': 'UnknownUsersPillow',
             'class': 'pillowtop.pillow.interface.ConstructedPillow',
             'instance': 'corehq.pillows.user.get_unknown_users_pillow',

--- a/testapps/test_pillowtop/tests/data/all-pillow-meta.json
+++ b/testapps/test_pillowtop/tests/data/all-pillow-meta.json
@@ -115,6 +115,13 @@
         "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
         "name": "CaseSearchToElasticsearchPillow"
     },
+    "CouchCaseToElasticsearchPillow": {
+        "advertised_name": "CouchCaseToElasticsearchPillow",
+        "change_feed_type": "KafkaChangeFeed",
+        "checkpoint_id": "couch-cases-to-elasticsearch",
+        "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
+        "name": "CouchCaseToElasticsearchPillow"
+    },
     "CouvertureFluffPillow": {
         "advertised_name": "fluff.CouvertureFluffPillow.testhq",
         "change_feed_type": "KafkaChangeFeed",

--- a/testapps/test_pillowtop/tests/test_case_pillow.py
+++ b/testapps/test_pillowtop/tests/test_case_pillow.py
@@ -5,7 +5,9 @@ from corehq.apps.change_feed.consumer.feed import change_meta_from_kafka_message
 from corehq.apps.change_feed.tests.utils import get_test_kafka_consumer
 from corehq.apps.es import CaseES
 from corehq.form_processor.tests.utils import FormProcessorTestUtils
-from corehq.pillows.case import CasePillow, get_sql_case_to_elasticsearch_pillow, get_couch_case_to_elasticsearch_pillow
+from corehq.pillows.case import (
+    CasePillow, get_sql_case_to_elasticsearch_pillow, get_couch_case_to_elasticsearch_pillow
+)
 from corehq.util.elastic import delete_es_index, ensure_index_deleted
 from corehq.util.test_utils import trap_extra_setup, create_and_save_a_case
 from elasticsearch.exceptions import ConnectionError

--- a/testapps/test_pillowtop/tests/test_case_pillow.py
+++ b/testapps/test_pillowtop/tests/test_case_pillow.py
@@ -5,10 +5,13 @@ from corehq.apps.change_feed.consumer.feed import change_meta_from_kafka_message
 from corehq.apps.change_feed.tests.utils import get_test_kafka_consumer
 from corehq.apps.es import CaseES
 from corehq.form_processor.tests.utils import FormProcessorTestUtils
-from corehq.pillows.case import CasePillow, get_sql_case_to_elasticsearch_pillow
+from corehq.pillows.case import CasePillow, get_sql_case_to_elasticsearch_pillow, get_couch_case_to_elasticsearch_pillow
 from corehq.util.elastic import delete_es_index, ensure_index_deleted
 from corehq.util.test_utils import trap_extra_setup, create_and_save_a_case
 from elasticsearch.exceptions import ConnectionError
+
+from dimagi.utils.couch.database import get_db
+from pillowtop.feed.couch import get_current_seq
 
 
 class CasePillowTest(TestCase):
@@ -94,6 +97,40 @@ class CasePillowTest(TestCase):
 
         # send to elasticsearch
         sql_pillow = get_sql_case_to_elasticsearch_pillow()
+        sql_pillow.process_changes(since=kafka_seq, forever=False)
+        self.elasticsearch.indices.refresh(self.pillow.es_index)
+
+        # confirm change made it to elasticserach
+        results = CaseES().run()
+        self.assertEqual(1, results.total)
+        case_doc = results.hits[0]
+        self.assertEqual(self.domain, case_doc['domain'])
+        self.assertEqual(case_id, case_doc['_id'])
+        self.assertEqual(case_name, case_doc['name'])
+
+    def test_kafka_couch_case_pillow(self):
+        consumer = get_test_kafka_consumer(topics.CASE)
+        # have to get the seq id before the change is processed
+        kafka_seq = consumer.offsets()['fetch'][(topics.CASE, 0)]
+        couch_seq = get_current_seq(get_db())
+
+        # make a case
+        case_id = uuid.uuid4().hex
+        case_name = 'case-name-{}'.format(uuid.uuid4().hex)
+        case = create_and_save_a_case(self.domain, case_id, case_name)
+
+        from corehq.apps.change_feed.pillow import get_default_couch_db_change_feed_pillow
+        change_feed_pillow = get_default_couch_db_change_feed_pillow('test')
+        change_feed_pillow.process_changes(couch_seq, forever=False)
+
+        # confirm change made it to kafka
+        message = consumer.next()
+        change_meta = change_meta_from_kafka_message(message.value)
+        self.assertEqual(case.case_id, change_meta.document_id)
+        self.assertEqual(self.domain, change_meta.domain)
+
+        # send to elasticsearch
+        sql_pillow = get_couch_case_to_elasticsearch_pillow()
         sql_pillow.process_changes(since=kafka_seq, forever=False)
         self.elasticsearch.indices.refresh(self.pillow.es_index)
 

--- a/testapps/test_pillowtop/tests/test_reindexer.py
+++ b/testapps/test_pillowtop/tests/test_reindexer.py
@@ -16,8 +16,7 @@ from corehq.apps.users.models import CommCareUser, WebUser
 from corehq.elastic import get_es_new
 from corehq.form_processor.tests.utils import FormProcessorTestUtils, \
     run_with_all_backends
-from corehq.pillows.case import CasePillow
-from corehq.pillows.mappings.case_mapping import CASE_INDEX
+from corehq.pillows.mappings.case_mapping import CASE_INDEX, CASE_INDEX_INFO
 from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_INDEX
 from corehq.pillows.mappings.domain_mapping import DOMAIN_INDEX
 from corehq.pillows.mappings.group_mapping import GROUP_INDEX_INFO
@@ -25,7 +24,7 @@ from corehq.pillows.mappings.user_mapping import USER_INDEX
 from corehq.pillows.mappings.xform_mapping import XFORM_INDEX
 from corehq.util.elastic import delete_es_index, ensure_index_deleted
 from corehq.util.test_utils import trap_extra_setup, create_and_save_a_form, create_and_save_a_case
-
+from pillowtop.es_utils import initialize_index_and_mapping
 
 DOMAIN = 'reindex-test-domain'
 
@@ -37,7 +36,7 @@ class PillowtopReindexerTest(TestCase):
     def setUpClass(cls):
         super(PillowtopReindexerTest, cls).setUpClass()
         with trap_extra_setup(ConnectionError):
-            CasePillow()  # verify connection to elasticsearch
+            initialize_index_and_mapping(get_es_new(), CASE_INDEX_INFO)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
@emord

@dimagi/scale-team

This adds a new pillow that sends cases to ES from the kafka change feed. Once this pillow has caught up we can remove the CasePillow and combine the couch and sql case kafka pillows.
