### PR TITLE
add strict mode to kafka change feeds and verify checkpoint management command

### DIFF
--- a/corehq/apps/change_feed/consumer/feed.py
+++ b/corehq/apps/change_feed/consumer/feed.py
@@ -21,7 +21,7 @@ class KafkaChangeFeed(ChangeFeed):
     Kafka-based implementation of a ChangeFeed
     """
 
-    def __init__(self, topics, group_id, partition=0, strict=False):
+    def __init__(self, topics, group_id, partition=0, strict=True):
         """
         Create a change feed listener for a list of kafka topics, a group ID, and partition.
 

--- a/corehq/apps/change_feed/consumer/feed.py
+++ b/corehq/apps/change_feed/consumer/feed.py
@@ -21,7 +21,7 @@ class KafkaChangeFeed(ChangeFeed):
     Kafka-based implementation of a ChangeFeed
     """
 
-    def __init__(self, topics, group_id, partition=0, strict=True):
+    def __init__(self, topics, group_id, partition=0, strict=False):
         """
         Create a change feed listener for a list of kafka topics, a group ID, and partition.
 

--- a/corehq/apps/change_feed/consumer/feed.py
+++ b/corehq/apps/change_feed/consumer/feed.py
@@ -3,12 +3,12 @@ from copy import copy
 
 from django.conf import settings
 from kafka import KafkaConsumer
-from kafka.common import ConsumerTimeout, OffsetOutOfRangeError
+from kafka.common import ConsumerTimeout
 
 from corehq.apps.change_feed.data_sources import get_document_store
-from corehq.apps.change_feed.exceptions import UnknownDocumentStore, UnavailableKafkaOffset
+from corehq.apps.change_feed.exceptions import UnknownDocumentStore
 from corehq.apps.change_feed.topics import get_multi_topic_offset, get_topic_offset, \
-    get_multi_topic_first_available_offsets, validate_offsets
+    validate_offsets
 from dimagi.utils.logging import notify_error
 from pillowtop.checkpoints.manager import PillowCheckpointEventHandler, DEFAULT_EMPTY_CHECKPOINT_SEQUENCE
 from pillowtop.feed.interface import ChangeFeed, Change, ChangeMeta

--- a/corehq/apps/change_feed/exceptions.py
+++ b/corehq/apps/change_feed/exceptions.py
@@ -6,3 +6,7 @@ class UnknownDocumentStore(ValueError):
 
 class MissingMetaInformationError(Exception):
     pass
+
+
+class UnavailableKafkaOffset(Exception):
+    pass

--- a/corehq/apps/change_feed/management/commands/validate_kafka_pillow_checkpoints.py
+++ b/corehq/apps/change_feed/management/commands/validate_kafka_pillow_checkpoints.py
@@ -1,0 +1,54 @@
+from optparse import make_option
+from django.core.management import BaseCommand
+from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed
+from corehq.apps.change_feed.exceptions import UnavailableKafkaOffset
+from corehq.apps.change_feed.topics import validate_offsets
+from pillowtop import get_all_pillow_instances
+
+
+class Command(BaseCommand):
+    help = ("Validates that all pillows that use kafka have checkpoints that still exist "
+            "in the kafka feed.")
+
+    option_list = BaseCommand.option_list + (
+        make_option('--print-only',
+                    action='store_true',
+                    dest='print_only',
+                    default=False,
+                    help="Only print information, don't fail if checkpoints aren't valid."),
+    )
+
+    def handle(self, *args, **options):
+        print_only = options['print_only']
+        validate_checkpoints(print_only)
+
+
+def validate_checkpoints(print_only):
+
+    for pillow in get_all_pillow_instances():
+        if isinstance(pillow.get_change_feed(), KafkaChangeFeed):
+            checkpoint_dict = _get_checkpoint_dict(pillow)
+            try:
+                validate_offsets(checkpoint_dict)
+            except UnavailableKafkaOffset as e:
+                message = u'Problem with checkpoint for {}: {}'.format(
+                    pillow.pillow_id, e
+                )
+                if print_only:
+                    print message
+                else:
+                    raise Exception(message)
+
+
+def _get_checkpoint_dict(pillow):
+    sequence = pillow.get_last_checkpoint_sequence()
+    if isinstance(sequence, dict):
+        sequence_dict = sequence
+    else:
+        sequence_dict = {
+            pillow.get_change_feed()._get_single_topic_or_fail(): int(sequence)
+        }
+    # filter out 0's since we don't want to check those as they are likely new pillows
+    return {
+        k: v for k, v in sequence_dict.items() if v > 0
+    }

--- a/corehq/apps/change_feed/tests/test_kafka_change_feed.py
+++ b/corehq/apps/change_feed/tests/test_kafka_change_feed.py
@@ -1,11 +1,13 @@
 import uuid
 from django.test import SimpleTestCase, TestCase
 from kafka import KeyedProducer
-from kafka.common import KafkaUnavailableError
+from kafka.common import KafkaUnavailableError, OffsetOutOfRangeError
 from corehq.apps.change_feed import topics
 from corehq.apps.change_feed.connection import get_kafka_client_or_none
 from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed, MultiTopicCheckpointEventHandler
+from corehq.apps.change_feed.exceptions import UnavailableKafkaOffset
 from corehq.apps.change_feed.producer import send_to_kafka
