### PR TITLE
fix caseid selection

### DIFF
--- a/corehq/apps/export/conversion_mappings.py
+++ b/corehq/apps/export/conversion_mappings.py
@@ -42,7 +42,7 @@ FORM_PROPERTY_MAPPING = {
 
 CASE_PROPERTY_MAPPING = {
     ("id", None): ([PathNode(name="number")], None),
-    ("_id", None): ([PathNode(name='caseid')], None),
+    ("_id", None): ([PathNode(name='_id')], None),
     ('type', None): ([PathNode(name='type')], None),
     ('closed', None): ([PathNode(name='closed')], None),
     ('closed_by', None): ([PathNode(name='closed_by')], None),


### PR DESCRIPTION
@czue another minor fix from running some dry runs. i'm having a hard time figuring out how to proceed on this migration. here are a couple thoughts:
- Ask VL to do QA of export conversions. This actually becomes fairly difficult because there is no way to create a domain that uses old exports. Probably doable on an old domain, but it would only test the lazy export conversion not the bulk migration (uses a lot of the same code though)
- Pick and handful of random domains, do the migration and incrementally address any issues that should arise
- Just do the whole thing (seems scary)

The most common failure mode of this is a selection of a system property does not persist to the migrated export or that we failed to include a system property that a client really wanted
