### PR TITLE
Change top 5 projects table on DimagiSphere

### DIFF
--- a/corehq/apps/hqadmin/static/hqadmin/js/project_map.js
+++ b/corehq/apps/hqadmin/static/hqadmin/js/project_map.js
@@ -311,6 +311,7 @@ var projectMapInit = function(mapboxAccessToken) {
         div.innerHTML += '<p>Number of Active Countries: ' + dataController.getNumActiveCountries() +  '</p>';
         div.innerHTML += '<p>Number of Active Mobile Users: ' + dataController.getNumUsers() +  '</p>';
         div.innerHTML += '<p>Number of Active Projects: ' + dataController.getNumProjects() +  '</p>';
+        div.innerHTML += '<br><p><em> Active: A project or user submitted a form in past 30 days.</em></p>';
         return div;
     };
 

--- a/corehq/apps/hqadmin/static/hqadmin/js/project_map.js
+++ b/corehq/apps/hqadmin/static/hqadmin/js/project_map.js
@@ -101,7 +101,7 @@ var projectMapInit = function(mapboxAccessToken) {
             var self = this;
             self.selectedCountry = ko.observable('country name');
             self.selectedProject = ko.observable('project name');
-            self.tableProperties = ['Organization', 'Sector', 'Deployed', 'Active Users', 'Countries'];
+            self.tableProperties = ['Sector', 'Sub-Sector', 'Active Users', 'Countries'];
             self.topFiveProjects = ko.observableArray();
         };
 

--- a/corehq/apps/hqadmin/static/hqadmin/js/project_map.js
+++ b/corehq/apps/hqadmin/static/hqadmin/js/project_map.js
@@ -236,14 +236,9 @@ var projectMapInit = function(mapboxAccessToken) {
                     datatype: "json",
                 }).done(function(data){
                     data[country].forEach(function(project){
-                        var deploymentDate = project['deployment']['date'];
-                        if (deploymentDate) {
-                            deploymentDate = deploymentDate.substring(0, 10);
-                        }
                         selectionModel.topFiveProjects.push({
-                            organization: project['internal']['organization_name'],
                             sector: project['internal']['area'],
-                            deployment: deploymentDate,
+                            sub_sector: project['internal']['sub_area'],
                             active_users: project['cp_n_active_cc_users'],
                             countries: capitalizeCountryNames(project['deployment']['countries']).join(', '),
                         });

--- a/corehq/apps/hqadmin/static/hqadmin/js/project_map.js
+++ b/corehq/apps/hqadmin/static/hqadmin/js/project_map.js
@@ -67,9 +67,9 @@ var projectMapInit = function(mapboxAccessToken) {
 
         that.getUnit = function (count) {
             if (is_project_count_map) {
-                return count > 1 ? 'projects' : 'project';
+                return count > 1 ? 'active projects' : 'active project';
             } else {
-                return count > 1 ? 'users' : 'user';
+                return count > 1 ? 'active users' : 'active user';
             }
         };
 
@@ -263,7 +263,7 @@ var projectMapInit = function(mapboxAccessToken) {
         function _getInfoContent(countryName) {
             var count = dataController.getCount(countryName);
             var unit = dataController.getUnit(count);
-            var message = count ? count + ' ' + unit : 'no ' + unit;
+            var message = count ? count + ' ' + unit : 'no ' + unit + 's';
             return '<b>' + countryName + '</b>: ' + message;
         }
         this._div.innerHTML = (props ? _getInfoContent(props.name) : 'Hover over a country');

--- a/corehq/apps/hqadmin/templates/hqadmin/project_map.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/project_map.html
@@ -67,9 +67,8 @@
               </thead>
               <tbody data-bind="foreach: {data: topFiveProjects}">
                 <tr class="project-row">
-                  <td data-bind="text: organization"></td>
                   <td data-bind="text: sector"></td>
-                  <td data-bind="text: deployment"></td>
+                  <td data-bind="text: sub_sector"></td>
                   <td data-bind="text: active_users"></td>
                   <td data-bind="text: countries"></td>
                 </tr>

--- a/corehq/apps/hqadmin/views.py
+++ b/corehq/apps/hqadmin/views.py
@@ -1186,8 +1186,7 @@ def top_five_projects_by_country(request):
         projects = (DomainES().is_active().real_domains()
                     .filter(filters.term('deployment.countries', country))
                     .sort('cp_n_active_cc_users', True)
-                    .source(['internal.organization_name', 'internal.area',
-                             'deployment.date', 'cp_n_active_cc_users', 'deployment.countries'])
+                    .source(['internal.area', 'internal.sub_area', 'cp_n_active_cc_users', 'deployment.countries'])
                     .size(5).run().hits)
         data = {country: projects}
     return json_response(data)


### PR DESCRIPTION
@czue @esoergel  

Per feedback from Gillian and Amelia:
1. change table properties listing top five projects showing only: Sector, Sub-sector, Number of active mobile users, Countries deployed
2. pluralize units in info control when there are 0 counts (i.e. "no active users")
3. add clarification on "active" terminology

best reviewed 🐡  by 🐡 
