### PR TITLE
make ExportSchema.get_all_checkpoints iterate

### DIFF
--- a/corehq/ex-submodules/couchexport/models.py
+++ b/corehq/ex-submodules/couchexport/models.py
@@ -141,12 +141,14 @@ class ExportSchema(Document, UnicodeMixIn):
 
     @classmethod
     def get_all_checkpoints(cls, index):
-        return cls.view("couchexport/schema_checkpoints",
+        doc_ids = [result["id"] for result in cls.get_db().view(
+            "couchexport/schema_checkpoints",
             startkey=[json.dumps(index)],
             endkey=[json.dumps(index), {}],
-            include_docs=True,
             reduce=False,
-        )
+        )]
+        for doc in iter_docs(cls.get_db(), doc_ids):
+            yield cls.wrap(doc)
 
     _tables = None
 

--- a/corehq/ex-submodules/couchexport/tasks.py
+++ b/corehq/ex-submodules/couchexport/tasks.py
@@ -51,10 +51,12 @@ def rebuild_schemas(index):
     all_checkpoints = ExportSchema.get_all_checkpoints(index)
     config = ExportConfiguration(db, index, disable_checkpoints=True)
     latest = config.create_new_checkpoint()
+    counter = 0
     for cp in all_checkpoints:
         cp.schema = latest.schema
         cp.save()
-    return len(all_checkpoints)
+        counter += 1
+    return counter
 
 
 @task

--- a/corehq/ex-submodules/couchexport/tests/test_schema.py
+++ b/corehq/ex-submodules/couchexport/tests/test_schema.py
@@ -42,13 +42,14 @@ class ExportSchemaTest(TestCase, DocTestMixin):
             dt = datetime.utcnow()
             schema1 = ExportSchema(index=index, timestamp=dt)
             schema1.save(**save_args)
-            self.assertEqual(schema1._id, ExportSchema.last(index)._id)
+            self.assert_docs_equal(schema1, ExportSchema.last(index))
             schema2 = ExportSchema(index=index, timestamp=dt + timedelta(seconds=1))
             schema2.save(**save_args)
-            self.assertEqual(schema2._id, ExportSchema.last(index)._id)
+            self.assert_docs_equal(schema2, ExportSchema.last(index))
             schema3 = ExportSchema(index=index, timestamp=dt - timedelta(seconds=1))
             schema3.save(**save_args)
-            self.assertEqual(schema2._id, ExportSchema.last(index)._id)
+            # still schema2 (which has a later date than schema3)
+            self.assert_docs_equal(schema2, ExportSchema.last(index))
 
     def test_get_all_checkpoints(self):
         index = ["mydomain", "myxmlns"]

--- a/corehq/ex-submodules/couchexport/tests/test_schema.py
+++ b/corehq/ex-submodules/couchexport/tests/test_schema.py
@@ -1,5 +1,6 @@
 from couchdbkit.ext.django.loading import get_db
 from django.test import TestCase, SimpleTestCase
+from corehq.util.test_utils import DocTestMixin
 from couchexport.export import SCALAR_NEVER_WAS, get_formatted_rows, scalar_never_was
 from couchexport.models import ExportSchema, SavedExportSchema, SplitColumn
 from datetime import datetime, timedelta
@@ -9,7 +10,7 @@ import json
 from couchexport.models import Format
 
 
-class ExportSchemaTest(TestCase):
+class ExportSchemaTest(TestCase, DocTestMixin):
 
     def testSaveAndLoad(self):
         index = ["foo", 2]
@@ -25,9 +26,16 @@ class ExportSchemaTest(TestCase):
         self.assertEqual(inner, back.schema)
         self.assertEqual(index, back.index)
 
-    def testGetLast(self):
+    def test_get_last(self):
         indices = ["a string", ["a", "list"]]
         save_args = get_safe_write_kwargs()
+
+        for index in indices:
+            self.addCleanup(
+                lambda idx: map(lambda cp: cp.delete(),
+                                ExportSchema.get_all_checkpoints(idx)),
+                index
+            )
 
         for index in indices:
             self.assertEqual(None, ExportSchema.last(index))
@@ -41,6 +49,21 @@ class ExportSchemaTest(TestCase):
             schema3 = ExportSchema(index=index, timestamp=dt - timedelta(seconds=1))
             schema3.save(**save_args)
             self.assertEqual(schema2._id, ExportSchema.last(index)._id)
+
+    def test_get_all_checkpoints(self):
+        index = ["mydomain", "myxmlns"]
+        self.addCleanup(lambda: map(lambda cp: cp.delete(),
+                                    ExportSchema.get_all_checkpoints(index)))
+
+        schema1 = ExportSchema(index=index, timestamp=datetime.utcnow())
+        schema1.save()
+        schema1_prime, = list(ExportSchema.get_all_checkpoints(index))
+        self.assert_docs_equal(schema1_prime, schema1)
+        schema2 = ExportSchema(index=index, timestamp=datetime.utcnow())
+        schema2.save()
+        schema1_prime, schema2_prime = list(ExportSchema.get_all_checkpoints(index))
+        self.assert_docs_equal(schema1_prime, schema1)
+        self.assert_docs_equal(schema2_prime, schema2)
 
 
 class SavedSchemaTest(TestCase):


### PR DESCRIPTION
to save memory in extreme situations

fixes: http://manage.dimagi.com/default.asp?236106 / follow up to https://github.com/dimagi/commcare-hq/pull/13068
