### PR TITLE
remove max_length from IntegerField

### DIFF
--- a/corehq/apps/smsbillables/migrations/0012_remove_max_length.py
+++ b/corehq/apps/smsbillables/migrations/0012_remove_max_length.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('smsbillables', '0011_date_to_datetime'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='smsgatewayfeecriteria',
+            name='country_code',
+            field=models.IntegerField(db_index=True, null=True, blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/corehq/apps/smsbillables/models.py
+++ b/corehq/apps/smsbillables/models.py
@@ -37,7 +37,7 @@ class SmsGatewayFeeCriteria(models.Model):
     backend_api_id = models.CharField(max_length=100, db_index=True)
     backend_instance = models.CharField(max_length=255, db_index=True, null=True)
     direction = models.CharField(max_length=10, db_index=True, choices=DIRECTION_CHOICES)
-    country_code = models.IntegerField(max_length=5, null=True, blank=True, db_index=True)
+    country_code = models.IntegerField(null=True, blank=True, db_index=True)
     prefix = models.CharField(max_length=10, blank=True, default="", db_index=True)
 
     class Meta:


### PR DESCRIPTION
removes a warning that appears in django 1.8:

```
smsbillables.SmsGatewayFeeCriteria.country_code: (fields.W122) 'max_length' is ignored when used with IntegerField
    HINT: Remove 'max_length' from field
```

@calellowitz 
