### PR TITLE
Remove integration test hook

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -635,22 +635,17 @@ class RestoreConfig(object):
             # store the task id in cache
             self.cache.set(self.async_cache_key, task.id, timeout=None)
         try:
-            response = task.get(timeout=self._get_task_timeout_or_raise(new_task))
+            response = task.get(timeout=self._get_task_timeout(new_task))
         except TimeoutError:
             # return a 202 with progress
             response = AsyncRestoreResponse(task, self.restore_user.username)
 
         return response
 
-    def _get_task_timeout_or_raise(self, new_task):
+    def _get_task_timeout(self, new_task):
         # if this is a new task, wait for INITIAL_ASYNC_TIMEOUT in case
         # this restore completes quickly. otherwise, only wait 1 second for
-        # a response. Integration tests with mobile set the overwrite_cache
-        # flag. This should always return a timeout response.
-        if self.overwrite_cache:
-            # for async restores with overwrite_cache, the first response
-            # should be a Timeout. This is used for testing purposes.
-            raise TimeoutError()
+        # a response.
         return INITIAL_ASYNC_TIMEOUT_THRESHOLD if new_task else 1
 
     def _generate_restore_response(self, async_task=None):

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
@@ -217,22 +217,6 @@ class AsyncRestoreTest(BaseAsyncRestoreTest):
         # http://manage.dimagi.com/default.asp?234245
         system_user_factory.create_case()
 
-
-class AsyncRestoreIntegrationParameters(BaseAsyncRestoreTest):
-    """When overwrite_cache is set, the async restore should always first return an
-    AsyncRestoreResponse as its first response
-
-    """
-    @mock.patch('casexml.apps.phone.restore.get_async_restore_payload')
-    def test_always_returns_async_restore_response(self, task):
-        delay = mock.MagicMock()
-        delay.id = 'random_task_id'
-        task.delay.return_value = delay
-
-        payload = self._restore_config(async=True, overwrite_cache=True).get_payload()
-        self.assertTrue(task.delay.called)
-        self.assertIsInstance(payload, AsyncRestoreResponse)
-
     @mock.patch.object(CachedPayload, 'finalize')  # fake that a cached payload exists
     @mock.patch.object(RestoreConfig, 'cache')
     @mock.patch('casexml.apps.phone.restore.get_async_restore_payload')


### PR DESCRIPTION
After talking with @amstone326 we decided that the async restore integration test should just act normally. Now an async restore with the overwrite_cache flag reacts the same as a regular async_restore (with the cache cleared).

code buddy @dannyroberts 
