### PR TITLE
couch to sql migration / prefactor

### DIFF
--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -103,21 +103,7 @@ def process_cases_with_casedb(xforms, case_db, config=None):
     cases = case_processing_result.cases
     xform = xforms[0]
 
-    # handle updating the sync records for apps that use sync mode
-    try:
-        relevant_log = xform.get_sync_token()
-    except ResourceNotFound:
-        if LOOSE_SYNC_TOKEN_VALIDATION.enabled(xform.domain):
-            relevant_log = None
-        else:
-            raise
-
-    if relevant_log:
-        # in reconciliation mode, things can be unexpected
-        relevant_log.strict = config.strict_asserts
-        from casexml.apps.case.util import update_sync_log_with_checks
-        update_sync_log_with_checks(relevant_log, xform, cases, case_db,
-                                    case_id_blacklist=config.case_id_blacklist)
+    _update_sync_logs(xform, case_db, config, cases)
 
     try:
         cases_received.send(sender=None, xform=xform, cases=cases)
@@ -135,6 +121,24 @@ def process_cases_with_casedb(xforms, case_db, config=None):
 
     case_processing_result.set_cases(cases)
     return case_processing_result
+
+
+def _update_sync_logs(xform, case_db, config, cases):
+    # handle updating the sync records for apps that use sync mode
+    try:
+        relevant_log = xform.get_sync_token()
+    except ResourceNotFound:
+        if LOOSE_SYNC_TOKEN_VALIDATION.enabled(xform.domain):
+            relevant_log = None
+        else:
+            raise
+
+    if relevant_log:
+        # in reconciliation mode, things can be unexpected
+        relevant_log.strict = config.strict_asserts
+        from casexml.apps.case.util import update_sync_log_with_checks
+        update_sync_log_with_checks(relevant_log, xform, cases, case_db,
+                                    case_id_blacklist=config.case_id_blacklist)
 
 
 class CaseProcessingConfig(object):

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -232,7 +232,7 @@ def _get_dirtiness_flags_for_outgoing_indices(case_db, case, tree_owners=None):
     for unowned_host_case in unowned_host_cases:
         # A host case of this extension is unowned, which means it could potentially touch an owned case
         # Check these unowned cases' outgoing indices and mark dirty if appropriate
