### PR TITLE
Limit get_session_schema to basic and case-free modules

### DIFF
--- a/corehq/apps/app_manager/tests/test_util.py
+++ b/corehq/apps/app_manager/tests/test_util.py
@@ -193,19 +193,6 @@ class SchemaTest(SimpleTestCase):
             },
         })
 
-    def test_get_session_schema_advanced_form(self):
-        m2, m2f0 = self.factory.new_advanced_module('visit history', 'visit')
-        self.factory.form_requires_case(m2f0, 'visit')
-
-        schema = util.get_session_schema(m2f0)
-        self.assertDictEqual(schema["structure"]["case_id_load_visit_0"], {
-            "reference": {
-                "source": "casedb",
-                "subset": "case",
-                "key": "@case_id",
-            },
-        })
-
     def test_get_case_sharing_hierarchy(self):
         with patch('corehq.apps.app_manager.util.get_case_sharing_apps_in_domain') as mock_sharing:
             mock_sharing.return_value = [self.factory.app, self.factory_2.app]

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -417,20 +417,24 @@ def get_casedb_schema(form):
 def get_session_schema(form):
     """Get form session schema definition
     """
+    from corehq.apps.app_manager.suite_xml.sections.entries import EntriesHelper
+    structure = {}
+    datums = EntriesHelper(form.get_app()).get_datums_meta_for_form_generic(form)
+    for datum in datums:
+        if not datum.is_new_case_id and datum.case_type and datum.datum.id == 'case_id':
+            structure['case_id'] = {
+                "reference": {
+                    "source": "casedb",
+                    "subset": "case",
+                    "key": "@case_id",
+                },
+            }
     return {
         "id": "commcaresession",
         "uri": "jr://instance/session",
         "name": "Session",
         "path": "/session/data",
-        "structure": {
-            "case_id": {
-                "reference": {
-                    "source": "casedb",
-                    "subset": "case",
-                    "key": "@case_id",
-                }
-            },
-        },
+        "structure": structure,
     }
 
 

--- a/corehq/apps/app_manager/util.py
+++ b/corehq/apps/app_manager/util.py
@@ -417,25 +417,20 @@ def get_casedb_schema(form):
 def get_session_schema(form):
     """Get form session schema definition
     """
-    from corehq.apps.app_manager.suite_xml.sections.entries import EntriesHelper
-    structure = {}
-    datums = EntriesHelper(form.get_app()).get_datums_meta_for_form_generic(form)
-    for datum in datums:
-        if not datum.is_new_case_id and datum.case_type:
-            session_var = datum.datum.id
-            structure[session_var] = {
-                "reference": {
-                    "source": "casedb",
-                    "subset": "case",
-                    "key": "@case_id",
-                },
-            }
     return {
         "id": "commcaresession",
         "uri": "jr://instance/session",
         "name": "Session",
         "path": "/session/data",
-        "structure": structure,
+        "structure": {
+            "case_id": {
+                "reference": {
+                    "source": "casedb",
+                    "subset": "case",
+                    "key": "@case_id",
+                }
+            },
+        },
     }
 
 


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?235160

Basically a bug in https://github.com/dimagi/commcare-hq/pull/12252 (specifically https://github.com/dimagi/commcare-hq/pull/12252/files#diff-8a78f7edae07ff768accdb85fbaace47R385), which didn't work with parent child case selection. Side effect is that `get_session_schema` no longer supports advanced modules at all, which is unfortunate but I think tolerable, since it's only used by vellum case management, which itself doesn't support advanced modules.

@emord 
cc @biyeun 
