### PR TITLE
Add support for case types not referenced in application

### DIFF
--- a/corehq/apps/app_manager/dbaccessors.py
+++ b/corehq/apps/app_manager/dbaccessors.py
@@ -324,3 +324,8 @@ def get_case_types_from_apps(domain):
          .size(0)
          .terms_aggregation('modules.case_type.exact', 'case_types'))
     return set(q.run().aggregations.case_types.keys)
+
+
+def get_case_sharing_apps_in_domain(domain, exclude_app_id=None):
+    apps = get_apps_in_domain(domain, include_remote=False)
+    return [a for a in apps if a.case_sharing and exclude_app_id != a.id]

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -99,6 +99,7 @@ from corehq.apps.app_manager import current_builds, app_strings, remote_app, \
 from corehq.apps.app_manager.suite_xml import xml_models as suite_models
 from corehq.apps.app_manager.dbaccessors import (
     get_app,
+    get_case_sharing_apps_in_domain,
     get_latest_build_doc,
     get_latest_released_app_doc,
     domain_has_apps,
@@ -5414,7 +5415,19 @@ class Application(ApplicationBase, TranslationMixin, HQMediaMixin):
         extra_types = set()
         if is_usercase_in_use(self.domain):
             extra_types.add(USERCASE_TYPE)
+
         return set(chain(*[m.get_case_types() for m in self.get_modules()])) | extra_types
+
+    @memoized
+    def get_shared_case_types(self):
+        shared_case_types = set()
+
+        if self.case_sharing:
+            apps = get_case_sharing_apps_in_domain(self.domain, self.id)
+            for app in apps:
+                shared_case_types |= set(chain(*[m.get_case_types() for m in app.get_modules()]))
+
+        return shared_case_types
 
     def has_media(self):
         return len(self.multimedia_map) > 0

--- a/corehq/apps/app_manager/tests/test_util.py
+++ b/corehq/apps/app_manager/tests/test_util.py
@@ -94,6 +94,7 @@ class GetCasePropertiesTest(SimpleTestCase, TestXmlMixin):
 class SchemaTest(SimpleTestCase):
     def setUp(self):
         self.factory = AppFactory()
+        self.factory_2 = AppFactory()
 
     def test_get_casedb_schema_form_without_cases(self):
         survey = self.add_form()
@@ -205,6 +206,26 @@ class SchemaTest(SimpleTestCase):
             },
         })
 
+    def test_get_case_sharing_hierarchy(self):
+        with patch('corehq.apps.app_manager.models.get_case_sharing_apps_in_domain') as mock_sharing:
+            mock_sharing.return_value = [self.factory.app, self.factory_2.app]
+            with patch('corehq.apps.app_manager.util.get_case_sharing_apps_in_domain') as mock_sharing_2:
+                mock_sharing_2.return_value = [self.factory.app, self.factory_2.app]
+                self.factory.app.case_sharing = True
+                self.factory_2.app.case_sharing = True
+
+                referral = self.add_form("referral")
+                child = self.add_form("child")
+                self.factory.form_opens_case(child, case_type='referral', is_subcase=True)
+                pregnancy = self.add_form("pregnancy")
+                self.factory.form_opens_case(pregnancy, case_type='referral', is_subcase=True)
+                referral_2 = self.add_form_app_2('referral')
+                schema = util.get_casedb_schema(referral_2)
+                subsets = {s["id"]: s for s in schema["subsets"]}
+                self.assertTrue(re.match(r'^parent \((pregnancy|child) or (pregnancy|child)\)$',
+                                subsets["parent"]["name"]))
+                self.assertEqual(subsets["parent"]["structure"], {"case_name": {}})
+
     # -- helpers --
 
     def assert_has_kv_pairs(self, test_dict, expected_dict):
@@ -224,5 +245,16 @@ class SchemaTest(SimpleTestCase):
         if case_updates:
             assert case_type, 'case_type is required with case_updates'
             self.factory.form_requires_case(
+                form, case_type=case_type, update=case_updates)
+        return form
+
+    def add_form_app_2(self, case_type=None, case_updates=None):
+        module_id = len(self.factory_2.app.modules)
+        module, form = self.factory_2.new_basic_module(module_id, case_type)
+        if case_type:
+            self.factory_2.form_opens_case(form, case_type)
+        if case_updates:
+            assert case_type, 'case_type is required with case_updates'
+            self.factory_2.form_requires_case(
                 form, case_type=case_type, update=case_updates)
         return form

--- a/corehq/apps/app_manager/tests/test_util.py
+++ b/corehq/apps/app_manager/tests/test_util.py
@@ -214,7 +214,7 @@ class SchemaTest(SimpleTestCase):
                 self.factory.app.case_sharing = True
                 self.factory_2.app.case_sharing = True
 
-                referral = self.add_form("referral")
+                self.add_form("referral")
                 child = self.add_form("child")
                 self.factory.form_opens_case(child, case_type='referral', is_subcase=True)
                 pregnancy = self.add_form("pregnancy")

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -6,7 +6,9 @@ import os
 import uuid
 import yaml
 from corehq import toggles
-from corehq.apps.app_manager.dbaccessors import get_apps_in_domain
+from corehq.apps.app_manager.dbaccessors import (
+    get_apps_in_domain, get_case_sharing_apps_in_domain
+)
 from corehq.apps.app_manager.exceptions import SuiteError
 from corehq.apps.app_manager.xpath import DOT_INTERPOLATE_PATTERN, UserCaseXPath
 from corehq.apps.builds.models import CommCareBuildConfig
@@ -194,11 +196,24 @@ class ParentCasePropertyBuilder(object):
                 forms_info.append((module.case_type, form))
         return forms_info
 
+    @property
+    @memoized
+    def case_sharing_app_forms_info(self):
+        forms_info = []
+        if self.app.case_sharing:
+            for app in self.get_other_case_sharing_apps_in_domain():
+                for module in app.get_modules():
+                    for form in module.get_forms():
+                        forms_info.append((module.case_type, form))
+        return forms_info
+
     @memoized
     def get_parent_types_and_contributed_properties(self, case_type):
         parent_types = set()
         case_properties = set()
-        for m_case_type, form in self.forms_info:
+        forms_info = self.forms_info + self.case_sharing_app_forms_info
+
+        for m_case_type, form in forms_info:
             p_types, c_props = form.get_parent_types_and_contributed_properties(m_case_type, case_type)
             parent_types.update(p_types)
             case_properties.update(c_props)
@@ -211,8 +226,7 @@ class ParentCasePropertyBuilder(object):
 
     @memoized
     def get_other_case_sharing_apps_in_domain(self):
-        apps = get_apps_in_domain(self.app.domain, include_remote=False)
-        return [a for a in apps if a.case_sharing and a.id != self.app.id]
+        return get_case_sharing_apps_in_domain(self.app.domain, self.app.id)
 
     @memoized
     def get_properties(self, case_type, already_visited=(),
@@ -346,7 +360,7 @@ def get_casedb_schema(form):
     """
     app = form.get_app()
     base_case_type = form.get_module().case_type
-    case_types = app.get_case_types()
+    case_types = app.get_case_types() | app.get_shared_case_types()
     per_type_defaults = get_per_type_defaults(app.domain, case_types)
     builder = ParentCasePropertyBuilder(app, ['case_name'], per_type_defaults)
     related = builder.get_parent_type_map(case_types, allow_multiple_parents=True)


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?234605#1200955

Properly displays the case hierarchy whenever case types have relationships that are only defined in other applications. This caused errors in cmitfb and the case summary

@orangejenny @snopoke 