-        for dirtiness_flag in _get_dirtiness_flags_for_outgoing_indices(unowned_host_case,
+        for dirtiness_flag in _get_dirtiness_flags_for_outgoing_indices(case_db, unowned_host_case,
                                                                         tree_owners=tree_owners):
             yield dirtiness_flag
 

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -174,7 +174,7 @@ def _get_or_update_cases(xforms, case_db):
     """
     domain = getattr(case_db, 'domain', None)
     touched_cases = FormProcessorInterface(domain).get_cases_from_forms(case_db, xforms)
-    _validate_indices(case_db, [case_update_meta.case for case_update_meta in touched_cases])
+    _validate_indices(case_db, [case_update_meta.case for case_update_meta in touched_cases.values()])
     dirtiness_flags = _get_all_dirtiness_flags_from_cases(case_db, touched_cases)
     extensions_to_close = get_all_extensions_to_close(domain, touched_cases.values())
     return CaseProcessingResult(

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -174,15 +174,9 @@ def _get_or_update_cases(xforms, case_db):
     """
     domain = getattr(case_db, 'domain', None)
     touched_cases = FormProcessorInterface(domain).get_cases_from_forms(case_db, xforms)
-
-    extensions_to_close = set()
-
     _validate_indices(case_db, [case_update_meta.case for case_update_meta in touched_cases])
     dirtiness_flags = _get_all_dirtiness_flags_from_cases(case_db, touched_cases)
-
-    for case_update_meta in touched_cases.values():
-        extensions_to_close = extensions_to_close | get_extensions_to_close(case_update_meta.case, domain)
-
+    extensions_to_close = get_all_extensions_to_close(domain, touched_cases.values())
     return CaseProcessingResult(
         domain,
         [update.case for update in touched_cases.values()],
@@ -283,6 +277,12 @@ def _is_change_of_ownership(previous_owner_id, next_owner_id):
         and previous_owner_id != UNOWNED_EXTENSION_OWNER_ID
         and previous_owner_id != next_owner_id
     )
+
+
+def get_all_extensions_to_close(domain, case_updates):
+    extensions_to_close = set()
+    for case_update_meta in case_updates:
+        extensions_to_close = extensions_to_close | get_extensions_to_close(case_update_meta.case, domain)
 
 
 def get_extensions_to_close(case, domain):

--- a/corehq/ex-submodules/casexml/apps/case/xform.py
+++ b/corehq/ex-submodules/casexml/apps/case/xform.py
@@ -283,6 +283,7 @@ def get_all_extensions_to_close(domain, case_updates):
     extensions_to_close = set()
     for case_update_meta in case_updates:
         extensions_to_close = extensions_to_close | get_extensions_to_close(case_update_meta.case, domain)
+    return extensions_to_close
 
 
 def get_extensions_to_close(case, domain):

--- a/corehq/form_processor/management/commands/migrate_domain_from_couch_to_sql.py
+++ b/corehq/form_processor/management/commands/migrate_domain_from_couch_to_sql.py
@@ -1,6 +1,11 @@
 from datetime import datetime
 from django.core.management.base import LabelCommand, CommandError
-from corehq.form_processor.utils import should_use_sql_backend
+from casexml.apps.case.xform import get_all_extensions_to_close, CaseProcessingResult
+from corehq.form_processor.interfaces.processor import FormProcessorInterface
+from corehq.form_processor.models import XFormInstanceSQL
+from corehq.form_processor.submission_post import CaseStockProcessingResult
+from corehq.form_processor.utils import should_use_sql_backend, adjust_datetimes
+from corehq.form_processor.utils.general import set_local_domain_sql_backend_override
 from corehq.util.dates import iso_string_to_datetime
 from couchforms.models import XFormInstance
 from fluff.management.commands.ptop_reindexer_fluff import ReindexEventHandler
@@ -18,6 +23,8 @@ class Command(LabelCommand):
 
 def _do_couch_to_sql_migration(domain):
     # (optional) collect some information about the domain's cases and forms for cross-checking
+    set_local_domain_sql_backend_override(domain)
+    assert should_use_sql_backend(domain)
     _process_main_forms(domain)
     _copy_unprocessed_forms(domain)
     # (optional) compare the information collected to the information at the beginning
@@ -28,11 +35,12 @@ def _process_main_forms(domain):
     # process main forms (including cases and ledgers)
     for change in _get_main_form_iterator(domain).iter_all_changes():
         form = change.get_document()
+        wrapped_form = XFormInstance.wrap(form)
         form_received = iso_string_to_datetime(form['received_on'])
         assert last_received_on <= form_received
         last_received_on = form_received
         print 'processing form {}: {}'.format(form['_id'], form_received)
-        _migrate_form_and_associated_models(domain, form)
+        _migrate_form_and_associated_models(domain, wrapped_form)
 
 
 def _get_main_form_iterator(domain):
@@ -44,35 +52,90 @@ def _get_main_form_iterator(domain):
     )
 
 
-def _migrate_form_and_associated_models(domain, form):
-    sql_form = _migrate_form_and_attachments(domain, form)
-    _migrate_submission_properties(domain, form, sql_form)
-    case_stock_result = _process_cases_and_ledgers(domain, sql_form)
+def _migrate_form_and_associated_models(domain, couch_form):
+    sql_form = _migrate_form_and_attachments(domain, couch_form)
+    case_stock_result = _get_case_and_ledger_updates(domain, sql_form)
     _save_migrated_models(sql_form, case_stock_result)
 
 
-def _migrate_form_and_attachments(domain, form):
+def _migrate_form_and_attachments(domain, couch_form):
     """
-    see form_processor.parsers.form._create_new_xform for what this should do
+    This copies the couch form into a new sql form but does not save it.
+
+    See form_processor.parsers.form._create_new_xform
+    and SubmissionPost._set_submission_properties for what this should do.
     """
