### PR TITLE
Remove underscore from bower resolution

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -66,7 +66,6 @@
     "jquery": "1.11.1",
     "bootstrap": "3.3.7",
     "select2": "4.0.0",
-    "underscore": "1.6.0",
     "backbone": "0.9.1"
   }
 }


### PR DESCRIPTION
@orangejenny 

Following output from `rm -rf bower_components && bower install` after this change to `bower.json`

```
Please note that,
    CommCareHQ depends on backbone#0.9.1 which resolved to backbone#0.9.1
    backbone.babysitter#0.1.12, backbone.wreqr#1.3.7 depends on backbone#>=0.9.9 <=1.3.x which resolved to backbone#1.2.3
    backbone.marionette#2.4.5 depends on backbone#1.0.0 - 1.3.2 which resolved to backbone#1.3.2
Resort to using backbone#0.9.1 which resolved to backbone#0.9.1
Code incompatibilities may occur.
```

@benrudolph I think you probably know the most about backbone in HQ (cloudcare right?) Any reason we're still on 0.9.1/do you think that could cause any bugs.

```
Please note that,
    bootstrap-timepicker#0.5.1 depends on bootstrap#~3.0 which resolved to bootstrap#3.0.3
    bootstrap-tour#0.10.2 depends on bootstrap#>=2.3.2 which resolved to bootstrap#3.0.3
    CommCareHQ depends on bootstrap#3.3.7 which resolved to bootstrap#3.3.7
Resort to using bootstrap#3.3.7 which resolved to bootstrap#3.3.7
Code incompatibilities may occur.
```

@orangejenny did you look at upgrading these libraries when doing the bootstrap upgrade?
