### PR TITLE
deprecate unbind

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/menus/menu_controller.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/apps/menus/menu_controller.js
@@ -112,7 +112,7 @@ FormplayerFrontend.module("SessionNavigate.MenuList", function (MenuList, Formpl
                 },
             });
 
-            $('#select-case').unbind('click').click(function () {
+            $('#select-case').off('click').click(function () {
                 FormplayerFrontend.trigger("menu:select", model.model.get('id'));
             });
             $('#case-detail-modal').find('.detail-tabs').html(tabListView.render().el);

--- a/corehq/apps/reports/static/reports/javascripts/maps.js
+++ b/corehq/apps/reports/static/reports/javascripts/maps.js
@@ -205,7 +205,7 @@ function resetTable(data) {
         }
     });
     rows = $(rows);
-    rows.unbind('click').unbind('mouseenter').unbind('mouseleave');
+    rows.off('click').off('mouseenter').off('mouseleave');
     rows.removeClass('inactive-row');
 }
 

--- a/corehq/apps/style/static/style/ko/components/inline_edit.js
+++ b/corehq/apps/style/static/style/ko/components/inline_edit.js
@@ -100,13 +100,13 @@ hqDefine('style/ko/components/inline_edit.js', function() {
                         if (self.postSave) {
                             self.postSave(data);
                         }
-                        $(window).unbind("beforeunload", self.beforeUnload);
+                        $(window).off("beforeunload", self.beforeUnload);
                     },
                     error: function () {
                         self.isEditing(true);
                         self.isSaving(false);
                         self.hasError(true);
-                        $(window).unbind("beforeunload", self.beforeUnload);
+                        $(window).off("beforeunload", self.beforeUnload);
                     },
                 });
             };


### PR DESCRIPTION
Followup to https://github.com/dimagi/commcare-hq/pull/13239: `unbind` was also deprecated. And `undelegate`, but we don't use that.

@esoergel / @czue 
