### PR TITLE
Migrate riak blobs to other riak

### DIFF
--- a/corehq/apps/domainsync/management/commands/copy_domain.py
+++ b/corehq/apps/domainsync/management/commands/copy_domain.py
@@ -29,7 +29,7 @@ NUM_PROCESSES = 8
 
 class Command(BaseCommand):
     help = "Copies the contents of a domain to another database. " \
-           "If tagetdb is not specified, the target is the database " \
+           "If targetdb is not specified, the target is the database " \
            "specified by COUCH_DATABASE in your settings."
     args = '<sourcedb> <domain> [<targetdb>]'
     option_list = BaseCommand.option_list + (

--- a/corehq/blobs/__init__.py
+++ b/corehq/blobs/__init__.py
@@ -6,15 +6,17 @@ DEFAULT_BUCKET = "_default"
 _db = []  # singleton/global, stack for tests to push temporary dbs
 
 
-def get_blob_db():
+def get_blob_db(django_settings=None):
     if not _db:
-        from django.conf import settings
-        db = _get_s3_db(settings)
+        if not django_settings:
+            from django.conf import settings
+            django_settings = settings
+        db = _get_s3_db(django_settings)
         if db is None:
-            db = _get_fs_db(settings)
-        elif getattr(settings, "BLOB_DB_MIGRATING_FROM_FS_TO_S3", False):
+            db = _get_fs_db(django_settings)
+        elif getattr(django_settings, "BLOB_DB_MIGRATING_FROM_FS_TO_S3", False):
             from .migratingdb import MigratingBlobDB
-            db = MigratingBlobDB(db, _get_fs_db(settings))
+            db = MigratingBlobDB(db, _get_fs_db(django_settings))
         _db.append(db)
     return _db[-1]
 

--- a/corehq/blobs/management/commands/migrate_blob_to_other_datacenter.py
+++ b/corehq/blobs/management/commands/migrate_blob_to_other_datacenter.py
@@ -1,0 +1,99 @@
+from collections import namedtuple
+import json
+from optparse import make_option
+
+from django.core.management.base import BaseCommand
+
+from couchforms.models import XFormInstance
+from corehq.apps.app_manager.models import Application, RemoteApp
+from corehq.apps.hqmedia.models import CommCareMultimedia
+
+BlobInfo = namedtuple('BlobInfo', ['type', 'id', 'external_blob_ids'])
+
+
+class Command(BaseCommand):
+    help = "Command to migrate a domain's attachemnts in the blobdb to a new blobdb"
+    args = '<domain>'
+    option_list = BaseCommand.option_list + ()
+
+    def handle(self, *args, **options):
+        domain = args[0]
+        blobs_to_copy = []
+        blobs_to_copy.extend(get_saved_exports_blobs(domain))
+        blobs_to_copy.extend(get_applications_blobs(domain))
+        blobs_to_copy.extend(get_multimedia_blobs(domain))
+        blobs_to_copy.extend(get_xforms_blobs(domain))
+        with open('test.jsonl', 'w') as f:
+            for doc in blobs_to_copy:
+                f.write(json.dumps(doc._asdict()))
+                f.write('\n')
+
+
+def get_saved_exports_blobs(domain):
+    # I think that this is only for caching exports, so not implementing
+    return []
+
+
+def get_applications_blobs(domain):
+    apps = []
+    apps.extend(Application.get_db().view(
+        'by_domain_doc_type_date/view',
+        startkey=[domain, 'Application', None],
+        endkey=[domain, 'Application', None, {}],
+        include_docs=True,
+        reduce=False,
+    ).all())
+    apps.extend(Application.get_db().view(
+        'by_domain_doc_type_date/view',
+        startkey=[domain, 'Application-Deleted', None],
+        endkey=[domain, 'Application-Deleted', None, {}],
+        include_docs=True,
+        reduce=False,
+    ).all())
+    apps.extend(RemoteApp.get_db().view(
+        'by_domain_doc_type_date/view',
+        startkey=[domain, 'RemoteApplication', None],
+        endkey=[domain, 'RemoteApplication', None, {}],
+        include_docs=True,
+        reduce=False,
+    ).all())
+    apps.extend(RemoteApp.get_db().view(
+        'by_domain_doc_type_date/view',
+        startkey=[domain, 'RemoteApplication-Deleted', None],
+        endkey=[domain, 'RemoteApplication-Deleted', None, {}],
+        include_docs=True,
+        reduce=False,
+    ).all())
+
+    return _format_return_value(apps)
+
+
+def get_multimedia_blobs(domain):
+    media = CommCareMultimedia.get_db().view(
+        'hqmedia/by_domain',
+        startkey=[domain],
+        endkey=[domain, {}],
+        include_docs=True,
+        reduce=False,
+    ).all()
+    return _format_return_value(media)
+
+
+def get_xforms_blobs(domain):
+    xforms = XFormInstance.get_db().view(
+        'couchforms/all_submissions_by_domain',
+        startkey=[domain],
+        endkey=[domain, {}],
+        include_docs=True,
+        reduce=False,
+    ).all()
+    return _format_return_value(xforms)
+
+
+def _format_return_value(docs):
+    return [
+        BlobInfo(doc['doc']['doc_type'], doc['id'],
+            [blob['id'] for blob in doc['doc']['external_blobs'].values()]
+        )
+        for doc in docs
+    ]

--- a/corehq/blobs/management/commands/migrate_blob_to_other_datacenter.py
+++ b/corehq/blobs/management/commands/migrate_blob_to_other_datacenter.py
@@ -180,6 +180,7 @@ def get_multimedia_blobs(domain):
 
 
 def get_xforms_blobs(domain):
+    # todo change to ES
     xforms = XFormInstance.get_db().view(
         'couchforms/all_submissions_by_domain',
         startkey=[domain],

--- a/corehq/blobs/management/commands/migrate_blob_to_other_datacenter.py
+++ b/corehq/blobs/management/commands/migrate_blob_to_other_datacenter.py
@@ -76,6 +76,7 @@ class Command(BaseCommand):
 
         self._set_to_data_source(options, blobs)
         self.output_blobs(blobs)
+        self.cleanup()
 
     def cleanup(self):
         if self.to_zip:

--- a/corehq/blobs/management/commands/migrate_blob_to_other_datacenter.py
+++ b/corehq/blobs/management/commands/migrate_blob_to_other_datacenter.py
@@ -99,11 +99,11 @@ class Command(BaseCommand):
             }
             to_db = get_blob_db(to_riak_settings)
 
-
         blob_zipfile = None
         if options['zip_file']:
             zfile = open(options['output_zip'], 'wb')
             blob_zipfile = zipfile.ZipFile(zfile, 'w')
+            blob_zipfile.write(options['output_jsonl'])
 
         if blob_zipfile or to_db:
             for info in blobs_to_copy:

--- a/corehq/blobs/management/commands/migrate_blob_to_other_datacenter.py
+++ b/corehq/blobs/management/commands/migrate_blob_to_other_datacenter.py
@@ -20,6 +20,8 @@ from corehq.blobs.exceptions import NotFound
 BlobInfo = namedtuple('BlobInfo', ['type', 'id', 'external_blobs'])
 MockSettings = namedtuple('MockSettings', ['S3_BLOB_DB_SETTINGS'])
 
+JSONL_NAME_IN_ZIPFILE = "blobs.jsonl"
+
 
 class Command(BaseCommand):
     help = "Command to migrate a domain's attachments in the blobdb to a new blobdb"
@@ -47,11 +49,6 @@ class Command(BaseCommand):
             action='store',
             dest='output_zip',
             default='blobs.zip',
-        ),
-        make_option('--output-jsonl-file',
-            action='store',
-            dest='output_jsonl',
-            default='blobs.jsonl',
         ),
         make_option('--no-zip-file',
             action='store_false',
@@ -129,7 +126,7 @@ class Command(BaseCommand):
             for doc in blobs_to_copy:
                 blobs_to_copy_str += json.dumps(doc._asdict()) + "\n"
 
-            zip_info = zipfile.ZipInfo(options['output_jsonl'])
+            zip_info = zipfile.ZipInfo(JSONL_NAME_IN_ZIPFILE)
             self.to_zip.writestr(zip_info, blobs_to_copy_str)
 
     def _get_blobs_to_copy(self, domain=None, options=None):
@@ -140,7 +137,7 @@ class Command(BaseCommand):
             blobs_to_copy.extend(get_multimedia_blobs(domain))
             blobs_to_copy.extend(get_xforms_blobs(domain))
         else:
-            blobs_to_copy_file = self.from_zip.open(options['output_jsonl'])
+            blobs_to_copy_file = self.from_zip.open(JSONL_NAME_IN_ZIPFILE)
             for line in blobs_to_copy_file:
                 blobs_to_copy.append(BlobInfo(**json.loads(line)))
 

--- a/corehq/blobs/management/commands/migrate_blob_to_other_datacenter.py
+++ b/corehq/blobs/management/commands/migrate_blob_to_other_datacenter.py
@@ -59,6 +59,7 @@ class Command(BaseCommand):
 
         from_riak_settings = {}
         if options['from_riak_url']:
+            print("the following options are for the from riak server ({0})".format(options['from_riak_url']))
             access_key = getpass("Please enter the from riak access key: ")
             secret_key = getpass("Please enter the from riak secret key: ")
             from_riak_settings = {
@@ -87,6 +88,7 @@ class Command(BaseCommand):
         to_riak_settings = {}
         to_db = None
         if options['to_riak_url']:
+            print("the following options are for the to riak server ({0})".format(options['to_riak_url']))
             access_key = getpass("Please enter the to riak access key: ")
             secret_key = getpass("Please enter the to riak secret key: ")
             from_riak_settings = {

--- a/corehq/blobs/management/commands/migrate_blob_to_other_datacenter.py
+++ b/corehq/blobs/management/commands/migrate_blob_to_other_datacenter.py
@@ -105,26 +105,27 @@ class Command(BaseCommand):
             zfile = open(options['output_zip'], 'wb')
             blob_zipfile = zipfile.ZipFile(zfile, 'w')
 
-        for info in blobs_to_copy:
-            bucket = join(_get_couchdb_name(eval(info.type)), safe_id(info.id))
-            for blob_id in info.external_blob_ids:
-                try:
-                    blob = db.get(blob_id, bucket).read()
-                except NotFound as e:
-                    print('Blob Not Found: ' + str(e))
-                else:
-                    if blob_zipfile:
-                        zip_info = zipfile.ZipInfo(join(bucket, blob_id))
-                        blob_zipfile.writestr(zip_info, blob)
-                    if to_db:
-                        print('writing blob ' + zip_info.filename)
-                        if isinstance(blob, unicode):
-                            content = StringIO(blob.encode("utf-8"))
-                        elif isinstance(blob, bytes):
-                            content = StringIO(blob)
-                        else:
-                            content = blob
-                        to_db.put(content, blob_id, bucket)
+        if blob_zipfile or to_db:
+            for info in blobs_to_copy:
+                bucket = join(_get_couchdb_name(eval(info.type)), safe_id(info.id))
+                for blob_id in info.external_blob_ids:
+                    try:
+                        blob = db.get(blob_id, bucket).read()
+                    except NotFound as e:
+                        print('Blob Not Found: ' + str(e))
+                    else:
+                        if blob_zipfile:
+                            zip_info = zipfile.ZipInfo(join(bucket, blob_id))
+                            blob_zipfile.writestr(zip_info, blob)
+                        if to_db:
+                            print('writing blob ' + zip_info.filename)
+                            if isinstance(blob, unicode):
+                                content = StringIO(blob.encode("utf-8"))
+                            elif isinstance(blob, bytes):
+                                content = StringIO(blob)
+                            else:
+                                content = blob
+                            to_db.put(content, blob_id, bucket)
 
         if blob_zipfile:
             blob_zipfile.close()

--- a/corehq/blobs/migrate.py
+++ b/corehq/blobs/migrate.py
@@ -12,7 +12,7 @@ can be run:
 The migration may be done automatically when running `./manage.py migrate`
 if there are only a few documents to be migrated. However, if there are
 many documents to be migrated then the normal migration process will
-stop and propmpt you to run the blob migration manually before
+stop and prompt you to run the blob migration manually before
 continuing with the normal migration process.
 
 ## Writing new migrations


### PR DESCRIPTION
This allows you to copy all external attachments stored in riak from one domain or in a zip file to either a zip file or another riak cluster.

Going to test this out by copying attachments from staging to my local install

@snopoke @czue 
