### PR TITLE
add an alternate flat locations fixture

### DIFF
--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -104,7 +104,7 @@ class HierarchicalLocationSerializer(object):
 
 
 class FlatLocationSerializer(object):
-    id = 'commtrack:locations_v2'
+    id = 'locations'
 
     def get_xml_nodes(self, restore_user, all_locations):
         if not toggles.FLAT_LOCATION_FIXTURE.enabled(restore_user.project.name):

--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -99,7 +99,7 @@ class HierarchicalLocationSerializer(object):
 class FlatLocationSerializer(object):
 
     def get_xml_nodes(self, fixture_id, restore_user, all_locations):
-        if not toggles.FLAT_LOCATION_FIXTURE.enabled(restore_user.project.name):
+        if not toggles.FLAT_LOCATION_FIXTURE.enabled(restore_user.domain):
             return []
 
         root_node = Element('fixture', {'id': fixture_id, 'user_id': restore_user.user_id})

--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -83,6 +83,9 @@ class LocationFixtureProvider(object):
 class HierarchicalLocationSerializer(object):
 
     def get_xml_nodes(self, fixture_id, restore_user, all_locations):
+        if not restore_user.project.uses_locations:
+            return []
+
         root_node = Element('fixture', {'id': fixture_id, 'user_id': restore_user.user_id})
         root_locations = all_locations.root_locations
 

--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -58,7 +58,9 @@ def should_sync_locations(last_sync, location_db, restore_user):
 
 
 class LocationFixtureProvider(object):
-    id = 'commtrack:locations'
+
+    def __init__(self, serializer):
+        self.serializer = serializer
 
     def __call__(self, restore_user, version, last_sync=None, app=None):
         """
@@ -79,6 +81,13 @@ class LocationFixtureProvider(object):
         if not should_sync_locations(last_sync, all_locations, restore_user):
             return []
 
+        return self.serializer.get_xml(restore_user, all_locations)
+
+
+class HierarchicalLocationSerializer(object):
+    id = 'commtrack:locations'
+
+    def get_xml(self, restore_user, all_locations):
         root_node = Element('fixture', {'id': self.id, 'user_id': restore_user.user_id})
         root_locations = all_locations.root_locations
 
@@ -87,7 +96,7 @@ class LocationFixtureProvider(object):
         return [root_node]
 
 
-location_fixture_generator = LocationFixtureProvider()
+location_fixture_generator = LocationFixtureProvider(HierarchicalLocationSerializer())
 
 
 def _all_locations(user):

--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -58,6 +58,7 @@ def should_sync_locations(last_sync, location_db, restore_user):
 
 
 class LocationFixtureProvider(object):
+    id = 'commtrack:locations'
 
     def __init__(self, serializers=None):
         if serializers is None:

--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -206,6 +206,12 @@ def _get_metadata_node(location):
 
 def _location_to_fixture(location_db, location, type):
     root = Element(type.code, {'id': location.location_id})
+    _fill_in_location_element(root, location)
+    _append_children(root, location_db, location_db.by_parent[location.location_id])
+    return root
+
+
+def _fill_in_location_element(xml_root, location):
     fixture_fields = [
         'name',
         'site_code',
@@ -219,8 +225,6 @@ def _location_to_fixture(location_db, location, type):
         field_node = Element(field)
         val = getattr(location, field)
         field_node.text = unicode(val if val is not None else '')
-        root.append(field_node)
+        xml_root.append(field_node)
 
-    root.append(_get_metadata_node(location))
-    _append_children(root, location_db, location_db.by_parent[location.location_id])
-    return root
+    xml_root.append(_get_metadata_node(location))

--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -96,7 +96,33 @@ class HierarchicalLocationSerializer(object):
         return [root_node]
 
 
+class FlatLocationSerializer(object):
+    id = 'commtrack:locations_v2'
+
+    def get_xml(self, restore_user, all_locations):
+        root_node = Element('fixture', {'id': self.id, 'user_id': restore_user.user_id})
+
+        outer_node = Element('locations')
+        root_node.append(outer_node)
+        for location in sorted(all_locations.by_id.values(), key=lambda l: l.site_code):
+            attrs = {
+                'type': location.location_type.code,
+                'id': location.location_id,
+            }
+            tmp_location = location
+            while tmp_location.parent:
+                tmp_location = tmp_location.parent
+                attrs['{}_id'.format(tmp_location.location_type.code)] = tmp_location.location_id
+
+            location_node = Element('location', attrs)
+            _fill_in_location_element(location_node, location)
+            outer_node.append(location_node)
+
+        return [root_node]
+
+
 location_fixture_generator = LocationFixtureProvider(HierarchicalLocationSerializer())
+flat_location_fixture_generator = LocationFixtureProvider(FlatLocationSerializer())
 
 
 def _all_locations(user):

--- a/corehq/apps/locations/fixtures.py
+++ b/corehq/apps/locations/fixtures.py
@@ -73,12 +73,7 @@ class LocationFixtureProvider(object):
         a fixture with ALL locations for the domain.
         """
         assert isinstance(restore_user, OTARestoreUser)
