### PR TITLE
Form icons

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1318,7 +1318,10 @@ class Form(IndexedFormBase, NavMenuItemMediaMixin):
 
     @memoized
     def get_action_type(self):
-        if self.get_subcase_types():
+
+        if self.actions.close_case.condition.type != 'never':
+            return 'close'
+        elif self.get_subcase_types():
             return 'open'
         elif self.requires_case():
             return 'update'
@@ -1333,7 +1336,10 @@ class Form(IndexedFormBase, NavMenuItemMediaMixin):
         if subcases:
             messages.append(_('This form opens a {}').format(', '.join(subcases)))
 
-        if self.requires_case():
+        if self.actions.close_case.condition != 'never':
+            messages.append(_('This form closes a {}').format(self.get_module().case_type))
+
+        elif self.requires_case():
             messages.append(_('This form updates a {}').format(self.get_module().case_type))
 
         return '. '.join(messages)

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1331,10 +1331,10 @@ class Form(IndexedFormBase, NavMenuItemMediaMixin):
         messages = []
 
         if subcases:
-            messages.append(_('This form opens cases for {}').format(', '.join(subcases)))
+            messages.append(_('This form opens a {}').format(', '.join(subcases)))
 
         if self.requires_case():
-            messages.append(('This form updates the {} case').format(self.get_module().case_type))
+            messages.append(_('This form updates a {}').format(self.get_module().case_type))
 
         return '. '.join(messages)
 

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1319,24 +1319,27 @@ class Form(IndexedFormBase, NavMenuItemMediaMixin):
     @memoized
     def get_action_type(self):
 
-        if self.actions.close_case.condition.type != 'never':
+        if self.actions.close_case.condition.is_active():
             return 'close'
-        elif self.get_subcase_types():
+        elif (self.actions.open_case.condition.is_active() or
+                self.actions.subcases):
             return 'open'
-        elif self.requires_case():
+        elif self.actions.update_case.condition.is_active():
             return 'update'
         else:
             return 'none'
 
     @memoized
     def get_icon_help_text(self):
-        subcases = self.get_subcase_types()
         messages = []
 
-        if subcases:
-            messages.append(_('This form opens a {}').format(', '.join(subcases)))
+        if self.actions.open_case.condition.is_active():
+            messages.append(_('This form opens a {}').format(self.get_module().case_type))
 
-        if self.actions.close_case.condition != 'never':
+        if self.actions.subcases:
+            messages.append(_('This form opens a subcase {}').format(', '.join(self.get_subcase_types())))
+
+        if self.actions.close_case.condition.is_active():
             messages.append(_('This form closes a {}').format(self.get_module().case_type))
 
         elif self.requires_case():

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1316,6 +1316,15 @@ class Form(IndexedFormBase, NavMenuItemMediaMixin):
                 actions[action_type] = a
         return actions
 
