### PR TITLE
Tranform dates in exports to request timezone

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -58,6 +58,7 @@ from corehq.apps.export.dbaccessors import (
     get_latest_form_export_schema,
 )
 from corehq.apps.export.utils import is_occurrence_deleted
+from corehq.apps.export.transforms import transform_date_to_request_timezone
 
 
 DAILY_SAVED_EXPORT_ATTACHMENT_NAME = "payload"
@@ -196,8 +197,8 @@ class ExportColumn(DocumentSchema):
         Transform the given value with the transform specified in self.item.transform.
         Also transform dates if the transform_dates flag is true.
         """
-        if transform_dates:
-            value = couch_to_excel_datetime(value, doc)
+
+        value = transform_date_to_request_timezone(value, doc, excel_format=transform_dates)
         if self.item.transform:
             value = TRANSFORM_FUNCTIONS[self.item.transform](value, doc)
         if self.deid_transform:

--- a/corehq/apps/export/tests/test_export_column.py
+++ b/corehq/apps/export/tests/test_export_column.py
@@ -348,7 +348,7 @@ class TestUserDefinedExportColumn(SimpleTestCase):
 
 class TestDatesInExportColumn(SimpleTestCase):
 
-    @patch('corehq.util.timezones.utils.get_timezone_for_request', lambda: pytz.UTC)
+    @patch('corehq.util.timezones.utils.get_timezone_for_domain', lambda _: pytz.UTC)
     def test_get_value_utc(self):
         column = ExportColumn(
             item=ExportItem(
@@ -367,7 +367,7 @@ class TestDatesInExportColumn(SimpleTestCase):
             '2016-09-02T10:00:00+00:00',
         )
 
-    @patch('corehq.util.timezones.utils.get_timezone_for_request', lambda: pytz.timezone('America/Chicago'))
+    @patch('corehq.util.timezones.utils.get_timezone_for_domain', lambda _: pytz.timezone('America/Chicago'))
     def test_get_value_chicago(self):
         column = ExportColumn(
             item=ExportItem(
@@ -386,7 +386,7 @@ class TestDatesInExportColumn(SimpleTestCase):
             '2016-09-02T05:00:00-05:00',
         )
 
-    @patch('corehq.util.timezones.utils.get_timezone_for_request', lambda: pytz.UTC)
+    @patch('corehq.util.timezones.utils.get_timezone_for_domain', lambda _: pytz.UTC)
     def test_get_value_utc_transform_dates(self):
         column = ExportColumn(
             item=ExportItem(
@@ -406,7 +406,7 @@ class TestDatesInExportColumn(SimpleTestCase):
             '2016-09-02 10:00:00',
         )
 
-    @patch('corehq.util.timezones.utils.get_timezone_for_request', lambda: pytz.timezone('America/Chicago'))
+    @patch('corehq.util.timezones.utils.get_timezone_for_domain', lambda _: pytz.timezone('America/Chicago'))
     def test_get_value_chicago_transform_dates(self):
         column = ExportColumn(
             item=ExportItem(
@@ -426,7 +426,7 @@ class TestDatesInExportColumn(SimpleTestCase):
             '2016-09-02 05:00:00',
         )
 
-    @patch('corehq.util.timezones.utils.get_timezone_for_request', lambda: pytz.UTC)
+    @patch('corehq.util.timezones.utils.get_timezone_for_domain', lambda _: pytz.UTC)
     def test_get_value_missing(self):
         column = ExportColumn(
             item=ExportItem(

--- a/corehq/apps/export/tests/test_export_column.py
+++ b/corehq/apps/export/tests/test_export_column.py
@@ -1,3 +1,4 @@
+import pytz
 from collections import namedtuple
 from django.test import SimpleTestCase
 from mock import patch
@@ -129,6 +130,7 @@ class StockExportColumnTest(SimpleTestCase):
 
             headers = list(column.get_headers())
             self.assertEqual(headers, ['water (123)', 'water (abc)'])
+
 
 class TestRowNumberColumn(SimpleTestCase):
 
@@ -342,3 +344,119 @@ class TestUserDefinedExportColumn(SimpleTestCase):
             result,
             '1234',
         )
+
+
+class TestDatesInExportColumn(SimpleTestCase):
+
+    @patch('corehq.util.timezones.utils.get_timezone_for_request', lambda: pytz.UTC)
+    def test_get_value_utc(self):
+        column = ExportColumn(
+            item=ExportItem(
+                path=[PathNode(name='form'), PathNode(name='date')],
+            ),
+        )
+
+        result = column.get_value(
+            'my-domain',
+            '1234',
+            {'date': '2016-09-02T10:00:00.000000Z'},
+            [PathNode(name='form')]
+        )
+        self.assertEqual(
+            result,
+            '2016-09-02T10:00:00+00:00',
+        )
+
+    @patch('corehq.util.timezones.utils.get_timezone_for_request', lambda: pytz.timezone('America/Chicago'))
+    def test_get_value_chicago(self):
+        column = ExportColumn(
+            item=ExportItem(
+                path=[PathNode(name='form'), PathNode(name='date')],
+            ),
+        )
+
+        result = column.get_value(
+            'my-domain',
+            '1234',
+            {'date': '2016-09-02T10:00:00.000000Z'},
+            [PathNode(name='form')]
+        )
+        self.assertEqual(
+            result,
+            '2016-09-02T05:00:00-05:00',
+        )
+
+    @patch('corehq.util.timezones.utils.get_timezone_for_request', lambda: pytz.UTC)
+    def test_get_value_utc_transform_dates(self):
+        column = ExportColumn(
+            item=ExportItem(
+                path=[PathNode(name='form'), PathNode(name='date')],
+            ),
+        )
+
+        result = column.get_value(
+            'my-domain',
+            '1234',
+            {'date': '2016-09-02T10:00:00.000000Z'},
+            [PathNode(name='form')],
+            transform_dates=True,
+        )
+        self.assertEqual(
+            result,
+            '2016-09-02 10:00:00',
+        )
+
+    @patch('corehq.util.timezones.utils.get_timezone_for_request', lambda: pytz.timezone('America/Chicago'))
+    def test_get_value_chicago_transform_dates(self):
+        column = ExportColumn(
+            item=ExportItem(
+                path=[PathNode(name='form'), PathNode(name='date')],
+            ),
+        )
+
+        result = column.get_value(
+            'my-domain',
+            '1234',
+            {'date': '2016-09-02T10:00:00.000000Z'},
+            [PathNode(name='form')],
+            transform_dates=True,
+        )
+        self.assertEqual(
+            result,
+            '2016-09-02 05:00:00',
+        )
+
+    @patch('corehq.util.timezones.utils.get_timezone_for_request', lambda: pytz.UTC)
+    def test_get_value_missing(self):
+        column = ExportColumn(
+            item=ExportItem(
+                path=[PathNode(name='form'), PathNode(name='date')],
+            ),
+        )
+
+        result = column.get_value(
+            'my-domain',
+            '1234',
+            {'date': ''},
+            [PathNode(name='form')],
+            transform_dates=True,
+        )
+        self.assertEqual(result, '')
+
+        result = column.get_value(
+            'my-domain',
+            '1234',
+            {},
+            [PathNode(name='form')],
+            transform_dates=True,
+        )
+        self.assertEqual(result, None)
+
+        result = column.get_value(
+            'my-domain',
+            '1234',
+            {'date': None},
+            [PathNode(name='form')],
+            transform_dates=True,
+        )
+        self.assertEqual(result, None)

--- a/corehq/apps/export/tests/test_get_export_file.py
+++ b/corehq/apps/export/tests/test_get_export_file.py
@@ -1,4 +1,5 @@
 import json
+import pytz
 from StringIO import StringIO
 
 from django.test import SimpleTestCase
@@ -267,6 +268,7 @@ class WriterTest(SimpleTestCase):
                 }
             )
 
+    @patch('corehq.util.timezones.utils.get_timezone_for_domain', lambda _: pytz.UTC)
     def test_transform_dates(self):
         """Ensure dates are transformed for excel when `transform_dates` is set to True"""
         export_instance = FormExportInstance(

--- a/corehq/apps/export/transforms.py
+++ b/corehq/apps/export/transforms.py
@@ -3,7 +3,7 @@ from django.core.cache import cache
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.users.util import cached_user_id_to_username, cached_owner_id_to_display
 from corehq.util.dates import iso_string_to_datetime
-from corehq.util.timezones.utils import get_timezone_aware_date_for_request
+from corehq.util.timezones.utils import get_timezone_aware_date_for_domain
 
 EXCEL_FORMAT = '%Y-%m-%d %H:%M:%S'
 
@@ -41,9 +41,9 @@ def _cached_case_id_to_case_name(case_id):
     return ret
 
 
-def transform_date_to_request_timezone(value, doc, excel_format=False):
+def transform_date_to_domain_timezone(domain, value, doc, excel_format=False):
     """
