### PR TITLE
set TESTS_SHOULD_USE_SQL_BACKEND = False in docker settings

### DIFF
--- a/docker/localsettings.py
+++ b/docker/localsettings.py
@@ -175,6 +175,7 @@ PHONE_TIMEZONES_SHOULD_BE_PROCESSED = True
 ENABLE_PRELOGIN_SITE = True
 
 TESTS_SHOULD_TRACK_CLEANLINESS = True
+TESTS_SHOULD_USE_SQL_BACKEND = False
 
 # touchforms must be running when this is false or not set
 # see also corehq.apps.sms.tests.util.TouchformsTestCase


### PR DESCRIPTION
for django 1.8 compatibility
- [ ] confirm that tests are fixed in https://github.com/dimagi/commcare-hq/pull/10639
