### PR TITLE
Give each report builder report its own data source

### DIFF
--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -51,7 +51,6 @@ from corehq.apps.userreports.ui.fields import JsonField
 from dimagi.utils.decorators.memoized import memoized
 
 
-
 class FilterField(JsonField):
     """
     A form field with a little bit of validation for report builder report
@@ -388,19 +387,6 @@ class DataSourceBuilder(object):
         if self.source_type == 'case':
             return u"{} (v{})".format(self.source_id, self.app.version)
 
-    def get_existing_match(self):
-        return DataSourceConfiguration.view(
-            'userreports/data_sources_by_build_info',
-            key=[
-                self.domain,
-                self.source_doc_type,
-                self.source_id,
-                self.app._id,
-                self.app.version
-            ],
-            include_docs=True,
-            reduce=False
-        ).one()
 
 
 def _legend(title, subtext):
@@ -651,13 +637,10 @@ class ConfigureNewReportBase(forms.Form):
             crispy.Hidden('filters', None, data_bind="value: filtersList.serializedProperties")
         )
 
-    def _build_data_source(self):
-        data_source_config = DataSourceConfiguration(
-            domain=self.domain,
+    def _get_data_source_configuration_kwargs(self):
+        return dict(
             display_name=self.ds_builder.data_source_name,
             referenced_doc_type=self.ds_builder.source_doc_type,
-            # The uuid gets truncated, so it's not really universally unique.
-            table_id=_clean_table_name(self.domain, str(uuid.uuid4().hex)),
             configured_filter=self.ds_builder.filter,
             configured_indicators=self.ds_builder.indicators(self._number_columns),
             meta=DataSourceMeta(build=DataSourceBuildInformation(
@@ -666,42 +649,34 @@ class ConfigureNewReportBase(forms.Form):
                 app_version=self.app.version,
             ))
         )
+
+    def _build_data_source(self):
+        data_source_config = DataSourceConfiguration(
+            domain=self.domain,
+            table_id=_clean_table_name(self.domain, str(uuid.uuid4().hex)),
+            **self._get_data_source_configuration_kwargs()
+        )
         data_source_config.validate()
         data_source_config.save()
         tasks.rebuild_indicators.delay(data_source_config._id)
         return data_source_config._id
 
     def update_report(self):
-        matching_data_source = self.ds_builder.get_existing_match()
-        if matching_data_source:
-            reactivated = False
-            if matching_data_source._id != self.existing_report.config_id:
 
-                # If no one else is using the current data source, delete it.
-                data_source = DataSourceConfiguration.get(self.existing_report.config_id)
-                if data_source.get_report_count() <= 1:
-                    data_source.deactivate()
-
-                self.existing_report.config_id = matching_data_source._id
-            elif matching_data_source.is_deactivated:
-                matching_data_source.is_deactivated = False
-                reactivated = True
-            changed = False
-            indicators = self.ds_builder.indicators(self._number_columns)
-            if matching_data_source.configured_indicators != indicators:
-                matching_data_source.configured_indicators = indicators
-                changed = True
-            if changed or reactivated:
-                matching_data_source.save()
-                tasks.rebuild_indicators.delay(matching_data_source._id)
-        else:
-            # Delete the old one if no other reports use it
-            old_data_source = DataSourceConfiguration.get(self.existing_report.config_id)
-            if old_data_source.get_report_count() <= 1:
-                old_data_source.deactivate()
-
+        data_source = DataSourceConfiguration.get(self.existing_report.config_id)
+        if data_source.get_report_count() > 1:
+            # If another report is pointing at this data source, create a new
+            # data source for this report so that we can change the indicators
+            # without worrying about breaking another report.
             data_source_config_id = self._build_data_source()
             self.existing_report.config_id = data_source_config_id
+        else:
+            indicators = self.ds_builder.indicators(self._number_columns)
+            if data_source.configured_indicators != indicators:
+                for property_name, value in self._get_data_source_configuration_kwargs().iteritems():
+                    setattr(data_source, property_name, value)
+                data_source.save()
+                tasks.rebuild_indicators.delay(data_source._id)
 
         self.existing_report.aggregation_columns = self._report_aggregation_cols
         self.existing_report.columns = self._report_columns
@@ -715,24 +690,7 @@ class ConfigureNewReportBase(forms.Form):
         """
         Creates data source and report config.
         """
-        matching_data_source = self.ds_builder.get_existing_match()
-        if matching_data_source:
-            data_source_config_id = matching_data_source._id
-            reactivated = False
-            if matching_data_source.is_deactivated:
-                matching_data_source.is_deactivated = False
-                reactivated = True
-            changed = False
-            indicators = self.ds_builder.indicators(self._number_columns)
-            if matching_data_source.configured_indicators != indicators:
-                matching_data_source.configured_indicators = indicators
-                changed = True
-            if changed or reactivated:
-                matching_data_source.save()
-                tasks.rebuild_indicators.delay(matching_data_source._id)
-        else:
-            data_source_config_id = self._build_data_source()
-
+        data_source_config_id = self._build_data_source()
         report = ReportConfiguration(
             domain=self.domain,
             config_id=data_source_config_id,

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -653,6 +653,7 @@ class ConfigureNewReportBase(forms.Form):
     def _build_data_source(self):
         data_source_config = DataSourceConfiguration(
             domain=self.domain,
+            # The uuid gets truncated, so it's not really universally unique.
             table_id=_clean_table_name(self.domain, str(uuid.uuid4().hex)),
             **self._get_data_source_configuration_kwargs()
         )

--- a/corehq/apps/userreports/tests/test_report_builder.py
+++ b/corehq/apps/userreports/tests/test_report_builder.py
@@ -5,7 +5,7 @@ from corehq.apps.app_manager.models import Application, Module
 from corehq.apps.userreports.dbaccessors import delete_all_report_configs
 from corehq.apps.userreports.models import DataSourceConfiguration, \
     ReportConfiguration
-from corehq.apps.userreports.reports.builder.forms import ConfigureListReportForm
+from corehq.apps.userreports.reports.builder.forms import ConfigureListReportForm, ConfigureTableReportForm
 
 
 def read(rel_path):
@@ -67,6 +67,54 @@ class ReportBuilderTest(TestCase):
         report_two = builder_form.create_report()
 
         self.assertNotEqual(report_one.config_id, report_two.config_id)
+
+    def test_updating_report_data_source(self):
+        """
+        Test that changing the app or number column for a report results in an update to the data source next time the
+        report is saved.
+        """
+
+        # Make report
+        builder_form = ConfigureTableReportForm(
+            "Test Report",
+            self.app._id,
+            "case",
+            "some_case_type",
+            existing_report=None,
+            data={
+                'group_by': 'closed',
+                'filters': '[]',
+                'columns': '[{"property": "closed", "display_text": "closed", "calculation": "Count per Choice"}]',
+            }
+        )
+        self.assertTrue(builder_form.is_valid())
+        report = builder_form.create_report()
+
+        self.assertEqual(report.config.configured_indicators[0]['datatype'], "string")
+
+        # Make an edit to the first report builder report
+        builder_form = ConfigureTableReportForm(
+            "Test Report",
+            self.app._id,
+            "case",
+            "some_case_type",
+            existing_report=report,
+            data={
+                'group_by': 'closed',
+                'filters': '[]',
+                # Note that a "Sum" calculation on the closed case property isn't very sensical, but doing it so that
+                # I can have a numeric calculation without having to create real case properties for this case type.
+                'columns': '[{"property": "closed", "display_text": "closed", "calculation": "Sum"}]',
+            }
+        )
+        self.assertTrue(builder_form.is_valid())
+        builder_form.update_report()
+
+        # reload report data source, because report.config is memoized
+        data_source = DataSourceConfiguration.get(report.config._id)
+        # The closed property indicator should now be decimal type because the user indicated that it was numeric by
+        # giving the column the "Sum" aggregation.
+        self.assertEqual(data_source.configured_indicators[0]['datatype'], "decimal")
 
     def test_updating_report_that_shares_data_source(self):
         """

