### PR TITLE
Updated instructions for Enable Privileges on Mobile

### DIFF
--- a/corehq/apps/settings/templates/settings/enable_superuser.html
+++ b/corehq/apps/settings/templates/settings/enable_superuser.html
@@ -7,14 +7,9 @@
             <legend>{% block title %}{% trans "Enable Privileges on Mobile" %}{% endblock %}</legend>
 
             <p>
-                {% blocktrans %}Scanning this QR code from CommCare will enable superuser privileges for your
-                device. {% endblocktrans %}
-            </p>
-
-            <p>
-                {% blocktrans %}This privilege will indicate to CommCare that the device is being used by an
-                <strong>internal Dimagi user</strong>, meaning that this QR code <strong>should not be shared with
-                partners or other external users for <em>any</em> reason</strong>.{% endblocktrans %}
+                {% blocktrans %}Scanning this QR code from CommCare will enable special privileges for your mobile
+                device, and should not be shared with partners or other external users for any reason.
+                {% endblocktrans %}
             </p>
 
             <p class="text-center">
@@ -22,8 +17,8 @@
             </p>
 
             <p>
-                {% blocktrans %}You can scan this QR code in CommCare by going to ‘App Manager Settings’ from the
-                app manager options menu, and then selecting ‘Authenticate as a Superuser’.{% endblocktrans %}
+                {% blocktrans %}You can scan this QR code in CommCare by going to the app manager options menu and
+                selecting 'Advanced', and then 'Enable Mobile Privileges'.{% endblocktrans %}
             </p>
 
         </fieldset>

--- a/corehq/apps/settings/urls.py
+++ b/corehq/apps/settings/urls.py
@@ -21,7 +21,7 @@ urlpatterns = patterns(
     url(r'^settings/$', MyAccountSettingsView.as_view(), name=MyAccountSettingsView.urlname),
     url(r'^projects/$', MyProjectsList.as_view(), name=MyProjectsList.urlname),
     url(r'^password/$', ChangeMyPasswordView.as_view(), name=ChangeMyPasswordView.urlname),
-    url(r'^mobile_privs/$', EnableMobilePrivilegesView.as_view(), name=EnableMobilePrivilegesView.urlname),
+    url(r'^mobile_privileges/$', EnableMobilePrivilegesView.as_view(), name=EnableMobilePrivilegesView.urlname),
     url(r'new_api_key/$', 'new_api_key', name='new_api_key'),
 )
 


### PR DESCRIPTION
Updated the text in the "Enable Privileges on Mobile" page. (And spelled "privs" correctly, because, as @proteusvacuum hinted, five fewer characters in a URL are not worth dumb spelling.)

@proteusvacuum cc @amstone326 @ctsims 
