### PR TITLE
Calculate number of active users per country for DimagiSphere

### DIFF
--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -874,12 +874,11 @@ class AdminDomainMapReport(AdminDomainStatsReport):
 
     def _calc_num_active_users_per_country(self):
         active_users_per_country = (NestedTermAggregationsHelper(
-                                        base_query=DomainES(),
-                                        terms=[AggregationTerm('countries', 'deployment.countries')],
-                                        bottom_level_aggregation=SumAggregation('users', 'cp_n_active_cc_users')
+                                    base_query=DomainES(),
+                                    terms=[AggregationTerm('countries', 'deployment.countries')],
+                                    bottom_level_aggregation=SumAggregation('users', 'cp_n_active_cc_users')
                                     ).get_data())
         return active_users_per_country
-
 
     @property
     def json_dict(self):

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -878,9 +878,14 @@ class AdminDomainMapReport(AdminDomainStatsReport):
                                         terms=[AggregationTerm('countries', 'deployment.countries')],
                                         bottom_level_aggregation=SumAggregation('users', 'cp_n_active_cc_users')
                                     ).get_data())
+        return active_users_per_country
 
 
-
+    @property
+    def json_dict(self):
+        json = super(AdminDomainMapReport, self).json_dict
+        json['users_per_country'] = dict(self._calc_num_active_users_per_country())
+        return json
 
 class AdminUserReport(AdminFacetedReport):
     slug = "user_list"


### PR DESCRIPTION
@czue @esoergel 

Created active_users_per_country dictionary for DimagiSphere to "toggle" display map between number of active mobile users and number of projects per country
