### PR TITLE
99DOTS case repeater

### DIFF
--- a/corehq/apps/api/resources/v0_4.py
+++ b/corehq/apps/api/resources/v0_4.py
@@ -20,7 +20,8 @@ from corehq.apps.api.util import get_object_or_not_exist, object_does_not_exist,
 from corehq.apps.app_manager import util as app_manager_util
 from corehq.apps.app_manager.models import Application, RemoteApp
 from corehq.apps.app_manager.dbaccessors import get_apps_in_domain
-from corehq.apps.repeaters.models import Repeater, repeater_types
+from corehq.apps.repeaters.models import Repeater
+from corehq.apps.repeaters.utils import get_all_repeater_types
 from corehq.apps.groups.models import Group
 from corehq.apps.cloudcare.api import ElasticCaseQuery
 from corehq.apps.users.util import format_username
@@ -187,7 +188,7 @@ class RepeaterResource(CouchResourceMixin, HqBaseResource, DomainSpecificResourc
 
     def obj_get(self, bundle, **kwargs):
         return get_object_or_not_exist(Repeater, kwargs['pk'], kwargs['domain'],
-                                       additional_doc_types=repeater_types.keys())
+                                       additional_doc_types=get_all_repeater_types().keys())
 
     def obj_create(self, bundle, request=None, **kwargs):
         bundle.obj.domain = kwargs['domain']

--- a/corehq/apps/domain/templates/domain/admin/domain_forwarding.html
+++ b/corehq/apps/domain/templates/domain/admin/domain_forwarding.html
@@ -7,7 +7,7 @@
         {{ pending_record_count }} pending items to be forwarded
     {% endblocktrans %}
     </div>
-    {% for cls, form_repeaters, type in repeaters %}
+    {% for cls, form_repeaters, type, custom_url in repeaters %}
     <div style="padding-bottom:2em;">
         <h2>{{ type }}</h2>
         {% if form_repeaters %}
@@ -42,7 +42,14 @@
         {% else %}
             <p>{% blocktrans %}You haven't configured any urls to forward to yet.{% endblocktrans %}</p>
         {% endif %}
-        <a class="btn btn-success" href="{% url "add_repeater" domain cls %}"><i class="fa fa-plus"></i> {% trans 'Add a forwarding location' %}</a>
+        <a class="btn btn-success"
+           href="
+                 {% if custom_url %}
+                     {{ custom_url }}
+                 {% else %}
+                     {% url "add_repeater" domain cls %}
+                 {% endif %}
+                 "><i class="fa fa-plus"></i> {% trans 'Add a forwarding location' %}</a>
     </div>
     {% endfor %}
 {% endblock %}

--- a/corehq/apps/domain/templates/domain/admin/domain_forwarding.html
+++ b/corehq/apps/domain/templates/domain/admin/domain_forwarding.html
@@ -9,7 +9,7 @@
     </div>
     {% for cls, form_repeaters, type in repeaters %}
     <div style="padding-bottom:2em;">
-        <h2>{% blocktrans %}Forward {{ type }}:{% endblocktrans %}</h2>
+        <h2>{{ type }}</h2>
         {% if form_repeaters %}
             <table class="table table-striped table-bordered">
             {% if form_repeaters %}

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -2124,18 +2124,6 @@ class CaseSearchConfigView(BaseAdminProjectSettingsView):
         }
 
 
-class RepeaterMixin(object):
-
-    @property
-    def friendly_repeater_names(self):
-        return {
-            'FormRepeater': _("Forward Forms"),
-            'CaseRepeater': _("Forward Cases"),
-            'ShortFormRepeater': _("Forward Form Stubs"),
-            'AppStructureRepeater': _("Forward App Schema Changes"),
-        }
-
-
 class DomainForwardingRepeatRecords(GenericTabularReport):
     name = 'Repeat Records'
     base_template = 'domain/repeat_record_report.html'
@@ -2256,7 +2244,7 @@ class DomainForwardingRepeatRecords(GenericTabularReport):
         )
 
 
-class DomainForwardingOptionsView(BaseAdminProjectSettingsView, RepeaterMixin):
+class DomainForwardingOptionsView(BaseAdminProjectSettingsView):
     urlname = 'domain_forwarding'
     page_title = ugettext_lazy("Data Forwarding")
     template_name = 'domain/admin/domain_forwarding.html'
@@ -2281,7 +2269,7 @@ class DomainForwardingOptionsView(BaseAdminProjectSettingsView, RepeaterMixin):
         }
 
 
-class AddRepeaterView(BaseAdminProjectSettingsView, RepeaterMixin):
+class AddRepeaterView(BaseAdminProjectSettingsView):
     urlname = 'add_repeater'
     page_title = ugettext_lazy("Forward Data")
     template_name = 'domain/admin/add_form_repeater.html'
@@ -2308,7 +2296,7 @@ class AddRepeaterView(BaseAdminProjectSettingsView, RepeaterMixin):
 
     @property
     def page_name(self):
-        return "Forward %s" % self.friendly_repeater_names.get(self.repeater_type, "Data")
+        return self.repeater_class.friendly_name
 
     @property
     @memoized

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -2129,10 +2129,10 @@ class RepeaterMixin(object):
     @property
     def friendly_repeater_names(self):
         return {
-            'FormRepeater': _("Forms"),
-            'CaseRepeater': _("Cases"),
-            'ShortFormRepeater': _("Form Stubs"),
-            'AppStructureRepeater': _("App Schema Changes"),
+            'FormRepeater': _("Forward Forms"),
+            'CaseRepeater': _("Forward Cases"),
+            'ShortFormRepeater': _("Forward Form Stubs"),
+            'AppStructureRepeater': _("Forward App Schema Changes"),
         }
 
 

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -2309,7 +2309,11 @@ class AddRepeaterView(BaseAdminProjectSettingsView):
         try:
             return get_all_repeater_types()[self.repeater_type]
         except KeyError:
-            raise Http404("No such repeater {}. Valid types: {}".format(self.repeater_type, get_all_repeater_types.keys()))
+            raise Http404(
+                "No such repeater {}. Valid types: {}".format(
+                    self.repeater_type, get_all_repeater_types.keys()
+                )
+            )
 
     @property
     @memoized

--- a/corehq/apps/domain/views.py
+++ b/corehq/apps/domain/views.py
@@ -2263,7 +2263,7 @@ class DomainForwardingOptionsView(BaseAdminProjectSettingsView):
                 r.friendly_name,
                 r.get_custom_url(self.domain)
             )
-            for r in get_all_repeater_types.values()
+            for r in get_all_repeater_types().values() if r.available_for_domain(self.domain)
         ]
 
     @property

--- a/corehq/apps/repeaters/dbaccessors.py
+++ b/corehq/apps/repeaters/dbaccessors.py
@@ -129,3 +129,10 @@ def delete_all_repeat_records():
             pass
         else:
             repeat_record.delete()
+
+
+@unit_testing_only
+def delete_all_repeaters():
+    from .models import Repeater
+    for repeater in Repeater.get_db().view('receiverwrapper/repeaters', reduce=False, include_docs=True).all():
+        Repeater.wrap(repeater['doc']).delete()

--- a/corehq/apps/repeaters/forms.py
+++ b/corehq/apps/repeaters/forms.py
@@ -176,7 +176,7 @@ class CaseRepeaterForm(GenericRepeaterForm):
         return ['white_listed_case_types'] + ['black_listed_users'] + fields
 
     def clean(self):
-        cleaned_data = super(GenericRepeaterForm, self).clean()
+        cleaned_data = super(CaseRepeaterForm, self).clean()
         white_listed_case_types = cleaned_data['white_listed_case_types']
         black_listed_users = cleaned_data['black_listed_users']
         if not set(white_listed_case_types).issubset([t[0] for t in self.case_type_choices]):

--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -204,6 +204,12 @@ class Repeater(QuickCachedDocumentMixin, Document, UnicodeMixIn):
     def get_custom_url(cls, domain):
         return None
 
+    @classmethod
+    def available_for_domain(cls, domain):
+        """Returns whether this repeater can be used by a particular domain
+        """
+        return True
+
     def get_pending_record_count(self):
         return get_pending_repeat_record_count(self.domain, self._id)
 

--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -599,7 +599,7 @@ class RepeatRecord(Document):
             return self.handle_failure(response, post_info, tries)
 
     def handle_success(self, response):
