### PR TITLE
Clear user data

### DIFF
--- a/corehq/apps/cloudcare/const.py
+++ b/corehq/apps/cloudcare/const.py
@@ -1,0 +1,1 @@
+CLOUDCARE_CLOSE_XMLNS = 'http://code.javarosa.org/cloudcare_close'

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -238,12 +238,11 @@ FormplayerFrontend.on('refreshApplication', function(appId) {
     tfLoading();
     resp = $.ajax(options);
     resp.fail(function () {
-            tfLoadingComplete(true);
-        })
-        .done(function() {
-            tfLoadingComplete();
-            FormplayerFrontend.trigger('navigateHome', appId)
-        });
+        tfLoadingComplete(true);
+    }).done(function() {
+        tfLoadingComplete();
+        FormplayerFrontend.trigger('navigateHome', appId);
+    });
 });
 
 FormplayerFrontend.on('clearUserData', function(appId) {
@@ -255,16 +254,15 @@ FormplayerFrontend.on('clearUserData', function(appId) {
         xhrFields: { withCredentials: true },
     });
     resp.fail(function (jqXHR) {
-            if (jqXHR.status === 400) {
-                tfLoadingComplete(true, gettext('Unable to clear user data for mobile worker'));
-            } else {
-                tfLoadingComplete(true, gettext('Unabled to clear user data'));
-            }
-        })
-        .done(function() {
-            tfLoadingComplete();
-            FormplayerFrontend.trigger('navigateHome', appId)
-        });
+        if (jqXHR.status === 400) {
+            tfLoadingComplete(true, gettext('Unable to clear user data for mobile worker'));
+        } else {
+            tfLoadingComplete(true, gettext('Unabled to clear user data'));
+        }
+    }).done(function() {
+        tfLoadingComplete();
+        FormplayerFrontend.trigger('navigateHome', appId);
+    });
 });
 
 FormplayerFrontend.on('navigateHome', function(appId) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -177,6 +177,7 @@ FormplayerFrontend.on("start", function (options) {
     user.apps = options.apps;
     user.domain = options.domain;
     user.formplayer_url = options.formplayer_url;
+    user.clearUserDataUrl = options.clearUserDataUrl;
     if (Backbone.history) {
         Backbone.history.start();
         // will be the same for every domain. TODO: get domain/username/pass from django
@@ -248,7 +249,7 @@ FormplayerFrontend.on('refreshApplication', function(appId) {
 FormplayerFrontend.on('clearUserData', function(appId) {
     var user = FormplayerFrontend.request('currentUser');
     var resp = $.ajax({
-        url: '/a/' + user.domain + '/cloudcare/api/reset_user/',
+        url: user.clearUserDataUrl,
         type: 'POST',
         dataType: "json",
         xhrFields: { withCredentials: true },

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/navigation/navigation_view.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/navigation/navigation_view.js
@@ -11,8 +11,9 @@ FormplayerFrontend.module("Navigation", function (Navigation, FormplayerFrontend
         className: 'formplayer-phone-navigation',
         template: '#formplayer-phone-navigation-template',
         events: {
-            'click .formplayer-back': 'onBack',
-            'click .formplayer-reload': 'onReload',
+            'click .js-formplayer-back': 'onBack',
+            'click .js-formplayer-reload': 'onReload',
+            'click .js-formplayer-clear-user-data': 'onClearUserData',
         },
         initialize: function(options) {
             this.appId = options.appId;
@@ -20,6 +21,10 @@ FormplayerFrontend.module("Navigation", function (Navigation, FormplayerFrontend
         onBack: function(e) {
             e.preventDefault();
             window.history.back();
+        },
+        onClearUserData: function(e) {
+            e.preventDefault();
+            FormplayerFrontend.trigger('clearUserData', this.appId);
         },
         onReload: function(e) {
             e.preventDefault();

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/util/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/util/util.js
@@ -13,7 +13,12 @@ Util.objectToEncodedUrl = function (object) {
 
 Util.currentUrlToObject = function () {
     var url = Backbone.history.getFragment();
-    return Util.CloudcareUrl.fromJson(Util.encodedUrlToObject(url));
+    try {
+        return Util.CloudcareUrl.fromJson(Util.encodedUrlToObject(url));
+    } catch (e) {
+        // This means that we're on the homepage
+        return new Util.CloudcareUrl();
+    }
 };
 
 Util.setUrlToObject = function (urlObject) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/util.js
@@ -120,10 +120,10 @@ hqDefine('cloudcare/js/util.js', function () {
         showLoading();
     };
 
-    var tfLoadingComplete = function (isError) {
+    var tfLoadingComplete = function (isError, message) {
         hideLoading();
         if (isError) {
-            showError(gettext('Error saving!'), $('#cloudcare-notifications'));
+            showError(message || gettext('Error saving!'), $('#cloudcare-notifications'));
         }
     };
 

--- a/corehq/apps/cloudcare/templates/formplayer/navigation.html
+++ b/corehq/apps/cloudcare/templates/formplayer/navigation.html
@@ -2,10 +2,11 @@
   <div class="navbar navbar-default navbar-static-top navbar-formplayer">
     <div class="container">
       <ul class="nav navbar-nav">
-        <li><a class="formplayer-back" href=""><i class="fa fa-chevron-left"></i></a></li>
+        <li><a class="js-formplayer-back" href=""><i class="fa fa-chevron-left"></i></a></li>
       </ul>
       <ul class="nav navbar-nav navbar-right">
-        <li><a class="formplayer-reload" href=""><i class="fa fa-refresh"></i></a></li>
+        <li><a class="js-formplayer-reload" href=""><i class="fa fa-refresh"></i></a></li>
+        <li><a class="js-formplayer-clear-user-data" href=""><i class="fa fa-trash"></i></a></li>
       </ul>
     </div>
   </div>

--- a/corehq/apps/cloudcare/urls.py
+++ b/corehq/apps/cloudcare/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import patterns, url, include
 
-from corehq.apps.cloudcare.views import EditCloudcareUserPermissionsView, CloudcareMain
+from corehq.apps.cloudcare.views import EditCloudcareUserPermissionsView, CloudcareMain, CloudcareResetUser
 
 app_urls = patterns('corehq.apps.cloudcare.views',
     url(r'^view/(?P<app_id>[\w-]+)/modules-(?P<module_id>[\w-]+)/forms-(?P<form_id>[\w-]+)/context/$',
@@ -24,6 +24,11 @@ api_urls = patterns('corehq.apps.cloudcare.views',
     url(r'^ledgers/$', 'get_ledgers', name='cloudcare_get_ledgers'),
     url(r'^render_form/$', 'render_form', name='cloudcare_render_form'),
     url(r'^sync_db/$', 'sync_db_api', name='cloudcare_sync_db'),
+    url(
+        r'^reset_user/$',
+        CloudcareResetUser.as_view(),
+        name=CloudcareResetUser.urlname
+    )
 )
 
 # used in settings urls

--- a/corehq/apps/cloudcare/urls.py
+++ b/corehq/apps/cloudcare/urls.py
@@ -1,6 +1,10 @@
 from django.conf.urls import patterns, url, include
 
-from corehq.apps.cloudcare.views import EditCloudcareUserPermissionsView, CloudcareMain, CloudcareResetUser
+from corehq.apps.cloudcare.views import (
+    EditCloudcareUserPermissionsView,
+    CloudcareMain,
+    CloudcareClearUserData,
+)
 
 app_urls = patterns('corehq.apps.cloudcare.views',
     url(r'^view/(?P<app_id>[\w-]+)/modules-(?P<module_id>[\w-]+)/forms-(?P<form_id>[\w-]+)/context/$',
@@ -25,9 +29,9 @@ api_urls = patterns('corehq.apps.cloudcare.views',
     url(r'^render_form/$', 'render_form', name='cloudcare_render_form'),
     url(r'^sync_db/$', 'sync_db_api', name='cloudcare_sync_db'),
     url(
-        r'^reset_user/$',
-        CloudcareResetUser.as_view(),
-        name=CloudcareResetUser.urlname
+        r'^clear_user_data/$',
+        CloudcareClearUserData.as_view(),
+        name=CloudcareClearUserData.urlname
     )
 )
 

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -218,15 +218,15 @@ class CloudcareMain(View):
             return render(request, "cloudcare/cloudcare_home.html", context)
 
 
-class CloudcareResetUser(View):
+class CloudcareClearUserData(View):
 
-    urlname = 'reset_user'
+    urlname = 'clear_user_data'
     http_method_names = ['post']
 
     @method_decorator(require_cloudcare_access)
     @method_decorator(requires_privilege_for_commcare_user(privileges.CLOUDCARE))
     def dispatch(self, request, *args, **kwargs):
-        return super(CloudcareResetUser, self).dispatch(request, *args, **kwargs)
+        return super(CloudcareClearUserData, self).dispatch(request, *args, **kwargs)
 
     def post(self, request, domain):
         couch_user = request.couch_user

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -50,6 +50,7 @@ from corehq.apps.cloudcare.dbaccessors import get_cloudcare_apps
 from corehq.apps.cloudcare.decorators import require_cloudcare_access
 from corehq.apps.cloudcare.exceptions import RemoteAppError
 from corehq.apps.cloudcare.models import ApplicationAccess
+from corehq.apps.cloudcare.const import CLOUDCARE_CLOSE_XMLNS
 from corehq.apps.cloudcare.touchforms_api import BaseSessionDataHelper, CaseSessionDataHelper
 from corehq.apps.domain.decorators import login_and_domain_required, login_or_digest_ex, domain_admin_required
 from corehq.apps.groups.models import Group
@@ -58,6 +59,7 @@ from corehq.apps.style.decorators import (
     use_datatables,
     use_jquery_ui,
 )
+from corehq.apps.hqcase.utils import update_case
 from corehq.apps.users.models import CouchUser, CommCareUser
 from corehq.apps.users.views import BaseUserSettingsView
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, FormAccessors, LedgerAccessors
@@ -214,6 +216,39 @@ class CloudcareMain(View):
             return render(request, "cloudcare/formplayer_home.html", context)
         else:
             return render(request, "cloudcare/cloudcare_home.html", context)
+
+
+class CloudcareResetUser(View):
+
+    urlname = 'reset_user'
+    http_method_names = ['post']
+
+    @method_decorator(require_cloudcare_access)
+    @method_decorator(requires_privilege_for_commcare_user(privileges.CLOUDCARE))
+    def dispatch(self, request, *args, **kwargs):
+        return super(CloudcareResetUser, self).dispatch(request, *args, **kwargs)
+
+    def post(self, request, domain):
+        couch_user = request.couch_user
+
+        if not couch_user.is_web_user:
+            # If this is called by a mobile user, it's most likely a mistake so we should
+            # not close all their cases.
+            return json_response({'status': 'fail'}, status_code=400)
+
+        case_ids = CaseAccessors(domain).get_open_case_ids_for_owner(couch_user.user_id)
+        for case_id in case_ids:
+            update_case(
+                domain,
+                case_id,
+                close=True,
+                xmlns=CLOUDCARE_CLOSE_XMLNS,
+            )
+
+        return json_response({
+            'status': 'ok',
+            'closed_cases_count': len(case_ids),
+        })
 
 
 @login_and_domain_required

--- a/corehq/apps/preview_app/templates/preview_app/base.html
+++ b/corehq/apps/preview_app/templates/preview_app/base.html
@@ -175,6 +175,7 @@
                 username: "{{ request.user.username  }}",
                 domain: "{{ request.domain }}",
                 formplayer_url: "{{ formplayer_url }}",
+                clearUserDataUrl: "{% url 'clear_user_data' request.domain %}",
                 phoneMode: true,
             })
         })

--- a/corehq/apps/preview_app/templates/preview_app/base.html
+++ b/corehq/apps/preview_app/templates/preview_app/base.html
@@ -111,6 +111,8 @@
         {% endif %}
 
         <script type="text/javascript" src="{% static 'jquery/dist/jquery.min.js' %}"></script>
+        <script src="{% static 'hqwebapp/js/ajax_csrf_setup.js' %}"></script>
+        <script src="{% static 'jquery.cookie/jquery.cookie.js' %}"></script>
         <script type="text/javascript" src="{% static 'bootstrap/dist/js/bootstrap.min.js' %}"></script>
         <script type="text/javascript" src="{% static 'hqwebapp/js/hqModules.js' %}"></script>
         <script type="text/javascript" src="{% static 'style/js/hq.helpers.js' %}"></script>


### PR DESCRIPTION
@biyeun @wpride @dimagi/product this enables users to "clear the user data." it simply closes all the cases associated with that user (archiving the forms did not work). one thing i changed was that i added a button to clear user data:

<img width="334" alt="screen shot 2016-08-25 at 5 42 43 pm" src="https://cloud.githubusercontent.com/assets/918514/17986987/868db9b2-6aeb-11e6-953e-2871674935b5.png">

i know we talked about having the refresh app and clear user data be in the same thing, but it got pretty frustrating to use. every time i wanted to make a minor change to my app i had to clear the data i  had made. i think these things should be separated just like they are in mobile (clearing the app vs. updating the app)

cc: @dannyroberts 
