### PR TITLE
Location restricted UCR

### DIFF
--- a/corehq/apps/locations/middleware.py
+++ b/corehq/apps/locations/middleware.py
@@ -26,7 +26,7 @@ class LocationAccessMiddleware(object):
         else:
             request.can_access_all_locations = False
             if (
-                not is_location_safe(view_fn, view_args, view_kwargs, request)
+                not is_location_safe(view_fn, view_args, view_kwargs)
                 or not user.get_sql_location(domain)
             ):
                 return location_restricted_response(request)

--- a/corehq/apps/locations/middleware.py
+++ b/corehq/apps/locations/middleware.py
@@ -26,7 +26,7 @@ class LocationAccessMiddleware(object):
         else:
             request.can_access_all_locations = False
             if (
-                not is_location_safe(view_fn, view_args, view_kwargs)
+                not is_location_safe(view_fn, view_args, view_kwargs, request)
                 or not user.get_sql_location(domain)
             ):
                 return location_restricted_response(request)

--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -324,6 +324,20 @@ class LocationManager(LocationQueriesMixin, TreeManager):
         direct_matches = self.filter_by_user_input(domain, user_input)
         return self.get_queryset_descendants(direct_matches, include_self=True)
 
+    def filter_by_user_input_accessible_to_user(self, domain, user, user_input):
+        if user.has_permission(domain, 'access_all_locations'):
+            return self.filter_by_user_input(domain, user_input)
+
+        users_location = user.get_sql_location(domain)
+        return (users_location.get_descendants(include_self=True)
+                .filter(domain=domain)
+                .filter(models.Q(name__icontains=user_input) |
+                        models.Q(site_code__icontains=user_input)))
+
+    def filter_path_by_user_input_accessible_to_user(self, domain, user, user_input):
+        direct_matches = self.filter_by_user_input_accessible_to_user(domain, user, user_input)
+        return self.get_queryset_descendants(direct_matches, include_self=True)
+
     def accessible_to_user(self, domain, user):
         if user.has_permission(domain, 'access_all_locations'):
             return self.get_queryset()

--- a/corehq/apps/locations/models.py
+++ b/corehq/apps/locations/models.py
@@ -276,7 +276,12 @@ class LocationQueriesMixin(object):
 
 
 class LocationQuerySet(LocationQueriesMixin, models.query.QuerySet):
-    pass
+    def accessible_to_user(self, domain, user):
+        if user.has_permission(domain, 'access_all_locations'):
+            return self
+
+        users_location = user.get_sql_location(domain)
+        return self & users_location.get_descendants(include_self=True)
 
 
 class LocationManager(LocationQueriesMixin, TreeManager):
@@ -324,19 +329,6 @@ class LocationManager(LocationQueriesMixin, TreeManager):
         direct_matches = self.filter_by_user_input(domain, user_input)
         return self.get_queryset_descendants(direct_matches, include_self=True)
 
-    def filter_by_user_input_accessible_to_user(self, domain, user, user_input):
-        if user.has_permission(domain, 'access_all_locations'):
-            return self.filter_by_user_input(domain, user_input)
-
-        users_location = user.get_sql_location(domain)
-        return (users_location.get_descendants(include_self=True)
-                .filter(domain=domain)
-                .filter(models.Q(name__icontains=user_input) |
-                        models.Q(site_code__icontains=user_input)))
-
-    def filter_path_by_user_input_accessible_to_user(self, domain, user, user_input):
-        direct_matches = self.filter_by_user_input_accessible_to_user(domain, user, user_input)
-        return self.get_queryset_descendants(direct_matches, include_self=True)
 
     def accessible_to_user(self, domain, user):
         if user.has_permission(domain, 'access_all_locations'):

--- a/corehq/apps/locations/permissions.py
+++ b/corehq/apps/locations/permissions.py
@@ -176,13 +176,12 @@ def conditionally_location_safe(conditional_function):
     return _inner
 
 
-
 def location_restricted_response(request):
     from corehq.apps.hqwebapp.views import no_permissions
     return no_permissions(request, message=LOCATION_ACCESS_DENIED)
 
 
