### PR TITLE
don't use removeProp on native properties

### DIFF
--- a/corehq/apps/fixtures/static/fixtures/js/lookup-manage.js
+++ b/corehq/apps/fixtures/static/fixtures/js/lookup-manage.js
@@ -242,7 +242,7 @@ $(function () {
                 }
                 else {
                     $.each($checkboxes, function() {
-                        $(this).removeProp("checked");
+                        $(this).prop("checked", false);
                     });
                 }
             }

--- a/corehq/apps/reports/static/reports/javascripts/reports.config.js
+++ b/corehq/apps/reports/static/reports/javascripts/reports.config.js
@@ -45,7 +45,7 @@ var HQReport = function (options) {
                     .button('reset')
                     .addClass('btn-primary')
                     .removeClass('disabled')
-                    .removeProp('disabled');
+                    .prop('disabled', false);
             }
             if (self.slug) {
                 if (self.isExportable) {
@@ -164,14 +164,14 @@ var HQReport = function (options) {
                 .button('reset')
                 .addClass('btn-primary')
                 .removeClass('disabled')
-                .removeProp('disabled');
+                .prop('disabled', false);
         });
         $('#paramSelectorForm fieldset').on('change apply', function () {
             $(self.filterSubmitSelector)
                 .button('reset')
                 .addClass('btn-primary')
                 .removeClass('disabled')
-                .removeProp('disabled');
+                .prop('disabled', false);
         });
     };
 

--- a/corehq/apps/style/static/style/js/components/multiselect_utils.js
+++ b/corehq/apps/style/static/style/js/components/multiselect_utils.js
@@ -82,7 +82,7 @@ hqDefine('style/js/components/multiselect_utils', function () {
                     if (that.search_left.val().length > 0) {
                         $('#' + selectAllId).addClass('disabled').prop('disabled', true);
                     } else {
-                        $('#' + selectAllId).removeClass('disabled').removeProp('disabled');
+                        $('#' + selectAllId).removeClass('disabled').prop('disabled', false);
                     }
                 });
 
@@ -98,7 +98,7 @@ hqDefine('style/js/components/multiselect_utils', function () {
                     if (that.search_right.val().length > 0) {
                         $('#' + removeAllId).addClass('disabled').prop('disabled', true);
                     } else {
-                        $('#' + removeAllId).removeClass('disabled').removeProp('disabled');
+                        $('#' + removeAllId).removeClass('disabled').prop('disabled', false);
                     }
                 });
             },
@@ -106,13 +106,13 @@ hqDefine('style/js/components/multiselect_utils', function () {
                 this.search_left.cache();
                 // remove search option so that user doesn't get confused
                 this.search_right.val('').search('');
-                $('#' + removeAllId).removeClass('disabled').removeProp('disabled');
+                $('#' + removeAllId).removeClass('disabled').prop('disabled', false);
                 this.search_right.cache();
             },
             afterDeselect: function(){
                 // remove search option so that user doesn't get confused
                 this.search_left.val('').search('');
-                $('#' + selectAllId).removeClass('disabled').removeProp('disabled');
+                $('#' + selectAllId).removeClass('disabled').prop('disabled', false);
                 this.search_left.cache();
                 this.search_right.cache();
             },


### PR DESCRIPTION
https://api.jquery.com/removeProp/ says "Do not use this method to remove native properties such as checked, disabled, or selected. This will remove the property completely and, once removed, cannot be added again to element. Use .prop() to set these properties to false instead."

@emord 
