### PR TITLE
remove deprecation warning

### DIFF
--- a/corehq/apps/accounting/tests/test_autopay.py
+++ b/corehq/apps/accounting/tests/test_autopay.py
@@ -1,6 +1,7 @@
 import mock
 
-from stripe import Charge, StripeObject
+from stripe import Charge
+from stripe.resource import StripeObject
 
 from django.core import mail
 


### PR DESCRIPTION
```
corehq/apps/accounting/tests/test_autopay.py:3: DeprecationWarning: Attribute `StripeObject` is being moved out of the `stripe` module in version 2.0 of the Stripe bindings.  Please access it in the appropriate submodule instead
  from stripe import Charge, StripeObject
```

@kaapstorm 
