### PR TITLE
Add owner and last modified by to reminder message context

### DIFF
--- a/corehq/apps/reminders/event_handlers.py
+++ b/corehq/apps/reminders/event_handlers.py
@@ -145,7 +145,7 @@ def _add_parent_case_to_template_params(case, result):
 def _add_owner_to_template_params(case, result):
     owner = get_wrapped_owner(get_owner_id(case))
     if owner:
-        result['owner'] = _get_obj_template_info(owner)
+        result['case']['owner'] = _get_obj_template_info(owner)
 
 
 def _add_modified_by_to_template_params(case, result):
@@ -155,7 +155,7 @@ def _add_modified_by_to_template_params(case, result):
         return
 
     if modified_by:
-        result['modified_by'] = _get_obj_template_info(modified_by)
+        result['case']['modified_by'] = _get_obj_template_info(modified_by)
 
 
 def get_message_template_params(case=None):

--- a/corehq/apps/reminders/event_handlers.py
+++ b/corehq/apps/reminders/event_handlers.py
@@ -155,7 +155,7 @@ def _add_modified_by_to_template_params(case, result):
         return
 
     if modified_by:
-        result['case']['modified_by'] = _get_obj_template_info(modified_by)
+        result['case']['last_modified_by'] = _get_obj_template_info(modified_by)
 
 
 def get_message_template_params(case=None):
@@ -178,7 +178,7 @@ def get_message_template_params(case=None):
             }
         }
         "owner": ... dict with selected info for the case owner ...
