### PR TITLE
v1 optimized pillows

### DIFF
--- a/corehq/ex-submodules/pillowtop/management/commands/run_ptop.py
+++ b/corehq/ex-submodules/pillowtop/management/commands/run_ptop.py
@@ -36,6 +36,15 @@ class Command(NoArgsCommand):
                     dest='pillow_name',
                     default=None,
                     help="Run a single specific pillow name from settings.PILLOWTOPS list"),
+        make_option('--optimize',
+                    action='store_true',
+                    default=False,
+                    dest='optimize',
+                    help=(
+                        'Runs a pillow optimized by only loading necessary apps. Must be used with'
+
+                        'pillow-name. See manage.py for how it is used.'
+                    ))
     )
 
     def handle_noargs(self, **options):

--- a/corehq/pillows/pillow_dependencies.yml
+++ b/corehq/pillows/pillow_dependencies.yml
@@ -1,0 +1,4 @@
+# pillow-name
+CasePillow:
+  - pillowtop
+  - couchforms

--- a/manage.py
+++ b/manage.py
@@ -136,5 +136,3 @@ if __name__ == "__main__":
             execute_from_command_line(sys.argv)
     else:
         execute_from_command_line(sys.argv)
-
-

--- a/manage.py
+++ b/manage.py
@@ -3,7 +3,9 @@
 import sys
 import os
 import mimetypes
+import yaml
 from collections import namedtuple
+from contextlib import contextmanager
 
 GeventCommand = namedtuple('GeventCommand', 'command contains')
 
@@ -56,12 +58,47 @@ def _should_patch_gevent(args, gevent_commands):
     return should_patch
 
 
+def _should_optimize_ptop(args):
+    return (
+        'run_ptop' in args and
+        '--optimize' in args and
+        any(map(lambda arg: arg.startswith('--pillow-name'), args))
+    )
+
+
+def _get_pillow_name(args):
+    for arg in args:
+        if arg.startswith('--pillow-name'):
+            return arg.split('=')[1]
+
+
+def _get_pillow_dependent_apps(pillow_name):
+    with open('./corehq/pillows/pillow_dependencies.yml', 'r+') as f:
+        dependencies = yaml.load(f)
+        return dependencies[pillow_name]
+
+
 def set_default_settings_path(argv):
     if len(argv) > 1 and argv[1] == 'test':
         module = 'testsettings'
     else:
         module = 'settings'
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", module)
+
+
+@contextmanager
+def dependent_apps(dependent_apps):
+    from django.conf import settings
+
+    _real_installed_apps = settings.INSTALLED_APPS
+    print 'overriding settings.INSTALLED_APPS to {}'.format(
+        ','.join(dependent_apps)
+    )
+    settings.INSTALLED_APPS = tuple(dependent_apps)
+    try:
+        yield
+    finally:
+        settings.INSTALLED_APPS = _real_installed_apps
 
 
 if __name__ == "__main__":
@@ -92,4 +129,12 @@ if __name__ == "__main__":
 
     set_default_settings_path(sys.argv)
     from django.core.management import execute_from_command_line
-    execute_from_command_line(sys.argv)
+    if _should_optimize_ptop(sys.argv):
+        pillow_name = _get_pillow_name(sys.argv)
+        apps = _get_pillow_dependent_apps(pillow_name)
+        with dependent_apps(apps):
+            execute_from_command_line(sys.argv)
+    else:
+        execute_from_command_line(sys.argv)
+
+


### PR DESCRIPTION
@czue @proteusvacuum this is a v1 optimized pillow attempt. Using this, it drops the overhead of running the CasePillow from 160 MB to 47 MB. I believe we have 51 pillows on prod so that's about 8 GB of RAM and if all pillows get reduced by that amount, it'll reduce overhead to approximately 2.3GB. Not to mention I think this will help with the starting and stopping of those processes

Not optimized:
<img width="919" alt="screen shot 2016-07-12 at 5 09 07 pm" src="https://cloud.githubusercontent.com/assets/918514/16826937/b83837b6-494f-11e6-8b1f-fbb8219ac5ec.png">

Optimized
<img width="897" alt="screen shot 2016-07-12 at 5 08 08 pm" src="https://cloud.githubusercontent.com/assets/918514/16826945/c2bbcd38-494f-11e6-83a7-9b297cbf81b0.png">

I was a bit surprised by how few apps the CasePillow needed to run, but it seemed to be working
