### PR TITLE
Simplify "My Account Settings" page for mobile workers

### DIFF
--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -134,12 +134,12 @@ class MyAccountSettingsView(BaseMyAccountView):
         from corehq.apps.users.forms import UpdateMyAccountInfoForm
         if self.request.method == 'POST':
             form = UpdateMyAccountInfoForm(
-                self.request.POST, username=self.request.couch_user.username,
+                self.request.POST, user=self.request.couch_user,
                 api_key=api_key
             )
         else:
             form = UpdateMyAccountInfoForm(
-                username=self.request.couch_user.username,
+                user=self.request.couch_user,
                 api_key=api_key
             )
         try:

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -13,6 +13,7 @@ from corehq.apps.style.decorators import use_select2
 from corehq.apps.users.forms import AddPhoneNumberForm
 from django.conf import settings
 from django.contrib import messages
+from django.http import Http404
 from django.views.decorators.http import require_POST
 from corehq.mobile_flags import SUPERUSER
 from corehq.tabs.tabclasses import MySettingsTab
@@ -228,7 +229,9 @@ class MyProjectsList(BaseMyAccountView):
 
     @method_decorator(login_required)
     def dispatch(self, request, *args, **kwargs):
-        # this is only here to add the login_required decorator
+        if not request.couch_user.is_web_user():
+            raise Http404
+
         return super(BaseMyAccountView, self).dispatch(request, *args, **kwargs)
 
     @property

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -223,7 +223,7 @@ class UpdateMyAccountInfoForm(BaseUpdateUserForm, BaseUserInfoForm):
     def __init__(self, *args, **kwargs):
         self.user = kwargs.pop('user', None)
         if not self.user:
-            raise MyAccountInfoFormException("Expected to be passed a user kwarg")
+            raise UpdateMyAccountInfoForm.MyAccountInfoFormException("Expected to be passed a user kwarg")
 
         self.username = self.user.username
         api_key = kwargs.pop('api_key') if 'api_key' in kwargs else None

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -217,9 +217,15 @@ class UpdateMyAccountInfoForm(BaseUpdateUserForm, BaseUserInfoForm):
         label=ugettext_lazy("Opt out of emails about CommCare updates."),
     )
 
+    class MyAccountInfoFormException(Exception):
+        pass
+
     def __init__(self, *args, **kwargs):
-        self.username = kwargs.pop('username') if 'username' in kwargs else None
-        self.user = kwargs.pop('user') if 'user' in kwargs else None
+        self.user = kwargs.pop('user', None)
+        if not self.user:
+            raise MyAccountInfoFormException("Expected to be passed a user kwarg")
+
+        self.username = self.user.username
         api_key = kwargs.pop('api_key') if 'api_key' in kwargs else None
 
         super(UpdateMyAccountInfoForm, self).__init__(*args, **kwargs)
@@ -253,14 +259,21 @@ class UpdateMyAccountInfoForm(BaseUpdateUserForm, BaseUserInfoForm):
         }
         self.new_helper.label_class = 'col-sm-3 col-md-2 col-lg-2'
         self.new_helper.field_class = 'col-sm-9 col-md-8 col-lg-6'
