### PR TITLE
add a soft assert for a loaded domain field on Subscriber

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -63,6 +63,7 @@ from corehq.const import USER_DATE_FORMAT
 from corehq.util.dates import get_first_last_days
 from corehq.util.mixin import ValidateModelMixin
 from corehq.util.quickcache import quickcache
+from corehq.util.soft_assert import soft_assert
 from corehq.util.view_utils import absolute_reverse
 from corehq.apps.analytics.tasks import track_workflow
 from corehq.privileges import REPORT_BUILDER_ADD_ON_PRIVS
@@ -73,6 +74,11 @@ MAX_INVOICE_COMMUNICATIONS = 5
 SMALL_INVOICE_THRESHOLD = 100
 
 UNLIMITED_FEATURE_USAGE = -1
+
+_soft_assert_domain_not_loaded = soft_assert(
+    to='{}@{}'.format('npellegrino', 'dimagi.com'),
+    exponential_backoff=False,
+)
 
 
 class BillingAccountType(object):
@@ -947,6 +953,9 @@ class Subscriber(models.Model):
         downgraded_privileges is the list of privileges that should be removed
         upgraded_privileges is the list of privileges that should be added
         """
+        _soft_assert_domain_not_loaded(isinstance(self.domain, basestring), "domain is object")
+
+
         if new_plan_version is None:
             new_plan_version = DefaultProductPlan.get_default_plan()
 

--- a/corehq/apps/accounting/tests/test_credit_lines.py
+++ b/corehq/apps/accounting/tests/test_credit_lines.py
@@ -308,7 +308,7 @@ class TestCreditTransfers(BaseAccountingTest):
             edition=SoftwarePlanEdition.STANDARD
         )
         first_sub = Subscription.new_domain_subscription(
-            self.account, self.domain, advanced_plan
+            self.account, self.domain.name, advanced_plan
         )
 
         product_credit = CreditLine.add_credit(

--- a/corehq/apps/accounting/tests/test_invoice_factory.py
+++ b/corehq/apps/accounting/tests/test_invoice_factory.py
@@ -43,7 +43,7 @@ class TestDomainInvoiceFactory(BaseAccountingTest):
     def test_incomplete_starting_coverage(self):
         some_plan = generator.subscribable_plan()
         subscription = Subscription.new_domain_subscription(
-            self.account, self.domain, some_plan,
+            self.account, self.domain.name, some_plan,
             date_start=self.invoice_start + datetime.timedelta(days=3)
         )
         subscriptions = self.invoice_factory._get_subscriptions()
@@ -56,7 +56,7 @@ class TestDomainInvoiceFactory(BaseAccountingTest):
     def test_incomplete_ending_coverage(self):
         some_plan = generator.subscribable_plan()
         subscription = Subscription.new_domain_subscription(
-            self.account, self.domain, some_plan,
+            self.account, self.domain.name, some_plan,
             date_start=self.invoice_start,
             date_end=self.invoice_end - datetime.timedelta(days=3)
         )
@@ -72,20 +72,20 @@ class TestDomainInvoiceFactory(BaseAccountingTest):
         some_plan = generator.subscribable_plan()
         middle_date = self.invoice_end - datetime.timedelta(days=15)
         Subscription.new_domain_subscription(
-            self.account, self.domain, some_plan,
+            self.account, self.domain.name, some_plan,
             date_start=self.invoice_start + datetime.timedelta(days=1),
             date_end=middle_date
         )
         next_start = middle_date + datetime.timedelta(days=2)
         next_end = next_start + datetime.timedelta(days=2)
         Subscription.new_domain_subscription(
-            self.account, self.domain, some_plan,
+            self.account, self.domain.name, some_plan,
             date_start=next_start,
             date_end=next_end,
         )
         final_start = next_end + datetime.timedelta(days=2)
         Subscription.new_domain_subscription(
-            self.account, self.domain, some_plan,
+            self.account, self.domain.name, some_plan,
             date_start=final_start,
             date_end=self.invoice_end - datetime.timedelta(days=1),
         )
@@ -98,7 +98,7 @@ class TestDomainInvoiceFactory(BaseAccountingTest):
     def test_full_coverage(self):
         some_plan = generator.subscribable_plan()
         Subscription.new_domain_subscription(
-            self.account, self.domain, some_plan,
+            self.account, self.domain.name, some_plan,
             date_start=self.invoice_start,
             date_end=self.invoice_end + datetime.timedelta(days=1),
         )


### PR DESCRIPTION
I came across a `ResourceConflict` during testing when a `Subscriber`'s `domain` is  of type `Domain` instead of `basestring`.  I think this is related to a similar error I've seen in production but have been unable to reproduce.  I'm adding a soft assert to help track it down.
