### PR TITLE
Shorten generated blob identifiers

### DIFF
--- a/corehq/blobs/interface.py
+++ b/corehq/blobs/interface.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 
 from corehq.blobs import DEFAULT_BUCKET
 from corehq.blobs.exceptions import ArgumentError
+from corehq.blobs.util import random_url_id
 
 SAFENAME = re.compile("^[a-z0-9_./{}-]+$", re.IGNORECASE)
 NOT_SET = object()
@@ -86,13 +87,28 @@ class AbstractBlobDB(object):
 
     @staticmethod
     def get_identifier(basename):
-        if not basename:
-            return uuid4().hex
-        if SAFENAME.match(basename) and "/" not in basename:
-            prefix = basename
-        else:
-            prefix = "unsafe"
-        return prefix + "." + uuid4().hex
+        """Get an unique random identifier
+
+        The identifier is chosen from a 64 bit key space, which is
+        suitably large for no likely collisions in 1000 concurrent keys.
+        1000 is an arbitrary number chosen as an upper bound of the
+        number of blobs associated with any given object. We may need to
+        change this if we ever expect an object to have significantly
+        more than 1000 blobs (attachments). The probability of a
+        collision with a 64 bit ID is:
+
+        k = 1000
+        N = 2 ** 64
+        (k ** 2) / (2 * 2 ** 64) = 2.7e-14
+
+        which is somewhere near the probability of a meteor landing on
+        your house. For most objects the number of blobs present at any
+        moment in time will be far lower, and therefore the probability
+        of a collision will be much lower as well.
+
+        http://preshing.com/20110504/hash-collision-probabilities/
+        """
+        return random_url_id(8)
 
     @staticmethod
     def get_args_for_delete(identifier=NOT_SET, bucket=NOT_SET):

--- a/corehq/blobs/tests/test_s3db.py
+++ b/corehq/blobs/tests/test_s3db.py
@@ -80,10 +80,11 @@ from testil import tempdir
 import corehq.blobs.s3db as mod
 from corehq.blobs.exceptions import ArgumentError
 from corehq.blobs.tests.util import TemporaryS3BlobDB
+from corehq.blobs.tests.test_fsdb import _BlobDBTests
 from corehq.util.test_utils import generate_cases, trap_extra_setup
 
 
-class TestS3BlobDB(TestCase):
+class TestS3BlobDB(TestCase, _BlobDBTests):
 
     @classmethod
     def setUpClass(cls):
