### PR TITLE
Cast kafka topics to strings

### DIFF
--- a/corehq/ex-submodules/fluff/indicators.py
+++ b/corehq/ex-submodules/fluff/indicators.py
@@ -382,7 +382,7 @@ class IndicatorDocument(schema.Document):
             'doc_type': doc_type,
             'save_direct_to_sql': cls().save_direct_to_sql,
             'deleted_types': cls.deleted_types,
-            'kafka_topic': cls().kafka_topic,
+            'kafka_topic': str(cls().kafka_topic),
         })
 
     @classmethod


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?232438#1187007

`IndicatorDocuments` subclass `schema.Documents` for which all properties are
`StringProperties` which are automatically cast to unicode

@millerdev 
fyi @snopoke 
