### PR TITLE
sort domains by name in dropdown

### DIFF
--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -139,7 +139,7 @@ def domains_for_user(context, request, selected_domain=None):
 
     domain_list = _get_domain_list(request.couch_user)
     ctxt = {
-        'domain_list': domain_list,
+        'domain_list': sorted(domain_list, key=lambda domain: domain['name'].lower()),
         'current_domain': selected_domain,
         'can_publish_to_exchange': (
             selected_domain is not None and selected_domain != 'public' and


### PR DESCRIPTION
Currently they're in scrambled order
<img width="242" alt="screen shot 2016-09-07 at 4 26 09 pm" src="https://cloud.githubusercontent.com/assets/137212/18327505/d8afb0ec-7518-11e6-9d79-8b8ed77a2df1.png">
