### PR TITLE
form_data returns empty dictionary on XMLSyntaxError

### DIFF
--- a/corehq/apps/receiverwrapper/tests/test_submit_errors.py
+++ b/corehq/apps/receiverwrapper/tests/test_submit_errors.py
@@ -106,6 +106,7 @@ class SubmissionErrorTest(TestCase):
         self.assertIsNotNone(log)
         self.assertIn('Invalid XML', log.problem)
         self.assertEqual("this isn't even close to xml", log.get_xml())
+        self.assertEqual(log.form_data, {})
 
     def test_missing_xmlns(self):
         file, res = self._submit('missing_xmlns.xml')

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -290,9 +290,13 @@ class XFormInstanceSQL(DisabledDbMixin, models.Model, RedisLockableMixIn, Attach
     @property
     @memoized
     def form_data(self):
+        from couchforms import XMLSyntaxError
         from .utils import convert_xform_to_json, adjust_datetimes
         xml = self.get_xml()
-        form_json = convert_xform_to_json(xml)
+        try:
+            form_json = convert_xform_to_json(xml)
+        except XMLSyntaxError:
+            return {}
         # we can assume all sql domains are new timezone domains
         with force_phone_timezones_should_be_processed():
             adjust_datetimes(form_json)

--- a/corehq/pillows/xform.py
+++ b/corehq/pillows/xform.py
@@ -176,5 +176,6 @@ def get_sql_form_reindexer():
         doc_provider,
         elasticsearch=get_es_new(),
         index_info=XFORM_INDEX_INFO,
+        doc_filter=xform_pillow_filter,
         doc_transform=transform_xform_for_elasticsearch
     )


### PR DESCRIPTION
Context: http://manage.dimagi.com/default.asp?236666

Instead of trying to return valid XML, as I tried in my first attempt in PR #13102, form_data catches when it's broken and returns an empty dictionary.

@snopoke cc @dannyroberts @biyeun @NoahCarnahan @orangejenny
