### PR TITLE
block double clicks on download

### DIFF
--- a/corehq/apps/export/static/export/js/list_exports.ng.js
+++ b/corehq/apps/export/static/export/js/list_exports.ng.js
@@ -80,6 +80,11 @@
             var currentUrl = useLegacyBulkExportUrl ? $scope.legacy_bulk_download_url : $scope.bulk_download_url;
             input.closest("form").attr("action", currentUrl);
         };
+        $scope.downloadRequested = function($event) {
+            var $btn = $($event.target);
+            $btn.addClass('disabled');
+            $btn.text(gettext('Download Requested'));
+        };
         $scope.selectAll = function () {
             _.each($scope.exports, function (exp) {
                 exp.addedToBulk = true;

--- a/corehq/apps/export/templates/export/partial/export_list_controller.html
+++ b/corehq/apps/export/templates/export/partial/export_list_controller.html
@@ -163,6 +163,7 @@
 
                                 <p ng-if="export.emailedExport.hasFile">
                                     <a href="{{ export.emailedExport.fileData.downloadUrl }}"
+                                       ng-click="downloadRequested($event)"
                                        class="btn btn-info btn-xs">
                                         <i class="fa fa-download"></i>
                                         {% trans "Download" %}


### PR DESCRIPTION
@orangejenny not the most angular way to do things, but didn't want to mutate the export model or do some other more invasive fix. this stops users from spamming the download button

http://manage.dimagi.com/default.asp?231800

cc: @calellowitz @sravfeyn 
