### PR TITLE
Datetime picker

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -53,7 +53,8 @@
     "moment": "2.12.0",
     "jquery-treetable": "^3.2.0",
     "css-grid-polyfill-binaries": "1.1.1",
-    "requirejs": "~2.3.1"
+    "requirejs": "~2.3.1",
+    "datetimepicker": "2.5.4"
   },
   "devDependencies": {
     "chai": "3.3.0",

--- a/corehq/apps/cloudcare/templates/cloudcare/cloudcare_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/cloudcare_home.html
@@ -23,12 +23,12 @@
 {% block stylesheets %}
     {% compress css %}
     <link rel="stylesheet" href="{% static 'nprogress/nprogress.css' %}">
-    <link rel="stylesheet" href="{% static 'jquery-ui/themes/base/jquery-ui.min.css' %}">
     <link type="text/css"
           rel="stylesheet"
           media="all"
           href="{% static 'datatables/media/css/jquery.dataTables.min.css' %}" />
     <link rel="stylesheet" href="{% static 'formplayer/style/webforms.css' %}">
+    <link rel="stylesheet" href="{% static 'datetimepicker/build/jquery.datetimepicker.min.css' %}">
     <link rel="stylesheet" href="{% static 'codemirror/lib/codemirror.css' %}" />
     {% endcompress %}
 
@@ -60,6 +60,7 @@
     <script src="{% static 'hqwebapp/js/lib/jquery.textchange.min.js' %}"></script>
     <script src="{% static 'nprogress/nprogress.js' %}"></script>
     <script src="{% static 'moment/min/moment.min.js' %}"></script>
+    <script src="{% static 'datetimepicker/build/jquery.datetimepicker.full.js' %}"></script>
 
     <script src="{% static 'style/js/ui-element.js' %}"></script>
     <script src="{% static 'case/js/cheapxml.js' %}"></script>

--- a/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
@@ -28,7 +28,6 @@
 {% block stylesheets %}
     {% compress css %}
         <link rel="stylesheet" href="{% static 'nprogress/nprogress.css' %}">
-        <link rel="stylesheet" href="{% static 'jquery-ui/themes/base/jquery-ui.min.css' %}">
         <link rel="stylesheet" href="{% static 'datetimepicker/build/jquery.datetimepicker.min.css' %}">
         <link type="text/css"
               rel="stylesheet"

--- a/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
@@ -29,6 +29,7 @@
     {% compress css %}
         <link rel="stylesheet" href="{% static 'nprogress/nprogress.css' %}">
         <link rel="stylesheet" href="{% static 'jquery-ui/themes/base/jquery-ui.min.css' %}">
+        <link rel="stylesheet" href="{% static 'datetimepicker/build/jquery.datetimepicker.min.css' %}">
         <link type="text/css"
               rel="stylesheet"
               media="all"

--- a/corehq/apps/cloudcare/templates/cloudcare/includes/touchforms-inline.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/includes/touchforms-inline.html
@@ -4,11 +4,13 @@
 <link rel="stylesheet" href="{% static 'jquery-ui/themes/base/jquery-ui.min.css' %}">
 <link rel="stylesheet" href="{% static 'nprogress/nprogress.css' %}">
 <link rel="stylesheet" href="{% static 'formplayer/style/webforms.css' %}">
+<link rel="stylesheet" href="{% static 'datetimepicker/build/jquery.datetimepicker.min.css' %}">
 {% if not exclude_jquery_ui_import %}
 <script src="{% static 'jquery-ui/jquery-ui.min.js' %}"></script>
 {% endif %}
 <script src="{% static 'nprogress/nprogress.js' %}"></script>
 <script src="{% static 'moment/moment.js' %}"></script>
+<script src="{% static 'datetimepicker/build/jquery.datetimepicker.full.js' %}"></script>
 <script src="{% static 'formplayer/script/vendor/shortcut.js' %}"></script>
 <script src="{% static 'formplayer/script/vendor/markdown-it-4.2.0.min.js' %}"></script>
 <script src="{% static 'formplayer/script/vendor/ba-tiny-pubsub.min.js' %}"></script>

--- a/corehq/apps/cloudcare/templates/formplayer/dependencies.html
+++ b/corehq/apps/cloudcare/templates/formplayer/dependencies.html
@@ -8,6 +8,7 @@
 <script src="{% static 'hqwebapp/js/lib/jquery.textchange.min.js' %}"></script>
 <script src="{% static 'codemirror/lib/codemirror.js' %}"></script>
 <script src="{% static 'codemirror/mode/xml/xml.js' %}"></script>
+<script src="{% static 'datetimepicker/build/jquery.datetimepicker.full.js' %}"></script>
 <script src="{% static 'cloudcare/js/util.js' %}"></script>
 <script src="{% static 'cloudcare/js/formplayer/apps/util/util.js' %}"></script>
 <script src="{% static 'cloudcare/js/formplayer/app.js' %}"></script>

--- a/corehq/apps/preview_app/templates/preview_app/base.html
+++ b/corehq/apps/preview_app/templates/preview_app/base.html
@@ -75,6 +75,8 @@
                   rel="stylesheet"
                   media="all"
                   href="{% static 'preview_app/less/preview_app.less' %}"/>
+            <link rel="stylesheet"
+                  href="{% static 'datetimepicker/build/jquery.datetimepicker.min.css' %}" />
           {% endcompress %}
         {% endif %}
         <link type="text/css"


### PR DESCRIPTION
@czue @wpride had some fun building out the date time question for new cloudcare (does not work on old cloudcare, but also doesn't break it). it also refactors the time and date entry to use the same library.

<img width="1551" alt="screen shot 2016-09-11 at 4 18 59 pm" src="https://cloud.githubusercontent.com/assets/918514/18420614/9dcb6a0a-7844-11e6-977f-caecce14d931.png">

<img width="701" alt="screen shot 2016-09-11 at 5 26 46 pm" src="https://cloud.githubusercontent.com/assets/918514/18420633/f7887fe2-7844-11e6-8a18-60e79a51991e.png">
<img width="812" alt="screen shot 2016-09-11 at 5 26 36 pm" src="https://cloud.githubusercontent.com/assets/918514/18420634/f788f04e-7844-11e6-828f-76a01ac86cb0.png">
<img width="676" alt="screen shot 2016-09-11 at 5 26 42 pm" src="https://cloud.githubusercontent.com/assets/918514/18420632/f78537ba-7844-11e6-8e45-e3ccd69a1170.png">

cross: https://github.com/dimagi/touchforms/pull/260
will, i couldn't figure out where to make the commcare-core PR against. we should standardize a branch for formplayer or something. here's the relevant commit: https://github.com/dimagi/commcare-core/commit/da4b5171678182050628ab8b86fcb701f9def989

all the prs are best read commit by commit

cc: @gcapalbo 