-def is_location_safe(view_fn, view_args, view_kwargs):
+def is_location_safe(view_fn, view_args, view_kwargs, request=None):
     """
     Check if view_fn had the @location_safe decorator applied.
     view_args and kwargs are also needed because view_fn alone doesn't always
@@ -193,7 +192,7 @@ def is_location_safe(view_fn, view_args, view_kwargs):
     if 'resource_name' in view_kwargs:
         return view_kwargs['resource_name'] in LOCATION_SAFE_TASTYPIE_RESOURCES
     if getattr(view_fn, '_conditionally_location_safe_function', False):
-        return view_fn._conditionally_location_safe_function(*view_args, **view_kwargs)
+        return view_fn._conditionally_location_safe_function(view_fn, request, *view_args, **view_kwargs)
     return False
 
 

--- a/corehq/apps/locations/permissions.py
+++ b/corehq/apps/locations/permissions.py
@@ -181,7 +181,7 @@ def location_restricted_response(request):
     return no_permissions(request, message=LOCATION_ACCESS_DENIED)
 
 
-def is_location_safe(view_fn, view_args, view_kwargs, request=None):
+def is_location_safe(view_fn, view_args, view_kwargs):
     """
     Check if view_fn had the @location_safe decorator applied.
     view_args and kwargs are also needed because view_fn alone doesn't always
@@ -192,7 +192,7 @@ def is_location_safe(view_fn, view_args, view_kwargs, request=None):
     if 'resource_name' in view_kwargs:
         return view_kwargs['resource_name'] in LOCATION_SAFE_TASTYPIE_RESOURCES
     if getattr(view_fn, '_conditionally_location_safe_function', False):
-        return view_fn._conditionally_location_safe_function(view_fn, request, *view_args, **view_kwargs)
+        return view_fn._conditionally_location_safe_function(view_fn, *view_args, **view_kwargs)
     return False
 
 

--- a/corehq/apps/locations/permissions.py
+++ b/corehq/apps/locations/permissions.py
@@ -164,6 +164,19 @@ def tastypie_location_safe(resource):
     return resource
 
 
+def conditionally_location_safe(conditional_function):
+    """Decorator to apply to a view function that verifies if something is location
+    safe based on the arguments or kwarguments. That function should return
+    True or False.
+
+    """
+    def _inner(view_fn):
+        view_fn._conditionally_location_safe_function = conditional_function
+        return view_fn
+    return _inner
+
+
+
 def location_restricted_response(request):
     from corehq.apps.hqwebapp.views import no_permissions
     return no_permissions(request, message=LOCATION_ACCESS_DENIED)
@@ -179,6 +192,8 @@ def is_location_safe(view_fn, view_args, view_kwargs):
         return True
     if 'resource_name' in view_kwargs:
         return view_kwargs['resource_name'] in LOCATION_SAFE_TASTYPIE_RESOURCES
+    if getattr(view_fn, '_conditionally_location_safe_function', False):
+        return view_fn._conditionally_location_safe_function(*view_args, **view_kwargs)
     return False
 
 

--- a/corehq/apps/locations/tests/test_location_queries.py
+++ b/corehq/apps/locations/tests/test_location_queries.py
@@ -68,7 +68,7 @@ class TestLocationScopedQueryset(BaseTestLocationQuerysetMethods):
         self.assertItemsEqual(self.locations.values(), all_locs)
 
     def test_location_restricted(self):
-        self._restrict_user_location()
+        self.restrict_user_to_location(self.web_user)
         accessible_locs = (
             SQLLocation.objects.accessible_to_user(self.domain, self.web_user)
         )
@@ -79,7 +79,7 @@ class TestLocationScopedQueryset(BaseTestLocationQuerysetMethods):
         )
 
     def test_filter_path_by_user_input(self):
-        self._restrict_user_location()
+        self.restrict_user_to_location(self.web_user)
 
         # User searching for higher in the hierarchy is only given the items
         # they are allowed to see
@@ -100,12 +100,3 @@ class TestLocationScopedQueryset(BaseTestLocationQuerysetMethods):
             .accessible_to_user(self.domain, self.web_user)
         )
         self.assertItemsEqual([], no_locs)
-
-    def _restrict_user_location(self):
-        role = UserRole(
-            domain=self.domain,
-            name='Regional Supervisor',
-            permissions=Permissions(access_all_locations=False),
-        )
-        role.save()
-        self.web_user.set_role(self.domain, role.get_qualified_id())

--- a/corehq/apps/locations/tests/test_location_queries.py
+++ b/corehq/apps/locations/tests/test_location_queries.py
@@ -1,6 +1,6 @@
 from ..models import SQLLocation
 from .util import LocationHierarchyTestCase
-from corehq.apps.users.models import  WebUser, UserRole, Permissions
+from corehq.apps.users.models import WebUser
 from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 
 
@@ -17,6 +17,7 @@ class BaseTestLocationQuerysetMethods(LocationHierarchyTestCase):
             ])
         ])
     ]
+
 
 class TestLocationQuerysetMethods(BaseTestLocationQuerysetMethods):
 

