### PR TITLE
disable pagination arrows at the ends

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/css/formplayer.css
+++ b/corehq/apps/cloudcare/static/cloudcare/css/formplayer.css
@@ -55,6 +55,12 @@
     cursor: pointer;
 }
 
+.paginate-disabled {
+    cursor: not-allowed;
+    pointer-events: none;
+    opacity: .5;
+    box-shadow: none;
+}
 
 /* Small screens will have these styles, mainly used written for preview mode */
 @media (max-width: 768px) {
@@ -62,16 +68,20 @@
         margin-top: 14px;
         margin-bottom: 6px;
     }
+
     h3 {
         font-size: 16px;
     }
+
     h2 {
         font-size: 20px;
     }
+
     .app-icon {
         height: 75px;
         font-size: 75px;
     }
+
     .module-icon {
         height: 30px;
         font-size: 30px;

--- a/corehq/apps/cloudcare/templates/formplayer/case_list.html
+++ b/corehq/apps/cloudcare/templates/formplayer/case_list.html
@@ -40,21 +40,39 @@
     <div>
         <nav>
             <ul class="pagination">
-                <li class="page-item">
+                <% if (currentPage > 0) { %>
+                <li class="page-item" id="prev-page">
                     <a class="page-link" aria-label="Previous" data-id="<%= currentPage - 1 %>">
                         <span aria-hidden="true">&laquo;</span>
                         <span class="sr-only">Previous</span>
                     </a>
                 </li>
+                <% } else { %>
+                <li class="paginate-disabled">
+                    <a class="paginate-disabled">
+                        <span aria-hidden="true">&laquo;</span>
+                        <span class="sr-only">Previous</span>
+                    </a>
+                </li>
+                <% } %>
                 <% for (i = 0; i < pageCount; i++) { %>
                 <li class="page-item"><a class="page-link" data-id="<%= i %>"><%= i %></a></li>
                 <% } %>
-                <li class="page-item">
+                <% if (currentPage < pageCount - 1) { %>
+                <li class="page-item" id="next-page">
                     <a class="page-link" aria-label="Next" data-id="<%= currentPage + 1 %>">
                         <span aria-hidden="true">&raquo;</span>
                         <span class="sr-only">Next</span>
                     </a>
                 </li>
+                <% } else { %>
+                <li class="paginate-disabled">
+                    <a class="paginate-disabled">
+                        <span aria-hidden="true">&raquo;</span>
+                        <span class="sr-only">Next</span>
+                    </a>
+                </li>
+                <% } %>
             </ul>
         </nav>
     </div>


### PR DESCRIPTION
Fixes http://manage.dimagi.com/default.asp?235303 by disabling and greying out arrows at either end

![screen shot 2016-08-17 at 3 16 47 pm](https://cloud.githubusercontent.com/assets/2293064/17749899/af01a8fe-648d-11e6-9a9b-e86b672f6e0d.png)

@benrudolph I'm sure there's some more succinct to change the CSS tags inline but couldn't get it working
