### PR TITLE
apps to ES kafka pillow + reindexer

### DIFF
--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -62,7 +62,7 @@ def app_doc_types():
     return {
         'Application': Application,
         'Application-Deleted': Application,
-        'RemoteAp': RemoteApp,
+        'RemoteApp': RemoteApp,
         'RemoteApp-Deleted': RemoteApp,
     }
 
@@ -482,7 +482,7 @@ def get_correct_app_class(doc):
     try:
         return app_doc_types()[doc['doc_type']]
     except KeyError:
-        raise DocTypeError()
+        raise DocTypeError(doc['doc_type'])
 
 
 def all_apps_by_domain(domain):

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -57,6 +57,16 @@ USER_CASE_XPATH_SUBSTRING_MATCHES = [
 ]
 
 
+def app_doc_types():
+    from corehq.apps.app_manager.models import Application, RemoteApp
+    return {
+        'Application': Application,
+        'Application-Deleted': Application,
+        'RemoteAp': RemoteApp,
+        'RemoteApp-Deleted': RemoteApp,
+    }
+
+
 def _prepare_xpath_for_validation(xpath):
     prepared_xpath = xpath.lower()
     prepared_xpath = prepared_xpath.replace('"', "'")
@@ -469,14 +479,8 @@ def is_sort_only_column(column):
 
 
 def get_correct_app_class(doc):
-    from corehq.apps.app_manager.models import Application, RemoteApp
     try:
-        return {
-            'Application': Application,
-            'Application-Deleted': Application,
-            "RemoteApp": RemoteApp,
-            "RemoteApp-Deleted": RemoteApp,
-        }[doc['doc_type']]
+        return app_doc_types()[doc['doc_type']]
     except KeyError:
         raise DocTypeError()
 

--- a/corehq/apps/change_feed/document_types.py
+++ b/corehq/apps/change_feed/document_types.py
@@ -1,4 +1,6 @@
 from collections import namedtuple
+
+from corehq.apps.app_manager.util import app_doc_types
 from corehq.apps.change_feed.exceptions import MissingMetaInformationError
 from couchforms.models import all_known_formlike_doc_types
 from dimagi.utils.couch.undo import DELETED_SUFFIX
@@ -11,6 +13,7 @@ META = 'meta'
 COMMCARE_USER = 'commcare-user'
 WEB_USER = 'web-user'
 GROUP = 'group'