--- a/corehq/apps/locations/tests/test_location_queries.py
+++ b/corehq/apps/locations/tests/test_location_queries.py
@@ -1,9 +1,10 @@
 from ..models import SQLLocation
 from .util import LocationHierarchyTestCase
+from corehq.apps.users.models import  WebUser, UserRole, Permissions
+from corehq.apps.users.dbaccessors.all_commcare_users import delete_all_users
 
 
-class TestLocationQuerysetMethods(LocationHierarchyTestCase):
-
+class BaseTestLocationQuerysetMethods(LocationHierarchyTestCase):
     location_type_names = ['state', 'county', 'city']
     location_structure = [
         ('Massachusetts', [
@@ -16,6 +17,8 @@ class TestLocationQuerysetMethods(LocationHierarchyTestCase):
             ])
         ])
     ]
+
+class TestLocationQuerysetMethods(BaseTestLocationQuerysetMethods):
 
     def test_filter_by_user_input(self):
         middlesex_locs = (SQLLocation.objects
@@ -40,3 +43,69 @@ class TestLocationQuerysetMethods(LocationHierarchyTestCase):
             ['Middlesex', 'Cambridge', 'Somerville'],
             [loc.name for loc in middlesex_locs]
         )
+
+
+class TestLocationScopedQueryset(BaseTestLocationQuerysetMethods):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestLocationScopedQueryset, cls).setUpClass()
+        delete_all_users()
+
+    def setUp(self):
+        super(TestLocationScopedQueryset, self).setUp()
+        self.web_user = WebUser.create(self.domain, 'blah', 'password')
+        self.web_user.set_location(self.domain, self.locations['Middlesex'])
+
+    def tearDown(self):
+        delete_all_users()
+        super(TestLocationScopedQueryset, self).tearDown()
+
+    def test_access_all_locations_enabled(self):
+        all_locs = (
+            SQLLocation.objects.accessible_to_user(self.domain, self.web_user)
+        )
+        self.assertItemsEqual(self.locations.values(), all_locs)
+
+    def test_location_restricted(self):
+        self._restrict_user_location()
+        accessible_locs = (
+            SQLLocation.objects.accessible_to_user(self.domain, self.web_user)
+        )
+
+        self.assertItemsEqual(
+            [self.locations[location] for location in ["Middlesex", "Cambridge", "Somerville"]],
+            accessible_locs
+        )
+
+    def test_filter_path_by_user_input(self):
+        self._restrict_user_location()
+
+        # User searching for higher in the hierarchy is only given the items
+        # they are allowed to see
+        middlesex_locs = (
+            SQLLocation.objects
+            .filter_path_by_user_input(self.domain, "Massachusetts")
+            .accessible_to_user(self.domain, self.web_user)
+        )
+        self.assertItemsEqual(
+            ['Middlesex', 'Cambridge', 'Somerville'],
+            [loc.name for loc in middlesex_locs]
+        )
+
+        # User searching for a branch they don't have access to get nothing
+        no_locs = (
+            SQLLocation.objects
+            .filter_path_by_user_input(self.domain, "Suffolk")
+            .accessible_to_user(self.domain, self.web_user)
+        )
+        self.assertItemsEqual([], no_locs)
+
+    def _restrict_user_location(self):
+        role = UserRole(
+            domain=self.domain,
+            name='Regional Supervisor',
+            permissions=Permissions(access_all_locations=False),
+        )
+        role.save()
+        self.web_user.set_role(self.domain, role.get_qualified_id())

--- a/corehq/apps/locations/tests/util.py
+++ b/corehq/apps/locations/tests/util.py
@@ -5,6 +5,7 @@ from corehq.util.test_utils import unit_testing_only
 from corehq.apps.commtrack.models import SupplyPointCase
 from corehq.apps.commtrack.tests.util import bootstrap_domain
 from corehq.dbaccessors.couchapps.all_docs import delete_all_docs_by_doc_type
+from corehq.apps.users.models import UserRole, Permissions
 
 from ..models import Location, SQLLocation, LocationType
 
@@ -151,6 +152,15 @@ class LocationHierarchyTestCase(TestCase):
     def tearDownClass(cls):
         cls.domain_obj.delete()
         delete_all_locations()
+
+    def restrict_user_to_location(self, user):
+        role = UserRole(
+            domain=self.domain,
+            name='Regional Supervisor',
+            permissions=Permissions(access_all_locations=False),
+        )
+        role.save()
+        user.set_role(self.domain, role.get_qualified_id())
 
 
 class LocationHierarchyPerTest(TestCase):

