### PR TITLE
don't change original doc

### DIFF
--- a/corehq/pillows/domain.py
+++ b/corehq/pillows/domain.py
@@ -17,7 +17,7 @@ from pillowtop.reindexer.reindexer import ElasticPillowReindexer
 def transform_domain_for_elasticsearch(doc_dict):
     doc_ret = copy.deepcopy(doc_dict)
     sub = Subscription.objects.filter(subscriber__domain=doc_dict['name'], is_active=True)
-    doc_ret['deployment'] = doc_dict.get('deployment', None) or {}
+    doc_ret['deployment'] = doc_ret.get('deployment', None) or {}
     countries = doc_ret['deployment'].get('countries', [])
     doc_ret['deployment']['countries'] = []
     if sub:


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?236168

@gcapalbo
buddy @emord

Not really sure how the error is happening since the domain's in question have correct country values. Testing locally the only time I could get it to error is if I ran the `transform_domain_for_elasticsearch` function twice on the same dict but I don't see how that could happen on prod.
