### PR TITLE
Add debug-only env parameter to ESQuery

### DIFF
--- a/corehq/elastic.py
+++ b/corehq/elastic.py
@@ -139,10 +139,21 @@ class ESError(Exception):
     pass
 
 
-def run_query(index_name, q):
+def run_query(index_name, q, debug_host=None):
+    # the debug_host parameter allows you to query another env for testing purposes
+    if debug_host:
+        if not settings.DEBUG:
+            raise Exception("You can only specify an ES env in DEBUG mode")
+        es_host = getattr(settings, 'ELASTICSEARCH_HOST_{}'.format(debug_host.upper()))
+        es_instance = Elasticsearch([{'host': es_host,
+                                      'port': settings.ELASTICSEARCH_PORT}],
+                                    timeout=3, max_retries=0)
+    else:
+        es_instance = get_es_new()
+
     es_meta = ES_META[index_name]
     try:
-        return get_es_new().search(es_meta.index, es_meta.type, body=q)
+        return es_instance.search(es_meta.index, es_meta.type, body=q)
     except RequestError as e:
         raise ESError(e)
 


### PR DESCRIPTION
It's often very useful to run queries against the production elasticsearch, but it's scary to change ELASTICSEARCH_HOST, as you could pretty easily screw stuff up if you forget about it.  This will let you easily run queries against an alternate host without risk of writing to that host.

I could see this go a lot farther (run ES-based reports locally off production data), but this is a good start.
@millerdev 
