### PR TITLE
Stock form export conversion

### DIFF
--- a/corehq/apps/export/tests/data/saved_export_schemas/stock_form_export.json
+++ b/corehq/apps/export/tests/data/saved_export_schemas/stock_form_export.json
@@ -1,0 +1,36 @@
+{
+    "_id": "6d7dfbcd373fdf08bb53f789e3ed4085",
+    "_rev": "5-77bce367d7a323b55a676acb0febe77b",
+    "app_id": "49b24e49b80a9ff27a7077df27b5d1b8",
+    "converted_saved_export_id": null,
+    "default_format": "xlsx",
+    "doc_type": "SavedExportSchema",
+    "domain": null,
+    "filter_function": "[]",
+    "include_errors": false,
+    "index": "[\"gcs-field\", \"http://openrosa.org/formdesigner/F77734D1-10C8-4B5B-87A3-6F4FDFBDD044\"]",
+    "is_safe": false,
+    "name": "Receive Stock",
+    "schema_id": "7148e256c21d00ad16a7ef95a2836d92",
+    "split_multiselects": false,
+    "tables": [
+        {
+            "columns": [
+                {
+                    "display": "product",
+                    "doc_type": "ExportColumn",
+                    "index": "form.transfer.entry.@id",
+                    "is_sensitive": false,
+                    "show": false,
+                    "tag": null,
+                    "transform": null
+                }
+            ],
+            "display": "Main table",
+            "doc_type": "ExportTable",
+            "index": "#"
+        }
+    ],
+    "transform_dates": true,
+    "type": "form"
+}

--- a/corehq/apps/export/tests/data/saved_export_schemas/stock_form_export_repeat.json
+++ b/corehq/apps/export/tests/data/saved_export_schemas/stock_form_export_repeat.json
@@ -1,0 +1,37 @@
+{
+    "_id": "6d7dfbcd373fdf08bb53f789e3ed4085",
+    "_rev": "5-77bce367d7a323b55a676acb0febe77b",
+    "app_id": "49b24e49b80a9ff27a7077df27b5d1b8",
+    "converted_saved_export_id": null,
+    "default_format": "xlsx",
+    "doc_type": "SavedExportSchema",
+    "domain": null,
+    "filter_function": "[]",
+    "include_errors": false,
+    "index": "[\"gcs-field\", \"http://openrosa.org/formdesigner/F77734D1-10C8-4B5B-87A3-6F4FDFBDD044\"]",
+    "is_safe": false,
+    "name": "Receive Stock",
+    "schema_id": "7148e256c21d00ad16a7ef95a2836d92",
+    "split_multiselects": false,
+    "tables": [
+        {
+            "columns": [
+                {
+                    "display": "product",
+                    "doc_type": "ExportColumn",
+                    "index": "transfer.entry.@id",
+                    "is_sensitive": false,
+                    "show": false,
+                    "tag": null,
+                    "transform": null
+                }
+            ],
+            "display": "Main table",
+            "doc_type": "ExportTable",
+            "index": "#.form.repeat.#"
+        }
+    ],
+    "transform_dates": true,
+    "type": "form"
+}
+

--- a/corehq/apps/export/tests/test_export_conversion.py
+++ b/corehq/apps/export/tests/test_export_conversion.py
@@ -632,6 +632,23 @@ class TestConvertStockFormExport(TestConvertBase):
                     ],
                     last_occurrences={cls.app_id: 2},
                 ),
+                ExportGroupSchema(
+                    path=[PathNode(name='form'), PathNode(name='repeat', is_repeat=True)],
+                    items=[
+                        StockItem(
+                            path=[
+                                PathNode(name='form'),
+                                PathNode(name='repeat', is_repeat=True),
+                                PathNode(name='transfer:questionid'),
+                                PathNode(name='entry'),
+                                PathNode(name='@id'),
+                            ],
+                            label='Question 1',
+                            last_occurrences={cls.app_id: 3},
+                        ),
+                    ],
+                    last_occurrences={cls.app_id: 2},
+                ),
             ]
         )
 
