### PR TITLE
Send staging notifications to staging

### DIFF
--- a/corehq/apps/hqadmin/management/commands/record_deploy_success.py
+++ b/corehq/apps/hqadmin/management/commands/record_deploy_success.py
@@ -91,8 +91,13 @@ class Command(BaseCommand):
 
         if hasattr(settings, 'MIA_THE_DEPLOY_BOT_API'):
             link = diff_link(STYLE_SLACK, compare_url)
+            if options['environment'] == 'staging':
+                channel = '#staging'
+            else:
+                channel = '#hq-ops'
             requests.post(settings.MIA_THE_DEPLOY_BOT_API, data=json.dumps({
                 "username": "Igor the Iguana",
+                "channel": channel,
                 "text": deploy_notification_text.format(
                     dashboard_link=dashboard_link(STYLE_SLACK, DASHBOARD_URL),
                     diff_link=link,


### PR DESCRIPTION
@orangejenny realized we were announcing in the staging channel when deploys were done and that seemed easy to fix

cc: @gcapalbo 
