### PR TITLE
Support multiple case references per form question

### DIFF
--- a/corehq/apps/app_manager/management/commands/migrate_app_to_cmitfb.py
+++ b/corehq/apps/app_manager/management/commands/migrate_app_to_cmitfb.py
@@ -51,7 +51,8 @@ class Command(BaseCommand):
                     xform = XForm(form.source)
                     xform.add_case_preloads(preload)
                     save_xform(app, form, ET.tostring(xform.xml))
-                    form.actions.load_from_form = form.actions.case_preload
+                    form.case_references = {path: [case_property]
+                        for path, case_property in preload.iteritems()}
                     form.actions.case_preload = PreloadAction()
 
         app.vellum_case_management = True

--- a/corehq/apps/app_manager/management/commands/migrate_app_to_cmitfb.py
+++ b/corehq/apps/app_manager/management/commands/migrate_app_to_cmitfb.py
@@ -51,8 +51,8 @@ class Command(BaseCommand):
                     xform = XForm(form.source)
                     xform.add_case_preloads(preload)
                     save_xform(app, form, ET.tostring(xform.xml))
-                    form.case_references = {path: [case_property]
-                        for path, case_property in preload.iteritems()}
+                    form.case_references = {"load": {path: [case_property]
+                        for path, case_property in preload.iteritems()}}
                     form.actions.case_preload = PreloadAction()
 
         app.vellum_case_management = True

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -1528,18 +1528,18 @@ class Form(IndexedFormBase, NavMenuItemMediaMixin):
     @property
     def case_references(self):
         refs = self.case_references_data or {}
-        if not refs and self.actions.load_from_form.preload:
+        if "load" not in refs and self.actions.load_from_form.preload:
             # for backward compatibility
             # preload only has one reference per question path
             preload = self.actions.load_from_form.preload
-            refs = {key: [value] for key, value in preload.iteritems()}
+            refs["load"] = {key: [value] for key, value in preload.iteritems()}
         return refs
 
     @case_references.setter
     def case_references(self, refs):
         """Set case references
 
-        format: {"/data/path": ["case_property", ...]}
+        format: {"load": {"/data/path": ["case_property", ...], ...}}
         """
         self.case_references_data = refs
         if self.actions.load_from_form.preload:
@@ -1615,7 +1615,8 @@ class Form(IndexedFormBase, NavMenuItemMediaMixin):
                                 questions,
                                 question_path
                             )
-        for question_path, case_properties in self.case_references.iteritems():
+        case_loads = self.case_references.get("load", {})
+        for question_path, case_properties in case_loads.iteritems():
             for name in case_properties:
                 self.add_property_load(
                     app_case_meta,

--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -374,7 +374,7 @@ class FormActions(DocumentSchema):
 
     case_preload = SchemaProperty(PreloadAction)
     referral_preload = SchemaProperty(PreloadAction)
-    load_from_form = SchemaProperty(PreloadAction)
+    load_from_form = SchemaProperty(PreloadAction)  # DEPRECATED
 
     usercase_update = SchemaProperty(UpdateCaseAction)
     usercase_preload = SchemaProperty(PreloadAction)
@@ -1305,6 +1305,7 @@ class Form(IndexedFormBase, NavMenuItemMediaMixin):
     form_filter = StringProperty()
     requires = StringProperty(choices=["case", "referral", "none"], default="none")
     actions = SchemaProperty(FormActions)
+    case_references_data = DictProperty()
 
     def add_stuff_to_xform(self, xform, build_profile_id=None):
         super(Form, self).add_stuff_to_xform(xform, build_profile_id)
@@ -1524,6 +1525,26 @@ class Form(IndexedFormBase, NavMenuItemMediaMixin):
         return {subcase.case_type for subcase in self.actions.subcases
                 if subcase.close_condition.type == "never" and subcase.case_type}
 
+    @property
+    def case_references(self):
+        refs = self.case_references_data or {}
+        if not refs and self.actions.load_from_form.preload:
+            # for backward compatibility
+            # preload only has one reference per question path
+            preload = self.actions.load_from_form.preload
+            refs = {key: [value] for key, value in preload.iteritems()}
+        return refs
+
+    @case_references.setter
+    def case_references(self, refs):
+        """Set case references
+
+        format: {"/data/path": ["case_property", ...]}
+        """
+        self.case_references_data = refs
+        if self.actions.load_from_form.preload:
+            self.actions.load_from_form = PreloadAction()
+
     @memoized
     def get_parent_types_and_contributed_properties(self, module_case_type, case_type):
         parent_types = set()
@@ -1594,6 +1615,15 @@ class Form(IndexedFormBase, NavMenuItemMediaMixin):
                                 questions,
                                 question_path
                             )