-        "modified_by": ... dict with selected info for the user who last modified the case ...
+        "last_modified_by": ... dict with selected info for the user who last modified the case ...
     }
     """
     result = {}

--- a/corehq/apps/reminders/models.py
+++ b/corehq/apps/reminders/models.py
@@ -1,4 +1,5 @@
 import pytz
+import string
 from datetime import timedelta, datetime, date, time
 import re
 from collections import namedtuple
@@ -208,7 +209,7 @@ class MessageVariable(object):
     def __init__(self, variable):
         self.variable = variable
 
-    def __unicode__(self):
+    def __repr__(self):
         return unicode(self.variable)
 
     @property
@@ -233,19 +234,24 @@ class MessageVariable(object):
             return MessageVariable(self.variable[item])
         except Exception:
             pass
-        return "(?)"
+        return MessageVariable('(?)')
+
+
+class MessageParamDict(dict):
+    def __missing__(self, key):
+        return MessageVariable('(?)')
 
 
 class Message(object):
 
     def __init__(self, template, **params):
         self.template = template
-        self.params = {}
+        self.params = MessageParamDict()
         for key, value in params.items():
             self.params[key] = MessageVariable(value)
 
     def __unicode__(self):
-        return self.template.format(**self.params)
+        return string.Formatter().vformat(self.template, (), self.params)
 
     @classmethod
     def render(cls, template, **params):

--- a/corehq/apps/reminders/tests/test_message_formatting.py
+++ b/corehq/apps/reminders/tests/test_message_formatting.py
@@ -139,12 +139,12 @@ class MessageTestCase(TestCase):
             child_expected_result = {'case': child_case.to_json()}
             child_expected_result['case']['parent'] = parent_case.to_json()
             child_expected_result['case']['owner'] = self.get_expected_template_params_for_mobile()
-            child_expected_result['case']['modified_by'] = self.get_expected_template_params_for_mobile()
+            child_expected_result['case']['last_modified_by'] = self.get_expected_template_params_for_mobile()
             self.assertEqual(get_message_template_params(child_case), child_expected_result)
 
             parent_expected_result = {'case': parent_case.to_json()}
             parent_expected_result['case']['owner'] = self.get_expected_template_params_for_mobile()
-            parent_expected_result['case']['modified_by'] = self.get_expected_template_params_for_mobile()
+            parent_expected_result['case']['last_modified_by'] = self.get_expected_template_params_for_mobile()
             self.assertEqual(get_message_template_params(parent_case), parent_expected_result)
 
     @run_with_all_backends
@@ -152,25 +152,25 @@ class MessageTestCase(TestCase):
         with self.create_parent_case(owner=self.mobile_user) as case:
             expected_result = {'case': case.to_json()}
             expected_result['case']['owner'] = self.get_expected_template_params_for_mobile()
-            expected_result['case']['modified_by'] = self.get_expected_template_params_for_mobile()
+            expected_result['case']['last_modified_by'] = self.get_expected_template_params_for_mobile()
             self.assertEqual(get_message_template_params(case), expected_result)
 
         with self.create_parent_case(owner=self.web_user) as case:
             expected_result = {'case': case.to_json()}
             expected_result['case']['owner'] = self.get_expected_template_params_for_web()
-            expected_result['case']['modified_by'] = self.get_expected_template_params_for_mobile()
+            expected_result['case']['last_modified_by'] = self.get_expected_template_params_for_mobile()
             self.assertEqual(get_message_template_params(case), expected_result)
 
         with self.create_parent_case(owner=self.group) as case:
             expected_result = {'case': case.to_json()}
             expected_result['case']['owner'] = self.get_expected_template_params_for_group()
-            expected_result['case']['modified_by'] = self.get_expected_template_params_for_mobile()
+            expected_result['case']['last_modified_by'] = self.get_expected_template_params_for_mobile()
             self.assertEqual(get_message_template_params(case), expected_result)
 
         with self.create_parent_case(owner=self.couch_location) as case:
             expected_result = {'case': case.to_json()}
             expected_result['case']['owner'] = self.get_expected_template_params_for_location()
-            expected_result['case']['modified_by'] = self.get_expected_template_params_for_mobile()
+            expected_result['case']['last_modified_by'] = self.get_expected_template_params_for_mobile()
             self.assertEqual(get_message_template_params(case), expected_result)
 
     @run_with_all_backends
@@ -178,11 +178,11 @@ class MessageTestCase(TestCase):
         with self.create_parent_case(modified_by=self.mobile_user, owner=self.couch_location) as case:
             expected_result = {'case': case.to_json()}
             expected_result['case']['owner'] = self.get_expected_template_params_for_location()
-            expected_result['case']['modified_by'] = self.get_expected_template_params_for_mobile()
+            expected_result['case']['last_modified_by'] = self.get_expected_template_params_for_mobile()
             self.assertEqual(get_message_template_params(case), expected_result)
 
         with self.create_parent_case(modified_by=self.web_user, owner=self.couch_location) as case:
             expected_result = {'case': case.to_json()}
             expected_result['case']['owner'] = self.get_expected_template_params_for_location()
-            expected_result['case']['modified_by'] = self.get_expected_template_params_for_web()
+            expected_result['case']['last_modified_by'] = self.get_expected_template_params_for_web()
             self.assertEqual(get_message_template_params(case), expected_result)

--- a/corehq/apps/reminders/tests/test_message_formatting.py
+++ b/corehq/apps/reminders/tests/test_message_formatting.py
@@ -1,5 +1,9 @@
+from corehq.apps.domain.models import Domain
+from corehq.apps.groups.models import Group
+from corehq.apps.locations.models import SQLLocation, LocationType
 from corehq.apps.reminders.event_handlers import get_message_template_params
 from corehq.apps.reminders.models import Message
+from corehq.apps.users.models import CommCareUser, WebUser
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.tests.utils import run_with_all_backends
 from corehq.util.test_utils import create_test_case, set_parent_case
@@ -9,8 +13,53 @@ from django.test import TestCase
 
 class MessageTestCase(TestCase):
 
-    def setUp(self):
-        self.domain = 'message-formatting-test'
+    @classmethod
+    def setUpClass(cls):
+        cls.domain = 'message-formatting-test'
+        cls.domain_obj = Domain(name=cls.domain)
+        cls.domain_obj.save()
+
+        cls.mobile_user = CommCareUser.create(
+            cls.domain,
+            'mobile1@message-formatting-test',
+            '12345',
+            first_name='Mobile',
+            last_name='User'
+        )
+
+        cls.web_user = WebUser.create(
+            cls.domain,
+            'web1@message-formatting-test',
+            '12345',
+            first_name='Web',
+            last_name='User'
+        )
+
+        cls.group = Group(domain=cls.domain, name='Test Group')
+        cls.group.save()
+
+        cls.location_type = LocationType.objects.create(
+            domain=cls.domain,
+            name='top-level',
+            code='top-level'
+        )
+
+        cls.location = SQLLocation.objects.create(
+            domain=cls.domain,
+            name='Test Location',
+            site_code='loc1234',
+            location_type=cls.location_type
+        )
+
+        cls.couch_location = cls.location.couch_location
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.mobile_user.delete()
+        cls.web_user.delete()
+        cls.group.delete()
+        cls.location.delete()
+        cls.location_type.delete()
 
     def test_message(self):
         message = 'The EDD for client with ID {case.external_id} is approaching in {case.edd.days_until} days.'
@@ -18,23 +67,97 @@ class MessageTestCase(TestCase):
         expected = 'The EDD for client with ID 123 is approaching in 30 days.'
         self.assertEqual(Message.render(message, case=case_json), expected)
 
-    def create_child_case(self):
-        return create_test_case(self.domain, 'child', 'P002', case_properties={'child_prop1': 'def'})
+    def create_child_case(self, owner=None, modified_by=None):
+        owner = owner or self.mobile_user
+        modified_by = modified_by or self.mobile_user
+        return create_test_case(self.domain, 'child', 'P002', case_properties={'child_prop1': 'def'},
+            owner_id=owner.get_id, user_id=modified_by.get_id)
 
-    def create_parent_case(self):
-        return create_test_case(self.domain, 'parent', 'P001', case_properties={'parent_prop1': 'abc'})
+    def create_parent_case(self, owner=None, modified_by=None):
+        owner = owner or self.mobile_user
+        modified_by = modified_by or self.mobile_user
+        return create_test_case(self.domain, 'parent', 'P001', case_properties={'parent_prop1': 'abc'},
+            owner_id=owner.get_id, user_id=modified_by.get_id)
+
+    def get_expected_template_params_for_mobile(self):
+        return {
+            'name': self.mobile_user.username,
+            'first_name': self.mobile_user.first_name,
+            'last_name': self.mobile_user.last_name,
+        }
+
+    def get_expected_template_params_for_web(self):
+        return {
+            'name': self.web_user.username,
+            'first_name': self.web_user.first_name,
+            'last_name': self.web_user.last_name,
+        }
+
+    def get_expected_template_params_for_group(self):
+        return {
+            'name': self.group.name,
+        }
+
+    def get_expected_template_params_for_location(self):
+        return {
+            'name': self.location.name,
+            'site_code': self.location.site_code,
+        }
 
     @run_with_all_backends
-    def test_template_params(self):
+    def test_case_template_params(self):
         with self.create_child_case() as child_case, self.create_parent_case() as parent_case:
             set_parent_case(self.domain, child_case, parent_case)
             child_case = CaseAccessors(self.domain).get_case(child_case.case_id)
             parent_case = CaseAccessors(self.domain).get_case(parent_case.case_id)
 
-            child_result = {'case': child_case.to_json()}
-            child_result['case']['parent'] = parent_case.to_json()
-            self.assertEqual(get_message_template_params(child_case), child_result)
+            child_expected_result = {'case': child_case.to_json()}
+            child_expected_result['case']['parent'] = parent_case.to_json()
+            child_expected_result['case']['owner'] = self.get_expected_template_params_for_mobile()
+            child_expected_result['case']['modified_by'] = self.get_expected_template_params_for_mobile()
+            self.assertEqual(get_message_template_params(child_case), child_expected_result)
 
-            parent_result = {'case': parent_case.to_json()}
-            parent_result['case']['parent'] = {}
-            self.assertEqual(get_message_template_params(parent_case), parent_result)
+            parent_expected_result = {'case': parent_case.to_json()}
+            parent_expected_result['case']['owner'] = self.get_expected_template_params_for_mobile()
+            parent_expected_result['case']['modified_by'] = self.get_expected_template_params_for_mobile()
+            self.assertEqual(get_message_template_params(parent_case), parent_expected_result)
+
+    @run_with_all_backends
+    def test_owner_template_params(self):
+        with self.create_parent_case(owner=self.mobile_user) as case:
+            expected_result = {'case': case.to_json()}
+            expected_result['case']['owner'] = self.get_expected_template_params_for_mobile()
+            expected_result['case']['modified_by'] = self.get_expected_template_params_for_mobile()
+            self.assertEqual(get_message_template_params(case), expected_result)
+
+        with self.create_parent_case(owner=self.web_user) as case:
+            expected_result = {'case': case.to_json()}
+            expected_result['case']['owner'] = self.get_expected_template_params_for_web()
+            expected_result['case']['modified_by'] = self.get_expected_template_params_for_mobile()
+            self.assertEqual(get_message_template_params(case), expected_result)
+
+        with self.create_parent_case(owner=self.group) as case:
+            expected_result = {'case': case.to_json()}
+            expected_result['case']['owner'] = self.get_expected_template_params_for_group()
+            expected_result['case']['modified_by'] = self.get_expected_template_params_for_mobile()
+            self.assertEqual(get_message_template_params(case), expected_result)
+
+        with self.create_parent_case(owner=self.couch_location) as case:
+            expected_result = {'case': case.to_json()}
+            expected_result['case']['owner'] = self.get_expected_template_params_for_location()
+            expected_result['case']['modified_by'] = self.get_expected_template_params_for_mobile()
+            self.assertEqual(get_message_template_params(case), expected_result)
+
+    @run_with_all_backends
+    def test_modified_by_template_params(self):
+        with self.create_parent_case(modified_by=self.mobile_user, owner=self.couch_location) as case:
+            expected_result = {'case': case.to_json()}
+            expected_result['case']['owner'] = self.get_expected_template_params_for_location()
+            expected_result['case']['modified_by'] = self.get_expected_template_params_for_mobile()
+            self.assertEqual(get_message_template_params(case), expected_result)
+
+        with self.create_parent_case(modified_by=self.web_user, owner=self.couch_location) as case:
+            expected_result = {'case': case.to_json()}
+            expected_result['case']['owner'] = self.get_expected_template_params_for_location()
+            expected_result['case']['modified_by'] = self.get_expected_template_params_for_web()
+            self.assertEqual(get_message_template_params(case), expected_result)


### PR DESCRIPTION
Allows you to make the following kinds of references in reminder messages:

{case.owner.name}
{case.last_modified_by.name}

Best reviewed commit by commit

@dannyroberts 