-    # convert couch form to SQL form
-    # adjust datetimes (if doing tzmigration)
-    # migrate all attachments
-    pass
+    interface = FormProcessorInterface(domain)
+
+    form_data = couch_form.form
+    # todo: timezone migration if we want here
+    # adjust_datetimes(form_data)
+    sql_form = interface.new_xform(form_data)
+    assert isinstance(sql_form, XFormInstanceSQL)
+    sql_form.domain = domain
+
+    # todo: attachments.
+    # note that if these are in the blobdb then we likely don't need to move them,
+    # just need to bring the references across
+    # interface.store_attachments(xform, attachments)
+
+    # submission properties
+    sql_form.auth_context = couch_form.auth_context
+    sql_form.submit_ip = couch_form.submit_ip
+
+    # todo: this property appears missing from sql forms - do we need it?
+    # sql_form.path = couch_form.path
+
+    sql_form.openrosa_headers = couch_form.openrosa_headers
+    sql_form.last_sync_token = couch_form.last_sync_token
+    sql_form.received_on = couch_form.received_on
+    sql_form.date_header = couch_form.date_header
+    sql_form.app_id = couch_form.app_id
+    sql_form.build_id = couch_form.build_id
+    # export_tag intentionally removed
+    # sql_form.export_tag = ["domain", "xmlns"]
+    sql_form.partial_submission = couch_form.partial_submission
+    return sql_form
 
 
-def _migrate_submission_properties(domain, couch_form_json, sql_form):
+def _get_case_and_ledger_updates(domain, sql_form):
     """
-    See SubmissionPost._set_submission_properties for what this should do
-    """
-    pass
+    Get a CaseStockProcessingResult with the appropriate cases and ledgers to
+    be saved.
 