@@ -94,113 +95,6 @@ class TestS3BlobDB(TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.db.close()
-
-    def test_put_and_get(self):
-        name = "test.1"
-        info = self.db.put(StringIO(b"content"), name)
-        with self.db.get(info.identifier) as fh:
-            self.assertEqual(fh.read(), b"content")
-
-    def test_put_and_get_with_unicode_names(self):
-        name = "test.\u4500"
-        bucket = "doc.4500"
-        info = self.db.put(StringIO(b"content"), name, bucket)
-        with self.db.get(info.identifier, bucket) as fh:
-            self.assertEqual(fh.read(), b"content")
-
-    def test_put_and_get_with_bucket(self):
-        name = "test.2"
-        bucket = "doc.2"
-        info = self.db.put(StringIO(b"content"), name, bucket)
-        with self.db.get(info.identifier, bucket) as fh:
-            self.assertEqual(fh.read(), b"content")
-
-    def test_put_with_bucket_and_get_without_bucket(self):
-        name = "test.3"
-        bucket = "doc.3"
-        info = self.db.put(StringIO(b"content"), name, bucket)
-        with self.assertRaises(mod.NotFound):
-            self.db.get(info.identifier)
-
-    def test_put_with_double_dotted_name(self):
-        name = "nations..mp3"
-        info = self.db.put(StringIO(b"content"), name)
-        with self.db.get(info.identifier) as fh:
-            self.assertEqual(fh.read(), b"content")
-
-    def test_put_from_get_stream(self):
-        name = "form.xml"
-        old = self.db.put(StringIO(b"content"), name, "old_bucket")
-        with self.db.get(old.identifier, "old_bucket") as fh:
-            new = self.db.put(fh, name, "new_bucket")
-        with self.db.get(new.identifier, "new_bucket") as fh:
-            self.assertEqual(fh.read(), b"content")
-
-    def test_delete(self):
-        name = "test.4"
-        bucket = "doc.4"
-        info = self.db.put(StringIO(b"content"), name, bucket)
-
-        self.assertTrue(self.db.delete(info.identifier, bucket), 'delete failed')
-
-        with self.assertRaises(mod.NotFound):
-            self.db.get(info.identifier, bucket)
-
-        # boto3 client reports that the object was deleted even if there was
-        # no object to delete
-        #self.assertFalse(self.db.delete(info.identifier, bucket), 'delete should fail')
-
-    def test_delete_bucket(self):
-        bucket = join("doctype", "ys7v136b")
-        info = self.db.put(StringIO(b"content"), bucket=bucket)
-        self.assertTrue(self.db.delete(bucket=bucket))
-
-        self.assertTrue(info.identifier)
-        with self.assertRaises(mod.NotFound):
-            self.db.get(info.identifier, bucket=bucket)
-
-    def test_delete_identifier_in_default_bucket(self):
-        info = self.db.put(StringIO(b"content"))
-        self.assertTrue(self.db.delete(info.identifier), 'delete failed')
-        with self.assertRaises(mod.NotFound):
-            self.db.get(info.identifier)
-
-    def test_delete_no_args(self):
-        info = self.db.put(StringIO(b"content"))
-        with self.assertRaises(ArgumentError):
-            self.db.delete()
-        # blobs in default bucket should not be deleted
-        with self.db.get(info.identifier) as fh:
-            self.assertEqual(fh.read(), b"content")
-        self.assertTrue(self.db.delete(bucket=mod.DEFAULT_BUCKET))
-
-    def test_prevent_delete_bucket_by_mistake(self):
-        info = self.db.put(StringIO(b"content"))
-        id_mistake = None
-        with self.assertRaises(ArgumentError):
-            self.db.delete(id_mistake, mod.DEFAULT_BUCKET)
-        # blobs in default bucket should not be deleted
-        with self.db.get(info.identifier) as fh:
-            self.assertEqual(fh.read(), b"content")
-        self.assertTrue(self.db.delete(bucket=mod.DEFAULT_BUCKET))
-
-    def test_bulk_delete(self):
-        blobs = [
-            ('test.5', 'doc.5'),
-            ('test.6', 'doc.6'),
-        ]
-        infos = [
-            self.db.put(StringIO(b"content-{}".format(blob[0])), blob[0], blob[1])
-            for blob in blobs
-        ]
-
-        blob_infos = zip(blobs, infos)
-        paths = [self.db.get_path(info.identifier, blob[1]) for blob, info in blob_infos]
-        self.assertTrue(self.db.bulk_delete(paths), 'delete failed')
-
-        for blob, info in blob_infos:
-            with self.assertRaises(mod.NotFound):
-                self.db.get(info.identifier, blob[1])
 
     def test_bucket_path(self):
         bucket = join("doctype", "8cd98f0")
@@ -224,22 +118,3 @@ class TestS3BlobDB(TestCase):
         bucket = join("doctype", "8cd98f0")
         info = self.db.put(StringIO(b"content"), name, bucket)
         self.assertTrue(info.identifier.startswith("unsafe."), info.identifier)
-
-    def test_empty_attachment_name(self):
-        info = self.db.put(StringIO(b"content"))
-        self.assertNotIn(".", info.identifier)
-
-
-@generate_cases([
-    ("test.1", "\u4500.1"),
-    ("test.1", "/tmp/notallowed"),
-    ("test.1", "."),
-    ("test.1", ".."),
-    ("test.1", "../notallowed"),
-    ("test.1", "notallowed/.."),
-    ("/test.1",),
-    ("../test.1",),
-], TestS3BlobDB)
-def test_bad_name(self, name, bucket=mod.DEFAULT_BUCKET):
-    with self.assertRaises(mod.BadName):
-        self.db.get(name, bucket)

--- a/corehq/blobs/tests/test_s3db.py
+++ b/corehq/blobs/tests/test_s3db.py
@@ -100,21 +100,3 @@ class TestS3BlobDB(TestCase, _BlobDBTests):
         bucket = join("doctype", "8cd98f0")
         self.db.put(StringIO(b"content"), bucket=bucket)
         self.assertEqual(self.db.get_path(bucket=bucket), bucket)
-
-    def test_safe_attachment_path(self):
-        name = "test.1"
-        bucket = join("doctype", "8cd98f0")
-        info = self.db.put(StringIO(b"content"), name, bucket)
-        self.assertTrue(info.identifier.startswith(name + "."), info.identifier)
-
-    def test_unsafe_attachment_path(self):
-        name = "\u4500.1"
-        bucket = join("doctype", "8cd98f0")
-        info = self.db.put(StringIO(b"content"), name, bucket)
-        self.assertTrue(info.identifier.startswith("unsafe."), info.identifier)
-
-    def test_unsafe_attachment_name(self):
-        name = "test/1"  # name with directory separator
-        bucket = join("doctype", "8cd98f0")
-        info = self.db.put(StringIO(b"content"), name, bucket)
-        self.assertTrue(info.identifier.startswith("unsafe."), info.identifier)

--- a/corehq/blobs/tests/test_util.py
+++ b/corehq/blobs/tests/test_util.py
@@ -13,3 +13,18 @@ class TestClosingContextProxy(TestCase):
             tmp.seek(0)
             proxy = mod.ClosingContextProxy(tmp)
             self.assertEqual(list(proxy), ["line 1\n", "line 2\n"])
+
+
+class TestRandomUrlId(TestCase):
+
+    sample_size = 100
+
+    def setUp(self):
+        self.ids = [mod.random_url_id(8) for x in xrange(self.sample_size)]
+
+    def test_random_id_length(self):
+        self.assertGreater(min(len(id) for id in self.ids), 0, self.ids)
+        self.assertEqual(max(len(id) for id in self.ids), 11, self.ids)
+
+    def test_random_id_randomness(self):
+        self.assertEqual(len(set(self.ids)), self.sample_size, self.ids)

--- a/corehq/blobs/util.py
+++ b/corehq/blobs/util.py
@@ -1,3 +1,6 @@
+import os
+from base64 import urlsafe_b64encode
+
 
 class ClosingContextProxy(object):
     """Context manager wrapper for object with close() method
@@ -42,3 +45,12 @@ class document_method(object):
         if obj is None:
             return self.func
         return self.func.__get__(obj, owner)
+
+
+def random_url_id(nbytes):
+    """Get a random URL-safe ID string
+
+    :param nbytes: Number of random bytes to include in the ID.
+    :returns: A URL-safe string.
+    """
+    return urlsafe_b64encode(os.urandom(nbytes)).decode('ascii').rstrip(u'=')


### PR DESCRIPTION
This should reduce the amount of RAM needed by the blob db backend. I have never once needed the filename that was previously embedded in the blob id, so I don't mind removing it.

Best to review commits individually. 51eb53d is refactoring only.

@snopoke @dannyroberts cc @proteusvacuum 
