### PR TITLE
Only get case tiles polyfill when needed

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/js/apps/menus/menu_view.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/js/apps/menus/menu_view.js
@@ -1,6 +1,6 @@
 /*global FormplayerFrontend */
 
-FormplayerFrontend.module("SessionNavigate.MenuList", function (MenuList, FormplayerFrontend, Backbone, Marionette) {
+FormplayerFrontend.module("SessionNavigate.MenuList", function (MenuList, FormplayerFrontend, Backbone, Marionette, $) {
     MenuList.MenuView = Marionette.ItemView.extend({
         tagName: "tr",
         className: "formplayer-request",
@@ -54,7 +54,7 @@ FormplayerFrontend.module("SessionNavigate.MenuList", function (MenuList, Formpl
     MenuList.CaseView = Marionette.ItemView.extend({
         tagName: "tr",
         getTemplate: function () {
-            if (_.isNull(this.options.tiles) || !this.tiles) {
+            if (_.isNull(this.options.tiles)) {
                 return "#case-view-item-template";
             } else {
                 return "#case-tile-view-item-template";
@@ -134,7 +134,11 @@ FormplayerFrontend.module("SessionNavigate.MenuList", function (MenuList, Formpl
         initialize: function (options) {
             this.tiles = options.tiles;
             this.styles = options.styles;
-            generateCaseTileStyles(options.tiles);
+            if (!_.isNull(this.options.tiles)) {
+                $.getScript("../../../../static/css-grid-polyfill-binaries/css-polyfills.js", function() {
+                    generateCaseTileStyles(options.tiles);
+                });
+            }
         },
 
         childViewOptions: function () {

--- a/corehq/apps/cloudcare/templates/formplayer/dependencies.html
+++ b/corehq/apps/cloudcare/templates/formplayer/dependencies.html
@@ -4,7 +4,6 @@
 <script src="{% static 'backbone.marionette/lib/backbone.marionette.js' %}"></script>
 <script src="{% static 'nprogress/nprogress.js' %}"></script>
 <script src="{% static 'moment/min/moment.min.js' %}"></script>
-<script src="{% static 'css-grid-polyfill-binaries/css-polyfills.js' %}"></script>
 <script src="{% static 'hqwebapp/js/lib/jquery.textchange.min.js' %}"></script>
 <script src="{% static 'cloudcare/js/util.js' %}"></script>
 <script src="{% static 'cloudcare/js/formplayer/js/apps/util/util.js' %}"></script>


### PR DESCRIPTION
@benrudolph this is great, will save us having to load the polyfill all the time (which generated tons of console output)

Clearly I have no idea to get this relative pathing correct. When I use 'static/css-polyfilll ////' then it gets plopped on top of the extant path (IE including a/[domain/apps/cloudcare etc)

Also doesn't resolve its dependency on css-polyiflls.js.map properly

Another fun thing to look at Tuesday
