### PR TITLE
UCR API: Add Type Information to Report Columns

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -668,6 +668,7 @@ class SimpleReportConfigurationResource(CouchResourceMixin, HqBaseResource, Doma
         return [{
             "column_id": c['column_id'],
             "display": c['display'],
+            "type": c["type"],
         } for c in obj_columns]
 
     def obj_get(self, bundle, **kwargs):

--- a/corehq/apps/api/tests.py
+++ b/corehq/apps/api/tests.py
@@ -1644,7 +1644,7 @@ class TestSimpleReportConfigurationResource(APIResourceTest):
                 "display": "expand display",
                 "type": "expanded",
                 "field": "my_field",
-                "max_expansion": 10, 
+                "max_expansion": 10,
             }
         ]
         cls.report_filters = [
@@ -1698,7 +1698,11 @@ class TestSimpleReportConfigurationResource(APIResourceTest):
         )
 
         self.assertEqual(
-            [{"column_id": c['column_id'], "display": c['display'], "type": c['type']} for c in self.report_columns],
+            [{
+                "column_id": c['column_id'],
+                "display": c['display'],
+                "type": c['type']
+            } for c in self.report_columns],
             columns
         )
         self.assertEqual(

--- a/corehq/apps/api/tests.py
+++ b/corehq/apps/api/tests.py
@@ -1638,6 +1638,13 @@ class TestSimpleReportConfigurationResource(APIResourceTest):
                 "type": "field",
                 "field": "my_field",
                 "aggregation": "simple",
+            },
+            {
+                "column_id": 'expand',
+                "display": "expand display",
+                "type": "expanded",
+                "field": "my_field",
+                "max_expansion": 10, 
             }
         ]
         cls.report_filters = [
@@ -1691,7 +1698,7 @@ class TestSimpleReportConfigurationResource(APIResourceTest):
         )
 
         self.assertEqual(
-            [{"column_id": c['column_id'], "display": c['display']} for c in self.report_columns],
+            [{"column_id": c['column_id'], "display": c['display'], "type": c['type']} for c in self.report_columns],
             columns
         )
         self.assertEqual(


### PR DESCRIPTION
@NoahCarnahan 

I realized we didn't have type information (which makes it hard to identify if something is a expanded column).

When getting report data returned, I wasn't able to figure out an easy way to send the expanded choice.  For example, if I expand on gender, right now the data returned is like gender_0, gender_1 and has no info that 0 maps to male, 1 maps to female, etc. 

Should I create a separate ticket for that? 
