### PR TITLE
Sort by server_date as backup

### DIFF
--- a/corehq/apps/reports/analytics/couchaccessors.py
+++ b/corehq/apps/reports/analytics/couchaccessors.py
@@ -140,7 +140,7 @@ def get_ledger_values_for_case_as_of(domain, case_id, section_id, as_of, program
     results = transactions.exclude(
         report__date__gt=as_of
     ).order_by(
-        'product_id', '-report__date'
+        'product_id', '-report__date', '-report__server_date'
     ).values_list(
         'product_id', 'stock_on_hand'
     ).distinct(

--- a/corehq/apps/reports/tests/test_supply_accessors.py
+++ b/corehq/apps/reports/tests/test_supply_accessors.py
@@ -1,8 +1,11 @@
 import uuid
 from datetime import datetime, timedelta
 from django.test import TestCase
+from dimagi.utils.parsing import json_format_datetime
 from corehq.apps.commtrack.helpers import make_product
-from corehq.apps.commtrack.tests.util import get_single_balance_block
+from corehq.apps.commtrack.tests.util import (
+    get_single_balance_block, get_single_transfer_block,
+)
 from corehq.apps.hqcase.utils import submit_case_blocks
 from corehq.apps.receiverwrapper.util import submit_form_locally
 from corehq.apps.reports.analytics.couchaccessors import get_ledger_values_for_case_as_of
@@ -51,3 +54,33 @@ class TestSupplyAccessors(TestCase):
         before_data = datetime.utcnow() - timedelta(days=2)
         self.assertEqual({}, get_ledger_values_for_case_as_of(
             domain=self.domain, case_id=case_id, section_id='stock', as_of=before_data))
+
+    def test_get_ledger_values_for_case_as_of_same_date(self):
+        case_id = uuid.uuid4().hex
+        form_xml = get_simple_form_xml(uuid.uuid4().hex, case_id)
+        submit_form_locally(form_xml, domain=self.domain)[1]
+
+        # submit ledger data
+        balances = (
+            (self.product_a._id, 100),
+        )
+        ledger_blocks = [
+            get_single_balance_block(case_id, prod_id, balance)
+            for prod_id, balance in balances
+        ]
+        submit_case_blocks(ledger_blocks, self.domain)
+
+        # submit two transfers at the same time
+        transfer_date = json_format_datetime(datetime.utcnow())
+        transfers = [
+            (self.product_a._id, 1, transfer_date),
+            (self.product_a._id, 2, transfer_date),
+        ]
+        for prod_id, transfer, date in transfers:
+            submit_case_blocks(get_single_transfer_block(case_id, None, prod_id, transfer, date), self.domain)
+
+        # check results
+        results = get_ledger_values_for_case_as_of(
+            domain=self.domain, case_id=case_id, section_id='stock', as_of=datetime.utcnow())
+        self.assertEqual(1, len(results))
+        self.assertEqual(97, results[self.product_a._id])


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?236117#1218242

There is an old bug with commtrack forms in formbuilder where they report the date of a stock transaction, but not a time. This report had several transactions on the same date but received at different times. I don't think that this will necessarily be right all the time (like in the case of out of order submissions), but it will be much closer most of the time.

The bug in formbuilder has been resolved for a while by writing now() instead of today(), but we aren't overwriting old xml.

@esoergel buddy @proteusvacuum 
