### PR TITLE
Clarify inactive domain message

### DIFF
--- a/corehq/apps/domain/decorators.py
+++ b/corehq/apps/domain/decorators.py
@@ -80,7 +80,7 @@ def login_and_domain_required(view_func):
             if user.is_authenticated() and user.is_active:
                 if not domain.is_active:
                     msg = _((
-                        'The domain "{domain}" has been deactivated. '
+                        'The domain "{domain}" has not yet been activated. '
                         'Please report an issue if you think this is a mistake.'
                     ).format(domain=domain_name))
                     messages.info(req, msg)


### PR DESCRIPTION
This message is shown when an active, logged-in user views a domain that hasn't yet been activated.  That is, a domain that was created by a new user who has never confirmed their email (or hasn't yet confirmed it).
http://manage.dimagi.com/default.asp?237559

@czue @orangejenny
