### PR TITLE
Tweaks to mobile flag

### DIFF
--- a/corehq/apps/settings/templates/settings/enable_superuser.html
+++ b/corehq/apps/settings/templates/settings/enable_superuser.html
@@ -4,7 +4,7 @@
 {% block page_content %}
     <form class="form-horizontal">
         <fieldset>
-            <legend>{% block title %}{% trans "Enable Superuser on Mobile" %}{% endblock %}</legend>
+            <legend>{% block title %}{% trans "Enable Privileges on Mobile" %}{% endblock %}</legend>
 
             <p>
                 {% blocktrans %}Scanning this QR code from CommCare will enable superuser privileges for your

--- a/corehq/apps/settings/urls.py
+++ b/corehq/apps/settings/urls.py
@@ -10,7 +10,7 @@ from corehq.apps.locations.urls import settings_urls as location_settings
 from corehq.apps.settings.views import (
     ChangeMyPasswordView,
     DefaultMySettingsView,
-    EnableSuperuserView,
+    EnableMobilePrivilegesView,
     MyAccountSettingsView,
     MyProjectsList,
 )
@@ -21,7 +21,7 @@ urlpatterns = patterns(
     url(r'^settings/$', MyAccountSettingsView.as_view(), name=MyAccountSettingsView.urlname),
     url(r'^projects/$', MyProjectsList.as_view(), name=MyProjectsList.urlname),
     url(r'^password/$', ChangeMyPasswordView.as_view(), name=ChangeMyPasswordView.urlname),
-    url(r'^superuser/$', EnableSuperuserView.as_view(), name=EnableSuperuserView.urlname),
+    url(r'^mobile_privs/$', EnableMobilePrivilegesView.as_view(), name=EnableMobilePrivilegesView.urlname),
     url(r'new_api_key/$', 'new_api_key', name='new_api_key'),
 )
 

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -15,7 +15,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.http import Http404
 from django.views.decorators.http import require_POST
-from corehq.mobile_flags import SUPERUSER
+from corehq.mobile_flags import MULTIPLE_APPS_UNLIMITED
 from corehq.tabs.tabclasses import MySettingsTab
 import langcodes
 
@@ -443,11 +443,11 @@ class EnableMobilePrivilegesView(BaseMyAccountView):
     def get(self, request, *args, **kwargs):
         message = json.dumps([
             {'username': request.user.username},
-            {'flag': SUPERUSER.slug}
+            {'flag': MULTIPLE_APPS_UNLIMITED.slug}
         ]).replace(' ', '')
         qrcode_data = json.dumps({
             'username': request.user.username,
-            'flag': SUPERUSER.slug,
+            'flag': MULTIPLE_APPS_UNLIMITED.slug,
             'signature': b64encode(sign(message))
         })
         qrcode = get_qrcode(qrcode_data)

--- a/corehq/apps/settings/views.py
+++ b/corehq/apps/settings/views.py
@@ -434,9 +434,9 @@ def get_qrcode(data):
     return png_data
 
 
-class EnableSuperuserView(BaseMyAccountView):
-    urlname = 'enable_superuser'
-    page_title = ugettext_lazy("Enable Superuser on Mobile")
+class EnableMobilePrivilegesView(BaseMyAccountView):
+    urlname = 'enable_mobile_privs'
+    page_title = ugettext_lazy("Enable Privileges on Mobile")
     template_name = 'settings/enable_superuser.html'
 
     @method_decorator(login_required)

