### PR TITLE
remove unnecessary slash from regex

### DIFF
--- a/corehq/apps/receiverwrapper/urls.py
+++ b/corehq/apps/receiverwrapper/urls.py
@@ -6,6 +6,6 @@ urlpatterns = patterns('corehq.apps.receiverwrapper.views',
     url(r'^secure/$', 'secure_post', name='receiver_secure_post'),
 
     # odk urls
-    url(r'^submission/?$',  'post', name="receiver_odk_post"),
+    url(r'^submission/?$', 'post', name="receiver_odk_post"),
     url(r'^(?P<app_id>[\w-]+)/$', 'post', name='receiver_post_with_app_id'),
 )

--- a/corehq/apps/receiverwrapper/urls.py
+++ b/corehq/apps/receiverwrapper/urls.py
@@ -2,10 +2,10 @@ from django.conf.urls import *
 
 urlpatterns = patterns('corehq.apps.receiverwrapper.views',
     url(r'^/?$', 'post', name='receiver_post'),
-    url(r'^/secure/(?P<app_id>[\w-]+)/$', 'secure_post', name='receiver_secure_post_with_app_id'),
-    url(r'^/secure/$', 'secure_post', name='receiver_secure_post'),
+    url(r'^secure/(?P<app_id>[\w-]+)/$', 'secure_post', name='receiver_secure_post_with_app_id'),
+    url(r'^secure/$', 'secure_post', name='receiver_secure_post'),
 
     # odk urls
-    url(r'^/submission/?$',  'post', name="receiver_odk_post"),
-    url(r'^/(?P<app_id>[\w-]+)/$', 'post', name='receiver_post_with_app_id'),
+    url(r'^submission/?$',  'post', name="receiver_odk_post"),
+    url(r'^(?P<app_id>[\w-]+)/$', 'post', name='receiver_post_with_app_id'),
 )


### PR DESCRIPTION
Gets rid of warnings in django 1.9:

```
WARNINGS:
?: (urls.W002) Your URL pattern '^/(?P<app_id>[\w-]+)/$' [name='receiver_post_with_app_id'] has a regex beginning with a '/'. Remove this slash as it is unnecessary.
?: (urls.W002) Your URL pattern '^/?$' [name='receiver_post'] has a regex beginning with a '/'. Remove this slash as it is unnecessary.
?: (urls.W002) Your URL pattern '^/secure/$' [name='receiver_secure_post'] has a regex beginning with a '/'. Remove this slash as it is unnecessary.
?: (urls.W002) Your URL pattern '^/secure/(?P<app_id>[\w-]+)/$' [name='receiver_secure_post_with_app_id'] has a regex beginning with a '/'. Remove this slash as it is unnecessary.
?: (urls.W002) Your URL pattern '^/submission/?$' [name='receiver_odk_post'] has a regex beginning with a '/'. Remove this slash as it is unnecessary.
```

@calellowitz 
