### PR TITLE
fix the reindexing gap

### DIFF
--- a/corehq/apps/change_feed/consumer/feed.py
+++ b/corehq/apps/change_feed/consumer/feed.py
@@ -106,6 +106,12 @@ class KafkaChangeFeed(ChangeFeed):
         topic = self._get_single_topic_or_fail()
         return get_topic_offset(topic)
 
+    def get_checkpoint_value(self):
+        try:
+            return self.get_latest_change_id()
+        except ValueError:
+            return json.dumps(self.get_current_offsets())
+
     def _get_consumer(self, timeout, auto_offset_reset='smallest'):
         config = {
             'group_id': self._group_id,

--- a/corehq/apps/cleanup/migrations/0012_add_es_index_to_checkpoint_ids.py
+++ b/corehq/apps/cleanup/migrations/0012_add_es_index_to_checkpoint_ids.py
@@ -47,7 +47,7 @@ def delete_checkpoints(apps, schema_editor):
     DjangoPillowCheckpoint = apps.get_model('pillowtop', 'DjangoPillowCheckpoint')
     for _, new_id in RENAMES:
         try:
-            checkpoint = DjangoPillowCheckpoint.objects.get(checkpoint_id='DefaultChangeFeedPillow')
+            checkpoint = DjangoPillowCheckpoint.objects.get(checkpoint_id=new_id)
             checkpoint.delete()
         except DjangoPillowCheckpoint.DoesNotExist:
             pass

--- a/corehq/apps/cleanup/migrations/0012_add_es_index_to_checkpoint_ids.py
+++ b/corehq/apps/cleanup/migrations/0012_add_es_index_to_checkpoint_ids.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from corehq.sql_db.operations import HqRunPython
+
+
+RENAMES = (
+    ("applications-to-elasticsearch", "ApplicationToElasticsearchPillow-hqapps_2016-07-11_2128"),
+    ("all-cases-to-elasticsearch", "CaseToElasticsearchPillow-hqcases_2016-03-04"),
+    ("all-xforms-to-elasticsearch", "XFormToElasticsearchPillow-xforms_2016-07-07"),
+    ("case-search-to-elasticsearch", "CaseSearchToElasticsearchPillow-case_search_2016-03-15"),
+    ("GroupPillow", "GroupPillow-hqgroups_20150403_1501"),
+    ("GroupToUserPillow", "GroupToUserPillow-hqusers_2016-07-19"),
+    ("KafkaDomainPillow", "KafkaDomainPillow-hqdomains_2016-08-08"),
+    ("ledger-to-elasticsearch", "LedgerToElasticsearchPillow-ledgers_2016-03-15"),
+    ("report-cases-to-elasticsearch", "ReportCaseToElasticsearchPillow-report_cases_czei39du507m9mmpqk3y01x72a3ux4p0"),
+    ("report-xforms-to-elasticsearch", "ReportXFormToElasticsearchPillow-report_xforms_20160707_2322"),
+    ("sql-sms-to-es", "SqlSMSPillow-smslogs_708c77f8e5fe00286fa5791e9fa7d45f"),
+    ("UnknownUsersPillow", "UnknownUsersPillow-hqusers_2016-07-19"),
+    ("UserPillow", "UserPillow-hqusers_2016-07-19"),
+)
+
+
+def copy_checkpoints(apps, schema_editor):
+    from pillowtop import get_all_pillow_instances
+    DjangoPillowCheckpoint = apps.get_model('pillowtop', 'DjangoPillowCheckpoint')
+    current_checkoint_ids = set(
+        [pillow_instance.checkpoint.checkpoint_id for pillow_instance in get_all_pillow_instances()]
+    )
+
+    for old_id, new_id in RENAMES:
+        try:
+            checkpoint = DjangoPillowCheckpoint.objects.get(checkpoint_id=old_id)
+            # since checkpoint_id is the primary key, this should make a new model
+            # which is good in case we need to rollback
+            checkpoint.checkpoint_id = new_id
+            checkpoint.save()
+            assert new_id in current_checkoint_ids
+        except DjangoPillowCheckpoint.DoesNotExist:
+            print 'warning: legacy pillow checkpoint with ID {} not found'.format(old_id)
+        except AssertionError:
+            print 'warning: no current pillow found with checkpoint ID {}'.format(new_id)
+
+
+def delete_checkpoints(apps, schema_editor):
+    DjangoPillowCheckpoint = apps.get_model('pillowtop', 'DjangoPillowCheckpoint')
+    for _, new_id in RENAMES:
+        try:
+            checkpoint = DjangoPillowCheckpoint.objects.get(checkpoint_id='DefaultChangeFeedPillow')
+            checkpoint.delete()
+        except DjangoPillowCheckpoint.DoesNotExist:
+            pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cleanup', '0011_merge_couch_sql_pillows'),
+    ]
+
+    operations = [
+        HqRunPython(copy_checkpoints, delete_checkpoints)
+    ]

--- a/corehq/ex-submodules/pillowtop/checkpoints/manager.py
+++ b/corehq/ex-submodules/pillowtop/checkpoints/manager.py
@@ -91,3 +91,8 @@ class PillowCheckpointEventHandler(ChangeEventHandler):
 
 def get_default_django_checkpoint_for_legacy_pillow_class(pillow_class):
     return PillowCheckpoint(pillow_class.get_legacy_name())
+
+
+def get_checkpoint_for_elasticsearch_pillow(pillow_id, index_info):
+    checkpoint_id = u'{}-{}'.format(pillow_id, index_info.index)
+    return PillowCheckpoint(checkpoint_id)

--- a/corehq/ex-submodules/pillowtop/feed/couch.py
+++ b/corehq/ex-submodules/pillowtop/feed/couch.py
@@ -34,6 +34,9 @@ class CouchChangeFeed(ChangeFeed):
     def get_current_offsets(self):
         return {self._couch_db.dbname: force_seq_int(self.get_latest_change_id())}
 