-    Transforms a date based on the current request's timezone.
+    Transforms a date based on the current domain's timezone.
     If transform_dates is True then the date is formatted for
     excel. If it cannot be parsed, it just returns the value.
     """
@@ -57,7 +57,7 @@ def transform_date_to_request_timezone(value, doc, excel_format=False):
         # Most likely not a date
         return value
 
-    date_value_aware = get_timezone_aware_date_for_request(date_value)
+    date_value_aware = get_timezone_aware_date_for_domain(domain, date_value)
 
     if excel_format:
         value = date_value_aware.strftime(EXCEL_FORMAT)

--- a/corehq/apps/export/transforms.py
+++ b/corehq/apps/export/transforms.py
@@ -2,6 +2,11 @@ from couchdbkit import ResourceNotFound
 from django.core.cache import cache
 from casexml.apps.case.models import CommCareCase
 from corehq.apps.users.util import cached_user_id_to_username, cached_owner_id_to_display
+from corehq.util.dates import iso_string_to_datetime
+from corehq.util.timezones.utils import get_timezone_aware_date_for_request
+
+EXCEL_FORMAT = '%Y-%m-%d %H:%M:%S'
+
 
 """
 Module for transforms used in exports.
@@ -34,3 +39,29 @@ def _cached_case_id_to_case_name(case_id):
         ret = None
     cache.set(key, ret)
     return ret
