### PR TITLE
domain notifications

### DIFF
--- a/corehq/apps/notifications/migrations/0005_domain_specific_notifications.py
+++ b/corehq/apps/notifications/migrations/0005_domain_specific_notifications.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.contrib.postgres.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('notifications', '0004_auto_20160830_2002'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='notification',
+            name='domain_specific',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name='notification',
+            name='domains',
+            field=django.contrib.postgres.fields.ArrayField(null=True, base_field=models.TextField(null=True, blank=True), size=None),
+        ),
+    ]

--- a/corehq/apps/notifications/models.py
+++ b/corehq/apps/notifications/models.py
@@ -2,6 +2,8 @@ import datetime
 
 from django.contrib.auth.models import User
 from django.db import models
+from django.db.models import Q
+from django.contrib.postgres.fields import ArrayField
 
 
 NOTIFICATION_TYPES = (
@@ -22,18 +24,24 @@ class Notification(models.Model):
     users_read = models.ManyToManyField(User)
     is_active = models.BooleanField(default=False)
     activated = models.DateTimeField(db_index=True, null=True, blank=True)
+    domain_specific = models.BooleanField(default=False)
+    domains = ArrayField(
+        models.TextField(null=True, blank=True),
+        null=True
+    )
 
     class Meta:
         ordering = ["-activated"]
 
     @classmethod
-    def get_by_user(cls, user, limit=10):
+    def get_by_user(cls, django_user, couch_user, limit=10):
         """Returns notifications for a particular user
 
         After five notifications all notifications should be marked as read.
         """
-        notes = cls.objects.filter(is_active=True, activated__gt=user.date_joined)[:limit]
-        read_notifications = set(cls.objects.filter(users_read=user).values_list('id', flat=True))
+        notes = cls.objects.filter(Q(domain_specific=False) | Q(domains__overlap=couch_user.domains),
+                                     is_active=True, activated__gt=django_user.date_joined)[:limit]
+        read_notifications = set(cls.objects.filter(users_read=django_user).values_list('id', flat=True))
 
         def _fmt_note(note_idx):
             index = note_idx[0]

--- a/corehq/apps/notifications/tests/test_notifications.py
+++ b/corehq/apps/notifications/tests/test_notifications.py
@@ -4,6 +4,7 @@ from django.contrib.auth.models import User
 from django.test import TestCase
 
 from corehq.apps.notifications.models import Notification, LastSeenNotification, IllegalModelStateException
+from corehq.apps.users.models import WebUser
 
 
 class NotificationTest(TestCase):
@@ -14,34 +15,35 @@ class NotificationTest(TestCase):
         self.user = User()
         self.user.username = 'mockmock@mockmock.com'
         self.user.save()
+        self.couch_user = WebUser(username=self.user.username)
 
     def tearDown(self):
         self.note.delete()
         self.user.delete()
 
     def test_activate(self):
-        notes = Notification.get_by_user(self.user)
+        notes = Notification.get_by_user(self.user, self.couch_user)
         self.assertEqual(len(notes), 0)
         self.note.activate()
-        notes = Notification.get_by_user(self.user)
+        notes = Notification.get_by_user(self.user, self.couch_user)
         self.assertEqual(len(notes), 1)
         self.assertEqual(notes[0]['isRead'], False)
 
     def test_deactivate(self):
         self.note.activate()
-        notes = Notification.get_by_user(self.user)
+        notes = Notification.get_by_user(self.user, self.couch_user)
         self.assertEqual(len(notes), 1)
         self.note.deactivate()
-        notes = Notification.get_by_user(self.user)
+        notes = Notification.get_by_user(self.user, self.couch_user)
         self.assertEqual(len(notes), 0)
 
     def test_mark_as_read(self):
         self.note.activate()
-        notes = Notification.get_by_user(self.user)
+        notes = Notification.get_by_user(self.user, self.couch_user)
         self.assertEqual(len(notes), 1)
         self.assertEqual(notes[0]['isRead'], False)
         self.note.mark_as_read(self.user)
-        notes = Notification.get_by_user(self.user)
+        notes = Notification.get_by_user(self.user, self.couch_user)
         self.assertEqual(len(notes), 1)
         self.assertEqual(notes[0]['isRead'], True)
 

--- a/corehq/apps/notifications/views.py
+++ b/corehq/apps/notifications/views.py
@@ -28,7 +28,7 @@ class NotificationsServiceRMIView(JSONResponseMixin, View):
     @allow_remote_invocation
     def get_notifications(self, in_data):
         # todo always grab alerts if they are still relevant
-        notifications = Notification.get_by_user(self.request.user)
+        notifications = Notification.get_by_user(self.request.user, self.request.couch_user)
         has_unread = len(filter(lambda x: not x['isRead'], notifications)) > 0
         last_seen_notification_date = LastSeenNotification.get_last_seen_notification_date_for_user(
             self.request.user


### PR DESCRIPTION
This allows notifications to go out only to specific domains, using the existing notification framework in hq.
@emord you have the most context and my buddy is offline this week
cc: @amsagoff 
