### PR TITLE
Don't allow existing usernames to be uploaded without ids

### DIFF
--- a/corehq/apps/users/bulkupload.py
+++ b/corehq/apps/users/bulkupload.py
@@ -25,7 +25,10 @@ from corehq.apps.groups.models import Group
 from corehq.apps.domain.forms import clean_password
 from corehq.apps.domain.models import Domain
 from corehq.apps.locations.models import SQLLocation
-from corehq.apps.users.dbaccessors.all_commcare_users import get_all_commcare_users_by_domain
+from corehq.apps.users.dbaccessors.all_commcare_users import (
+    get_all_commcare_users_by_domain,
+    get_user_docs_by_username,
+)
 from corehq.apps.users.models import UserRole
 
 from .forms import get_mobile_worker_max_username_length
@@ -85,6 +88,23 @@ def check_duplicate_usernames(user_specs):
     if duplicated_usernames:
         raise UserUploadError(_("The following usernames have duplicate entries in "
             "your file: " + ', '.join(duplicated_usernames)))
+
+
+def check_existing_usernames(user_specs, domain):
+    usernames_without_ids = set()
+
+    for row in user_specs:
+        username = row.get('username')
+        user_id = row.get('user_id')
+        if username and user_id:
+            continue
+        usernames_without_ids.add(normalize_username(username, domain))
+
+    existing_usernames = [u.get('username') for u in get_user_docs_by_username(usernames_without_ids)]
+
+    if existing_usernames:
+        raise UserUploadError(_("The following usernames already exist and must "
+            "have an id specified to be updated: " + ', '.join(existing_usernames)))
 
 
 class GroupMemoizer(object):

--- a/corehq/apps/users/tests/bulk_upload.py
+++ b/corehq/apps/users/tests/bulk_upload.py
@@ -4,6 +4,7 @@ from corehq.apps.accounting.tests.utils import DomainSubscriptionMixin
 from corehq.apps.commtrack.tests.util import CommTrackTest, make_loc
 from corehq.apps.users.bulkupload import (
     check_duplicate_usernames,
+    check_existing_usernames,
     SiteCodeToSupplyPointCache,
     UserLocMapping,
     UserUploadError,
@@ -301,3 +302,14 @@ class TestUserBulkUploadUtils(SimpleTestCase):
             check_duplicate_usernames(user_specs)
         except UserUploadError:
             self.fail('UserUploadError incorrectly raised')
+
+    def test_existing_username_with_no_id(self):
+        user_specs = [
+            {
+                u'username': u'hello',
+            },
+        ]
+
+        with patch('corehq.apps.users.bulkupload.get_user_docs_by_username',
+                return_value=[{'username': 'hello@domain.commcarehq.org'}]):
+            self.assertRaises(UserUploadError, check_existing_usernames, user_specs, 'domain')

--- a/corehq/apps/users/views/mobile/users.py
+++ b/corehq/apps/users/views/mobile/users.py
@@ -64,6 +64,7 @@ from corehq.apps.style.decorators import (
 from corehq.apps.users.analytics import get_search_users_in_domain_es_query
 from corehq.apps.users.bulkupload import (
     check_duplicate_usernames,
+    check_existing_usernames,
     check_headers,
     dump_users_and_groups,
     GroupNameError,
@@ -915,6 +916,12 @@ class UploadCommCareUsers(BaseManageCommCareUserView):
         # convert to list here because iterator destroys the row once it has
         # been read the first time
         self.user_specs = list(self.user_specs)
+
+        try:
+            check_existing_usernames(self.user_specs, self.domain)
+        except UserUploadError as e:
+            messages.error(request, _(e.message))
+            return HttpResponseRedirect(reverse(UploadCommCareUsers.urlname, args=[self.domain]))
 
         try:
             check_duplicate_usernames(self.user_specs)


### PR DESCRIPTION
Fails the entire upload if there's an existing username without a corresponding id.

@snopoke 
