### PR TITLE
Redirect to apps list if no appId

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -125,8 +125,10 @@ FormplayerFrontend.on('startForm', function (data) {
 
             if(resp.nextScreen !== null && resp.nextScreen !== undefined) {
                 FormplayerFrontend.trigger("renderResponse", resp.nextScreen);
-            } else {
+            } else if(urlObject.appId !== null && urlObject.appId !== undefined) {
                 FormplayerFrontend.trigger("apps:currentApp");
+            } else {
+                FormplayerFrontend.navigate('/apps', { trigger: true });
             }
         } else {
             showError(resp.output, $("#cloudcare-notifications"));


### PR DESCRIPTION
This should fix http://manage.dimagi.com/default.asp?236171 which was caused when we tried to redirect to the current app after submitting an incomplete form but this value was not set. 
