### PR TITLE
make cloudant api key scripts less chatty

### DIFF
--- a/scripts/cloudant/create_databases.py
+++ b/scripts/cloudant/create_databases.py
@@ -1,4 +1,4 @@
-from manage_cloudant import authenticate_cloudant_instance
+from manage_cloudant import authenticate_cloudant_instance, run_ask_runs
 
 if __name__ == '__main__':
 
@@ -12,6 +12,10 @@ if __name__ == '__main__':
 
     cloudant_instance = authenticate_cloudant_instance(args.username)
 
+    ask_runs = []
+
     for database in args.databases:
         if not cloudant_instance.database_exists(database):
-            cloudant_instance.create_database(database)
+            ask_runs.append(cloudant_instance.create_database(database))
+
+    run_ask_runs(ask_runs)

--- a/scripts/cloudant/generate_api_key.py
+++ b/scripts/cloudant/generate_api_key.py
@@ -1,4 +1,4 @@
-from manage_cloudant import authenticate_cloudant_instance
+from manage_cloudant import authenticate_cloudant_instance, run_ask_runs
 
 if __name__ == '__main__':
 
@@ -11,9 +11,14 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     cloudant_instance = authenticate_cloudant_instance(args.username)
-    api_key, api_password = cloudant_instance.generate_api_key()
+    api_key, api_password = cloudant_instance.generate_api_key().ask_and_run()
     print 'New API key generated.'
     print 'API Key:', api_key
     print 'API Password:', api_password
+
+    ask_runs = []
+
     for database in args.databases:
-        cloudant_instance.get_db(database).grant_api_key_access(api_key)
+        ask_runs.append(cloudant_instance.get_db(database).grant_api_key_access(api_key))
+
+    run_ask_runs(ask_runs)

--- a/scripts/cloudant/grant_api_key.py
+++ b/scripts/cloudant/grant_api_key.py
@@ -1,4 +1,4 @@
-from manage_cloudant import authenticate_cloudant_instance
+from manage_cloudant import authenticate_cloudant_instance, run_ask_runs
 
 if __name__ == '__main__':
 
@@ -13,5 +13,10 @@ if __name__ == '__main__':
 
     cloudant_instance = authenticate_cloudant_instance(args.username)
 
+    ask_runs = []
+
     for database in args.databases:
-        cloudant_instance.get_db(database).grant_api_key_access(args.api_key_to_grant)
+        ask_runs.append(
+            cloudant_instance.get_db(database).grant_api_key_access(args.api_key_to_grant))
+
+    run_ask_runs(ask_runs)

--- a/scripts/cloudant/manage_cloudant.py
+++ b/scripts/cloudant/manage_cloudant.py
@@ -8,6 +8,12 @@ import requests
 Auth = namedtuple('Auth', 'username password')
 
 
+class AskRun(namedtuple('AskRun', 'ask run')):
+    def ask_and_run(self):
+        ask_user(self.ask())
+        return self.run()
+
+
 class CloudantInstance(Auth):
 
     def create_database(self, db_name):
@@ -19,14 +25,18 @@ class CloudantInstance(Auth):
     def get_db(self, db_name):
         return CloudantDatabase(self, db_name)
 
-    def generate_api_key(self, ask=True):
-        if ask:
-            ask_user('Generating new API key for {}'.format(self.username))
-        new_api_key_response = requests.post(
-            'https://{username}.cloudant.com/_api/v2/api_keys'.format(username=self.username),
-            auth=self).json()
-        assert new_api_key_response['ok'] is True
-        return Auth(new_api_key_response['key'], new_api_key_response['password'])
+    def generate_api_key(self):
+        def ask():
+            return 'Generating new API key for {}'.format(self.username)
+
+        def run():
+            new_api_key_response = requests.post(
+                'https://{username}.cloudant.com/_api/v2/api_keys'.format(username=self.username),
+                auth=self).json()
+            assert new_api_key_response['ok'] is True
+            return Auth(new_api_key_response['key'], new_api_key_response['password'])
+
+        return AskRun(ask, run)
 
 
 class CloudantDatabase(namedtuple('CloudantInstance', 'instance db_name')):
