### PR TITLE
Fix bug in UCR "expanded columns"

### DIFF
--- a/corehq/apps/userreports/sql/columns.py
+++ b/corehq/apps/userreports/sql/columns.py
@@ -119,7 +119,7 @@ def _expand_column(report_column, distinct_values, lang):
         alias = u"{}-{}".format(report_column.column_id, index)
         if val is None:
             sql_agg_col = SumWhen(
-                whens={"{} is NULL".format(report_column.field): 1}, else_=0, alias=alias
+                whens={'"{}" is NULL'.format(report_column.field): 1}, else_=0, alias=alias
             )
         else:
             sql_agg_col = SumWhen(report_column.field, whens={val: 1}, else_=0, alias=alias)

--- a/corehq/apps/userreports/tests/test_columns.py
+++ b/corehq/apps/userreports/tests/test_columns.py
@@ -268,7 +268,7 @@ class TestExpandedColumn(TestCase):
         columns to null than it does for comparing to non-null values. e.g.
             "my_column = 4" vs "my_column is NULL"
         """
-        field_name = 'my_field'
+        field_name = 'field_name_with_CAPITAL_letters'
         submitted_vals = [None, None, 'foo']
         data_source, _ = self._build_report(submitted_vals, field=field_name)
 


### PR DESCRIPTION
Fixes: http://manage.dimagi.com/default.asp?231573

Follow on from https://github.com/dimagi/commcare-hq/pull/12211
Column names need to be quoted, otherwise capital letters will be converted to lowercase letters (and probably other things will happen too). I'm thinking of making a change to `SumWhen` (in sql-agg) that will allow `SumWhen(whens={None:"foo", "bar":"baz})` to work as expected, but I want to roll out this quick fix first because a user is currently blocked on this.

@gcapalbo 
@czue might be interested too
