### PR TITLE
adding moment.js to edit form page

### DIFF
--- a/corehq/apps/reports/templates/reports/form/edit_submission.html
+++ b/corehq/apps/reports/templates/reports/form/edit_submission.html
@@ -3,7 +3,8 @@
 {% load i18n %}
 
 {% block js-inline %}{{ block.super }}
-{% include 'cloudcare/includes/touchforms-inline.html' %}
+    <script type="text/javascript" src="{% static 'moment/moment.js' %}"></script>
+    {% include 'cloudcare/includes/touchforms-inline.html' %}
 {% endblock %}
 
 {% block head %}{{ block.super }}


### PR DESCRIPTION
@benrudolph cc: @snopoke 
It turns out it was only included in the base template if the `use_daterangepicker` decorator was being used.
