### PR TITLE
set TESTS_SHOULD_USE_SQL_BACKEND to False where required

### DIFF
--- a/corehq/apps/cleanup/tests/test_fix_forms_and_apps_with_missing_xmlns.py
+++ b/corehq/apps/cleanup/tests/test_fix_forms_and_apps_with_missing_xmlns.py
@@ -3,7 +3,7 @@ import os
 import uuid
 
 from django.core.management import call_command
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from elasticsearch import ConnectionError
 from testil import tempdir
 
@@ -170,6 +170,7 @@ class TestFixFormsWithMissingXmlns(TestCase, TestXmlMixin):
                 self.assertTrue(form.unique_id not in log)
                 self.assertTrue(xform._id not in log)
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_app_with_bad_form(self):
         good_form, bad_form, good_xform, bad_xforms = self.build_app_with_bad_form()
         self._refresh_pillow()
@@ -188,6 +189,7 @@ class TestFixFormsWithMissingXmlns(TestCase, TestXmlMixin):
                     self.assertTrue(xform._id in log)
             self.assertNoMissingXmlnss()
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_app_with_recently_fixed_form(self):
         form, good_build, bad_build, good_xform, bad_xform = self.build_app_with_recently_fixed_form()
         self._refresh_pillow()
@@ -216,6 +218,7 @@ class TestFixFormsWithMissingXmlns(TestCase, TestXmlMixin):
         )
         self.assertNoMissingXmlnss()
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_fix_xforms_with_missing_xmlns_task(self):
         """Tests the ability to find anomalies that violate our asssumptions
         about all applications and builds being fixes
@@ -235,6 +238,7 @@ class TestFixFormsWithMissingXmlns(TestCase, TestXmlMixin):
             )
             self.assertEqual(stats['not_fixed_undefined_xmlns'][DOMAIN], len(bad_xforms))
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_fix_xforms_with_missing_xmlns_task_fixed(self):
         """Tests the ability to fix xforms with the periodic cron task
         """

--- a/corehq/apps/cleanup/tests/test_swap_duplicates.py
+++ b/corehq/apps/cleanup/tests/test_swap_duplicates.py
@@ -2,7 +2,7 @@ import os
 import uuid
 
 from django.core.management import call_command
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from testil import tempdir
 
 from corehq.apps.app_manager.tests import TestXmlMixin
@@ -23,6 +23,7 @@ class TestFixFormsWithMissingXmlns(TestCase, TestXmlMixin):
         _, xform, __ = submit_form_locally(xform_source, DOMAIN)
         return xform
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_simple_swap(self):
         # Test a form with a single dup
         bad_form_id = self._submit_form()._id
@@ -52,6 +53,7 @@ class TestFixFormsWithMissingXmlns(TestCase, TestXmlMixin):
                 )
             )
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_non_swaps(self):
         # Test a form with multiple dups
         form_with_multi_dups_id = self._submit_form()._id

--- a/corehq/apps/cloudcare/tests/test_api.py
+++ b/corehq/apps/cloudcare/tests/test_api.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.core.urlresolvers import reverse
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.models import CommCareCase
@@ -116,55 +116,66 @@ class CaseAPITest(TestCase):
     def expectedAll(self):
         return len(self.user_ids) * len(self.case_types) * 3
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testGetAllOpen(self):
         list = get_filtered_cases(self.domain, status=CASE_STATUS_OPEN)
         self.assertEqual(self.expectedOpen, len(list))
         self.assertListMatches(list, lambda c: not c['closed'])
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testGetAllWithClosed(self):
         list = get_filtered_cases(self.domain, status=CASE_STATUS_ALL)
         self.assertEqual(self.expectedOpen + self.expectedClosed, len(list))
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testGetAllOpenWithType(self):
         list = get_filtered_cases(self.domain, status=CASE_STATUS_OPEN, case_type=self.test_type)
         self.assertEqual(self.expectedOpenByType, len(list))
         self.assertListMatches(list, lambda c: not c['closed'] and c['properties']['case_type'] == self.test_type)
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testGetAllWithClosedAndType(self):
         list = get_filtered_cases(self.domain, status=CASE_STATUS_ALL, case_type=self.test_type)
         self.assertEqual(self.expectedByType, len(list))
         self.assertListMatches(list, lambda c: c['properties']['case_type'] == self.test_type)
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testGetOwnedOpen(self):
         list = get_filtered_cases(self.domain, user_id=self.test_user_id, status=CASE_STATUS_OPEN, footprint=False)
         self.assertEqual(self.expectedOpenByUser, len(list))
         self.assertListMatches(list, lambda c: not c['closed'] and c['user_id'] == self.test_user_id)
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testGetOwnedClosed(self):
         list = get_filtered_cases(self.domain, user_id=self.test_user_id, status=CASE_STATUS_CLOSED, footprint=False)
         self.assertEqual(self.expectedClosedByUser, len(list))
         self.assertListMatches(list, lambda c: c['closed'] and c['user_id'] == self.test_user_id)
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testGetOwnedBoth(self):
         list = get_filtered_cases(self.domain, user_id=self.test_user_id, status=CASE_STATUS_ALL, footprint=False)
         self.assertEqual(self.expectedByUser, len(list))
         self.assertListMatches(list, lambda c: c['user_id'] == self.test_user_id)
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testGetOwnedOpenWithFootprint(self):
         list = get_filtered_cases(self.domain, user_id=self.test_user_id, status=CASE_STATUS_OPEN, footprint=True)
         self.assertEqual(self.expectedOpenByUserWithFootprint, len(list))
         self.assertListMatches(list, lambda c: not c['closed'] or c['user_id'] != self.test_user_id)
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testGetOwnedClosedWithFootprint(self):
         list = get_filtered_cases(self.domain, user_id=self.test_user_id, status=CASE_STATUS_CLOSED, footprint=True)
         self.assertEqual(self.expectedClosedByUserWithFootprint, len(list))
         self.assertListMatches(list, lambda c: c['closed'] or c['user_id'] != self.test_user_id)
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testGetOwnedBothWithFootprint(self):
         list = get_filtered_cases(self.domain, user_id=self.test_user_id, status=CASE_STATUS_ALL, footprint=True)
         self.assertEqual(self.expectedOpenByUserWithFootprint + self.expectedClosedByUserWithFootprint, len(list))
         # I don't think we can say anything super useful about this base set
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testGetAllStripHistory(self):
         list = get_filtered_cases(self.domain, status=CASE_STATUS_ALL, footprint=True,
                                   strip_history=True)
@@ -172,6 +183,7 @@ class CaseAPITest(TestCase):
         self.assertListMatches(list, lambda c: len(c._couch_doc.actions) == 0)
         self.assertListMatches(list, lambda c: len(c._couch_doc.xform_ids) == 0)
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testGetAllIdsOnly(self):
         list = get_filtered_cases(self.domain, status=CASE_STATUS_ALL, footprint=True,
                                   ids_only=True)
@@ -179,6 +191,7 @@ class CaseAPITest(TestCase):
         self.assertListMatches(list, lambda c: isinstance(c._couch_doc, dict))
         self.assertListMatches(list, lambda c: isinstance(c.to_json(), basestring))
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testGetAllIdsOnlyStripHistory(self):
         list = get_filtered_cases(self.domain, status=CASE_STATUS_ALL, footprint=True,
                                   ids_only=True, strip_history=True)
@@ -188,18 +201,21 @@ class CaseAPITest(TestCase):
         self.assertListMatches(list, lambda c: 'xform_ids' not in c._couch_doc)
         self.assertListMatches(list, lambda c: isinstance(c.to_json(), basestring))
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testFiltersOnAll(self):
         list = get_filtered_cases(self.domain, status=CASE_STATUS_ALL,
                                   filters={"properties/case_name": _type_to_name(self.test_type)})
         self.assertEqual(self.expectedByType, len(list))
         self.assertListMatches(list, lambda c: c['properties']['case_name'] == _type_to_name(self.test_type))
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testFiltersOnOwned(self):
         list = get_filtered_cases(self.domain, user_id=self.test_user_id, status=CASE_STATUS_ALL,
                                   filters={"properties/case_name": _type_to_name(self.test_type)})
         self.assertEqual(2, len(list))
         self.assertListMatches(list, lambda c: c['properties']['case_name'] == _type_to_name(self.test_type))
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testFiltersWithoutFootprint(self):
         name = _type_to_name(_child_case_type(self.test_type))
         list = get_filtered_cases(self.domain, user_id=self.test_user_id, status=CASE_STATUS_ALL,
@@ -208,6 +224,7 @@ class CaseAPITest(TestCase):
         self.assertEqual(1, len(list))
         self.assertListMatches(list, lambda c: c['properties']['case_name'] == name)
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testFiltersWithFootprint(self):
         name = _type_to_name(_child_case_type(self.test_type))
         list = get_filtered_cases(self.domain, user_id=self.test_user_id, status=CASE_STATUS_ALL,
@@ -217,6 +234,7 @@ class CaseAPITest(TestCase):
         # so just ensure the whole footprint including open and closed is available
         self.assertEqual(self.expectedOpenByUserWithFootprint + self.expectedClosedByUserWithFootprint, len(list))
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testCaseAPIResultJSON(self):
         try:
             case = CommCareCase()
@@ -235,6 +253,7 @@ class CaseAPITest(TestCase):
         finally:
             case.delete()
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testGetCasesCaching(self):
         user = self.users[0]
 
@@ -262,6 +281,7 @@ class CaseAPITest(TestCase):
         cases_not_cached = json.loads(result.content)
         self.assertEqual(len(cases) + 1, len(cases_not_cached))
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testGetCasesNoCaching(self):
         """
         Tests get_cases when it shouldn't cache. E.g. when ids_only is false or cache is false

