### PR TITLE
move indirect models.py imports out of __init__.py

### DIFF
--- a/custom/enikshay/__init__.py
+++ b/custom/enikshay/__init__.py
@@ -1,1 +1,0 @@
-from custom.enikshay.integrations.ninetyninedots.repeater_generators import RegisterPatientPayloadGenerator

--- a/custom/enikshay/integrations/ninetyninedots/models.py
+++ b/custom/enikshay/integrations/ninetyninedots/models.py
@@ -1,0 +1,1 @@
+from custom.enikshay.integrations.ninetyninedots.repeater_generators import RegisterPatientPayloadGenerator, UpdatePatientPayloadGenerator

--- a/custom/enikshay/models.py
+++ b/custom/enikshay/models.py
@@ -1,1 +1,0 @@
-from custom.enikshay.integrations.ninetyninedots.repeater_generators import RegisterPatientPayloadGenerator

--- a/custom/enikshay/models.py
+++ b/custom/enikshay/models.py
@@ -1,0 +1,1 @@
+from custom.enikshay.integrations.ninetyninedots.repeater_generators import RegisterPatientPayloadGenerator


### PR DESCRIPTION
@proteusvacuum 

Needed for django 1.9
