### PR TITLE
nested ES query fix

### DIFF
--- a/corehq/apps/api/es.py
+++ b/corehq/apps/api/es.py
@@ -446,8 +446,8 @@ class ReportXFormES(XFormES):
                                     "path": "form.case",
                                     "filter": {
                                         "or": [
-                                            {"term": {"@case_id": "%s" % case_id}},
-                                            {"term": {"case_id": "%s" % case_id}}
+                                            {"term": {"form.case.@case_id": "%s" % case_id}},
+                                            {"term": {"form.case.case_id": "%s" % case_id}}
                                         ]
                                     }
                                 }


### PR DESCRIPTION
@sravfeyn 
Quoted from ES docs: "Note that any fields referenced inside the query must use the complete path (fully qualified)."

Not sure how this ever worked. Tested the query via ES HEAD and changing to the full path returns the currect results.
