### PR TITLE
add expression column type to UCR reports

### DIFF
--- a/corehq/apps/app_manager/fixtures/mobile_ucr.py
+++ b/corehq/apps/app_manager/fixtures/mobile_ucr.py
@@ -133,7 +133,7 @@ class ReportFixturesProvider(object):
             rows_elem.append(_row_to_row_elem(
                 dict(
                     zip(
-                        map(lambda column_config: column_config.column_id, data_source.column_configs),
+                        map(lambda column_config: column_config.column_id, data_source.top_level_columns),
                         map(str, total_row)
                     )
                 ),

--- a/corehq/apps/userreports/README.md
+++ b/corehq/apps/userreports/README.md
@@ -1349,6 +1349,36 @@ Then you will get a report like this:
 
 Expanded columns have an optional parameter `"max_expansion"` (defaults to 10) which limits the number of columns that can be created.  WARNING: Only override the default if you are confident that there will be no adverse performance implications for the server.
 
+### Expression columns
+
+Expression columns can be used to do just-in-time calculations on the data coming out of reports.
+They allow you to use any UCR expression on the data in the report row.
+These can be referenced according to the `column_id`s from the other defined column.
+They can support advanced use cases like doing math on two different report columns,
+or doing conditional logic based on the contents of another column.
+
+A simple example is below, which assumes another called "number" in the report and shows
+how you could make a column that is 10 times that column.
+
+
+```json
+{
+    "type": "expression",
+    "column_id": "by_tens",
+    "display": "Counting by tens",
+    "expression": {
+        "type": "evaluator",
+        "statement": "a * b",
+        "context_variables": {
+            "a": {
+                "type": "property_name",
+                "property_name": "number"
+            },
+            "b": 10
+        }
+    }
+}
+```
 
 ### The "aggregation" column property
 

--- a/corehq/apps/userreports/reports/data_source.py
+++ b/corehq/apps/userreports/reports/data_source.py
@@ -49,8 +49,8 @@ class ConfigurableReportDataSource(object):
         return self._config
 
     @property
-    def column_configs(self):
-        return self.data_source.column_configs
+    def top_level_columns(self):
+        return self.data_source.top_level_columns
 
     @property
     def filters(self):

--- a/corehq/apps/userreports/reports/data_source.py
+++ b/corehq/apps/userreports/reports/data_source.py
@@ -82,6 +82,10 @@ class ConfigurableReportDataSource(object):
         return self.data_source.columns
 
     @property
+    def inner_columns(self):
+        return self.data_source.inner_columns
+
+    @property
     def column_warnings(self):
         return self.data_source.column_warnings
 

--- a/corehq/apps/userreports/reports/factory.py
+++ b/corehq/apps/userreports/reports/factory.py
@@ -6,7 +6,7 @@ from corehq.apps.userreports.reports.filters.specs import ReportFilter
 from corehq.apps.userreports.reports.specs import PieChartSpec, \
     MultibarAggregateChartSpec, MultibarChartSpec, \
     FieldColumn, PercentageColumn, ExpandedColumn, AggregateDateColumn, \
-    OrderBySpec, LocationColumn
+    OrderBySpec, LocationColumn, ExpressionColumn
 
 
 class ReportFactory(object):
@@ -33,6 +33,7 @@ class ReportColumnFactory(object):
         'field': FieldColumn,
         'percent': PercentageColumn,
         'location': LocationColumn,
+        'expression': ExpressionColumn,
     }
 
     @classmethod

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -27,7 +27,7 @@ from sqlagg.columns import (
 )
 from corehq.apps.reports.sqlreport import DatabaseColumn, AggregateColumn
 from corehq.apps.userreports.specs import TypeProperty
-from corehq.apps.userreports.sql import get_expanded_column_config, SqlColumnConfig
+from corehq.apps.userreports.sql import get_expanded_column_config, ColumnConfig
 from corehq.apps.userreports.transforms.factory import TransformFactory
 from corehq.apps.userreports.util import localize
 from dimagi.utils.decorators.memoized import memoized
@@ -136,7 +136,7 @@ class FieldColumn(ReportColumn):
                 )
 
     def get_column_config(self, data_source_config, lang):
