### PR TITLE
Allow system form submissions with aysnc restores

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
@@ -26,6 +26,7 @@ from casexml.apps.phone.const import ASYNC_RESTORE_CACHE_KEY_PREFIX
 from casexml.apps.phone.tasks import get_async_restore_payload, ASYNC_RESTORE_SENT
 from casexml.apps.phone.tests.utils import create_restore_user
 from corehq.apps.receiverwrapper.auth import AuthContext
+from couchforms.models import DefaultAuthContext
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 from corehq.util.test_utils import flag_enabled
 
@@ -203,6 +204,18 @@ class AsyncRestoreTest(BaseAsyncRestoreTest):
             correct_user_factory.create_case()
             revoke.assert_called_with(fake_task_id)
             self.assertIsNone(restore_config.cache.get(cache_id))
+
+    @flag_enabled('ASYNC_RESTORE')
+    def test_submit_system_form(self):
+        system_user_factory = CaseFactory(
+            domain=self.domain,
+            form_extras={
+                'auth_context': DefaultAuthContext()
+            }
+        )
+        # This would fail hard if there was no AuthContext:
+        # http://manage.dimagi.com/default.asp?234245
+        system_user_factory.create_case()
 
 
 class AsyncRestoreIntegrationParameters(BaseAsyncRestoreTest):

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -137,7 +137,9 @@ class SubmissionPost(object):
             return failure_result
 
         if ASYNC_RESTORE.enabled(self.domain):
-            self._invalidate_async_tasks(self.auth_context.user_id)
+            if not isinstance(self.auth_context, DefaultAuthContext):
+                # If this is a system form (with DefaultAuthContext) we don't invalidate restores
+                self._invalidate_async_tasks(self.auth_context.user_id)
 
         result = process_xform_xml(self.domain, self.instance, self.attachments)
         submitted_form = result.submitted_form


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?234245
When the async restore flag was enabled, system form submissions would fail because the `DefaultAuthContext` had no `user_id`. 
@dannyroberts 

@amstone326, I know you've been hit by this bug a couple of times :(
