### PR TITLE
Include PreFilters in ConfigurableReport view data_source

### DIFF
--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -167,7 +167,7 @@ class ConfigurableReport(JSONResponseMixin, BaseDomainView):
     @property
     @memoized
     def data_source(self):
-        report = ReportFactory.from_spec(self.spec)
+        report = ReportFactory.from_spec(self.spec, include_prefilters=True)
         report.lang = self.lang
         return report
 


### PR DESCRIPTION
Found a bug when previewing a report that uses PreFilters. They need to be included in the ConfigurableReport view data_source.

@NoahCarnahan cc @czue 
