### PR TITLE
remove unused emits from all_forms/views

### DIFF
--- a/corehq/couchapps/all_forms/views/view/map.js
+++ b/corehq/couchapps/all_forms/views/view/map.js
@@ -40,23 +40,14 @@ function(doc) {
             username: get_username(doc)
         };
 
-        var times = {
-            completion: completion_time,
-            submission: submission_time
-        };
         if (xmlns) {
-            for (var status in times) {
-                if (times.hasOwnProperty(status)) {
-                    emit([status,                   doc.domain, times[status]], emit_entry);
-                    emit([status+" xmlns",          doc.domain, xmlns,      times[status]], emit_entry);
-                    emit([status+" app",            doc.domain, app_id,     times[status]], emit_entry);
-                    emit([status+" user",           doc.domain, user_id,    times[status]], emit_entry);
-                    emit([status+" app user",       doc.domain, app_id, user_id, times[status]], emit_entry);
-                    emit([status+" xmlns app",      doc.domain, xmlns, app_id,  times[status]], emit_entry);
-                    emit([status+" xmlns user",     doc.domain, xmlns, user_id, times[status]], emit_entry);
-                    emit([status+" xmlns app user", doc.domain, xmlns, app_id, user_id, times[status]], emit_entry);
-                }
-            }
+            var status = 'submission';
+            emit(['submission', doc.domain, submission_time], emit_entry);
+            emit(['submission xmlns', doc.domain, xmlns, submission_time], emit_entry);
+            emit(['submission app', doc.domain, app_id, submission_time], emit_entry);
+            emit(['submission user', doc.domain, user_id, submission_time], emit_entry);
+            emit(['submission xmlns app', doc.domain, xmlns, app_id, submission_time], emit_entry);
+            emit(['submission xmlns user', doc.domain, xmlns, user_id, submission_time], emit_entry);
         }
     }
 }

--- a/corehq/couchapps/all_forms/views/view/map.js
+++ b/corehq/couchapps/all_forms/views/view/map.js
@@ -41,7 +41,6 @@ function(doc) {
         };
 
         if (xmlns) {
-            var status = 'submission';
             emit(['submission', doc.domain, submission_time], emit_entry);
             emit(['submission xmlns', doc.domain, xmlns, submission_time], emit_entry);
             emit(['submission app', doc.domain, app_id, submission_time], emit_entry);


### PR DESCRIPTION
reduces view size by 63% (were 16 emits, now there are 6)

This is a step on towards https://trello.com/c/XfVvd7v4/31-all-forms-view-couch-view. Rewriting all the places that are using this view is a little bigger (though manageable) and we can have this benefit right now with a reindex, so I thought I'd put it out there and see what you think.

@czue 
