### PR TITLE
Kill `previous_parents`

### DIFF
--- a/corehq/apps/locations/forms.py
+++ b/corehq/apps/locations/forms.py
@@ -277,18 +277,14 @@ class LocationForm(forms.Form):
                 prop_name = k[len('prop:'):]
                 setattr(location, prop_name, v)
 
-        orig_parent_id = self.cleaned_data.get('orig_parent_id')
-        reparented = orig_parent_id is not None
-        if reparented:
-            # todo: this property isn't used. could be deleted if we aren't expecting
-            # to do anything more with the data
-            location.flag_post_move = True
-            location.previous_parents.append(orig_parent_id)
         if commit:
             location.save()
 
         if not is_new:
-            location_edited.send(sender='loc_mgmt', loc=location, moved=reparented)
+            orig_parent_id = self.cleaned_data.get('orig_parent_id')
+            reparented = orig_parent_id is not None
+            location_edited.send(sender='loc_mgmt', loc=location,
+                                 moved=reparented, previous_parent=orig_parent_id)
 
         return location
 

--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -524,7 +524,6 @@ class Location(SyncCouchToSQLMixin, CachedCouchDocumentMixin, Document):
     # a list of doc ids, referring to the parent location, then the
     # grand-parent, and so on up to the root location in the hierarchy
     lineage = StringListProperty()
-    previous_parents = StringListProperty()
 
     @classmethod
     def wrap(cls, data):

--- a/custom/ilsgateway/models.py
+++ b/custom/ilsgateway/models.py
@@ -543,7 +543,7 @@ def domain_pre_delete_receiver(domain, **kwargs):
 
 
 @receiver(location_edited)
-def location_edited_receiver(sender, loc, moved, **kwargs):
+def location_edited_receiver(sender, loc, moved, previous_parent, **kwargs):
     from custom.ilsgateway.utils import last_location_group
     config = ILSGatewayConfig.for_domain(loc.domain)
     if not config or not config.enabled:
@@ -558,7 +558,7 @@ def location_edited_receiver(sender, loc, moved, **kwargs):
             domain=loc.domain,
             type='parent_change',
             sql_location=loc.sql_location,
-            data={'previous_parent': loc.previous_parents[-1], 'current_parent': loc.parent_id}
+            data={'previous_parent': previous_parent, 'current_parent': loc.parent_id}
         )
 
     group = last_location_group(loc)


### PR DESCRIPTION
@czue
Doing some locations clean-up, gonna try PRing indepent changes where possible, definitely want to wait on tests.
This field wasn't duplicated on `SQLLocation`, and it turns out it's only used in one place - as a way to pass a parameter to some `custom/` code.
