### PR TITLE
return rate table even when amount is None

### DIFF
--- a/corehq/apps/smsbillables/async_handlers.py
+++ b/corehq/apps/smsbillables/async_handlers.py
@@ -119,7 +119,7 @@ class PublicSMSRatesAsyncHandler(BaseAsyncHandler):
                 backend_instance=backend_instance_id,
                 country_code=country_code
             )
-            if not gateway_fee:
+            if not gateway_fee or gateway_fee.amount is None:
                 return None
             usd_gateway_fee = gateway_fee.amount / gateway_fee.currency.rate_to_default
             usage_fee = SmsUsageFee.get_by_criteria(direction)


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?233234

Twilio fees are causing this function to error because `amount` is `None`.  This at least shows the other gateway fees.  Longer term we should figure out what to do for Twilio.

@gcapalbo 
