### PR TITLE
upgrade underscore to 1.8

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,8 +3,7 @@
   "version": "0.0.1",
   "dependencies": {
     "jquery": "1.11.1",
-    "underscore": "1.6.0",
-    "underscore-1.8.3": "underscore#1.8.3",
+    "underscore": "1.8.3",
     "jquery-form": "3.45.0",
     "jquery.cookie": "dimagi/jquery-cookie#1.4.1",
     "jquery-timeago": "1.2.0",

--- a/corehq/apps/cloudcare/templates/formplayer/dependencies.html
+++ b/corehq/apps/cloudcare/templates/formplayer/dependencies.html
@@ -1,5 +1,5 @@
 {% load hq_shared_tags %}
-<script src="{% static 'underscore-1.8.3/underscore.js' %}"></script>
+<script src="{% static 'underscore/underscore.js' %}"></script>
 <script src="{% static 'backbone-1.3.2/backbone.js' %}"></script>
 <script src="{% static 'backbone.marionette/lib/backbone.marionette.js' %}"></script>
 <script src="{% static 'nprogress/nprogress.js' %}"></script>


### PR DESCRIPTION
Would like to merge concurrently with https://github.com/dimagi/Vellum/pull/721 for the sake of sanity (might not actually be necessary).

Will put on staging for a bit, but release notes imply that the only breaking changes are to `_.matches`, which we don't use, and `_.template`, which are addressed in https://github.com/dimagi/commcare-hq/pull/12897 and https://github.com/dimagi/MediaUploader/pull/19

@emord / @biyeun 
