### PR TITLE
Fix transient stock on hand bug

### DIFF
--- a/corehq/apps/locations/tests/test_products_at_location.py
+++ b/corehq/apps/locations/tests/test_products_at_location.py
@@ -7,6 +7,8 @@ from ..models import Location, LocationType
 
 class ProductsAtLocationTest(TestCase):
 
+    domain = 'test-products-at-location'
+
     def assertEqualProducts(self, products1, products2):
         self.assertEquals(
             sorted(p.product_id for p in products1),
@@ -14,17 +16,22 @@ class ProductsAtLocationTest(TestCase):
         )
 
     def setUp(self):
-        self.domain = bootstrap_domain()
+        self.project = bootstrap_domain(self.domain)
         self.products = SQLProduct.objects.filter(domain=self.domain)
-        LocationType(domain=self.domain.name, name='type').save()
+        LocationType(domain=self.domain, name='type').save()
+
+    def tearDown(self):
+        self.project.delete()
 
     def test_add_products(self):
         couch_location = Location(
             name="Camelot",
-            domain=self.domain.name,
+            domain=self.domain,
             location_type="type",
         )
         couch_location.save()
+        self.addCleanup(couch_location.delete)
+
         location = couch_location.sql_location
         location.products = self.products
         location.save()

--- a/corehq/apps/locations/tests/test_site_code.py
+++ b/corehq/apps/locations/tests/test_site_code.py
@@ -4,18 +4,25 @@
 from corehq.apps.commtrack.tests.util import bootstrap_domain
 from django.test import TestCase
 from corehq.apps.locations.models import Location, LocationType
+from corehq.apps.locations.tests.util import delete_all_locations
 
 
 class SiteCodeTest(TestCase):
 
+    domain = 'test-site-code'
+
     def setUp(self):
-        self.domain = bootstrap_domain()
-        LocationType(domain=self.domain.name, name='type').save()
+        self.project = bootstrap_domain(self.domain)
+        LocationType(domain=self.domain, name='type').save()
+
+    def tearDown(self):
+        self.project.delete()
+        delete_all_locations()
 
     def testSimpleName(self):
         location = Location(
             name="Some Location",
-            domain=self.domain.name,
+            domain=self.domain,
             location_type="type"
         )
 
@@ -26,7 +33,7 @@ class SiteCodeTest(TestCase):
     def testOtherCharacters(self):
         location = Location(
             name=u"Somé$ #Location (Old)",
-            domain=self.domain.name,
+            domain=self.domain,
             location_type="type"
         )
 
@@ -37,7 +44,7 @@ class SiteCodeTest(TestCase):
     def testDoesntDuplicate(self):
         location = Location(
             name="Location",
-            domain=self.domain.name,
+            domain=self.domain,
             location_type="type"
         )
 
@@ -47,7 +54,7 @@ class SiteCodeTest(TestCase):
 
         location = Location(
             name="Location",
-            domain=self.domain.name,
+            domain=self.domain,
             location_type="type"
         )
 


### PR DESCRIPTION
@czue at long last i reproduced the:

```
FAIL: test_transfer_first_doc_order (corehq.apps.commtrack.tests.test_xml.CommTrackBalanceTransferTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/benrudolph/Dimagi/commcare-hq/corehq/util/test_utils.py", line 232, in inner
    return helper(*args, **kwargs)
  File "/Users/benrudolph/Dimagi/commcare-hq/corehq/util/test_utils.py", line 205, in __call__
    call_with_settings(fn_with_pre_and_post, run_config.settings, args, kwargs)
  File "/Users/benrudolph/Dimagi/commcare-hq/corehq/util/test_utils.py", line 220, in call_with_settings
    fn(*args, **kwargs)
  File "/Users/benrudolph/Dimagi/commcare-hq/corehq/util/test_utils.py", line 201, in fn_with_pre_and_post
    self.fn(*args, **kwargs)
  File "/Users/benrudolph/Dimagi/commcare-hq/corehq/apps/commtrack/tests/test_xml.py", line 399, in test_transfer_first_doc_order
    self.check_product_stock(self.sp, product, final, 0)
  File "/Users/benrudolph/Dimagi/commcare-hq/corehq/apps/commtrack/tests/test_xml.py", line 228, in check_product_stock
    self.assertEqual(expected_soh, latest_trans.stock_on_hand)
AssertionError: Decimal('50.0') != 150
```

that has been plaguing or travis builds. found all tests that used `bootstrap_domain` without a domain param to find what other tests were inputing data into the commtrack domain.  eventually found ou tit was `SiteCodeTest` (fixed a few other tests as well). you should be able to repro the error locally by running 

```
REUSE_DB=1 sniffer -x corehq/apps/locations/tests/test_site_code.py -x corehq/apps/commtrack/tests/test_xml.py
```

cc: @orangejenny
