### PR TITLE
Log export migrations

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1790,6 +1790,7 @@ class ConversionMeta(DocumentSchema):
 class ExportMigrationMeta(Document):
     saved_export_id = StringProperty()
     domain = StringProperty()
+    export_type = StringProperty(choices=[FORM_EXPORT, CASE_EXPORT])
 
     skipped_tables = SchemaListProperty(ConversionMeta)
     skipped_columns = SchemaListProperty(ConversionMeta)

--- a/corehq/apps/export/tasks.py
+++ b/corehq/apps/export/tasks.py
@@ -1,10 +1,14 @@
 import urllib
+import logging
 from celery.task import task
 
 from corehq.apps.export.export import get_export_file, rebuild_export
+from corehq.apps.export.utils import convert_saved_export_to_export_instance
 from couchexport.models import Format
 from couchexport.tasks import escape_quotes
 from soil.util import expose_cached_download
+
+logger = logging.getLogger('export_migration')
 
 
 @task
@@ -37,3 +41,33 @@ def populate_export_download_task(export_instances, filters, download_id, filena
 @task(queue='background_queue', ignore_result=True)
 def rebuild_export_task(export_instance, last_access_cutoff=None, filter=None):
     rebuild_export(export_instance, last_access_cutoff, filter)
+
+
+@task(queue='background_queue')
+def async_convert_saved_export_to_export_instance(domain, legacy_export, dryrun=False):
+    export_instance, meta = convert_saved_export_to_export_instance(
+        domain,
+        legacy_export,
+        dryrun=dryrun,
+    )
+
+    for table_meta in meta.skipped_tables:
+        _log_conversion_meta(meta, table_meta, 'table')
+
+    for column_meta in meta.skipped_columns:
+        _log_conversion_meta(meta, column_meta, 'column')
+
+
+def _log_conversion_meta(meta, conversion_meta, type_):
+    logger.info(
+        'domain={domain} export_id={export_id} export_type={export_type} '
+        'remote={remote} type={type} path={path} reason={reason}'.format(
+            domain=meta.domain,
+            export_id=meta.saved_export_id,
+            export_type=meta.export_type,
+            remote=meta.is_remote_app_migration,
+            type=type_,
+            path=conversion_meta.path,
+            reason=conversion_meta.failure_reason,
+        )
+    )

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -60,6 +60,7 @@ def convert_saved_export_to_export_instance(domain, saved_export, dryrun=False):
     migration_meta = ExportMigrationMeta(
         saved_export_id=saved_export._id,
         domain=domain,
+        export_type=export_type,
         is_remote_app_migration=is_remote_app_migration,
         migration_date=datetime.utcnow(),
     )

--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -188,12 +188,6 @@ class BaseExportView(BaseProjectDataView):
         context = self.export_helper.get_context()
         context.update({'export_home_url': self.export_home_url})
 
-        async_convert_saved_export_to_export_instance.delay(
-            self.domain,
-            self.export_helper.custom_export,
-            dryrun=True
-        )
-
         return context
 
     def commit(self, request):
@@ -324,6 +318,16 @@ class BaseModifyCustomExportView(BaseExportView):
     @property
     def export_id(self):
         return self.kwargs.get('export_id')
+
+    @property
+    def page_context(self):
+        if not use_new_exports(self.domain):
+            async_convert_saved_export_to_export_instance.delay(
+                self.domain,
+                self.export_helper.custom_export,
+                dryrun=True
+            )
+        return super(BaseModifyCustomExportView, self).page_context
 
     @property
     @memoized

--- a/corehq/apps/export/views.py
+++ b/corehq/apps/export/views.py
@@ -60,6 +60,7 @@ from corehq.apps.export.const import (
     CASE_EXPORT,
     MAX_EXPORTABLE_ROWS,
 )
+from corehq.apps.export.tasks import async_convert_saved_export_to_export_instance
 from corehq.apps.export.dbaccessors import (
     get_form_export_instances,
     get_case_export_instances,
@@ -186,6 +187,13 @@ class BaseExportView(BaseProjectDataView):
         # clear what this view specifically needs to render.
         context = self.export_helper.get_context()
         context.update({'export_home_url': self.export_home_url})
+
+        async_convert_saved_export_to_export_instance.delay(
+            self.domain,
+            self.export_helper.custom_export,
+            dryrun=True
+        )
+
         return context
 
     def commit(self, request):

--- a/settings.py
+++ b/settings.py
@@ -114,6 +114,7 @@ ANALYTICS_LOG_FILE = "%s/%s" % (FILEPATH, "commcarehq.analytics.log")
 DATADOG_LOG_FILE = "%s/%s" % (FILEPATH, "commcarehq.datadog.log")
 FORMPLAYER_TIMING_FILE = "%s/%s" % (FILEPATH, "formplayer.timing.log")
 FORMPLAYER_DIFF_FILE = "%s/%s" % (FILEPATH, "formplayer.diff.log")
+EXPORT_MIGRATION_LOG_FILE = "%s/%s" % (FILEPATH, "export_migration.log")
 
 LOCAL_LOGGING_HANDLERS = {}
 LOCAL_LOGGING_LOGGERS = {}
@@ -1015,6 +1016,14 @@ LOGGING = {
             'maxBytes': 10 * 1024 * 1024,  # 10 MB
             'backupCount': 20  # Backup 200 MB of logs
         },
+        'export_migration': {
+            'level': 'INFO',
+            'class': 'logging.handlers.RotatingFileHandler',
+            'formatter': 'simple',
+            'filename': EXPORT_MIGRATION_LOG_FILE,
+            'maxBytes': 10 * 1024 * 1024,  # 10 MB
+            'backupCount': 20  # Backup 200 MB of logs
+        },
         'mail_admins': {
             'level': 'ERROR',
             'class': 'corehq.util.log.HqAdminEmailHandler',
@@ -1097,6 +1106,10 @@ LOGGING = {
             'level': 'INFO',
             'propogate': True,
         },
+        'export_migration': {
+            'handlers': ['export_migration'],
+            'level': 'INFO',
+        }
     }
 }
 


### PR DESCRIPTION
@czue @NoahCarnahan this will async log all conversions. label because there's an ansible portion to this. the output in the logfile looks like this:

```
2016-08-12 20:00:04,494 INFO domain=aspace export_id=92e5f9a6624a637c2080957475cd446d export_type=case remote=False type=column path=updated_unknown_properties.name reason=Column not found in new schema
```