-        """Do something once the repeater succeeds
+        """Do something with the response if the repeater succeeds
         """
         self.last_checked = datetime.utcnow()
         self.next_check = None

--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -4,6 +4,8 @@ from datetime import datetime, timedelta
 import logging
 import urllib
 import urlparse
+from django.utils.translation import ugettext_lazy as _
+
 from requests.exceptions import Timeout, ConnectionError
 from corehq.apps.cachehq.mixins import QuickCachedDocumentMixin
 from corehq.form_processor.exceptions import XFormNotFound
@@ -203,6 +205,8 @@ class Repeater(QuickCachedDocumentMixin, Document, UnicodeMixIn):
     use_basic_auth = BooleanProperty(default=False)
     username = StringProperty()
     password = StringProperty()
+    friendly_name = _("Data")
+
 
     def get_pending_record_count(self):
         return get_pending_repeat_record_count(self.domain, self._id)
@@ -334,6 +338,7 @@ class FormRepeater(Repeater):
 
     include_app_id_param = BooleanProperty(default=True)
     white_listed_form_xmlns = StringListProperty(default=[])  # empty value means all form xmlns are accepted
+    friendly_name = _("Forward Forms")
 
     @memoized
     def payload_doc(self, repeat_record):
@@ -378,6 +383,7 @@ class CaseRepeater(Repeater):
     version = StringProperty(default=V2, choices=LEGAL_VERSIONS)
     white_listed_case_types = StringListProperty(default=[])  # empty value means all case-types are accepted
     black_listed_users = StringListProperty(default=[])  # users who caseblock submissions should be ignored
+    friendly_name = _("Forward Cases")
 
     def allowed_to_forward(self, payload):
         allowed_case_type = not self.white_listed_case_types or payload.type in self.white_listed_case_types
@@ -411,6 +417,7 @@ class ShortFormRepeater(Repeater):
     """
 
     version = StringProperty(default=V2, choices=LEGAL_VERSIONS)
+    friendly_name = _("Forward Form Stubs")
 
     @memoized
     def payload_doc(self, repeat_record):
@@ -432,6 +439,7 @@ class ShortFormRepeater(Repeater):
 
 @register_repeater_type
 class AppStructureRepeater(Repeater):
+    friendly_name = _("Forward App Schema Changes")
 
     def payload_doc(self, repeat_record):
         return None

--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -42,14 +42,7 @@ from .const import (
     POST_TIMEOUT,
 )
 from .exceptions import RequestConnectionError
-
-
-repeater_types = {}
-
-
-def register_repeater_type(cls):
-    repeater_types[cls.__name__] = cls
-    return cls
+from .utils import get_all_repeater_types
 
 
 def simple_post_with_cached_timeout(data, url, expiry=60 * 60, force_send=False, *args, **kwargs):
@@ -268,7 +261,7 @@ class Repeater(QuickCachedDocumentMixin, Document, UnicodeMixIn):
     @quickcache(['cls.__name__', 'domain'], timeout=5 * 60, memoize_timeout=10)
     def by_domain(cls, domain):
         key = [domain]
-        if cls.__name__ in repeater_types:
+        if cls.__name__ in get_all_repeater_types():
             key.append(cls.__name__)
         elif cls.__name__ == Repeater.__name__:
             # In this case the wrap function delegates to the
@@ -305,6 +298,7 @@ class Repeater(QuickCachedDocumentMixin, Document, UnicodeMixIn):
     @staticmethod
     def get_class_from_doc_type(doc_type):
         doc_type = doc_type.replace(DELETED, '')
+        repeater_types = get_all_repeater_types()
         if doc_type in repeater_types:
             return repeater_types[doc_type]
         else:
@@ -332,7 +326,6 @@ class Repeater(QuickCachedDocumentMixin, Document, UnicodeMixIn):
         return headers
 
 
-@register_repeater_type
 class FormRepeater(Repeater):
     """
     Record that forms should be repeated to a new url
@@ -376,7 +369,6 @@ class FormRepeater(Repeater):
         return "forwarding forms to: %s" % self.url
 
 
-@register_repeater_type
 class CaseRepeater(Repeater):
     """
     Record that cases should be repeated to a new url
@@ -412,7 +404,6 @@ class CaseRepeater(Repeater):
         return "forwarding cases to: %s" % self.url
 
 
-@register_repeater_type
 class ShortFormRepeater(Repeater):
     """
     Record that form id & case ids should be repeated to a new url
@@ -440,7 +431,6 @@ class ShortFormRepeater(Repeater):
         return "forwarding short form to: %s" % self.url
 
 
-@register_repeater_type
 class AppStructureRepeater(Repeater):
     friendly_name = _("Forward App Schema Changes")
 

--- a/corehq/apps/repeaters/models.py
+++ b/corehq/apps/repeaters/models.py
@@ -207,6 +207,9 @@ class Repeater(QuickCachedDocumentMixin, Document, UnicodeMixIn):
     password = StringProperty()
     friendly_name = _("Data")
 
+    @classmethod
+    def get_custom_url(cls, domain):
+        return None
 
     def get_pending_record_count(self):
         return get_pending_repeat_record_count(self.domain, self._id)

--- a/corehq/apps/repeaters/repeater_generators.py
+++ b/corehq/apps/repeaters/repeater_generators.py
@@ -48,6 +48,20 @@ class BasePayloadGenerator(object):
             "</data>" % datetime.utcnow()
         )
 
+    def handle_success(self, response, payload_doc):
+        """handle a successful post
+
+        e.g. could be used to store something to the payload_doc once a
+        response is recieved
+
+        """
+        return True
+
+    def handle_failure(self, response, payload_doc):
+        """handle a failed post
+        """
+        return True
+
 
 @RegisterGenerator(FormRepeater, 'form_xml', 'XML', is_default=True)
 class FormRepeaterXMLPayloadGenerator(BasePayloadGenerator):

--- a/corehq/apps/repeaters/tests/test_repeater.py
+++ b/corehq/apps/repeaters/tests/test_repeater.py
@@ -159,7 +159,7 @@ class RepeaterTest(BaseRepeaterTest):
         record = RepeatRecord(domain=self.domain, next_check=now)
         self.assertIsNone(record.last_checked)
 
-        record.update_failure()
+        record.set_next_try()
         self.assertTrue(record.last_checked > now)
         self.assertEqual(record.next_check, record.last_checked + MIN_RETRY_WAIT)
 

--- a/corehq/apps/repeaters/utils.py
+++ b/corehq/apps/repeaters/utils.py
@@ -3,6 +3,7 @@ from django.conf import settings
 
 from dimagi.utils.modules import to_function
 
+
 def get_all_repeater_types():
     return OrderedDict([
         (to_function(cls, failhard=True).__name__, to_function(cls, failhard=True)) for cls in settings.REPEATERS

--- a/corehq/apps/repeaters/utils.py
+++ b/corehq/apps/repeaters/utils.py
@@ -1,0 +1,9 @@
+from collections import OrderedDict
+from django.conf import settings
+
+from dimagi.utils.modules import to_function
+
+def get_all_repeater_types():
+    return OrderedDict([
+        (to_function(cls, failhard=True).__name__, to_function(cls, failhard=True)) for cls in settings.REPEATERS
+    ])

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -610,9 +610,9 @@ ICDS_REPORTS = StaticToggle(
     [NAMESPACE_DOMAIN]
 )
 
-ENIKSHAY_INTEGRATIONS = StaticToggle(
-    'enikshay_integrations',
-    'Enable access to eNikshay external integrations',
+NINETYNINE_DOTS = StaticToggle(
+    '99dots_integration',
+    'Enable access to 99DOTS',
     TAG_ONE_OFF,
     [NAMESPACE_DOMAIN]
 )

--- a/custom/enikshay/__init__.py
+++ b/custom/enikshay/__init__.py
@@ -1,0 +1,1 @@
+from custom.enikshay.integrations.ninetyninedots.repeater_generators import RegisterPatientPayloadGenerator

--- a/custom/enikshay/case_utils.py
+++ b/custom/enikshay/case_utils.py
@@ -5,7 +5,7 @@ from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from custom.enikshay.exceptions import ENikshayCaseNotFound
 
 
-def get_open_episode_case(domain, person_case_id):
+def get_open_episode_case_from_person(domain, person_case_id):
     """
     Gets the first open 'episode' case for the person
 
@@ -36,7 +36,7 @@ def get_open_episode_case(domain, person_case_id):
 
 def get_adherence_cases_between_dates(domain, person_case_id, start_date, end_date):
     case_accessor = CaseAccessors(domain)
