### PR TITLE
parent_id > parent_location_id

### DIFF
--- a/corehq/apps/locations/bulk.py
+++ b/corehq/apps/locations/bulk.py
@@ -151,7 +151,7 @@ class LocationImporter(object):
                     )
                 }
 
-            parent = parent_id or existing.parent_id
+            parent = parent_id or existing.parent_location_id
 
         form_data['site_code'] = provided_code
 

--- a/corehq/apps/locations/forms.py
+++ b/corehq/apps/locations/forms.py
@@ -91,7 +91,7 @@ class LocationForm(forms.Form):
         kwargs['initial'] = dict(self.location._doc)
         if not self.is_new_location:
             kwargs['initial']['location_type'] = self.location.location_type
-        kwargs['initial']['parent_id'] = self.location.parent_id
+        kwargs['initial']['parent_id'] = self.location.parent_location_id
         lat, lon = (getattr(self.location, k, None)
                     for k in ('latitude', 'longitude'))
         kwargs['initial']['coordinates'] = ('%s, %s' % (lat, lon)
@@ -120,8 +120,8 @@ class LocationForm(forms.Form):
 
     def get_fields(self, is_new):
         if is_new:
-            parent = (Location.get(self.location.parent_id)
-                      if self.location.parent_id else None)
+            parent = (Location.get(self.location.parent_location_id)
+                      if self.location.parent_location_id else None)
             child_types = allowed_child_types(self.location.domain, parent)
             return filter(None, [
                 _("Location Information"),
@@ -171,13 +171,13 @@ class LocationForm(forms.Form):
 
     def clean_parent_id(self):
         if self.is_new_location:
-            parent_id = self.location.parent_id
+            parent_id = self.location.parent_location_id
         else:
             parent_id = self.cleaned_data['parent_id'] or None
         parent = Location.get(parent_id) if parent_id else None
         self.cleaned_data['parent'] = parent
 
-        if self.location.location_id is not None and self.location.parent_id != parent_id:
+        if self.location.location_id is not None and self.location.parent_location_id != parent_id:
             # location is being re-parented
 
             if parent and self.location.location_id in parent.path:
@@ -189,7 +189,7 @@ class LocationForm(forms.Form):
                     'moved to a different parent'
                 )
 
-            self.cleaned_data['orig_parent_id'] = self.location.parent_id
+            self.cleaned_data['orig_parent_id'] = self.location.parent_location_id
 
         return parent_id
 

--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -484,6 +484,10 @@ class SQLLocation(SyncSQLToCouchMixin, MPTTModel):
     def location_type_name(self):
         return self.location_type.name
 
+    @property
+    def parent_location_id(self):
+        return self.parent.location_id if self.parent else None
+
 
 def _filter_for_archived(locations, include_archive_ancestors):
     """
@@ -698,8 +702,8 @@ class Location(SyncCouchToSQLMixin, CachedCouchDocumentMixin, Document):
         location_type = self._sql_location_type or sql_location.location_type
         sql_location.location_type = location_type
         # sync parent connection
-        sql_location.parent = (SQLLocation.objects.get(location_id=self.parent_id)
-                               if self.parent_id else None)
+        sql_location.parent = (SQLLocation.objects.get(location_id=self.parent_location_id)
+                               if self.parent_location_id else None)
 
         self._migration_sync_to_sql(sql_location)
 
@@ -793,14 +797,14 @@ class Location(SyncCouchToSQLMixin, CachedCouchDocumentMixin, Document):
         return not self.lineage
 
     @property
-    def parent_id(self):
+    def parent_location_id(self):
         if self.is_root:
             return None
         return self.lineage[0]
 
     @property
     def parent(self):
-        parent_id = self.parent_id
+        parent_id = self.parent_location_id
         return Location.get(parent_id) if parent_id else None
 
     def siblings(self, parent=None):

--- a/corehq/apps/locations/tests/test_location_import.py
+++ b/corehq/apps/locations/tests/test_location_import.py
@@ -53,7 +53,7 @@ class LocationImportTest(CommTrackTest):
 
         self.assertTrue(data['name'] in self.names_of_locs())
         new_loc = Location.get(result['id'])
-        self.assertEqual(new_loc.parent_id, self.test_state._id)
+        self.assertEqual(new_loc.parent_location_id, self.test_state._id)
 
     def test_import_with_location_id(self):
         """
@@ -181,7 +181,7 @@ class LocationImportTest(CommTrackTest):
         result = import_location(self.domain.name, 'outlet', data)
         new_loc = Location.get(result['id'])
         self.assertEqual(existing._id, new_loc._id)
-        self.assertEqual(new_loc.parent_id, new_parent._id)
+        self.assertEqual(new_loc.parent_location_id, new_parent._id)
 
     def test_change_to_invalid_parent(self):
         parent = make_loc('original parent', type='village')
@@ -200,7 +200,7 @@ class LocationImportTest(CommTrackTest):
         self.assertTrue('Invalid parent type' in result['message'])
         new_loc = Location.get(existing._id)
         self.assertEqual(existing._id, new_loc._id)
-        self.assertEqual(new_loc.parent_id, parent._id)
+        self.assertEqual(new_loc.parent_location_id, parent._id)
 
     def test_updating_existing_location_properties(self):
         existing = make_loc('existingloc2', type='state', domain=self.domain.name)

--- a/corehq/apps/locations/tests/test_locations.py
+++ b/corehq/apps/locations/tests/test_locations.py
@@ -166,7 +166,7 @@ class LocationsTest(LocationTestBase):
         # parent and parent_id
         self.assertEqual(
             self.user.location.location_id,
-            test_state1.parent_id
+            test_state1.parent_location_id
         )
         self.assertEqual(
             self.user.location.location_id,

--- a/corehq/apps/locations/views.py
+++ b/corehq/apps/locations/views.py
@@ -303,7 +303,7 @@ class NewLocationView(BaseLocationView):
 
     @property
     def parent_pages(self):
-        selected = self.location.location_id or self.location.parent_id
+        selected = self.location.location_id or self.location.parent_location_id
         breadcrumbs = [{
             'title': LocationsListView.page_title,
             'url': reverse(
@@ -353,7 +353,7 @@ class NewLocationView(BaseLocationView):
             'form': self.location_form,
             'location': self.location,
             'consumption': self.consumption,
-            'locations': load_locs_json(self.domain, self.location.parent_id,
+            'locations': load_locs_json(self.domain, self.location.parent_location_id,
                                         user=self.request.couch_user),
             'form_tab': self.form_tab,
         }

--- a/custom/ilsgateway/models.py
+++ b/custom/ilsgateway/models.py
@@ -558,7 +558,7 @@ def location_edited_receiver(sender, loc, moved, **kwargs):
             domain=loc.domain,
             type='parent_change',
             sql_location=loc.sql_location,
-            data={'previous_parent': loc.previous_parents[-1], 'current_parent': loc.parent_id}
+            data={'previous_parent': loc.previous_parents[-1], 'current_parent': loc.parent_location_id}
         )
 
     group = last_location_group(loc)

--- a/custom/ilsgateway/tests/test_report_runner.py
+++ b/custom/ilsgateway/tests/test_report_runner.py
@@ -88,7 +88,7 @@ class TestReportRunner(TestCase):
                 'name': location.name,
                 'data-field-group': group,
                 'location_type': location.location_type,
-                'parent_id': location.parent_id
+                'parent_id': location.parent_location_id
             }
         )
         form.save()

--- a/custom/openlmis/commtrack.py
+++ b/custom/openlmis/commtrack.py
@@ -49,10 +49,10 @@ def sync_facility_to_supply_point(domain, facility):
         'longitude': facility.longitude,
     }
     parent_sp = None
-    if facility.parent_id:
-        parent_sp = get_supply_point(domain, facility.parent_id)
+    if facility.parent_location_id:
+        parent_sp = get_supply_point(domain, facility.parent_location_id)
         if not parent_sp:
-            raise BadParentException('No matching supply point with code %s found' % facility.parent_id)
+            raise BadParentException('No matching supply point with code %s found' % facility.parent_location_id)
 
     if supply_point is None:
         if parent_sp:
@@ -63,7 +63,7 @@ def sync_facility_to_supply_point(domain, facility):
         return facility_loc.linked_supply_point()
     else:
         facility_loc = supply_point.location
-        if parent_sp and facility_loc.parent_id != parent_sp.location.location_id:
+        if parent_sp and facility_loc.parent_location_id != parent_sp.location.location_id:
             raise BadParentException('You are trying to move a location. This is currently not supported.')
 
         should_save = apply_updates(facility_loc, facility_dict)

--- a/custom/openlmis/commtrack.py
+++ b/custom/openlmis/commtrack.py
@@ -49,10 +49,10 @@ def sync_facility_to_supply_point(domain, facility):
         'longitude': facility.longitude,
     }
     parent_sp = None
-    if facility.parent_location_id:
-        parent_sp = get_supply_point(domain, facility.parent_location_id)
+    if facility.parent_id:
+        parent_sp = get_supply_point(domain, facility.parent_id)
         if not parent_sp:
-            raise BadParentException('No matching supply point with code %s found' % facility.parent_location_id)
+            raise BadParentException('No matching supply point with code %s found' % facility.parent_id)
 
     if supply_point is None:
         if parent_sp:
@@ -63,7 +63,7 @@ def sync_facility_to_supply_point(domain, facility):
         return facility_loc.linked_supply_point()
     else:
         facility_loc = supply_point.location
-        if parent_sp and facility_loc.parent_location_id != parent_sp.location.location_id:
+        if parent_sp and facility_loc.parent_id != parent_sp.location.location_id:
             raise BadParentException('You are trying to move a location. This is currently not supported.')
 
         should_save = apply_updates(facility_loc, facility_dict)


### PR DESCRIPTION
Since `SQLLocation.parent` is a foreign key, django reserves the use of `SQLLocation.parent_id`, and what's more, this refers to the django primary key, NOT the UUID.  We could have saved a lot of headache by setting `primary_key=True` on `SQLLocation.location_id` so `SQLLocation.id` wouldn't have been created.

@benrudolph
