### PR TITLE
Removed deactivated/archived users from users lists in Project Performance Dashboard

### DIFF
--- a/corehq/apps/reports/standard/project_health.py
+++ b/corehq/apps/reports/standard/project_health.py
@@ -225,7 +225,7 @@ class MonthlyPerformanceSummary(jsonobject.JsonObject):
         if self._previous_summary:
             unhealthy_users = filter(
                 lambda stub: stub.is_active and not stub.is_performing and not
-                CommCareUser.get(stub.user_id).is_deleted(),
+                CommCareUser.get(stub.user_id).is_deleted() and CommCareUser.get(stub.user_id).is_active,
                 self.get_all_user_stubs_with_extra_data()
             )
             return sorted(unhealthy_users, key=lambda stub: stub.delta_forms)
@@ -238,7 +238,7 @@ class MonthlyPerformanceSummary(jsonobject.JsonObject):
         if self._previous_summary:
             dropouts = filter(
                 lambda stub: not stub.is_active and not
-                CommCareUser.get(stub.user_id).is_deleted(),
+                CommCareUser.get(stub.user_id).is_deleted() and CommCareUser.get(stub.user_id).is_active,
                 self.get_all_user_stubs_with_extra_data()
             )
             return sorted(dropouts, key=lambda stub: stub.delta_forms)
@@ -251,7 +251,7 @@ class MonthlyPerformanceSummary(jsonobject.JsonObject):
         if self._previous_summary:
             dropouts = filter(
                 lambda stub: stub.is_newly_performing and not
-                CommCareUser.get(stub.user_id).is_deleted(),
+                CommCareUser.get(stub.user_id).is_deleted() and CommCareUser.get(stub.user_id).is_active,
                 self.get_all_user_stubs_with_extra_data()
             )
             return sorted(dropouts, key=lambda stub: -stub.delta_forms)

--- a/corehq/apps/reports/standard/project_health.py
+++ b/corehq/apps/reports/standard/project_health.py
@@ -3,7 +3,6 @@ import datetime
 from django.utils.translation import ugettext_lazy
 from corehq.apps.data_analytics.models import MALTRow
 from corehq.apps.domain.models import Domain
-from corehq.apps.users.models import CommCareUser
 from corehq.apps.reports.standard import ProjectReport
 from corehq.apps.style.decorators import use_nvd3
 from corehq.apps.users.util import raw_username

--- a/corehq/apps/reports/standard/project_health.py
+++ b/corehq/apps/reports/standard/project_health.py
@@ -51,11 +51,11 @@ class MonthlyMALTRows(jsonobject.JsonObject):
 
     def __init__(self, domain, month, performance_threshold, not_deleted_active_users, users, has_filter):
         self._rows = MALTRow.objects.filter(
-                        domain_name=domain,
-                        month=month,
-                        user_type__in=['CommCareUser', 'CommCareUser-Deleted'],
-                        user_id__in=not_deleted_active_users,
-                     ).distinct('user_id')
+            domain_name=domain,
+            month=month,
+            user_type__in=['CommCareUser', 'CommCareUser-Deleted'],
+            user_id__in=not_deleted_active_users,
+        ).distinct('user_id')
 
         if has_filter:
             self._rows = self._rows.filter(user_id__in=users).distinct('user_id')

