### PR TITLE
make autopay more fault tolerant

### DIFF
--- a/corehq/apps/accounting/models.py
+++ b/corehq/apps/accounting/models.py
@@ -2951,7 +2951,7 @@ class StripePaymentMethod(PaymentMethod):
         return 'auto_pay_{billing_account_id}'.format(billing_account_id=billing_account.id)
 
     def create_charge(self, card, amount_in_dollars, description=None):
-        """ Charges a stripe card and returns a payment record """
+        """ Charges a stripe card and returns a transaction id """
         amount_in_cents = int((amount_in_dollars * Decimal('100')).quantize(Decimal(10)))
         transaction_record = stripe.Charge.create(
             card=card,
@@ -2960,7 +2960,7 @@ class StripePaymentMethod(PaymentMethod):
             currency=settings.DEFAULT_CURRENCY,
             description=description if description else '',
         )
-        return PaymentRecord.create_record(self, transaction_record.id, amount_in_dollars)
+        return transaction_record.id
 
 
 class PaymentRecord(models.Model):

--- a/corehq/apps/accounting/payment_handlers.py
+++ b/corehq/apps/accounting/payment_handlers.py
@@ -415,7 +415,10 @@ class AutoPayInvoicePaymentHandler(object):
         """ Pays the full balance of all autopayable invoices on date_due """
         autopayable_invoices = Invoice.autopayable_invoices(date_due)
         for invoice in autopayable_invoices:
-            self._pay_invoice(invoice)
+            try:
+                self._pay_invoice(invoice)
+            except Exception as e:
+                log_accounting_error("Error autopaying invoice %d: %s" % (invoice.id, e.message))
 
     def _pay_invoice(self, invoice):
         log_accounting_info("[Autopay] Autopaying invoice {}".format(invoice.id))

--- a/corehq/apps/accounting/payment_handlers.py
+++ b/corehq/apps/accounting/payment_handlers.py
@@ -415,38 +415,39 @@ class AutoPayInvoicePaymentHandler(object):
         """ Pays the full balance of all autopayable invoices on date_due """
         autopayable_invoices = Invoice.autopayable_invoices(date_due)
         for invoice in autopayable_invoices:
-            log_accounting_info("[Autopay] Autopaying invoice {}".format(invoice.id))
-            amount = invoice.balance.quantize(Decimal(10) ** -2)
-            if not amount:
-                continue
+            self._pay_invoice(invoice)
 
-            auto_payer = invoice.subscription.account.auto_pay_user
-            payment_method = StripePaymentMethod.objects.get(web_user=auto_payer)
-            autopay_card = payment_method.get_autopay_card(invoice.subscription.account)
-            if autopay_card is None:
-                continue
+    def _pay_invoice(self, invoice):
+        log_accounting_info("[Autopay] Autopaying invoice {}".format(invoice.id))
+        amount = invoice.balance.quantize(Decimal(10) ** -2)
+        if not amount:
+            return
 
-            try:
-                with transaction.atomic():
-                    payment_record = PaymentRecord.create_record(payment_method, 'temp_transaction_id', amount)
-                    invoice.pay_invoice(payment_record)
-                    invoice.subscription.account.last_payment_method = LastPayment.CC_AUTO
-                    invoice.account.save()
-                    transaction_id = payment_method.create_charge(
-                        autopay_card,
-                        amount_in_dollars=amount,
-                        description='Auto-payment for Invoice %s' % invoice.invoice_number,
-                    )
-            except stripe.error.CardError:
-                self._handle_card_declined(invoice, payment_method)
-                continue
-            except payment_method.STRIPE_GENERIC_ERROR as e:
-                self._handle_card_errors(invoice, e)
-                continue
-            else:
-                payment_record.transaction_id = transaction_id
-                payment_record.save()
-                self._send_payment_receipt(invoice, payment_record)
+        auto_payer = invoice.subscription.account.auto_pay_user
+        payment_method = StripePaymentMethod.objects.get(web_user=auto_payer)
+        autopay_card = payment_method.get_autopay_card(invoice.subscription.account)
+        if autopay_card is None:
+            return
+
+        try:
+            with transaction.atomic():
+                payment_record = PaymentRecord.create_record(payment_method, 'temp_transaction_id', amount)
+                invoice.pay_invoice(payment_record)
+                invoice.subscription.account.last_payment_method = LastPayment.CC_AUTO
+                invoice.account.save()
+                transaction_id = payment_method.create_charge(
+                    autopay_card,
+                    amount_in_dollars=amount,
+                    description='Auto-payment for Invoice %s' % invoice.invoice_number,
+                )
+        except stripe.error.CardError:
+            self._handle_card_declined(invoice, payment_method)
+        except payment_method.STRIPE_GENERIC_ERROR as e:
+            self._handle_card_errors(invoice, e)
+        else:
+            payment_record.transaction_id = transaction_id
+            payment_record.save()
+            self._send_payment_receipt(invoice, payment_record)
 
     def _send_payment_receipt(self, invoice, payment_record):
         from corehq.apps.accounting.tasks import send_purchase_receipt