@@ -42,47 +52,59 @@ class CloudantDatabase(namedtuple('CloudantInstance', 'instance db_name')):
             .format(username=self.instance.username, database=self.db_name)
         )
 
-    def create(self, ask=True):
+    def create(self):
         db_uri = self._get_db_uri()
-        if ask:
-            ask_user('Creating database {}'.format(db_uri))
 
-        response = requests.put(db_uri, auth=self.instance).json()
-        print response
+        def ask():
+            return 'Creating database {}'.format(db_uri)
+
+        def run():
+            return requests.put(db_uri, auth=self.instance).json()
+
+        return AskRun(ask, run)
 
     def exists(self):
         db_uri = self._get_db_uri()
         status_code = requests.get(db_uri, auth=self.instance).status_code
         return status_code == 200
 
-    def grant_api_key_access(self, api_key, ask=True):
+    def grant_api_key_access(self, api_key):
         db_uri = self._get_db_uri()
         security_url = self._get_security_url()
         security = requests.get(security_url, auth=self.instance).json()
         assert api_key
-        if ask:
-            ask_user('Granting api_key {} access to database {}'.format(api_key, db_uri))
+
         if not security:
             security = {'cloudant': {}}
         security['cloudant'][api_key] = ["_admin", "_reader", "_writer", "_replicator"]
 
-        security = requests.put(security_url, auth=self.instance, json=security).json()
-        print security
+        def ask():
+            return 'Granting api_key {} access to database {}'.format(api_key, db_uri)
 
-    def revoke_api_key_access(self, api_key, ask=True):
+        def run():
+            return requests.put(security_url, auth=self.instance, json=security).json()
+
+        return AskRun(ask, run)
+
+    def revoke_api_key_access(self, api_key):
         db_uri = self._get_db_uri()
         security_url = self._get_security_url()
         security = requests.get(security_url, auth=self.instance).json()
         assert api_key
-        if ask:
-            ask_user('Revoking api_key {} access to database {}'.format(api_key, db_uri))
+
         if not security:
             security = {'cloudant': {}}
+
         if api_key in security['cloudant']:
             del security['cloudant'][api_key]
 
-        security = requests.put(security_url, auth=self.instance, json=security).json()
-        print security
+        def ask():
+            return 'Revoking api_key {} access to database {}'.format(api_key, db_uri)
+
+        def run():
+            return requests.put(security_url, auth=self.instance, json=security).json()
+
+        return AskRun(ask, run)
 
 
 def get_cloudant_password(username):
@@ -95,6 +117,14 @@ def ask_user(statement):
     if y != 'y':
         print 'Aborting'
         exit(0)
+
+
+def run_ask_runs(ask_runs):
+    for ask_run in ask_runs:
+        print ask_run.ask()
+    ask_user('The proceeding steps will be performed')
+    for ask_run in ask_runs:
+        print ask_run.run()
 
 
 def authenticate_cloudant_instance(username):

--- a/scripts/cloudant/manage_cloudant.py
+++ b/scripts/cloudant/manage_cloudant.py
@@ -122,7 +122,7 @@ def ask_user(statement):
 def run_ask_runs(ask_runs):
     for ask_run in ask_runs:
         print ask_run.ask()
-    ask_user('The proceeding steps will be performed')
+    ask_user('The preceding steps will be performed')
     for ask_run in ask_runs:
         print ask_run.run()
 

--- a/scripts/cloudant/revoke_api_key.py
+++ b/scripts/cloudant/revoke_api_key.py
@@ -1,4 +1,4 @@
-from manage_cloudant import authenticate_cloudant_instance
+from manage_cloudant import authenticate_cloudant_instance, run_ask_runs
 
 if __name__ == '__main__':
 
@@ -13,5 +13,9 @@ if __name__ == '__main__':
 
     cloudant_instance = authenticate_cloudant_instance(args.username)
 
+    ask_runs = []
     for database in args.databases:
-        cloudant_instance.get_db(database).revoke_api_key_access(args.api_key_to_revoke)
+        ask_runs.append(
+            cloudant_instance.get_db(database).revoke_api_key_access(args.api_key_to_revoke))
+
+    run_ask_runs(ask_runs)


### PR DESCRIPTION
it used to require confirmation for each db separately; now it shows you all the operations and then asks you to confirm once.
