### PR TITLE
Don't allow duplicate usernames in bulk user upload

### DIFF
--- a/corehq/apps/users/bulkupload.py
+++ b/corehq/apps/users/bulkupload.py
@@ -68,6 +68,20 @@ def check_headers(user_specs):
         raise UserUploadError('\n'.join(messages))
 
 
+def check_duplicate_usernames(user_specs):
+    usernames = set()
+    duplicated_usernames = set()
+
+    for row in user_specs:
+        username = row.get('username')
+        if username and username in usernames:
+            duplicated_usernames.add(username)
+        usernames.add(username)
+
+    raise UserUploadError(_("The following usernames have duplicate entries in "
+        "your file: " + ', '.join(duplicated_usernames)))
+
+
 class GroupMemoizer(object):
     """
 

--- a/corehq/apps/users/tests/bulk_upload.py
+++ b/corehq/apps/users/tests/bulk_upload.py
@@ -1,8 +1,13 @@
 from copy import deepcopy
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 from corehq.apps.accounting.tests.utils import DomainSubscriptionMixin
 from corehq.apps.commtrack.tests.util import CommTrackTest, make_loc
-from corehq.apps.users.bulkupload import UserLocMapping, SiteCodeToSupplyPointCache
+from corehq.apps.users.bulkupload import (
+    check_duplicate_usernames,
+    SiteCodeToSupplyPointCache,
+    UserLocMapping,
+    UserUploadError,
+)
 from corehq.apps.users.tasks import bulk_upload_async
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
@@ -192,3 +197,20 @@ class TestUserBulkUpload(TestCase, DomainSubscriptionMixin):
             list([])
         )
         self.assertEqual(self.user.email, updated_user_spec['email'].lower())
+
+
+class TestUserBulkUploadUtils(SimpleTestCase):
+
+    def test_check_duplicate_usernames(self):
+        user_specs = [
+            {
+                u'username': u'hello',
+                u'user_id': u'should not update',
+            },
+            {
+                u'username': u'hello',
+                u'user_id': u'other id',
+            },
+        ]
+
+        self.assertRaises(UserUploadError, check_duplicate_usernames, user_specs)

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -62,7 +62,13 @@ from corehq.apps.style.decorators import (
     use_multiselect,
 )
 from corehq.apps.users.analytics import get_search_users_in_domain_es_query
-from corehq.apps.users.bulkupload import check_headers, dump_users_and_groups, GroupNameError, UserUploadError
+from corehq.apps.users.bulkupload import (
+    check_duplicate_usernames,
+    check_headers,
+    dump_users_and_groups,
+    GroupNameError,
+    UserUploadError,
+)
 from corehq.apps.users.decorators import require_can_edit_commcare_users
 from corehq.apps.users.forms import (
     CommCareAccountForm, UpdateCommCareUserInfoForm, CommtrackUserForm,
@@ -898,6 +904,7 @@ class UploadCommCareUsers(BaseManageCommCareUserView):
 
         try:
             check_headers(self.user_specs)
+            check_duplicate_usernames(self.user_specs)
         except UserUploadError as e:
             messages.error(request, _(e.message))
             return HttpResponseRedirect(reverse(UploadCommCareUsers.urlname, args=[self.domain]))


### PR DESCRIPTION
https://docs.google.com/document/d/1Ta9TMnDHxNbYT-oa8_3HbejyK0wsSJXkXD_MbMHZIZY/edit#heading=h.2rt0j413hc3b

Doesn't start the upload when there are duplicate usernames

@czue 
