### PR TITLE
accommodate changes to last_login in django 1.8

### DIFF
--- a/corehq/apps/users/models.py
+++ b/corehq/apps/users/models.py
@@ -1077,12 +1077,12 @@ class CouchUser(Document, DjangoUserMixin, IsMemberOfMixin, UnicodeMixIn, EulaMi
         except User.DoesNotExist:
             django_user = User(username=self.username)
         for attr in DjangoUserMixin.ATTRS:
-            attr_val = getattr(self, attr) or ''
+            attr_val = getattr(self, attr)
+            if not attr_val and attr != 'last_login':
+                attr_val = ''
             # truncate names when saving to django
             if attr == 'first_name' or attr == 'last_name':
                 attr_val = attr_val[:30]
-            if attr == 'last_login' and attr_val == '':
-                attr_val = None
             setattr(django_user, attr, attr_val)
         django_user.DO_NOT_SAVE_COUCH_USER= True
         return django_user

--- a/custom/ewsghana/tests/test_reminders.py
+++ b/custom/ewsghana/tests/test_reminders.py
@@ -310,10 +310,12 @@ class TestReminders(EWSTestCase):
         self.assertEqual(smses.count(), 2)
 
     def test_visit_reminder(self):
+        now = datetime.utcnow()
+        self.web_user2.last_login = now - timedelta(weeks=1)
+        self.web_user2.save()
         reminder_to_visit_website()
         smses = SMS.objects.all()
         self.assertEqual(smses.count(), 0)
-        now = datetime.utcnow()
         self.web_user2.last_login = now - timedelta(weeks=14)
         self.web_user2.save()
 


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.10/releases/1.8/#abstractuser-last-login-allows-null-values

Assign `last_login` during test.  Also refactor `sync_to_django_user` to make logic clearer.

@calellowitz 
