### PR TITLE
API wrappers for case and form data from ES

### DIFF
--- a/corehq/apps/api/models.py
+++ b/corehq/apps/api/models.py
@@ -9,6 +9,7 @@ from django.contrib.auth.models import check_password
 from django.http import HttpResponse
 
 from corehq.apps.api.resources import DictObject
+from corehq.form_processor.abstract_models import CaseToXMLMixin
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAccessors
 from couchforms import const
 from dimagi.ext.couchdbkit import *
@@ -158,7 +159,7 @@ class ESXFormInstance(DictObject):
         return self.form_data.get(const.TAG_NAME, "")
 
 
-class ESCase(DictObject):
+class ESCase(DictObject, CaseToXMLMixin):
     """This wrapper around case data returned from ES which
     provides attribute access and helper functions for
     the Case API.

--- a/corehq/apps/api/models.py
+++ b/corehq/apps/api/models.py
@@ -7,7 +7,7 @@ from django.contrib.auth.hashers import make_password
 from django.contrib.auth.models import check_password
 from django.http import HttpResponse
 
-from corehq.apps.api.resources import dict_object
+from corehq.apps.api.resources import DictObject
 from couchforms import const
 from dimagi.ext.couchdbkit import *
 
@@ -95,7 +95,7 @@ require_api_user = _require_api_user()
 require_api_user_permission = _require_api_user
 
 
-class ESXFormInstance(dict_object):
+class ESXFormInstance(DictObject):
     """This wrapper around form data returned from ES which
     provides attribute access and helper functions for
     the Form API.

--- a/corehq/apps/api/models.py
+++ b/corehq/apps/api/models.py
@@ -223,7 +223,7 @@ class ESCase(DictObject, CaseToXMLMixin):
         return {
             index.identifier: case_to_es_case(accessor.get_case(index.case_id))
             for index in self._reverse_indices
-            }
+        }
 
     @property
     def parent_cases(self):
@@ -232,7 +232,7 @@ class ESCase(DictObject, CaseToXMLMixin):
         return {
             index['identifier']: case_to_es_case(accessor.get_case(index['referenced_id']))
             for index in self.indices
-            }
+        }
 
     @property
     def xforms_by_name(self):

--- a/corehq/apps/api/models.py
+++ b/corehq/apps/api/models.py
@@ -1,4 +1,5 @@
 import os
+from collections import defaultdict
 from functools import wraps
 
 from couchdbkit.exceptions import ResourceNotFound
@@ -8,6 +9,7 @@ from django.contrib.auth.models import check_password
 from django.http import HttpResponse
 
 from corehq.apps.api.resources import DictObject
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAccessors
 from couchforms import const
 from dimagi.ext.couchdbkit import *
 
@@ -154,3 +156,102 @@ class ESXFormInstance(DictObject):
     @property
     def name(self):
         return self.form_data.get(const.TAG_NAME, "")
