### PR TITLE
Make date format in sms surveys configurable

### DIFF
--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -302,6 +302,7 @@ class Domain(QuickCachedDocumentMixin, Document, SnapshotMixin):
     send_to_duplicated_case_numbers = BooleanProperty(default=True)
     enable_registration_welcome_sms_for_case = BooleanProperty(default=False)
     enable_registration_welcome_sms_for_mobile_worker = BooleanProperty(default=False)
+    sms_survey_date_format = StringProperty()
 
     # exchange/domain copying stuff
     is_snapshot = BooleanProperty(default=False)

--- a/corehq/apps/sms/forms.py
+++ b/corehq/apps/sms/forms.py
@@ -20,7 +20,7 @@ from django.core.exceptions import ValidationError
 from corehq.apps.reminders.forms import validate_time
 from django.utils.translation import ugettext as _, ugettext_noop, ugettext_lazy
 from corehq.apps.sms.util import (validate_phone_number, strip_plus,
-    get_sms_backend_classes)
+    get_sms_backend_classes, ALLOWED_SURVEY_DATE_FORMATS)
 from corehq.apps.domain.models import DayTimeWindow
 from corehq.apps.users.models import CommCareUser
 from corehq.apps.groups.models import Group
@@ -187,6 +187,15 @@ class SettingsForm(Form):
         choices=ENABLED_DISABLED_CHOICES,
     )
 
+    sms_survey_date_format = ChoiceField(
+        required=False,
+        label=ugettext_lazy("SMS Survey Date Format"),
+        choices=(
+            (df.human_readable_format, ugettext_lazy(df.human_readable_format))
+            for df in ALLOWED_SURVEY_DATE_FORMATS
+        ),
+    )
+
     # Chat Settings
     use_custom_case_username = ChoiceField(
         required=False,
@@ -244,6 +253,8 @@ class SettingsForm(Form):
         required=False,
         label=ugettext_noop("Enter Chat Template Identifier"),
     )
+
+    # Registration settings
     sms_case_registration_enabled = ChoiceField(
         required=False,
         choices=ENABLED_DISABLED_CHOICES,
@@ -326,6 +337,11 @@ class SettingsForm(Form):
                                    "with more than one mobile worker or case. SMS surveys "
                                    "and keywords will still only work for unique phone "
                                    "numbers in your project."),