-        return SqlColumnConfig(columns=[
+        return ColumnConfig(columns=[
             DatabaseColumn(
                 header=self.get_header(lang),
                 agg_column=SQLAGG_COLUMN_MAP[self.aggregation](self.field, alias=self.column_id),
@@ -167,7 +167,7 @@ class LocationColumn(ReportColumn):
                 row[column_name] = '{} ({})'.format(row[column_name], _('Invalid Location'))
 
     def get_column_config(self, data_source_config, lang):
-        return SqlColumnConfig(columns=[
+        return ColumnConfig(columns=[
             DatabaseColumn(
                 header=self.get_header(lang),
                 agg_column=SimpleColumn(self.field, alias=self.column_id),
@@ -204,7 +204,7 @@ class AggregateDateColumn(ReportColumn):
     format = StringProperty(required=False)
 
     def get_column_config(self, data_source_config, lang):
-        return SqlColumnConfig(columns=[
+        return ColumnConfig(columns=[
             AggregateColumn(
                 header=self.get_header(lang),
                 aggregate_fn=lambda year, month: {'year': year, 'month': month},
@@ -249,7 +249,7 @@ class PercentageColumn(ReportColumn):
         # todo: better checks that fields are not expand
         num_config = self.numerator.get_column_config(data_source_config, lang)
         denom_config = self.denominator.get_column_config(data_source_config, lang)
-        return SqlColumnConfig(columns=[
+        return ColumnConfig(columns=[
             AggregateColumn(
                 header=self.get_header(lang),
                 aggregate_fn=lambda n, d: {'num': n, 'denom': d},

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -4,6 +4,7 @@ from datetime import date
 from django.utils.translation import ugettext as _
 from jsonobject.exceptions import BadValueError
 from corehq.apps.userreports.exceptions import InvalidQueryColumn
+from corehq.apps.userreports.expressions import ExpressionFactory
 
 from corehq.apps.userreports.reports.sorting import ASCENDING, DESCENDING
 from corehq.apps.userreports.sql.columns import DEFAULT_MAXIMUM_EXPANSION
@@ -29,6 +30,7 @@ from corehq.apps.userreports.specs import TypeProperty
 from corehq.apps.userreports.sql import get_expanded_column_config, SqlColumnConfig
 from corehq.apps.userreports.transforms.factory import TransformFactory
 from corehq.apps.userreports.util import localize
+from dimagi.utils.decorators.memoized import memoized
 
 
 SQLAGG_COLUMN_MAP = {
@@ -321,6 +323,15 @@ class PercentageColumn(ReportColumn):
 def _add_column_id_if_missing(obj):
     if obj.get('column_id') is None:
         obj['column_id'] = obj.get('alias') or obj['field']
+
+
+class ExpressionColumn(BaseReportColumn):
+    expression = DefaultProperty(required=True)
+
+    @property
+    @memoized
+    def wrapped_expression(self):
+        return ExpressionFactory.from_spec(self.expression)
 
 
 class ChartSpec(JsonObject):

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -44,19 +44,32 @@ SQLAGG_COLUMN_MAP = {
 }
 
 
-class ReportColumn(JsonObject):
+class BaseReportColumn(JsonObject):
     type = StringProperty(required=True)
     column_id = StringProperty(required=True)
     display = DefaultProperty()
     description = StringProperty()
-    transform = DictProperty()
-    calculate_total = BooleanProperty(default=False)
 
     @classmethod
     def wrap(cls, obj):
         if 'display' not in obj and 'column_id' in obj:
             obj['display'] = obj['column_id']
-        return super(ReportColumn, cls).wrap(obj)
+        return super(BaseReportColumn, cls).wrap(obj)
+
+    def get_header(self, lang):
+        return localize(self.display, lang)
+
+    def get_column_ids(self):
+        """
+        Used as an abstraction layer for columns that can contain more than one data column
+        (for example, PercentageColumns).
+        """
+        return [self.column_id]
+
+
+class ReportColumn(BaseReportColumn):
+    transform = DictProperty()
+    calculate_total = BooleanProperty(default=False)
 
     def format_data(self, data):
         """
@@ -82,16 +95,6 @@ class ReportColumn(JsonObject):
         the query (e.g. an aggregate date splitting into year and month)
         """
         raise InvalidQueryColumn(_("You can't query on columns of type {}".format(self.type)))
-
-    def get_header(self, lang):
-        return localize(self.display, lang)
-
-    def get_column_ids(self):
-        """
-        Used as an abstraction layer for columns that can contain more than one data column
-        (for example, PercentageColumns).
-        """
-        return [self.column_id]
 
 
 class FieldColumn(ReportColumn):

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -68,6 +68,9 @@ class BaseReportColumn(JsonObject):
         """
         return [self.column_id]
 
+    def get_column_config(self, data_source_config, lang):
+        raise NotImplementedError('subclasses must override this')
+
 
 class ReportColumn(BaseReportColumn):
     transform = DictProperty()
@@ -78,9 +81,6 @@ class ReportColumn(BaseReportColumn):
         Subclasses can apply formatting to the entire dataset.
         """
         pass
-
-    def get_sql_column_config(self, data_source_config, lang):
-        raise NotImplementedError('subclasses must override this')
 
     def get_format_fn(self):
         """
@@ -135,7 +135,7 @@ class FieldColumn(ReportColumn):
                     float(row[column_name]) / total
                 )
 
-    def get_sql_column_config(self, data_source_config, lang):
+    def get_column_config(self, data_source_config, lang):
         return SqlColumnConfig(columns=[
             DatabaseColumn(
                 header=self.get_header(lang),
@@ -166,7 +166,7 @@ class LocationColumn(ReportColumn):
             except BadValueError:
                 row[column_name] = '{} ({})'.format(row[column_name], _('Invalid Location'))
 
-    def get_sql_column_config(self, data_source_config, lang):
+    def get_column_config(self, data_source_config, lang):
         return SqlColumnConfig(columns=[
             DatabaseColumn(
                 header=self.get_header(lang),
@@ -191,7 +191,7 @@ class ExpandedColumn(ReportColumn):
         _add_column_id_if_missing(obj)
         return super(ExpandedColumn, cls).wrap(obj)
 
-    def get_sql_column_config(self, data_source_config, lang):
+    def get_column_config(self, data_source_config, lang):
         return get_expanded_column_config(data_source_config, self, lang)
 
 
@@ -203,7 +203,7 @@ class AggregateDateColumn(ReportColumn):
     field = StringProperty(required=True)
     format = StringProperty(required=False)
 
-    def get_sql_column_config(self, data_source_config, lang):
+    def get_column_config(self, data_source_config, lang):
         return SqlColumnConfig(columns=[
             AggregateColumn(
                 header=self.get_header(lang),
@@ -245,10 +245,10 @@ class PercentageColumn(ReportColumn):
         default='percent'
     )
 
-    def get_sql_column_config(self, data_source_config, lang):
+    def get_column_config(self, data_source_config, lang):
         # todo: better checks that fields are not expand
-        num_config = self.numerator.get_sql_column_config(data_source_config, lang)
-        denom_config = self.denominator.get_sql_column_config(data_source_config, lang)
+        num_config = self.numerator.get_column_config(data_source_config, lang)
+        denom_config = self.denominator.get_column_config(data_source_config, lang)
         return SqlColumnConfig(columns=[
             AggregateColumn(
                 header=self.get_header(lang),

--- a/corehq/apps/userreports/reports/specs.py
+++ b/corehq/apps/userreports/reports/specs.py
@@ -27,7 +27,7 @@ from sqlagg.columns import (
     SimpleColumn,
     YearColumn,
 )
-from corehq.apps.reports.sqlreport import DatabaseColumn, AggregateColumn, Column
+from corehq.apps.reports.sqlreport import DatabaseColumn, AggregateColumn
 from corehq.apps.userreports.specs import TypeProperty
 from corehq.apps.userreports.sql import get_expanded_column_config, ColumnConfig
 from corehq.apps.userreports.transforms.factory import TransformFactory

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -352,12 +352,11 @@ class ConfigurableReport(JSONResponseMixin, BaseDomainView):
             echo = int(params.get('sEcho', 1))
             if sort_column and echo != 1:
                 data_source.set_order_by(
-                    [(data_source.column_configs[int(sort_column)].column_id, sort_order.upper())]
+                    [(data_source.top_level_columns[int(sort_column)].column_id, sort_order.upper())]
                 )
 
             datatables_params = DatatablesParams.from_request_dict(params)
             page = list(data_source.get_data(start=datatables_params.start, limit=datatables_params.count))
-
             total_records = data_source.get_total_records()
             total_row = data_source.get_total_row() if data_source.has_total_row else None
         except UserReportsError as e:
@@ -446,7 +445,7 @@ class ConfigurableReport(JSONResponseMixin, BaseDomainView):
         raw_rows = list(data.get_data())
         headers = [column.header for column in self.data_source.columns]
 
-        column_id_to_expanded_column_ids = get_expanded_columns(data.column_configs, data.config)
+        column_id_to_expanded_column_ids = get_expanded_columns(data.top_level_columns, data.config)
         column_ids = []
         for column in self.spec.report_columns:
             column_ids.extend(column_id_to_expanded_column_ids.get(column.column_id, [column.column_id]))

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -338,12 +338,12 @@ class ConfigurableReport(JSONResponseMixin, BaseDomainView):
 
     @property
     def headers(self):
-        return DataTablesHeader(*[col.data_tables_column for col in self.data_source.columns])
+        return DataTablesHeader(*[col.data_tables_column for col in self.data_source.inner_columns])
 
     def get_ajax(self, params):
         try:
             data_source = self.data_source
-            if len(data_source.columns) > 50 and not DISABLE_COLUMN_LIMIT_IN_UCR.enabled(self.domain):
+            if len(data_source.inner_columns) > 50 and not DISABLE_COLUMN_LIMIT_IN_UCR.enabled(self.domain):
                 raise UserReportsError(_("This report has too many columns to be displayed"))
             data_source.set_filter_values(self.filter_values)
 

--- a/corehq/apps/userreports/sql/__init__.py
+++ b/corehq/apps/userreports/sql/__init__.py
@@ -1,3 +1,3 @@
 from .adapter import get_indicator_table, IndicatorSqlAdapter, metadata, ErrorRaisingIndicatorSqlAdapter
-from .columns import get_expanded_column_config, SqlColumnConfig
+from .columns import get_expanded_column_config, ColumnConfig
 from .util import get_column_name

--- a/corehq/apps/userreports/sql/columns.py
+++ b/corehq/apps/userreports/sql/columns.py
@@ -7,7 +7,7 @@ from fluff import TYPE_STRING
 from fluff.util import get_column_type
 
 
-class SqlColumnConfig(object):
+class ColumnConfig(object):
     """
     Stub object to send column information to the data source
     """
@@ -63,7 +63,7 @@ def get_expanded_column_config(data_source_configuration, column_config, lang):
             data_source_configuration, column_config, column_config.max_expansion
         )
     except ColumnNotFoundError as e:
-        return SqlColumnConfig([], warnings=[unicode(e)])
+        return ColumnConfig([], warnings=[unicode(e)])
     else:
         if over_expansion_limit:
             column_warnings.append(_(
@@ -73,7 +73,7 @@ def get_expanded_column_config(data_source_configuration, column_config, lang):
                 header=column_config.get_header(lang),
                 max=column_config.max_expansion,
             ))
-        return SqlColumnConfig(_expand_column(column_config, vals, lang), warnings=column_warnings)
+        return ColumnConfig(_expand_column(column_config, vals, lang), warnings=column_warnings)
 
 
 DEFAULT_MAXIMUM_EXPANSION = 10

--- a/corehq/apps/userreports/sql/data_source.py
+++ b/corehq/apps/userreports/sql/data_source.py
@@ -65,7 +65,7 @@ class ConfigurableReportSqlDataSource(SqlData):
         return get_engine_id(self.config)
 
     @property
-    def column_configs(self):
+    def top_level_columns(self):
         """
         This returns a list of BaseReportColumn objects that define the top-level columns
         in the report.
@@ -120,11 +120,11 @@ class ConfigurableReportSqlDataSource(SqlData):
                 for sort_column_id, order in self._order_by
                 for order_by in self._get_db_column_ids(sort_column_id)
             ]
-        elif self.column_configs:
+        elif self.top_level_columns:
             try:
                 return [
                     OrderBy(order_by, is_ascending=True)
-                    for order_by in self._get_db_column_ids(self.column_configs[0].column_id)
+                    for order_by in self._get_db_column_ids(self.top_level_columns[0].column_id)
                 ]
             except InvalidQueryColumn:
                 pass
@@ -188,7 +188,7 @@ class ConfigurableReportSqlDataSource(SqlData):
         def _get_relevant_column_ids(col, column_id_to_expanded_column_ids):
             return column_id_to_expanded_column_ids.get(col.column_id, [col.column_id])
 
-        expanded_columns = get_expanded_columns(self.column_configs, self.config)
+        expanded_columns = get_expanded_columns(self.top_level_columns, self.config)
 
         qc = self.query_context()
         for c in self.columns:
@@ -199,7 +199,7 @@ class ConfigurableReportSqlDataSource(SqlData):
             session.connection(),
             [
                 column_id
-                for col in self.column_configs for column_id in _get_relevant_column_ids(col, expanded_columns)
+                for col in self.top_level_columns for column_id in _get_relevant_column_ids(col, expanded_columns)
                 if col.calculate_total
             ],
             self.filter_values
@@ -207,7 +207,7 @@ class ConfigurableReportSqlDataSource(SqlData):
 
         total_row = [
             _clean_total_row(totals.get(column_id), col)
-            for col in self.column_configs for column_id in _get_relevant_column_ids(
+            for col in self.top_level_columns for column_id in _get_relevant_column_ids(
                 col, expanded_columns
             )
         ]

--- a/corehq/apps/userreports/sql/data_source.py
+++ b/corehq/apps/userreports/sql/data_source.py
@@ -164,7 +164,7 @@ class ConfigurableReportSqlDataSource(SqlData):
 
     @property
     def has_total_row(self):
-        return any(column_config.calculate_total for column_config in self.column_configs)
+        return any(column_config.calculate_total for column_config in self.db_column_configs)
 
     @method_decorator(catch_and_raise_exceptions)
     def get_total_records(self):

--- a/corehq/apps/userreports/sql/data_source.py
+++ b/corehq/apps/userreports/sql/data_source.py
@@ -85,12 +85,12 @@ class ConfigurableReportSqlDataSource(SqlData):
         ]
 
     @property
-    def db_column_configs(self):
-        return [col for col in self._column_configs.values() if isinstance(col, ReportColumn)]
+    def top_level_db_columns(self):
+        return [col for col in self.top_level_columns if isinstance(col, ReportColumn)]
 
     @property
-    def computed_column_configs(self):
-        return [col for col in self._column_configs.values() if isinstance(col, ExpressionColumn)]
+    def top_level_computed_columns(self):
+        return [col for col in self.top_level_columns if isinstance(col, ExpressionColumn)]
 
     @property
     def table_name(self):
@@ -156,7 +156,7 @@ class ConfigurableReportSqlDataSource(SqlData):
 
     @property
     def sql_column_configs(self):
-        return [col.get_column_config(self.config, self.lang) for col in self.db_column_configs]
+        return [col.get_column_config(self.config, self.lang) for col in self.top_level_db_columns]
 
     @property
     def column_warnings(self):
@@ -167,10 +167,10 @@ class ConfigurableReportSqlDataSource(SqlData):
     def get_data(self, start=None, limit=None):
         ret = super(ConfigurableReportSqlDataSource, self).get_data(start=start, limit=limit)
 
-        for report_column in self.db_column_configs:
+        for report_column in self.top_level_db_columns:
             report_column.format_data(ret)
 
-        for computed_column in self.computed_column_configs:
+        for computed_column in self.top_level_computed_columns:
             for row in ret:
                 row[computed_column.column_id] = computed_column.wrapped_expression(row)
 
@@ -178,7 +178,7 @@ class ConfigurableReportSqlDataSource(SqlData):
 
     @property
     def has_total_row(self):
-        return any(column_config.calculate_total for column_config in self.db_column_configs)
+        return any(column_config.calculate_total for column_config in self.top_level_db_columns)
 
     @method_decorator(catch_and_raise_exceptions)
     def get_total_records(self):

--- a/corehq/apps/userreports/sql/data_source.py
+++ b/corehq/apps/userreports/sql/data_source.py
@@ -66,6 +66,10 @@ class ConfigurableReportSqlDataSource(SqlData):
 
     @property
     def column_configs(self):
+        """
+        This returns a list of BaseReportColumn objects that define the top-level columns
+        in the report.
+        """
         return self._column_configs.values()
 
     @property

--- a/corehq/apps/userreports/sql/data_source.py
+++ b/corehq/apps/userreports/sql/data_source.py
@@ -138,7 +138,7 @@ class ConfigurableReportSqlDataSource(SqlData):
 
     @property
     def sql_column_configs(self):
-        return [col.get_sql_column_config(self.config, self.lang) for col in self.db_column_configs]
+        return [col.get_column_config(self.config, self.lang) for col in self.db_column_configs]
 
     @property
     def column_warnings(self):

--- a/corehq/apps/userreports/tests/test_columns.py
+++ b/corehq/apps/userreports/tests/test_columns.py
@@ -195,7 +195,7 @@ class TestExpandedColumn(TestCase):
         self.addCleanup(report_config.delete)
         data_source = ReportFactory.from_spec(report_config)
 
-        return data_source, data_source.column_configs[0]
+        return data_source, data_source.top_level_columns[0]
 
     def setUp(self):
         super(TestExpandedColumn, self).setUp()

--- a/corehq/apps/userreports/tests/test_report_data.py
+++ b/corehq/apps/userreports/tests/test_report_data.py
@@ -69,6 +69,34 @@ class ReportDataTest(TestCase):
                     "column_id": "number",
                     "display": "Number",
                     "aggregation": "simple",
+                },
+                {
+                    "type": "expression",
+                    "column_id": "ten",
+                    "display": "The Number Ten",
+                    "expression": {
+                        'type': 'constant',
+                        'constant': 10,
+                    }
+                },
+                {
+                    "type": "expression",
+                    "column_id": "by_tens",
+                    "display": "Counting by tens",
+                    "expression": {
+                        "type": "evaluator",
+                        "statement": "a * b",
+                        "context_variables": {
+                            "a": {
+                                "type": "property_name",
+                                "property_name": "number",
+                            },
+                            "b": {
+                                "type": "property_name",
+                                "property_name": "ten",
+                            }
+                        }
+                    }
                 }
             ],
             filters=[],
@@ -110,6 +138,8 @@ class ReportDataTest(TestCase):
         for row in report_data:
             self.assertTrue(row['name'] in rows_by_name)
             self.assertEqual(rows_by_name[row['name']].number, row['number'])
+            self.assertEqual(10, row['ten'])
+            self.assertEqual(10 * row['number'], row['by_tens'])
 
     def test_limit(self):
         count = 5


### PR DESCRIPTION
this is the other thing I demo'd tuesday. the whole hierarchy of `Column` and `ColumnConfig` objects is super confusing in these reports and I would like to clean it up a bit more but decided to just put this up for now since I wasn't quite sure how to do that and there's messy dependencies on `SqlData`.

@emord might be a good person to review since he's been in this code recently. cc buddy @snopoke . probably easiest by commit.