+        for question_path, case_properties in self.case_references.iteritems():
+            for name in case_properties:
+                self.add_property_load(
+                    app_case_meta,
+                    module_case_type,
+                    name,
+                    questions,
+                    question_path
+                )
 
 
 class MappingItem(DocumentSchema):
@@ -2619,6 +2649,14 @@ class AdvancedForm(IndexedFormBase, NavMenuItemMediaMixin):
             scheduler_updates = set()
 
         return updates.union(scheduler_updates)
+
+    @property
+    def case_references(self):
+        return {}
+
+    @case_references.setter
+    def case_references(self, refs):
+        pass
 
     @memoized
     def get_parent_types_and_contributed_properties(self, module_case_type, case_type):

--- a/corehq/apps/app_manager/tests/test_case_refs_from_fb.py
+++ b/corehq/apps/app_manager/tests/test_case_refs_from_fb.py
@@ -26,18 +26,36 @@ class FormCaseReferenceTest(SimpleTestCase):
             })
         }
         self.form.case_references = _get_case_references(post_data)
-        self.assertEqual(self.form.case_references, {"/data/question": ["name"]})
+        self.assertEqual(self.form.case_references,
+            {"load": {"/data/question": ["name"]}})
         self.assertFalse(self.form.actions.load_from_form.preload)
 
     def test_two_references(self):
         refs = {
-            "/data/question": ["name", "dob"],
-            "/data/other_question": ["close_reason"],
+            "load": {
+                "/data/question": ["name", "dob"],
+                "/data/other_question": ["close_reason"],
+            },
         }
         post_data = {"case_references": json.dumps(refs)}
         self.form.case_references = _get_case_references(post_data)
         self.assertEqual(self.form.case_references, refs)
         self.assertFalse(self.form.actions.load_from_form.preload)
+
+    def test_legacy_preload_action_case_references(self):
+        self.form.actions.load_from_form = PreloadAction({
+            "preload": {
+                "/data/question": "name"
+            },
+            "condition": {
+                "answer": None,
+                "question": None,
+                "type": "always",
+                "operator": None,
+            }
+        })
+        self.assertEqual(self.form.case_references,
+            {"load": {"/data/question": ["name"]}})
 
 
 class AdvancedFormCaseReferenceTest(SimpleTestCase):
@@ -65,8 +83,10 @@ class AdvancedFormCaseReferenceTest(SimpleTestCase):
 
     def test_two_references(self):
         refs = {
-            "/data/question": ["name", "dob"],
-            "/data/other_question": ["close_reason"],
+            "load": {
+                "/data/question": ["name", "dob"],
+                "/data/other_question": ["close_reason"],
+            },
         }
         post_data = {"case_references": json.dumps(refs)}
         self.form.case_references = _get_case_references(post_data)

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -242,12 +242,7 @@ def _edit_form_attr(request, domain, app_id, unique_form_id, attr):
     lang = request.COOKIES.get('lang', app.langs[0])
 
     def should_edit(attribute):
-        if attribute in request.POST:
-            return True
-        elif attribute in request.FILES:
-            return True
-        else:
-            return False
+        return attribute in request.POST
 
     if should_edit("name"):
         name = request.POST['name']