-
-        if not restore_user.project.uses_locations:
-            return []
-
-        all_locations = _all_locations(restore_user)
-
+        all_locations = restore_user.get_locations_to_sync()
         if not should_sync_locations(last_sync, all_locations, restore_user):
             return []
 
@@ -130,7 +125,7 @@ flat_location_fixture_generator = LocationFixtureProvider(
 )
 
 
-def _all_locations(user):
+def get_all_locations_to_sync(user):
     if toggles.SYNC_ALL_LOCATIONS.enabled(user.domain):
         return LocationSet(SQLLocation.active_objects.filter(domain=user.domain))
     else:

--- a/corehq/apps/locations/tests/data/expand_from_root_flat.xml
+++ b/corehq/apps/locations/tests/data/expand_from_root_flat.xml
@@ -1,4 +1,4 @@
-<fixture id="commtrack:locations_v2" user_id="{user_id}">
+<fixture id="locations" user_id="{user_id}">
     <locations>
         <location county_id="{suffolk_id}" id="{boston_id}" state_id="{massachusetts_id}" type="city">
             <name>Boston</name>

--- a/corehq/apps/locations/tests/data/expand_from_root_flat.xml
+++ b/corehq/apps/locations/tests/data/expand_from_root_flat.xml
@@ -1,0 +1,124 @@
+<fixture id="commtrack:locations_v2" user_id="{user_id}">
+    <locations>
+        <location county_id="{suffolk_id}" id="{boston_id}" state_id="{massachusetts_id}" type="city">
+            <name>Boston</name>
+            <site_code>boston</site_code>
+            <external_id/>
+            <latitude/>
+            <longitude/>
+            <location_type>city</location_type>
+            <supply_point_id/>
+            <location_data/>
+        </location>
+        <location county_id="{new_york_city_id}" id="{brooklyn_id}" state_id="{new_york_id}" type="city">
+            <name>Brooklyn</name>
+            <site_code>brooklyn</site_code>
+            <external_id/>
+            <latitude/>
+            <longitude/>
+            <location_type>city</location_type>
+            <supply_point_id/>
+            <location_data/>
+        </location>
+        <location county_id="{middlesex_id}" id="{cambridge_id}" state_id="{massachusetts_id}" type="city">
+            <name>Cambridge</name>
+            <site_code>cambridge</site_code>
+            <external_id/>
+            <latitude/>
+            <longitude/>
+            <location_type>city</location_type>
+            <supply_point_id/>
+            <location_data/>
+        </location>
+        <location county_id="{new_york_city_id}" id="{manhattan_id}" state_id="{new_york_id}" type="city">
+            <name>Manhattan</name>
+            <site_code>manhattan</site_code>
+            <external_id/>
+            <latitude/>
+            <longitude/>
+            <location_type>city</location_type>
+            <supply_point_id/>
+            <location_data/>
+        </location>
+        <location id="{massachusetts_id}" type="state">
+            <name>Massachusetts</name>
+            <site_code>massachusetts</site_code>
+            <external_id/>
+            <latitude/>
+            <longitude/>
+            <location_type>state</location_type>
+            <supply_point_id/>
+            <location_data/>
+        </location>
+        <location id="{middlesex_id}" state_id="{massachusetts_id}" type="county">
+            <name>Middlesex</name>
+            <site_code>middlesex</site_code>
+            <external_id/>
+            <latitude/>
+            <longitude/>
+            <location_type>county</location_type>
+            <supply_point_id/>
+            <location_data/>
+        </location>
+        <location id="{new_york_id}" type="state">
+            <name>New York</name>
+            <site_code>new_york</site_code>
+            <external_id/>
+            <latitude/>
+            <longitude/>
+            <location_type>state</location_type>
+            <supply_point_id/>
+            <location_data/>
+        </location>
+        <location id="{new_york_city_id}" state_id="{new_york_id}" type="county">
+            <name>New York City</name>
+            <site_code>new_york_city</site_code>
+            <external_id/>
+            <latitude/>
+            <longitude/>
+            <location_type>county</location_type>
+            <supply_point_id/>
+            <location_data/>
+        </location>
+        <location county_id="{new_york_city_id}" id="{queens_id}" state_id="{new_york_id}" type="city">
+            <name>Queens</name>
+            <site_code>queens</site_code>
+            <external_id/>
+            <latitude/>
+            <longitude/>
+            <location_type>city</location_type>
+            <supply_point_id/>
+            <location_data/>
+        </location>
+        <location county_id="{suffolk_id}" id="{revere_id}" state_id="{massachusetts_id}" type="city">
+            <name>Revere</name>
+            <site_code>revere</site_code>
+            <external_id/>
+            <latitude/>
+            <longitude/>
+            <location_type>city</location_type>
+            <supply_point_id/>
+            <location_data/>
+        </location>
+        <location county_id="{middlesex_id}" id="{somerville_id}" state_id="{massachusetts_id}" type="city">
+            <name>Somerville</name>
+            <site_code>somerville</site_code>
+            <external_id/>
+            <latitude/>
+            <longitude/>
+            <location_type>city</location_type>
+            <supply_point_id/>
+            <location_data/>
+        </location>
+        <location id="{suffolk_id}" state_id="{massachusetts_id}" type="county">
+            <name>Suffolk</name>
+            <site_code>suffolk</site_code>
+            <external_id/>
+            <latitude/>
+            <longitude/>
+            <location_type>county</location_type>
+            <supply_point_id/>
+            <location_data/>
+        </location>
+    </locations>
+</fixture>

