### PR TITLE
Download java modal

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases.js
@@ -1,3 +1,4 @@
+/* globals: ga_track_event */
 hqDefine('app_manager/js/releases.js', function () {
     function SavedApp(app_data, releasesMain) {
         var self = ko.mapping.fromJS(app_data);
@@ -31,6 +32,10 @@ hqDefine('app_manager/js/releases.js', function () {
             return profiles;
         };
 
+        self.track_deploy_type = function(type) {
+            ga_track_event('App Manager', 'Deploy Type', type);
+        }
+
         self.changeAppCode = function () {
             self.app_code(null);
             self.failed_url_generation(false);
@@ -38,7 +43,7 @@ hqDefine('app_manager/js/releases.js', function () {
         };
 
         self.onSMSPanelClick = function() {
-            track_deploy_type('Send to phone via SMS');
+            self.track_deploy_type('Send to phone via SMS');
             self.generate_short_url('short_url');
         };
 

--- a/corehq/apps/app_manager/static/app_manager/js/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases.js
@@ -40,7 +40,7 @@ hqDefine('app_manager/js/releases.js', function () {
         self.onSMSPanelClick = function() {
             track_deploy_type('Send to phone via SMS');
             self.generate_short_url('short_url');
-        }
+        };
 
         self.build_profile.subscribe(self.changeAppCode);
 

--- a/corehq/apps/app_manager/static/app_manager/js/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases.js
@@ -34,7 +34,7 @@ hqDefine('app_manager/js/releases.js', function () {
 
         self.track_deploy_type = function(type) {
             ga_track_event('App Manager', 'Deploy Type', type);
-        }
+        };
 
         self.changeAppCode = function () {
             self.app_code(null);

--- a/corehq/apps/app_manager/static/app_manager/js/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases.js
@@ -37,6 +37,11 @@ hqDefine('app_manager/js/releases.js', function () {
             self.generating_url(false);
         };
 
+        self.onSMSPanelClick = function() {
+            track_deploy_type('Send to phone via SMS');
+            self.generate_short_url('short_url');
+        }
+
         self.build_profile.subscribe(self.changeAppCode);
 
         self.should_generate_url = function(url_type) {

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases.html
@@ -61,9 +61,6 @@
     analytics.workflow('Visited the Release Manager');
 </script>
 <script>
-    function track_deploy_type(type) {
-        ga_track_event('App Manager', 'Deploy Type', type);
-    }
     $(function () {
         gaTrackLink('a.view-source-files-link', 'App Manager', 'Deploy Type', 'View Source Files');
     });

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases_deploy_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases_deploy_modal.html
@@ -161,13 +161,19 @@
                 <div class="panel panel-default">
                     <div class="panel-heading">
                         <a data-toggle="collapse"
-                           data-parent="#deploy-accordion" href="#panel-java"
-                           data-bind="click: function() { track_deploy_type('Download to Java Phone'); },"
+                           data-parent="#deploy-accordion"
+                           data-bind="
+                           click: function() { track_deploy_type('Download to Java Phone'); },
+                           attr: {
+                               href: '#' + id() + '_download_java',
+                               'data-target': '#' + id() + '_download_java'
+                            }
+                           "
                            aria-expanded="true" aria-controls="panel-java">
                             {% trans "Download to Java Phone" %}
                         </a>
                     </div>
-                    <div class="panel-collapse collapse" id="panel-java">
+                    <div class="panel-collapse collapse" data-bind="attr: {id: id() + '_download_java'}">
                         <div class="panel-body">
                             <ol>
                                 <li>
@@ -191,13 +197,19 @@
                 <div class="panel panel-default">
                     <div class="panel-heading">
                             <a data-toggle="collapse"
-                               data-parent="#deploy-accordion" href="#panel-sms"
-                               data-bind="click: function() { track_deploy_type('Send to phone via SMS'); }, click: function() { generate_short_url('short_url'); }"
+                               data-parent="#deploy-accordion"
+                               data-bind="
+                                   click: onSMSPanelClick,
+                                   attr: {
+                                      href: '#' + id() + '_sms',
+                                      'data-target': '#' + id() + '_sms'
+                                   }
+                                "
                                aria-expanded="true" aria-controls="panel-sms">
                             {% trans "Send to phone via SMS" %}
                         </a>
                     </div>
-                    <div class="panel-collapse collapse" id="panel-sms">
+                    <div class="panel-collapse collapse" data-bind="attr: {id: id() + '_sms'}">
                         <div class="panel-body">
                             <div data-bind="bootstrapTabs: true">
                                 <div class="tabbable">

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases_deploy_modal.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases_deploy_modal.html
@@ -19,10 +19,16 @@
                 <a href="{% url "mobile_workers" domain %}">{% trans "create your first mobile worker" %}</a>.
             </div>
         {% else %}
-            <div class="panel-group" id="deploy-accordion">
+            <div class="panel-group" data-bind="attr: {id: 'deploy-accordion_' + id()}">
                 <div class="panel panel-default">
                     <div class="panel-heading">
-                        <a data-toggle="collapse" data-parent="#deploy-accordion" href="#panel-android" aria-expanded="true" aria-controls="panel-android">
+                        <a
+                            data-toggle="collapse"
+                            href="#panel-android"
+                            aria-expanded="true"
+                            aria-controls="panel-android"
+                            data-bind="attr: {'data-parent': '#deploy-accordion_' + id()}"
+                            >
                             {% trans "Download to Android" %}
                         </a>
                     </div>
@@ -161,12 +167,12 @@
                 <div class="panel panel-default">
                     <div class="panel-heading">
                         <a data-toggle="collapse"
-                           data-parent="#deploy-accordion"
                            data-bind="
                            click: function() { track_deploy_type('Download to Java Phone'); },
                            attr: {
                                href: '#' + id() + '_download_java',
-                               'data-target': '#' + id() + '_download_java'
+                               'data-target': '#' + id() + '_download_java',
+                               'data-parent': '#deploy-accordion_' + id()
                             }
                            "
                            aria-expanded="true" aria-controls="panel-java">
@@ -197,12 +203,12 @@
                 <div class="panel panel-default">
                     <div class="panel-heading">
                             <a data-toggle="collapse"
-                               data-parent="#deploy-accordion"
                                data-bind="
                                    click: onSMSPanelClick,
                                    attr: {
                                       href: '#' + id() + '_sms',
-                                      'data-target': '#' + id() + '_sms'
+                                      'data-target': '#' + id() + '_sms',
+                                      'data-parent': '#deploy-accordion_' + id()
                                    }
                                 "
                                aria-expanded="true" aria-controls="panel-sms">
@@ -267,10 +273,13 @@
                     <div class="panel panel-default">
                         <div class="panel-heading">
                             <a data-toggle="collapse"
-                               data-parent="#deploy-accordion" href="#panel-multimedia"
                                data-bind="
                                   click: function() { track_deploy_type('Download Multimedia'); },
-                                  attr: {href: '#' + id() + '_multimedia', 'data-target': '#' + id() + '_multimedia'}
+                                  attr: {
+                                    href: '#' + id() + '_multimedia',
+                                    'data-target': '#' + id() + '_multimedia',
+                                    'data-parent': '#deploy-accordion_' + id()
+                                  }
                                "
                                aria-expanded="true" aria-controls="panel-multimedia">
                                 {% trans 'Download Multimedia' %}


### PR DESCRIPTION
@orangejenny this fixes up a few issues with the deploy modal. best read commit-by-commit. in essence, since we were using ids in the modal and multiple modals were being generated, the modal would behave weirdly by not opening after a second modal was opened or not properly closing other modals in the group. this should fix all those issues

http://manage.dimagi.com/default.asp?232280#1184182

interrupt: @calellowitz @sravfeyn 
