### PR TITLE
Move drilldown bindings above advanced bindings

### DIFF
--- a/corehq/apps/reports/templates/reports/filters/form_app_module_drilldown.html
+++ b/corehq/apps/reports/templates/reports/filters/form_app_module_drilldown.html
@@ -75,23 +75,40 @@
 {% endif %}
 {% endblock %}
 
-{% block filter_js %} {{ block.super }}
-{% if unknown_available or display_app_type %}
+{% block filter_js %}
 <script>
-    $.getScript("{% static 'reports/ko/report_filter.advanced_forms_options.js' %}", function () {
-       $('#{{ css_id }}-advanced-options').advanceFormsOptions({
-           show: {{ show_advanced|JSON }},
-           is_unknown_shown: {{ unknown.show|yesno:'true,false' }},
-           selected_unknown_form: '{{ unknown.selected }}',
-           all_unknown_forms: {{ unknown.options|JSON }},
-           caption_text: '{{ unknown.default_text }}',
-           css_id: '{{ css_id }}',
-           css_class: '{{ css_id }}-unknown_controls',
-       });
-       $('.hq-help-template').each(function () {
-            COMMCAREHQ.transformHelpTemplate($(this), true);
-        });
-    });
+
+ $.when(
+     $.getScript("{% static 'reports/ko/report_filter.drilldown_options.js' %}"),
+     $.getScript("{% static 'reports/ko/report_filter.advanced_forms_options.js' %}")
+ ).done(function () {
+
+     // This is copied from drilldown_options.html because the order matters
+     {% if not is_empty %}
+     $('#{{ css_id }}').drilldownOptionFilter({
+         drilldown_map: {{ option_map|JSON }},
+         controls: {{ controls|JSON }},
+         selected: {{ selected|JSON }},
+         notifications: {{ notifications|JSON }},
+     });
+     {% endif %}
+
+     {% if unknown_available or display_app_type %}
+     $('#{{ css_id }}-advanced-options').advanceFormsOptions({
+         show: {{ show_advanced|JSON }},
+         is_unknown_shown: {{ unknown.show|yesno:'true,false' }},
+         selected_unknown_form: '{{ unknown.selected }}',
+         all_unknown_forms: {{ unknown.options|JSON }},
+         caption_text: '{{ unknown.default_text }}',
+         css_id: '{{ css_id }}',
+         css_class: '{{ css_id }}-unknown_controls',
+     });
+     $('.hq-help-template').each(function () {
+         COMMCAREHQ.transformHelpTemplate($(this), true);
+     });
+     {% endif %}
+
+ });
+
 </script>
-{% endif %}
 {% endblock %}


### PR DESCRIPTION
These two pieces of functionality are order-sensitive, so this commit
pulls one and puts it in line immediately before the other.  The second
function attempts to apply bindings to html that is generated in the
first function. (There is some minor duplication from the super
template)
@orangejenny @benrudolph
http://manage.dimagi.com/default.asp?231773
