### PR TITLE
Refactor selected_users in MonthlyPerformanceSummary

### DIFF
--- a/corehq/apps/reports/standard/project_health.py
+++ b/corehq/apps/reports/standard/project_health.py
@@ -53,7 +53,7 @@ class MonthlyPerformanceSummary(jsonobject.JsonObject):
     active = jsonobject.IntegerProperty()
     performing = jsonobject.IntegerProperty()
 
-    def __init__(self, domain, month, users, has_filter, active_not_deleted_users,
+    def __init__(self, domain, month, selected_users, active_not_deleted_users,
                  performance_threshold, previous_summary=None,
                  delta_high_performers=0, delta_low_performers=0):
         self._previous_summary = previous_summary
@@ -65,9 +65,9 @@ class MonthlyPerformanceSummary(jsonobject.JsonObject):
             user_type__in=['CommCareUser', 'CommCareUser-Deleted'],
             user_id__in=active_not_deleted_users,
         )
-        if has_filter:
+        if selected_users:
             base_queryset = base_queryset.filter(
-                user_id__in=users,
+                user_id__in=selected_users,
             )
 
         self._user_stat_from_malt = (base_queryset
@@ -355,8 +355,7 @@ class ProjectHealthDashboard(ProjectReport):
                 performance_threshold=performance_threshold,
                 month=month_as_date,
                 previous_summary=last_month_summary,
-                users=filtered_users,
-                has_filter=bool(self.get_group_location_ids()),
+                selected_users=filtered_users,
                 active_not_deleted_users=active_not_deleted_users,
             )
             six_month_summary.append(this_month_summary)

--- a/corehq/apps/reports/tests/test_project_health.py
+++ b/corehq/apps/reports/tests/test_project_health.py
@@ -105,8 +105,7 @@ class MonthlyPerformanceSummaryTests(SetupProjectPerformanceMixin, TestCase):
             performance_threshold=15,
             month=cls.prev_month_as_date,
             previous_summary=None,
-            users=users_in_group,
-            has_filter=False,
+            selected_users=users_in_group,
             active_not_deleted_users=active_not_deleted_users,
         )
         cls.month = MonthlyPerformanceSummary(
@@ -114,8 +113,7 @@ class MonthlyPerformanceSummaryTests(SetupProjectPerformanceMixin, TestCase):
             performance_threshold=15,
             month=cls.month_as_date,
             previous_summary=cls.prev_month,
-            users=users_in_group,
-            has_filter=False,
+            selected_users=users_in_group,
             active_not_deleted_users=active_not_deleted_users,
         )
 


### PR DESCRIPTION
As follow-up to feedback in #12617, removed flag `has_filter` for when filter is applied, and passed in `selected_users` (list of users after filter is applied) as parameter to MonthlyPerformanceSummary
@esoergel 