--- a/corehq/apps/reports_core/filters.py
+++ b/corehq/apps/reports_core/filters.py
@@ -266,10 +266,10 @@ class DynamicChoiceListFilter(BaseFilter):
 
     def context(self, values, lang=None):
         context = super(DynamicChoiceListFilter, self).context(values, lang)
-        context['value'] = self._values_to_dict(values)
+        context['value'] = self._format_values_for_display(values)
         return context
 
-    def _values_to_dict(self, values):
+    def _format_values_for_display(self, values):
         """Some values are returned as Choice objects which need to be converted to
         dicts to be displayed properly
         """

--- a/corehq/apps/reports_core/filters.py
+++ b/corehq/apps/reports_core/filters.py
@@ -25,7 +25,7 @@ class BaseFilter(object):
         self.name = name
         self.params = params or []
 
-    def get_value(self, context, user):
+    def get_value(self, context, user=None):
         kwargs = {
             "request_user": user
         }

--- a/corehq/apps/reports_core/filters.py
+++ b/corehq/apps/reports_core/filters.py
@@ -64,20 +64,10 @@ class BaseFilter(object):
         context = {
             'label': localize(self.label, lang),
             'css_id': self.css_id,
-            'value': self._values_to_dict(values),
+            'value': values,
         }
         context.update(self.filter_context())
         return context
