### PR TITLE
report xforms to ES kafka pillow and reindexer

### DIFF
--- a/corehq/apps/hqcase/management/commands/ptop_reindexer_v2.py
+++ b/corehq/apps/hqcase/management/commands/ptop_reindexer_v2.py
@@ -9,6 +9,7 @@ from corehq.pillows.domain import get_domain_reindexer
 from corehq.pillows.group import get_group_reindexer
 from corehq.pillows.groups_to_user import get_groups_to_user_reindexer
 from corehq.pillows.ledger import get_ledger_v2_reindexer, get_ledger_v1_reindexer
+from corehq.pillows.reportxform import get_report_xform_reindexer
 from corehq.pillows.sms import get_sms_reindexer
 from corehq.pillows.user import get_user_reindexer
 from corehq.pillows.xform import (
@@ -66,6 +67,7 @@ class Command(BaseCommand):
             'ledger-v2': get_ledger_v2_reindexer,
             'ledger-v1': get_ledger_v1_reindexer,
             'sms': get_sms_reindexer,
+            'report-xform': get_report_xform_reindexer,
         }
         if index not in reindex_fns:
             raise CommandError('Supported indices to reindex are: {}'.format(','.join(reindex_fns.keys())))

--- a/corehq/apps/hqcase/management/commands/ptop_reindexer_v2.py
+++ b/corehq/apps/hqcase/management/commands/ptop_reindexer_v2.py
@@ -9,7 +9,7 @@ from corehq.pillows.domain import get_domain_reindexer
 from corehq.pillows.group import get_group_reindexer
 from corehq.pillows.groups_to_user import get_groups_to_user_reindexer
 from corehq.pillows.ledger import get_ledger_v2_reindexer, get_ledger_v1_reindexer
-from corehq.pillows.reportxform import get_report_xform_reindexer
+from corehq.pillows.reportxform import get_report_xform_couch_reindexer
 from corehq.pillows.sms import get_sms_reindexer
 from corehq.pillows.user import get_user_reindexer
 from corehq.pillows.xform import (
@@ -67,7 +67,7 @@ class Command(BaseCommand):
             'ledger-v2': get_ledger_v2_reindexer,
             'ledger-v1': get_ledger_v1_reindexer,
             'sms': get_sms_reindexer,
-            'report-xform': get_report_xform_reindexer,
+            'report-xform': get_report_xform_couch_reindexer,
         }
         if index not in reindex_fns:
             raise CommandError('Supported indices to reindex are: {}'.format(','.join(reindex_fns.keys())))

--- a/corehq/pillows/mappings/reportxform_mapping.py
+++ b/corehq/pillows/mappings/reportxform_mapping.py
@@ -1,5 +1,8 @@
+from corehq.pillows.base import DEFAULT_META
 from corehq.pillows.core import DATE_FORMATS_STRING, DATE_FORMATS_ARR
 from corehq.util.elastic import es_index
+from pillowtop.es_utils import ElasticsearchIndexInfo
+
 REPORT_XFORM_INDEX = es_index("report_xforms_20150406_1136")
 
 CASE_MAPPING_FRAGMENT = {
@@ -148,3 +151,14 @@ REPORT_XFORM_MAPPING = {
         }
     ]
 }
+
+REPORT_XFORM_ALIAS = "report_xform"
+REPORT_XFORM_TYPE = "report_xforms"
+
+REPORT_XFORM_INDEX_INFO = ElasticsearchIndexInfo(
+    index=REPORT_XFORM_INDEX,
+    alias=REPORT_XFORM_ALIAS,
+    type=REPORT_XFORM_TYPE,
+    meta=DEFAULT_META,
+    mapping=REPORT_XFORM_MAPPING,
+)

--- a/corehq/pillows/mappings/reportxform_mapping.py
+++ b/corehq/pillows/mappings/reportxform_mapping.py
@@ -152,8 +152,8 @@ REPORT_XFORM_MAPPING = {
     ]
 }
 
