### PR TITLE
Fix Tableau Nav Bug

### DIFF
--- a/custom/icds/static/tableau_app.js
+++ b/custom/icds/static/tableau_app.js
@@ -100,7 +100,7 @@ function updateViz(marks) {
 
             _.each(pairs, function(pair){
                 debugHtml.push("<li><b>" + pair.fieldName + "</b>: "+ pair.formattedValue + "</li>");
-                newSheet = extractSheetName(pair, currentSheet);
+                newSheet = extractSheetName(pair, newSheet);
                 var newParam = extractParam(pair, currentParams);
                 $.extend(newParams, newParam);
             });


### PR DESCRIPTION
Not sure when this broke, but the old logic would replace the newSheet with the old (currentSheet).  This correctly passes in the newly set sheet so it is not overwritten. 

Will need deployed to India.  Interrupt team: @czue @mkangia @emord 
