### PR TITLE
Simplify report submitting

### DIFF
--- a/corehq/apps/accounting/templates/accounting/report_filter_actions.html
+++ b/corehq/apps/accounting/templates/accounting/report_filter_actions.html
@@ -4,7 +4,7 @@
 {% block report_filter_actions %}
     <div id="savedReports" class="{{ report_filter_form_action_css_class }}">
         <button id="apply-filters" type="submit"
-                class="filters btn disabled"
+                class="filters btn btn-primary disable-on-submit"
                 data-loading-text="{% trans 'Generating Report...' %}"
                 data-standard-text="{% trans 'Apply' %}">
             {% trans 'Apply' %}

--- a/corehq/apps/reports/static/reports/javascripts/reports.async.js
+++ b/corehq/apps/reports/static/reports/javascripts/reports.async.js
@@ -47,10 +47,6 @@ var HQAsyncReport = function (o) {
 
         self.updateReport(true, window.location.search.substr(1), self.standardReport.filterSet);
 
-        // only update the report if there are actually filters set
-        if (!self.standardReport.needsFilters) {
-            self.standardReport.filterSubmitButton.addClass('disabled');
-        }
         self.filterForm.submit(function () {
             var params = hqImport('reports/javascripts/reports.util.js').urlSerialize(this);
             History.pushState(null,window.location.title,
@@ -115,26 +111,6 @@ var HQAsyncReport = function (o) {
 
                 $('.loading-backdrop').fadeOut();
                 self.hqLoading.fadeOut();
-
-                if (!initial_load || !self.standardReport.needsFilters) {
-                    self.standardReport.filterSubmitButton
-                        .button('reset');
-                    setTimeout(function () {
-                        // Bootstrap clears all btn styles except btn on reset
-                        // This gets around it by waiting 10ms.
-                        self.standardReport.filterSubmitButton
-                            .removeClass('btn-primary')
-                            .addClass('disabled')
-                            .prop('disabled', true);
-
-                    }, 10);
-                } else {
-                    self.standardReport.filterSubmitButton
-                        .button('reset')
-                        .addClass('btn-primary')
-                        .removeClass('disabled')
-                        .prop('disabled', false);
-                }
             },
             error: function (data) {
                 self.reportRequest = null;
@@ -160,7 +136,10 @@ var HQAsyncReport = function (o) {
                     self.hqLoading.fadeIn();
                 }
 
-            }
+            },
+            complete: function() {
+                self.standardReport.filterSubmitButton.button('reset');
+            },
         });
     };
 

--- a/corehq/apps/reports/templates/reports/partials/filter_panel.html
+++ b/corehq/apps/reports/templates/reports/partials/filter_panel.html
@@ -5,8 +5,7 @@
 {% block report_filter_actions %}
 <div id="savedReports"
      class="{{ report_filter_form_action_css_class }}">
-    <button id="apply-filters" type="submit" class="filters btn disabled"
-        disabled="disabled"
+    <button id="apply-filters" type="submit" class="filters btn btn-primary disable-on-submit"
         data-loading-text="{% trans 'Generating Report...' %}"
         data-standard-text="{% trans 'Apply' %}">
         {% trans 'Apply' %}

--- a/corehq/apps/reports_core/templates/reports_core/base_template_new.html
+++ b/corehq/apps/reports_core/templates/reports_core/base_template_new.html
@@ -122,9 +122,6 @@
             event.preventDefault();
             reportTables.render();
         });
-        // after we've registered the event that prevents the default form submission
-        // we can enable the submit button
-        $("#apply-filters").prop('disabled', false);
 
         $(function() {
             $('.header-popover').popover({

--- a/corehq/apps/userreports/templates/userreports/partials/filter_panel.html
+++ b/corehq/apps/userreports/templates/userreports/partials/filter_panel.html
@@ -9,10 +9,10 @@
                 <div class="btn-group">
                     <button id="apply-filters"
                             type="submit"
-                            class="filters btn btn-primary"
+                            class="filters btn btn-primary disable-on-submit"
                             data-loading-text="{% trans 'Generating Report...' %}"
                             data-standard-text="{% trans 'Apply' %}"
-                            disabled >
+                            >
                         {% trans 'Apply' %}
                     </button>
                 </div>


### PR DESCRIPTION
@emord @biyeun this simplifies the report submit button. I think there were race conditions and perhaps the upgrade in jquery brought them to light. In any case this works locally for all the major reports
http://manage.dimagi.com/default.asp?237437
cc: @gcapalbo 
