### PR TITLE
Enable map reports

### DIFF
--- a/corehq/apps/reports_core/templates/reports_core/base_template_new.html
+++ b/corehq/apps/reports_core/templates/reports_core/base_template_new.html
@@ -158,12 +158,6 @@
         {% endblocktrans %}
         <div id="warning-message"></div>
     </div>
-    <div id="report-info" class="alert alert-info hide">
-        {% blocktrans %}
-        Note:
-        {% endblocktrans %}
-        <span id="info-message"></span>
-    </div>
     {% endblock report_alerts %}
     {% block main_column_content %}
     {% block filter_panel %}
@@ -188,6 +182,13 @@
         </section>
         <div id="zoomtofit" class="leaflet-control-layers" style="display: none;">
             <div id="zoomtofit-target" class="zoomtofit leaflet-control-layers-toggle" title="{% trans "Fit all data into view" %}"></div>
+        </div>
+
+        <div id="report-info" class="alert alert-info hide">
+            {% blocktrans %}
+            Note:
+            {% endblocktrans %}
+            <span id="info-message"></span>
         </div>
         {% endblock %}
         {% block reporttable %}

--- a/corehq/apps/reports_core/templates/reports_core/base_template_new.html
+++ b/corehq/apps/reports_core/templates/reports_core/base_template_new.html
@@ -58,6 +58,15 @@
             }
         };
 
+        var paginationNotice = function (data) {
+            if (data.aaData.length < data.iTotalRecords) {
+                $('#info-message').html("Showing the current page of data. Switch pages to see more data.");
+                $('#report-info').removeClass('hide');
+            } else {
+                $('#report-info').addClass('hide');
+            }
+        };
+
         var errorCallback = function (jqXHR, textStatus, errorThrown) {
             $('#error-message').html(errorThrown);
             $('#report-error').removeClass('hide');
@@ -97,7 +106,7 @@
                 fixColsNumLeft: {{ report_table.left_col.fixed.num }},
                 fixColsWidth: {{ report_table.left_col.fixed.width }},
             {% endif %}
-            successCallbacks: [successCallback, updateCharts, updateMap],
+            successCallbacks: [successCallback, updateCharts, updateMap, paginationNotice],
             errorCallbacks: [errorCallback]
         });
         $('#paramSelectorForm').submit(function(event) {
@@ -148,6 +157,12 @@
         Warning:
         {% endblocktrans %}
         <div id="warning-message"></div>
+    </div>
+    <div id="report-info" class="alert alert-info hide">
+        {% blocktrans %}
+        Note:
+        {% endblocktrans %}
+        <span id="info-message"></span>
     </div>
     {% endblock report_alerts %}
     {% block main_column_content %}

--- a/corehq/apps/reports_core/templates/reports_core/base_template_new.html
+++ b/corehq/apps/reports_core/templates/reports_core/base_template_new.html
@@ -60,7 +60,7 @@
 
         var paginationNotice = function (data) {
             if (data.aaData.length < data.iTotalRecords) {
-                $('#info-message').html("Showing the current page of data. Switch pages to see more data.");
+                $('#info-message').html("{% trans 'Showing the current page of data. Switch pages to see more data.' %}");
                 $('#report-info').removeClass('hide');
             } else {
                 $('#report-info').addClass('hide');

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -271,6 +271,8 @@ class ConfigurableReport(JSONResponseMixin, BaseDomainView):
         }
         context.update(self.saved_report_context_data)
         context.update(self.pop_report_builder_context_data())
+        if isinstance(self.spec, ReportConfiguration) and self.spec.report_meta.builder_report_type == 'map':
+            context['report_table']['default_rows'] = 100
         return context
 
     def pop_report_builder_context_data(self):

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -93,7 +93,6 @@ from corehq.apps.userreports.util import has_report_builder_access, \
     allowed_report_builder_reports, number_of_report_builder_reports
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
-from corehq.toggles import REPORT_BUILDER_MAP_REPORTS
 from corehq.util.couch import get_document_or_404
 
 
@@ -237,11 +236,7 @@ class ReportBuilderView(BaseDomainView):
     @use_datatables
     def dispatch(self, request, *args, **kwargs):
         if has_report_builder_access(request):
-            report_type = kwargs.get('report_type', None)
-            if report_type != 'map' or toggle_enabled(request, REPORT_BUILDER_MAP_REPORTS):
-                return super(ReportBuilderView, self).dispatch(request, *args, **kwargs)
-            else:
-                raise Http404
+            return super(ReportBuilderView, self).dispatch(request, *args, **kwargs)
         else:
             raise Http404
 
@@ -442,9 +437,7 @@ class ReportBuilderTypeSelect(JSONResponseMixin, ReportBuilderView):
                 help_text=_('A table of aggregated data from form submissions or case properties.'
                             ' You choose the columns and rows.'),
             ),
-        ]
-        if REPORT_BUILDER_MAP_REPORTS.enabled(self.domain):
-            tiles.append(TileConfiguration(
+            TileConfiguration(
                 title=_('Map'),
                 slug='map',
                 analytics_usage_label="Map",
@@ -454,7 +447,8 @@ class ReportBuilderTypeSelect(JSONResponseMixin, ReportBuilderView):
                 url=reverse('report_builder_select_source', args=[self.domain, 'map']),
                 help_text=_('A map to show data from your cases or forms.'
                             ' You choose the property to map.'),
-            ))
+            )
+        ]
         return tiles
 
 

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -320,13 +320,6 @@ REPORT_BUILDER_BETA_GROUP = StaticToggle(
     [NAMESPACE_DOMAIN],
 )
 
-REPORT_BUILDER_MAP_REPORTS = StaticToggle(
-    'report_builder_map_reports',
-    'Report Builder map reports',
-    TAG_PRODUCT_PATH,
-    [NAMESPACE_DOMAIN]
-)
-
 STOCK_TRANSACTION_EXPORT = StaticToggle(
     'ledger_export',
     'Show "export transactions" link on case details page',


### PR DESCRIPTION
This PR changes default page size to 100 for map reports, adds a notice if data extends beyond a single page, and drops the toggle.

The pagination notice looks like so:

![pagination_notice](https://cloud.githubusercontent.com/assets/708421/17621394/4c766402-6093-11e6-9887-2a5a46c8a859.png)

More context at [Trello](https://trello.com/c/LutdwNCP/31-handle-paging-in-maps-and-release).

One digression from requirements is that I placed the notice where other messages are shown, but I'm happy to move it to between the map and the table if people feel that's a better place.

@NoahCarnahan cc @sheelio @czue @proteusvacuum 
