### PR TITLE
replace unique foreign key relation with one to one

### DIFF
--- a/corehq/apps/notifications/migrations/0004_auto_20160830_2002.py
+++ b/corehq/apps/notifications/migrations/0004_auto_20160830_2002.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('notifications', '0003_lastseennotification'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='lastseennotification',
+            name='user',
+            field=models.OneToOneField(to=settings.AUTH_USER_MODEL),
+            preserve_default=True,
+        ),
+    ]

--- a/corehq/apps/notifications/models.py
+++ b/corehq/apps/notifications/models.py
@@ -75,7 +75,7 @@ class Notification(models.Model):
 
 
 class LastSeenNotification(models.Model):
-    user = models.ForeignKey(User, unique=True)
+    user = models.OneToOneField(User)
     last_seen_date = models.DateTimeField()
 
     @classmethod


### PR DESCRIPTION
Addresses

```
notifications.LastSeenNotification.user: (fields.W342) Setting unique=True on a ForeignKey has the same effect as using a OneToOneField.
```

@calellowitz 
