### PR TITLE
Single-line version of inline edit widget

### DIFF
--- a/corehq/apps/app_manager/templatetags/xforms_extras.py
+++ b/corehq/apps/app_manager/templatetags/xforms_extras.py
@@ -69,7 +69,7 @@ def inline_edit_trans(name, langs=None, url='', saveValueName='', readOnlyClass=
             name: 'name',
             value: '%(value)s',
             placeholder: '%(placeholder)s',
-            rows: 1,
+            nodeName: 'input',
             lang: '%(lang)s',
             url: '{}',
             saveValueName: '{}',

--- a/corehq/apps/style/static/style/ko/components/inline_edit.js
+++ b/corehq/apps/style/static/style/ko/components/inline_edit.js
@@ -1,18 +1,19 @@
 /*
- * Component for an inline editing widget: a piece of text that, when clicked on, turns into a textarea.
- * The textarea is accompanied by a save button capable of saving the new value to the server via ajax.
+ * Component for an inline editing widget: a piece of text that, when clicked on, turns into an input (textarea or
+ * text input). The input is accompanied by a save button capable of saving the new value to the server via ajax.
  *
  * Required parameters
  *  - url: The URL to call on save.
  *
  * Optional parameters
  *  - value: Text to display and edit
- *  - name: HTML name of textarea
- *  - id: HTML id of textarea
+ *  - name: HTML name of input
+ *  - id: HTML id of input
  *  - placeholder: Text to display when in read-only mode if value is blank
  *  - lang: Display this language code in a badge next to the widget.
- *  - rows: Number of rows in textarea.
- *  - cols: Number of cols in textarea.
+ *  - nodeName: 'textarea' or 'input'. Defaults to 'textarea'.
+ *  - rows: Number of rows in input.
+ *  - cols: Number of cols in input.
  *  - saveValueName: Name to associate with text value when saving. Defaults to 'value'.
  *  - saveParams: Any additional data to pass along. May contain observables.
  *  - errorMessage: Message to display if server returns an error.
@@ -39,6 +40,7 @@ hqDefine('style/ko/components/inline_edit.js', function() {
             self.lang = params.lang || '';
 
             // Styling
+            self.nodeName = params.nodeName || 'textarea';
             self.rows = params.rows || 2;
             self.cols = params.cols || "";
             self.readOnlyClass = params.readOnlyClass || '';
@@ -143,12 +145,22 @@ hqDefine('style/ko/components/inline_edit.js', function() {
             </div>\
             <div class="read-write form-inline" data-bind="visible: isEditing()">\
                 <div class="form-group langcode-container">\
-                    <textarea class="form-control" data-bind="\
-                        attr: {name: name, id: id, placeholder: placeholder, rows: rows, cols: cols},\
-                        value: value,\
-                        hasFocus: isEditing(),\
-                        event: {blur: blur},\
-                    "></textarea>\
+                    <!-- ko if: nodeName === "textarea" -->\
+                        <textarea class="form-control" data-bind="\
+                            attr: {name: name, id: id, placeholder: placeholder, rows: rows, cols: cols},\
+                            value: value,\
+                            hasFocus: isEditing(),\
+                            event: {blur: blur},\
+                        "></textarea>\
+                    <!-- /ko -->\
+                    <!-- ko if: nodeName === "input" -->\
+                        <input type="text" class="form-control" data-bind="\
+                            attr: {name: name, id: id, placeholder: placeholder, rows: rows, cols: cols},\
+                            value: value,\
+                            hasFocus: isEditing(),\
+                            event: {blur: blur},\
+                        " />\
+                    <!-- /ko -->\
                     <!-- ko if: lang -->\
                         <span class="btn btn-xs btn-info btn-langcode-preprocessed langcode-input pull-right"\
                               data-bind="text: lang, visible: !value()"\


### PR DESCRIPTION
Kriti pointed out that multi-line inputs don't make sense for form/module names, since the phone only displays one line.

@benrudolph 

<img width="448" alt="screen shot 2016-07-26 at 6 21 46 pm" src="https://cloud.githubusercontent.com/assets/1486591/17157514/e7907d8a-535d-11e6-8f0f-bb82663198cf.png">

<img width="420" alt="screen shot 2016-07-26 at 6 21 33 pm" src="https://cloud.githubusercontent.com/assets/1486591/17157515/e97d1fe0-535d-11e6-9e8c-4422e40d054a.png">

http://manage.dimagi.com/default.asp?233262