+    def get_checkpoint_value(self):
+        return str(self.get_latest_change_id())
+
 
 def change_from_couch_row(couch_change, document_store=None):
     return Change(

--- a/corehq/ex-submodules/pillowtop/feed/interface.py
+++ b/corehq/ex-submodules/pillowtop/feed/interface.py
@@ -126,3 +126,9 @@ class ChangeFeed(object):
         """
         :return: A dictionary of ``(topic/db_name, offset integer)`` pairs
         """
+
+    @abstractmethod
+    def get_checkpoint_value(self):
+        """
+        :return: The current string change ID, or a json string if multiple feeds are used
+        """

--- a/corehq/ex-submodules/pillowtop/feed/mock.py
+++ b/corehq/ex-submodules/pillowtop/feed/mock.py
@@ -24,6 +24,9 @@ class MockChangeFeed(ChangeFeed):
     def get_current_offsets(self):
         return {'test': self.get_latest_change_id()}
 
+    def get_checkpoint_value(self):
+        return str(self.get_latest_change_id())
+
 
 class RandomChangeFeed(ChangeFeed):
     """
@@ -49,6 +52,9 @@ class RandomChangeFeed(ChangeFeed):
 
     def get_current_offsets(self):
         return {'test': self.get_latest_change_id()}
+
+    def get_checkpoint_value(self):
+        return str(self.get_latest_change_id())
 
 
 def random_change(sequence_id):

--- a/corehq/ex-submodules/pillowtop/reindexer/change_providers/form.py
+++ b/corehq/ex-submodules/pillowtop/reindexer/change_providers/form.py
@@ -1,7 +1,6 @@
 from corehq.form_processor.backends.sql.dbaccessors import FormAccessorSQL, doc_type_to_state
 from corehq.form_processor.change_publishers import change_meta_from_sql_form
 from corehq.form_processor.utils.general import should_use_sql_backend
-from corehq.util.couch_helpers import MultiKeyViewArgsProvider
 from corehq.util.pagination import paginate_function, ArgsListProvider
 from couchforms.models import XFormInstance, all_known_formlike_doc_types
 from pillowtop.feed.interface import Change

--- a/corehq/ex-submodules/pillowtop/reindexer/reindexer.py
+++ b/corehq/ex-submodules/pillowtop/reindexer/reindexer.py
@@ -3,7 +3,6 @@ from abc import ABCMeta, abstractmethod
 from datetime import datetime
 
 import six
-
 from corehq.apps.change_feed.document_types import is_deletion
 from corehq.util.doc_processor.interface import BaseDocProcessor, BulkDocProcessor
 from pillowtop.es_utils import set_index_reindex_settings, \
@@ -82,6 +81,12 @@ def _prepare_index_for_usage(es, index_info):
     es.indices.refresh(index_info.index)
 
 
+def _set_checkpoint_id(pillow):
+    checkpoint_value = pillow.get_change_feed().get_checkpoint_value()
+    pillow_logging.info('setting checkpoint to {}'.format(checkpoint_value))
+    pillow.checkpoint.update_to(checkpoint_value)
+
+
 class ElasticPillowReindexer(PillowChangeProviderReindexer):
     in_place = False
 
@@ -100,6 +105,7 @@ class ElasticPillowReindexer(PillowChangeProviderReindexer):
     def reindex(self):
         if not self.in_place and not self.start_from:
             _prepare_index_for_reindex(self.es, self.index_info)
+            _set_checkpoint_id(self.pillow)
 
         super(ElasticPillowReindexer, self).reindex()
 
@@ -182,7 +188,7 @@ class ResumableBulkElasticPillowReindexer(Reindexer):
     in_place = False
 
     def __init__(self, doc_provider, elasticsearch, index_info,
-                 doc_filter=None, doc_transform=None, chunk_size=1000):
+                 doc_filter=None, doc_transform=None, chunk_size=1000, pillow=None):
         self.doc_provider = doc_provider
         self.es = elasticsearch
         self.index_info = index_info
@@ -190,6 +196,7 @@ class ResumableBulkElasticPillowReindexer(Reindexer):
         self.doc_processor = BulkPillowReindexProcessor(
             self.es, self.index_info, doc_filter, doc_transform
         )
+        self.pillow = pillow
 
     def consume_options(self, options):
         self.reset = options.pop("reset", False)
@@ -212,6 +219,8 @@ class ResumableBulkElasticPillowReindexer(Reindexer):
 
         if not self.in_place and (self.reset or not processor.has_started()):
             _prepare_index_for_reindex(self.es, self.index_info)
+            if self.pillow:
+                _set_checkpoint_id(self.pillow)
 
         processor.run()
 

--- a/corehq/ex-submodules/pillowtop/reindexer/reindexer.py
+++ b/corehq/ex-submodules/pillowtop/reindexer/reindexer.py
@@ -81,7 +81,7 @@ def _prepare_index_for_usage(es, index_info):
     es.indices.refresh(index_info.index)
 
 
-def _set_checkpoint_id(pillow):
+def _set_checkpoint(pillow):
     checkpoint_value = pillow.get_change_feed().get_checkpoint_value()
     pillow_logging.info('setting checkpoint to {}'.format(checkpoint_value))
     pillow.checkpoint.update_to(checkpoint_value)
@@ -105,7 +105,7 @@ class ElasticPillowReindexer(PillowChangeProviderReindexer):
     def reindex(self):
         if not self.in_place and not self.start_from:
             _prepare_index_for_reindex(self.es, self.index_info)
-            _set_checkpoint_id(self.pillow)
+            _set_checkpoint(self.pillow)
 
         super(ElasticPillowReindexer, self).reindex()
 
@@ -220,7 +220,7 @@ class ResumableBulkElasticPillowReindexer(Reindexer):
         if not self.in_place and (self.reset or not processor.has_started()):
             _prepare_index_for_reindex(self.es, self.index_info)
             if self.pillow:
-                _set_checkpoint_id(self.pillow)
+                _set_checkpoint(self.pillow)
 
         processor.run()
 

--- a/corehq/pillows/application.py
+++ b/corehq/pillows/application.py
@@ -43,4 +43,5 @@ def get_app_reindexer():
         elasticsearch=get_es_new(),
         index_info=APP_INDEX_INFO,
         doc_transform=transform_app_for_es,
+        pillow=get_app_to_elasticsearch_pillow(),
     )

--- a/corehq/pillows/application.py
+++ b/corehq/pillows/application.py
@@ -5,7 +5,7 @@ from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed
 from corehq.elastic import get_es_new
 from corehq.pillows.mappings.app_mapping import APP_INDEX_INFO
 from corehq.util.doc_processor.couch import CouchDocumentProvider
-from pillowtop.checkpoints.manager import PillowCheckpoint, PillowCheckpointEventHandler
+from pillowtop.checkpoints.manager import PillowCheckpointEventHandler, get_checkpoint_for_elasticsearch_pillow
 from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors import ElasticProcessor
 from pillowtop.reindexer.reindexer import ResumableBulkElasticPillowReindexer
@@ -18,9 +18,7 @@ def transform_app_for_es(doc_dict):
 
 
 def get_app_to_elasticsearch_pillow(pillow_id='ApplicationToElasticsearchPillow'):
-    checkpoint = PillowCheckpoint(
-        'applications-to-elasticsearch',
-    )
+    checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, APP_INDEX_INFO)
     app_processor = ElasticProcessor(
         elasticsearch=get_es_new(),
         index_info=APP_INDEX_INFO,

--- a/corehq/pillows/application.py
+++ b/corehq/pillows/application.py
@@ -18,6 +18,7 @@ def transform_app_for_es(doc_dict):
 
 
 def get_app_to_elasticsearch_pillow(pillow_id='ApplicationToElasticsearchPillow'):
+    assert pillow_id == 'ApplicationToElasticsearchPillow', 'Pillow ID is not allowed to change'
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, APP_INDEX_INFO)
     app_processor = ElasticProcessor(
         elasticsearch=get_es_new(),

--- a/corehq/pillows/case.py
+++ b/corehq/pillows/case.py
@@ -33,6 +33,7 @@ def transform_case_for_elasticsearch(doc_dict):
 
 
 def get_case_to_elasticsearch_pillow(pillow_id='CaseToElasticsearchPillow'):
+    assert pillow_id == 'CaseToElasticsearchPillow', 'Pillow ID is not allowed to change'
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, CASE_INDEX_INFO)
     case_processor = ElasticProcessor(
         elasticsearch=get_es_new(),

--- a/corehq/pillows/case.py
+++ b/corehq/pillows/case.py
@@ -61,7 +61,8 @@ def get_couch_case_reindexer():
         doc_provider,
         elasticsearch=get_es_new(),
         index_info=CASE_INDEX_INFO,
-        doc_transform=transform_case_for_elasticsearch
+        doc_transform=transform_case_for_elasticsearch,
+        pillow=get_case_to_elasticsearch_pillow()
     )
 
 

--- a/corehq/pillows/case.py
+++ b/corehq/pillows/case.py
@@ -11,7 +11,7 @@ from corehq.pillows.mappings.case_mapping import CASE_INDEX_INFO
 from corehq.pillows.utils import get_user_type
 from corehq.util.doc_processor.couch import CouchDocumentProvider
 from corehq.util.doc_processor.sql import SqlDocumentProvider
-from pillowtop.checkpoints.manager import PillowCheckpoint
+from pillowtop.checkpoints.manager import get_checkpoint_for_elasticsearch_pillow
 from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors.elastic import ElasticProcessor
 from pillowtop.reindexer.reindexer import ResumableBulkElasticPillowReindexer
@@ -33,9 +33,7 @@ def transform_case_for_elasticsearch(doc_dict):
 
 
 def get_case_to_elasticsearch_pillow(pillow_id='CaseToElasticsearchPillow'):
-    checkpoint = PillowCheckpoint(
-        'all-cases-to-elasticsearch',
-    )
+    checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, CASE_INDEX_INFO)
     case_processor = ElasticProcessor(
         elasticsearch=get_es_new(),
         index_info=CASE_INDEX_INFO,

--- a/corehq/pillows/case_search.py
+++ b/corehq/pillows/case_search.py
@@ -17,7 +17,7 @@ from corehq.form_processor.utils.general import should_use_sql_backend
 from corehq.pillows.mappings.case_mapping import CASE_ES_TYPE
 from corehq.pillows.mappings.case_search_mapping import CASE_SEARCH_INDEX, \
     CASE_SEARCH_MAPPING, CASE_SEARCH_INDEX_INFO
-from pillowtop.checkpoints.manager import PillowCheckpoint
+from pillowtop.checkpoints.manager import get_checkpoint_for_elasticsearch_pillow
 from pillowtop.es_utils import initialize_index_and_mapping
 from pillowtop.feed.interface import Change
 from pillowtop.pillow.interface import ConstructedPillow
@@ -70,9 +70,7 @@ class CaseSearchPillowProcessor(ElasticProcessor):
 
 
 def get_case_search_to_elasticsearch_pillow(pillow_id='CaseSearchToElasticsearchPillow'):
-    checkpoint = PillowCheckpoint(
-        'case-search-to-elasticsearch',
-    )
+    checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, CASE_SEARCH_INDEX_INFO)
     case_processor = CaseSearchPillowProcessor(
         elasticsearch=get_es_new(),
         index_info=CASE_SEARCH_INDEX_INFO,

--- a/corehq/pillows/case_search.py
+++ b/corehq/pillows/case_search.py
@@ -70,6 +70,7 @@ class CaseSearchPillowProcessor(ElasticProcessor):
 
 
 def get_case_search_to_elasticsearch_pillow(pillow_id='CaseSearchToElasticsearchPillow'):
+    assert pillow_id == 'CaseSearchToElasticsearchPillow', 'Pillow ID is not allowed to change'
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, CASE_SEARCH_INDEX_INFO)
     case_processor = CaseSearchPillowProcessor(
         elasticsearch=get_es_new(),

--- a/corehq/pillows/domain.py
+++ b/corehq/pillows/domain.py
@@ -30,6 +30,7 @@ def transform_domain_for_elasticsearch(doc_dict):
 
 
 def get_domain_kafka_to_elasticsearch_pillow(pillow_id='KafkaDomainPillow'):
+    assert pillow_id == 'KafkaDomainPillow', 'Pillow ID is not allowed to change'
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, DOMAIN_INDEX_INFO)
     domain_processor = ElasticProcessor(
         elasticsearch=get_es_new(),

--- a/corehq/pillows/domain.py
+++ b/corehq/pillows/domain.py
@@ -29,7 +29,7 @@ def transform_domain_for_elasticsearch(doc_dict):
     return doc_ret
 
 
-def get_domain_kafka_to_elasticsearch_pillow(pillow_id='domain-kafka-to-es'):
+def get_domain_kafka_to_elasticsearch_pillow(pillow_id='KafkaDomainPillow'):
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, DOMAIN_INDEX_INFO)
     domain_processor = ElasticProcessor(
         elasticsearch=get_es_new(),

--- a/corehq/pillows/domain.py
+++ b/corehq/pillows/domain.py
@@ -7,7 +7,7 @@ from corehq.apps.domain.models import Domain
 from corehq.elastic import get_es_new
 from corehq.pillows.mappings.domain_mapping import DOMAIN_INDEX_INFO
 from django_countries.data import COUNTRIES
-from pillowtop.checkpoints.manager import PillowCheckpoint, PillowCheckpointEventHandler
+from pillowtop.checkpoints.manager import PillowCheckpointEventHandler, get_checkpoint_for_elasticsearch_pillow
 from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors import ElasticProcessor
 from pillowtop.reindexer.change_providers.couch import CouchViewChangeProvider
@@ -30,7 +30,7 @@ def transform_domain_for_elasticsearch(doc_dict):
 
 
 def get_domain_kafka_to_elasticsearch_pillow(pillow_id='domain-kafka-to-es'):
-    checkpoint = PillowCheckpoint(pillow_id)
+    checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, DOMAIN_INDEX_INFO)
     domain_processor = ElasticProcessor(
         elasticsearch=get_es_new(),
         index_info=DOMAIN_INDEX_INFO,

--- a/corehq/pillows/group.py
+++ b/corehq/pillows/group.py
@@ -4,8 +4,7 @@ from corehq.apps.groups.models import Group
 from corehq.elastic import get_es_new
 
 from .mappings.group_mapping import GROUP_INDEX_INFO
-from pillowtop.checkpoints.manager import PillowCheckpoint, PillowCheckpointEventHandler, \
-    get_checkpoint_for_elasticsearch_pillow
+from pillowtop.checkpoints.manager import PillowCheckpointEventHandler, get_checkpoint_for_elasticsearch_pillow
 from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors import ElasticProcessor
 from pillowtop.reindexer.change_providers.couch import CouchViewChangeProvider

--- a/corehq/pillows/group.py
+++ b/corehq/pillows/group.py
@@ -4,7 +4,8 @@ from corehq.apps.groups.models import Group
 from corehq.elastic import get_es_new
 
 from .mappings.group_mapping import GROUP_INDEX_INFO
-from pillowtop.checkpoints.manager import PillowCheckpoint, PillowCheckpointEventHandler
+from pillowtop.checkpoints.manager import PillowCheckpoint, PillowCheckpointEventHandler, \
+    get_checkpoint_for_elasticsearch_pillow
 from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors import ElasticProcessor
 from pillowtop.reindexer.change_providers.couch import CouchViewChangeProvider
@@ -15,9 +16,7 @@ def get_group_pillow(pillow_id='group-pillow'):
     """
     This pillow adds users from xform submissions that come in to the User Index if they don't exist in HQ
     """
-    checkpoint = PillowCheckpoint(
-        pillow_id,
-    )
+    checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, GROUP_INDEX_INFO)
     processor = ElasticProcessor(
         elasticsearch=get_es_new(),
         index_info=GROUP_INDEX_INFO,

--- a/corehq/pillows/group.py
+++ b/corehq/pillows/group.py
@@ -12,7 +12,7 @@ from pillowtop.reindexer.change_providers.couch import CouchViewChangeProvider
 from pillowtop.reindexer.reindexer import ElasticPillowReindexer
 
 
-def get_group_pillow(pillow_id='group-pillow'):
+def get_group_pillow(pillow_id='GroupPillow'):
     """
     This pillow adds users from xform submissions that come in to the User Index if they don't exist in HQ
     """

--- a/corehq/pillows/group.py
+++ b/corehq/pillows/group.py
@@ -16,6 +16,7 @@ def get_group_pillow(pillow_id='GroupPillow'):
     """
     This pillow adds users from xform submissions that come in to the User Index if they don't exist in HQ
     """
+    assert pillow_id == 'GroupPillow', 'Pillow ID is not allowed to change'
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, GROUP_INDEX_INFO)
     processor = ElasticProcessor(
         elasticsearch=get_es_new(),

--- a/corehq/pillows/groups_to_user.py
+++ b/corehq/pillows/groups_to_user.py
@@ -3,8 +3,8 @@ from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed
 from corehq.apps.change_feed.document_types import GROUP
 from corehq.apps.groups.models import Group
 from corehq.elastic import stream_es_query, get_es_new, ES_META
-from corehq.pillows.mappings.user_mapping import USER_INDEX
-from pillowtop.checkpoints.manager import PillowCheckpoint, PillowCheckpointEventHandler
+from corehq.pillows.mappings.user_mapping import USER_INDEX, USER_INDEX_INFO
+from pillowtop.checkpoints.manager import PillowCheckpointEventHandler, get_checkpoint_for_elasticsearch_pillow
 from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors import PillowProcessor
 from pillowtop.reindexer.change_providers.couch import CouchViewChangeProvider
@@ -24,9 +24,7 @@ class GroupsToUsersProcessor(PillowProcessor):
 
 
 def get_group_to_user_pillow(pillow_id='GroupToUserPillow'):
-    checkpoint = PillowCheckpoint(
-        pillow_id,
-    )
+    checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, USER_INDEX_INFO)
     processor = GroupsToUsersProcessor()
     return ConstructedPillow(
         name=pillow_id,

--- a/corehq/pillows/groups_to_user.py
+++ b/corehq/pillows/groups_to_user.py
@@ -24,6 +24,7 @@ class GroupsToUsersProcessor(PillowProcessor):
 
 
 def get_group_to_user_pillow(pillow_id='GroupToUserPillow'):
+    assert pillow_id == 'GroupToUserPillow', 'Pillow ID is not allowed to change'
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, USER_INDEX_INFO)
     processor = GroupsToUsersProcessor()
     return ConstructedPillow(

--- a/corehq/pillows/ledger.py
+++ b/corehq/pillows/ledger.py
@@ -8,7 +8,7 @@ from corehq.form_processor.utils.general import should_use_sql_backend
 from corehq.pillows.mappings.ledger_mapping import LEDGER_INDEX_INFO
 from corehq.util.doc_processor.sql import SqlDocumentProvider
 from corehq.util.quickcache import quickcache
-from pillowtop.checkpoints.manager import PillowCheckpoint, PillowCheckpointEventHandler
+from pillowtop.checkpoints.manager import PillowCheckpointEventHandler, get_checkpoint_for_elasticsearch_pillow
 from pillowtop.feed.interface import Change
 from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors.elastic import ElasticProcessor
@@ -56,9 +56,7 @@ def _get_daily_consumption_for_ledger(ledger):
 
 
 def get_ledger_to_elasticsearch_pillow(pillow_id='LedgerToElasticsearchPillow'):
-    checkpoint = PillowCheckpoint(
-        'ledger-to-elasticsearch',
-    )
+    checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, LEDGER_INDEX_INFO)
     processor = ElasticProcessor(
         elasticsearch=get_es_new(),
         index_info=LEDGER_INDEX_INFO,

--- a/corehq/pillows/ledger.py
+++ b/corehq/pillows/ledger.py
@@ -56,6 +56,7 @@ def _get_daily_consumption_for_ledger(ledger):
 
 
 def get_ledger_to_elasticsearch_pillow(pillow_id='LedgerToElasticsearchPillow'):
+    assert pillow_id == 'LedgerToElasticsearchPillow', 'Pillow ID is not allowed to change'
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, LEDGER_INDEX_INFO)
     processor = ElasticProcessor(
         elasticsearch=get_es_new(),

--- a/corehq/pillows/reportcase.py
+++ b/corehq/pillows/reportcase.py
@@ -33,6 +33,7 @@ def transform_case_to_report_es(doc_dict):
 
 
 def get_report_case_to_elasticsearch_pillow(pillow_id='ReportCaseToElasticsearchPillow'):
+    assert pillow_id == 'ReportCaseToElasticsearchPillow', 'Pillow ID is not allowed to change'
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, REPORT_CASE_INDEX_INFO)
     form_processor = ElasticProcessor(
         elasticsearch=get_es_new(),

--- a/corehq/pillows/reportcase.py
+++ b/corehq/pillows/reportcase.py
@@ -6,7 +6,7 @@ from corehq.apps.change_feed import topics
 from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed, MultiTopicCheckpointEventHandler
 from corehq.elastic import get_es_new
 from corehq.pillows.mappings.reportcase_mapping import REPORT_CASE_INDEX_INFO
-from pillowtop.checkpoints.manager import PillowCheckpoint
+from pillowtop.checkpoints.manager import get_checkpoint_for_elasticsearch_pillow
 from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors import ElasticProcessor
 from pillowtop.reindexer.change_providers.case import get_domain_case_change_provider
@@ -33,9 +33,7 @@ def transform_case_to_report_es(doc_dict):
 
 
 def get_report_case_to_elasticsearch_pillow(pillow_id='ReportCaseToElasticsearchPillow'):
-    checkpoint = PillowCheckpoint(
-        'report-cases-to-elasticsearch',
-    )
+    checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, REPORT_CASE_INDEX_INFO)
     form_processor = ElasticProcessor(
         elasticsearch=get_es_new(),
         index_info=REPORT_CASE_INDEX_INFO,

--- a/corehq/pillows/reportxform.py
+++ b/corehq/pillows/reportxform.py
@@ -6,7 +6,7 @@ from corehq.elastic import get_es_new
 from corehq.pillows.base import convert_property_dict
 from corehq.pillows.mappings.reportxform_mapping import REPORT_XFORM_INDEX_INFO
 from corehq.pillows.xform import transform_xform_for_elasticsearch, xform_pillow_filter
-from pillowtop.checkpoints.manager import PillowCheckpoint, get_checkpoint_for_elasticsearch_pillow
+from pillowtop.checkpoints.manager import get_checkpoint_for_elasticsearch_pillow
 from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors import ElasticProcessor
 from pillowtop.reindexer.change_providers.form import get_domain_form_change_provider

--- a/corehq/pillows/reportxform.py
+++ b/corehq/pillows/reportxform.py
@@ -36,6 +36,7 @@ def transform_xform_for_report_forms_index(doc_dict):
 
 
 def get_report_xform_to_elasticsearch_pillow(pillow_id='ReportXFormToElasticsearchPillow'):
+    assert pillow_id == 'ReportXFormToElasticsearchPillow', 'Pillow ID is not allowed to change'
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, REPORT_XFORM_INDEX_INFO)
     form_processor = ElasticProcessor(
         elasticsearch=get_es_new(),

--- a/corehq/pillows/reportxform.py
+++ b/corehq/pillows/reportxform.py
@@ -6,7 +6,7 @@ from corehq.elastic import get_es_new
 from corehq.pillows.base import convert_property_dict
 from corehq.pillows.mappings.reportxform_mapping import REPORT_XFORM_INDEX_INFO
 from corehq.pillows.xform import transform_xform_for_elasticsearch, xform_pillow_filter
-from pillowtop.checkpoints.manager import PillowCheckpoint
+from pillowtop.checkpoints.manager import PillowCheckpoint, get_checkpoint_for_elasticsearch_pillow
 from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors import ElasticProcessor
 from pillowtop.reindexer.change_providers.form import get_domain_form_change_provider
@@ -36,9 +36,7 @@ def transform_xform_for_report_forms_index(doc_dict):
 
 
 def get_report_xform_to_elasticsearch_pillow(pillow_id='ReportXFormToElasticsearchPillow'):
-    checkpoint = PillowCheckpoint(
-        'report-xforms-to-elasticsearch',
-    )
+    checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, REPORT_XFORM_INDEX_INFO)
     form_processor = ElasticProcessor(
         elasticsearch=get_es_new(),
         index_info=REPORT_XFORM_INDEX_INFO,

--- a/corehq/pillows/sms.py
+++ b/corehq/pillows/sms.py
@@ -3,19 +3,18 @@ from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed
 from corehq.apps.sms.change_publishers import change_meta_from_sms
 from corehq.elastic import get_es_new
 from corehq.pillows.mappings.sms_mapping import SMS_INDEX_INFO
-from pillowtop.checkpoints.manager import PillowCheckpoint, PillowCheckpointEventHandler
+from pillowtop.checkpoints.manager import PillowCheckpointEventHandler, get_checkpoint_for_elasticsearch_pillow
 from pillowtop.feed.interface import Change
 from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors.elastic import ElasticProcessor
 from pillowtop.reindexer.change_providers.django_model import DjangoModelChangeProvider
 from pillowtop.reindexer.reindexer import ElasticPillowReindexer
 
-SMS_PILLOW_CHECKPOINT_ID = 'sql-sms-to-es'
 SMS_PILLOW_KAFKA_CONSUMER_GROUP_ID = 'sql-sms-to-es'
 
 
 def get_sql_sms_pillow(pillow_id='sql-sms-pillow'):
-    checkpoint = PillowCheckpoint(SMS_PILLOW_CHECKPOINT_ID)
+    checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, SMS_INDEX_INFO)
     processor = ElasticProcessor(
         elasticsearch=get_es_new(),
         index_info=SMS_INDEX_INFO,

--- a/corehq/pillows/sms.py
+++ b/corehq/pillows/sms.py
@@ -13,7 +13,7 @@ from pillowtop.reindexer.reindexer import ElasticPillowReindexer
 SMS_PILLOW_KAFKA_CONSUMER_GROUP_ID = 'sql-sms-to-es'
 
 
-def get_sql_sms_pillow(pillow_id='sql-sms-pillow'):
+def get_sql_sms_pillow(pillow_id='SqlSMSPillow'):
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, SMS_INDEX_INFO)
     processor = ElasticProcessor(
         elasticsearch=get_es_new(),

--- a/corehq/pillows/sms.py
+++ b/corehq/pillows/sms.py
@@ -14,6 +14,7 @@ SMS_PILLOW_KAFKA_CONSUMER_GROUP_ID = 'sql-sms-to-es'
 
 
 def get_sql_sms_pillow(pillow_id='SqlSMSPillow'):
+    assert pillow_id == 'SqlSMSPillow', 'Pillow ID is not allowed to change'
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, SMS_INDEX_INFO)
     processor = ElasticProcessor(
         elasticsearch=get_es_new(),

--- a/corehq/pillows/user.py
+++ b/corehq/pillows/user.py
@@ -10,7 +10,7 @@ from corehq.elastic import (
 )
 from corehq.pillows.mappings.user_mapping import USER_INDEX, USER_INDEX_INFO
 from corehq.util.quickcache import quickcache
-from pillowtop.checkpoints.manager import PillowCheckpoint
+from pillowtop.checkpoints.manager import get_checkpoint_for_elasticsearch_pillow
 from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors import ElasticProcessor, PillowProcessor
 from pillowtop.reindexer.change_providers.couch import CouchViewChangeProvider
@@ -77,9 +77,7 @@ def get_unknown_users_pillow(pillow_id='unknown-users-pillow'):
     """
     This pillow adds users from xform submissions that come in to the User Index if they don't exist in HQ
     """
-    checkpoint = PillowCheckpoint(
-        pillow_id,
-    )
+    checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, USER_INDEX_INFO)
     processor = UnknownUsersProcessor()
     change_feed = KafkaChangeFeed(topics=[FORM, FORM_SQL], group_id='unknown-users')
     return ConstructedPillow(
@@ -101,9 +99,7 @@ def add_demo_user_to_user_index():
 
 
 def get_user_pillow(pillow_id='UserPillow'):
-    checkpoint = PillowCheckpoint(
-        pillow_id,
-    )
+    checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, USER_INDEX_INFO)
     user_processor = ElasticProcessor(
         elasticsearch=get_es_new(),
         index_info=USER_INDEX_INFO,

--- a/corehq/pillows/user.py
+++ b/corehq/pillows/user.py
@@ -99,6 +99,7 @@ def add_demo_user_to_user_index():
 
 
 def get_user_pillow(pillow_id='UserPillow'):
+    assert pillow_id == 'UserPillow', 'Pillow ID is not allowed to change'
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, USER_INDEX_INFO)
     user_processor = ElasticProcessor(
         elasticsearch=get_es_new(),

--- a/corehq/pillows/xform.py
+++ b/corehq/pillows/xform.py
@@ -118,6 +118,7 @@ def transform_xform_for_elasticsearch(doc_dict):
 
 
 def get_xform_to_elasticsearch_pillow(pillow_id='XFormToElasticsearchPillow'):
+    assert pillow_id == 'XFormToElasticsearchPillow', 'Pillow ID is not allowed to change'
     checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, XFORM_INDEX_INFO)
     form_processor = ElasticProcessor(
         elasticsearch=get_es_new(),

--- a/corehq/pillows/xform.py
+++ b/corehq/pillows/xform.py
@@ -19,7 +19,7 @@ from couchforms.const import RESERVED_WORDS, DEVICE_LOG_XMLNS
 from couchforms.jsonobject_extensions import GeoPointProperty
 from couchforms.models import XFormInstance, XFormArchived, XFormError, XFormDeprecated, \
     XFormDuplicate, SubmissionErrorLog
-from pillowtop.checkpoints.manager import PillowCheckpoint
+from pillowtop.checkpoints.manager import get_checkpoint_for_elasticsearch_pillow
 from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors.elastic import ElasticProcessor
 from pillowtop.reindexer.reindexer import ResumableBulkElasticPillowReindexer
@@ -118,9 +118,7 @@ def transform_xform_for_elasticsearch(doc_dict):
 
 
 def get_xform_to_elasticsearch_pillow(pillow_id='XFormToElasticsearchPillow'):
-    checkpoint = PillowCheckpoint(
-        'all-xforms-to-elasticsearch',
-    )
+    checkpoint = get_checkpoint_for_elasticsearch_pillow(pillow_id, XFORM_INDEX_INFO)
     form_processor = ElasticProcessor(
         elasticsearch=get_es_new(),
         index_info=XFORM_INDEX_INFO,

--- a/corehq/pillows/xform.py
+++ b/corehq/pillows/xform.py
@@ -153,7 +153,8 @@ def get_couch_form_reindexer():
         elasticsearch=get_es_new(),
         index_info=XFORM_INDEX_INFO,
         doc_filter=xform_pillow_filter,
-        doc_transform=transform_xform_for_elasticsearch
+        doc_transform=transform_xform_for_elasticsearch,
+        pillow=get_xform_to_elasticsearch_pillow(),
     )
 
 

--- a/testapps/test_pillowtop/tests/data/all-pillow-meta.json
+++ b/testapps/test_pillowtop/tests/data/all-pillow-meta.json
@@ -30,7 +30,7 @@
     "ApplicationToElasticsearchPillow": {
         "advertised_name": "ApplicationToElasticsearchPillow",
         "change_feed_type": "KafkaChangeFeed",
-        "checkpoint_id": "applications-to-elasticsearch",
+        "checkpoint_id": "ApplicationToElasticsearchPillow-test_hqapps_2016-07-11_2128",
         "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
         "name": "ApplicationToElasticsearchPillow"
     },
@@ -58,14 +58,14 @@
     "CaseToElasticsearchPillow": {
         "advertised_name": "CaseToElasticsearchPillow",
         "change_feed_type": "KafkaChangeFeed",
-        "checkpoint_id": "all-cases-to-elasticsearch",
+        "checkpoint_id": "CaseToElasticsearchPillow-test_hqcases_2016-03-04",
         "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
         "name": "CaseToElasticsearchPillow"
     },
     "CaseSearchToElasticsearchPillow": {
         "advertised_name": "CaseSearchToElasticsearchPillow",
         "change_feed_type": "KafkaChangeFeed",
-        "checkpoint_id": "case-search-to-elasticsearch",
+        "checkpoint_id": "CaseSearchToElasticsearchPillow-test_case_search_2016-03-15",
         "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
         "name": "CaseSearchToElasticsearchPillow"
     },
@@ -107,14 +107,14 @@
     "GroupPillow": {
         "advertised_name": "GroupPillow",
         "change_feed_type": "KafkaChangeFeed",
-        "checkpoint_id": "GroupPillow",
+        "checkpoint_id": "GroupPillow-test_hqgroups_20150403_1501",
         "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
         "name": "GroupPillow"
     },
     "GroupToUserPillow": {
         "advertised_name": "GroupToUserPillow",
         "change_feed_type": "KafkaChangeFeed",
-        "checkpoint_id": "GroupToUserPillow",
+        "checkpoint_id": "GroupToUserPillow-test_hqusers_2016-07-19",
         "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
         "name": "GroupToUserPillow"
     },
@@ -135,7 +135,7 @@
     "KafkaDomainPillow": {
         "advertised_name": "KafkaDomainPillow",
         "change_feed_type": "KafkaChangeFeed",
-        "checkpoint_id": "KafkaDomainPillow",
+        "checkpoint_id": "KafkaDomainPillow-test_hqdomains_2016-08-08",
         "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
         "name": "KafkaDomainPillow"
     },
@@ -149,7 +149,7 @@
     "LedgerToElasticsearchPillow": {
         "advertised_name": "LedgerToElasticsearchPillow",
         "change_feed_type": "KafkaChangeFeed",
-        "checkpoint_id": "ledger-to-elasticsearch",
+        "checkpoint_id": "LedgerToElasticsearchPillow-test_ledgers_2016-03-15",
         "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
         "name": "LedgerToElasticsearchPillow"
     },
@@ -212,21 +212,21 @@
     "ReportCaseToElasticsearchPillow": {
         "advertised_name": "ReportCaseToElasticsearchPillow",
         "change_feed_type": "KafkaChangeFeed",
-        "checkpoint_id": "report-cases-to-elasticsearch",
+        "checkpoint_id": "ReportCaseToElasticsearchPillow-test_report_cases_czei39du507m9mmpqk3y01x72a3ux4p0",
         "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
         "name": "ReportCaseToElasticsearchPillow"
     },
     "ReportXFormToElasticsearchPillow": {
         "advertised_name": "ReportXFormToElasticsearchPillow",
         "change_feed_type": "KafkaChangeFeed",
-        "checkpoint_id": "report-xforms-to-elasticsearch",
+        "checkpoint_id": "ReportXFormToElasticsearchPillow-test_report_xforms_20160707_2322",
         "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
         "name": "ReportXFormToElasticsearchPillow"
     },
     "SqlSMSPillow": {
         "advertised_name": "SqlSMSPillow",
         "change_feed_type": "KafkaChangeFeed",
-        "checkpoint_id": "sql-sms-to-es",
+        "checkpoint_id": "SqlSMSPillow-test_smslogs_708c77f8e5fe00286fa5791e9fa7d45f",
         "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
         "name": "SqlSMSPillow"
     },
@@ -254,7 +254,7 @@
     "UnknownUsersPillow": {
         "advertised_name": "UnknownUsersPillow",
         "change_feed_type": "KafkaChangeFeed",
-        "checkpoint_id": "UnknownUsersPillow",
+        "checkpoint_id": "UnknownUsersPillow-test_hqusers_2016-07-19",
         "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
         "name": "UnknownUsersPillow"
     },
@@ -275,7 +275,7 @@
     "UserPillow": {
         "advertised_name": "UserPillow",
         "change_feed_type": "KafkaChangeFeed",
-        "checkpoint_id": "UserPillow",
+        "checkpoint_id": "UserPillow-test_hqusers_2016-07-19",
         "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
         "name": "UserPillow"
     },
@@ -303,7 +303,7 @@
     "XFormToElasticsearchPillow": {
         "advertised_name": "XFormToElasticsearchPillow",
         "change_feed_type": "KafkaChangeFeed",
-        "checkpoint_id": "all-xforms-to-elasticsearch",
+        "checkpoint_id": "XFormToElasticsearchPillow-test_xforms_2016-07-07",
         "full_class_name": "pillowtop.pillow.interface.ConstructedPillow",
         "name": "XFormToElasticsearchPillow"
     },

--- a/testapps/test_pillowtop/tests/test_reindexer.py
+++ b/testapps/test_pillowtop/tests/test_reindexer.py
@@ -23,8 +23,11 @@ from corehq.pillows.mappings.group_mapping import GROUP_INDEX_INFO
 from corehq.pillows.mappings.user_mapping import USER_INDEX
 from corehq.pillows.mappings.xform_mapping import XFORM_INDEX
 from corehq.util.elastic import delete_es_index, ensure_index_deleted
-from corehq.util.test_utils import trap_extra_setup, create_and_save_a_form, create_and_save_a_case
+from corehq.util.test_utils import trap_extra_setup, create_and_save_a_form, create_and_save_a_case, generate_cases
+from pillowtop.checkpoints.manager import DEFAULT_EMPTY_CHECKPOINT_SEQUENCE
 from pillowtop.es_utils import initialize_index_and_mapping
+from pillowtop.utils import get_pillow_by_name
+from testapps.test_pillowtop.utils import real_pillow_settings
 
 DOMAIN = 'reindex-test-domain'
 
@@ -124,6 +127,59 @@ class PillowtopReindexerTest(TestCase):
         results = esquery.run()
         self.assertEqual(0, results.total)
 
+
+class CheckpointCreationTest(TestCase):
+    # this class is only here so you can run these explicitly
+    pass
+
+
+@generate_cases([
+    ('app', 'ApplicationToElasticsearchPillow'),
+    ('case', 'CaseToElasticsearchPillow'),
+    ('form', 'XFormToElasticsearchPillow'),
+    ('domain', 'KafkaDomainPillow'),
+    ('user', 'UserPillow'),
+    ('group', 'GroupPillow'),
+    ('ledger-v1', 'LedgerToElasticsearchPillow'),
+    ('sms', 'SqlSMSPillow'),
+    ('report-case', 'ReportCaseToElasticsearchPillow'),
+    ('report-xform', 'ReportXFormToElasticsearchPillow'),
+], CheckpointCreationTest)
+def test_checkpoint_creation(self, reindex_id, pillow_name):
+    with real_pillow_settings():
+        pillow = get_pillow_by_name(pillow_name)
+        random_seq = uuid.uuid4().hex
+        pillow.checkpoint.update_to(random_seq)
+        self.assertEqual(random_seq, pillow.checkpoint.get_current_sequence_id())
+        call_command('ptop_reindexer_v2', reindex_id, cleanup=True, noinput=True)
+        pillow = get_pillow_by_name(pillow_name)
+        self.assertNotEqual(random_seq, pillow.checkpoint.get_current_sequence_id())
+        self.assertEqual(
+            str(pillow.get_change_feed().get_checkpoint_value()),
+            pillow.checkpoint.get_current_sequence_id(),
+        )
+
+
+@generate_cases([
+    ('sql-case', 'CaseToElasticsearchPillow'),
+    ('sql-form', 'XFormToElasticsearchPillow'),
+    ('ledger-v2', 'LedgerToElasticsearchPillow'),
+    ('groups-to-user', 'UserPillow'),
+], CheckpointCreationTest)
+def test_no_checkpoint_creation(self, reindex_id, pillow_name):
+    # these pillows should not touch checkpoints since they are run with other
+    # reindexers
+    with real_pillow_settings():
+        pillow = get_pillow_by_name(pillow_name)
+        random_seq = uuid.uuid4().hex
+        pillow.checkpoint.update_to(random_seq)
+        self.assertEqual(random_seq, pillow.checkpoint.get_current_sequence_id())
+        call_command('ptop_reindexer_v2', reindex_id, cleanup=True, noinput=True)
+        pillow = get_pillow_by_name(pillow_name)
+        self.assertEqual(
+            random_seq,
+            pillow.checkpoint.get_current_sequence_id(),
+        )
 
 class UserReindexerTest(TestCase):
     dependent_apps = [


### PR DESCRIPTION
this does two main things:
1. ties elastic pillow checkpoint IDs to the elastic indices (and migrates the current checkpoints)
2. sets a checkpoint on reindex for the first pillow that touches the index

i'm not totally happy with this. in particular it feels pretty hacky that, e.g. the 'form' reindexer sets the checkpoint and the 'form-sql' doesn't (i think this is currently necessary due to the fact that they will be run in serial and therefore by the time 'form-sql' runs it would be setting a checkpoint that is now too late and would cause us to miss some couch forms that have come in while the 'form' reindexer was running). I think the better thing to do would have the notion of a "reindexer-group" or something, but I haven't done that yet.

i also want to clean up how we're using pillow_id a little, and do a bit more testing.

@snopoke @emord cc @benrudolph 
