### PR TITLE
upgrade django-angular to 0.7.16

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -64,7 +64,7 @@ django-countries==3.3
 reportlab==3.0
 stripe==1.12.2
 django-compressor==1.6
-django-angular==0.7.8
+django-angular==0.7.16
 Pycco==0.3.0
 django-mptt==0.7.4
 jsonpath-rw==1.4.0


### PR DESCRIPTION
https://github.com/jrief/django-angular/blob/master/docs/changelog.rst#0716

Supports django 1.9 ([current version](https://github.com/jrief/django-angular/blob/master/docs/changelog.rst#079) doesn't have full support for 1.7).  Not upgrading all the way to 0.8.4 since that introduces some breaking changes.

@calellowitz 
