### PR TITLE
Rename SyncRequest -> RemoteRequest

### DIFF
--- a/corehq/apps/app_manager/suite_xml/generator.py
+++ b/corehq/apps/app_manager/suite_xml/generator.py
@@ -13,7 +13,7 @@ from corehq.apps.app_manager.suite_xml.post_process.instances import EntryInstan
 from corehq.apps.app_manager.suite_xml.sections.menus import MenuContributor
 from corehq.apps.app_manager.suite_xml.sections.resources import FormResourceContributor, LocaleResourceContributor
 from corehq.apps.app_manager.suite_xml.post_process.workflow import WorkflowHelper
-from corehq.apps.app_manager.suite_xml.sections.sync_requests import SyncRequestContributor
+from corehq.apps.app_manager.suite_xml.sections.remote_requests import RemoteRequestContributor
 from corehq.apps.app_manager.suite_xml.xml_models import Suite, MediaResource
 from corehq.apps.app_manager import id_strings
 from corehq.apps.app_manager.util import split_path
@@ -49,7 +49,7 @@ class SuiteGenerator(object):
         entries = EntriesContributor(self.suite, self.app, self.modules)
         menus = MenuContributor(self.suite, self.app, self.modules)
         careplan_menus = CareplanMenuContributor(self.suite, self.app, self.modules)
-        sync_requests = SyncRequestContributor(self.suite, self.app, self.modules)
+        remote_requests = RemoteRequestContributor(self.suite, self.app, self.modules)
         for module in self.modules:
             self.suite.entries.extend(entries.get_module_contributions(module))
 
@@ -60,7 +60,7 @@ class SuiteGenerator(object):
                 menus.get_module_contributions(module)
             )
 
