### PR TITLE
Replaced is_active filter with is_active_project filter

### DIFF
--- a/corehq/apps/es/domains.py
+++ b/corehq/apps/es/domains.py
@@ -94,8 +94,9 @@ def in_domains(domains):
 def is_active(is_active=True):
     return filters.term('is_active', is_active)
 
-# Project is active
+
 def is_active_project(is_active=True):
+    # Project is active - has submitted a form in the last 30 days
     return filters.term('cp_is_active', is_active)
 
 

--- a/corehq/apps/es/domains.py
+++ b/corehq/apps/es/domains.py
@@ -44,6 +44,7 @@ class DomainES(HQESQuery):
             last_modified,
             in_domains,
             is_active,
+            is_active_project,
             created_by_user,
         ] + super(DomainES, self).builtin_filters
 
@@ -92,6 +93,10 @@ def in_domains(domains):
 
 def is_active(is_active=True):
     return filters.term('is_active', is_active)
+
+# Project is active
+def is_active_project(is_active=True):
+    return filters.term('cp_is_active', is_active)
 
 
 def created_by_user(creating_user):

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -938,7 +938,7 @@ class AdminUserReport(AdminFacetedReport):
     es_index = 'users'
 
     es_facet_list = [
-        "is_active",  # this is NOT "has submitted a form in the last 30 days"
+        "is_active",  # a user can log in to the project
         "is_staff",
         "is_superuser",
         "domain",

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -883,7 +883,7 @@ class AdminDomainMapReport(AdminDomainStatsReport):
 
     def _calc_num_active_users_per_country(self, filters):
         active_users_per_country = (NestedTermAggregationsHelper(
-                                    base_query=DomainES().is_active().real_domains().filter(filters),
+                                    base_query=DomainES().real_domains().is_active_project().filter(filters),
                                     terms=[AggregationTerm('countries', 'deployment.countries')],
                                     bottom_level_aggregation=SumAggregation('users', 'cp_n_active_cc_users')
                                     ).get_data())
@@ -891,15 +891,15 @@ class AdminDomainMapReport(AdminDomainStatsReport):
 
     def _calc_num_projs_per_countries(self, filters):
         num_projects_by_country = (DomainES()
-                                   .is_active()
                                    .real_domains()
+                                   .is_active_project()
                                    .filter(filters)
                                    .terms_aggregation('deployment.countries', 'countries')
                                    .size(0).run().aggregations.countries.counts_by_bucket())
         return num_projects_by_country
 
     def _calc_total_active_real_projects(self, filters):
-        total_num_projects = (DomainES().is_active().real_domains()
+        total_num_projects = (DomainES().is_active_project().real_domains()
                               .filter(filters)
                               .count())
         return total_num_projects


### PR DESCRIPTION
@czue @esoergel 

Fixing a bug - previously used `is_active()` filter on DomainES, which does not filter out inactive projects. Created a new filter `is_active_project()` on DomainES, which correctly finds projects that are active (submitted a form in the last 30 days)