-REPORT_XFORM_ALIAS = "report_xform"
-REPORT_XFORM_TYPE = "report_xforms"
+REPORT_XFORM_ALIAS = "report_xforms"
+REPORT_XFORM_TYPE = "report_xform"
 
 REPORT_XFORM_INDEX_INFO = ElasticsearchIndexInfo(
     index=REPORT_XFORM_INDEX,

--- a/corehq/pillows/reportxform.py
+++ b/corehq/pillows/reportxform.py
@@ -2,7 +2,7 @@ from django.conf import settings
 
 from corehq.pillows.base import convert_property_dict
 from corehq.pillows.xform import transform_xform_for_elasticsearch
-from .mappings.reportxform_mapping import REPORT_XFORM_INDEX, REPORT_XFORM_MAPPING
+from .mappings.reportxform_mapping import REPORT_XFORM_INDEX_INFO
 from .xform import XFormPillow
 
 COMPUTED_CASEBLOCKS_KEY = '_case_blocks'
@@ -15,10 +15,10 @@ class ReportXFormPillow(XFormPillow):
     """
     es_alias = "report_xforms"
     es_type = "report_xform"
-    es_index = REPORT_XFORM_INDEX
+    es_index = REPORT_XFORM_INDEX_INFO.index
 
     #type level mapping
-    default_mapping = REPORT_XFORM_MAPPING
+    default_mapping = REPORT_XFORM_INDEX_INFO.mapping
 
     def change_transform(self, doc_dict):
         return transform_xform_for_report_forms_index(doc_dict)
@@ -32,7 +32,7 @@ def transform_xform_for_report_forms_index(doc_dict):
         if domain not in getattr(settings, 'ES_XFORM_FULL_INDEX_DOMAINS', []):
             # full indexing is only enabled for select domains on an opt-in basis
             return None
-        convert_property_dict(doc_ret['form'], REPORT_XFORM_MAPPING['properties']['form'], override_root_keys=['case'])
+        convert_property_dict(doc_ret['form'], REPORT_XFORM_INDEX_INFO.mapping['properties']['form'], override_root_keys=['case'])
         if 'computed_' in doc_ret:
             convert_property_dict(doc_ret['computed_'], {})
 

--- a/corehq/pillows/reportxform.py
+++ b/corehq/pillows/reportxform.py
@@ -46,7 +46,11 @@ def report_xform_filter(doc_dict):
 def transform_xform_for_report_forms_index(doc_dict):
     doc_ret = transform_xform_for_elasticsearch(doc_dict, include_props=False)
     if doc_ret:
-        convert_property_dict(doc_ret['form'], REPORT_XFORM_INDEX_INFO.mapping['properties']['form'], override_root_keys=['case'])
+        convert_property_dict(
+            doc_ret['form'],
+            REPORT_XFORM_INDEX_INFO.mapping['properties']['form'],
+            override_root_keys=['case']
+        )
         if 'computed_' in doc_ret:
             convert_property_dict(doc_ret['computed_'], {})
 

--- a/corehq/pillows/xform.py
+++ b/corehq/pillows/xform.py
@@ -66,8 +66,8 @@ class XFormPillow(HQPillow):
     handler_domain_map = {}
     default_mapping = XFORM_MAPPING
 
-    def change_transform(self, doc_dict, include_props=True):
-        return transform_xform_for_elasticsearch(doc_dict, include_props)
+    def change_transform(self, doc_dict):
+        return transform_xform_for_elasticsearch(doc_dict)
 
 
 def device_log_filter(doc_dict):

--- a/corehq/util/couch_doc_processor.py
+++ b/corehq/util/couch_doc_processor.py
@@ -36,6 +36,7 @@ class ResumableDocsByTypeIterator(object):
         self.original_doc_types = doc_types = sorted(doc_types)
         self.iteration_key = iteration_key
         self.chunk_size = chunk_size
+        self.view_event_handler = view_event_handler
         iteration_name = "{}/{}".format(iteration_key, " ".join(doc_types))
         self.iteration_id = hashlib.sha1(iteration_name).hexdigest()
         try:
@@ -163,6 +164,7 @@ class ResumableDocsByTypeIterator(object):
             self.original_doc_types,
             self.iteration_key,
             self.chunk_size,
+            self.view_event_handler
         )
 
 

--- a/settings.py
+++ b/settings.py
@@ -1474,6 +1474,11 @@ PILLOWTOPS = {
             'instance': 'corehq.pillows.reportcase.get_report_case_to_elasticsearch_pillow',
         },
         {
+            'name': 'ReportXFormToElasticsearchPillow',
+            'class': 'pillowtop.pillow.interface.ConstructedPillow',
+            'instance': 'corehq.pillows.reportxform.get_report_xform_to_elasticsearch_pillow',
+        },
+        {
             'name': 'SqlXFormToElasticsearchPillow',
             'class': 'pillowtop.pillow.interface.ConstructedPillow',
             'instance': 'corehq.pillows.xform.get_sql_xform_to_elasticsearch_pillow',

--- a/testapps/test_pillowtop/tests/data/all-pillow-meta.json
+++ b/testapps/test_pillowtop/tests/data/all-pillow-meta.json
@@ -429,6 +429,13 @@
         "name": "ReportXFormPillow",
         "unique_id": "test_report_xforms_20150406_1136"
     },
+    "ReportXFormToElasticsearchPillow": {
+        "advertised_name": "ReportXFormToElasticsearchPillow",
+        "change_feed_type": "KafkaChangeFeed",
+        "checkpoint_id": "report-xforms-to-elasticsearch",
+        "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
+        "name": "ReportXFormToElasticsearchPillow"
+    },
     "SqlCaseToElasticsearchPillow": {
         "advertised_name": "SqlCaseToElasticsearchPillow",
         "change_feed_type": "KafkaChangeFeed",

--- a/testapps/test_pillowtop/tests/test_report_xform_pillow.py
+++ b/testapps/test_pillowtop/tests/test_report_xform_pillow.py
@@ -1,0 +1,116 @@
+from django.test import TestCase, override_settings
+from elasticsearch.exceptions import ConnectionError
+
+from corehq.apps.change_feed import topics
+from corehq.apps.change_feed.consumer.feed import change_meta_from_kafka_message
+from corehq.apps.change_feed.pillow import get_default_couch_db_change_feed_pillow
+from corehq.apps.change_feed.tests.utils import get_test_kafka_consumer, get_current_multi_topic_seq
+from corehq.apps.es import FormES
+from corehq.elastic import get_es_new
+from corehq.form_processor.interfaces.processor import FormProcessorInterface
+from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends
+from corehq.form_processor.utils import TestFormMetadata
+from corehq.form_processor.utils.general import should_use_sql_backend
+from corehq.pillows.mappings.reportxform_mapping import REPORT_XFORM_INDEX_INFO
+from corehq.pillows.reportxform import ReportXFormPillow, get_report_xform_to_elasticsearch_pillow
+from corehq.util.elastic import ensure_index_deleted
+from corehq.util.test_utils import trap_extra_setup, get_form_ready_to_save
+from couchforms.models import XFormInstance
+from pillowtop.es_utils import initialize_index_and_mapping
+from pillowtop.feed.couch import get_current_seq
+
+DOMAIN = 'report-xform-pillowtest-domain'
+
+
+@override_settings(ES_XFORM_FULL_INDEX_DOMAINS=[DOMAIN])
+class ReportXformPillowTest(TestCase):
+
+    def setUp(self):
+        super(ReportXformPillowTest, self).setUp()
+        FormProcessorTestUtils.delete_all_xforms()
+        with trap_extra_setup(ConnectionError):
+            self.elasticsearch = get_es_new()
+            ensure_index_deleted(REPORT_XFORM_INDEX_INFO.index)
+            initialize_index_and_mapping(self.elasticsearch, REPORT_XFORM_INDEX_INFO)
+
+    def tearDown(self):
+        ensure_index_deleted(REPORT_XFORM_INDEX_INFO.index)
+        super(ReportXformPillowTest, self).tearDown()
+
+    def test_report_xform_pillow_couch(self):
+        couch_seq = get_current_seq(XFormInstance.get_db())
+
+        # make a form
+        metadata = TestFormMetadata(domain=DOMAIN)
+        form = get_form_ready_to_save(metadata)
+        FormProcessorInterface(domain=DOMAIN).save_processed_models([form])
+        self.addCleanup(form.delete)
+
+        # send to elasticsearch
+        self._sync_couch_xforms_to_es(since=couch_seq)
+
+        # verify there
+        results = FormES("report_xforms").run()
+        self.assertEqual(1, results.total, results.hits)
+        form_doc = results.hits[0]
+        self.assertEqual(DOMAIN, form_doc['domain'])
+        self.assertEqual(metadata.xmlns, form_doc['xmlns'])
+        self.assertEqual('XFormInstance', form_doc['doc_type'])
+        self.assertEqual(form.form_id, form_doc['_id'])
+
+    def test_unsupported_domain(self):
+        couch_seq = get_current_seq(XFormInstance.get_db())
+
+        # make a form
+        metadata = TestFormMetadata(domain='unsupported-domain')
+        form = get_form_ready_to_save(metadata)
+        FormProcessorInterface(domain='unsupported-domain').save_processed_models([form])
+        self.addCleanup(form.delete)
+
+        # send to elasticsearch
+        self._sync_couch_xforms_to_es(since=couch_seq)
+
+        # verify there
+        results = FormES("report_xforms").run()
+        self.assertEqual(0, results.total)
+
+    @run_with_all_backends
+    def test_report_xform_kafka_pillow(self):
+        consumer = get_test_kafka_consumer(topics.FORM, topics.FORM_SQL)
+        # have to get the seq id before the change is processed
+        kafka_seq = get_current_multi_topic_seq([topics.FORM, topics.FORM_SQL])
+        couch_seq = get_current_seq(XFormInstance.get_db())
+
+        # make a form
+        metadata = TestFormMetadata(domain=DOMAIN)
+        form = get_form_ready_to_save(metadata)
+        FormProcessorInterface(domain=DOMAIN).save_processed_models([form])
+
+        if not should_use_sql_backend(DOMAIN):
+            # publish couch changes to kafka
+            couch_producer_pillow = get_default_couch_db_change_feed_pillow('test-report-xform-couch-pillow')
+            couch_producer_pillow.process_changes(since=couch_seq, forever=False)
+
+        # confirm change made it to kafka
+        message = consumer.next()
+        change_meta = change_meta_from_kafka_message(message.value)
+        self.assertEqual(form.form_id, change_meta.document_id)
+        self.assertEqual(DOMAIN, change_meta.domain)
+
+        # send to elasticsearch
+        report_xform_kafka_pillow = get_report_xform_to_elasticsearch_pillow()
+        report_xform_kafka_pillow.process_changes(since=kafka_seq, forever=False)
+        self.elasticsearch.indices.refresh(REPORT_XFORM_INDEX_INFO.index)
+
+        # confirm change made it to elasticserach
+        results = FormES("report_xforms").remove_default_filters().run()
+        self.assertEqual(1, results.total, results.hits)
+        form_doc = results.hits[0]
+        self.assertEqual(DOMAIN, form_doc['domain'])
+        self.assertEqual(metadata.xmlns, form_doc['xmlns'])
+        self.assertEqual('XFormInstance', form_doc['doc_type'])
+        self.assertEqual(form.form_id, form_doc['_id'])
+
+    def _sync_couch_xforms_to_es(self, since=0):
+        ReportXFormPillow().process_changes(since=since, forever=False)
+        self.elasticsearch.indices.refresh(REPORT_XFORM_INDEX_INFO.index)

--- a/testapps/test_pillowtop/tests/test_report_xform_pillow.py
+++ b/testapps/test_pillowtop/tests/test_report_xform_pillow.py
@@ -12,7 +12,8 @@ from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_a
 from corehq.form_processor.utils import TestFormMetadata
 from corehq.form_processor.utils.general import should_use_sql_backend
 from corehq.pillows.mappings.reportxform_mapping import REPORT_XFORM_INDEX_INFO
-from corehq.pillows.reportxform import ReportXFormPillow, get_report_xform_to_elasticsearch_pillow
+from corehq.pillows.reportxform import ReportXFormPillow, get_report_xform_to_elasticsearch_pillow, \
+    get_report_xform_couch_reindexer
 from corehq.util.elastic import ensure_index_deleted
 from corehq.util.test_utils import trap_extra_setup, get_form_ready_to_save
 from couchforms.models import XFormInstance
@@ -114,3 +115,45 @@ class ReportXformPillowTest(TestCase):
     def _sync_couch_xforms_to_es(self, since=0):
         ReportXFormPillow().process_changes(since=since, forever=False)
         self.elasticsearch.indices.refresh(REPORT_XFORM_INDEX_INFO.index)
+
+
+@override_settings(ES_XFORM_FULL_INDEX_DOMAINS=[DOMAIN])
+class ReportXformReindexerTest(TestCase):
+
+    def setUp(self):
+        super(ReportXformReindexerTest, self).setUp()
+        FormProcessorTestUtils.delete_all_xforms()
+        with trap_extra_setup(ConnectionError):
+            self.elasticsearch = get_es_new()
+            ensure_index_deleted(REPORT_XFORM_INDEX_INFO.index)
+            initialize_index_and_mapping(self.elasticsearch, REPORT_XFORM_INDEX_INFO)
+
+    def tearDown(self):
+        ensure_index_deleted(REPORT_XFORM_INDEX_INFO.index)
+        super(ReportXformReindexerTest, self).tearDown()
+
+    def test_report_xform_couch_reindexer(self):
+        forms_included = set()
+        for i in range(3):
+            form = self._create_form(DOMAIN)
+            forms_included.add(form.form_id)
+
+        # excluded form
+        self._create_form('unsupported')
+
+        reindexer = get_report_xform_couch_reindexer()
+        reindexer.consume_options({'reset': True})
+        reindexer.reindex()
+
+        # verify there
+        results = FormES("report_xforms").run()
+        self.assertEqual(3, results.total, results.hits)
+        form_ids_in_es = {form_doc['_id'] for form_doc in results.hits}
+        self.assertEqual(forms_included, form_ids_in_es)
+
+    def _create_form(self, domain):
+        metadata = TestFormMetadata(domain=domain)
+        form = get_form_ready_to_save(metadata)
+        FormProcessorInterface(domain=domain).save_processed_models([form])
+        self.addCleanup(form.delete)
+        return form


### PR DESCRIPTION
@emord

@dimagi/scale-team

This adds a new kafka pillow that sends xforms to the report_xforms ES index. Once this pillow has caught up we can remove the ReportXFormsPillow.