--- a/corehq/apps/commtrack/tests/test_dbaccessors.py
+++ b/corehq/apps/commtrack/tests/test_dbaccessors.py
@@ -1,4 +1,4 @@
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from corehq.form_processor.tests.utils import run_with_all_backends
 from corehq.form_processor.interfaces.supply import SupplyInterface
@@ -28,6 +28,7 @@ class SupplyPointDBAccessorsTest(TestCase):
         self.project.delete()
         super(SupplyPointDBAccessorsTest, self).tearDown()
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_get_supply_point_ids_in_domain_by_location(self):
         actual = get_supply_point_ids_in_domain_by_location(self.domain)
         expected = {

--- a/corehq/apps/commtrack/tests/test_rebuild.py
+++ b/corehq/apps/commtrack/tests/test_rebuild.py
@@ -1,4 +1,4 @@
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from casexml.apps.case.cleanup import rebuild_case_from_forms
 from casexml.apps.case.mock import CaseFactory
 from corehq.apps.commtrack.helpers import make_product
@@ -71,6 +71,7 @@ class RebuildStockStateTest(TestCase):
 
         self._assert_stats(2, 200, 200)
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_inferred(self):
         self._submit_ledgers(LEDGER_BLOCKS_INFERRED)
         # this is weird behavior:

--- a/corehq/apps/commtrack/tests/test_sms_reporting.py
+++ b/corehq/apps/commtrack/tests/test_sms_reporting.py
@@ -1,5 +1,7 @@
 from decimal import Decimal
 from casexml.apps.stock.models import StockReport, StockTransaction
+from django.test import override_settings
+
 from corehq.apps.commtrack.models import StockState
 from corehq.apps.commtrack.tests.util import CommTrackTest, FIXED_USER, ROAMING_USER
 from corehq.apps.commtrack.sms import handle
@@ -36,6 +38,7 @@ class SMSTests(CommTrackTest):
 class StockReportTest(SMSTests):
     user_definitions = [ROAMING_USER, FIXED_USER]
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testStockReportRoaming(self):
         self.assertEqual(0, len(get_commtrack_forms(self.domain.name)))
         amounts = {
@@ -66,6 +69,7 @@ class StockReportTest(SMSTests):
             self.assertEqual(0, trans.quantity)
             self.assertEqual(amt, trans.stock_on_hand)
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testStockReportFixed(self):
         self.assertEqual(0, len(get_commtrack_forms(self.domain.name)))
 
@@ -103,6 +107,7 @@ class StockReportTest(SMSTests):
                 subtype
             )
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testStockReceipt(self):
         original_amounts = {
             'pp': 10,
@@ -136,6 +141,7 @@ class StockReportTest(SMSTests):
             expected_amount = original_amounts[code] + received_amounts[code]
             self.check_stock(code, expected_amount)
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testStockLosses(self):
         original_amounts = {
             'pp': 10,
@@ -168,6 +174,7 @@ class StockReportTest(SMSTests):
             expected_amount = original_amounts[code] - lost_amounts[code]
             self.check_stock(code, expected_amount)
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testStockConsumption(self):
         original_amounts = {
             'pp': 10,
@@ -209,6 +216,7 @@ class StockAndReceiptTest(SMSTests):
         super(StockAndReceiptTest, self).setUp()
         STOCK_AND_RECEIPT_SMS_HANDLER.set(self.domain, True, NAMESPACE_DOMAIN)
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_soh_and_receipt(self):
         handled = handle(self.users[0].get_verified_number(), 'pp 20.30')
         self.assertTrue(handled)

--- a/corehq/apps/hqadmin/tests/test_authenticate_as.py
+++ b/corehq/apps/hqadmin/tests/test_authenticate_as.py
@@ -1,4 +1,4 @@
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.core.urlresolvers import reverse
 
 from corehq.apps.domain.models import Domain
@@ -85,6 +85,7 @@ class AuthenticateAsIntegrationTest(TestCase):
         cls.domain.delete()
         super(AuthenticateAsIntegrationTest, cls).tearDownClass()
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_authenticate_as(self):
         self.client.login(username=self.username, password=self.password)
 
@@ -102,6 +103,7 @@ class AuthenticateAsIntegrationTest(TestCase):
             self.mobile_worker.get_django_user().id
         )
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_permisssions_for_authenticate_as(self):
         self.client.login(username=self.regular_name, password=self.password)
 

--- a/corehq/apps/importer/tests.py
+++ b/corehq/apps/importer/tests.py
@@ -293,6 +293,7 @@ class ImporterTest(TestCase):
         self.assertEqual(0, res['match_count'])
         self.assertEqual(0, len(get_case_ids_in_domain(self.domain)))
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testBasicChunking(self):
         config = self._config(self.default_headers)
         file = MockExcelFile(header_columns=self.default_headers, num_rows=5)

--- a/corehq/apps/locations/tests/test_location_fixtures.py
+++ b/corehq/apps/locations/tests/test_location_fixtures.py
@@ -5,7 +5,7 @@ from xml.etree import ElementTree
 from corehq.util.test_utils import flag_enabled
 
 from datetime import datetime, timedelta
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from casexml.apps.phone.models import SyncLog
 from casexml.apps.phone.tests.utils import create_restore_user
 from corehq.apps.domain.shortcuts import create_domain
@@ -256,6 +256,7 @@ class ForkedHierarchyLocationFixturesTest(LocationHierarchyPerTest, FixtureHasLo
         self.location_types = setup_location_types_with_structure(self.domain, self.location_type_structure)
         self.locations = setup_locations_with_structure(self.domain, self.location_structure)
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_forked_locations(self, *args):
         self.user.set_location(self.locations['Massachusetts'].couch_location)
         location_type = self.locations['Massachusetts'].location_type

--- a/corehq/apps/reports/tests/test_export_api.py
+++ b/corehq/apps/reports/tests/test_export_api.py
@@ -3,6 +3,7 @@ import time
 import uuid
 
 from django.core.urlresolvers import reverse
+from django.test import override_settings
 from django.test.client import Client
 
 from elasticsearch.exceptions import ConnectionError
@@ -116,6 +117,7 @@ class ExportTest(BaseAccountingTest, DomainSubscriptionMixin):
         self.es.indices.refresh(XFORM_INDEX_INFO.index)
         return form_pair
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testExportTokenMigration(self):
         c = Client()
         c.login(**{'username': 'test', 'password': 'foobar'})
@@ -133,6 +135,7 @@ class ExportTest(BaseAccountingTest, DomainSubscriptionMixin):
         prev_checkpoint = ExportSchema.get(prev_token)
         assert prev_checkpoint.timestamp
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testExportTokens(self):
         c = Client()
         c.login(**{'username': 'test', 'password': 'foobar'})
@@ -162,6 +165,7 @@ class ExportTest(BaseAccountingTest, DomainSubscriptionMixin):
         self.assertTrue(_content(resp) is not None)
         self.assertTrue("X-CommCareHQ-Export-Token" in resp)
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testExportFilter(self):
         c = Client()
         c.login(**{'username': 'test', 'password': 'foobar'})

--- a/corehq/apps/reports/tests/test_form_export.py
+++ b/corehq/apps/reports/tests/test_form_export.py
@@ -4,7 +4,7 @@ import datetime
 
 import mock
 from django.core.urlresolvers import reverse
-from django.test import TestCase, SimpleTestCase
+from django.test import TestCase, SimpleTestCase, override_settings
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.apps.export.models import FormExportInstance, TableConfiguration, ExportColumn, ScalarItem, PathNode
 from corehq.apps.reports.models import FormExportSchema
@@ -180,6 +180,7 @@ class FormExportTest(TestCase):
         f.name = 'form.xml'
         return self.client.post(self.url, {'xml_submission_file': f})
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_include_duplicates(self):
         self.post_it()
         self.post_it()
@@ -196,6 +197,7 @@ class FormExportTest(TestCase):
         self.assertEqual(data['Export']['headers'], ['Name'])
         self.assertEqual(len(data['Export']['rows']), 1)
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_exclude_unknown_users(self):
         self.post_it(form_id='good', user_id=self.couch_user._id)
         files = self.custom_export.get_export_files()

--- a/corehq/apps/reports/tests/test_supply_accessors.py
+++ b/corehq/apps/reports/tests/test_supply_accessors.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import datetime, timedelta
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from corehq.apps.commtrack.helpers import make_product
 from corehq.apps.commtrack.tests import get_single_balance_block
 from corehq.apps.hqcase.utils import submit_case_blocks
@@ -24,6 +24,7 @@ class TestSupplyAccessors(TestCase):
                                                               as_of=datetime.utcnow()))
 
     # @run_with_all_backends
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_get_ledger_values_for_case_as_of(self):
         case_id = uuid.uuid4().hex
         form_xml = get_simple_form_xml(uuid.uuid4().hex, case_id)

--- a/corehq/apps/userreports/tests/test_columns.py
+++ b/corehq/apps/userreports/tests/test_columns.py
@@ -1,7 +1,7 @@
 import uuid
 
 from sqlagg import SumWhen
-from django.test import SimpleTestCase, TestCase
+from django.test import SimpleTestCase, TestCase, override_settings
 
 from casexml.apps.case.util import post_case_blocks
 from corehq.apps.userreports import tasks
@@ -206,6 +206,7 @@ class TestExpandedColumn(TestCase):
         connection_manager.dispose_engine(UCR_ENGINE_ID)
         super(TestExpandedColumn, self).tearDown()
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_getting_distinct_values(self):
         data_source, column = self._build_report([
             'apple',
@@ -221,6 +222,7 @@ class TestExpandedColumn(TestCase):
         distinct_vals, too_many_values = _get_distinct_values(data_source.config, column)
         self.assertListEqual(distinct_vals, [])
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_too_large_expansion(self):
         vals = ['foo' + str(i) for i in range(DEFAULT_MAXIMUM_EXPANSION + 1)]
         data_source, column = self._build_report(vals)
@@ -228,6 +230,7 @@ class TestExpandedColumn(TestCase):
         self.assertTrue(too_many_values)
         self.assertEqual(len(distinct_vals), DEFAULT_MAXIMUM_EXPANSION)
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_allowed_expansion(self):
         num_columns = DEFAULT_MAXIMUM_EXPANSION + 1
         vals = ['foo' + str(i) for i in range(num_columns)]
@@ -241,6 +244,7 @@ class TestExpandedColumn(TestCase):
         self.assertFalse(too_many_values)
         self.assertEqual(len(distinct_vals), num_columns)
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_unbuilt_data_source(self):
         data_source, column = self._build_report(['apple'], build_data_source=False)
         distinct_vals, too_many_values = _get_distinct_values(data_source.config, column)
@@ -261,6 +265,7 @@ class TestExpandedColumn(TestCase):
         self.assertEqual(type(cols[0].view), SumWhen)
         self.assertEqual(cols[1].view.whens, {'negative': 1})
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_none_in_values(self):
         """
         Confirm that expanded columns work when one of the distinct values is None.

--- a/corehq/apps/userreports/tests/test_view.py
+++ b/corehq/apps/userreports/tests/test_view.py
@@ -4,7 +4,7 @@ import uuid
 from mock import patch
 from django.http import HttpRequest
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from casexml.apps.case.signals import case_post_save
 
 from corehq.apps.userreports import tasks
@@ -157,6 +157,7 @@ class ConfigurableReportViewTest(ConfigurableReportTestMixin, TestCase):
         super(ConfigurableReportViewTest, self).setUp()
         self._delete_everything()
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_export_table(self):
         """
         Test the output of ConfigurableReport.export_table()
@@ -174,12 +175,14 @@ class ConfigurableReportViewTest(ConfigurableReportTestMixin, TestCase):
         ]
         self.assertEqual(view.export_table, expected)
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_export_to_excel_size_under_limit(self):
         report, view = self._build_report_and_view()
 
         response = json.loads(view.export_size_check_response.content)
         self.assertEqual(response['export_allowed'], True)
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_export_to_excel_size_over_limit(self):
         report, view = self._build_report_and_view()
 

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_bugs.py
@@ -36,6 +36,7 @@ class CaseBugTest(TestCase, TestFileMixin):
         super(CaseBugTest, self).setUp()
         delete_all_cases()
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_conflicting_ids(self):
         """
         If a form and a case share an ID it's a conflict

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_multi_case_submits.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_multi_case_submits.py
@@ -15,6 +15,7 @@ class MultiCaseTest(TestCase):
         delete_all_xforms()
         delete_all_cases()
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testParallel(self):
         file_path = os.path.join(os.path.dirname(__file__), "data", "multicase", "parallel_cases.xml")
         with open(file_path, "rb") as f:
@@ -24,6 +25,7 @@ class MultiCaseTest(TestCase):
         self.assertEqual(4, len(cases))
         self._check_ids(form, cases)
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testMixed(self):
         file_path = os.path.join(os.path.dirname(__file__), "data", "multicase", "mixed_cases.xml")
         with open(file_path, "rb") as f:
@@ -32,6 +34,7 @@ class MultiCaseTest(TestCase):
         self.assertEqual(4, len(cases))
         self._check_ids(form, cases)
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testCasesInRepeats(self):
         file_path = os.path.join(os.path.dirname(__file__), "data", "multicase", "case_in_repeats.xml")
         with open(file_path, "rb") as f:

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_multimedia.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_multimedia.py
@@ -6,7 +6,7 @@ import hashlib
 from django.conf import settings
 from django.template import Template, Context
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 import lxml
 from django.core.files.uploadedfile import UploadedFile
 from mock import patch
@@ -259,6 +259,7 @@ class CaseMultimediaTest(BaseCaseMultimediaTest):
                 hashlib.md5(case.get_attachment(attach_name)).hexdigest()
             )
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testUpdateWithNoNewAttachment(self):
         _, case = self._doCreateCaseWithMultimedia()
         bulk_save = XFormInstance.get_db().bulk_save

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_out_of_order_processing.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_out_of_order_processing.py
@@ -13,6 +13,7 @@ class OutOfOrderCaseTest(TestCase):
         super(OutOfOrderCaseTest, self).setUp()
         delete_all_cases()
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testOutOfOrderSubmissions(self):
         dir = os.path.join(os.path.dirname(__file__), "data", "ordering")
         for fname in ('update_oo.xml', 'create_oo.xml'):

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_rebuild.py
@@ -1,6 +1,6 @@
 import uuid
 from couchdbkit.exceptions import ResourceNotFound
-from django.test import TestCase, SimpleTestCase
+from django.test import TestCase, SimpleTestCase, override_settings
 from casexml.apps.case import const
 from casexml.apps.case.cleanup import rebuild_case_from_forms
 from casexml.apps.case.exceptions import MissingServerDate
@@ -69,6 +69,7 @@ class CaseRebuildTest(TestCase):
         else:
             self.fail(msg)
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_couch_action_equality(self):
         case_id = _post_util(create=True)
         _post_util(case_id=case_id, p1='p1', p2='p2')
@@ -95,6 +96,7 @@ class CaseRebuildTest(TestCase):
         copy.updated_unknown_properties['pnew'] = ''
         self.assertTrue(copy != orig)
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_couch_soft_rebuild(self):
         user_id = 'test-basic-rebuild-user'
         now = datetime.utcnow()
@@ -125,6 +127,7 @@ class CaseRebuildTest(TestCase):
         self.assertEqual(case.p2, 'p2-1') # updated (back!)
         self.assertEqual(case.p3, 'p3-2') # new
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_couch_action_comparison(self):
         user_id = 'test-action-comparison-user'
         case_id = _post_util(create=True, property='a1 wins', user_id=user_id)
@@ -182,6 +185,7 @@ class CaseRebuildTest(TestCase):
     def test_rebuild_empty(self):
         self.assertEqual(None, rebuild_case_from_forms('anydomain', 'notarealid', RebuildWithReason(reason='test')))
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_couch_rebuild_deleted_case(self):
         # Note: Can't run this on SQL because if a case gets hard deleted then
         # there is no way to find out which forms created / updated it without
@@ -202,6 +206,7 @@ class CaseRebuildTest(TestCase):
         self.assertEqual(case.p2, 'p2')
         self.assertEqual(3, len(primary_actions(case)))  # create + update
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_couch_reconcile_actions(self):
         now = datetime.utcnow()
         # make sure we timestamp everything so they have the right order

--- a/corehq/ex-submodules/casexml/apps/case/tests/test_signals.py
+++ b/corehq/ex-submodules/casexml/apps/case/tests/test_signals.py
@@ -1,4 +1,4 @@
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from casexml.apps.case.mock import CaseFactory
 from casexml.apps.case.models import CommCareCase
 from casexml.apps.case.signals import cases_received
@@ -9,6 +9,7 @@ from couchforms.models import XFormInstance
 
 class TestCasesReceivedSignal(TestCase):
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_casedb_already_has_cases(self):
         casedb_cache = FormProcessorInterface().casedb_cache
         case = CaseFactory().create_case()

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_ota_restore.py
@@ -132,6 +132,7 @@ class OtaRestoreTest(TestCase, TestFileMixin):
         self.assertNotEqual(restore_payload, restore_config_cached.get_payload().as_string())
         self.assertNotEqual(restore_payload, restore_config_overwrite.get_payload().as_string())
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testUserRestoreWithCase(self):
         xml_data = self.get_xml('create_short')
         xml_data = xml_data.format(user_id=self.restore_user.user_id)
@@ -198,9 +199,11 @@ class OtaRestoreTest(TestCase, TestFileMixin):
             restore_payload
         )
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testSyncTokenWithItems(self):
         self._test_sync_token(items=True)
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testSyncTokenWithoutItems(self):
         self._test_sync_token(items=False)
 
@@ -282,6 +285,7 @@ class OtaRestoreTest(TestCase, TestFileMixin):
         check_xml_line_by_line(self, expected_sync_restore_payload,
                                sync_restore_payload)
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testRestoreAttributes(self):
         xml_data = self.get_xml('attributes')
         xml_data = xml_data.format(user_id=self.restore_user.user_id)

--- a/corehq/ex-submodules/couchforms/tests/test_dbaccessors.py
+++ b/corehq/ex-submodules/couchforms/tests/test_dbaccessors.py
@@ -1,5 +1,5 @@
 import datetime
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from corehq.form_processor.tests.utils import FormProcessorTestUtils
 from corehq.form_processor.utils import get_simple_wrapped_form, TestFormMetadata
@@ -58,16 +58,19 @@ class TestDBAccessors(TestCase):
         cls.xform_deleted.delete()
         super(TestDBAccessors, cls).tearDownClass()
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_get_form_ids_by_type_xforminstance(self):
         form_ids = get_form_ids_by_type(self.domain, 'XFormInstance')
         self.assertEqual(len(form_ids), len(self.xforms))
         self.assertEqual(set(form_ids), {form._id for form in self.xforms})
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_get_form_ids_by_type_xformerror(self):
         form_ids = get_form_ids_by_type(self.domain, 'XFormError')
         self.assertEqual(len(form_ids), len(self.xform_errors))
         self.assertEqual(set(form_ids), {form._id for form in self.xform_errors})
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_get_forms_by_type_xforminstance(self):
         forms = get_forms_by_type(self.domain, 'XFormInstance', limit=10)
         self.assertEqual(len(forms), len(self.xforms))
@@ -76,6 +79,7 @@ class TestDBAccessors(TestCase):
         for form in forms:
             self.assertIsInstance(form, XFormInstance)
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_get_forms_by_type_xformerror(self):
         forms = get_forms_by_type(self.domain, 'XFormError', limit=10)
         self.assertEqual(len(forms), len(self.xform_errors))
@@ -84,6 +88,7 @@ class TestDBAccessors(TestCase):
         for form in forms:
             self.assertIsInstance(form, XFormError)
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_get_deleted_form_ids_for_user(self):
         ids = get_deleted_form_ids_for_user(self.user_id2)
         self.assertEqual(len(ids), 1)
@@ -92,6 +97,7 @@ class TestDBAccessors(TestCase):
         ids = get_deleted_form_ids_for_user(self.user_id1)
         self.assertEqual(len(ids), 0)
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_get_form_ids_for_user(self):
         ids = get_form_ids_for_user(self.domain, self.user_id1)
         self.assertEqual(len(ids), 1)

--- a/corehq/ex-submodules/couchforms/tests/test_post.py
+++ b/corehq/ex-submodules/couchforms/tests/test_post.py
@@ -1,5 +1,5 @@
 import json
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.conf import settings
 import os
 from corehq.apps.tzmigration import phone_timezones_should_be_processed
@@ -59,6 +59,7 @@ class PostTest(TestCase, TestFileMixin):
         self.assertDictEqual(xform_json, expected)
 
     @run_pre_and_post_timezone_migration
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_cloudant_template(self):
         self._test('cloudant-template', tz_differs=True)
         FormProcessorTestUtils.delete_all_xforms()

--- a/corehq/form_processor/tests/test_sharding.py
+++ b/corehq/form_processor/tests/test_sharding.py
@@ -31,6 +31,7 @@ class ShardingTests(TestCase):
         FormProcessorTestUtils.delete_all_sql_cases(DOMAIN)
         super(ShardingTests, self).tearDown()
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_objects_only_in_one_db(self):
         case_id = uuid4().hex
         form = create_form_for_test(DOMAIN, case_id=case_id)
@@ -49,6 +50,7 @@ class ShardingTests(TestCase):
         self.assertEqual(1, len(dbs_with_form))
         self.assertEqual(1, len(dbs_with_case))
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_objects_distributed_to_all_dbs(self):
         """
         Rudimentary test to ensure that not all cases / forms get saved to the same DB.

--- a/custom/ewsghana/tests/test_input_stock_view.py
+++ b/custom/ewsghana/tests/test_input_stock_view.py
@@ -1,6 +1,6 @@
 from decimal import Decimal
 from django.core.urlresolvers import reverse
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from casexml.apps.stock.models import StockTransaction, StockReport
 from corehq.apps.accounting.models import SoftwarePlanEdition
 from corehq.apps.accounting.tests.utils import DomainSubscriptionMixin
@@ -209,6 +209,7 @@ class TestInputStockView(TestCase, DomainSubscriptionMixin):
         response = self.client.get(view_url, follow=True)
         self.assertEqual(response.status_code, 200)
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_web_user_report_submission(self):
         self.client.login(username=self.username5, password=self.password5)
         view_url = reverse('input_stock', kwargs={'domain': TEST_DOMAIN, 'site_code': 'tsactive'})
@@ -270,6 +271,7 @@ class TestInputStockView(TestCase, DomainSubscriptionMixin):
 
         self.assertEqual(reports.count(), 2)
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_incomplete_report_submission(self):
         self.client.login(username=self.username5, password=self.password5)
         view_url = reverse('input_stock', kwargs={'domain': TEST_DOMAIN, 'site_code': 'tsactive'})

--- a/custom/ewsghana/tests/test_reminders.py
+++ b/custom/ewsghana/tests/test_reminders.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 from decimal import Decimal
 
 from casexml.apps.stock.models import StockTransaction, StockReport
+from django.test import override_settings
 
 from corehq.apps.commtrack.models import StockState
 from corehq.apps.locations.tests.util import make_loc
@@ -309,6 +310,7 @@ class TestReminders(EWSTestCase):
         smses = SMS.objects.all()
         self.assertEqual(smses.count(), 2)
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_visit_reminder(self):
         reminder_to_visit_website()
         smses = SMS.objects.all()

--- a/custom/ilsgateway/tests/handlers/translation.py
+++ b/custom/ilsgateway/tests/handlers/translation.py
@@ -1,3 +1,5 @@
+from django.test import override_settings
+
 from corehq.apps.commtrack.models import StockState
 from corehq.util.translation import localize
 from custom.ilsgateway.tanzania.reminders import LANGUAGE_CONFIRM, SOH_CONFIRM
@@ -9,6 +11,7 @@ class TranslationTest(ILSTestScript):
     def setUp(self):
         super(TranslationTest, self).setUp()
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_soh(self):
         with localize('sw'):
             response1 = unicode(SOH_CONFIRM)

--- a/custom/ilsgateway/tests/test_reminders2.py
+++ b/custom/ilsgateway/tests/test_reminders2.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 
+from django.test import override_settings
+
 from corehq.apps.commtrack.models import CommtrackConfig, ConsumptionConfig
 from corehq.apps.consumption.shortcuts import set_default_consumption_for_supply_point
 from corehq.apps.sms.tests import setup_default_sms_test_backend, delete_domain_phone_numbers
@@ -269,6 +271,7 @@ class TestStockOut(RemindersTest):
         set_default_consumption_for_supply_point(TEST_DOMAIN, cls.dp.get_id, cls.facility_sp_id, 100)
         set_default_consumption_for_supply_point(TEST_DOMAIN, cls.ip.get_id, cls.facility_sp_id, 100)
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_reminder(self):
         now = datetime.utcnow()
         self.assertEqual(0, len(list(StockoutReminder(TEST_DOMAIN, now).get_people())))

--- a/custom/uth/tests/uth_tests.py
+++ b/custom/uth/tests/uth_tests.py
@@ -1,5 +1,5 @@
 import uuid
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.util import post_case_blocks
 from corehq.apps.users.models import CommCareUser
@@ -118,6 +118,7 @@ class VscanTests(UTHTests):
 
         return packed_directory
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def testAttachments(self):
         self.assertEqual(len(CommCareCase.get(self.case_id).case_attachments), 0)
         scan_path = os.path.join(

--- a/testapps/test_pillowtop/tests/test_reindexer.py
+++ b/testapps/test_pillowtop/tests/test_reindexer.py
@@ -2,7 +2,7 @@ import uuid
 
 from django.conf import settings
 from django.core.management import call_command
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from elasticsearch.exceptions import ConnectionError
 
 from corehq.apps.case_search.models import CaseSearchConfig
@@ -44,6 +44,7 @@ class PillowtopReindexerTest(TestCase):
             ensure_index_deleted(index)
         super(PillowtopReindexerTest, cls).tearDownClass()
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=False)
     def test_domain_reindexer(self):
         delete_all_domains()
         ensure_index_deleted(DOMAIN_INDEX)


### PR DESCRIPTION
A lot of tests use Couch forms/cases and require `TESTS_SHOULD_USE_SQL_BACKEND==False`.

For some reason this issue is exposed when using django 1.8, so I'm fixing them here.
