### PR TITLE
Include other columns when not ignoring unspecified options

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1616,7 +1616,8 @@ class SplitExportColumn(ExportColumn):
             return value
 
         if not isinstance(value, basestring):
-            return [None] * len(self.item.options) + [] if self.ignore_unspecified_options else [value]
+            unspecified_options = [] if self.ignore_unspecified_options else [value]
+            return [None] * len(self.item.options) + unspecified_options
 
         selected = OrderedDict((x, 1) for x in value.split(" "))
         row = []

--- a/corehq/apps/export/tests/test_export_column.py
+++ b/corehq/apps/export/tests/test_export_column.py
@@ -56,6 +56,24 @@ class SplitColumnTest(SimpleTestCase):
             [1, None, "b d"]
         )
 
+    def test_get_value_numerical(self):
+        column = SplitExportColumn(
+            item=MultipleChoiceItem(
+                path=[PathNode(name='form'), PathNode(name='q1')],
+                options=[Option(value='1'), Option(value='2')]
+            ),
+            ignore_unspecified_options=False
+        )
+        doc = {"q1": 3}
+        self.assertEqual(column.get_value(
+            'domain',
+            'docid',
+            doc,
+            [PathNode(name='form')],
+            split_column=True),
+            [None, None, 3]
+        )
+
     def test_ignore_extas(self):
         column = SplitExportColumn(
             item=MultipleChoiceItem(


### PR DESCRIPTION
In form exports, if `split_column` was True and `ignore_unspecified_options` was False, columns would be omitted.

@dannyroberts @biyeun cc @benrudolph 