+from corehq.apps.change_feed.topics import get_multi_topic_first_available_offsets
 from corehq.util.test_utils import trap_extra_setup
 from dimagi.utils.decorators.memoized import memoized
 from pillowtop.checkpoints.manager import PillowCheckpoint
@@ -43,6 +45,25 @@ class KafkaChangeFeedTest(SimpleTestCase):
         found_change_ids = set([change.id for change in changes])
         for expected_id in set([meta.document_id for meta in expected_metas]):
             self.assertTrue(expected_id in found_change_ids)
+
+    @trap_extra_setup(KafkaUnavailableError)
+    def test_expired_checkpoint_iteration_strict(self):
+        feed = KafkaChangeFeed(topics=[topics.FORM, topics.CASE], group_id='test-kafka-feed', strict=True)
+        first_avaliable_offsets = get_multi_topic_first_available_offsets([topics.FORM, topics.CASE])
+        since = {
+            topic: first_available - 1 for topic, first_available in first_avaliable_offsets.items()
+        }
+        with self.assertRaises(UnavailableKafkaOffset):
+            feed.iter_changes(since=since, forever=False).next()
+
+    @trap_extra_setup(KafkaUnavailableError)
+    def test_non_expired_checkpoint_iteration_strict(self):
+        feed = KafkaChangeFeed(topics=[topics.FORM, topics.CASE], group_id='test-kafka-feed', strict=True)
+        first_avaliable_offsets = get_multi_topic_first_available_offsets([topics.FORM, topics.CASE])
+        since = {
+            topic: first_available for topic, first_available in first_avaliable_offsets.items()
+        }
+        feed.iter_changes(since=since, forever=False).next()
 
 
 class KafkaCheckpointTest(TestCase):

--- a/corehq/apps/change_feed/tests/test_kafka_change_feed.py
+++ b/corehq/apps/change_feed/tests/test_kafka_change_feed.py
@@ -1,7 +1,7 @@
 import uuid
 from django.test import SimpleTestCase, TestCase
 from kafka import KeyedProducer
-from kafka.common import KafkaUnavailableError, OffsetOutOfRangeError
+from kafka.common import KafkaUnavailableError
 from corehq.apps.change_feed import topics
 from corehq.apps.change_feed.connection import get_kafka_client_or_none
 from corehq.apps.change_feed.consumer.feed import KafkaChangeFeed, MultiTopicCheckpointEventHandler

--- a/corehq/apps/change_feed/topics.py
+++ b/corehq/apps/change_feed/topics.py
@@ -83,7 +83,7 @@ def validate_offsets(expected_offsets):
     in the current kafka feed
     """
     if expected_offsets:
-        available_offsets = get_multi_topic_first_available_offsets(expected_offsets.keys())
+        available_offsets = get_multi_topic_first_available_offsets([str(x) for x in expected_offsets.keys()])
         for topic in expected_offsets.keys():
             if expected_offsets[topic] < available_offsets[topic]:
                 messsage = (

--- a/corehq/apps/change_feed/topics.py
+++ b/corehq/apps/change_feed/topics.py
@@ -55,9 +55,21 @@ def get_all_offsets():
 def get_multi_topic_offset(topics):
     """
     :returns: A dict of offsets keyed by topic"""
+    return _get_topic_offsets(topics, latest=True)
+
+
+def get_multi_topic_first_available_offsets(topics):
+    """
+    :returns: A dict of offsets keyed by topic"""
+    return _get_topic_offsets(topics, latest=False)
+
+
+def _get_topic_offsets(topics, latest):
+    # https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-OffsetRequest
+    time_value = -1 if latest else -2
     assert set(topics) <= set(ALL)
     client = get_kafka_client()
-    offset_requests = [OffsetRequest(topic, 0, -1, 1) for topic in topics]
+    offset_requests = [OffsetRequest(topic, 0, time_value, 1) for topic in topics]
     responses = client.send_offset_request(offset_requests)
     return {
         r.topic: r.offsets[0] for r in responses

--- a/corehq/apps/change_feed/topics.py
+++ b/corehq/apps/change_feed/topics.py
@@ -46,6 +46,12 @@ def get_topic_offset(topic):
     return get_multi_topic_offset([topic])[topic]
 
 
+def get_all_offsets():
+    """
+    :returns: A dict of offsets keyed by topic"""
+    return get_multi_topic_offset(ALL)
+
+
 def get_multi_topic_offset(topics):
     """
     :returns: A dict of offsets keyed by topic"""
@@ -56,9 +62,3 @@ def get_multi_topic_offset(topics):
     return {
         r.topic: r.offsets[0] for r in responses
     }
-
-
-def get_all_offsets():
-    """
-    :returns: A dict of offsets keyed by topic"""
-    return get_multi_topic_offset(ALL)


### PR DESCRIPTION
@dimagi/scale-team wanted to get this out and do some testing before fully plugging everything in.

this adds a way to check if a checkpoint offset is available in the kafka feed.

it also adds a strict mode to pillows so that they won't run if they have expired checkpoints (but doesn't turn it on yet), and a management command to run this that we can run on deploy after i've had a chance to test it a bit more.

wait for tests. probably easiest to review all at once.
