### PR TITLE
More friendly handling of multiselect questions in report builder

### DIFF
--- a/corehq/apps/userreports/README.md
+++ b/corehq/apps/userreports/README.md
@@ -440,7 +440,7 @@ Here is a simple example that demonstrates the structure. The keys of `propertie
 
 ```json
 {
-    "type": "named",
+    "type": "dict",
     "properties": {
         "name": "a constant name",
         "value": {

--- a/corehq/apps/userreports/reports/builder/__init__.py
+++ b/corehq/apps/userreports/reports/builder/__init__.py
@@ -158,23 +158,25 @@ def make_owner_name_indicator(column_id):
     return _make_user_group_or_location_indicator("owner_id", column_id)
 
 
-def make_form_question_indicator(question, column_id=None):
+def make_form_question_indicator(question, column_id=None, root_doc=False):
     """
     Return a data source indicator configuration (a dict) for the given form
     question.
     """
     path = question['value'].split('/')
     data_type = question['type']
+    expression = {
+        "type": "property_path",
+        'property_path': ['form'] + path[2:],
+    }
+    if root_doc:
+        expression = {"type": "root_doc", "expression": expression}
     return {
         "type": "expression",
         "column_id": column_id or question['value'],
         "display_name": path[-1],
         "datatype": get_form_indicator_data_type(data_type),
-        "expression": {
-            "type": "property_path",
-            'property_path': ['form'] + path[2:],
-        },
-
+        "expression": expression
     }
 
 
@@ -190,7 +192,7 @@ def make_multiselect_question_indicator(question, column_id=None):
     }
 
 
-def make_form_meta_block_indicator(spec, column_id=None):
+def make_form_meta_block_indicator(spec, column_id=None, root_doc=False):
     """
     Return a data source indicator configuration (a dict) for the given
     form meta field and data type.
@@ -200,15 +202,18 @@ def make_form_meta_block_indicator(spec, column_id=None):
         field_name = [field_name]
     data_type = spec[1]
     column_id = column_id or field_name[0]
+    expression = {
+        "type": "property_path",
+        "property_path": ['form', 'meta'] + field_name,
+    }
+    if root_doc:
+        expression = {"type": "root_doc", "expression": expression}
     return {
         "type": "expression",
         "column_id": column_id,
         "display_name": field_name[0],
         "datatype": get_form_indicator_data_type(data_type),
-        "expression": {
-            "type": "property_path",
-            "property_path": ['form', 'meta'] + field_name,
-        }
+        "expression": expression
     }
 
 

--- a/corehq/apps/userreports/reports/builder/__init__.py
+++ b/corehq/apps/userreports/reports/builder/__init__.py
@@ -178,6 +178,18 @@ def make_form_question_indicator(question, column_id=None):
     }
 
 
+def make_multiselect_question_indicator(question, column_id=None):
+    path = question['value'].split('/')
+    return {
+        "type": "choice_list",
+        "column_id": column_id or question['value'],
+        "display_name": path[-1],
+        "property_path": ['form'] + path[2:],
+        "select_style": "multiple",
+        "choices": [o['value'] for o in question['options']],
+    }
+
+
 def make_form_meta_block_indicator(spec, column_id=None):
     """
     Return a data source indicator configuration (a dict) for the given

--- a/corehq/apps/userreports/reports/builder/columns.py
+++ b/corehq/apps/userreports/reports/builder/columns.py
@@ -31,8 +31,8 @@ class ColumnOption(object):
             return ("Count per Choice",)
         return ("Count per Choice", "Sum", "Average")
 
-    def to_column_dict(self, index, display_text, aggregation):
-        return {
+    def to_column_dicts(self, index, display_text, aggregation):
+        return [{
             "format": "default",
             "aggregation": self.aggregation_map[aggregation],
             "field": self.indicator_id,
@@ -40,7 +40,7 @@ class ColumnOption(object):
             "type": "field",
             "display": display_text,
             "transform": {'type': 'custom', 'custom_type': 'short_decimal_display'},
-        }
+        }]
 
 
 class QuestionColumnOption(ColumnOption):
@@ -62,8 +62,8 @@ class CountColumn(ColumnOption):
         # be more accurate.
         return ("Count",)
 
-    def to_column_dict(self, index, display_text, aggregation):
+    def to_column_dicts(self, index, display_text, aggregation):
         # aggregation is only an arg so that we match the the parent's method signature.
-        column_dict = super(CountColumn, self).to_column_dict(index, display_text, "Sum")
-        del column_dict['transform']
-        return column_dict
+        column_dicts = super(CountColumn, self).to_column_dicts(index, display_text, "Sum")
+        del column_dicts[0]['transform']
+        return column_dicts

--- a/corehq/apps/userreports/reports/builder/columns.py
+++ b/corehq/apps/userreports/reports/builder/columns.py
@@ -54,6 +54,21 @@ class MultiselectQuestionColumnOption(QuestionColumnOption):
         super(QuestionColumnOption, self).__init__(id, display, indicator_id, False)
         self.question_source = question_source
 
+    def to_column_dicts(self, index, display_text, aggregation):
+
+        columns = []
+        for choice_index, choice in enumerate(self.question_source['options']):
+            columns.append({
+                "type": "field",
+                "column_id": "column_{}_{}".format(index, choice_index),
+                "format": "default",
+                "aggregation": self.aggregation_map[aggregation],
+                "field": "{}_{}".format(self.indicator_id, choice['value']),
+                "display": "{} - {}".format(display_text, choice['label']),
+            })
+
+        return columns
+
 
 class CountColumn(ColumnOption):
     def __init__(self, display):

--- a/corehq/apps/userreports/reports/builder/columns.py
+++ b/corehq/apps/userreports/reports/builder/columns.py
@@ -31,7 +31,7 @@ class ColumnOption(object):
             return ("Count per Choice",)
         return ("Count per Choice", "Sum", "Average")
 
-    def to_column_dicts(self, index, display_text, aggregation):
+    def to_column_dicts(self, index, display_text, aggregation, is_aggregated_on=False):
         return [{
             "format": "default",
             "aggregation": self.aggregation_map[aggregation],
@@ -54,7 +54,12 @@ class MultiselectQuestionColumnOption(QuestionColumnOption):
         super(QuestionColumnOption, self).__init__(id, display, indicator_id, False)
         self.question_source = question_source
 
-    def to_column_dicts(self, index, display_text, aggregation):
+    def to_column_dicts(self, index, display_text, aggregation, is_aggregated_on=False):
+
+        if is_aggregated_on:
+            return super(MultiselectQuestionColumnOption, self).to_column_dicts(
+                index, display_text, aggregation, is_aggregated_on=False
+            )
 
         columns = []
         for choice_index, choice in enumerate(self.question_source['options']):
@@ -83,7 +88,7 @@ class CountColumn(ColumnOption):
         # be more accurate.
         return ("Count",)
 
-    def to_column_dicts(self, index, display_text, aggregation):
+    def to_column_dicts(self, index, display_text, aggregation, is_aggregated_on=False):
         # aggregation is only an arg so that we match the the parent's method signature.
         column_dicts = super(CountColumn, self).to_column_dicts(index, display_text, "Sum")
         del column_dicts[0]['transform']

--- a/corehq/apps/userreports/reports/builder/columns.py
+++ b/corehq/apps/userreports/reports/builder/columns.py
@@ -49,6 +49,12 @@ class QuestionColumnOption(ColumnOption):
         self.question_source = question_source
 
 
+class MultiselectQuestionColumnOption(QuestionColumnOption):
+    def __init__(self, id, display, indicator_id, question_source):
+        super(QuestionColumnOption, self).__init__(id, display, indicator_id, False)
+        self.question_source = question_source
+
+
 class CountColumn(ColumnOption):
     def __init__(self, display):
         super(CountColumn, self).__init__('computed/count', display, "count", False)

--- a/corehq/apps/userreports/reports/builder/columns.py
+++ b/corehq/apps/userreports/reports/builder/columns.py
@@ -50,6 +50,8 @@ class QuestionColumnOption(ColumnOption):
 
 
 class MultiselectQuestionColumnOption(QuestionColumnOption):
+    LABEL_DIVIDER = " - "
+
     def __init__(self, id, display, indicator_id, question_source):
         super(QuestionColumnOption, self).__init__(id, display, indicator_id, False)
         self.question_source = question_source
@@ -69,7 +71,7 @@ class MultiselectQuestionColumnOption(QuestionColumnOption):
                 "format": "default",
                 "aggregation": self.aggregation_map[aggregation],
                 "field": "{}_{}".format(self.indicator_id, choice['value']),
-                "display": "{} - {}".format(display_text, choice['label']),
+                "display": display_text + self.LABEL_DIVIDER + choice['label']
             })
 
         return columns

--- a/corehq/apps/userreports/reports/builder/columns.py
+++ b/corehq/apps/userreports/reports/builder/columns.py
@@ -57,6 +57,7 @@ class MultiselectQuestionColumnOption(QuestionColumnOption):
         self.question_source = question_source
 
     def to_column_dicts(self, index, display_text, aggregation, is_aggregated_on=False):
+        assert aggregation in ["Count per Choice", "simple"]
 
         if is_aggregated_on:
             return super(MultiselectQuestionColumnOption, self).to_column_dicts(
@@ -69,12 +70,17 @@ class MultiselectQuestionColumnOption(QuestionColumnOption):
                 "type": "field",
                 "column_id": "column_{}_{}".format(index, choice_index),
                 "format": "default",
-                "aggregation": self.aggregation_map[aggregation],
+                "aggregation": "sum",
                 "field": "{}_{}".format(self.indicator_id, choice['value']),
                 "display": display_text + self.LABEL_DIVIDER + choice['label']
             })
 
         return columns
+
+    @property
+    @memoized
+    def aggregation_options(self):
+        return ("Count per Choice",)
 
 
 class CountColumn(ColumnOption):

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -1182,7 +1182,9 @@ class ConfigureListReportForm(ConfigureNewReportBase):
                 if mselect_indicator_id:
                     if mselect_indicator_id not in added_multiselect_columns:
                         added_multiselect_columns.add(mselect_indicator_id)
-                        display = " - ".join(display.split(" - ")[:-1])
+                        display = MultiselectQuestionColumnOption.LABEL_DIVIDER.join(
+                            display.split(MultiselectQuestionColumnOption.LABEL_DIVIDER)[:-1]
+                        )
                     else:
                         continue
 

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -271,10 +271,8 @@ class DataSourceBuilder(object):
                 ))
             elif prop.type == "question":
                 if prop.source['type'] == "MSelect":
