### PR TITLE
Fix prime restore

### DIFF
--- a/corehq/apps/ota/tasks.py
+++ b/corehq/apps/ota/tasks.py
@@ -84,7 +84,7 @@ def _get_cached_payload(restore_config):
     try:
         # must set this to False before attempting to check the cache
         restore_config.overwrite_cache = False
-        payload = restore_config.get_cached_payload()
+        payload = restore_config.get_cached_response()
     finally:
         restore_config.overwrite_cache = original
     return payload

--- a/corehq/ex-submodules/casexml/apps/phone/restore.py
+++ b/corehq/ex-submodules/casexml/apps/phone/restore.py
@@ -595,7 +595,7 @@ class RestoreConfig(object):
         self.validate()
         self.delete_cached_payload_if_necessary()
 
-        cached_response = self._get_cached_response()
+        cached_response = self.get_cached_response()
         if cached_response:
             return cached_response
         # Start new sync
@@ -613,7 +613,7 @@ class RestoreConfig(object):
         self.set_cached_payload_if_necessary(response, self.restore_state.duration)
         return response
 
-    def _get_cached_response(self):
+    def get_cached_response(self):
         if self.overwrite_cache:
             return CachedResponse(None)
 


### PR DESCRIPTION
Prime restore was breaking because I renamed a method. 
@emord 
