### PR TITLE
remove unnecessary null=True

### DIFF
--- a/corehq/apps/locations/migrations/0003_remove_null_True.py
+++ b/corehq/apps/locations/migrations/0003_remove_null_True.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('locations', '0002_auto_20160420_2105'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='sqllocation',
+            name='_products',
+            field=models.ManyToManyField(to='products.SQLProduct'),
+        ),
+    ]

--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -281,7 +281,7 @@ class SQLLocation(SyncSQLToCouchMixin, MPTTModel):
     # since stocks_all_products can cause an empty list to
     # be what is stored for a location that actually has
     # all products available.
-    _products = models.ManyToManyField(SQLProduct, null=True)
+    _products = models.ManyToManyField(SQLProduct)
     stocks_all_products = models.BooleanField(default=True)
 
     supply_point_id = models.CharField(max_length=255, db_index=True, unique=True, null=True)


### PR DESCRIPTION
Removes warning in django 1.8:

```
locations.SQLLocation._products: (fields.W340) null has no effect on ManyToManyField.
```

@calellowitz 
