### PR TITLE
Refactor debugger to not use second call

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
@@ -329,6 +329,9 @@ WebFormSession.prototype.answerQuestion = function(q) {
         },
         function(resp) {
             $.publish('session.reconcile', [resp, q]);
+            if (self.answerCallback !== undefined) {
+                self.answerCallback(self.session_id);
+            }
         });
 };
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
@@ -135,6 +135,7 @@ WebFormSession.prototype.serverRequest = function (requestParams, callback, bloc
     requestParams['session-id'] = self.session_id;
     // stupid hack for now to make up for both being used in different requests
     requestParams['session_id'] = self.session_id;
+    requestParams['debuggerEnabled'] = true;
     if (this.blockingRequestInProgress) {
         return;
     }
@@ -299,8 +300,8 @@ WebFormSession.prototype.answerQuestion = function(q) {
         },
         function(resp) {
             $.publish('session.reconcile', [resp, q]);
-            if (self.answerCallback !== undefined) {
-                self.answerCallback(self.session_id);
+            if (self.answerCallback !== undefined && resp.instanceXml !== undefined) {
+                self.answerCallback(resp.instanceXml);
             }
         });
 };

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
@@ -185,7 +185,7 @@ WebFormSession.prototype.displayInstanceXml = function(resp) {
         self = this,
         codeMirror;
 
-    if (!self.debuggerEnabled || !resp.instanceXml.output) {
+    if (!self.debuggerEnabled || !resp.instanceXml || !resp.instanceXml.output) {
         return;
     }
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/webformsession.js
@@ -222,8 +222,8 @@ WebFormSession.prototype.handleSuccess = function(resp, callback) {
         self.lastRequestHandled = resp.seq_id;
 
         try {
-            self.displayInstanceXml(resp);
             callback(resp);
+            self.displayInstanceXml(resp);
         } catch (err) {
             console.error(err);
             self.onerror({message: Formplayer.Utils.touchformsError(err)});

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -145,8 +145,8 @@ FormplayerFrontend.on('startForm', function (data) {
         }
     };
     data.formplayerEnabled = true;
-    data.answerCallback = function(sessionId) {
-        FormplayerFrontend.trigger('debugger.formXML', sessionId);
+    data.answerCallback = function(instanceXml) {
+        FormplayerFrontend.trigger('debugger.formXML', instanceXml);
     };
     data.resourceMap = function(resource_path) {
         var urlObject = Util.currentUrlToObject();
@@ -157,39 +157,24 @@ FormplayerFrontend.on('startForm', function (data) {
     sess.renderFormXml(data, $('#webforms'));
 });
 
-FormplayerFrontend.on('debugger.formXML', function(sessionId) {
-    var user = FormplayerFrontend.request('currentUser');
-    var success = function(data) {
-        var $instanceTab = $('#debugger-xml-instance-tab'),
-            codeMirror;
+FormplayerFrontend.on('debugger.formXML', function(data) {
+    var $instanceTab = $('#debugger-xml-instance-tab'),
+    codeMirror;
 
-        codeMirror = CodeMirror(function(el) {
-            $('#xml-viewer-pretty').html(el);
-        }, {
-            value: data.output,
-            mode: 'xml',
-            viewportMargin: Infinity,
-            readOnly: true,
-            lineNumbers: true,
-        });
+    codeMirror = CodeMirror(function(el) {
+        $('#xml-viewer-pretty').html(el);
+    }, {
+        value: data.output,
+        mode: 'xml',
+        viewportMargin: Infinity,
+        readOnly: true,
+        lineNumbers: true,
+    });
 
-        $instanceTab.off();
-        $instanceTab.on('shown.bs.tab', function() {
-            codeMirror.refresh();
-        });
-    };
-    var options = {
-        url: user.formplayer_url + '/get-instance',
-        data: JSON.stringify({
-            'session-id': sessionId,
-            'domain': user.domain,
-            'username': user.username,
-        }),
-        success: success,
-    };
-    Util.setCrossDomainAjaxOptions(options);
-
-    $.ajax(options);
+    $instanceTab.off();
+    $instanceTab.on('shown.bs.tab', function() {
+        codeMirror.refresh();
+    });
 });
 
 FormplayerFrontend.on("start", function (options) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -145,8 +145,11 @@ FormplayerFrontend.on('startForm', function (data) {
         }
     };
     data.formplayerEnabled = true;
+    data.debuggerEnabled = user.debuggerEnabled;
     data.answerCallback = function(instanceXml) {
-        FormplayerFrontend.trigger('debugger.formXML', instanceXml);
+        if (user.debuggerEnabled) {
+            FormplayerFrontend.trigger('debugger.formXML', instanceXml);
+        }
     };
     data.resourceMap = function(resource_path) {
         var urlObject = Util.currentUrlToObject();
@@ -159,7 +162,7 @@ FormplayerFrontend.on('startForm', function (data) {
 
 FormplayerFrontend.on('debugger.formXML', function(data) {
     var $instanceTab = $('#debugger-xml-instance-tab'),
-    codeMirror;
+        codeMirror;
 
     codeMirror = CodeMirror(function(el) {
         $('#xml-viewer-pretty').html(el);
@@ -185,6 +188,7 @@ FormplayerFrontend.on("start", function (options) {
     user.apps = options.apps;
     user.domain = options.domain;
     user.formplayer_url = options.formplayer_url;
+    user.debuggerEnabled = options.debuggerEnabled;
     FormplayerFrontend.request('gridPolyfillPath', options.gridPolyfillPath);
     if (Backbone.history) {
         Backbone.history.start();

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -1,4 +1,4 @@
-/*global Marionette, Backbone, WebFormSession, Util, CodeMirror */
+/*global Marionette, Backbone, WebFormSession, Util */
 
 /**
  * The primary Marionette application managing menu navigation and launching form entry
@@ -146,11 +146,6 @@ FormplayerFrontend.on('startForm', function (data) {
     };
     data.formplayerEnabled = true;
     data.debuggerEnabled = user.debuggerEnabled;
-    data.answerCallback = function(instanceXml) {
-        if (user.debuggerEnabled) {
-            FormplayerFrontend.trigger('debugger.formXML', instanceXml);
-        }
-    };
     data.resourceMap = function(resource_path) {
         var urlObject = Util.currentUrlToObject();
         var appId = urlObject.appId;
@@ -158,26 +153,6 @@ FormplayerFrontend.on('startForm', function (data) {
     };
     var sess = new WebFormSession(data);
     sess.renderFormXml(data, $('#webforms'));
-});
-
-FormplayerFrontend.on('debugger.formXML', function(data) {
-    var $instanceTab = $('#debugger-xml-instance-tab'),
-        codeMirror;
-
-    codeMirror = CodeMirror(function(el) {
-        $('#xml-viewer-pretty').html(el);
-    }, {
-        value: data.output,
-        mode: 'xml',
-        viewportMargin: Infinity,
-        readOnly: true,
-        lineNumbers: true,
-    });
-
-    $instanceTab.off();
-    $instanceTab.on('shown.bs.tab', function() {
-        codeMirror.refresh();
-    });
 });
 
 FormplayerFrontend.on("start", function (options) {

--- a/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
@@ -72,6 +72,10 @@
         var username = "{{ username  }}";
         var domain = "{{ domain }}";
         var formplayer_url = "{{ formplayer_url }}";
+        var instanceViewerEnabled = false;
+        {% if request|toggle_enabled:"INSTANCE_VIEWER" %}
+            instanceViewerEnabled = true;
+        {% endif %}
         var options = {
             "apps": apps,
             "language": language,
@@ -79,6 +83,7 @@
             "domain": domain,
             "formplayer_url": formplayer_url,
             "gridPolyfillPath": "{% static 'css-grid-polyfill-binaries/css-polyfills.js' %}",
+            "debuggerEnabled": instanceViewerEnabled,
         };
         FormplayerFrontend.start(options);
     </script>


### PR DESCRIPTION
We can include the instanceXml in every form response easily and cheaply,  so do so here. Saves us a second call to Formplayer and some callbacks between JS modules. LMK if you think there's a problem with doing it this way.

Also displays XML on form load instead of waiting for first answer

cross https://github.com/dimagi/formplayer/pull/139
