### PR TITLE
Fix cloudcare

### DIFF
--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -114,7 +114,7 @@ class CloudcareMain(View):
             else:
                 # legacy functionality - use the latest build regardless of stars
                 apps = [get_latest_build_doc(domain, app['_id']) for app in apps]
-                apps = [get_app_json(app) for app in apps if app]
+                apps = [get_app_json(ApplicationBase.wrap(app)) for app in apps if app]
 
         else:
             # big TODO: write a new apps view for Formplayer, can likely cut most out now


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?235516

looks like we need to leave [line 117 of cloudcare/views.py](https://github.com/dimagi/commcare-hq/pull/12870/files#diff-06a95e48a38d4b903d82b63e672199ebL117) as it was before that change since the result from `get_latest_build_doc` didn't change (it's still a dict)
