### PR TITLE
support remote apps

### DIFF
--- a/corehq/apps/export/conversion_mappings.py
+++ b/corehq/apps/export/conversion_mappings.py
@@ -35,7 +35,7 @@ FORM_PROPERTY_MAPPING = {
     ("received_on", None): ([PathNode(name="received_on")], None),
     ("submit_ip", None): ([PathNode(name="submit_ip")], None),
     ("xmlns", None): ([PathNode(name="xmlns")], None),
-    ("form.@name", None): ("form.@name", None),
+    ("form.@name", None): ([PathNode(name='form'), PathNode(name='@name')], None),
     ("form.@xmlns", None): ([PathNode(name="xmlns")], None),
     ("id", None): ([PathNode(name="number")], None),
 }

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1652,6 +1652,8 @@ class ExportMigrationMeta(Document):
     converted_tables = SchemaListProperty(ConversionMeta)
     converted_columns = SchemaListProperty(ConversionMeta)
 
+    is_remote_app_migration = BooleanProperty(default=False)
+
     class Meta:
         app_label = 'export'
 

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1654,6 +1654,8 @@ class ExportMigrationMeta(Document):
 
     is_remote_app_migration = BooleanProperty(default=False)
 
+    migration_date = DateTimeProperty()
+
     class Meta:
         app_label = 'export'
 

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -388,7 +388,8 @@ class TableConfiguration(DocumentSchema):
         return None, None
 
         :param item_path: A list of path nodes that identify a column
