### PR TITLE
Fix errors on user invite due to navigation

### DIFF
--- a/corehq/apps/reports/standard/deployments.py
+++ b/corehq/apps/reports/standard/deployments.py
@@ -46,7 +46,7 @@ class DeploymentsReport(GenericTabularReport, ProjectReport, ProjectReportParame
     @classmethod
     def show_in_navigation(cls, domain=None, project=None, user=None):
         # for commtrack projects - only show if the user can view apps
-        if project.commtrack_enabled:
+        if project and project.commtrack_enabled:
             return user and (user.is_superuser or user.has_permission(domain, 'edit_apps'))
         return super(DeploymentsReport, cls).show_in_navigation(domain, project, user)
 


### PR DESCRIPTION
This is a bit of a strange error, happening on some projects when the user gets an invite and tries to accept it. This should check for `project is None` anyway as the kwargs allow the project to be `None`

@dannyroberts @kaapstorm 
buddy @snopoke 