+            ),
+            FieldWithHelpBubble(
+                'sms_survey_date_format',
+                help_bubble_text=_("Choose the format in which date questions "
+                                   "should be answered in SMS surveys."),
             ),
         ]
         return crispy.Fieldset(

--- a/corehq/apps/sms/handlers/form_session.py
+++ b/corehq/apps/sms/handlers/form_session.py
@@ -1,3 +1,4 @@
+from corehq.apps.domain.models import Domain
 from corehq.apps.sms.api import (
     MessageMetadata,
     add_msg_tags,
@@ -5,7 +6,7 @@ from corehq.apps.sms.api import (
     log_sms_exception,
 )
 from corehq.apps.sms.messages import *
-from corehq.apps.sms.util import format_message_list
+from corehq.apps.sms.util import format_message_list, get_date_format
 from touchforms.formplayer.api import current_question
 from corehq.apps.smsforms.app import (
     _get_responses,
@@ -170,16 +171,20 @@ def validate_answer(event, text, v):
         except ValueError:
             error_msg = get_message(MSG_INVALID_LONG, v)
     
-    # Validate date (Format: YYYYMMDD)
+    # Validate date (Format: specified by Domain.sms_survey_date_format, default: YYYYMMDD)
     elif event.datatype == "date":
-        try:
-            assert len(text) == 8
-            int(text)
-            text = "%s-%s-%s" % (text[0:4], text[4:6], text[6:])
-            parse(text)
-            valid = True
-        except Exception:
-            error_msg = get_message(MSG_INVALID_DATE, v)
+        domain_obj = Domain.get_by_name(v.domain)
+        df = get_date_format(domain_obj.sms_survey_date_format)
+
+        if df.is_valid(text):
+            try:
+                text = df.parse(text).strftime('%Y-%m-%d')
+                valid = True
+            except (ValueError, TypeError):
+                pass
+
+        if not valid:
+            error_msg = get_message(MSG_INVALID_DATE, v, context=(df.human_readable_format,))
 
     # Validate time (Format: HHMM, 24-hour)
     elif event.datatype == "time":

--- a/corehq/apps/sms/messages.py
+++ b/corehq/apps/sms/messages.py
@@ -52,7 +52,7 @@ _MESSAGES = {
     MSG_INVALID_INT: ugettext_noop("Invalid integer entered."),
     MSG_INVALID_FLOAT: ugettext_noop("Invalid decimal number entered."),
     MSG_INVALID_LONG: ugettext_noop("Invalid long integer entered."),
-    MSG_INVALID_DATE: ugettext_noop("Invalid date format: expected YYYYMMDD."),
+    MSG_INVALID_DATE: ugettext_noop("Invalid date format: expected {0}."),
     MSG_INVALID_TIME: ugettext_noop("Invalid time format: expected HHMM (24-hour)."),
     MSG_KEYWORD_NOT_FOUND: ugettext_noop("Keyword not found: '{0}'"),
     MSG_START_KEYWORD_USAGE: ugettext_noop("Usage: {0} <keyword>"),

--- a/corehq/apps/sms/tests/inbound_handlers.py
+++ b/corehq/apps/sms/tests/inbound_handlers.py
@@ -266,7 +266,8 @@ class KeywordTestCase(TouchformsTestCase):
         sms = incoming("999123", "x", "TEST")
         self.assertMetadataEqual(sms, session._id, WORKFLOW_KEYWORD)
 
-        sms = self.assertLastOutboundSMSEquals(self.user1, "%s date" % get_message(MSG_INVALID_DATE))
+        sms = self.assertLastOutboundSMSEquals(self.user1, "%s date" %
+            get_message(MSG_INVALID_DATE, context=('YYYYMMDD',)))
         self.assertMetadataEqual(sms, session._id, WORKFLOW_KEYWORD)
 
         sms = incoming("999123", "20140101", "TEST")
@@ -331,10 +332,9 @@ class KeywordTestCase(TouchformsTestCase):
         self.assertLastOutboundSMSEquals(self.user1, get_message(MSG_MISSING_EXTERNAL_ID))
         self.assertNoNewSubmission(form)
 
-        def get_field_and_message(field_name, msg_id):
-            msg1 = get_message(MSG_FIELD_DESCRIPTOR,
-                context=(field_name,))
-            msg2 = get_message(msg_id)
+        def get_field_and_message(field_name, msg_id, additional_context=None):
+            msg1 = get_message(MSG_FIELD_DESCRIPTOR, context=(field_name,))
+            msg2 = get_message(msg_id, context=additional_context)
             return "%s%s" % (msg1, msg2)
 
         # Test validation on all fields from structured sms: positional args
@@ -363,7 +363,8 @@ class KeywordTestCase(TouchformsTestCase):
         self.assertLastOutboundSMSEquals(self.user1, get_field_and_message("q_long", MSG_INVALID_LONG))
         self.assertNoNewSubmission(form)
         incoming("999123", "validation_test_ss_1 abc 2 c 50 21.3 -100 x 2345", "TEST")
-        self.assertLastOutboundSMSEquals(self.user1, get_field_and_message("q_date", MSG_INVALID_DATE))
+        self.assertLastOutboundSMSEquals(self.user1,
+            get_field_and_message("q_date", MSG_INVALID_DATE, ('YYYYMMDD',)))
         self.assertNoNewSubmission(form)
         incoming("999123", "validation_test_ss_1 abc 2 c 50 21.3 -100 20140101 x", "TEST")
         self.assertLastOutboundSMSEquals(self.user1, get_field_and_message("q_time", MSG_INVALID_TIME))
@@ -412,7 +413,8 @@ class KeywordTestCase(TouchformsTestCase):
         self.assertLastOutboundSMSEquals(self.user1, get_field_and_message("q_long", MSG_INVALID_LONG))
         self.assertNoNewSubmission(form)
         incoming("999123", "validation_test_ss_2,abc,2,1 c,50,21.3,-100,x,2345", "TEST")
-        self.assertLastOutboundSMSEquals(self.user1, get_field_and_message("q_date", MSG_INVALID_DATE))
+        self.assertLastOutboundSMSEquals(self.user1,
+            get_field_and_message("q_date", MSG_INVALID_DATE, ('YYYYMMDD',)))
         self.assertNoNewSubmission(form)
         incoming("999123", "validation_test_ss_2,abc,2,1 c,50,21.3,-100,20140101,x", "TEST")
         self.assertLastOutboundSMSEquals(self.user1, get_field_and_message("q_time", MSG_INVALID_TIME))
@@ -461,7 +463,8 @@ class KeywordTestCase(TouchformsTestCase):
         self.assertLastOutboundSMSEquals(self.user1, get_field_and_message("ARG6", MSG_INVALID_LONG))
         self.assertNoNewSubmission(form)
         incoming("999123", "validation_test_ss_3,arg1abc,arg22,arg31 c,arg450,arg521.3,arg6-100,arg7x,arg82345", "TEST")
-        self.assertLastOutboundSMSEquals(self.user1, get_field_and_message("ARG7", MSG_INVALID_DATE))
+        self.assertLastOutboundSMSEquals(self.user1,
+            get_field_and_message("ARG7", MSG_INVALID_DATE, ('YYYYMMDD',)))
         self.assertNoNewSubmission(form)
         incoming("999123", "validation_test_ss_3,arg1abc,arg22,arg31 c,arg450,arg521.3,arg6-100,arg720140101,arg8x", "TEST")
         self.assertLastOutboundSMSEquals(self.user1, get_field_and_message("ARG8", MSG_INVALID_TIME))
@@ -510,7 +513,8 @@ class KeywordTestCase(TouchformsTestCase):
         self.assertLastOutboundSMSEquals(self.user1, get_field_and_message("ARG6", MSG_INVALID_LONG))
         self.assertNoNewSubmission(form)
         incoming("999123", "validation_test_ss_4,arg1=abc,arg2=2,arg3=1 c,arg4=50,arg5=21.3,arg6=-100,arg7=x,arg8=2345", "TEST")
-        self.assertLastOutboundSMSEquals(self.user1, get_field_and_message("ARG7", MSG_INVALID_DATE))
+        self.assertLastOutboundSMSEquals(self.user1,
+            get_field_and_message("ARG7", MSG_INVALID_DATE, ('YYYYMMDD',)))
         self.assertNoNewSubmission(form)
         incoming("999123", "validation_test_ss_4,arg1=abc,arg2=2,arg3=1 c,arg4=50,arg5=21.3,arg6=-100,arg7=20140101,arg8=x", "TEST")
         self.assertLastOutboundSMSEquals(self.user1, get_field_and_message("ARG8", MSG_INVALID_TIME))

--- a/corehq/apps/sms/tests/util.py
+++ b/corehq/apps/sms/tests/util.py
@@ -294,6 +294,8 @@ class TouchformsTestCase(LiveServerTestCase, DomainSubscriptionMixin):
         if getattr(settings, "SKIP_TOUCHFORMS_TESTS", False):
             raise SkipTest("because settings.SKIP_TOUCHFORMS_TESTS")
 
+        super(TouchformsTestCase, cls).setUpClass()
+
     def setUp(self):
         self.users = []
         self.apps = []

--- a/corehq/apps/sms/util.py
+++ b/corehq/apps/sms/util.py
@@ -13,11 +13,38 @@ from dimagi.utils.modules import to_function
 from django.utils.translation import ugettext as _
 
 
+class DateFormat(object):
+    def __init__(self, human_readble_format, c_standard_format, validate_regex):
+        self.human_readble_format = human_readble_format
+        self.c_standard_format = c_standard_format
+        self.validate_regex = validate_regex
+
+    def parse(self, value):
+        return datetime.strptime(value, self.c_standard_format)
+
+    def is_valid(self, value):
+        return re.match(value, self.validate_regex) is not None
+
+
+# A project can specify the expected format of answers to date questions
+# in SMS Surveys. These are the available choices.
+ALLOWED_SURVEY_DATE_FORMATS = (
+    DateFormat('YYYYMMDD', '%Y%m%d', '^\d{8}$'),
+    DateFormat('MMDDYYYY', '%m%d%Y', '^\d{8}$'),
+    DateFormat('DDMMYYYY', '%d%m%Y', '^\d{8}$'),
+)
+
+SURVEY_DATE_FORMAT_LOOKUP = {df.human_readble_format: df for df in ALLOWED_SURVEY_DATE_FORMATS}
+
 phone_number_plus_re = re.compile("^\+{0,1}\d+$")
 
 
 class ContactNotFoundException(Exception):
     pass
+
+
+def get_date_format(human_readable_format):
+    return SURVEY_DATE_FORMAT_LOOKUP.get(human_readable_format, ALLOWED_SURVEY_DATE_FORMATS[0])
 
 
 def strip_plus(phone_number):

--- a/corehq/apps/sms/util.py
+++ b/corehq/apps/sms/util.py
@@ -14,16 +14,16 @@ from django.utils.translation import ugettext as _
 
 
 class DateFormat(object):
-    def __init__(self, human_readble_format, c_standard_format, validate_regex):
-        self.human_readble_format = human_readble_format
+    def __init__(self, human_readable_format, c_standard_format, validate_regex):
+        self.human_readable_format = human_readable_format
         self.c_standard_format = c_standard_format
         self.validate_regex = validate_regex
 
     def parse(self, value):
-        return datetime.strptime(value, self.c_standard_format)
+        return datetime.datetime.strptime(value, self.c_standard_format)
 
     def is_valid(self, value):
-        return re.match(value, self.validate_regex) is not None
+        return re.match(self.validate_regex, value) is not None
 
 
 # A project can specify the expected format of answers to date questions
@@ -34,7 +34,7 @@ ALLOWED_SURVEY_DATE_FORMATS = (
     DateFormat('DDMMYYYY', '%d%m%Y', '^\d{8}$'),
 )
 
-SURVEY_DATE_FORMAT_LOOKUP = {df.human_readble_format: df for df in ALLOWED_SURVEY_DATE_FORMATS}
+SURVEY_DATE_FORMAT_LOOKUP = {df.human_readable_format: df for df in ALLOWED_SURVEY_DATE_FORMATS}
 
 phone_number_plus_re = re.compile("^\+{0,1}\d+$")
 

--- a/corehq/apps/sms/views.py
+++ b/corehq/apps/sms/views.py
@@ -1842,6 +1842,8 @@ class SMSSettingsView(BaseMessagingSectionView):
                     [w.to_json() for w in domain_obj.restricted_sms_times],
                 "send_to_duplicated_case_numbers":
                     enabled_disabled(domain_obj.send_to_duplicated_case_numbers),
+                "sms_survey_date_format":
+                    domain_obj.sms_survey_date_format,
                 "use_custom_case_username":
                     default_custom(domain_obj.custom_case_username),
                 "custom_case_username":
@@ -1905,6 +1907,8 @@ class SMSSettingsView(BaseMessagingSectionView):
                  "custom_case_username"),
                 ("send_to_duplicated_case_numbers",
                  "send_to_duplicated_case_numbers"),
+                ("sms_survey_date_format",
+                 "sms_survey_date_format"),
                 ("sms_conversation_length",
                  "sms_conversation_length"),
                 ("count_messages_as_read_by_anyone",


### PR DESCRIPTION
Allows users to answer date questions in sms surveys with a format specified in a project-wide setting, instead of forcing everyone to use YYYYMMDD.

@dannyroberts 
