### PR TITLE
fix reindex queries

### DIFF
--- a/corehq/form_processor/backends/sql/dbaccessors.py
+++ b/corehq/form_processor/backends/sql/dbaccessors.py
@@ -66,8 +66,6 @@ def get_cursor(model):
 
 
 class ReindexAccessor(six.with_metaclass(ABCMeta)):
-    # TODO: implement this https://wiki.postgresql.org/images/3/35/Pagination_Done_the_PostgreSQL_Way.pdf
-
     @abstractproperty
     def startkey_attribute_name(self):
         """

--- a/corehq/form_processor/tests/test_reindex_accessors.py
+++ b/corehq/form_processor/tests/test_reindex_accessors.py
@@ -80,8 +80,7 @@ class BaseUnshardedAccessorMixin(object):
         self.assertEqual(self._get_doc_ids(docs), self.second_batch[:2])
 
         last_doc = self.accessor_class().get_doc(self.second_batch[0])
-
-        docs = self._get_docs(self.middle, last_doc_pk=last_doc.pk, limit=2)
+        docs = self._get_docs(self._get_last_modified_date(last_doc), last_doc_pk=last_doc.pk, limit=2)
         self.assertEqual(self._get_doc_ids(docs), self.second_batch[1:3])
 
 
@@ -114,6 +113,10 @@ class BaseCaseReindexAccessorTest(BaseReindexAccessorTest):
     @classmethod
     def _get_doc_ids(cls, docs):
         return [doc.case_id for doc in docs]
+
+    @classmethod
+    def _get_last_modified_date(cls, doc):
+        return doc.server_modified_on
 
 
 class UnshardedCaseReindexAccessorTests(BaseUnshardedAccessorMixin, BaseCaseReindexAccessorTest, TestCase):
@@ -153,6 +156,10 @@ class BaseFormReindexAccessorTest(BaseReindexAccessorTest):
     def _get_doc_ids(cls, docs):
         return [doc.form_id for doc in docs]
 
+    @classmethod
+    def _get_last_modified_date(cls, doc):
+        return doc.received_on
+
 
 class UnshardedFormReindexAccessorTests(BaseUnshardedAccessorMixin, BaseFormReindexAccessorTest, TestCase):
 
@@ -191,6 +198,10 @@ class BaseLedgerReindexAccessorTest(BaseReindexAccessorTest):
     @classmethod
     def _get_doc_ids(cls, docs):
         return [doc.ledger_reference.as_id() for doc in docs]
+
+    @classmethod
+    def _get_last_modified_date(cls, doc):
+        return doc.last_modified
 
 
 class UnshardedLedgerReindexAccessorTests(BaseUnshardedAccessorMixin, BaseLedgerReindexAccessorTest, TestCase):

--- a/corehq/sql_accessors/migrations/0034_update_reindex_functions.py
+++ b/corehq/sql_accessors/migrations/0034_update_reindex_functions.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
-from corehq.sql_db.operations import RawSQLMigration
+from django.db import migrations
 
-migrator = RawSQLMigration(('corehq', 'sql_accessors', 'sql_templates'), {})
+from corehq.sql_db.operations import noop_migration
 
 
 class Migration(migrations.Migration):
@@ -14,7 +13,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrator.get_migration('get_all_cases_modified_since_1.sql'),
-        migrator.get_migration('get_all_forms_received_since_1.sql'),
-        migrator.get_migration('get_all_ledger_values_modified_since_1.sql'),
+        noop_migration()
     ]

--- a/corehq/sql_accessors/migrations/0039_update_reindex_queries.py
+++ b/corehq/sql_accessors/migrations/0039_update_reindex_queries.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+from corehq.sql_db.operations import RawSQLMigration
+
+migrator = RawSQLMigration(('corehq', 'sql_accessors', 'sql_templates'), {})
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sql_accessors', '0038_save_case_deletion_fields'),
+    ]
+
+    operations = [
+        migrator.get_migration('get_all_cases_modified_since_2.sql'),
+        migrator.get_migration('get_all_forms_received_since_2.sql'),
+        migrator.get_migration('get_all_ledger_values_modified_since_2.sql'),
+    ]

--- a/corehq/sql_accessors/sql_templates/get_all_cases_modified_since_2.sql
+++ b/corehq/sql_accessors/sql_templates/get_all_cases_modified_since_2.sql
@@ -4,14 +4,9 @@ CREATE FUNCTION get_all_cases_modified_since(reference_date timestamp with time 
 RETURNS SETOF form_processor_commcarecasesql AS $$
 BEGIN
     RETURN QUERY
-    SELECT cases.* FROM (
-        SELECT * FROM form_processor_commcarecasesql as case_table
-        WHERE case_table.server_modified_on >= reference_date
-        LIMIT query_limit + 1
-    ) AS cases
-    WHERE cases.id > last_id
-    ORDER BY cases.server_modified_on, cases.id
-    LIMIT query_limit
-    ;
+    SELECT * FROM form_processor_commcarecasesql as case_table
+        WHERE (case_table.modified_on, case_table.id) > (reference_date, last_id)
+        ORDER BY case_table.server_modified_on, case_table.id
+        LIMIT query_limit;
 END;
 $$ LANGUAGE plpgsql;

--- a/corehq/sql_accessors/sql_templates/get_all_forms_received_since_2.sql
+++ b/corehq/sql_accessors/sql_templates/get_all_forms_received_since_2.sql
@@ -4,14 +4,9 @@ CREATE FUNCTION get_all_forms_received_since(reference_date timestamp with time 
 RETURNS SETOF form_processor_xforminstancesql AS $$
 BEGIN
     RETURN QUERY
-    SELECT forms.* FROM (
-        SELECT * FROM form_processor_xforminstancesql as form_table
-        WHERE form_table.received_on >= reference_date
-        LIMIT query_limit + 1
-    ) AS forms
-    WHERE forms.id > last_id
-    ORDER BY forms.received_on, forms.id
-    LIMIT query_limit
-    ;
+    SELECT * FROM form_processor_xforminstancesql as form_table
+        WHERE (form_table.received_on, form_table.id) > (reference_date, last_id)
+        ORDER BY form_table.received_on, form_table.id
+        LIMIT query_limit;
 END;
 $$ LANGUAGE plpgsql;

--- a/corehq/sql_accessors/sql_templates/get_all_ledger_values_modified_since_2.sql
+++ b/corehq/sql_accessors/sql_templates/get_all_ledger_values_modified_since_2.sql
@@ -4,14 +4,9 @@ CREATE FUNCTION get_all_ledger_values_modified_since(reference_date timestamp wi
 RETURNS SETOF form_processor_ledgervalue AS $$
 BEGIN
     RETURN QUERY
-    SELECT ledgers.* FROM (
-        SELECT * FROM form_processor_ledgervalue
-        WHERE last_modified >= reference_date
-        LIMIT query_limit + 1
-    ) AS ledgers
-    WHERE ledgers.id > last_id
-    ORDER BY ledgers.last_modified, ledgers.id
-    LIMIT query_limit
-    ;
+    SELECT * FROM form_processor_ledgervalue
+        WHERE (last_modified, id) > (reference_date, last_id)
+        ORDER BY last_modified, id
+        LIMIT query_limit;
 END;
 $$ LANGUAGE plpgsql;


### PR DESCRIPTION
@czue 

I discovered a serious issue with these queries. Because the inner queries don't sort each query returns a somewhat arbitrary set of rows so the more pages you have the more rows you are likely to miss.

These queries should do index only scans: https://wiki.postgresql.org/images/3/35/Pagination_Done_the_PostgreSQL_Way.pdf
