### PR TITLE
Get phone time, not server time

### DIFF
--- a/corehq/apps/reports/standard/monitoring.py
+++ b/corehq/apps/reports/standard/monitoring.py
@@ -44,6 +44,7 @@ from corehq.apps.users.models import CommCareUser
 from corehq.const import SERVER_DATETIME_FORMAT
 from corehq.util.timezones.conversions import ServerTime, PhoneTime
 from corehq.util.view_utils import absolute_reverse
+from dimagi.utils.couch.safe_index import safe_index
 from dimagi.utils.dates import DateSpan, today_or_tomorrow
 from dimagi.utils.decorators.memoized import memoized
 from dimagi.utils.parsing import json_format_date, string_to_utc_datetime
@@ -1241,7 +1242,7 @@ class WorkerActivityTimes(WorkerMonitoringChartBase,
             else:
                 all_times.append(
                     PhoneTime(
-                        string_to_utc_datetime(form['received_on']),
+                        string_to_utc_datetime(safe_index(form, ['form', 'meta', 'timeEnd'])),
                         self.timezone,
                     )
                     .user_time(self.timezone)


### PR DESCRIPTION
@czue @mkangia http://manage.dimagi.com/default.asp?234052 kind of surprised this was just now caught 😳 wasn't able to exactly reproduce since mwellcare hasn't gone through the TZ migrations yet and still has funky timeEnd values. i convinced myself though that the behavior we saw makes sense. it was taking the UTC received_on date as PhoneTime and since the migration hadn't taken place on mwellcare it was adjusting the time to the proper timezone: https://github.com/dimagi/commcare-hq/blob/br/worker-activity-times-tz/corehq/util/timezones/conversions.py#L133. anyways this should now at least have the same behavior as submit history

cc: @orangejenny 
