### PR TITLE
Users can filter by country or/and sector on DimagiSphere

### DIFF
--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -883,7 +883,7 @@ class AdminDomainMapReport(AdminDomainStatsReport):
 
     def _calc_num_active_users_per_country(self, filters):
         active_users_per_country = (NestedTermAggregationsHelper(
-                                    base_query=DomainES(),
+                                    base_query=DomainES().filter(filters),
                                     terms=[AggregationTerm('countries', 'deployment.countries')],
                                     bottom_level_aggregation=SumAggregation('users', 'cp_n_active_cc_users')
                                     ).get_data())

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -542,6 +542,19 @@ FACET_MAPPING = [
     ]),
 ]
 
+DIMAGISPHERE_FACET_MAPPING = [
+    ("Location", True, [
+        {"facet": "deployment.countries.exact", "name": "Country", "collapsed": True},
+    ]),
+    ("Type", True, [
+        {"facet": "internal.area.exact", "name": "Sector", "expanded": True},
+        {"facet": "internal.sub_area.exact", "name": "Sub-Sector", "expanded": True},
+    ]),
+    ("Self Starters", False, [
+        {"facet": "internal.self_started", "name": "Self Started", "expanded": True},
+    ]),
+]
+
 
 class AdminReport(GenericTabularReport):
     dispatcher = AdminReportDispatcher
@@ -839,6 +852,7 @@ class AdminDomainMapReport(AdminDomainStatsReport):
     name = ugettext_noop('Project Map')
     facet_title = ugettext_noop("Project Facets")
     search_for = ugettext_noop("projects...")
+    es_facet_mapping = DIMAGISPHERE_FACET_MAPPING
     base_template = "hqadmin/project_map.html"
 
     exportable = False

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -898,21 +898,17 @@ class AdminDomainMapReport(AdminDomainStatsReport):
 
     def parse_params(self, es_params):
         es_filters = {}
+        country_params = es_params.get('deployment.countries.exact')
+        sector_params = es_params.get('internal.area.exact')
 
-        def get_country_params():
-            if es_params.get('deployment.countries.exact'):
-                return filters.term("deployment.countries", es_params.get('deployment.countries.exact'))
-
-        def get_sector_params():
-            if es_params.get('internal.area.exact'):
-                return filters.term("internal.area", es_params.get('internal.area.exact')[0].lower())
-
-        if get_country_params() is not None and get_sector_params() is not None:
-            es_filters = filters.AND(get_country_params(), get_sector_params())
-        elif get_country_params() is not None:
-            es_filters = get_country_params()
-        elif get_sector_params() is not None:
-            es_filters = get_sector_params()
+        if country_params and sector_params:
+            es_filters = (filters.AND(
+                            filters.term("deployment.countries", country_params),
+                            filters.term("internal.area", sector_params[0].lower())))
+        elif country_params:
+            es_filters = filters.term("deployment.countries", country_params)
+        elif sector_params:
+            es_filters = filters.term("internal.area", sector_params[0].lower())
 
         return es_filters
 


### PR DESCRIPTION
@NoahCarnahan @czue 

Modified the sidebar to allow users to only see filters by countries and sectors. Once filters are applied, DimagiSphere map will display new counts of active users / projects per country