--- a/corehq/apps/userreports/tests/test_report_builder.py
+++ b/corehq/apps/userreports/tests/test_report_builder.py
@@ -70,8 +70,8 @@ class ReportBuilderTest(TestCase):
 
     def test_updating_report_data_source(self):
         """
-        Test that changing the app or number column for a report results in an update to the data source next time the
-        report is saved.
+        Test that changing the app or number column for a report results in an update to the data source next time
+        the report is saved.
         """
 
         # Make report
@@ -102,8 +102,9 @@ class ReportBuilderTest(TestCase):
             data={
                 'group_by': 'closed',
                 'filters': '[]',
-                # Note that a "Sum" calculation on the closed case property isn't very sensical, but doing it so that
-                # I can have a numeric calculation without having to create real case properties for this case type.
+                # Note that a "Sum" calculation on the closed case property isn't very sensical, but doing it so
+                # that I can have a numeric calculation without having to create real case properties for this case
+                #  type.
                 'columns': '[{"property": "closed", "display_text": "closed", "calculation": "Sum"}]',
             }
         )
@@ -112,8 +113,8 @@ class ReportBuilderTest(TestCase):
 
         # reload report data source, because report.config is memoized
         data_source = DataSourceConfiguration.get(report.config._id)
-        # The closed property indicator should now be decimal type because the user indicated that it was numeric by
-        # giving the column the "Sum" aggregation.
+        # The closed property indicator should now be decimal type because the user indicated that it was numeric
+        # by giving the column the "Sum" aggregation.
         self.assertEqual(data_source.configured_indicators[0]['datatype'], "decimal")
 
     def test_updating_report_that_shares_data_source(self):

