### PR TITLE
Implement IETF advice for browser compatibility

### DIFF
--- a/corehq/apps/reports/tests/test_util.py
+++ b/corehq/apps/reports/tests/test_util.py
@@ -4,7 +4,7 @@ from elasticsearch.exceptions import ConnectionError
 from mock import Mock
 
 from corehq.apps.domain.shortcuts import create_domain
-from corehq.apps.reports.util import create_export_filter, safe_filename
+from corehq.apps.reports.util import create_export_filter, safe_for_fs
 from corehq.apps.users.models import CommCareUser
 from corehq.elastic import get_es_new
 from corehq.pillows.mappings.xform_mapping import XFORM_INDEX_INFO
@@ -59,8 +59,8 @@ class ReportUtilTests(TestCase):
 
 class TestSafeFilename(SimpleTestCase):
 
-    def test_safe_filename_bytestring(self):
-        self.assertEqual(safe_filename('spam*?: 𐍃𐍀𐌰𐌼-&.txt'), 'spam 𐍃𐍀𐌰𐌼-&.txt')
+    def test_safe_for_fs_bytestring(self):
+        self.assertEqual(safe_for_fs('spam*?: 𐍃𐍀𐌰𐌼-&.txt'), 'spam 𐍃𐍀𐌰𐌼-&.txt')
 
-    def test_safe_filename_unicode(self):
-        self.assertEqual(safe_filename(u'spam*?: 𐍃𐍀𐌰𐌼-&.txt'), u'spam 𐍃𐍀𐌰𐌼-&.txt')
+    def test_safe_for_fs_unicode(self):
+        self.assertEqual(safe_for_fs(u'spam*?: 𐍃𐍀𐌰𐌼-&.txt'), u'spam 𐍃𐍀𐌰𐌼-&.txt')

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -463,9 +463,9 @@ def safe_for_fs(filename):
 
     Unicode or bytestring datatype of filename is preserved.
 
-    >>> safe_filename(u'spam*?: 𐍃𐍀𐌰𐌼-&.txt')
+    >>> safe_for_fs(u'spam*?: 𐍃𐍀𐌰𐌼-&.txt')
     u'spam 𐍃𐍀𐌰𐌼-&.txt'
-    >>> safe_filename('spam*?: 𐍃𐍀𐌰𐌼-&.txt')
+    >>> safe_for_fs('spam*?: 𐍃𐍀𐌰𐌼-&.txt')
     'spam 𐍃𐍀𐌰𐌼-&.txt'
     """
     is_unicode = isinstance(filename, unicode)

--- a/corehq/apps/reports/util.py
+++ b/corehq/apps/reports/util.py
@@ -457,7 +457,7 @@ def get_INFilter_bindparams(base_name, values):
     return tuple(get_INFilter_element_bindparam(base_name, i) for i, val in enumerate(values))
 
 
-def safe_filename(filename):
+def safe_for_fs(filename):
     """
     Returns a filename with FAT32-, NTFS- and HFS+-illegal characters removed.
 

--- a/corehq/apps/reports/views.py
+++ b/corehq/apps/reports/views.py
@@ -22,7 +22,6 @@ import pytz
 import re
 from StringIO import StringIO
 import tempfile
-import unicodedata
 from urllib2 import URLError
 
 from django.conf import settings


### PR DESCRIPTION
Context: http://manage.dimagi.com/default.asp?236479

Implements [IETF advice](https://tools.ietf.org/html/rfc6266#appendix-D) for disastrous [browser compatibility](http://greenbytes.de/tech/tc2231/#attfnboth) for Content-Disposition header fields.

@dannyroberts @biyeun 