+    @memoized
+    def get_action_type(self):
+        if self.get_subcase_types():
+            return 'open'
+        elif self.requires_case():
+            return 'update'
+        else:
+            return 'none'
+
     def active_actions(self):
         if self.get_app().application_version == APP_V1:
             action_types = (

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1325,6 +1325,19 @@ class Form(IndexedFormBase, NavMenuItemMediaMixin):
         else:
             return 'none'
 
+    @memoized
+    def get_icon_help_text(self):
+        subcases = self.get_subcase_types()
+        messages = []
+
+        if subcases:
+            messages.append(_('This form opens cases for {}').format(', '.join(subcases)))
+
+        if self.requires_case():
+            messages.append(('This form updates the {} case').format(self.get_module().case_type))
+
+        return '. '.join(messages)
+
     def active_actions(self):
         if self.get_app().application_version == APP_V1:
             action_types = (

--- a/corehq/apps/app_manager/templates/app_manager/managed_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/managed_app.html
@@ -210,7 +210,7 @@
                                             <i class="drag_handle"></i>
                                             {% if form.get_action_type == 'open' %}
                                             <i
-                                                class="fa fa-play-circle"
+                                                class="fa fa-external-link"
                                                 data-toggle="tooltip"
                                                 data-placement="top"
                                                 title="{{ form.get_icon_help_text }}"
@@ -226,7 +226,7 @@
                                             </i>
                                             {% elif form.get_action_type == 'update' %}
                                             <i
-                                                class="fa fa-pencil-square"
+                                                class="fa fa-undo"
                                                 data-toggle="tooltip"
                                                 data-placement="top"
                                                 title="{{ form.get_icon_help_text }}"

--- a/corehq/apps/app_manager/templates/app_manager/managed_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/managed_app.html
@@ -216,6 +216,14 @@
                                                 title="{{ form.get_icon_help_text }}"
                                                 >
                                             </i>
+                                            {% elif form.get_action_type == 'close' %}
+                                            <i
+                                                class="fa fa-ban"
+                                                data-toggle="tooltip"
+                                                data-placement="top"
+                                                title="{{ form.get_icon_help_text }}"
+                                                >
+                                            </i>
                                             {% elif form.get_action_type == 'update' %}
                                             <i
                                                 class="fa fa-pencil-square"

--- a/corehq/apps/app_manager/templates/app_manager/managed_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/managed_app.html
@@ -45,6 +45,7 @@
     {% if app.get_doc_type == "Application" %}
     <script>
         $(function () {
+            $('[data-toggle="tooltip"]').tooltip()
             $('.edit-form-pencil').hide().tooltip({
                 title: "{% trans "Edit in form builder" %}",
                 placement: 'auto'
@@ -207,9 +208,25 @@
                                         <!--[F]-->
                                         <a id="view_form_{{ module.id }}_{{ form.id }}_sidebar" href="{% url "view_form" domain app.id module.id form.id %}">
                                             <i class="drag_handle"></i>
-                                            {% if form.get_action_type == 'open' %}<i class="fa fa-play-circle"></i>
-                                            {% elif form.get_action_type == 'update' %}<i class="fa fa-pencil-square"></i>
-                                            {% else %}<i class="fa fa-file-o"></i>{% endif %}
+                                            {% if form.get_action_type == 'open' %}
+                                            <i
+                                                class="fa fa-play-circle"
+                                                data-toggle="tooltip"
+                                                data-placement="top"
+                                                title="{{ form.get_icon_help_text }}"
+                                                >
+                                            </i>
+                                            {% elif form.get_action_type == 'update' %}
+                                            <i
+                                                class="fa fa-pencil-square"
+                                                data-toggle="tooltip"
+                                                data-placement="top"
+                                                title="{{ form.get_icon_help_text }}"
+                                                >
+                                            </i>
+                                            {% else %}
+                                            <i class="fa fa-file-o"></i>
+                                            {% endif %}
                                             <span {% if form == selected_form %}class="variable-form_name"{% endif %}>
                                             {{ form.name|html_trans:langs }}
                                             </span>

--- a/corehq/apps/app_manager/templates/app_manager/managed_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/managed_app.html
@@ -208,6 +208,7 @@
                                         <!--[F]-->
                                         <a id="view_form_{{ module.id }}_{{ form.id }}_sidebar" href="{% url "view_form" domain app.id module.id form.id %}">
                                             <i class="drag_handle"></i>
+                                            {% if request|toggle_enabled:"SUPPORT" %}
                                             {% if form.get_action_type == 'open' %}
                                             <i
                                                 class="fa fa-external-link"
@@ -234,6 +235,7 @@
                                             </i>
                                             {% else %}
                                             <i class="fa fa-file-o"></i>
+                                            {% endif %}
                                             {% endif %}
                                             <span {% if form == selected_form %}class="variable-form_name"{% endif %}>
                                             {{ form.name|html_trans:langs }}

--- a/corehq/apps/app_manager/templates/app_manager/managed_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/managed_app.html
@@ -209,33 +209,19 @@
                                         <a id="view_form_{{ module.id }}_{{ form.id }}_sidebar" href="{% url "view_form" domain app.id module.id form.id %}">
                                             <i class="drag_handle"></i>
                                             {% if request|toggle_enabled:"SUPPORT" %}
+                                            <i
                                             {% if form.get_action_type == 'open' %}
-                                            <i
                                                 class="fa fa-external-link"
-                                                data-toggle="tooltip"
-                                                data-placement="top"
-                                                title="{{ form.get_icon_help_text }}"
-                                                >
-                                            </i>
                                             {% elif form.get_action_type == 'close' %}
-                                            <i
                                                 class="fa fa-ban"
-                                                data-toggle="tooltip"
-                                                data-placement="top"
-                                                title="{{ form.get_icon_help_text }}"
-                                                >
-                                            </i>
                                             {% elif form.get_action_type == 'update' %}
-                                            <i
                                                 class="fa fa-undo"
+                                            {% endif %}
+                                                title="{{ form.get_icon_help_text }}"
                                                 data-toggle="tooltip"
                                                 data-placement="top"
-                                                title="{{ form.get_icon_help_text }}"
                                                 >
                                             </i>
-                                            {% else %}
-                                            <i class="fa fa-file-o"></i>
-                                            {% endif %}
                                             {% endif %}
                                             <span {% if form == selected_form %}class="variable-form_name"{% endif %}>
                                             {{ form.name|html_trans:langs }}

--- a/corehq/apps/app_manager/templates/app_manager/managed_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/managed_app.html
@@ -207,6 +207,9 @@
                                         <!--[F]-->
                                         <a id="view_form_{{ module.id }}_{{ form.id }}_sidebar" href="{% url "view_form" domain app.id module.id form.id %}">
                                             <i class="drag_handle"></i>
+                                            {% if form.get_action_type == 'open' %}<i class="fa fa-play-circle"></i>
+                                            {% elif form.get_action_type == 'update' %}<i class="fa fa-pencil-square"></i>
+                                            {% else %}<i class="fa fa-file-o"></i>{% endif %}
                                             <span {% if form == selected_form %}class="variable-form_name"{% endif %}>
                                             {{ form.name|html_trans:langs }}
                                             </span>


### PR DESCRIPTION
@dimagi/product @orangejenny @biyeun  Icons for forms in the app builder

![screen shot 2016-07-22 at 4 24 37 pm](https://cloud.githubusercontent.com/assets/918514/17070292/0889ddca-5029-11e6-920d-1daf7b5cc2f8.png)
![screen shot 2016-07-22 at 4 24 29 pm](https://cloud.githubusercontent.com/assets/918514/17070293/088e73bc-5029-11e6-9592-efa4d8856b4b.png)

This was hugely helpful in me understanding my own app structure. Granted I'm not the target user, but strongly think this is a win. Realize we may argue on icons. Some other possibilities for form open/update:

Open:  
<img width="193" alt="screen shot 2016-07-22 at 4 28 25 pm" src="https://cloud.githubusercontent.com/assets/918514/17070344/566157ee-5029-11e6-95e7-3e1343bac9aa.png">
<img width="183" alt="screen shot 2016-07-22 at 4 29 41 pm" src="https://cloud.githubusercontent.com/assets/918514/17070374/8972f62e-5029-11e6-9e22-1334b34295ed.png">

Update:
<img width="165" alt="screen shot 2016-07-22 at 4 29 08 pm" src="https://cloud.githubusercontent.com/assets/918514/17070360/6f5d9fe6-5029-11e6-80a9-808c84f3f2b4.png">
