### PR TITLE
Speed up app status

### DIFF
--- a/corehq/apps/reports/filters/users.py
+++ b/corehq/apps/reports/filters/users.py
@@ -308,11 +308,19 @@ class ExpandedMobileWorkerFilter(BaseMultipleOptionFilter):
                 return q.filter(id_filter)
 
     @classmethod
-    def pull_users_and_groups(cls, domain, mobile_user_and_group_slugs, include_inactive=False):
+    def pull_users_and_groups(cls, domain, mobile_user_and_group_slugs,
+                              include_inactive=False, limit_user_ids=None):
         user_ids = cls.selected_user_ids(mobile_user_and_group_slugs)
         user_types = cls.selected_user_types(mobile_user_and_group_slugs)
         group_ids = cls.selected_group_ids(mobile_user_and_group_slugs)
         users = []
+
+        if limit_user_ids:
+            if not user_ids:
+                user_ids = limit_user_ids
+            else:
+                user_ids = set(limit_user_ids).intersection(set(user_ids))
+
         if user_ids or HQUserType.REGISTERED in user_types:
             users = util.get_all_users_by_domain(
                 domain=domain,

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -106,6 +106,11 @@ class ApplicationStatusReport(DeploymentsReport):
 
     @property
     @memoized
+    def selected_app_id(self):
+        return self.request_params.get(SelectApplicationFilter.slug, None)
+
+    @property
+    @memoized
     def users(self):
         mobile_user_and_group_slugs = self.request.GET.getlist(ExpandedMobileWorkerFilter.slug)
         users_data = ExpandedMobileWorkerFilter.pull_users_and_groups(
@@ -118,10 +123,9 @@ class ApplicationStatusReport(DeploymentsReport):
     @property
     def rows(self):
         rows = []
-        selected_app = self.request_params.get(SelectApplicationFilter.slug, None)
 
         user_ids = map(lambda user: user.user_id, self.users)
-        user_xform_dicts_map = get_last_form_submissions_by_user(self.domain, user_ids, selected_app)
+        user_xform_dicts_map = get_last_form_submissions_by_user(self.domain, user_ids, self.selected_app_id)
 
         for user in self.users:
             xform_dict = last_seen = last_sync = app_name = None
@@ -162,7 +166,7 @@ class ApplicationStatusReport(DeploymentsReport):
                     u'{} {} {}', app_name, mark_safe(build_html), commcare_version_html
                 )
 
-            if app_name is None and selected_app:
+            if app_name is None and self.selected_app_id:
                 continue
 
             last_sync_log = SyncLog.last_for_user(user.user_id)

--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -113,10 +113,15 @@ class ApplicationStatusReport(DeploymentsReport):
     @memoized
     def users(self):
         mobile_user_and_group_slugs = self.request.GET.getlist(ExpandedMobileWorkerFilter.slug)
+
+        if self.selected_app_id:
+            limit_user_ids = get_all_user_ids_submitted(self.domain, self.selected_app_id)
+
         users_data = ExpandedMobileWorkerFilter.pull_users_and_groups(
             self.domain,
             mobile_user_and_group_slugs,
-            include_inactive=False
+            include_inactive=False,
+            limit_user_ids=limit_user_ids,
         )
         return users_data.combined_users
 


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?231917

Originally I had changed the app status report to limit user ids to only users that had submitted to the app if an app was chosen. This commit changed the filters that

https://github.com/dimagi/commcare-hq/commit/fd4d56a68a8d199a0c5b528a9840ef96b3f9929a

but that goes down to `get_all_users_by_domain` which causes the same slowdowns I saw in a previous ticket. This should be marginally faster

@czue 
