### PR TITLE
A few fixes for formplayer edit submissions

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/touchforms-inline.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/touchforms-inline.js
@@ -56,6 +56,7 @@
                 data.onLoading = onLoading;
                 data.onLoadingComplete = onLoadingComplete;
                 data.uses_sql_backend = options.uses_sql_backend;
+                data.formplayerEnabled = options.formplayerEnabled;
                 data.domain = options.domain;
                 var sess = new WebFormSession(data);
                 sess.load($target, options.lang);

--- a/corehq/apps/reports/templates/reports/form/edit_submission.html
+++ b/corehq/apps/reports/templates/reports/form/edit_submission.html
@@ -12,7 +12,6 @@
         GMAPS_API_KEY = '{{ maps_api_key|safe }}'; // maps api is a global variable depended on by touchforms
         var edit_context = {{ edit_context|JSON }};
         var uses_sql_backend = {{ use_sqlite_backend|JSON }};
-        var uses_sql_backend = {{ use_sqlite_backend|JSON }};
         var formplayerEnabled = false;
         {% if request|toggle_enabled:"USE_FORMPLAYER" %}
         formplayerEnabled = true;

--- a/corehq/apps/reports/templates/reports/form/edit_submission.html
+++ b/corehq/apps/reports/templates/reports/form/edit_submission.html
@@ -12,11 +12,17 @@
         GMAPS_API_KEY = '{{ maps_api_key|safe }}'; // maps api is a global variable depended on by touchforms
         var edit_context = {{ edit_context|JSON }};
         var uses_sql_backend = {{ use_sqlite_backend|JSON }};
+        var uses_sql_backend = {{ use_sqlite_backend|JSON }};
+        var formplayerEnabled = false;
+        {% if request|toggle_enabled:"USE_FORMPLAYER" %}
+        formplayerEnabled = true;
+        {% endif %}
         $('#edit-container').inlineTouchform({
             formUrl: edit_context.formUrl,
             submitUrl: edit_context.submitUrl,
             sessionData: edit_context.sessionData,
             uses_sql_backend: uses_sql_backend,
+            formplayerEnabled: formplayerEnabled,
             domain: edit_context.domain,
             onsubmit: function () {
                 window.location.href = edit_context.returnUrl;

--- a/settings.py
+++ b/settings.py
@@ -602,7 +602,7 @@ TEST_RUNNER = 'testrunner.TwoStageTestRunner'
 HQ_ACCOUNT_ROOT = "commcarehq.org"
 
 XFORMS_PLAYER_URL = "http://localhost:4444/"  # touchform's setting
-FORMPLAYER_URL = 'http://localhost:8090'
+FORMPLAYER_URL = 'http://localhost:8080'
 
 ####### Couchlog config #######
 


### PR DESCRIPTION
@wpride @kaapstorm @proteusvacuum i tested out using the new formplayer backend to create a subcase during edit submissions. the new backend does indeed fix the issue.

http://manage.dimagi.com/default.asp?229942

will -- there's an issue with the formplayer changing the instanceID of the form xml which means it by passes the duplicate form workflow and the form gets lost. until that's fixed edit forms won't work
