### PR TITLE
Deprecate Location.location_type

### DIFF
--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -715,6 +715,8 @@ class Location(SyncCouchToSQLMixin, CachedCouchDocumentMixin, Document):
 
     @property
     def location_type(self):
+        notify_of_deprecation(
+            "You should use either location_type_name or location_type_object")
         return self.location_type_object.name
 
     _sql_location_type = None

--- a/custom/intrahealth/utils.py
+++ b/custom/intrahealth/utils.py
@@ -132,7 +132,7 @@ def get_location_by_type(form, type):
             return loc
     for loc_id in loc.lineage:
         loc = Location.get(loc_id)
-        if unicode(loc.location_type).lower().replace(" ", "") == type:
+        if unicode(loc.location_type_name).lower().replace(" ", "") == type:
             return loc
 
 


### PR DESCRIPTION
`Location.location_type` means something different from `SQLLocation.location_type`, so this will warn us of any remaining usages of the former (I've already done a cleanup pass to catch the obvious ones).
@czue @orangejenny
