### PR TITLE
Warn on no app_id

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -42,6 +42,11 @@ FormplayerFrontend.getCurrentRoute = function () {
  */
 FormplayerFrontend.reqres.setHandler('resourceMap', function (resource_path, app_id) {
     var currentApp = FormplayerFrontend.request("appselect:getApp", app_id);
+    if (!currentApp) {
+        console.warn('App is undefined for app_id: ' + app_id);
+        console.warn('Not processing resource: ' + resource_path);
+        return;
+    }
     if (resource_path.substring(0, 7) === 'http://') {
         return resource_path;
     } else if (!_.isEmpty(currentApp.get("multimedia_map"))) {


### PR DESCRIPTION
@wpride the enkishay app isn't returning a defined app id in the menu response (still trying to figure out why). that causes the resource map to fail. i don't think we should fail hard on that so i added this as a bandaid. this will probably just make it fail at a different step in the process..

cc: @dannyroberts 
