### PR TITLE
Allow evaluator expression variables to be None or boolean

### DIFF
--- a/corehq/apps/userreports/expressions/utils.py
+++ b/corehq/apps/userreports/expressions/utils.py
@@ -1,6 +1,7 @@
 import copy
 import ast
 from datetime import date, datetime, timedelta
+from types import NoneType
 
 from simpleeval import SimpleEval, DEFAULT_OPERATORS, InvalidExpression, DEFAULT_FUNCTIONS
 
@@ -35,7 +36,7 @@ def eval_statements(statement, variable_context):
     """
     # variable values should be numbers
     var_types = set(type(value) for value in variable_context.values())
-    if not var_types.issubset(set([int, float, long, date, datetime])):
+    if not var_types.issubset({int, float, long, date, datetime, NoneType, bool}):
         raise InvalidExpression
 
     evaluator = SimpleEval(operators=SAFE_OPERATORS, names=variable_context, functions=FUNCTIONS)

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -884,7 +884,12 @@ def test_invalid_eval_expression(self, source_doc, statement, context):
     ("a*b", {"a": 2, "b": 23}, 2 * 23),
     ("a*b if a > b else b -a", {"a": 2, "b": 23}, 23 - 2),
     ("'text1' if a < 5 else `text2`", {"a": 4}, 'text1'),
+    ("a if a else b", {"a": 0, "b": 1}, 1),
+    ("a if a else b", {"a": False, "b": 1}, 1),
+    ("a if a else b", {"a": None, "b": 1}, 1),
     ("range(1, a)", {"a": 5}, [1, 2, 3, 4]),
+    ("a or b", {"a": 0, "b": 1}, True),
+    ("a and b", {"a": 0, "b": 1}, False),
     # ranges > 100 items aren't supported
     ("range(200)", {}, None),
 ])
@@ -897,6 +902,7 @@ def test_supported_evaluator_statements(self, eq, context, expected_value):
     ("a + b", {"a": 2, "b": 'text'}),
     # missing context
     ("a + (a*b)", {"a": 2}),
+    # power function not supported
     ("a**b", {"a": 2, "b": 23}),
     ("lambda x: x*x", {"a": 2}),
     ("int(10 in range(1,20))", {"a": 2}),


### PR DESCRIPTION
This is going to allow us to evaluate coalesce-style expressions like ...

``` JavaScript
  {
    "display_name": "Selected Date", 
    "datatype": "date", 
    "type": "expression", 
    "column_id": "selected_date", 
    "expression": {
      "datatype": "date", 
      "type": "evaluator", 
      "context_variables": {
        "screening_date": {
          "datatype": "date", 
          "type": "property_path", 
          "property_path": [
            "form", 
            "date"
          ]
        }, 
        "adoption_date": {
          "datatype": "date", 
          "type": "property_path", 
          "property_path": [
            "form", 
            "selected_date"
          ]
        }
      }, 
      "statement": "screening_date if screening_date else adoption_date"
    }
  }
```

@czue cc @NoahCarnahan 
