### PR TITLE
add xform_ids to case json for SQL cases

### DIFF
--- a/corehq/apps/reports/tests/test_esaccessors.py
+++ b/corehq/apps/reports/tests/test_esaccessors.py
@@ -1036,6 +1036,8 @@ class TestCaseESAccessorsSQL(TestCaseESAccessors):
         )
 
         case.track_create(CaseTransaction(
+            type=CaseTransaction.TYPE_FORM,
+            form_id=uuid.uuid4().hex,
             case=case,
             server_date=opened_on,
         ))

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -582,7 +582,10 @@ class CommCareCaseSQL(DisabledDbMixin, models.Model, RedisLockableMixIn,
     @memoized
     def xform_ids(self):
         from corehq.form_processor.backends.sql.dbaccessors import CaseAccessorSQL
-        return CaseAccessorSQL.get_case_xform_ids(self.case_id)
+        if self.is_saved():
+            return CaseAccessorSQL.get_case_xform_ids(self.case_id)
+        else:
+            return [t.form_id for t in self.transactions if not t.revoked and t.is_form_transaction]
 
     @property
     def user_id(self):

--- a/corehq/form_processor/serializers.py
+++ b/corehq/form_processor/serializers.py
@@ -118,6 +118,7 @@ class CommCareCaseSQLSerializer(DeletableModelSerializer):
     indices = CommCareCaseIndexSQLSerializer(many=True, read_only=True)
     actions = CaseTransactionActionSerializer(many=True, read_only=True, source='non_revoked_transactions')
     case_json = serializers.JSONField()
+    xform_ids = serializers.ListField()
 
     class Meta:
         model = CommCareCaseSQL


### PR DESCRIPTION
This is an expensive field to add since it requires a DB query to get the list of form IDs but it is required by the API's.

Although this requires a reindex we should just be able to do it in place and since it's only for SQL cases it shouldn't take long.

@emord 