@@ -646,6 +663,27 @@ class TestConvertStockFormExport(TestConvertBase):
         index, column = table.get_column(
             [
                 PathNode(name='form'),
+                PathNode(name='transfer:questionid'),
+                PathNode(name='entry'),
+                PathNode(name='@id'),
+            ],
+            'StockItem',
+            None,
+        )
+        self.assertTrue(column.selected)
+
+    def test_convert_form_export_stock_in_repeat(self, _, __):
+        saved_export_schema = SavedExportSchema.wrap(self.get_json('stock_form_export_repeat'))
+        with mock.patch(
+                'corehq.apps.export.models.new.FormExportDataSchema.generate_schema_from_builds',
+                return_value=self.schema):
+            instance, _ = convert_saved_export_to_export_instance(self.domain, saved_export_schema)
+
+        table = instance.get_table([PathNode(name='form'), PathNode(name='repeat', is_repeat=True)])
+        index, column = table.get_column(
+            [
+                PathNode(name='form'),
+                PathNode(name='repeat', is_repeat=True),
                 PathNode(name='transfer:questionid'),
                 PathNode(name='entry'),
                 PathNode(name='@id'),

--- a/corehq/apps/export/tests/test_export_conversion.py
+++ b/corehq/apps/export/tests/test_export_conversion.py
@@ -25,6 +25,7 @@ from corehq.apps.export.utils import (
     _convert_index_to_path_nodes,
     revert_new_exports,
     _is_remote_app_conversion,
+    _is_form_stock_question,
     migrate_domain,
 )
 from corehq.apps.export.const import (
@@ -70,6 +71,30 @@ class TestMigrateDomain(TestCase):
         self.assertFalse(toggle_enabled(NEW_EXPORTS.slug, self.domain, namespace=NAMESPACE_DOMAIN))
         migrate_domain(self.domain)
         self.assertTrue(toggle_enabled(NEW_EXPORTS.slug, self.domain, namespace=NAMESPACE_DOMAIN))
+
+
+class TestIsFormStockExportQuestion(SimpleTestCase):
+    """Ensures that we can guess that a column is a stock question"""
+
+
+@generate_cases([
+    ('form.balance.entry.@id', True),
+    ('form.balance.entry.@notme', False),
+    ('form.balance.@date', True),
+    ('form.balance.@notme', False),
+
+    ('form.transfer.entry.@id', True),
+    ('form.transfer.entry.@notme', False),
+    ('form.transfer.@date', True),
+    ('form.transfer.@notme', False),
+
+    ('form.notme.@quantity', False),
+    ('tooshort', False),
+    ('tooshort.tooshort', False),
+    ('', False),
+], TestIsFormStockExportQuestion)
+def test_is_form_stock_question(self, index, expected):
+    self.assertEqual(_is_form_stock_question(index), expected)
 
 
 class TestIsRemoteAppConversion(TestCase):

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -147,10 +147,12 @@ def convert_saved_export_to_export_instance(domain, saved_export, dryrun=False):
                         column_index=column.index,
                     )
                     info.append('Column is part of a repeat: {}'. format(old_table.index))
+
                 column_path = _convert_index_to_path_nodes(index)
                 # The old style column indexes always look like they contains no repeats,
                 # so replace that parts that could be repeats with the table path
                 column_path = table_path + column_path[len(table_path):]
+
 
                 system_property = _get_system_property(
                     column.index,
@@ -174,6 +176,16 @@ def convert_saved_export_to_export_instance(domain, saved_export, dryrun=False):
                     new_column = _get_for_single_node_repeat(instance.tables, column_path, transform)
                     if new_column:
                         info.append('Column is for a repeat with just a single instance')
+
+                # If we still haven't found the column, try to find it as a stock question
+                if not new_column and _is_form_stock_question(index):
+                    new_column = _get_column_for_stock_form_export(
+                        new_table,
+                        column_path,
+                        index
+                    )
+                    if new_column:
+                        info.append('Column is a stock form question')
 
                 if not new_column:
                     raise SkipConversion('Column not found in new schema')
@@ -282,11 +294,38 @@ def _get_for_single_node_repeat(tables, column_path, transform):
             return new_column
 
 
+def _get_column_for_stock_form_export(new_table, column_path, index):
+    # Takes a path like column.transfer:question_id.@date
+    # and maps it to column.transfer.@date
+    def _remove_question_id_from_path(path):
+        parts = path.split('.')
+        parts_without_question_ids = map(lambda part: part.split(':')[0], parts)
+        return '.'.join(parts_without_question_ids)
+
+    stock_columns = filter(lambda c: c.item.doc_type == 'StockItem', new_table.columns)
+
+    # Map column to its readable path (dot path)
+    stock_column_to_readable_path = {c: c.item.readable_path for c in stock_columns}
+
+    matched_columns = []
+    for column, readable_path in stock_column_to_readable_path.iteritems():
+        if _remove_question_id_from_path(readable_path) == index:
+            matched_columns.append(column)
+
+    if len(matched_columns) == 1:
+        return matched_columns[0]
+    elif len(matched_columns) == 0:
+        return None
+    else:
+        raise SkipConversion('Multiple matched stock nodes')
+
+
 def _is_form_stock_question(index):
     parts = index.split('.')
     parent_stock_attributes = ['@date', '@type', '@entity-id', '@section-id']
     entry_stock_attributes = ['@id', '@quantity']
 
+    # Attempts to take a balance node and convert it. It is looks for an index that matches:
     # <balance|transfer>.<@date|@type...>
     try:
         parent_tag_name, attribute = parts[-2:]
@@ -296,6 +335,7 @@ def _is_form_stock_question(index):
     except ValueError:
         return False
 
+    # Attempts to take an entry node and convert it. It is looks for an index that matches:
     # <balance|transfer>.entry.<@id|@quantity>
     try:
         parent_tag_name, tag_name, attribute = parts[-3:]
@@ -388,7 +428,6 @@ def _get_normal_column(new_table, column_path, transform):
         'MultipleChoiceItem',
         'GeopointItem',
         'MultiMediaItem',
-        'StockItem',
         'ExportItem',
     ]
     # Since old exports had no concept of item type, we just guess all


### PR DESCRIPTION
@czue @NoahCarnahan this'll enable stock conversion for most cases. in the edge case where people have two stock question at the same level, there's no way to distinguish which question it is so we just have to ignore it 😕 the more i'm looking at the migration log the more impossible this task seems. i think there are a few bugs in the export generation code in the legacy system that generate indexes that are impossible to map to the new exports and don't yield any data anyways 🐟 or 🏠 
