### PR TITLE
Show multi-bar controls only if more than one bar

### DIFF
--- a/corehq/apps/reports_core/static/reports_core/js/charts.js
+++ b/corehq/apps/reports_core/static/reports_core/js/charts.js
@@ -134,7 +134,7 @@ hqDefine('reports_core/js/charts.js', function() {
                 .transitionDuration(350)
                 .reduceXTicks(true)
                 .rotateLabels(0)
-                .showControls(true)
+                .showControls(config.y_axis_columns.length > 1)
                 .groupSpacing(0.1)
                 .stacked(config.is_stacked || false)
                 .staggerLabels(shouldStaggerXAxis(record))


### PR DESCRIPTION
Requested by Digital Green, but a good idea generally: If there is only one bar, multi-bar chart controls "Grouped" and "Stacked" don't make sense, and should be hidden.

Before:
![now_you_see_it](https://cloud.githubusercontent.com/assets/708421/18004790/634720dc-6b96-11e6-9e73-95688f9447da.png)

After:
![now_you_dont](https://cloud.githubusercontent.com/assets/708421/18004793/666cdd42-6b96-11e6-8cb6-556741d4acd5.png)

@czue @orangejenny @NoahCarnahan 
