### PR TITLE
Fix location meta

### DIFF
--- a/corehq/apps/export/const.py
+++ b/corehq/apps/export/const.py
@@ -14,7 +14,7 @@ from corehq.apps.export.transforms import (
 
 # When fixing a bug that requires existing schemas to be rebuilt,
 # bump the version number.
-DATA_SCHEMA_VERSION = 5
+DATA_SCHEMA_VERSION = 6
 
 DEID_ID_TRANSFORM = "deid_id"
 DEID_DATE_TRANSFORM = "deid_date"

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -199,6 +199,17 @@ class ExportColumn(DocumentSchema):
         Transform the given value with the transform specified in self.item.transform.
         Also transform dates if the transform_dates flag is true.
         """
+
+        # When XML elements have additional attributes in them, the text node is
+        # put inside of the #text key. For example:
+        #
+        # <element id="123">value</element>  -> {'#text': 'value', 'id':'123'}
+        #
+        # Whereas elements without additional attributes just take on the string value:
+        #
+        # <element>value</element>  -> 'value'
+        #
+        # This line ensures that we grab the actual value instead of the dictionary
         if isinstance(value, dict) and '#text' in value:
             value = value.get('#text')
 

--- a/corehq/apps/export/models/new.py
+++ b/corehq/apps/export/models/new.py
@@ -199,6 +199,9 @@ class ExportColumn(DocumentSchema):
         Transform the given value with the transform specified in self.item.transform.
         Also transform dates if the transform_dates flag is true.
         """
+        if isinstance(value, dict) and '#text' in value:
+            value = value.get('#text')
+
         if transform_dates:
             value = couch_to_excel_datetime(value, doc)
         if self.item.transform:

--- a/corehq/apps/export/system_properties.py
+++ b/corehq/apps/export/system_properties.py
@@ -18,6 +18,8 @@ from corehq.apps.export.models import (
     PathNode,
     StockExportColumn,
     RowNumberColumn,
+    SplitGPSExportColumn,
+    GeopointItem,
 )
 
 # System properties to be displayed above the form questions
@@ -110,10 +112,10 @@ BOTTOM_MAIN_FORM_TABLE_PROPERTIES = [
         is_advanced=True,
         help_text=_("The id of the device that submitted this form")
     ),
-    ExportColumn(
+    SplitGPSExportColumn(
         tags=[PROPERTY_TAG_INFO],
         label='location',
-        item=ExportItem(path=[
+        item=GeopointItem(path=[
             PathNode(name='form'), PathNode(name='meta'), PathNode(name='location')
         ]),
         is_advanced=True,

--- a/corehq/apps/export/tests/test_export_column.py
+++ b/corehq/apps/export/tests/test_export_column.py
@@ -37,6 +37,30 @@ class TestExportColumn(SimpleTestCase):
         col = ExportColumn(transform='deid_date')
         self.assertEqual(col.transform, 'deid_date')
 
+    def test_get_value(self):
+        column = ExportColumn(
+            item=ExportItem(
+                path=[PathNode(name='form'), PathNode(name='q1')],
+            ),
+        )
+        doc = {"q1": "answer"}
+        self.assertEqual(
+            column.get_value('domain', 'docid', doc, [PathNode(name='form')]),
+            "answer",
+        )
+
+    def test_get_value_with_text(self):
+        column = ExportColumn(
+            item=ExportItem(
+                path=[PathNode(name='form'), PathNode(name='q1')],
+            ),
+        )
+        doc = {"q1": {'#text': "answer"}}
+        self.assertEqual(
+            column.get_value('domain', 'docid', doc, [PathNode(name='form')]),
+            "answer",
+        )
+
 
 class SplitColumnTest(SimpleTestCase):
 


### PR DESCRIPTION
@czue @NoahCarnahan this does two things.
1. Ensures that if there is a node that has `#text` we query for the `#text` node. For example `form.meta.location.#text` should still return the location node
2. Makes the location system property a proper GPS column so that it's splittable

<img width="284" alt="screen shot 2016-10-10 at 11 12 40 am" src="https://cloud.githubusercontent.com/assets/918514/19240986/b87b75d2-8eda-11e6-8bba-88a7e1189659.png">

http://manage.dimagi.com/default.asp?239006

cc: @orangejenny 
