### PR TITLE
Fix errors on bad bucket path due to unsafe doc id

### DIFF
--- a/corehq/blobs/mixin.py
+++ b/corehq/blobs/mixin.py
@@ -52,10 +52,7 @@ class BlobMixin(Document):
         if self._id is None:
             raise ResourceNotFound(
                 "cannot manipulate attachment on unidentified document")
-        identifier = self._id
-        if not SAFENAME.match(identifier):
-            identifier = u'unsafe-' + sha1(identifier.encode('utf-8')).hexdigest()
-        return join(_get_couchdb_name(type(self)), identifier)
+        return join(_get_couchdb_name(type(self)), safe_id(self._id))
 
     @property
     def blobs(self):
@@ -266,7 +263,7 @@ class BlobHelper(object):
         return BlobMixin.blobs.fget(self)
 
     def _blobdb_bucket(self):
-        return join(self.database.dbname, self._id)
+        return join(self.database.dbname, safe_id(self._id))
 
     def put_attachment(self, content, name=None, *args, **kw):
         if self._attachments is None and self.couch_only:
@@ -452,3 +449,9 @@ def bulk_atomic_blobs(docs):
 @memoized
 def _get_couchdb_name(doc_class):
     return doc_class.get_db().dbname
+
+
+def safe_id(identifier):
+    if not SAFENAME.match(identifier):
+        identifier = u'sha1-' + sha1(identifier.encode('utf-8')).hexdigest()
+    return identifier

--- a/corehq/blobs/tests/test_mixin.py
+++ b/corehq/blobs/tests/test_mixin.py
@@ -517,7 +517,8 @@ class TestBlobHelper(BaseTestCase):
     def make_doc(self, type_=mod.BlobHelper, doc=None):
         if doc is None:
             doc = {}
-        doc["_id"] = uuid.uuid4().hex
+        if "_id" not in doc:
+            doc["_id"] = uuid.uuid4().hex
         if doc.get("_attachments"):
             for name, attach in doc["_attachments"].iteritems():
                 self.couch.put_attachment(doc, name=name, **attach)
@@ -528,6 +529,16 @@ class TestBlobHelper(BaseTestCase):
                 obj.put_attachment(name=name, **attach)
             self.couch.save_log = save_log
         return obj
+
+    def test_put_attachment_for_doc_with_bad_path_id(self):
+        obj = self.make_doc(doc={
+            "_id": "uuid:some-random-value",
+            "external_blobs": {},
+        })
+        name = "test.0"
+        data = "\u4500 content"
+        obj.put_attachment(data, name)
+        self.assertEqual(obj.fetch_attachment(name), data)
 
     def test_put_and_fetch_attachment_from_couch(self):
         obj = self.make_doc(doc={"_attachments": {}})

--- a/corehq/blobs/tests/test_mixin.py
+++ b/corehq/blobs/tests/test_mixin.py
@@ -29,10 +29,12 @@ class BaseTestCase(TestCase):
     def tearDownClass(cls):
         cls.db.close()
 
-    def make_doc(self, type_=None):
+    def make_doc(self, type_=None, id=None):
         if type_ is None:
             type_ = FakeCouchDocument
-        return type_({"_id": uuid.uuid4().hex})
+        if id is None:
+            id = uuid.uuid4().hex
+        return type_({"_id": id})
 
     def setUp(self):
         self.obj = self.make_doc()
@@ -61,6 +63,13 @@ class TestBlobMixin(BaseTestCase):
     def test_put_attachment_without_name(self):
         with self.assertRaises(mod.InvalidAttachment):
             self.obj.put_attachment("content")
+
+    def test_put_attachment_for_doc_with_bad_path_id(self):
+        obj = self.make_doc(id="uuid:some-random-value")
+        name = "test.0"
+        data = "\u4500 content"
+        obj.put_attachment(data, name)
+        self.assertEqual(obj.fetch_attachment(name), data)
 
     def test_put_attachment_unicode(self):
         name = "test.1"


### PR DESCRIPTION
Original error:

```
Traceback (most recent call first):

BadName: unsafe path name: u'commcarehq/uuid:2a90447b-cc5e-4653-9cec-35745a207f5a'
  File "/home/cchq/www/production/releases/2016-08-08_19.08/corehq/blobs/s3db.py", line 107, in safepath
    raise BadName(u"unsafe path name: %r" % path)
  File "/home/cchq/www/production/releases/2016-08-08_19.08/corehq/blobs/s3db.py", line 114, in safejoin
    return safepath(root) + "/" + safepath(subpath)
  File "/home/cchq/www/production/releases/2016-08-08_19.08/corehq/blobs/s3db.py", line 99, in get_path
    return safejoin(bucket, identifier)
  File "/home/cchq/www/production/releases/2016-08-08_19.08/corehq/blobs/s3db.py", line 42, in put
    path = self.get_path(identifier, bucket)
  File "/home/cchq/www/production/releases/2016-08-08_19.08/corehq/blobs/mixin.py", line 94, in put_attachment
    info = db.put(content, name, bucket)
  File "/home/cchq/www/production/releases/2016-08-08_19.08/corehq/blobs/mixin.py", line 361, in put_attachment
    *args, **kw)
  File "/home/cchq/www/production/releases/2016-08-08_19.08/corehq/blobs/mixin.py", line 442, in bulk_atomic_blobs
    doc.put_attachment(name=name, **info)
  File "/usr/lib/python2.7/contextlib.py", line 17, in __enter__
    return self.gen.next()
  File "/home/cchq/www/production/releases/2016-08-08_19.08/corehq/form_processor/backends/couch/processor.py", line 67, in save_processed_models
    with bulk_atomic_blobs(docs):
  File "/home/cchq/www/production/releases/2016-08-08_19.08/corehq/form_processor/interfaces/processor.py", line 126, in save_processed_models
    stock_result=stock_result,
```

@emord @dannyroberts 
