### PR TITLE
Invalidate initial restore cache on form submission for everyone!

### DIFF
--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -633,7 +633,7 @@ class RestoreConfig(object):
             task = get_async_restore_payload.delay(self)
             new_task = True
             # store the task id in cache
-            self.cache.set(self.async_cache_key, task.id, timeout=None)
+            self.cache.set(self.async_cache_key, task.id, timeout=24 * 60 * 60)
         try:
             response = task.get(timeout=self._get_task_timeout(new_task))
         except TimeoutError:

--- a/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/tests/test_async_restore.py
@@ -7,12 +7,12 @@ from celery.exceptions import TimeoutError
 from celery.result import AsyncResult
 
 from casexml.apps.case.xml import V2
-from casexml.apps.case.mock import CaseFactory
 from casexml.apps.case.tests.util import (
     delete_all_cases,
     delete_all_sync_logs,
 )
 from corehq.apps.domain.models import Domain
+from corehq.form_processor.tests.utils import run_with_all_backends
 from casexml.apps.phone.restore import (
     RestoreConfig,
     RestoreParams,
@@ -25,7 +25,6 @@ from casexml.apps.phone.restore import (
 from casexml.apps.phone.const import ASYNC_RESTORE_CACHE_KEY_PREFIX, RESTORE_CACHE_KEY_PREFIX
 from casexml.apps.phone.tasks import get_async_restore_payload, ASYNC_RESTORE_SENT
 from casexml.apps.phone.tests.utils import create_restore_user
-from couchforms.models import DefaultAuthContext
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 from corehq.util.test_utils import flag_enabled
 from corehq.apps.receiverwrapper.util import submit_form_locally
@@ -166,6 +165,7 @@ class AsyncRestoreTest(BaseAsyncRestoreTest):
         self.assertTrue(restore_config.force_cache)
 
     @flag_enabled('ASYNC_RESTORE')
+    @run_with_all_backends
     def test_restore_in_progress_form_submitted_kills_old_jobs(self):
         """If the user submits a form somehow while a job is running, the job should be terminated
         """
@@ -178,7 +178,7 @@ class AsyncRestoreTest(BaseAsyncRestoreTest):
         restore_config.cache.set(initial_sync_cache_id, fake_cached_thing)
 
         form = """
-        <data>
+        <data xmlns="http://openrosa.org/formdesigner/blah">
             <meta>
                 <userID>{user_id}</userID>
             </meta>
@@ -199,17 +199,18 @@ class AsyncRestoreTest(BaseAsyncRestoreTest):
             self.assertIsNone(restore_config.cache.get(initial_sync_cache_id))
 
     @flag_enabled('ASYNC_RESTORE')
-    def test_submit_system_form(self):
-        system_user_factory = CaseFactory(
-            domain=self.domain,
-            form_extras={
-                'auth_context': DefaultAuthContext()
-            }
-        )
-        # This would fail hard if there was no AuthContext:
-        # http://manage.dimagi.com/default.asp?234245
-        system_user_factory.create_case()
+    @run_with_all_backends
+    def test_submit_form_no_userid(self):
+        form = """
+        <data xmlns="http://openrosa.org/formdesigner/blah">
+            <meta>
+                <deviceID>test</deviceID>
+            </meta>
+        </data>
+        """
+        submit_form_locally(form, self.domain)
 
+    @run_with_all_backends
     @mock.patch.object(CachedPayload, 'finalize')  # fake that a cached payload exists
     @mock.patch.object(RestoreConfig, 'cache')
     @mock.patch('casexml.apps.phone.restore.get_async_restore_payload')

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -15,6 +15,7 @@ from django.http import (
 import sys
 import couchforms
 from casexml.apps.case.exceptions import PhoneDateValueError, IllegalCaseId, UsesReferrals
+from casexml.apps.case.xml import V2
 from corehq.toggles import ASYNC_RESTORE
 from corehq.apps.commtrack.exceptions import MissingProductId
 from corehq.apps.tzmigration import timezone_migration_in_progress
@@ -23,7 +24,7 @@ from corehq.form_processor.interfaces.dbaccessors import FormAccessors
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.parsers.form import process_xform_xml
 from corehq.form_processor.utils.metadata import scrub_meta
-from casexml.apps.phone.const import ASYNC_RESTORE_CACHE_KEY_PREFIX
+from casexml.apps.phone.const import ASYNC_RESTORE_CACHE_KEY_PREFIX, RESTORE_CACHE_KEY_PREFIX
 from couchforms.const import BadRequest, DEVICE_LOG_XMLNS
 from couchforms.models import DefaultAuthContext, UnfinishedSubmissionStub
 from couchforms.signals import successful_form_received
@@ -130,6 +131,9 @@ class SubmissionPost(object):
         if task_id is not None:
             revoke_celery_task(task_id)
             cache.delete(cache_key)
+
+        first_sync_cache_key = restore_cache_key(RESTORE_CACHE_KEY_PREFIX, user_id, version=V2)
+        cache.delete(first_sync_cache_key)
 
     def run(self):
         failure_result = self._handle_basic_failure_modes()

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -140,15 +140,13 @@ class SubmissionPost(object):
         if failure_result:
             return failure_result
 
-        if ASYNC_RESTORE.enabled(self.domain):
-            if not isinstance(self.auth_context, DefaultAuthContext):
-                # If this is a system form (with DefaultAuthContext) we don't invalidate restores
-                self._invalidate_async_tasks(self.auth_context.user_id)
-
         result = process_xform_xml(self.domain, self.instance, self.attachments)
         submitted_form = result.submitted_form
 
         self._post_process_form(submitted_form)
+
+        if ASYNC_RESTORE.enabled(self.domain):
+            self._invalidate_async_tasks(submitted_form.user_id)
 
         if submitted_form.is_submission_error_log:
             self.formdb.save_new_form(submitted_form)

--- a/corehq/form_processor/tests/test_basic_cases.py
+++ b/corehq/form_processor/tests/test_basic_cases.py
@@ -7,12 +7,17 @@ from casexml.apps.case.mock import CaseBlock
 from casexml.apps.case.tests.util import check_user_has_case
 from casexml.apps.case.util import post_case_blocks
 from casexml.apps.phone.tests.utils import create_restore_user
+from casexml.apps.phone.restore import restore_cache_key
+from casexml.apps.phone.const import RESTORE_CACHE_KEY_PREFIX
 from corehq.apps.domain.models import Domain
+from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from corehq.form_processor.interfaces.processor import FormProcessorInterface
 from corehq.form_processor.tests.utils import FormProcessorTestUtils, run_with_all_backends
 from corehq.form_processor.backends.couch.update_strategy import coerce_to_datetime
+from dimagi.utils.couch.cache.cache_core import get_redis_default_cache
+
 
 DOMAIN = 'fundamentals'
 
@@ -266,6 +271,22 @@ class FundamentalCaseTests(TestCase):
         # update the date_opened to date type to check for value on restore
         case['update']['date_opened'] = case['update']['date_opened'].date()
         check_user_has_case(self, user, case.as_xml())
+
+    @run_with_all_backends
+    def test_restore_caches_cleared(self):
+        cache = get_redis_default_cache()
+        cache_key = restore_cache_key(RESTORE_CACHE_KEY_PREFIX, 'user_id', version="2.0")
+        cache.set(cache_key, 'test-thing')
+        self.assertEqual(cache.get(cache_key), 'test-thing')
+        form = """
+            <data xmlns="http://openrosa.org/formdesigner/blah">
+                <meta>
+                    <userID>{user_id}</userID>
+                </meta>
+            </data>
+        """
+        submit_form_locally(form.format(user_id='user_id'), DOMAIN)
+        self.assertIsNone(cache.get(cache_key))
 
 
 def _submit_case_block(create, case_id, **kwargs):


### PR DESCRIPTION
Async restores were forcing initial syncs to be cached in redis, however this cache wasn't getting invalidated when a user submitted a form. Now, they are invalidated when that user submits any form. 

I'm not 100% sure this is desired behaviour, as this deviates from non-async domains which do the following:
- if the initial sync took over 1 minute, store the cache
- this cache gets invalidated after an hour, no matter if that user submitted forms or not (i.e. if they clear user data and do a restore - they will get old data)

Async domains now do the following:
- always cache the initial restore
- if the user submits a form, or after an hour, invalidate the cache (i.e. the initial restore is always recomputed if the user submits a form).

@phillipm was having issues with the integration tests as AFAIK it was relying on clearing user data and verifying that a restore worked properly.

@snopoke, do you think that we should invalidate initial restores when users submit a form for non async domains too?

CC: @kaapstorm 
