### PR TITLE
begin moving indirect model imports out of __init__.py

### DIFF
--- a/corehq/apps/reports/dispatcher.py
+++ b/corehq/apps/reports/dispatcher.py
@@ -1,20 +1,23 @@
-from django.utils.decorators import method_decorator
 from django.core.urlresolvers import reverse
 from django.http import Http404, HttpResponseRedirect, HttpResponseBadRequest
-from django.views.generic.base import View
+from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext
-from corehq.apps.accounting.utils import domain_has_privilege
-from corehq.apps.domain.decorators import login_and_domain_required, cls_to_view
-from corehq.apps.domain.utils import get_domain_module_map
+from django.views.generic.base import View
+
 from dimagi.utils.decorators.datespan import datespan_in_request
+
 from django_prbac.exceptions import PermissionDenied
 from django_prbac.utils import has_privilege
 
-from corehq.apps.domain.models import Domain
-from corehq.apps.reports.exceptions import BadRequestError
 from corehq import privileges
 from corehq.apps.accounting.decorators import requires_privilege_with_fallback
+from corehq.apps.accounting.utils import domain_has_privilege
+from corehq.apps.domain.decorators import login_and_domain_required, cls_to_view
+from corehq.apps.domain.models import Domain
+from corehq.apps.domain.utils import get_domain_module_map
 from corehq.apps.hqwebapp.templatetags.hq_shared_tags import toggle_enabled
+from corehq.apps.reports.exceptions import BadRequestError
+
 
 datespan_default = datespan_in_request(
     from_param="startdate",

--- a/corehq/apps/reports/dispatcher.py
+++ b/corehq/apps/reports/dispatcher.py
@@ -88,18 +88,18 @@ class ReportDispatcher(View):
 
         corehq_reports = process(getattr(reports, attr_name, ()))
 
-        module_name = get_domain_module_map().get(domain, domain)
-        try:
+        module_name = get_domain_module_map().get(domain)
+        if module_name is None:
+            custom_reports = ()
+        else:
             module = __import__(module_name, fromlist=['reports'])
             reports = getattr(module, 'reports')
             custom_reports = process(getattr(reports, attr_name, ()))
-        except ImportError:
-            custom_reports = ()
 
-        # soon to be removed
-        if not custom_reports:
-            domain_module = Domain.get_module_by_name(domain)
-            custom_reports = process(getattr(domain_module, attr_name, ()))
+            # soon to be removed
+            if not custom_reports:
+                domain_module = Domain.get_module_by_name(domain)
+                custom_reports = process(getattr(domain_module, attr_name, ()))
 
         return corehq_reports + custom_reports
 

--- a/corehq/apps/reports/dispatcher.py
+++ b/corehq/apps/reports/dispatcher.py
@@ -76,7 +76,6 @@ class ReportDispatcher(View):
     def get_reports(self, domain=None):
         attr_name = self.map_name
         from corehq import reports
-        domain_module = Domain.get_module_by_name(domain)
         if domain:
             project = Domain.get_by_name(domain)
         else:
@@ -90,11 +89,16 @@ class ReportDispatcher(View):
         corehq_reports = process(getattr(reports, attr_name, ()))
 
         module_name = get_domain_module_map().get(domain, domain)
-        module = __import__(module_name, fromlist=['reports'])
-        reports = getattr(module, 'reports')
-        custom_reports = process(getattr(reports, attr_name, ()))
+        try:
+            module = __import__(module_name, fromlist=['reports'])
+            reports = getattr(module, 'reports')
+            custom_reports = process(getattr(reports, attr_name, ()))
+        except ImportError:
+            custom_reports = ()
 
+        # soon to be removed
         if not custom_reports:
+            domain_module = Domain.get_module_by_name(domain)
             custom_reports = process(getattr(domain_module, attr_name, ()))
 
         return corehq_reports + custom_reports

--- a/custom/_legacy/a5288/__init__.py
+++ b/custom/_legacy/a5288/__init__.py
@@ -1,7 +1,0 @@
-from a5288.reports import MissedCallbackReport
-
-CUSTOM_REPORTS = (
-    ('Custom Reports', (
-        MissedCallbackReport,
-    )),
-)

--- a/custom/_legacy/a5288/reports.py
+++ b/custom/_legacy/a5288/reports.py
@@ -120,3 +120,10 @@ class MissedCallbackReport(CustomProjectReport, GenericTabularReport):
     
     def _fmt_highlight(self, value):
         return self.table_cell(value, '<div style="background-color:#f33; font-weight:bold; text-align:center">%s</div>' % value)
+
+
+CUSTOM_REPORTS = (
+    ('Custom Reports', (
+        MissedCallbackReport,
+    )),
+)


### PR DESCRIPTION
Needed for django 1.9, which fails hard if models.py is imported directly or indirectly in **init**.py

Doing a first pass with a5288.

@dannyroberts @sravfeyn 
