### PR TITLE
Validate payment e-mail addresses

### DIFF
--- a/corehq/apps/accounting/static/accounting/ko/accounting.payment_method_handler.js
+++ b/corehq/apps/accounting/static/accounting/ko/accounting.payment_method_handler.js
@@ -203,6 +203,7 @@ hqDefine('accounting/ko/accounting.payment_method_handler.js', function () {
             errorThrown = errorThrown || 500;
             self.serverErrorMsg(self.errorMessages[errorThrown]);
             self.selectedCard().isProcessing(false);
+            self.paymentProcessing(false);
         };
 
         self.handleProcessingErrors = function (response) {
@@ -227,8 +228,8 @@ hqDefine('accounting/ko/accounting.payment_method_handler.js', function () {
                     }
                 }
                 self.paymentIsComplete(true);
-                self.paymentProcessing(false);
             }
+            self.paymentProcessing(false);
             self.handleProcessingErrors(response);
         };
 

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -10,7 +10,9 @@ import pytz
 
 from couchdbkit import ResourceNotFound
 import dateutil
+from django.core.exceptions import ValidationError
 from django.core.paginator import Paginator
+from django.core.validators import validate_email
 from django.views.decorators.debug import sensitive_post_parameters
 from django.views.generic import View
 from django.db.models import Sum
@@ -1085,6 +1087,16 @@ class CreditsWireInvoiceView(DomainAccountingSettings):
 
     def post(self, request, *args, **kwargs):
         emails = request.POST.get('emails', []).split()
+        invalid_emails = []
+        for email in emails:
+            try:
+                validate_email(email)
+            except ValidationError:
+                invalid_emails.append(email)
+        if invalid_emails:
+            message = ('The following e-mail addresses failed validation: ' +
+                       ', '.join(['"{}"'.format(email) for email in invalid_emails]))
+            return json_response({'error': {'message': message}})
         amount = Decimal(request.POST.get('amount', 0))
         wire_invoice_factory = DomainWireInvoiceFactory(request.domain, contact_emails=emails)
         try:

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -1094,8 +1094,8 @@ class CreditsWireInvoiceView(DomainAccountingSettings):
             except ValidationError:
                 invalid_emails.append(email)
         if invalid_emails:
-            message = ('The following e-mail addresses failed validation: ' +
-                       ', '.join(['"{}"'.format(email) for email in invalid_emails]))
+            message = (_('The following e-mail addresses contain invalid characters, or are missing required '
+                         'characters: ') + ', '.join(['"{}"'.format(email) for email in invalid_emails]))
             return json_response({'error': {'message': message}})
         amount = Decimal(request.POST.get('amount', 0))
         wire_invoice_factory = DomainWireInvoiceFactory(request.domain, contact_emails=emails)


### PR DESCRIPTION
Context: http://manage.dimagi.com/default.asp?236551

I explored doing the validation client-side and server-side. This commit is for the server-side implementation. I found client-side validation using `EmailSelect2Handler` was going to be a bigger lift for me, but my feelings won't be hurt if you think we should go there instead.

![e-mail_validation](https://cloud.githubusercontent.com/assets/708421/18253117/832ffb22-7392-11e6-8f7e-e208fabc7283.png)

@nickpell @dannyroberts @biyeun cc @NoahCarnahan @orangejenny 
