### PR TITLE
Add column info to UCR data API

### DIFF
--- a/corehq/apps/api/resources/v0_5.py
+++ b/corehq/apps/api/resources/v0_5.py
@@ -546,7 +546,7 @@ class StockTransactionResource(HqBaseResource, ModelResource):
 
 
 ConfigurableReportData = namedtuple("ConfigurableReportData", [
-    "data", "id", "domain", "total_records", "get_params", "next_page"
+    "data", "columns", "id", "domain", "total_records", "get_params", "next_page"
 ])
 
 
@@ -556,6 +556,7 @@ class ConfigurableReportDataResource(HqBaseResource, DomainSpecificResourceMixin
     ConfigurableReport view.
     """
     data = fields.ListField(attribute="data", readonly=True)
+    columns = fields.ListField(attribute="columns", readonly=True)
     total_records = fields.IntegerField(attribute="total_records", readonly=True)
     next_page = fields.CharField(attribute="next_page", readonly=True)
 
@@ -609,8 +610,14 @@ class ConfigurableReportDataResource(HqBaseResource, DomainSpecificResourceMixin
         report.set_filter_values(filter_values)
 
         page = list(report.get_data(start=start, limit=limit))
+
+        columns = [
+            {"header": column.header, "slug": column.slug}
+            for column in report.columns
+        ]
+
         total_records = report.get_total_records()
-        return page, total_records
+        return page, columns, total_records
 
     def obj_get(self, bundle, **kwargs):
         domain = kwargs['domain']
@@ -619,11 +626,12 @@ class ConfigurableReportDataResource(HqBaseResource, DomainSpecificResourceMixin
         limit = self._get_limit_param(bundle)
 
         report_config = self._get_report_configuration(pk, domain)
-        page, total_records = self._get_report_data(
+        page, columns, total_records = self._get_report_data(
             report_config, domain, start, limit, bundle.request.GET)
 
         return ConfigurableReportData(
             data=page,
+            columns=columns,
             total_records=total_records,
             id=report_config._id,
             domain=domain,

--- a/corehq/apps/userreports/sql/columns.py
+++ b/corehq/apps/userreports/sql/columns.py
@@ -22,6 +22,15 @@ class SqlColumnConfig(object):
         self.warnings = warnings if warnings is not None else []
 
 
+class UCRExpandDatabaseSubcolumn(DatabaseColumn):
+    """
+    A light wrapper around DatabaseColumn that stores the expand value that this DatabaseColumn is based on.
+    """
+    def __init__(self, header, agg_column, expand_value, format_fn=None, slug=None, *args, **kwargs):
+        self.expand_value = expand_value
+        super(UCRExpandDatabaseSubcolumn, self).__init__(header, agg_column, format_fn=None, slug=None, *args, **kwargs)
+
+
 def column_to_sql(column):
     # we have to explicitly truncate the column IDs otherwise postgres will do it
     # and will choke on them if there are duplicates: http://manage.dimagi.com/default.asp?175495
@@ -124,9 +133,10 @@ def _expand_column(report_column, distinct_values, lang):
         else:
             sql_agg_col = SumWhen(report_column.field, whens={val: 1}, else_=0, alias=alias)
 
-        columns.append(DatabaseColumn(
+        columns.append(UCRExpandDatabaseSubcolumn(
             u"{}-{}".format(report_column.get_header(lang), val),
             sql_agg_col,
+            val,
             sortable=False,
             data_slug=u"{}-{}".format(report_column.column_id, index),
             format_fn=report_column.get_format_fn(),

--- a/corehq/apps/userreports/sql/columns.py
+++ b/corehq/apps/userreports/sql/columns.py
@@ -28,7 +28,9 @@ class UCRExpandDatabaseSubcolumn(DatabaseColumn):
     """
     def __init__(self, header, agg_column, expand_value, format_fn=None, slug=None, *args, **kwargs):
         self.expand_value = expand_value
-        super(UCRExpandDatabaseSubcolumn, self).__init__(header, agg_column, format_fn=None, slug=None, *args, **kwargs)
+        super(UCRExpandDatabaseSubcolumn, self).__init__(
+            header, agg_column, format_fn=None, slug=None, *args, **kwargs
+        )
 
 
 def column_to_sql(column):


### PR DESCRIPTION
Addresses [#234901](http://manage.dimagi.com/default.asp?234901).

Adds the `"columns"` property to the object returned by the `ConfigurableReportDataResource` api endpoint. e.g.

``` json
{
  "columns": [
    {
      "header": "Name",
      "slug": "column_agg"
    },
    {
      "expand_column_value": "VT",
      "header": "state-VT",
      "slug": "column_0-0"
    },
    {
      "expand_column_value": "MA",
      "header": "state-MA",
      "slug": "column_0-1"
    }
  ],
  "data": [
    {
      "column_0-0": 1,
      "column_0-1": 1,
      "column_agg": "Noah"
    },
    ...
  ],
  ...
}
```

@snopoke @gcapalbo  Best reviewed commit-by-commit.
