### PR TITLE
ICDS Tableau: Update per user filtering to use site code

### DIFF
--- a/custom/icds_reports/static/tableau_app.js
+++ b/custom/icds_reports/static/tableau_app.js
@@ -1,11 +1,12 @@
 var viz = {},
     workbook = {},
     LOCATIONS_MAP = {
-        'state': 1,
-        'district': 2,
-        'block': 3,
-        'supervisor': 4,
-        'awc': 5,
+        'national': 1,
+        'state': 2,
+        'district': 3,
+        'block': 4,
+        'supervisor': 5,
+        'awc': 6,
     };
 
 var tableauOptions = {};

--- a/custom/icds_reports/views.py
+++ b/custom/icds_reports/views.py
@@ -50,7 +50,7 @@ def _get_user_location(user, domain):
         location_type_name = loc.location_type.name
         location_site_code = loc.site_code
     except Exception:
-        location_type_name = 'state'
+        location_type_name = 'national'
         location_site_code = ''
     return location_type_name, location_site_code
 

--- a/custom/icds_reports/views.py
+++ b/custom/icds_reports/views.py
@@ -21,10 +21,10 @@ def tableau(request, domain, workbook, worksheet):
 
     # set report view-by level based on user's location level
     couch_user = getattr(request, 'couch_user', None)
-    location_type_name, location_name = _get_user_location(couch_user, domain)
+    location_type_name, location_site_code = _get_user_location(couch_user, domain)
     context.update({
         'view_by': location_type_name,
-        'view_by_value': location_name,
+        'view_by_value': location_site_code,
     })
 
     # the header is added by nginx
@@ -48,11 +48,11 @@ def _get_user_location(user, domain):
         user_location_id = user.get_domain_membership(domain).location_id
         loc = SQLLocation.by_location_id(user_location_id)
         location_type_name = loc.location_type.name
-        location_name = loc.name
+        location_site_code = loc.site_code
     except Exception:
         location_type_name = 'state'
-        location_name = ''
-    return location_type_name, location_name
+        location_site_code = ''
+    return location_type_name, location_site_code
 
 
 def get_tableau_trusted_url(client_ip):


### PR DESCRIPTION
We currently determine the logged in users location, and pass the locations name and level to Tableau to pre-filter the data.  

This change instead passes the user's location's site code.  
