### PR TITLE
First pass on cloudcare rename

### DIFF
--- a/corehq/apps/cloudcare/templates/cloudcare/config.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/config.html
@@ -148,11 +148,10 @@
         <div id="cloudcare-app-settings-form" data-bind="with: applicationAccess">
             <label class="radio">
                 <input type="radio" value="false" data-bind="checked: restrict.JSON"/>
-                {% blocktrans %}Allow all mobile workers to see all {% endblocktrans %}
                 {% if request|is_new_cloudcare %}
-                web apps.
+                {% blocktrans %}Allow all mobile workers to see all web apps.{% endblocktrans %}
                 {% else %}
-                CloudCare {% trans "apps" %}.
+                {% blocktrans %}Allow all mobile workers to see all CloudCare apps.{% endblocktrans %}
                 {% endif %}
             </label>
             <label class="radio">

--- a/corehq/apps/cloudcare/templates/cloudcare/config.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/config.html
@@ -138,17 +138,30 @@
 {% endblock %}
 
 {% block page_content %}
+    {% if request|is_new_cloudcare %}
+    <h2>{% trans 'Manage Web Apps Permissions' %}</h2>
+    {% else %}
     <h2>{% trans 'Manage CloudCare Permissions' %}</h2>
+    {% endif %}
     <section id="cloudcare-app-settings" style="display: none">
         <div data-bind="saveButton: saveButton"></div>
         <div id="cloudcare-app-settings-form" data-bind="with: applicationAccess">
             <label class="radio">
                 <input type="radio" value="false" data-bind="checked: restrict.JSON"/>
-                {% blocktrans %}Allow all mobile workers to see all CloudCare apps{% endblocktrans %}
+                {% blocktrans %}Allow all mobile workers to see all {% endblocktrans %}
+                {% if request|is_new_cloudcare %}
+                web apps.
+                {% else %}
+                CloudCare {% trans "apps" %}.
+                {% endif %}
             </label>
             <label class="radio">
                 <input type="radio" value="true" data-bind="checked: restrict.JSON"/>
+                {% if request|is_new_cloudcare %}
+                {% blocktrans %}Customize each mobile worker's access to web apps{% endblocktrans %}
+                {% else %}
                 {% blocktrans %}Customize each mobile worker's CloudCare access{% endblocktrans %}
+                {% endif %}
                 <code data-bind="visible: !restrict()">...</code>
             </label>
             <div data-bind="visible: restrict">
@@ -194,10 +207,18 @@
                             </ul>
                         </li>
                     </ul>
+                    {% if request|is_new_cloudcare %}
+                    <p>{% blocktrans %}...and all other mobile workers do not have access to any web apps.{% endblocktrans %}</p>
+                    {% else %}
                     <p>{% blocktrans %}...and all other mobile workers have no access to CloudCare.{% endblocktrans %}</p>
+                    {% endif %}
                 </div>
                 <div data-bind="if: !app_groups().length">
+                    {% if request|is_new_cloudcare %}
+                    {% trans 'No Web Apps Available' %}
+                    {% else %}
                     {% trans 'No CloudCare Applications Available' %}
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/formplayer_home.html
@@ -4,7 +4,7 @@
 {% load compress %}
 
 {% block title %}
-    {% trans "CloudCare" %}
+    {% trans "Web Apps" %}
 {% endblock %}
 
 {% block page_title %}{% endblock %}
@@ -24,7 +24,7 @@
 {% block navigation %}{{ block.super }}
   <div class="navbar navbar-inverse navbar-cloudcare navbar-static-top">
     <div class="container-fluid">
-      <a class="navbar-brand" href="{% url 'cloudcare_default' domain %}"><i class="fcc fcc-flower"></i> Cloudcare</a>
+      <a class="navbar-brand" href="{% url 'cloudcare_default' domain %}"><i class="fcc fcc-flower"></i> Web Apps</a>
       <ul class="nav navbar-nav navbar-right" >
         <li><a href="#" id="commcare-menu-toggle">{% trans 'Show Full Menu' %}</a></li>
       </ul>

--- a/corehq/apps/cloudcare/templates/cloudcare/insufficient_privilege.html
+++ b/corehq/apps/cloudcare/templates/cloudcare/insufficient_privilege.html
@@ -4,6 +4,10 @@
 
 {% block main_column %}
     <div>
-      {% trans "Sorry! Your domain subscription does not include CloudCare. Please do upgrade." %}
+    {% if request|is_new_cloudcare %}
+    {% trans "Sorry! Your domain subscription does not include web apps. Please upgrade." %}
+    {% else %}
+    {% trans "Sorry! Your domain subscription does not include CloudCare. Please upgrade." %}
+    {% endif %}
     </div>
 {% endblock %}

--- a/corehq/apps/cloudcare/views.py
+++ b/corehq/apps/cloudcare/views.py
@@ -597,7 +597,13 @@ class HttpResponseConflict(HttpResponse):
 class EditCloudcareUserPermissionsView(BaseUserSettingsView):
     template_name = 'cloudcare/config.html'
     urlname = 'cloudcare_app_settings'
-    page_title = ugettext_noop("CloudCare Permissions")
+
+    @property
+    def page_title(self):
+        if toggles.USE_FORMPLAYER_FRONTEND.enabled(self.domain):
+            return _("Web Apps Permissions")
+        else:
+            return _("CloudCare Permissions")
 
     @method_decorator(domain_admin_required)
     @method_decorator(requires_privilege_with_fallback(privileges.CLOUDCARE))

