### PR TITLE
Make sure location_type names and codes are unique

### DIFF
--- a/corehq/apps/locations/exceptions.py
+++ b/corehq/apps/locations/exceptions.py
@@ -2,3 +2,7 @@
 
 class LocationImportError(Exception):
     pass
+
+
+class LocationConsistencyError(Exception):
+    pass

--- a/corehq/apps/locations/migrations/0004_auto_20160914_2030.py
+++ b/corehq/apps/locations/migrations/0004_auto_20160914_2030.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('locations', '0003_remove_null_True'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='locationtype',
+            unique_together=set([('domain', 'name'), ('domain', 'code')]),
+        ),
+    ]

--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -124,6 +124,10 @@ class LocationType(models.Model):
 
     class Meta:
         app_label = 'locations'
+        unique_together = (
+            ('domain', 'code'),
+            ('domain', 'name'),
+        )
 
     def __init__(self, *args, **kwargs):
         super(LocationType, self).__init__(*args, **kwargs)

--- a/corehq/apps/locations/static/locations/ko/location_types.js
+++ b/corehq/apps/locations/static/locations/ko/location_types.js
@@ -80,6 +80,27 @@ hqDefine('locations/ko/location_types.js', function(){
                 }
             });
 
+            // Make sure name and code are unique
+            _.each(['name', 'code'], function (field) {
+                var counts_by_value = _.countBy(self.loc_types(), function (loc_type) {
+                    return loc_type[field]();
+                });
+                var duplicates = [];
+                _.each(counts_by_value, function (count, value) {
+                    if (count > 1) {
+                        duplicates.push(value);
+                        valid = false;
+                    }
+                });
+                _.each(self.loc_types(), function (loc_type) {
+                    var has_error = (field === 'name') ? loc_type.duplicate_name_error : loc_type.duplicate_code_error;
+                    has_error(false);
+                    if (_.contains(duplicates, loc_type[field]())) {
+                        has_error(true);
+                    }
+                });
+            });
+
             var top_level_loc = false;
             $.each(self.loc_types(), function(i, e) {
                 if (!e.parent_type()) {
@@ -166,6 +187,8 @@ hqDefine('locations/ko/location_types.js', function(){
         self.view = view_model;
 
         self.name_error = ko.observable(false);
+        self.duplicate_name_error = ko.observable(false);
+        self.duplicate_code_error = ko.observable(false);
 
         self.validate = function() {
             self.name_error(false);

--- a/corehq/apps/locations/templates/locations/location_types.html
+++ b/corehq/apps/locations/templates/locations/location_types.html
@@ -170,10 +170,13 @@
                         </thead>
                         <tbody data-bind="foreach: loc_types">
                         <tr data-bind="bind_element: Object()">
-                            <td class="form-group" data-bind="css: { 'has-error': name_error }">
+                            <td class="form-group" data-bind="css: { 'has-error': name_error() || duplicate_name_error() }">
                                 <input class="loctype_name form-control" data-bind="value: name" type="text" />
                                 <div class="help-block" data-bind="visible: name_error">
                                     {% trans "Required" %}
+                                </div>
+                                <div class="help-block" data-bind="visible: duplicate_name_error">
+                                    {% trans "This field must be unique" %}
                                 </div>
                             </td>
                             <td class="form-group">
@@ -185,8 +188,12 @@
                                                    optionsCaption: '\u2013top level\u2013'">
                                 </select>
                             </td>
-                            <td class="form-group" data-bind="visible: $parent.advanced_mode">
+                            <td class="form-group" data-bind="visible: $parent.advanced_mode,
+                                                              css: { 'has-error': duplicate_code_error }">
                                 <input class="form-control typecode" data-bind="value: code" type="text" />
+                                <div class="help-block" data-bind="visible: duplicate_code_error">
+                                    {% trans "This field must be unique" %}
+                                </div>
                             </td>
                             <td class="form-group" data-bind="visible: $parent.advanced_mode">
                                 <select class="form-control"


### PR DESCRIPTION
@czue @orangejenny
This does three things:
- adds a db constraint that location types be unique by both name and code
- adds client-side validation of the same
- fails hard on the server if client validation broke

best read :blowfish: by :blowfish: 

Prod has only one domain for which this is an issue, which we're resolving manually.
I'll similarly verify staging and India before allowing this to be merged.  If the migration fails, it provides enough information to fix it.  Here's how to check for uniqueness:

``` python
from corehq.apps.locations.models import *
from django.db.models import *
(LocationType.objects
 .values('domain', 'name')
 .order_by()
 .annotate(count=Count('pk'))
 .filter(count__gt=1))
(LocationType.objects
 .values('domain', 'code')
 .order_by()
 .annotate(count=Count('pk'))
 .filter(count__gt=1))
```

@sheelio FYI
