### PR TITLE
fallback to get_by_name in project_info

### DIFF
--- a/corehq/apps/appstore/views.py
+++ b/corehq/apps/appstore/views.py
@@ -2,6 +2,7 @@ import json
 from datetime import date
 from urllib import urlencode
 
+from couchdbkit import ResourceNotFound
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.core.urlresolvers import reverse
@@ -212,7 +213,10 @@ class ProjectInformationView(BaseCommCareExchangeSectionView):
     @property
     @memoized
     def project(self):
-        return Domain.get(self.snapshot)
+        try:
+            return Domain.get(self.snapshot)
+        except ResourceNotFound:
+            return Domain.get_by_name(self.snapshot)
 
     def dispatch(self, request, *args, **kwargs):
         if not can_view_app(request, self.project):


### PR DESCRIPTION
This fixes a really nasty bug which i thought originally was my local configuration, but was actually a core issue with the project_info view in the exchange. apparently we've been inconsistently passing ids and names to the project_info reverse url method. oi.

http://manage.dimagi.com/default.asp?236825

@dannyroberts @kaapstorm 
