### PR TITLE
Report Builder: Increase column limit to 40

### DIFF
--- a/corehq/apps/userreports/templates/userreports/partials/property_list_configuration.html
+++ b/corehq/apps/userreports/templates/userreports/partials/property_list_configuration.html
@@ -137,7 +137,7 @@ TODO:
             {# there must be no whitespace between <tbody> and <tr> #}
             {# the .hide().fadeIn() will fail badly on FireFox #}
             </tr></tbody>
-            <tbody data-bind="visible: columns().length < 25" class="add-prop">
+            <tbody data-bind="visible: columns().length < 40" class="add-prop">
                 <tr>
                     <td></td>
                     <td colspan="4">


### PR DESCRIPTION
@NoahCarnahan 

Got a request from a partner to increase the column limit again.  Are there performance or other concerns we have about the column limit (i'm guessing usability/readability is not great, but they're emailing and exporting to Excel)? 
