### PR TITLE
Default to closing ES indices

### DIFF
--- a/corehq/apps/hqadmin/management/commands/prune_elastic_indices.py
+++ b/corehq/apps/hqadmin/management/commands/prune_elastic_indices.py
@@ -1,16 +1,19 @@
 from optparse import make_option
+import elasticsearch
 from django.core.management import BaseCommand
 from corehq.elastic import get_es_new
 from corehq.pillows.utils import get_all_expected_es_indices
 
 
 class Command(BaseCommand):
-    help = 'Delete all unreferenced elasticsearch indices.'
+    help = 'Close all unreferenced elasticsearch indices.'
 
     option_list = BaseCommand.option_list + (
         make_option('--verbose', help='Additional logging.', action='store_true',
                     default=False),
         make_option('--noinput', help='Do not prompt user for input', action='store_true',
+                    default=False),
+        make_option('--delete', help='Delete the indices', action='store_true',
                     default=False),
     )
 
@@ -18,6 +21,7 @@ class Command(BaseCommand):
         es = get_es_new()
         # call this before getting existing indices because apparently getting the pillow will create the index
         # if it doesn't exist
+        # fixme: this can delete real indices if a reindex is in progress
         found_indices = set(es.indices.get_aliases().keys())
         expected_indices = {info.index for info in get_all_expected_es_indices()}
 
@@ -29,19 +33,52 @@ class Command(BaseCommand):
             print 'expecting {} indices:\n{}\n'.format(len(expected_indices),
                                                        '\n'.join(sorted(expected_indices)))
 
-        to_delete = set([index for index in found_indices if index not in expected_indices])
-        if to_delete:
-            if options['noinput'] or raw_input(
-                    '\n'.join([
-                        'Really delete ALL the unrecognized elastic indices?',
-                        'Here are the indices that will be deleted:',
-                        '\n'.join(sorted(to_delete)),
-                        'This operation is not reversible and all data will be lost.',
-                        'Type "delete indices" to continue:\n',
-                    ])).lower() == 'delete indices':
-                for index in to_delete:
-                    es.indices.delete(index)
+        unref_indices = set([index for index in found_indices if index not in expected_indices])
+        if unref_indices:
+            if options['delete']:
+                _delete_indices(es, unref_indices)
             else:
-                print 'aborted'
+                _close_indices(es, unref_indices, options['noinput'])
         else:
             print 'no indices need pruning'
+
+
+def _delete_indices(es, to_delete):
+    # always ask for confirmation when doing irreversible things
+    if raw_input(
+            '\n'.join([
+                'Really delete ALL the unrecognized elastic indices?',
+                'Here are the indices that will be deleted:',
+                '\n'.join(sorted(to_delete)),
+                'This operation is not reversible and all data will be lost.',
+                'Type "delete indices" to continue:\n',
+            ])).lower() == 'delete indices':
+        for index in to_delete:
+            try:
+                es.indices.flush(index)
+            except elasticsearch.exceptions.AuthorizationException:
+                # already closed
+                pass
+            es.indices.delete(index)
+    else:
+        print 'aborted'
+
+
+def _close_indices(es, to_close, noinput):
+    if noinput or raw_input(
+            '\n'.join([
+                'Really close ALL the unrecognized elastic indices?',
+                'Here are the indices that will be closed:',
+                '\n'.join(sorted(to_close)),
+                'This operation is totally reversible but some downtime occur',
+                'Type "close indices" to continue:\n',
+            ])).lower() == 'close indices':
+        for index in to_close:
+            try:
+                es.indices.flush(index)
+            except elasticsearch.exceptions.AuthorizationException:
+                # already closed
+                pass
+            es.indices.close(index)
+    else:
+        print 'aborted'


### PR DESCRIPTION
This changes `prune_elastic_indices` to flushing and closing an index instead of deleting. Closing an index provides all the same benefits of deleting except that it doesn't delete it from the disk.

Will also have a followup PR to make sure this doesn't delete UCR indices.

@czue 
