### PR TITLE
Only fire mismatch revs when revs are stale

### DIFF
--- a/corehq/apps/change_feed/tests/test_pillow.py
+++ b/corehq/apps/change_feed/tests/test_pillow.py
@@ -111,6 +111,13 @@ class TestElasticProcessorPillows(SimpleTestCase):
             data_source_type='couch',
             data_source_name='test_commcarehq'
         )
+        newer_metadata = ChangeMeta(
+            document_id='test-id',
+            # Rev is lower than the rev in the fetched document and we should not throw an error
+            document_rev='2-me',
+            data_source_type='couch',
+            data_source_name='test_commcarehq'
+        )
         stale_metadata = ChangeMeta(
             document_id='test-id',
             document_rev='4-me',  # Rev is higher than the rev in the fetched document so it is stale
@@ -145,6 +152,18 @@ class TestElasticProcessorPillows(SimpleTestCase):
                     sequence_id='3',
                     document=document,
                     metadata=good_metadata
+                )
+            )
+        except DocumentMismatchError:
+            self.fail('Incorectly raise a DocumentMismatchError for matching revs')
+
+        try:
+            self.pillow.process_change(
+                Change(
+                    id='test-id',
+                    sequence_id='3',
+                    document=document,
+                    metadata=newer_metadata
                 )
             )
         except DocumentMismatchError:

--- a/corehq/apps/change_feed/tests/test_pillow.py
+++ b/corehq/apps/change_feed/tests/test_pillow.py
@@ -97,7 +97,7 @@ class TestElasticProcessorPillows(SimpleTestCase):
             'doc_type': 'CommCareCase',
             'type': 'mother',
             'domain': 'rev-domain',
-            '_rev': 'match-me',
+            '_rev': '3-me',
         }
         broken_metadata = ChangeMeta(
             document_id='test-id',
@@ -107,7 +107,13 @@ class TestElasticProcessorPillows(SimpleTestCase):
         )
         good_metadata = ChangeMeta(
             document_id='test-id',
-            document_rev='match-me',
+            document_rev='3-me',
+            data_source_type='couch',
+            data_source_name='test_commcarehq'
+        )
+        stale_metadata = ChangeMeta(
+            document_id='test-id',
+            document_rev='4-me',  # Rev is higher than the rev in the fetched document so it is stale
             data_source_type='couch',
             data_source_name='test_commcarehq'
         )
@@ -119,6 +125,16 @@ class TestElasticProcessorPillows(SimpleTestCase):
                     sequence_id='3',
                     document=document,
                     metadata=broken_metadata
+                )
+            )
+
+        with self.assertRaises(DocumentMismatchError):
+            self.pillow.process_change(
+                Change(
+                    id='test-id',
+                    sequence_id='3',
+                    document=document,
+                    metadata=stale_metadata
                 )
             )
 

--- a/corehq/ex-submodules/pillowtop/utils.py
+++ b/corehq/ex-submodules/pillowtop/utils.py
@@ -234,14 +234,13 @@ def ensure_matched_revisions(change):
             fetched_rev = _convert_rev_to_int(fetched_document['_rev'])
             stored_rev = _convert_rev_to_int(change.metadata.document_rev)
             if fetched_rev < stored_rev or stored_rev == -1:
-                pillow_logging.warning(
-                    u"Mismatched revs for {}: Cloudant rev {} vs. Changes feed rev {}".format(
-                        change.id,
-                        fetched_document['_rev'],
-                        change.metadata.document_rev,
-                    )
+                message = u"Mismatched revs for {}: Cloudant rev {} vs. Changes feed rev {}".format(
+                    change.id,
+                    fetched_document['_rev'],
+                    change.metadata.document_rev
                 )
-                raise DocumentMismatchError(u'Mismatched revs')
+                pillow_logging.warning(message)
+                raise DocumentMismatchError(message)
 
 
 def _convert_rev_to_int(rev):

--- a/corehq/ex-submodules/pillowtop/utils.py
+++ b/corehq/ex-submodules/pillowtop/utils.py
@@ -230,18 +230,18 @@ def ensure_matched_revisions(change):
             change.metadata and
             change.metadata.document_rev is not None):
 
