### PR TITLE
new date created when domain copied

### DIFF
--- a/corehq/apps/domain/models.py
+++ b/corehq/apps/domain/models.py
@@ -681,6 +681,7 @@ class Domain(QuickCachedDocumentMixin, Document, SnapshotMixin):
             new_domain.is_test = "none"
             new_domain.internal = InternalProperties()
             new_domain.creating_user = user.username if user else None
+            new_domain.date_created = datetime.utcnow()
 
             for field in self._dirty_fields:
                 if hasattr(new_domain, field):


### PR DESCRIPTION
Was really confusing to me that if you copy an app from the exchange into a new domain the `date_created` property could be back in 2012. If you really need to know when an app was originally created you could go through the `copy_history` and look at those apps.

buddy @proteusvacuum 
