### PR TITLE
Show report modules

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/managed_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/managed_app.html
@@ -257,7 +257,7 @@
                           method="post" class="hide">{% csrf_token %}
                     <input id="new-module-type" type="hidden" name="module_type" />
                 </form>
-                {% if show_care_plan or show_advanced or show_shadow_modules %}
+                {% if show_care_plan or show_advanced or show_report_modules or show_shadow_modules %}
                     <li class="sort-disabled dropdown">
                         <a href="#" data-toggle="dropdown">
                             <i class="new-module-icon fa fa-plus icon-blue"></i>
@@ -275,7 +275,7 @@
                                 </a>
                             </li>
                             {% endif %}
-                            {% if request|toggle_enabled:'MOBILE_UCR' %}
+                            {% if show_report_modules %}
                             <li>
                                 <a href="#" class="new-module" data-type="report">
                                     {% trans "New Report Module" %}

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -258,6 +258,10 @@ def get_apps_base_context(request, domain, app):
                     or getattr(app, 'commtrack_enabled', False)
                 )
             ),
+            'show_report_modules': (
+                v2_app
+                and toggles.MOBILE_UCR.enabled(domain)
+            ),
             'show_shadow_modules': (
                 v2_app
                 and toggles.APP_BUILDER_SHADOW_MODULES.enabled(domain)


### PR DESCRIPTION
When looking at how a new "User Module" type would work, I noticed this. 

This change shows report modules even if advanced/careplan/shadow modules are not enabled.

![new_report_module](https://cloud.githubusercontent.com/assets/708421/17664202/c052bf36-62f2-11e6-946b-5cc52bec4aa4.png)

@czue, buddy @proteusvacuum 
