### PR TITLE
Add variable fetch limit to deploys page

### DIFF
--- a/corehq/apps/app_manager/const.py
+++ b/corehq/apps/app_manager/const.py
@@ -60,3 +60,5 @@ STOCK_QUESTION_TAG_NAMES = [
     'balance',
     'transfer',
 ]
+
+DEFAULT_FETCH_LIMIT = 5

--- a/corehq/apps/app_manager/static/app_manager/js/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases.js
@@ -201,7 +201,7 @@ hqDefine('app_manager/js/releases.js', function () {
         self.buildState = ko.observable('');
         self.fetchState = ko.observable('');
         self.nextVersionToFetch = null;
-        self.fetchLimit = o.fetchLimit;
+        self.fetchLimit = o.fetchLimit || 5;
         self.deployAnyway = {};
         self.currentAppVersion = ko.observable(self.options.currentAppVersion);
         self.lastAppVersion = ko.observable();

--- a/corehq/apps/app_manager/static/app_manager/js/releases.js
+++ b/corehq/apps/app_manager/static/app_manager/js/releases.js
@@ -201,7 +201,7 @@ hqDefine('app_manager/js/releases.js', function () {
         self.buildState = ko.observable('');
         self.fetchState = ko.observable('');
         self.nextVersionToFetch = null;
-        self.fetchLimit = 5;
+        self.fetchLimit = o.fetchLimit;
         self.deployAnyway = {};
         self.currentAppVersion = ko.observable(self.options.currentAppVersion);
         self.lastAppVersion = ko.observable();

--- a/corehq/apps/app_manager/static/app_manager/spec/releases_spec.js
+++ b/corehq/apps/app_manager/static/app_manager/spec/releases_spec.js
@@ -1,3 +1,4 @@
+/* eslint-env mocha */
 /* global $, sinon */
 
 describe('App Releases', function() {
@@ -11,7 +12,7 @@ describe('App Releases', function() {
                 build_comment: '',
                 build_broken: false,
                 is_released: false,
-                domain: 'test-domain'
+                domain: 'test-domain',
             }, extraProps);
         });
     }
@@ -20,13 +21,13 @@ describe('App Releases', function() {
             download_multimedia: 'download_multimedia_url ___',
             fetch: 'fetch_url',
             odk_media: 'odk_media',
-            odk: 'odk'
+            odk: 'odk',
         },
         options = {
             urls: urls,
             currentAppVersion: -1,
             recipient_contacts: [],
-            download_modal_id: '#download-zip-modal-test'
+            download_modal_id: '#download-zip-modal-test',
         };
     describe('SavedApp', function() {
         var releases = null,
@@ -44,20 +45,20 @@ describe('App Releases', function() {
         });
 
         it('should only make one request when downloading zip', function() {
-            app = releases.savedApps()[0];
+            var app = releases.savedApps()[0];
             app.download_application_zip();
             assert.equal($.ajax.callCount, 1);
         });
 
         it('should use the correct URL for downloading ccz', function() {
-            app = releases.savedApps()[0];
+            var app = releases.savedApps()[0];
             app.download_application_zip();
             assert.equal($.ajax.callCount, 1);
             assert.equal(ajax_stub.firstCall.args[0].url, releases.url('download_zip', app.id()));
         });
 
         it('should use the correct URL for downloading multimedia', function() {
-            app = releases.savedApps()[0];
+            var app = releases.savedApps()[0];
             app.download_application_zip(true);
             assert.equal($.ajax.callCount, 1);
             assert.equal(ajax_stub.firstCall.args[0].url, releases.url('download_multimedia', app.id()));
@@ -68,7 +69,7 @@ describe('App Releases', function() {
                 ajax_stub.reset();
                 ajax_stub.onFirstCall(0).yieldsTo("success", {
                     download_id: '123' + app.id(),
-                    download_url: 'pollUrl'
+                    download_url: 'pollUrl',
                 });
                 ajax_stub.onSecondCall().yieldsTo("success", 'ready_123' + app.id());
 

--- a/corehq/apps/app_manager/templates/app_manager/app_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/app_view.html
@@ -107,7 +107,7 @@
 
                 // Load the content
                 $.ajax({
-                    url: "{% url 'release_manager_ajax' domain app.get_id %}",
+                    url: "{% url 'release_manager_ajax' domain app.get_id %}?limit={{fetchLimit}}",
                     success: function(content) {
                         state = "loaded";
                         showSpinner = false;

--- a/corehq/apps/app_manager/templates/app_manager/partials/releases.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/releases.html
@@ -42,7 +42,8 @@
             urls: urls,
             currentAppVersion: {% if app.version %}{{ app.version }}{% else %}-1{% endif %},
             recipient_contacts: {{ sms_contacts|JSON }},
-            download_modal_id: '#download-zip-modal'
+            download_modal_id: '#download-zip-modal',
+            fetchLimit: {{ fetchLimit }},
         };
         var el = $('#releases-table');
         var releasesMain = new ReleasesMain(o);

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -215,6 +215,7 @@ def get_app_view_context(request, app):
         )
     })
     context['is_app_view'] = True
+    context['fetchLimit'] = request.GET.get('limit', 5)
     return context
 
 

--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -35,6 +35,7 @@ from corehq.apps.app_manager.const import (
     APP_V2,
     MAJOR_RELEASE_TO_VERSION,
     AUTO_SELECT_USERCASE,
+    DEFAULT_FETCH_LIMIT,
 )
 from corehq.apps.app_manager.util import (
     get_settings_values,
@@ -215,7 +216,11 @@ def get_app_view_context(request, app):
         )
     })
     context['is_app_view'] = True
-    context['fetchLimit'] = request.GET.get('limit', 5)
+    try:
+        context['fetchLimit'] = int(request.GET.get('limit', DEFAULT_FETCH_LIMIT))
+    except ValueError:
+        context['fetchLimit'] = DEFAULT_FETCH_LIMIT
+
     return context
 
 

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -32,6 +32,7 @@ from corehq.util.timezones.utils import get_timezone_for_user
 
 from corehq.apps.app_manager.dbaccessors import get_app, get_latest_build_doc
 from corehq.apps.app_manager.models import BuildProfile
+from corehq.apps.app_manager.const import DEFAULT_FETCH_LIMIT
 from corehq.apps.users.models import CommCareUser
 from corehq.util.view_utils import reverse
 from corehq.apps.app_manager.decorators import (
@@ -107,7 +108,7 @@ def releases_ajax(request, domain, app_id, template='app_manager/partials/releas
         'build_profile_access': build_profile_access,
         'lastest_j2me_enabled_build': CommCareBuildConfig.latest_j2me_enabled_config().label,
         'vellum_case_management': app.vellum_case_management,
-        'fetchLimit': request.GET.get('limit', 5),
+        'fetchLimit': request.GET.get('limit', DEFAULT_FETCH_LIMIT),
     })
     if not app.is_remote_app():
         # Multimedia is not supported for remote applications at this time.

--- a/corehq/apps/app_manager/views/releases.py
+++ b/corehq/apps/app_manager/views/releases.py
@@ -107,6 +107,7 @@ def releases_ajax(request, domain, app_id, template='app_manager/partials/releas
         'build_profile_access': build_profile_access,
         'lastest_j2me_enabled_build': CommCareBuildConfig.latest_j2me_enabled_config().label,
         'vellum_case_management': app.vellum_case_management,
+        'fetchLimit': request.GET.get('limit', 5),
     })
     if not app.is_remote_app():
         # Multimedia is not supported for remote applications at this time.


### PR DESCRIPTION
Appending for e.g. `?limit=100` will now fetch 100 results at at time. This should allow searching of releases more easily.

@czue 
buddy @emord 
