### PR TITLE
Allow dates to have no answer

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/form_entry/entrycontrols_full.js
@@ -314,7 +314,7 @@ function DateTimeEntryBase(question, options) {
                 }
                 self.answer(moment(newDate).format(self.serverFormat));
             }
-        }).val(moment(self.answer()).format(self.clientFormat));
+        }).val(self.answer() ? moment(self.answer()).format(self.clientFormat) : self.answer());
     };
 }
 DateTimeEntryBase.prototype = Object.create(EntrySingleAnswer.prototype);


### PR DESCRIPTION
@wpride @biyeun this allows dates to be null or undefined:

Before
<img width="1317" alt="screen shot 2016-09-26 at 10 42 14 am" src="https://cloud.githubusercontent.com/assets/918514/18838631/226435ac-83d6-11e6-8247-82713dded5bf.png">
After
<img width="1426" alt="screen shot 2016-09-26 at 10 42 33 am" src="https://cloud.githubusercontent.com/assets/918514/18838630/2261f6fc-83d6-11e6-86e0-a9063c428609.png">