@@ -259,7 +254,7 @@ def _edit_form_attr(request, domain, app_id, unique_form_id, attr):
         resp['update'] = {'.variable-form_name': form.name[lang]}
     if should_edit('comment'):
         form.comment = request.POST['comment']
-    if should_edit("xform"):
+    if should_edit("xform") or "xform" in request.FILES:
         try:
             # support FILES for upload and POST for ajax post from Vellum
             try:
@@ -283,8 +278,6 @@ def _edit_form_attr(request, domain, app_id, unique_form_id, attr):
                     pass
             if xform:
                 save_xform(app, form, xform)
-                case_references = json.loads(request.POST.get('references', "{}"))
-                _update_case_refs_from_form_builder(form, case_references)
             else:
                 raise Exception("You didn't select a form to upload")
         except Exception, e:
@@ -292,6 +285,8 @@ def _edit_form_attr(request, domain, app_id, unique_form_id, attr):
                 return HttpResponseBadRequest(unicode(e))
             else:
                 messages.error(request, unicode(e))
+    if should_edit("references") or should_edit("case_references"):
+        form.case_references = _get_case_references(request.POST)
     if should_edit("show_count"):
         show_count = request.POST['show_count']
         form.show_count = True if show_count == "True" else False
@@ -357,7 +352,7 @@ def new_form(request, domain, app_id, module_id):
 def patch_xform(request, domain, app_id, unique_form_id):
     patch = request.POST['patch']
     sha1_checksum = request.POST['sha1']
-    case_references = json.loads(request.POST.get('references', "{}"))
+    case_references = _get_case_references(request.POST)
 
     app = get_app(domain, app_id)
     form = app.get_form(unique_form_id)
@@ -369,8 +364,8 @@ def patch_xform(request, domain, app_id, unique_form_id):
     dmp = diff_match_patch()
     xform, _ = dmp.patch_apply(dmp.patch_fromText(patch), current_xml)
     save_xform(app, form, xform)
-
-    _update_case_refs_from_form_builder(form, case_references)
+    if "case_references" in request.POST or "references" in request.POST:
+        form.case_references = case_references
 
     response_json = {
         'status': 'ok',
@@ -651,6 +646,14 @@ def form_casexml(request, domain, form_unique_id):
     return HttpResponse(form.create_casexml())
 
 
-def _update_case_refs_from_form_builder(form, reference_json):
-    if form.form_type == 'module_form':
-        form.actions.load_from_form = PreloadAction.wrap(reference_json)
+def _get_case_references(data):
+    def is_valid(value):
+        return isinstance(value, list) and all(isinstance(v, unicode) for v in value)
+    if "references" in data:
+        # old/deprecated format
+        refs = {k: [v] for k, v in json.loads(data['references'])["preload"].items()}
+    else:
+        refs = json.loads(data.get('case_references', '{}'))
+    if not all(is_valid(v) for v in refs.values()):
+        raise ValueError("bad case references data: {!r}".format(refs))
+    return refs

--- a/corehq/apps/app_manager/views/forms.py
+++ b/corehq/apps/app_manager/views/forms.py
@@ -651,9 +651,12 @@ def _get_case_references(data):
         return isinstance(value, list) and all(isinstance(v, unicode) for v in value)
     if "references" in data:
         # old/deprecated format
-        refs = {k: [v] for k, v in json.loads(data['references'])["preload"].items()}
+        preload = json.loads(data['references'])["preload"]
+        refs = {
+            "load": {k: [v] for k, v in preload.items()}
+        }
     else:
         refs = json.loads(data.get('case_references', '{}'))
-    if not all(is_valid(v) for v in refs.values()):
+    if set(refs) - {"load"} or not all(is_valid(v) for v in refs["load"].values()):
         raise ValueError("bad case references data: {!r}".format(refs))
     return refs


### PR DESCRIPTION
Next up: make vellum send case references in the new format, which supports multiple case properties per question. This PR is backward-compatible with the old format, which is currently used in vellum.

@emord cc @esoergel 
