### PR TITLE
Fix annoying issue where hitting 'back' wouldnt return to app list

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/session_nav.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/session_nav.js
@@ -85,7 +85,7 @@ FormplayerFrontend.module("SessionNavigate", function (SessionNavigate, Formplay
     });
 
     FormplayerFrontend.on("apps:list", function () {
-        FormplayerFrontend.navigate("/");
+        FormplayerFrontend.navigate("apps");
         API.listApps();
     });
 


### PR DESCRIPTION
Hitting 'back' wasn't causing the app list page to reload when it was the target - appears that you need a url route besides '/' for this to work. 
