### PR TITLE
Case export migration

### DIFF
--- a/corehq/apps/export/const.py
+++ b/corehq/apps/export/const.py
@@ -14,7 +14,7 @@ from corehq.apps.export.transforms import (
 
 # When fixing a bug that requires existing schemas to be rebuilt,
 # bump the version number.
-DATA_SCHEMA_VERSION = 3
+DATA_SCHEMA_VERSION = 4
 
 DEID_ID_TRANSFORM = "deid_id"
 DEID_DATE_TRANSFORM = "deid_date"

--- a/corehq/apps/export/management/commands/revert_migrate_exports_for_domain.py
+++ b/corehq/apps/export/management/commands/revert_migrate_exports_for_domain.py
@@ -1,0 +1,24 @@
+from optparse import make_option
+from django.core.management.base import LabelCommand
+
+from corehq.apps.export.utils import revert_migrate_domain
+
+
+class Command(LabelCommand):
+    help = "Reverts a migrated export domain from new exports to old ones for a given domain"
+
+    option_list = LabelCommand.option_list + (
+        make_option(
+            '--dry-run',
+            action='store_true',
+            dest='dryrun',
+            default=False,
+            help='Runs a dry run on the export reversion'
+        ),
+    )
+
+    def handle(self, domain, *args, **options):
+        dryrun = options.pop('dryrun')
+        if dryrun:
+            print '*** Running in dryrun mode. Will not save any reversions ***'
+        revert_migrate_domain(domain, dryrun)

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -959,7 +959,7 @@ class ExportDataSchema(Document):
                 identifier,
             )
 
-            current_schema.record_update(app.copy_of or app_id, app.version)
+            current_schema.record_update(app.copy_of or app._id, app.version)
 
         current_schema.domain = domain
         current_schema.app_id = app_id

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -19,6 +19,7 @@ from corehq.apps.app_manager.dbaccessors import (
     get_built_app_ids_with_submissions_for_app_id,
     get_all_built_app_ids_and_versions,
     get_latest_app_ids_and_versions,
+    get_app_ids_in_domain,
 )
 from corehq.apps.app_manager.models import Application
 from corehq.apps.app_manager.util import get_case_properties, ParentCasePropertyBuilder
@@ -51,6 +52,7 @@ from corehq.apps.export.const import (
     PLAIN_USER_DEFINED_SPLIT_TYPE,
     DATA_SCHEMA_VERSION,
 )
+from corehq.apps.export.exceptions import BadExportConfiguration
 from corehq.apps.export.dbaccessors import (
     get_latest_case_export_schema,
     get_latest_form_export_schema,
@@ -942,6 +944,9 @@ class ExportDataSchema(Document):
         )
         if app_id:
             app_build_ids.append(app_id)
+        else:
+            app_build_ids.extend(cls._get_current_app_ids_for_domain(domain))
+
         for app_doc in iter_docs(Application.get_db(), app_build_ids):
             if (not app_doc.get('has_submissions', False) and
                     app_doc.get('copy_of')):
@@ -954,7 +959,7 @@ class ExportDataSchema(Document):
                 identifier,
             )
 
-            current_schema.record_update(app_id, app.version)
+            current_schema.record_update(app.copy_of or app_id, app.version)
 
         current_schema.domain = domain
         current_schema.app_id = app_id
@@ -1065,6 +1070,10 @@ class FormExportDataSchema(ExportDataSchema):
 
     def _set_identifier(self, form_xmlns):
         self.xmlns = form_xmlns
+
+    @classmethod
+    def _get_current_app_ids_for_domain(cls, domain):
+        raise BadExportConfiguration('Form exports should only use one app_id and this should not be called')
 
     @staticmethod
     def _get_app_build_ids_to_process(domain, app_id, last_app_versions):
@@ -1203,6 +1212,10 @@ class CaseExportDataSchema(ExportDataSchema):
 
     def _set_identifier(self, case_type):
         self.case_type = case_type
+
+    @classmethod
+    def _get_current_app_ids_for_domain(cls, domain):
+        return get_app_ids_in_domain(domain)
 
     @staticmethod
     def _get_app_build_ids_to_process(domain, app_id, last_app_versions):

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1011,6 +1011,7 @@ class ExportDataSchema(Document):
             return group_schema
 
         previous_group_schemas = schemas[0].group_schemas
+        last_app_versions = schemas[0].last_app_versions
         for current_schema in schemas[1:]:
             group_schemas = _merge_lists(
                 previous_group_schemas,
@@ -1020,8 +1021,14 @@ class ExportDataSchema(Document):
                 copyfn=lambda group_schema: ExportGroupSchema(group_schema.to_json())
             )
             previous_group_schemas = group_schemas
+            last_app_versions = _merge_dicts(
+                last_app_versions,
+                current_schema.last_app_versions,
+                max,
+            )
 
         schema.group_schemas = group_schemas
+        schema.last_app_versions = last_app_versions
 
         return schema
 

--- a/corehq/apps/export/tests/test_export_data_schema.py
+++ b/corehq/apps/export/tests/test_export_data_schema.py
@@ -596,6 +596,63 @@ class TestBuildingCaseSchemaFromApplication(TestCase, TestXmlMixin):
         self.assertEqual(len(new_schema.group_schemas), 2)
 
 