-        :param item_doc_type: The doc type of the item (often just ExportItem)
+        :param item_doc_type: The doc type of the item (often just ExportItem). If getting
+                UserDefinedExportColumn, set this to None
         :param column_transform: A transform that is applied on the column
         :returns index, column: The index of the column in the list and an ExportColumn
         """
@@ -396,6 +397,11 @@ class TableConfiguration(DocumentSchema):
             if (column.item.path == item_path and
                     column.item.transform == column_transform and
                     column.item.doc_type == item_doc_type):
+                return index, column
+            # No item doc type searches for a UserDefinedExportColumn
+            elif (isinstance(column, UserDefinedExportColumn) and
+                    column.custom_path == item_path and
+                    item_doc_type is None):
                 return index, column
         return None, None
 

--- a/corehq/apps/export/system_properties.py
+++ b/corehq/apps/export/system_properties.py
@@ -54,6 +54,15 @@ BOTTOM_MAIN_FORM_TABLE_PROPERTIES = [
     ),
     ExportColumn(
         tags=[PROPERTY_TAG_INFO],
+        label='started_time',
+        item=ExportItem(path=[
+            PathNode(name='form'), PathNode(name='meta'), PathNode(name='timeStart')
+        ]),
+        help_text=_('The time at which this form was started'),
+        selected=True,
+    ),
+    ExportColumn(
+        tags=[PROPERTY_TAG_INFO],
         label='username',
         item=ExportItem(path=[
             PathNode(name='form'), PathNode(name='meta'), PathNode(name='username')

--- a/corehq/apps/export/tests/data/saved_export_schemas/remote_app.json
+++ b/corehq/apps/export/tests/data/saved_export_schemas/remote_app.json
@@ -1,0 +1,330 @@
+{
+   "_id": "92e5f9a6624a637c2080957475cd4456",
+   "_rev": "2-c5dde9983fa0c0cbd1499a4830d7843f",
+   "doc_type": "SavedExportSchema",
+   "domain": null,
+   "name": "Case Example",
+   "index": "[\"aspace\", \"RegCase\"]",
+   "transform_dates": true,
+   "filter_function": "[]",
+   "schema_id": "92e5f9a6624a637c2080957475cd3a85",
+   "tables": [
+       {
+           "index": "#",
+           "display": "Cases",
+           "columns": [
+               {
+                   "index": "DOB",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "DOB Saved"
+               },
+               {
+                   "index": "ag",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "ag"
+               },
+               {
+                   "index": "age",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "age"
+               },
+               {
+                   "index": "balding",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "balding"
+               },
+               {
+                   "index": "birthday",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "birthday"
+               },
+               {
+                   "index": "dob",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "dob"
+               },
+               {
+                   "index": "name",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "name"
+               },
+               {
+                   "index": "question1",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "question1"
+               },
+               {
+                   "index": "question4",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "question4"
+               },
+               {
+                   "index": "question6",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "question6"
+               },
+               {
+                   "index": "village",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "village"
+               },
+               {
+                   "index": "_id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.case_id"
+               },
+               {
+                   "index": "type",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.case_type"
+               },
+               {
+                   "index": "closed",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.closed"
+               },
+               {
+                   "index": "closed_by",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.closed_by_user_id"
+               },
+               {
+                   "index": "closed_by",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": "corehq.apps.export.transforms.user_id_to_username",
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.closed_by_username"
+               },
+               {
+                   "index": "closed_on",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.closed_date"
+               },
+               {
+                   "index": "computed_modified_on_",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.computed_modified_on_"
+               },
+               {
+                   "index": "domain",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.domain"
+               },
+               {
+                   "index": "external_id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.external_id"
+               },
+               {
+                   "index": "user_id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.last_modified_by_user_id"
+               },
+               {
+                   "index": "user_id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": "corehq.apps.export.transforms.user_id_to_username",
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.last_modified_by_username"
+               },
+               {
+                   "index": "modified_on",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.last_modified_date"
+               },
+               {
+                   "index": "opened_by",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.opened_by_user_id"
+               },
+               {
+                   "index": "opened_by",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": "corehq.apps.export.transforms.user_id_to_username",
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.opened_by_username"
+               },
+               {
+                   "index": "opened_on",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.opened_date"
+               },
+               {
+                   "index": "owner_id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.owner_id"
+               },
+               {
+                   "index": "owner_id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": "corehq.apps.export.transforms.owner_id_to_display",
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.owner_name"
+               },
+               {
+                   "index": "server_modified_on",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.server_last_modified_date"
+               },
+               {
+                   "index": "version",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "info.version"
+               },
+               {
+                   "index": "_rev",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "server._rev"
+               },
+               {
+                   "index": "doc_type",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "server.doc_type"
+               },
+               {
+                   "index": "initial_processing_complete",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "server.initial_processing_complete"
+               },
+               {
+                   "index": "id",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "row.number"
+               }
+           ],
+           "doc_type": "ExportTable"
+       }
+    ],
+   "default_format": "csv",
+   "type": "case",
+   "is_safe": false
+}
+

--- a/corehq/apps/export/tests/data/saved_export_schemas/remote_app_repeats.json
+++ b/corehq/apps/export/tests/data/saved_export_schemas/remote_app_repeats.json
@@ -1,0 +1,34 @@
+{
+   "_id": "ben5f9a6624a637c2080957475cd4456",
+   "_rev": "2-c5dde9983fa0c0cbd1499a4830d7843f",
+   "doc_type": "SavedExportSchema",
+   "domain": null,
+   "name": "Case Example",
+   "index": "[\"aspace\", \"RegCase\"]",
+   "transform_dates": true,
+   "filter_function": "[]",
+   "schema_id": "92e5f9a6624a637c2080957475cd3a85",
+   "tables": [
+       {
+           "index": "#.form.repeat.#",
+           "display": "Custom Repeat",
+           "columns": [
+               {
+                   "index": "DOB",
+                   "show": false,
+                   "is_sensitive": false,
+                   "transform": null,
+                   "doc_type": "ExportColumn",
+                   "tag": null,
+                   "display": "DOB Saved"
+               }
+           ],
+           "doc_type": "ExportTable"
+       }
+    ],
+   "default_format": "csv",
+   "type": "case",
+   "is_safe": false
+}
+
+

--- a/corehq/apps/export/tests/test_export_conversion.py
+++ b/corehq/apps/export/tests/test_export_conversion.py
@@ -210,6 +210,10 @@ class TestConvertSavedExportSchemaToCaseExportInstance(TestCase, TestFileMixin):
     'corehq.apps.export.models.new.get_request',
     return_value=MockRequest(domain='my-domain'),
 )
+@mock.patch(
+    'corehq.apps.export.utils._is_remote_app_conversion',
+    return_value=False,
+)
 class TestConvertSavedExportSchemaToFormExportInstance(TestCase, TestFileMixin):
     file_path = ('data', 'saved_export_schemas')
     root = os.path.dirname(__file__)
@@ -284,7 +288,7 @@ class TestConvertSavedExportSchemaToFormExportInstance(TestCase, TestFileMixin):
     def setUp(self):
         delete_all_export_instances()
 
-    def test_basic_conversion(self, _):
+    def test_basic_conversion(self, _, __):
 
         saved_export_schema = SavedExportSchema.wrap(self.get_json('basic'))
         with mock.patch(
@@ -310,7 +314,7 @@ class TestConvertSavedExportSchemaToFormExportInstance(TestCase, TestFileMixin):
         self.assertEqual(column.label, 'Question One')
         self.assertEqual(column.selected, True)
 
-    def test_repeat_conversion(self, _):
+    def test_repeat_conversion(self, _, __):
         saved_export_schema = SavedExportSchema.wrap(self.get_json('repeat'))
         with mock.patch(
                 'corehq.apps.export.models.new.FormExportDataSchema.generate_schema_from_builds',
@@ -339,7 +343,7 @@ class TestConvertSavedExportSchemaToFormExportInstance(TestCase, TestFileMixin):
         )
         self.assertEqual(column.selected, True)
 
-    def test_nested_repeat_conversion(self, _):
+    def test_nested_repeat_conversion(self, _, __):
         saved_export_schema = SavedExportSchema.wrap(self.get_json('repeat_nested'))
         with mock.patch(
                 'corehq.apps.export.models.new.FormExportDataSchema.generate_schema_from_builds',
@@ -383,7 +387,7 @@ class TestConvertSavedExportSchemaToFormExportInstance(TestCase, TestFileMixin):
         self.assertEqual(column.label, 'Modified Nested')
         self.assertEqual(column.selected, True)
 
-    def test_transform_conversion(self, _):
+    def test_transform_conversion(self, _, __):
         saved_export_schema = SavedExportSchema.wrap(self.get_json('deid_transforms'))
         with mock.patch(
                 'corehq.apps.export.models.new.FormExportDataSchema.generate_schema_from_builds',
@@ -402,7 +406,7 @@ class TestConvertSavedExportSchemaToFormExportInstance(TestCase, TestFileMixin):
         )
         self.assertEqual(column.deid_transform, DEID_DATE_TRANSFORM)
 
-    def test_system_property_conversion(self, _):
+    def test_system_property_conversion(self, _, __):
         saved_export_schema = SavedExportSchema.wrap(self.get_json('system_properties'))
         with mock.patch(
                 'corehq.apps.export.models.new.FormExportDataSchema.generate_schema_from_builds',

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -356,7 +356,6 @@ def migrate_domain(domain, dryrun=False):
                     dryrun=dryrun
                 )
             except Exception, e:
-                raise e
                 print 'Failed parsing {}: {}'.format(old_export['_id'], e)
             else:
                 metas.append(migration_meta)

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -2,8 +2,7 @@ from datetime import datetime
 
 from dimagi.utils.couch.undo import DELETED_SUFFIX
 from dimagi.utils.modules import to_function
-from toggle.models import Toggle
-from toggle.shortcuts import clear_toggle_cache, set_toggle
+from toggle.shortcuts import set_toggle
 
 from corehq.toggles import NEW_EXPORTS, NAMESPACE_DOMAIN
 from corehq.util.log import with_progress_bar

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -2,8 +2,12 @@ from datetime import datetime
 
 from dimagi.utils.couch.undo import DELETED_SUFFIX
 from dimagi.utils.modules import to_function
+from toggle.models import Toggle
+from toggle.shortcuts import clear_toggle_cache, set_toggle
 
+from corehq.toggles import NEW_EXPORTS, NAMESPACE_DOMAIN
 from corehq.util.log import with_progress_bar
+from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_js_domain_cachebuster
 from corehq.apps.reports.dbaccessors import (
     stale_get_exports_json,
     stale_get_export_count,
@@ -359,6 +363,11 @@ def migrate_domain(domain, dryrun=False):
                 print 'Failed parsing {}: {}'.format(old_export['_id'], e)
             else:
                 metas.append(migration_meta)
+
+    if not dryrun:
+        set_toggle(NEW_EXPORTS.slug, domain, True, namespace=NAMESPACE_DOMAIN)
+        toggle_js_domain_cachebuster.clear(domain)
+
     for meta in metas:
         print ''
         print '***' * 15

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -356,11 +356,16 @@ def migrate_domain(domain, dryrun=False):
                     dryrun=dryrun
                 )
             except Exception, e:
+                raise e
                 print 'Failed parsing {}: {}'.format(old_export['_id'], e)
             else:
                 metas.append(migration_meta)
     for meta in metas:
-        print 'Export information for export: {}'.format(meta.saved_export_id)
+        print ''
+        print '***' * 15
+        print '* Export information for export: {}'.format(meta.saved_export_id)
+        print '***' * 15
+        print ''
 
         if meta.skipped_tables:
             print '## Skipped tables: ##'

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 
 from dimagi.utils.couch.undo import DELETED_SUFFIX
 from dimagi.utils.modules import to_function
@@ -55,7 +56,8 @@ def convert_saved_export_to_export_instance(domain, saved_export, dryrun=False):
     migration_meta = ExportMigrationMeta(
         saved_export_id=saved_export._id,
         domain=domain,
-        is_remote_app_migration=is_remote_app_migration
+        is_remote_app_migration=is_remote_app_migration,
+        migration_date=datetime.utcnow(),
     )
     # Build a new schema and instance
     if export_type == FORM_EXPORT:

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -384,6 +384,16 @@ def migrate_domain(domain, dryrun=False):
         set_toggle(NEW_EXPORTS.slug, domain, True, namespace=NAMESPACE_DOMAIN)
         toggle_js_domain_cachebuster.clear(domain)
 
+    # Remote app migrations must have access to UserDefined columns and tables
+    if any(map(lambda meta: meta.is_remote_app_migration, metas)):
+        set_toggle(
+            ALLOW_USER_DEFINED_EXPORT_COLUMNS.slug,
+            domain,
+            True,
+            namespace=NAMESPACE_DOMAIN
+        )
+        toggle_js_domain_cachebuster.clear(domain)
+
     for meta in metas:
         print ''
         print '***' * 15

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -241,6 +241,10 @@ def _convert_transform(serializable_transform):
 
 
 def _get_system_property(index, transform, export_type, table_path):
+    """
+    Given an old style export index and a transform, returns new style list of PathNodes
+    and transform
+    """
     from .models import (
         MAIN_TABLE,
         CASE_HISTORY_TABLE,

--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -1558,7 +1558,7 @@ class BaseEditNewCustomExportView(BaseModifyNewCustomView):
                         legacy_export.converted_saved_export_id
                     )
                 else:
-                    export_instance, _ = convert_saved_export_to_export_instance(
+                    export_instance, meta = convert_saved_export_to_export_instance(
                         self.domain,
                         legacy_export,
                     )


### PR DESCRIPTION
@czue @NoahCarnahan prs are getting a bit backed up here, but this includes this PR: https://github.com/dimagi/commcare-hq/pull/12664

Everything after https://github.com/dimagi/commcare-hq/commit/8c2595a6d9726dca24181647d21814eb05e2b5be is new. this will finally support remote app migration. When it detects that any remote apps are being migrated, it will turn on user defined columns for exports flag. then any columns/tables that have been skipped because we couldn't find them in the schema are automatically added as a user defined column/table.

cc: @esoergel @orangejenny 