+APP = 'app'
 
 
 DocumentMetadata = namedtuple(
@@ -38,6 +41,8 @@ def _get_primary_type(raw_doc_type):
         return WEB_USER
     elif raw_doc_type in ('Group', 'Group-Deleted'):
         return GROUP
+    elif raw_doc_type in app_doc_types().keys():
+        return APP
     else:
         # at some point we may want to make this more granular
         return META

--- a/corehq/apps/change_feed/pillow.py
+++ b/corehq/apps/change_feed/pillow.py
@@ -60,6 +60,11 @@ def get_domain_db_kafka_pillow(pillow_id):
     return get_change_feed_pillow_for_db(pillow_id, couch_config.get_db_for_class(Domain))
 
 
+def get_application_db_kafka_pillow(pillow_id):
+    from corehq.apps.app_manager.models import Application
+    return get_change_feed_pillow_for_db(pillow_id, couch_config.get_db_for_class(Application))
+
+
 def get_change_feed_pillow_for_db(pillow_id, couch_db):
     kafka_client = get_kafka_client_or_none()
     processor = KafkaProcessor(

--- a/corehq/apps/change_feed/topics.py
+++ b/corehq/apps/change_feed/topics.py
@@ -1,10 +1,11 @@
-from .document_types import CASE, FORM, DOMAIN, META
+from .document_types import CASE, FORM, DOMAIN, META, APP
 
 # this is redundant but helps avoid import warnings until nothing references these
 CASE = CASE
 FORM = FORM
 DOMAIN = DOMAIN
 META = META
+APP = APP
 
 # new models
 CASE_SQL = 'case-sql'
@@ -28,6 +29,7 @@ ALL = (
     META,
     SMS,
     WEB_USER,
+    APP,
 )
 
 

--- a/corehq/apps/hqcase/management/commands/ptop_reindexer_v2.py
+++ b/corehq/apps/hqcase/management/commands/ptop_reindexer_v2.py
@@ -1,6 +1,8 @@
 from copy import deepcopy
 from optparse import make_option
 from django.core.management import BaseCommand, CommandError
+
+from corehq.pillows.application import get_app_reindexer
 from corehq.pillows.case import (
     get_couch_case_reindexer, get_sql_case_reindexer, get_resumable_couch_case_reindexer
 )
@@ -67,6 +69,7 @@ class Command(BaseCommand):
             'ledger-v1': get_ledger_v1_reindexer,
             'sms': get_sms_reindexer,
             'report-xform': get_report_xform_couch_reindexer,
+            'app': get_app_reindexer,
         }
         if index not in reindex_fns:
             raise CommandError('Supported indices to reindex are: {}'.format(','.join(reindex_fns.keys())))

--- a/corehq/ex-submodules/pillowtop/reindexer/reindexer.py
+++ b/corehq/ex-submodules/pillowtop/reindexer/reindexer.py
@@ -111,6 +111,7 @@ class BulkPillowReindexProcessor(BaseDocProcessor):
     def should_process(self, doc):
         if self.doc_filter:
             return not self.doc_filter(doc)
+        return True
 
     def process_bulk_docs(self, docs, couchdb):
         changes = [self._doc_to_change(doc, couchdb) for doc in docs]

--- a/corehq/ex-submodules/pillowtop/reindexer/reindexer.py
+++ b/corehq/ex-submodules/pillowtop/reindexer/reindexer.py
@@ -114,6 +114,9 @@ class BulkPillowReindexProcessor(BaseDocProcessor):
         return True
 
     def process_bulk_docs(self, docs, couchdb):
+        if len(docs) == 0:
+            return True
+
         changes = [self._doc_to_change(doc, couchdb) for doc in docs]
 
         bulk_changes = build_bulk_payload(self.index_info, changes, self.doc_transform)

--- a/corehq/pillows/application.py
+++ b/corehq/pillows/application.py
@@ -1,6 +1,6 @@
 from corehq.apps.app_manager.models import ApplicationBase
 from corehq.apps.app_manager.util import get_correct_app_class
-from corehq.pillows.mappings.app_mapping import APP_INDEX, APP_MAPPING
+from corehq.pillows.mappings.app_mapping import APP_INDEX_INFO
 from pillowtop.listener import AliasedElasticPillow
 
 
@@ -12,23 +12,11 @@ class AppPillow(AliasedElasticPillow):
     document_class = ApplicationBase
     couch_filter = "app_manager/all_apps"
     es_timeout = 60
-    es_alias = "hqapps"
-    es_type = "app"
-    es_meta = {
-        "settings": {
-            "analysis": {
-                "analyzer": {
-                    "default": {
-                        "type": "custom",
-                        "tokenizer": "whitespace",
-                        "filter": ["lowercase"]
-                    },
-                }
-            }
-        }
-    }
-    es_index = APP_INDEX
-    default_mapping = APP_MAPPING
+    es_alias = APP_INDEX_INFO.alias
+    es_type = APP_INDEX_INFO.type
+    es_meta = APP_INDEX_INFO.meta
+    es_index = APP_INDEX_INFO.index
+    default_mapping = APP_INDEX_INFO.mapping
 
     def change_transform(self, doc_dict):
         # perform any lazy migrations

--- a/corehq/pillows/application.py
+++ b/corehq/pillows/application.py
@@ -1,7 +1,13 @@
 from corehq.apps.app_manager.models import ApplicationBase
 from corehq.apps.app_manager.util import get_correct_app_class
+from corehq.apps.change_feed import topics
+from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed
+from corehq.elastic import get_es_new
 from corehq.pillows.mappings.app_mapping import APP_INDEX_INFO
+from pillowtop.checkpoints.manager import PillowCheckpoint, PillowCheckpointEventHandler
 from pillowtop.listener import AliasedElasticPillow
+from pillowtop.pillow.interface import ConstructedPillow
+from pillowtop.processors import ElasticProcessor
 
 
 class AppPillow(AliasedElasticPillow):
@@ -19,6 +25,30 @@ class AppPillow(AliasedElasticPillow):
     default_mapping = APP_INDEX_INFO.mapping
 
     def change_transform(self, doc_dict):
-        # perform any lazy migrations
-        doc = get_correct_app_class(doc_dict).wrap(doc_dict)
-        return doc.to_json()
+        return transform_app_for_es(doc_dict)
+
+
+def transform_app_for_es(doc_dict):
+    # perform any lazy migrations
+    doc = get_correct_app_class(doc_dict).wrap(doc_dict)
+    return doc.to_json()
+
+
+def get_app_to_elasticsearch_pillow(pillow_id='ApplicationToElasticsearchPillow'):
+    checkpoint = PillowCheckpoint(
+        'applications-to-elasticsearch',
+    )
+    app_processor = ElasticProcessor(
+        elasticsearch=get_es_new(),
+        index_info=APP_INDEX_INFO,
+        doc_prep_fn=transform_app_for_es
+    )
+    return ConstructedPillow(
+        name=pillow_id,
+        checkpoint=checkpoint,
+        change_feed=KafkaChangeFeed(topics=[topics.APP], group_id='apps-to-es'),
+        processor=app_processor,
+        change_processed_event_handler=PillowCheckpointEventHandler(
+            checkpoint=checkpoint, checkpoint_frequency=100,
+        ),
+    )

--- a/corehq/pillows/mappings/app_mapping.py
+++ b/corehq/pillows/mappings/app_mapping.py
@@ -1,4 +1,5 @@
 from corehq.util.elastic import es_index
+from pillowtop.es_utils import ElasticsearchIndexInfo
 
 APP_INDEX = es_index("hqapps_2016-03-01_2128")
 APP_MAPPING={'_meta': {'created': None},
@@ -304,3 +305,26 @@ APP_MAPPING={'_meta': {'created': None},
                 'use_custom_suite': {'type': 'boolean'},
                 'user_type': {'type': 'string'},
                 'version': {'type': 'long'}}}
+
+APP_ES_ALIAS = "hqapps"
+APP_ES_TYPE = "app"
+APP_ES_META = {
+    "settings": {
+        "analysis": {
+            "analyzer": {
+                "default": {
+                    "type": "custom",
+                    "tokenizer": "whitespace",
+                    "filter": ["lowercase"]
+                },
+            }
+        }
+    }
+}
+APP_INDEX_INFO = ElasticsearchIndexInfo(
+    index=APP_INDEX,
+    alias=APP_ES_ALIAS,
+    type=APP_ES_TYPE,
+    meta=APP_ES_META,
+    mapping=APP_MAPPING
+)

--- a/settings.py
+++ b/settings.py
@@ -1449,6 +1449,11 @@ PILLOWTOPS = {
         'corehq.pillows.reportcase.ReportCasePillow',
         'corehq.pillows.reportxform.ReportXFormPillow',
         {
+            'name': 'AppDbChangeFeedPillow',
+            'class': 'pillowtop.pillow.interface.ConstructedPillow',
+            'instance': 'corehq.apps.change_feed.pillow.get_application_db_kafka_pillow',
+        },
+        {
             'name': 'DefaultChangeFeedPillow',
             'class': 'pillowtop.pillow.interface.ConstructedPillow',
             'instance': 'corehq.apps.change_feed.pillow.get_default_couch_db_change_feed_pillow',

--- a/settings.py
+++ b/settings.py
@@ -1454,6 +1454,11 @@ PILLOWTOPS = {
             'instance': 'corehq.apps.change_feed.pillow.get_application_db_kafka_pillow',
         },
         {
+            'name': 'ApplicationToElasticsearchPillow',
+            'class': 'pillowtop.pillow.interface.ConstructedPillow',
+            'instance': 'corehq.pillows.application.get_app_to_elasticsearch_pillow',
+        },
+        {
             'name': 'DefaultChangeFeedPillow',
             'class': 'pillowtop.pillow.interface.ConstructedPillow',
             'instance': 'corehq.apps.change_feed.pillow.get_default_couch_db_change_feed_pillow',

--- a/testapps/test_pillowtop/tests/data/all-pillow-meta.json
+++ b/testapps/test_pillowtop/tests/data/all-pillow-meta.json
@@ -55,6 +55,13 @@
         "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
         "name": "ApplicationBlobDeletionPillow"
     },
+    "ApplicationToElasticsearchPillow": {
+        "advertised_name": "ApplicationToElasticsearchPillow",
+        "change_feed_type": "KafkaChangeFeed",
+        "checkpoint_id": "applications-to-elasticsearch",
+        "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
+        "name": "ApplicationToElasticsearchPillow"
+    },
     "BlobDeletionPillow": {
         "advertised_name": "BlobDeletionPillow",
         "change_feed_type": "KafkaChangeFeed",

--- a/testapps/test_pillowtop/tests/data/all-pillow-meta.json
+++ b/testapps/test_pillowtop/tests/data/all-pillow-meta.json
@@ -31,6 +31,13 @@
         "include_docs": false,
         "name": "AncHmisCaseFluffPillow"
     },
+    "AppDbChangeFeedPillow": {
+        "advertised_name": "AppDbChangeFeedPillow",
+        "change_feed_type": "CouchChangeFeed",
+        "checkpoint_id": "AppDbChangeFeedPillow",
+        "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
+        "name": "AppDbChangeFeedPillow"
+    },
     "AppPillow": {
         "advertised_name": "corehq.pillows.application.AppPillow.test_hqapps_2016-03-01_2128.testhq",
         "change_feed_type": "CouchChangeFeed",

--- a/testapps/test_pillowtop/tests/test_app_pillow.py
+++ b/testapps/test_pillowtop/tests/test_app_pillow.py
@@ -1,0 +1,58 @@
+from django.test import TestCase
+from elasticsearch.exceptions import ConnectionError
+
+from corehq.apps.app_manager.models import Application
+from corehq.apps.app_manager.tests import AppFactory
+from corehq.apps.es import AppES
+from corehq.elastic import get_es_new
+from corehq.form_processor.tests.utils import FormProcessorTestUtils
+from corehq.pillows.application import AppPillow
+from corehq.pillows.mappings.app_mapping import APP_INDEX_INFO
+from corehq.util.elastic import ensure_index_deleted
+from corehq.util.test_utils import trap_extra_setup
+from pillowtop.es_utils import initialize_index_and_mapping
+from pillowtop.feed.couch import get_current_seq
+
+
+class AppPillowTest(TestCase):
+
+    domain = 'app-pillowtest-domain'
+
+    def setUp(self):
+        super(AppPillowTest, self).setUp()
+        FormProcessorTestUtils.delete_all_cases()
+        with trap_extra_setup(ConnectionError):
+            self.es = get_es_new()
+
+        ensure_index_deleted(APP_INDEX_INFO.index)
+        initialize_index_and_mapping(self.es, APP_INDEX_INFO)
+
+    def tearDown(self):
+        # ensure_index_deleted(APP_INDEX_INFO.index)
+        super(AppPillowTest, self).tearDown()
+
+    def test_app_pillow_couch(self):
+        since = get_current_seq(Application.get_db())
+
+        name = 'test app 1'
+        app = self._create_app(name)
+        pillow = AppPillow()
+        pillow.process_changes(since, forever=False)
+        self.es.indices.refresh(APP_INDEX_INFO.index)
+
+        # verify there
+        results = AppES().run()
+        self.assertEqual(1, results.total)
+        app_doc = results.hits[0]
+        self.assertEqual(self.domain, app_doc['domain'])
+        self.assertEqual(app['_id'], app_doc['_id'])
+        self.assertEqual(name, app_doc['name'])
+
+    def _create_app(self, name):
+        factory = AppFactory(domain=self.domain, name=name, build_version='2.11')
+        module1, form1 = factory.new_basic_module('open_case', 'house')
+        factory.form_opens_case(form1)
+        app = factory.app
+        app.save()
+        self.addCleanup(app.delete)
+        return app

--- a/testapps/test_pillowtop/tests/test_app_pillow.py
+++ b/testapps/test_pillowtop/tests/test_app_pillow.py
@@ -34,7 +34,7 @@ class AppPillowTest(TestCase):
         initialize_index_and_mapping(self.es, APP_INDEX_INFO)
 
     def tearDown(self):
-        # ensure_index_deleted(APP_INDEX_INFO.index)
+        ensure_index_deleted(APP_INDEX_INFO.index)
         super(AppPillowTest, self).tearDown()
 
     def test_app_pillow_couch(self):
@@ -60,7 +60,6 @@ class AppPillowTest(TestCase):
         kafka_seq = consumer.offsets()['fetch'][(topics.APP, 0)]
         couch_seq = get_current_seq(Application.get_db())
 
-        # make a case
         app_name = 'app-{}'.format(uuid.uuid4().hex)
         app = self._create_app(app_name)
 

--- a/testapps/test_pillowtop/tests/test_app_pillow.py
+++ b/testapps/test_pillowtop/tests/test_app_pillow.py
@@ -1,12 +1,18 @@
+import uuid
+
 from django.test import TestCase
 from elasticsearch.exceptions import ConnectionError
 
 from corehq.apps.app_manager.models import Application
 from corehq.apps.app_manager.tests import AppFactory
+from corehq.apps.change_feed import topics
+from corehq.apps.change_feed.consumer.feed import change_meta_from_kafka_message
+from corehq.apps.change_feed.pillow import get_application_db_kafka_pillow
+from corehq.apps.change_feed.tests.utils import get_test_kafka_consumer
 from corehq.apps.es import AppES
 from corehq.elastic import get_es_new
 from corehq.form_processor.tests.utils import FormProcessorTestUtils
-from corehq.pillows.application import AppPillow
+from corehq.pillows.application import AppPillow, get_app_to_elasticsearch_pillow
 from corehq.pillows.mappings.app_mapping import APP_INDEX_INFO
 from corehq.util.elastic import ensure_index_deleted
 from corehq.util.test_utils import trap_extra_setup
@@ -34,7 +40,7 @@ class AppPillowTest(TestCase):
     def test_app_pillow_couch(self):
         since = get_current_seq(Application.get_db())
 
-        name = 'test app 1'
+        name = 'app-{}'.format(uuid.uuid4().hex)
         app = self._create_app(name)
         pillow = AppPillow()
         pillow.process_changes(since, forever=False)
@@ -47,6 +53,38 @@ class AppPillowTest(TestCase):
         self.assertEqual(self.domain, app_doc['domain'])
         self.assertEqual(app['_id'], app_doc['_id'])
         self.assertEqual(name, app_doc['name'])
+
+    def test_app_pillow_kafka(self):
+        consumer = get_test_kafka_consumer(topics.APP)
+        # have to get the seq id before the change is processed
+        kafka_seq = consumer.offsets()['fetch'][(topics.APP, 0)]
+        couch_seq = get_current_seq(Application.get_db())
+
+        # make a case
+        app_name = 'app-{}'.format(uuid.uuid4().hex)
+        app = self._create_app(app_name)
+
+        app_db_pillow = get_application_db_kafka_pillow('test_app_db_pillow')
+        app_db_pillow.process_changes(couch_seq, forever=False)
+
+        # confirm change made it to kafka
+        message = consumer.next()
+        change_meta = change_meta_from_kafka_message(message.value)
+        self.assertEqual(app._id, change_meta.document_id)
+        self.assertEqual(self.domain, change_meta.domain)
+
+        # send to elasticsearch
+        app_pillow = get_app_to_elasticsearch_pillow()
+        app_pillow.process_changes(since=kafka_seq, forever=False)
+        self.es.indices.refresh(APP_INDEX_INFO.index)
+
+        # confirm change made it to elasticserach
+        results = AppES().run()
+        self.assertEqual(1, results.total)
+        app_doc = results.hits[0]
+        self.assertEqual(self.domain, app_doc['domain'])
+        self.assertEqual(app['_id'], app_doc['_id'])
+        self.assertEqual(app_name, app_doc['name'])
 
     def _create_app(self, name):
         factory = AppFactory(domain=self.domain, name=name, build_version='2.11')


### PR DESCRIPTION
@emord

@dimagi/scale-team

This adds a new pillow that sends apps to ES from the kafka change feed. Once this pillow has caught up we can remove the AppPillow.

Bulk reindexer still needed (once https://github.com/dimagi/commcare-hq/pull/12299 is merged)
