### PR TITLE
Use greppable debug_hosts variables [ci skip]

### DIFF
--- a/corehq/apps/es/es_query.py
+++ b/corehq/apps/es/es_query.py
@@ -75,13 +75,11 @@ Running against production
 --------------------------
 Since the ESQuery library is read-only, it's mostly safe to run against
 production. You can define alternate elasticsearch hosts in your localsettings
-file using the prefix 'ELASTICSEARCH_HOST_' and pass in this host name as the
-``debug_host`` to the constructor:
+file in the ``ELASTICSEARCH_DEBUG_HOSTS`` dictionary and pass in this host name
+as the ``debug_host`` to the constructor:
 
 .. code-block:: python
 
-    >>> print settings.ELASTICSEARCH_HOST_PROD
-    hqes0.internal-va.commcarehq.org
     >>> CaseES(debug_host='prod').domain('dimagi').count()
     120
 

--- a/corehq/elastic.py
+++ b/corehq/elastic.py
@@ -144,7 +144,7 @@ def run_query(index_name, q, debug_host=None):
     if debug_host:
         if not settings.DEBUG:
             raise Exception("You can only specify an ES env in DEBUG mode")
-        es_host = getattr(settings, 'ELASTICSEARCH_HOST_{}'.format(debug_host.upper()))
+        es_host = settings.ELASTICSEARCH_DEBUG_HOSTS[debug_host]
         es_instance = Elasticsearch([{'host': es_host,
                                       'port': settings.ELASTICSEARCH_PORT}],
                                     timeout=3, max_retries=0)

--- a/dev_settings.py
+++ b/dev_settings.py
@@ -87,6 +87,9 @@ SHARED_DRIVE_ROOT = shared_dirname
 
 PHONE_TIMEZONES_SHOULD_BE_PROCESSED = True
 
-ELASTICSEARCH_HOST_PROD = 'hqes0.internal-va.commcarehq.org'
-ELASTICSEARCH_HOST_STAGING = 'hqes0-staging.internal-va.commcarehq.org'
-ELASTICSEARCH_HOST_INDIA = '10.162.36.221'
+# These ES hosts are to be used strictly for DEBUG mode read operations
+ELASTICSEARCH_DEBUG_HOSTS = {
+    'prod': 'hqes0.internal-va.commcarehq.org',
+    'staging': 'hqes0-staging.internal-va.commcarehq.org',
+    'india': '10.162.36.221',
+}


### PR DESCRIPTION
@millerdev
From your suggestion here:
https://github.com/dimagi/commcare-hq/pull/12970#discussion_r76164214
Thanks for the suggestion, I much prefer this option - I wasn't too proud of knowingly breaking the grep test.
