### PR TITLE
waiting for document ready

### DIFF
--- a/corehq/apps/notifications/static/notifications/spec/NotificationsService.spec.mo.js
+++ b/corehq/apps/notifications/static/notifications/spec/NotificationsService.spec.mo.js
@@ -19,6 +19,7 @@ describe('NotificationsService Unit Tests', function() {
             };
         };
 
+    window.analytics = {trackUsageLink: sinon.stub()};
     var fakePromise = new FakePromise({});
     sinon.stub(jQuery, 'ajax', fakePromise.mock);
 

--- a/corehq/apps/notifications/templates/notifications/partials/global_notifications.html
+++ b/corehq/apps/notifications/templates/notifications/partials/global_notifications.html
@@ -1,9 +1,11 @@
 {% load i18n %}
 <script>
-    $('#notification-link').click(function() {
-        ga_track_event('Notification', 'Opened Message', this.href);
+    $(function() {
+        $('#notification-link').click(function() {
+            ga_track_event('Notification', 'Opened Message', this.href);
+        });
+        window.analytics.trackUsageLink($('#notification-icon'), 'Notification', 'Clicked Bell Icon')
     });
-    analytics.trackUsageLink($('#notification-icon'), 'Notification', 'Clicked Bell Icon')
 </script>
 <li id="js-settingsmenu-notifications" class="dropdown">
     <a href="#" class="dropdown-toggle dropdown-toggle-with-icon" data-toggle="dropdown" id="notification-icon">


### PR DESCRIPTION
@millerdev 
missing document ready was stopping the jquery from binding to the dom elements, which had not always loaded in time.
mocha tests in the suite pass locally but they complain about a missing reference, likely because our analytics code is not loaded into the test file but im not sure
