### PR TITLE
adding analytics to hq notifications

### DIFF
--- a/corehq/apps/notifications/templates/notifications/partials/global_notifications.html
+++ b/corehq/apps/notifications/templates/notifications/partials/global_notifications.html
@@ -1,12 +1,10 @@
 {% load i18n %}
-{% block js-inline %}{{ block.super }}
-    <script>
-        $('#notification-link').click(function() {
-            ga_track_event('Notification', 'Opened Message', this.href);
-        });
-        analytics.trackUsageLink($('#notification-icon'), 'Notification', 'Clicked Bell Icon')
-    </script>
-{% endblock %}
+<script>
+    $('#notification-link').click(function() {
+        ga_track_event('Notification', 'Opened Message', this.href);
+    });
+    analytics.trackUsageLink($('#notification-icon'), 'Notification', 'Clicked Bell Icon')
+</script>
 <li id="js-settingsmenu-notifications" class="dropdown">
     <a href="#" class="dropdown-toggle dropdown-toggle-with-icon" data-toggle="dropdown" id="notification-icon">
         <i class="icon-bell-alt fa fa-bell nav-main-icon"

--- a/corehq/apps/notifications/templates/notifications/partials/global_notifications.html
+++ b/corehq/apps/notifications/templates/notifications/partials/global_notifications.html
@@ -1,6 +1,14 @@
 {% load i18n %}
+{% block js-inline %}{{ block.super }}
+    <script>
+        $('#notification-link').click(function() {
+            ga_track_event('Notification', 'Opened Message', this.href);
+        });
+        analytics.trackUsageLink($('#notification-icon'), 'Notification', 'Clicked Bell Icon')
+    </script>
+{% endblock %}
 <li id="js-settingsmenu-notifications" class="dropdown">
-    <a href="#" class="dropdown-toggle dropdown-toggle-with-icon" data-toggle="dropdown">
+    <a href="#" class="dropdown-toggle dropdown-toggle-with-icon" data-toggle="dropdown" id="notification-icon">
         <i class="icon-bell-alt fa fa-bell nav-main-icon"
            data-bind="css: {'notifications-active-icon': hasUnread()}"></i>
     </a>
@@ -15,7 +23,7 @@
                 'notifications-info': isInfo(),
                 'notifications-unread': !isRead()
             }">
-            <a data-bind="attr: {href: url}, click: markAsRead" class="clearfix" target="_blank">
+            <a data-bind="attr: {href: url}, click: markAsRead" class="clearfix" target="_blank" id="notification-link">
                 <span class="notifications-icon">
                     <i class="notifications-type fa"
                        data-bind="css: {


### PR DESCRIPTION
cc: @millerdev or anyone
Adding analytics for the new notifications ui. For the first one i chose not to use the preferred `trackUsageLink` function, because I needed access to the event to get the correct url
