### PR TITLE
bootstrap 3.3.6 => 3.3.7

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -47,7 +47,7 @@
     "bootstrap-tour": "0.10.2",
     "jquery.caret": "~1.5.2",
     "syntaxhighlighter": "alexgorbatchev/syntaxhighlighter#3.0.83",
-    "bootstrap": "3.3.6",
+    "bootstrap": "3.3.7",
     "font-awesome": "fontawesome#4.5.0",
     "ui-select": "angular-ui/ui-select#v0.13.2",
     "jquery-migrate": "1.2.1",
@@ -64,7 +64,7 @@
   "private": true,
   "resolutions": {
     "jquery": "1.11.1",
-    "bootstrap": "3.3.6",
+    "bootstrap": "3.3.7",
     "select2": "4.0.0",
     "underscore": "1.6.0",
     "backbone": "0.9.1"


### PR DESCRIPTION
Upgrade bootstrap so we can eventually use jQuery 3.

Release notes say there aren't many changes: https://github.com/twbs/bootstrap/releases/tag/v3.3.7

This is a minor enough upgrade that I don't think passive testing on staging will be useful. Quickly checked locally everything I could think of that's bootstrap-related: tooltips, modals, tabs, dropdowns, datepicker, timepicker, typeahead, guided tour, datatables, and vellum's tooltips/dropdowns/modals.

@emord 
