### PR TITLE
Assert rev in pillow processor

### DIFF
--- a/corehq/apps/change_feed/document_types.py
+++ b/corehq/apps/change_feed/document_types.py
@@ -101,6 +101,7 @@ def change_meta_from_doc_meta_and_document(doc_meta, document, data_source_type,
         raise MissingMetaInformationError(u"No doc ID!!".format(document))
     return ChangeMeta(
         document_id=doc_id or document['_id'],
+        document_rev=document.get('_rev', None),
         data_source_type=data_source_type,
         data_source_name=data_source_name,
         document_type=doc_meta.raw_doc_type,

--- a/corehq/apps/change_feed/tests/test_pillow.py
+++ b/corehq/apps/change_feed/tests/test_pillow.py
@@ -127,4 +127,4 @@ class TestElasticProcessorPillows(SimpleTestCase):
                 )
             )
         except DocumentMismatchError:
-            self.fail('Incorectly raise a document not found error for matching revs')
+            self.fail('Incorectly raise a DocumentMismatchError for matching revs')

--- a/corehq/apps/change_feed/tests/test_pillow.py
+++ b/corehq/apps/change_feed/tests/test_pillow.py
@@ -10,7 +10,9 @@ from corehq.apps.change_feed.consumer.feed import change_meta_from_kafka_message
 from corehq.apps.change_feed.pillow import get_change_feed_pillow_for_db
 from corehq.apps.change_feed.data_sources import COUCH
 from corehq.pillows.case import get_case_to_elasticsearch_pillow
+from corehq.pillows.mappings.case_mapping import CASE_INDEX_INFO
 from corehq.util.test_utils import trap_extra_setup
+from corehq.util.elastic import ensure_index_deleted
 from pillowtop.feed.interface import Change, ChangeMeta
 from pillowtop.dao.exceptions import DocumentMismatchError
 
@@ -82,6 +84,9 @@ class TestElasticProcessorPillows(SimpleTestCase):
     def setUp(self):
         with patch('pillowtop.checkpoints.manager.get_or_create_checkpoint'):
             self.pillow = get_case_to_elasticsearch_pillow()
+
+    def tearDown(self):
+        ensure_index_deleted(CASE_INDEX_INFO.index)
 
     def test_mismatched_rev(self):
         """

--- a/corehq/apps/change_feed/tests/test_pillow.py
+++ b/corehq/apps/change_feed/tests/test_pillow.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from mock import patch, MagicMock
+from mock import patch
 from django.conf import settings
 from django.test import SimpleTestCase
 from fakecouch import FakeCouchDb

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -15,6 +15,7 @@ from fluff.signals import get_migration_context, get_tables_to_rebuild, reformat
 from pillowtop.checkpoints.manager import PillowCheckpoint
 from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors import PillowProcessor
+from pillowtop.utils import ensure_matched_revisions
 
 
 REBUILD_CHECK_INTERVAL = 10 * 60  # in seconds
@@ -120,6 +121,7 @@ class ConfigurableReportPillowProcessor(ConfigurableReportTableManagerMixin, Pil
             if table.config.domain == domain:
                 # only bother getting the document if we have a domain match from the metadata
                 doc = change.get_document()
+                ensure_matched_revisions(change)
                 if table.config.filter(doc):
                     # best effort will swallow errors in the table
                     table.best_effort_save(doc)

--- a/corehq/apps/userreports/pillow.py
+++ b/corehq/apps/userreports/pillow.py
@@ -15,7 +15,7 @@ from fluff.signals import get_migration_context, get_tables_to_rebuild, reformat
 from pillowtop.checkpoints.manager import PillowCheckpoint
 from pillowtop.pillow.interface import ConstructedPillow
 from pillowtop.processors import PillowProcessor
-from pillowtop.utils import ensure_matched_revisions
+from pillowtop.utils import ensure_matched_revisions, ensure_document_exists
 
 
 REBUILD_CHECK_INTERVAL = 10 * 60  # in seconds
@@ -121,6 +121,7 @@ class ConfigurableReportPillowProcessor(ConfigurableReportTableManagerMixin, Pil
             if table.config.domain == domain:
                 # only bother getting the document if we have a domain match from the metadata
                 doc = change.get_document()
+                ensure_document_exists(change)
                 ensure_matched_revisions(change)
                 if table.config.filter(doc):
                     # best effort will swallow errors in the table

--- a/corehq/ex-submodules/pillowtop/dao/exceptions.py
+++ b/corehq/ex-submodules/pillowtop/dao/exceptions.py
@@ -2,3 +2,7 @@
 
 class DocumentNotFoundError(Exception):
     pass
+
+
+class DocumentMismatchError(Exception):
+    pass

--- a/corehq/ex-submodules/pillowtop/feed/interface.py
+++ b/corehq/ex-submodules/pillowtop/feed/interface.py
@@ -11,6 +11,7 @@ class ChangeMeta(jsonobject.JsonObject):
     This is only used in kafka-based pillows.
     """
     document_id = DefaultProperty(required=True)