-            self.suite.sync_requests.extend(sync_requests.get_module_contributions(module))
+            self.suite.remote_requests.extend(remote_requests.get_module_contributions(module))
 
         self._add_sections([
             FixtureContributor(self.suite, self.app, self.modules),

--- a/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
+++ b/corehq/apps/app_manager/suite_xml/sections/remote_requests.py
@@ -11,14 +11,14 @@ from corehq.apps.app_manager.suite_xml.xml_models import (
     SessionDatum,
     Stack,
     StackDatum,
-    SyncRequest,
-    SyncRequestPost,
-    SyncRequestQuery,
-    SyncRequestSession,
+    RemoteRequest,
+    RemoteRequestPost,
+    RemoteRequestQuery,
+    RemoteRequestSession,
     Text,
 )
 from corehq.apps.app_manager.util import module_offers_search
-from corehq.apps.app_manager.xpath import XPath, CaseTypeXpath, InstanceXpath, CaseIDXPath
+from corehq.apps.app_manager.xpath import XPath, CaseTypeXpath, InstanceXpath
 from corehq.util.view_utils import absolute_reverse
 
 
@@ -34,17 +34,17 @@ class QuerySessionXPath(InstanceXpath):
         return 'session/data/{}'.format(self)
 
 
-class SyncRequestContributor(SuiteContributorByModule):
+class RemoteRequestContributor(SuiteContributorByModule):
     """
-    Adds a sync-request node, which sets the URL and query details for
+    Adds a remote-request node, which sets the URL and query details for
     synchronous searching and case claiming.
 
     Search is available from the module's case list.
 
-    See "sync-request" in the `CommCare 2.0 Suite Definition`_ for details.
+    See "remote-request" in the `CommCare 2.0 Suite Definition`_ for details.
 
 
-    .. _CommCare 2.0 Suite Definition: https://github.com/dimagi/commcare/wiki/Suite20#sync-request
+    .. _CommCare 2.0 Suite Definition: https://github.com/dimagi/commcare/wiki/Suite20#remote-request
 
     """
 
@@ -54,8 +54,8 @@ class SyncRequestContributor(SuiteContributorByModule):
 
             details_helper = DetailsHelper(self.app)
 
-            sync_request = SyncRequest(
-                post=SyncRequestPost(
+            remote_request = RemoteRequest(
+                post=RemoteRequestPost(
                     url=absolute_reverse('claim_case', args=[domain]),
                     relevant=module.search_config.relevant,
                     data=[
@@ -85,10 +85,10 @@ class SyncRequestContributor(SuiteContributorByModule):
                     ),
                 ],
 
-                session=SyncRequestSession(
+                session=RemoteRequestSession(
                     queries=[
-                        SyncRequestQuery(
-                            url=absolute_reverse('sync_search', args=[domain]),
+                        RemoteRequestQuery(
+                            url=absolute_reverse('remote_search', args=[domain]),
                             storage_instance=RESULTS_INSTANCE,
                             data=[
                                 QueryData(
@@ -124,7 +124,7 @@ class SyncRequestContributor(SuiteContributorByModule):
             # Open first form in module
             frame.add_command(XPath.string(id_strings.menu_id(module)))
             frame.add_datum(StackDatum(id='case_id', value=QuerySessionXPath('case_id').instance()))
-            sync_request.stack.add_frame(frame)
+            remote_request.stack.add_frame(frame)
 
-            return [sync_request]
+            return [remote_request]
         return []

--- a/corehq/apps/app_manager/suite_xml/xml_models.py
+++ b/corehq/apps/app_manager/suite_xml/xml_models.py
@@ -421,7 +421,7 @@ class QueryPrompt(DisplayNode):
     key = StringField('@key')
 
 
-class SyncRequestPost(XmlObject):
+class RemoteRequestPost(XmlObject):
     ROOT_NAME = 'post'
 
     url = StringField('@url')
@@ -429,7 +429,7 @@ class SyncRequestPost(XmlObject):
     data = NodeListField('data', QueryData)
 
 
-class SyncRequestQuery(OrderedXmlObject, XmlObject):
+class RemoteRequestQuery(OrderedXmlObject, XmlObject):
     ROOT_NAME = 'query'
     ORDER = ('data', 'prompts')
 
@@ -439,31 +439,31 @@ class SyncRequestQuery(OrderedXmlObject, XmlObject):
     prompts = NodeListField('prompt', QueryPrompt)
 
 
-class SyncRequestSession(OrderedXmlObject, XmlObject):
+class RemoteRequestSession(OrderedXmlObject, XmlObject):
     ROOT_NAME = 'session'
     ORDER = ('queries', 'data')
 
-    queries = NodeListField('query', SyncRequestQuery)
+    queries = NodeListField('query', RemoteRequestQuery)
     data = NodeListField('datum', SessionDatum)
 
 
-class SyncRequest(OrderedXmlObject, XmlObject):
+class RemoteRequest(OrderedXmlObject, XmlObject):
     """
     Used to set the URL and query details for synchronous search.
 
-    See "sync-request" in the `CommCare 2.0 Suite Definition`_ for details.
+    See "remote-request" in the `CommCare 2.0 Suite Definition`_ for details.
 
 
-    .. _CommCare 2.0 Suite Definition: https://github.com/dimagi/commcare/wiki/Suite20#sync-request
+    .. _CommCare 2.0 Suite Definition: https://github.com/dimagi/commcare/wiki/Suite20#remote-request
 
     """
-    ROOT_NAME = 'sync-request'
+    ROOT_NAME = 'remote-request'
     ORDER = ('post', 'command', 'instances', 'session', 'stack')
 
-    post = NodeField('post', SyncRequestPost)
+    post = NodeField('post', RemoteRequestPost)
     instances = NodeListField('instance', Instance)
     command = NodeField('command', Command)
-    session = NodeField('session', SyncRequestSession)
+    session = NodeField('session', RemoteRequestSession)
     stack = NodeField('stack', Stack)
 
 
@@ -740,6 +740,6 @@ class Suite(OrderedXmlObject):
     details = NodeListField('detail', Detail)
     entries = NodeListField('entry', Entry)
     menus = NodeListField('menu', Menu)
-    sync_requests = NodeListField('sync-request', SyncRequest)
+    remote_requests = NodeListField('remote-request', RemoteRequest)
 
     fixtures = NodeListField('fixture', Fixture)

--- a/corehq/apps/app_manager/tests/data/suite/remote_request.xml
+++ b/corehq/apps/app_manager/tests/data/suite/remote_request.xml
@@ -1,5 +1,5 @@
 <partial>
-  <sync-request>
+  <remote-request>
     <post url="https://www.example.com/a/test_domain/phone/claim-case/"
           relevant="count(instance('casedb')/casedb/case[@case_id=instance('querysession')/session/data/case_id]) = 0">
       <data key="case_id" ref="instance('querysession')/session/data/case_id"/>
@@ -44,5 +44,5 @@
         <datum id="case_id" value="instance('querysession')/session/data/case_id"/>
       </create>
     </stack>
-  </sync-request>
+  </remote-request>
 </partial>

--- a/corehq/apps/app_manager/tests/test_suite_remote_request.py
+++ b/corehq/apps/app_manager/tests/test_suite_remote_request.py
@@ -9,7 +9,7 @@ from corehq.apps.app_manager.tests.util import TestXmlMixin, SuiteMixin
 DOMAIN = 'test_domain'
 
 
-class SyncRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
+class RemoteRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
     file_path = ('data', 'suite')
 
     def setUp(self):
@@ -25,14 +25,14 @@ class SyncRequestSuiteTest(SimpleTestCase, TestXmlMixin, SuiteMixin):
             ]
         )
 
-    def test_sync_request(self):
+    def test_remote_request(self):
         """
-        Suite should include sync-request if searching is configured
+        Suite should include remote-request if searching is configured
         """
         with patch('corehq.util.view_utils.get_url_base') as get_url_base_patch:
             get_url_base_patch.return_value = 'https://www.example.com'
             suite = self.app.create_suite()
-        self.assertXmlPartialEqual(self.get_xml('sync_request'), suite, "./sync-request[1]")
+        self.assertXmlPartialEqual(self.get_xml('remote_request'), suite, "./remote-request[1]")
 
     def test_case_search_action(self):
         """

--- a/corehq/apps/ota/tests/test_search_claim_endpoints.py
+++ b/corehq/apps/ota/tests/test_search_claim_endpoints.py
@@ -134,7 +134,7 @@ class CaseClaimEndpointTests(TestCase):
 
         client = Client()
         client.login(username=USERNAME, password=PASSWORD)
-        url = reverse('sync_search', kwargs={'domain': DOMAIN})
+        url = reverse('remote_search', kwargs={'domain': DOMAIN})
         response = client.get(url, {'name': 'Jamie Hand', 'case_type': CASE_TYPE})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(re.sub(PATTERN, TIMESTAMP, response.content), known_result)

--- a/corehq/apps/ota/urls.py
+++ b/corehq/apps/ota/urls.py
@@ -8,6 +8,6 @@ urlpatterns = patterns('corehq.apps.ota.views',
     url(r'^prime_restore/$', PrimeRestoreCacheView.as_view(), name=PrimeRestoreCacheView.urlname),
     url(r'^prime_restore/advanced/$', AdvancedPrimeRestoreCacheView.as_view(),
         name=AdvancedPrimeRestoreCacheView.urlname),
-    url(r'^search/$', 'search', name='sync_search'),
+    url(r'^search/$', 'search', name='remote_search'),
     url(r'^claim-case/$', 'claim', name='claim_case'),
 )


### PR DESCRIPTION
We realized that "sync" was really confusing naming for this node, so are renaming it to `remote-request` before anyone starts using this. 
Coupled with: https://github.com/dimagi/commcare-core/pull/369

@kaapstorm, @phillipm 
