### PR TITLE
Remove check for duplicate usernames

### DIFF
--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -908,7 +908,6 @@ class UploadCommCareUsers(BaseManageCommCareUserView):
 
         try:
             check_headers(self.user_specs)
-            check_duplicate_usernames(self.user_specs)
         except UserUploadError as e:
             messages.error(request, _(e.message))
             return HttpResponseRedirect(reverse(UploadCommCareUsers.urlname, args=[self.domain]))


### PR DESCRIPTION
@calellowitz This is going to be a bit more in depth than I thought. `self.user_specs` uses an object that deletes the row after it parses it. Will look into it more later today, but would be good to unblock users for now
