### PR TITLE
Soft prompt to comment on build

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases.html
@@ -201,7 +201,7 @@
                     <inline-edit params="
                         value: build_comment,
                         rows: 1,
-                        placeholder: '{% trans "(No Comment)"|escapejs %}',
+                        placeholder: '{% trans "(Click here to add a comment)"|escapejs %}',
                         url: '{% url "update_build_comment" domain app.id %}',
                         saveParams: {'build_id': id},
                         saveValueName: 'comment',


### PR DESCRIPTION
Change the build comment placeholder text from:
`(No Comment)`
to
`(Click here to add a comment)`
on the releases page.
@czue
