### PR TITLE
Disable scroll input for dates

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -307,6 +307,7 @@ function DateTimeEntryBase(question, options) {
             format: self.clientFormat,
             maxDate: maxDate,
             minDate: minDate,
+            scrollInput: false,
             onChangeDateTime: function(newDate) {
                 if (!newDate) {
                     self.answer(Formplayer.Const.NO_ANSWER);


### PR DESCRIPTION
@biyeun this disables scrolling in the datetime widget

@emord i looked into using the bootstrap daterangepicker and unfortunately they don't have _just_ a time picker
