### PR TITLE
Fix care-bihar restore

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -885,7 +885,7 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, EulaMi
             COMMCARE_USER_TYPE_DEMO
         )
 
-        session_data = copy.deepcopy(dict(self.user_data))
+        session_data = self.to_json().get('user_data')
 
         if self.is_commcare_user() and self.is_demo_user:
             session_data.update({


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?232769

A project somehow has an array value for user_data, and `dict()` only
does a shallow conversion, leaving the value as a jsonobject
`JsonArray`.  This change uses the `to_json()` method to more reliably
convert to basic python types, while ignoring the question of how/why
that project has complex types in the `user_data` dict in the first
place.

@czue
