### PR TITLE
Fix JS error on UCRs

### DIFF
--- a/corehq/apps/reports_core/templates/reports_core/base_template_new.html
+++ b/corehq/apps/reports_core/templates/reports_core/base_template_new.html
@@ -59,11 +59,13 @@
         };
 
         var paginationNotice = function (data) {
-            if (data.aaData.length < data.iTotalRecords) {
-                $('#info-message').html("{% trans 'Showing the current page of data. Switch pages to see more data.' %}");
-                $('#report-info').removeClass('hide');
-            } else {
-                $('#report-info').addClass('hide');
+            if (data.aaData !== undefined && data.iTotalRecords !== undefined) {
+                if (data.aaData.length < data.iTotalRecords) {
+                    $('#info-message').html("{% trans 'Showing the current page of data. Switch pages to see more data.' %}");
+                    $('#report-info').removeClass('hide');
+                } else {
+                    $('#report-info').addClass('hide');
+                }
             }
         };
 


### PR DESCRIPTION
Fixes part of [#235367](http://manage.dimagi.com/default.asp?235367)

Check if `aaData` exists (it won't if there is a warning returned), e.g. https://github.com/dimagi/commcare-hq/commit/25f26a00960e6751c3bad493c83f97a3592e4cb8#diff-783410c84f07dfc780a4e0e3a8e6dfa9R177

@snopoke @gcapalbo 
