### PR TITLE
Change color scale for DimagiSphere

### DIFF
--- a/corehq/apps/hqadmin/static/hqadmin/js/project_map.js
+++ b/corehq/apps/hqadmin/static/hqadmin/js/project_map.js
@@ -2,7 +2,7 @@ var projectMapInit = function(mapboxAccessToken) {
     // courtesy of http://colorbrewer2.org/
     var COUNTRY_COLORS = ['#fef0d9','#fdd49e','#fdbb84','#fc8d59','#e34a33','#b30000'];
     var PROJECT_COUNTS_THRESHOLD = [10, 20, 30, 40, 50];
-    var USER_COUNTS_THRESHOLD = [100, 200, 300, 400, 500];
+    var USER_COUNTS_THRESHOLD = [10, 100, 500, 1000, 4000];
 
     var selectionModel;
 
@@ -283,7 +283,7 @@ var projectMapInit = function(mapboxAccessToken) {
             div.innerHTML += thresholds[i] + '<br>';
         }
         div.innerHTML += '<i style="background:' + COUNTRY_COLORS[thresholds.length] + '"></i> '
-                         + (thresholds[thresholds.length-1] + 1)+ '&ndash;';
+                         + (thresholds[thresholds.length-1] + 1)+ '+';
 
         return div;
     };


### PR DESCRIPTION
Per feedback from Gillian on [Google Doc](https://docs.google.com/document/d/1-uhfUmCWBtu9E6N930dede33uVwC5aYZlvMNHpE3vnU/edit), changed the color scale for displaying the number of active mobile users to better show distribution

@czue 
