### PR TITLE
don't use imports from __init__ that require models

### DIFF
--- a/corehq/apps/api/object_fetch_api.py
+++ b/corehq/apps/api/object_fetch_api.py
@@ -5,11 +5,13 @@ from django.core.urlresolvers import reverse
 from django.http import HttpResponse, Http404, StreamingHttpResponse, HttpResponseForbidden
 from django.utils.decorators import method_decorator
 from django.views.generic import View
+
+from dimagi.utils.django.cached_object import IMAGE_SIZE_ORDERING, OBJECT_ORIGINAL
+
+from corehq.apps.domain.decorators import login_or_digest_or_basic_or_apikey
 from corehq.apps.reports.views import can_view_attachments
 from corehq.form_processor.exceptions import CaseNotFound, AttachmentNotFound
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors, get_cached_case_attachment, FormAccessors
-from dimagi.utils.django.cached_object import IMAGE_SIZE_ORDERING, OBJECT_ORIGINAL
-from corehq.apps.domain.decorators import login_or_digest_or_basic_or_apikey
 
 
 class CaseAttachmentAPI(View):

--- a/corehq/apps/commtrack/sms.py
+++ b/corehq/apps/commtrack/sms.py
@@ -19,7 +19,7 @@ from corehq.apps.commtrack.util import get_supply_point_and_location
 from corehq.apps.commtrack.xmlutil import XML
 from corehq.apps.products.models import Product
 from corehq.apps.users.models import CouchUser
-from corehq.apps.receiverwrapper import submit_form_locally
+from corehq.apps.receiverwrapper.util import submit_form_locally
 from xml.etree import ElementTree
 from casexml.apps.case.mock import CaseBlock
 from corehq.apps.commtrack.exceptions import (

--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -7,7 +7,7 @@ from django.template.loader import render_to_string
 from corehq.apps.app_manager.dbaccessors import get_brief_apps_in_domain
 from corehq.apps.cachehq.mixins import QuickCachedDocumentMixin
 from corehq.apps.domain.exceptions import DomainDeleteException
-from corehq.apps.tzmigration import set_migration_complete
+from corehq.apps.tzmigration.api import set_migration_complete
 from corehq.dbaccessors.couchapps.all_docs import \
     get_all_doc_ids_for_domain_grouped_by_db
 from corehq.util.soft_assert import soft_assert

--- a/corehq/apps/hqcase/utils.py
+++ b/corehq/apps/hqcase/utils.py
@@ -15,7 +15,7 @@ from corehq.form_processor.interfaces.dbaccessors import get_cached_case_attachm
 from dimagi.utils.parsing import json_format_datetime
 from casexml.apps.phone.caselogic import get_related_cases
 from corehq.apps.hqcase.exceptions import CaseAssignmentError
-from corehq.apps.receiverwrapper import submit_form_locally
+from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.apps.users.util import SYSTEM_USER_ID
 from casexml.apps.case import const
 

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -111,7 +111,7 @@ from corehq.apps.hqcase.export import export_cases
 from corehq.apps.hqwebapp.utils import csrf_inline
 from corehq.apps.locations.permissions import can_edit_form_location
 from corehq.apps.products.models import SQLProduct
-from corehq.apps.receiverwrapper import submit_form_locally
+from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.apps.userreports.util import default_language as ucr_default_language
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.export import export_users

--- a/corehq/apps/smsforms/util.py
+++ b/corehq/apps/smsforms/util.py
@@ -1,4 +1,4 @@
-from corehq.apps.receiverwrapper import submit_form_locally
+from corehq.apps.receiverwrapper.util import submit_form_locally
 
 
 def form_requires_input(form):

--- a/corehq/form_processor/models.py
+++ b/corehq/form_processor/models.py
@@ -25,7 +25,7 @@ from corehq.form_processor import signals
 from corehq.form_processor.abstract_models import DEFAULT_PARENT_IDENTIFIER
 from corehq.form_processor.exceptions import InvalidAttachment, UnknownActionType
 from corehq.form_processor.track_related import TrackRelatedChanges
-from corehq.apps.tzmigration import force_phone_timezones_should_be_processed
+from corehq.apps.tzmigration.api import force_phone_timezones_should_be_processed
 from corehq.sql_db.routers import db_for_read_write
 from couchforms import const
 from couchforms.jsonobject_extensions import GeoPointProperty

--- a/corehq/form_processor/submission_post.py
+++ b/corehq/form_processor/submission_post.py
@@ -18,7 +18,7 @@ from casexml.apps.case.exceptions import PhoneDateValueError, IllegalCaseId, Use
 from casexml.apps.case.xml import V2
 from corehq.toggles import ASYNC_RESTORE
 from corehq.apps.commtrack.exceptions import MissingProductId
-from corehq.apps.tzmigration import timezone_migration_in_progress
+from corehq.apps.tzmigration.api import timezone_migration_in_progress
 from corehq.form_processor.exceptions import CouchSaveAborted
 from corehq.form_processor.interfaces.dbaccessors import FormAccessors
 from corehq.form_processor.interfaces.processor import FormProcessorInterface

--- a/corehq/tabs/templatetags/menu_tags.py
+++ b/corehq/tabs/templatetags/menu_tags.py
@@ -2,7 +2,7 @@ from django import template
 from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
 
-from corehq.tabs import MENU_TABS
+from corehq.tabs.config import MENU_TABS
 from corehq.tabs.exceptions import TabClassError, TabClassErrorSummary
 from corehq.tabs.utils import path_starts_with_url
 

--- a/corehq/util/timezones/conversions.py
+++ b/corehq/util/timezones/conversions.py
@@ -1,7 +1,7 @@
 from django.utils.encoding import smart_str
 import pytz
 
-from corehq.apps.tzmigration import phone_timezones_have_been_processed
+from corehq.apps.tzmigration.api import phone_timezones_have_been_processed
 
 from corehq.const import USER_DATETIME_FORMAT, SERVER_DATETIME_FORMAT
 from corehq.util.soft_assert import soft_assert

--- a/custom/uth/utils.py
+++ b/custom/uth/utils.py
@@ -1,4 +1,4 @@
-from corehq.apps.receiverwrapper import submit_form_locally
+from corehq.apps.receiverwrapper.util import submit_form_locally
 from casexml.apps.case.models import CommCareCase
 from lxml import etree
 import os


### PR DESCRIPTION
django 1.9 fails hard if **init** imports models (even indirectly)

@calellowitz 
