### PR TITLE
Offer boolean operators that return allowed data types

### DIFF
--- a/corehq/apps/userreports/README.md
+++ b/corehq/apps/userreports/README.md
@@ -503,6 +503,7 @@ The from_date_expression and to_date_expression can be any valid expressions, or
 This returns 25 (1 + 20 - 2 + 6).
 
 `statement` can be any statement that returns a valid number. All python math [operators](https://en.wikibooks.org/wiki/Python_Programming/Basic_Math#Mathematical_Operators) except power operator are available for use.
+Boolean operators `and` and `or` are also available to be used as ternary and coalesce operators, e.g.  `"statement": "a or b"` will return `b` if `a` is zero or null, otherwise `a`; `"statement": "a and b or c"` will return `c` if `a` **or `b`** are zero or null, otherwise `b`.
 
 `context_variables` is a dictionary of Expressions where keys are names of variables used in the `statement` and values are expressions to generate those variables.
 Variables can be any valid numbers (Python datatypes `int`, `float` and `long` are considered valid numbers.) or also expressions that return numbers. In addition to numbers the following types are supported:

--- a/corehq/apps/userreports/expressions/utils.py
+++ b/corehq/apps/userreports/expressions/utils.py
@@ -1,4 +1,5 @@
 import copy
+import operator as op
 import ast
 from datetime import date, datetime, timedelta
 
@@ -17,7 +18,11 @@ def safe_range(start, *args):
 
 
 SAFE_OPERATORS = copy.copy(DEFAULT_OPERATORS)
-SAFE_OPERATORS[ast.Pow] = safe_pow_fn  # don't allow power operations
+SAFE_OPERATORS.update({
+    ast.Pow: safe_pow_fn,  # don't allow power operations
+    ast.Or: op.or_,  # Allows coalesce
+    ast.And: op.and_,  # Can't have "or" without "and". Allows ternary
+})
 
 FUNCTIONS = DEFAULT_FUNCTIONS
 FUNCTIONS.update({


### PR DESCRIPTION
The changes to README.md explain this PR pretty well.

This is not a requirement for my current UCR work, but it is a nice-to-have. I'd like to use it for something like this,

``` json
  {
    "display_name": "Selected Date", 
    "datatype": "date", 
    "expression": {
      "datatype": "date", 
      "type": "evaluator", 
      "statement": "screening_date or adoption_date", 
      "context_variables": {
        "screening_date": {
          "datatype": "date", 
          "type": "property_path", 
          "property_path": [
            "form", 
            "date"
          ]
        }, 
        "adoption_date": {
          "datatype": "date", 
          "type": "property_path", 
          "property_path": [
            "form", 
            "selected_date"
          ]
        }
      }
    }, 
    "is_primary_key": false, 
    "transform": {}, 
    "is_nullable": true, 
    "type": "expression", 
    "column_id": "selected_date"
  }, 
```

where one form has a date value named `date` and the other has named it `selected_date`.

Alternatively, I could just edit one of the forms and rename the question to match the other form, but I thought this might be a useful addition.

@czue cc @nickpell 
