### PR TITLE
target = parent for app preview

### DIFF
--- a/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/build_errors.html
@@ -317,5 +317,12 @@
                 {% trans "Errors Building an Application" %}
             </a>
         </p>
+        {% if in_iframe %}
+        <script>
+            $('#build-errors a').each(function(index) {
+                $(this).attr('target', '_parent');
+            });
+        </script>
+        {% endif %}
     </div>
 {% endif %}

--- a/corehq/apps/app_manager/views/cli.py
+++ b/corehq/apps/app_manager/views/cli.py
@@ -100,7 +100,8 @@ def direct_ccz(request, domain):
             'build_errors': errors,
             'domain': domain,
             'langs': langs,
-            'lang': lang
+            'lang': lang,
+            'in_iframe': True,
         })
         return json_response(
             {'error_html': error_html},


### PR DESCRIPTION
@biyeun this'll ensure that when we hit a build error link in the preview app, we'll change the url of the parent window.

cc: @orangejenny 
