### PR TITLE
report cases to ES kafka pillow

### DIFF
--- a/corehq/pillows/mappings/reportcase_mapping.py
+++ b/corehq/pillows/mappings/reportcase_mapping.py
@@ -1,4 +1,6 @@
+from corehq.pillows.base import DEFAULT_META
 from corehq.util.elastic import es_index
+from pillowtop.es_utils import ElasticsearchIndexInfo
 
 ##################
 # NOTE to the next person who updates this name:
@@ -127,3 +129,14 @@ REPORT_CASE_MAPPING={'_meta': {'comment': '2013-11-05 dmyung',
                 'user_id': {'type': 'string'},
                 'version': {'type': 'string'},
                 'xform_ids': {'index': 'not_analyzed', 'type': 'string'}}}
+
+REPORT_CASE_ES_ALIAS = "report_cases"
+REPORT_CASE_ES_TYPE = "report_case"
+
+REPORT_CASE_INDEX_INFO = ElasticsearchIndexInfo(
+    index=REPORT_CASE_INDEX,
+    alias=REPORT_CASE_ES_ALIAS,
+    type=REPORT_CASE_ES_TYPE,
+    meta=DEFAULT_META,
+    mapping=REPORT_CASE_MAPPING,
+)

--- a/corehq/pillows/reportcase.py
+++ b/corehq/pillows/reportcase.py
@@ -1,6 +1,6 @@
 import copy
 from corehq.pillows.case import CasePillow
-from corehq.pillows.mappings.reportcase_mapping import REPORT_CASE_MAPPING, REPORT_CASE_INDEX
+from corehq.pillows.mappings.reportcase_mapping import REPORT_CASE_INDEX_INFO
 from django.conf import settings
 from .base import convert_property_dict
 
