### PR TITLE
Allow custom export columns

### DIFF
--- a/corehq/apps/export/models/__init__.py
+++ b/corehq/apps/export/models/__init__.py
@@ -10,6 +10,7 @@ from .new import (
     SplitUserDefinedExportColumn,
     StockExportColumn,
     MultiMediaExportColumn,
+    UserDefinedExportColumn,
     ExportRow,
     ExportInstance,
     FormExportInstance,

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1324,6 +1324,10 @@ class UserDefinedExportColumn(ExportColumn):
     # export schema, the path is defined on the column.
     custom_path = SchemaListProperty(PathNode)
 
+    def get_value(self, domain, doc_id, doc, base_path, **kwargs):
+        path = [x.name for x in self.custom_path[len(base_path):]]
+        return NestedDictGetter(path)(doc)
+
 
 class SplitUserDefinedExportColumn(ExportColumn):
     split_type = StringProperty(

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -266,6 +266,8 @@ class ExportColumn(DocumentSchema):
                 return CaseIndexExportColumn.wrap(data)
             elif doc_type == 'SplitUserDefinedExportColumn':
                 return SplitUserDefinedExportColumn.wrap(data)
+            elif doc_type == 'UserDefinedExportColumn':
+                return UserDefinedExportColumn.wrap(data)
             elif doc_type == 'SplitGPSExportColumn':
                 return SplitGPSExportColumn.wrap(data)
             elif doc_type == 'MultiMediaExportColumn':
@@ -1309,6 +1311,18 @@ def _merge_dicts(one, two, resolvefn):
         for key in one.viewkeys() & two.viewkeys()
     })
     return merged
+
+
+class UserDefinedExportColumn(ExportColumn):
+    """
+    This model represents a column that a user has defined the path to the
+    data within the form. It should only be needed for RemoteApps
+    """
+
+    # On normal columns, the path is defined on an ExportItem.
+    # Since a UserDefinedExportColumn is not associated with the
+    # export schema, the path is defined on the column.
+    custom_path = SchemaListProperty(PathNode)
 
 
 class SplitUserDefinedExportColumn(ExportColumn):

--- a/corehq/apps/export/static/export/js/models.js
+++ b/corehq/apps/export/static/export/js/models.js
@@ -340,6 +340,7 @@ hqDefine('export/js/models.js', function () {
         ExportInstance: ExportInstance,
         ExportColumn: ExportColumn,
         ExportItem: ExportItem,
+        PathNode: PathNode,
     };
 
 });

--- a/corehq/apps/export/static/export/js/models.js
+++ b/corehq/apps/export/static/export/js/models.js
@@ -273,7 +273,7 @@ hqDefine('export/js/models.js', function () {
      * This model represents a column that a user has defined the path to the
      * data within the form. It should only be needed for RemoteApps
      */
-    UserDefinedExportColumn = function(columnJSON) {
+    var UserDefinedExportColumn = function(columnJSON) {
         var self = this;
         ko.mapping.fromJS(columnJSON, UserDefinedExportColumn.mapping, self);
         self.showOptions = ko.observable(false);

--- a/corehq/apps/export/static/export/js/models.js
+++ b/corehq/apps/export/static/export/js/models.js
@@ -288,15 +288,7 @@ hqDefine('export/js/models.js', function () {
     };
 
     UserDefinedExportColumn.prototype.customPathToNodes = function() {
-        var parts = this.customPathString().split('.');
-        console.log(parts)
-        this.custom_path(_.map(parts, function(part) {
-            return new PathNode({
-                name: part,
-                is_repeat: false,
-                doc_type: 'PathNode',
-            });
-        }));
+        this.custom_path(utils.customPathToNodes(this.customPathString()));
     };
 
     UserDefinedExportColumn.mapping = {

--- a/corehq/apps/export/static/export/js/models.js
+++ b/corehq/apps/export/static/export/js/models.js
@@ -167,7 +167,7 @@ hqDefine('export/js/models.js', function () {
             doc_type: 'UserDefinedExportColumn',
             label: '',
             custom_path: [],
-        }))
+        }));
     };
 
     TableConfiguration.mapping = {
@@ -303,7 +303,7 @@ hqDefine('export/js/models.js', function () {
             create: function(options) {
                 return new PathNode(options.data);
             },
-        }
+        },
     };
 
     var ExportItem = function(itemJSON) {

--- a/corehq/apps/export/static/export/js/utils.js
+++ b/corehq/apps/export/static/export/js/utils.js
@@ -25,10 +25,22 @@ hqDefine('export/js/utils.js', function () {
         }).join('.')
     };
 
+    var customPathToNodes = function(customPath) {
+        var parts = customPathString.split('.');
+        return _.map(parts, function(part) {
+            return new PathNode({
+                name: part,
+                is_repeat: false,
+                doc_type: 'PathNode',
+            });
+        });
+    };
+
     return {
         getTagCSSClass: getTagCSSClass,
         redirect: redirect,
         animateToEl: animateToEl,
         readablePath: readablePath,
+        customPathToNodes: customPathToNodes,
     };
 });

