### PR TITLE
add reindex_sql_forms_in_domain command

### DIFF
--- a/corehq/apps/hqcase/management/commands/reindex_sql_forms_in_domain.py
+++ b/corehq/apps/hqcase/management/commands/reindex_sql_forms_in_domain.py
@@ -1,0 +1,22 @@
+from django.core.management import BaseCommand
+
+from corehq.form_processor.backends.sql.dbaccessors import *
+from corehq.pillows.xform import *
+
+
+def reindex_sql_forms_in_domain(domain):
+    for state, _ in XFormInstanceSQL.STATES:
+        doc_ids = FormAccessorSQL.get_form_ids_in_domain_by_state(domain, state)
+        for form in FormAccessorSQL.get_forms(doc_ids):
+            form_json = form.to_json(include_attachments=True)
+            txform = transform_xform_for_elasticsearch(form_json)
+            reindexer = get_sql_form_reindexer()
+            reindexer.doc_processor.process_bulk_docs([txform])
+
+
+class Command(BaseCommand):
+    args = 'domain'
+    help = 'Reindex a pillowtop index'
+
+    def handle(self, domain, *args, **options):
+        reindex_sql_forms_in_domain(domain)


### PR DESCRIPTION
@benrudolph @snopoke 

I couldn't think of a better way to do this. It doesn't really work within the reindexer system; I made a number of attempts to do that, but it felt like this rabbit hole, so I pulled out the essence of what happens when you run a reindexer, and just wrote that for-loop.

I also just ran this on nufnip-baseline-1 and betterbirth-light-touch to fix the missing forms they were seeing.
