### PR TITLE
Show dropdown of location types for top level locations

### DIFF
--- a/corehq/apps/locations/static/locations/ko/location_drilldown.async.js
+++ b/corehq/apps/locations/static/locations/ko/location_drilldown.async.js
@@ -201,7 +201,8 @@ function LocationModel(data, root, depth, func, withAllOption) {
         var types = [];
         $.each(root.location_types, function(i, loc_type) {
             $.each(loc_type.allowed_parents, function(i, parent_type) {
-                if (loc.type() === parent_type) {
+                if (loc.type() === parent_type ||
+                    (loc.type() === undefined && parent_type === null)) {
                     types.push(loc_type.type);
                 }
             });


### PR DESCRIPTION
introduced https://github.com/dimagi/commcare-hq/commit/2039cc27

http://manage.dimagi.com/default.asp?237275

Pretty ugly fix. knockout uses `undefined` by default, but the way we pass in the hierarchy the `parent_type` is interpreted as `null` Thought about changing it back to `==` but decided to be explicit

@esoergel buddy @proteusvacuum 
