### PR TITLE
Initial support for stock in exports

### DIFF
--- a/corehq/apps/app_manager/const.py
+++ b/corehq/apps/app_manager/const.py
@@ -55,3 +55,8 @@ AMPLIFIES_NOT_SET = 'not_set'
 DEFAULT_MONTH_FILTER_PERIOD_LENGTH = 0
 
 CLAIM_DEFAULT_RELEVANT_CONDITION = "count(instance('casedb')/casedb/case[@case_id=instance('querysession')/session/data/case_id]) = 0"
+
+STOCK_QUESTION_TAG_NAMES = [
+    'balance',
+    'transfer',
+]

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -948,6 +948,17 @@ class XForm(WrappedNode):
                     "type": "DataBindOnly",
                     "calculate": bind.attrib.get('calculate') if hasattr(bind, 'attrib') else None,
                 }
+
+                # Include meta information about the stock entry
+                if data_node.tag_name == 'entry':
+                    parent = next(data_node.xml.iterancestors())
+                    if parent:
+                        question.update({
+                            "type": "Stock",
+                            "stock_entry_attributes": data_node.xml.attrib,
+                            "stock_type_attributes": parent.attrib,
+                        })
+
                 if use_hashtags:
                     hashtag_path = self.hashtag_path(path)
                     question.update({

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -954,7 +954,6 @@ class XForm(WrappedNode):
                     parent = next(data_node.xml.iterancestors())
                     if parent and WrappedNode(parent).tag_name in STOCK_QUESTION_TAG_NAMES:
                         question.update({
-                            "type": "Stock",
                             "stock_entry_attributes": data_node.xml.attrib,
                             "stock_type_attributes": parent.attrib,
                         })

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -7,7 +7,7 @@ from corehq import toggles
 from corehq.apps.app_manager.const import (
     APP_V1, SCHEDULE_PHASE, SCHEDULE_LAST_VISIT, SCHEDULE_LAST_VISIT_DATE,
     CASE_ID, USERCASE_ID, SCHEDULE_UNSCHEDULED_VISIT, SCHEDULE_CURRENT_VISIT_NUMBER,
-    SCHEDULE_GLOBAL_NEXT_VISIT_DATE, SCHEDULE_NEXT_DUE,
+    SCHEDULE_GLOBAL_NEXT_VISIT_DATE, SCHEDULE_NEXT_DUE, STOCK_QUESTION_TAG_NAMES
 )
 from lxml import etree as ET
 from corehq.util.view_utils import get_request
@@ -952,7 +952,7 @@ class XForm(WrappedNode):
                 # Include meta information about the stock entry
                 if data_node.tag_name == 'entry':
                     parent = next(data_node.xml.iterancestors())
-                    if parent:
+                    if parent and WrappedNode(parent).tag_name in STOCK_QUESTION_TAG_NAMES:
                         question.update({
                             "type": "Stock",
                             "stock_entry_attributes": data_node.xml.attrib,

--- a/corehq/apps/export/models/__init__.py
+++ b/corehq/apps/export/models/__init__.py
@@ -25,6 +25,7 @@ from .new import (
     ScalarItem,
     GeopointItem,
     CaseIndexItem,
+    StockItem,
     Option,
     MultipleChoiceItem,
     MultiMediaItem,

--- a/corehq/apps/export/models/__init__.py
+++ b/corehq/apps/export/models/__init__.py
@@ -11,6 +11,7 @@ from .new import (
     StockExportColumn,
     MultiMediaExportColumn,
     UserDefinedExportColumn,
+    StockFormExportColumn,
     ExportRow,
     ExportInstance,
     FormExportInstance,

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1057,7 +1057,6 @@ class FormExportDataSchema(ExportDataSchema):
         'Image': MultiMediaItem,
         'Audio': MultiMediaItem,
         'Video': MultiMediaItem,
-        'Stock': StockItem,
     })
 
     @property
@@ -1122,7 +1121,7 @@ class FormExportDataSchema(ExportDataSchema):
             )
             for question in group_questions:
                 # Create ExportItem based on the question type
-                if question['type'] == 'Stock':
+                if 'stock_type_attributes' in question:
                     items = FormExportDataSchema._get_stock_items_from_question(
                         question,
                         app_id,

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -923,6 +923,7 @@ class ExportDataSchema(Document):
 
         original_id, original_rev = None, None
         current_schema = cls.get_latest_export_schema(domain, app_id, identifier)
+        force_rebuild = True
         if (current_schema
                 and not force_rebuild
                 and current_schema.version == DATA_SCHEMA_VERSION):
@@ -1164,10 +1165,11 @@ class FormExportDataSchema(ExportDataSchema):
         # Strips the last value in the path
         # E.G. /data/balance/entry --> /data/balance
         parent_path = question['value'][:question['value'].rfind('/')]
+        question_id = question['stock_type_attributes']['type']
         for attribute in question['stock_type_attributes']:
             items.append(StockItem.create_from_question(
                 question,
-                '{}/@{}'.format(parent_path, attribute),
+                '{}:{}/@{}'.format(parent_path, question_id, attribute),
                 app_id,
                 app_version,
                 repeats,
@@ -1176,7 +1178,7 @@ class FormExportDataSchema(ExportDataSchema):
         for attribute in question['stock_entry_attributes']:
             items.append(StockItem.create_from_question(
                 question,
-                '{}/@{}'.format(question['value'], attribute),
+                '{}:{}/@{}'.format(question['value'], question_id, attribute),
                 app_id,
                 app_version,
                 repeats,

--- a/corehq/apps/export/tests/data/stock_form.xml
+++ b/corehq/apps/export/tests/data/stock_form.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<h:html xmlns:h="http://www.w3.org/1999/xhtml" xmlns:orx="http://openrosa.org/jr/xforms" xmlns="http://www.w3.org/2002/xforms" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:vellum="http://commcarehq.org/xforms/vellum">
+	<h:head>
+		<h:title>More Stock!</h:title>
+		<model>
+			<instance>
+				<data xmlns:jrm="http://dev.commcarehq.org/jr/xforms" xmlns="http://openrosa.org/formdesigner/B7C62A88-4DE6-4AAF-930B-2DA6F83BCB7B" uiVersion="1" version="1" name="More Stock!">
+					<balance entity-id="" date="" xmlns="http://commcarehq.org/ledger/v1" type="balance_one" section-id="">
+						<entry id="" quantity="" />
+					</balance>
+				</data>
+			</instance>
+			<instance src="jr://instance/ledgerdb" id="ledger" />
+			<bind nodeset="/data/balance[@type='balance_one']" />
+			<bind nodeset="/data/balance[@type='balance_one']/entry/@quantity" />
+			<setvalue event="xforms-ready" ref="/data/balance[@type='balance_one']/@date" value="now()" />
+			<itext>
+				<translation lang="en" default="" />
+				<translation lang="fra" />
+				<translation lang="es" />
+			</itext>
+		</model>
+	</h:head>
+	<h:body />
+</h:html>

--- a/corehq/apps/export/tests/test_export_data_schema.py
+++ b/corehq/apps/export/tests/test_export_data_schema.py
@@ -117,7 +117,7 @@ class TestFormExportDataSchema(SimpleTestCase, TestXmlMixin):
             self.assertTrue(any(map(
                 lambda item: item.path == [
                     PathNode(name='form'),
-                    PathNode(name='balance'),
+                    PathNode(name='balance:balance_one'),
                     PathNode(name=parent_attr),
                 ],
                 group_schema.items,
@@ -127,7 +127,7 @@ class TestFormExportDataSchema(SimpleTestCase, TestXmlMixin):
             self.assertTrue(any(map(
                 lambda item: item.path == [
                     PathNode(name='form'),
-                    PathNode(name='balance'),
+                    PathNode(name='balance:balance_one'),
                     PathNode(name='entry'),
                     PathNode(name=entry_attr),
                 ],

--- a/corehq/apps/export/tests/test_export_data_schema.py
+++ b/corehq/apps/export/tests/test_export_data_schema.py
@@ -99,6 +99,41 @@ class TestFormExportDataSchema(SimpleTestCase, TestXmlMixin):
         self.assertEqual(form_items[1].options[0].value, 'choice1')
         self.assertEqual(form_items[1].options[1].value, 'choice2')
 
+    def test_xform_parsing_with_stock_questions(self):
+        form_xml = self.get_xml('stock_form')
+        schema = FormExportDataSchema._generate_schema_from_xform(
+            XForm(form_xml),
+            [],
+            ['en'],
+            self.app_id,
+            1
+        )
+        self.assertEqual(len(schema.group_schemas), 1)
+        group_schema = schema.group_schemas[0]
+
+        self.assertEqual(len(group_schema.items), 6)
+        self.assertTrue(all(map(lambda item: item.doc_type == 'StockItem', group_schema.items)))
+        for parent_attr in ['@type', '@entity-id', '@date', '@section-id']:
+            self.assertTrue(any(map(
+                lambda item: item.path == [
+                    PathNode(name='form'),
+                    PathNode(name='balance'),
+                    PathNode(name=parent_attr),
+                ],
+                group_schema.items,
+            )))
+
+        for entry_attr in ['@id', '@quantity']:
+            self.assertTrue(any(map(
+                lambda item: item.path == [
+                    PathNode(name='form'),
+                    PathNode(name='balance'),
+                    PathNode(name='entry'),
+                    PathNode(name=entry_attr),
+                ],
+                group_schema.items,
+            )))
+
     def test_question_path_to_path_nodes(self):
         """
         Confirm that _question_path_to_path_nodes() works as expected

--- a/corehq/apps/export/tests/test_export_views.py
+++ b/corehq/apps/export/tests/test_export_views.py
@@ -34,6 +34,7 @@ class ExportViewTest(TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.user.delete()
+        cls.domain.delete()
 
     def setUp(self):
         self.client.login(username=self.username, password=self.password)


### PR DESCRIPTION
@czue @NoahCarnahan wanted to get your guys' thoughts on this approach before diving too much further. Essentially this approach will "explode" a stock question into many ExportItems and will look something like this:

<img width="996" alt="screen shot 2016-08-08 at 12 51 38 pm" src="https://cloud.githubusercontent.com/assets/918514/17488426/5a852ce2-5d67-11e6-9ced-bfa1bfd59e5e.png">

There are a few caveats to this approach which I think exist in the current platform. Question ids play no part in the question path. For example, a form submission from stock:

```
<n0:transfer date="2016-08-08" dest="xxxx" section-id="stock" type="received" xmlns:n0="http://commcarehq.org/ledger/v1">
    <n0:entry id="xxxx" quantity="24"/>
</n0:transfer>
```

The question id is actually stored in the "type" attribute. Thus if you were to have two transfer questions at the same level in the form xml, i'm pretty sure that'd result in unexpected results because `form['transfer']['entry']` will resolve to one value when in fact there are multiple values
