### PR TITLE
Fix accepting domain invitation

### DIFF
--- a/corehq/apps/users/views/__init__.py
+++ b/corehq/apps/users/views/__init__.py
@@ -37,7 +37,8 @@ from corehq.apps.analytics.tasks import (
     track_existing_user_accepted_invite_on_hubspot,
 )
 from corehq.apps.analytics.utils import get_meta
-from corehq.apps.domain.decorators import (login_and_domain_required, require_superuser, domain_admin_required)
+from corehq.apps.domain.decorators import (login_and_domain_required, require_superuser, domain_admin_required,
+    load_domain)
 from corehq.apps.domain.models import Domain
 from corehq.apps.domain.views import BaseDomainView
 from corehq.apps.es import AppES
@@ -701,6 +702,7 @@ class UserInvitationView(object):
 
 @sensitive_post_parameters('password')
 def accept_invitation(request, domain, invitation_id):
+    load_domain(request, domain)
     return UserInvitationView()(request, invitation_id, domain=domain)
 
 


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?236664

Introduced with https://github.com/dimagi/commcare-hq/pull/13034

Looks like some of the new additions to [corehq.tabs.uitab](https://github.com/dimagi/commcare-hq/blob/e954aaddd5d9f6d1517b3ad16fb9d636d167a19a/corehq/tabs/uitab.py) create a dependency on request.project being present. request.project is normally added with the login_and_domain_required decorator which isn't used in the domain invitation view.

@benrudolph code buddy
fyi @esoergel @biyeun 

@biyeun should we revert https://github.com/dimagi/commcare-hq/pull/13098 and https://github.com/dimagi/commcare-hq/pull/13142 or are those still good changes to have?
