### PR TITLE
Remove ready handlers other than $()

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/managed_app.html
+++ b/corehq/apps/app_manager/templates/app_manager/managed_app.html
@@ -66,7 +66,7 @@
     </script>
     {% endif %}
     <script>
-        $(document).ready(function () {
+        $(function () {
             // https://github.com/twitter/bootstrap/issues/6122
             // this is necessary to get popovers to be able to extend
             // outside the borders of their containing div
@@ -94,7 +94,7 @@
         });
     </script>
     <script>
-        $(document).ready(function() {
+        $(function() {
             gaTrackLink($('#edit_label'), 'App Builder', 'Open Form', 'Edit Label');
             {% for module in app.get_modules %}
                 {% for form in module.get_forms %}

--- a/corehq/apps/data_interfaces/templates/data_interfaces/add_automatic_update_rule.html
+++ b/corehq/apps/data_interfaces/templates/data_interfaces/add_automatic_update_rule.html
@@ -79,7 +79,7 @@
             return $scope.action == 'UPDATE_AND_CLOSE' || $scope.action == 'UPDATE';
         };
 
-        angular.element(document).ready(function() {
+        $(function() {
             djangoRMI.get_case_property_map().success(function(response) {
                 if(response.success) {
                     $scope.case_property_map = response.data;

--- a/corehq/apps/domain/templates/domain/admin/add_form_repeater.html
+++ b/corehq/apps/domain/templates/domain/admin/add_form_repeater.html
@@ -6,7 +6,7 @@
 
 {% block js-inline %} {{ block.super }}
     <script>
-        $(document).ready(function() {
+        $(function() {
             var $testLinkButton = $('#test-forward-link'),
                 $testResult = $('#test-forward-result');
 

--- a/corehq/apps/domain/templates/domain/repeat_record_report.html
+++ b/corehq/apps/domain/templates/domain/repeat_record_report.html
@@ -16,7 +16,7 @@
 
 {% block js-inline %}{{ block.super }}
 <script>
-    $(document).ready(function() {
+    $(function() {
         var codeMirror = null;
         $('#view-record-payload-modal').on('shown.bs.modal', function(event) {
             var recordData = $(event.relatedTarget).data(),

--- a/corehq/apps/domain/templates/domain/snapshot_settings.html
+++ b/corehq/apps/domain/templates/domain/snapshot_settings.html
@@ -40,7 +40,7 @@
             return false;
         }
 
-        $(document).ready(function() {
+        $(function() {
             {% for snapshot in snapshots %}
                 $('#publish_{{ snapshot.name }}').click(function() {
                     ga_track_event('Exchange', 'Publish Previous Version', '{{ snapshot.name }}');

--- a/corehq/apps/groups/templates/groups/group_members.html
+++ b/corehq/apps/groups/templates/groups/group_members.html
@@ -103,7 +103,7 @@
                 }
             }
 
-            $(document).ready(function() {
+            $(function() {
                 $('#edit_membership').submit(function() {
                     $(this).find(':button').attr('disabled', 'disabled');
                     $(this).ajaxSubmit({

--- a/corehq/apps/hqadmin/templates/hqadmin/dimagisphere/form_feed.html
+++ b/corehq/apps/hqadmin/templates/hqadmin/dimagisphere/form_feed.html
@@ -99,7 +99,7 @@
 
 	{% block script_panel %}
         <script>
-jQuery(document).ready(function($) {
+$(function() {
     var filter = {};
 
     // courtesy of http://colorbrewer2.org/

--- a/corehq/apps/importer/templates/importer/excel_commit.html
+++ b/corehq/apps/importer/templates/importer/excel_commit.html
@@ -30,7 +30,7 @@
                         clearInterval(autoRefresh);
                     }
             };
-            $(document).ready(function () {
+            $(function () {
                 pollDownloader();
                 autoRefresh = setInterval(pollDownloader, 2000);
             });

--- a/corehq/apps/reports/templates/reports/partials/base_maps.html
+++ b/corehq/apps/reports/templates/reports/partials/base_maps.html
@@ -15,7 +15,7 @@
             ICON_PATH = '{% static 'leaflet/dist/images' %}';
             MIN_HEIGHT = 300; //px
 
-            $(document).ready(function() {
+            $(function() {
                 if (CONTEXT !== '') {
                     load(CONTEXT, ICON_PATH);
                 }

--- a/corehq/apps/reports/templates/reports/partials/generic_piechart.html
+++ b/corehq/apps/reports/templates/reports/partials/generic_piechart.html
@@ -2,7 +2,7 @@
 {% with chartdiv|default:"pieplaceholder" as chartdiv %}
     {% with hoverdiv|default:"piehoverplaceholder" as hoverdiv %}
     <script>
-        $(document).ready(function() {
+        $(function() {
             var data = [
             {% for point in chart_data %}
                 { label: "{{ point.display }}",  data: {{ point.value }}{% if point.color %}, color: "{{ point.color }}" {% endif %}} ,

--- a/corehq/apps/reports/templates/reports/reportdata/case_details.html
+++ b/corehq/apps/reports/templates/reports/reportdata/case_details.html
@@ -17,7 +17,7 @@
 
 {% block js-inline %}{{ block.super }}
     <script>
-    $(document).ready(function() {
+    $(function() {
         // this adds clickable links to our form and case elements
         var form_lookup_dict = {{ form_lookups|JSON }};
         var urlBase = "{% url "render_form_data" domain 'placeholder-formid' %}";

--- a/corehq/apps/style/static/style/ko/components.ko.js
+++ b/corehq/apps/style/static/style/ko/components.ko.js
@@ -6,7 +6,7 @@ _.each(components, function(moduleName, elementName) {
     ko.components.register(elementName, hqImport(moduleName));
 });
 
-$(document).ready(function() {
+$(function() {
     _.each(_.keys(components), function(elementName) {
         _.each($(elementName), function(el) { $(el).koApplyBindings(); });
     });

--- a/corehq/apps/style/templates/style/partials/form_list_form.html
+++ b/corehq/apps/style/templates/style/partials/form_list_form.html
@@ -66,7 +66,7 @@
 </form>
 
 <script>
-    $(document).ready(function() {
+    $(function() {
         function Row(data, keys) {
             var self = this;
             self.errors = ('form_errors' in data) ? data.form_errors : {};

--- a/corehq/apps/style/templates/style/soil_status_full.html
+++ b/corehq/apps/style/templates/style/soil_status_full.html
@@ -25,7 +25,7 @@
                     clearInterval(autoRefresh);
                 }
         };
-        $(document).ready(function () {
+        $(function () {
             pollDownloader();
             autoRefresh = setInterval(pollDownloader, 2000);
         });

--- a/corehq/ex-submodules/soil/templates/soil/file_download.html
+++ b/corehq/ex-submodules/soil/templates/soil/file_download.html
@@ -21,7 +21,7 @@
 	            clearInterval(autoRefresh);
 	        }
         };
-        $(document).ready(function () {
+        $(function () {
             autoRefresh = setInterval(pollDownloader, 2000);
         });
     </script>

--- a/custom/_legacy/pact/templates/pact/patient/pactpatient_log.html
+++ b/custom/_legacy/pact/templates/pact/patient/pactpatient_log.html
@@ -1,13 +1,12 @@
 {% extends "pact/patient/pactpatient_base.html" %}
 {% block extrahead %}
     <script>
-        $(document).ready(
-                function () {
-                    //$("#tbl_issues").tablesorter({ sortList:[ [0, 0] ], });
-                    $("#tbl_issues").tablesorter();
-                    $("abbr.timeago").timeago();
-                }
-        );</script>
+        $(function () {
+            //$("#tbl_issues").tablesorter({ sortList:[ [0, 0] ], });
+            $("#tbl_issues").tablesorter();
+            $("abbr.timeago").timeago();
+        });
+    </script>
 
 {% endblock extrahead %}
 {% block patient-tab-container %}

--- a/custom/bihar/templates/bihar/reports/report.html
+++ b/custom/bihar/templates/bihar/reports/report.html
@@ -5,7 +5,7 @@
 
 {% block js-inline %} {{ block.super }}
     <script type="text/javascript">
-        $(document).ready(function () {
+        $(function () {
             var reportContent = $('#report-content');
 
             // a bit hackish, but allows to display table content with sticky headers and vertical

--- a/custom/ewsghana/templates/ewsghana/partials/map.html
+++ b/custom/ewsghana/templates/ewsghana/partials/map.html
@@ -22,7 +22,7 @@
         return map;
     }
 
-    $(document).ready(function() {
+    $(function() {
         if (CONTEXT !== '') {
             var map = load(CONTEXT, ICON_PATH);
             $('#export-jpg').click(function() {

--- a/custom/icds_reports/templates/icds_reports/multi_report.html
+++ b/custom/icds_reports/templates/icds_reports/multi_report.html
@@ -55,7 +55,7 @@
 
 {% block js-inline %} {{ block.super }}
     <script type="text/javascript">
-        $(document).ready(function() {
+        $(function() {
             $('#fieldset_location_async').on('change', 'select', function(e) {
                 e.stopPropagation();
                 var state = $('select.form-control')[0].selectedIndex;

--- a/custom/opm/templates/opm/map_template.html
+++ b/custom/opm/templates/opm/map_template.html
@@ -73,7 +73,7 @@ CONTEXT = {{ context|JSON }};
 ICON_PATH = '{% static 'reports/css/leaflet/images' %}';
 MIN_HEIGHT = 300; //px
 
-$(document).ready(function() {
+$(function() {
     if (CONTEXT !== '') {
         load(CONTEXT, ICON_PATH);
         var div = '<div id="extra-legend" class="control-pane leaflet-control"><h4>AWC Name</h4><div>' +


### PR DESCRIPTION
https://jquery.com/upgrade-guide/3.0/#breaking-change-on-quot-ready-quot-fn-removed

https://jquery.com/upgrade-guide/3.0/#deprecated-document-ready-handlers-other-than-jquery-function

@emord 