+    document_rev = jsonobject.StringProperty()  # Only relevant for Couch documents
     data_source_type = jsonobject.StringProperty(required=True)
     data_source_name = jsonobject.StringProperty(required=True)
     document_type = DefaultProperty()

--- a/corehq/ex-submodules/pillowtop/processors/elastic.py
+++ b/corehq/ex-submodules/pillowtop/processors/elastic.py
@@ -36,7 +36,7 @@ class ElasticProcessor(PillowProcessor):
         if doc is None:
             pillow_logging.warning("Unable to get document from change: {}".format(change))
             raise DocumentNotFoundError()  # force a retry
-        if doc and '_rev' in doc and change.metadata.document_rev is not None:
+        if doc and '_rev' in doc and change.metadata and change.metadata.document_rev is not None:
             if doc['_rev'] != change.metadata.document_rev:
                 pillow_logging.warning(
                     u"Mismatched revs for {}: Cloudant rev {} vs. Changes feed rev {}".format(

--- a/corehq/ex-submodules/pillowtop/processors/elastic.py
+++ b/corehq/ex-submodules/pillowtop/processors/elastic.py
@@ -36,6 +36,16 @@ class ElasticProcessor(PillowProcessor):
         if doc is None:
             pillow_logging.warning("Unable to get document from change: {}".format(change))
             raise DocumentNotFoundError()  # force a retry
+        if doc and '_rev' in doc and change.metadata.document_rev is not None:
+            if doc['_rev'] != change.metadata.document_rev:
+                pillow_logging.warning(
+                    u"Mismatched revs for {}: Cloudant rev {} vs. Changes feed rev {}".format(
+                        change.id,
+                        doc['_rev'],
+                        change.metadata.document_rev,
+                    )
+                )
+                raise DocumentNotFoundError(u'Mismatched revs')
 
         if self.doc_filter_fn and self.doc_filter_fn(doc):
             return

--- a/corehq/ex-submodules/pillowtop/processors/elastic.py
+++ b/corehq/ex-submodules/pillowtop/processors/elastic.py
@@ -4,7 +4,7 @@ import time
 from elasticsearch.exceptions import RequestError, ConnectionError, NotFoundError, ConflictError
 
 from pillowtop.dao.exceptions import DocumentNotFoundError
-from pillowtop.utils import ensure_matched_revisions
+from pillowtop.utils import ensure_matched_revisions, ensure_document_exists
 from pillowtop.exceptions import PillowtopIndexingError
 from pillowtop.logger import pillow_logging
 from .interface import PillowProcessor
@@ -34,10 +34,8 @@ class ElasticProcessor(PillowProcessor):
             return
 
         doc = change.get_document()
-        if doc is None:
-            pillow_logging.warning("Unable to get document from change: {}".format(change))
-            raise DocumentNotFoundError()  # force a retry
 
+        ensure_document_exists(change)
         ensure_matched_revisions(change)
 
         if self.doc_filter_fn and self.doc_filter_fn(doc):

--- a/corehq/ex-submodules/pillowtop/processors/elastic.py
+++ b/corehq/ex-submodules/pillowtop/processors/elastic.py
@@ -3,7 +3,7 @@ import time
 
 from elasticsearch.exceptions import RequestError, ConnectionError, NotFoundError, ConflictError
 
-from pillowtop.dao.exceptions import DocumentNotFoundError
+from pillowtop.dao.exceptions import DocumentNotFoundError, DocumentMismatchError
 from pillowtop.exceptions import PillowtopIndexingError
 from pillowtop.logger import pillow_logging
 from .interface import PillowProcessor
@@ -45,7 +45,7 @@ class ElasticProcessor(PillowProcessor):
                         change.metadata.document_rev,
                     )
                 )
