### PR TITLE
fix 500 when unauthenticated user hits view

### DIFF
--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -340,6 +340,7 @@ class AppDiffView(LoginAndDomainMixin, BasePageView, DomainViewMixin):
     template_name = 'app_manager/app_diff.html'
 
     @use_angular_js
+    @login_and_domain_required
     def dispatch(self, request, *args, **kwargs):
         try:
             self.first_app_id = self.kwargs["first_app_id"]


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?232864

Needed because `self.request.couch_user` is referenced before the superclass `dispatch` method is called.

@kaapstorm 
