### PR TITLE
Add overwrite_cache to async restores

### DIFF
--- a/corehq/apps/hqadmin/templates/hqadmin/admin_restore.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/admin_restore.html
@@ -38,6 +38,8 @@
                     <ul class="list-inline">
                         <li><a href="https://confluence.dimagi.com/display/commcarehq/Hidden+features#Hiddenfeatures-PhoneRestore" target="_blank">Docs</a></li>
                         <li><a href="{{request.get_full_path}}&raw=true">Raw</a></li>
+                        <li><a href="{{request.get_full_path}}&overwrite_cache=true">Overwrite Cache</a></li>
+                        <li><a href="?{% url_replace 'since' restore_id %}">Next Sync</a></li>
                     </ul>
                     <div>
                         <ul class="nav nav-tabs" role="tablist">

--- a/corehq/apps/hqadmin/views.py
+++ b/corehq/apps/hqadmin/views.py
@@ -405,7 +405,6 @@ class AdminRestoreView(TemplateView):
         if not self.user:
             return HttpResponseNotFound('User %s not found.' % full_username)
 
-        self.overwrite_cache = request.GET.get('ignore_cache') == 'true'
         self.app_id = kwargs.get('app_id', None)
 
         raw = request.GET.get('raw') == 'true'
@@ -417,7 +416,7 @@ class AdminRestoreView(TemplateView):
 
     def _get_restore_response(self):
         return get_restore_response(
-            self.user.domain, self.user, overwrite_cache=self.overwrite_cache, app_id=self.app_id,
+            self.user.domain, self.user, app_id=self.app_id,
             **get_restore_params(self.request)
         )
 

--- a/corehq/apps/hqadmin/views.py
+++ b/corehq/apps/hqadmin/views.py
@@ -32,6 +32,7 @@ from restkit.errors import Unauthorized
 from couchdbkit import ResourceNotFound
 
 from casexml.apps.case.models import CommCareCase
+from casexml.apps.phone.xml import SYNC_XMLNS
 from corehq.apps.callcenter.indicator_sets import CallCenterIndicators
 from corehq.apps.callcenter.utils import CallCenterCase
 from corehq.apps.hqwebapp.tasks import send_html_email_async
@@ -426,9 +427,11 @@ class AdminRestoreView(TemplateView):
         timing_context = timing_context or TimingContext(self.user.username)
         string_payload = ''.join(response.streaming_content)
         xml_payload = etree.fromstring(string_payload)
+        restore_id_element = xml_payload.find('{{{0}}}Sync/{{{0}}}restore_id'.format(SYNC_XMLNS))
         formatted_payload = etree.tostring(xml_payload, pretty_print=True)
         context.update({
             'payload': formatted_payload,
+            'restore_id': restore_id_element.text if restore_id_element is not None else None,
             'status_code': response.status_code,
             'timing_data': timing_context.to_list()
         })

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -411,3 +411,16 @@ def prelogin_url(context, urlname):
         return reverse(urlname, args=[context['LANGUAGE_CODE']])
     else:
         return reverse(urlname)
+
+
+@register.simple_tag(takes_context=True)
+def url_replace(context, field, value):
+    """Usage <a href="?{% url_replace 'since' restore_id %}">
+    will replace the 'since' parmeter in the url with <restore_id>
+    note the presense of the '?' in the href value
+
+    http://stackoverflow.com/a/16609591/2957657
+    """
+    params = context['request'].GET.copy()
+    params[field] = value
+    return params.urlencode()

--- a/corehq/apps/ota/views.py
+++ b/corehq/apps/ota/views.py
@@ -111,7 +111,8 @@ def get_restore_params(request):
         'state': request.GET.get('state'),
         'items': request.GET.get('items') == 'true',
         'as_user': request.GET.get('as'),
-        'has_data_cleanup_privelege': has_privilege(request, privileges.DATA_CLEANUP)
+        'has_data_cleanup_privelege': has_privilege(request, privileges.DATA_CLEANUP),
+        'overwrite_cache': request.GET.get('overwrite_cache') == 'true',
     }
 
 

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -231,7 +231,7 @@ class AsyncRestoreResponse(object):
         self.task = task
         self.username = username
 
