### PR TITLE
clear external_blobs from export schemas

### DIFF
--- a/corehq/ex-submodules/couchexport/util.py
+++ b/corehq/ex-submodules/couchexport/util.py
@@ -41,10 +41,10 @@ intersect_filters = intersect_functions
 
 
 def clear_attachments(schema_or_doc):
-    if schema_or_doc and '_attachments' in schema_or_doc:
-        del schema_or_doc['_attachments']
-    if schema_or_doc and 'case_attachments' in schema_or_doc:
-        del schema_or_doc['case_attachments']
+    for noisy_property in ('_attachments', 'external_blobs', 'case_attachments'):
+        if schema_or_doc and noisy_property in schema_or_doc:
+            del schema_or_doc[noisy_property]
+
     if schema_or_doc:
         for action in schema_or_doc.get('actions', []):
             if 'attachments' in action and 'updated_unknown_properties' in action:


### PR DESCRIPTION
was running into same problem we had with attachments (which get cleaned out of docs before
building a schema): since form instances belonging to the same schema all have
differently named attachments, if included external_blobs will make the schema size
grow unbounded

Fixes: http://manage.dimagi.com/default.asp?236106

@kaapstorm @benrudolph @millerdev FYI
