### PR TITLE
Remove unreliable check

### DIFF
--- a/corehq/apps/hqadmin/service_checks.py
+++ b/corehq/apps/hqadmin/service_checks.py
@@ -134,17 +134,11 @@ def check_heartbeat():
         t = cresource.get("api/workers", params_dict={'status': True}).body_string()
         all_workers = json.loads(t)
         bad_workers = []
-        expected_running, expected_stopped = parse_celery_workers(all_workers)
+        expected_running = parse_celery_workers(all_workers)
 
         for hostname in expected_running:
             if not all_workers[hostname]:
                 bad_workers.append('* {} celery worker down'.format(hostname))
-
-        for hostname in expected_stopped:
-            if all_workers[hostname]:
-                bad_workers.append(
-                    '* {} celery worker is running when we expect it to be stopped.'.format(hostname)
-                )
 
         if bad_workers:
             return ServiceStatus(False, '\n'.join(bad_workers))

--- a/corehq/apps/hqadmin/tests/test_utils.py
+++ b/corehq/apps/hqadmin/tests/test_utils.py
@@ -91,20 +91,20 @@ class TestParseCeleryWorkers(SimpleTestCase):
 
 @generate_cases([
     # Ensures we correctly parse a single regular worker
-    ({'regular_host': True}, (['regular_host'], [])),
+    ({'regular_host': True}, ['regular_host']),
     # Ensures we correctly parse a single timestamped worker
-    ({'main_.20_timestamp': True}, (['main_.20_timestamp'], [])),
+    ({'main_.20_timestamp': True}, ['main_.20_timestamp']),
     # Ensures we parse timestamped and regular
     ({
         'main_.40_timestamp': True,
         'regular_host': True,
-    }, (['regular_host', 'main_.40_timestamp'], [])),
+    }, ['regular_host', 'main_.40_timestamp']),
     # Ensures we correctly parse multiple timestamped workers
     ({
         'main_.40_timestamp': True,
         'main_.20_timestamp': True,
         'main_.30_timestamp': True,
-    }, (['main_.40_timestamp'], ['main_.30_timestamp', 'main_.20_timestamp'])),
+    }, ['main_.40_timestamp']),
 
     # Ensures we correctly parse multiple timestamped workers
     ({
@@ -113,10 +113,7 @@ class TestParseCeleryWorkers(SimpleTestCase):
         'main_.30_timestamp': True,
         'secondary_.30_timestamp': True,
         'secondary_.20_timestamp': True,
-    }, (
-        ['main_.40_timestamp', 'secondary_.30_timestamp'],
-        ['main_.30_timestamp', 'main_.20_timestamp', 'secondary_.20_timestamp'],
-    )),
+    }, ['main_.40_timestamp', 'secondary_.30_timestamp']),
 
 ], TestParseCeleryWorkers)
 def test_parse_celery_workers(self, workers, expected):

--- a/corehq/apps/hqadmin/utils.py
+++ b/corehq/apps/hqadmin/utils.py
@@ -92,7 +92,6 @@ def parse_celery_workers(celery_workers):
     Parses the response from the flower get workers api into a list of hosts
     we expect to be running and a list of hosts we expect to be stopped
     """
-    expect_stopped = []
     expect_running = filter(
         lambda hostname: not hostname.endswith('_timestamp'),
         celery_workers.keys(),
@@ -112,5 +111,4 @@ def parse_celery_workers(celery_workers):
 
         sorted_workers = sorted(list(group), reverse=True)
         expect_running.append(sorted_workers.pop(0))
-        expect_stopped.extend(sorted_workers)
-    return expect_running, expect_stopped
+    return expect_running


### PR DESCRIPTION
@gcapalbo this does not work as expected. Sometimes flower will randomly say that the old process is up and sometimes down when the old process is running a worker to finish out a task