-    episode = get_open_episode_case(domain, person_case_id)
+    episode = get_open_episode_case_from_person(domain, person_case_id)
     indexed_cases = case_accessor.get_reverse_indexed_cases([episode.case_id])
     open_pertinent_adherence_cases = [
         case for case in indexed_cases

--- a/custom/enikshay/case_utils.py
+++ b/custom/enikshay/case_utils.py
@@ -1,0 +1,49 @@
+import pytz
+from django.utils.dateparse import parse_datetime
+
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from custom.enikshay.exceptions import ENikshayCaseNotFound
+
+
+def get_open_episode_case(domain, person_case_id):
+    """
+    Gets the first open 'episode' case for the person
+
+    Assumes the following case structure:
+    Person <--ext-- Occurrence <--ext-- Episode
+
+    """
+    case_accessor = CaseAccessors(domain)
+    occurrence_cases = case_accessor.get_reverse_indexed_cases([person_case_id])
+    open_occurrence_cases = [case for case in occurrence_cases
+                             if not case.closed and case.type == "occurrence"]
+    if not open_occurrence_cases:
+        raise ENikshayCaseNotFound(
+            "Person with id: {} exists but has no open occurence cases".format(person_case_id)
+        )
+    occurence_case = open_occurrence_cases[0]
+    episode_cases = case_accessor.get_reverse_indexed_cases([occurence_case.case_id])
+    open_episode_cases = [case for case in episode_cases
+                          if not case.closed and case.type == "episode" and
+                          case.dynamic_case_properties().get('episode_type') == "confirmed_tb"]
+    if open_episode_cases:
+        return open_episode_cases[0]
+    else:
+        raise ENikshayCaseNotFound(
+            "Person with id: {} exists but has no open episode cases".format(person_case_id)
+        )
+
+
+def get_adherence_cases_between_dates(domain, person_case_id, start_date, end_date):
+    case_accessor = CaseAccessors(domain)
+    episode = get_open_episode_case(domain, person_case_id)
+    indexed_cases = case_accessor.get_reverse_indexed_cases([episode.case_id])
+    open_pertinent_adherence_cases = [
+        case for case in indexed_cases
+        if not case.closed and case.type == "adherence" and
+        (start_date.astimezone(pytz.UTC) <=
+         parse_datetime(case.dynamic_case_properties().get('adherence_date')).astimezone(pytz.UTC) <=
+         end_date.astimezone(pytz.UTC))
+    ]
+
+    return open_pertinent_adherence_cases

--- a/custom/enikshay/case_utils.py
+++ b/custom/enikshay/case_utils.py
@@ -3,6 +3,56 @@ from django.utils.dateparse import parse_datetime
 
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from custom.enikshay.exceptions import ENikshayCaseNotFound
+from corehq.form_processor.exceptions import CaseNotFound
+
+CASE_TYPE_ADHERENCE = "adherence"
+CASE_TYPE_OCCURRENCE = "occurrence"
+CASE_TYPE_EPISODE = "episode"
+CASE_TYPE_PERSON = "person"
+
+
+def get_parent_of_case(domain, case_id, parent_case_type):
+    case_accessor = CaseAccessors(domain)
+    try:
+        if not isinstance(case_id, basestring):
+            case_id = case_id.case_id
+
+        child_case = case_accessor.get_case(case_id)
+    except CaseNotFound:
+        raise ENikshayCaseNotFound(
+            "Couldn't find case: {}".format(case_id)
+        )
+
+    parent_case_ids = [
+        indexed_case.referenced_id for indexed_case in child_case.indices
+        if indexed_case.referenced_type == parent_case_type
+    ]
+    parent_cases = case_accessor.get_cases(parent_case_ids)
+    open_parent_cases = [
+        occurrence_case for occurrence_case in parent_cases
+        if not occurrence_case.closed
+    ]
+
+    if not open_parent_cases:
+        raise ENikshayCaseNotFound(
+            "Couldn't find any open {} cases for id: {}".format(parent_case_type, case_id)
+        )
+
+    return open_parent_cases[0]
+
+
+def get_occurrence_case_from_episode(domain, episode_case_id):
+    """
+    Gets the first open occurrence case for an episode
+    """
+    return get_parent_of_case(domain, episode_case_id, CASE_TYPE_OCCURRENCE)
+
+
+def get_person_case_from_occurrence(domain, occurrence_case_id):
+    """
+    Gets the first open person case for an occurrence
+    """
+    return get_parent_of_case(domain, occurrence_case_id, CASE_TYPE_PERSON)
 
 
 def get_open_episode_case_from_person(domain, person_case_id):
@@ -16,15 +66,15 @@ def get_open_episode_case_from_person(domain, person_case_id):
     case_accessor = CaseAccessors(domain)
     occurrence_cases = case_accessor.get_reverse_indexed_cases([person_case_id])
     open_occurrence_cases = [case for case in occurrence_cases
-                             if not case.closed and case.type == "occurrence"]
+                             if not case.closed and case.type == CASE_TYPE_OCCURRENCE]
     if not open_occurrence_cases:
         raise ENikshayCaseNotFound(
-            "Person with id: {} exists but has no open occurence cases".format(person_case_id)
+            "Person with id: {} exists but has no open occurrence cases".format(person_case_id)
         )
-    occurence_case = open_occurrence_cases[0]
-    episode_cases = case_accessor.get_reverse_indexed_cases([occurence_case.case_id])
+    occurrence_case = open_occurrence_cases[0]
+    episode_cases = case_accessor.get_reverse_indexed_cases([occurrence_case.case_id])
     open_episode_cases = [case for case in episode_cases
-                          if not case.closed and case.type == "episode" and
+                          if not case.closed and case.type == CASE_TYPE_EPISODE and
                           case.dynamic_case_properties().get('episode_type') == "confirmed_tb"]
     if open_episode_cases:
         return open_episode_cases[0]
@@ -40,7 +90,7 @@ def get_adherence_cases_between_dates(domain, person_case_id, start_date, end_da
     indexed_cases = case_accessor.get_reverse_indexed_cases([episode.case_id])
     open_pertinent_adherence_cases = [
         case for case in indexed_cases
-        if not case.closed and case.type == "adherence" and
+        if not case.closed and case.type == CASE_TYPE_ADHERENCE and
         (start_date.astimezone(pytz.UTC) <=
          parse_datetime(case.dynamic_case_properties().get('adherence_date')).astimezone(pytz.UTC) <=
          end_date.astimezone(pytz.UTC))

--- a/custom/enikshay/exceptions.py
+++ b/custom/enikshay/exceptions.py
@@ -1,0 +1,6 @@
+class ENikshayException(Exception):
+    pass
+
+
+class ENikshayCaseNotFound(Exception):
+    pass

--- a/custom/enikshay/integrations/ninetyninedots/exceptions.py
+++ b/custom/enikshay/integrations/ninetyninedots/exceptions.py
@@ -1,3 +1,2 @@
 class AdherenceException(Exception):
-    def __init__(self, message):
-        self.message = message
+    pass

--- a/custom/enikshay/integrations/ninetyninedots/repeater_generators.py
+++ b/custom/enikshay/integrations/ninetyninedots/repeater_generators.py
@@ -1,0 +1,63 @@
+import uuid
+import json
+import phonenumbers
+import jsonobject
+from corehq.apps.repeaters.models import RegisterGenerator
+from corehq.apps.repeaters.repeater_generators import BasePayloadGenerator
+
+from custom.enikshay.integrations.ninetyninedots.repeaters import NinetyNineDotsRegisterPatientRepeater
+from custom.enikshay.case_utils import (
+    get_occurrence_case_from_episode,
+    get_person_case_from_occurrence,
+)
+
+
+class RegisterPatientPayload(jsonobject.JsonObject):
+    beneficiary_id = jsonobject.StringProperty(required=True)
+    phone_numbers = jsonobject.StringProperty(required=True)
+
+
+@RegisterGenerator(NinetyNineDotsRegisterPatientRepeater, 'case_json', 'JSON', is_default=True)
+class RegisterPatientPayloadGenerator(BasePayloadGenerator):
+    @property
+    def content_type(self):
+        return 'application/json'
+
+    def get_test_payload(self, domain):
+        return json.dumps(RegisterPatientPayload(
+            beneficiary_id=uuid.uuid4().hex,
+            phone_numbers=_format_number(_parse_number("0123456789"))
+        ).to_json())
+
+    def get_payload(self, repeat_record, payload_doc):
+        occurence_case = get_occurrence_case_from_episode(payload_doc.domain, payload_doc.case_id)
+        person_case = get_person_case_from_occurrence(payload_doc.domain, occurence_case)
+        data = RegisterPatientPayload(
+            beneficiary_id=person_case.case_id,
+            phone_numbers=_get_phone_numbers(person_case)
+        )
+        return json.dumps(data.to_json())
+
+    def handle_success(self, response, payload_doc):
+        pass
+
+
+def _get_phone_numbers(payload_doc):
+    primary_number = _parse_number(payload_doc.dynamic_case_properties().get('mobile_number'))
+    backup_number = _parse_number(payload_doc.dynamic_case_properties().get('backup_number'))
+    if backup_number is not None:
+        return ", ".join([_format_number(primary_number), _format_number(backup_number)])
+    return _format_number(primary_number)
+
+
+def _parse_number(number):
+    if number is not None:
+        return phonenumbers.parse(number, "IN")
+
+
+def _format_number(phonenumber):
+    if phonenumber is not None:
+        return phonenumbers.format_number(
+            phonenumber,
+            phonenumbers.PhoneNumberFormat.INTERNATIONAL
+        ).replace(" ", "")

--- a/custom/enikshay/integrations/ninetyninedots/repeater_generators.py
+++ b/custom/enikshay/integrations/ninetyninedots/repeater_generators.py
@@ -77,8 +77,9 @@ def _update_episode_case(domain, case_id, updated_properties):
 
 
 def _get_phone_numbers(payload_doc):
-    primary_number = _parse_number(payload_doc.dynamic_case_properties().get('mobile_number'))
-    backup_number = _parse_number(payload_doc.dynamic_case_properties().get('backup_number'))
+    case_properties = payload_doc.dynamic_case_properties()
+    primary_number = _parse_number(case_properties.get('mobile_number'))
+    backup_number = _parse_number(case_properties.get('backup_number'))
     if backup_number is not None:
         return ", ".join([_format_number(primary_number), _format_number(backup_number)])
     return _format_number(primary_number)

--- a/custom/enikshay/integrations/ninetyninedots/repeater_generators.py
+++ b/custom/enikshay/integrations/ninetyninedots/repeater_generators.py
@@ -60,7 +60,7 @@ class RegisterPatientPayloadGenerator(BasePayloadGenerator):
                     "dots_99_registered": "false",
                     "dots_99_error": "{}: {}".format(
                         response.status_code,
-                        json.loads(response.message).get('error')
+                        response.json().get('error')
                     ),
                 }
             )

