### PR TITLE
make navigation menus more responsive in tablet and phone modes

### DIFF
--- a/corehq/apps/notifications/templates/notifications/partials/global_notifications.html
+++ b/corehq/apps/notifications/templates/notifications/partials/global_notifications.html
@@ -11,6 +11,7 @@
     <a href="#" data-bind="click: bellClickHandler" class="dropdown-toggle dropdown-toggle-with-icon" data-toggle="dropdown" id="notification-icon">
         <i class="icon-bell-alt fa fa-bell nav-main-icon"
            data-bind="css: {'notifications-active-icon': !seen()}"></i>
+        <span class="responsive-label">{% trans "Notifications" %}</span>
     </a>
     <ul class="dropdown-menu notifications-dropdown dropdown-menu-right"
         role="menu">

--- a/corehq/apps/style/static/style/less/_hq/navbar.less
+++ b/corehq/apps/style/static/style/less/_hq/navbar.less
@@ -186,19 +186,6 @@
   }
 }
 
-.navbar-collapse {
-  padding-right: @navbar-padding-horizontal;
-  padding-left:  @navbar-padding-horizontal;
-}
-
-.container,
-.container-fluid {
-  > .navbar-collapse {
-    margin-right: -@navbar-padding-horizontal;
-    margin-left: -@navbar-padding-horizontal;
-  }
-}
-
 .navbar-toggle {
   margin-right: @navbar-padding-horizontal;
 }
@@ -207,3 +194,114 @@
   background-color: #F4F4F4;
 }
 
+.collapse-mainmenu-toggle,
+.collapse-fullmenu-toggle {
+  display: none;
+  float: left;
+  line-height: @navbar-height;
+}
+.responsive-label {
+  display: none;
+}
+
+
+@media(max-width: 959px) {
+  .mainmenu-tabs.collapsing,
+  .mainmenu-tabs.collapse {
+    border-top: 1px solid darken(@navbar-default-bg, 5);
+    width: 100%;
+    box-sizing: content-box;
+    margin-left: -10px;
+    padding-right: 20px;
+  }
+
+  .mainmenu-tabs.collapse {
+    display: none;
+    height: 0;
+    .transition(height 1s);
+  }
+
+  .mainmenu-tabs.collapse.in {
+    display: block;
+    height: auto;
+  }
+  .collapse-mainmenu-toggle {
+    display: block;
+  }
+}
+
+@media (max-width: 767px) {
+  .collapse-mainmenu-toggle {
+    display: none;
+  }
+  .collapse-fullmenu-toggle {
+    display: block;
+    float: right;
+    > a {
+      line-height: @navbar-height;
+    }
+  }
+  .mainmenu-tabs.collapsing,
+  .mainmenu-tabs.collapse {
+    box-sizing: border-box;
+    width: auto;
+    padding: 0;
+   }
+  .mainmenu-tabs.collapse {
+    display: block;
+    height: auto !important;
+  }
+  .mainmenu-tabs {
+    clear: both;
+  }
+  .nav-settings-bar {
+    float: none !important;
+    clear: both;
+  }
+  .fullmenu .navbar-nav {
+    padding-right: 0;
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
+    border-top: 1px solid darken(@navbar-default-bg, 5) !important;
+  }
+  .responsive-label {
+    display: inline;
+  }
+  .navbar-nav > li > a.dropdown-toggle-with-icon {
+    padding-bottom: 10px !important;
+  }
+  .nav-main-icon {
+    font-size: 1em !important;
+  }
+  .fullmenu .dropdown-menu {
+    background-color: lighten(@navbar-default-bg, 5) !important;
+  }
+  .fullmenu .navbar-nav .open .dropdown-menu > li > a {
+    .transition(background-color .5s);
+    &:hover {
+      background-color: @navbar-default-bg !important;
+    }
+  }
+  .fullmenu .navbar-nav .dropdown > .dropdown-menu {
+    height: 0;
+    .transition(height 1s);
+  }
+  .fullmenu .navbar-nav .dropdown.open > .dropdown-menu {
+    height: auto;
+  }
+  .fullmenu .navbar-nav .open .dropdown-menu .dropdown-header.nav-header {
+    padding: 5px 19px;
+  }
+}
+
+@media (min-width: 767px) {
+  .fullmenu.collapse {
+    display: block;
+  }
+}
+
+@media (min-width: 960px) {
+  .mainmenu-tabs.collapse {
+    display: block;
+  }
+}

--- a/corehq/apps/style/templates/style/base.html
+++ b/corehq/apps/style/templates/style/base.html
@@ -222,7 +222,16 @@
             <div id="hq-navigation"
                  class="navbar navbar-default navbar-static-top navbar-hq-main-menu">
                 <div class="container-fluid">
-                    <div class="navbar-header">
+                    <ul class="nav navbar-nav collapse-fullmenu-toggle" id="hq-fullmenu-responsive" role="menu">
+                        <li>
+                            <a href="#hq-full-menu" data-toggle="collapse">
+                                <i class="fa fa-bars"></i>
+                                {% trans "Menu" %}
+                            </a>
+                        </li>
+                    </ul>
+
+                    <div class="navbar-header hq-header">
                         <a href="{% url "homepage" %}" class="navbar-brand">
                             {% if CUSTOM_LOGO_URL %}
                                 <img src="{{ CUSTOM_LOGO_URL }}" alt="CommCare HQ Logo" />
