### PR TITLE
Upgrade jQuery to 2.2.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "CommCareHQ",
   "version": "0.0.1",
   "dependencies": {
-    "jquery": "1.11.1",
+    "jquery": "2.2.0",
     "underscore": "1.8.3",
     "jquery-form": "3.45.0",
     "jquery.cookie": "dimagi/jquery-cookie#1.4.1",
@@ -63,7 +63,7 @@
   },
   "private": true,
   "resolutions": {
-    "jquery": "1.11.1",
+    "jquery": "2.2.0",
     "bootstrap": "3.3.7",
     "select2": "4.0.0",
     "underscore": "1.6.0",


### PR DESCRIPTION
Putting this on staging for a bit, although there should not be any breaking changes:

https://blog.jquery.com/2013/04/18/jquery-2-0-released/
https://blog.jquery.com/2014/01/24/jquery-1-11-and-2-1-released/
https://blog.jquery.com/2016/01/08/jquery-2-2-and-1-12-released/

@NoahCarnahan / @kaapstorm 