-        fetched_rev = _convert_rev_to_int(fetched_document['_rev'])
-        stored_rev = _convert_rev_to_int(change.metadata.document_rev)
-
-        if change.metadata and (fetched_rev < stored_rev or stored_rev == -1):
-            pillow_logging.warning(
-                u"Mismatched revs for {}: Cloudant rev {} vs. Changes feed rev {}".format(
-                    change.id,
-                    fetched_document['_rev'],
-                    change.metadata.document_rev,
+        if change.metadata and fetched_document['_rev'] != change.metadata.document_rev:
+            fetched_rev = _convert_rev_to_int(fetched_document['_rev'])
+            stored_rev = _convert_rev_to_int(change.metadata.document_rev)
+            if fetched_rev < stored_rev or stored_rev == -1:
+                pillow_logging.warning(
+                    u"Mismatched revs for {}: Cloudant rev {} vs. Changes feed rev {}".format(
+                        change.id,
+                        fetched_document['_rev'],
+                        change.metadata.document_rev,
+                    )
                 )
-            )
-            raise DocumentMismatchError(u'Mismatched revs')
+                raise DocumentMismatchError(u'Mismatched revs')
 
 
 def _convert_rev_to_int(rev):

--- a/corehq/ex-submodules/pillowtop/utils.py
+++ b/corehq/ex-submodules/pillowtop/utils.py
@@ -230,7 +230,10 @@ def ensure_matched_revisions(change):
             change.metadata and
             change.metadata.document_rev is not None):
 
-        if change.metadata and fetched_document['_rev'] != change.metadata.document_rev:
+        fetched_rev = _convert_rev_to_int(fetched_document['_rev'])
+        stored_rev = _convert_rev_to_int(change.metadata.document_rev)
+
+        if change.metadata and (fetched_rev < stored_rev or stored_rev == -1):
             pillow_logging.warning(
                 u"Mismatched revs for {}: Cloudant rev {} vs. Changes feed rev {}".format(
                     change.id,
@@ -239,6 +242,13 @@ def ensure_matched_revisions(change):
                 )
             )
             raise DocumentMismatchError(u'Mismatched revs')
+
+
+def _convert_rev_to_int(rev):
+    try:
+        return int(rev.split('-')[0])
+    except (ValueError, AttributeError):
+        return -1
 
 
 def ensure_document_exists(change):

--- a/corehq/ex-submodules/pillowtop/utils.py
+++ b/corehq/ex-submodules/pillowtop/utils.py
@@ -225,19 +225,20 @@ def ensure_matched_revisions(change):
     """
     fetched_document = change.get_document()
 
-    if (fetched_document and
-            '_rev' in fetched_document and
-            change.metadata and
-            change.metadata.document_rev is not None):
+    change_has_rev = change.metadata and change.metadata.document_rev is not None
+    doc_has_rev = fetched_document and '_rev' in fetched_document
+    if doc_has_rev and change_has_rev:
 
-        if change.metadata and fetched_document['_rev'] != change.metadata.document_rev:
-            fetched_rev = _convert_rev_to_int(fetched_document['_rev'])
-            stored_rev = _convert_rev_to_int(change.metadata.document_rev)
+        doc_rev = fetched_document['_rev']
+        change_rev = change.metadata.document_rev
+        if doc_rev != change_rev:
+            fetched_rev = _convert_rev_to_int(doc_rev)
+            stored_rev = _convert_rev_to_int(change_rev)
             if fetched_rev < stored_rev or stored_rev == -1:
                 message = u"Mismatched revs for {}: Cloudant rev {} vs. Changes feed rev {}".format(
                     change.id,
-                    fetched_document['_rev'],
-                    change.metadata.document_rev
+                    doc_rev,
+                    change_rev
                 )
                 pillow_logging.warning(message)
                 raise DocumentMismatchError(message)


### PR DESCRIPTION
@snopoke how about something simple like this? it sort of handles revs that aren't in the format `[0-9]*-.*`, but not very well. i don't think we have to worry about that too much though

http://manage.dimagi.com/default.asp?239085

cc: @orangejenny 
