### PR TITLE
Update 'Distance from here' case list xpath expressions

### DIFF
--- a/corehq/apps/app_manager/detail_screen.py
+++ b/corehq/apps/app_manager/detail_screen.py
@@ -280,7 +280,7 @@ class TimeAgo(FormattedDetailColumn):
 @register_format_type('distance')
 class Distance(FormattedDetailColumn):
     XPATH_FUNCTION = u"if(here() = '' or {xpath} = '', '', concat(round(distance({xpath}, here()) div 100) div 10, ' km'))"
-    SORT_XPATH_FUNCTION = u'if({xpath} = '', 2147483647, round(distance({xpath}, here())))'
+    SORT_XPATH_FUNCTION = u"if({xpath} = '', 2147483647, round(distance({xpath}, here())))"
     SORT_TYPE = 'double'
 
 

--- a/corehq/apps/app_manager/detail_screen.py
+++ b/corehq/apps/app_manager/detail_screen.py
@@ -279,8 +279,8 @@ class TimeAgo(FormattedDetailColumn):
 
 @register_format_type('distance')
 class Distance(FormattedDetailColumn):
-    XPATH_FUNCTION = u"if(here() = '', '', if({xpath} = '', '', concat(round(distance({xpath}, here()) div 1000), ' km')))"
-    SORT_XPATH_FUNCTION = u'round(distance({xpath}, here()))'
+    XPATH_FUNCTION = u"if(here() = '' or {xpath} = '', '', concat(round(distance({xpath}, here()) div 100) div 10, ' km'))"
+    SORT_XPATH_FUNCTION = u'if({xpath} = '', 2147483647, round(distance({xpath}, here())))'
     SORT_TYPE = 'double'
 
 

--- a/corehq/apps/app_manager/tests/test_case_detail_distance.py
+++ b/corehq/apps/app_manager/tests/test_case_detail_distance.py
@@ -129,7 +129,7 @@ class CaseDetailDistance(SimpleTestCase, TestXmlMixin):
                     </template>
                     <sort direction="descending" order="1" type="double">
                         <text>
-                            <xpath function="if(gps= '', 2147483647, round(distance(case_name, here())))"/>
+                            <xpath function="if(gps = '', 2147483647, round(distance(case_name, here())))"/>
                         </text>
                     </sort>
                 </field>

--- a/corehq/apps/app_manager/tests/test_case_detail_distance.py
+++ b/corehq/apps/app_manager/tests/test_case_detail_distance.py
@@ -129,7 +129,7 @@ class CaseDetailDistance(SimpleTestCase, TestXmlMixin):
                     </template>
                     <sort direction="descending" order="1" type="double">
                         <text>
-                            <xpath function="if(gps = '', 2147483647, round(distance(case_name, here())))"/>
+                            <xpath function="if(gps = '', 2147483647, round(distance(gps, here())))"/>
                         </text>
                     </sort>
                 </field>

--- a/corehq/apps/app_manager/tests/test_case_detail_distance.py
+++ b/corehq/apps/app_manager/tests/test_case_detail_distance.py
@@ -33,12 +33,12 @@ class CaseDetailDistance(SimpleTestCase, TestXmlMixin):
                     </header>
                     <template>
                         <text>
-                            <xpath function="if(here() = '', '', if(case_name = '', '', concat(round(distance(case_name, here()) div 1000), ' km')))"/>
+                            <xpath function="if(here() = '' or case_name = '', '', concat(round(distance(case_name, here()) div 100) div 10, ' km'))"/>
                         </text>
                     </template>
                     <sort direction="ascending" order="1" type="double">
                         <text>
-                                <xpath function="round(distance(case_name, here()))"/>
+                                <xpath function="if(case_name = '', 2147483647, round(distance(case_name, here())))"/>
                         </text>
                     </sort>
                 </field>
@@ -79,7 +79,7 @@ class CaseDetailDistance(SimpleTestCase, TestXmlMixin):
                     </template>
                     <sort direction="descending" order="1" type="double">
                         <text>
-                            <xpath function="round(distance(case_name, here()))"/>
+                            <xpath function="if(case_name = '', 2147483647, round(distance(case_name, here())))"/>
                         </text>
                     </sort>
                 </field>
@@ -129,7 +129,7 @@ class CaseDetailDistance(SimpleTestCase, TestXmlMixin):
                     </template>
                     <sort direction="descending" order="1" type="double">
                         <text>
-                            <xpath function="round(distance(gps, here()))"/>
+                            <xpath function="if(gps= '', 2147483647, round(distance(case_name, here())))"/>
                         </text>
                     </sort>
                 </field>
@@ -159,7 +159,7 @@ class CaseDetailDistance(SimpleTestCase, TestXmlMixin):
                     </header>
                     <template>
                         <text>
-                            <xpath function="if(here() = '', '', if(case_name = '', '', concat(round(distance(case_name, here()) div 1000), ' km')))"/>
+                            <xpath function="if(here() = '' or case_name = '', '', concat(round(distance(case_name, here()) div 100) div 10, ' km'))"/>
                         </text>
                     </template>
                 </field>


### PR DESCRIPTION
- For sorting by distance, if there is no gps value for the case property in question, use the max int value. This will make all cases with blank gps values sort to the bottom.
- Show 1 decimal point of precision to get more fine-grained info on values below 1 km.

follow up to work done in https://github.com/dimagi/commcare-hq/pull/10023 and https://github.com/dimagi/commcare-hq/pull/10317

I manually configured a ccz with these changes, but didn't test building an app using a local instance of HQ. 

@snopoke can you take a look at this?
