### PR TITLE
POC rip out fab dependency

### DIFF
--- a/corehq/apps/hqadmin/pillow_settings.py
+++ b/corehq/apps/hqadmin/pillow_settings.py
@@ -1,4 +1,5 @@
 import jsonobject
+import os
 import yaml
 
 
@@ -95,7 +96,6 @@ def test_pillow_settings(env_name, pillows_by_group, extra_debugging=False):
         print dump_yaml([action.to_json()
                          for action in get_pillow_actions_for_env(env_name)])
 
-    from fab.utils import get_pillow_env_config
     pillows = list(get_pillows_for_env([get_pillow_env_config(env_name)], pillows_by_group=pillows_by_group))
 
     print 'Included Pillows'
@@ -104,3 +104,21 @@ def test_pillow_settings(env_name, pillows_by_group, extra_debugging=False):
     print 'Excluded Pillows'
     pillow_configs = list(_get_pillow_configs_from_settings_dict(pillows_by_group))
     print dump_yaml(sorted(set(pillow_configs) - set(pillows)))
+
+
+def get_pillow_env_config(environment):
+    pillow_conf = {}
+    pillow_file = os.path.join(
+        'deployment/commcare-hq-deploy/fab',
+        'pillows',
+        '{}.yml'.format(environment)
+    )
+    if os.path.exists(pillow_file):
+        with open(pillow_file, 'r+') as f:
+            yml = yaml.load(f)
+            pillow_conf.update(yml)
+    else:
+        return None
+
+    return pillow_conf
+


### PR DESCRIPTION
@czue do you have opinions on ripping out the deploy submodule? this is the last hard dependency we have on it in HQ (there's one other reference to it in the `scripts` dir but that can be easily moved). part of me feels like it's easier to iterate on deploy when you don't have to update the submodule, but the other part feels like it's kind of nice to run deploy from the hq directory. i also think having deploy stand alone in its own repo will totally kill the notion that the code you have locally is in any way tied to the deploy.

this pr is mainly to open the idea, not a full fledged implementation yet
