### PR TITLE
don't use sql backend for iquitos domain

### DIFF
--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -810,7 +810,7 @@ TF_USES_SQLITE_BACKEND = PredictablyRandomToggle(
     TAG_PRODUCT_PATH,
     [NAMESPACE_DOMAIN],
     0.8,
-    always_disabled=['hsph-betterbirth'],
+    always_disabled=['hsph-betterbirth', 'iquitos'],
 )
 
 


### PR DESCRIPTION
Fixes http://manage.dimagi.com/default.asp?237835

Core issue is that the mobile users on this domain are too big to restore
