### PR TITLE
Change properties displayed for top 5 projects on DimagiSphere

### DIFF
--- a/corehq/apps/hqadmin/static/hqadmin/js/project_map.js
+++ b/corehq/apps/hqadmin/static/hqadmin/js/project_map.js
@@ -219,7 +219,7 @@ var projectMapInit = function(mapboxAccessToken) {
                 formattedCountryName += country.substring(1).toLowerCase();
             }
             return formattedCountryName;
-        })
+        });
     }
 
     function onEachFeature(feature, layer) {

--- a/corehq/apps/hqadmin/static/hqadmin/js/project_map.js
+++ b/corehq/apps/hqadmin/static/hqadmin/js/project_map.js
@@ -101,7 +101,7 @@ var projectMapInit = function(mapboxAccessToken) {
             var self = this;
             self.selectedCountry = ko.observable('country name');
             self.selectedProject = ko.observable('project name');
-            self.tableProperties = ['Name', 'Sector', 'Organization', 'Deployment Date'];
+            self.tableProperties = ['Organization', 'Sector', 'Deployed', 'Active Users', 'Countries'];
             self.topFiveProjects = ko.observableArray();
         };
 
@@ -210,6 +210,18 @@ var projectMapInit = function(mapboxAccessToken) {
         info.update();
     }
 
+    function formatCountryNames(countries) {
+        return countries.map(function(country) {
+            var formattedCountryName = country.charAt(0).toUpperCase();
+            if (country.indexOf(",") > -1) {
+                formattedCountryName += country.substring(1, country.indexOf(",")).toLowerCase();
+            } else {
+                formattedCountryName += country.substring(1).toLowerCase();
+            }
+            return formattedCountryName;
+        })
+    }
+
     function onEachFeature(feature, layer) {
         layer.on({
             mouseover: highlightFeature,
@@ -224,11 +236,16 @@ var projectMapInit = function(mapboxAccessToken) {
                     datatype: "json",
                 }).done(function(data){
                     data[country].forEach(function(project){
+                        var deploymentDate = project['deployment']['date'];
+                        if (deploymentDate) {
+                            deploymentDate = deploymentDate.substring(0, 10);
+                        }
                         selectionModel.topFiveProjects.push({
-                            name: project['name'],
-                            sector: project['internal']['area'],
                             organization: project['internal']['organization_name'],
-                            deployment: project['deployment']['date'].substring(0,10),
+                            sector: project['internal']['area'],
+                            deployment: deploymentDate,
+                            active_users: project['cp_n_active_cc_users'],
+                            countries: formatCountryNames(project['deployment']['countries']).join(', '),
                         });
                     });
                 });

--- a/corehq/apps/hqadmin/static/hqadmin/js/project_map.js
+++ b/corehq/apps/hqadmin/static/hqadmin/js/project_map.js
@@ -210,7 +210,7 @@ var projectMapInit = function(mapboxAccessToken) {
         info.update();
     }
 
-    function formatCountryNames(countries) {
+    function capitalizeCountryNames(countries) {
         return countries.map(function(country) {
             var formattedCountryName = country.charAt(0).toUpperCase();
             if (country.indexOf(",") > -1) {
@@ -245,7 +245,7 @@ var projectMapInit = function(mapboxAccessToken) {
                             sector: project['internal']['area'],
                             deployment: deploymentDate,
                             active_users: project['cp_n_active_cc_users'],
-                            countries: formatCountryNames(project['deployment']['countries']).join(', '),
+                            countries: capitalizeCountryNames(project['deployment']['countries']).join(', '),
                         });
                     });
                 });

--- a/corehq/apps/hqadmin/templates/hqadmin/project_map.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/project_map.html
@@ -47,9 +47,15 @@
     <div class="modal-dialog" role="document">
       <div class="modal-content">
         <div class="modal-header row">
-            <h4 class="modal-title table center" id="modal-title">
-              <span>Projects in <span class="country-name" data-bind="text: selectedCountry"></span></span>
-            </h4>
+            <div class="col-md-2"></div>
+            <div class="col-md-8 center">
+                <h4 class="modal-title table center" id="modal-title">
+                    <span>Projects in <span class="country-name" data-bind="text: selectedCountry"></span> with the Most Users</span>
+                </h4>
+            </div>
+            <div class="col-md-2">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            </div>
         </div>
         <div class="modal-body">
           <div class="table">

--- a/corehq/apps/hqadmin/templates/hqadmin/project_map.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/project_map.html
@@ -61,10 +61,11 @@
               </thead>
               <tbody data-bind="foreach: {data: topFiveProjects}">
                 <tr class="project-row">
-                  <td data-bind="text: name"></td>
-                  <td data-bind="text: sector"></td>
                   <td data-bind="text: organization"></td>
+                  <td data-bind="text: sector"></td>
                   <td data-bind="text: deployment"></td>
+                  <td data-bind="text: active_users"></td>
+                  <td data-bind="text: countries"></td>
                 </tr>
               </tbody>
             </table>

--- a/corehq/apps/hqadmin/views.py
+++ b/corehq/apps/hqadmin/views.py
@@ -1186,9 +1186,8 @@ def top_five_projects_by_country(request):
         projects = (DomainES().is_active()
                     .filter(filters.term('deployment.countries', country))
                     .sort('cp_n_active_cc_users', True)
-                    .source(['name', 'cp_n_active_cc_users',
-                             'deployment.countries', 'internal.organization_name',
-                             'internal.area', 'internal.notes', 'deployment.date'])
+                    .source(['internal.organization_name', 'internal.area',
+                             'deployment.date', 'cp_n_active_cc_users', 'deployment.countries'])
                     .size(5).run().hits)
         data = {country: projects}
     return json_response(data)


### PR DESCRIPTION
Per feedback from Gillian, when user clicks on a country, it will display top five most active projects based on the number of active mobile users with the following properties: 
- organization name
- sector
- deployment date
- number of active users
- countries

@czue