--- a/custom/enikshay/integrations/ninetyninedots/repeaters.py
+++ b/custom/enikshay/integrations/ninetyninedots/repeaters.py
@@ -27,10 +27,11 @@ class NinetyNineDotsRegisterPatientRepeater(CaseRepeater):
     def allowed_to_forward(self, case):
         # checks whitelisted case types and users
         allowed_case_types_and_users = super(NinetyNineDotsRegisterPatientRepeater, self).allowed_to_forward(case)
-        enabled = case.dynamic_case_properties().get('dots_99_enabled') == 'true'
+        case_properties = case.dynamic_case_properties()
+        enabled = case_properties.get('dots_99_enabled') == 'true'
         not_registered = (
-            case.dynamic_case_properties().get('dots_99_registered') == 'false' or
-            case.dynamic_case_properties().get('dots_99_registered') is None
+            case_properties.get('dots_99_registered') == 'false' or
+            case_properties.get('dots_99_registered') is None
         )
         return allowed_case_types_and_users and enabled and not_registered
 

--- a/custom/enikshay/integrations/ninetyninedots/repeaters.py
+++ b/custom/enikshay/integrations/ninetyninedots/repeaters.py
@@ -1,0 +1,32 @@
+from corehq.toggles import NINETYNINE_DOTS
+from django.core.urlresolvers import reverse
+from django.utils.translation import ugettext_lazy as _
+
+from corehq.apps.repeaters.models import CaseRepeater
+
+
+class NinetyNineDotsRegisterPatientRepeater(CaseRepeater):
+    class Meta(object):
+        app_label = 'repeaters'
+
+    friendly_name = _("99DOTS Patient Registration")
+
+    @classmethod
+    def available_for_domain(cls, domain):
+        return NINETYNINE_DOTS.enabled(domain)
+
+    @classmethod
+    def get_custom_url(cls, domain):
+        from custom.enikshay.integrations.ninetyninedots.views import RegisterPatientRepeaterView
+        return reverse(RegisterPatientRepeaterView.urlname, args=[domain])
+
+    def allowed_to_forward(self, case):
+        # checks whitelisted case types and users
+        allowed_case_types_and_users = super(NinetyNineDotsRegisterPatientRepeater, self).allowed_to_forward(case)
+        enabled = case.dynamic_case_properties().get('dots_99_enabled') == 'true'
+        not_registered = (
+            case.dynamic_case_properties().get('dots_99_registered') == 'false' or
+            case.dynamic_case_properties().get('dots_99_registered') is None
+        )
+
+        return allowed_case_types_and_users and enabled and not_registered

--- a/custom/enikshay/integrations/ninetyninedots/repeaters.py
+++ b/custom/enikshay/integrations/ninetyninedots/repeaters.py
@@ -2,7 +2,12 @@ from corehq.toggles import NINETYNINE_DOTS
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
 
+from casexml.apps.case.models import CommCareCase
+from corehq.form_processor.models import CommCareCaseSQL
+
 from corehq.apps.repeaters.models import CaseRepeater
+from corehq.apps.repeaters.signals import create_repeat_records
+from casexml.apps.case.signals import case_post_save
 
 
 class NinetyNineDotsRegisterPatientRepeater(CaseRepeater):
@@ -28,10 +33,16 @@ class NinetyNineDotsRegisterPatientRepeater(CaseRepeater):
             case.dynamic_case_properties().get('dots_99_registered') == 'false' or
             case.dynamic_case_properties().get('dots_99_registered') is None
         )
-
         return allowed_case_types_and_users and enabled and not_registered
 
     def allow_retries(self, response):
         if response is not None and response.status_code == 500:
             return True
         return False
+
+
+def create_case_repeat_records(sender, case, **kwargs):
+    create_repeat_records(NinetyNineDotsRegisterPatientRepeater, case)
+
+case_post_save.connect(create_case_repeat_records, CommCareCase)
+case_post_save.connect(create_case_repeat_records, CommCareCaseSQL)

--- a/custom/enikshay/integrations/ninetyninedots/repeaters.py
+++ b/custom/enikshay/integrations/ninetyninedots/repeaters.py
@@ -2,7 +2,6 @@ from corehq.toggles import NINETYNINE_DOTS
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
 
-from casexml.apps.case.models import CommCareCase
 from corehq.form_processor.models import CommCareCaseSQL
 
 from corehq.apps.repeaters.models import CaseRepeater
@@ -44,5 +43,4 @@ class NinetyNineDotsRegisterPatientRepeater(CaseRepeater):
 def create_case_repeat_records(sender, case, **kwargs):
     create_repeat_records(NinetyNineDotsRegisterPatientRepeater, case)
 
-case_post_save.connect(create_case_repeat_records, CommCareCase)
 case_post_save.connect(create_case_repeat_records, CommCareCaseSQL)

--- a/custom/enikshay/integrations/ninetyninedots/repeaters.py
+++ b/custom/enikshay/integrations/ninetyninedots/repeaters.py
@@ -30,3 +30,8 @@ class NinetyNineDotsRegisterPatientRepeater(CaseRepeater):
         )
 
         return allowed_case_types_and_users and enabled and not_registered
+
+    def allow_retries(self, response):
+        if response is not None and response.status_code == 500:
+            return True
+        return False

--- a/custom/enikshay/integrations/ninetyninedots/tests/test_integration.py
+++ b/custom/enikshay/integrations/ninetyninedots/tests/test_integration.py
@@ -12,10 +12,12 @@ from custom.enikshay.integrations.ninetyninedots.views import (
     validate_adherence_values,
     validate_beneficiary_id
 )
+from custom.enikshay.case_utils import (
+    get_open_episode_case_from_person,
+    get_adherence_cases_between_dates,
+)
 from custom.enikshay.integrations.ninetyninedots.utils import (
     create_adherence_cases,
-    get_open_episode_case,
-    get_adherence_cases_between_dates,
     update_adherence_confidence_level,
     update_default_confidence_level,
 )
@@ -74,7 +76,7 @@ class NinetyNineDotsCaseTests(ENikshayCaseStructureMixin, TestCase):
     @run_with_all_backends
     def test_get_episode(self):
         self.create_case_structure()
-        self.assertEqual(get_open_episode_case(self.domain, 'person').case_id, 'episode')
+        self.assertEqual(get_open_episode_case_from_person(self.domain, 'person').case_id, 'episode')
 
     @run_with_all_backends
     def test_create_adherence_cases(self):
@@ -192,5 +194,5 @@ class NinetyNineDotsCaseTests(ENikshayCaseStructureMixin, TestCase):
         self.create_case_structure()
         confidence_level = "new_confidence_level"
         update_default_confidence_level(self.domain, self.person_id, confidence_level)
-        episode = get_open_episode_case(self.domain, self.person_id)
+        episode = get_open_episode_case_from_person(self.domain, self.person_id)
         self.assertEqual(episode.dynamic_case_properties().get('default_adherence_confidence'), confidence_level)

--- a/custom/enikshay/integrations/ninetyninedots/tests/test_repeaters.py
+++ b/custom/enikshay/integrations/ninetyninedots/tests/test_repeaters.py
@@ -1,5 +1,9 @@
 import json
+from collections import namedtuple
 from django.test import TestCase
+
+from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+
 from custom.enikshay.tests.utils import ENikshayCaseStructureMixin
 from custom.enikshay.integrations.ninetyninedots.repeater_generators import RegisterPatientPayloadGenerator
 
