### PR TITLE
Moved set performance threshold link to above active users trend

### DIFF
--- a/corehq/apps/reports/templates/reports/project_health/project_health_dashboard.html
+++ b/corehq/apps/reports/templates/reports/project_health/project_health_dashboard.html
@@ -183,16 +183,15 @@
 {% endblock page_title %}
 {% block reportcontent %}
     {% include "reports/project_health/partials/last_month_stats.html" %}
+    {% if request.user.is_superuser %}
+    <p>
+        <a href="{% url 'domain_internal_settings' domain %}">
+        {% trans "Set Performance Threshold" %}
+        </a>
+    </p>
+    {% endif %}
     <div class="col-md-6">
-        <h2>{% trans "Active Users Trend" %}
-            {% if request.user.is_superuser %}
-                <small>
-                    <a href="{% url 'domain_internal_settings' domain %}">
-                    {% trans "Set Performance Threshold" %}
-                    </a>
-                </small>
-            {% endif %}
-        </h2>
+        <h2>{% trans "Active Users Trend" %}</h2>
             <p class="lead">
                 {% trans "Proportion of users that are active (submitting at least one form) over time." %}
             </p>


### PR DESCRIPTION
Per request from @sheelio, moving "Set Performance Threshold" link to above Active Users Trend chart 
@esoergel @czue 
![screen shot 2016-07-28 at 4 56 33 pm](https://cloud.githubusercontent.com/assets/8680734/17229143/50dc1e48-54e4-11e6-9e3e-5a7afc3ed425.png)
