### PR TITLE
explicitly list options with non-falsy defaults

### DIFF
--- a/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
+++ b/corehq/apps/couch_sql_migration/management/commands/migrate_domain_from_couch_to_sql.py
@@ -30,9 +30,8 @@ class Command(LabelCommand):
 
     @staticmethod
     def require_only_option(sole_option, options):
-        base_options = {option.dest for option in LabelCommand.option_list}
         assert all(not value for key, value in options.items()
-                   if key not in base_options and key != sole_option)
+                   if key not in ['skip_checks', 'verbosity'] and key != sole_option)
 
     def handle_label(self, domain, **options):
         if should_use_sql_backend(domain):


### PR DESCRIPTION
Needed for django 1.8, since `LabelCommand.option_list` becomes empty.  See failed [test](https://travis-ci.org/dimagi/commcare-hq/jobs/157956695) for more info.

@snopoke Can you confirm that `require_only_option` still works as originally intended?

cc: @dannyroberts @sravfeyn 