@@ -232,10 +241,17 @@
                             {% endif %}
                         </a>
                     </div>
-                    <nav class="collapse navbar-collapse" role="navigation">
-                        {% block tabs %}
-                            {% format_main_menu %}
-                        {% endblock %}
+
+                    <ul class="nav navbar-nav collapse-mainmenu-toggle" id="hq-mainmenu-responsive" role="menu">
+                        <li>
+                            <a href="#hq-main-tabs" data-toggle="collapse">
+                                <i class="fa fa-bars"></i>
+                                {% trans "Menu" %}
+                            </a>
+                        </li>
+                    </ul>
+
+                    <nav class="navbar-menus fullmenu collapse" id="hq-full-menu" role="navigation">
                         <div class="nav-settings-bar pull-right">
                         {% if request.user.is_authenticated %}
                             {% include 'style/includes/global_navigation_bar.html' %}
@@ -243,6 +259,9 @@
                             <a href="{% url "login" %}" class="btn btn-primary navbar-btn">{% trans 'Sign In' %}</a>
                         {% endif %}
                         </div>
+                        {% block tabs %}
+                            {% format_main_menu %}
+                        {% endblock %}
                     </nav>
                 </div>
             </div>

--- a/corehq/apps/style/templates/style/includes/global_navigation_bar.html
+++ b/corehq/apps/style/templates/style/includes/global_navigation_bar.html
@@ -18,7 +18,7 @@
 <ul class="nav navbar-nav" role="menu">
     <li id="settingsmenu-projectSettings" class="dropdown">
         <a href="#" class="dropdown-toggle dropdown-toggle-with-icon" data-toggle="dropdown">
-            <i class="icon-cog fa fa-cog nav-main-icon"></i>
+            <i class="fa fa-cog nav-main-icon"></i> <span class="responsive-label">{% trans "Manage" %}</span>
         </a>
         <ul class="dropdown-menu dropdown-menu-right" role="menu">
             <li class="dropdown-header nav-header">{% trans 'Logged in As' %}</li>
@@ -72,7 +72,7 @@
     </li>
     <li id="settingsmenu-help" class="dropdown">
         <a href="#" class="dropdown-toggle dropdown-toggle-with-icon" data-toggle="dropdown">
-            <i class="fa fa-question-circle icon-question-sign nav-main-icon"></i>
+            <i class="fa fa-question-circle nav-main-icon"></i> <span class="responsive-label">{% trans "Help &amp; Resources" %}</span>
         </a>
         <ul class="dropdown-menu dropdown-menu-right" role="menu">
             <li class="dropdown-header nav-header">{% trans 'CommCare Help' %}</li>
@@ -97,6 +97,7 @@
     {% include 'notifications/partials/global_notifications.html' %}
     <li id="settingsmenu-project" class="dropdown">
         <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+            <span class="responsive-label">{% trans "Project" %}:</span>
             {% if domain %}
                 {% ifequal domain 'public' %}
                     {% trans 'CommCare HQ Demo Project' %}

--- a/corehq/tabs/templates/tabs/menu_main.html
+++ b/corehq/tabs/templates/tabs/menu_main.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% load cache %}
 {% get_current_language as LANGUAGE_CODE %}
-<ul class="nav navbar-nav" role="menu">
+<ul class="nav navbar-nav mainmenu-tabs collapse" id="hq-main-tabs" role="menu">
     {% for tab in tabs %}
     {% cache 500 header_tab tab.class_name tab.domain tab.is_active_tab tab.couch_user.get_id LANGUAGE_CODE %}
     {% with tab.dropdown_items as items %}


### PR DESCRIPTION
@benrudolph / @orangejenny 
cc @dimagi/product 

// Phone collapsed and uncollapsed
// ------------------------------------
<img width="793" alt="screen shot 2016-07-26 at 5 34 06 pm" src="https://cloud.githubusercontent.com/assets/716573/17156414/b8c3ade8-5357-11e6-8ebb-de17e8202194.png">
<img width="750" alt="screen shot 2016-07-26 at 5 33 54 pm" src="https://cloud.githubusercontent.com/assets/716573/17156413/b8c2fba0-5357-11e6-9772-43d65597e141.png">

// Tablet collapsed and uncollapsed
// ------------------------------------
<img width="920" alt="screen shot 2016-07-26 at 5 34 13 pm" src="https://cloud.githubusercontent.com/assets/716573/17156416/b8c51d04-5357-11e6-8699-37d6a5c1626d.png">
<img width="900" alt="screen shot 2016-07-26 at 5 34 18 pm" src="https://cloud.githubusercontent.com/assets/716573/17156415/b8c517b4-5357-11e6-98f2-623567f30531.png">

// Full Width
// ------------------------------------
<img width="1050" alt="screen shot 2016-07-26 at 5 34 29 pm" src="https://cloud.githubusercontent.com/assets/716573/17156417/b8d1c590-5357-11e6-80de-abf290d3e526.png">
