### PR TITLE
Client-side pagination for Project Performance Dashboard

### DIFF
--- a/corehq/apps/reports/templates/reports/project_health/partials/user_list.html
+++ b/corehq/apps/reports/templates/reports/project_health/partials/user_list.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% load hq_shared_tags %}
-<table class="table table-striped">
+<table class="table table-striped datatable" width="100%">
     <thead>
         <tr>
             <th></th>

--- a/corehq/apps/reports/templates/reports/project_health/project_health_dashboard.html
+++ b/corehq/apps/reports/templates/reports/project_health/project_health_dashboard.html
@@ -156,10 +156,19 @@
         }
     }
 
+    function setupDataTables(){
+        $('.datatable').DataTable({
+            "ordering": false,
+            "searching": false,
+            "lengthChange": false,
+        })
+    }
+
     $(function() {
         setupCharts();
         setupPopovers();
         setupLineChart();
+        setupDataTables();
     });
 </script>
 {% endblock %}


### PR DESCRIPTION
@esoergel As a follow up to #12464 (to be closed), I am using DataTables to paginate user tables for Low Performing, Inactive, and High Performing users in Project Performance Dashboard. @czue Checked in with Ethan, and will work on server-side pagination next.

![screen shot 2016-07-26 at 1 03 40 pm](https://cloud.githubusercontent.com/assets/8680734/17147753/195b456a-5332-11e6-99f0-d53697edf5a4.png)
