### PR TITLE
correctly populate external_id properties in importer when column is renamed

### DIFF
--- a/corehq/apps/importer/tests.py
+++ b/corehq/apps/importer/tests.py
@@ -268,6 +268,25 @@ class ImporterTest(TestCase):
         # shouldn't create any more cases, just the one
         self.assertEqual(1, len(self.accessor.get_case_ids_in_domain()))
 
+    @run_with_all_backends
+    def test_external_id_matching_on_create_with_custom_column_name(self):
+        headers = ['id_column', 'age', 'sex', 'location']
+        external_id = 'external-id-test'
+        config = self._config(headers, search_field='external_id')
+        file = MockExcelFile(
+            header_columns=headers,
+            num_rows=2,
+            row_generator=id_match_generator(external_id)
+        )
+        res = do_import(file, config, self.domain)
+        self.assertEqual(1, res['created_count'])
+        self.assertEqual(1, res['match_count'])
+        self.assertFalse(res['errors'])
+        case_ids = self.accessor.get_case_ids_in_domain()
+        self.assertEqual(1, len(case_ids))
+        case = self.accessor.get_case(case_ids[0])
+        self.assertEqual(external_id, case.external_id)
+
     def testNoCreateNew(self):
         config = self._config(self.default_headers, create_new_cases=False)
         file = MockExcelFile(header_columns=self.default_headers, num_rows=5)

--- a/corehq/apps/importer/util.py
+++ b/corehq/apps/importer/util.py
@@ -31,7 +31,7 @@ from couchexport.export import SCALAR_NEVER_WAS
 # Don't allow users to change the case type by accident using a custom field. But do allow users to change
 # owner_id, external_id, etc. (See also custom_data_fields.models.RESERVED_WORDS)
 RESERVED_FIELDS = ('type',)
-
+EXTERNAL_ID = 'external_id'
 
 class ImporterConfig(object):
     """
@@ -235,8 +235,12 @@ def convert_custom_fields_to_struct(config):
             if case_fields[i]:
                 field_map[field]['field_name'] = case_fields[i]
             elif custom_fields[i]:
-                field_map[field]['field_name'] = custom_fields[i]
-
+                # if we have configured this field for external_id populate external_id instead
+                # of the default property name from the column
+                if config.search_field == EXTERNAL_ID and field == config.search_column:
+                    field_map[field]['field_name'] = EXTERNAL_ID
+                else:
+                    field_map[field]['field_name'] = custom_fields[i]
     return field_map
 
 
@@ -377,7 +381,7 @@ def lookup_case(search_field, search_id, domain, case_type):
                 found = True
         except CaseNotFound:
             pass
-    elif search_field == 'external_id':
+    elif search_field == EXTERNAL_ID:
         cases_by_type = case_accessors.get_cases_by_external_id(search_id, case_type=case_type)
         if not cases_by_type:
             return (None, LookupErrors.NotFound)

--- a/corehq/apps/importer/views.py
+++ b/corehq/apps/importer/views.py
@@ -4,8 +4,7 @@ from django.utils.datastructures import MultiValueDictKeyError
 from corehq.apps.app_manager.dbaccessors import get_case_types_from_apps
 from corehq.apps.importer import base
 from corehq.apps.importer import util as importer_util
-from corehq.apps.importer.exceptions import ImporterExcelFileEncrypted, \
-    ImporterFileNotFound, ImporterExcelError, ImporterError, ImporterRefError
+from corehq.apps.importer.exceptions import ImporterError
 from corehq.apps.importer.tasks import bulk_import_async
 from django.views.decorators.http import require_POST
 


### PR DESCRIPTION
also fixes external id matching for newly created cases.

http://manage.dimagi.com/default.asp?234225

@mkangia @emord cc @benrudolph 
