### PR TITLE
Default admin report date range to 90 days

### DIFF
--- a/corehq/apps/hqadmin/views.py
+++ b/corehq/apps/hqadmin/views.py
@@ -685,7 +685,7 @@ class FlagBrokenBuilds(FormView):
 
 
 @require_superuser
-@datespan_in_request(from_param="startdate", to_param="enddate", default_days=365)
+@datespan_in_request(from_param="startdate", to_param="enddate", default_days=90)
 def stats_data(request):
     histo_type = request.GET.get('histogram_type')
     interval = request.GET.get("interval", "week")


### PR DESCRIPTION
@dimagi/scale-team 

@amsagoff changing the admin report graphs to default to the last 90 days from a year. You can still manually change these filters, but loading these all at once puts a lot of load on our DB and causes other reports to time out
