### PR TITLE
Cast ValuesListQuerySet to list

### DIFF
--- a/corehq/apps/reports/commtrack/util.py
+++ b/corehq/apps/reports/commtrack/util.py
@@ -110,6 +110,7 @@ def get_product_id_name_mapping(domain):
 
 
 def get_product_ids_for_program(domain, program_id):
-    return SQLProduct.objects.filter(
+    qs = SQLProduct.objects.filter(
         domain=domain, program_id=program_id
     ).values_list('product_id', flat=True)
+    return list(qs)


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?232778
@dannyroberts 

The only other place in the code using this function are the data sources in https://github.com/dimagi/commcare-hq/blob/b899d07de443cd0b49298f6be95cc0e7d713f3fe/corehq/apps/reports/commtrack/data_sources.py.  All of those looked to me like they treated the return value just as a list.  But if something does try to treat the return value as a queryset it would fail hard.

@czue fyi