-        task_info = self.task.info if self.task.info else {}
+        task_info = self.task.info if self.task.info and isinstance(self.task.info, dict) else {}
         self.progress = {
             'done': task_info.get('done', 0),
             'total': task_info.get('total', 0),
@@ -589,8 +589,9 @@ class RestoreConfig(object):
 
     def get_payload(self):
         self.validate()
+        self.delete_cached_payload_if_necessary()
 
-        cached_response = self._get_cached_payload()
+        cached_response = self._get_cached_response()
         if cached_response:
             return cached_response
         # Start new sync
@@ -608,7 +609,7 @@ class RestoreConfig(object):
         self.set_cached_payload_if_necessary(response, self.restore_state.duration)
         return response
 
-    def _get_cached_payload(self):
+    def _get_cached_response(self):
         if self.overwrite_cache:
             return CachedResponse(None)
 
@@ -631,20 +632,26 @@ class RestoreConfig(object):
             # start a new task
             task = get_async_restore_payload.delay(self)
             new_task = True
-
             # store the task id in cache
             self.cache.set(self.async_cache_key, task.id, timeout=None)
-
         try:
-            # if this is a new task, wait for INITIAL_ASYNC_TIMEOUT in case
-            # this restore completes quickly. otherwise, only wait 1 second for
-            # a response
-            response = task.get(timeout=INITIAL_ASYNC_TIMEOUT_THRESHOLD if new_task else 1)
+            response = task.get(timeout=self._get_task_timeout_or_raise(new_task))
         except TimeoutError:
             # return a 202 with progress
             response = AsyncRestoreResponse(task, self.restore_user.username)
 
         return response
+
+    def _get_task_timeout_or_raise(self, new_task):
+        # if this is a new task, wait for INITIAL_ASYNC_TIMEOUT in case
+        # this restore completes quickly. otherwise, only wait 1 second for
+        # a response. Integration tests with mobile set the overwrite_cache
+        # flag. This should always return a timeout response.
+        if self.overwrite_cache:
+            # for async restores with overwrite_cache, the first response
+            # should be a Timeout. This is used for testing purposes.
+            raise TimeoutError()
+        return INITIAL_ASYNC_TIMEOUT_THRESHOLD if new_task else 1
 
     def _generate_restore_response(self, async_task=None):
         """
@@ -719,3 +726,7 @@ class RestoreConfig(object):
 
     def _set_cache_in_redis(self, cache_payload):
         self.cache.set(self._initial_cache_key, cache_payload, self.cache_timeout)
+
+    def delete_cached_payload_if_necessary(self):
+        if self.overwrite_cache and self.cache.get(self._initial_cache_key):
+            self.cache.delete(self._initial_cache_key)

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
@@ -1,4 +1,5 @@
 import mock
+from cStringIO import StringIO
 from django.test import TestCase, SimpleTestCase
 from corehq.apps.app_manager.tests.util import TestXmlMixin
 
@@ -15,9 +16,11 @@ from corehq.apps.domain.models import Domain
 from casexml.apps.phone.restore import (
     RestoreConfig,
     RestoreParams,
+    RestoreCacheSettings,
     AsyncRestoreResponse,
     FileRestoreResponse,
     restore_cache_key,
+    CachedPayload
 )
 from casexml.apps.phone.const import ASYNC_RESTORE_CACHE_KEY_PREFIX
 from casexml.apps.phone.tasks import get_async_restore_payload, ASYNC_RESTORE_SENT
@@ -27,7 +30,7 @@ from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 from corehq.util.test_utils import flag_enabled
 
 
-class AsyncRestoreTest(TestCase):
+class BaseAsyncRestoreTest(TestCase):
     dependent_apps = [
         'auditcare',
         'django_digest',
@@ -50,7 +53,7 @@ class AsyncRestoreTest(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(AsyncRestoreTest, cls).setUpClass()
+        super(BaseAsyncRestoreTest, cls).setUpClass()
         delete_all_cases()
         delete_all_sync_logs()
         delete_all_users()
@@ -65,18 +68,23 @@ class AsyncRestoreTest(TestCase):
         delete_all_cases()
         delete_all_sync_logs()
         delete_all_users()
-        super(AsyncRestoreTest, cls).tearDownClass()
+        super(BaseAsyncRestoreTest, cls).tearDownClass()
 
-    def _restore_config(self, async=True, sync_log_id=''):
+    def _restore_config(self, async=True, sync_log_id='', overwrite_cache=False):
         restore_config = RestoreConfig(
             project=self.project,
             restore_user=self.user,
             params=RestoreParams(sync_log_id=sync_log_id, version=V2),
+            cache_settings=RestoreCacheSettings(
+                overwrite_cache=overwrite_cache
+            ),
             async=async
         )
         self.addCleanup(restore_config.cache.clear)
         return restore_config
 
+
+class AsyncRestoreTest(BaseAsyncRestoreTest):
     @mock.patch('casexml.apps.phone.restore.get_async_restore_payload')
     def test_regular_restore_doesnt_start_task(self, task):
         """
@@ -103,11 +111,11 @@ class AsyncRestoreTest(TestCase):
 
         restore_config = self._restore_config(async=True)
         initial_payload = restore_config.get_payload()
-        self.assertTrue(isinstance(initial_payload, AsyncRestoreResponse))
+        self.assertIsInstance(initial_payload, AsyncRestoreResponse)
 
         subsequent_restore = self._restore_config(async=True)
         subsequent_payload = subsequent_restore.get_payload()
-        self.assertTrue(isinstance(subsequent_payload, AsyncRestoreResponse))
+        self.assertIsInstance(subsequent_payload, AsyncRestoreResponse)
 
     def test_subsequent_syncs_when_job_complete(self):
         # First sync, return a timout. Ensure that the async_task_id gets set
@@ -121,7 +129,7 @@ class AsyncRestoreTest(TestCase):
             restore_config = self._restore_config(async=True)
             initial_payload = restore_config.get_payload()
             self.assertIsNotNone(restore_config.cache.get(cache_id))
-            self.assertTrue(isinstance(initial_payload, AsyncRestoreResponse))
+            self.assertIsInstance(initial_payload, AsyncRestoreResponse)
             # new synclog should not have been created
             self.assertIsNone(restore_config.restore_state.current_sync_log)
 
@@ -195,6 +203,38 @@ class AsyncRestoreTest(TestCase):
             correct_user_factory.create_case()
             revoke.assert_called_with(fake_task_id)
             self.assertIsNone(restore_config.cache.get(cache_id))
+
+
+class AsyncRestoreIntegrationParameters(BaseAsyncRestoreTest):
+    """When overwrite_cache is set, the async restore should always first return an
+    AsyncRestoreResponse as its first response
+
+    """
+    @mock.patch('casexml.apps.phone.restore.get_async_restore_payload')
+    def test_always_returns_async_restore_response(self, task):
+        delay = mock.MagicMock()
+        delay.id = 'random_task_id'
+        task.delay.return_value = delay
+
+        payload = self._restore_config(async=True, overwrite_cache=True).get_payload()
+        self.assertTrue(task.delay.called)
+        self.assertIsInstance(payload, AsyncRestoreResponse)
+
+    @mock.patch.object(CachedPayload, 'finalize')  # fake that a cached payload exists
+    @mock.patch.object(RestoreConfig, 'cache')
+    @mock.patch('casexml.apps.phone.restore.get_async_restore_payload')
+    def test_clears_cache(self, task, cache, _):
+        delay = mock.MagicMock()
+        delay.id = 'random_task_id'
+        task.delay.return_value = delay
+        cache_get = mock.MagicMock().return_value = StringIO('<restore_id>123</restore_id>')
+        cache.get.return_value = cache_get
+
+        self._restore_config(async=True, overwrite_cache=False).get_payload()
+        self.assertFalse(cache.delete.called)
+
+        self._restore_config(async=True, overwrite_cache=True).get_payload()
+        self.assertTrue(cache.delete.called)
 
 
 class TestAsyncRestoreResponse(TestXmlMixin, SimpleTestCase):


### PR DESCRIPTION
For integration testing we need a way of consistently skipping the cache on async restores while still kicking off an async task. The `overwrite_cache` parameter mostly did this before, without actually overwriting the cache. Now, if there is a cached payload in redis, adding the `overwrite_cache` will actually remove it.

The integration testing mechanism should first submit the `overwrite_cache` parameter in the sync. This will return an initial  async restore response. Subsequent requests should not have that parameter, and will return either an async restore response if the task is not complete, or a full response if it is (if subsequent requests do include that parameter, it will just keep starting new tasks every time the previous one finishes, as the cache will keep getting deleted).

Note: this renames the `ignore_cache` parameter that was used in the admin restore view to `overwrite_cache` to be more consistent with the internals.

@amstone326 
cc @millerdev 
