### PR TITLE
Add boolean option for case actions.

### DIFF
--- a/corehq/apps/app_manager/models.py
+++ b/corehq/apps/app_manager/models.py
@@ -269,7 +269,7 @@ class FormActionCondition(DocumentSchema):
     type = StringProperty(choices=["if", "always", "never"], default="never")
     question = StringProperty()
     answer = StringProperty()
-    operator = StringProperty(choices=['=', 'selected'], default='=')
+    operator = StringProperty(choices=['=', 'selected', 'boolean_true'], default='=')
 
     def is_active(self):
         return self.type in ('if', 'always')

--- a/corehq/apps/app_manager/templates/app_manager/partials/case_config_shared.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/case_config_shared.html
@@ -22,16 +22,17 @@
         "/>
         <select class="form-control" data-bind="
                 optstr: [
-                    {label:'{% trans "is" %}',value:'='},
-                    {label:'{% trans "has selected" %}',value:'selected'}
+                    {label:'{% trans "is" %}', value:'='},
+                    {label:'{% trans "has selected" %}', value:'selected'},
+                    {label:'{% trans "is true" %}', value:'boolean_true'}
                 ],
                 value: operator"></select>
-        <span data-bind="if: $root.getAnswers({question: question()}).length">
+        <span data-bind="if: $root.getAnswers({question: question()}).length && operator() != 'boolean_true'">
             <select class="form-control" data-bind="
                 optstr: $root.getAnswers({question: question()}),
                 value: answer"></select>
         </span>
-        <span data-bind="if: !$root.getAnswers({question: question()}).length">
+        <span data-bind="if: !$root.getAnswers({question: question()}).length && operator() != 'boolean_true'">
             <input type="text" class="form-control" data-bind="value: answer"/>
         </span>
     </div>

--- a/corehq/apps/app_manager/tests/test_form_preparation_v2.py
+++ b/corehq/apps/app_manager/tests/test_form_preparation_v2.py
@@ -579,6 +579,7 @@ class TestXForm(SimpleTestCase, TestXmlMixin):
             (condition_case('false()', 'never')),
             (condition_case("/data/question1 = 'yes'", 'if', '/data/question1', 'yes')),
             (condition_case("selected(/data/question1, 'yes')", 'if', '/data/question1', 'yes', 'selected')),
+            (condition_case("/data/question1", 'if', '/data/question1', None, 'boolean_true')),
         ]
 
         for case in cases:

--- a/corehq/apps/app_manager/xform.py
+++ b/corehq/apps/app_manager/xform.py
@@ -1281,6 +1281,8 @@ class XForm(WrappedNode):
         elif condition.type == 'if':
             if condition.operator == 'selected':
                 template = u"selected({path}, '{answer}')"
+            elif condition.operator == 'boolean_true':
+                template = u"{path}"
             else:
                 template = u"{path} = '{answer}'"
             return template.format(


### PR DESCRIPTION
![screenshot from 2016-10-09 20-48-56](https://cloud.githubusercontent.com/assets/146896/19225110/635c23da-8e62-11e6-8385-57520e749dfc.png)

Gives the option to use a "raw" boolean value as the condition to do form actions. I was a bit surprised that this didn't already exist, so this might just be my "developer brain" projecting onto Commcare.

This means you can have hidden values that resolve to a boolean (e.g. `1=1`), instead of coercing it to some value (`if(1=1, 'open_case', 'close_case')`), which I think will allow for more DRYness in hidden values. 

I was also considering adding an 'is false' option (which would resolve to `not(value)`), but wasn't sure if that was confusing for non-programmers.

@dimagi/product not sure if you have an opinion on this...

CC: @millerdev 
