### PR TITLE
Use unix epoch for date

### DIFF
--- a/custom/enikshay/fixtures.py
+++ b/custom/enikshay/fixtures.py
@@ -30,7 +30,7 @@ class CalendarFixtureProvider(object):
                 current_year_element.append(current_month_element)
 
             current_day_element = Element('day', {
-                'date': str(current_day.toordinal()),
+                'date': str(current_day.strftime('%s')),
                 'number': str(current_day.day),
                 'name': _(current_day.strftime('%A')),
                 'week': str(current_day.isocalendar()[1]),


### PR DESCRIPTION
Mobile uses unix epoch rather than ordinals for dates

@czue @amstone326 
