### PR TITLE
drop data-toggle

### DIFF
--- a/corehq/apps/toggle_ui/templates/toggle/flags.html
+++ b/corehq/apps/toggle_ui/templates/toggle/flags.html
@@ -102,7 +102,7 @@
                     {% endwith %}
                 {% endif %}
                 <td>
-                    <a href="{% url "edit_toggle" toggle.slug %}" role="button" data-toggle="modal" class="btn btn-primary">{% trans "Edit" %}</a>
+                    <a href="{% url "edit_toggle" toggle.slug %}" role="button" class="btn btn-primary">{% trans "Edit" %}</a>
                 </td>
             </tr>
             {% endfor %}


### PR DESCRIPTION
This causes a JavaScript error when an edit button is clicked on the feature flags page. It's harmless, because you immediately go to another page, but was confusing me while testing out jq3 changes.

@biyeun 