@@ -12,8 +12,8 @@ class ReportCasePillow(CasePillow):
     """
     es_alias = "report_cases"
     es_type = "report_case"
-    es_index = REPORT_CASE_INDEX
-    default_mapping = REPORT_CASE_MAPPING
+    es_index = REPORT_CASE_INDEX_INFO.index
+    default_mapping = REPORT_CASE_INDEX_INFO.mapping
 
     @classmethod
     def get_unique_id(cls):
@@ -30,7 +30,7 @@ def transform_case_to_report_es(doc_dict):
     doc_ret = copy.deepcopy(doc_dict)
     convert_property_dict(
         doc_ret,
-        REPORT_CASE_MAPPING,
+        REPORT_CASE_INDEX_INFO.mapping,
         override_root_keys=['_id', 'doc_type', '_rev', '#export_tag']
     )
     return doc_ret

--- a/corehq/pillows/reportcase.py
+++ b/corehq/pillows/reportcase.py
@@ -20,9 +20,17 @@ class ReportCasePillow(CasePillow):
         return '8c10a7564b6af5052f8b86693bf6ac07'
 
     def change_transform(self, doc_dict):
-        if doc_dict.get('domain', None) not in getattr(settings, 'ES_CASE_FULL_INDEX_DOMAINS', []):
-            # full indexing is only enabled for select domains on an opt-in basis
-            return None
-        doc_ret = copy.deepcopy(doc_dict)
-        convert_property_dict(doc_ret, self.default_mapping, override_root_keys=['_id', 'doc_type', '_rev', '#export_tag'])
-        return doc_ret
+        return transform_case_to_report_es(doc_dict)
+
+
+def transform_case_to_report_es(doc_dict):
+    if doc_dict.get('domain', None) not in getattr(settings, 'ES_CASE_FULL_INDEX_DOMAINS', []):
+        # full indexing is only enabled for select domains on an opt-in basis
+        return None
+    doc_ret = copy.deepcopy(doc_dict)
+    convert_property_dict(
+        doc_ret,
+        REPORT_CASE_MAPPING,
+        override_root_keys=['_id', 'doc_type', '_rev', '#export_tag']
+    )
+    return doc_ret

--- a/settings.py
+++ b/settings.py
@@ -1469,6 +1469,11 @@ PILLOWTOPS = {
             'instance': 'corehq.apps.userreports.pillow.get_kafka_ucr_static_pillow',
         },
         {
+            'name': 'ReportCaseToElasticsearchPillow',
+            'class': 'pillowtop.pillow.interface.ConstructedPillow',
+            'instance': 'corehq.pillows.reportcase.get_report_case_to_elasticsearch_pillow',
+        },
+        {
             'name': 'SqlXFormToElasticsearchPillow',
             'class': 'pillowtop.pillow.interface.ConstructedPillow',
             'instance': 'corehq.pillows.xform.get_sql_xform_to_elasticsearch_pillow',

--- a/testapps/test_pillowtop/tests/data/all-pillow-meta.json
+++ b/testapps/test_pillowtop/tests/data/all-pillow-meta.json
@@ -398,6 +398,13 @@
         "name": "ReportCasePillow",
         "unique_id": "8c10a7564b6af5052f8b86693bf6ac07"
     },
+    "ReportCaseToElasticsearchPillow": {
+        "advertised_name": "ReportCaseToElasticsearchPillow",
+        "change_feed_type": "KafkaChangeFeed",
+        "checkpoint_id": "report-cases-to-elasticsearch",
+        "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
+        "name": "ReportCaseToElasticsearchPillow"
+    },
     "ReportXFormPillow": {
         "advertised_name": "corehq.pillows.reportxform.ReportXFormPillow.test_report_xforms_20150406_1136.testhq",
         "change_feed_type": "CouchChangeFeed",

--- a/testapps/test_pillowtop/tests/test_pillows_cases.py
+++ b/testapps/test_pillowtop/tests/test_pillows_cases.py
@@ -4,7 +4,7 @@ from casexml.apps.case.xform import extract_case_blocks
 from corehq.apps.api.es import report_term_filter
 from corehq.pillows.base import VALUE_TAG
 from corehq.pillows.case import CasePillow
-from corehq.pillows.reportcase import ReportCasePillow
+from corehq.pillows.reportcase import transform_case_to_report_es
 from corehq.pillows.reportxform import ReportXFormPillow
 from corehq.pillows.xform import XFormPillow
 from corehq.pillows.mappings.reportcase_mapping import REPORT_CASE_MAPPING
@@ -522,9 +522,7 @@ class testReportCaseProcessing(TestCase):
     def testReportCaseTransform(self):
         case = EXAMPLE_CASE
         case['domain'] = settings.ES_CASE_FULL_INDEX_DOMAINS[0]
-        report_pillow = ReportCasePillow(online=False)
-        processed_case = report_pillow.change_transform(case)
-        mapping = report_pillow.default_mapping
+        processed_case = transform_case_to_report_es(case)
 
         #known properties, not #value'd
         self.assertEqual(processed_case['user_id'], case['user_id'])

--- a/testapps/test_pillowtop/tests/test_report_case_pillow.py
+++ b/testapps/test_pillowtop/tests/test_report_case_pillow.py
@@ -1,0 +1,114 @@
+import uuid
+
+from django.test import TestCase, override_settings
+from elasticsearch.exceptions import ConnectionError
+
+from casexml.apps.case.models import CommCareCase
+from corehq.apps.change_feed import topics
+from corehq.apps.change_feed.consumer.feed import change_meta_from_kafka_message
+from corehq.apps.change_feed.pillow import get_default_couch_db_change_feed_pillow
+from corehq.apps.change_feed.tests.utils import get_test_kafka_consumer, get_current_multi_topic_seq
+from corehq.apps.es import CaseES
+from corehq.elastic import get_es_new
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends
+from corehq.form_processor.utils.general import should_use_sql_backend
+from corehq.pillows.mappings.reportcase_mapping import REPORT_CASE_INDEX_INFO
+from corehq.pillows.reportcase import ReportCasePillow, get_report_case_to_elasticsearch_pillow
+from corehq.util.elastic import ensure_index_deleted
+from corehq.util.test_utils import trap_extra_setup, create_and_save_a_case
+from pillowtop.es_utils import initialize_index_and_mapping
+from pillowtop.feed.couch import get_current_seq
+
+DOMAIN = 'report-case-pillowtest-domain'
+
+
+@override_settings(ES_CASE_FULL_INDEX_DOMAINS=[DOMAIN])
+class ReportCasePillowTest(TestCase):
+
+    def setUp(self):
+        super(ReportCasePillowTest, self).setUp()
+        FormProcessorTestUtils.delete_all_cases()
+        with trap_extra_setup(ConnectionError):
+            self.elasticsearch = get_es_new()
+            ensure_index_deleted(REPORT_CASE_INDEX_INFO.index)
+            initialize_index_and_mapping(self.elasticsearch, REPORT_CASE_INDEX_INFO)
+
+    def tearDown(self):
+        ensure_index_deleted(REPORT_CASE_INDEX_INFO.index)
+        super(ReportCasePillowTest, self).tearDown()
+
+    def test_report_case_pillow_couch(self):
+        couch_seq = get_current_seq(CommCareCase.get_db())
+
+        # make a case
+        case_id = uuid.uuid4().hex
+        case_name = 'case-name-{}'.format(uuid.uuid4().hex)
+        case = create_and_save_a_case(DOMAIN, case_id, case_name)
+        self.addCleanup(case.delete)
+
+        # send to elasticsearch
+        self._sync_couch_cases_to_es(since=couch_seq)
+
+        # verify there
+        results = CaseES('report_cases').run()
+        self.assertEqual(1, results.total)
+        case_doc = results.hits[0]
+        self.assertEqual(DOMAIN, case_doc['domain'])
+        self.assertEqual(case_id, case_doc['_id'])
+        self.assertEqual(case_name, case_doc['name'])
+
+    def test_case_unsupported_domain(self):
+        couch_seq = get_current_seq(CommCareCase.get_db())
+
+        # make a case
+        case_id = uuid.uuid4().hex
+        case_name = 'case-name-{}'.format(uuid.uuid4().hex)
+        case = create_and_save_a_case('another-domain', case_id, case_name)
+        self.addCleanup(case.delete)
+
+        # send to elasticsearch
+        self._sync_couch_cases_to_es(since=couch_seq)
+
+        # verify there
+        results = CaseES('report_cases').run()
+        self.assertEqual(0, results.total)
+
+    @run_with_all_backends
+    def test_report_case_kafka_pillow(self):
+        consumer = get_test_kafka_consumer(topics.CASE, topics.CASE_SQL)
+        # have to get the seq id before the change is processed
+        kafka_seq = get_current_multi_topic_seq([topics.CASE, topics.CASE_SQL])
+        couch_seq = get_current_seq(CommCareCase.get_db())
+
+        # make a case
+        case_id = uuid.uuid4().hex
+        case_name = 'case-name-{}'.format(uuid.uuid4().hex)
+        case = create_and_save_a_case(DOMAIN, case_id, case_name)
+
+        if not should_use_sql_backend(DOMAIN):
+            # publish couch changes to kafka
+            couch_producer_pillow = get_default_couch_db_change_feed_pillow('test-report-case-couch-pillow')
+            couch_producer_pillow.process_changes(since=couch_seq, forever=False)
+
+        # confirm change made it to kafka
+        message = consumer.next()
+        change_meta = change_meta_from_kafka_message(message.value)
+        self.assertEqual(case.case_id, change_meta.document_id)
+        self.assertEqual(DOMAIN, change_meta.domain)
+
+        # send to elasticsearch
+        report_case_kafka_pillow = get_report_case_to_elasticsearch_pillow()
+        report_case_kafka_pillow.process_changes(since=kafka_seq, forever=False)
+        self.elasticsearch.indices.refresh(REPORT_CASE_INDEX_INFO.index)
+
+        # confirm change made it to elasticserach
+        results = CaseES('report_cases').run()
+        self.assertEqual(1, results.total)
+        case_doc = results.hits[0]
+        self.assertEqual(DOMAIN, case_doc['domain'])
+        self.assertEqual(case_id, case_doc['_id'])
+        self.assertEqual(case_name, case_doc['name'])
+
+    def _sync_couch_cases_to_es(self, since=0):
+        ReportCasePillow().process_changes(since=since, forever=False)
+        self.elasticsearch.indices.refresh(REPORT_CASE_INDEX_INFO.index)


### PR DESCRIPTION
@emord

@dimagi/scale-team

This adds a new kafka pillow that sends cases to the report_case ES index. Once this pillow has caught up we can remove the ReportCasePillow.

Bulk reindexer still needed (once #12299 is merged)