+
+
+def transform_date_to_request_timezone(value, doc, excel_format=False):
+    """
+    Transforms a date based on the current request's timezone.
+    If transform_dates is True then the date is formatted for
+    excel. If it cannot be parsed, it just returns the value.
+    """
+
+    if not value:
+        return value
+
+    try:
+        date_value = iso_string_to_datetime(value, strict=True)
+    except ValueError:
+        # Most likely not a date
+        return value
+
+    date_value_aware = get_timezone_aware_date_for_request(date_value)
+
+    if excel_format:
+        value = date_value_aware.strftime(EXCEL_FORMAT)
+    else:
+        value = date_value_aware.isoformat()
+
+    return value

--- a/corehq/util/timezones/utils.py
+++ b/corehq/util/timezones/utils.py
@@ -62,7 +62,6 @@ def get_timezone_for_user(couch_user_or_id, domain):
     return get_timezone_for_domain(domain)
 
 
-
-def get_timezone_aware_date_for_request(date):
+def get_timezone_aware_date_for_domain(domain, date):
     tz_utc_aware_date = pytz.utc.localize(date)
-    return tz_utc_aware_date.astimezone(get_timezone_for_request())
+    return tz_utc_aware_date.astimezone(get_timezone_for_domain(domain))

--- a/corehq/util/timezones/utils.py
+++ b/corehq/util/timezones/utils.py
@@ -1,5 +1,5 @@
-from django.core.exceptions import ValidationError
 import pytz
+from django.core.exceptions import ValidationError
 from corehq.apps.domain.models import Domain
 from corehq.apps.users.models import CouchUser, WebUser
 from corehq.util.global_request import get_request
@@ -60,3 +60,9 @@ def get_timezone_for_user(couch_user_or_id, domain):
                 return coerce_timezone_value(domain_membership.timezone)
 
     return get_timezone_for_domain(domain)
+
+
+
+def get_timezone_aware_date_for_request(date):
+    tz_utc_aware_date = pytz.utc.localize(date)
+    return tz_utc_aware_date.astimezone(get_timezone_for_request())


### PR DESCRIPTION
@czue @dannyroberts been meaning to do this for a while. all dates will now be in iso format instead of the other datetime format with the Z at the end (except if they want to transform to excel, then it'll be in excel format)

https://dimagi.uservoice.com/forums/194740-data/suggestions/9904056-have-data-export-timezone-match-project-domain-tim
