### PR TITLE
Uneditable export columns

### DIFF
--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -1454,6 +1454,8 @@ class UserDefinedExportColumn(ExportColumn):
     data within the form. It should only be needed for RemoteApps
     """
 
+    is_editable = BooleanProperty(default=True)
+
     # On normal columns, the path is defined on an ExportItem.
     # Since a UserDefinedExportColumn is not associated with the
     # export schema, the path is defined on the column.

--- a/corehq/apps/export/static/export/js/models.js
+++ b/corehq/apps/export/static/export/js/models.js
@@ -320,6 +320,7 @@ hqDefine('export/js/models.js', function () {
         e.preventDefault();
         table.columns.push(new UserDefinedExportColumn({
             selected: true,
+            is_editable: true,
             deid_transform: null,
             doc_type: 'UserDefinedExportColumn',
             label: '',
@@ -512,6 +513,10 @@ hqDefine('export/js/models.js', function () {
         return gettext(this.help_text);
     };
 
+    ExportColumn.prototype.isEditable = function() {
+        return false;
+    };
+
     ExportColumn.mapping = {
         include: [
             'item',
@@ -553,6 +558,14 @@ hqDefine('export/js/models.js', function () {
         return true;
     };
 
+    UserDefinedExportColumn.prototype.formatProperty = function() {
+        return _.map(this.custom_path(), function(node) { return node.name(); }).join('.');
+    };
+
+    UserDefinedExportColumn.prototype.isEditable = function() {
+        return this.is_editable();
+    };
+
     UserDefinedExportColumn.prototype.customPathToNodes = function() {
         this.custom_path(utils.customPathToNodes(this.customPathString()));
     };
@@ -564,6 +577,7 @@ hqDefine('export/js/models.js', function () {
             'doc_type',
             'custom_path',
             'label',
+            'is_editable',
         ],
         custom_path: {
             create: function(options) {

--- a/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
+++ b/corehq/apps/export/templates/export/partial/new_customize_export_templates.html
@@ -148,7 +148,7 @@
                                            class="field-include"
                                            data-bind="checked: column.selected" />
                                     <!--/ko-->
-                                    <!-- ko if: column.isUserDefined -->
+                                    <!-- ko if: column.isEditable() -->
                                     <div class="remove-user-defined-column pull-right">
                                         <button class="btn btn-danger btn-xs" data-bind="
                                             click: function() {
@@ -167,8 +167,8 @@
                                             attr: { class: hqImport('export/js/utils.js').getTagCSSClass(tag) }"></span>
                                     </span>
 
-                                    <!-- ko if: !column.isUserDefined -->
-                                    <code data-toggle="tooltip" data-placement="top" 
+                                    <!-- ko if: !column.isEditable() -->
+                                    <code data-toggle="tooltip" data-placement="top"
                                         data-bind="
                                             text: column.formatProperty(),
                                             attr: {
@@ -180,7 +180,7 @@
                                             }
                                         "></code>
                                     <!-- /ko -->
-                                    <!-- ko if: column.isUserDefined -->
+                                    <!-- ko if: column.isEditable() -->
                                     <input
                                         type="text"
                                         class="form-control"

--- a/corehq/apps/export/tests/data/saved_export_schemas/case.json
+++ b/corehq/apps/export/tests/data/saved_export_schemas/case.json
@@ -35,10 +35,10 @@
                    "index": "age",
                    "show": false,
                    "is_sensitive": false,
-                   "transform": null,
+                   "transform": "couchexport.deid.deid_ID",
                    "doc_type": "ExportColumn",
                    "tag": null,
-                   "display": "age"
+                   "display": "Age Label"
                },
                {
                    "index": "balding",

--- a/corehq/apps/export/tests/test_export_conversion.py
+++ b/corehq/apps/export/tests/test_export_conversion.py
@@ -146,27 +146,37 @@ class TestConvertBase(TestCase, TestFileMixin):
         super(TestConvertBase, self).setUp()
         delete_all_export_instances()
 
-    def _convert_form_export(self, export_file_name):
+    def _convert_form_export(self, export_file_name, force=False):
+        return self._convert_export(
+            'corehq.apps.export.models.new.FormExportDataSchema.generate_schema_from_builds',
+            export_file_name,
+            force=force
+        )
+
+    def _convert_case_export(self, export_file_name, force=False):
+        return self._convert_export(
+            'corehq.apps.export.models.new.CaseExportDataSchema.generate_schema_from_builds',
+            export_file_name,
+            force=force
+        )
+
+    def _convert_export(self, mock_path, export_file_name, force=False):
         saved_export_schema = SavedExportSchema.wrap(self.get_json(export_file_name))
 
         with mock.patch.object(SavedExportSchema, 'save', return_value='False Save'):
             with mock.patch(
-                    'corehq.apps.export.models.new.FormExportDataSchema.generate_schema_from_builds',
+                    mock_path,
                     return_value=self.schema):
-                instance, meta = convert_saved_export_to_export_instance(self.domain, saved_export_schema)
+                instance, meta = convert_saved_export_to_export_instance(
+                    self.domain,
+                    saved_export_schema,
+                    force_convert_columns=force,
+                )
 
         return instance, meta
 
-    def _convert_case_export(self, export_file_name):
-        saved_export_schema = SavedExportSchema.wrap(self.get_json(export_file_name))
 
-        with mock.patch.object(SavedExportSchema, 'save', return_value='False Save'):
-            with mock.patch(
-                    'corehq.apps.export.models.new.CaseExportDataSchema.generate_schema_from_builds',
-                    return_value=self.schema):
-                instance, meta = convert_saved_export_to_export_instance(self.domain, saved_export_schema)
 
-        return instance, meta
 
 
 @mock.patch(

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -42,7 +42,11 @@ def is_occurrence_deleted(last_occurrences, app_ids_and_versions):
     return is_deleted
 
 
-def convert_saved_export_to_export_instance(domain, saved_export, dryrun=False):
+def convert_saved_export_to_export_instance(
+        domain,
+        saved_export,
+        force_convert_columns=False,
+        dryrun=False):
     from .models import (
         FormExportDataSchema,
         FormExportInstance,
@@ -214,7 +218,7 @@ def convert_saved_export_to_export_instance(domain, saved_export, dryrun=False):
                     info.append('Column has deid_transform: {}'.format(transform))
                 ordering.append(new_column)
             except SkipConversion, e:
-                if is_remote_app_migration:
+                if is_remote_app_migration or force_convert_columns:
                     # In the event that we skip a column and it's a remote application,
                     # just add a user defined column
                     new_column = _create_user_defined_column(column, column_path, transform)
@@ -265,6 +269,7 @@ def _create_user_defined_column(old_column, column_path, transform):
         selected=True,
         deid_transform=transform,
         custom_path=column_path,
+        is_editable=False,
     )
     return column
 

--- a/corehq/apps/export/utils.py
+++ b/corehq/apps/export/utils.py
@@ -223,6 +223,7 @@ def convert_saved_export_to_export_instance(
                     # just add a user defined column
                     new_column = _create_user_defined_column(column, column_path, transform)
                     new_table.columns.append(new_column)
+                    ordering.append(new_column)
                 else:
                     migration_meta.skipped_columns.append(ConversionMeta(
                         path=column.index,


### PR DESCRIPTION
@czue @NoahCarnahan this implement "uneditable" user defined columns. Thought here is that when we do a migration we can now just force add the columns for the existing exports. this'll hopefully get us closer to 0 domains on old exports. open for review, still need to write tests and hook it up to the migrate_exports command

cc: @gcapalbo 
