### PR TITLE
Br/mm export filtering

### DIFF
--- a/corehq/apps/export/forms.py
+++ b/corehq/apps/export/forms.py
@@ -349,6 +349,8 @@ class GenericFilterFormExportDownloadForm(BaseFilterExportDownloadForm):
             'xmlns': export.xmlns if hasattr(export, 'xmlns') else '',
             'export_id': export.get_id,
             'zip_name': 'multimedia-{}'.format(unidecode(export.name)),
+            'user_types': self.data['user_types'],
+            'group': self.data['group'],
             'download_id': download_id
         }
 

--- a/corehq/apps/export/forms.py
+++ b/corehq/apps/export/forms.py
@@ -349,7 +349,7 @@ class GenericFilterFormExportDownloadForm(BaseFilterExportDownloadForm):
             'xmlns': export.xmlns if hasattr(export, 'xmlns') else '',
             'export_id': export.get_id,
             'zip_name': 'multimedia-{}'.format(unidecode(export.name)),
-            'user_types': self.data['user_types'],
+            'user_types': self._get_es_user_types(),
             'group': self.data['group'],
             'download_id': download_id
         }

--- a/corehq/apps/reports/analytics/couchaccessors.py
+++ b/corehq/apps/reports/analytics/couchaccessors.py
@@ -147,19 +147,3 @@ def get_ledger_values_for_case_as_of(domain, case_id, section_id, as_of, program
         'product_id'
     )
     return dict(results)
-
-
-def get_form_ids_having_multimedia(domain, app_id, xmlns, startdate, enddate):
-    from couchforms.models import XFormInstance
-
-    key = [domain, app_id, xmlns]
-    form_ids = {
-        f['id'] for f in
-        XFormInstance.get_db().view(
-            "attachments/attachments",
-            start_key=key + [startdate],
-            end_key=key + [enddate, {}],
-            reduce=False
-        )
-    }
-    return form_ids

--- a/corehq/apps/reports/analytics/esaccessors.py
+++ b/corehq/apps/reports/analytics/esaccessors.py
@@ -585,6 +585,4 @@ def scroll_case_names(domain, case_ids):
 def _get_attachment_dicts_from_form(form):
     if 'external_blobs' in form:
         return form['external_blobs'].values()
-    elif '_attachments' in form:
-        return form['_attachments'].values()
     return []

--- a/corehq/apps/reports/analytics/esaccessors.py
+++ b/corehq/apps/reports/analytics/esaccessors.py
@@ -541,14 +541,13 @@ def get_aggregated_ledger_values(domain, case_ids, section_id, entry_ids=None):
 
 
 def get_form_ids_having_multimedia(domain, app_id, xmlns, startdate, enddate):
-    # TODO: Remove references to _attachments once all forms have been migrated to Riak
     query = (FormES()
              .domain(domain)
              .app(app_id)
              .xmlns(xmlns)
              .submitted(gte=startdate, lte=enddate)
              .remove_default_filter("has_user")
-             .source(['_attachments', '_id', 'external_blobs']))
+             .source(['_id', 'external_blobs']))
     form_ids = set()
     for form in query.scroll():
         try:

--- a/corehq/apps/reports/analytics/esaccessors.py
+++ b/corehq/apps/reports/analytics/esaccessors.py
@@ -540,7 +540,7 @@ def get_aggregated_ledger_values(domain, case_ids, section_id, entry_ids=None):
     ).get_data()
 
 
-def get_form_ids_having_multimedia(domain, app_id, xmlns, startdate, enddate):
+def get_form_ids_having_multimedia(domain, app_id, xmlns, startdate, enddate, user_types=None, group=None):
     query = (FormES()
              .domain(domain)
              .app(app_id)
@@ -548,6 +548,19 @@ def get_form_ids_having_multimedia(domain, app_id, xmlns, startdate, enddate):
              .submitted(gte=startdate, lte=enddate)
              .remove_default_filter("has_user")
              .source(['_id', 'external_blobs']))
+
+    if user_types:
+        query = query.user_type(user_types)
+
+    if group:
+        results = (GroupES()
+            .domain(domain)
+            .group_ids([group])
+            .source(['users'])).run().hits
+        assert len(results) <= 1
+        user_ids = results[0]['users']
+        query = query.user_id(user_ids)
+
     form_ids = set()
     for form in query.scroll():
         try:

--- a/corehq/apps/reports/tasks.py
+++ b/corehq/apps/reports/tasks.py
@@ -283,10 +283,30 @@ def _store_excel_in_redis(file):
 
 
 @task
-def build_form_multimedia_zip(domain, xmlns, startdate, enddate, app_id,
-                              export_id, zip_name, download_id, export_is_legacy):
+def build_form_multimedia_zip(
+        domain,
+        xmlns,
+        startdate,
+        enddate,
+        app_id,
+        export_id,
+        zip_name,
+        download_id,
+        export_is_legacy,
+        user_types=None,
+        group=None):
 
-    form_ids = _get_form_ids_having_multimedia(domain, app_id, xmlns, startdate, enddate, export_is_legacy)
+    import ipdb; ipdb.set_trace()
+    form_ids = _get_form_ids_having_multimedia(
+        domain,
+        app_id,
+        xmlns,
+        startdate,
+        enddate,
+        export_is_legacy,
+        user_types=user_types,
+        group=group,
+    )
     properties = _get_export_properties(export_id, export_is_legacy)
 
     if not app_id:
@@ -429,7 +449,15 @@ def _get_export_properties(export_id, export_is_legacy):
     return properties
 
 
-def _get_form_ids_having_multimedia(domain, app_id, xmlns, startdate, enddate, export_is_legacy):
+def _get_form_ids_having_multimedia(
+        domain,
+        app_id,
+        xmlns,
+        startdate,
+        enddate,
+        export_is_legacy,
+        user_types=None,
+        group=None):
     """
     Return a list of form ids.
     Each form has a multimedia attachment and meets the given filters.
@@ -447,6 +475,8 @@ def _get_form_ids_having_multimedia(domain, app_id, xmlns, startdate, enddate, e
         xmlns,
         startdate,
         enddate,
+        group=group,
+        user_types=user_types,
     )
 
 


### PR DESCRIPTION
@czue @NoahCarnahan this has mm downloads respect filters. also removes couch call to get form ids for old exports. noah any reason we didn't do this before? i can't remember if that was deliberate or not

http://manage.dimagi.com/default.asp?238002

cc: @orangejenny 
