### PR TITLE
Rename views

### DIFF
--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -238,7 +238,7 @@ class DomainRegistrationForm(forms.Form):
         return self.cleaned_data
 
 
-class NewWebUserRegistrationForm(NoAutocompleteMixin, DomainRegistrationForm):
+class WebUserInvitationForm(NoAutocompleteMixin, DomainRegistrationForm):
     """
     Form for a brand new user, before they've created a domain or done anything on CommCare HQ.
     """
@@ -275,7 +275,7 @@ class NewWebUserRegistrationForm(NoAutocompleteMixin, DomainRegistrationForm):
                                                </a>.""")))
 
     def __init__(self, *args, **kwargs):
-        super(NewWebUserRegistrationForm, self).__init__(*args, **kwargs)
+        super(WebUserInvitationForm, self).__init__(*args, **kwargs)
         initial_create_domain = kwargs.get('initial', {}).get('create_domain', True)
         data_create_domain = self.data.get('create_domain', "True")
         if not initial_create_domain or data_create_domain == "False":

--- a/corehq/apps/registration/forms.py
+++ b/corehq/apps/registration/forms.py
@@ -27,7 +27,7 @@ from corehq.apps.style import crispy as hqcrispy
 mark_safe_lazy = lazy(mark_safe, six.text_type)
 
 
-class RegisterNewWebUserForm(forms.Form):
+class RegisterWebUserForm(forms.Form):
     # Use: NewUserRegistrationView
     # Not inheriting from other forms to de-obfuscate the role of this form.
 
@@ -53,7 +53,7 @@ class RegisterNewWebUserForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         self.show_phone_number = kwargs.pop('show_number', False)
-        super(RegisterNewWebUserForm, self).__init__(*args, **kwargs)
+        super(RegisterWebUserForm, self).__init__(*args, **kwargs)
 
         if not self.show_phone_number:
             del self.fields['phone_number']

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -27,8 +27,7 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.domain.exceptions import NameUnavailableException
 from corehq.apps.hqwebapp.views import BasePageView
 from corehq.apps.registration.models import RegistrationRequest
-from corehq.apps.registration.forms import NewWebUserRegistrationForm, DomainRegistrationForm, \
-    RegisterNewWebUserForm
+from corehq.apps.registration.forms import NewWebUserRegistrationForm, DomainRegistrationForm, RegisterWebUserForm
 from corehq.apps.registration.utils import activate_new_user, send_new_request_update_email, request_new_domain, \
     send_domain_registration_email
 from corehq.apps.style.decorators import use_blazy, use_jquery_ui, \
@@ -81,7 +80,7 @@ class ProcessRegistrationView(JSONResponseMixin, View):
 
     @allow_remote_invocation
     def register_new_user(self, data):
-        reg_form = RegisterNewWebUserForm(
+        reg_form = RegisterWebUserForm(
             data['data'],
             show_number=(self.ab.version == ab_tests.NEW_USER_NUMBER_OPTION_SHOW_NUM)
         )
@@ -160,7 +159,7 @@ class UserRegistrationView(BasePageView):
     @property
     def page_context(self):
         return {
-            'reg_form': RegisterNewWebUserForm(
+            'reg_form': RegisterWebUserForm(
                 initial={'email': self.prefilled_email},
                 show_number=(self.ab.version == ab_tests.NEW_USER_NUMBER_OPTION_SHOW_NUM)
             ),

--- a/corehq/apps/registration/views.py
+++ b/corehq/apps/registration/views.py
@@ -27,7 +27,7 @@ from corehq.apps.domain.models import Domain
 from corehq.apps.domain.exceptions import NameUnavailableException
 from corehq.apps.hqwebapp.views import BasePageView
 from corehq.apps.registration.models import RegistrationRequest
-from corehq.apps.registration.forms import NewWebUserRegistrationForm, DomainRegistrationForm, RegisterWebUserForm
+from corehq.apps.registration.forms import DomainRegistrationForm, RegisterWebUserForm
 from corehq.apps.registration.utils import activate_new_user, send_new_request_update_email, request_new_domain, \
     send_domain_registration_email
 from corehq.apps.style.decorators import use_blazy, use_jquery_ui, \

--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -44,8 +44,7 @@ from corehq.apps.es import AppES
 from corehq.apps.es.queries import search_string_query
 from corehq.apps.hqwebapp.utils import send_confirmation_email
 from corehq.apps.hqwebapp.views import BasePageView, logout
-from corehq.apps.registration.forms import AdminInvitesUserForm, \
-    NewWebUserRegistrationForm
+from corehq.apps.registration.forms import AdminInvitesUserForm, WebUserInvitationForm
 from corehq.apps.registration.utils import activate_new_user
 from corehq.apps.reports.util import get_possible_reports
 from corehq.apps.sms.verify import (
@@ -640,7 +639,7 @@ class UserInvitationView(object):
                 return render(request, self.template, context)
         else:
             if request.method == "POST":
-                form = NewWebUserRegistrationForm(request.POST)
+                form = WebUserInvitationForm(request.POST)
                 if form.is_valid():
                     # create the new user
                     user = activate_new_user(form, domain=invitation.domain)
@@ -661,7 +660,7 @@ class UserInvitationView(object):
                 if CouchUser.get_by_username(invitation.email):
                     return HttpResponseRedirect(reverse("login") + '?next=' +
                         reverse('domain_accept_invitation', args=[invitation.domain, invitation.get_id]))
-                form = NewWebUserRegistrationForm(initial={
+                form = WebUserInvitationForm(initial={
                     'email': invitation.email,
                     'hr_name': invitation.domain,
                     'create_domain': False,


### PR DESCRIPTION
Sometimes code grows into an unintentionally hostile shape...we have both a `NewWebUserRegistrationForm` and a `RegisterNewWebUserForm`.

Sanity tested web user signup and web user invitation flows.

@NoahCarnahan / @kaapstorm 
