### PR TITLE
Allow manually modifying form link datums

### DIFF
--- a/corehq/apps/app_manager/static/app_manager/js/form_workflow.js
+++ b/corehq/apps/app_manager/static/app_manager/js/form_workflow.js
@@ -108,6 +108,7 @@ hqDefine('app_manager/js/form_workflow.js', function() {
         self.autoLink = ko.observable();
         self.forms = workflow.forms || [];
         self.datums = ko.observableArray();
+        self.manualDatums = ko.observable(false);
         self.datumsFetched = ko.observable(false);
         self.serializedDatums = ko.observable('');
 
@@ -133,9 +134,23 @@ hqDefine('app_manager/js/form_workflow.js', function() {
             });
         };
 
+        self.enableManualDatums = function(){
+            self.manualDatums(true);
+        };
+
+        self.disableManualDatums = function(){
+            self.manualDatums(false);
+            $('#form-workflow .workflow-change-trigger').trigger('change');
+            self.datums.removeAll();
+        };
+
        // initialize
         self.autoLink(self.get_form_by_id(self.formId()).autoLink);
         self.datums(self.wrap_datums(datums));
+        self.manualDatums(self.datums().length && self.autoLink());
+        self.showLinkDatums = ko.computed(function(){
+            return (!self.autoLink() || self.manualDatums());
+        });
 
         self.formId.subscribe(function(form_id) {
             self.autoLink(self.get_form_by_id(form_id).autoLink);

--- a/corehq/apps/app_manager/static/app_manager/js/form_workflow.js
+++ b/corehq/apps/app_manager/static/app_manager/js/form_workflow.js
@@ -112,12 +112,12 @@ hqDefine('app_manager/js/form_workflow.js', function() {
         self.serializedDatums = ko.observable('');
 
         self.get_form_by_id = function(form_id) {
-            return _.find(self.forms, function(form){ return form.uniqueId === form_id; })
+            return _.find(self.forms, function(form){ return form.uniqueId === form_id; });
         };
 
         self.serializeDatums = function() {
             var jsonDatums = JSON.stringify(_.map(self.datums(), function (datum) {
-                return {'name': datum.name, 'xpath': datum.xpath()}
+                return {'name': datum.name, 'xpath': datum.xpath()};
             }));
             self.serializedDatums(jsonDatums);
         };
@@ -149,10 +149,10 @@ hqDefine('app_manager/js/form_workflow.js', function() {
                 workflow.formDatumsUrl,
                 {form_id: self.formId()},
                 function (data) {
-                    self.datums(self.wrap_datums(data))
+                    self.datums(self.wrap_datums(data));
                 },
                 "json"
-            )
+            );
         };
 
         self.errors = ko.computed(function() {

--- a/corehq/apps/app_manager/templates/app_manager/partials/form_workflow.html
+++ b/corehq/apps/app_manager/templates/app_manager/partials/form_workflow.html
@@ -81,25 +81,45 @@
             </div>
             <input type="hidden" name="datums_json" data-bind="value: formLink.serializedDatums"/>
         </div>
-        <div class="row help-block" data-bind="visible: !formLink.autoLink()">
-            <div class="col-sm-12">
-            <p>
-                {% trans "This form requires manual linking." %}
-                <button class="btn btn-default btn-sm" data-bind="click: formLink.fetchDatums">
-                    <!-- ko if: formLink.datumsFetched() -->
-                    {% trans "Refresh" %}
-                    <!-- /ko -->
-                    <!-- ko if: !formLink.datumsFetched() -->
-                    {% trans "Continue" %}
-                    <!-- /ko -->
-                </button>
-            </p>
+        <div class="row">
+            <div class="col-sm-12" data-bind="visible: !formLink.autoLink()">
+                <p>{% trans "This form requires manual linking." %}</p>
             </div>
-            <div class="col-sm-12">
-            <p data-bind="visible: formLink.datumsFetched() && formLink.datums().length === 0">
-                {% trans "No additional linking required." %}
-            </p>
+            <div class="col-sm-12" data-bind="visible: formLink.autoLink()">
+                <p>{% trans "This form doesn't require manual linking." %}</p>
             </div>
+            <div class="col-sm-12" data-bind="visible: formLink.autoLink() && !formLink.manualDatums()">
+                <span data-bind="click: enableManualDatums" class="btn btn-default btn-sm">
+                    {% trans "Enable manual linking" %}
+                </span>
+            </div>
+            <div class="col-sm-12" data-bind="visible: formLink.manualDatums">
+                <span data-bind="click: disableManualDatums" class="btn btn-danger btn-sm">
+                    {% trans "Disable manual linking" %}
+                </span>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-sm-12"  data-bind="visible: formLink.showLinkDatums()">
+                <p>
+                    <button class="btn btn-default btn-sm" data-bind="click: formLink.fetchDatums">
+                        <!-- ko if: formLink.datumsFetched() -->
+                        {% trans "Refresh" %}
+                        <!-- /ko -->
+                        <!-- ko if: !formLink.datumsFetched() -->
+                        {% trans "Continue" %}
+                        <!-- /ko -->
+                    </button>
+                </p>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-sm-12" data-bind="visible: formLink.datumsFetched() && formLink.datums().length === 0 && !formLink.autoLink()">
+                <p>
+                    {% trans "No additional linking required." %}
+                </p>
+            </div>
+        </div>
             <div data-bind="foreach: formLink.datums, visible: formLink.datumsFetched() && formLink.datums().length" class="col-sm-12">
                 <div class="form-group col-sm-12">
                     <div class="panel panel-default">


### PR DESCRIPTION
This shows a button that allows you to modify form link datums even if those form links can be "automatically" linked.
This allows for form linking between forms with the same case type, where the first form both loads and creates a case of the same type. This way you can choose the case you want to load (i.e. the case that is loaded, or the case that is created). 
@snopoke heads up
@millerdev 
