### PR TITLE
fix user data api

### DIFF
--- a/corehq/apps/api/resources/v0_1.py
+++ b/corehq/apps/api/resources/v0_1.py
@@ -256,6 +256,13 @@ class CommCareUserResource(UserResource):
             bundle.data['extras'] = extras
         return super(UserResource, self).dehydrate(bundle)
 
+    def dehydrate_user_data(self, bundle):
+        user_data = bundle.obj.user_data
+        if self.determine_format(bundle.request) == 'application/xml':
+            # attribute names can't start with digits in xml
+            user_data = {k: v for k, v in user_data.iteritems() if not k[0].isdigit()}
+        return user_data
+
     def obj_get_list(self, bundle, **kwargs):
         domain = kwargs['domain']
         show_archived = _safe_bool(bundle, 'archived')


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?234404

@czue  Fixed in the way you described in the ticket. Not sure this is the greatest solution since it makes it harder to get data from our api (some data is in the json, that isn't in the xml), but don't think there's a way around it unless we change our api backend/format.

I'll put a warning up on confluence if this gets merged
