### PR TITLE
Change attribute from is_viewable to is_editable for DatespanFilter

### DIFF
--- a/corehq/apps/reports/filters/dates.py
+++ b/corehq/apps/reports/filters/dates.py
@@ -18,7 +18,7 @@ class DatespanFilter(BaseReportFilter):
     slug = "datespan"
     inclusive = True
     default_days = 30
-    is_viewable = True
+    is_editable = True
 
     @property
     def datespan(self):
@@ -55,7 +55,7 @@ class HiddenLastMonthDateFilter(DatespanFilter):
     label = ugettext_lazy("Date Range")
     slug = "datespan"
     inclusive = True
-    is_viewable = False
+    is_editable = False
 
     @property
     def datespan(self):

--- a/corehq/apps/reports/generic.py
+++ b/corehq/apps/reports/generic.py
@@ -435,10 +435,11 @@ class GenericReportView(object):
         current_config_id = self.request.GET.get('config_id', '')
         default_config = ReportConfig.default()
 
-        def is_datespan(field):
+        def is_editable_datespan(field):
             field_fn = to_function(field) if isinstance(field, basestring) else field
-            return issubclass(field_fn, DatespanFilter) and field_fn.is_viewable
-        has_datespan = any([is_datespan(field) for field in self.fields])
+            return issubclass(field_fn, DatespanFilter) and field_fn.is_editable
+
+        has_datespan = any([is_editable_datespan(field) for field in self.fields])
 
         self.context.update(
             report=dict(


### PR DESCRIPTION
As follow-up to #12638, attribute `is_viewable` for DatespanFilter and HiddenLastMonthDateFilter is changed to `is_editable`. Project Performance Dashboard does have a datespan, though it shouldn't be editable. 

@czue @esoergel 