--- a/corehq/apps/locations/tests/test_location_fixtures.py
+++ b/corehq/apps/locations/tests/test_location_fixtures.py
@@ -25,7 +25,7 @@ from .util import (
     LocationTypeStructure,
 )
 from ..fixtures import _location_to_fixture, LocationSet, should_sync_locations, location_fixture_generator, \
-    flat_location_fixture_generator
+    LocationFixtureProvider, FlatLocationSerializer, HierarchicalLocationSerializer
 from ..models import SQLLocation, LocationType, Location
 
 DEPENDENT_APPS = [
@@ -70,7 +70,9 @@ class FixtureHasLocationsMixin(TestXmlMixin):
             )
             for desired_location in desired_locations
         }  # eg: {"massachusetts_id" = self.locations["Massachusetts"].location_id}
-        generator = flat_location_fixture_generator if flat else location_fixture_generator
+
+        serializer = FlatLocationSerializer() if flat else HierarchicalLocationSerializer()
+        generator = LocationFixtureProvider(serializers=[serializer])
         fixture = ElementTree.tostring(generator(self.user, V2)[0])
         desired_fixture = self.get_xml(xml_name).format(
             user_id=self.user.user_id,

--- a/corehq/apps/locations/tests/test_location_fixtures.py
+++ b/corehq/apps/locations/tests/test_location_fixtures.py
@@ -25,7 +25,7 @@ from .util import (
     LocationTypeStructure,
 )
 from ..fixtures import _location_to_fixture, LocationSet, should_sync_locations, location_fixture_generator, \
-    LocationFixtureProvider, FlatLocationSerializer, HierarchicalLocationSerializer
+    flat_location_fixture_generator
 from ..models import SQLLocation, LocationType, Location
 
 DEPENDENT_APPS = [
@@ -71,8 +71,7 @@ class FixtureHasLocationsMixin(TestXmlMixin):
             for desired_location in desired_locations
         }  # eg: {"massachusetts_id" = self.locations["Massachusetts"].location_id}
 
-        serializer = FlatLocationSerializer() if flat else HierarchicalLocationSerializer()
-        generator = LocationFixtureProvider(serializers=[serializer])
+        generator = flat_location_fixture_generator if flat else location_fixture_generator
         fixture = ElementTree.tostring(generator(self.user, V2)[0])
         desired_fixture = self.get_xml(xml_name).format(
             user_id=self.user.user_id,

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -213,10 +213,11 @@ class OTARestoreCommCareUser(OTARestoreUser):
 
     @memoized
     def get_locations_to_sync(self):
-        if not self.project.uses_locations:
-            return []
-
+        from corehq.apps.locations.fixtures import LocationSet
         from corehq.apps.locations.fixtures import get_all_locations_to_sync
+
+        if not self.project.uses_locations:
+            return LocationSet()
         return get_all_locations_to_sync(self)
 
 

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -213,11 +213,7 @@ class OTARestoreCommCareUser(OTARestoreUser):
 
     @memoized
     def get_locations_to_sync(self):
-        from corehq.apps.locations.fixtures import LocationSet
         from corehq.apps.locations.fixtures import get_all_locations_to_sync
-
-        if not self.project.uses_locations:
-            return LocationSet()
         return get_all_locations_to_sync(self)
 
 

--- a/corehq/ex-submodules/casexml/apps/phone/models.py
+++ b/corehq/ex-submodules/casexml/apps/phone/models.py
@@ -105,6 +105,12 @@ class OTARestoreUser(object):
     def get_ucr_filter_value(self, ucr_filter, ui_filter):
         return ucr_filter.get_filter_value(self._couch_user, ui_filter)
 
+    def get_locations_to_sync(self):
+        """
+        Returns a LocationSet object contianing all locations that should sync
+        """
+        raise NotImplementedError()
+
 
 class OTARestoreWebUser(OTARestoreUser):
 
@@ -144,6 +150,11 @@ class OTARestoreWebUser(OTARestoreUser):
         from corehq.apps.fixtures.models import UserFixtureStatus
 
         return UserFixtureStatus.DEFAULT_LAST_MODIFIED
+
+    def get_locations_to_sync(self):
+        # todo: not yet implemented for web users
+        from corehq.apps.locations.fixtures import LocationSet
+        return LocationSet()
 
 
 class OTARestoreCommCareUser(OTARestoreUser):
@@ -199,6 +210,14 @@ class OTARestoreCommCareUser(OTARestoreUser):
         from corehq.apps.fixtures.models import UserFixtureType
 
         return self._couch_user.fixture_status(UserFixtureType.LOCATION)
+
+    @memoized
+    def get_locations_to_sync(self):
+        if not self.project.uses_locations:
+            return []
+
+        from corehq.apps.locations.fixtures import get_all_locations_to_sync
+        return get_all_locations_to_sync(self)
 
 
 class CaseState(LooselyEqualDocumentSchema, IndexHoldingMixIn):

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -341,6 +341,13 @@ SYNC_ALL_LOCATIONS = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
+FLAT_LOCATION_FIXTURE = StaticToggle(
+    'flat_location_fixture',
+    'Sync the location fixture in a flat format.',
+    TAG_PRODUCT_PATH,
+    [NAMESPACE_DOMAIN]
+)
+
 EXTENSION_CASES_SYNC_ENABLED = StaticToggle(
     'extension_sync',
     'Enable extension syncing',

--- a/settings.py
+++ b/settings.py
@@ -544,6 +544,7 @@ FIXTURE_GENERATORS = {
     # fixtures that must be sent along with the phones cases
     'case': [
         "corehq.apps.locations.fixtures.location_fixture_generator",
+        "corehq.apps.locations.fixtures.flat_location_fixture_generator",
     ]
 }
 


### PR DESCRIPTION
This adds a feature flag that adds a second locations fixture in a flat format (which is often easier to work with in apps). 

The format might change a bit, but want to iterate on this with kriti for UATBC.

``` xml
<fixture id="commtrack:locations_v2" user_id="d7c3c4246b1126d6506522d4feb235df">
    <locations>
      <location id="dae90df587e610adb7baedf1d5038abf" state_id="dae90df587e610adb7baedf1d5039270" type="city">
        <name>Cape Town</name>
        <site_code>cape_town</site_code>
        <external_id/>
        <latitude/>
        <longitude/>
        <location_type>City</location_type>
        <supply_point_id>23b435953e894b8dbfc5ad0e03f0b81d</supply_point_id>
        <location_data/>
      </location>
      <location city_id="dae90df587e610adb7baedf1d5038abf" id="dae90df587e610adb7baedf1d503885a" state_id="dae90df587e610adb7baedf1d5039270" type="neighborhood">
        <name>Vredehoek</name>
        <site_code>vredehoek</site_code>
        <external_id/>
        <latitude>-33.9411000000</latitude>
        <longitude>18.4232000000</longitude>
        <location_type>Neighborhood</location_type>
        <supply_point_id>ad9dbae5bbd24a12b1c352e0b625ef03</supply_point_id>
        <location_data/>
      </location>
      <location id="dae90df587e610adb7baedf1d5039270" type="state">
        <name>Western Cape</name>
        <site_code>western_cape</site_code>
        <external_id/>
        <latitude/>
        <longitude/>
        <location_type>State</location_type>
        <supply_point_id>896373cca62c454f8d9fa41a544e7e6a</supply_point_id>
        <location_data/>
      </location>
    </locations>
  </fixture>
```

@esoergel @sheelio and @proteusvacuum probably interested. can review either way. tried to break up by :fish: but took a couple small detours.
