### PR TITLE
Exclude domain snapshots from results by default

### DIFF
--- a/corehq/apps/callcenter/utils.py
+++ b/corehq/apps/callcenter/utils.py
@@ -232,7 +232,6 @@ def get_call_center_domains():
     result = (
         DomainES()
         .is_active()
-        .is_snapshot(False)
         .filter(filters.term('call_center_config.enabled', True))
         .source([
             'name',

--- a/corehq/apps/es/domains.py
+++ b/corehq/apps/es/domains.py
@@ -44,7 +44,6 @@ class DomainES(HQESQuery):
             last_modified,
             in_domains,
             is_active,
-            is_snapshot,
             created_by_user,
         ] + super(DomainES, self).builtin_filters
 
@@ -93,11 +92,6 @@ def in_domains(domains):
 
 def is_active(is_active=True):
     return filters.term('is_active', is_active)
-
-
-def is_snapshot(is_snapshot=True):
-    # TODO remove
-    return filters.term('is_snapshot', is_snapshot)
 
 
 def created_by_user(creating_user):

--- a/corehq/apps/es/domains.py
+++ b/corehq/apps/es/domains.py
@@ -22,6 +22,14 @@ from . import filters
 
 class DomainES(HQESQuery):
     index = 'domains'
+    default_filters = {
+        'not_snapshot': filters.NOT(filters.term('is_snapshot', True)),
+    }
+
+    def only_snapshots(self):
+        """Normally snapshots are excluded, instead, return only snapshots"""
+        return (self.remove_default_filter('not_snapshot')
+                .filter(filters.term('is_snapshot', True)))
 
     @property
     def builtin_filters(self):
@@ -88,6 +96,7 @@ def is_active(is_active=True):
 
 
 def is_snapshot(is_snapshot=True):
+    # TODO remove
     return filters.term('is_snapshot', is_snapshot)
 
 

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -169,7 +169,7 @@ def rebuild_export_async(config, schema):
 
 @periodic_task(run_every=crontab(hour="22", minute="0", day_of_week="*"), queue='background_queue')
 def update_calculated_properties():
-    results = DomainES().is_snapshot(False).fields(["name", "_id"]).run().hits
+    results = DomainES().fields(["name", "_id"]).run().hits
     all_stats = _all_domain_stats()
     for r in results:
         dom = r["name"]


### PR DESCRIPTION
It's weird that domains and snapshots are the same thing.  At least this way DomainES will behave intuitively by default.
@calellowitz  @benrudolph
