### PR TITLE
show app builder notifications to all superusers

### DIFF
--- a/corehq/apps/app_manager/views/formdesigner.py
+++ b/corehq/apps/app_manager/views/formdesigner.py
@@ -35,7 +35,6 @@ from corehq.apps.app_manager.decorators import require_can_edit_apps
 from corehq.apps.analytics.tasks import track_entered_form_builder_on_hubspot
 from corehq.apps.analytics.utils import get_meta
 from corehq.apps.tour import tours
-from corehq.toggles import APP_BUILDER_NOTIFICATIONS
 
 
 logger = logging.getLogger(__name__)
@@ -138,7 +137,7 @@ def form_designer(request, domain, app_id, module_id=None, form_id=None):
         'app_callout_templates': next(app_callout_templates),
         'scheduler_data_nodes': scheduler_data_nodes,
         'include_fullstory': include_fullstory,
-        'notifications_enabled': APP_BUILDER_NOTIFICATIONS.enabled(domain),
+        'notifications_enabled': request.user.is_superuser,
         'notify_facility': get_facility_for_form(domain, app_id, form.unique_id),
     })
     notify_form_opened(domain, request.couch_user, app_id, form.unique_id)

--- a/corehq/apps/app_manager/views/notifications.py
+++ b/corehq/apps/app_manager/views/notifications.py
@@ -19,17 +19,17 @@ def notify_form_changed(domain, couch_user, app_id, unique_form_id):
 
 
 def notify_event(domain, couch_user, app_id, unique_form_id, message):
-    message = {
+
+    message_obj = RedisMessage(json.dumps({
         'domain': domain,
         'user_id': couch_user._id,
         'username': couch_user.username,
         'text': message,
         'timestamp': json_format_datetime(datetime.datetime.utcnow()),
-    }
-    message = RedisMessage(json.dumps(message))
+    }))
     RedisPublisher(
         facility=get_facility_for_form(domain, app_id, unique_form_id), broadcast=True
-    ).publish_message(message)
+    ).publish_message(message_obj)
 
 
 def get_facility_for_form(domain, app_id, unique_form_id):

--- a/corehq/apps/app_manager/views/notifications.py
+++ b/corehq/apps/app_manager/views/notifications.py
@@ -19,7 +19,8 @@ def notify_form_changed(domain, couch_user, app_id, unique_form_id):
 
 
 def notify_event(domain, couch_user, app_id, unique_form_id, message):
-    message = '{} (<a href="https://confluence.dimagi.com/display/ccinternal/App+Builder+Notifications">what is this?</a>)'.format(message)
+    doc_url = 'https://confluence.dimagi.com/display/ccinternal/App+Builder+Notifications'
+    message = '{} (<a href="{}" target="_blank">what is this?</a>)'.format(message, doc_url)
     message_obj = RedisMessage(json.dumps({
         'domain': domain,
         'user_id': couch_user._id,

--- a/corehq/apps/app_manager/views/notifications.py
+++ b/corehq/apps/app_manager/views/notifications.py
@@ -19,7 +19,7 @@ def notify_form_changed(domain, couch_user, app_id, unique_form_id):
 
 
 def notify_event(domain, couch_user, app_id, unique_form_id, message):
-
+    message = '{} (<a href="https://confluence.dimagi.com/display/ccinternal/App+Builder+Notifications">what is this?</a>)'.format(message)
     message_obj = RedisMessage(json.dumps({
         'domain': domain,
         'user_id': couch_user._id,

--- a/corehq/apps/app_manager/views/notifications.py
+++ b/corehq/apps/app_manager/views/notifications.py
@@ -3,7 +3,6 @@ import datetime
 from django.utils.translation import ugettext as _
 from ws4redis.publisher import RedisPublisher
 from ws4redis.redis_store import RedisMessage
-from corehq.toggles import APP_BUILDER_NOTIFICATIONS
 from dimagi.utils.parsing import json_format_datetime
 
 
@@ -20,18 +19,17 @@ def notify_form_changed(domain, couch_user, app_id, unique_form_id):
 
 
 def notify_event(domain, couch_user, app_id, unique_form_id, message):
-    if APP_BUILDER_NOTIFICATIONS.enabled(domain):
-        message = {
-            'domain': domain,
-            'user_id': couch_user._id,
-            'username': couch_user.username,
-            'text': message,
-            'timestamp': json_format_datetime(datetime.datetime.utcnow()),
-        }
-        message = RedisMessage(json.dumps(message))
-        RedisPublisher(
-            facility=get_facility_for_form(domain, app_id, unique_form_id), broadcast=True
-        ).publish_message(message)
+    message = {
+        'domain': domain,
+        'user_id': couch_user._id,
+        'username': couch_user.username,
+        'text': message,
+        'timestamp': json_format_datetime(datetime.datetime.utcnow()),
+    }
+    message = RedisMessage(json.dumps(message))
+    RedisPublisher(
+        facility=get_facility_for_form(domain, app_id, unique_form_id), broadcast=True
+    ).publish_message(message)
 
 
 def get_facility_for_form(domain, app_id, unique_form_id):

--- a/corehq/toggles.py
+++ b/corehq/toggles.py
@@ -925,11 +925,3 @@ CLOUDCARE_LATEST_BUILD = StaticToggle(
     TAG_ONE_OFF,
     [NAMESPACE_DOMAIN, NAMESPACE_USER]
 )
-
-
-APP_BUILDER_NOTIFICATIONS = StaticToggle(
-    'app_builder_notifications',
-    'Enable app builder notifications on duplicate form edits.',
-    TAG_PRODUCT_CORE,
-    [NAMESPACE_DOMAIN]
-)

--- a/docker/localsettings.py
+++ b/docker/localsettings.py
@@ -76,14 +76,21 @@ COUCH_USERNAME = ''
 COUCH_PASSWORD = ''
 COUCH_DATABASE_NAME = 'commcarehq'
 
+redis_host = 'redis'
+
 redis_cache = {
     'BACKEND': 'django_redis.cache.RedisCache',
-    'LOCATION': 'redis://redis:6379/0',
+    'LOCATION': 'redis://{}:6379/0'.format(redis_host),
     'OPTIONS': {},
 }
+
 CACHES = {
     'default': redis_cache,
     'redis': redis_cache
+}
+
+WS4REDIS_CONNECTION = {
+    'host': redis_host,
 }
 
 ELASTICSEARCH_HOST = 'elasticsearch'


### PR DESCRIPTION
I was thinking about this and I think this is one of those rare features that I don't feel bad about rolling out as superuser-only. my rationale is that it doesn't provide a notably different UX, just a layer of additional feedback on top of the existing UX so it doesn't have some of the problems we've had of, e.g. demos looking different on a dimagi account than otherwise. I also think that 95% of the time if some dimagis are app building, then most of the app-building is being done by only dimagis. additionally, making it superuser-only is required anyways right now because there is some tech debt work to make the websockets framework support custom domain-level permissions, so that work would need to be required to happen before we released widely regardless.

i'm keen to get this out in the wild and see if it adds value, and doing it this way explicitly internally makes sense to me as a way to build out the featureset since we are likely the most important users of this feature. curious if anyone has any objections to that?

cc @dimagi/product @orangejenny and @emord buddy