+class TestBuildingCaseSchemaFromMultipleApplications(TestCase, TestXmlMixin):
+    file_path = ['data']
+    root = os.path.dirname(__file__)
+    domain = 'aspace'
+    case_type = 'candy'
+
+    @classmethod
+    def setUpClass(cls):
+        cls.current_app = Application.wrap(cls.get_json('basic_case_application'))
+
+        cls.first_build = Application.wrap(cls.get_json('basic_case_application'))
+        cls.first_build._id = '123'
+        cls.first_build.copy_of = cls.current_app.get_id
+        cls.first_build.version = 3
+
+        cls.other_build = Application.wrap(cls.get_json('basic_case_application'))
+        cls.other_build._id = '456'
+        cls.other_build.copy_of = 'other-app-id'
+        cls.other_build.version = 4
+        cls.other_build.has_submissions = True
+
+        cls.apps = [
+            cls.current_app,
+            cls.first_build,
+            cls.other_build,
+        ]
+        with drop_connected_signals(app_post_save):
+            for app in cls.apps:
+                app.save()
+
+    @classmethod
+    def tearDownClass(cls):
+        for app in cls.apps:
+            app.delete()
+
+    def tearDown(self):
+        delete_all_export_data_schemas()
+
+    def test_multiple_app_schema_generation(self):
+        schema = CaseExportDataSchema.generate_schema_from_builds(
+            self.domain,
+            self.current_app._id,
+            self.case_type,
+        )
+
+        self.assertEqual(
+            schema.last_app_versions[self.other_build.copy_of],
+            self.other_build.version,
+        )
+        # One for case, one for case history
+        self.assertEqual(len(schema.group_schemas), 2)
+
+        group_schema = schema.group_schemas[0]
+        self.assertEqual(group_schema.last_occurrences[self.current_app._id], self.current_app.version)
+        self.assertEqual(len(group_schema.items), 2)
+
+
 class TestBuildingParentCaseSchemaFromApplication(TestCase, TestXmlMixin):
     file_path = ['data']
     root = os.path.dirname(__file__)

--- a/corehq/apps/export/tests/test_export_views.py
+++ b/corehq/apps/export/tests/test_export_views.py
@@ -45,7 +45,7 @@ class ExportViewTest(TestCase):
     def test_create_form_export(self):
         resp = self.client.get(
             reverse(CreateNewCustomFormExportView.urlname, args=[self.domain.name]),
-            {'export_tag': 'my_sweet_xmlns'}
+            {'export_tag': 'my_sweet_xmlns', 'app_id': 'r2d2'}
         )
         self.assertEqual(resp.status_code, 200)
 

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -20,6 +20,10 @@ from corehq.apps.app_manager.dbaccessors import (
     get_app,
     get_brief_apps_in_domain,
 )
+from .dbaccessors import (
+    get_form_export_instances,
+    get_case_export_instances,
+)
 from .exceptions import SkipConversion
 from .const import (
     CASE_EXPORT,
@@ -476,7 +480,7 @@ def _is_remote_app_conversion(domain, app_id, export_type):
         return any(map(lambda app: app.is_remote_app(), apps))
 
 
-def revert_new_exports(new_exports):
+def revert_new_exports(new_exports, dryrun=False):
     """
     Takes a list of new style ExportInstance and marks them as deleted as well as restoring
     the old export it was converted from (if it was converted from an old export)
@@ -490,11 +494,27 @@ def revert_new_exports(new_exports):
             schema_cls = FormExportSchema if new_export.type == FORM_EXPORT else CaseExportSchema
             old_export = schema_cls.get(new_export.legacy_saved_export_schema_id)
             old_export.doc_type = old_export.doc_type.rstrip(DELETED_SUFFIX)
-            old_export.save()
+            if not dryrun:
+                old_export.save()
             reverted_exports.append(old_export)
         new_export.doc_type += DELETED_SUFFIX
-        new_export.save()
+        if not dryrun:
+            new_export.save()
     return reverted_exports
+
+
+def revert_migrate_domain(domain, dryrun=False):
+    instances = get_form_export_instances(domain)
+    instances.extend(get_case_export_instances(domain))
+
+    reverted_exports = revert_new_exports(instances, dryrun=dryrun)
+
+    if not dryrun:
+        set_toggle(NEW_EXPORTS.slug, domain, False, namespace=NAMESPACE_DOMAIN)
+        toggle_js_domain_cachebuster.clear(domain)
+
+    for reverted_export in reverted_exports:
+        print 'Reverted export: {}'.format(reverted_export._id)
 
 
 def migrate_domain(domain, dryrun=False):


### PR DESCRIPTION
@czue @NoahCarnahan couple things going on here. best read 🐟. this adds the ability to revert a migration. it gets all current app ids if none are specified (this is important for migrating case exports). `last_app_versions` was completely broken. fixed it and added a test (it's not being used anywhere which is why we didn't notice, but it was confusing when i was trying to inspect an export)

cc: @dannyroberts 
