### PR TITLE
Add locations fixture to the set of auto-detected instances

### DIFF
--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -94,6 +94,13 @@ class EntryInstances(PostProcessor):
             if instance_name in unknown_instance_ids:
                 instances.add(Instance(id=instance_name, src='jr://fixture/{}'.format(instance_name)))
                 unknown_instance_ids.remove(instance_name)
+        instance_name = 'locations'
+        if instance_name in unknown_instance_ids:
+            if toggles.FLAT_LOCATION_FIXTURE.enabled(self.app.domain):
+                instances.add(Instance(id=instance_name, src='jr://fixture/{}'.format(instance_name)))
+            else:
+                instances.add(Instance(id=instance_name, src='jr://fixture/commtrack:{}'.format(instance_name)))
+            unknown_instance_ids.remove(instance_name)
         return instances, unknown_instance_ids
 
 
@@ -116,7 +123,6 @@ class register_factory(object):
 INSTANCE_BY_ID = {
     'groups': Instance(id='groups', src='jr://fixture/user-groups'),
     'reports': Instance(id='reports', src='jr://fixture/commcare:reports'),
-    'locations': Instance(id='locations', src='jr://fixture/commtrack:locations'),
     'ledgerdb': Instance(id='ledgerdb', src='jr://instance/ledgerdb'),
     'casedb': Instance(id='casedb', src='jr://instance/casedb'),
     'commcaresession': Instance(id='commcaresession', src='jr://instance/session'),

--- a/corehq/apps/app_manager/suite_xml/post_process/instances.py
+++ b/corehq/apps/app_manager/suite_xml/post_process/instances.py
@@ -116,6 +116,7 @@ class register_factory(object):
 INSTANCE_BY_ID = {
     'groups': Instance(id='groups', src='jr://fixture/user-groups'),
     'reports': Instance(id='reports', src='jr://fixture/commcare:reports'),
+    'locations': Instance(id='locations', src='jr://fixture/commtrack:locations'),
     'ledgerdb': Instance(id='ledgerdb', src='jr://instance/ledgerdb'),
     'casedb': Instance(id='casedb', src='jr://instance/casedb'),
     'commcaresession': Instance(id='commcaresession', src='jr://instance/session'),


### PR DESCRIPTION
http://manage.dimagi.com/default.asp?238363

@benrudolph

fyi @snopoke / @dannyroberts I can't think of a reason _not_ to auto-detect as many of the standard instances as we can think to add, but let me know if I'm missing something
