### PR TITLE
Update link to deactivate user documentation

### DIFF
--- a/corehq/apps/users/templates/users/edit_commcare_user.html
+++ b/corehq/apps/users/templates/users/edit_commcare_user.html
@@ -271,7 +271,7 @@
                         <p>
                             {% blocktrans with couch_user.human_friendly_name as friendly_name %}
                             If you ever want to use {{ friendly_name }}'s data in the future, we suggest that you use the <strong>Deactivate User</strong> option
-                            <a href="{{ archive_url }}">here</a>.
+                                <a href="https://confluence.dimagi.com/display/commcarepublic/Create+and+Manage+CommCare+Mobile+Workers#CreateandManageCommCareMobileWorkers-D.Deactivate(Formerly%22Archive%22)andDeleteMobileWorkers" target="_blank">described here</a>.
                             {% endblocktrans %}
                         </p>
                         <p>


### PR DESCRIPTION
The `archive_url` link no longer existed

http://manage.dimagi.com/default.asp?232289#1187014

@millerdev 
FYI @phillipm 