-                    if is_multiselect_chart_report:
-                        ret.append(make_form_question_indicator(prop.source, prop.column_id))
-                    else:
-                        ret.append(make_multiselect_question_indicator(prop.source, prop.column_id))
+                    ret.append(make_form_question_indicator(prop.source, prop.column_id))  # For filters and aggregation
+                    ret.append(make_multiselect_question_indicator(prop.source, prop.column_id))  # For column display
                 else:
                     indicator = make_form_question_indicator(prop.source, prop.column_id, root_doc=is_multiselect_chart_report)
                     if prop.source['type'] == "DataBindOnly" and number_columns:
@@ -1264,15 +1262,15 @@ class ConfigureTableReportForm(ConfigureListReportForm, ConfigureBarChartReportF
         for i, conf in enumerate(self.cleaned_data['columns']):
             columns.extend(
                 self.report_column_options[conf['property']].to_column_dicts(
-                    i, conf['display_text'], conf['calculation']
+                    i, conf['display_text'], conf['calculation'], is_aggregated_on=conf["property"] == self.aggregation_field
                 )
             )
 
         # Add the aggregation indicator to the columns if it's not already present.
-        displaying_agg_column = bool([c for c in columns if c['field'] == agg_field_id])
+        displaying_agg_column = bool([c for c in self.cleaned_data['columns'] if c['property'] == self.aggregation_field])
         if not displaying_agg_column:
             new_columns = self._get_column_option_by_indicator_id(agg_field_id).to_column_dicts(
-                "agg", agg_field_text, 'simple'
+                "agg", agg_field_text, 'simple', is_aggregated_on=True
             )
             new_columns.extend(columns)
             columns = new_columns

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -1098,11 +1098,10 @@ class ConfigureListReportForm(ConfigureNewReportBase):
 
     @property
     def _report_columns(self):
-        return [
-            self.report_column_options[conf['property']].to_column_dict(
-                i, conf['display_text'], "simple"
-            ) for i, conf in enumerate(self.cleaned_data['columns'])
-        ]
+        columns = []
+        for i, conf in enumerate(self.cleaned_data['columns']):
+            columns.extend(self.report_column_options[conf['property']].to_column_dicts(i, conf['display_text'], "simple"))
+        return columns
 
     @property
     def _report_aggregation_cols(self):
@@ -1147,21 +1146,22 @@ class ConfigureTableReportForm(ConfigureListReportForm, ConfigureBarChartReportF
         agg_field_id = self.data_source_properties[self.aggregation_field].column_id
         agg_field_text = self.data_source_properties[self.aggregation_field].text
 
-        columns = [
-            self.report_column_options[conf['property']].to_column_dict(
-                i, conf['display_text'], conf['calculation']
+        columns = []
+        for i, conf in enumerate(self.cleaned_data['columns']):
+            columns.extend(
+                self.report_column_options[conf['property']].to_column_dicts(
+                    i, conf['display_text'], conf['calculation']
+                )
             )
-            for i, conf in enumerate(self.cleaned_data['columns'])
-        ]
 
         # Add the aggregation indicator to the columns if it's not already present.
         displaying_agg_column = bool([c for c in columns if c['field'] == agg_field_id])
         if not displaying_agg_column:
-            columns = [
-                self._get_column_option_by_indicator_id(agg_field_id).to_column_dict(
-                    "agg", agg_field_text, 'simple'
-                )
-            ] + columns
+            new_columns = self._get_column_option_by_indicator_id(agg_field_id).to_column_dicts(
+                "agg", agg_field_text, 'simple'
+            )
+            new_columns.extend(columns)
+            columns = new_columns
         else:
             # Don't expand the aggregation column
             for c in columns:

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -13,7 +13,7 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _, ugettext_noop, ugettext_lazy
 
 from corehq.apps.userreports.reports.builder.columns import \
-    QuestionColumnOption, ColumnOption, CountColumn
+    QuestionColumnOption, ColumnOption, CountColumn, MultiselectQuestionColumnOption
 from crispy_forms import layout as crispy
 from crispy_forms.bootstrap import StrictButton
 from crispy_forms.helper import FormHelper
@@ -614,7 +614,10 @@ class ConfigureNewReportBase(forms.Form):
         options = OrderedDict()
         for id_, prop in self.data_source_properties.iteritems():
             if prop.type == "question":
-                option = QuestionColumnOption(id_, prop.text, prop.column_id, prop.is_non_numeric, prop.source)
+                if prop.source['type'] == "MSelect":
+                    option = MultiselectQuestionColumnOption(id_, prop.text, prop.column_id, prop.source)
+                else:
+                    option = QuestionColumnOption(id_, prop.text, prop.column_id, prop.is_non_numeric, prop.source)
             else:
                 # meta properties
                 option = ColumnOption(id_, prop.text, prop.column_id, prop.is_non_numeric)

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -936,7 +936,6 @@ class ConfigureNewReportBase(forms.Form):
         return [col["field"] for col in self._report_columns if col.get("aggregation", None) in ["avg", "sum"]]
 
     @property
-    @memoized
     def _is_multiselect_chart_report(self):
         return False
 
@@ -1280,15 +1279,13 @@ class ConfigureTableReportForm(ConfigureListReportForm, ConfigureBarChartReportF
             )
 
         # Add the aggregation indicator to the columns if it's not already present.
-        displaying_agg_column = bool(
-            [c for c in self.cleaned_data['columns'] if c['property'] == self.aggregation_field]
+        displaying_agg_column = any(
+            c for c in self.cleaned_data['columns'] if c['property'] == self.aggregation_field
         )
         if not displaying_agg_column:
-            new_columns = self._get_column_option_by_indicator_id(agg_field_id).to_column_dicts(
+            columns = self._get_column_option_by_indicator_id(agg_field_id).to_column_dicts(
                 "agg", agg_field_text, 'simple', is_aggregated_on=True
-            )
-            new_columns.extend(columns)
-            columns = new_columns
+            ) + columns
         else:
             # Don't expand the aggregation column
             for c in columns:

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -271,10 +271,14 @@ class DataSourceBuilder(object):
                 ))
             elif prop.type == "question":
                 if prop.source['type'] == "MSelect":
-                    ret.append(make_form_question_indicator(prop.source, prop.column_id))  # For filters and aggregation
-                    ret.append(make_multiselect_question_indicator(prop.source, prop.column_id))  # For column display
+                    # For filters and aggregation:
+                    ret.append(make_form_question_indicator(prop.source, prop.column_id))
+                    # For column display:
+                    ret.append(make_multiselect_question_indicator(prop.source, prop.column_id))
                 else:
-                    indicator = make_form_question_indicator(prop.source, prop.column_id, root_doc=is_multiselect_chart_report)
+                    indicator = make_form_question_indicator(
+                        prop.source, prop.column_id, root_doc=is_multiselect_chart_report
+                    )
                     if prop.source['type'] == "DataBindOnly" and number_columns:
                         if indicator['column_id'] in number_columns:
                             indicator['datatype'] = 'decimal'
@@ -722,7 +726,9 @@ class ConfigureNewReportBase(forms.Form):
             display_name=self.ds_builder.data_source_name,
             referenced_doc_type=self.ds_builder.source_doc_type,
             configured_filter=self.ds_builder.filter,
-            configured_indicators=self.ds_builder.indicators(self._number_columns, self._is_multiselect_chart_report),
+            configured_indicators=self.ds_builder.indicators(
+                self._number_columns, self._is_multiselect_chart_report
+            ),
             base_item_expression=base_item_expression,
             meta=DataSourceMeta(build=DataSourceBuildInformation(
                 source_id=self.report_source_id,
@@ -1210,7 +1216,9 @@ class ConfigureListReportForm(ConfigureNewReportBase):
     def _report_columns(self):
         columns = []
         for i, conf in enumerate(self.cleaned_data['columns']):
-            columns.extend(self.report_column_options[conf['property']].to_column_dicts(i, conf['display_text'], "simple"))
+            columns.extend(
+                self.report_column_options[conf['property']].to_column_dicts(i, conf['display_text'], "simple")
+            )
         return columns
 
     @property
@@ -1264,12 +1272,17 @@ class ConfigureTableReportForm(ConfigureListReportForm, ConfigureBarChartReportF
         for i, conf in enumerate(self.cleaned_data['columns']):
             columns.extend(
                 self.report_column_options[conf['property']].to_column_dicts(
-                    i, conf['display_text'], conf['calculation'], is_aggregated_on=conf["property"] == self.aggregation_field
+                    i,
+                    conf['display_text'],
+                    conf['calculation'],
+                    is_aggregated_on=conf["property"] == self.aggregation_field
                 )
             )
 
         # Add the aggregation indicator to the columns if it's not already present.
-        displaying_agg_column = bool([c for c in self.cleaned_data['columns'] if c['property'] == self.aggregation_field])
+        displaying_agg_column = bool(
+            [c for c in self.cleaned_data['columns'] if c['property'] == self.aggregation_field]
+        )
         if not displaying_agg_column:
             new_columns = self._get_column_option_by_indicator_id(agg_field_id).to_column_dicts(
                 "agg", agg_field_text, 'simple', is_aggregated_on=True

--- a/corehq/apps/userreports/reports/builder/forms.py
+++ b/corehq/apps/userreports/reports/builder/forms.py
@@ -46,7 +46,7 @@ from corehq.apps.userreports.reports.builder import (
     make_form_question_indicator,
     make_owner_name_indicator,
     get_filter_format_from_question_type,
-    make_user_name_indicator)
+    make_user_name_indicator, make_multiselect_question_indicator)
 from corehq.apps.userreports.exceptions import BadBuilderConfigError
 from corehq.apps.userreports.sql import get_column_name
 from corehq.apps.userreports.ui.fields import JsonField
@@ -213,13 +213,14 @@ class DataSourceBuilder(object):
                     prop.source, prop.column_id
                 ))
             elif prop.type == "question":
-                indicator = make_form_question_indicator(
-                    prop.source, prop.column_id
-                )
-                if prop.source['type'] == "DataBindOnly" and number_columns:
-                    if indicator['column_id'] in number_columns:
-                        indicator['datatype'] = 'decimal'
-                ret.append(indicator)
+                if prop.source['type'] == "MSelect":
+                    ret.append(make_multiselect_question_indicator(prop.source, prop.column_id))
+                else:
+                    indicator = make_form_question_indicator(prop.source, prop.column_id)
+                    if prop.source['type'] == "DataBindOnly" and number_columns:
+                        if indicator['column_id'] in number_columns:
+                            indicator['datatype'] = 'decimal'
+                    ret.append(indicator)
             elif prop.type == 'case_property' and prop.source == 'computed/owner_name':
                 ret.append(make_owner_name_indicator(prop.column_id))
             elif prop.type == 'case_property' and prop.source == 'computed/user_name':

--- a/corehq/apps/userreports/tests/data/forms/simple.xml
+++ b/corehq/apps/userreports/tests/data/forms/simple.xml
@@ -9,12 +9,14 @@
 					<last_name />
 					<children />
 					<dob />
+                    <state />
 				</data>
 			</instance>
 			<bind nodeset="/data/first_name" type="xsd:string" />
 			<bind nodeset="/data/last_name" type="xsd:string" />
 			<bind nodeset="/data/children" type="xsd:int" />
 			<bind nodeset="/data/dob" type="xsd:date" />
+            <bind nodeset="/data/state" />
 			<itext>
 				<translation lang="en" default="">
 					<text id="first_name-label">
@@ -29,6 +31,18 @@
 					<text id="dob-label">
 						<value>Date of Birth</value>
 					</text>
+                    <text id="state-label">
+                        <value>state</value>
+                    </text>
+                    <text id="state-MA-label">
+                        <value>MA</value>
+                    </text>
+                    <text id="state-MN-label">
+                        <value>MN</value>
+                    </text>
+                    <text id="state-VT-label">
+                        <value>VT</value>
+                    </text>
 				</translation>
 			</itext>
 		</model>
@@ -46,5 +60,20 @@
 		<input ref="/data/dob">
 			<label ref="jr:itext('dob-label')" />
 		</input>
+        <select ref="/data/state">
+            <label ref="jr:itext('state-label')" />
+            <item>
+                <label ref="jr:itext('state-MA-label')" />
+                <value>MA</value>
+            </item>
+            <item>
+                <label ref="jr:itext('state-MN-label')" />
+                <value>MN</value>
+            </item>
+            <item>
+                <label ref="jr:itext('state-VT-label')" />
+                <value>VT</value>
+            </item>
+        </select>
 	</h:body>
 </h:html>

--- a/corehq/apps/userreports/tests/test_report_builder.py
+++ b/corehq/apps/userreports/tests/test_report_builder.py
@@ -218,7 +218,8 @@ class MultiselectQuestionTest(ReportBuilderDBTest):
 
     def testReportColumnOptions(self):
         """
-        Confirm that form.report_column_options contains MultiselectQuestionColumnOption objects for mselect questions.
+        Confirm that form.report_column_options contains MultiselectQuestionColumnOption objects for mselect
+        questions.
         """
 
         builder_form = ConfigureListReportForm(


### PR DESCRIPTION
This PR changes the behavior of columns based on mutliselect questions in report builder reports.

Now, when you select a multiselect question, the report will contain one column per choice in the current version of the form. The column will contain a 1 if the choice was selected, or 0 if it was not. This allows users to sum or average these columns in aggregated reports.

Additionally, if a graph report uses a multiselect question for its chart segments, then one segment will be displayed for each option, with the count for that segment equaling the number of submissions that selected that option.

Best reviewed commit-by-commit
@kaapstorm 
