### PR TITLE
Make Spanish translations appear on HQ

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -140,9 +140,9 @@ CSRF_SOFT_MODE = True
 
 MIDDLEWARE_CLASSES = [
     'corehq.middleware.NoCacheMiddleware',
-    'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
+    'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',

--- a/settings.py
+++ b/settings.py
@@ -56,6 +56,7 @@ LANGUAGE_CODE = 'en-us'
 
 LANGUAGES = (
     ('en', 'English'),
+    ('es', 'Spanish'),
     ('fra', 'French'),  # we need this alias
     ('hin', 'Hindi'),
     ('sw', 'Swahili'),


### PR DESCRIPTION
Michelle is working on a proposal to get HQ translated into Spanish.  I noticed that we're already set up for translations on transifex, but we don't actually display those translations.  Turns out that's simply because `'es'` isn't in `settings.LANGUAGES`.  Ideally we'd only show options from `settings.LANGUAGES` in the dropdown where you select a language (since those are the only ones we'll actually sorta translate), but we currently need to keep the full list of every language because that's used in cloudcare for app translations.

Read the commits separately, the messages have more context.