-                raise DocumentNotFoundError(u'Mismatched revs')
+                raise DocumentMismatchError(u'Mismatched revs')
 
         if self.doc_filter_fn and self.doc_filter_fn(doc):
             return

--- a/corehq/ex-submodules/pillowtop/utils.py
+++ b/corehq/ex-submodules/pillowtop/utils.py
@@ -12,7 +12,7 @@ from dimagi.utils.modules import to_function
 
 from pillowtop.exceptions import PillowNotFoundError
 from pillowtop.logger import pillow_logging
-from pillowtop.dao.exceptions import DocumentMismatchError
+from pillowtop.dao.exceptions import DocumentMismatchError, DocumentNotFoundError
 
 
 def _get_pillow_instance(full_class_str):
@@ -239,3 +239,15 @@ def ensure_matched_revisions(change):
                 )
             )
             raise DocumentMismatchError(u'Mismatched revs')
+
+
+def ensure_document_exists(change):
+    """
+    Ensures that the document recorded in Kafka exists and is properly returned
+
+    :raises: DocumentNotFoundError - Raised when the document is not found
+    """
+    doc = change.get_document()
+    if doc is None:
+        pillow_logging.warning("Unable to get document from change: {}".format(change))
+        raise DocumentNotFoundError()  # force a retry

--- a/corehq/ex-submodules/pillowtop/utils.py
+++ b/corehq/ex-submodules/pillowtop/utils.py
@@ -11,6 +11,8 @@ from dimagi.utils.chunked import chunked
 from dimagi.utils.modules import to_function
 
 from pillowtop.exceptions import PillowNotFoundError
+from pillowtop.logger import pillow_logging
+from pillowtop.dao.exceptions import DocumentMismatchError
 
 
 def _get_pillow_instance(full_class_str):
@@ -209,3 +211,31 @@ def prepare_bulk_payloads(bulk_changes, max_size, chunk_size=100):
             payloads[-1] = appended_payload
 
     return filter(None, payloads)
+
+
+def ensure_matched_revisions(change):
+    """
+    This function ensures that the document fetched from a change matches the
+    revision at which it was pushed to kafka at.
+
+    See http://manage.dimagi.com/default.asp?237983 for more details
+
+    :raises: DocumentMismatchError - Raised when the revisions of the fetched document
+        and the change metadata do not match
+    """
+    fetched_document = change.get_document()
+
+    if (fetched_document and
+            '_rev' in fetched_document and
+            change.metadata and
+            change.metadata.document_rev is not None):
+
+        if change.metadata and fetched_document['_rev'] != change.metadata.document_rev:
+            pillow_logging.warning(
+                u"Mismatched revs for {}: Cloudant rev {} vs. Changes feed rev {}".format(
+                    change.id,
+                    fetched_document['_rev'],
+                    change.metadata.document_rev,
+                )
+            )
+            raise DocumentMismatchError(u'Mismatched revs')


### PR DESCRIPTION
@czue @snopoke this'll publish the doc rev to the changes feed and then assert that the revs are the same. curious to see if any of these pop up in the coming days. i think we only need it for the ElasticProcessor but i may be overlooking another place where it might be useful

http://manage.dimagi.com/default.asp?237983
http://manage.dimagi.com/default.asp?237943

cc: @proteusvacuum
