### PR TITLE
CSS belongs in the head

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/form_designer.html
+++ b/corehq/apps/app_manager/templates/app_manager/form_designer.html
@@ -7,6 +7,11 @@
     {% if include_fullstory %}
         {% include 'analytics/fullstory.html' %}
     {% endif %}
+    {% if not vellum_debug %}
+        <link href="{% static "app_manager/js/vellum/style.css" %}" type="text/css" rel="stylesheet"/>
+    {% elif vellum_debug == "dev-min" %}
+        <link href="{% static 'formdesigner/_build/style.css' %}" type="text/css" rel="stylesheet"/>
+    {% endif %}
 {% endblock %}
 
 {% block js %}{{ block.super }}
@@ -14,11 +19,6 @@
 {% endblock %}
 
 {% block js-inline %}{{ block.super }}
-    {% if not vellum_debug %}
-        <link href="{% static "app_manager/js/vellum/style.css" %}" type="text/css" rel="stylesheet"/>
-    {% elif vellum_debug == "dev-min" %}
-        <link href="{% static 'formdesigner/_build/style.css' %}" type="text/css" rel="stylesheet"/>
-    {% endif %}
     {% if request.guided_tour %}{% include request.guided_tour.template %}{% endif %}
     <script>
         var CKEDITOR_BASEPATH = "{% static "app_manager/js/vellum/lib/ckeditor/" %}";


### PR DESCRIPTION
This is what's been causing the new "Display Text" placeholder to appear dark instead of light grey. ckeditor injects placeholder styles into the page's head, but they were getting overridden by style.css being included at the end of the body.

I'm guessing that putting the stylesheet link in the body instead of head was an oversight. Poked around in local hq with VELLUM_DEBUG off and didn't see anything obviously broken.

@biyeun / @emord 
