### PR TITLE
Catch stripe errors

### DIFF
--- a/corehq/apps/accounting/utils.py
+++ b/corehq/apps/accounting/utils.py
@@ -205,6 +205,7 @@ def get_customer_cards(username, domain):
     from corehq.apps.accounting.models import (
         StripePaymentMethod, PaymentMethodType,
     )
+    import stripe
     try:
         payment_method = StripePaymentMethod.objects.get(
             web_user=username,
@@ -213,6 +214,8 @@ def get_customer_cards(username, domain):
         stripe_customer = payment_method.customer
         return stripe_customer.cards
     except StripePaymentMethod.DoesNotExist:
+        pass
+    except stripe.error.AuthenticationError:
         pass
     return None
 

--- a/corehq/apps/accounting/utils.py
+++ b/corehq/apps/accounting/utils.py
@@ -216,7 +216,10 @@ def get_customer_cards(username, domain):
     except StripePaymentMethod.DoesNotExist:
         pass
     except stripe.error.AuthenticationError:
-        pass
+        if not settings.STRIPE_PRIVATE_KEY:
+            log_accounting_info("Private key is not defined in settings")
+        else:
+            raise
     return None
 
 

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -808,6 +808,9 @@ class EditExistingBillingAccountView(DomainAccountingSettings, AsyncHandlerMixin
         }
 
     def _get_cards(self):
+        if not settings.STRIPE_PRIVATE_KEY:
+            return []
+
         user = self.request.user.username
         payment_method, new_payment_method = StripePaymentMethod.objects.get_or_create(
             web_user=user,


### PR DESCRIPTION
@proteusvacuum @nickpell guessing you guys have the most context here

http://manage.dimagi.com/default.asp?233482#1195638

looks like there may have been more payment method types before: https://github.com/dimagi/commcare-hq/blob/undefined-stripe/corehq/apps/accounting/models.py#L210

any reason why parts of accounting depends on stripe as the only payment type?

cc @czue 
