### PR TITLE
upgrade django-two-factor-auth to 1.4.0

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -74,7 +74,7 @@ git+git://github.com/smartfile/django-transfer.git@6e0dc94c3341c358fca8eb2bf74e2
 Pygments==2.0.2
 tinys3==0.1.11
 django-formtools==1.0
-django-two-factor-auth==1.2.2
+django-two-factor-auth==1.4.0
 datadog==0.10.0
 django-websocket-redis==0.4.6
 django-redis-sessions==0.5.0


### PR DESCRIPTION
Support django 1.8+

http://django-two-factor-auth.readthedocs.io/en/stable/release-notes.html
