### PR TITLE
UCR: Only show pagination warning on map reports

### DIFF
--- a/corehq/apps/reports_core/templates/reports_core/base_template_new.html
+++ b/corehq/apps/reports_core/templates/reports_core/base_template_new.html
@@ -59,12 +59,16 @@
         };
 
         var paginationNotice = function (data) {
-            if (data.aaData !== undefined && data.iTotalRecords !== undefined) {
-                if (data.aaData.length < data.iTotalRecords) {
-                    $('#info-message').html("{% trans 'Showing the current page of data. Switch pages to see more data.' %}");
-                    $('#report-info').removeClass('hide');
-                } else {
-                    $('#report-info').addClass('hide');
+            if (mapSpec) {  // Only show warning for map reports
+                if (data.aaData !== undefined && data.iTotalRecords !== undefined) {
+                    if (data.aaData.length < data.iTotalRecords) {
+                        $('#info-message').html(
+                            "{% trans 'Showing the current page of data. Switch pages to see more data.' %}"
+                        );
+                        $('#report-info').removeClass('hide');
+                    } else {
+                        $('#report-info').addClass('hide');
+                    }
                 }
             }
         };

--- a/corehq/apps/reports_core/templates/reports_core/base_template_new.html
+++ b/corehq/apps/reports_core/templates/reports_core/base_template_new.html
@@ -59,11 +59,13 @@
         };
 
         var paginationNotice = function (data) {
-            if (data.aaData.length < data.iTotalRecords) {
-                $('#info-message').html("{% trans 'Showing the current page of data. Switch pages to see more data.' %}");
-                $('#report-info').removeClass('hide');
-            } else {
-                $('#report-info').addClass('hide');
+            if (data.aaData !== undefined && data.iTotalRecords !== undefined) {
+                if (data.aaData.length < data.iTotalRecords) {
+                    $('#info-message').html("{% trans 'Showing the current page of data. Switch pages to see more data.' %}");
+                    $('#report-info').removeClass('hide');
+                } else {
+                    $('#report-info').addClass('hide');
+                }
             }
         };
 


### PR DESCRIPTION
@kaapstorm 
The pagination warning shows on other types of reports, which I don't think was intentional.