+
+
+class ESCase(DictObject):
+    """This wrapper around case data returned from ES which
+    provides attribute access and helper functions for
+    the Case API.
+    """
+
+    @property
+    def case_id(self):
+        return self._id
+
+    @property
+    def server_opened_on(self):
+        try:
+            open_action = self.actions[0]
+            return open_action['server_date']
+        except Exception:
+            pass
+
+    @property
+    def indices(self):
+        from casexml.apps.case.sharedmodels import CommCareCaseIndex
+        return [CommCareCaseIndex.wrap(index) for index in self._data['indices']]
+
+    def get_index_map(self):
+        from corehq.form_processor.abstract_models import get_index_map
+        return get_index_map(self.indices)
+
+    def get_properties_in_api_format(self):
+        return dict(self.dynamic_case_properties().items() + {
+            "external_id": self.external_id,
+            "owner_id": self.owner_id,
+            # renamed
+            "case_name": self.name,
+            # renamed
+            "case_type": self.type,
+            # renamed
+            "date_opened": self.opened_on,
+            # all custom properties go here
+        }.items())
+
+    def dynamic_case_properties(self):
+        from casexml.apps.case.models import CommCareCase
+        if self.case_json is not None:
+            dynamic_props = self.case_json
+        else:
+            dynamic_props = CommCareCase.wrap(self._data).dynamic_case_properties()
+        return dynamic_props
+
+    @property
+    def _reverse_indices(self):
+        return CaseAccessors(self.domain).get_all_reverse_indices_info([self._id])
+
+    def get_forms(self):
+        from corehq.apps.api.util import form_to_es_form
+        forms = FormAccessors(self.domain).get_forms(self.xform_ids)
+        return filter(None, [form_to_es_form(form) for form in forms])
+
+    @property
+    def child_cases(self):
+        from corehq.apps.api.util import case_to_es_case
+        accessor = CaseAccessors(self.domain)
+        return {
+            index.identifier: case_to_es_case(accessor.get_case(index.case_id))
+            for index in self._reverse_indices
+            }
+
+    @property
+    def parent_cases(self):
+        from corehq.apps.api.util import case_to_es_case
+        accessor = CaseAccessors(self.domain)
+        return {
+            index['identifier']: case_to_es_case(accessor.get_case(index['referenced_id']))
+            for index in self.indices
+            }
+
+    @property
+    def xforms_by_name(self):
+        return _group_by_dict(self.get_forms(), lambda form: form.name)
+
+    @property
+    def xforms_by_xmlns(self):
+        return _group_by_dict(self.get_forms(), lambda form: form.xmlns)
+
+
+def _group_by_dict(objs, fn):
+    """
+    Itertools.groupby returns a transient iterator with alien
+    data types in it. This returns a dictionary of lists.
+    Less efficient but clients can write naturally and used
+    only for things that have to fit in memory easily anyhow.
+    """
+    result = defaultdict(list)
+    for obj in objs:
+
+        key = fn(obj)
+        result[key].append(obj)
+    return result

--- a/corehq/apps/api/resources/__init__.py
+++ b/corehq/apps/api/resources/__init__.py
@@ -14,13 +14,13 @@ from corehq.apps.api.util import get_obj
 class dict_object(object):
 
     def __init__(self, dict):
-        self.dict = dict
+        self._data = dict
 
     def __getattr__(self, item):
-        return self.dict[item]
+        return self._data[item]
 
     def __repr__(self):
-        return 'dict_object(%r)' % self.dict
+        return 'dict_object(%r)' % self._data
 
 
 def build_content_type(format, encoding='utf-8'):

--- a/corehq/apps/api/resources/__init__.py
+++ b/corehq/apps/api/resources/__init__.py
@@ -17,7 +17,7 @@ class dict_object(object):
         self._data = dict
 
     def __getattr__(self, item):
-        return self._data[item]
+        return self._data.get(item, None)
 
     def __repr__(self):
         return 'dict_object(%r)' % self._data

--- a/corehq/apps/api/resources/__init__.py
+++ b/corehq/apps/api/resources/__init__.py
@@ -13,8 +13,8 @@ from corehq.apps.api.util import get_obj
 
 class dict_object(object):
 
-    def __init__(self, dict):
-        self._data = dict
+    def __init__(self, dict=None):
+        self._data = dict or {}
 
     def __getattr__(self, item):
         return self._data.get(item, None)

--- a/corehq/apps/api/resources/__init__.py
+++ b/corehq/apps/api/resources/__init__.py
@@ -11,7 +11,7 @@ from corehq.apps.accounting.utils import domain_has_privilege
 from corehq.apps.api.util import get_obj
 
 
-class dict_object(object):
+class DictObject(object):
 
     def __init__(self, dict=None):
         self._data = dict or {}
@@ -20,7 +20,7 @@ class dict_object(object):
         return self._data.get(item, None)
 
     def __repr__(self):
-        return 'dict_object(%r)' % self._data
+        return 'DictObject(%r)' % self._data
 
 
 def build_content_type(format, encoding='utf-8'):

