### PR TITLE
Short-circuit context-lookups for remote apps

### DIFF
--- a/corehq/apps/app_manager/views/apps.py
+++ b/corehq/apps/app_manager/views/apps.py
@@ -245,7 +245,7 @@ def get_apps_base_context(request, domain, app):
         'timezone': timezone,
     }
 
-    if app:
+    if app and not app.is_remote_app():
         app.assert_app_v2()
         context.update({
             'show_care_plan': (


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?237621
I believe the next block of context is irrelevant for remote apps, @dannyroberts, can you confirm?

At any rate, this allows the application page to load for remote apps
