### PR TITLE
drop indices created in django 1.9

### DIFF
--- a/corehq/form_processor/migrations/0035_remove_varchar_pattern_ops_indexes.py
+++ b/corehq/form_processor/migrations/0035_remove_varchar_pattern_ops_indexes.py
@@ -14,17 +14,27 @@ class Migration(migrations.Migration):
 
     NOOP_REVERSE = 'SELECT 1'
     operations = [
+        # TODO - remove when django>=1.9
         HqRunSQL(
             'DROP INDEX IF EXISTS form_processor_caseattach_attachment_uuid_4c1d2c3ea75567cc_like',
+            NOOP_REVERSE
+        ),
+        HqRunSQL(
+            'DROP INDEX IF EXISTS form_processor_caseattachmentsql_attachment_uuid_8d145664_like',
             NOOP_REVERSE
         ),
         HqRunSQL(
             'DROP INDEX IF EXISTS form_processor_xforminstancesql_form_uuid_12662b9ceadeeecc_like',
             NOOP_REVERSE
         ),
+        # TODO - remove when django>=1.9
         HqRunSQL(
             'DROP INDEX IF EXISTS form_processor_xformattac_attachment_uuid_6d1d0a1eff4ada21_like',
             NOOP_REVERSE
+        ),
+        HqRunSQL(
+            'DROP INDEX IF EXISTS form_processor_xformattachmentsql_attachment_uuid_51177a7e_like',
+            NOOP_REVERSE,
         ),
         HqRunSQL(
             'DROP INDEX IF EXISTS form_processor_xformattachmentsql_name_4b9f1b0d840a70bc_like',


### PR DESCRIPTION
Seems that django 1.9 creates indices with different names than django 1.8, so we need different `DROP INDEX` statements

@kaapstorm 