--- a/corehq/apps/export/static/export/js/utils.js
+++ b/corehq/apps/export/static/export/js/utils.js
@@ -19,9 +19,16 @@ hqDefine('export/js/utils.js', function () {
         }, 'slow', undefined, callback);
     };
 
+    var readablePath = function(pathNodes) {
+        return _.map(pathNodes, function(pathNode) {
+            return pathNode.name();
+        }).join('.')
+    };
+
     return {
         getTagCSSClass: getTagCSSClass,
         redirect: redirect,
         animateToEl: animateToEl,
+        readablePath: readablePath,
     };
 });

--- a/corehq/apps/export/static/export/js/utils.js
+++ b/corehq/apps/export/static/export/js/utils.js
@@ -25,10 +25,11 @@ hqDefine('export/js/utils.js', function () {
         }).join('.')
     };
 
-    var customPathToNodes = function(customPath) {
+    var customPathToNodes = function(customPathString) {
+        var models = hqImport('export/js/models.js');
         var parts = customPathString.split('.');
         return _.map(parts, function(part) {
-            return new PathNode({
+            return new models.PathNode({
                 name: part,
                 is_repeat: false,
                 doc_type: 'PathNode',

--- a/corehq/apps/export/static/export/js/utils.js
+++ b/corehq/apps/export/static/export/js/utils.js
@@ -19,12 +19,31 @@ hqDefine('export/js/utils.js', function () {
         }, 'slow', undefined, callback);
     };
 
+    /**
+     * readablePath
+     *
+     * Takes an array of PathNodes and converts them to a string dot path.
+     *
+     * @param {Array} pathNodes - An array of PathNodes to be converted to a string
+     *      dot path.
+     * @returns {string} A string dot path that represents the array of PathNodes
+     */
     var readablePath = function(pathNodes) {
         return _.map(pathNodes, function(pathNode) {
             return pathNode.name();
         }).join('.')
     };
 
+    /**
+     * customPathToNodes
+     *
+     * This function takes a string path like form.meta.question and
+     * returns the equivalent path in an array of PathNodes.
+     *
+     * @param {string} customPathString - A string dot path to be converted
+     *      to PathNodes.
+     * @returns {Array} Returns an array of PathNodes.
+     */
     var customPathToNodes = function(customPathString) {
         var models = hqImport('export/js/models.js');
         var parts = customPathString.split('.');

--- a/corehq/apps/export/static/export/js/utils.js
+++ b/corehq/apps/export/static/export/js/utils.js
@@ -31,7 +31,7 @@ hqDefine('export/js/utils.js', function () {
     var readablePath = function(pathNodes) {
         return _.map(pathNodes, function(pathNode) {
             return pathNode.name();
-        }).join('.')
+        }).join('.');
     };
 
     /**

--- a/corehq/apps/export/static/export/spec/Exports.Utils.spec.js
+++ b/corehq/apps/export/static/export/spec/Exports.Utils.spec.js
@@ -32,7 +32,7 @@ describe('Export Utility functions', function() {
             var nodes = utils.customPathToNodes(customPath);
 
             assert.equal(nodes.length, 2);
-            assert.isTrue(_.all(nodes, function(n) { return n instanceof models.PathNode }));
+            assert.isTrue(_.all(nodes, function(n) { return n instanceof models.PathNode; }));
 
             assert.equal(nodes[0].name(), 'form');
             assert.isFalse(nodes[0].is_repeat());

--- a/corehq/apps/export/static/export/spec/Exports.Utils.spec.js
+++ b/corehq/apps/export/static/export/spec/Exports.Utils.spec.js
@@ -2,6 +2,7 @@
 describe('Export Utility functions', function() {
     var constants = hqImport('export/js/const.js');
     var utils = hqImport('export/js/utils.js');
+    var models = hqImport('export/js/models.js');
 
     describe('#getTagCSSClass', function() {
         it('Should get regular tag class', function() {
@@ -12,6 +13,32 @@ describe('Export Utility functions', function() {
         it('Should get warning tag class', function() {
             var cls = utils.getTagCSSClass(constants.TAG_DELETED);
             assert.equal(cls, 'label label-warning');
+        });
+    });
+
+    describe('#readablePath', function() {
+        it('Should convert an anrray of PathNode to a dot path', function() {
+            var nodes = [
+                new models.PathNode({ name: 'form', is_repeat: false, doc_type: 'PathNode' }),
+                new models.PathNode({ name: 'photo', is_repeat: false, doc_type: 'PathNode' }),
+            ];
+            assert.equal(utils.readablePath(nodes), 'form.photo');
+        });
+    });
+
+    describe('#customPathToNodes', function() {
+        it('Should convert a string path to PathNodes', function() {
+            var customPath = 'form.photo';
+            var nodes = utils.customPathToNodes(customPath);
+
+            assert.equal(nodes.length, 2);
+            assert.isTrue(_.all(nodes, function(n) { return n instanceof models.PathNode }));
+
+            assert.equal(nodes[0].name(), 'form');
+            assert.isFalse(nodes[0].is_repeat());
+
+            assert.equal(nodes[1].name(), 'photo');
+            assert.isFalse(nodes[1].is_repeat());
         });
     });
 });

--- a/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
+++ b/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
@@ -87,6 +87,17 @@
                             {% endif %}
                         </tr>
                         </thead>
+                        <tfoot>
+                            <tr>
+                                <td colspan="100%">
+                                    <button class="btn btn-default btn-sm" data-bind="
+                                        click: table.addUserDefinedExportColumn
+                                    ">
+                                    Add custom export property
+                                    </button>
+                                </td>
+                            </tr>
+                        </tfoot>
                         <tbody data-bind="
                             sortable: {
                                 data: table.columns,
@@ -119,6 +130,8 @@
                                             text: tag,
                                             attr: { class: hqImport('export/js/utils.js').getTagCSSClass(tag) }"></span>
                                     </span>
+
+                                    <!-- ko if: !column.isUserDefined -->
                                     <code data-toggle="tooltip" data-placement="top" 
                                         data-bind="
                                             text: column.formatProperty(),
@@ -130,6 +143,16 @@
                                                 'export-tooltip': column.translatedHelp()
                                             }
                                         "></code>
+                                    <!-- /ko -->
+                                    <!-- ko if: column.isUserDefined -->
+                                    <input
+                                        type="text"
+                                        class="form-control"
+                                        data-bind="
+                                            value: column.customPathString
+                                        "
+                                    />
+                                    <!-- /ko -->
                                 </td>
                                 <td><input class="form-control" type="text" data-bind="value: column.label" /></td>
                                 {% if export_instance.type == 'case' and request|feature_preview_enabled:"SPLIT_MULTISELECT_CASE_EXPORT"%}

--- a/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
+++ b/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
@@ -123,6 +123,17 @@
                                            class="field-include"
                                            data-bind="checked: column.selected" />
                                     <!--/ko-->
+                                    <!-- ko if: column.isUserDefined -->
+                                    <div class="remove-user-defined-column pull-right">
+                                        <button class="btn btn-danger btn-xs" data-bind="
+                                            click: function() {
+                                                $parent.columns.remove(column)
+                                            }
+                                        ">
+                                        Remove
+                                        </button>
+                                    </div>
+                                    <!-- /ko -->
                                 </td>
                                 <td>
                                     <span data-bind="foreach: { data: column.tags, as: 'tag' }">

--- a/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
+++ b/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
@@ -87,6 +87,9 @@
                             {% endif %}
                         </tr>
                         </thead>
+
+
+                        {% if request|toggle_enabled:ALLOW_USER_DEFINED_EXPORT_COLUMNS %}
                         <tfoot>
                             <tr>
                                 <td colspan="100%">
@@ -98,6 +101,8 @@
                                 </td>
                             </tr>
                         </tfoot>
+                        {% endif %}
+
                         <tbody data-bind="
                             sortable: {
                                 data: table.columns,

--- a/corehq/apps/export/tests/test_export_column.py
+++ b/corehq/apps/export/tests/test_export_column.py
@@ -21,6 +21,7 @@ from corehq.apps.export.models import (
     ExportItem,
     SplitUserDefinedExportColumn,
     SplitExportColumn,
+    UserDefinedExportColumn,
     MultipleChoiceItem,
     Option,
 )
@@ -315,4 +316,26 @@ class TestMultiMediaExportColumn(SimpleTestCase):
             '=HYPERLINK("{}?attachment=1234.jpg")'.format(
                 absolute_reverse('download_attachment', args=('my-domain', '1234'))
             )
+        )
+
+
+class TestUserDefinedExportColumn(SimpleTestCase):
+
+    def test_get_value(self):
+        column = UserDefinedExportColumn(
+            custom_path=[
+                PathNode(name='form'),
+                PathNode(name='question1'),
+            ]
+        )
+
+        result = column.get_value(
+            'my-domain',
+            '1234',
+            {'question1': '1234'},
+            [PathNode(name='form')]
+        )
+        self.assertEqual(
+            result,
+            '1234',
         )

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -855,3 +855,10 @@ EMG_AND_REC_SMS_HANDLERS = StaticToggle(
     TAG_EXPERIMENTAL,
     [NAMESPACE_DOMAIN]
 )
+
+ALLOW_USER_DEFINED_EXPORT_COLUMNS = StaticToggle(
+    'allow_user_defined_export_columns',
+    'Allows users to specify their own export columns',
+    TAG_ONE_OFF,
+    [NAMESPACE_DOMAIN],
+)


### PR DESCRIPTION
@czue @NoahCarnahan here's my first go at allowing RemoteApps to use our new export system. This doesn't allow for any repeat groups/arrays in the data submitted. To allow for that there are two options I think:
1. Allow people to specify custom tables and the path to those tables (can get hairy with nested arrays...). This I think is more work and complexity.
2. If a question is an array just stringify the result and put it in the cell. This is doesn't allow for very good exports, but drastically reduces LOE and complexity.

Here is a screen shots of how this currently works:

<img width="1016" alt="screen shot 2016-07-24 at 10 24 37 am" src="https://cloud.githubusercontent.com/assets/918514/17084429/47d08c6e-518b-11e6-8f7b-d1dc6a08c041.png">

:fish: or 🏠 