-
-    def _values_to_dict(self, values):
-        """Some values are returned as Choice objects which need to be converted to
-        dicts to be displayed properly
-        """
-        if values:
-            return [
-                dict(value._asdict()) if isinstance(value, Choice) else value
-                for value in values
-            ]
 
     def filter_context(self):
         """
@@ -274,6 +264,21 @@ class DynamicChoiceListFilter(BaseFilter):
         self.url_generator = url_generator
         self.choice_provider = choice_provider
 
+    def context(self, values, lang=None):
+        context = super(DynamicChoiceListFilter, self).context(values, lang)
+        context['value'] = self._values_to_dict(values)
+        return context
+
+    def _values_to_dict(self, values):
+        """Some values are returned as Choice objects which need to be converted to
+        dicts to be displayed properly
+        """
+        if values:
+            return [
+                dict(value._asdict()) if isinstance(value, Choice) else value
+                for value in values
+            ]
+
     def value(self, **kwargs):
         selection = unicode(kwargs.get(self.name, ""))
         if selection:
@@ -288,4 +293,4 @@ class DynamicChoiceListFilter(BaseFilter):
             if choice_provider_default is not None:
                 return choice_provider_default
 
-        return [Choice(SHOW_ALL_CHOICE, ugettext('Show all'))]
+        return [Choice(SHOW_ALL_CHOICE, "[{}]".format(ugettext('Show All')))]

--- a/corehq/apps/reports_core/templates/reports_core/filters/dynamic_choice_list_filter/dynamic_choice_list.html
+++ b/corehq/apps/reports_core/templates/reports_core/filters/dynamic_choice_list_filter/dynamic_choice_list.html
@@ -2,5 +2,7 @@
 {% block filter-controls %}
     <input type="hidden"
            class="form-control"
-           name="{{ filter.css_id }}" id="{{ filter.css_id }}-input" />
+           name="{{ context_.css_id }}"
+           id="{{ context_.css_id }}-input"
+    />
 {% endblock %}

--- a/corehq/apps/reports_core/templates/reports_core/filters/dynamic_choice_list_filter/dynamic_choice_list.js
+++ b/corehq/apps/reports_core/templates/reports_core/filters/dynamic_choice_list_filter/dynamic_choice_list.js
@@ -1,10 +1,14 @@
 {% load reports_core_tags %}
+{% load hq_shared_tags %}
 // note: this depends on choice-list-api.js
-var filter_id = "#{{ filter.css_id }}-input";
+var filter_id = "#{{ context_.css_id }}-input",
+    initialValues = _.map({{context_.value|JSON}}, function(value){
+        return choiceListUtils.formatValueForSelect2(value);
+    }),
 // TODO: Ideally the separator would be defined in one place. Right now it is
 //       also defined corehq.apps.userreports.reports.filters.CHOICE_DELIMITER
-var separator = "\u001F";
-var initialValues = $(filter_id).val() !== "" ? $(filter_id).val().split(separator) : [];
+    separator = "\u001F";
+
 $(filter_id).select2({
     minimumInputLength: 0,
     multiple: true,
@@ -21,6 +25,4 @@ $(filter_id).select2({
         cache: true
     }
 });
-$(filter_id).select2('data', _.map(initialValues, function(v){
-    return {id: v, text: v};
-}));
+$(filter_id).select2('data', initialValues);

--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -100,6 +100,10 @@ class ChainableChoiceProvider(ChoiceProvider):
     def query_count(self, query_context):
         pass
 
+    @abstractmethod
+    def default_value(self, user):
+        pass
+
 
 class DataSourceColumnChoiceProvider(ChoiceProvider):
 

--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -160,15 +160,14 @@ class LocationChoiceProvider(ChainableChoiceProvider):
         self.include_descendants = spec.get('include_descendants', self.include_descendants)
 
     def _locations_query(self, query_text, user):
-        location_queryset = SQLLocation.active_objects
+        active_locations = SQLLocation.active_objects
         if query_text:
-            return location_queryset.filter_path_by_user_input_accessible_to_user(
+            return active_locations.filter_path_by_user_input(
                 domain=self.domain,
-                user=user,
                 user_input=query_text
-            )
+            ).accessible_to_user(self.domain, user)
 
-        return location_queryset.accessible_to_user(self.domain, user).filter(domain=self.domain)
+        return active_locations.accessible_to_user(self.domain, user).filter(domain=self.domain)
 
     def query(self, query_context):
         # todo: consider making this an extensions framework similar to custom expressions

--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -160,14 +160,15 @@ class LocationChoiceProvider(ChainableChoiceProvider):
         self.include_descendants = spec.get('include_descendants', self.include_descendants)
 
     def _locations_query(self, query_text, user):
-        location_queryset = SQLLocation.active_objects.accessible_to_user(self.domain, user)
+        location_queryset = SQLLocation.active_objects
         if query_text:
-            return location_queryset.filter_path_by_user_input(
+            return location_queryset.filter_path_by_user_input_accessible_to_user(
                 domain=self.domain,
+                user=user,
                 user_input=query_text
             )
 
-        return location_queryset.filter(domain=self.domain)
+        return location_queryset.accessible_to_user(self.domain, user).filter(domain=self.domain)
 
     def query(self, query_context):
         # todo: consider making this an extensions framework similar to custom expressions

--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -43,6 +43,8 @@ class ChoiceQueryContext(object):
 class ChoiceProvider(object):
     __metaclass__ = ABCMeta
 
+    location_safe = False
+
     def __init__(self, report, filter_slug):
         self.report = report
         self.filter_slug = filter_slug
@@ -140,6 +142,8 @@ class DataSourceColumnChoiceProvider(ChoiceProvider):
 
 
 class LocationChoiceProvider(ChainableChoiceProvider):
+
+    location_safe = True
 
     def __init__(self, report, filter_slug):
         super(LocationChoiceProvider, self).__init__(report, filter_slug)

--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -190,8 +190,13 @@ class LocationChoiceProvider(ChainableChoiceProvider):
     def default_value(self, user):
         """Return only the locations this user can access
         """
+        location = user.get_sql_location(self.domain)
+        if location:
+            return self._locations_to_choices([location])
+
         return self._locations_to_choices(
-            self._locations_query(query_text=None, user=user))
+            self._locations_query(query_text=None, user=user)
+        )
 
     def _locations_to_choices(self, locations):
         return [Choice(loc.location_id, loc.display_name) for loc in locations]

--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -224,7 +224,7 @@ class UserChoiceProvider(ChainableChoiceProvider):
         return [Choice(user_id, raw_username(username))
                 for user_id, username in user_es.values_list('_id', 'username')]
 
-    def default_value(self):
+    def default_value(self, user):
         return None
 
 
@@ -254,7 +254,7 @@ class GroupChoiceProvider(ChainableChoiceProvider):
         return [Choice(group_id, name)
                 for group_id, name in group_es.values_list('_id', 'name')]
 
-    def default_value(self):
+    def default_value(self, user):
         return None
 
 

--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -149,12 +149,14 @@ class LocationChoiceProvider(ChainableChoiceProvider):
         self.include_descendants = spec.get('include_descendants', self.include_descendants)
 
     def _locations_query(self, query_text, user):
+        location_queryset = SQLLocation.active_objects.accessible_to_user(self.domain, user)
         if query_text:
-            return SQLLocation.active_objects.filter_path_by_user_input(
-                domain=self.domain, user_input=query_text)
-        else:
-            return SQLLocation.active_objects.accessible_to_user(self.domain, user).filter(domain=self.domain)
-            # return SQLLocation.active_objects.filter(domain=self.domain)
+            return location_queryset.filter_path_by_user_input(
+                domain=self.domain,
+                user_input=query_text
+            )
+
+        return location_queryset.filter(domain=self.domain)
 
     def query(self, query_context):
         # todo: consider making this an extensions framework similar to custom expressions

--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -224,6 +224,9 @@ class UserChoiceProvider(ChainableChoiceProvider):
         return [Choice(user_id, raw_username(username))
                 for user_id, username in user_es.values_list('_id', 'username')]
 
+    def default_value(self):
+        return None
+
 
 class GroupChoiceProvider(ChainableChoiceProvider):
 
@@ -250,6 +253,9 @@ class GroupChoiceProvider(ChainableChoiceProvider):
     def get_choices_from_es_query(group_es):
         return [Choice(group_id, name)
                 for group_id, name in group_es.values_list('_id', 'name')]
+
+    def default_value(self):
+        return None
 
 
 class AbstractMultiProvider(ChoiceProvider):

--- a/corehq/apps/userreports/reports/filters/choice_providers.py
+++ b/corehq/apps/userreports/reports/filters/choice_providers.py
@@ -168,9 +168,6 @@ class LocationChoiceProvider(ChainableChoiceProvider):
 
     def query(self, query_context):
         # todo: consider making this an extensions framework similar to custom expressions
-        # todo: does this need fancier permission restrictions and what not?
-        # see e.g. locations.views.child_locations_for_select2
-
         locations = self._locations_query(query_context.query, query_context.user).order_by('name')
 
         return [
@@ -188,7 +185,16 @@ class LocationChoiceProvider(ChainableChoiceProvider):
                 selected_locations, include_self=True
             )
 
-        return [Choice(loc.location_id, loc.display_name) for loc in selected_locations]
+        return self._locations_to_choices(selected_locations)
+
+    def default_value(self, user):
+        """Return only the locations this user can access
+        """
+        return self._locations_to_choices(
+            self._locations_query(query_text=None, user=user))
+
+    def _locations_to_choices(self, locations):
+        return [Choice(loc.location_id, loc.display_name) for loc in locations]
 
 
 class UserChoiceProvider(ChainableChoiceProvider):

--- a/corehq/apps/userreports/reports/util.py
+++ b/corehq/apps/userreports/reports/util.py
@@ -11,3 +11,15 @@ def get_expanded_columns(column_configs, data_source_config):
         for column_config in column_configs
         if column_config.type == 'expanded'
     }
+
+
+def has_location_filter(view_fn, *args, **kwargs):
+    """check that the report has at least one location choice provider filter
+    """
+    from corehq.apps.userreports.reports.view import ConfigurableReport
+    report = ConfigurableReport(args=args, kwargs=kwargs)
+    return any(
+        filter_.choice_provider.location_safe
+        if hasattr(filter_, 'choice_provider') else False
+        for filter_ in report.filters
+    )

--- a/corehq/apps/userreports/reports/util.py
+++ b/corehq/apps/userreports/reports/util.py
@@ -1,3 +1,4 @@
+from corehq.apps.userreports.models import get_report_config
 from corehq.apps.userreports.sql import get_expanded_column_config
 
 
@@ -16,10 +17,9 @@ def get_expanded_columns(column_configs, data_source_config):
 def has_location_filter(view_fn, *args, **kwargs):
     """check that the report has at least one location choice provider filter
     """
-    from corehq.apps.userreports.reports.view import ConfigurableReport
-    report = ConfigurableReport(args=args, kwargs=kwargs)
+    report, _ = get_report_config(config_id=kwargs.get('subreport_slug'), domain=kwargs.get('domain'))
     return any(
         filter_.choice_provider.location_safe
         if hasattr(filter_, 'choice_provider') else False
-        for filter_ in report.filters
+        for filter_ in report.ui_filters
     )

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -184,7 +184,7 @@ class ConfigurableReport(JSONResponseMixin, BaseDomainView):
     @property
     @memoized
     def filter_values(self):
-        return get_filter_values(self.filters, self.request_dict, self.request.user)
+        return get_filter_values(self.filters, self.request_dict, self.request.couch_user)
 
     @property
     @memoized

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -98,7 +98,7 @@ def query_dict_to_dict(query_dict, domain):
     return request_dict
 
 
-def _has_location_filter(view_fn, request, *args, **kwargs):
+def _has_location_filter(view_fn, *args, **kwargs):
     """check that the report has at least one location choice provider filter
     """
     # God help me.

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -65,7 +65,7 @@ from corehq.apps.reports.datatables import DataTablesHeader
 UCR_EXPORT_TO_EXCEL_ROW_LIMIT = 1000
 
 
-def get_filter_values(filters, request_dict):
+def get_filter_values(filters, request_dict, user=None):
     """
     Return a dictionary mapping filter ids to specified values
     :param filters: A list of corehq.apps.reports_core.filters.BaseFilter
