### PR TITLE
Fixed bug on filtering sectors and countries

### DIFF
--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -910,8 +910,8 @@ class AdminDomainMapReport(AdminDomainStatsReport):
         sector_params = es_params.get('internal.area.exact')
         if country_params and sector_params:
             es_filters = (filters.AND(
-                            filters.term("deployment.countries.exact", country_params),
-                            filters.term("internal.area.exact", sector_params)))
+                          filters.term("deployment.countries.exact", country_params),
+                          filters.term("internal.area.exact", sector_params)))
         elif country_params:
             es_filters = filters.term("deployment.countries.exact", country_params)
         elif sector_params:

--- a/corehq/apps/hqadmin/reports.py
+++ b/corehq/apps/hqadmin/reports.py
@@ -908,15 +908,14 @@ class AdminDomainMapReport(AdminDomainStatsReport):
         es_filters = {}
         country_params = es_params.get('deployment.countries.exact')
         sector_params = es_params.get('internal.area.exact')
-
         if country_params and sector_params:
             es_filters = (filters.AND(
-                            filters.term("deployment.countries", country_params),
-                            filters.term("internal.area", sector_params[0].lower())))
+                            filters.term("deployment.countries.exact", country_params),
+                            filters.term("internal.area.exact", sector_params)))
         elif country_params:
-            es_filters = filters.term("deployment.countries", country_params)
+            es_filters = filters.term("deployment.countries.exact", country_params)
         elif sector_params:
-            es_filters = filters.term("internal.area", sector_params[0].lower())
+            es_filters = filters.term("internal.area.exact", sector_params)
 
         return es_filters
 


### PR DESCRIPTION
Fixing bug - previously, ES query would not recognize spaces (i.e. "Economic Development" would return 0 results). Using `exact` from domain mapping

@NoahCarnahan