--- a/corehq/apps/userreports/tests/test_report_builder.py
+++ b/corehq/apps/userreports/tests/test_report_builder.py
@@ -3,7 +3,8 @@ from django.test import TestCase
 from corehq.apps.app_manager.const import APP_V2
 from corehq.apps.app_manager.models import Application, Module
 from corehq.apps.userreports.dbaccessors import delete_all_report_configs
-from corehq.apps.userreports.models import DataSourceConfiguration
+from corehq.apps.userreports.models import DataSourceConfiguration, \
+    ReportConfiguration
 from corehq.apps.userreports.reports.builder.forms import ConfigureListReportForm
 
 
@@ -29,10 +30,49 @@ class ReportBuilderTest(TestCase):
             config.delete()
         delete_all_report_configs()
 
-    def test_updating_out_of_date_report(self):
+    def test_data_source_exclusivity(self):
         """
-        Test that editing a report for an outdated data source creates a new data source.
-        Data sources are tied to app version.
+        Report builder reports based on the same form/case_type should have
+        different data sources (they were previously sharing them)
+        """
+
+        # Make report
+        builder_form = ConfigureListReportForm(
+            "Report one",
+            self.app._id,
+            "form",
+            self.form.unique_id,
+            existing_report=None,
+            data={
+                'filters': '[]',
+                'columns': '[{"property": "/data/first_name", "display_text": "first name"}]',
+            }
+        )
+        self.assertTrue(builder_form.is_valid())
+        report_one = builder_form.create_report()
+
+        # Make another report
+        builder_form = ConfigureListReportForm(
+            "Report two",
+            self.app._id,
+            "form",
+            self.form.unique_id,
+            existing_report=None,
+            data={
+                'filters': '[]',
+                'columns': '[{"property": "/data/first_name", "display_text": "first name"}]',
+            }
+        )
+        self.assertTrue(builder_form.is_valid())
+        report_two = builder_form.create_report()
+
+        self.assertNotEqual(report_one.config_id, report_two.config_id)
+
+    def test_updating_report_that_shares_data_source(self):
+        """
+        If a report builder builder report shares a data source with another report,
+        then editing the report builder report should result in a new data source
+        being created for the report.
         """
 
         # Make report
@@ -49,12 +89,15 @@ class ReportBuilderTest(TestCase):
         )
         self.assertTrue(builder_form.is_valid())
         report = builder_form.create_report()
-        first_data_source_id = report.config_id
 
-        # Bump version of app by saving it
-        self.app.save()
+        # Make another report that references the same data source
+        report_two = ReportConfiguration(
+            domain="domain",
+            config_id=report.config_id
+        )
+        report_two.save()
 
-        # Modify the report
+        # Make an edit to the first report builder report
         builder_form = ConfigureListReportForm(
             "Test Report",
             self.app._id,
@@ -68,6 +111,5 @@ class ReportBuilderTest(TestCase):
         )
         self.assertTrue(builder_form.is_valid())
         report = builder_form.update_report()
-        second_data_source_id = report.config_id
 
-        self.assertNotEqual(first_data_source_id, second_data_source_id)
+        self.assertNotEqual(report.config_id, report_two.config_id)


### PR DESCRIPTION
Previously, we tried to share data sources between report builder reports in an attempt to save storage space. However, this resulted in a very annoying layer of complexity which seems unnecessary, makes future features harder to implement. This PR ends that sharing.

cc @emord 
FYI @kaapstorm 
Can be reviewed commit-by-commit
