### PR TITLE
Default XMLNS to None for SQL forms

### DIFF
--- a/corehq/apps/receiverwrapper/tests/test_submit_errors.py
+++ b/corehq/apps/receiverwrapper/tests/test_submit_errors.py
@@ -107,6 +107,7 @@ class SubmissionErrorTest(TestCase):
         self.assertIn('Invalid XML', log.problem)
         self.assertEqual("this isn't even close to xml", log.get_xml())
 
+    @run_with_all_backends
     def test_missing_xmlns(self):
         file, res = self._submit('missing_xmlns.xml')
         self.assertEqual(500, res.status_code)

--- a/corehq/form_processor/backends/sql/processor.py
+++ b/corehq/form_processor/backends/sql/processor.py
@@ -148,7 +148,8 @@ class FormProcessorSQL(object):
             form_id=uuid.uuid4().hex,
             received_on=datetime.datetime.utcnow(),
             problem=message,
-            state=XFormInstanceSQL.SUBMISSION_ERROR_LOG
+            state=XFormInstanceSQL.SUBMISSION_ERROR_LOG,
+            xmlns=''
         )
         cls.store_attachments(xform, [Attachment(
             name=ATTACHMENT_NAME,

--- a/corehq/form_processor/migrations/0062_auto_20160905_0938.py
+++ b/corehq/form_processor/migrations/0062_auto_20160905_0938.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('form_processor', '0061_blob_bucket'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='xforminstancesql',
+            name='xmlns',
+            field=models.CharField(default=None, max_length=255),
+            preserve_default=True,
+        ),
+    ]

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -185,7 +185,7 @@ class XFormInstanceSQL(DisabledDbMixin, models.Model, RedisLockableMixIn, Attach
 
     domain = models.CharField(max_length=255, default=None)
     app_id = models.CharField(max_length=255, null=True)
-    xmlns = models.CharField(max_length=255)
+    xmlns = models.CharField(max_length=255, default=None)
     user_id = models.CharField(max_length=255, null=True)
 
     # When a form is deprecated, the existing form receives a new id and its original id is stored in orig_id


### PR DESCRIPTION
This will prevent any forms from being created without an XMLNS. Previously the form XMLNS would just be an empty string, now the DB will reject the save with an IntegrityError.

@biyeun 
