### PR TITLE
Retry clearing paywall flags if save conflicts

### DIFF
--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 
+from couchdbkit import ResourceConflict
 from django.core.urlresolvers import reverse
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _, ungettext
@@ -36,15 +37,17 @@ class BaseModifySubscriptionHandler(object):
         self.privileges = filter(lambda x: x in self.supported_privileges(), changed_privs)
 
     def get_response(self):
-        return filter(
-            lambda message: message is not None,
-            map(
-                lambda privilege: self.privilege_to_response_function()[privilege](
-                    self.domain, self.new_plan_version
-                ),
-                self.privileges
-            )
-        )
+        responses = []
+        for privilege in self.privileges:
+            try:
+                response = self.privilege_to_response_function()[privilege](self.domain, self.new_plan_version)
+            except ResourceConflict:
+                # Something else updated the domain. Reload and try again.
+                self.domain = Domain.get_by_name(self.domain.name)
+                response = self.privilege_to_response_function()[privilege](self.domain, self.new_plan_version)
+            if response is not None:
+                responses.append(response)
+        return responses
 
     @property
     def action_type(self):

--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -1,7 +1,6 @@
 import datetime
 import json
 
-from couchdbkit import ResourceConflict
 from django.core.urlresolvers import reverse
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _, ungettext
@@ -209,20 +208,11 @@ class DomainDowngradeActionHandler(BaseModifySubscriptionActionHandler):
 
     @staticmethod
     def response_report_builder(project, new_plan_version):
-
-        def clear_paywall_flags(project_):
-            project_.requested_report_builder_trial = []
-            project_.requested_report_builder_subscription = []
-
         if not _has_report_builder_add_on(new_plan_version):
-            clear_paywall_flags(project)
-            try:
-                project.save()
-            except ResourceConflict:
-                # Try again (FB 236568), but don't overwrite changes
-                project = Domain.get_by_name(project.get_id)
-                clear_paywall_flags(project)
-                project.save()
+            # Clear paywall flags
+            project.requested_report_builder_trial = []
+            project.requested_report_builder_subscription = []
+            project.save()
 
             # Deactivate all report builder data sources
             builder_reports = _get_report_builder_reports(project)

--- a/corehq/apps/accounting/subscription_changes.py
+++ b/corehq/apps/accounting/subscription_changes.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 
+from couchdbkit import ResourceConflict
 from django.core.urlresolvers import reverse
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _, ungettext
@@ -208,11 +209,20 @@ class DomainDowngradeActionHandler(BaseModifySubscriptionActionHandler):
 
     @staticmethod
     def response_report_builder(project, new_plan_version):
+
+        def clear_paywall_flags(project_):
+            project_.requested_report_builder_trial = []
+            project_.requested_report_builder_subscription = []
+
         if not _has_report_builder_add_on(new_plan_version):
-            # Clear paywall flags
-            project.requested_report_builder_trial = []
-            project.requested_report_builder_subscription = []
-            project.save()
+            clear_paywall_flags(project)
+            try:
+                project.save()
+            except ResourceConflict:
+                # Try again (FB 236568), but don't overwrite changes
+                project = Domain.get_by_name(project.get_id)
+                clear_paywall_flags(project)
+                project.save()
 
             # Deactivate all report builder data sources
             builder_reports = _get_report_builder_reports(project)

--- a/corehq/apps/accounting/tests/test_subscription_changes.py
+++ b/corehq/apps/accounting/tests/test_subscription_changes.py
@@ -1,14 +1,17 @@
 from django.test import SimpleTestCase
+from mock import patch, Mock
 
 from corehq.apps.accounting.models import (
     Subscription, BillingAccount, DefaultProductPlan, SoftwarePlanEdition,
     Subscriber)
+from corehq.apps.accounting.subscription_changes import DomainDowngradeActionHandler
 from corehq.apps.accounting.tests import generator
 from corehq.apps.accounting.tests.base_tests import BaseAccountingTest
 from corehq.apps.domain.models import Domain
 from corehq.apps.users.models import (
     Permissions, UserRole, UserRolePresets, WebUser, CommCareUser,
 )
+from corehq.privileges import REPORT_BUILDER_ADD_ON_PRIVS
 
 
 class TestSubscriptionEmailLogic(SimpleTestCase):
@@ -160,3 +163,34 @@ class TestUserRoleSubscriptionChanges(BaseAccountingTest):
         generator.delete_all_subscriptions()
         generator.delete_all_accounts()
         super(TestUserRoleSubscriptionChanges, self).tearDown()
+
+
+class TestSubscriptionChangeResourceConflict(BaseAccountingTest):
+
+    def setUp(self):
+        self.domain_name = 'test-domain-changes'
+        self.domain = Domain(
+            name=self.domain_name,
+            is_active=True,
+            description='spam',
+        )
+        self.domain.save()
+
+    def test_domain_changes(self):
+        role = Mock()
+        role.memberships_granted.all.return_value = []
+        version = Mock()
+        version.role.get_cached_role.return_value = role
+        handler = DomainDowngradeActionHandler(
+            self.domain, new_plan_version=version, changed_privs=REPORT_BUILDER_ADD_ON_PRIVS
+        )
+
+        conflicting_domain = Domain.get_by_name(self.domain_name)
+        conflicting_domain.description = 'eggs'
+        conflicting_domain.save()
+
+        get_by_name_func = Domain.get_by_name
+        with patch('corehq.apps.accounting.subscription_changes.Domain') as Domain_patch:
+            Domain_patch.get_by_name.side_effect = lambda name: get_by_name_func(name)
+            handler.get_response()
+            Domain_patch.get_by_name.assert_called_with(self.domain_name)


### PR DESCRIPTION
@nickpell is this what you had in mind? Are there other changes to `project` made before calling this method that this `save()` is also meant to save and that will be lost by fetching the instance again?

Do we know what's causing the conflict? Will this change resolve the problem?

cc @dannyroberts @biyeun @orangejenny @NoahCarnahan 