--- a/corehq/mobile_flags.py
+++ b/corehq/mobile_flags.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 MobileFlag = namedtuple('MobileFlag', 'slug label')
 
 
-SUPERUSER = MobileFlag(
-    'superuser',
-    'Enable superuser-only features'
+MULTIPLE_APPS_UNLIMITED = MobileFlag(
+    'multiple_apps_unlimited',
+    'Enable unlimited multiple apps'
 )

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1316,7 +1316,7 @@ class MySettingsTab(UITab):
 
         if (
             self.couch_user and self.couch_user.is_dimagi or
-            toggles.MOBILE_PRIVILEGES_FLAG.enabled(self.domain)
+            toggles.MOBILE_PRIVILEGES_FLAG.enabled(self.couch_user.username)
         ):
             menu_items.append({
                 'title': EnableMobilePrivilegesView.page_title,

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1285,7 +1285,7 @@ class MySettingsTab(UITab):
     def sidebar_items(self):
         from corehq.apps.settings.views import (
             ChangeMyPasswordView,
-            EnableSuperuserView,
+            EnableMobilePrivilegesView,
             MyAccountSettingsView,
             MyProjectsList,
             TwoFactorProfileView,
@@ -1316,8 +1316,8 @@ class MySettingsTab(UITab):
 
         if self.couch_user and self.couch_user.is_dimagi:
             menu_items.append({
-                'title': EnableSuperuserView.page_title,
-                'url': reverse(EnableSuperuserView.urlname),
+                'title': EnableMobilePrivilegesView.page_title,
+                'url': reverse(EnableMobilePrivilegesView.urlname),
             })
         return [[_("Manage My Settings"), menu_items]]
 

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -1314,7 +1314,10 @@ class MySettingsTab(UITab):
             }
         ])
 
-        if self.couch_user and self.couch_user.is_dimagi:
+        if (
+            self.couch_user and self.couch_user.is_dimagi or
+            toggles.MOBILE_PRIVILEGES_FLAG.enabled(self.domain)
+        ):
             menu_items.append({
                 'title': EnableMobilePrivilegesView.page_title,
                 'url': reverse(EnableMobilePrivilegesView.urlname),

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -406,12 +406,12 @@ LOOSE_SYNC_TOKEN_VALIDATION = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
-# This toggle offers the "multiple_apps_unlimited" mobile flag to non-Dimagi users of the given domain
+# This toggle offers the "multiple_apps_unlimited" mobile flag to non-Dimagi users
 MOBILE_PRIVILEGES_FLAG = StaticToggle(
     'mobile_privileges_flag',
     'Offer "Enable Privileges on Mobile" flag.',
     TAG_EXPERIMENTAL,
-    [NAMESPACE_DOMAIN]
+    [NAMESPACE_USER]
 )
 
 MULTIPLE_LOCATIONS_PER_USER = StaticToggle(

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -406,6 +406,14 @@ LOOSE_SYNC_TOKEN_VALIDATION = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
+# This toggle offers the "multiple_apps_unlimited" mobile flag to non-Dimagi users of the given domain
+MOBILE_PRIVILEGES_FLAG = StaticToggle(
+    'mobile_privileges_flag',
+    'Offer "Enable Privileges on Mobile" flag.',
+    TAG_EXPERIMENTAL,
+    [NAMESPACE_DOMAIN]
+)
+
 MULTIPLE_LOCATIONS_PER_USER = StaticToggle(
     'multiple_locations',
     "Enable multiple locations per user on domain.",


### PR DESCRIPTION
As per e-mail conversation, this implements the following requests:
1. Change the language of the tab containing the barcode to say "Enable Privileges on Mobile" instead of "Enable Superuser on Mobile"
2. Change the name of the flag that is being sent down when the barcode is scanned from "superuser" to "multiple_apps_unlimited"
3. Create a feature flag that, if turned on for a domain, will make the tab containing the barcode appear in that domain (even if they do not fulfill the current requirements for it to appear).

One difference though; the flag to offer mobile privileges to non-Dimagi users needs to be a user-based flag instead of a domain-based flag, because users' settings are not domain specific. (The domain is given as "my_account_settings".)

And a heads-up that the text below the QR Code still reads, "You can scan this QR code in CommCare by going to ‘App Manager Settings’ from the app manager options menu, and then selecting ‘Authenticate as a Superuser’." I'm not sure if that will still be true.

@proteusvacuum cc @amstone326 @ctsims 
