### PR TITLE
Added link to set performance threshold for Project Performance Dashboard

### DIFF
--- a/corehq/apps/reports/standard/project_health.py
+++ b/corehq/apps/reports/standard/project_health.py
@@ -391,4 +391,5 @@ class ProjectHealthDashboard(ProjectReport):
             'this_month': six_months_reports[-1],
             'last_month': six_months_reports[-2],
             'threshold': performance_threshold,
+            'domain': self.domain,
         }

--- a/corehq/apps/reports/templates/reports/project_health/project_health_dashboard.html
+++ b/corehq/apps/reports/templates/reports/project_health/project_health_dashboard.html
@@ -153,7 +153,15 @@
 {% block reportcontent %}
     {% include "reports/project_health/partials/last_month_stats.html" %}
     <div class="col-md-6">
-        <h2>{% trans "Active Users Trend" %} <small><a href="{% url 'domain_internal_settings' domain %}">{% trans "Set Performance Threshold" %}</a></small></h2>
+        <h2>{% trans "Active Users Trend" %}
+            {% if request.user.is_superuser %}
+                <small>
+                    <a href="{% url 'domain_internal_settings' domain %}">
+                    {% trans "Set Performance Threshold" %}
+                    </a>
+                </small>
+            {% endif %}
+        </h2>
             <p class="lead">
                 {% trans "Proportion of users that are active (submitting at least one form) over time." %}
             </p>

--- a/corehq/apps/reports/templates/reports/project_health/project_health_dashboard.html
+++ b/corehq/apps/reports/templates/reports/project_health/project_health_dashboard.html
@@ -153,7 +153,7 @@
 {% block reportcontent %}
     {% include "reports/project_health/partials/last_month_stats.html" %}
     <div class="col-md-6">
-        <h2>{% trans "Active Users Trend" %}</h2>
+        <h2>{% trans "Active Users Trend" %} <small><a href="{% url 'domain_internal_settings' domain %}">{% trans "Set Performance Threshold" %}</a></small></h2>
             <p class="lead">
                 {% trans "Proportion of users that are active (submitting at least one form) over time." %}
             </p>


### PR DESCRIPTION
@esoergel @czue Per spec on [Google Doc](https://docs.google.com/spreadsheets/d/1hr5-u9Ni90yhumGJqvROeNvqqn0daIPRVLuzCiIbwb8/edit?ts=5760652c#gid=1814269798), I've added a link to the Project Information page, where performance threshold can be set
