### PR TITLE
add app_label to zipline models

### DIFF
--- a/custom/zipline/models.py
+++ b/custom/zipline/models.py
@@ -41,6 +41,7 @@ class EmergencyOrderStatusUpdate(models.Model):
     )
 
     class Meta:
+        app_label = 'zipline'
         index_together = [
             ['order', 'package_number'],
         ]
@@ -123,6 +124,10 @@ class EmergencyOrderStatusUpdate(models.Model):
 
 
 class EmergencyOrder(models.Model):
+
+    class Meta:
+        app_label = 'zipline'
+
     domain = models.CharField(max_length=126)
 
     # The id of the user who initiated the order
@@ -200,6 +205,8 @@ class EmergencyOrder(models.Model):
 class EmergencyOrderPackage(models.Model):
 
     class Meta:
+        app_label = 'zipline'
+
         index_together = [
             ['order', 'package_number'],
         ]
@@ -287,6 +294,7 @@ class BaseOrderableProduct(models.Model):
 
     class Meta:
         abstract = True
+        app_label = 'zipline'
         unique_together = [
             ['domain', 'code'],
         ]


### PR DESCRIPTION
Fixes warnings like:
`RemovedInDjango19Warning: Model class custom.zipline.models.EmergencyOrderPackage doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.`

@gcapalbo 
