### PR TITLE
excluding mobile workers from cc analytics

### DIFF
--- a/corehq/apps/analytics/tasks.py
+++ b/corehq/apps/analytics/tasks.py
@@ -254,8 +254,9 @@ def track_new_user_accepted_invite_on_hubspot(webuser, cookies, meta):
 
 
 @analytics_task()
-def track_clicked_preview_on_hubspot(webuser, cookies, meta):
-    _send_form_to_hubspot(HUBSPOT_CLICKED_PREVIEW_FORM_ID, webuser, cookies, meta)
+def track_clicked_preview_on_hubspot(couchuser, cookies, meta):
+    if couchuser.is_web_user():
+        _send_form_to_hubspot(HUBSPOT_CLICKED_PREVIEW_FORM_ID, couchuser, cookies, meta)
 
 
 @analytics_task()


### PR DESCRIPTION
@sravfeyn 
Mobile users authenticating for cloudcare were being tracked in hubspot and it was messing with some data. This makes sure only web users will get have data added to hubspot for our analytics related to cloudcare
