### PR TITLE
fixed bug - calculating first month of inactive users

### DIFF
--- a/corehq/apps/reports/standard/project_health.py
+++ b/corehq/apps/reports/standard/project_health.py
@@ -273,7 +273,7 @@ class ProjectHealthDashboard(ProjectReport):
         last_month_summary = None
         performance_threshold = get_performance_threshold(self.domain)
         users_in_group = self.get_users_by_filtered_groupids()
-        for i in range(-5, 1):
+        for i in range(-6, 1):
             year, month = add_months(now.year, now.month, i)
             month_as_date = datetime.date(year, month, 1)
             this_month_summary = MonthlyPerformanceSummary(
@@ -290,7 +290,7 @@ class ProjectHealthDashboard(ProjectReport):
                 this_month_summary.set_num_inactive_users(len(this_month_summary.get_dropouts()))
             this_month_summary.set_percent_active()
             last_month_summary = this_month_summary
-        return six_month_summary
+        return six_month_summary[1:]
 
     @property
     def template_context(self):


### PR DESCRIPTION
Calculating # inactive users for the first month (of six_month_summary) requires one more month prior to see the number of users that has dropped off 
@benrudolph as a follow up to #12282 
