### PR TITLE
Fix intermittent test failure

### DIFF
--- a/corehq/apps/commtrack/tests/test_xml.py
+++ b/corehq/apps/commtrack/tests/test_xml.py
@@ -389,7 +389,7 @@ class CommTrackBalanceTransferTest(CommTrackSubmissionTest):
         self.submit_xml_form(balance_submission(initial_amounts))
 
         # then mark some receipts
-        transfers = [(p._id, float(50 - 10*i)) for i, p in enumerate(self.products)]
+        transfers = [(p._id, float(50 - 10*i + 3)) for i, p in enumerate(self.products)]
         # then set to 50
         final = float(50)
         balance_amounts = [(p._id, final) for p in self.products]

--- a/corehq/sql_accessors/migrations/0041_latest_ledger_transactions_fix.py
+++ b/corehq/sql_accessors/migrations/0041_latest_ledger_transactions_fix.py
@@ -6,17 +6,15 @@ from django.db import migrations
 from corehq.form_processor.models import XFormInstanceSQL
 from corehq.sql_db.operations import RawSQLMigration
 
-migrator = RawSQLMigration(('corehq', 'sql_accessors', 'sql_templates'), {
-    'FORM_STATE_DELETED': XFormInstanceSQL.DELETED
-})
+migrator = RawSQLMigration(('corehq', 'sql_accessors', 'sql_templates'))
 
 
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('sql_accessors', '0014_ledger_transactions'),
+        ('sql_accessors', '0040_fix_case_reindex_query'),
     ]
 
     operations = [
-        migrator.get_migration('get_ledger_transactions_for_case.sql'),
+        migrator.get_migration('get_latest_ledger_transaction.sql'),
     ]

--- a/corehq/sql_accessors/sql_templates/get_latest_ledger_transaction.sql
+++ b/corehq/sql_accessors/sql_templates/get_latest_ledger_transaction.sql
@@ -7,6 +7,6 @@ BEGIN
     RETURN QUERY
     SELECT * FROM form_processor_ledgertransaction
     WHERE case_id = p_case_id AND section_id = p_section_id AND entry_id = p_entry_id
-    ORDER BY report_date DESC limit 1;
+    ORDER BY report_date DESC, "id" DESC limit 1;
 END;
 $$ LANGUAGE plpgsql;


### PR DESCRIPTION
First I modified the test a bit so I could tell if the 150 number was coming from where I expected:

``` diff
diff --git a/corehq/apps/commtrack/tests/test_xml.py b/corehq/apps/commtrack/tests/test_xml.py
index e542f3a..34f0017 100644
--- a/corehq/apps/commtrack/tests/test_xml.py
+++ b/corehq/apps/commtrack/tests/test_xml.py
@@ -389,7 +389,7 @@ class CommTrackBalanceTransferTest(CommTrackSubmissionTest):
         self.submit_xml_form(balance_submission(initial_amounts))

         # then mark some receipts
-        transfers = [(p._id, float(50 - 10*i)) for i, p in enumerate(self.products)]
+        transfers = [(p._id, float(50 - 10*i + 3)) for i, p in enumerate(self.products)]
         # then set to 50
         final = float(50)
         balance_amounts = [(p._id, final) for p in self.products]
```

This changed the error message to `AssertionError: Decimal('50.0') != 153`, which was helpful in verifying the source of the number, but did not pinpoint the root of the problem.

After running the test in a loop many times I noticed that it was failing on the SQL backend only. I tweaked the test a bit to run only against the SQL backend:

``` diff
diff --git a/corehq/apps/commtrack/tests/test_xml.py b/corehq/apps/commtrack/tests/test_xml.py
index 34f0017..925fa6c 100644
--- a/corehq/apps/commtrack/tests/test_xml.py
+++ b/corehq/apps/commtrack/tests/test_xml.py
@@ -381,7 +381,11 @@ class CommTrackBalanceTransferTest(CommTrackSubmissionTest):
         for product, amt in transfers:
             self.check_product_stock(self.sp, product, initial + amt, amt)

-    @run_with_all_backends
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
+    def setUp(self):
+        super(CommTrackBalanceTransferTest, self).setUp()
+
+    @override_settings(TESTS_SHOULD_USE_SQL_BACKEND=True)
     def test_transfer_first_doc_order(self):
         # first set to 100
         initial = float(100)
```

Immediately I saw a dramatic increase in the failure rate (probably just chance).

