### PR TITLE
Use Kafka change feed for blob deletion pillow

### DIFF
--- a/corehq/blobs/pillow.py
+++ b/corehq/blobs/pillow.py
@@ -1,12 +1,7 @@
-from os.path import join
 from corehq.apps.change_feed import topics
 from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed
-from corehq.apps.app_manager.models import Application
 from corehq.blobs import get_blob_db
-from corehq.util.couchdb_management import couch_config
-from dimagi.utils.couch.database import get_db
 from pillowtop.checkpoints.manager import PillowCheckpoint, PillowCheckpointEventHandler
-from pillowtop.feed.couch import CouchChangeFeed
 from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors import PillowProcessor
 
@@ -19,46 +14,28 @@ KAFKA_CHECKPOINT_FREQUENCY = 1000
 
 class BlobDeletionProcessor(PillowProcessor):
 
-    def __init__(self, blob_db, bucket_base):
+    def __init__(self, blob_db):
         super(BlobDeletionProcessor, self).__init__()
         self.blob_db = blob_db
-        self.bucket_base = bucket_base
 
     def process_change(self, pillow_instance, change):
         if change.deleted:
-            bucket = join(self.bucket_base, change.id)
+            bucket = "{}/{}".format(change.meta.data_source_name, change.id)
             self.blob_db.delete(bucket=bucket)
 
 
-def get_main_blob_deletion_pillow(pillow_id):
-    """Get blob deletion pillow for the main couch database
-
-    Using the KafkaChangeFeed ties this to the main couch database.
+def get_blob_deletion_pillow(pillow_id):
+    """Get blob deletion pillow
     """
-    return _get_blob_deletion_pillow(
-        pillow_id,
-        get_db(None),
-        PillowCheckpoint('kafka-blob-deletion-pillow-checkpoint'),
-        KafkaChangeFeed(topics=[topics.META], group_id='blob-deletion-group'),
-    )
-
-
-def get_application_blob_deletion_pillow(pillow_id):
-    """Get blob deletion pillow for the apps couch database"""
-    couch_db = couch_config.get_db_for_class(Application)
-    return _get_blob_deletion_pillow(pillow_id, couch_db)
-
-
-def _get_blob_deletion_pillow(pillow_id, couch_db, checkpoint=None, change_feed=None):
-    if checkpoint is None:
-        checkpoint = PillowCheckpoint(pillow_id)
-    if change_feed is None:
-        change_feed = CouchChangeFeed(couch_db, include_docs=False)
+    checkpoint = PillowCheckpoint(pillow_id)
     return ConstructedPillow(
         name=pillow_id,
         checkpoint=checkpoint,
-        change_feed=change_feed,
-        processor=BlobDeletionProcessor(get_blob_db(), couch_db.dbname),
+        change_feed=KafkaChangeFeed(
+            topics=[topics.META, topics.APP],
+            group_id='blob-deletion-group',
+        ),
+        processor=BlobDeletionProcessor(get_blob_db()),
         change_processed_event_handler=PillowCheckpointEventHandler(
             checkpoint=checkpoint,
             checkpoint_frequency=KAFKA_CHECKPOINT_FREQUENCY,

--- a/corehq/blobs/pillow.py
+++ b/corehq/blobs/pillow.py
@@ -20,7 +20,8 @@ class BlobDeletionProcessor(PillowProcessor):
 
     def process_change(self, pillow_instance, change):
         if change.deleted:
-            bucket = "{}/{}".format(change.meta.data_source_name, change.id)
+            dbname = change.metadata.data_source_name
+            bucket = "{}/{}".format(dbname, change.id)
             self.blob_db.delete(bucket=bucket)
 
 

--- a/corehq/blobs/tests/test_pillow.py
+++ b/corehq/blobs/tests/test_pillow.py
@@ -9,12 +9,15 @@ class TestBlobDeletionProcessor(BaseTestCase):
 
     def setUp(self):
         super(TestBlobDeletionProcessor, self).setUp()
-        db_name = _get_couchdb_name(type(self.obj))
-        self.processor = BlobDeletionProcessor(self.db, db_name)
+        self.processor = BlobDeletionProcessor(self.db)
 
     def test_process_change_with_deleted_document(self):
         self.obj.put_attachment("content", "name")
-        change = Config(id=self.obj._id, deleted=True)
+        change = Config(
+            id=self.obj._id,
+            deleted=True,
+            metadata=Config(data_source_name=_get_couchdb_name(type(self.obj))),
+        )
         self.processor.process_change(None, change)
         msg = "FakeCouchDocument attachment: 'name'"
         with assert_raises(ResourceNotFound, msg=msg):

--- a/settings.py
+++ b/settings.py
@@ -1544,12 +1544,7 @@ PILLOWTOPS = {
         {
             'name': 'BlobDeletionPillow',
             'class': 'pillowtop.pillow.interface.ConstructedPillow',
-            'instance': 'corehq.blobs.pillow.get_main_blob_deletion_pillow',
-        },
-        {
-            'name': 'ApplicationBlobDeletionPillow',
-            'class': 'pillowtop.pillow.interface.ConstructedPillow',
-            'instance': 'corehq.blobs.pillow.get_application_blob_deletion_pillow',
+            'instance': 'corehq.blobs.pillow.get_blob_deletion_pillow',
         },
         {
             'name': 'CaseSearchToElasticsearchPillow',

--- a/testapps/test_pillowtop/tests/data/all-pillow-meta.json
+++ b/testapps/test_pillowtop/tests/data/all-pillow-meta.json
@@ -20,13 +20,6 @@
         "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
         "name": "AppDbChangeFeedPillow"
     },
-    "ApplicationBlobDeletionPillow": {
-        "advertised_name": "ApplicationBlobDeletionPillow",
-        "change_feed_type": "CouchChangeFeed",
-        "checkpoint_id": "ApplicationBlobDeletionPillow",
-        "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
-        "name": "ApplicationBlobDeletionPillow"
-    },
     "ApplicationToElasticsearchPillow": {
         "advertised_name": "ApplicationToElasticsearchPillow",
         "change_feed_type": "KafkaChangeFeed",
@@ -37,7 +30,7 @@
     "BlobDeletionPillow": {
         "advertised_name": "BlobDeletionPillow",
         "change_feed_type": "KafkaChangeFeed",
-        "checkpoint_id": "kafka-blob-deletion-pillow-checkpoint",
+        "checkpoint_id": "BlobDeletionPillow",
         "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
         "name": "BlobDeletionPillow"
     },


### PR DESCRIPTION
A single pillow now processes both application and main db blob deletions.

Follow up on https://github.com/dimagi/commcare-hq/commit/ceaedba69cf70e21dcc8bc8c6050714ba3a56440#commitcomment-17248339

@czue does this look like it will work?