@@ -21,3 +25,34 @@ class TestRegisterPatientPayloadGenerator(ENikshayCaseStructureMixin, TestCase):
         })
         actual_payload = payload_generator.get_payload(None, self.cases[self.episode_id])
         self.assertEqual(expected_payload, actual_payload)
+
+    def test_handle_success(self):
+        payload_generator = RegisterPatientPayloadGenerator(None)
+        Response = namedtuple("Response", 'status_code')
+        payload_generator.handle_success(Response(201), self.cases[self.episode_id])
+        updated_episode_case = CaseAccessors(self.domain).get_case(self.episode_id)
+        self.assertEqual(
+            updated_episode_case.dynamic_case_properties().get('dots_99_registered'),
+            'true'
+        )
+        self.assertEqual(
+            updated_episode_case.dynamic_case_properties().get('dots_99_error'),
+            ''
+        )
+
+    def test_handle_failure(self):
+        payload_generator = RegisterPatientPayloadGenerator(None)
+        Response = namedtuple("Response", 'status_code message')
+        error = {
+            "error": "Something went terribly wrong",
+        }
+        payload_generator.handle_failure(Response(400, json.dumps(error)), self.cases[self.episode_id])
+        updated_episode_case = CaseAccessors(self.domain).get_case(self.episode_id)
+        self.assertEqual(
+            updated_episode_case.dynamic_case_properties().get('dots_99_registered'),
+            'false'
+        )
+        self.assertEqual(
+            updated_episode_case.dynamic_case_properties().get('dots_99_error'),
+            "400: {}".format(error['error'])
+        )

--- a/custom/enikshay/integrations/ninetyninedots/tests/test_repeaters.py
+++ b/custom/enikshay/integrations/ninetyninedots/tests/test_repeaters.py
@@ -1,8 +1,8 @@
 import json
 from datetime import datetime
 from django.test import TestCase
+from django.test.utils import override_settings
 
-from corehq.form_processor.tests.utils import run_with_all_backends
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from casexml.apps.case.mock import CaseStructure
 from corehq.apps.repeaters.models import RepeatRecord
@@ -72,7 +72,7 @@ class TestRegisterPatientRepeater(ENikshayCaseStructureMixin, TestCase):
         )
         self.create_case(dots_registered_case)
 
-    @run_with_all_backends
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
     def test_trigger(self):
         # 99dots not enabled
         self.create_case(self.episode)
@@ -96,7 +96,7 @@ class TestRegisterPatientPayloadGenerator(ENikshayCaseStructureMixin, TestCase):
         super(TestRegisterPatientPayloadGenerator, self).tearDown()
         delete_all_cases()
 
-    @run_with_all_backends
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
     def test_get_payload(self):
         payload_generator = RegisterPatientPayloadGenerator(None)
         expected_numbers = u"+91{}, +91{}".format(
@@ -110,7 +110,7 @@ class TestRegisterPatientPayloadGenerator(ENikshayCaseStructureMixin, TestCase):
         actual_payload = payload_generator.get_payload(None, self.cases[self.episode_id])
         self.assertEqual(expected_payload, actual_payload)
 
-    @run_with_all_backends
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
     def test_handle_success(self):
         payload_generator = RegisterPatientPayloadGenerator(None)
         payload_generator.handle_success(MockResponse(201, {"success": "hooray"}), self.cases[self.episode_id])
@@ -124,7 +124,7 @@ class TestRegisterPatientPayloadGenerator(ENikshayCaseStructureMixin, TestCase):
             ''
         )
 