After poking around for a bit I zeroed in on the [`get_latest_transaction`](https://github.com/dimagi/commcare-hq/blob/b4fc360fddaaeec458129587f0683a40a295fa70/corehq/apps/commtrack/tests/test_xml.py#L222), paying particular attention to how the [SQL version](https://github.com/dimagi/commcare-hq/blob/b4fc360fddaaeec458129587f0683a40a295fa70/corehq/sql_accessors/sql_templates/get_latest_ledger_transaction.sql#L10) defined the "latest" transaction. Note the difference with ["non-SQL" version](https://github.com/dimagi/commcare-hq/blob/b4fc360fddaaeec458129587f0683a40a295fa70/corehq/ex-submodules/casexml/apps/stock/models.py#L120) (I think it's still SQL, but not sharded). After adding a break point I was able to verify that the test was sometimes generating transactions with duplicate dates:

``` py
nosetests corehq.apps.commtrack.tests.test_xml:CommTrackBalanceTransferTest.test_transfer_first_doc_order -x --verbosity=1
> /Users/dimagi/code/commcare-hq/corehq/form_processor/backends/sql/dbaccessors.py(970)get_latest_transaction()
-> return LedgerTransaction.objects.raw(
(Pdb) l
965         @staticmethod
966         def get_latest_transaction(case_id, section_id, entry_id, stop=[1]):
967             try:
968                 if stop:
969                     import bug; bug.trace()
970  ->             return LedgerTransaction.objects.raw(
971                     "SELECT * FROM get_latest_ledger_transaction(%s, %s, %s)",
972                     [case_id, section_id, entry_id]
973                 )[0]
974             except IndexError:
975                 return None
(Pdb) print "\n".join(str(x) for x in LedgerTransaction.objects.filter(case_id=case_id, section_id=section_id, entry_id=entry_id))
LedgerTransaction(form_id='69a335ccf6e84c0294c0a701da588415', server_date='2016-10-04 16:29:39.670963', report_date='2016-10-04 16:29:39.664862', type='balance', case_id='b14064c2fa9f49959a51d06f5a7092f1', entry_id='d7846889843aff9308d2c25dc1d28d7d', section_id='stock', user_defined_type='None', delta='100', updated_balance='100')
LedgerTransaction(form_id='0c0644fe7a514ddfabb79056f8df4ae9', server_date='2016-10-04 16:29:40.127196', report_date='2016-10-04 16:29:40.119990', type='transfer', case_id='b14064c2fa9f49959a51d06f5a7092f1', entry_id='d7846889843aff9308d2c25dc1d28d7d', section_id='stock', user_defined_type='None', delta='53', updated_balance='153')
LedgerTransaction(form_id='0c0644fe7a514ddfabb79056f8df4ae9', server_date='2016-10-04 16:29:40.127196', report_date='2016-10-04 16:29:40.119990', type='balance', case_id='b14064c2fa9f49959a51d06f5a7092f1', entry_id='d7846889843aff9308d2c25dc1d28d7d', section_id='stock', user_defined_type='None', delta='-103', updated_balance='50')
(Pdb) print "\n".join(str(x.id) for x in LedgerTransaction.objects.filter(case_id=case_id, section_id=section_id, entry_id=entry_id))
101
105
106
(Pdb) print "\n".join(str(x.report_date) for x in LedgerTransaction.objects.filter(case_id=case_id, section_id=section_id, entry_id=entry_id))
2016-10-04 16:29:39.664862
2016-10-04 16:29:40.119990  <------ NOTE: duplicate report_date; get_latest_ledger_transaction 
2016-10-04 16:29:40.119990          somtimes returns the wrong row
```

Since the sharded-SQL statement is only ordering by `report_date`, which is not unique, it could sometimes return the wrong row.

The fix in this PR is reliable in environments with a single shard only, although I suspect it is not much worse than the previous behavior in sharded environments. I ran the test in a loop for a long time and did not observe any failures, so I'm fairly certain this really fixes the test.

I suspect there is a real bug in `get_latest_ledger_transaction` on sharded environments. It would become apparent if two transactions with the same `report_date` for a given case/section/entry were submitted to different shards and `form_processor_ledgertransaction_id_seq` on one shard was ahead of the other, causing that shard to incorrectly have the "latest" transaction due to the (unreliable compared to other shards) value of the sequence in that shard. We could solve this issue by using a (shared) postgres sequence to tag each transaction with a monotonically increasing sequence number, and use that number in the order by clause in the proxy db to order results from all shards.

Also, I'm not sure if I need to create a database migration to make this change take effect in production, but this should at least fix the tests.

@snopoke cc @proteusvacuum 
