### PR TITLE
Formplayer handle html errors

### DIFF
--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/app.js
@@ -7,6 +7,7 @@
 var FormplayerFrontend = new Marionette.Application();
 
 var showError = hqImport('cloudcare/js/util.js').showError;
+var showHTMLError = hqImport('cloudcare/js/util.js').showHTMLError;
 var showSuccess = hqImport('cloudcare/js/util.js').showSuccess;
 var tfLoading = hqImport('cloudcare/js/util.js').tfLoading;
 var tfLoadingComplete = hqImport('cloudcare/js/util.js').tfLoadingComplete;
@@ -94,8 +95,12 @@ $(document).on("ajaxStart", function () {
     tfLoadingComplete();
 });
 
-FormplayerFrontend.reqres.setHandler('showError', function (errorMessage) {
-    showError(errorMessage, $("#cloudcare-notifications"), 10000);
+FormplayerFrontend.on('showError', function (errorMessage, isHTML) {
+    if (isHTML) {
+        showHTMLError(errorMessage, $("#cloudcare-notifications"), 10000);
+    } else {
+        showError(errorMessage, $("#cloudcare-notifications"), 10000);
+    }
 });
 
 FormplayerFrontend.reqres.setHandler('showSuccess', function(successMessage) {

--- a/corehq/apps/cloudcare/static/cloudcare/js/formplayer/entities/menu.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/formplayer/entities/menu.js
@@ -47,7 +47,7 @@ FormplayerFrontend.module("Entities", function (Entities, FormplayerFrontend, Ba
                 FormplayerFrontend.trigger('startForm', response, this.app_id);
             }
             else if(response.exception){
-                FormplayerFrontend.request('showError', response.exception);
+                FormplayerFrontend.trigger('showError', response.exception, response.type === 'html');
             }
         },
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/util.js
@@ -95,6 +95,10 @@ hqDefine('cloudcare/js/util.js', function () {
         _show(message, location, autoHideTime, "alert alert-danger");
     };
 
+    var showHTMLError = function (message, $el, autoHideTime) {
+        _show(message, $el, autoHideTime, "", true);
+    };
+
     var showSuccess = function (message, location, autoHideTime) {
         if (message === undefined) {
             message = "success";
@@ -102,13 +106,27 @@ hqDefine('cloudcare/js/util.js', function () {
         _show(message, location, autoHideTime, "alert alert-success");
     };
 
-    var _show = function (message, location, autoHideTime, classes) {
-        var alert = $("<div />");
-        alert.addClass(classes).text(message);
-        alert.append($("<a />").addClass("close").attr("data-dismiss", "alert").html("&times;"));
-        location.append(alert);
+    var _show = function (message, location, autoHideTime, classes, isHTML) {
+        var $container = $("<div />"),
+            $alertDialog;
+        $container.addClass(classes)
+        if (isHTML) {
+            $container.html(message);
+            $alertDialog = $container.find('.alert');
+        } else {
+            $container.text(message);
+            $alertDialog = $container;
+        }
+        $alertDialog
+            .prepend(
+                $("<a />")
+                .addClass("close")
+                .attr("data-dismiss", "alert")
+                .html("&times;")
+            );
+        location.append($container);
         if (autoHideTime) {
-            alert.delay(autoHideTime).fadeOut(500);
+            $container.delay(autoHideTime).fadeOut(500);
         }
     };
 
@@ -158,6 +176,7 @@ hqDefine('cloudcare/js/util.js', function () {
         getSessionContextUrl: getSessionContextUrl,
         isParentField: isParentField,
         showError: showError,
+        showHTMLError: showHTMLError,
         showSuccess: showSuccess,
         showLoading: showLoading,
         tfLoading: tfLoading,

--- a/corehq/apps/cloudcare/static/cloudcare/js/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/util.js
@@ -88,25 +88,25 @@ hqDefine('cloudcare/js/util.js', function () {
         return field ? field.startsWith('parent/') : false;
     };
 
-    var showError = function (message, location, autoHideTime) {
+    var showError = function (message, $el, autoHideTime) {
         if (message === undefined) {
             message = gettext("Sorry, an error occurred while processing that request.");
         }
-        _show(message, location, autoHideTime, "alert alert-danger");
+        _show(message, $el, autoHideTime, "alert alert-danger");
     };
 
     var showHTMLError = function (message, $el, autoHideTime) {
         _show(message, $el, autoHideTime, "", true);
     };
 
-    var showSuccess = function (message, location, autoHideTime) {
+    var showSuccess = function (message, $el, autoHideTime) {
         if (message === undefined) {
             message = "Success";
         }
-        _show(message, location, autoHideTime, "alert alert-success");
+        _show(message, $el, autoHideTime, "alert alert-success");
     };
 
-    var _show = function (message, location, autoHideTime, classes, isHTML) {
+    var _show = function (message, $el, autoHideTime, classes, isHTML) {
         var $container = $("<div />"),
             $alertDialog;
         $container.addClass(classes)
@@ -125,7 +125,7 @@ hqDefine('cloudcare/js/util.js', function () {
                 .attr("data-dismiss", "alert")
                 .html("&times;")
             );
-        location.append($container);
+        $el.append($container);
         if (autoHideTime) {
             $container.delay(autoHideTime).fadeOut(500);
         }

--- a/corehq/apps/cloudcare/static/cloudcare/js/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/util.js
@@ -96,6 +96,7 @@ hqDefine('cloudcare/js/util.js', function () {
     };
 
     var showHTMLError = function (message, $el, autoHideTime) {
+        message = message || gettext("Sorry, an error occurred while processing that request.");
         _show(message, $el, autoHideTime, "", true);
     };
 

--- a/corehq/apps/cloudcare/static/cloudcare/js/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/util.js
@@ -90,7 +90,7 @@ hqDefine('cloudcare/js/util.js', function () {
 
     var showError = function (message, location, autoHideTime) {
         if (message === undefined) {
-            message = "sorry, there was an error";
+            message = gettext("Sorry, an error occurred while processing that request.");
         }
         _show(message, location, autoHideTime, "alert alert-danger");
     };
@@ -101,7 +101,7 @@ hqDefine('cloudcare/js/util.js', function () {
 
     var showSuccess = function (message, location, autoHideTime) {
         if (message === undefined) {
-            message = "success";
+            message = "Success";
         }
         _show(message, location, autoHideTime, "alert alert-success");
     };

--- a/corehq/apps/cloudcare/static/cloudcare/js/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/util.js
@@ -112,6 +112,7 @@ hqDefine('cloudcare/js/util.js', function () {
         $container.addClass(classes)
         if (isHTML) {
             $container.html(message);
+            // HTML errors already have an alert dialog
             $alertDialog = $container.find('.alert');
         } else {
             $container.text(message);

--- a/corehq/apps/cloudcare/static/cloudcare/js/util.js
+++ b/corehq/apps/cloudcare/static/cloudcare/js/util.js
@@ -110,7 +110,7 @@ hqDefine('cloudcare/js/util.js', function () {
     var _show = function (message, $el, autoHideTime, classes, isHTML) {
         var $container = $("<div />"),
             $alertDialog;
-        $container.addClass(classes)
+        $container.addClass(classes);
         if (isHTML) {
             $container.html(message);
             // HTML errors already have an alert dialog


### PR DESCRIPTION
@wpride this is the frontend to handle HTML errors (can be merged at any time). it's slightly hackish because our errors messages are so tightly coupled with the html rendered. can be read commit by commit 🐟 

cc: @proteusvacuum 
