### PR TITLE
Catch type and zero division errors in UCR evaluator expression

### DIFF
--- a/corehq/apps/userreports/expressions/specs.py
+++ b/corehq/apps/userreports/expressions/specs.py
@@ -266,7 +266,7 @@ class EvalExpressionSpec(JsonObject):
         var_dict = self.get_variables(item, context)
         try:
             return eval_statements(self.statement, var_dict)
-        except (InvalidExpression, SyntaxError):
+        except (InvalidExpression, SyntaxError, TypeError, ZeroDivisionError):
             return None
 
     def get_variables(self, item, context):

--- a/corehq/apps/userreports/tests/test_expressions.py
+++ b/corehq/apps/userreports/tests/test_expressions.py
@@ -919,6 +919,21 @@ def test_unsupported_evaluator_statements(self, eq, context):
     self.assertEqual(expression({}), None)
 
 
+@generate_cases([
+    ("a/b", {"a": 5, "b": None}, TypeError),
+    ("a/b", {"a": 5, "b": 0}, ZeroDivisionError),
+])
+def test_errors_in_evaluator_statements(self, eq, context, error_type):
+    with self.assertRaises(error_type):
+        eval_statements(eq, context)
+    expression = ExpressionFactory.from_spec({
+        "type": "evaluator",
+        "statement": eq,
+        "context_variables": context
+    })
+    self.assertEqual(expression({}), None)
+
+
 class TestFormsExpressionSpec(TestCase):
 
     def setUp(self):


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?235729

cc @esoergel @millerdev 
