### PR TITLE
Control tour on server, not client

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/form_designer.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_designer.html
@@ -66,10 +66,7 @@
                         less_error.hide();
                     }
                     {% if request.guided_tour %}
-                    // Only do guided tour if this is an app with the external data tree available
-                    if ($(".fd-accessory-pane:visible").length) {
-                        form_tour_start();
-                    }
+                    form_tour_start();
                     {% endif %}
                 },
                 {% else %}

--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -116,7 +116,8 @@ def form_designer(request, domain, app_id, module_id=None, form_id=None):
             if getattr(f, 'schedule', False) and f.schedule.enabled
         ])
 
-    if tours.VELLUM_CASE_MANAGEMENT.is_enabled(request.user) and app.vellum_case_management:
+    if tours.VELLUM_CASE_MANAGEMENT.is_enabled(request.user) \
+        and app.vellum_case_management and form.requires_case():
         request.guided_tour = tours.VELLUM_CASE_MANAGEMENT.get_tour_data()
 
     context = get_apps_base_context(request, domain, app)


### PR DESCRIPTION
`:visible` throws an error on prod - `VM633:211 Uncaught DOMException: Failed to execute 'querySelector' on 'Document': ':visible' is not a valid selector.(…)` but not on dev

Result is that the guided tour gets shown for all apps, not only those with case management on.

@emord / @millerdev 