@@ -75,7 +75,7 @@ def get_filter_values(filters, request_dict):
     """
     try:
         return {
-            filter.css_id: filter.get_value(request_dict)
+            filter.css_id: filter.get_value(request_dict, user)
             for filter in filters
         }
     except FilterException, e:
@@ -184,7 +184,7 @@ class ConfigurableReport(JSONResponseMixin, BaseDomainView):
     @property
     @memoized
     def filter_values(self):
-        return get_filter_values(self.filters, self.request_dict)
+        return get_filter_values(self.filters, self.request_dict, self.request.user)
 
     @property
     @memoized

--- a/corehq/apps/userreports/reports/view.py
+++ b/corehq/apps/userreports/reports/view.py
@@ -200,7 +200,11 @@ class ConfigurableReport(JSONResponseMixin, BaseDomainView):
     @property
     @memoized
     def filter_values(self):
-        return get_filter_values(self.filters, self.request_dict, self.request.couch_user)
+        try:
+            user = self.request.couch_user
+        except AttributeError:
+            user = None
+        return get_filter_values(self.filters, self.request_dict, user=user)
 
     @property
     @memoized

--- a/corehq/apps/userreports/tests/test_choice_provider.py
+++ b/corehq/apps/userreports/tests/test_choice_provider.py
@@ -202,9 +202,9 @@ class LocationChoiceProviderTest(ChoiceProviderTestMixin, LocationHierarchyTestC
                 searchable_text=[location.site_code, location.name]
             )
             for location in [
-                    self.locations['Cambridge'],
-                    self.locations['Middlesex'],
-                    self.locations['Somerville'],
+                self.locations['Cambridge'],
+                self.locations['Middlesex'],
+                self.locations['Somerville'],
             ]
         ]
         self.static_choice_provider = StaticChoiceProvider(scoped_choices)

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -37,6 +37,7 @@ from couchexport.files import Temp
 from couchexport.models import Format
 from couchexport.shortcuts import export_response
 from dimagi.utils.decorators.memoized import memoized
+from corehq.util.quickcache import quickcache
 from dimagi.utils.logging import notify_exception
 from dimagi.utils.web import json_response
 
@@ -47,6 +48,7 @@ from corehq.apps.app_manager.models import Application, Form
 from corehq.apps.app_manager.util import purge_report_from_mobile_ucr
 from corehq.apps.dashboard.models import IconContext, TileConfiguration, Tile
 from corehq.apps.domain.decorators import login_and_domain_required, login_or_basic
+from corehq.apps.locations.permissions import conditionally_location_safe
 from corehq.apps.domain.views import BaseDomainView
 from corehq.apps.reports.dispatcher import cls_to_view_login_and_domain
 from corehq.apps.style.decorators import (
@@ -81,7 +83,10 @@ from corehq.apps.userreports.reports.builder.forms import (
     ConfigureListReportForm,
     ConfigureWorkerReportForm,
     ConfigureMapReportForm)
-from corehq.apps.userreports.reports.filters.choice_providers import ChoiceQueryContext
+from corehq.apps.userreports.reports.filters.choice_providers import (
+    ChoiceQueryContext,
+    LocationChoiceProvider
+)
 from corehq.apps.userreports.reports.view import ConfigurableReport
 from corehq.apps.userreports.sql import IndicatorSqlAdapter
 from corehq.apps.userreports.tasks import rebuild_indicators, resume_building_indicators
@@ -1215,14 +1220,24 @@ def data_source_status(request, domain, config_id):
     config, _ = get_datasource_config_or_404(config_id, domain)
     return json_response({'isBuilt': config.meta.build.finished})
 
-
-@login_and_domain_required
-def choice_list_api(request, domain, report_id, filter_id):
+@quickcache(['domain', 'report_id', 'filter_id'], timeout=5 * 60)
+def _get_report_filter(domain, report_id, filter_id):
     report = get_report_config_or_404(report_id, domain)[0]
     report_filter = report.get_ui_filter(filter_id)
     if report_filter is None:
         raise Http404(_(u'Filter {} not found!').format(filter_id))
+    return report_filter
 
+def _is_location_safe_choice_list(domain, report_id, filter_id):
+    report_filter = _get_report_filter(domain, report_id, filter_id)
+    if hasattr(report_filter, 'choice_provider'):
+        return report_filter.choice_provider.location_safe
+    return False
+
+@login_and_domain_required
+@conditionally_location_safe(_is_location_safe_choice_list)
+def choice_list_api(request, domain, report_id, filter_id):
+    report_filter = _get_report_filter(domain, report_id, filter_id)
     if hasattr(report_filter, 'choice_provider'):
         query_context = ChoiceQueryContext(
             query=request.GET.get('q', None),

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1228,7 +1228,7 @@ def _get_report_filter(domain, report_id, filter_id):
     return report_filter
 
 
-def _is_location_safe_choice_list(view_fn, request, domain, report_id, filter_id, **view_kwargs):
+def _is_location_safe_choice_list(view_fn, domain, report_id, filter_id, **view_kwargs):
     report_filter = _get_report_filter(domain, report_id, filter_id)
     if hasattr(report_filter, 'choice_provider'):
         return report_filter.choice_provider.location_safe

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1230,7 +1230,7 @@ def _get_report_filter(domain, report_id, filter_id):
     return report_filter
 
 
-def _is_location_safe_choice_list(domain, report_id, filter_id):
+def _is_location_safe_choice_list(view_fn, request, domain, report_id, filter_id, **view_kwargs):
     report_filter = _get_report_filter(domain, report_id, filter_id)
     if hasattr(report_filter, 'choice_provider'):
         return report_filter.choice_provider.location_safe

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -37,7 +37,6 @@ from couchexport.files import Temp
 from couchexport.models import Format
 from couchexport.shortcuts import export_response
 from dimagi.utils.decorators.memoized import memoized
-from corehq.util.quickcache import quickcache
 from dimagi.utils.logging import notify_exception
 from dimagi.utils.web import json_response
 
@@ -85,7 +84,6 @@ from corehq.apps.userreports.reports.builder.forms import (
     ConfigureMapReportForm)
 from corehq.apps.userreports.reports.filters.choice_providers import (
     ChoiceQueryContext,
-    LocationChoiceProvider
 )
 from corehq.apps.userreports.reports.view import ConfigurableReport
 from corehq.apps.userreports.sql import IndicatorSqlAdapter

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -101,6 +101,7 @@ from corehq.apps.userreports.util import (
     allowed_report_builder_reports,
     number_of_report_builder_reports
 )
+from corehq.apps.userreports.reports.util import has_location_filter
 from corehq.apps.users.decorators import require_permission
 from corehq.apps.users.models import Permissions
 from corehq.util.couch import get_document_or_404
@@ -1229,10 +1230,7 @@ def _get_report_filter(domain, report_id, filter_id):
 
 
 def _is_location_safe_choice_list(view_fn, domain, report_id, filter_id, **view_kwargs):
-    report_filter = _get_report_filter(domain, report_id, filter_id)
-    if hasattr(report_filter, 'choice_provider'):
-        return report_filter.choice_provider.location_safe
-    return False
+    return has_location_filter(view_fn, domain=domain, subreport_slug=report_id)
 
 
 @login_and_domain_required

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1227,7 +1227,8 @@ def choice_list_api(request, domain, report_id, filter_id):
         query_context = ChoiceQueryContext(
             query=request.GET.get('q', None),
             limit=int(request.GET.get('limit', 20)),
-            page=int(request.GET.get('page', 1)) - 1
+            page=int(request.GET.get('page', 1)) - 1,
+            user=request.couch_user
         )
         return json_response([
             choice._asdict() for choice in

--- a/corehq/apps/userreports/views.py
+++ b/corehq/apps/userreports/views.py
@@ -1220,6 +1220,7 @@ def data_source_status(request, domain, config_id):
     config, _ = get_datasource_config_or_404(config_id, domain)
     return json_response({'isBuilt': config.meta.build.finished})
 
+
 @quickcache(['domain', 'report_id', 'filter_id'], timeout=5 * 60)
 def _get_report_filter(domain, report_id, filter_id):
     report = get_report_config_or_404(report_id, domain)[0]
@@ -1228,11 +1229,13 @@ def _get_report_filter(domain, report_id, filter_id):
         raise Http404(_(u'Filter {} not found!').format(filter_id))
     return report_filter
 
+
 def _is_location_safe_choice_list(domain, report_id, filter_id):
     report_filter = _get_report_filter(domain, report_id, filter_id)
     if hasattr(report_filter, 'choice_provider'):
         return report_filter.choice_provider.location_safe
     return False
+
 
 @login_and_domain_required
 @conditionally_location_safe(_is_location_safe_choice_list)


### PR DESCRIPTION
This restricts UCR data to the location a user is assigned to if they have the `access_all_locations` flag set to `False`.

@esoergel and @sheelio I wasn't sure how to deal with adding the "Reports" tab at the top of the screen, since right now clicking that leads to a non-location safe page, and we don't have a list view of all the reports that we can redirect to instead. Not sure if there is a plan for this. For now, you'll have to be given a link to the reports you want to see (but then you'll see a list of all the reports you have access to in the sidebar)

cc: @benrudolph 
