### PR TITLE
Multiline regex for markdown

### DIFF
--- a/corehq/apps/app_manager/translations.py
+++ b/corehq/apps/app_manager/translations.py
@@ -552,7 +552,7 @@ def update_form_translations(sheet, rows, missing_cols, app):
             value_node.xml.append(n)
 
     def _looks_like_markdown(str):
-        return re.search(r'^\d+[\.\)] |^\*|~~.+~~|# |\*{1,3}\S+\*{1,3}|\[.+\]\(\S+\)', str)
+        return re.search(r'^\d+[\.\)] |^\*|~~.+~~|# |\*{1,3}\S+\*{1,3}|\[.+\]\(\S+\)', str, re.M)
 
     def get_markdown_node(text_node_):
         return text_node_.find("./{f}value[@form='markdown']")


### PR DESCRIPTION
Python wasn't recognizing this kind of text as markdown

```
this is my list
* thing1
* thing2
```

The vellum version of this regex is already multiline: https://github.com/dimagi/Vellum/blob/master/src/javaRosa/util.js#L58

@benrudolph / @emord 
