### PR TITLE
Fix case api

### DIFF
--- a/corehq/apps/api/models.py
+++ b/corehq/apps/api/models.py
@@ -12,6 +12,7 @@ from corehq.apps.api.resources import DictObject
 from corehq.form_processor.abstract_models import CaseToXMLMixin
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAccessors
 from couchforms import const
+from dateutil.parser import parse as parse_datetime
 from dimagi.ext.couchdbkit import *
 
 PERMISSION_POST_SMS = "POST_SMS"
@@ -159,6 +160,13 @@ class ESXFormInstance(DictObject):
         return self.form_data.get(const.TAG_NAME, "")
 
 
+def get_datetime_or_none(string):
+    try:
+        return parse_datetime(string)
+    except:
+        return None
+
+
 class ESCase(DictObject, CaseToXMLMixin):
     """This wrapper around case data returned from ES which
     provides attribute access and helper functions for
@@ -176,6 +184,10 @@ class ESCase(DictObject, CaseToXMLMixin):
             return open_action['server_date']
         except Exception:
             pass
+
+    @property
+    def opened_on(self):
+        return get_datetime_or_none(self._data['opened_on'])
 
     @property
     def indices(self):


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?235285

@snopoke there's a couple ways to fix the issue - this way opts to keep ESCase as close to resembling an actual case as possible (making the opened_on date be a timestamp rather than leaving it a string).  If you agree with this approach we should also probably do this for the other timestamps / booleans, etc.

@dannyroberts code buddy
