### PR TITLE
make management command compatible with django 1.7/1.8

### DIFF
--- a/corehq/apps/hqcase/management/commands/ptop_reindexer_v2.py
+++ b/corehq/apps/hqcase/management/commands/ptop_reindexer_v2.py
@@ -89,7 +89,13 @@ class Command(BaseCommand):
             return raw_input("Are you sure you want to delete the current index (if it exists)? y/n\n") == 'y'
 
         reindexer = reindex_fns[index]()
-        reindexer_options = clean_options(options)
+        if not BaseCommand.option_list:
+            reindexer_options = {
+                key: value for key, value in options.items()
+                if value is not None and key in [option.dest for option in self.option_list]
+            }
+        else:  # remove when django>=1.8
+            reindexer_options = clean_options(options)
         unconsumed = reindexer.consume_options(reindexer_options)
         if unconsumed:
             raise CommandError(


### PR DESCRIPTION
`BaseCommand.option_list` is `()` in django 1.8, breaking this management command