-    @run_with_all_backends
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
     def test_handle_failure(self):
         payload_generator = RegisterPatientPayloadGenerator(None)
         error = {

--- a/custom/enikshay/integrations/ninetyninedots/tests/test_repeaters.py
+++ b/custom/enikshay/integrations/ninetyninedots/tests/test_repeaters.py
@@ -1,11 +1,77 @@
 import json
+from datetime import datetime
 from collections import namedtuple
 from django.test import TestCase
 
+from corehq.form_processor.tests.utils import run_with_all_backends
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
+from casexml.apps.case.mock import CaseStructure
+from corehq.apps.repeaters.models import RepeatRecord
+from corehq.apps.repeaters.dbaccessors import delete_all_repeat_records, delete_all_repeaters
+from casexml.apps.case.tests.util import delete_all_cases
 
 from custom.enikshay.tests.utils import ENikshayCaseStructureMixin
 from custom.enikshay.integrations.ninetyninedots.repeater_generators import RegisterPatientPayloadGenerator
+from custom.enikshay.integrations.ninetyninedots.repeaters import NinetyNineDotsRegisterPatientRepeater
+
+
+class TestRegisterPatientRepeater(ENikshayCaseStructureMixin, TestCase):
+    def setUp(self):
+        super(TestRegisterPatientRepeater, self).setUp()
+        delete_all_repeat_records()
+        delete_all_repeaters()
+        delete_all_cases()
+        self.repeater = NinetyNineDotsRegisterPatientRepeater(
+            domain=self.domain,
+            url='case-repeater-url',
+        )
+        self.repeater.save()
+
+    def tearDown(self):
+        super(TestRegisterPatientRepeater, self).tearDown()
+        delete_all_repeat_records()
+        delete_all_repeaters()
+        delete_all_cases()
+
+    @classmethod
+    def repeat_records(cls, domain_name):
+        return RepeatRecord.all(domain=domain_name, due_before=datetime.utcnow())
+
+    @run_with_all_backends
+    def test_trigger(self):
+        self.repeater.white_listed_case_types = ['episode']
+        self.repeater.save()
+
+        # 99dots not enabled
+        self.create_case(self.episode)
+        self.assertEqual(0, len(self.repeat_records(self.domain).all()))
+
+        # enable 99dots, should register a repeat record
+        dots_enabled_case = CaseStructure(
+            case_id=self.episode_id,
+            attrs={
+                'case_type': 'episode',
+                "update": dict(
+                    dots_99_enabled='true',
+                )
+            }
+        )
+        self.create_case(dots_enabled_case)
+        self.assertEqual(1, len(self.repeat_records(self.domain).all()))
+
+        # set as registered, shouldn't register a new repeat record
+        dots_registered_case = CaseStructure(
+            case_id=self.episode_id,
+            attrs={
+                'create': True,
+                'case_type': 'episode',
+                "update": dict(
+                    dots_99_registered='true',
+                )
+            }
+        )
+        self.create_case(dots_registered_case)
+        self.assertEqual(1, len(self.repeat_records(self.domain).all()))
 
 
 class TestRegisterPatientPayloadGenerator(ENikshayCaseStructureMixin, TestCase):
@@ -13,6 +79,7 @@ class TestRegisterPatientPayloadGenerator(ENikshayCaseStructureMixin, TestCase):
         super(TestRegisterPatientPayloadGenerator, self).setUp()
         self.cases = self.create_case_structure()
 
+    @run_with_all_backends
     def test_get_payload(self):
         payload_generator = RegisterPatientPayloadGenerator(None)
         expected_numbers = u"+91{}, +91{}".format(
@@ -26,6 +93,7 @@ class TestRegisterPatientPayloadGenerator(ENikshayCaseStructureMixin, TestCase):
         actual_payload = payload_generator.get_payload(None, self.cases[self.episode_id])
         self.assertEqual(expected_payload, actual_payload)
 
+    @run_with_all_backends
     def test_handle_success(self):
         payload_generator = RegisterPatientPayloadGenerator(None)
         Response = namedtuple("Response", 'status_code')
@@ -40,6 +108,7 @@ class TestRegisterPatientPayloadGenerator(ENikshayCaseStructureMixin, TestCase):
             ''
         )
 
+    @run_with_all_backends
     def test_handle_failure(self):
         payload_generator = RegisterPatientPayloadGenerator(None)
         Response = namedtuple("Response", 'status_code message')

--- a/custom/enikshay/integrations/ninetyninedots/tests/test_repeaters.py
+++ b/custom/enikshay/integrations/ninetyninedots/tests/test_repeaters.py
@@ -88,10 +88,13 @@ class TestRegisterPatientRepeater(ENikshayCaseStructureMixin, TestCase):
 
 
 class TestRegisterPatientPayloadGenerator(ENikshayCaseStructureMixin, TestCase):
+
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
     def setUp(self):
         super(TestRegisterPatientPayloadGenerator, self).setUp()
         self.cases = self.create_case_structure()
 
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
     def tearDown(self):
         super(TestRegisterPatientPayloadGenerator, self).tearDown()
         delete_all_cases()

--- a/custom/enikshay/integrations/ninetyninedots/tests/test_repeaters.py
+++ b/custom/enikshay/integrations/ninetyninedots/tests/test_repeaters.py
@@ -1,0 +1,23 @@
+import json
+from django.test import TestCase
+from custom.enikshay.tests.utils import ENikshayCaseStructureMixin
+from custom.enikshay.integrations.ninetyninedots.repeater_generators import RegisterPatientPayloadGenerator
+
+
+class TestRegisterPatientPayloadGenerator(ENikshayCaseStructureMixin, TestCase):
+    def setUp(self):
+        super(TestRegisterPatientPayloadGenerator, self).setUp()
+        self.cases = self.create_case_structure()
+
+    def test_get_payload(self):
+        payload_generator = RegisterPatientPayloadGenerator(None)
+        expected_numbers = u"+91{}, +91{}".format(
+            self.cases[self.person_id].dynamic_case_properties()['mobile_number'].replace("0", ""),
+            self.cases[self.person_id].dynamic_case_properties()['backup_number'].replace("0", "")
+        )
+        expected_payload = json.dumps({
+            'beneficiary_id': self.person_id,
+            'phone_numbers': expected_numbers,
+        })
+        actual_payload = payload_generator.get_payload(None, self.cases[self.episode_id])
+        self.assertEqual(expected_payload, actual_payload)

--- a/custom/enikshay/integrations/ninetyninedots/urls.py
+++ b/custom/enikshay/integrations/ninetyninedots/urls.py
@@ -1,8 +1,16 @@
 from django.conf.urls import patterns, url
+from custom.enikshay.integrations.ninetyninedots.views import RegisterPatientRepeaterView
 
 urlpatterns = patterns(
     'custom.enikshay.integrations.ninetyninedots.views',
     url(r'^update_patient_adherence$', 'update_patient_adherence'),
     url(r'^update_adherence_confidence$', 'update_adherence_confidence'),
     url(r'^update_default_confidence$', 'update_default_confidence'),
+    url(r'^update_default_confidence$', 'update_default_confidence'),
+    url(
+        r'^new_register_patient_repeater$',
+        RegisterPatientRepeaterView.as_view(),
+        {'repeater_type': 'NinetyNineDotsRegisterPatientRepeater'},
+        name=RegisterPatientRepeaterView.urlname
+    ),
 )

--- a/custom/enikshay/integrations/ninetyninedots/utils.py
+++ b/custom/enikshay/integrations/ninetyninedots/utils.py
@@ -7,7 +7,7 @@ from dimagi.utils.decorators.memoized import memoized
 
 from casexml.apps.case.mock import CaseFactory, CaseStructure, CaseIndex
 from custom.enikshay.integrations.ninetyninedots.exceptions import AdherenceException
-from custom.enikshay.case_utils import get_open_episode_case, get_adherence_cases_between_dates
+from custom.enikshay.case_utils import get_open_episode_case_from_person, get_adherence_cases_between_dates
 from custom.enikshay.exceptions import ENikshayCaseNotFound
 
 
@@ -47,7 +47,7 @@ class AdherenceCaseFactory(object):
     @memoized
     def _episode_case(self):
         try:
-            return get_open_episode_case(self.domain, self._person_case.case_id)
+            return get_open_episode_case_from_person(self.domain, self._person_case.case_id)
         except ENikshayCaseNotFound as e:
             raise AdherenceException(e.message)
 

--- a/custom/enikshay/integrations/ninetyninedots/utils.py
+++ b/custom/enikshay/integrations/ninetyninedots/utils.py
@@ -1,6 +1,4 @@
 import uuid
-import pytz
-from django.utils.dateparse import parse_datetime
 
 from corehq.form_processor.interfaces.dbaccessors import CaseAccessors
 from casexml.apps.case.const import CASE_INDEX_EXTENSION, UNOWNED_EXTENSION_OWNER_ID
@@ -9,6 +7,8 @@ from dimagi.utils.decorators.memoized import memoized
 
 from casexml.apps.case.mock import CaseFactory, CaseStructure, CaseIndex
 from custom.enikshay.integrations.ninetyninedots.exceptions import AdherenceException
+from custom.enikshay.case_utils import get_open_episode_case, get_adherence_cases_between_dates
+from custom.enikshay.exceptions import ENikshayCaseNotFound
 
 
 class AdherenceCaseFactory(object):
@@ -34,7 +34,7 @@ class AdherenceCaseFactory(object):
         try:
             return self.case_accessor.get_case(self.person_id)
         except CaseNotFound:
-            raise AdherenceException(message="No patient exists with this beneficiary ID")
+            raise AdherenceException("No patient exists with this beneficiary ID")
 
     @property
     @memoized
@@ -46,7 +46,10 @@ class AdherenceCaseFactory(object):
     @property
     @memoized
     def _episode_case(self):
-        return get_open_episode_case(self.domain, self._person_case.case_id)
+        try:
+            return get_open_episode_case(self.domain, self._person_case.case_id)
+        except ENikshayCaseNotFound as e:
+            raise AdherenceException(e.message)
 
     def create_adherence_cases(self, adherence_points, adherence_source):
         return self.case_factory.create_or_update_cases([
@@ -81,7 +84,10 @@ class AdherenceCaseFactory(object):
         }
 
     def update_adherence_cases(self, start_date, end_date, confidence_level):
-        adherence_cases = get_adherence_cases_between_dates(self.domain, self.person_id, start_date, end_date)
+        try:
+            adherence_cases = get_adherence_cases_between_dates(self.domain, self.person_id, start_date, end_date)
+        except ENikshayCaseNotFound as e:
+            raise AdherenceException(e.message)
         adherence_case_ids = [case.case_id for case in adherence_cases]
         return self.case_factory.create_or_update_cases([
             CaseStructure(
@@ -109,50 +115,6 @@ class AdherenceCaseFactory(object):
                 walk_related=False
             )
         ])
-
-
-def get_open_episode_case(domain, person_case_id):
-    """
-    Gets the first open 'episode' case for the person
-
-    Assumes the following case structure:
-    Person <--ext-- Occurrence <--ext-- Episode
-
-    """
-    case_accessor = CaseAccessors(domain)
-    occurrence_cases = case_accessor.get_reverse_indexed_cases([person_case_id])
-    open_occurrence_cases = [case for case in occurrence_cases
-                             if not case.closed and case.type == "occurrence"]
-    if not open_occurrence_cases:
-        raise AdherenceException(
-            message="Person with id: {} exists but has no open occurence cases".format(person_case_id)
-        )
-    occurence_case = open_occurrence_cases[0]
-    episode_cases = case_accessor.get_reverse_indexed_cases([occurence_case.case_id])
-    open_episode_cases = [case for case in episode_cases
-                          if not case.closed and case.type == "episode" and
-                          case.dynamic_case_properties().get('episode_type') == "confirmed_tb"]
-    if open_episode_cases:
-        return open_episode_cases[0]
-    else:
-        raise AdherenceException(
-            message="Person with id: {} exists but has no open episode cases".format(person_case_id)
-        )
-
-
-def get_adherence_cases_between_dates(domain, person_case_id, start_date, end_date):
-    case_accessor = CaseAccessors(domain)
-    episode = get_open_episode_case(domain, person_case_id)
-    indexed_cases = case_accessor.get_reverse_indexed_cases([episode.case_id])
-    open_pertinent_adherence_cases = [
-        case for case in indexed_cases
-        if not case.closed and case.type == "adherence" and
-        (start_date.astimezone(pytz.UTC) <=
-         parse_datetime(case.dynamic_case_properties().get('adherence_date')).astimezone(pytz.UTC) <=
-         end_date.astimezone(pytz.UTC))
-    ]
-
-    return open_pertinent_adherence_cases
 
 
 def create_adherence_cases(domain, person_id, adherence_points, adherence_source="99DOTS"):

--- a/custom/enikshay/integrations/ninetyninedots/views.py
+++ b/custom/enikshay/integrations/ninetyninedots/views.py
@@ -95,26 +95,26 @@ def update_default_confidence(request, domain):
 
 def validate_beneficiary_id(beneficiary_id):
     if beneficiary_id is None:
-        raise AdherenceException(message="Beneficiary ID is null")
+        raise AdherenceException("Beneficiary ID is null")
     if not isinstance(beneficiary_id, basestring):
-        raise AdherenceException(message="Beneficiary ID should be a string")
+        raise AdherenceException("Beneficiary ID should be a string")
 
 
 def validate_dates(start_date, end_date):
     if start_date is None:
-        raise AdherenceException(message="start_date is null")
+        raise AdherenceException("start_date is null")
     if end_date is None:
-        raise AdherenceException(message="end_date is null")
+        raise AdherenceException("end_date is null")
     try:
         parse_datetime(start_date).astimezone(pytz.UTC)
         parse_datetime(end_date).astimezone(pytz.UTC)
     except:
-        raise AdherenceException(message="Malformed Date")
+        raise AdherenceException("Malformed Date")
 
 
 def validate_adherence_values(adherence_values):
     if adherence_values is None or not isinstance(adherence_values, list):
-        raise AdherenceException(message="Adherences invalid")
+        raise AdherenceException("Adherences invalid")
 
 
 def validate_confidence_level(confidence_level):

--- a/custom/enikshay/integrations/ninetyninedots/views.py
+++ b/custom/enikshay/integrations/ninetyninedots/views.py
@@ -8,12 +8,19 @@ from corehq import toggles
 from corehq.apps.domain.decorators import login_or_digest_or_basic_or_apikey
 from dimagi.utils.web import json_response
 
+from corehq.apps.repeaters.views import AddCaseRepeaterView
 from custom.enikshay.integrations.ninetyninedots.exceptions import AdherenceException
 from custom.enikshay.integrations.ninetyninedots.utils import (
     create_adherence_cases,
     update_adherence_confidence_level,
     update_default_confidence_level,
 )
+
+
+class RegisterPatientRepeaterView(AddCaseRepeaterView):
+    urlname = 'add_99dots_repeater'
+    page_title = "99DOTS"
+    page_name = "99DOTS forwarder"
 
 
 @toggles.NINETYNINE_DOTS.required_decorator()

--- a/custom/enikshay/integrations/ninetyninedots/views.py
+++ b/custom/enikshay/integrations/ninetyninedots/views.py
@@ -16,7 +16,7 @@ from custom.enikshay.integrations.ninetyninedots.utils import (
 )
 
 
-@toggles.ENIKSHAY_INTEGRATIONS.required_decorator()
+@toggles.NINETYNINE_DOTS.required_decorator()
 @login_or_digest_or_basic_or_apikey()
 @require_POST
 @csrf_exempt
@@ -39,7 +39,7 @@ def update_patient_adherence(request, domain):
     return json_response({"success": "Patient adherences updated."})
 
 
-@toggles.ENIKSHAY_INTEGRATIONS.required_decorator()
+@toggles.NINETYNINE_DOTS.required_decorator()
 @login_or_digest_or_basic_or_apikey()
 @require_POST
 @csrf_exempt
@@ -70,7 +70,7 @@ def update_adherence_confidence(request, domain):
     return json_response({"success": "Patient adherences updated."})
 
 
-@toggles.ENIKSHAY_INTEGRATIONS.required_decorator()
+@toggles.NINETYNINE_DOTS.required_decorator()
 @login_or_digest_or_basic_or_apikey()
 @require_POST
 @csrf_exempt

--- a/custom/enikshay/tests/test_case_utils.py
+++ b/custom/enikshay/tests/test_case_utils.py
@@ -1,0 +1,61 @@
+from datetime import datetime
+import pytz
+
+from django.test import TestCase
+from custom.enikshay.tests.utils import ENikshayCaseStructureMixin
+from corehq.form_processor.tests.utils import run_with_all_backends
+
+from custom.enikshay.case_utils import (
+    get_open_episode_case_from_person,
+    get_adherence_cases_between_dates,
+)
+
+
+class ENikshayCaseUtilsTests(ENikshayCaseStructureMixin, TestCase):
+    @run_with_all_backends
+    def test_get_adherence_cases_between_dates(self):
+        self.create_case_structure()
+        adherence_dates = [
+            datetime(2005, 7, 10),
+            datetime(2016, 8, 10),
+            datetime(2016, 8, 11),
+            datetime(2016, 8, 12),
+            datetime(2017, 9, 10),
+        ]
+        self.create_adherence_cases(adherence_dates)
+        fetched_cases = get_adherence_cases_between_dates(
+            self.domain,
+            self.person_id,
+            start_date=datetime(2016, 7, 1, tzinfo=pytz.UTC),
+            end_date=datetime(2016, 8, 13, tzinfo=pytz.UTC),
+        )
+        self.assertEqual(len(fetched_cases), 3)
+        self.assertItemsEqual(
+            ["2016-08-10", "2016-08-11", "2016-08-12"],
+            [case.case_id for case in fetched_cases]
+        )
+
+        fetched_cases = get_adherence_cases_between_dates(
+            self.domain,
+            self.person_id,
+            start_date=datetime(2010, 7, 1, tzinfo=pytz.UTC),
+            end_date=datetime(2010, 8, 13, tzinfo=pytz.UTC),
+        )
+        self.assertEqual(len(fetched_cases), 0)
+
+        fetched_cases = get_adherence_cases_between_dates(
+            self.domain,
+            self.person_id,
+            start_date=datetime(2016, 8, 10, tzinfo=pytz.UTC),
+            end_date=datetime(2016, 8, 10, tzinfo=pytz.UTC),
+        )
+        self.assertEqual(len(fetched_cases), 1)
+        self.assertEqual(
+            "2016-08-10",
+            fetched_cases[0].case_id,
+        )
+
+    @run_with_all_backends
+    def test_get_episode(self):
+        self.create_case_structure()
+        self.assertEqual(get_open_episode_case_from_person(self.domain, 'person').case_id, 'episode')

--- a/custom/enikshay/tests/test_case_utils.py
+++ b/custom/enikshay/tests/test_case_utils.py
@@ -3,18 +3,32 @@ import pytz
 
 from django.test import TestCase
 from custom.enikshay.tests.utils import ENikshayCaseStructureMixin
-from corehq.form_processor.tests.utils import run_with_all_backends
+from corehq.form_processor.tests.utils import run_with_all_backends, FormProcessorTestUtils
 
 from custom.enikshay.case_utils import (
     get_open_episode_case_from_person,
     get_adherence_cases_between_dates,
+    get_occurrence_case_from_episode,
+    get_person_case_from_occurrence,
 )
 
 
 class ENikshayCaseUtilsTests(ENikshayCaseStructureMixin, TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(ENikshayCaseUtilsTests, cls).setUpClass()
+        FormProcessorTestUtils.delete_all_cases()
+
+    def setUp(self):
+        super(ENikshayCaseUtilsTests, self).setUp()
+        self.cases = self.create_case_structure()
+
+    def tearDown(self):
+        super(ENikshayCaseUtilsTests, self).tearDown()
+        FormProcessorTestUtils.delete_all_cases()
+
     @run_with_all_backends
     def test_get_adherence_cases_between_dates(self):
-        self.create_case_structure()
         adherence_dates = [
             datetime(2005, 7, 10),
             datetime(2016, 8, 10),
@@ -57,5 +71,18 @@ class ENikshayCaseUtilsTests(ENikshayCaseStructureMixin, TestCase):
 
     @run_with_all_backends
     def test_get_episode(self):
-        self.create_case_structure()
         self.assertEqual(get_open_episode_case_from_person(self.domain, 'person').case_id, 'episode')
+
+    @run_with_all_backends
+    def test_get_occurrence_case_from_episode(self):
+        self.assertEqual(
+            get_occurrence_case_from_episode(self.domain, self.episode_id).case_id,
+            self.occurrence_id
+        )
+
+    @run_with_all_backends
+    def test_get_person_case_from_occurrence(self):
+        self.assertEqual(
+            get_person_case_from_occurrence(self.domain, self.occurrence_id).case_id,
+            self.person_id
+        )

--- a/custom/enikshay/tests/utils.py
+++ b/custom/enikshay/tests/utils.py
@@ -66,3 +66,31 @@ class ENikshayCaseStructureMixin(object):
             )],
         )
         return {case.case_id: case for case in self.factory.create_or_update_cases([episode])}
+
+    def create_adherence_cases(self, adherence_dates):
+        return self.factory.create_or_update_cases([
+            CaseStructure(
+                case_id=adherence_date.strftime('%Y-%m-%d'),
+                attrs={
+                    "case_type": "adherence",
+                    "create": True,
+                    "update": {
+                        "name": adherence_date,
+                        "adherence_value": "unobserved_dose",
+                        "adherence_source": "99DOTS",
+                        "adherence_date": adherence_date,
+                        "person_name": "Pippin",
+                        "adherence_confidence": "medium",
+                        "shared_number_99_dots": False,
+                    },
+                },
+                indices=[CaseIndex(
+                    CaseStructure(case_id=self.episode_id, attrs={"create": False}),
+                    identifier='host',
+                    relationship=CASE_INDEX_EXTENSION,
+                    related_type='episode',
+                )],
+                walk_related=False,
+            )
+            for adherence_date in adherence_dates
+        ])

--- a/custom/enikshay/tests/utils.py
+++ b/custom/enikshay/tests/utils.py
@@ -14,8 +14,9 @@ class ENikshayCaseStructureMixin(object):
         self.occurrence_id = u"occurrence"
         self.episode_id = u"episode"
 
-    def create_case_structure(self):
-        person = CaseStructure(
+    @property
+    def person(self):
+        return CaseStructure(
             case_id=self.person_id,
             attrs={
                 "case_type": "person",
@@ -29,7 +30,10 @@ class ENikshayCaseStructureMixin(object):
                 )
             },
         )
-        occurrence = CaseStructure(
+
+    @property
+    def occurrence(self):
+        return CaseStructure(
             case_id=self.occurrence_id,
             attrs={
                 'create': True,
@@ -39,13 +43,16 @@ class ENikshayCaseStructureMixin(object):
                 )
             },
             indices=[CaseIndex(
-                person,
+                self.person,
                 identifier='host',
                 relationship=CASE_INDEX_EXTENSION,
-                related_type=person.attrs['case_type'],
+                related_type=self.person.attrs['case_type'],
             )],
         )
-        episode = CaseStructure(
+
+    @property
+    def episode(self):
+        return CaseStructure(
             case_id=self.episode_id,
             attrs={
                 'create': True,
@@ -60,13 +67,18 @@ class ENikshayCaseStructureMixin(object):
                 )
             },
             indices=[CaseIndex(
-                occurrence,
+                self.occurrence,
                 identifier='host',
                 relationship=CASE_INDEX_EXTENSION,
-                related_type=occurrence.attrs['case_type'],
+                related_type=self.occurrence.attrs['case_type'],
             )],
         )
-        return {case.case_id: case for case in self.factory.create_or_update_cases([episode])}
+
+    def create_case(self, case):
+        return self.factory.create_or_update_cases([case])
+
+    def create_case_structure(self):
+        return {case.case_id: case for case in self.factory.create_or_update_cases([self.episode])}
 
     def create_adherence_cases(self, adherence_dates):
         return self.factory.create_or_update_cases([

--- a/custom/enikshay/tests/utils.py
+++ b/custom/enikshay/tests/utils.py
@@ -22,6 +22,9 @@ class ENikshayCaseStructureMixin(object):
                 "create": True,
                 "update": dict(
                     name="Pippin",
+                    aadhaar_number="499118665246",
+                    mobile_number="0123456789",
+                    dob="1987-08-15",
                 )
             },
         )
@@ -31,7 +34,7 @@ class ENikshayCaseStructureMixin(object):
                 'create': True,
                 'case_type': 'occurrence',
                 "update": dict(
-                    person_id=self.person_id
+                    name="Occurrence #1",
                 )
             },
             indices=[CaseIndex(
@@ -48,7 +51,6 @@ class ENikshayCaseStructureMixin(object):
                 'case_type': 'episode',
                 "update": dict(
                     person_name="Pippin",
-                    person_id=self.person_id,
                     opened_on=datetime(1989, 6, 11, 0, 0),
                     patient_type="new",
                     hiv_status="reactive",

--- a/custom/enikshay/tests/utils.py
+++ b/custom/enikshay/tests/utils.py
@@ -1,0 +1,66 @@
+from datetime import datetime
+
+from casexml.apps.case.mock import CaseFactory, CaseStructure, CaseIndex
+from casexml.apps.case.const import CASE_INDEX_EXTENSION
+
+
+class ENikshayCaseStructureMixin(object):
+    def setUp(self):
+        super(ENikshayCaseStructureMixin, self).setUp()
+        self.domain = getattr(self, 'domain', 'fake-domain-from-mixin')
+        self.factory = CaseFactory(domain=self.domain)
+
+        self.person_id = "person"
+        self.occurrence_id = "occurrence"
+        self.episode_id = "episode"
+
+    def create_case_structure(self):
+        person = CaseStructure(
+            case_id=self.person_id,
+            attrs={
+                "case_type": "person",
+                "create": True,
+                "update": dict(
+                    name="Pippin",
+                )
+            },
+        )
+        occurrence = CaseStructure(
+            case_id=self.occurrence_id,
+            attrs={
+                'create': True,
+                'case_type': 'occurrence',
+                "update": dict(
+                    person_id=self.person_id
+                )
+            },
+            indices=[CaseIndex(
+                person,
+                identifier='host',
+                relationship=CASE_INDEX_EXTENSION,
+                related_type=person.attrs['case_type'],
+            )],
+        )
+        episode = CaseStructure(
+            case_id=self.episode_id,
+            attrs={
+                'create': True,
+                'case_type': 'episode',
+                "update": dict(
+                    person_name="Pippin",
+                    person_id=self.person_id,
+                    opened_on=datetime(1989, 6, 11, 0, 0),
+                    patient_type="new",
+                    hiv_status="reactive",
+                    episode_type="confirmed_tb",
+                    default_adherence_confidence="high",
+                )
+            },
+            indices=[CaseIndex(
+                occurrence,
+                identifier='host',
+                relationship=CASE_INDEX_EXTENSION,
+                related_type=occurrence.attrs['case_type'],
+            )],
+        )
+        return {case.case_id: case for case in self.factory.create_or_update_cases([episode])}

--- a/custom/enikshay/tests/utils.py
+++ b/custom/enikshay/tests/utils.py
@@ -10,9 +10,9 @@ class ENikshayCaseStructureMixin(object):
         self.domain = getattr(self, 'domain', 'fake-domain-from-mixin')
         self.factory = CaseFactory(domain=self.domain)
 
-        self.person_id = "person"
-        self.occurrence_id = "occurrence"
-        self.episode_id = "episode"
+        self.person_id = u"person"
+        self.occurrence_id = u"occurrence"
+        self.episode_id = u"episode"
 
     def create_case_structure(self):
         person = CaseStructure(
@@ -24,6 +24,7 @@ class ENikshayCaseStructureMixin(object):
                     name="Pippin",
                     aadhaar_number="499118665246",
                     mobile_number="0123456789",
+                    backup_number="0999999999",
                     dob="1987-08-15",
                 )
             },

--- a/settings.py
+++ b/settings.py
@@ -1588,7 +1588,11 @@ BASE_REPEATERS = (
     'corehq.apps.repeaters.models.AppStructureRepeater',
 )
 
-REPEATERS = BASE_REPEATERS + LOCAL_REPEATERS
+CUSTOM_REPEATERS = (
+    'custom.enikshay.integrations.ninetyninedots.repeaters.NinetyNineDotsRegisterPatientRepeater',
+)
+
+REPEATERS = BASE_REPEATERS + LOCAL_REPEATERS + CUSTOM_REPEATERS
 
 
 

--- a/settings.py
+++ b/settings.py
@@ -765,6 +765,7 @@ LOCAL_APPS = ()
 LOCAL_COUCHDB_APPS = ()
 LOCAL_MIDDLEWARE_CLASSES = ()
 LOCAL_PILLOWTOPS = {}
+LOCAL_REPEATERS = ()
 
 # Prelogin site
 ENABLE_PRELOGIN_SITE = False
@@ -1578,6 +1579,16 @@ PILLOWTOPS = {
         },
     ]
 }
