### PR TITLE
Safe getattr for old exports

### DIFF
--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -53,11 +53,11 @@ def convert_saved_export_to_export_instance(domain, saved_export):
     instance.name = saved_export.name
     instance.is_deidentified = saved_export.is_safe
     instance.export_format = saved_export.default_format
-    instance.transform_dates = saved_export.transform_dates
+    instance.transform_dates = getattr(saved_export, 'transform_dates', False)
     instance.legacy_saved_export_schema_id = saved_export._id
     if saved_export.type == FORM_EXPORT:
-        instance.split_multiselects = saved_export.split_multiselects
-        instance.include_errors = saved_export.include_errors
+        instance.split_multiselects = getattr(saved_export, 'split_multiselects', False)
+        instance.include_errors = getattr(saved_export, 'include_errors', False)
 
     # With new export instance, copy over preferences from previous export
     for old_table in saved_export.tables:


### PR DESCRIPTION
@NoahCarnahan i have a feeling there are going to be a lot of these as i test the conversion function... the old exports does this really hacky attribute setting so that only some of the exports have these attributes (https://github.com/dimagi/commcare-hq/blob/br/export-conversion-fixups/corehq/apps/export/custom_export_helpers.py#L119)

cc: @orangejenny @esoergel 