--- a/corehq/apps/export/templates/export/download_export.html
+++ b/corehq/apps/export/templates/export/download_export.html
@@ -98,24 +98,31 @@
                     {% endblocktrans %}
                 </p>
                 <p>
+                     {% if request|is_new_cloudcare %}
                     {% blocktrans %}
                         To get started, please
                         <a href="https://confluence.dimagi.com/display/commcarepublic/Deploy+and+Install+an+Application+on+CommCareHQ"
                            target="_blank">deploy</a>
                         your application and submit data from a phone. You may also
-                    {% endblocktrans %}
                         <a href="https://confluence.dimagi.com/display/commcarepublic/CloudCare+-+Web+Data+Entry"
-                           target="_blank">{% trans "submit data via" %}
-                           {% if request|is_new_cloudcare %}
-                           web apps
-                           {% else %}
-                           CloudCare
-                           {% endif %}
+                           target="_blank">submit data via web apps
                         </a>
-                    {% blocktrans %}
                         , depending on your project's
                         <a href="https://www.commcarehq.org/pricing/" target="_blank">plan level</a>.
                     {% endblocktrans %}
+                    {% else %}
+                    {% blocktrans %}
+                        To get started, please
+                        <a href="https://confluence.dimagi.com/display/commcarepublic/Deploy+and+Install+an+Application+on+CommCareHQ"
+                           target="_blank">deploy</a>
+                        your application and submit data from a phone. You may also
+                        <a href="https://confluence.dimagi.com/display/commcarepublic/CloudCare+-+Web+Data+Entry"
+                           target="_blank">submit data via CloudCare
+                        </a>
+                        , depending on your project's
+                        <a href="https://www.commcarehq.org/pricing/" target="_blank">plan level</a>.
+                    {% endblocktrans %}
+                    {% endif %}
                 </p>
             </div>
         {% else %}

--- a/corehq/apps/export/templates/export/download_export.html
+++ b/corehq/apps/export/templates/export/download_export.html
@@ -103,8 +103,17 @@
                         <a href="https://confluence.dimagi.com/display/commcarepublic/Deploy+and+Install+an+Application+on+CommCareHQ"
                            target="_blank">deploy</a>
                         your application and submit data from a phone. You may also
+                    {% endblocktrans %}
                         <a href="https://confluence.dimagi.com/display/commcarepublic/CloudCare+-+Web+Data+Entry"
-                           target="_blank">submit data via CloudCare</a>, depending on your project's
+                           target="_blank">{% trans "submit data via" %}
+                           {% if request|is_new_cloudcare %}
+                           web apps
+                           {% else %}
+                           CloudCare
+                           {% endif %}
+                        </a>
+                    {% blocktrans %}
+                        , depending on your project's
                         <a href="https://www.commcarehq.org/pricing/" target="_blank">plan level</a>.
                     {% endblocktrans %}
                 </p>

--- a/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
+++ b/corehq/apps/hqwebapp/templatetags/hq_shared_tags.py
@@ -215,6 +215,12 @@ def toggle_enabled(request, toggle_or_toggle_name):
     return _toggle_enabled(corehq.toggles, request, toggle_or_toggle_name)
 
 
+@register.filter
+def is_new_cloudcare(request):
+    from corehq import toggles
+    return _toggle_enabled(toggles, request, toggles.USE_FORMPLAYER_FRONTEND)
+
+
 @register.simple_tag
 def toggle_js_url(domain, username):
     return '{url}?username={username}&cachebuster={domain_cb}-{user_cb}'.format(

--- a/corehq/tabs/tabclasses.py
+++ b/corehq/tabs/tabclasses.py
@@ -632,12 +632,18 @@ class ApplicationsTab(UITab):
 
 
 class CloudcareTab(UITab):
-    title = ugettext_noop("CloudCare")
     view = "corehq.apps.cloudcare.views.default"
 
     url_prefix_formats = ('/a/{domain}/cloudcare/',)
 
     ga_tracker = GaTracker('CloudCare', 'Click Cloud-Care top-level nav')
+
+    @property
+    def title(self):
+        if toggles.USE_FORMPLAYER_FRONTEND.enabled(self.domain):
+            return _("Web Apps")
+        else:
+            return _("CloudCare")
 
     @property
     def _is_viewable(self):
@@ -982,8 +988,12 @@ class ProjectUsersTab(UITab):
             ]
 
             if self.can_view_cloudcare:
+                if toggles.USE_FORMPLAYER_FRONTEND.enabled(self.domain):
+                    title = _("Web Apps Permissions")
+                else:
+                    title = _("CloudCare Permissions")
                 mobile_users_menu.append({
-                    'title': _('CloudCare Permissions'),
+                    'title': title,
                     'url': reverse('cloudcare_app_settings',
                                    args=[self.domain])
                 })


### PR DESCRIPTION
@czue @dimagi/product first pass on renaming cloudcare to "web apps." one fairly hard thing to change is the actual CloudCare setting in the app manager: https://github.com/dimagi/commcare-hq/blob/br/rename-cloudcare/corehq/apps/app_manager/static/app_manager/json/commcare-app-settings.yaml#L80. Cory wonder if you know any clever ideas to be able to toggle the name based on the flag. otherwise i think we'll have to do something pretty hacky. Haven't touched the billing or pricing too much either. Pricing will be hard in the sense that we may have users who haven't logged in yet so we don't know what their status is in regards to Old Cloudcare vs. New

cc: @orangejenny 