--- a/corehq/apps/accounting/tests/test_autopay.py
+++ b/corehq/apps/accounting/tests/test_autopay.py
@@ -112,8 +112,7 @@ class TestBillingAutoPay(BaseInvoiceTestCase):
         self._create_autopay_method(fake_customer)
 
         self.original_outbox_length = len(mail.outbox)
-        with self.assertRaises(Exception):
-            self._run_autopay()
+        self._run_autopay()
         self.assertFalse(fake_create.called)
         self._assert_no_side_effects()
 
@@ -124,8 +123,7 @@ class TestBillingAutoPay(BaseInvoiceTestCase):
         self._create_autopay_method(fake_customer)
 
         self.original_outbox_length = len(mail.outbox)
-        with self.assertRaises(Exception):
-            self._run_autopay()
+        self._run_autopay()
         self._assert_no_side_effects()
 
     def _run_autopay(self):

--- a/corehq/apps/accounting/tests/test_autopay.py
+++ b/corehq/apps/accounting/tests/test_autopay.py
@@ -1,6 +1,6 @@
 import mock
 
-from stripe import Charge
+from stripe import Charge, StripeObject
 
 from django.core import mail
 
@@ -85,6 +85,7 @@ class TestBillingAutoPay(BaseInvoiceTestCase):
     @mock.patch.object(Charge, 'create')
     def test_pay_autopayable_invoices(self, fake_charge, fake_customer):
         self._create_autopay_method(fake_customer)
+        fake_charge.return_value = StripeObject(id='transaction_id')
 
         original_outbox_length = len(mail.outbox)
 

--- a/corehq/apps/accounting/tests/test_autopay.py
+++ b/corehq/apps/accounting/tests/test_autopay.py
@@ -102,3 +102,36 @@ class TestBillingAutoPay(BaseInvoiceTestCase):
                                                   customer_id=self.fake_stripe_customer.id)
         self.payment_method.set_autopay(self.fake_card, self.autopay_account, self.domain)
         self.payment_method.save()
+
+    @mock.patch.object(StripePaymentMethod, 'customer')
+    @mock.patch.object(Charge, 'create')
+    @mock.patch.object(PaymentRecord, 'create_record')
+    def test_when_create_record_fails_stripe_is_not_charged(self, fake_create_record, fake_create, fake_customer):
+        fake_create_record.side_effect = Exception
+        self._create_autopay_method(fake_customer)
+
+        self.original_outbox_length = len(mail.outbox)
+        with self.assertRaises(Exception):
+            self._run_autopay()
+        self.assertFalse(fake_create.called)
+        self._assert_no_side_effects()
+
+    @mock.patch.object(StripePaymentMethod, 'customer')
+    @mock.patch.object(Charge, 'create')
+    def test_when_stripe_fails_no_payment_record_exists(self, fake_create, fake_customer):
+        fake_create.side_effect = Exception
+        self._create_autopay_method(fake_customer)
+
+        self.original_outbox_length = len(mail.outbox)
+        with self.assertRaises(Exception):
+            self._run_autopay()
+        self._assert_no_side_effects()
+
+    def _run_autopay(self):
+        autopayable_invoice = Invoice.objects.filter(subscription=self.subscription)
+        date_due = autopayable_invoice.first().date_due
+        AutoPayInvoicePaymentHandler().pay_autopayable_invoices(date_due)
+
+    def _assert_no_side_effects(self):
+        self.assertEqual(PaymentRecord.objects.count(), 0)
+        self.assertEqual(len(mail.outbox), self.original_outbox_length)


### PR DESCRIPTION
To avoid a repeat of an issue like http://manage.dimagi.com/default.asp?222722 I've made the autopay workflow more fault tolerant (like in https://github.com/dimagi/commcare-hq/pull/11071)

Recommend 🐡 

@kaapstorm 