+
+        basic_fields = [
+            cb3_layout.Div(*username_controls),
+            hqcrispy.Field('first_name'),
+            hqcrispy.Field('last_name'),
+            hqcrispy.Field('email'),
+        ]
+
+        if self.set_email_opt_out:
+            basic_fields.append(twbscrispy.PrependedText('email_opt_out', ''))
+
         self.new_helper.layout = cb3_layout.Layout(
             cb3_layout.Fieldset(
                 ugettext_lazy("Basic"),
-                cb3_layout.Div(*username_controls),
-                hqcrispy.Field('first_name'),
-                hqcrispy.Field('last_name'),
-                hqcrispy.Field('email'),
-                twbscrispy.PrependedText('email_opt_out', ''),
+                *basic_fields
             ),
             cb3_layout.Fieldset(
                 ugettext_lazy("Other Options"),
@@ -277,8 +290,15 @@ class UpdateMyAccountInfoForm(BaseUpdateUserForm, BaseUserInfoForm):
         )
 
     @property
+    def set_email_opt_out(self):
+        return self.user.is_web_user()
+
+    @property
     def direct_properties(self):
-        return self.fields.keys()
+        result = self.fields.keys()
+        if not self.set_email_opt_out:
+            result.remove('email_opt_out')
+        return result
 
 
 class UpdateCommCareUserInfoForm(BaseUserInfoForm, UpdateUserRoleForm):

--- a/corehq/apps/users/forms.py
+++ b/corehq/apps/users/forms.py
@@ -275,7 +275,7 @@ class UpdateMyAccountInfoForm(BaseUpdateUserForm, BaseUserInfoForm):
                 ugettext_lazy("Basic"),
                 *basic_fields
             ),
-            cb3_layout.Fieldset(
+            (hqcrispy.FieldsetAccordionGroup if self.collapse_other_options else cb3_layout.Fieldset)(
                 ugettext_lazy("Other Options"),
                 hqcrispy.Field('language'),
                 cb3_layout.Div(*api_key_controls),
@@ -292,6 +292,10 @@ class UpdateMyAccountInfoForm(BaseUpdateUserForm, BaseUserInfoForm):
     @property
     def set_email_opt_out(self):
         return self.user.is_web_user()
+
+    @property
+    def collapse_other_options(self):
+        return self.user.is_commcare_user()
 
     @property
     def direct_properties(self):

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1290,32 +1290,36 @@ class MySettingsTab(UITab):
             MyProjectsList,
             TwoFactorProfileView,
         )
-        items = [
-            [_("Manage My Settings"), [
-                {
-                    'title': _(MyAccountSettingsView.page_title),
-                    'url': reverse(MyAccountSettingsView.urlname),
-                },
-                {
-                    'title': _(MyProjectsList.page_title),
-                    'url': reverse(MyProjectsList.urlname),
-                },
-                {
-                    'title': _(ChangeMyPasswordView.page_title),
-                    'url': reverse(ChangeMyPasswordView.urlname),
-                },
-                {
-                    'title': _(TwoFactorProfileView.page_title),
-                    'url': reverse(TwoFactorProfileView.urlname),
-                }
-            ]]
+        menu_items = [
+            {
+                'title': MyAccountSettingsView.page_title,
+                'url': reverse(MyAccountSettingsView.urlname),
+            },
         ]
+
+        if self.couch_user and self.couch_user.is_web_user():
+            menu_items.append({
+                'title': MyProjectsList.page_title,
+                'url': reverse(MyProjectsList.urlname),
+            })
+
+        menu_items.extend([
+            {
+                'title': ChangeMyPasswordView.page_title,
+                'url': reverse(ChangeMyPasswordView.urlname),
+            },
+            {
+                'title': TwoFactorProfileView.page_title,
+                'url': reverse(TwoFactorProfileView.urlname),
+            }
+        ])
+
         if self.couch_user and self.couch_user.is_dimagi:
-            items[0][1].append({
-                'title': _(EnableSuperuserView.page_title),
+            menu_items.append({
+                'title': EnableSuperuserView.page_title,
                 'url': reverse(EnableSuperuserView.urlname),
             })
-        return items
+        return [[_("Manage My Settings"), menu_items]]
 
 
 class AccountingTab(UITab):


### PR DESCRIPTION
spec is [here](https://docs.google.com/document/d/16i2wZzXjvT1lJEke8mL10fJPQJsSDkI0yh7g5XZ7qEs/edit#heading=h.q6cqq8l0nf3i)
- makes "My Projects List" view inaccessible to mobile workers
- removes email opt out from the fields on "My Account Settings" page for mobile workers
- collapses "Other Options" for mobile workers on "My Account Settings" page

@dannyroberts 
