### PR TITLE
size() deprecated

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/app_manager.js
+++ b/corehq/apps/app_manager/static/app_manager/js/app_manager.js
@@ -104,7 +104,7 @@ hqDefine('app_manager/js/app_manager.js', function () {
         $('.drag_handle').addClass(COMMCAREHQ.icons.GRIP);
         $('.sortable').each(function () {
             var min_elem = $(this).hasClass('sortable-forms') ? 1 : 2;
-            if ($(this).children().not('.sort-disabled').size() < min_elem) {
+            if ($(this).children().not('.sort-disabled').length < min_elem) {
                 var $sortable = $(this);
                 $('.drag_handle', this).each(function () {
                     if ($(this).closest('.sortable')[0] === $sortable[0]) {
@@ -117,7 +117,7 @@ hqDefine('app_manager/js/app_manager.js', function () {
             var $sortable = $(this);
             var sorting_forms = $sortable.hasClass('sortable-forms');
             var min_elem = $(this).hasClass('sortable-forms') ? 0 : 1;
-            if ($(this).children().not('.sort-disabled').size() > min_elem) {
+            if ($(this).children().not('.sort-disabled').length > min_elem) {
                 var init_dict = {
                     handle: '.drag_handle ',
                     items: ">*:not(.sort-disabled)",


### PR DESCRIPTION
`size` was deprecated in 1.8 and removed in 3.0: https://api.jquery.com/size/

The [main migration guide](https://jquery.com/upgrade-guide/3.0/) doesn't call this out as a breaking change, which is a little bit concerning. Had a look through [other removed functions](https://api.jquery.com/category/removed/) and don't see anything else that's problematic for us.

@emord 
