### PR TITLE
Dynamically display the total number of active/real projects on DimagiSphere

### DIFF
--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -896,6 +896,12 @@ class AdminDomainMapReport(AdminDomainStatsReport):
                                    .size(0).run().aggregations.countries.counts_by_bucket())
         return num_projects_by_country
 
+    def _calc_total_active_real_projects(self, filters):
+        total_num_projects = (DomainES().is_active().real_domains()
+                              .filter(filters)
+                              .count())
+        return total_num_projects
+
     def parse_params(self, es_params):
         es_filters = {}
         country_params = es_params.get('deployment.countries.exact')
@@ -918,6 +924,7 @@ class AdminDomainMapReport(AdminDomainStatsReport):
         params = self.parse_params(self.es_params)
         json['users_per_country'] = dict(self._calc_num_active_users_per_country(params))
         json['country_projs_count'] = self._calc_num_projs_per_countries(params)
+        json['total_num_projects'] = self._calc_total_active_real_projects(params)
         return json
 
 class AdminUserReport(AdminFacetedReport):

--- a/corehq/apps/hqadmin/static/hqadmin/js/project_map.js
+++ b/corehq/apps/hqadmin/static/hqadmin/js/project_map.js
@@ -32,12 +32,12 @@ var projectMapInit = function(mapboxAccessToken) {
 
                 projects_per_country = data.country_projs_count;
                 users_per_country = data.users_per_country;
+                totalNumProjects = data.total_num_projects;
 
                 Object.keys(projects_per_country).map(function(country) {
                     if (projects_per_country[country] > maxNumProjects) {
                         maxNumProjects = projects_per_country[country];
                     }
-                    totalNumProjects += projects_per_country[country];
                 });
 
                 Object.keys(users_per_country).map(function(country) {


### PR DESCRIPTION
@czue @calellowitz 

Fixing a bug. Previously, total number of active/real projects = the sum of number of projects per country. However, this was misleading since a project could be deployed in multiple countries and would be over-counted (once for each country it is deployed in). Now, total number of active/real projects is calculated on the backend.
