### PR TITLE
Allow adding custom case properties to persistent case tile

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1826,6 +1826,7 @@ class Detail(IndexedSchema, CaseListLookupMixin):
 
     # If True, a small tile will display the case name after selection.
     persist_case_context = BooleanProperty()
+    persistent_case_context_xml = StringProperty(default='case_name')
 
     # If True, use case tiles in the case list
     use_case_tiles = BooleanProperty()

--- a/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
+++ b/corehq/apps/app_manager/static/app_manager/js/detail-screen-config.js
@@ -858,6 +858,7 @@ hqDefine('app_manager/js/detail-screen-config.js', function () {
                 this.allowsTabs = options.allowsTabs;
                 this.useCaseTiles = ko.observable(spec[this.columnKey].use_case_tiles ? "yes" : "no");
                 this.persistCaseContext = ko.observable(spec[this.columnKey].persist_case_context || false);
+                this.persistentCaseContextXML = ko.observable(spec[this.columnKey].persistent_case_context_xml|| 'case_name');
                 this.persistTileOnForms = ko.observable(spec[this.columnKey].persist_tile_on_forms || false);
                 this.enableTilePullDown = ko.observable(spec[this.columnKey].pull_down_tile || false);
                 this.allowsEmptyColumns = options.allowsEmptyColumns;
@@ -937,6 +938,9 @@ hqDefine('app_manager/js/detail-screen-config.js', function () {
                     that.saveButton.fire('change');
                 });
                 this.persistCaseContext.subscribe(function(){
+                    that.saveButton.fire('change');
+                });
+                this.persistentCaseContextXML.subscribe(function(){
                     that.saveButton.fire('change');
                 });
                 this.persistTileOnForms.subscribe(function(){
@@ -1037,8 +1041,9 @@ hqDefine('app_manager/js/detail-screen-config.js', function () {
                         function(c){return c.serialize();}
                     ));
 
-                    data.useCaseTiles = this.useCaseTiles() == "yes" ? true : false;
+                    data.useCaseTiles = this.useCaseTiles() === "yes" ? true : false;
                     data.persistCaseContext = this.persistCaseContext();
+                    data.persistentCaseContextXML = this.persistentCaseContextXML();
                     data.persistTileOnForms = this.persistTileOnForms();
                     data.enableTilePullDown = this.persistTileOnForms() ? this.enableTilePullDown() : false;
 

--- a/corehq/apps/app_manager/suite_xml/sections/details.py
+++ b/corehq/apps/app_manager/suite_xml/sections/details.py
@@ -85,7 +85,7 @@ class DetailContributor(SectionContributor):
                                     if d:
                                         r.append(d)
                         if detail.persist_case_context and not detail.persist_tile_on_forms:
-                            d = self._get_persistent_case_context_detail(module)
+                            d = self._get_persistent_case_context_detail(module, detail.persistent_case_context_xml)
                             r.append(d)
                 if module.fixture_select.active:
                     d = self._get_fixture_detail(module)
@@ -258,7 +258,7 @@ class DetailContributor(SectionContributor):
         return action
 
     @staticmethod
-    def _get_persistent_case_context_detail(module):
+    def _get_persistent_case_context_detail(module, xml):
         return Detail(
             id=id_strings.persistent_case_context_detail(module),
             title=Text(),
@@ -272,7 +272,7 @@ class DetailContributor(SectionContributor):
                     grid_y=0,
                 ),
                 header=Header(text=Text()),
-                template=Template(text=Text(xpath_function="case_name")),
+                template=Template(text=Text(xpath_function=xml)),
             )]
         )
 

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_list.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_list.html
@@ -55,7 +55,13 @@
         <div class="checkbox">
             <label>
                 <input type="checkbox" data-bind="checked: persistCaseContext">
-                {% trans "Show the case name at the top of the screen when filling out forms" %}
+                {% trans "Show some information about the case at the top of the screen when filling out forms" %}
+            </label>
+        </div>
+        <div class="" data-bind="visible: persistCaseContext">
+            <label>
+                {% trans "Case property to show:" %}
+                <input type="text" data-bind="value: persistentCaseContextXML" placeholder="e.g. case_name" />
             </label>
         </div>
     </div>

--- a/corehq/apps/app_manager/views/modules.py
+++ b/corehq/apps/app_manager/views/modules.py
@@ -641,6 +641,7 @@ def edit_module_detail_screens(request, domain, app_id, module_id):
     fixture_select = params.get('fixture_select', None)
     sort_elements = params.get('sort_elements', None)
     persist_case_context = params.get('persistCaseContext', None)
+    persistent_case_context_xml = params.get('persistentCaseContextXML', None)
     use_case_tiles = params.get('useCaseTiles', None)
     persist_tile_on_forms = params.get("persistTileOnForms", None)
     pull_down_tile = params.get("enableTilePullDown", None)
@@ -667,6 +668,7 @@ def edit_module_detail_screens(request, domain, app_id, module_id):
         detail.short.columns = map(DetailColumn.from_json, short)
         if persist_case_context is not None:
             detail.short.persist_case_context = persist_case_context
+            detail.short.persistent_case_context_xml = persistent_case_context_xml
         if use_case_tiles is not None:
             detail.short.use_case_tiles = use_case_tiles
         if persist_tile_on_forms is not None:


### PR DESCRIPTION
This allows showing the host or parent name with xml like:
`instance('casedb')/casedb/case[@case_id=index/host]/case_name`
Should still default to `case_name`

**Before**
![screenshot_2016-08-04-15-09-01](https://cloud.githubusercontent.com/assets/146896/17417063/65c1c42c-5a5f-11e6-8228-26efc535901b.png)
**After**
![screenshot_2016-08-04-15-01-08](https://cloud.githubusercontent.com/assets/146896/17417068/69cbdc2e-5a5f-11e6-89db-1a63387a5b23.png)

@dannyroberts 
