### PR TITLE
restore some broken help links in app settings

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yaml
+++ b/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yaml
@@ -68,7 +68,7 @@
 
 - id: case_sharing
   name: "Case Sharing"
-  description: 'Allow mobile workers in the same case sharing group to share case lists.  Read more on the <a href="https://confluence.dimagi.com/display/commcarepublic/Case+Sharing"/>Help Site</a>'
+  description: 'Allow mobile workers in the same case sharing group to share case lists.  Read more on the <a href="https://confluence.dimagi.com/display/commcarepublic/Case+Sharing">Help Site</a>'
   description_format: html
   widget: bool
   default: false
@@ -78,7 +78,7 @@
 
 - id: cloudcare_enabled
   name: "CloudCare"
-  description: 'Allow mobile workers to access the web-based version of your application. Read more on the <a href="https://confluence.dimagi.com/display/commcarepublic/Using+CloudCare"/>Help Site</a>'
+  description: 'Allow mobile workers to access the web-based version of your application. Read more on the <a href="https://confluence.dimagi.com/display/commcarepublic/Using+CloudCare">Help Site</a>'
   description_format: html
   widget: bool
   default: false


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?237754

turns out it's only these two settings, not a more general bug, and they've been not-links for three years

@biyeun 
