### PR TITLE
migrate deferred attachments when editing/deprecating a form

### DIFF
--- a/corehq/blobs/mixin.py
+++ b/corehq/blobs/mixin.py
@@ -356,6 +356,16 @@ class DeferredBlobMixin(BlobMixin):
             )) for name, info in self._deferred_blobs.iteritems())
         return value
 
+    @property
+    def persistent_blobs(self):
+        """Get a dict like `blobs` containing only non-deferred items"""
+        value = super(DeferredBlobMixin, self).blobs
+        if self._deferred_blobs:
+            value = value.copy()
+            for name in self._deferred_blobs:
+                value.pop(name, None)
+        return value
+
     def put_attachment(self, content, name=None, *args, **kw):
         if self._deferred_blobs:
             self._deferred_blobs.pop(name, None)

--- a/corehq/ex-submodules/couchforms/tests/test_edits.py
+++ b/corehq/ex-submodules/couchforms/tests/test_edits.py
@@ -12,7 +12,7 @@ from corehq.apps.receiverwrapper import submit_form_locally
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAccessors
 from couchforms.models import (
     UnfinishedSubmissionStub,
-)
+    XFormInstance)
 
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends, post_xform
@@ -286,5 +286,9 @@ class EditFormTest(TestCase, TestFileMixin):
         form_xml = xform.get_xml()
         xform.delete_attachment('form.xml')
         xform.get_db().put_attachment(xform.to_json(), form_xml, 'form.xml')
+        # make sure that worked
+        updated_form_xml = XFormInstance.get(xform._id).get_xml()
+        self.assertEqual(form_xml, updated_form_xml)
         # this call was previously failing
-        submit_case_blocks(case_block, domain=self.domain, form_id=form_id)
+        updated_form = submit_case_blocks(case_block, domain=self.domain, form_id=form_id)
+        self.assertEqual(form_xml, XFormInstance.get(updated_form.deprecated_form_id).get_xml())

--- a/corehq/ex-submodules/couchforms/tests/test_edits.py
+++ b/corehq/ex-submodules/couchforms/tests/test_edits.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 import os
 import uuid
 
@@ -10,9 +10,7 @@ from casexml.apps.case.mock import CaseBlock
 from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.receiverwrapper import submit_form_locally
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAccessors
-from couchforms.models import (
-    UnfinishedSubmissionStub,
-    XFormInstance)
+from couchforms.models import UnfinishedSubmissionStub, XFormInstance
 
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends, post_xform

--- a/corehq/ex-submodules/couchforms/tests/test_edits.py
+++ b/corehq/ex-submodules/couchforms/tests/test_edits.py
@@ -276,3 +276,15 @@ class EditFormTest(TestCase, TestFileMixin):
                 [create_form_id, edit_form_id, second_edit_form_id],
                 [a.xform_id for a in case.actions]
             )
+
+    def test_couch_blob_migration_edit(self):
+        form_id = uuid.uuid4().hex
+        case_id = uuid.uuid4().hex
+        case_block = CaseBlock(create=True, case_id=case_id).as_string()
+        xform = submit_case_blocks(case_block, domain=self.domain, form_id=form_id)
+        # explicitly convert to old-style couch attachments to test the migration workflow
+        form_xml = xform.get_xml()
+        xform.delete_attachment('form.xml')
+        xform.get_db().put_attachment(xform.to_json(), form_xml, 'form.xml')
+        # this call was previously failing
+        submit_case_blocks(case_block, domain=self.domain, form_id=form_id)

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -219,6 +219,9 @@ class XFormInstanceSQL(DisabledDbMixin, models.Model, RedisLockableMixIn, Attach
     deleted_on = models.DateTimeField(null=True)
     deletion_id = models.CharField(max_length=255, null=True)
 
+    # for compatability with corehq.blobs.mixin.DeferredBlobMixin interface
+    persistent_blobs = None
+
     @classmethod
     def get_obj_id(cls, obj):
         return obj.form_id

--- a/corehq/form_processor/parsers/form.py
+++ b/corehq/form_processor/parsers/form.py
@@ -198,7 +198,7 @@ def apply_deprecation(existing_xform, new_xform, interface=None):
     if existing_xform.persistent_blobs:
         for name, meta in existing_xform.persistent_blobs.items():
             with existing_xform.fetch_attachment(name, stream=True) as content:
-                new_xform.deferred_put_attachment(
+                existing_xform.deferred_put_attachment(
                     content,
                     name=name,
                     content_type=meta.content_type,

--- a/corehq/form_processor/parsers/form.py
+++ b/corehq/form_processor/parsers/form.py
@@ -195,6 +195,15 @@ def apply_deprecation(existing_xform, new_xform, interface=None):
 
     interface = interface or FormProcessorInterface(existing_xform.domain)
 
+    if existing_xform.persistent_blobs:
+        for name, meta in existing_xform.persistent_blobs.items():
+            with existing_xform.fetch_attachment(name, stream=True) as content:
+                new_xform.deferred_put_attachment(
+                    content,
+                    name=name,
+                    content_type=meta.content_type,
+                    content_length=meta.content_length,
+                )
     new_xform.form_id = existing_xform.form_id
     existing_xform = interface.assign_new_id(existing_xform)
     existing_xform.orig_id = new_xform.form_id


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?234481

@millerdev the issue was that when you deprecate a form the ID changes, which was calling subsequent lookups to the blobdb to fail. this works around it by explicitly adding any couch attachments to `_deferred_blobs` during the deprecation process. open to other ideas about how to do this if you have them.

cc @emord 
