### PR TITLE
replace unique foreign key relation with one to one

### DIFF
--- a/custom/ilsgateway/migrations/0010_auto_20160830_1923.py
+++ b/custom/ilsgateway/migrations/0010_auto_20160830_1923.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import datetime
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ilsgateway', '0009_auto_20160413_1311'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='deliverygroupreport',
+            name='report_date',
+            field=models.DateTimeField(default=datetime.datetime.utcnow),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='slabconfig',
+            name='sql_location',
+            field=models.OneToOneField(to='locations.SQLLocation'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='supplypointstatus',
+            name='status_type',
+            field=models.CharField(max_length=50, choices=[(b'rr_fac', b'rr_fac'), (b'trans_fac', b'trans_fac'), (b'soh_fac', b'soh_fac'), (b'super_fac', b'super_fac'), (b'rr_dist', b'rr_dist'), (b'del_del', b'del_del'), (b'la_fac', b'la_fac'), (b'del_dist', b'del_dist'), (b'del_fac', b'del_fac')]),
+            preserve_default=True,
+        ),
+    ]

--- a/custom/ilsgateway/models.py
+++ b/custom/ilsgateway/models.py
@@ -478,7 +478,7 @@ class PendingReportingDataRecalculation(models.Model):
 
 class SLABConfig(models.Model):
     is_pilot = models.BooleanField(default=False)
-    sql_location = models.ForeignKey(SQLLocation, null=False, unique=True)
+    sql_location = models.OneToOneField(SQLLocation, null=False)
     closest_supply_points = models.ManyToManyField(SQLLocation, related_name='+')
 
     class Meta:


### PR DESCRIPTION
As advised by django 1.8:

```
ilsgateway.SLABConfig.sql_location: (fields.W342) Setting unique=True on a ForeignKey has the same effect as using a OneToOneField.
```

Also adds a migration; picks up a few other un-migrated changes.

@calellowitz 