+    See SubmissionPost.process_xforms_for_cases and methods it calls for the equivalent
+    section of the form-processing code.
+    """
+    from casexml.apps.case.xform import get_and_check_xform_domain
+    from corehq.apps.commtrack.processing import process_stock
 
-def _process_cases_and_ledgers(domain, sql_form):
-    """
-    See SubmissionPost.process_xforms_for_cases for what this should do
-    """
-    pass
+    interface = FormProcessorInterface(domain)
+
+    get_and_check_xform_domain(sql_form)
+    xforms = [sql_form]
+    # todo: I think this can be changed to lock=False
+    with interface.casedb_cache(domain=domain, lock=True, deleted_ok=True, xforms=xforms) as case_db:
+        touched_cases = FormProcessorInterface(domain).get_cases_from_forms(case_db, xforms)
+        extensions_to_close = get_all_extensions_to_close(domain, touched_cases.values())
+        case_result = CaseProcessingResult(
+            domain,
+            [update.case for update in touched_cases.values()],
+            [],  # ignore dirtiness_flags,
+            extensions_to_close
+        )
+        # todo: is this necessary?
+        for case in case_result.cases:
+            case_db.mark_changed(case)
+
+        stock_result = process_stock(xforms, case_db)
+        cases = case_db.get_cases_for_saving(sql_form.received_on)
+        stock_result.populate_models()
+
+    return CaseStockProcessingResult(
+        case_result=case_result,
+        case_models=cases,
+        stock_result=stock_result,
+    )
 
 
 def _save_migrated_models(sql_form, case_stock_result):

--- a/corehq/form_processor/management/commands/migrate_domain_from_couch_to_sql.py
+++ b/corehq/form_processor/management/commands/migrate_domain_from_couch_to_sql.py
@@ -1,0 +1,109 @@
+from datetime import datetime
+from django.core.management.base import LabelCommand, CommandError
+from corehq.form_processor.utils import should_use_sql_backend
+from corehq.util.dates import iso_string_to_datetime
+from couchforms.models import XFormInstance
+from fluff.management.commands.ptop_reindexer_fluff import ReindexEventHandler
+from pillowtop.reindexer.change_providers.couch import CouchDomainDocTypeChangeProvider
+
+
+class Command(LabelCommand):
+
+    def handle_label(self, domain, **options):
+        if should_use_sql_backend(domain):
+            raise CommandError(u'It looks like {} has already been migrated.'.format(domain))
+
+        _do_couch_to_sql_migration(domain)
+
+
+def _do_couch_to_sql_migration(domain):
+    # (optional) collect some information about the domain's cases and forms for cross-checking
+    _process_main_forms(domain)
+    _copy_unprocessed_forms(domain)
+    # (optional) compare the information collected to the information at the beginning
+
+
+def _process_main_forms(domain):
+    last_received_on = datetime.min
+    # process main forms (including cases and ledgers)
+    for change in _get_main_form_iterator(domain).iter_all_changes():
+        form = change.get_document()
+        form_received = iso_string_to_datetime(form['received_on'])
+        assert last_received_on <= form_received
+        last_received_on = form_received
+        print 'processing form {}: {}'.format(form['_id'], form_received)
+        _migrate_form_and_associated_models(domain, form)
+
+
+def _get_main_form_iterator(domain):
+    return CouchDomainDocTypeChangeProvider(
+        couch_db=XFormInstance.get_db(),
+        domains=[domain],
+        doc_types=['XFormInstance'],
+        event_handler=ReindexEventHandler(u'couch to sql migrator ({})'.format(domain)),
+    )
+
+
+def _migrate_form_and_associated_models(domain, form):
+    sql_form = _migrate_form_and_attachments(domain, form)
+    _migrate_submission_properties(domain, form, sql_form)
+    case_stock_result = _process_cases_and_ledgers(domain, sql_form)
+    _save_migrated_models(sql_form, case_stock_result)
+
+
+def _migrate_form_and_attachments(domain, form):
+    """
+    see form_processor.parsers.form._create_new_xform for what this should do
+    """
+    # convert couch form to SQL form
+    # adjust datetimes (if doing tzmigration)
+    # migrate all attachments
+    pass
+
+
+def _migrate_submission_properties(domain, couch_form_json, sql_form):
+    """
+    See SubmissionPost._set_submission_properties for what this should do
+    """
+    pass
+
+
+def _process_cases_and_ledgers(domain, sql_form):
+    """
+    See SubmissionPost.process_xforms_for_cases for what this should do
+    """
+    pass
+
+
+def _save_migrated_models(sql_form, case_stock_result):
+    """
+    See SubmissionPost.save_processed_models for ~what this should do.
+    However, note that that function does some things that this one shouldn't,
+    e.g. process ownership cleanliness flags.
+    """
+
+
+def _copy_unprocessed_forms(domain):
+    # copy unprocessed forms
+    for change in _get_unprocessed_form_iterator(domain).iter_all_changes():
+        form = change.get_document()
+        print 'copying unprocessed {} {}: {}'.format(form['doc_type'], form['_id'], form['received_on'])
+        # save updated models
+
+
+def _get_unprocessed_form_iterator(domain):
+    return CouchDomainDocTypeChangeProvider(
+        couch_db=XFormInstance.get_db(),
+        domains=[domain],
+        doc_types=[
+            'XFormArchived',
+            'XFormError',
+            'XFormDeprecated',
+            'XFormDuplicate',
+            # todo: need to figure out which of these we plan on supporting
+            'XFormInstance-Deleted',
+            'HQSubmission',
+            'SubmissionErrorLog',
+        ],
+        event_handler=ReindexEventHandler(u'couch to sql migrator ({} unprocessed forms)'.format(domain)),
+    )

--- a/corehq/form_processor/tests/test_use_sql_backend.py
+++ b/corehq/form_processor/tests/test_use_sql_backend.py
@@ -2,7 +2,7 @@ import uuid
 from django.test import TestCase
 from corehq.apps.domain.shortcuts import create_domain
 from corehq.form_processor.utils.general import get_local_domain_sql_backend_override, \
-    set_local_domain_sql_backend_override, should_use_sql_backend_in_prod
+    set_local_domain_sql_backend_override, _should_use_sql_backend_in_prod
 
 
 class UseSqlBackendTest(TestCase):
@@ -18,6 +18,6 @@ class UseSqlBackendTest(TestCase):
     def test_test_local_domain_sql_backend_override_overrides(self):
         domain_name = uuid.uuid4().hex
         create_domain(domain_name)
-        self.assertFalse(should_use_sql_backend_in_prod(domain_name))
+        self.assertFalse(_should_use_sql_backend_in_prod(domain_name))
         set_local_domain_sql_backend_override(domain_name)
-        self.assertTrue(should_use_sql_backend_in_prod(domain_name))
+        self.assertTrue(_should_use_sql_backend_in_prod(domain_name))

--- a/corehq/form_processor/tests/test_use_sql_backend.py
+++ b/corehq/form_processor/tests/test_use_sql_backend.py
@@ -1,0 +1,23 @@
+import uuid
+from django.test import TestCase
+from corehq.apps.domain.shortcuts import create_domain
+from corehq.form_processor.utils.general import get_local_domain_sql_backend_override, \
+    set_local_domain_sql_backend_override, should_use_sql_backend_in_prod
+
+
+class UseSqlBackendTest(TestCase):
+
+    def test_local_domain_sql_backend_override_initial_none(self):
+        self.assertIsNone(get_local_domain_sql_backend_override(uuid.uuid4().hex))
+
+    def test_local_domain_sql_backend_override(self):
+        domain_name = uuid.uuid4().hex
+        set_local_domain_sql_backend_override(domain_name)
+        self.assertTrue(get_local_domain_sql_backend_override(domain_name))
+
+    def test_test_local_domain_sql_backend_override_overrides(self):
+        domain_name = uuid.uuid4().hex
+        create_domain(domain_name)
+        self.assertFalse(should_use_sql_backend_in_prod(domain_name))
+        set_local_domain_sql_backend_override(domain_name)
+        self.assertTrue(should_use_sql_backend_in_prod(domain_name))

--- a/corehq/form_processor/utils/general.py
+++ b/corehq/form_processor/utils/general.py
@@ -25,12 +25,10 @@ def should_use_sql_backend(domain_object_or_name):
     if settings.UNIT_TESTING:
         return _should_use_sql_backend_in_tests(domain_object_or_name)
 
-    return should_use_sql_backend_in_prod(domain_object_or_name)
+    return _should_use_sql_backend_in_prod(domain_object_or_name)
 
 
-def should_use_sql_backend_in_prod(domain_object_or_name):
-    # the only reason this method is "public" is so it can be called directly by a handful of tests.
-    # everything else should call should_use_sql_backend instead
+def _should_use_sql_backend_in_prod(domain_object_or_name):
     from corehq.apps.domain.models import Domain
     # TODO: remove toggle once all domains have been migrated
     if isinstance(domain_object_or_name, Domain):

--- a/corehq/form_processor/utils/general.py
+++ b/corehq/form_processor/utils/general.py
@@ -29,6 +29,8 @@ def should_use_sql_backend(domain_object_or_name):
 
 
 def should_use_sql_backend_in_prod(domain_object_or_name):
+    # the only reason this method is "public" is so it can be called directly by a handful of tests.
+    # everything else should call should_use_sql_backend instead
     from corehq.apps.domain.models import Domain
     # TODO: remove toggle once all domains have been migrated
     if isinstance(domain_object_or_name, Domain):

--- a/corehq/form_processor/utils/general.py
+++ b/corehq/form_processor/utils/general.py
@@ -22,10 +22,14 @@ def set_local_domain_sql_backend_override(domain):
 
 
 def should_use_sql_backend(domain_object_or_name):
-    from corehq.apps.domain.models import Domain
     if settings.UNIT_TESTING:
         return _should_use_sql_backend_in_tests(domain_object_or_name)
 
+    return should_use_sql_backend_in_prod(domain_object_or_name)
+
+
+def should_use_sql_backend_in_prod(domain_object_or_name):
+    from corehq.apps.domain.models import Domain
     # TODO: remove toggle once all domains have been migrated
     if isinstance(domain_object_or_name, Domain):
         domain_name = domain_object_or_name.name

--- a/corehq/form_processor/utils/general.py
+++ b/corehq/form_processor/utils/general.py
@@ -3,6 +3,23 @@ from django.conf import settings
 from corehq.toggles import USE_SQL_BACKEND, NAMESPACE_DOMAIN, NEW_EXPORTS, TF_USES_SQLITE_BACKEND
 from dimagi.utils.logging import notify_exception
 
+import threading
+
+_thread_local = threading.local()
+
+
+def get_local_domain_sql_backend_override(domain):
+    try:
+        return _thread_local.use_sql_backend[domain]
+    except (AttributeError, KeyError):
+        return None
+
+
+def set_local_domain_sql_backend_override(domain):
+    use_sql_backend_dict = getattr(_thread_local, 'use_sql_backend', {})
+    use_sql_backend_dict[domain] = True
+    _thread_local.use_sql_backend = use_sql_backend_dict
+
 
 def should_use_sql_backend(domain_object_or_name):
     from corehq.apps.domain.models import Domain
@@ -19,6 +36,11 @@ def should_use_sql_backend(domain_object_or_name):
 
     if domain_object is None:
         return False
+
+    local_override = get_local_domain_sql_backend_override(domain_name)
+    if local_override is not None:
+        return local_override
+
     toggle_enabled = USE_SQL_BACKEND.enabled(domain_name)
     if toggle_enabled:
         try:


### PR DESCRIPTION
@dimagi/scale-team this isn't done yet but wanted to get some high-level feedback on the approach and also run tests. 

I think this is going to be quite doable though the current approach I'm taking involves forking a decent amount of the form-processing code which I can see being a pain to maintain over time. The other option would be to add parameters to those methods and keep the code in one place which adds a different kind of complexity.

I jotted this down, as well as a number of other thoughts/questions in [the google doc](https://docs.google.com/document/d/1eIU6pJ6xBQokCa7AHUxOWDUFX2kLfwl6kIoNuRRpcts/edit#heading=h.a4ng5uahq1ik).

Probably useful to read :fish: though it may make sense to review `migrate_domain_from_couch_to_sql.py` all at once
