### PR TITLE
Catch ValueError on malformed group data

### DIFF
--- a/corehq/apps/groups/views.py
+++ b/corehq/apps/groups/views.py
@@ -120,7 +120,13 @@ def edit_group(request, domain, group_id):
 def update_group_data(request, domain, group_id):
     group = Group.get(group_id)
     if group.domain == domain:
-        updated_data = json.loads(request.POST["group-data"])
+        try:
+            updated_data = json.loads(request.POST["group-data"])
+        except ValueError:
+            messages.error(request, _(
+                "Unable to update group data. Please check the key-value mappings and try to update again."
+            ))
+            return HttpResponseRedirect(request.META['HTTP_REFERER'])
         group.metadata = updated_data
         group.save()
         messages.success(request, _("Group '%s' data updated!") % group.name)


### PR DESCRIPTION
Context: http://manage.dimagi.com/default.asp?237001

I wasn't able to reproduce this. 

The 500 messages (there were two of them) have `request.POST["group-data"] == "{"` which makes no sense to me, because the JSON is created by `$("#group-data").val(JSON.stringify(this.val()));` [over here](https://github.com/dimagi/commcare-hq/blob/1cca5c4d72b015e59b33f04b8b1dd25c25c746cc/corehq/apps/groups/templates/groups/group_members.html#L37-L37). 

Anyway, this change handles invalid JSON more gracefully.

@biyeun @dannyroberts 
