### PR TITLE
Add support for internal copy in S3 blob db

### DIFF
--- a/corehq/blobs/util.py
+++ b/corehq/blobs/util.py
@@ -15,7 +15,7 @@ class ClosingContextProxy(object):
         return iter(self._obj)
 
     def __enter__(self):
-        return self._obj
+        return self
 
     def __exit__(self, *args):
         self._obj.close()

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -84,7 +84,7 @@ git+git://github.com/dimagi/pyzxcvbn.git#egg=pyzxcvbn
 django-statici18n==1.1.5
 django-simple-captcha==0.5.1
 httpagentparser==1.7.8
-boto3==1.2.3
+boto3==1.4.0
 simpleeval==0.8.7
 laboratory==0.2.0
 ConcurrentLogHandler==0.9.1


### PR DESCRIPTION
Internal copy performs an efficient copy operation when `put`ting a blob that was previously loaded using `get`.

A new version of boto3 (v1.4.0) is needed for the copy operation. The upgrade also simplified multipart upload support.

@snopoke cc @NoahCarnahan 
