### PR TITLE
Case list: copying property name triggering display text change

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -565,7 +565,7 @@ hqDefine('app_manager/js/detail-screen-config.js', function () {
 
                 var icon = (module.CC_DETAIL_SCREEN.isAttachmentProperty(this.original.field)
                    ? COMMCAREHQ.icons.PAPERCLIP : null);
-                this.field = uiElement.input().val(this.original.field).setIcon(icon);
+                this.field = uiElement.input(this.original.field).setIcon(icon);
 
                 // Make it possible to observe changes to this.field
                 // note that observableVal is read only!

--- a/corehq/apps/style/static/style/js/ui-element.js
+++ b/corehq/apps/style/static/style/js/ui-element.js
@@ -130,8 +130,8 @@ var uiElement;
     };
 
     uiElement = {
-        input: function () {
-            return new Input($('<input type="text" class="form-control"/>'), function ($elem) {
+        input: function (value) {
+            return new Input($('<input type="text" class="form-control"/>').val(value), function ($elem) {
                 return $elem.val();
             }, function ($elem, value) {
                 return $elem.val(value);


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?231878

Because the input was getting created without a value and the value is set later, the first time a user pressed any key, the textchange plugin would compare the initial value (the property name) with its understanding of the initial value (a blank string), see they're different, and fire a textchange event that would update the display text.

@kaapstorm 