+
+BASE_REPEATERS = (
+    'corehq.apps.repeaters.models.FormRepeater',
+    'corehq.apps.repeaters.models.CaseRepeater',
+    'corehq.apps.repeaters.models.ShortFormRepeater',
+    'corehq.apps.repeaters.models.AppStructureRepeater',
+)
+
+REPEATERS = BASE_REPEATERS + LOCAL_REPEATERS
+
 
 
 STATIC_UCR_REPORTS = [

--- a/settings.py
+++ b/settings.py
@@ -1595,7 +1595,6 @@ CUSTOM_REPEATERS = (
 REPEATERS = BASE_REPEATERS + LOCAL_REPEATERS + CUSTOM_REPEATERS
 
 
-
 STATIC_UCR_REPORTS = [
     os.path.join('custom', '_legacy', 'mvp', 'ucr', 'reports', 'deidentified_va_report.json'),
     os.path.join('custom', 'abt', 'reports', 'incident_report.json'),

--- a/settings.py
+++ b/settings.py
@@ -388,6 +388,7 @@ HQ_APPS = (
     'custom.common',
 
     'custom.icds_reports',
+    'custom.enikshay.integrations.ninetyninedots'
 )
 
 # DEPRECATED use LOCAL_APPS instead; can be removed with testrunner.py


### PR DESCRIPTION
This is a pretty big one:
- Refactor of repeaters to allow us to add custom repeaters
- Adds the 99DOTS register patient repeater (outlined [here](https://docs.google.com/document/d/1PH4EPcSqhsYP-lV-_4_V6C9AvkpaBmIEe5ID5U2mAlc/edit#heading=h.n5l7q7bz65k1)) -- Still need to add the "update patient" repeater, but thought I'd get feedback on this approach while I work on it.

The refactor does a few things:
- Defines repeaters in settings, so we can have different repeaters active on different environments, etc.
- Moves a bunch of state / properties back into their respective classes so that we only have one-way dependencies (i.e. the generic repeater code needs to know nothing about the enabled repeaters)
- Adds `handle_success` and `handle_failure` methods to repeat records so that we can carry out actions on success / failure (e.g. update a case property)
- Adds `available_for_domain` to repeaters so they can be turned on / off depending on logic
- Adds `allow_retries` to the repeater to turn on / off retries depending on some logic based on the response (i.e. we don't just hammer the endpoint if there is an error in the data that we are sending).

For eNikshay I also added the `ENikshayCaseStructureMixin`, which should help whenever case structures change in the app.

Code Buddy @emord 
FYI @czue 