--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -83,7 +83,7 @@ class XFormInstanceResource(SimpleSortableResourceMixin, HqBaseResource, DomainS
     cases = UseIfRequested(
         ToManyDocumentsField(
             'corehq.apps.api.resources.v0_4.CommCareCaseResource',
-            attribute=lambda xform: casexml_xform.cases_referenced_by_xform(xform.form_data)
+            attribute=lambda xform: casexml_xform.cases_referenced_by_xform(xform)
         )
     )
 

--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -8,17 +8,18 @@ from tastypie.authentication import Authentication
 from tastypie.exceptions import BadRequest
 
 from casexml.apps.case.models import CommCareCase
-from corehq.apps.api.models import ESXFormInstance
+from corehq.apps.api.models import ESXFormInstance, ESCase
 from corehq.apps.api.resources.auth import DomainAdminAuthentication, RequirePermissionAuthentication
 from corehq.apps.api.resources.v0_1 import _safe_bool
 from corehq.apps.api.resources.meta import CustomResourceMeta
-from corehq.form_processor.exceptions import XFormNotFound
+from corehq.form_processor.exceptions import XFormNotFound, CaseNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAccessors
 from couchforms.models import doc_types, XFormInstance
 from casexml.apps.case import xform as casexml_xform
 from custom.hope.models import HOPECase, CC_BIHAR_NEWBORN, CC_BIHAR_PREGNANCY
 
-from corehq.apps.api.util import get_object_or_not_exist, object_does_not_exist, get_obj, form_to_es_form
+from corehq.apps.api.util import get_object_or_not_exist, object_does_not_exist, get_obj, form_to_es_form, \
+    case_to_es_case
 from corehq.apps.app_manager import util as app_manager_util
 from corehq.apps.app_manager.models import Application, RemoteApp
 from corehq.apps.app_manager.dbaccessors import get_apps_in_domain
@@ -219,57 +220,28 @@ class RepeaterResource(CouchResourceMixin, HqBaseResource, DomainSpecificResourc
         list_allowed_methods = ['get', 'post']
 
 
-def group_by_dict(objs, fn):
-    """
-    Itertools.groupby returns a transient iterator with alien
-    data types in it. This returns a dictionary of lists.
-    Less efficient but clients can write naturally and used
-    only for things that have to fit in memory easily anyhow.
-    """
-    result = defaultdict(list)
-    for obj in objs:
-
-        key = fn(obj)
-        result[key].append(obj)
-    return result
-
-
-def _child_cases_attribute(case):
-    return {
-        index.identifier: CaseAccessors(case.domain).get_case(index.referenced_id)
-        for index in case.reverse_indices
-    }
-
-
-def _parent_cases_attribute(case):
-    return {
-        index.identifier: CaseAccessors(case.domain).get_case(index.referenced_id)
-        for index in case.indices
-    }
-
-
 class CommCareCaseResource(SimpleSortableResourceMixin, v0_3.CommCareCaseResource, DomainSpecificResourceMixin):
     xforms_by_name = UseIfRequested(ToManyListDictField(
         'corehq.apps.api.resources.v0_4.XFormInstanceResource',
-        attribute=lambda case: group_by_dict(case.get_forms(), lambda form: form.name)
+        attribute='xforms_by_name'
     ))
 
     xforms_by_xmlns = UseIfRequested(ToManyListDictField(
         'corehq.apps.api.resources.v0_4.XFormInstanceResource',
-        attribute=lambda case: group_by_dict(case.get_forms(), lambda form: form.xmlns)
+        attribute='xforms_by_xmlns'
     ))
 
     child_cases = UseIfRequested(
         ToManyDictField(
             'corehq.apps.api.resources.v0_4.CommCareCaseResource',
-            attribute=_child_cases_attribute
+            attribute='child_cases'
         )
     )
 
     parent_cases = UseIfRequested(
         ToManyDictField(
             'corehq.apps.api.resources.v0_4.CommCareCaseResource',
-            attribute=_parent_cases_attribute
+            attribute='parent_cases'
         )
     )
 
@@ -279,6 +251,14 @@ class CommCareCaseResource(SimpleSortableResourceMixin, v0_3.CommCareCaseResourc
     date_modified = fields.CharField(attribute='modified_on', default="1900-01-01")
     server_date_modified = fields.CharField(attribute='server_modified_on', default="1900-01-01")
     server_date_opened = fields.CharField(attribute='server_opened_on', default="1900-01-01")
+
+    def obj_get(self, bundle, **kwargs):
+        case_id = kwargs['pk']
+        try:
+            case = CaseAccessors(kwargs['domain']).get_case(case_id)
+            return case_to_es_case(case)
+        except CaseNotFound:
+            raise object_does_not_exist("CommCareCase", case_id)
 
     def case_es(self, domain):
         return MOCK_CASE_ES or CaseES(domain)
@@ -298,7 +278,7 @@ class CommCareCaseResource(SimpleSortableResourceMixin, v0_3.CommCareCaseResourc
         # Note that CaseES is used only as an ES client, for `run_query` against the proper index
         return ElasticAPIQuerySet(
             payload=query,
-            model=CommCareCase,
+            model=ESCase,
             es_client=self.case_es(domain)
         ).order_by('server_modified_on')
 
@@ -306,6 +286,7 @@ class CommCareCaseResource(SimpleSortableResourceMixin, v0_3.CommCareCaseResourc
         max_limit = 100 # Today, takes ~25 seconds for some domains
         serializer = CommCareCaseSerializer()
         ordering = ['server_date_modified', 'date_modified']
+        object_class = ESCase
 
 
 class GroupResource(CouchResourceMixin, HqBaseResource, DomainSpecificResourceMixin):

--- a/corehq/apps/api/tests.py
+++ b/corehq/apps/api/tests.py
@@ -731,20 +731,19 @@ class TestWebUserResource(APIResourceTest):
         self.addCleanup(user.delete)
 
         user_json = {
-            "email":"admin@example.com",
-            "first_name":"Joe",
+            "email": "admin@example.com",
+            "first_name": "Joe",
             "is_admin": True,
-            "last_name":"Admin",
-            "permissions":{
-                "edit_apps":True,
-                "edit_commcare_users":True,
-                "edit_data":True,
-                "edit_web_users":True,
-                "view_reports":True
+            "last_name": "Admin",
+            "permissions": {
+                "edit_apps": True,
+                "edit_commcare_users": True,
+                "edit_data": True,
+                "edit_web_users": True,
+                "view_reports": True
             },
-            "phone_numbers":[
-            ],
-            "role":"admin"
+            "phone_numbers": [],
+            "role": "admin"
         }
 
         backend_id = user._id
@@ -815,8 +814,8 @@ class TestRepeaterResource(APIResourceTest):
 
         api_case_repeater = filter(lambda r: r['type'] == 'CaseRepeater', api_repeaters)[0]
         self.assertEqual(api_case_repeater['id'], case_repeater._id)
-        self.assertEqual(api_case_repeater['url'], case_repeater.url)    
-        self.assertEqual(api_case_repeater['domain'], case_repeater.domain)    
+        self.assertEqual(api_case_repeater['url'], case_repeater.url)
+        self.assertEqual(api_case_repeater['domain'], case_repeater.domain)
 
     def test_create(self):
 

--- a/corehq/apps/api/tests.py
+++ b/corehq/apps/api/tests.py
@@ -517,8 +517,7 @@ class TestHOPECaseResource(APIResourceTest):
         self.assertEqual(len(api_cases), 2)
 
         api_case = api_cases['mother_lists'][0]
-        self.assertEqual(dateutil.parser.parse(api_case['server_date_modified']), backend_case.server_modified_on)
-
+        self.assertEqual(api_case['id'], backend_case.case_id)
         backend_case.delete()
 
 

--- a/corehq/apps/api/tests.py
+++ b/corehq/apps/api/tests.py
@@ -2,7 +2,6 @@ import base64
 import json
 import uuid
 from datetime import datetime
-import dateutil.parser
 
 from django.conf import settings
 from django.core.urlresolvers import reverse
@@ -22,6 +21,7 @@ from corehq.apps.userreports.models import ReportConfiguration, \
 from corehq.apps.userreports.tasks import rebuild_indicators
 from corehq.pillows.case import transform_case_for_elasticsearch
 from couchforms.models import XFormInstance
+from dimagi.utils.parsing import json_format_datetime
 
 from django_prbac.models import Role
 
@@ -265,8 +265,7 @@ class TestXFormInstanceResource(APIResourceTest):
 
         api_form = api_forms[0]
         self.assertEqual(api_form['form']['@xmlns'], backend_form.xmlns)
-        self.assertEqual(api_form['received_on'], backend_form.received_on.isoformat())
-
+        self.assertEqual(api_form['received_on'], json_format_datetime(backend_form.received_on))
         backend_form.delete()
 
     def test_get_list_xmlns(self):
@@ -397,8 +396,7 @@ class TestCommCareCaseResource(APIResourceTest):
         self.assertEqual(len(api_cases), 1)
 
         api_case = api_cases[0]
-        self.assertEqual(dateutil.parser.parse(api_case['server_date_modified']), backend_case.server_modified_on)
-
+        self.assertEqual(api_case['server_date_modified'], json_format_datetime(backend_case.server_modified_on))
         backend_case.delete()
 
     @run_with_all_backends

--- a/corehq/apps/api/util.py
+++ b/corehq/apps/api/util.py
@@ -56,3 +56,8 @@ def form_to_es_form(xform_instance):
         es_form = transform_xform_for_elasticsearch(json_form)
         return ESXFormInstance(es_form)
 
+
+def case_to_es_case(case):
+    from corehq.pillows.case import transform_case_for_elasticsearch
+    from corehq.apps.api.models import ESCase
+    return ESCase(transform_case_for_elasticsearch(case.to_json()))

--- a/corehq/apps/api/util.py
+++ b/corehq/apps/api/util.py
@@ -45,3 +45,14 @@ def get_obj(bundle_or_obj):
         return bundle_or_obj.obj
     else:
         return bundle_or_obj
+
+
+def form_to_es_form(xform_instance):
+    from corehq.pillows.xform import transform_xform_for_elasticsearch, xform_pillow_filter
+    from corehq.apps.api.models import ESXFormInstance
+
+    json_form = xform_instance.to_json()
+    if not xform_pillow_filter(json_form):
+        es_form = transform_xform_for_elasticsearch(json_form)
+        return ESXFormInstance(es_form)
+

--- a/corehq/ex-submodules/casexml/apps/case/xml/generator.py
+++ b/corehq/ex-submodules/casexml/apps/case/xml/generator.py
@@ -1,5 +1,3 @@
-from iso8601 import iso8601
-
 from casexml.apps.case.xml import V1, V2, V3, check_version, V2_NAMESPACE
 from xml.etree import ElementTree
 import logging

--- a/corehq/ex-submodules/casexml/apps/case/xml/generator.py
+++ b/corehq/ex-submodules/casexml/apps/case/xml/generator.py
@@ -1,7 +1,16 @@
+from iso8601 import iso8601
+
 from casexml.apps.case.xml import V1, V2, V3, check_version, V2_NAMESPACE
 from xml.etree import ElementTree
 import logging
 from dimagi.utils.parsing import json_format_datetime, json_format_date
+
+
+def datetime_to_xml_string(datetime_string):
+    if isinstance(datetime_string, basestring):
+        return datetime_string
+
+    return json_format_datetime(datetime_string)
 
 
 def safe_element(tag, text=None):
@@ -99,7 +108,7 @@ class V1CaseXMLGenerator(CaseXMLGeneratorBase):
         root.append(safe_element("case_id", self.case.case_id))
         if self.case.modified_on:
             root.append(safe_element("date_modified",
-                                     json_format_datetime(self.case.modified_on)))
+                                     datetime_to_xml_string(self.case.modified_on)))
         return root
 
     def get_case_type_element(self):
@@ -138,7 +147,7 @@ class V2CaseXMLGenerator(CaseXMLGeneratorBase):
             "user_id": self.case.user_id or '',
         }
         if self.case.modified_on:
-            root.attrib["date_modified"] = json_format_datetime(self.case.modified_on)
+            root.attrib["date_modified"] = datetime_to_xml_string(self.case.modified_on)
         return root
 
     def get_case_type_element(self):
@@ -210,9 +219,9 @@ class CaseDBXMLGenerator(V2CaseXMLGenerator):
 
     def add_base_properties(self, element):
         element.append(self.get_case_name_element())
-        element.append(safe_element("date_opened", json_format_datetime(self.case.opened_on)))
+        element.append(safe_element("date_opened", datetime_to_xml_string(self.case.opened_on)))
         if self.case.modified_on:
-            element.append(safe_element("last_modified", json_format_datetime(self.case.modified_on)))
+            element.append(safe_element("last_modified", datetime_to_xml_string(self.case.modified_on)))
 
     def get_element(self):
         element = self.get_root_element()

--- a/corehq/form_processor/abstract_models.py
+++ b/corehq/form_processor/abstract_models.py
@@ -110,14 +110,6 @@ class AbstractXFormInstance(object):
         raise NotImplementedError()
 
     @property
-    def version(self):
-        return self.form_data.get(const.TAG_VERSION, "")
-
-    @property
-    def uiversion(self):
-        return self.form_data.get(const.TAG_UIVERSION, "")
-
-    @property
     def type(self):
         return self.form_data.get(const.TAG_TYPE, "")
 

--- a/corehq/form_processor/abstract_models.py
+++ b/corehq/form_processor/abstract_models.py
@@ -131,6 +131,16 @@ class AbstractXFormInstance(object):
         return None
 
 
+def get_index_map(indices):
+    return dict([
+        (index.identifier, {
+            "case_type": index.referenced_type,
+            "case_id": index.referenced_id,
+            "relationship": index.relationship,
+        }) for index in indices
+    ])
+
+
 class AbstractCommCareCase(object):
 
     # @property
@@ -224,13 +234,8 @@ class AbstractCommCareCase(object):
 
     @memoized
     def get_index_map(self, reversed=False):
-        return dict([
-            (index.identifier, {
-                "case_type": index.referenced_type,
-                "case_id": index.referenced_id,
-                "relationship": index.relationship,
-            }) for index in (self.indices if not reversed else self.reverse_indices)
-        ])
+        indices = self.indices if not reversed else self.reverse_indices
+        return get_index_map(indices)
 
     def get_properties_in_api_format(self):
         return dict(self.dynamic_case_properties().items() + {

--- a/corehq/form_processor/abstract_models.py
+++ b/corehq/form_processor/abstract_models.py
@@ -141,7 +141,21 @@ def get_index_map(indices):
     ])
 
 
-class AbstractCommCareCase(object):
+class CaseToXMLMixin(object):
+    def to_xml(self, version, include_case_on_closed=False):
+        from xml.etree import ElementTree
+        from casexml.apps.phone.xml import get_case_element
+        if self.closed:
+            if include_case_on_closed:
+                elem = get_case_element(self, ('create', 'update', 'close'), version)
+            else:
+                elem = get_case_element(self, ('close'), version)
+        else:
+            elem = get_case_element(self, ('create', 'update'), version)
+        return ElementTree.tostring(elem)
+
+
+class AbstractCommCareCase(CaseToXMLMixin):
 
     # @property
     # def case_id(self):


### PR DESCRIPTION
@emord 
cc @czue @benrudolph 

This PR attempts to address the issues with the API not being fully compatible with SQL data by creating new wrapper classes for the ES data (instead of using `CommCareCase`). 

These wrappers provide attribute access as well as any further DB access required by the API.

Unfortunately there is a bit of code duplication between these wrappers and the Couch / SQL models but removing the duplication would require significantly more code changes.

One option that I'd like to explore is to use the Tastypie resources in the other places that require 'API' formatted data.

Note that one difference in the API data is that dates are now formatted with the timezone suffix (Z). Previously the timezone suffix was omitted:

```
"2016-08-11T08:57:17.096000" -->  "2016-08-11T08:57:17.096000Z"
```
