### PR TITLE
Re-instate pencil icons on app manager menu

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/managed_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/managed_app.html
@@ -51,8 +51,15 @@
                 placement: 'auto'
             });
             $('.edit-form-li').each(function () {
-                if (!{{ formdesigner|JSON }}) {
-                    $(this).find('.edit-form-pencil').addClass('no-data');
+                var $this = $(this);
+                if (!{{ formdesigner|JSON }} || !$this.hasClass("active")) {
+                    var $pencil = $this.find('.edit-form-pencil');
+                    $pencil.addClass('no-data');
+                    $this.hover(function() {
+                        $pencil.removeClass('no-data');
+                    }, function() {
+                        $pencil.addClass('no-data');
+                    });
                 }
             });
         });

--- a/corehq/apps/style/static/app_manager/less/app_manager/navigation.less
+++ b/corehq/apps/style/static/app_manager/less/app_manager/navigation.less
@@ -70,10 +70,10 @@ nav.app-manager-content {
     position: absolute;
     right: -13px;
     top: 3px;
-    opacity: 0.0;
+    opacity: 0.5;
     .transition(all .6s);
     &.no-data {
-      display: none;
+      opacity: 0.0;
     }
   }
 


### PR DESCRIPTION
Merged https://github.com/dimagi/commcare-hq/pull/12842 locally and realized that pencil icons aren't showing on hover.

@biyeun feel free to change, I just wanted to get a quick fix in

@NoahCarnahan this needs to be merged before today's deploy
