### PR TITLE
OpenClinica export bug

### DIFF
--- a/custom/openclinica/reports.py
+++ b/custom/openclinica/reports.py
@@ -109,8 +109,9 @@ class OdmExportReport(ProjectReport, CaseListMixin, GenericReportView):
     @property
     def rows(self):
         audit_log_id_ref = {'id': 0}  # To exclude audit logs, set `custom.openclinica.const.AUDIT_LOGS = False`
-        for res in self.es_results['hits'].get('hits', []):
-            case = CommCareCase.wrap(res['_source'])
+        query = self._build_query().case_type(CC_SUBJECT_CASE_TYPE)
+        for result in query.scroll():
+            case = CommCareCase.wrap(result)
             if not self.is_subject_selected(case):
                 continue
             subject = Subject.wrap(case, audit_log_id_ref)
@@ -133,7 +134,7 @@ class OdmExportReport(ProjectReport, CaseListMixin, GenericReportView):
         ODM XML document.
         """
         audit_log_id_ref = {'id': 0}  # To exclude audit logs, set `custom.openclinica.const.AUDIT_LOGS = False`
-        query = self._build_query().start(0).size(SIZE_LIMIT)
+        query = self._build_query().case_type(CC_SUBJECT_CASE_TYPE).start(0).size(SIZE_LIMIT)
         for result in query.scroll():
             case = CommCareCase.wrap(result)
             if not self.is_subject_selected(case):


### PR DESCRIPTION
This fixes a bug in the OpenClinica export, where the values returned by `get_all_rows()` did not match the headers in `subject_headers()`. 

The bug was introduced with the API functionality, when more subject properties were added to `get_all_rows()` for registering subjects using the OpenClinica web service, but `subject_headers()` wasn't updated accordingly.

@nickpell, @snopoke 
