### PR TITLE
Use inline edit widget for report modules

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/module_view.html
+++ b/corehq/apps/app_manager/templates/app_manager/module_view.html
@@ -217,19 +217,6 @@
 {% endblock %}
 
 {% block form-view %}
-    {% inline_edit_trans module.name langs edit_name_url saveValueName='name' readOnlyClass='h3' postSave="function(data) { return hqImport('app_manager/js/app_manager.js').updateDOM(data.update); }" %}
-    <br />
-    <inline-edit params="
-        name: 'comment',
-        id:'comment-id',
-        readOnlyClass: 'app-comment',
-        value: '{{ module.comment|escapejs }}',
-        placeholder: '{% trans "Enter module description here"|escapejs %}',
-        url: '{% url "corehq.apps.app_manager.views.edit_module_attr" domain app.id module.id 'comment' %}',
-        saveValueName: 'comment',
-        cols: 50,
-    "></inline-edit>
-    <br />
     {% include 'app_manager/partials/module_view_heading.html' %}
 <div class="tabbable">
 <ul class="nav nav-tabs" id="module-view-tabs">

--- a/corehq/apps/app_manager/templates/app_manager/partials/mobile_report_configs.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/mobile_report_configs.html
@@ -16,12 +16,6 @@
     <div class="tab-pane active" id="settings">
         <div class="form-horizontal">
             <fieldset>
-                <div class="form-group" id="module-name">
-                    <label class="control-label col-sm-2">{% trans "Module Name" %}</label>
-                    <div class="col-sm-4">
-                        <input type="text" class="form-control" data-bind="value: currentModuleName">
-                    </div>
-                </div>
                 {% include "app_manager/partials/module_filter.html" with ko_value="currentModuleFilter" %}
                 {% include 'app_manager/partials/nav_menu_media.html' with ICON_LABEL="Icon" AUDIO_LABEL="Audio" %}
             </fieldset>

--- a/corehq/apps/app_manager/templates/app_manager/partials/module_view_heading.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/module_view_heading.html
@@ -1,5 +1,20 @@
 {% load i18n %}
 {% load xforms_extras %}
+
+{% inline_edit_trans module.name langs edit_name_url saveValueName='name' readOnlyClass='h3' postSave="function(data) { return hqImport('app_manager/js/app_manager.js').updateDOM(data.update); }" %}
+<br />
+<inline-edit params="
+    name: 'comment',
+    id:'comment-id',
+    readOnlyClass: 'app-comment',
+    value: '{{ module.comment|escapejs }}',
+    placeholder: '{% trans "Enter module description here"|escapejs %}',
+    url: '{% url "corehq.apps.app_manager.views.edit_module_attr" domain app.id module.id 'comment' %}',
+    saveValueName: 'comment',
+    cols: 50,
+"></inline-edit>
+<br />
+
 <div id="build_errors"></div>
 <div class="pull-right">
     <form action="{% url "delete_module" domain app.id module.unique_id %}" method="post">


### PR DESCRIPTION
Shorten module_view.html a bit, and make report modules consistent with other modules.

Before:
<img width="1063" alt="screen shot 2016-09-20 at 3 07 22 pm" src="https://cloud.githubusercontent.com/assets/1486591/18684958/26e49d92-7f44-11e6-8a9e-8bb6eef0da6c.png">

After:
<img width="1059" alt="screen shot 2016-09-20 at 3 07 40 pm" src="https://cloud.githubusercontent.com/assets/1486591/18684966/2be0c41a-7f44-11e6-894f-deb2e744ae2b.png">

@biyeun / @nickpell 
