### PR TITLE
getGo isn't used

### DIFF
--- a/corehq/apps/style/static/style/js/hq_extensions.jquery.js
+++ b/corehq/apps/style/static/style/js/hq_extensions.jquery.js
@@ -1,10 +1,6 @@
 (function () {
     'use strict';
     $.extend({
-        // thanks to http://stackoverflow.com/questions/1149454/non-ajax-get-post-using-jquery-plugin
-        getGo: function (url, params) {
-            document.location = url + '?' + $.param(params);
-        },
         postGo: function (url, params) {
             params.csrfmiddlewaretoken = $.cookie('csrftoken');
             var $form = $("<form>")


### PR DESCRIPTION
jQuery 3 changes `param` (https://jquery.com/upgrade-guide/3.0/#breaking-change-jquery-param-no-longer-converts-20-to-a-plus-sign) which likely doesn't affect this function, but it turns out we're not actually using this function anymore.