--- a/corehq/apps/reports/standard/project_health.py
+++ b/corehq/apps/reports/standard/project_health.py
@@ -45,53 +45,80 @@ class UserActivityStub(namedtuple('UserStub', ['user_id', 'username', 'num_forms
         return self.num_forms_submitted_next_month - self.num_forms_submitted
 
 
+class MonthlyMALTRows(jsonobject.JsonObject):
+    month = jsonobject.DateProperty()
+    domain = jsonobject.StringProperty()
+
+    def __init__(self, domain, month, performance_threshold, not_deleted_active_users, users, has_filter):
+        self._rows = MALTRow.objects.filter(
+                        domain_name=domain,
+                        month=month,
+                        user_type__in=['CommCareUser', 'CommCareUser-Deleted'],
+                        user_id__in=not_deleted_active_users,
+                     ).distinct('user_id')
+
+        if has_filter:
+            self._rows = self._rows.filter(user_id__in=users).distinct('user_id')
+
+        self._threshold = performance_threshold
+
+        super(MonthlyMALTRows, self).__init__(
+            domain=domain,
+            month=month,
+        )
+
+    def get_num_high_performing_users(self):
+        return self._rows.filter(num_of_forms__gte=self._threshold).count()
+
+    def get_num_active_users(self):
+        return self._rows.filter(num_of_forms__gt=0).count()
+
+    def get_num_low_performing_users(self):
+        return self.get_num_active_users() - self.get_num_high_performing_users()
+
+    def generate_user_stubs(self):
+        return {
+            row.user_id: UserActivityStub(
+                user_id=row.user_id,
+                username=raw_username(row.username),
+                num_forms_submitted=row.num_of_forms,
+                is_performing=row.num_of_forms >= self._threshold,
+                previous_stub=None,
+                next_stub=None,
+            ) for row in self._rows
+        }
+
+
 class MonthlyPerformanceSummary(jsonobject.JsonObject):
     month = jsonobject.DateProperty()
     domain = jsonobject.StringProperty()
-    performance_threshold = jsonobject.IntegerProperty()
     active = jsonobject.IntegerProperty()
     performing = jsonobject.IntegerProperty()
 
-    def __init__(self, domain, month, users, has_filter,
-                 performance_threshold, previous_summary=None,
-                 delta_high_performers=0, delta_low_performers=0):
+    def __init__(self, domain, month, monthly_malt_rows, previous_summary=None):
         self._previous_summary = previous_summary
-        self._domain = domain
         self._next_summary = None
-        not_deleted_active_users = UserES().domain(domain).values_list("_id", flat=True)
-        base_queryset = MALTRow.objects.filter(
-            domain_name=domain,
-            month=month,
-            user_type__in=['CommCareUser', 'CommCareUser-Deleted'],
-            user_id__in=not_deleted_active_users,
-        )
-        if has_filter:
-            base_queryset = base_queryset.filter(
-                user_id__in=users,
-            )
-        self._distinct_user_ids = base_queryset.distinct('user_id')
+        self._monthly_malt_rows = monthly_malt_rows
 
-        num_performing_users = (base_queryset
-                                .filter(num_of_forms__gte=performance_threshold)
-                                .distinct('user_id')
-                                .count())
-
-        num_active_users = self._distinct_user_ids.count()
-        num_low_performing_user = num_active_users - num_performing_users
-
-        if self._previous_summary:
-            delta_high_performers = num_performing_users - self._previous_summary.number_of_performing_users
-            delta_low_performers = num_low_performing_user - self._previous_summary.number_of_low_performing_users
+        num_high_performers = self._monthly_malt_rows.get_num_high_performing_users()
+        num_low_performers = self._monthly_malt_rows.get_num_low_performing_users()
+        num_active_users = self._monthly_malt_rows.get_num_active_users()
+        if previous_summary:
+            delta_high_performers = num_high_performers - previous_summary.performing
+            delta_low_performers = num_low_performers - previous_summary.low_performing
+        else:
+            delta_high_performers = 0
+            delta_low_performers = 0
 
         super(MonthlyPerformanceSummary, self).__init__(
             month=month,
             domain=domain,
-            performance_threshold=performance_threshold,
             active=num_active_users,
             inactive=0,
             total_users_by_month=0,
             percent_active=0,
-            performing=num_performing_users,
+            performing=num_high_performers,
+            low_performing=num_low_performers,
             delta_high_performers=delta_high_performers,
             delta_low_performers=delta_low_performers,
         )
@@ -179,16 +206,7 @@ class MonthlyPerformanceSummary(jsonobject.JsonObject):
             return float(self.delta_inactive / float(self._previous_summary.number_of_inactive_users)) * 100.
 
     def _get_all_user_stubs(self):
-        return {
-            row.user_id: UserActivityStub(
-                user_id=row.user_id,
-                username=raw_username(row.username),
-                num_forms_submitted=row.num_of_forms,
-                is_performing=row.num_of_forms >= self.performance_threshold,
-                previous_stub=None,
-                next_stub=None,
-            ) for row in self._distinct_user_ids
-        }
+        return self._monthly_malt_rows.generate_user_stubs()
 
     @memoized
     def get_all_user_stubs_with_extra_data(self):
@@ -338,28 +356,40 @@ class ProjectHealthDashboard(ProjectReport):
         users_set = self.get_unique_users(users_list_by_location, users_list_by_group)
         return users_set
 
+    def create_monthly_summary(self, month_as_date, threshold, filtered_users, last_month_summary):
+        monthly_malt_rows = MonthlyMALTRows(
+            domain=self.domain,
+            month=month_as_date,
+            performance_threshold=threshold,
+            users=filtered_users,
+            has_filter=bool(self.get_group_location_ids()),
+            not_deleted_active_users=UserES().domain(self.domain).values_list("_id", flat=True),
+        )
+        this_month_summary = MonthlyPerformanceSummary(
+            domain=self.domain,
+            month=month_as_date,
+            previous_summary=last_month_summary,
+            monthly_malt_rows=monthly_malt_rows,
+        )
+        if last_month_summary is not None:
+            last_month_summary.set_next_month_summary(this_month_summary)
+            this_month_summary.set_num_inactive_users(len(this_month_summary.get_dropouts()))
+        this_month_summary.set_percent_active()
+        return this_month_summary
+
     def previous_six_months(self):
         now = datetime.datetime.utcnow()
         six_month_summary = []
         last_month_summary = None
         performance_threshold = get_performance_threshold(self.domain)
         filtered_users = self.get_users_by_filter()
+
         for i in range(-6, 1):
             year, month = add_months(now.year, now.month, i)
             month_as_date = datetime.date(year, month, 1)
-            this_month_summary = MonthlyPerformanceSummary(
-                domain=self.domain,
-                performance_threshold=performance_threshold,
-                month=month_as_date,
-                previous_summary=last_month_summary,
-                users=filtered_users,
-                has_filter=bool(self.get_group_location_ids()),
-            )
+            this_month_summary = self.create_monthly_summary(month_as_date, performance_threshold,
+                                                             filtered_users, last_month_summary)
             six_month_summary.append(this_month_summary)
-            if last_month_summary is not None:
-                last_month_summary.set_next_month_summary(this_month_summary)
-                this_month_summary.set_num_inactive_users(len(this_month_summary.get_dropouts()))
-            this_month_summary.set_percent_active()
             last_month_summary = this_month_summary
         return six_month_summary[1:]
 

--- a/corehq/apps/reports/tests/test_project_health.py
+++ b/corehq/apps/reports/tests/test_project_health.py
@@ -103,6 +103,7 @@ class MonthlyMALTRowsTests(SetupProjectPerformanceMixin, TestCase):
     @classmethod
     def setUpClass(cls):
         super(MonthlyMALTRowsTests, cls).setUpClass()
+        cls.class_setup()
         not_deleted_active_users = [cls.user._id, cls.user1._id, cls.user2._id]
         cls.prev_month_malt_rows = MonthlyMALTRows(
             domain=cls.DOMAIN_NAME,
@@ -120,7 +121,6 @@ class MonthlyMALTRowsTests(SetupProjectPerformanceMixin, TestCase):
             has_filter=False,
             not_deleted_active_users=not_deleted_active_users,
         )
-        cls.class_setup()
 
     @classmethod
     def tearDownClass(cls):
@@ -148,6 +148,7 @@ class MonthlyPerformanceSummaryTests(SetupProjectPerformanceMixin, TestCase):
     def setUpClass(cls):
         super(MonthlyPerformanceSummaryTests, cls).setUpClass()
         cls.class_setup()
+        not_deleted_active_users = [cls.user._id, cls.user1._id, cls.user2._id]
         filtered_users = []
         previous_month_malt_rows = MonthlyMALTRows(
             domain=cls.DOMAIN_NAME,
@@ -155,6 +156,7 @@ class MonthlyPerformanceSummaryTests(SetupProjectPerformanceMixin, TestCase):
             performance_threshold=15,
             users=filtered_users,
             has_filter=False,
+            not_deleted_active_users=not_deleted_active_users,
         )
         this_month_malt_rows = MonthlyMALTRows(
             domain=cls.DOMAIN_NAME,
@@ -162,6 +164,7 @@ class MonthlyPerformanceSummaryTests(SetupProjectPerformanceMixin, TestCase):
             performance_threshold=15,
             users=filtered_users,
             has_filter=False,
+            not_deleted_active_users=not_deleted_active_users,
         )
         cls.prev_month = MonthlyPerformanceSummary(
             domain=cls.DOMAIN_NAME,

--- a/corehq/apps/reports/tests/test_project_health.py
+++ b/corehq/apps/reports/tests/test_project_health.py
@@ -1,7 +1,8 @@
 from django.test import TestCase
 import datetime
 from dimagi.utils.dates import add_months
-from corehq.apps.reports.standard.project_health import MonthlyPerformanceSummary, ProjectHealthDashboard
+from corehq.apps.reports.standard.project_health import MonthlyPerformanceSummary,\
+                                                        ProjectHealthDashboard, MonthlyMALTRows
 from corehq.apps.data_analytics.models import MALTRow
 from corehq.const import MISSING_APP_ID
 from corehq.apps.domain.models import Domain
@@ -92,28 +93,87 @@ class SetupProjectPerformanceMixin(object):
         malt_user_prev.save()
 
 
+class MonthlyMALTRowsTests(SetupProjectPerformanceMixin, TestCase):
+    DOMAIN_NAME = "test_domain"
+    now = datetime.datetime.utcnow()
+    year, month = add_months(now.year, now.month, 1)
+    month_as_date = datetime.date(year, month, 1)
+    prev_month_as_date = datetime.date(year, month - 1, 1)
+
+    @classmethod
+    def setUpClass(cls):
+        super(MonthlyMALTRowsTests, cls).setUpClass()
+        not_deleted_active_users = [cls.user._id, cls.user1._id, cls.user2._id]
+        cls.prev_month_malt_rows = MonthlyMALTRows(
+            domain=cls.DOMAIN_NAME,
+            month=cls.prev_month_as_date,
+            performance_threshold=15,
+            users=[],
+            has_filter=False,
+            not_deleted_active_users=not_deleted_active_users,
+        )
+        cls.month_malt_rows = MonthlyMALTRows(
+            domain=cls.DOMAIN_NAME,
+            month=cls.month_as_date,
+            performance_threshold=15,
+            users=[],
+            has_filter=False,
+            not_deleted_active_users=not_deleted_active_users,
+        )
+        cls.class_setup()
+
+    @classmethod
+    def tearDownClass(cls):
+        super(MonthlyMALTRowsTests, cls).tearDownClass()
+        cls.class_teardown()
+
+    def test_get_num_high_performing_users(self):
+        """
+        get_num_high_performing_users() should return 2 when there are 2 users
+        who submitted more or equal to the performance threhold
+        """
+        self.assertEqual(self.month_malt_rows.get_num_high_performing_users(), 2)
+
+    def test_get_num_active_users(self):
+        """
+        get_num_active_users() should return 2 when there are 2 users
+        who submitted any forms
+        """
+        self.assertEqual(self.month_malt_rows.get_num_active_users(), 2)
+
+
 class MonthlyPerformanceSummaryTests(SetupProjectPerformanceMixin, TestCase):
 
     @classmethod
     def setUpClass(cls):
         super(MonthlyPerformanceSummaryTests, cls).setUpClass()
         cls.class_setup()
-        users_in_group = []
+        filtered_users = []
+        previous_month_malt_rows = MonthlyMALTRows(
+            domain=cls.DOMAIN_NAME,
+            month=cls.prev_month_as_date,
+            performance_threshold=15,
+            users=filtered_users,
+            has_filter=False,
+        )
+        this_month_malt_rows = MonthlyMALTRows(
+            domain=cls.DOMAIN_NAME,
+            month=cls.month_as_date,
+            performance_threshold=15,
+            users=filtered_users,
+            has_filter=False,
+        )
         cls.prev_month = MonthlyPerformanceSummary(
             domain=cls.DOMAIN_NAME,
-            performance_threshold=15,
             month=cls.prev_month_as_date,
             previous_summary=None,
-            users=users_in_group,
-            has_filter=False,
+            monthly_malt_rows=previous_month_malt_rows,
         )
         cls.month = MonthlyPerformanceSummary(
             domain=cls.DOMAIN_NAME,
-            performance_threshold=15,
             month=cls.month_as_date,
             previous_summary=cls.prev_month,
-            users=users_in_group,
-            has_filter=False,
+            monthly_malt_rows=this_month_malt_rows,
         )
 
     @classmethod
@@ -161,9 +221,9 @@ class MonthlyPerformanceSummaryTests(SetupProjectPerformanceMixin, TestCase):
 
     def test_get_all_user_stubs(self):
         """
-        get_all_user_stubs() should contain two users from this month
+        _get_all_user_stubs() should contain two users from this month
         """
-        self.assertEqual(len(self.month.get_all_user_stubs().keys()), 2)
+        self.assertEqual(len(self.month._get_all_user_stubs().keys()), 2)
 
 
 @mock.patch('corehq.apps.reports.standard.project_health.GroupES', GroupESFake)

--- a/corehq/apps/reports/tests/test_project_health.py
+++ b/corehq/apps/reports/tests/test_project_health.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 import datetime
 from dimagi.utils.dates import add_months
 from corehq.apps.reports.standard.project_health import MonthlyPerformanceSummary,\
-                                                        ProjectHealthDashboard, MonthlyMALTRows
+    ProjectHealthDashboard, MonthlyMALTRows
 from corehq.apps.data_analytics.models import MALTRow
 from corehq.const import MISSING_APP_ID
 from corehq.apps.domain.models import Domain


### PR DESCRIPTION
@esoergel @czue Per spec on [Google Spreadsheet](https://docs.google.com/spreadsheets/d/1hr5-u9Ni90yhumGJqvROeNvqqn0daIPRVLuzCiIbwb8/edit?ts=5760652c#gid=1814269798), deactivated users will not be displayed in users (low performing, new inactive, new high performing) tables 
